### PR TITLE
Add helper function to convert bytes to a human readable representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,15 @@
 * Datepicker has been upgraded the latest version
 * Bowser has been upgraded to the latest version
 
+## Helpers
+
+* A new humanizeFilesize helper for converting bytes to a human readable representation.
+
 # 0.28.2
 
 * `Pod`: now accepts a `displayEditButtonOnHover` prop which will hide the edit button until the mouse is hovering over it.
 * `Pod`: now accepts a `triggerEditOnContent` prop will trigger the `onEdit` function when clicking the content.
 * `Pod`: the colours of an editable pod have been updated to be more consistent.
-
-## Helpers
-
-* A new numberToHumanSize helper for converting bytes to a human readable representation.
 
 # 0.28.1
 

--- a/src/utils/helpers/i18n/__spec__.js
+++ b/src/utils/helpers/i18n/__spec__.js
@@ -87,20 +87,20 @@ describe('I18n Helper', () => {
     });
   });
 
-  describe("numberToHumanSize", () => {
+  describe("humanizeFilesize", () => {
     it("returns a human readable version of x bytes", () => {
-      expect(Helper.numberToHumanSize(0)).toEqual('0 Bytes');
-      expect(Helper.numberToHumanSize(1500)).toEqual('1.5 KB');
-      expect(Helper.numberToHumanSize(15000)).toEqual('15 KB');
-      expect(Helper.numberToHumanSize(150000)).toEqual('150 KB');
-      expect(Helper.numberToHumanSize(1500000)).toEqual('1.5 MB');
-      expect(Helper.numberToHumanSize(15000000)).toEqual('15 MB');
-      expect(Helper.numberToHumanSize(150000000)).toEqual('150 MB');
-      expect(Helper.numberToHumanSize(1500000000)).toEqual('1.5 GB');
-      expect(Helper.numberToHumanSize(15000000000)).toEqual('15 GB');
-      expect(Helper.numberToHumanSize(150000000000)).toEqual('150 GB');
-      expect(Helper.numberToHumanSize(1500000000000)).toEqual('1.5 TB');
-      expect(Helper.numberToHumanSize(15000000000000)).toEqual('15 TB');
+      expect(Helper.humanizeFilesize(0)).toEqual('0 Bytes');
+      expect(Helper.humanizeFilesize(1500)).toEqual('1.5 KB');
+      expect(Helper.humanizeFilesize(15000)).toEqual('15 KB');
+      expect(Helper.humanizeFilesize(150000)).toEqual('150 KB');
+      expect(Helper.humanizeFilesize(1500000)).toEqual('1.5 MB');
+      expect(Helper.humanizeFilesize(15000000)).toEqual('15 MB');
+      expect(Helper.humanizeFilesize(150000000)).toEqual('150 MB');
+      expect(Helper.humanizeFilesize(1500000000)).toEqual('1.5 GB');
+      expect(Helper.humanizeFilesize(15000000000)).toEqual('15 GB');
+      expect(Helper.humanizeFilesize(150000000000)).toEqual('150 GB');
+      expect(Helper.humanizeFilesize(1500000000000)).toEqual('1.5 TB');
+      expect(Helper.humanizeFilesize(15000000000000)).toEqual('15 TB');
     });
   });
 

--- a/src/utils/helpers/i18n/i18n.js
+++ b/src/utils/helpers/i18n/i18n.js
@@ -82,10 +82,10 @@ const I18nHelper = {
    * Formats the bytes in number into a more understandable representation
    * (e.g., giving it 1500 yields 1.5 KB)
    *
-   * @method numberToHumanSize
+   * @method humanizeFilesize
    * @param {Number} number
    */
-  numberToHumanSize: (number) => {
+  humanizeFilesize: (number) => {
     if (number == 0) return '0 Bytes';
     let k = 1000;
     let sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];


### PR DESCRIPTION
Adds a helper function that allows you to convert a number (bytes) into a human readable representation. Converts the number to `['Bytes', 'KB', 'MB', 'GB', 'TB']`:

```
numberToHumanSize(1500000) => 1.5 MB
```
