### PR TITLE
Fix the issue for input error icon and error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Bug Fixes
 
 * CSS fixes to input error icon and error message.
+* CSS fixes to input placeholder text for IE11.
 
 # 0.14.4
 

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -98,7 +98,10 @@
   }
 
   &::-webkit-input-placeholder,
-  &::-moz-placeholder,
+  &::-moz-placeholder {
+    color: $grey-dark-blue-40;
+  }
+
   &:-ms-input-placeholder {
     color: $grey-dark-blue-40;
   }


### PR DESCRIPTION
### Description

Fix the issue: https://github.com/Sage/carbon/issues/506
When changing the input value (e.g. decimal) and triggering an error, the input field becomes non-editable and the error message is not properly aligned.
### Screenshots / Gifs

before the fix: input field is not editable, error message is not properly aligned
<img width="824" alt="screen shot 2016-08-13 at 18 32 26" src="https://cloud.githubusercontent.com/assets/145826/17644651/580fb2fe-6184-11e6-833c-5cfbdbedf2d6.png">

after the fix: input field is editable, error message is properly aligned
<img width="819" alt="screen shot 2016-08-13 at 18 32 33" src="https://cloud.githubusercontent.com/assets/145826/17644652/5df686d4-6184-11e6-8643-1ce2f4270458.png">
