### PR TITLE
Tweaks Column implementation

### DIFF
--- a/src/components/row/__spec__.js
+++ b/src/components/row/__spec__.js
@@ -6,7 +6,6 @@ import { shallow } from 'enzyme';
 import Logger from './../../utils/logger';
 
 describe('Row', () => {
-
   describe('when column number is NOT passed', () => {
     let instance;
     let columns;
@@ -22,7 +21,7 @@ describe('Row', () => {
         </Row>
       );
 
-      columns = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'carbon-column');
+      columns = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'carbon-row__column');
     });
 
     describe('render', () => {
@@ -52,7 +51,7 @@ describe('Row', () => {
           </Row>
         );
 
-        columns = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'carbon-column');
+        columns = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'carbon-row__column');
         expect(columns.length).toEqual(2);
       });
     });
@@ -80,25 +79,25 @@ describe('Row', () => {
 
     describe('Column offset', () => {
       it('renders a div with an additional offset CSS class', () => {
-        expect(columns[0].className).toEqual('carbon-column carbon-column--offset-2');
+        expect(columns[0].className).toEqual('carbon-column carbon-row__column carbon-row__column--offset-2');
       });
     });
 
     describe('Column span', () => {
       it('renders a div with an additional span CSS class', () => {
-        expect(columns[1].className).toEqual('carbon-column carbon-column--span-3');
+        expect(columns[1].className).toEqual('carbon-column carbon-row__column carbon-row__column--span-3');
       });
     });
 
     describe('Column classes', () => {
       it('renders a div with all additional column classes', () => {
-        expect(columns[2].className).toEqual('carbon-column extra-class');
+        expect(columns[2].className).toEqual('carbon-column carbon-row__column extra-class');
       });
     });
 
     describe('Column align', () => {
       it('renders a div with alignment class', () => {
-        expect(columns[3].className).toEqual('carbon-column carbon-column--align-center');
+        expect(columns[3].className).toEqual('carbon-column carbon-row__column carbon-row__column--align-center');
       });
     });
   });
@@ -152,8 +151,8 @@ describe('Row', () => {
     });
 
     it('applies custom class', () => {
-      let rowNode = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'carbon-column')[0];
-      expect(rowNode.className).toEqual('carbon-column carbon-column--column-divide');
+      let rowNode = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'carbon-row__column')[0];
+      expect(rowNode.className).toEqual('carbon-column carbon-row__column carbon-row__column--column-divide');
     });
   });
 
