### PR TITLE
Various demosite QA fixes

### DIFF
--- a/demo/utils/site-map-helper/generate-menu/generate-menu.js
+++ b/demo/utils/site-map-helper/generate-menu/generate-menu.js
@@ -14,9 +14,9 @@ const createMenuLink = (name, url, active, external) => {
       linkProp = external ? { href: url, target: "_blank" } : { to: url };
 
   return (
-    <MenuListItem key={ name } name={ name }>
+    <MenuListItem key={ name } name={ humanName(name) }>
       <Link className={ classes } { ...linkProp }>
-        { titleize(humanize(name.replace("/", ""))) }
+        { humanName(name) }
       </Link>
     </MenuListItem>
   );
@@ -78,4 +78,8 @@ const generateMenu = () => {
   }
 
   return menu;
+}
+
+const humanName = (key) => {
+  return titleize(humanize(key.replace("/", "")));
 }

--- a/demo/views/pages/component/component-api/component-api.js
+++ b/demo/views/pages/component/component-api/component-api.js
@@ -9,7 +9,7 @@ class ComponentAPI extends React.Component {
       <PageContentArea
         title={ "Props for " + this.props.definition.get('name') + " Component" }
       >
-        <Table shrink={ true } className="component-api">
+        <Table shrink={ true } className="demo-component-api">
           { this._buildRows() }
         </Table>
       </PageContentArea>
@@ -30,13 +30,13 @@ class ComponentAPI extends React.Component {
     this.props.definition.get('props').sort().forEach((prop, index) => {
       rows.push(
         <TableRow key={ index }>
-          <TableCell className="component-api__cell">{ prop }</TableCell>
-          <TableCell className="component-api__cell component-api__cell--align-center">
+          <TableCell className="demo-component-api__cell">{ prop }</TableCell>
+          <TableCell className="demo-component-api__cell" align='center'>
             { this._isRequired(prop) }
           </TableCell>
-          <TableCell className="component-api__cell">{ this._type(prop) }</TableCell>
-          <TableCell className="component-api__cell">{ this._default(prop) }</TableCell>
-          <TableCell className="component-api__cell">{ this._description(prop) }</TableCell>
+          <TableCell className="demo-component-api__cell">{ this._type(prop) }</TableCell>
+          <TableCell className="demo-component-api__cell demo-component-api__default">{ this._default(prop) }</TableCell>
+          <TableCell className="demo-component-api__cell">{ this._description(prop) }</TableCell>
         </TableRow>
       );
     });
@@ -46,7 +46,7 @@ class ComponentAPI extends React.Component {
 
   _isRequired = (prop) => {
     if (this.props.definition.get('requiredProps').includes(prop)) {
-      return <Icon type="tick" className="component-api__tick" />
+      return <Icon type="tick" className="demo-component-api__tick" />
     }
   }
 

--- a/demo/views/pages/component/component-api/component-api.scss
+++ b/demo/views/pages/component/component-api/component-api.scss
@@ -1,14 +1,17 @@
 @import 'colors';
 
-.component-api__cell {
-  white-space: pre-line;
-  word-break: normal;
+.demo-component-api {
+  &__cell {
+    line-height: 1.5em;
+    white-space: pre-line;
+    word-break: normal;
+  }
+
+  &__default {
+    white-space: nowrap;
+  }
 }
 
-.component-api__cell--align-center {
-  text-align: center;
-}
-
-.component-api__tick {
+.demo-component-api__tick {
   color: $green;
 }

--- a/demo/views/pages/component/component-preview/component-preview.js
+++ b/demo/views/pages/component/component-preview/component-preview.js
@@ -30,15 +30,15 @@ class ComponentPreview extends React.Component {
         title='Preview'
         link={ `https://github.com/Sage/carbon/tree/master/src/components/${this.props.definition.get('key')}` }
       >
-        <div className= { `component-preview component-preview--${this.props.definition.get('key')}` }>
-          <div className='component-preview__component-wrapper'>
+        <div className= { `demo-component-preview demo-component-preview--${this.props.definition.get('key')}` }>
+          <div className='demo-component-preview__component-wrapper'>
             <div id="carbon-demo" />
             <div ref='demo' />
           </div>
 
           <SimpleHeading title="Code"></SimpleHeading>
 
-          <div className='component-preview__interaction'>
+          <div className='demo-component-preview__interaction'>
             <Fields name={ this.props.name } definition={ this.props.definition } />
             { this.renderCode() }
           </div>

--- a/demo/views/pages/component/component-preview/component-preview.scss
+++ b/demo/views/pages/component/component-preview/component-preview.scss
@@ -1,6 +1,6 @@
 @import 'colors';
 
-.component-preview {
+.demo-component-preview {
   &__interaction {
     display: flex;
   }
@@ -16,6 +16,24 @@
     flex-shrink: 0;
     padding: 20px;
     width: 350px;
+    .carbon-checkbox {
+      .common-input__field {
+        box-sizing: border-box;
+        float: right;
+        padding-left: 15px;
+      }
+      .common-input__label {
+        text-align: right;
+      }
+    }
+  }
+
+  .carbon-textarea {
+    display: flex;
+
+    .common-input__label {
+      margin-top: 9px;
+    }
   }
 
   .demo-code {
@@ -23,5 +41,26 @@
     flex-shrink: 1;
     flex-grow: 1;
     overflow-x: auto;
+  }
+}
+
+.demo-component-preview--app-wrapper {
+  .carbon-app-wrapper {
+    background-image: linear-gradient(to right, rgba($blue, 0.2), rgba($blue, 0.2)),
+                      linear-gradient(to right, rgba($blue, 0.2), rgba($blue, 0.2));
+    background-clip: padding-box,
+                     content-box;
+    height: 30px;
+    line-height: 30px;
+    min-width: 944px;
+  }
+}
+
+.demo-component-preview--row {
+  .carbon-row__column {
+    div {
+      background-color: $green;
+      height: 10px;
+    }
   }
 }

--- a/demo/views/pages/component/component-preview/fields/fields.js
+++ b/demo/views/pages/component/component-preview/fields/fields.js
@@ -10,7 +10,7 @@ import Textarea from 'components/textarea';
 import Textbox from 'components/textbox';
 
 export default props => (
-  <form className='component-preview__controls'>
+  <form className='demo-component-preview__controls'>
     { buildFields(props) }
   </form>
 )
@@ -79,18 +79,19 @@ const fieldComponent = (name, prop, value, field, options, requirement) => {
         key: name + prop,
         label: titleize(kebabCase(prop)).replace(/-/g, " "),
         onChange: ComponentActions.updateDefinition.bind(this, name, prop),
-        value: value
+        value: value,
+        labelInline: true,
+        labelWidth: 40
       };
 
   if (requirement) {
     let disabled = !ComponentStore.data.getIn([name, 'propValues', requirement]);
     commonfieldProps.disabled = disabled;
-    commonfieldProps.labelHelp = "requires " + requirement;
+    commonfieldProps.fieldHelp = "requires " + requirement;
   }
 
   if (field !== Checkbox) {
-    commonfieldProps.labelInline = true;
-    commonfieldProps.labelWidth = 40;
+    commonfieldProps.labelAlign = 'right';
   }
 
   if (field === Textarea) {

--- a/src/components/app-wrapper/definition.js
+++ b/src/components/app-wrapper/definition.js
@@ -4,11 +4,8 @@ import Definition from './../../../demo/utils/definition';
 
 let definition = new Definition('app-wrapper', AppWrapper, {
   propValues: {
-    children: `<div style={{ backgroundColor: "white"  }}>
-    This component will wrap it's children within the width constraints of your application.
-  </div>`
+    children: "This component will wrap its children within the width constraints of your application."
   },
-  hiddenProps: ['children'],
   propTypes: {
     children: 'Node',
     className: 'String',

--- a/src/components/row/definition.js
+++ b/src/components/row/definition.js
@@ -22,17 +22,14 @@ let columnDefinition = new Definition('child', {}, {
 
 let definition = new Definition('row', Row, {
   associatedDefinitions: [columnDefinition],
-  js: `function style() {
-  return { backgroundColor: '#50B848', height: '10px' };
-}`,
   hiddenProps: ['children'],
   propValues: {
-    children: `<div style={ style() } />
-  <div style={ style() } />
-  <div style={ style() } />
-  <div style={ style() } />
-  <div style={ style() } />
-  <div style={ style() } />`
+    children: `<div/>
+  <div/>
+  <div/>
+  <div/>
+  <div/>
+  <div/>`
   },
   propTypes: {
     gutter: "String",


### PR DESCRIPTION
## Description

* the default value cell in the props table has had whitespace wrapping removed to stop newlines on a hyphen, this makes the values easier to consume
* fixes filter on menu list to handle spaces
* tweaks label positioning for textareas within the preview control form so that Children label doesn't look out of place
* text is less cramped with increased line height for  table descriptions
* uses background image to highlight padding on `AppWrapper` demo
* `AppWrapper` children is now editable like other components
* use Carbon colour for `Row` and simplify code output
* form field labels are aligned right and check boxes / text fields aligned left

UX and design changes signed off by Kyle

* [SCOUTING] `ComponentApi` and `ComponentPreview` components use `demo-` prefix to avoid clashes with other BEM identifiers

## Screenshots / Gifs
### whitespace wrapping
![screen shot 2017-02-21 at 11 34 57](https://cloud.githubusercontent.com/assets/10499070/23204444/83094f82-f8de-11e6-85a6-8ebfe23dee7f.png)
### field alignment
![image](https://cloud.githubusercontent.com/assets/10499070/23204704/89b96e1a-f8df-11e6-80b8-a8e109ba0ded.png)
![image](https://cloud.githubusercontent.com/assets/10499070/23204466/9b1083c0-f8de-11e6-8b58-42af144e208a.png)
### table text spacing
![image](https://cloud.githubusercontent.com/assets/10499070/23204515/c8854264-f8de-11e6-97e1-bd0321ed1fc8.png)
### app wrapper padding css
![image](https://cloud.githubusercontent.com/assets/10499070/23204519/d14ed3ce-f8de-11e6-9dd3-365e5a4c371a.png)
### children label align
![image](https://cloud.githubusercontent.com/assets/10499070/23204546/eb113e96-f8de-11e6-9945-cba2194436fe.png)


