### PR TITLE
move ncp dep to devdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "history": "^1.12.5",
     "i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc8.tar.gz",
     "immutable": "^3.7.5",
+    "ncp": "^2.0.0",
     "react": "^0.14.0",
     "react-addons-css-transition-group": "^0.14.0",
     "react-dom": "^0.14.0",
@@ -41,7 +42,6 @@
     "form-serialize": "^0.7.0",
     "lodash": "^3.10.1",
     "moment": "^2.10.6",
-    "ncp": "^2.0.0",
     "react-date-picker": "^3.1.5",
     "react-highcharts": "^5.0.4",
     "superagent": "^1.4.0"


### PR DESCRIPTION
due to the alternative way we do releases now, we no longer need ncp as a dependency - only as a dev dependency.
