### PR TITLE
Refactor Form Buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ The following utils have had minor internal changes to satisfy the introduction 
 * `TableHeader`: improve accessibility of sortable columns. They can now receive focus via the keyboard, and include `aria-sort` and `aria-label` attributes to indicate they are sortable, the current sort direction, and which direction the column will be sorted when sorting is next activated.
 * `Browser`: add a new method `setInputFocus` to focus on the input field of passed in ref but does not select text
 * `MenuItem`: focus outline is now fully visible when an item is focused.
+* `Form` now has default `SaveButton` and `CancelButton` functional stateless componenents. The former can be overriden with a new prop of `customSaveButton`.
 
 ## Deployment Changes
 
@@ -111,7 +112,6 @@ You can now pass `--cdn` to the gulp task to bundle assets pointing towards the 
 * `Dropdown`: Options list is always rendered to the DOM, but is hidden until selected
 * `Textarea` now accepts a new prop `warnOverLimit` to display the character count message in red.
 * Simplify character count in `Textarea`.
-* `Form` now has default `SaveButton` and `CancelButton` functional stateless componenents. The former can be overriden with a new prop of `customSaveButton`.
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ You can now pass `--cdn` to the gulp task to bundle assets pointing towards the 
 * `Dropdown`: Options list is always rendered to the DOM, but is hidden until selected
 * `Textarea` now accepts a new prop `warnOverLimit` to display the character count message in red.
 * Simplify character count in `Textarea`.
+* `Form` now has default `SaveButton` and `CancelButton` functional stateless componenents. The former can be overriden with a new prop of `customSaveButton`.
 
 ## Bug Fixes
 

--- a/src/components/form/__spec__.js
+++ b/src/components/form/__spec__.js
@@ -9,13 +9,12 @@ import Dialog from './../dialog';
 import I18n from "i18n-js";
 import CancelButton from './cancel-button';
 import SaveButton from './save-button';
+import FormSummary from './form-summary';
 import Button from './../button';
 import MultiActionButton from './../multi-action-button';
 
 import { mount, shallow } from 'enzyme';
 import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
-
-import FormSummary from './form-summary';
 
 describe('Form', () => {
   let instance, wrapper;
@@ -451,6 +450,12 @@ describe('Form', () => {
             expect(saveButton.prop('errors')).toEqual(2);
             expect(saveButton.prop('warnings')).toEqual(3);
           });
+
+          it('renders a form summary with expected props', () => {
+            let summary = wrapper.find(FormSummary);
+            expect(summary.prop('errors')).toEqual(2)
+            expect(summary.prop('warnings')).toEqual(3)
+          });
         });
 
         describe('when an additional save button is passed in', () => {
@@ -489,6 +494,22 @@ describe('Form', () => {
         it('does show a cancel button', () => {
           let wrapper = shallow(<Form />);
           expect(wrapper.find(CancelButton).length).toEqual(1);
+        });
+      });
+    });
+
+    describe('Summary', () => {
+      describe('when showSummary prop is false', () => {
+        it('does not show a form summary', () => {
+          let wrapper = shallow(<Form showSummary={ false } />);
+          expect(wrapper.find(FormSummary).length).toEqual(0);
+        });
+      });
+
+      describe('when showSummary prop is true (default)', () => {
+        it('does show a form summary', () => {
+          let wrapper = shallow(<Form />);
+          expect(wrapper.find(FormSummary).length).toEqual(1);
         });
       });
     });

