### PR TITLE
Fix prefix position in inline label inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 * `Link`: tabindex default and switch control via a prop
 * `Decimal` now emits value of 0 on blur if cleared.
 
+## CSS Changes
+
+* Input prefix is now positioned correctly when using inline labels
+
 # 0.27.2
 
 * `Decimal` component can validate properly with alternative i18n settings

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -258,6 +258,12 @@
   top: 8px;
 }
 
+.common-input--label-inline {
+  .common-input__prefix {
+    left: 23px;
+  }
+}
+
 .common-input__input--fake {
   text-align: left;
   overflow: hidden;


### PR DESCRIPTION
# Description

This fixes a positioning issue when using `prefix` in inline label forms.
# Screenshots

before
<img width="695" alt="screen shot 2016-10-28 at 10 49 43 am" src="https://cloud.githubusercontent.com/assets/2337105/19800723/52b3d4a8-9cfc-11e6-94f7-6948babddd76.png">

after
<img width="691" alt="screen shot 2016-10-28 at 10 49 14 am" src="https://cloud.githubusercontent.com/assets/2337105/19800729/5acf0fe0-9cfc-11e6-9c76-796a38e0c1da.png">
