### PR TITLE
SPIKE-2: componentised translations

### DIFF
--- a/src/components/form/form-summary/__spec__.js
+++ b/src/components/form/form-summary/__spec__.js
@@ -5,7 +5,7 @@ import Icon from './../../icon';
 
 import FormSummary from './form-summary';
 
-describe('<FormSummary />', () => {
+fdescribe('<FormSummary />', () => {
   let block = '.carbon-form-summary',
       wrapper;
 

--- a/src/components/form/form-summary/form-summary.js
+++ b/src/components/form/form-summary/form-summary.js
@@ -1,7 +1,8 @@
-import I18n from 'i18n-js';
 import React from 'react';
 
 import Icon from './../../icon';
+
+import translate from './translations';
 
 const FormSummary = props =>
   <div className='carbon-form-summary'>
@@ -34,39 +35,6 @@ const summary = (props, key) => {
 };
 
 /**
- * Returns the default translation set
- *
- * @param {number} errorCount
- * @param {number} warningCount
- * @return {object} default translations
- */
-const defaultTranslations = (errorCount, warningCount) => {
-  return {
-    errors: {
-      defaultValue: {
-        one: `There is ${ errorCount } error`,
-        other: `There are ${ errorCount } errors`
-      },
-      count: parseInt(errorCount)
-    },
-    warnings: {
-      defaultValue: {
-        one: `There is ${ warningCount } warning`,
-        other: `There are ${ warningCount } warnings`
-      },
-      count: parseInt(warningCount)
-    },
-    errors_and_warnings: {
-      defaultValue: {
-        one: `and ${ warningCount } warning`,
-        other: `and ${ warningCount } warnings`
-      },
-      count: parseInt(warningCount)
-    }
-  };
-};
-
-/**
  * Adds an 's' to pluralise (keys will always be error or warning)
  *
  * @param {string} key
@@ -95,12 +63,7 @@ const translationKey = (props, key) => {
  * @return {string} correct translation
  */
 const translation = (props, key) => {
-  key = translationKey(props, key);
-
-  let defaultTranslation = defaultTranslations(props.errors, props.warnings)[key],
-      location = `errors.messages.form_summary.${key}`;
-
-  return I18n.t(location, defaultTranslation);
+  return translate(props.errors, props.warnings)[translationKey(props, key)];
 };
 
 /**

--- a/src/components/form/form-summary/translations.js
+++ b/src/components/form/form-summary/translations.js
@@ -1,0 +1,20 @@
+import I18n from 'i18n-js';
+
+export default (errorCount, warningCount) => {
+  let translations = {
+    'en': {
+      errors:              errorCount   > 1 ? `There are ${ errorCount } errors`     : `There is ${ errorCount } error`,
+      warnings:            warningCount > 1 ? `There are ${ warningCount } warnings` : `There is ${ warningCount } warning`,
+      errors_and_warnings: warningCount > 1 ? `and ${ warningCount } warnings`       : `and ${ warningCount } warning`
+    },
+    default: {
+      errors:              errorCount   > 1 ? `There are ${ errorCount } errors`     : `There is ${ errorCount } error`,
+      warnings:            warningCount > 1 ? `There are ${ warningCount } warnings` : `There is ${ warningCount } warning`,
+      errors_and_warnings: warningCount > 1 ? `and ${ warningCount } warnings`       : `and ${ warningCount } warning`
+    }
+  };
+
+  let key = (typeof translations[I18n.locale] === 'undefined') ? 'default' : I18n.locale;
+
+  return translations[key];
+};


### PR DESCRIPTION
## Description

* This is the best I can do in 45 mins
* Translations are stored in a separate file inside the component
* This file contains a bit of logic (in the example, there are pluralisations based on data values)
* I18n is used for the locale only
* Tests still pass so the default translations is still falling through correctly (note the way the tests don't rely on I18n itself to pass, they haven't changed for this spike - except for `fdescribe`)

### Technical Problems

* logic in the translations file, ideally this would be reduced to help those translating, who might not be technical, to focus on the task - could this be abstracted so translations inherits from something? Perhaps the I18n could live there and things like pluralisation could be handled at this level?
* mechanism for getting the default - I tried a `switch` but the resulting code was more complex

### Benefits

* Only the translations an app needs are loaded
* Translation files are easier to edit
* There's no need to define simple translations just to use a Carbon based app in a given language - you only need to define translations for your own components
* Translation effort is open source
* Potential to remove I18n dependency (and dependency on gems etc.)
* Simplification of component files

### Drawbacks

* Multiple files to edit for translators
* Possible duplicated logic or re-invention of I18n

# TODO
- [ ] Release notes

# Related Issues / Pull Requests

* https://github.com/Sage/carbon/issues/789