--- a/src/components/form/__spec__.js
+++ b/src/components/form/__spec__.js
@@ -461,7 +461,7 @@ describe('Form', () => {
         describe('when an additional save button is passed in', () => {
           beforeEach(() => {
             let customButton = (<Button className='my-custom-class'>Save</Button>)
-            wrapper = mount(
+            wrapper = shallow(
               <Form
                 cancelText='Some custom text'
                 saveText='Some custom save text'

--- a/src/components/form/__spec__.js
+++ b/src/components/form/__spec__.js
@@ -7,14 +7,18 @@ import Validation from './../../utils/validations/presence';
 import ImmutableHelper from './../../utils/helpers/immutable';
 import Dialog from './../dialog';
 import I18n from "i18n-js";
+import CancelButton from './cancel-button';
+import SaveButton from './save-button';
+import Button from './../button';
+import MultiActionButton from './../multi-action-button';
 
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
 
 import FormSummary from './form-summary';
 
 describe('Form', () => {
-  let instance;
+  let instance, wrapper;
 
   beforeEach(() => {
     instance = TestUtils.renderIntoDocument(
@@ -407,67 +411,68 @@ describe('Form', () => {
       let buttonContainers;
 
       beforeEach(() => {
-        buttons = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'button')
-        buttonContainers = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'div');
+        wrapper = mount(<Form />)
+        buttons = wrapper.find(Button)
+        buttonContainers = TestUtils.scryRenderedDOMComponentsWithTag(wrapper, 'div');
       });
 
-      it('renders two buttons', () => {
-        expect(buttons.length).toEqual(2);
-      });
-
-      it('renders a secondary cancel button with cancelClasses', () => {
-        TestUtils.findRenderedDOMComponentWithClass(instance, 'carbon-form__cancel');
-        expect(buttons[1].className).toMatch('carbon-button carbon-button--secondary');
-      });
-
-      it('when cancelText prop is passed it renders the secondary button with the prop', () => {
-        instance = TestUtils.renderIntoDocument(
-          <Form cancelText={'Foo'} />
-        );
-        buttons = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'button')
-        expect(buttons[1].innerHTML).toEqual('Foo');
-      });
-
-      it('when cancelText prop is not passed it renders the secondary button with default text', () => {
-        expect(buttons[1].innerHTML).toEqual(
-          I18n.t('actions.cancel', { defaultValue: 'Cancel' })
-        );
-      });
-
-      it('renders a primary save button with saveClasses', () => {
-        expect(buttons[0].className).toMatch('carbon-button carbon-button--primary');
-        expect(buttonContainers[1].className).toEqual('carbon-form__save');
-      });
-
-      it('renders an undisabled save button if not submitting', () => {
-        expect(buttons[0].disabled).toBeFalsy();
-      });
-
-      it('renders a disabled save button if saving', () => {
-        instance = TestUtils.renderIntoDocument(
-          <Form saving={true} />
-        );
-        buttons = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'button')
-        expect(buttons[0].disabled).toBeTruthy();
-      });
-
-      describe('when saveButtonProps is passed', () => {
-        it('sets save button props', () => {
-          let theme = 'magenta';
-
-          instance = TestUtils.renderIntoDocument(<Form saveButtonProps={ { theme: theme } } />);
-          buttons = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'button')
-          expect(buttons[0].className).toContain(`carbon-button--${theme}`);
+      describe('the save button', () => {
+        it('by default it renders a save button', () => {
+          expect(wrapper.find('.carbon-form-save').exists()).toBeTruthy();
         });
       });
 
-      describe('when cancelButtonProps is passed', () => {
-        it('sets cancel button props', () => {
-          let theme = 'red';
+      describe('the buttons', () => {
+        let wrapper;
 
-          instance = TestUtils.renderIntoDocument(<Form cancelButtonProps={ { theme: theme } } />);
-          buttons = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'button')
-          expect(buttons[1].className).toContain(`carbon-button--${theme}`);
+        describe('when no additional buttons are passed in', () => {
+          beforeEach(() => {
+            wrapper = shallow(
+              <Form
+                cancelText='Some custom text'
+                saveText='Some custom save text'
+                saving={ false }
+                saveButtonProps={ { theme: 'red' } }
+              />
+            )
+            wrapper.setState({ errorCount: 2, warningCount: 3 });
+          });
+
+          it('renders a cancel button with expected props', () => {
+            let cancelButton = wrapper.find(CancelButton);
+            expect(cancelButton.prop('cancelText')).toEqual('Some custom text')
+          });
+
+          it('renders a save button with expected props', () => {
+            let saveButton = wrapper.find(SaveButton);
+            expect(saveButton.prop('saveText')).toEqual('Some custom save text');
+            expect(saveButton.prop('saving')).toBeFalsy();
+            expect(saveButton.prop('saveButtonProps')).toEqual({ theme: 'red' })
+            expect(saveButton.prop('errors')).toEqual(2);
+            expect(saveButton.prop('warnings')).toEqual(3);
+          });
+        });
+
+        describe('when an additional save button is passed in', () => {
+          beforeEach(() => {
+            let customButton = (<Button className='my-custom-class'>Save</Button>)
+            wrapper = mount(
+              <Form
+                cancelText='Some custom text'
+                saveText='Some custom save text'
+                saving={ false }
+                customSaveButton={ customButton }
+              />
+            )
+          });
+
+          it('does not render the standard SaveButton', () => {
+            expect(wrapper.find(SaveButton).exists()).toBeFalsy();
+          });
+
+          it('renders a custom save button with expected props', () => {
+            expect(wrapper.find('.my-custom-class').length).toEqual(1);
+          });
         });
       });
     });
@@ -475,33 +480,31 @@ describe('Form', () => {
     describe('Cancel Button', () => {
       describe('when cancel prop is false', () => {
         it('does not show a cancel button', () => {
-          let instance = TestUtils.renderIntoDocument(<Form cancel={ false } />);
-          let buttons = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'button');
-          expect(buttons.length).toEqual(1);
+          let wrapper = shallow(<Form cancel={ false } />);
+          expect(wrapper.find(CancelButton).length).toEqual(0);
         });
       });
 
       describe('when cancel props is true (default)', () => {
         it('does show a cancel button', () => {
-          let buttons = TestUtils.findRenderedDOMComponentWithClass(instance, 'carbon-form__cancel');
-          expect(buttons).toBeDefined();
+          let wrapper = shallow(<Form />);
+          expect(wrapper.find(CancelButton).length).toEqual(1);
         });
       });
     });
 
     describe('Save Button', () => {
-      describe('when save is true or is not set to false', () => {
-        it('shows a save button', () => {
-          let instance = TestUtils.renderIntoDocument(<Form save={ true }/>);
-          let button = TestUtils.findRenderedDOMComponentWithClass(instance, 'carbon-form__save')
+      describe('when save prop is false', () => {
+        it('does not show a save button', () => {
+          let wrapper = shallow(<Form save={ false } />);
+          expect(wrapper.find(SaveButton).length).toEqual(0);
         });
       });
 
-      describe('when save is set to false', () => {
-        it('does not show a save button', () => {
-          let instance = TestUtils.renderIntoDocument(<Form save={ false }/>);
-          let buttons = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'button');
-          expect(buttons.length).toEqual(1);
+      describe('when save props is true (default)', () => {
+        it('does show a save button', () => {
+          let wrapper = shallow(<Form />);
+          expect(wrapper.find(SaveButton).length).toEqual(1);
         });
       });
     });
@@ -522,53 +525,6 @@ describe('Form', () => {
       });
     });
 
-    describe("Error reporting on buttons", () => {
-      let wrapper;
-
-      beforeEach(() => wrapper = shallow(<Form />))
-
-      describe('errorMessage', () => {
-        beforeEach(() => wrapper.setState({ errorCount: 2}));
-
-        it('renders FormSummary with 2 errors', () => {
-          let formSummary = wrapper.find(FormSummary);
-          expect(formSummary.prop('errors')).toEqual(2);
-          expect(formSummary.prop('warnings')).toEqual(0);
-        });
-
-        it('adds BEM modifier for invalid state on the save button', () => {
-          expect(wrapper.find('.carbon-form__save.carbon-form__save--invalid').length).toEqual(1);
-        });
-      });
-
-      describe('warningMessage', () => {
-        beforeEach(() => wrapper.setState({ warningCount: 2 }));
-
-        it('renders FormSummary with 2 warnings', () => {
-          let formSummary = wrapper.find(FormSummary);
-          expect(formSummary.prop('errors')).toEqual(0);
-          expect(formSummary.prop('warnings')).toEqual(2);
-        });
-
-        it('adds BEM modifier for invalid state on the save button', () => {
-          expect(wrapper.find('.carbon-form__save.carbon-form__save--invalid').length).toEqual(1);
-        });
-      });
-
-      describe('warning and error message', () => {
-        beforeEach(() => wrapper.setState({ errorCount: 2, warningCount: 2 }));
-
-        it('renders FormSummary with 2 errros and 2 warnings', () => {
-          let formSummary = wrapper.find(FormSummary);
-          expect(formSummary.prop('errors')).toEqual(2);
-          expect(formSummary.prop('warnings')).toEqual(2);
-        });
-
-        it('adds BEM modifier for invalid state on the save button', () => {
-          expect(wrapper.find('.carbon-form__save.carbon-form__save--invalid').length).toEqual(1);
-        });
-      });
-    });
   });
 
   describe("tags", () => {
@@ -578,15 +534,6 @@ describe('Form', () => {
       it('include correct component, element and role data tags', () => {
         rootTagTest(wrapper, 'form', 'bar', 'baz');
       });
-    });
-
-    describe("on internal elements", () => {
-      let wrapper = shallow(<Form />);
-
-      elementsTagTest(wrapper, [
-        'cancel',
-        'save',
-      ]);
     });
   });
 });

--- a/src/components/form/cancel-button/__spec__.js
+++ b/src/components/form/cancel-button/__spec__.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { elementsTagTest, rootTagTest } from '../../../utils/helpers/tags/tags-specs';
+import { shallow } from 'enzyme';
+import CancelButton from './cancel-button';
+import Button from './../../button';
+
+describe('CancelButton', () => {
+ let wrapper, clickSpy;
+
+ beforeEach(() => {
+   wrapper = shallow(
+     <CancelButton
+       cancelText='This is a cancel button'
+     />
+   );
+ });
+
+  describe('the standard class', () => {
+    it('renders it', () => {
+      let button = wrapper.find('.carbon-form-cancel__button');
+      expect(wrapper.hasClass('carbon-form-cancel')).toBeTruthy();
+    });
+  });
+
+  describe('the save text', () => {
+    describe('when custom saveText is passed in', () => {
+      it('renders it', () => {
+        let button = wrapper.find('.carbon-form-cancel__button');
+        expect(button.prop('children')).toEqual('This is a cancel button');
+      });
+    });
+
+    describe('when no custom text is passed in', () => {
+       beforeEach(() => {
+         wrapper = shallow(<CancelButton />);
+       });
+
+      it('renders the default', () => {
+        let button = wrapper.find('.carbon-form-cancel__button');
+        expect(button.prop('children')).toEqual('Cancel');
+      });
+    });
+  });
+
+  describe('the button classes', () => {
+    describe('when a custom class is passed in', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+         <CancelButton
+           cancelButtonProps={ { className: 'my-custom-button-class' } }
+         />
+       );
+     });
+
+      it('outputs it', () => {
+        expect(wrapper.find('.my-custom-button-class').exists()).toBeTruthy;
+        expect(wrapper.find('.carbon-form-cancel__button')).toBeFalsy;
+      });
+    });
+  });
+
+  describe('clicking cancel', () => {
+    describe('when the onClick event has been provided', () => {
+      beforeEach(() => {
+        clickSpy = jasmine.createSpy('clickSpy')
+        wrapper = shallow(
+         <CancelButton
+           cancelClick={ clickSpy }
+         />
+        );
+      });
+
+      it('is triggered on click', () => {
+       let button = wrapper.find('.carbon-form-cancel__button')
+       expect(button.prop('onClick')).toEqual(clickSpy)
+      });
+    });
+  });
+
+  describe("tags", () => {
+    describe("on component", () => {
+      let wrapper = shallow(<CancelButton data-element='bar' data-role='baz' />);
+
+      it('include correct component, element and role data tags', () => {
+        rootTagTest(wrapper, 'cancel', 'bar', 'baz');
+      });
+    });
+  });
+});

--- a/src/components/form/cancel-button/__spec__.js
+++ b/src/components/form/cancel-button/__spec__.js
@@ -5,7 +5,7 @@ import CancelButton from './cancel-button';
 import Button from './../../button';
 
 describe('CancelButton', () => {
-  let wrapper, clickSpy;
+  let wrapper, clickFunction;
 
   beforeEach(() => {
     wrapper = shallow(<CancelButton/>);
@@ -44,15 +44,15 @@ describe('CancelButton', () => {
   });
 
   it('adds the onClick prop to the button', () => {
-    clickSpy = jasmine.createSpy('clickSpy')
+    clickFunction = () => { };
     wrapper = shallow(
       <CancelButton
-        cancelClick={ clickSpy }
+        cancelClick={ clickFunction }
       />
     );
 
     let button = wrapper.find('.carbon-form-cancel__button')
-    expect(button.prop('onClick')).toEqual(clickSpy)
+    expect(button.prop('onClick')).toEqual(clickFunction)
   });
 
   describe("tags", () => {

--- a/src/components/form/cancel-button/__spec__.js
+++ b/src/components/form/cancel-button/__spec__.js
@@ -5,76 +5,54 @@ import CancelButton from './cancel-button';
 import Button from './../../button';
 
 describe('CancelButton', () => {
- let wrapper, clickSpy;
+  let wrapper, clickSpy;
 
- beforeEach(() => {
-   wrapper = shallow(
-     <CancelButton
-       cancelText='This is a cancel button'
-     />
-   );
- });
-
-  describe('the standard class', () => {
-    it('renders it', () => {
-      let button = wrapper.find('.carbon-form-cancel__button');
-      expect(wrapper.hasClass('carbon-form-cancel')).toBeTruthy();
-    });
+  beforeEach(() => {
+    wrapper = shallow(<CancelButton/>);
   });
 
-  describe('the save text', () => {
-    describe('when custom saveText is passed in', () => {
-      it('renders it', () => {
-        let button = wrapper.find('.carbon-form-cancel__button');
-        expect(button.prop('children')).toEqual('This is a cancel button');
-      });
-    });
-
-    describe('when no custom text is passed in', () => {
-       beforeEach(() => {
-         wrapper = shallow(<CancelButton />);
-       });
-
-      it('renders the default', () => {
-        let button = wrapper.find('.carbon-form-cancel__button');
-        expect(button.prop('children')).toEqual('Cancel');
-      });
-    });
+  it('renders the standard class', () => {
+    let button = wrapper.find('.carbon-form-cancel__button');
+    expect(wrapper.hasClass('carbon-form-cancel')).toBeTruthy();
   });
 
-  describe('the button classes', () => {
-    describe('when a custom class is passed in', () => {
-      beforeEach(() => {
-        wrapper = shallow(
-         <CancelButton
-           cancelButtonProps={ { className: 'my-custom-button-class' } }
-         />
-       );
-     });
+  it('renders a custom class if provided', () => {
+    wrapper = shallow(
+      <CancelButton
+        cancelButtonProps={ { className: 'my-custom-button-class' } }
+      />
+    );
 
-      it('outputs it', () => {
-        expect(wrapper.find('.my-custom-button-class').exists()).toBeTruthy;
-        expect(wrapper.find('.carbon-form-cancel__button')).toBeFalsy;
-      });
-    });
+    expect(wrapper.find('.my-custom-button-class').exists()).toBeTruthy;
+    expect(wrapper.find('.carbon-form-cancel__button')).toBeFalsy;
   });
 
-  describe('clicking cancel', () => {
-    describe('when the onClick event has been provided', () => {
-      beforeEach(() => {
-        clickSpy = jasmine.createSpy('clickSpy')
-        wrapper = shallow(
-         <CancelButton
-           cancelClick={ clickSpy }
-         />
-        );
-      });
+  it('renders the default text', () => {
+    let button = wrapper.find('.carbon-form-cancel__button');
+    expect(button.prop('children')).toEqual('Cancel');
+  });
 
-      it('is triggered on click', () => {
-       let button = wrapper.find('.carbon-form-cancel__button')
-       expect(button.prop('onClick')).toEqual(clickSpy)
-      });
-    });
+  it('renders custom text when provided', () => {
+    wrapper = shallow(
+       <CancelButton
+         cancelText='This is a cancel button'
+       />
+     );
+
+    let button = wrapper.find('.carbon-form-cancel__button');
+    expect(button.prop('children')).toEqual('This is a cancel button');
+  });
+
+  it('adds the onClick prop to the button', () => {
+    clickSpy = jasmine.createSpy('clickSpy')
+    wrapper = shallow(
+      <CancelButton
+        cancelClick={ clickSpy }
+      />
+    );
+
+    let button = wrapper.find('.carbon-form-cancel__button')
+    expect(button.prop('onClick')).toEqual(clickSpy)
   });
 
   describe("tags", () => {

--- a/src/components/form/cancel-button/cancel-button.js
+++ b/src/components/form/cancel-button/cancel-button.js
@@ -1,0 +1,27 @@
+import I18n from "i18n-js";
+import React from 'react';
+import { tagComponent } from '../../../utils/helpers/tags';
+import Button from './../../button';
+
+const CancelButton = (props) =>
+  <div className="carbon-form-cancel" { ...tagComponent('cancel', props) }>
+    <Button { ...cancelButtonProps(props) } data-element='cancel'>
+       { cancelText(props) }
+    </Button>
+  </div>
+;
+
+const cancelButtonProps = (props) => {
+  return({
+    onClick: props.cancelClick,
+    type: 'button',
+    className: 'carbon-form-cancel__button',
+    ...props.cancelButtonProps
+  });
+};
+
+const cancelText = (props) => {
+  return props.cancelText || I18n.t('actions.cancel', { defaultValue: 'Cancel' });
+};
+
+export default CancelButton;

--- a/src/components/form/cancel-button/cancel-button.js
+++ b/src/components/form/cancel-button/cancel-button.js
@@ -1,18 +1,18 @@
-import I18n from "i18n-js";
+import I18n from 'i18n-js';
 import React from 'react';
 import { tagComponent } from '../../../utils/helpers/tags';
 import Button from './../../button';
 
-const CancelButton = (props) =>
-  <div className="carbon-form-cancel" { ...tagComponent('cancel', props) }>
+const CancelButton = props =>
+  <div className='carbon-form-cancel' { ...tagComponent('cancel', props) }>
     <Button { ...cancelButtonProps(props) } data-element='cancel'>
-       { cancelText(props) }
+      { cancelText(props) }
     </Button>
   </div>
 ;
 
 const cancelButtonProps = (props) => {
-  return({
+  return ({
     onClick: props.cancelClick,
     type: 'button',
     className: 'carbon-form-cancel__button',

--- a/src/components/form/cancel-button/package.json
+++ b/src/components/form/cancel-button/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "./cancel-button.js"
+}

--- a/src/components/form/definition.js
+++ b/src/components/form/definition.js
@@ -19,12 +19,14 @@ let definition = new Definition('form', Form, {
   relatedComponentsNotes: `
 * Editing a number of closely related inputs? [Try Fieldset](/components/fieldset).
  `,
-  hiddenProps: ["validateOnMount", "saveButtonProps", "cancelButtonProps"],
+  hiddenProps: ["validateOnMount", "saveButtonProps", "cancelButtonProps", "customSaveButton", "children"],
   propOptions: {
     buttonAlign: OptionsHelper.alignBinary
   },
   propTypes: {
     cancel: "Boolean",
+    children: "Node",
+    className: "String",
     afterFormValidation: "Function",
     beforeFormValidation: "Function",
     buttonAlign: "String",
@@ -32,6 +34,7 @@ let definition = new Definition('form', Form, {
     validateOnMount: "Boolean",
     cancelText: "String",
     cancelButtonProps: "Object",
+    customSaveButton: "Object",
     saveText: "String",
     saveButtonProps: "Object",
     onCancel: "Function",
@@ -42,6 +45,7 @@ let definition = new Definition('form', Form, {
   },
   propDescriptions: {
     cancel: "Set to false to hide the cancel button.",
+    children: "This component supports children.",
     afterFormValidation: "A callback triggered after the validation has been ran on the form.",
     beforeFormValidation: "A callback triggered before the validation has been ran on the form.",
     buttonAlign: "Controls which direction the form buttons align.",
@@ -49,6 +53,7 @@ let definition = new Definition('form', Form, {
     validateOnMount: "Determines if validation should be ran on mount of the component.",
     cancelText: "Supply custom text for the cancel button.",
     cancelButtonProps: "Supply custom props to the cancel button.",
+    customSaveButton: "Supply a custom Save button which overrides the standard button",
     saveText: "Supply custom text for the save button.",
     saveButtonProps: "Supply custom props for the save button.",
     onCancel: "A callback triggered when the form is cancelled.",

--- a/src/components/form/definition.js
+++ b/src/components/form/definition.js
@@ -37,7 +37,8 @@ let definition = new Definition('form', Form, {
     onCancel: "Function",
     save: "Boolean",
     additionalActions: "Node",
-    onSubmit: "Function"
+    onSubmit: "Function",
+    iterative: "Boolean",
   },
   propDescriptions: {
     cancel: "Set to false to hide the cancel button.",
@@ -53,7 +54,8 @@ let definition = new Definition('form', Form, {
     onCancel: "A callback triggered when the form is cancelled.",
     save: "Set to false to hide the save button.",
     additionalActions: "Supply additional buttons alongside the form's buttons.",
-    onSubmit: "A callback triggered when the form is submitted with passing validation."
+    onSubmit: "A callback triggered when the form is submitted with passing validation.",
+    iterative: "A flag for when the user should be able to repeatedly save & re-use a form."
   },
   propValues: {
     activeInput: '',

--- a/src/components/form/definition.js
+++ b/src/components/form/definition.js
@@ -42,6 +42,7 @@ let definition = new Definition('form', Form, {
     additionalActions: "Node",
     onSubmit: "Function",
     iterative: "Boolean",
+    summary: "Boolean",
   },
   propDescriptions: {
     cancel: "Set to false to hide the cancel button.",
@@ -60,7 +61,8 @@ let definition = new Definition('form', Form, {
     save: "Set to false to hide the save button.",
     additionalActions: "Supply additional buttons alongside the form's buttons.",
     onSubmit: "A callback triggered when the form is submitted with passing validation.",
-    iterative: "A flag for when the user should be able to repeatedly save & re-use a form."
+    iterative: "A flag for when the user should be able to repeatedly save & re-use a form.",
+    summary: "Set to false to hide the summary"
   },
   propValues: {
     activeInput: '',

--- a/src/components/form/form-summary/form-summary.js
+++ b/src/components/form/form-summary/form-summary.js
@@ -117,7 +117,7 @@ const summary = (props, key) => {
   if (props[pluralize(key)] > 0) {
     return (
       <span className={ `carbon-form-summary__summary carbon-form-summary__${key}-summary` }>
-        <Icon className='carbon-form-summary__icon' type={ `${key}` } />
+        <Icon className='carbon-form-summary__icon' type={ key } />
         <span
           className='carbon-form-summary__text'
           data-element={ pluralize(key) }

--- a/src/components/form/form-summary/form-summary.js
+++ b/src/components/form/form-summary/form-summary.js
@@ -24,25 +24,13 @@ FormSummary.propTypes = {
 };
 
 /**
- * builds a summary in JSX
+ * Adds an 's' to pluralise (keys will always be error or warning)
  *
- * @param {object} props
  * @param {string} key
- * @return {JSX}
+ * @return {string} pluralized key
  */
-const summary = (props, key) => {
-  if (props[pluralize(key)] > 0) {
-    return (
-      <span className={ `carbon-form-summary__summary carbon-form-summary__${key}-summary` }>
-        <Icon className='carbon-form-summary__icon' type={ `${key}` } />
-        <span
-          className='carbon-form-summary__text'
-          data-element={ pluralize(key) }
-          dangerouslySetInnerHTML={{ __html: translation(props, key) }}
-        />
-      </span>
-    );
-  }
+const pluralize = (key) => {
+  return `${key}s`;
 };
 
 /**
@@ -56,36 +44,37 @@ const defaultTranslations = (errorCount, warningCount) => {
   return {
     errors: {
       defaultValue: {
-        one: `There is ${ errorCount } error`,
-        other: `There are ${ errorCount } errors`
+        one: `There is ${errorCount} error`,
+        other: `There are ${errorCount} errors`
       },
-      count: parseInt(errorCount)
+      count: parseInt(errorCount, 10)
     },
     warnings: {
       defaultValue: {
-        one: `There is ${ warningCount } warning`,
-        other: `There are ${ warningCount } warnings`
+        one: `There is ${warningCount} warning`,
+        other: `There are ${warningCount} warnings`
       },
-      count: parseInt(warningCount)
+      count: parseInt(warningCount, 10)
     },
     errors_and_warnings: {
       defaultValue: {
-        one: `and ${ warningCount } warning`,
-        other: `and ${ warningCount } warnings`
+        one: `and ${warningCount} warning`,
+        other: `and ${warningCount} warnings`
       },
-      count: parseInt(warningCount)
+      count: parseInt(warningCount, 10)
     }
   };
 };
 
 /**
- * Adds an 's' to pluralise (keys will always be error or warning)
+ * decides whether the warning message should be appended to the sentence or output as a sentence on it's own
  *
+ * @param {object} props
  * @param {string} key
- * @return {string} pluralized key
+ * @return {boolean} true if the warning message needs to be appended
  */
-const pluralize = (key) => {
-  return `${key}s`;
+const warningAppend = (props, key) => {
+  return props.errors > 0 && props.warnings > 0 && key === 'warning';
 };
 
 /**
@@ -107,23 +96,35 @@ const translationKey = (props, key) => {
  * @return {string} correct translation
  */
 const translation = (props, key) => {
-  key = translationKey(props, key);
+  const parsedKey = translationKey(props, key);
 
-  let defaultTranslation = defaultTranslations(props.errors, props.warnings)[key],
-      location = `errors.messages.form_summary.${key}`;
+  const defaultTranslation = defaultTranslations(props.errors, props.warnings)[parsedKey],
+      location = `errors.messages.form_summary.${parsedKey}`;
 
   return I18n.t(location, defaultTranslation);
 };
 
 /**
- * decides whether the warning message should be appended to the sentence or output as a sentence on it's own
+ * builds a summary in JSX
  *
  * @param {object} props
  * @param {string} key
- * @return {boolean} true if the warning message needs to be appended
+ * @return {JSX}
  */
-const warningAppend = (props, key) => {
-  return props.errors > 0 && props.warnings > 0 && key === 'warning';
+const summary = (props, key) => {
+  if (props[pluralize(key)] > 0) {
+    return (
+      <span className={ `carbon-form-summary__summary carbon-form-summary__${key}-summary` }>
+        <Icon className='carbon-form-summary__icon' type={ `${key}` } />
+        <span
+          className='carbon-form-summary__text'
+          data-element={ pluralize(key) }
+          dangerouslySetInnerHTML={ { __html: translation(props, key) } }
+        />
+      </span>
+    );
+  }
+  return null;
 };
 
 export default FormSummary;

--- a/src/components/form/form-summary/form-summary.js
+++ b/src/components/form/form-summary/form-summary.js
@@ -9,10 +9,12 @@ const FormSummary = props =>
   <div className='carbon-form-summary' { ...tagComponent('form-summary', props) }>
     { summary(props, 'error') }
     { summary(props, 'warning') }
+    { props.children }
   </div>
 ;
 
 FormSummary.propTypes = {
+  children: PropTypes.node,
   errors: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number

--- a/src/components/form/form-summary/form-summary.scss
+++ b/src/components/form/form-summary/form-summary.scss
@@ -1,10 +1,10 @@
 @import "./../../../style-config/colors";
 
 .carbon-form-summary {
-  display: inline-flex;
+  display: inline-block;
+  align-items: center;
   font-size: 13px;
   font-weight: 700;
-  padding: 0 3px;
   white-space: nowrap;
 
   &__summary {

--- a/src/components/form/form-summary/form-summary.scss
+++ b/src/components/form/form-summary/form-summary.scss
@@ -1,7 +1,7 @@
 @import "./../../../style-config/colors";
 
 .carbon-form-summary {
-  display: inline-block;
+  display: inline-flex;
   align-items: center;
   font-size: 13px;
   font-weight: 700;

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -4,6 +4,7 @@ import Serialize from 'form-serialize';
 import classNames from 'classnames';
 import CancelButton from './cancel-button';
 import SaveButton from './save-button';
+import FormSummary from './form-summary';
 import { validProps } from '../../utils/ether';
 import { tagComponent } from '../../utils/helpers/tags';
 
@@ -138,11 +139,11 @@ class Form extends React.Component {
     save: PropTypes.bool,
 
     /**
-    * Additional actions rendered next to the save and cancel buttons
-    *
-    * @property additionalActions
-    * @type {String|JSX}
-    */
+     * Additional actions rendered next to the save and cancel buttons
+     *
+     * @property additionalActions
+     * @type {String|JSX}
+     */
     additionalActions: PropTypes.node,
 
     /**
@@ -175,7 +176,15 @@ class Form extends React.Component {
      * @property children
      * @type {Node}
      */
-    children: PropTypes.node
+    children: PropTypes.node,
+
+    /**
+     * Hide or show the summary
+     *
+     * @property showSummary
+     * @type {Boolean}
+     */
+    showSummary: PropTypes.bool
   }
 
   static defaultProps = {
@@ -185,7 +194,8 @@ class Form extends React.Component {
     save: true,
     saving: false,
     validateOnMount: false,
-    customSaveButton: null
+    customSaveButton: null,
+    showSummary: true
   }
 
   static childContextTypes = {
@@ -566,15 +576,34 @@ class Form extends React.Component {
   }
 
   /**
-   * Returns the buttons for the form
+   * Returns a form summary
    *
-   * @method buttons
+   * @method saveButtonWithSummary
    * @return {Object} JSX
    */
-  buttons = () => {
+  saveButtonWithSummary = () => {
+    return (
+      <FormSummary
+        className='carbon-form__summary'
+        errors={ this.state.errorCount }
+        warnings={ this.state.warningCount }
+      >
+        { this.saveButton() }
+      </FormSummary>
+    );
+  }
+
+  /**
+   * Returns the footer for the form
+   *
+   * @method footer
+   * @return {Object} JSX
+   */
+  formFooter = () => {
+    const save = this.props.showSummary ? this.saveButtonWithSummary() : this.saveButton();
     return (
       <div>
-        { this.saveButton() }
+        { save }
         { this.cancelButton() }
       </div>
     );
@@ -599,10 +628,10 @@ class Form extends React.Component {
    * @method buttonClasses
    * @return {String} Main className
    */
-  get buttonClasses() {
+  get footerClasses() {
     return classNames(
-      'carbon-form__buttons',
-      `carbon-form__buttons--${this.props.buttonAlign}`
+      'carbon-form__footer',
+      `carbon-form__footer--${this.props.buttonAlign}`
     );
   }
 
@@ -624,8 +653,8 @@ class Form extends React.Component {
 
         { this.props.children }
 
-        <div className={ this.buttonClasses }>
-          { this.buttons() }
+        <div className={ this.footerClasses }>
+          { this.formFooter() }
           { this.additionalActions }
         </div>
       </form>

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -602,9 +602,10 @@ class Form extends React.Component {
   formFooter = () => {
     const save = this.props.showSummary ? this.saveButtonWithSummary() : this.saveButton();
     return (
-      <div>
+      <div className={ this.footerClasses }>
         { save }
         { this.cancelButton() }
+        { this.additionalActions }
       </div>
     );
   }
@@ -653,10 +654,7 @@ class Form extends React.Component {
 
         { this.props.children }
 
-        <div className={ this.footerClasses }>
-          { this.formFooter() }
-          { this.additionalActions }
-        </div>
+        { this.formFooter() }
       </form>
     );
   }

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Serialize from 'form-serialize';
+import classNames from 'classnames';
 import CancelButton from './cancel-button';
 import SaveButton from './save-button';
-import Serialize from "form-serialize";
-import classNames from 'classnames';
 import { validProps } from '../../utils/ether';
 import { tagComponent } from '../../utils/helpers/tags';
 
@@ -32,24 +32,6 @@ import { tagComponent } from '../../utils/helpers/tags';
  * @constructor
  */
 class Form extends React.Component {
-  /**
-   * stores the document - allows us to override it different contexts, such as
-   * when running tests.
-   *
-   * @property _document
-   * @type {document}
-   */
-  _document = document;
-
-  /**
-   * stores the window - allows us to override it different contexts, such as
-   * when running tests.
-   *
-   * @property _window
-   * @type {window}
-   */
-  _window = window;
-
   static propTypes = {
 
     /**
@@ -172,20 +154,28 @@ class Form extends React.Component {
     onSubmit: PropTypes.func,
 
     /**
-     * Currently active input in form
-     *
-     * @property activeInput
-     * @type {Node}
-     */
-    activeInput: PropTypes.node,
-
-    /**
      * Override Save Button
      *
      * @property customSaveButton
      * @type {Node}
      */
     customSaveButton: PropTypes.node,
+
+    /**
+     * A custom class name for the component.
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    /**
+     * Children elements
+     *
+     * @property children
+     * @type {Node}
+     */
+    children: PropTypes.node
   }
 
   static defaultProps = {
@@ -213,6 +203,24 @@ class Form extends React.Component {
     modal: PropTypes.object
   }
 
+  state = {
+    /**
+     * Tracks the number of errors in the form
+     *
+     * @property errorCount
+     * @type {Number}
+     */
+    errorCount: 0,
+
+    /**
+     * Tracks the number of warnings in the form
+     *
+     * @property warningCount
+     * @type {Number}
+     */
+    warningCount: 0
+  }
+
   /**
    * Returns form object to child components.
    *
@@ -234,6 +242,18 @@ class Form extends React.Component {
         validate: this.validate
       }
     };
+  }
+
+  /**
+   * Runs once the component has mounted.
+   *
+   * @method componentDidMount
+   * @return {void}
+   */
+  componentDidMount() {
+    if (this.props.validateOnMount) {
+      this.validate();
+    }
   }
 
   /**
@@ -262,30 +282,30 @@ class Form extends React.Component {
   }
 
   /**
+   * stores the document - allows us to override it different contexts, such as
+   * when running tests.
+   *
+   * @property _document
+   * @type {document}
+   */
+  _document = document;
+
+  /**
+   * stores the window - allows us to override it different contexts, such as
+   * when running tests.
+   *
+   * @property _window
+   * @type {window}
+   */
+  _window = window;
+
+  /**
    * @method activeInputHasValidation
    * @param {}
    * @return {Boolean} active input exists and is decorated with validation
    */
   activeInputExistsAndHasValidation = () => {
     return this.activeInput && this.activeInput.immediatelyHideMessage;
-  }
-
-  state = {
-    /**
-     * Tracks the number of errors in the form
-     *
-     * @property errorCount
-     * @type {Number}
-     */
-    errorCount: 0,
-
-    /**
-     * Tracks the number of warnings in the form
-     *
-     * @property warningCount
-     * @type {Number}
-     */
-    warningCount: 0
   }
 
   /**
@@ -313,18 +333,6 @@ class Form extends React.Component {
    * @type {Number}
    */
   warningCount = 0;
-
-  /**
-   * Runs once the component has mounted.
-   *
-   * @method componentDidMount
-   * @return {void}
-   */
-  componentDidMount() {
-    if (this.props.validateOnMount) {
-      this.validate();
-    }
-  }
 
   /**
    * Increase current error count in state by 1.
@@ -404,7 +412,7 @@ class Form extends React.Component {
       this.props.beforeFormValidation(ev);
     }
 
-    let valid = this.validate();
+    const valid = this.validate();
 
     if (!valid) { ev.preventDefault(); }
 
@@ -427,12 +435,12 @@ class Form extends React.Component {
     let valid = true,
         errors = 0;
 
-    for (let key in this.inputs) {
-      let input = this.inputs[key];
+    for (const key in this.inputs) {
+      const input = this.inputs[key];
 
       if (!input.props.disabled && !input.validate()) {
         valid = false;
-        errors++;
+        errors += 1;
       }
     }
 
@@ -450,7 +458,7 @@ class Form extends React.Component {
    * @return {Object} Serialized object of fields
    */
   serialize = (opts) => {
-    return Serialize(this.refs.form, opts);
+    return Serialize(this.form, opts);
   }
 
   /**
@@ -460,7 +468,7 @@ class Form extends React.Component {
    * @return {Object} props for form element
    */
   htmlProps = () => {
-    let { ...props } = validProps(this);
+    const { ...props } = validProps(this);
     delete props.activeInput;
     delete props.onSubmit;
     props.className = this.mainClasses;
@@ -496,7 +504,7 @@ class Form extends React.Component {
   cancelButton = () => {
     if (!this.props.cancel) { return null; }
 
-    let cancelProps = {
+    const cancelProps = {
       cancelText: this.props.cancelText,
       cancelClick: this.cancelForm,
       ...this.props.cancelButtonProps
@@ -533,7 +541,7 @@ class Form extends React.Component {
    * @return {Object} JSX
    */
   defaultSaveButton = () => {
-    return(
+    return (
       <SaveButton
         saveButtonProps={ this.props.saveButtonProps }
         saveText={ this.props.saveText }
@@ -594,7 +602,7 @@ class Form extends React.Component {
   get buttonClasses() {
     return classNames(
       'carbon-form__buttons',
-      `carbon-form__buttons--${ this.props.buttonAlign }`
+      `carbon-form__buttons--${this.props.buttonAlign}`
     );
   }
 
@@ -606,7 +614,12 @@ class Form extends React.Component {
    */
   render() {
     return (
-      <form onSubmit={ this.handleOnSubmit } { ...this.htmlProps() } ref="form" { ...tagComponent('form', this.props) }>
+      <form
+        onSubmit={ this.handleOnSubmit }
+        ref={ (c) => { this.form = c; } }
+        { ...this.htmlProps() }
+        { ...tagComponent('form', this.props) }
+      >
         { generateCSRFToken(this._document) }
 
         { this.props.children }
@@ -629,12 +642,11 @@ class Form extends React.Component {
  * @return {Object} JSX hidden CSRF token
  */
 function generateCSRFToken(doc) {
-  let meta = doc.getElementsByTagName('meta'),
-      csrfAttr,
-      csrfValue;
+  const meta = doc.getElementsByTagName('meta');
+  let csrfAttr, csrfValue;
 
-  for (var i = 0; i < meta.length; i++) {
-    var item = meta[i];
+  for (let i = 0; i < meta.length; i++) {
+    const item = meta[i];
 
     if (item.getAttribute('name') === 'csrf-param') {
       csrfAttr = item.getAttribute('content');
@@ -643,7 +655,7 @@ function generateCSRFToken(doc) {
     }
   }
 
-  return <input type="hidden" name={ csrfAttr } value={ csrfValue } readOnly="true" />;
+  return <input type='hidden' name={ csrfAttr } value={ csrfValue } readOnly='true' />;
 }
 
 export default Form;

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -5,23 +5,26 @@
   display: inline-block;
 }
 
-.carbon-form__buttons--right {
+.carbon-form__footer {
+  align-items: center;
   display: flex;
   flex-direction: row;
+  margin-top: 20px;
+}
+
+.carbon-form__footer--right {
   justify-content: flex-end;
 }
 
 .carbon-form-cancel {
   border-radius: 4px;
   display: inline-block;
-  margin-top: 20px;
   padding: 8px 0 8px 8px;
 }
 
 .carbon-form-save {
   border-radius: 4px;
   display: inline-block;
-  margin-top: 20px;
   padding: 8px;
 }
 

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -1,33 +1,30 @@
 @import "./../../style-config/colors";
 
-.carbon-form__save--invalid {
-  background-color: $grey-dark-blue-5;
-}
-
-.carbon-form__summary {
-  margin: 0 10px;
-}
-
-.carbon-form__save,
-.carbon-form__cancel {
-  border-radius: 4px;
-  display: inline-block;
-  margin-top: 20px;
-}
-
-.carbon-form__save {
-  padding: 8px;
-}
-
-.carbon-form__cancel {
-  padding: 8px 0 8px 8px;
-}
-
 .carbon-form__additional-actions {
   padding-left: 10px;
   display: inline-block;
 }
 
 .carbon-form__buttons--right {
-  text-align: right;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.carbon-form-cancel {
+  border-radius: 4px;
+  display: inline-block;
+  margin-top: 20px;
+  padding: 8px 0 8px 8px;
+}
+
+.carbon-form-save {
+  border-radius: 4px;
+  display: inline-block;
+  margin-top: 20px;
+  padding: 8px;
+}
+
+.carbon-form-save--invalid {
+  background-color: $grey-dark-blue-5;
 }

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -8,7 +8,6 @@
 .carbon-form__footer {
   align-items: center;
   display: flex;
-  flex-direction: row;
   margin-top: 20px;
 }
 
@@ -17,14 +16,10 @@
 }
 
 .carbon-form-cancel {
-  border-radius: 4px;
-  display: inline-block;
   padding: 8px 0 8px 8px;
 }
 
 .carbon-form-save {
-  border-radius: 4px;
-  display: inline-block;
   padding: 8px;
 }
 

--- a/src/components/form/save-button/__spec__.js
+++ b/src/components/form/save-button/__spec__.js
@@ -72,12 +72,6 @@ describe('SaveButton', () => {
       expect(wrapper.hasClass('carbon-form-save')).toBeTruthy();
       expect(wrapper.hasClass('carbon-form-save--invalid')).toBeTruthy();
     });
-
-    it('renders with form summary', () => {
-      let summary = wrapper.find('.carbon-form-save__summary');
-      expect(summary.prop('errors')).toEqual(2)
-      expect(summary.prop('warnings')).toEqual(1)
-    });
   });
 
   it('the button is enabled when the form is not saving', () => {

--- a/src/components/form/save-button/__spec__.js
+++ b/src/components/form/save-button/__spec__.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import { elementsTagTest, rootTagTest } from '../../../utils/helpers/tags/tags-specs';
+import { shallow, mount } from 'enzyme';
+import SaveButton from './save-button';
+import Button from './../../button';
+
+describe('SaveButton', () => {
+ let wrapper;
+
+ beforeEach(() => {
+   wrapper = shallow(
+     <SaveButton
+       saveText='This is a save button'
+       saving={ false }
+     />
+   );
+ });
+
+  describe('the save text', () => {
+    describe('when custom saveText is passed in', () => {
+      it('renders it', () => {
+        let button = wrapper.find('.carbon-form-save__button');
+        expect(button.prop('children')).toEqual('This is a save button');
+        expect(button.prop('disabled')).toBeFalsy();
+      });
+    });
+
+    describe('when no custom text is passed in', () => {
+       beforeEach(() => {
+         wrapper = shallow(<SaveButton saving={ false } />);
+       });
+
+      it('renders the default', () => {
+        let button = wrapper.find('.carbon-form-save__button');
+        expect(button.prop('children')).toEqual('Save');
+        expect(button.prop('disabled')).toBeFalsy();
+      });
+    });
+  });
+
+  describe('the button classes', () => {
+    describe('when a custom class is passed in', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+         <SaveButton
+           saveText='This a save button'
+           saving={ false }
+           saveButtonProps={ { className: 'my-custom-button-class' } }
+         />
+       );
+     });
+
+      it('outputs it', () => {
+        expect(wrapper.find('.my-custom-button-class').exists()).toBeTruthy;
+        expect(wrapper.find('.carbon-form-save__button')).toBeFalsy;
+      });
+    });
+  });
+
+  describe('when there are no errors or warnings', () => {
+    it('renders with a main class', () => {
+     expect(wrapper.find('.carbon-form-save').exists()).toBeTruthy();
+     expect(wrapper.find('.carbon-form-save--invalid').exists()).toBeFalsy();
+    });
+  });
+
+  describe('when there are errors or warnings', () => {
+    beforeEach(() => {
+      let errors = 2;
+      let warnings = 1;
+       wrapper = shallow(
+         <SaveButton
+           saveText='This a save'
+           errors={ errors }
+           warnings={ warnings }
+           saving={ false }
+         />
+       );
+     });
+
+    it('renders with a main class and invalid class', () => {
+      expect(wrapper.hasClass('carbon-form-save')).toBeTruthy();
+      expect(wrapper.hasClass('carbon-form-save--invalid')).toBeTruthy();
+    });
+
+    it('renders with form summary', () => {
+      let summary = wrapper.find('.carbon-form-save__summary');
+      expect(summary.prop('errors')).toEqual(2)
+      expect(summary.prop('warnings')).toEqual(1)
+    });
+  });
+
+  describe('the saving behaviour', () => {
+    describe('when the form is not saving', () => {
+      it('the button is enabled', () => {
+        expect(wrapper.props.disabled).toBeFalsy();
+      });
+    });
+
+    describe('when the form is saving', () => {
+      beforeEach(() => {
+       wrapper = shallow(
+         <SaveButton
+           saveText='This a save'
+           saving={ true }
+         />
+       );
+     });
+
+      it('the button is disabled', () => {
+        let button = wrapper.find('.carbon-form-save__button');
+        expect(button.prop('disabled')).toBeTruthy();
+      });
+    });
+  });
+
+  describe("tags", () => {
+    describe("on component", () => {
+      let wrapper = shallow(<SaveButton data-element='bar' data-role='baz' />);
+
+      it('include correct component, element and role data tags', () => {
+        rootTagTest(wrapper, 'save', 'bar', 'baz');
+      });
+    });
+  });
+});

--- a/src/components/form/save-button/__spec__.js
+++ b/src/components/form/save-button/__spec__.js
@@ -5,60 +5,51 @@ import SaveButton from './save-button';
 import Button from './../../button';
 
 describe('SaveButton', () => {
- let wrapper;
+  let wrapper;
 
- beforeEach(() => {
+  beforeEach(() => {
    wrapper = shallow(
      <SaveButton
-       saveText='This is a save button'
        saving={ false }
      />
    );
- });
-
-  describe('the save text', () => {
-    describe('when custom saveText is passed in', () => {
-      it('renders it', () => {
-        let button = wrapper.find('.carbon-form-save__button');
-        expect(button.prop('children')).toEqual('This is a save button');
-        expect(button.prop('disabled')).toBeFalsy();
-      });
-    });
-
-    describe('when no custom text is passed in', () => {
-       beforeEach(() => {
-         wrapper = shallow(<SaveButton saving={ false } />);
-       });
-
-      it('renders the default', () => {
-        let button = wrapper.find('.carbon-form-save__button');
-        expect(button.prop('children')).toEqual('Save');
-        expect(button.prop('disabled')).toBeFalsy();
-      });
-    });
   });
 
-  describe('the button classes', () => {
-    describe('when a custom class is passed in', () => {
-      beforeEach(() => {
-        wrapper = shallow(
-         <SaveButton
-           saveText='This a save button'
-           saving={ false }
-           saveButtonProps={ { className: 'my-custom-button-class' } }
-         />
-       );
-     });
+  it('renders the standard class', () => {
+    let button = wrapper.find('.carbon-form-save__button');
+    expect(wrapper.hasClass('carbon-form-save')).toBeTruthy();
+  });
 
-      it('outputs it', () => {
-        expect(wrapper.find('.my-custom-button-class').exists()).toBeTruthy;
-        expect(wrapper.find('.carbon-form-save__button')).toBeFalsy;
-      });
-    });
+  it('renders a custom class if provided', () => {
+    wrapper = shallow(
+      <SaveButton
+        saving={ false }
+        saveButtonProps={ { className: 'my-custom-button-class' } }
+      />
+    );
+
+    expect(wrapper.find('.my-custom-button-class').exists()).toBeTruthy;
+    expect(wrapper.find('.carbon-form-save__button')).toBeFalsy;
+  });
+
+  it('renders the default text', () => {
+    let button = wrapper.find('.carbon-form-save__button');
+    expect(button.prop('children')).toEqual('Save');
+  });
+
+  it('renders custom text when provided', () => {
+    wrapper = shallow(
+      <SaveButton
+        saveText='This is a save button'
+      />
+    );
+
+    let button = wrapper.find('.carbon-form-save__button');
+    expect(button.prop('children')).toEqual('This is a save button');
   });
 
   describe('when there are no errors or warnings', () => {
-    it('renders with a main class', () => {
+    it('renders with the expected class', () => {
      expect(wrapper.find('.carbon-form-save').exists()).toBeTruthy();
      expect(wrapper.find('.carbon-form-save--invalid').exists()).toBeFalsy();
     });
@@ -70,7 +61,6 @@ describe('SaveButton', () => {
       let warnings = 1;
        wrapper = shallow(
          <SaveButton
-           saveText='This a save'
            errors={ errors }
            warnings={ warnings }
            saving={ false }
@@ -78,7 +68,7 @@ describe('SaveButton', () => {
        );
      });
 
-    it('renders with a main class and invalid class', () => {
+    it('renders with a default and invalid class', () => {
       expect(wrapper.hasClass('carbon-form-save')).toBeTruthy();
       expect(wrapper.hasClass('carbon-form-save--invalid')).toBeTruthy();
     });
@@ -90,28 +80,19 @@ describe('SaveButton', () => {
     });
   });
 
-  describe('the saving behaviour', () => {
-    describe('when the form is not saving', () => {
-      it('the button is enabled', () => {
-        expect(wrapper.props.disabled).toBeFalsy();
-      });
-    });
+  it('the button is enabled when the form is not saving', () => {
+    expect(wrapper.props.disabled).toBeFalsy();
+  });
 
-    describe('when the form is saving', () => {
-      beforeEach(() => {
-       wrapper = shallow(
-         <SaveButton
-           saveText='This a save'
-           saving={ true }
-         />
-       );
-     });
+  it('the button is disabled when the form is saving', () => {
+    wrapper = shallow(
+      <SaveButton
+        saving={ true }
+      />
+    );
 
-      it('the button is disabled', () => {
-        let button = wrapper.find('.carbon-form-save__button');
-        expect(button.prop('disabled')).toBeTruthy();
-      });
-    });
+    let button = wrapper.find('.carbon-form-save__button');
+    expect(button.prop('disabled')).toBeTruthy();
   });
 
   describe("tags", () => {

--- a/src/components/form/save-button/package.json
+++ b/src/components/form/save-button/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "./save-button.js"
+}

--- a/src/components/form/save-button/save-button.js
+++ b/src/components/form/save-button/save-button.js
@@ -4,15 +4,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { tagComponent } from '../../../utils/helpers/tags';
 import Button from './../../button';
-import FormSummary from './../form-summary';
 
 const SaveButton = props =>
   <div className={ saveClasses(props) } { ...tagComponent('save', props) }>
-    <FormSummary
-      className='carbon-form-save__summary'
-      errors={ props.errors }
-      warnings={ props.warnings }
-    />
     <Button { ...saveButtonProps(props) } data-element='save'>
       { saveText(props) }
     </Button>

--- a/src/components/form/save-button/save-button.js
+++ b/src/components/form/save-button/save-button.js
@@ -1,11 +1,12 @@
 import classNames from 'classnames';
-import I18n from "i18n-js";
+import I18n from 'i18n-js';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { tagComponent } from '../../../utils/helpers/tags';
 import Button from './../../button';
 import FormSummary from './../form-summary';
 
-const SaveButton = (props) =>
+const SaveButton = props =>
   <div className={ saveClasses(props) } { ...tagComponent('save', props) }>
     <FormSummary
       className='carbon-form-save__summary'
@@ -18,8 +19,16 @@ const SaveButton = (props) =>
   </div>
 ;
 
+const saveClasses = (props) => {
+  return classNames(
+    'carbon-form-save', {
+      'carbon-form-save--invalid': props.errors || props.warnings
+    }
+  );
+};
+
 const saveButtonProps = (props) => {
-  return({
+  return ({
     as: 'primary',
     disabled: props.saving,
     className: 'carbon-form-save__button',
@@ -31,12 +40,15 @@ const saveText = (props) => {
   return props.saveText || I18n.t('actions.save', { defaultValue: 'Save' });
 };
 
-const saveClasses = (props) => {
-  return classNames(
-    "carbon-form-save", {
-      "carbon-form-save--invalid": props.errors || props.warnings
-    }
-  );
+SaveButton.propTypes = {
+  errors: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]),
+  warnings: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ])
 };
 
 export default SaveButton;

--- a/src/components/form/save-button/save-button.js
+++ b/src/components/form/save-button/save-button.js
@@ -1,0 +1,42 @@
+import classNames from 'classnames';
+import I18n from "i18n-js";
+import React from 'react';
+import { tagComponent } from '../../../utils/helpers/tags';
+import Button from './../../button';
+import FormSummary from './../form-summary';
+
+const SaveButton = (props) =>
+  <div className={ saveClasses(props) } { ...tagComponent('save', props) }>
+    <FormSummary
+      className='carbon-form-save__summary'
+      errors={ props.errors }
+      warnings={ props.warnings }
+    />
+    <Button { ...saveButtonProps(props) } data-element='save'>
+      { saveText(props) }
+    </Button>
+  </div>
+;
+
+const saveButtonProps = (props) => {
+  return({
+    as: 'primary',
+    disabled: props.saving,
+    className: 'carbon-form-save__button',
+    ...props.saveButtonProps
+  });
+};
+
+const saveText = (props) => {
+  return props.saveText || I18n.t('actions.save', { defaultValue: 'Save' });
+};
+
+const saveClasses = (props) => {
+  return classNames(
+    "carbon-form-save", {
+      "carbon-form-save--invalid": props.errors || props.warnings
+    }
+  );
+};
+
+export default SaveButton;


### PR DESCRIPTION
# Description
This PR replaces the default `Save` and `Cancel` buttons in the form with functional stateless `SaveButton` and `CancelButton` components. The `SaveButton` can now be overridden with a user passing a `customSaveButton` node prop into the component.

# TODO
- [x] Release notes

# Screenshots / Gifs
![form](https://cloud.githubusercontent.com/assets/3748093/26440009/613eb612-4122-11e7-8ca1-cbb709120d13.png)

# Testing Instructions
This can be tested by ensuring that nothing has changed with default form behaviour. Additionally that the `customSaveButton` prop replaces the default `SaveButton` and functions correctly in the context of the form. 