### PR TITLE
Add $app-light-font-family HelveticaNeue-Light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.13.1
+* Adds `$app-light-font-family` Sass variable.
+
 # 0.13.0
 
 * A developer can choose for a Table to not automatically render with a `tbody`, allowing them to manually render it `<Table tbody={ false }>`.
@@ -5,7 +8,6 @@
 * Inputs can be rendered with fake inputs, useful for pages with lots of inputs where performance can be an issue.
 * Number does not show undefined when value props is not provided and user enter alphabets 
 * Adds external link icon.
-* Adds `$app-light-font-family` Sass variable.
 * Adds new colors: `$grey-dark-blue-5`, `$grey-header`.
 
 # 0.12.2

--- a/src/style-config/general.scss
+++ b/src/style-config/general.scss
@@ -1,6 +1,7 @@
 @import 'colors';
 
 $app-font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif !default;
+$app-light-font-family: 'HelveticaNeue-Light', 'Helvetica Neue', Helvetica, Arial, sans-serif !default;
 $app-font-size: 12px !default;
 $app-line-height: 16px !default;
 $app-text-color: $grey-dark !default;


### PR DESCRIPTION
Unfortunately my previous PR https://github.com/Sage/carbon/pull/508 added this sass variable to `lib` instead of `src` so, although it was merged, it didn't actually make it into the release. My apologies for that!

HelveticaNeue-Light is used as part of the menu and table content in the new design:

<img width="148" alt="screen shot 2016-08-13 at 18 20 05" src="https://cloud.githubusercontent.com/assets/145826/17644590/cd69422e-6182-11e6-9a37-e86065593d5e.png">
