### PR TITLE
Currency switch tweak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 
 * A new `humanizeFilesize` helper for converting bytes to a human readable representation.
 * `roundForAbbreviation` is added to handle the number element of `abbreviateNumber` as well as forcing any abbreviated number to one decimal place
+* `abbreviateCurrency` takes unit value
+
 
 ## CSS Changes
 

--- a/src/utils/helpers/i18n/__spec__.js
+++ b/src/utils/helpers/i18n/__spec__.js
@@ -61,11 +61,11 @@ describe('I18n Helper', () => {
     it("creates the correct abbreviation", () => {
       expect(Helper.abbreviateCurrency('-345')).toEqual('£-345.00');
       expect(Helper.abbreviateCurrency('345')).toEqual('£345.00');
-      expect(Helper.abbreviateCurrency('678', { locale: 'fr' })).toEqual('678.00 €');
-      expect(Helper.abbreviateCurrency('123456', { locale: 'en' })).toEqual('£123.5k');
-      expect(Helper.abbreviateCurrency('567890', { locale: 'fr' })).toEqual('567.9k €');
-      expect(Helper.abbreviateCurrency('987654321', { locale: 'en' })).toEqual('£987.7m');
-      expect(Helper.abbreviateCurrency('234567890', { locale: 'fr' })).toEqual('234.6m €');
+      expect(Helper.abbreviateCurrency('678', { locale: 'fr', unit: '€' })).toEqual('678.00 €');
+      expect(Helper.abbreviateCurrency('123456', { locale: 'en', unit: '£' })).toEqual('£123.5k');
+      expect(Helper.abbreviateCurrency('567890', { locale: 'fr', unit: '€' })).toEqual('567.9k €');
+      expect(Helper.abbreviateCurrency('987654321', { locale: 'en', unit: '£' })).toEqual('£987.7m');
+      expect(Helper.abbreviateCurrency('234567890', { locale: 'fr', unit: '€' })).toEqual('234.6m €');
     });
   });
 

--- a/src/utils/helpers/i18n/i18n.js
+++ b/src/utils/helpers/i18n/i18n.js
@@ -57,8 +57,9 @@ const I18nHelper = {
     let locale = options.locale || 'en',
         sign = num < 0 ? '-' : '',
         abbr = I18nHelper.abbreviateNumber(num),
-        format = I18nHelper.format(locale);
-    return format.format.replace("%u", format.unit).replace("%n", abbr).replace("%s", sign);
+        format = I18nHelper.format(locale),
+        unit = options.unit || format.unit;
+    return format.format.replace("%u", unit).replace("%n", abbr).replace("%s", sign);
   },
 
   /**


### PR DESCRIPTION
# Description

* we need to use the unit to create a converted currency in I18n as the unit position is `locale` specific and separate from the currency symbol

# TODO
- [x] Release notes