### PR TITLE
bump to 0.1.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0
+
+TBC
+
 # 0.0.2
 
 ## Decimal Component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon",
-  "version": "0.0.2",
+  "version": "0.1.0-beta",
   "description": "Fundamental building blocks.",
   "main": "index.js",
   "style": [


### PR DESCRIPTION
Master will now be anything for the next `minor` release. As we are still in `beta` then this can include breaking changes.

Any bug fixes should be targetted for the `release` branch which is on `0.0.2`.
