### PR TITLE
fixes bug where Date is reset to old value on blur

### DIFF
--- a/src/components/date/__spec__.js
+++ b/src/components/date/__spec__.js
@@ -171,16 +171,6 @@ describe('Date', () => {
     });
   });
 
-
-  describe('updateVisibleValue', () => {
-    it('calls set state with the calculated value', () => {
-      spyOn(instance, 'setState');
-      instance.updateVisibleValue();
-
-      expect(instance.setState).toHaveBeenCalledWith({ visibleValue: today });
-    });
-  });
-
   describe('handleVisibleInputChange', () => {
     beforeEach(() => {
       spyOn(instance, 'setState');
@@ -292,24 +282,6 @@ describe('Date', () => {
       let cell = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'dp-day')[1];
       TestUtils.Simulate.click(cell, { nativeEvent: { stopImmediatePropagation: () => {} } } );
       expect(instance.emitOnChangeCallback).toHaveBeenCalled();
-    });
-
-    it('updates the visible value', () => {
-      spyOn(instance, 'updateVisibleValue')
-      let cell = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'dp-day')[1];
-      TestUtils.Simulate.click(cell, { nativeEvent: { stopImmediatePropagation: () => {} } } );
-      expect(instance.updateVisibleValue).toHaveBeenCalled();
-    });
-  });
-
-  describe('handleBlur', () => {
-    beforeEach(() => {
-      spyOn(instance, 'updateVisibleValue');
-      TestUtils.Simulate.blur(instance._input);
-    });
-
-    it('updates the visible value', () => {
-      expect(instance.updateVisibleValue).toHaveBeenCalled();
     });
   });
 

--- a/src/components/date/date.js
+++ b/src/components/date/date.js
@@ -197,19 +197,6 @@ class Date extends React.Component {
   }
 
   /**
-   * Updates field with the formatted date value.
-   *
-   * @method updateVisibleValue
-   * @return {void}
-   */
-  updateVisibleValue = () => {
-    let date = formatVisibleValue(this.props.value, this);
-    this.setState({
-      visibleValue: date
-    });
-  }
-
-  /**
    * Handles user input and updates date picker appropriately.
    *
    * @method handleVisibleInputChange
@@ -253,17 +240,6 @@ class Date extends React.Component {
     this.blockBlur = true;
     this.closeDatePicker();
     this.emitOnChangeCallback(val);
-    this.updateVisibleValue();
-  }
-
-  /**
-   * Updates visible value on blur
-   *
-   * @method handleBlur
-   * @return {void}
-   */
-  handleBlur = () => {
-    this.updateVisibleValue();
   }
 
   /**
@@ -317,7 +293,6 @@ class Date extends React.Component {
     let { ...props } = validProps(this);
     props.className = this.inputClasses;
     props.onChange = this.handleVisibleInputChange;
-    props.onBlur = this.handleBlur;
     props.value = this.state.visibleValue;
     props.onKeyDown = this.handleKeyDown;
 


### PR DESCRIPTION
## Description

* blur functionality was using a value that was only updated if it was valid hence appearing to be reset
* it was also forcing the date through a moment js validator that replaced it with `Invalid date` - this was removed in order to show the user their mistake
* as the `updateVisibleValue` and blur functionality had no other purpose it has been removed

# TODO
- [ ] Release notes

# Related Issues / Pull Requests

https://github.com/Sage/carbon/issues/886