### PR TITLE
Fixes buttonAlign on ShowEditPod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.35.0
 
+## Bug Fix
+
+* `ShowEditPod`: `beforeFormValidation` and `buttonAlign` props are now passed to the `Form` as they should be
+
 ## InlineInputs Component
 A simple `InlineInputs` wrapper component which allows multiple input fields to be displayed horizontally
 with a label.

--- a/src/components/show-edit-pod/__spec__.js
+++ b/src/components/show-edit-pod/__spec__.js
@@ -6,6 +6,8 @@ import Textbox from './../textbox';
 import Pod from './../pod';
 import Events from './../../utils/helpers/events'
 
+import { shallow } from 'enzyme';
+
 import ReactDOM from 'react-dom';
 
 describe('ShowEditPod', () => {
@@ -340,6 +342,49 @@ describe('ShowEditPod', () => {
   describe('render', () => {
     it('renders a parent pod', () => {
       TestUtils.findRenderedComponentWithType(instance, Pod);
+    });
+  });
+
+  describe("edit form props", () => {
+    it("creates a Form with the expected props when editing is set to true", () => {
+      let beforeFormValidation = jasmine.createSpy(),
+          wrapper = shallow(
+            <ShowEditPod
+              beforeFormValidation={ beforeFormValidation }
+              buttonAlign='left'
+              cancel={ false }
+              cancelText='Cancel Me'
+              editing={ true }
+              saveText='Save Me'
+              saving={ false }
+              validateOnMount={ true }
+            />
+          );
+
+      let editForm = wrapper.find(Form),
+          instance = wrapper.instance()
+
+      let props = editForm.props();
+
+      expect(props.afterFormValidation).toEqual(instance.onSaveEditForm);
+      expect(props.beforeFormValidation).toEqual(beforeFormValidation);
+      expect(props.buttonAlign).toEqual('left');
+      expect(props.cancel).toEqual(false);
+      expect(props.cancelText).toEqual('Cancel Me');
+      expect(props.onCancel).toEqual(instance.onCancelEditForm);
+      expect(props.additionalActions).toEqual(null);
+      expect(props.saveText).toEqual('Save Me');
+      expect(props.saving).toEqual(false);
+      expect(props.validateOnMount).toEqual(true);
+
+      describe("where onDelete is provided", () => {
+        it("should get through to the delete button Link", () => {
+          let onDelete = jasmine.createSpy();
+          wrapper.setProps({ onDelete: onDelete });
+          let deleteButton = shallow(wrapper.find(Form).props().additionalActions).find(Link);
+          expect(deleteButton.props('onClick')).toEqual(onDelete);
+        });
+      });
     });
   });
 });

--- a/src/components/show-edit-pod/show-edit-pod.js
+++ b/src/components/show-edit-pod/show-edit-pod.js
@@ -237,7 +237,8 @@ class ShowEditPod extends React.Component {
     return (
       <Form
         afterFormValidation={ this.onSaveEditForm }
-        beforeFormValidation={ this.beforeFormValidation }
+        beforeFormValidation={ this.props.beforeFormValidation }
+        buttonAlign={ this.props.buttonAlign }
         cancel={ this.props.cancel }
         cancelText={ this.props.cancelText }
         onCancel={ this.onCancelEditForm }


### PR DESCRIPTION
## Description 

* This prop never actually made it through to the contained `Form`
* Coverage was increased on the relationship between props into `ShowEditPod` and it's contained `Form` to make sure that all the props going in ended up where they should
* This also revealed a further error where the `beforeFormValidation` prop was treated like a callback property on `ShowEditPod` when actually it was a React prop passed in

## QA Notes

* The original bug was just the button align, which can be tested on the demo site.
* Use [this QA branch](https://github.com/Sage/carbon/tree/button-align-prop-added-to-show-edit-form--QA-branch) - you might need to run `rm -rf node_modules; npm install` if gulp throws errors - this branch will give access to the new demo site with the fix

# TODO
- [x] Release notes

# Screenshots / Gifs
![align](https://cloud.githubusercontent.com/assets/10499070/24245536/2ac04986-0fbb-11e7-9f56-3b128b478619.gif)

