### PR TITLE
fix to warning icon color, refactor classes for warning svg

### DIFF
--- a/src/utils/decorators/input-icon/input-icon.scss
+++ b/src/utils/decorators/input-icon/input-icon.scss
@@ -46,14 +46,14 @@
 .common-input__input:hover ~ label .carbon-input-icon--warning:hover {
   border-color: $warning;
   background-color: $warning;
-  .carbon-icon__svg-group {
+  .carbon-icon:before  {
     fill: $white;
   }
 }
 .common-input__input:focus ~ label .carbon-input-icon--warning {
   border-color: $warning-hover;
   background-color: $warning-hover;
-  .carbon-icon__svg-group {
+  .carbon-icon:before  {
     fill: $white;
   }
 }

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -214,14 +214,8 @@
     font-size: 20px;
   }
 
-  .carbon-icon__svg--warning {
-    height: 20px;
-    margin: -2px 0 0 0;
-    width: 26px;
-
-    .carbon-icon__svg-group {
-      fill: $warning;
-    }
+  &.common-input__icon--warning {
+    color: $warning;
   }
 }
 


### PR DESCRIPTION
# Description
Fixes issue introduced by this PR where CSS targeting warning SVG not rewritten to target icon font.

https://github.com/Sage/carbon/pull/878

![screen shot 2016-11-16 at 10 41 13](https://cloud.githubusercontent.com/assets/9549240/20344094/39d41f78-abe9-11e6-9cf0-415382c76909.png)