@@ -177,11 +176,6 @@ describe('Row', () => {
   describe('deprecated functionality', () => {
     beforeEach(() => {
       var process = { env: { NODE_ENV: 'development' } }
-    });
-
-    it('wraps the child in a column component', () => {
-      let wrapper = shallow(<Row><div>Foo</div></Row>);
-      expect(wrapper.find(Column).length).toEqual(1);
     });
 
     it('Calls the logger to report the deprecation', () => {

--- a/src/components/row/column/__spec__.js
+++ b/src/components/row/column/__spec__.js
@@ -3,7 +3,6 @@ import { shallow } from 'enzyme';
 import Column from './';
 
 describe('Column', () => {
-
   let wrapper = shallow(
     <Column className='myclass'>
       <span />
@@ -18,7 +17,12 @@ describe('Column', () => {
     expect(wrapper.node.props.className).toEqual('carbon-column myclass');
   });
 
-  describe('options', () => {
+  /**
+   * These should be un-x-ed as the classes will be in here once we're up to React 16
+   * This is related to TODOs in the Row component
+   * TODO: CarbonV2
+   */
+  xdescribe('options', () => {
     describe('columnOffset', () => {
       it('renders a columnOffset class', () => {
         wrapper.setProps({ columnOffset: 2 });

--- a/src/components/row/column/column.js
+++ b/src/components/row/column/column.js
@@ -1,20 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
 const Column = (props) => {
-  const columnClasses = classNames(
-    "carbon-column",
-    props.className, {
-      [`carbon-column--offset-${ props.columnOffset }`]: props.columnOffset,
-      [`carbon-column--span-${ props.columnSpan }`]: props.columnSpan,
-      [`carbon-column--align-${ props.columnAlign }`]: props.columnAlign,
-      "carbon-column--column-divide": props.columnDivide
-    }
-  );
-
   return (
-    <div className={ columnClasses } >
+    <div className={ `carbon-column ${props.className}` }>
       { props.children }
     </div>
   );

--- a/src/components/row/row.js
+++ b/src/components/row/row.js
@@ -105,7 +105,7 @@ class Row extends React.Component {
      * This functionality is maintaining the deprecated behaviour
      * where Row can have any immediate children. As of React 16 this
      * will break and therefore we have added a column component to deal
-     * with the complications and maintian functionality.
+     * with the complications and maintain functionality.
      *
      * Removing the deprecated behaviour in Carbon v2 we can likely
      * remove the buildColumns and buildColumn function and just render the Row's
@@ -113,17 +113,21 @@ class Row extends React.Component {
      *
      * TODO: CarbonV2
      */
+    let columnClasses = classNames(
+      "carbon-row__column",
+      child.props.className, {
+        [`carbon-row__column--offset-${child.props.columnOffset}`]: child.props.columnOffset,
+        [`carbon-row__column--span-${child.props.columnSpan}`]: child.props.columnSpan,
+        [`carbon-row__column--align-${child.props.columnAlign}`]: child.props.columnAlign,
+        "carbon-row__column--column-divide": this.props.columnDivide
+      }
+    );
 
-    if (child.type === Column) {
-      return React.cloneElement(child, { key: key, columnDivide: this.props.columnDivide }, child.props.children);
-    } else {
+    if (child.type !== Column) {
       Logger.deprecate('Row Component should only have an immediate child of type Column');
-      return (
-        <Column key={ key } { ...child.props } columnDivide={ this.props.columnDivide }>
-          { child }
-        </Column>
-      );
     }
+
+    return React.cloneElement(child, { className: columnClasses, key: key }, child.props.children);
   }
 
   /**

--- a/src/components/row/row.scss
+++ b/src/components/row/row.scss
@@ -19,11 +19,11 @@ $sizes: ("extra-small", $grid-margin-extra-small),
       margin-bottom: -($size);
       margin-left: -($size);
 
-      > .carbon-column {
+      > .carbon-row__column {
         margin-bottom: $size;
         padding-left: $size;
 
-        &.carbon-column--column-divide {
+        &.carbon-row__column--column-divide {
           position: relative;
 
           &:before {
@@ -44,18 +44,18 @@ $sizes: ("extra-small", $grid-margin-extra-small),
     }
   }
 
-  .carbon-column {
+  .carbon-row__column {
     box-sizing: border-box;
     float: left;
     min-height: 1px;
     width: 100%;
 
-    &.carbon-column--align-center,
-    &.carbon-column--align-middle {
+    &.carbon-row__column--align-center,
+    &.carbon-row__column--align-middle {
       text-align: center;
     }
 
-    &.carbon-column--align-right {
+    &.carbon-row__column--align-right {
       text-align: right;
     }
   }
@@ -64,7 +64,7 @@ $sizes: ("extra-small", $grid-margin-extra-small),
     $width: 100% / $i;
 
     &.carbon-row--columns-#{$i} {
-      > .carbon-column {
+      > .carbon-row__column {
         width: $width;
 
         &:nth-child(#{$i}n+1) {
@@ -75,7 +75,7 @@ $sizes: ("extra-small", $grid-margin-extra-small),
       // span columns:
       @for $y from 2 through $i {
         @if $y != $i {
-          > .carbon-column--span-#{$y} {
+          > .carbon-row__column--span-#{$y} {
             width: (100% / $i) * $y;
           }
         }
@@ -84,7 +84,7 @@ $sizes: ("extra-small", $grid-margin-extra-small),
       // offset columns:
       @for $y from 1 through $i {
         @if $y != $i {
-          > .carbon-column--offset-#{$y} {
+          > .carbon-row__column--offset-#{$y} {
             margin-left: $width * $y;
           }
         }


### PR DESCRIPTION
## Description

* Deprecation was wrapping in a Column and causing double classes to be added, as well as creating a possibility of styles clashing due to unexpected HTML structure changes (breaking change).
* It turned out to be easier just to remove this wrapper and roll back the classes in Row

## Todo

- [x] release notes - not required, this is a patch on v1

## QA Steps

* This fixed the build in an app
* Should be sense checked in the demo site
