### PR TITLE
Final column update

### DIFF
--- a/lib/components/row/row.js
+++ b/lib/components/row/row.js
@@ -136,9 +136,15 @@ var Row = _wrapComponent('Row')((_temp2 = _class = function (_React$Component) {
 
       if (child.type !== _column2.default) {
         _logger2.default.deprecate('Row Component should only have an immediate child of type Column');
-      }
 
-      return _react3.default.cloneElement(child, { className: columnClasses, key: key }, child.props.children);
+        return _react3.default.createElement(
+          'div',
+          { key: key, className: columnClasses },
+          child
+        );
+      } else {
+        _react3.default.cloneElement(child, { className: columnClasses, key: key }, child.props.children);
+      }
     }, _temp), _possibleConstructorReturn(_this, _ret);
   }
 

--- a/src/components/row/row.js
+++ b/src/components/row/row.js
@@ -125,9 +125,15 @@ class Row extends React.Component {
 
     if (child.type !== Column) {
       Logger.deprecate('Row Component should only have an immediate child of type Column');
-    }
 
-    return React.cloneElement(child, { className: columnClasses, key: key }, child.props.children);
+      return (
+        <div key={ key } className={ columnClasses }>
+          { child }
+        </div>
+      );
+    } else {
+      return React.cloneElement(child, { className: columnClasses, key: key }, child.props.children);
+    }
   }
 
   /**


### PR DESCRIPTION
As part of the Row Column change we have kept the existing functionality as deprecated. In the transition to this new way we have lost the wrapping div around the rows children that some apps will rely on for specs.

This div has been re-added

Before refactor - https://github.com/Sage/carbon/blob/v0.36.3/src/components/row/row.js#L102-L106


No Release notes required