### PR TITLE
renamed tableHeader prop to thead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Improvements
 
 * Improved store reset. `store.reset()` will now reset the store to its initial data, whether or not history is enabled.
-* Add `tableHeader` prop to `Table` component that allows you to set a row wrapped in a `thead` tag.
+* Add `thead` prop to `Table` component that allows you to set a row wrapped in a `thead` tag.
 
 ## New Components
 

--- a/src/components/table/__spec__.js
+++ b/src/components/table/__spec__.js
@@ -368,8 +368,8 @@ describe('Table', () => {
     });
   });
 
-  describe('tableHeader', () => {
-    describe('when tableHeader is not provided', () => {
+  describe('thead', () => {
+    describe('when thead is not provided', () => {
       it('returns the the correct markup', () => {
         instance = TestUtils.renderIntoDocument(
           <Table path='/test'>
@@ -380,7 +380,7 @@ describe('Table', () => {
       });
     });
 
-    describe('when tableHeader is provided', () => {
+    describe('when thead is provided', () => {
       it('returns the the correct markup', () => {
         let header = (
           <TableRow key="header">
@@ -390,12 +390,12 @@ describe('Table', () => {
           </TableRow>
         );
         instance = TestUtils.renderIntoDocument(
-          <Table path='/test' tableHeader={header}>
+          <Table path='/test' thead={header}>
           </Table>
         );
         let parent = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'thead')[0];
         expect(parent).toBeDefined();
-        expect(instance.tableHeader).toEqual(
+        expect(instance.thead).toEqual(
           <thead className="ui-table__header">
             {header}
           </thead>

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -60,7 +60,7 @@ import Pager from './../pager';
  *   totalRecords                             // Required - Total number of records
  *   showPageSizeSelection={ false }          // Options  - Show page size selection
  *   pageSizeSelectionOptions={ sizeOptions } // Optional - Page Size Options
- *   tableHeader={ TableRow }                 // Optional - A TableRow to be wrapped in <thead>
+ *   thead={ TableRow }                       // Optional - A TableRow to be wrapped in <thead>
  * />
  *
  * == Sorting
@@ -163,10 +163,10 @@ class Table extends React.Component {
     /**
      * TableRows to be wrapped in <thead>
      *
-     * @property tableHeader
+     * @property thead
      * @type {Object}
      */
-    tableHeader: React.PropTypes.object
+    thead: React.PropTypes.object
   }
 
   /**
@@ -458,16 +458,16 @@ class Table extends React.Component {
 
 
   /**
-   * Returns tableHeader content wrapped in <thead>
+   * Returns thead content wrapped in <thead>
    *
-   * @method tableHeader
+   * @method thead
    * @return {JSX}
    */
-  get tableHeader() {
-    if (this.props.tableHeader) {
+  get thead() {
+    if (this.props.thead) {
       return (
         <thead className="ui-table__header">
-          { this.props.tableHeader }
+          { this.props.thead }
         </thead>
       );
     }
@@ -483,7 +483,7 @@ class Table extends React.Component {
       <div className={ this.mainClasses }>
         <div className={ this.wrapperClasses } ref={ (wrapper) => { this._wrapper = wrapper; } } >
           <table className={ this.tableClasses } ref={ (table) => { this._table = table; } } >
-            { this.tableHeader }
+            { this.thead }
             <tbody>
               { this.props.children }
             </tbody>


### PR DESCRIPTION
We should get out of the habit of prepending prop names with the component name.
