### PR TITLE
adds tab to focus on edit of show edit pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * 'Content' now has additional display options to customise the alignment, to render inline with it's title and to customise the title's width.
 * `Row` component can now be given a size to control the size of the gutter using the prop `gutter` (eg. `extra-small`, `small`, `medium`, `large` or `extra-large`).
 * `Row` can enable `columnDivide` to add dividing lines between columns.
+* `ShowEditPod` requires a tab press to focus on the first field of the contained form rather than automatically focusing on the first field
 
 ## Minor Improvements
 
@@ -30,6 +31,7 @@
 * Text Area now scrollable except when expandable.
 * Pod lifecycle methods are no longer defined as class properties.
 * Input validation decorator was not re-checking validity for warnings
+* `Pod` applies props to it's container rather than the first child of that container keeping things consistent
 
 # 0.25.3
 

--- a/src/components/pod/__spec__.js
+++ b/src/components/pod/__spec__.js
@@ -263,7 +263,7 @@ describe('Pod', () => {
   describe('render', () => {
     it('applies all props to the pod', () => {
       instance = TestUtils.renderIntoDocument(<Pod foo="bar" />);
-      let div = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'div')[1];
+      let div = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'div')[0];
       expect(div.props.foo).toEqual("bar");
     });
 

--- a/src/components/pod/pod.js
+++ b/src/components/pod/pod.js
@@ -396,8 +396,8 @@ class Pod extends React.Component {
     if (!this.state.collapsed) { content = this.podContent; }
 
     return (
-      <div className={ this.mainClasses }>
-        <div className={ this.blockClasses } { ...props }>
+      <div className={ this.mainClasses } { ...props }>
+        <div className={ this.blockClasses }>
           <div className={ this.contentClasses } >
             { this.podHeader }
             { content }

--- a/src/components/show-edit-pod/__spec__.js
+++ b/src/components/show-edit-pod/__spec__.js
@@ -5,6 +5,8 @@ import Form from './../form';
 import Textbox from './../textbox';
 import Pod from './../pod';
 
+import ReactDOM from 'react-dom';
+
 describe('ShowEditPod', () => {
   let instance, externalInstance, spy, cancelSpy,
       content = <div className='foo'/>,
@@ -52,6 +54,15 @@ describe('ShowEditPod', () => {
       it('sets the editing state to true', () => {
         instance.onEdit();
         expect(instance.state.editing).toBeTruthy();
+      });
+
+      it("sets focus on the DOM node", () => {
+        instance.control = 'props';
+        let focusSpy = jasmine.createSpy('focus');
+        spyOn(ReactDOM, 'findDOMNode').and.returnValue({ focus: focusSpy });
+        instance.onEdit();
+        expect(ReactDOM.findDOMNode).toHaveBeenCalled();
+        expect(focusSpy).toHaveBeenCalled();
       });
 
       describe('when edit function is passed', () => {

--- a/src/components/show-edit-pod/show-edit-pod.js
+++ b/src/components/show-edit-pod/show-edit-pod.js
@@ -6,6 +6,8 @@ import classNames from 'classnames';
 import I18n from 'i18n-js';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
+import ReactDOM from 'react-dom';
+
 class ShowEditPod extends React.Component {
 
   // Determines if controlled internally via state
@@ -130,6 +132,8 @@ class ShowEditPod extends React.Component {
     if (this.stateControlled) {
       this.setState({ editing: true });
     }
+
+    ReactDOM.findDOMNode(this.refs.podFocus).focus();
   }
 
   /**
@@ -284,7 +288,7 @@ class ShowEditPod extends React.Component {
    */
   render() {
     return (
-      <Pod className={ this.mainClasses } { ...this.podProps }>
+      <Pod className={ this.mainClasses } { ...this.podProps } ref='podFocus' tabIndex='-1'>
         <ReactCSSTransitionGroup
           transitionName={ this.props.transitionName }
           transitionEnterTimeout={ 300 }

--- a/src/components/show-edit-pod/show-edit-pod.scss
+++ b/src/components/show-edit-pod/show-edit-pod.scss
@@ -1,5 +1,11 @@
 @import "./../../style-config/colors";
 
+.carbon-show-edit-pod {
+  &:focus {
+    outline: none;
+  }
+}
+
 .carbon-show-edit-pod__delete {
   color: $red;
 


### PR DESCRIPTION
# Description
- focus is applied to the parent so that pressing tab once highlights the first field
- this allows for any input to be used first even if focusing triggers some visual state that might not be desired on edit click (such as drop-down, where focus opens the options)
- achieved with `tabIndex`, `focus()` and `ReactDOM`
- outline is removed on the focused element on load, this is OK as this element should not be visible on focus
- additionally, `...this.props` is now rendered on the container element with `Pod` - it has been moved from the first child - this makes the above change work but also maintains logic and consistency as one would expect the props applied to a Component to be added to the containing element within that component
# TODO
- [x] Release notes
# Screenshots / Gifs

![pod](https://cloud.githubusercontent.com/assets/10499070/18671020/5258d01a-7f3a-11e6-918c-c270c199c3b6.gif)
