### PR TITLE
More robust column child check

### DIFF
--- a/lib/components/row/column/column.js
+++ b/lib/components/row/column/column.js
@@ -22,6 +22,8 @@ var Column = function Column(props) {
   );
 };
 
+Column.isColumn = true;
+
 Column.PropTypes = {
   columnAlign: _propTypes2.default.oneOfType([_propTypes2.default.number, _propTypes2.default.string]),
 

--- a/lib/components/row/row.js
+++ b/lib/components/row/row.js
@@ -134,7 +134,10 @@ var Row = _wrapComponent('Row')((_temp2 = _class = function (_React$Component) {
        */
       var columnClasses = (0, _classnames2.default)("carbon-row__column", child.props.columnClasses, (_classNames = {}, _defineProperty(_classNames, 'carbon-row__column--offset-' + child.props.columnOffset, child.props.columnOffset), _defineProperty(_classNames, 'carbon-row__column--span-' + child.props.columnSpan, child.props.columnSpan), _defineProperty(_classNames, 'carbon-row__column--align-' + child.props.columnAlign, child.props.columnAlign), _defineProperty(_classNames, "carbon-row__column--column-divide", _this.props.columnDivide), _classNames));
 
-      if (child.type !== _column2.default) {
+      if (child.type && child.type.isColumn) {
+        columnClasses = (0, _classnames2.default)(columnClasses, child.props.className);
+        return _react3.default.cloneElement(child, { className: columnClasses, key: key }, child.props.children);
+      } else {
         _logger2.default.deprecate('Row Component should only have an immediate child of type Column');
 
         return _react3.default.createElement(
@@ -142,9 +145,6 @@ var Row = _wrapComponent('Row')((_temp2 = _class = function (_React$Component) {
           { key: key, className: columnClasses },
           child
         );
-      } else {
-        columnClasses = (0, _classnames2.default)(columnClasses, child.props.className);
-        return _react3.default.cloneElement(child, { className: columnClasses, key: key }, child.props.children);
       }
     }, _temp), _possibleConstructorReturn(_this, _ret);
   }

--- a/src/components/row/column/column.js
+++ b/src/components/row/column/column.js
@@ -9,6 +9,8 @@ const Column = (props) => {
   );
 };
 
+Column.isColumn = true;
+
 Column.PropTypes = {
   columnAlign: PropTypes.oneOfType([
     PropTypes.number,

--- a/src/components/row/row.js
+++ b/src/components/row/row.js
@@ -123,20 +123,20 @@ class Row extends React.Component {
       }
     );
 
-    if (child.type !== Column) {
+    if (child.type && child.type.isColumn) {
+      columnClasses = classNames(columnClasses, child.props.className);
+      return React.cloneElement(
+        child,
+        { className: columnClasses, key: key },
+        child.props.children
+      );
+    } else {
       Logger.deprecate('Row Component should only have an immediate child of type Column');
 
       return (
         <div key={ key } className={ columnClasses }>
           { child }
         </div>
-      );
-    } else {
-      columnClasses = classNames(columnClasses, child.props.className);
-      return React.cloneElement(
-        child,
-        { className: columnClasses, key: key },
-        child.props.children
       );
     }
   }


### PR DESCRIPTION
The Row deprecation warning was occurring incorrectly in applications that used Carbon.

I have added a property to the Column component which can be removed in V2 to robustly check if the component is a column 