### PR TITLE
Fixed initial value display bug in DropdownFilter freetext mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.34.3
+
+## Component Enhancements
+
+* `Dropdown-Filter`: Added support for write-in initial value to be displayed in `freetext` mode. Previously, if `value` property did not match an `options` item, no value was displayed.
+
 # 0.34.2
 
 ## Bug fix

--- a/src/components/dropdown-filter/__spec__.js
+++ b/src/components/dropdown-filter/__spec__.js
@@ -643,10 +643,21 @@ describe('DropdownFilter', () => {
         instance.visibleValue = 'foo';
         expect(instance.inputProps.value).toEqual('foo');
       });
+
+      describe('and freetext value is present', () => {
+        it('displays freetext value', () => {
+          let value = 'foo';
+
+          instance = TestUtils.renderIntoDocument(
+            <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value={ value } freetext={ true } />
+          );
+          expect(instance.inputProps.value).toEqual(value);
+        });
+      });
     });
 
     describe('when filter is set', () => {
-      it('does not use the filter value', () => {
+      it('uses the filter value', () => {
         instance.visibleValue = 'foo';
         instance.setState({ filter: 'bar' });
         expect(instance.inputProps.value).toEqual('bar');

--- a/src/components/dropdown-filter/dropdown-filter.js
+++ b/src/components/dropdown-filter/dropdown-filter.js
@@ -369,6 +369,8 @@ class DropdownFilter extends Dropdown {
     if (typeof this.state.filter === 'string') {
       // if filter has a value, use that instead
       value = this.state.filter;
+    } else if (this.props.freetext && this.props.value && value === '') {
+      value = this.props.value;
     }
 
     props.readOnly = this.props.readOnly || false;


### PR DESCRIPTION
# Description
Added support for write-in initial value to be displayed in `freetext` mode. Previously, if `value` property did not match an `options` item, no value was displayed.

Signed-off-by: Darren Hill <darren.hill@sage.com>