### PR TITLE
Fixes widths and spacings on filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 ## Component Enhancements
 
+* `Content` now has additional display options to customise the alignment, to render inline with it's title and to customise the title's width.
 * `Link` component now has a prop of `iconAlign` to align icons to the right of the link's text.
-* 'Content' now has additional display options to customise the alignment, to render inline with it's title and to customise the title's width.
 * `Row` component can now be given a size to control the size of the gutter using the prop `gutter` (eg. `extra-small`, `small`, `medium`, `large` or `extra-large`).
 * `Row` can enable `columnDivide` to add dividing lines between columns.
 * `ShowEditPod` requires a tab press to focus on the first field of the contained form rather than automatically focusing on the first field
@@ -26,6 +26,7 @@
 * Have increased pill font size and weight
 * Carbon Components CSS now imports from relative paths
 * removes uneccessary space from clearfix in `Row` component
+* `Filter` handles it's child inputs more robustly by over-riding widths and margins when children are displayed inline
 
 ## Bug Fixes
 

--- a/demo/views/forms/filter-demo/filter-demo.js
+++ b/demo/views/forms/filter-demo/filter-demo.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { connect } from 'utils/flux';
+import AppStore from './../../../stores/app';
+import AppActions from './../../../actions/app';
+import Example from './../../../components/example';
+
+import Filter from 'components/filter';
+import DateRange from 'components/date-range';
+import Textbox from 'components/textbox';
+
+class FilterDemo extends React.Component {
+
+  /**
+   * @method value
+   */
+  value = (key) => {
+    return this.state.appStore.getIn(['filter', key]);
+  }
+
+  /**
+   * @method action
+   */
+  get action() {
+    return AppActions.appValueUpdated.bind(this, 'filter');
+  }
+
+  /**
+   * @method demo
+   */
+  get demo() {
+    return (
+      <Filter>
+        <Textbox label="First Name" labelInline={ true }/>
+        <DateRange labelsInline={ true } onChange={ () => {} } value={[]} startLabel="foo" endLabel="bar" />
+        <Textbox label="Last" labelInline={ true }/>
+        <Textbox label="A very long label" labelInline={ true }/>
+      </Filter>
+    );
+  }
+
+  /**
+   * @method code
+   */
+  get code() {
+    return "pending";
+  }
+
+  /**
+   * @method controls
+   */
+  get controls() {
+    return (
+      <div>
+        Pending
+      </div>
+    );
+  }
+
+  /**
+   * @method render
+   */
+  render() {
+    return (
+      <Example
+        title="Filter"
+        readme="components/filter"
+        demo={ this.demo }
+        code={ this.code }
+        controls={ this.controls }
+      />
+    );
+  }
+}
+
+export default connect(FilterDemo, AppStore);

--- a/demo/views/forms/filter-demo/package.json
+++ b/demo/views/forms/filter-demo/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "./filter-demo.js"
+}

--- a/demo/views/forms/forms.js
+++ b/demo/views/forms/forms.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import FormDemo from './form-demo';
+import FilterDemo from './filter-demo';
 import Fieldset from './fieldset-demo';
 import TextboxDemo from './textbox-demo';
 import DecimalDemo from './decimal-demo';
@@ -22,6 +23,7 @@ class Forms extends React.Component {
       <div>
         <h1>Forms</h1>
         <FormDemo />
+        <FilterDemo />
         <CheckboxDemo />
         <RadioButtonDemo/>
         <TextboxDemo />

--- a/src/components/filter/filter.scss
+++ b/src/components/filter/filter.scss
@@ -7,12 +7,25 @@
     text-align: right;
   }
 
+  .common-input,
   > * {
     display: inline-block;
-    margin-left: ($grid-margin / 2);
+    margin-left: $grid-margin;
 
     &:first-child {
       margin-left: 0;
+    }
+  }
+
+  .common-input--label-inline {
+    .common-input__field {
+      margin-left: $grid-margin / 2;
+    }
+
+    .common-input__field,
+    .common-input__label {
+      padding-left: 0;
+      width: auto;
     }
   }
 


### PR DESCRIPTION
# Description
- over-rides widths, paddings and margins on inputs and labels in the `Filter` component when the contents are displayed inline
- provides a basic demo of the filter
- [SCOUTING] release note quotes and alphabetise component enhancements
# Screenshots / Gifs

![screen shot 2016-09-21 at 11 53 40](https://cloud.githubusercontent.com/assets/10499070/18708285/1550a3e2-7ff2-11e6-8c6f-5a2fa9628fed.png)
