### PR TITLE
various QA problems fixed

### DIFF
--- a/demo/views/common/sub-page-navigation/sub-page-navigation.scss
+++ b/demo/views/common/sub-page-navigation/sub-page-navigation.scss
@@ -1,7 +1,7 @@
 @import 'colors';
 @import "./../../../style-config/demo-variables";
 
-.demo-sub-page-navigation{
+.demo-sub-page-navigation {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -13,6 +13,10 @@
 
   &__link {
     max-width: 49%;
+
+    .carbon-link__anchor {
+      display: block;
+    }
   }
 
   &__next {

--- a/demo/views/pages/component/component-preview/component-preview.scss
+++ b/demo/views/pages/component/component-preview/component-preview.scss
@@ -7,7 +7,7 @@
   &__component-wrapper {
     margin-bottom: 30px;
     min-height: 100px;
-    padding: 20px;
+    padding: 20px 0;
   }
   &__controls {
     background-color: $grey-dark-blue-10;

--- a/src/components/animated-menu-button/definition.js
+++ b/src/components/animated-menu-button/definition.js
@@ -41,7 +41,8 @@ let definition = new Definition('animated-menu-button', AnimatedMenuButton, {
       <p><Link>First Option</Link></p>
       <p><Link>Another Option</Link></p>
     </div>
-  </Row>`
+  </Row>`,
+    direction: 'right'
   }
 });
 

--- a/src/components/carousel/slide/definition.js
+++ b/src/components/carousel/slide/definition.js
@@ -1,6 +1,14 @@
 import Slide from './';
 import Definition from './../../../../demo/utils/definition';
 
-let definition = new Definition('slide', Slide, {});
+let definition = new Definition('slide', Slide, {
+  props: [ 'children' ],
+  propTypes: {
+    children: 'Node'
+  },
+  propDescriptions: {
+    children: 'This component supports children.'
+  }
+});
 
 export default definition;

--- a/src/components/link/definition.js
+++ b/src/components/link/definition.js
@@ -15,7 +15,10 @@ let definition = new Definition('link', Link, {
     href: 'String',
     iconAlign: 'String',
     tabbable: 'Boolean',
-    to: 'String'
+    to: 'String',
+    tooltipAlign: "String",
+    tooltipPosition: "String",
+    tooltipMessage: "String"
   },
   propDescriptions: {
     children: 'Child content to render in the link.',
@@ -24,7 +27,10 @@ let definition = new Definition('link', Link, {
     icon: 'An icon to display next to the link.',
     iconAlign: 'Which side of the link to the render the link.',
     tabbable: 'Whether to include the link in the tab order of the page',
-    to: 'Using `to` instead of `href` will create a React Router link rather than a web href.'
+    to: 'Using `to` instead of `href` will create a React Router link rather than a web href.',
+    tooltipAlign: "Aligns the tooltip.",
+    tooltipMessage: "A message to display as a tooltip to the link.",
+    tooltipPosition: "Positions the tooltip with the link."
   },
   propOptions: {
     icon: OptionsHelper.icons,

--- a/src/components/menu/submenu-block/definition.js
+++ b/src/components/menu/submenu-block/definition.js
@@ -4,6 +4,13 @@ import Definition from './../../../../demo/utils/definition';
 let definition = new Definition('submenu-block', SubmenuBlock, {
   description: '[content needed] Basic example of the component',
   designerNotes: '[content needed] Basic designs description for the component',
+  props: [ 'children' ],
+  propTypes: {
+    children: 'Node'
+  },
+  propDescriptions: {
+    children: 'This component supports children.'
+  }
 });
 
 export default definition;


### PR DESCRIPTION
## Description

* `AnimatedMenuButton`: pops out to the right so it stays on screen
* `ComponentPreview`: `padding: 20px;` removed from edges of preview area so it aligns with other content elements on the component page
* `SubPageNavigation`: `display: block;` ensures tabable area is markable as focused more clearly

* `Link`: has the tooltip prop descriptions filled in copied from other components
* `Slide` && `SubmenuBlock`: these sub components get children added as props for their description tables

* [SCOUTING] space added in css

## Screengrabs

**shows animated menu and removed padding**
![animated](https://cloud.githubusercontent.com/assets/10499070/23014267/1d8e8b66-f426-11e6-8d52-96930eb9a6d8.gif)

**focus on sub-nav links**
![image](https://cloud.githubusercontent.com/assets/10499070/23014410/c278dee2-f426-11e6-9739-3c3920d7eaaf.png)

**Link prop descriptions**
![image](https://cloud.githubusercontent.com/assets/10499070/23014479/1eeaf570-f427-11e6-894e-ebaf6f99e3b0.png)

**Basic children output**
![image](https://cloud.githubusercontent.com/assets/10499070/23014497/32f9be98-f427-11e6-92ee-1cf7507baaf4.png)

