### PR TITLE
Set common-input__prefix font size to the same as common-input__input

### DIFF
--- a/lib/utils/decorators/input/input.scss
+++ b/lib/utils/decorators/input/input.scss
@@ -253,7 +253,6 @@
 
 .common-input__prefix {
   font-weight: bold;
-  font-size: $input-common-font-size;
   left: 7px;
   position: absolute;
   top: 8px;

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -253,6 +253,7 @@
 
 .common-input__prefix {
   font-weight: bold;
+  font-size: $input-common-font-size;
   left: 7px;
   position: absolute;
   top: 8px;


### PR DESCRIPTION
The font size for input prefixes was being set to 13px and the input value to 14px, causing alignment issues as seen below

![image](https://cloud.githubusercontent.com/assets/3748093/21716941/c8430924-d405-11e6-8897-cb19ef12615d.png)

