### PR TITLE
Modal component linting fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 * `Date`: fixed the warning about an uncontrolled input component
 * Fix presence validator bug validating value as false if no props sent to validator.
 
+## Linting Updates
+
+The following component have had minor internal changes to satisfy the introduction of stricter linting rules:
+
+* Confirm
+* Dialog
+* DialogFullScreen
+* Flash
+
 # 1.0.0
 
 ## Package Name Change

--- a/src/components/confirm/confirm.js
+++ b/src/components/confirm/confirm.js
@@ -1,10 +1,10 @@
 import React from 'react';
+import I18n from 'i18n-js';
+import classNames from 'classnames';
+import { assign } from 'lodash';
 import PropTypes from 'prop-types';
 import Dialog from '../dialog';
 import Button from '../button';
-import I18n from "i18n-js";
-import classNames from 'classnames';
-import { assign } from 'lodash';
 
 /**
  * A Confirm widget.
@@ -67,10 +67,6 @@ class Confirm extends Dialog {
     size: 'extra-small',
     showCloseIcon: false
   })
-
-  constructor() {
-    super();
-  }
 
   /**
    * Returns main classes for the component combined with
@@ -141,7 +137,7 @@ class Confirm extends Dialog {
    * @method dialogTitle
    */
   get modalHTML() {
-    let dialog = super.modalHTML,
+    const dialog = super.modalHTML,
         children = [].concat(dialog.props.children, this.confirmButtons);
     return React.cloneElement(dialog, {}, children);
   }

--- a/src/components/dialog-full-screen/dialog-full-screen.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import classNames from 'classnames';
 import Icon from './../icon';
 import Modal from './../modal';
-import classNames from 'classnames';
 
 /**
  * A DialogFullScreen widget.
@@ -69,7 +69,7 @@ class DialogFullScreen extends Modal {
   get modalHTML() {
     return (
       <div
-        ref={ (d) => this._dialog = d }
+        ref={ (d) => { this._dialog = d; } }
         className={ this.dialogClasses }
         { ...this.componentTags(this.props) }
       >
@@ -97,11 +97,10 @@ class DialogFullScreen extends Modal {
    * @return {Object} JSX
    */
   renderTitle = () => {
-    if (typeof(this.props.title) === 'string' || this.props.title instanceof String) {
+    if (typeof (this.props.title) === 'string' || this.props.title instanceof String) {
       return <h2 className='carbon-dialog-full-screen__title' data-element='title'>{ this.props.title }</h2>;
-    } else {
-      return this.props.title;
     }
+    return this.props.title;
   }
 }
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import Icon from './../icon';
-import Modal from './../modal';
 import Bowser from 'bowser';
 import classNames from 'classnames';
 import { assign } from 'lodash';
