### PR TITLE
Fix 404 for the carbon logo on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Carbon [ ![Codeship Status for Sage/carbon](https://codeship.com/projects/dd2c7bd0-6c4e-0133-1f77-72bb5571e5ad/status?branch=master)](https://codeship.com/projects/115478)
 
-<img src="./../master/logo/carbon-logo.png" width="50">
+<img src="https://raw.githubusercontent.com/Sage/carbon/master/logo/carbon-logo.png" width="50">
 
 Carbon is a library of reusable [React](https://facebook.github.io/react/) components and an interface for easily building user interfaces based on [Flux](https://facebook.github.io/flux/).
 


### PR DESCRIPTION
![npm_missing_logo](https://cloud.githubusercontent.com/assets/52329/26202200/68914852-3bce-11e7-85f5-54baf5ccc5e6.png)

Replace relative path with absolute path so that it renders correctly on https://www.npmjs.com/package/carbon.js
