### PR TITLE
makes clip path work in FireFox

### DIFF
--- a/demo2/views/chrome/sectioniser/sectioniser.js
+++ b/demo2/views/chrome/sectioniser/sectioniser.js
@@ -12,6 +12,14 @@ export default props => (
   </div>
 );
 
+/**
+ * builds the sections
+ *
+ * @private
+ * @method _sections
+ * @param {Object} props
+ * @return {Component}
+ */
 const _sections = (props) => {
   return props.children.map((child, i) => {
     return <div
@@ -19,22 +27,68 @@ const _sections = (props) => {
              style={ _prepareStyles(props, i) }
            >
              { child }
+             <div className='sectioniser__svg'>{ _prepareSVG(props, i) }</div>
            </div>
   });
 }
 
+/**
+ * calculates the depth based on section order position and bounds of depth range
+ *
+ * @private
+ * @method _depth
+ * @param {Object} props
+ * @param {Number} i - section index
+ * @return {Number} depth for this section
+ */
+const _depth = (props, i) => {
+  let min = parseInt(props.minDepth, 10),
+      max = parseInt(props.maxDepth, 10),
+      len = props.children.length;
+
+  return (((max - min) / len) * (len - i)) + min;
+}
+
+/**
+ * generates inline clip path styles and tweaks for sections but not for the first section as the
+ * clipped path effects the top of the element, not the bottom
+ *
+ * @private
+ * @method _prepareStyles
+ * @param {Object} props
+ * @param {Number} i - section index
+ * @return {Object} inline style object
+ */
 const _prepareStyles = (props, i) => {
   if (i > 0) {
-    let min = parseInt(props.minDepth, 10),
-        max = parseInt(props.maxDepth, 10),
-        len = props.children.length;
-
-    let depth = `${(((max - min) / len) * (len - i)) + min}px`;
-
     return {
-      marginTop: `-${depth}`,
-      WebkitClipPath: `polygon(50% ${depth}, 100% 0, 100% 100%, 0 100%, 0 0)`,
+      clipPath: `url("#clip-shape-${i}")`,
+      marginTop: `-${(_depth(props, i))}%`,
+      WebkitClipPath: `polygon(0 0, 50% ${_depth(props, i)}%, 100% 0, 100% 100%, 0 100%)`,
       zIndex: i
     };
   }
+}
+
+/**
+ * generates an SVG version of the clip-path
+ *
+ * @private
+ * @method _prepareSVG
+ * @param {Object} props
+ * @param {Number} i - section index
+ * @return {Component} SVG component
+ */
+const _prepareSVG = (props, i) => {
+  let depth = _depth(props, i);
+
+  return (
+    <svg width="0" height="0">
+      <defs>
+        <clipPath id={ `clip-shape-${i}` } clipPathUnits="objectBoundingBox">
+          <polygon points={ `0 0, 0.5 ${(_depth(props, i) / 100)}, 1 0, 1 1, 0 1` } />
+        </clipPath>
+      </defs>
+    </svg>
+  );
 }

--- a/demo2/views/chrome/sectioniser/sectioniser.scss
+++ b/demo2/views/chrome/sectioniser/sectioniser.scss
@@ -1,10 +1,17 @@
 .sectioniser {
-  display: flex;
-  flex-direction: column;
-
   .demo-wrapper {
     padding-bottom: 0;
     padding-top: 0;
+  }
+
+  > * {
+    position: relative;
+  }
+
+  // fix SVG height to 0 as the SVG is used for firefox and needs to be removed
+  // from the rendering in Chrome to avoid spacing issues
+  &__svg {
+    height: 0;
   }
 
   // this is a work-around a pixel error with `clip-path` and SVG backgrounds

--- a/demo2/views/pages/home/home.js
+++ b/demo2/views/pages/home/home.js
@@ -15,8 +15,8 @@ class Home extends React.Component {
   render() {
     return (
       <Sectioniser
-        minDepth='20'
-        maxDepth='45'
+        minDepth='2'
+        maxDepth='5'
       >
         <PageHeaderLarge />
         <ComponentShowcase />


### PR DESCRIPTION
## Description

* after discussions with UX for the demo site we decided to leave IE out of the clip-path as borders wouldn't work responsively given the fixed menu
* for FireFox however an SVG technique had to be used so now it does clip-path and SVG
* a proportional method is used as SVGs need percentages (flex is also removed on the sectioniser as it wasn't actually necessary, plus, it means Firefox can't handle horizontal margins)
* IE will [support clip-path soon](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/masks/) (it's part of the masks standard)