### PR TITLE
Update Banner Component

### DIFF
--- a/demo/stores/app.js
+++ b/demo/stores/app.js
@@ -6,6 +6,11 @@ import Immutable from 'immutable';
 import FormInputHelper from './../helpers/form-input-helper';
 
 let data = ImmutableHelper.parseJSON({
+  banner: {
+    as: "error",
+    title: "Lorem ipsum dolor",
+    text: "Nullam id dolor id nibh ultricies vehicula ut id elit."
+  },
   button: {
     text: "Action"
   },

--- a/demo/views/notifications/banner-demo/banner-demo.js
+++ b/demo/views/notifications/banner-demo/banner-demo.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import { connect } from 'utils/flux';
+import AppStore from './../../../stores/app';
+import AppActions from './../../../actions/app';
+import Example from './../../../components/example';
+import AsDropdown from './../../../components/as-dropdown';
+
+import Banner from 'components/banner';
+import Row from 'components/row';
+import Checkbox from 'components/checkbox';
+import Textarea from 'components/textarea';
+
+class BannerDemo extends React.Component {
+  /**
+   * @method value
+   */
+  value = (key) => {
+    return this.state.appStore.getIn(['banner', key]);
+  }
+
+  /**
+   * @method action
+   */
+  get action() {
+    return AppActions.appValueUpdated.bind(this, 'banner');
+  }
+
+  /**
+   * @method demo
+   */
+  get demo() {
+    return (
+      <Banner
+        as={ this.value('as') }
+        open={ true }
+        title={ this.value('title') }
+      >
+        { this.value('text') || " " }
+      </Banner>
+    );
+  }
+
+  /**
+   * @method code
+   */
+  get code() {
+    let html = "import Banner from 'carbon/lib/components/banner';\n\n";
+
+    html += "<Banner";
+    html += `\n  as='${this.value('as')}'`;
+    html += `\n  open='${true}'`;
+    html += `\n  title='${this.value('title')}'`;
+    html += "\n>\n";
+    html += `  ${this.value('text')}`;
+    html += "\n</Banner>\n\n";
+
+    return html;
+  }
+
+  /**
+   * @method controls
+   */
+  get controls() {
+    return (
+      <div>
+        <Row>
+          <Textarea
+            label="Title"
+            value={ this.value('title') }
+            onChange={ this.action.bind(this, 'title') }
+          />
+        </Row>
+        <Row>
+          <Textarea
+            label="Content"
+            value={ this.value('text') }
+            onChange={ this.action.bind(this, 'text') }
+          />
+        </Row>
+
+        <Row>
+          <AsDropdown
+            value={ this.value('as') }
+            onChange={ this.action.bind(this, 'as') }
+          />
+        </Row>
+      </div>
+    );
+  }
+
+  /**
+   * @method render
+   */
+  render() {
+    return (
+      <Example
+        title="Banner"
+        readme="components/banner"
+        demo={ this.demo }
+        code={ this.code }
+        controls={ this.controls }
+      />
+    );
+  }
+}
+
+export default connect(BannerDemo, AppStore);

--- a/demo/views/notifications/banner-demo/package.json
+++ b/demo/views/notifications/banner-demo/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "./banner-demo.js"
+}

--- a/demo/views/notifications/notifications.js
+++ b/demo/views/notifications/notifications.js
@@ -2,6 +2,7 @@ import React from 'react';
 import FlashDemo from './flash-demo';
 import MessageDemo from './message-demo';
 import ToastDemo from './toast-demo';
+import BannerDemo from './banner-demo';
 
 class Notifications extends React.Component {
   /**
@@ -14,6 +15,7 @@ class Notifications extends React.Component {
         <FlashDemo />
         <MessageDemo />
         <ToastDemo />
+        <BannerDemo />
       </div>
     );
   }

--- a/src/components/banner/__spec__.js
+++ b/src/components/banner/__spec__.js
@@ -1,66 +1,64 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import TestUtils from 'react/lib/ReactTestUtils';
 import Banner from './banner';
 
 describe('Banner', () => {
-  let infoInstance, newInstance, warningInstance;
-  let spy;
+  let warningInstance, infoInstance, errorInstance, customInstance;
 
   beforeEach(() => {
-    spy = jasmine.createSpy('click');
+    warningInstance = TestUtils.renderIntoDocument(
+      <Banner as='warning' open={true} title='My Title'>Some warning</Banner>
+    )
 
     infoInstance = TestUtils.renderIntoDocument(
-      <Banner
-        as='info'
-        title='Info'
-        className='customClass'
-        message="Info Message."
-        buttonAction={ spy } />
-    );
+      <Banner as='info' open={true}>Some information</Banner>
+    )
 
-    newInstance = TestUtils.renderIntoDocument(
-      <Banner
-        as='new'
-        title="New"
-        message="New Message."
-        buttonAction={ spy } />
-    );
+    errorInstance = TestUtils.renderIntoDocument(
+      <Banner as='error' open={true}>Some error</Banner>
+    )
 
-    warningInstance = TestUtils.renderIntoDocument(
-      <Banner
-        as='warning'
-        title="Warning"
-        message="Warning Message."
-        buttonText="Button Text"
-        buttonAction={ spy } />
-    );
+    customInstance = TestUtils.renderIntoDocument(
+      <Banner className='fancy' as='info' open={true}>Some information</Banner>
+    )
   });
 
-  describe('mainClasses', () => {
-    it('returns the base banner class', () => {
-      expect(newInstance.mainClasses).toEqual('ui-banner ui-banner--new');
+  describe('A Banner instance', () => {
+    it('renders children passed to it', () => {
+      expect(warningInstance.props.children).toEqual('Some warning');
     });
 
-    describe('when passed extra classes via props', () => {
-      it('appends the extra classes to the base class', () => {
-        expect(infoInstance.mainClasses).toEqual('ui-banner ui-banner--info customClass');
-      });
+    it('sets a dialog header', () => {
+      let header = TestUtils.findRenderedDOMComponentWithClass(warningInstance, 'ui-banner__title');
+      expect(header.textContent).toEqual('My Title');
+    });
+
+    it('renders type icon', () => {
+      let icon = TestUtils.findRenderedDOMComponentWithClass(errorInstance, 'ui-banner__type-icon');
+      expect(icon.className).toEqual("ui-banner__type-icon icon-error");
     });
   });
 
-  describe('buttonClasses', () => {
-    it('returns the class for the button depending on the as prop', () => {
-      expect(infoInstance.buttonClasses).toEqual('ui-banner__action ui-banner__action--info');
-      expect(newInstance.buttonClasses).toEqual('ui-banner__action ui-banner__action--new');
-      expect(warningInstance.buttonClasses).toEqual('ui-banner__action ui-banner__action--warning');
-    });
-  });
+  describe('class names', () => {
+    let warningDOM, infoDOM, customDOM;
 
-  describe('render', () => {
-    it('renders a content, information and a action', () => {
-      expect(TestUtils.scryRenderedDOMComponentsWithClass(infoInstance, 'ui-banner__content').length).toEqual(1);
-      expect(TestUtils.scryRenderedDOMComponentsWithClass(infoInstance, 'ui-banner__info').length).toEqual(1);
-      expect(TestUtils.scryRenderedDOMComponentsWithClass(infoInstance, 'ui-banner__action').length).toEqual(1);
+    beforeEach(() => {
+      warningDOM = ReactDOM.findDOMNode(warningInstance);
+      infoDOM = ReactDOM.findDOMNode(infoInstance);
+      customDOM = ReactDOM.findDOMNode(customInstance);
+    });
+
+    it('adds a className of ui-banner--warning when type is warning', () => {
+      expect(warningDOM.className).toEqual('ui-banner ui-banner--warning');
+    });
+
+    it('adds a className of ui-banner--info when type is info', () => {
+      expect(infoDOM.className).toEqual('ui-banner ui-banner--info');
+    });
+
+    it('adds any additional classes passed', () => {
+      expect(customDOM.className).toEqual('ui-banner fancy ui-banner--info');
     });
   });
 });

--- a/src/components/banner/banner.js
+++ b/src/components/banner/banner.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import Button from './../button';
-import classNames from 'classnames';
 import Icon from './../icon';
+import classNames from 'classnames';
 
 /**
  * A Banner widget.
@@ -14,10 +13,9 @@ import Icon from './../icon';
  *
  * To render the Banner:
  *
- *   <Banner
- *      title="This is a title"
- *      message="This is my message."
- *      buttonAction={ this.handleButtonClick } />
+ *   <Banner title="This is a title" open={ true }>
+ *     My banner content
+ *   </Banner>
  *
  * Additionally you can pass optional props to the Banner component
  *
@@ -34,108 +32,71 @@ class Banner extends React.Component {
   static propTypes = {
 
     /**
-     * Customizes the appearance through icon and colour
+     * Customizes the appearance through colour
      * (see the 'iconColorSets' for possible values)
      *
      * @property as
      * @type {String}
-     * @default 'info'
+     * @default 'error'
      */
     as: React.PropTypes.string,
 
     /**
-     * Title to be displayed.
+     * Determines if the banner is open.
      *
-     * @property title
-     * @type {String}
+     * @property open
+     * @type {Boolean}
+     * @default true
      */
-    title: React.PropTypes.string.isRequired,
-
-    /**
-     * Message to be displayed.
-     *
-     * @property message
-     * @type {String}
-     */
-    message: React.PropTypes.string.isRequired,
-
-    /**
-     * Text to display on button.
-     *
-     * @property buttonText
-     * @type {String}
-     * @default 'Got it!'
-     */
-    buttonText: React.PropTypes.string,
-
-    /**
-     * The action to trigger on click.
-     *
-     * @property buttonAction
-     * @type {func}
-     */
-    buttonAction: React.PropTypes.func.isRequired
+    open: React.PropTypes.bool
   }
 
   static defaultProps = {
-    as: 'info',
-    buttonText: 'Got it!'
+    as: 'error',
+    open: true
   }
 
   /**
-   * Classes for the banner
+   * Classes to be applied to the component.
    *
-   * @method mainClasses
-   * @return {String} Main className
+   * @method componentClasses
    */
-  get mainClasses() {
+  get componentClasses() {
     return classNames(
       'ui-banner',
-      `ui-banner--${this.props.as}`,
-      this.props.className
+      this.props.className,
+      'ui-banner--' + this.props.as
     );
   }
 
-  /**
-   * Classes for the button action
-   *
-   * @method buttonClasses
-   * @return {String} classNames for button
-   */
-  get buttonClasses() {
-    return classNames(
-      'ui-banner__action',
-      `ui-banner__action--${this.props.as}`
-    );
+  get titleHTML() {
+    if (this.props.title) {
+      return(
+        <div className='ui-banner__title'>
+          { this.props.title }
+        </div>
+      );
+    }
   }
 
-  /**
-   * Renders the component.
-   *
-   * @method render
-   */
-  render() {
-    return (
-      <div className={ this.mainClasses }>
+  get bannerContent() {
+    return this.props.open ? (
+      <div className={ this.componentClasses }>
+        <div className="ui-banner__type">
+          <Icon className="ui-banner__type-icon" type={ this.props.as } />
+        </div>
         <div className="ui-banner__content">
-          <Icon className="ui-banner__icon" type={ this.props.as } />
-
-          <div className='ui-banner__info'>
-            <div className='ui-banner__title'>
-              { this.props.title }
-            </div>
-
-            <div className='ui-banner__message'>
-              { this.props.message }
-            </div>
+          { this.titleHTML }
+          <div className="ui-banner__body">
+            { this.props.children }
           </div>
-
-          <Button onClick={ this.props.buttonAction } className={ this.buttonClasses }>
-            { this.props.buttonText }
-          </Button>
         </div>
       </div>
-    );
+    ) : null;
+  }
+
+  render() {
+    return (this.bannerContent);
   }
 }
 

--- a/src/components/banner/banner.scss
+++ b/src/components/banner/banner.scss
@@ -1,59 +1,73 @@
 @import 'colors';
-@import 'general';
-@import 'input-field';
+@import 'z-index';
+
+$banner-border: 1px solid !default;
+$banner-border-radius: 4px !default;
+$banner-width: 300px !default;
 
 .ui-banner {
-  color: white;
-  width: 100%;
+  position: relative;
+  border: $banner-border;
+  margin-bottom: 20px;
+}
+
+.ui-banner__type {
+  height: 100%;
+  margin-top: 0;
+  position: absolute;
+  width: 30px;
+  text-align: center;
+
+  .ui-banner__type-icon {
+    display: block;
+    position: relative;
+    top: 50%;
+
+    &:before {
+      color: #FFF;
+      display: block;
+      font-size: 24px;
+      margin-top: -6px;
+    }
+  }
+
+  .ui-icon__svg {
+    height: 24px;
+    margin-top: -12px;
+    width: 30px;
+
+    .ui-icon__svg-group {
+      fill: $white;
+    }
+  }
+}
+
+.ui-banner__close {
+  cursor: pointer;
 }
 
 .ui-banner__content {
-  box-sizing: border-box;
-  height: ($input-common-height - 2) + ($grid-margin * 2);
-  margin: 0 auto;
-  padding: $grid-margin ($grid-margin * 2);
-}
-
-.ui-banner__icon,
-.ui-banner__info,
-.ui-banner__action {
-  display: inline-block;
-  position: relative;
-}
-
-.ui-banner__icon {
-  float: left;
-  text-align: center;
-  top: -5px;
-
-  &:before {
-    font-size: 50px;
-    position: relative;
-    top: 11px;
-  }
+  padding: 15px 50px;
+  white-space: pre-wrap;
 }
 
 .ui-banner__title {
   font-weight: bold;
 }
 
-.ui-banner__info {
-  margin-left: $grid-margin;
-}
-
-.ui-banner__action {
-  background-color: white;
-  border: none;
-  float: right;
-}
-
 @mixin banner-theme($type, $color, $border, $background, $color-hover) {
   .ui-banner--#{$type} {
-    background-color: $color;
-  }
+    background-color: $background;
+    border-color: $border;
 
-  .ui-banner__action--#{$type} {
-    color: $color;
+    .ui-banner__type {
+      background-color: $color;
+    }
+
+    .ui-banner__title {
+      color: $color;
+      margin-bottom:3px;
+    }
   }
 }
 


### PR DESCRIPTION
This PR updates the existing `Banner` component, as apparently this is not used and currently out-of-date. 

The use case for the updated `Banner` component is shown in the screenshot below. 

Essentially a message needs to be presented inline in a coloured box, with corresponding icon and title.

The styling is very similar to the `Toast` component.

<img width="1216" alt="screen shot 2016-08-13 at 17 48 53" src="https://cloud.githubusercontent.com/assets/145826/17644423/3c0b5ab4-617e-11e6-9899-8727fc75f557.png">
