### PR TITLE
Set AppWrapper min-width to $app-width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Minor Changes
 
 * Form now accepts a `onSubmit` prop which is only called when the form is valid.
+* AppWrapper now has a minium width of 958px.
 
 # 0.20.0
 

--- a/lib/components/app-wrapper/app-wrapper.scss
+++ b/lib/components/app-wrapper/app-wrapper.scss
@@ -2,6 +2,7 @@
 
 .ui-app-wrapper {
   max-width: $app-max-width;
+  min-width: $app-width;
   margin: 0 auto;
   padding: 0 40px;
 


### PR DESCRIPTION
Currently the AppWrapper has no minimum width and thus the UI can be squashed up, so this sets a minimum width to resolve that issue.
