### PR TITLE
Decimal Highlighting - Carbon-68

### DIFF
--- a/src/components/decimal/__spec__.js
+++ b/src/components/decimal/__spec__.js
@@ -180,11 +180,63 @@ describe('Decimal', () => {
     describe('handleBlur', () => {
       beforeEach(() => {
         spyOn(instance, 'setState');
+        instance.highlighted = true;
         TestUtils.Simulate.blur(instance.refs.visible);
       });
 
       it('calls setState with the formatted visible value', () => {
         expect(instance.setState).toHaveBeenCalledWith({ visibleValue: "1,000.00" });
+      });
+
+      it('sets the highlighted property to false', () => {
+        expect(instance.highlighted).toBeFalsy();
+      });
+    });
+
+    describe("handleOnClick", function() {
+      let visible;
+
+      beforeEach(function() {
+        visible = instance.refs.visible;
+        spyOn(visible, 'setSelectionRange');
+      });
+
+      describe("when the caret is at the edge of the value", function() {
+        beforeEach(function() {
+          visible.selectionStart = 0;
+          visible.selectionEnd = 0;
+          TestUtils.Simulate.click(visible);
+        });
+
+        it("should call setSelectionRange method", function() {
+          expect(visible.setSelectionRange).toHaveBeenCalledWith(0, visible.value.length);
+        });
+      });
+
+      describe("when the caret is within the value", function() {
+        beforeEach(function() {
+          visible.value = '100';
+          spyOn(visible, 'selectionStart');
+          TestUtils.Simulate.click(visible);
+        });
+
+        it("should not call setSelectionRange method", function() {
+          expect(visible.setSelectionRange).not.toHaveBeenCalled();
+        });
+      });
+
+      describe("when highlighted is true", function() {
+        beforeEach(function() {
+          instance.highlighted = true;
+          visible.selectionStart = 0
+          visible.selectionEnd = 0
+          TestUtils.Simulate.click(visible);
+        });
+
+        it("resets highlighted to false and does not call setSelectionRange", function() {
+          expect(instance.highlighted).toBeFalsy();
+          expect(visible.setSelectionRange).not.toHaveBeenCalled();
+        });
       });
     });
 

--- a/src/components/decimal/decimal.js
+++ b/src/components/decimal/decimal.js
@@ -35,6 +35,17 @@ class Decimal extends React.Component {
    */
   _document = document;
 
+  /**
+   * Used within the onClick and onBlur method to
+   * check if the current visible input value is
+   * highlighted
+   *
+   * @property highlighted
+   * @type {Boolean}
+   */
+  highlighted = false;
+
+
   static defaultProps = {
     /**
      * Sets the default value of the decimal field
@@ -120,6 +131,28 @@ class Decimal extends React.Component {
    */
   handleBlur = () => {
     this.setState({ visibleValue: formatVisibleValue(this.props.value, this) });
+    this.highlighted = false;
+  }
+
+  /*
+   * Selects visible input text depending on where the user clicks
+   *
+   * @method handleOnClick
+   * @param {Object} ev event
+   */
+  handleOnClick = () => {
+    // if value is already highlighted then don't re-highlight it
+    if (this.highlighted) {
+      this.highlighted = false;
+      return;
+    }
+
+    let input = this.refs.visible;
+    // only do it if the selection is not within the value
+    if ((input.selectionStart === 0) && (input.selectionEnd === 0)) {
+      input.setSelectionRange(0, input.value.length);
+      this.highlighted = true;
+    }
   }
 
   /**
@@ -133,6 +166,7 @@ class Decimal extends React.Component {
     props.className = this.inputClasses;
     props.ref = "visible";
     props.onChange = this.handleVisibleInputChange;
+    props.onClick = this.handleOnClick;
     props.name = null;
     props.onBlur = this.handleBlur;
     props.value = this.state.visibleValue;


### PR DESCRIPTION
When clicking into a decimal field, it should highlight the string similar to how it does in the current UI components.
