### PR TITLE
Centres content regardless of menu state for demo site

### DIFF
--- a/demo2/views/chrome/chrome.js
+++ b/demo2/views/chrome/chrome.js
@@ -11,12 +11,12 @@ import Footer from './footer'
 import Header from './header';
 import Menu from './menu';
 
-const RESIZE_WIDTH = 1400;
+const RESIZE_WIDTH = 1090;
 
 class Chrome extends React.Component {
   render() {
     return (
-      <div>
+      <div className='chrome'>
         <Menu
           isTablet={ this._isSmallScreen() }
           menuOpen={ this.state.appStore.get('menuOpen') }

--- a/demo2/views/chrome/chrome.scss
+++ b/demo2/views/chrome/chrome.scss
@@ -1,0 +1,10 @@
+.chrome {
+  @media(min-width: 1090px) {
+    padding-left: 290px;
+  }
+  .demo-menu {
+    @media(min-width: 1090px) {
+      position: relative;
+    }
+  }
+}

--- a/demo2/views/chrome/header/header.scss
+++ b/demo2/views/chrome/header/header.scss
@@ -5,7 +5,7 @@
   z-index: 10;
 
   &__menu-toggle {
-    @media (min-width: 1400px) {
+    @media (min-width: 1090px) {
       display: none;
     }
   }

--- a/demo2/views/chrome/package.json
+++ b/demo2/views/chrome/package.json
@@ -1,3 +1,4 @@
 {
-  "main": "./chrome.js"
+  "main": "./chrome.js",
+  "style": "./chrome.scss"
 }


### PR DESCRIPTION
# Description

* at 1090px, the width of the 800px designs + a 250px sidebar + 2*20px padding on the menu the change occurs to fix the menu
* at this point padding is used on the chrome to force the contents to squeeze into the reminaing space and centre

# TODO
- [ ] Release notes

# Related Issues / Pull Requests

# Screenshots / Gifs

example too large for gif software
