### PR TITLE
Pass valid state with form callback

### DIFF
--- a/src/components/show-edit-pod/show-edit-pod.js
+++ b/src/components/show-edit-pod/show-edit-pod.js
@@ -95,7 +95,7 @@ class ShowEditPod extends React.Component {
     ev.preventDefault();
 
     if (valid) {
-      this.props.afterFormValidation(ev);
+      this.props.afterFormValidation(ev, valid);
       this.setState({ editing: false });
     }
   }


### PR DESCRIPTION
The valid state of the form was not being passed with the callback - this fixes that.
