### PR TITLE
router no longer throws error if cant find dom element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.6
+
+## Bug Fixes
+
+* `startRouter` no longer throws an error if it cannot find an element to render the component to.
+
 # 0.1.5
 
 ## Bug Fixes

--- a/src/utils/router/__spec__.js
+++ b/src/utils/router/__spec__.js
@@ -13,6 +13,7 @@ describe('startRouter', () => {
 
   describe('default', () => {
     beforeEach(() => {
+      spyOn(document, 'getElementById').and.returnValue('foo');
       startRouter(routes);
       router = render.calls.mostRecent().args[0];
     });
@@ -38,6 +39,17 @@ describe('startRouter', () => {
 
     it('renders the router with the element', () => {
       expect(render).toHaveBeenCalledWith(router, 'foo');
+    });
+  });
+
+  describe('with no target', () => {
+    beforeEach(() => {
+      spyOn(console, 'warn');
+      startRouter(routes);
+    });
+
+    it('does not call render', () => {
+      expect(render).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/router/router.js
+++ b/src/utils/router/router.js
@@ -31,9 +31,11 @@ export function startRouter(routes, target = document.getElementById('app')) {
   let history = createBrowserHistory();
 
   // render the router into the DOM
-  ReactDOM.render((
-    <Router history={ history }>
-      { routes }
-    </Router>
-  ), target);
+  if (target) {
+    ReactDOM.render((
+      <Router history={ history }>
+        { routes }
+      </Router>
+    ), target);
+  }
 }


### PR DESCRIPTION
We were getting errors in CI when running tests that dont have a DOM.

``` bash
Invariant Violation: _registerComponent(...): Target container is not a DOM element.
Invariant Violation: _registerComponent(...): Target container is not a DOM element.
at http://127.0.0.1:46419/assets/ui.js:48913 in invariant
```
