### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ See the guide on [installing unreleased changes](https://github.com/Sage/carbon/
 
 * Bump the version in `package.json`.
 * Ensure the `CHANGELOG.md` is up to date.
+* Run `npm install` to make sure the packages are all up to date.
 * Run `npm run-script release` to update `/lib`.
 * If releasing a minor version, create a branch from `master`.
 * If releasing a patch version, create a branch from `release`.


### PR DESCRIPTION
Adds missing instruction to readme

:warning: we are currently preparing for a `v1.0.0` release, so please target your PR to the relevant branch:

* `master` - v1.0.0 (breaking changes)
* `release-candidate` - v0.x (new features)
* `release` - v0.x.x (bug fixes)

# Description

# TODO
- [ ] Release notes

# Related Issues / Pull Requests

# Screenshots / Gifs
