### PR TITLE
Allows translations to have HTML in them

### DIFF
--- a/src/components/form/form-summary/__spec__.js
+++ b/src/components/form/form-summary/__spec__.js
@@ -22,7 +22,7 @@ describe('<FormSummary />', () => {
     });
 
     it("the correct translation wrapped in the text class", () => {
-      let text = wrapper.find(`${block}__text`).text();
+      let text = wrapper.find(`${block}__text`).render().text();
       expect(text).toContain('There is 1 error');
     });
   });
@@ -40,7 +40,7 @@ describe('<FormSummary />', () => {
     });
 
     it("the correct translation wrapped in a class that brings accessible contrast", () => {
-      let text = wrapper.find(`${block}__text`).text();
+      let text = wrapper.find(`${block}__text`).render().text();
       expect(text).toContain('There is 1 warning');
     });
   });
@@ -62,7 +62,7 @@ describe('<FormSummary />', () => {
     });
 
     it("the correct translation", () => {
-      let text = wrapper.text();
+      let text = wrapper.render().text();
       expect(text).toContain('There is 1 error');
       expect(text).toContain('and 1 warning');
     });

--- a/src/components/form/form-summary/form-summary.js
+++ b/src/components/form/form-summary/form-summary.js
@@ -27,7 +27,7 @@ const summary = (props, key) => {
     return (
       <span className={ `carbon-form-summary__summary carbon-form-summary__${key}-summary` }>
         <Icon className='carbon-form-summary__icon' type={ `${key}` } />
-        <span className='carbon-form-summary__text'>{ translation(props, key) }</span>
+        <span className='carbon-form-summary__text' dangerouslySetInnerHTML={ { __html: translation(props, key) } } />
       </span>
     );
   }


### PR DESCRIPTION
# Description

* We use `dangerouslySetInnerHTML` so that translations can contain html where needed
* This is still secure as the app owner retains full control over the translations they provide
* Due to [this issue](https://github.com/airbnb/enzyme/issues/419) with Enzyme and `dangerouslySetInnerHTML` `render()` was used to in order to get at the text used for the translation tests

# TODO
- [x] Release notes - not required, there's already [a release note](https://github.com/Sage/carbon/blob/release-candidate/CHANGELOG.md#0350) from the original work

# Related Issues / Pull Requests
https://github.com/Sage/carbon/pull/1130