### PR TITLE
CARBON-102 fixes dropdown bug - bumps to v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.7
+
+## Bug Fixes
+
+* [CARBON-102](https://sageone.atlassian.net/browse/CARBON-102) - Fixes bug - 'item is undefined triggered when clicking away from dropdown with option highlighted'.
+
 # 0.1.6
 
 ## Bug Fixes

--- a/lib/components/dropdown/dropdown.js
+++ b/lib/components/dropdown/dropdown.js
@@ -147,7 +147,7 @@ var Dropdown = (0, _utilsDecoratorsInput2['default'])((0, _utilsDecoratorsInputI
 
           if (highlighted != _this.props.value) {
             var item = _this.props.options.find(function (item) {
-              return item.get('id') === highlighted;
+              return item.get('id') == highlighted;
             });
 
             _this.emitOnChangeCallback(highlighted, item.get('name'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Fundamental building blocks.",
   "main": "index.js",
   "style": [

--- a/src/components/dropdown/__spec__.js
+++ b/src/components/dropdown/__spec__.js
@@ -194,7 +194,7 @@ describe('Dropdown', () => {
     describe('if blur is not blocked', () => {
       beforeEach(() => {
         instance = TestUtils.renderIntoDocument(
-          <Dropdown options={ Immutable.fromJS([{ id: '1', name: 'foo' }, { id: '2', name: 'bar' }]) } value="1" />
+          <Dropdown options={ Immutable.fromJS([{ id: 1, name: 'foo' }, { id: 2, name: 'bar' }]) } value="1" />
         );
         spyOn(instance, 'setState');
         spyOn(instance, 'emitOnChangeCallback');

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -209,7 +209,7 @@ class Dropdown extends React.Component {
 
       if (highlighted != this.props.value) {
         let item = this.props.options.find((item) => {
-          return item.get('id') === highlighted;
+          return item.get('id') == highlighted;
         });
 
         this.emitOnChangeCallback(highlighted, item.get('name'));


### PR DESCRIPTION
Steps
- Expand dropdown menu
- Hover over a different item so it is highlighted
- Click away from the dropdown to close the menu without selecting an option

Observed
Clicking away from the dropdown when an option is highlighted fails to close the dropdown and triggers a javascript error in the console - `TypeError: item is undefined.`
The user has to select one of the different options in order to close the dropdown menu.

Expected
Clicking away from the dropdown should close the dropdown menu without the user having to select a option. It also shouldn't trigger an error.
