### PR TITLE
fix mailto bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Form now accepts a `onSubmit` prop which is only called when the form is valid.
 * AppWrapper now has a minimum width of 958px.
 * SUG-19: Change padding for the MessageComponent when transparent and non dismissable. When transparent is applied the padding reduces to 2px, but if it's dismissable it enlarges to it's original to prevent overlap.
+* allows `Link` component to handle `mailto:` as an href prefix, previously the `to:` would have been stripped from the string
 
 # 0.20.0
 

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -112,7 +112,7 @@ class _Link extends React.Component {
    * @return {Regex}
    */
   get typeRegex() {
-    return /^href:|to:/;
+    return /^href:|^to:/;
   }
 
   /**


### PR DESCRIPTION
# Description
- using regex to remove `to:` in order to process links as href or react router was accidentally breaking `mailto:` prefixes and as a result any email links
- this is fixed by using the `^` to prefix `to:` also meaning the prefix is removed only if it's at the start of the href prop
# TODO
- [x] Release notes
