### PR TITLE
remove calls to toJS from tables

### DIFF
--- a/src/components/table-ajax/table-ajax.js
+++ b/src/components/table-ajax/table-ajax.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Request from 'superagent';
 import serialize from './../../utils/helpers/serialize';
+import Immutable from 'immutable';
 import { Table, TableRow, TableCell, TableHeader } from './../table';
 
 /**
@@ -314,7 +315,7 @@ class TableAjax extends Table {
    * @return {Object} params for query
    */
   queryParams = (element, options) => {
-    let query = options.filter || {};
+    let query =  { name: options.filter.get('name') || '' };
     query.page = (element === "filter") ? "1" : options.currentPage;
     query.rows = options.pageSize;
     if (options.sortOrder) { query.sord = options.sortOrder; }
@@ -332,7 +333,7 @@ class TableAjax extends Table {
   emitOptions = (props = this.props) => {
     return {
       currentPage: this.state.currentPage,
-      filter: props.filter ? props.filter.toJS() : {},
+      filter: props.filter || Immutable.Map(),
       pageSize: this.state.pageSize,
       sortedColumn: this.state.sortedColumn,
       sortOrder: this.state.sortOrder

--- a/src/components/table/__spec__.js
+++ b/src/components/table/__spec__.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import TestUtils from 'react/lib/ReactTestUtils';
 import Immutable from 'immutable';
+import ImmutableHelper from './../../utils/helpers/immutable';
 import { Table, TableHeader, TableRow, TableCell } from './table';
 import ActionToolbar from './../action-toolbar';
 
@@ -399,7 +400,7 @@ describe('Table', () => {
     let data;
 
     beforeEach(() => {
-      data = Immutable.fromJS({ foo: "bar" });
+      data = ImmutableHelper.parseJSON({ foo: "bar" });
       instance = TestUtils.renderIntoDocument(
         <Table filter={ data }></Table>
       );
@@ -419,7 +420,7 @@ describe('Table', () => {
         instance.componentWillReceiveProps({ filter: data });
         expect(instance.emitOnChangeCallback).toHaveBeenCalledWith('filter', {
           currentPage: '',
-          filter: { foo: 'qux' },
+          filter: data,
           pageSize: '',
           sortOrder: '',
           sortedColumn: ''
@@ -635,7 +636,7 @@ describe('Table', () => {
     it('gathers all relevent props to emit', () => {
       expect(instancePager.emitOptions()).toEqual({
         currentPage: '1',
-        filter: {},
+        filter: Immutable.OrderedMap(),
         pageSize: '10',
         sortOrder: '',
         sortedColumn: ''
@@ -654,7 +655,7 @@ describe('Table', () => {
 
         expect(instanceCustomSort.emitOptions(props)).toEqual({
           currentPage: '1',
-          filter: {},
+          filter: Immutable.OrderedMap(),
           pageSize: '10',
           sortOrder: 'asc',
           sortedColumn: 'foo'
@@ -666,7 +667,7 @@ describe('Table', () => {
       it('emits the custom props', () => {
         expect(instanceCustomSort.emitOptions()).toEqual({
           currentPage: '10',
-          filter: {},
+          filter: Immutable.OrderedMap(),
           pageSize: '25',
           sortOrder: 'desc',
           sortedColumn: 'name'
@@ -677,7 +678,7 @@ describe('Table', () => {
     it('gathers all relevent props to emit using passed in props', () => {
       let props = {
         currentPage: '9',
-        filter: Immutable.fromJS({ foo: 'bar' }),
+        filter: ImmutableHelper.parseJSON({ foo: 'bar' }),
         pageSize: '100',
         sortOrder: 'asc',
         sortedColumn: 'foo'
@@ -685,7 +686,7 @@ describe('Table', () => {
 
       expect(instancePager.emitOptions(props)).toEqual({
         currentPage: '9',
-        filter: { foo: 'bar' },
+        filter: props.filter,
         pageSize: '100',
         sortOrder: 'asc',
         sortedColumn: 'foo'

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -724,7 +724,7 @@ class Table extends React.Component {
     return {
       // What if paginate if false - think about when next change functionality is added
       currentPage: currentPage,
-      filter: props.filter ? props.filter.toJS() : {},
+      filter: props.filter || Immutable.OrderedMap(),
       pageSize: props.pageSize || '',
       sortOrder: props.sortOrder || '',
       sortedColumn: props.sortedColumn || ''


### PR DESCRIPTION
Left toJS in Dropdowns as there is a separate issue to refactor those components,
# Related Issues / Pull Requests

https://github.com/Sage/carbon/issues/210
