### PR TITLE
Allow fieldHelp to render HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.17.0
+
+## Minor Improvements
+
+* Allow fieldHelp to render HTML
+
 # 0.16.0
 
 ## Minor Improvements

--- a/src/utils/decorators/input-label/__spec__.js
+++ b/src/utils/decorators/input-label/__spec__.js
@@ -91,7 +91,7 @@ class LabelHelpClass {
   props = {
     name: 'foo',
     label: 'test label',
-    fieldHelp: 'help label',
+    fieldHelp: 'help label <span>hello</span>',
     labelInline: true,
     labelWidth: 20
   };
@@ -236,7 +236,7 @@ describe('InputLabel', () => {
       it('renders the help within a span', () => {
         let help = instanceLabelHelp.fieldHelpHTML;
         expect(help.type).toEqual('span');
-        expect(help.props.children).toEqual('help label');
+        expect(help.props.dangerouslySetInnerHTML.__html).toEqual('help label <span>hello</span>');
       });
     });
 

--- a/src/utils/decorators/input-label/input-label.js
+++ b/src/utils/decorators/input-label/input-label.js
@@ -169,9 +169,11 @@ let InputLabel = (ComposedComponent) => class Component extends ComposedComponen
       }
 
       return (
-        <span className={ this.fieldHelpClasses } style={ style }>
-          { this.props.fieldHelp }
-        </span>
+        <span
+          className={ this.fieldHelpClasses }
+          style={ style }
+          dangerouslySetInnerHTML={ { __html: this.props.fieldHelp } }
+        />
       );
     }
   }


### PR DESCRIPTION
I have a design where the fieldHelp has a link in it. Currently you would not be able to use the `fieldHelp` prop as that will not render HTML, and you'd have to roll your own solution. This is a simple way of fixing this.

![image](https://cloud.githubusercontent.com/assets/2031/15927222/1e18db68-2e38-11e6-98d8-32fd6838483e.png)
