### PR TITLE
Added on tab click method to tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.25.3
+
+## Bug Fix
+
+* Added check to componentWillReceiveProps in Tabs to only update if state doesn't match nextProps.selectedTabId
 
 # 0.25.2
 
@@ -6,10 +11,6 @@
 * Row now supports immutable children.
 * Row columns now clear when there are more columns than the defined number.
 * Editable Pod is now aligned properly with title.
-
-## Minor Improvements
-
-* Added onTabClick props function to Tabs component to provide a way to add functionality which will only be called on tab click.
 
 # 0.25.1
 

--- a/src/components/tabs/__spec__.js
+++ b/src/components/tabs/__spec__.js
@@ -260,25 +260,6 @@ describe('Tabs', () => {
         expect(clickSpy).toHaveBeenCalledWith('foo');
       });
     });
-
-    describe('when an onTabClick prop is passed', () => {
-      it('calls the prop', () => {
-        let clickSpy = jasmine.createSpy('tabClick');
-
-        let instance = TestUtils.renderIntoDocument(
-          <Tabs onTabClick={ clickSpy } >
-            <Tab title='Tab Title 1' tabId='uniqueid1'>
-              <Textbox name='foo'/>
-              <Textbox name='bar'/>
-            </Tab>
-          </Tabs>
-        );
-        let tabHeaders = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'carbon-tabs__headers__header');
-        TestUtils.Simulate.click(tabHeaders[0]);
-
-        expect(clickSpy).toHaveBeenCalledWith('uniqueid1');
-      });
-    });
   });
 
   describe('mainClasses', () => {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -99,14 +99,6 @@ class Tabs extends React.Component {
     selectedTabId: React.PropTypes.string,
 
     /**
-    * Emitted when a tab header is clicked
-    *
-    * @property onTabClick
-    * @type {Func}
-    **/
-    onTabClick: React.PropTypes.func,
-
-    /**
      * Individual tabs
      *
      * @property children
@@ -247,9 +239,6 @@ class Tabs extends React.Component {
   handleTabClick = (ev) => {
     let tabid = ev.target.dataset.tabid;
     this.updateVisibleTab(tabid);
-    if (this.props.onTabClick) {
-      this.props.onTabClick(tabid);
-    }
   }
 
   updateVisibleTab(tabid) {


### PR DESCRIPTION
# Description

Added onTabClick function to Tabs component which is only triggered when the tab is clicked not when it is changed programmatically

This turned out to be necessary to provide a way to change the selectedTabId store object in the parent application on a tab change
# Related Issues / Pull Requests

This change is necessary due to the changes made in https://github.com/Sage/carbon/pull/696