+import PropTypes from 'prop-types';
+import Icon from './../icon';
+import Modal from './../modal';
 
 /**
  * A Dialog widget.
@@ -121,13 +121,13 @@ class Dialog extends Modal {
    * @return {void}
    */
   centerDialog = () => {
-    let height = this._dialog.offsetHeight / 2,
-        width = this._dialog.offsetWidth / 2,
-        midPointY = window.innerHeight / 2 + window.pageYOffset,
-        midPointX = window.innerWidth / 2 + window.pageXOffset;
+    const height = this._dialog.offsetHeight / 2,
+        width = this._dialog.offsetWidth / 2;
+    let midPointY = (window.innerHeight / 2) + window.pageYOffset,
+        midPointX = (window.innerWidth / 2) + window.pageXOffset;
 
-    midPointY = midPointY - height;
-    midPointX = midPointX - width;
+    midPointY -= height;
+    midPointX -= width;
 
     if (midPointY < 20) {
       midPointY = 20;
@@ -139,8 +139,8 @@ class Dialog extends Modal {
       midPointX = 20;
     }
 
-    this._dialog.style.top = midPointY + "px";
-    this._dialog.style.left = midPointX + "px";
+    this._dialog.style.top = `${midPointY}px`;
+    this._dialog.style.left = `${midPointX}px`;
   }
 
   /**
@@ -221,13 +221,14 @@ class Dialog extends Modal {
 
   get closeIcon() {
     if (this.props.showCloseIcon) {
-      return <Icon
-        className="carbon-dialog__close"
+      return (<Icon
+        className='carbon-dialog__close'
         data-element='close'
         onClick={ this.props.onCancel }
-        type="close"
-      />;
+        type='close'
+      />);
     }
+    return null;
   }
 
   componentTags(props) {
@@ -247,7 +248,7 @@ class Dialog extends Modal {
   get modalHTML() {
     return (
       <div
-        ref={ (d) => this._dialog = d }
+        ref={ (d) => { this._dialog = d; } }
         className={ this.dialogClasses }
         { ...this.componentTags(this.props) }
       >

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -221,12 +221,14 @@ class Dialog extends Modal {
 
   get closeIcon() {
     if (this.props.showCloseIcon) {
-      return (<Icon
-        className='carbon-dialog__close'
-        data-element='close'
-        onClick={ this.props.onCancel }
-        type='close'
-      />);
+      return (
+        <Icon
+          className='carbon-dialog__close'
+          data-element='close'
+          onClick={ this.props.onCancel }
+          type='close'
+        />
+      );
     }
     return null;
   }

--- a/src/components/flash/__spec__.js
+++ b/src/components/flash/__spec__.js
@@ -148,28 +148,28 @@ describe('Flash', () => {
     describe("if there is an event", () => {
       it('calls preventDefault on it', () => {
         let spy = jasmine.createSpy('preventDefault');
-        defaultInstance.toggleDialog(null, { preventDefault: spy });
+        defaultInstance.toggleDialog(null)({ preventDefault: spy });
         expect(spy).toHaveBeenCalled();
       });
     });
 
     it('sets the state to the opposite of what it was', () => {
       defaultInstance.setState({ dialogs: { foo: false }});
-      defaultInstance.toggleDialog('foo');
+      defaultInstance.toggleDialog('foo')();
       expect(defaultInstance.state.dialogs.foo).toBeTruthy();
     });
 
     it('calls startTimeout if the state is truthy', () => {
       spyOn(defaultInstance, 'startTimeout');
       defaultInstance.setState({ dialogs: { foo: true }});
-      defaultInstance.toggleDialog('foo');
+      defaultInstance.toggleDialog('foo')();
       expect(defaultInstance.startTimeout).toHaveBeenCalled();
     });
 
     it('calls stopTimeout if the state is falsey', () => {
       spyOn(defaultInstance, 'stopTimeout');
       defaultInstance.setState({ dialogs: { foo: false }});
-      defaultInstance.toggleDialog('foo');
+      defaultInstance.toggleDialog('foo')();
       expect(defaultInstance.stopTimeout).toHaveBeenCalled();
     });
   });
@@ -215,12 +215,14 @@ describe('Flash', () => {
 
     describe('if the text does contains ::more::', () => {
       it('returns the text and creates an alert', () => {
-        spyOn(defaultInstance, 'toggleDialog');
+        const toggleDialogSpy = jasmine.createSpy();
+        spyOn(defaultInstance, 'toggleDialog').and.returnValue(toggleDialogSpy);
         let markup = defaultInstance.findMore("yep ::more:: with dialog");
         expect(markup.props.children[0]).toEqual("yep");
         expect(markup.props.children[2].props.className).toEqual("carbon-flash__link");
         markup.props.children[2].props.onClick();
-        expect(defaultInstance.toggleDialog).toHaveBeenCalled();
+        expect(defaultInstance.toggleDialog).toHaveBeenCalledWith('yep');
+        expect(toggleDialogSpy).toHaveBeenCalled();
       });
     });
   });

--- a/src/components/flash/flash.js
+++ b/src/components/flash/flash.js
@@ -301,7 +301,8 @@ class Flash extends React.Component {
    * @return {HTML}
    */
   findMore = (text) => {
-    if (typeof text !== 'string') { return text; }
+    let value = text;
+    if (typeof text !== 'string') { return value; }
 
     // detect any instances of "::more::" in the text
     const parts = text.split('::more::');
@@ -325,7 +326,7 @@ class Flash extends React.Component {
       );
 
       // create text for item
-      return (
+      value = (
         <span>
           { title }&nbsp;
           <Link
@@ -339,7 +340,7 @@ class Flash extends React.Component {
       );
     }
 
-    return text;
+    return value;
   }
 
   /**


### PR DESCRIPTION
To prepare for the future upgrade of [carbon-factory](https://github.com/Sage/carbon-factory), that will introduce stricter linting rules, this PR updates the modal components to pre-emptively resolve the errors.

- Alert (no linting errors found)
- Confirm
- Dialog
- DialogFullScreen
- Flash

There are no functional changes to the components.

Most of the changes are minor. The biggest were to the `Flash` component where I removed the usage of `bind` for `toggleDialog`. This required some updates to the specs where that function was being tested directly. I also introduced a default for the `timeout` prop of zero.

