### PR TITLE
Fixes detail footnote overlay problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ If you have Google Analytics enabled (`window.ga` is defined), and you are using
 * `Alert`: default size has been fixed to `extra-small`.
 * `ButtonToggle`: css typo corrected
 * `Confirm`: default size has been fixed to `extra-small`.
+* `Detail`: Footnote is allowed to expand vertically
 * `Heading`: alignment is fixed in IE where `hr` was centring by default
 * `Link`: CSS inheritance has been updated to better support buttons.
 * `MenuList`: item filter search icon positioning is fixed

--- a/src/components/detail/detail.scss
+++ b/src/components/detail/detail.scss
@@ -41,7 +41,7 @@ $carbon-detail-icon-size: 16px;
 .carbon-detail__footnote {
   color: $grey-dark-blue-80;
   font-size: 13px;
-  position: absolute;
+  position: relative;
   margin-top: -2px;
 
   .carbon-detail--has-icon & {


### PR DESCRIPTION
## Description

* `position: absolute;` was meaning the footnote wasn't taking up space in the flow.

## TODO
- [x] Release notes

## Screenshots / Gifs
This flicks between `absolute` being set to `relative`

![relative](https://cloud.githubusercontent.com/assets/10499070/26192246/d3ed506c-3ba8-11e7-9f35-b11d4423487a.gif)

## Testing Instructions
* Will be available on the main in-app branch