### PR TITLE
Remove style from package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.36.0
 
+* Removed the style node from `package.json` in table-ajax. This file doesn't exist.
 * Add `additionalRequestParams` prop to `DropdownFilterAjax`
 
 # 0.35.1

--- a/src/components/table-ajax/package.json
+++ b/src/components/table-ajax/package.json
@@ -1,5 +1,4 @@
 {
   "main": "./table-ajax.js",
-  "name": "Table Ajax",
-  "style": "./table-ajax.scss"
+  "name": "Table Ajax"
 }


### PR DESCRIPTION
Needed to remove the style node from the package.json file, as the file doesn't actually exist - this was causing problems with a third-party module which looks for the file, but errors out when it can't find it.

:warning: we are currently preparing for a `v1.0.0` release, so please target your PR to the relevant branch:

* `master` - v1.0.0 (breaking changes)
* `release-candidate` - v0.x (new features)
* `release` - v0.x.x (bug fixes)

# Description

# TODO
- [x] Release notes

# Related Issues / Pull Requests

# Screenshots / Gifs
