### PR TITLE
adds tabindex to links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Component Enhancements
 
 * `Icon`: new Icons added - Draft, Github, Twitter & Dribble
+* `Link`: tabindex default and switch control via a prop
 
 # 0.27.2
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "homepage": "https://github.com/Sage/carbon#readme",
   "devDependencies": {
-    "carbon-factory": "git+ssh://git@github.com/Sage/carbon-factory.git#v0.1.0",
+    "carbon-factory": "git+ssh://git@github.com/Sage/carbon-factory.git#v0.2.0",
+    "enzyme": "^2.5.1",
     "express": "~4.13.3",
     "flux": "~2.1.1",
     "gulp": "~3.9.0",
@@ -31,9 +32,10 @@
     "i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc8.tar.gz",
     "immutable": "~3.7.5",
     "ncp": "~2.0.0",
-    "react": "~0.14.0",
-    "react-addons-css-transition-group": "~0.14.0",
-    "react-dom": "~0.14.0",
+    "react": "~0.14.8",
+    "react-addons-css-transition-group": "~0.14.8",
+    "react-addons-test-utils": "~0.14.8",
+    "react-dom": "^0.14.8",
     "react-highlight": "~0.6.1",
     "react-router": "~1.0.0"
   },

--- a/src/components/link/__spec__.js
+++ b/src/components/link/__spec__.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
 import TestUtils from 'react/lib/ReactTestUtils';
-import Link from './link';
+
 import Icon from './../icon';
+import Link from './link';
 
 describe('Link', () => {
   let basicLink, disabledLink, customLink, actionLink, spy;
@@ -43,6 +45,21 @@ describe('Link', () => {
   describe('A disabled link', () => {
     it('renders a link with the disabled attribute', () => {
       expect(disabledLink.props.disabled).toBeTruthy();
+    });
+  });
+
+  describe("tabbable", () => {
+    it("has tabindex by default", () => {
+      let wrapper = shallow(<Link href='#'>My Link</Link>);
+      expect(wrapper.props()['tabIndex']).toEqual('0');
+    });
+    it("disabled over-rides tab index setting", () => {
+      let wrapper = shallow(<Link href='#' tabbable={ true } disabled={ true }>My Link</Link>);
+      expect(wrapper.props()['tabIndex']).toEqual('-1');
+    });
+    it("doesn't have tab index if it is set to not be tabbable", () => {
+      let wrapper = shallow(<Link href='#' tabbable={ false }>My Link</Link>);
+      expect(wrapper.props()['tabIndex']).toEqual('-1');
     });
   });
 

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -53,6 +53,17 @@ class _Link extends React.Component {
     iconAlign: React.PropTypes.string,
 
     /**
+     * Allows the <a> tag to be set in or out of the tab order of the page
+     * Boolean is used as tabindex > 0 is not really necessary, HTML order should
+     * take precedence
+     *
+     * @property tabbable
+     * @type {Boolean}
+     * @default true
+     */
+    tabbable: React.PropTypes.bool,
+
+    /**
      * Use `to` to use the React Router link. You can also prefix your value
      * with `to:` or `href:` to override the prop type.
      *
@@ -74,7 +85,8 @@ class _Link extends React.Component {
   }
 
   static defaultProps = {
-    iconAlign: 'left'
+    iconAlign: 'left',
+    tabbable: true
   }
 
   /**
@@ -86,7 +98,10 @@ class _Link extends React.Component {
   get componentProps() {
     let { ...props } = this.props;
 
+    props.tabIndex = this.tabIndex;
+
     delete props.href;
+    delete props.tabbable;
     delete props.to;
 
     props.className = this.componentClasses;
@@ -152,6 +167,16 @@ class _Link extends React.Component {
         tooltipPosition={ this.props.tooltipPosition }
       />
     );
+  }
+
+  /**
+   * Returns 0 or -1 for tabindex
+   *
+   * @method tabIndex
+   * @return {String} 0 or -1
+   */
+  get tabIndex() {
+    return this.props.tabbable && !this.props.disabled ? '0' : '-1';
   }
 
   /**


### PR DESCRIPTION
# Description
- `tabindex` HTML property is added to links in the `Link` component
- Links with `href` are automatically tabbable but not all links have this property
- Links will default to `0` which will put them in the HTML flow where they are rendered
- `tabbable={ true }` will set the tabindex to `0`
- `tabbable={ false }` will set the tabindex to `-1`
- values greater than 0 are not allowed currently as they are not really necessary, HTML order should define tab order
- also uses Enzyme for the tests required and groups and alphabetices load order in `__spec__` file
# TODO
- [x] Release notes
# Related Issues / Pull Requests
# Screenshots / Gifs
