### PR TITLE
Change dropdowns to always keep options in the DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Component Enhancements
 
+* `Dropdown`: Options list is always rendered to the DOM, but is hidden until selected
 * `Textarea` now accepts a new prop `warnOverLimit` to display the character count message in red.
 * Simplify character count in `Textarea`.
 

--- a/src/components/dropdown-filter-ajax/__spec__.js
+++ b/src/components/dropdown-filter-ajax/__spec__.js
@@ -270,11 +270,12 @@ describe('DropdownFilterAjax', () => {
       expect(instance.listeningToScroll).toBeFalsy();
     });
 
-    describe('when list exists', () => {
+    describe('when list is open', () => {
       it('should reset the scroll top', () => {
         instance.refs.list = {
           scrollTop: 100
         };
+        instance.setState({ open: true });
         instance.resetScroll();
         expect(instance.refs.list.scrollTop).toEqual(0);
       });

--- a/src/components/dropdown-filter-ajax/dropdown-filter-ajax.js
+++ b/src/components/dropdown-filter-ajax/dropdown-filter-ajax.js
@@ -238,11 +238,10 @@ class DropdownFilterAjax extends DropdownFilter {
    * @method resetScroll
    */
   resetScroll = () => {
-    let list = this.refs.list;
-
     this.listeningToScroll = false;
 
-    if (list) {
+    if (this.state.open) {
+      let list = this.refs.list;
       list.scrollTop = 0;
     }
   }

--- a/src/components/dropdown-filter/__spec__.js
+++ b/src/components/dropdown-filter/__spec__.js
@@ -12,7 +12,7 @@ describe('DropdownFilter', () => {
 
   beforeEach(() => {
     instance = TestUtils.renderIntoDocument(
-      <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" />
+      <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" />
     );
   });
 
@@ -31,7 +31,7 @@ describe('DropdownFilter', () => {
       describe('when freetext value not set', () => {
         it('sets default filter', () => {
           instance = TestUtils.renderIntoDocument(
-            <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" freetext={ true } />
+            <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" freetext={ true } />
           );
           expect(instance.state.filter).toBeNull();
         });
@@ -44,7 +44,7 @@ describe('DropdownFilter', () => {
           instance = TestUtils.renderIntoDocument(
             <DropdownFilter
               name="foo"
-              options={ Immutable.fromJS([{}]) }
+              options={ Immutable.fromJS([]) }
               value=""
               visibleValue={ value }
               freetext={ true }
@@ -84,7 +84,7 @@ describe('DropdownFilter', () => {
         let visible = 'Value';
 
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" freetext={ true } />
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" freetext={ true } />
         );
         spyOn(instance, 'setState');
         instance.selectValue('', visible);
@@ -97,7 +97,7 @@ describe('DropdownFilter', () => {
     describe('when in suggest mode', () => {
       beforeEach(() => {
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" suggest={ true } />
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" suggest={ true } />
         );
         spyOn(instance, 'setState');
       });
@@ -132,7 +132,7 @@ describe('DropdownFilter', () => {
     describe('when in freetext mode', () => {
       beforeEach(() => {
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" freetext={ true } />
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" freetext={ true } />
         );
         spyOn(instance, 'setState');
       });
@@ -181,7 +181,7 @@ describe('DropdownFilter', () => {
     describe('when in create mode', () => {
       it('triggers emitOnChangeCallback', () => {
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" create={ function() {} } />
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" create={ function() {} } />
         );
         spyOn(instance, 'emitOnChangeCallback');
         TestUtils.Simulate.change(instance._input, {
@@ -206,7 +206,7 @@ describe('DropdownFilter', () => {
       describe('if in create mode', () => {
         it('preserves filter', () => {
           instance = TestUtils.renderIntoDocument(
-            <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" create={ function() {} } />
+            <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" create={ function() {} } />
           );
           spyOn(instance, 'setState');
           instance.handleBlur();
@@ -315,7 +315,7 @@ describe('DropdownFilter', () => {
           let onBlur = jasmine.createSpy('onBlur');
 
           instance = TestUtils.renderIntoDocument(
-            <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" onBlur={ onBlur } />
+            <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" onBlur={ onBlur } />
           );
           instance.handleBlur();
           expect(onBlur).toHaveBeenCalled();
@@ -328,7 +328,7 @@ describe('DropdownFilter', () => {
     describe('if in suggest mode', () => {
       it('does not call setState', () => {
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" suggest={ true } />
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" suggest={ true } />
         );
         spyOn(instance, 'setState');
         instance.handleFocus();
@@ -339,7 +339,7 @@ describe('DropdownFilter', () => {
     describe('if in freetext mode', () => {
       it('does not call setState', () => {
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" freetext={ true } />
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" freetext={ true } />
         );
         spyOn(instance, 'setState');
         instance.handleFocus();
@@ -378,7 +378,7 @@ describe('DropdownFilter', () => {
       ev = {};
       spy = jasmine.createSpy();
       instance = TestUtils.renderIntoDocument(
-        <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" create={ spy } />
+        <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" create={ spy } />
       );
       spyOn(instance, 'setState');
       instance.handleCreate(ev);
@@ -482,7 +482,7 @@ describe('DropdownFilter', () => {
       describe('if in suggest mode and list is opening', () => {
         it('filters the list', () => {
           instance = TestUtils.renderIntoDocument(
-            <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" suggest={ true } />
+            <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" suggest={ true } />
           );
           instance.openingList = true;
           instance.setState({ filter: 'foo' });
@@ -493,7 +493,7 @@ describe('DropdownFilter', () => {
       describe('if in suggest mode and list is not opening', () => {
         it('filters the list', () => {
           instance = TestUtils.renderIntoDocument(
-            <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" suggest={ true } />
+            <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" suggest={ true } />
           );
           instance.setState({ filter: 'foo' });
           expect(instance.prepareList(opts).length).toEqual(2);
@@ -503,7 +503,7 @@ describe('DropdownFilter', () => {
       describe('if in freetext mode and list is opening', () => {
         it('filters the list', () => {
           instance = TestUtils.renderIntoDocument(
-            <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" freetext={ true } />
+            <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" freetext={ true } />
           );
           instance.openingList = true;
           instance.setState({ filter: 'foo' });
@@ -514,7 +514,7 @@ describe('DropdownFilter', () => {
       describe('if in freetext mode and list is not opening', () => {
         it('filters the list', () => {
           instance = TestUtils.renderIntoDocument(
-            <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" freetext={ true } />
+            <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" freetext={ true } />
           );
           instance.setState({ filter: 'foo' });
           expect(instance.prepareList(opts).length).toEqual(2);
@@ -551,7 +551,7 @@ describe('DropdownFilter', () => {
     describe('if in create mode', () => {
       beforeEach(() => {
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" create={ function() {} } />
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" create={ function() {} } />
         );
       });
 
@@ -586,7 +586,7 @@ describe('DropdownFilter', () => {
     describe('when in suggest mode', () => {
       it('returns false', () => {
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" suggest={ true } />
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" suggest={ true } />
         );
         expect(instance.showArrow()).toBeFalsy();
       });
@@ -595,7 +595,7 @@ describe('DropdownFilter', () => {
     describe('when in freetext mode', () => {
       it('returns false', () => {
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" freetext={ true } />
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" freetext={ true } />
         );
         expect(instance.showArrow()).toBeFalsy();
       });
@@ -626,7 +626,7 @@ describe('DropdownFilter', () => {
     describe('if in create mode', () => {
       it('does not add the class', () => {
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" create={ function() {} } />
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" create={ function() {} } />
         );
         expect(instance.inputClasses).not.toMatch('carbon-dropdown__input--filtered');
       });
@@ -635,7 +635,7 @@ describe('DropdownFilter', () => {
     describe('if in freetext mode', () => {
       it('does not add the class', () => {
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" freetext={ true } />
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" freetext={ true } />
         );
         expect(instance.inputClasses).not.toMatch('carbon-dropdown__input--filtered');
       });
@@ -660,7 +660,7 @@ describe('DropdownFilter', () => {
     describe('when readOnly is set as a prop', () => {
       it('sets the value', () => {
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" readOnly={ true } />
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" readOnly={ true } />
         );
         expect(instance.inputProps.readOnly).toBeTruthy();
       });
@@ -683,7 +683,7 @@ describe('DropdownFilter', () => {
           let value = 'foo';
 
           instance = TestUtils.renderIntoDocument(
-            <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } visibleValue={ value } freetext={ true } />
+            <DropdownFilter name="foo" options={ Immutable.fromJS([]) } visibleValue={ value } freetext={ true } />
           );
           expect(instance.inputProps.value).toEqual(value);
         });
@@ -744,7 +744,7 @@ describe('DropdownFilter', () => {
       describe('when freetextName not set', () => {
         it('only renders one hidden input', () => {
           instance = TestUtils.renderIntoDocument(
-            <DropdownFilter name="foo" options={ Immutable.fromJS([{}]) } value="1" freetext={ true } />
+            <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" freetext={ true } />
           );
           inputs = TestUtils.findAllInRenderedTree(instance, (node) => {
             return TestUtils.isDOMComponent(node) &&
@@ -762,7 +762,7 @@ describe('DropdownFilter', () => {
           instance = TestUtils.renderIntoDocument(
             <DropdownFilter
               name="foo"
-              options={ Immutable.fromJS([{}]) }
+              options={ Immutable.fromJS([]) }
               value="1"
               freetext={ true }
               freetextName={ name }

--- a/src/components/dropdown-filter/dropdown-filter.js
+++ b/src/components/dropdown-filter/dropdown-filter.js
@@ -262,7 +262,7 @@ class DropdownFilter extends Dropdown {
 
       // if user has entered a search filter
       options = options.filter((option) => {
-        if (option.name.search(regex) > -1) {
+        if (option.name && option.name.search(regex) > -1) {
           option.name = this.highlightMatches(option.name, filter);
           return option;
         }

--- a/src/components/dropdown/__spec__.js
+++ b/src/components/dropdown/__spec__.js
@@ -12,7 +12,7 @@ describe('Dropdown', () => {
 
   beforeEach(() => {
     instance = TestUtils.renderIntoDocument(
-      <Dropdown name="foo" options={ Immutable.fromJS([{}]) } value="1" />
+      <Dropdown name="foo" options={ Immutable.fromJS([]) } value="1" />
     );
   });
 
@@ -44,7 +44,7 @@ describe('Dropdown', () => {
 
       beforeEach(() => {
         instanceWithCache = TestUtils.renderIntoDocument(
-          <Dropdown name="foo" cacheVisibleValue={ true } options={ Immutable.fromJS([{}]) } value="1" />
+          <Dropdown name="foo" cacheVisibleValue={ true } options={ Immutable.fromJS([]) } value="1" />
         );
       });
 
@@ -81,7 +81,7 @@ describe('Dropdown', () => {
 
     describe('if autoFocus', () => {
       it('does sets focus on the input', () => {
-        instance = TestUtils.renderIntoDocument(<Dropdown options={ Immutable.fromJS([{}]) } autoFocus />);
+        instance = TestUtils.renderIntoDocument(<Dropdown options={ Immutable.fromJS([]) } autoFocus />);
         spyOn(instance._input, 'focus');
         instance.componentDidMount();
         expect(instance._input.focus).toHaveBeenCalled();
@@ -116,7 +116,7 @@ describe('Dropdown', () => {
         let onBlur = jasmine.createSpy('onBlur');
 
         instance = TestUtils.renderIntoDocument(
-          <Dropdown options={ Immutable.fromJS([{}]) } value="1" onBlur={ onBlur } />
+          <Dropdown options={ Immutable.fromJS([]) } value="1" onBlur={ onBlur } />
         );
         instance.selectValue('10', 'foo');
         expect(onBlur).toHaveBeenCalled();
@@ -282,7 +282,7 @@ describe('Dropdown', () => {
           let onBlur = jasmine.createSpy('onBlur');
 
           instance = TestUtils.renderIntoDocument(
-            <Dropdown options={ Immutable.fromJS([{}]) } value="1" onBlur={ onBlur } />
+            <Dropdown options={ Immutable.fromJS([]) } value="1" onBlur={ onBlur } />
           );
           TestUtils.Simulate.blur(instance._input);
           expect(onBlur).toHaveBeenCalled();
@@ -345,7 +345,7 @@ describe('Dropdown', () => {
       describe('if there is no value', () => {
         it('it returns the visible value', () => {
           instance = TestUtils.renderIntoDocument(
-            <Dropdown name="foo" options={ Immutable.Map([]) } value="" />
+            <Dropdown name="foo" options={ Immutable.fromJS([]) } value="" />
           );
           expect(instance.nameByID()).toEqual(instance.visibleValue);
         });
@@ -816,8 +816,21 @@ describe('Dropdown', () => {
       expect(instance.listBlockProps.onTouchStart).toEqual(instance.handleTouchEvent),
       expect(instance.listBlockProps.onTouchEnd).toEqual(instance.handleTouchEvent),
       expect(instance.listBlockProps.onTouchCancel).toEqual(instance.handleTouchEvent),
-      expect(instance.listBlockProps.onTouchMove).toEqual(instance.handleTouchEvent),
-      expect(instance.listBlockProps.className).toEqual('carbon-dropdown__list-block');
+      expect(instance.listBlockProps.onTouchMove).toEqual(instance.handleTouchEvent);
+    });
+
+    describe('when the list is closed', () => {
+      it('has a hidden class', () => {
+        instance.setState({ open: false });
+        expect(instance.listBlockProps.className).toEqual('carbon-dropdown__list-block carbon-dropdown__list-hidden');
+      });
+    });
+
+    describe('when the list is open', () => {
+      it('it does not have the hidden class', () => {
+        instance.setState({ open: true });
+        expect(instance.listBlockProps.className).toEqual('carbon-dropdown__list-block');
+      });
     });
   });
 
@@ -830,17 +843,8 @@ describe('Dropdown', () => {
   });
 
   describe('listHTML', () => {
-    describe('if closed', () => {
-      it('returns null', () => {
-        expect(instance.listHTML).toBe(null);
-      });
-    });
-
-    describe('if open', () => {
-      it('returns the html', () => {
-        instance.setState({ open: true });
-        expect(TestUtils.isElement(instance.listHTML)).toBeTruthy();
-      });
+    it('returns the html', () => {
+      expect(TestUtils.isElement(instance.listHTML)).toBeTruthy();
     });
   });
 
@@ -881,7 +885,8 @@ describe('Dropdown', () => {
     });
 
     it('returns the list', () => {
-      expect(instance.additionalInputContent[1].props.className).toEqual('carbon-dropdown__list-block');
+      let classes = 'carbon-dropdown__list-block carbon-dropdown__list-hidden';
+      expect(instance.additionalInputContent[1].props.className).toEqual(classes);
     });
   });
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -314,7 +314,7 @@ class Dropdown extends React.Component {
   handleKeyDown = (ev) => {
     ev.stopPropagation();
 
-    if (!this.refs.list) {
+    if (!this.state.open) {
       // if up/down/space then open list
       if (Events.isUpKey(ev) || Events.isDownKey(ev) || Events.isSpaceKey(ev)) {
         ev.preventDefault();
@@ -501,7 +501,7 @@ class Dropdown extends React.Component {
       onTouchEnd: this.handleTouchEvent,
       onTouchCancel: this.handleTouchEvent,
       onTouchMove: this.handleTouchEvent,
-      className: 'carbon-dropdown__list-block'
+      className: classNames('carbon-dropdown__list-block', { 'carbon-dropdown__list-hidden': !this.state.open })
     };
   }
 
@@ -549,8 +549,6 @@ class Dropdown extends React.Component {
    * @return {Object} JSX
    */
   get listHTML() {
-    if (!this.state.open) { return null; }
-
     return (
       <ul { ...this.listProps }>
         { this.results(this.options) }

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -2,6 +2,7 @@
 @import "./../../style-config/z-index";
 @import "./../../style-config/general";
 @import "./../../style-config/input-field";
+@import "./../../style-config/mixins";
 
 $dropdown-input-icon-width: 20px !default;
 
@@ -17,7 +18,7 @@ $dropdown-input-icon-width: 20px !default;
 }
 
 .carbon-dropdown__list-hidden {
-  display: none;
+  @include visually-hidden
 }
 
 .carbon-dropdown__list {

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -16,6 +16,10 @@ $dropdown-input-icon-width: 20px !default;
   }
 }
 
+.carbon-dropdown__list-hidden {
+  display: none;
+}
+
 .carbon-dropdown__list {
   background-color: $white;
   border: 1px solid $border-color;

--- a/src/style-config/mixins.scss
+++ b/src/style-config/mixins.scss
@@ -240,3 +240,12 @@
   #{$attr}:    -moz-calc(#{$sum});
   #{$attr}:         calc(#{$sum});
 }
+
+@mixin visually-hidden() {
+  // From https://snook.ca/archives/html_and_css/hiding-content-for-accessibility
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute !important;
+  width: 1px;
+}


### PR DESCRIPTION
# Description

Currently, dropdown selects only render the options list if the
component is focused. This makes testing applications using browser
automation difficult as these options cannot be selected.

This PR ensures that the options are always rendered within the DOM, but
makes them hidden unless the component is focused.

# TODO
- [x] Release notes


* Note that a lot of the changes are fixes for associated tests where an array containing a single blank JS object was being passed as the options array.