### PR TITLE
CARBON-673 visibleValue was recalculated using the old props.

### DIFF
--- a/src/components/decimal/__spec__.js
+++ b/src/components/decimal/__spec__.js
@@ -4,6 +4,7 @@ import Decimal from './decimal';
 import I18n from "i18n-js";
 import ReactDOM from 'react-dom';
 import Events from './../../utils/helpers/events';
+import { shallow } from 'enzyme';
 
 describe('Decimal', () => {
   var instance;
@@ -46,13 +47,24 @@ describe('Decimal', () => {
     });
 
     describe('when precision is passed', () => {
-      it('sets the visibleValue state to teh formatted version using i18n opts', () => {
+      it('sets the visibleValue state to the formatted version using i18n opts', () => {
         instance = TestUtils.renderIntoDocument(
           <Decimal name="total" value="12345.67891" precision={ 5 } />
         );
         expect(instance.state.visibleValue).toEqual("12,345.67891");
       });
+
+      it('updates the visibleValue state when the precision is changed', () => {
+        let wrapper = shallow(
+          <Decimal name="total" value="12345.67891" precision={ 5 } />
+        );
+        expect(wrapper.state().visibleValue).toEqual("12,345.67891");
+
+        wrapper.setProps({ precision: 2 });
+        expect(wrapper.state().visibleValue).toEqual("12,345.68");
+      });
     });
+    
 
     describe('with alternative I18n options', () => {
       beforeEach(() => {

--- a/src/components/decimal/decimal.js
+++ b/src/components/decimal/decimal.js
@@ -88,14 +88,14 @@ class Decimal extends React.Component {
    * only when the field is not the active element.
    *
    * @method componentWillReceiveProps
-   * @param {Object} props The new props passed down to the component
+   * @param {Object} newProps The new props passed down to the component
    * @return {void}
    */
-  componentWillReceiveProps(props) {
+  componentWillReceiveProps(newProps) {
     if (this._document.activeElement != this._input) {
-      let value = props.value || 0.00;
+      let value = newProps.value || 0.00;
       if (canConvertToBigNumber(value)) {
-        value = I18nHelper.formatDecimal(value, this.props.precision);
+        value = I18nHelper.formatDecimal(value, newProps.precision);
       }
       this.setState({ visibleValue: value });
     }


### PR DESCRIPTION
Fixes issue #1117.

Instead of using the `props` argument that is passed in to
`componentWillReceiveProps`, `visibleValue` was recalculated using the old
`this.props.precision`.

Renamed the argument from `props` to `newProps`, and calculated
`visibleValue` using `newProps.precision`.

Added a unit test to replicate the issue / verify the fix (which uses enzyme
to set props and check the state of the component).