### PR TITLE
Ensure show edit pod external control works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.22.1
+
+## Bug Fix
+
+* ShowEditPod shows edit content when controlled externally
+
 # 0.22.0
 
 ## Breaking Change - CSS Naming

--- a/src/components/show-edit-pod/__spec__.js
+++ b/src/components/show-edit-pod/__spec__.js
@@ -6,11 +6,11 @@ import Textbox from './../textbox';
 import Pod from './../pod';
 
 describe('ShowEditPod', () => {
-  let instance, externalInstance, spy, cancelSpy;
+  let instance, externalInstance, spy, cancelSpy,
+      content = <div className='foo'/>,
+      editFields = [ <Textbox key='1' /> ];
 
   beforeEach(() => {
-    let content = <div className='foo'/>,
-        editFields = [ <Textbox key='1' /> ];
 
     spy = jasmine.createSpy('afterFormValidation');
     cancelSpy = jasmine.createSpy('onCancel');
@@ -32,7 +32,7 @@ describe('ShowEditPod', () => {
       />
     );
   });
-  
+
   describe('componentWillMount', () => {
     describe('when editing prop is set', () => {
       it('keeps control as props', () => {
@@ -206,6 +206,27 @@ describe('ShowEditPod', () => {
 
     it('renders the editField', () => {
       TestUtils.findRenderedComponentWithType(instance, Textbox);
+    });
+
+    describe('when controlled by props', () => {
+      beforeEach(() => {
+        externalInstance = TestUtils.renderIntoDocument(
+          <ShowEditPod
+            afterFormValidation={ spy }
+            onCancel={ cancelSpy }
+            editFields={ editFields }
+            editing={ true }
+          />
+        );
+      });
+
+      it('returns a form', () => {
+        TestUtils.findRenderedComponentWithType(externalInstance, Form);
+      });
+
+      it('renders the editField', () => {
+        TestUtils.findRenderedComponentWithType(externalInstance, Textbox);
+      });
     });
   });
 

--- a/src/components/show-edit-pod/show-edit-pod.js
+++ b/src/components/show-edit-pod/show-edit-pod.js
@@ -227,7 +227,7 @@ class ShowEditPod extends React.Component {
    * @method content
    */
   get content() {
-    return this.state.editing ?
+    return this[this.control].editing ?
       <div key='edit'>{ this.editContent }</div> :
       <div key='show'>{ this.props.children }</div>;
   }


### PR DESCRIPTION
During a merge of the ShowEditPod Transition and external there was a incorrectly fixed conflict. This means that the show edit pod external control will not work correctly
