### PR TITLE
Fixes issues with Pager page number input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug Fix
 
 * `Dropdown`: adds a set of ontouch events to the list in order to stop blurring from happening until after the touch event which fixes a bug with the input update on finger tap on touch screens
+* `Pager`: fixes out of range values being entered
 * `TableHeader`: fix overflow issue so that tooltip / help components aren't cut off.
 * `Decimal`: fix issue where `visibleValue` was not updated after a change to `precision`.
 

--- a/src/components/pager/__spec__.js
+++ b/src/components/pager/__spec__.js
@@ -3,6 +3,8 @@ import TestUtils from 'react/lib/ReactTestUtils';
 import NumberComponent from './../number';
 import Pager from './pager';
 
+import { shallow } from 'enzyme';
+
 describe('Pager', () => {
   let instance, instance2, spy1, spy2;
 
@@ -329,5 +331,48 @@ describe('Pager', () => {
     it('adds a class of unselectable', () => {
       expect(TestUtils.scryRenderedDOMComponentsWithClass(instance, 'unselectable').length).toBeTruthy();
     });
+  });
+});
+
+describe("Page number value change (from 3):", () => {
+  let number,
+      wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <Pager
+        currentPage='3'
+        onPagination={ () => {} }
+        pageSize='10'
+        totalRecords='49'
+      />
+    );
+    number = wrapper.find('.carbon-pager__current-page');
+  });
+
+  it("changes to 0 and causes no change", () => {
+    number.simulate('change', { target: { value: '0' } });
+    number = wrapper.find('.carbon-pager__current-page');
+    expect(number.prop('value')).toEqual('3');
+  });
+  it("changes to >maxPage and causes no change", () => {
+    number.simulate('change', { target: { value: '6' } });
+    number = wrapper.find('.carbon-pager__current-page');
+    expect(number.prop('value')).toEqual('3');
+  });
+  it("changes to 1 and sets it to 1", () => {
+    number.simulate('change', { target: { value: '1' } });
+    number = wrapper.find('.carbon-pager__current-page');
+    expect(number.prop('value')).toEqual('1');
+  });
+  it("changes to maxPage and sets it to maxPage", () => {
+    number.simulate('change', { target: { value: '5' } });
+    number = wrapper.find('.carbon-pager__current-page');
+    expect(number.prop('value')).toEqual('5');
+  });
+  it("changes to '' and sets it to ''", () => {
+    number.simulate('change', { target: { value:  '' } });
+    number = wrapper.find('.carbon-pager__current-page');
+    expect(number.prop('value')).toEqual('');
   });
 });

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -114,13 +114,28 @@ class Pager extends React.Component {
   }
 
   /**
+   * Decides if a value is within page range
+   * The === '' means backspace can be used in the field to clear it for UX reasons
+   *
+   * @method withinRange
+   * @return {Boolean}
+   */
+  withinRange = (page) => {
+    return (page >= 1 && page <= this.maxPage) || page === '';
+  }
+
+  /**
    * Handle current page input internally until blur event
    *
    * @method handleCurrentPageInputChange
    * @return {Void}
    */
   handleCurrentPageInputChange = (ev) => {
-    this.setState({ currentPage: ev.target.value });
+    let next = ev.target.value;
+
+    if (this.withinRange(next)) {
+      this.setState({ currentPage: next });
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

* Stops `-` being a value that is accepted.
* Forces range to be adhered to in the `Pager` component: `0..maxPage` - this is the correct place as it has knowledge of the range.
* Blocking invalid values is consistent with other Number components.

## Todo

- [x] release notes

## QA Steps

Pull down the branch and test in the old demo site

## Related

https://github.com/Sage/carbon/pull/1147