### PR TITLE
Amend dialog vertical positioning

### DIFF
--- a/src/components/dialog/__spec__.js
+++ b/src/components/dialog/__spec__.js
@@ -7,7 +7,7 @@ import Button from './../button';
 import Row from './../row'
 
 describe('Dialog', () => {
-  let instance, onCancel;
+  let instance, onCancel, computedStyleSpy, getPropertyValueSpy, computedStyles;
 
   beforeEach(() => {
     onCancel = jasmine.createSpy('cancel');
@@ -60,6 +60,12 @@ describe('Dialog', () => {
           expect(window.addEventListener).toHaveBeenCalledWith('keyup', instance.closeModal);
         });
 
+
+        it('prevents scrolling on the document', () => {
+          instance.componentDidUpdate();
+          expect(document.body.style.overflow).toEqual('hidden');
+        });
+
         describe('when the dialog is already listening', () => {
           it('does not set up event listeners', () => {
             let spy = spyOn(window, 'addEventListener');
@@ -86,6 +92,11 @@ describe('Dialog', () => {
           expect(window.removeEventListener).toHaveBeenCalledWith('resize', instance.centerDialog);
           expect(window.removeEventListener).toHaveBeenCalledWith('keyup', instance.closeModal);
         });
+
+        it('allows scrolling on the document', () => {
+          instance.componentDidUpdate();
+          expect(document.body.style.overflow).toEqual('scroll');
+        });
       });
     });
   });
@@ -95,6 +106,11 @@ describe('Dialog', () => {
       instance = TestUtils.renderIntoDocument(
         <Dialog open={ true } onCancel={ onCancel } />
       );
+      computedStyles = {
+        'padding-top': '20px',
+        'padding-bottom': '20px'
+      }
+      computedStyleSpy = spyOn(window, 'getComputedStyle').and.returnValue(computedStyles);
     });
 
     describe('when dialog is lower than 20px', () => {
@@ -125,6 +141,19 @@ describe('Dialog', () => {
         expect(instance._dialog.style.left).toEqual('20px');
       });
     });
+
+    describe('when dialog is taller than the window', () => {
+      it('sets the correct height', () => {
+        instance._dialog = {
+          style: {},
+          offsetHeight: 361
+        };
+        window.innerHeight = 250;
+        instance.centerDialog();
+        expect(instance._dialog.style.height).toEqual('20px');
+      });
+    });
+
 
     describe('when ios', () => {
       it('does not remove page y offset', () => {

--- a/src/components/dialog/__spec__.js
+++ b/src/components/dialog/__spec__.js
@@ -97,35 +97,6 @@ describe('Dialog', () => {
       );
     });
 
-    describe('when dialog is lower than 20px', () => {
-      it('sets top position to the correct value', () => {
-        instance.centerDialog();
-        expect(instance._dialog.style.top).toEqual('150px');
-      });
-    });
-
-    describe('when dialog is higher than 20px', () => {
-      it('sets top position to 20px', () => {
-        instance._dialog = {
-          style: {},
-          offsetHeight: 261
-        };
-        instance.centerDialog();
-        expect(instance._dialog.style.top).toEqual('20px');
-      });
-    });
-
-    describe('when dialog is less than 20px from the side', () => {
-      it('sets top position to 20px', () => {
-        instance._dialog = {
-          style: {},
-          offsetWidth: 361
-        };
-        instance.centerDialog();
-        expect(instance._dialog.style.left).toEqual('20px');
-      });
-    });
-
     describe('when ios', () => {
       it('does not remove page y offset', () => {
         Bowser.ios = true;

--- a/src/components/dialog/__spec__.js
+++ b/src/components/dialog/__spec__.js
@@ -7,7 +7,7 @@ import Button from './../button';
 import Row from './../row'
 
 describe('Dialog', () => {
-  let instance, onCancel, computedStyleSpy, getPropertyValueSpy, computedStyles;
+  let instance, onCancel;
 
   beforeEach(() => {
     onCancel = jasmine.createSpy('cancel');
@@ -60,12 +60,6 @@ describe('Dialog', () => {
           expect(window.addEventListener).toHaveBeenCalledWith('keyup', instance.closeModal);
         });
 
-
-        it('prevents scrolling on the document', () => {
-          instance.componentDidUpdate();
-          expect(document.body.style.overflow).toEqual('hidden');
-        });
-
         describe('when the dialog is already listening', () => {
           it('does not set up event listeners', () => {
             let spy = spyOn(window, 'addEventListener');
@@ -92,11 +86,6 @@ describe('Dialog', () => {
           expect(window.removeEventListener).toHaveBeenCalledWith('resize', instance.centerDialog);
           expect(window.removeEventListener).toHaveBeenCalledWith('keyup', instance.closeModal);
         });
-
-        it('allows scrolling on the document', () => {
-          instance.componentDidUpdate();
-          expect(document.body.style.overflow).toEqual('scroll');
-        });
       });
     });
   });
@@ -106,11 +95,6 @@ describe('Dialog', () => {
       instance = TestUtils.renderIntoDocument(
         <Dialog open={ true } onCancel={ onCancel } />
       );
-      computedStyles = {
-        'padding-top': '20px',
-        'padding-bottom': '20px'
-      }
-      computedStyleSpy = spyOn(window, 'getComputedStyle').and.returnValue(computedStyles);
     });
 
     describe('when dialog is lower than 20px', () => {
@@ -142,24 +126,36 @@ describe('Dialog', () => {
       });
     });
 
-    describe('when dialog is taller than the window', () => {
-      it('sets the correct height', () => {
-        instance._dialog = {
-          style: {},
-          offsetHeight: 361
-        };
-        window.innerHeight = 250;
-        instance.centerDialog();
-        expect(instance._dialog.style.height).toEqual('20px');
-      });
-    });
-
-
     describe('when ios', () => {
       it('does not remove page y offset', () => {
         Bowser.ios = true;
         instance.centerDialog();
         expect(instance._dialog.style.top).toEqual('150px');
+      });
+    });
+
+
+    describe('when dialog is taller than the window', () => {
+      it('it sets the top margin to auto', () => {
+        instance._dialog = {
+          style: {},
+          offsetHeight: 500
+        };
+        window.innerHeight = 400;
+        instance.centerDialog();
+        expect(instance._dialog.style.marginTop).toEqual('auto');
+      });
+    });
+
+    describe('when dialog is not taller than the window', () => {
+      it('it sets the top margin to auto', () => {
+        instance._dialog = {
+          style: {},
+          offsetHeight: 400
+        };
+        window.innerHeight = 800;
+        instance.centerDialog();
+        expect(instance._dialog.style.marginTop).toEqual('0');
       });
     });
   });

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -111,6 +111,7 @@ class Dialog extends Modal {
    */
   get onOpening() {
     this.centerDialog();
+    document.body.style.overflow = "hidden";
     window.addEventListener('resize', this.centerDialog);
   }
 
@@ -123,6 +124,7 @@ class Dialog extends Modal {
    * @return {Void}
    */
   get onClosing() {
+    document.body.style.overflow = "scroll";
     window.removeEventListener('resize', this.centerDialog);
   }
 
@@ -136,7 +138,8 @@ class Dialog extends Modal {
     let height = this._dialog.offsetHeight / 2,
         width = this._dialog.offsetWidth / 2,
         midPointY = window.innerHeight / 2 + window.pageYOffset,
-        midPointX = window.innerWidth / 2 + window.pageXOffset;
+        midPointX = window.innerWidth / 2 + window.pageXOffset,
+        dialogHeight = this._dialog.offsetHeight;
 
     midPointY = midPointY - height;
     midPointX = midPointX - width;
@@ -149,6 +152,12 @@ class Dialog extends Modal {
 
     if (midPointX < 20) {
       midPointX = 20;
+    }
+
+    if (dialogHeight > window.innerHeight) {
+      let topPadding = parseInt(window.getComputedStyle(this._dialog).getPropertyValue("padding-top"))
+      let bottomPadding = parseInt(window.getComputedStyle(this._dialog).getPropertyValue("padding-bottom"))
+      this._dialog.style.height = ((window.innerHeight - topPadding - bottomPadding - midPointY) + "px")
     }
 
     this._dialog.style.top = midPointY + "px";

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -111,7 +111,6 @@ class Dialog extends Modal {
    */
   get onOpening() {
     this.centerDialog();
-    document.body.style.overflow = "hidden";
     window.addEventListener('resize', this.centerDialog);
   }
 
@@ -124,7 +123,6 @@ class Dialog extends Modal {
    * @return {Void}
    */
   get onClosing() {
-    document.body.style.overflow = "scroll";
     window.removeEventListener('resize', this.centerDialog);
   }
 
@@ -155,9 +153,9 @@ class Dialog extends Modal {
     }
 
     if (dialogHeight > window.innerHeight) {
-      let topPadding = parseInt(window.getComputedStyle(this._dialog).getPropertyValue("padding-top"))
-      let bottomPadding = parseInt(window.getComputedStyle(this._dialog).getPropertyValue("padding-bottom"))
-      this._dialog.style.height = ((window.innerHeight - topPadding - bottomPadding - midPointY) + "px")
+      this._dialog.style.marginTop = 'auto';
+    } else {
+      this._dialog.style.marginTop = '0';
     }
 
     this._dialog.style.top = midPointY + "px";
@@ -231,12 +229,13 @@ class Dialog extends Modal {
    */
   get modalHTML() {
     return (
-      <div ref={ (d) => this._dialog = d } className={ this.dialogClasses }>
-        { this.dialogTitle }
-        { this.closeIcon }
-
-        <div className='carbon-dialog__content'>
-          { this.props.children }
+      <div className='carbon-dialog__container'>
+        <div ref={ (d) => this._dialog = d } className={ this.dialogClasses }>
+          { this.dialogTitle }
+          { this.closeIcon }
+          <div className='carbon-dialog__content'>
+            { this.props.children }
+          </div>
         </div>
       </div>
     );

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -134,22 +134,14 @@ class Dialog extends Modal {
    */
   centerDialog = () => {
     let height = this._dialog.offsetHeight / 2,
-        width = this._dialog.offsetWidth / 2,
         midPointY = window.innerHeight / 2 + window.pageYOffset,
-        midPointX = window.innerWidth / 2 + window.pageXOffset,
         dialogHeight = this._dialog.offsetHeight;
 
     midPointY = midPointY - height;
-    midPointX = midPointX - width;
 
-    if (midPointY < 20) {
-      midPointY = 20;
-    } else if (Bowser.ios) {
+    if (Bowser.ios) {
       midPointY -= window.pageYOffset;
-    }
-
-    if (midPointX < 20) {
-      midPointX = 20;
+      this._dialog.style.top = midPointY + "px";
     }
 
     if (dialogHeight > window.innerHeight) {
@@ -157,9 +149,6 @@ class Dialog extends Modal {
     } else {
       this._dialog.style.marginTop = '0';
     }
-
-    this._dialog.style.top = midPointY + "px";
-    this._dialog.style.left = midPointX + "px";
   }
 
   /**
@@ -229,13 +218,11 @@ class Dialog extends Modal {
    */
   get modalHTML() {
     return (
-      <div className='carbon-dialog__container'>
-        <div ref={ (d) => this._dialog = d } className={ this.dialogClasses }>
-          { this.dialogTitle }
-          { this.closeIcon }
-          <div className='carbon-dialog__content'>
-            { this.props.children }
-          </div>
+      <div ref={ (d) => this._dialog = d } className={ this.dialogClasses }>
+        { this.dialogTitle }
+        { this.closeIcon }
+        <div className='carbon-dialog__content'>
+          { this.props.children }
         </div>
       </div>
     );

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -3,19 +3,6 @@
 
 $dialog-padding: 20px;
 
-.carbon-dialog__container {
-  align-items: center;
-  background-color: rgba(60, 66, 79, 0.6);
-  bottom: 0;
-  display: flex;
-  justify-content: center;
-  left: 0;
-  position: fixed;
-  right: 0;
-  top: 0;
-  z-index: 1002;
-}
-
 .carbon-dialog__dialog {
   background-color: $grey-light;
   border-radius: 5px;

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -3,15 +3,27 @@
 
 $dialog-padding: 20px;
 
+.carbon-dialog__container {
+  align-items: center;
+  background-color: rgba(60, 66, 79, 0.6);
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 1002;
+}
+
 .carbon-dialog__dialog {
   background-color: $grey-light;
   border-radius: 5px;
   box-shadow: 0 4px 8px #555;
+  flex-direction: column;
+  overflow-y: hidden;
   padding: $dialog-padding;
-  position: absolute;
-  top: 50%;
-  z-index: $z-dialog;
-  overflow: hidden;
+  position: relative;
 }
 
 .carbon-dialog__dialog--extra-small   { width: 300px; }
@@ -34,7 +46,8 @@ $dialog-padding: 20px;
 
 .carbon-dialog__content {
   width: 100%;
-  overflow: scroll;
+  height: 92%;
+  overflow-y: scroll;
 }
 
 .carbon-dialog__close {

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -11,6 +11,7 @@ $dialog-padding: 20px;
   position: absolute;
   top: 50%;
   z-index: $z-dialog;
+  overflow: hidden;
 }
 
 .carbon-dialog__dialog--extra-small   { width: 300px; }
@@ -33,6 +34,7 @@ $dialog-padding: 20px;
 
 .carbon-dialog__content {
   width: 100%;
+  overflow: scroll;
 }
 
 .carbon-dialog__close {

--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -7,10 +7,12 @@ $modal-initial-position: 60px;
 $modal-animation-length: 300ms;
 
 .carbon-modal__background {
-  background-color: #3C424F;
+  align-items: center;
+  background-color: rgba(60, 66, 79, $modal-background-opacity);
   bottom: 0;
+  display: flex;
+  justify-content: center;
   left: 0;
-  opacity: $modal-background-opacity;
   position: fixed;
   right: 0;
   top: 0;


### PR DESCRIPTION
First pass at changing the `Dialog` component in line with [these designs for inventory](https://app.zeplin.io/project.html#pid=589c9e75003c0d771f97f5c9&sid=589c9f4eb9d031891fc5a971). The default behaviour should be that if a `Dialog` is taller than the viewport then it sticks to the bottom of the window with `overflow: scroll` on the content (instead of the current behaviour that it extends to fit content, with the window then scrolling).

I've extended the `centerDialog` method, because there is an existing resize listener for it, to check whether the dialog is bigger than the window. If so it uses flexbox & applies `margin-top: auto` to stick it to the bottom of the viewport.

