### PR TITLE
Update fieldset input css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 0.21.0
 
+## CSS Changes
+ * Fieldset inputs have had `position: relative` removed from hover/focus and from error-icons.
+
 ## Minor Improvements
 
 * Input components now accept an onPaste prop.

--- a/src/components/fieldset/fieldset.scss
+++ b/src/components/fieldset/fieldset.scss
@@ -14,13 +14,11 @@
   }
 
   .common-input__input--error {
-    position: relative;
     z-index: 1;
   }
 
   .common-input__input:focus,
   .common-input__input:hover {
-    position: relative;
     z-index: 2;
   }
 


### PR DESCRIPTION
This css was changing position from absolute to relative for checkboxes, causing it to move position.
