### PR TITLE
dialog center on init and cancelHandler to onCancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # 0.3.0
 
-TBC
+## Breaking Change
+
+* The `cancelHandler` method on `Dialog` based components has been renamed to `onCancel` to bring in line with the convention we would like to progress with for this kind of action name.
+
+## Bug Fixes
+
+* Dialog now centers itself if open on initialize.
 
 # 0.2.0
 

--- a/example/views/dummy/subviews/history/index.js
+++ b/example/views/dummy/subviews/history/index.js
@@ -30,7 +30,7 @@ class History extends React.Component {
 
         <Alert  title="Alert"
                 open={ this.state.userStore.get('alertOpen') }
-                cancelHandler={ UserActions.userAlertClosed }>
+                onCancel={ UserActions.userAlertClosed }>
                 The page is now in it's previous state.
         </Alert>
       </div>

--- a/example/views/dummy/subviews/user-dialog/index.js
+++ b/example/views/dummy/subviews/user-dialog/index.js
@@ -15,7 +15,7 @@ class UserDialog extends React.Component {
       <Dialog
         title="Edit My Details"
         open={ this.state.userStore.get('dialogOpen') }
-        cancelHandler={ UserActions.userDialogClosed }>
+        onCancel={ UserActions.userDialogClosed }>
 
         <Form model="contact">
           <Row>

--- a/src/components/alert/README.md
+++ b/src/components/alert/README.md
@@ -11,7 +11,7 @@ import Alert from 'carbon/lib/components/alert';
 *  To render a Alert:
 
 ```javascript
-   <Alert cancelHandler={ customEventHandler } open={ false }/>
+   <Alert onCancel={ customEventHandler } open={ false }/>
 ```
 
  The component rendering the Alert must pass down a prop of 'open' in order to open the alert.

--- a/src/components/alert/__spec__.js
+++ b/src/components/alert/__spec__.js
@@ -5,12 +5,12 @@ import Alert from './alert';
 
 describe('Alert', () => {
   let instance;
-  let cancelHandler = jasmine.createSpy('cancel');
+  let onCancel = jasmine.createSpy('cancel');
 
   beforeEach(() => {
     instance = TestUtils.renderIntoDocument(
       <Alert
-        cancelHandler={ cancelHandler }
+        onCancel={ onCancel }
         open={ true }
         title="Alert title" />
     );

--- a/src/components/alert/alert.js
+++ b/src/components/alert/alert.js
@@ -11,7 +11,7 @@ import Dialog from '../dialog';
  *
  * To render a Alert:
  *
- *   <Alert cancelHandler={ customEventHandler } open={ false }/>
+ *   <Alert onCancel={ customEventHandler } open={ false }/>
  *
  * The component rendering the Alert must pass down a prop of 'open' in order to open the alert.
  *

--- a/src/components/confirm/README.md
+++ b/src/components/confirm/README.md
@@ -14,7 +14,7 @@ import Confirm from 'carbon/lib/components/confirm';
 <Confirm
   title='Are you sure?'
   confirmHandler={ customConfirmHandler }
-  cancelHandler={ customCancelHandler }
+  onCancel={ customCancelHandler }
   open={ false }
   This is the content message
 </Confirm>
@@ -30,6 +30,6 @@ import Confirm from 'carbon/lib/components/confirm';
 | ------------- |  ------------- |  ------------- | ------------- | ------------- |
 | title         | false          | String         |               | Confirm dialog title  |
 | confirmHandler | false          | Function           |               | Callback for when the yes button is clicked  |
-| cancelHandler  | false         | Function        |               | Callback for when the no button is clicked |
+| onCancel      | false         | Function        |               | Callback for when the no button is clicked |
 | open          | false          | Boolean        |               | Pass true if you want the confirm to open |
 | children      | false          | String        |               | Confirm dialog content to show to the user |

--- a/src/components/confirm/__spec__.js
+++ b/src/components/confirm/__spec__.js
@@ -5,13 +5,13 @@ import Confirm from './confirm';
 
 describe('Confirm', () => {
   let instance;
-  let cancelHandler = jasmine.createSpy('cancel');
+  let onCancel = jasmine.createSpy('cancel');
   let confirmHandler = jasmine.createSpy('confirm');
 
   beforeEach(() => {
     instance = TestUtils.renderIntoDocument(
       <Confirm
-        cancelHandler={ cancelHandler }
+        onCancel={ onCancel }
         confirmHandler={ confirmHandler }
         open={ true }
         title="Confrim title" />
@@ -59,9 +59,9 @@ describe('Confirm', () => {
         expect(no.className).toEqual('ui-confirm__button ui-confirm__no');
       });
 
-      it('triggers the cancelHandler when the no button is clicked', () => {
+      it('triggers the onCancel when the no button is clicked', () => {
         TestUtils.Simulate.click(noButton);
-        expect(cancelHandler).toHaveBeenCalled();
+        expect(onCancel).toHaveBeenCalled();
       });
     });
   });

--- a/src/components/confirm/confirm.js
+++ b/src/components/confirm/confirm.js
@@ -17,7 +17,7 @@ import I18n from "i18n-js";
  *   <Confirm
  *      title='Are you sure?"
  *      confirmHandler={ customConfirmHandler }
- *      cancelHandler={ customCancelHandler }
+ *      onCancel={ customCancelHandler }
  *      open={ false }
  *    This is the content message
  *   </Confirm>
@@ -93,7 +93,7 @@ class Confirm extends Dialog {
     return (
       <div className='ui-confirm__buttons' >
         <div className='ui-confirm__button ui-confirm__no'>
-          <Button as='secondary' onClick={ this.props.cancelHandler }>{ cancelText() }</Button>
+          <Button as='secondary' onClick={ this.props.onCancel }>{ cancelText() }</Button>
         </div>
 
         <div className='ui-confirm__button ui-confirm__yes'>

--- a/src/components/dialog/__spec__.js
+++ b/src/components/dialog/__spec__.js
@@ -7,14 +7,38 @@ import Button from './../button';
 
 describe('Dialog', () => {
   let instance;
-  let cancelHandler = jasmine.createSpy('cancel');
+  let onCancel = jasmine.createSpy('cancel');
 
   describe('Lifecycle functions', () => {
+    describe('componentDidMount', () => {
+      describe('when dialog is open', () => {
+        it('centers the dialog', () => {
+          instance = TestUtils.renderIntoDocument(
+            <Dialog open={ true } onCancel={ () => {} } />
+          );
+          spyOn(instance, "centerDialog");
+          instance.componentDidMount();
+          expect(instance.centerDialog).toHaveBeenCalled();
+        });
+      });
+
+      describe('when dialog is closed', () => {
+        it('does not center the dialog', () => {
+          instance = TestUtils.renderIntoDocument(
+            <Dialog open={ false } onCancel={ () => {} } />
+          );
+          spyOn(instance, "centerDialog");
+          instance.componentDidMount();
+          expect(instance.centerDialog).not.toHaveBeenCalled();
+        });
+      });
+    });
+
     describe('componentDidUpdate', () => {
       describe('when the dialog is open', () => {
         beforeEach(() => {
           instance = TestUtils.renderIntoDocument(
-            <Dialog open={ true } cancelHandler={ cancelHandler } />
+            <Dialog open={ true } onCancel={ onCancel } />
           );
         });
 
@@ -47,7 +71,7 @@ describe('Dialog', () => {
       describe('when the dialog is closed', () => {
         beforeEach(() => {
           instance = TestUtils.renderIntoDocument(
-            <Dialog cancelHandler={ cancelHandler } />
+            <Dialog onCancel={ onCancel } />
           );
         });
 
@@ -65,7 +89,7 @@ describe('Dialog', () => {
   describe('centerDialog', () => {
     beforeEach(() => {
       instance = TestUtils.renderIntoDocument(
-        <Dialog open={ true } cancelHandler={ cancelHandler } />
+        <Dialog open={ true } onCancel={ onCancel } />
       );
     });
 
@@ -110,21 +134,21 @@ describe('Dialog', () => {
   describe('closeDialog', () => {
     beforeEach(() => {
       instance = TestUtils.renderIntoDocument(
-        <Dialog open={ true } cancelHandler={ cancelHandler } />
+        <Dialog open={ true } onCancel={ onCancel } />
       );
     });
 
     describe('when the esc key is released', () => {
       it('calls the cancel dialog handler', () => {
         instance.closeDialog({ keyCode: 27 });
-        expect(cancelHandler).toHaveBeenCalled();
+        expect(onCancel).toHaveBeenCalled();
       });
     });
 
     describe('when any other key is released', () => {
       it('calls the cancel dialog handler', () => {
         instance.closeDialog({ keyCode: 8 });
-        expect(cancelHandler).toHaveBeenCalled();
+        expect(onCancel).toHaveBeenCalled();
       });
     });
   });
@@ -134,7 +158,7 @@ describe('Dialog', () => {
       beforeEach(() => {
         instance = TestUtils.renderIntoDocument(
           <Dialog
-            cancelHandler={ cancelHandler }
+            onCancel={ onCancel }
             open={ true }
             title="Dialog title" />
         );
@@ -151,7 +175,7 @@ describe('Dialog', () => {
       beforeEach(() => {
         instance = TestUtils.renderIntoDocument(
           <Dialog
-            cancelHandler={ cancelHandler }
+            onCancel={ onCancel }
             open={ true } />
         );
       });
@@ -173,7 +197,7 @@ describe('Dialog', () => {
       beforeEach(() => {
         instance = TestUtils.renderIntoDocument(
           <Dialog
-            cancelHandler={ cancelHandler }
+            onCancel={ onCancel }
             className="foo"
             open={ true } >
 
@@ -196,7 +220,7 @@ describe('Dialog', () => {
       it('closes when the exit icon is click', () => {
         let closeIcon = TestUtils.findRenderedDOMComponentWithClass(instance, 'ui-dialog__close');
         TestUtils.Simulate.click(closeIcon);
-        expect(cancelHandler).toHaveBeenCalled();
+        expect(onCancel).toHaveBeenCalled();
       });
 
       it('renders the children passed to it', () => {
@@ -208,7 +232,7 @@ describe('Dialog', () => {
         it('adds the size class to the dialog', () => {
           instance = TestUtils.renderIntoDocument(
             <Dialog
-              cancelHandler={ cancelHandler }
+              onCancel={ onCancel }
               open={ true }
               size='small' />
           );
@@ -220,7 +244,7 @@ describe('Dialog', () => {
 
     describe('when dialog is closed', () => {
       instance = TestUtils.renderIntoDocument(
-        <Dialog cancelHandler={ cancelHandler } />
+        <Dialog onCancel={ onCancel } />
       );
 
       it('renders a parent div with mainClasses attached', () => {

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -14,7 +14,7 @@ import Bowser from 'bowser';
  *
  * To render a Dialog:
  *
- *   <Dialog cancelHandler={ customEventHandler } />
+ *   <Dialog onCancel={ customEventHandler } />
  *
  * The component rendering the Dialog must pass down a prop of 'open' in order to open the dialog.
  *
@@ -31,10 +31,10 @@ class Dialog extends React.Component {
     /**
      * A custom close event handler
      *
-     * @property cancelHandler
+     * @property onCancel
      * @type {Function}
      */
-    cancelHandler: React.PropTypes.func.isRequired,
+    onCancel: React.PropTypes.func.isRequired,
 
     /**
      * Sets the open state of the dialog
@@ -70,9 +70,21 @@ class Dialog extends React.Component {
   getChildContext() {
     return {
       dialog: {
-        cancelHandler: this.props.cancelHandler
+        onCancel: this.props.onCancel
       }
     };
+  }
+
+  /**
+   * A lifecycle method to update the component on initialize
+   *
+   * @method componentDidMount
+   * @return {void}
+   */
+  componentDidMount() {
+    if (this.props.open) {
+      this.centerDialog();
+    }
   }
 
   /**
@@ -81,7 +93,7 @@ class Dialog extends React.Component {
    * @method componentDidUpdate
    * @return {void}
    */
-  componentDidUpdate = () => {
+  componentDidUpdate() {
     if (this.props.open && !this.listening) {
       this.centerDialog();
       this.listening = true;
@@ -103,7 +115,7 @@ class Dialog extends React.Component {
    */
   closeDialog = (ev) => {
     if (ev.keyCode === 27) {
-      this.props.cancelHandler();
+      this.props.onCancel();
     }
   }
 
@@ -211,7 +223,7 @@ class Dialog extends React.Component {
     return (
       <div ref="dialog" className={ dialogClasses }>
         { this.dialogTitle }
-        <Icon className="ui-dialog__close" type="close" onClick={ this.props.cancelHandler } />
+        <Icon className="ui-dialog__close" type="close" onClick={ this.props.onCancel } />
 
         <div className='ui-dialog__content'>
           { this.props.children }

--- a/src/components/form/__spec__.js
+++ b/src/components/form/__spec__.js
@@ -170,12 +170,12 @@ describe('Form', () => {
 
     describe('when the form is inside a dialog', () => {
       it('uses the dialogs cancel handler instead', () => {
-        let spy = jasmine.createSpy('cancelHandler');
+        let spy = jasmine.createSpy('onCancel');
         let nestedInstance = TestUtils.renderIntoDocument(
           <Dialog
             title="test"
             open={ true }
-            cancelHandler={ spy }>
+            onCancel={ spy }>
 
             <Form>
               <Textbox

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -252,7 +252,7 @@ class Form extends React.Component {
    */
   cancelForm = () => {
     if (this.context.dialog) {
-      this.context.dialog.cancelHandler();
+      this.context.dialog.onCancel();
     } else {
       // history comes from react router
       if (!this._window.history) {


### PR DESCRIPTION
## Breaking Change
- The `cancelHandler` method on `Dialog` based components has been renamed to `onCancel` to bring in line with the convention we would like to progress with for this kind of action name.
## Bug Fixes
- Dialog now centers itself if open on initialize.
