### PR TITLE
Fixes the markup for the Step component

### DIFF
--- a/src/components/multi-step-wizard/step/step.js
+++ b/src/components/multi-step-wizard/step/step.js
@@ -352,15 +352,15 @@ class Step extends React.Component {
         <div className={ this.mainClasses }>
           <div className={ 'multi-step-wizard-step__indicator-bar ' + this.indicatorStatus }>
             <div className='multi-step-wizard-step__indicator-background' />
-            <div className='multi-step-wizard-step__indicator-icon'>
-              <div className='multi-step-wizard-step__indicator-placeholder'>
-                <div className={ 'multi-step-wizard-step__indicator-icon__content ' + this.indicatorStatus }>
-                  { this.indicatorHTML }
-                </div>
+          </div>
+          <div className='multi-step-wizard-step__indicator-icon'>
+            <div className='multi-step-wizard-step__indicator-placeholder'>
+              <div className={ 'multi-step-wizard-step__indicator-icon__content ' + this.indicatorStatus }>
+                { this.indicatorHTML }
               </div>
             </div>
-            { this.stepHTML }
           </div>
+          { this.stepHTML }
         </div>
       );
     } else {


### PR DESCRIPTION
Fixes an issue with the markup for the step component.

Reverts a change made in https://github.com/Sage/carbon/pull/1165 (https://github.com/Sage/carbon/commit/04c62348b65e72f68e0be534b16b531bb67051de#diff-c766474a1ee42631d328f96554489d72L353)

No release notes since this bug was introduced in v1.0.0 and that's not released yet.