### PR TITLE
Adds text wrapping for newlines to p tag

### DIFF
--- a/src/utils/css/modules/text-styles.scss
+++ b/src/utils/css/modules/text-styles.scss
@@ -8,6 +8,10 @@
   @include text-theme($set...);
 }
 
+p {
+  white-space: pre-wrap;
+}
+
 .text--tag {
   font-size: 10px;
   font-weight: bold;


### PR DESCRIPTION
# Description
- adds `white-space: pre-wrap;` to all `<p>` tags
- this is a good candidate for global setting
- means that when a `TextArea` is used to format blocks of text in paragraphs or with other user generated newlines those newlines are retained when the text is output in a `<p>` tag
# TODO
- [ ] Release notes
