### PR TITLE
Allow custom labels to be defined for Confirm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Adds `$app-medium-font-family` Sass variable.
 * Icons - plus, minus, processing. Update contact icons
 * Improve tile footer style
+* Add ability to set custom labels on Confirm dialog.
 
 # 0.13.0
 

--- a/src/components/confirm/README.md
+++ b/src/components/confirm/README.md
@@ -30,6 +30,8 @@ import Confirm from 'carbon/lib/components/confirm';
 | ------------- |  ------------- |  ------------- | ------------- | ------------- |
 | title         | false          | String         |               | Confirm dialog title  |
 | onConfirm     | false          | Function       |               | Callback for when the yes button is clicked  |
+| confirmLabel  | false          | String         | 'Yes'         | Label text for the confirm button  |
 | onCancel      | false          | Function       |               | Callback for when the no button is clicked |
+| cancelLabel   | false          | String         | 'No'          | Label text for the cancel button |
 | open          | false          | Boolean        |               | Pass true if you want the confirm to open |
 | children      | false          | String         |               | Confirm dialog content to show to the user |

--- a/src/components/confirm/__spec__.js
+++ b/src/components/confirm/__spec__.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import TestUtils from 'react/lib/ReactTestUtils';
 import Dialog from './../dialog'
 import Confirm from './confirm';
@@ -45,6 +46,11 @@ describe('Confirm', () => {
         expect(yes.className).toEqual('ui-confirm__button ui-confirm__yes');
       });
 
+      it('returns a default Yes label', () => {
+        let node = ReactDOM.findDOMNode(yesButton);
+        expect(node.innerHTML).toEqual('Yes');
+      });
+
       it('triggers the onConfirm when the yes button is clicked', () => {
         TestUtils.Simulate.click(yesButton);
         expect(onConfirm).toHaveBeenCalled();
@@ -61,9 +67,40 @@ describe('Confirm', () => {
         expect(no.className).toEqual('ui-confirm__button ui-confirm__no');
       });
 
+      it('returns a default No label', () => {
+        let node = ReactDOM.findDOMNode(noButton);
+        expect(node.innerHTML).toEqual('No');
+      });
+
       it('triggers the onCancel when the no button is clicked', () => {
         TestUtils.Simulate.click(noButton);
         expect(onCancel).toHaveBeenCalled();
+      });
+    });
+
+    describe('when custom labels are defined', () => {
+      beforeEach(() => {
+        instance = TestUtils.renderIntoDocument(
+          <Confirm
+            onCancel={ onCancel }
+            onConfirm={ onConfirm }
+            open={ true }
+            confirmLabel='Delete'
+            cancelLabel='Cancel'
+          />
+        );
+        yesButton = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'ui-confirm__yes')[0];
+        noButton = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'ui-confirm__no')[0];
+      });
+
+      it('returns a custom confirm label', () => {
+        let node = ReactDOM.findDOMNode(yesButton);
+        expect(node.textContent).toEqual('Delete');
+      });
+
+      it('returns a custom cancel label', () => {
+        let node = ReactDOM.findDOMNode(noButton);
+        expect(node.textContent).toEqual('Cancel');
       });
     });
   });

--- a/src/components/confirm/confirm.js
+++ b/src/components/confirm/confirm.js
@@ -42,7 +42,23 @@ class Confirm extends Dialog {
      * @property onConfirm
      * @type {Function}
      */
-    onConfirm: React.PropTypes.func.isRequired
+    onConfirm: React.PropTypes.func.isRequired,
+
+    /**
+     * Customise the confirm button label
+     *
+     * @property onConfirm
+     * @type {String}
+     */
+    confirmLabel: React.PropTypes.string,
+
+    /**
+     * Customise the cancel button label
+     *
+     * @property onConfirm
+     * @type {String}
+     */
+    cancelLabel: React.PropTypes.string
   }
 
   static defaultProps = {
@@ -101,11 +117,15 @@ class Confirm extends Dialog {
     return (
       <div className='ui-confirm__buttons' >
         <div className='ui-confirm__button ui-confirm__no'>
-          <Button as='secondary' onClick={ this.props.onCancel }>{ cancelText() }</Button>
+          <Button as='secondary' onClick={ this.props.onCancel }>
+            { this.props.cancelLabel || I18n.t('confirm.no', { defaultValue: 'No' }) }
+          </Button>
         </div>
 
         <div className='ui-confirm__button ui-confirm__yes'>
-          <Button as='primary' onClick={ this.props.onConfirm }>{ confirmText() }</Button>
+          <Button as='primary' onClick={ this.props.onConfirm }>
+            { this.props.confirmLabel || I18n.t('confirm.yes', { defaultValue: 'Yes' }) }
+          </Button>
         </div>
       </div>
     );
@@ -122,14 +142,6 @@ class Confirm extends Dialog {
     dialog.props.children.push(this.confirmButtons);
     return dialog;
   }
-}
-
-function confirmText() {
-  return I18n.t('confirm.yes', { defaultValue: 'Yes' });
-}
-
-function cancelText() {
-  return I18n.t('confirm.no', { defaultValue: 'No' });
 }
 
 export default Confirm;


### PR DESCRIPTION
I was given design that was a confirmation dialog, but the labels were specific to the task, rather than the default yes/no. This PR allows you to customise the labels, so these designs can be simply created:

![screenshot 2016-05-23 12 00 47](https://cloud.githubusercontent.com/assets/2031/15470841/bb6240ae-20ea-11e6-90c3-f79036ab4a0a.png)
