### PR TITLE
Search - Add to all input fields

### DIFF
--- a/src/utils/decorators/input/input.js
+++ b/src/utils/decorators/input/input.js
@@ -3,6 +3,7 @@ import shouldComponentUpdate from './../../helpers/should-component-update';
 import { assign } from 'lodash';
 import guid from './../../helpers/guid';
 import classNames from 'classnames';
+import Icon from './../../../components/icon';
 
 /**
  * Input decorator.
@@ -163,8 +164,11 @@ let Input = (ComposedComponent) => class Component extends ComposedComponent {
    * @return {String} Input class names
    */
   get inputClasses() {
-    let classes = super.inputClasses || "";
-    return `${classes} common-input__input`;
+    return classNames(
+      super.inputClasses,
+      'common-input__input',
+      { 'common-input__input--search': this.props.search }
+    );
   }
 
   /**
@@ -241,6 +245,12 @@ let Input = (ComposedComponent) => class Component extends ComposedComponent {
     }
   }
 
+  get searchHTML() {
+    if (this.props.search) {
+      return <Icon type='search' className='common-input__search' />
+    }
+  }
+
   /**
    * Returns HTML for the input.
    *
@@ -254,6 +264,7 @@ let Input = (ComposedComponent) => class Component extends ComposedComponent {
     return (
       <div { ...this.fieldProps }>
         { this.prefixHTML }
+        { this.searchHTML }
         { input }
         { this.additionalInputContent }
       </div>

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -190,3 +190,14 @@
   position: absolute;
   top: 8px;
 }
+
+.common-input__input--search {
+  padding-left: 26px;
+}
+
+.common-input__search {
+  color: $grey-dark-blue-40;
+  left: 5px;
+  position: absolute;
+  top: 6px;
+}


### PR DESCRIPTION
This is a possibly way of implementing a search fields for inputs. As its just styling you can pass a prop of search=true to any input.

Alternatives could be to just apply to textboxes? I don't know what the other use cases could be (see below)

<img width="792" alt="screen shot 2016-02-28 at 18 35 40" src="https://cloud.githubusercontent.com/assets/5382335/13381082/1969c340-de4a-11e5-9b6e-3dbce2f71473.png">
