### PR TITLE
Add minimum width to app wrapper component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Input components now accept an onPaste prop.
 * Add character count to textarea
 * Form now accepts a `onSubmit` prop which is only called when the form is valid.
-* AppWrapper now has a minium width of 958px.
+* AppWrapper now has a minimum width of 958px.
 * SUG-19: Change padding for the MessageComponent when transparent and non dismissable. When transparent is applied the padding reduces to 2px, but if it's dismissable it enlarges to it's original to prevent overlap.
 
 # 0.20.0

--- a/src/components/app-wrapper/app-wrapper.scss
+++ b/src/components/app-wrapper/app-wrapper.scss
@@ -2,6 +2,7 @@
 
 .ui-app-wrapper {
   max-width: $app-max-width;
+  min-width: $app-width;
   margin: 0 auto;
   padding: 0 40px;
 


### PR DESCRIPTION
Currently the AppWrapper has no minimum width and thus the UI can be squashed

Note that PR https://github.com/Sage/carbon/pull/658 meant to add this functionality but the code was added to `/lib` and not `/src`
