### PR TITLE
Fix input placeholder text style for IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * ButtonToggle.
 
+## Bug Fixes
+
+* CSS fixes to input placeholder text for IE11.
+
 # 0.14.4
 
 ## Bug Fixes

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -98,7 +98,10 @@
   }
 
   &::-webkit-input-placeholder,
-  &::-moz-placeholder,
+  &::-moz-placeholder {
+    color: $grey-dark-blue-40;
+  }
+
   &:-ms-input-placeholder {
     color: $grey-dark-blue-40;
   }


### PR DESCRIPTION
### Description

Fix the issue: https://github.com/Sage/carbon/issues/536 
Manual test performed on (Mac) Chrome/Firefox/Safari & (Windows) IE11 and look fine.
### Screenshots / Gifs

IE11 screenshot before fix: 
See https://github.com/Sage/carbon/issues/536 

IE11 screenshot after fix:

<img width="101" alt="screen shot 2016-08-13 at 18 34 03" src="https://cloud.githubusercontent.com/assets/145826/17644658/871019cc-6184-11e6-92fa-b9ece90ced0b.png">
