### PR TITLE
Fixes pod centred edit button misalign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.34.4
+
+## Bug fix
+
+* `Pod`: corrects misalignment caused by centering
+
 # 0.34.3
 
 ## Component Enhancements

--- a/src/components/pod/pod.scss
+++ b/src/components/pod/pod.scss
@@ -54,7 +54,6 @@
   display: inline-block;
   vertical-align: top;
   cursor: pointer;
-  position: absolute;
 }
 
 .carbon-pod__edit-action--no-border,


### PR DESCRIPTION
## Description

* this was a side effect of an unnecessary `position: absolute;` property

## TODO
- [x] Release notes

## Screenshots / Gifs
![pod](https://cloud.githubusercontent.com/assets/10499070/23214288/fd6102d0-f905-11e6-9dda-6b5b79b6ba4f.gif)

## Related issues
https://github.com/Sage/carbon/issues/1102