### PR TITLE
Illegal export declaration fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * The package name has been updated to `carbon-react`.
 
+## Carbon Factory Updated
+
+* Now using v0.3.6, which includes the fix for the `illegal export declaration` error.
+
 ## :warning: Major Change - React 15 Upgrade
 
 * React has been upgraded to version 15.5.0 - https://github.com/facebook/react/releases

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/Sage/carbon#readme",
   "devDependencies": {
     "babel-standalone": "~6.17.0",
-    "carbon-factory": "git+ssh://git@github.com/Sage/carbon-factory.git#v0.3.0",
+    "carbon-factory": "0.3.6",
     "enzyme": "~2.8.2",
     "express": "~4.14.0",
     "flux": "~2.1.1",


### PR DESCRIPTION
Update `carbon-factory` to v0.3.6, which includes the `envify` fix to addresses the `illegal export declaration` error.