### PR TITLE
updated pill disabled color and business and individual icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
-# 0.18.0
+# 0.18.1
 
+## Minor Changes
+
+* Disabled Pill's colours have been updated.
+* Individual and Business SVGs have been updated in Icon.
+
+# 0.18.0
 
 ## !! BREAKING CHANGE !!
 

--- a/src/components/icon/icon.js
+++ b/src/components/icon/icon.js
@@ -426,12 +426,8 @@ const Icon = TooltipDecorator(class Icon extends React.Component {
   get renderBusinessIcon() {
     return {
       __html:
-        '<svg class="ui-icon__svg ui-icon__svg--business" width="16px" height="16px" viewBox="0 0 16 16">' +
-            '<g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">' +
-                '<g id="business" fill="currentColor">' +
-                  '<path fill="currentColor" fill-rule="evenodd" d="M7 16h7.993155C15.550051 16 16 15.553384 16 15.0024554V7H2v8.0024554C2 15.5536886 2.45078 16 3.006845 16H5v-6h2v6zm2-6h4v3H9v-3zM5.399994 0h7.200012L18 6H0l5.399994-6z"/>' +
-                '</g>' +
-            '</g>' +
+        '<svg class="ui-icon__svg ui-icon__svg--business" width="16" height="16" viewBox="0 0 16 16">' +
+          '<path id="business" fill="currentColor" fill-rule="evenodd" d="M14 8v7.002c0 .55-.456.998-1.002.998H3.002C2.45 16 2 15.554 2 15.002V8H0l2-5h12l2 5h-2zM4 10h2v6H4v-6zm4 0h4v3H8v-3zM3 1c0-.552.456-1 .995-1h8.01c.55 0 .995.444.995 1v1H3V1z"/>' +
         '</svg>'
     };
   }
@@ -444,12 +440,8 @@ const Icon = TooltipDecorator(class Icon extends React.Component {
   get renderIndividualIcon() {
     return {
       __html:
-        '<svg class="ui-icon__svg ui-icon__svg--individual" width="16px" height="16px" viewBox="0 0 16 16">' +
-            '<g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">' +
-                '<g id="individual" fill="currentColor">' +
-                  '<path fill="currentColor" fill-rule="evenodd" d="M15.98642 11.2560819c.006876-.0499498.011419-.1002324.01358-.1508295C15.917431 9.401891 12.143433 8 8 8S.023747 9.401891 0 11.2603787c.001017.0761355.008515.1517135.022283.2266423l-.010409 1.64102C.00527 14.1691032.835758 15 1.866717 15h12.266566C15.162298 15 16 14.1618954 16 13.128041v-1.8719591h-.01358zM8 6c1.656854 0 3-1.3431458 3-3S9.656854 0 8 0 5 1.3431458 5 3s1.343146 3 3 3z"/>' +
-                '</g>' +
-            '</g>' +
+        '<svg class="ui-icon__svg ui-icon__svg--individual" width="16" height="16">' +
+          '<path fill="currentColor" fill-rule="evenodd" d="M15.986 12.256c.007-.05.012-.1.014-.15-.083-1.704-3.886-4.195-8.03-4.195-4.143 0-7.946 2.493-7.97 4.35 0 .078.01.153.022.228l-.016 2.51C.003 15.558.448 16 1 16h14c.555 0 1-.45 1-1.003v-2.74h-.014zM8 6c1.657 0 3-1.343 3-3S9.657 0 8 0 5 1.343 5 3s1.343 3 3 3z"/>' +
         '</svg>'
     };
   }

--- a/src/components/pill/pill.scss
+++ b/src/components/pill/pill.scss
@@ -29,8 +29,8 @@
 }
 
 .ui-pill--disabled--fill {
-  background-color: $grey-mid;
-  color: $white;
+  background-color: $grey-dark-blue-20;
+  color: $grey-dark-blue-60;
 }
 
 @each $set in $colorIconSets {


### PR DESCRIPTION
# Description

• updating the business shop icon to differentiate from the home icon and updated colour as per the original design.
• Updated the disabled pill icon to reflect our disabled button state pan-sage one.
# Screenshots / Gifs

**Before:**
<img width="513" alt="screen shot 2016-08-13 at 18 44 44" src="https://cloud.githubusercontent.com/assets/145826/17644710/1121a904-6186-11e6-9551-8be0adf491a5.png">

**After:**
<img width="489" alt="screen shot 2016-08-13 at 18 44 51" src="https://cloud.githubusercontent.com/assets/145826/17644711/1605cbc6-6186-11e6-9c32-24a0694f6239.png">
