### PR TITLE
Track error and warning count in instance rather than state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.25.4
+
+## Bug Fixes
+
+* Form now tracks error and warning count on instance as well as in state.
+
+# 0.25.3
+
+# Bug Fixes
+
+* Tabs component - added check to ensure that onTabChange is not called if the selectedTabId prop is changed to the existing state of the tabs component
+
 # 0.25.2
 
 ## Bug Fix

--- a/src/components/form/__spec__.js
+++ b/src/components/form/__spec__.js
@@ -61,7 +61,7 @@ describe('Form', () => {
 
   describe('incrementErrorCount', () => {
     it('increments the state error count', () => {
-      instance.setState({ errorCount: 2 });
+      instance.errorCount = 2;
       instance.incrementErrorCount();
       expect(instance.state.errorCount).toEqual(3);
     });
@@ -69,7 +69,7 @@ describe('Form', () => {
 
   describe('decrementErrorCount', () => {
     it('decreases the state error count', () => {
-      instance.setState({ errorCount: 2 });
+      instance.errorCount = 2;
       instance.decrementErrorCount();
       expect(instance.state.errorCount).toEqual(1);
     });
@@ -77,7 +77,7 @@ describe('Form', () => {
 
   describe('incrementWarningCount', () => {
     it('increments the state warning count', () => {
-      instance.setState({ warningCount: 2 });
+      instance.warningCount = 2;
       instance.incrementWarningCount();
       expect(instance.state.warningCount).toEqual(3);
     });
@@ -85,7 +85,7 @@ describe('Form', () => {
 
   describe('decrementWarningCount', () => {
     it('decreases the state warning count', () => {
-      instance.setState({ warningCount: 2 });
+      instance.warningCount = 2;
       instance.decrementWarningCount();
       expect(instance.state.warningCount).toEqual(1);
     });

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -214,8 +214,25 @@ class Form extends React.Component {
    * @property inputs
    * @type {Object}
    */
-  inputs = {
-  }
+  inputs = {};
+
+  /**
+   * Tracks current errorCount
+   * Need to track separately from state due to async nature of setState
+   *
+   * @property errorCount
+   * @type {Number}
+   */
+  errorCount = 0;
+
+  /**
+   * Tracks current warningCount
+   * Need to track separately from state due to async nature of setState
+   *
+   * @property errorCount
+   * @type {Number}
+   */
+  warningCount = 0;
 
   /**
    * Runs once the component has mounted.
@@ -236,7 +253,8 @@ class Form extends React.Component {
    * @return {void}
    */
   incrementErrorCount = () => {
-    this.setState({ errorCount: this.state.errorCount + 1 });
+    this.errorCount += 1;
+    this.setState({ errorCount: this.errorCount });
   }
 
   /**
@@ -246,7 +264,8 @@ class Form extends React.Component {
    * @return {void}
    */
   decrementErrorCount = () => {
-    this.setState({ errorCount: this.state.errorCount - 1 });
+    this.errorCount -= 1;
+    this.setState({ errorCount: this.errorCount });
   }
 
   /**
@@ -256,7 +275,8 @@ class Form extends React.Component {
    * @return {void}
    */
   incrementWarningCount = () => {
-    this.setState({ warningCount: this.state.warningCount + 1 });
+    this.warningCount += 1;
+    this.setState({ warningCount: this.warningCount });
   }
 
   /**
@@ -266,7 +286,8 @@ class Form extends React.Component {
    * @return {void}
    */
   decrementWarningCount = () => {
-    this.setState({ warningCount: this.state.warningCount - 1 });
+    this.warningCount -= 1;
+    this.setState({ warningCount: this.warningCount });
   }
 
   /**


### PR DESCRIPTION
Reviewed here 
https://github.com/Sage/carbon/pull/750
