### PR TITLE
demo site wrap next and previous links to keep centred

### DIFF
--- a/demo2/views/page-sections/sub-page-navigation/sub-page-navigation.js
+++ b/demo2/views/page-sections/sub-page-navigation/sub-page-navigation.js
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 import ArrowLink from '../../components/arrow-link';
+import Wrapper from '../../chrome/wrapper';
 
 /**
  * Creates a Link wrapped HTML component that renders a label with prefix and an arrow icon
@@ -12,10 +13,12 @@ import ArrowLink from '../../components/arrow-link';
  * @return {SubPageNavigation}
  */
 export default props => (
-  <nav className='demo-sub-page-navigation'>
-    { _link(props.previousPage, 'previous') }
-    { _link(props.nextPage,     'next') }
-  </nav>
+  <Wrapper>
+    <nav className='demo-sub-page-navigation'>
+      { _link(props.previousPage, 'previous') }
+      { _link(props.nextPage,     'next') }
+    </nav>
+  </Wrapper>
 );
 
 /**

--- a/demo2/views/page-sections/sub-page-navigation/sub-page-navigation.scss
+++ b/demo2/views/page-sections/sub-page-navigation/sub-page-navigation.scss
@@ -3,7 +3,13 @@
 
 .demo-sub-page-navigation{
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
+  padding: 50px 0;
+
+  @media (min-width: 300px) {
+    flex-direction: row;
+  }
 
   &__link {
     max-width: 49%;


### PR DESCRIPTION
# Description

* wraps the next and previous to keep it centred

