### PR TITLE
fixes long word breaking in carbon-content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Carbon Components CSS now imports from relative paths
 * removes uneccessary space from clearfix in `Row` component
 * Aligned MultiActionButton icon to center
+* `Content` components now handles wrapping more robustly with single words longer than the content width wrapping correctly
 * `Filter` handles it's child inputs more robustly by over-riding widths and margins when children are displayed inline
 * Darken colour of text--secondary
 * Fieldset - readonly fields maintain border

--- a/src/components/content/content.scss
+++ b/src/components/content/content.scss
@@ -17,6 +17,7 @@
 .carbon-content__body {
   margin-top: 2px;
   white-space: pre-wrap;
+  word-wrap: break-word;
 
   .carbon-content--inline & {
     display: inline-block;


### PR DESCRIPTION
# Description
- when a single word is wider than the `carbon-content__body` that is in it will break
- this doesn't effect the breaking of word-wrapped paragraphs or the preservation of newlines
# Screenshots / Gifs

![screen shot 2016-09-28 at 09 30 34](https://cloud.githubusercontent.com/assets/10499070/18906151/42990008-855e-11e6-8ccd-be84ad2b4fce.png)
