### PR TITLE
Bump to RC3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0-rc3",
   "description": "A library of reusable React components and an interface for easily building user interfaces based on Flux.",
   "main": "index.js",
   "engineStrict": true,


### PR DESCRIPTION
Bumps to RC3 as RC2 was missing the lib folder and had already been published to npm so can't overwrite.