### PR TITLE
adds a new component for displaying two tone text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.34.0
+
+A new `Title` component for splitting text into two sections with one side formatted bold and the other not
+
+```
+  <Title
+    start='First bit of the title'
+    end='and the last bit of the title'
+    highlight='start'
+  />
+```
+
 # 0.33.1
 
 ## Bug fix

--- a/src/components/title/__spec__.js
+++ b/src/components/title/__spec__.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Title from './title';
+
+describe('<Title />', () => {
+  let wrapper;
+
+  describe("basic rendering", () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <Title
+          start='This is the start'
+          end='and this is the end'
+        />
+      );
+    });
+
+    it("renders a start section", () => {
+      let start = wrapper.find('.carbon-title__start');
+      expect(start.length).toEqual(1);
+      expect(start.text()).toEqual('This is the start');
+    });
+
+    it("renders an end section", () => {
+      let end = wrapper.find('.carbon-title__end');
+      expect(end.length).toEqual(1);
+      expect(end.text()).toEqual('and this is the end');
+    });
+  });
+
+  it("renders a start modifier if start is highlighted", () => {
+    let wrapper = shallow(<Title highlight='start' />);
+    expect(wrapper.find('.carbon-title--start-highlighted').length).toEqual(1);
+  });
+
+  it("renders a end modifier if end is highlighted", () => {
+    let wrapper = shallow(<Title highlight='end' />);
+    expect(wrapper.find('.carbon-title--end-highlighted').length).toEqual(1);
+  });
+});

--- a/src/components/title/definition.js
+++ b/src/components/title/definition.js
@@ -1,0 +1,22 @@
+import Title from './';
+
+let definition = {
+  component: Title,
+  key: 'title',
+  text: {
+    bemClass: 'carbon-title',
+    details: '[content needed] Basic designs description for the component',
+    description: '[content needed] Basic example of the component',
+    name: 'Title',
+    type: 'layout'
+  },
+  defaultProps: Title.defaultProps,
+  props: Title.propTypes
+};
+
+definition.demoProps = {
+  start: 'This is the first part',
+  end: 'and this is the second part'
+};
+
+export default definition;

--- a/src/components/title/package.json
+++ b/src/components/title/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./title.js",
+  "style": "./title.scss"
+}

--- a/src/components/title/title.js
+++ b/src/components/title/title.js
@@ -1,0 +1,72 @@
+import classNames from 'classnames';
+import React from 'react';
+
+/**
+ * A Title widget.
+ *
+ * == How to use a Title in a component:
+ *
+ * In your file
+ *
+ *   import Title from 'carbon/lib/components/title';
+ *
+ * To render the Title:
+ *
+ *   <Title
+ *     start='First bit of the title'
+ *     end='and the last bit of the title'
+ *     highlight='start'
+ *   />
+ *
+ * @class Title
+ * @constructor
+ */
+class Title extends React.Component {
+  static propTypes = {
+    /**
+     * first part of the title
+     *
+     * @property start
+     * @type {string}
+     */
+    start: React.PropTypes.string,
+
+    /**
+     * second part of the title
+     *
+     * @property end
+     * @type {string}
+     */
+    end: React.PropTypes.string,
+
+    /**
+     * decides which part of the title to highlight, either 'start' or 'end'
+     *
+     * @property highlight
+     * @type {string}
+     */
+    highlight: React.PropTypes.string
+  }
+
+  static defaultProps = {
+    highlight: 'start'
+  }
+
+  classes() {
+    return classNames(
+      `carbon-title--${this.props.highlight}-highlighted`,
+      'carbon-title'
+    );
+  }
+
+  render() {
+    return (
+      <span className={ this.classes() }>
+        <span className='carbon-title__start'>{ this.props.start }</span>
+        <span className='carbon-title__end'>{ this.props.end }</span>
+      </span>
+    );
+  }
+}
+
+export default Title;

--- a/src/components/title/title.scss
+++ b/src/components/title/title.scss
@@ -1,0 +1,15 @@
+.carbon-title {
+  font-weight: normal;
+}
+
+.carbon-title--start-highlighted {
+  .carbon-title__start {
+    font-weight: bold;
+  }
+}
+
+.carbon-title--end-highlighted {
+  .carbon-title__end {
+    font-weight: bold;
+  }
+}


### PR DESCRIPTION
## Description

* called `Title` as this style looks to be used quite commonly (currently in the demo site and one proprietary project)
* provides a toggle for highlighting the `start` or the `end` of the title

# TODO
- [x] Release notes

# Screenshots / Gifs

Realises this design:

![screen shot 2017-01-18 at 10 06 03](https://cloud.githubusercontent.com/assets/10499070/22059754/10759d7e-dd66-11e6-8650-97c7cd7102be.png)

