### PR TITLE
makes heading styles more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.22.0
+
+## Minor Improvements
+
+* makes heading font styles more flexible, providing `h*`, `.h*` and `@include h*()`
+
 # 0.21.1
 
 ## Minor Improvements

--- a/src/utils/css/modules/base-text.scss
+++ b/src/utils/css/modules/base-text.scss
@@ -4,9 +4,16 @@ body {
   font-size: $app-font-size;
 }
 
-h1 { font-size: 24px; line-height: 32px; font-weight: 300; }
-h2 { font-size: 1.8em; margin-bottom: 12px; font-weight: 300; }
-h3 { font-size: 1.6em; margin-bottom: 16px; font-weight: 300; }
-h4 { font-size: 1.4em; margin-bottom: 14px; font-weight: 300; }
-h5 { font-size: 1.2em; margin-bottom: 12px; font-weight: 300; }
-h6 { font-size: 1.1em; margin-bottom: 11px; font-weight: 300; }
+@mixin h1() { font-size: 24px;  font-weight: 300; line-height: 32px; }
+@mixin h2() { font-size: 1.8em; font-weight: 300; margin-bottom: 12px; }
+@mixin h3() { font-size: 1.6em; font-weight: 300; margin-bottom: 16px; }
+@mixin h4() { font-size: 1.4em; font-weight: 300; margin-bottom: 14px; }
+@mixin h5() { font-size: 1.2em; font-weight: 300; margin-bottom: 12px; }
+@mixin h6() { font-size: 1.1em; font-weight: 300; margin-bottom: 11px; }
+
+h1, .h1 { @include h1(); }
+h2, .h2 { @include h2(); }
+h3, .h3 { @include h3(); }
+h4, .h4 { @include h4(); }
+h5, .h5 { @include h5(); }
+h6, .h6 { @include h6(); }


### PR DESCRIPTION
# Description
- users can how apply an `.h*` class to any element or mixin in the font styles to other elements
- this allows for heading styles to be applied without heading semantics and for consistent heading styles to applied via inheritance rather than fixing styles in components
