### PR TITLE
fix for demo site decimal precision

### DIFF
--- a/src/components/decimal/definition.js
+++ b/src/components/decimal/definition.js
@@ -3,6 +3,9 @@ import Definition from './../../../demo/utils/definition';
 import OptionsHelper from './../../utils/helpers/options-helper';
 
 let definition = new Definition('decimal', Decimal, {
+  hiddenProps: [
+    'precision'
+  ],
   type: 'form',
   propTypes: {
     align: "String",
@@ -10,7 +13,7 @@ let definition = new Definition('decimal', Decimal, {
   },
   propDescriptions: {
     align: "Sets the alignment of the text within the decimal component",
-    precision: "Sets the precision of the decimal"
+    precision: "Sets the precision of the decimal - only available on page load"
   },
   propOptions: {
     align: OptionsHelper.alignBinary


### PR DESCRIPTION
* dynmaic prop setting isn't a real world example for Decimal, so the component has been built with a bug
* however, in order to get the site live and becasue dynamic precision setting isn't a common use case we've temporarily patched this demo site only
* [this issue](https://github.com/Sage/carbon/issues/1117) has been raised