### PR TITLE
Table component linting fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,16 @@
 
 The following component have had minor internal changes to satisfy the introduction of stricter linting rules:
 
+* ActionToolbar
 * Confirm
 * Dialog
 * DialogFullScreen
 * Flash
+* Table
+* TableAjax
+* TableCell
+* TableHeader
+* TableRow
 
 # 1.0.0
 

--- a/demo/utils/definition/table-definition/table-definition.js
+++ b/demo/utils/definition/table-definition/table-definition.js
@@ -39,7 +39,7 @@ function buildRows() {
 }`;
 
   definition.propTypes = assign({}, definition.propTypes, {
-    actions: 'Array',
+    actions: 'Object',
     currentPage: 'String',
     children: 'Node',
     className: 'String',
@@ -62,7 +62,7 @@ function buildRows() {
     totalRecords: 'String'
   });
   definition.propDescriptions = assign({}, definition.propDescriptions, {
-    actions: 'The actions to display in the toolbar',
+    actions: 'Specify actions to be used by the ActionToolbar component.',
     currentPage: 'Controls the current page number of a paginated data set.',
     children: 'This component supports children.',
     className: 'Classes to apply to the component.',

--- a/demo/utils/definition/table-definition/table-definition.js
+++ b/demo/utils/definition/table-definition/table-definition.js
@@ -4,12 +4,12 @@ import { assign } from 'lodash';
 export default (definition) => {
   definition.type = 'grids';
   definition.propValues = assign({}, definition.propValues, {
-    path: "/countries",
-    children: "{ buildRows() }"
+    path: '/countries',
+    children: '{ buildRows() }'
   });
   definition.hiddenProps = definition.hiddenProps.concat(['currentPage', 'filter', 'totalRecords', 'pageSizeSelectionOptions']);
   definition.propRequires = {
-    showPageSizeSelection: "paginate"
+    showPageSizeSelection: 'paginate'
   };
 
   definition.js = `
@@ -39,39 +39,49 @@ function buildRows() {
 }`;
 
   definition.propTypes = assign({}, definition.propTypes, {
-    currentPage: "String",
-    filter: "Object",
-    highlightable: "Boolean",
-    onChange: "Function",
-    onHighlight: "Function",
-    onPageSizeChange: "Function",
-    onSelect: "Function",
-    pageSize: "String",
-    pageSizeSelectionOptions: "Object",
-    paginate: "Boolean",
-    selectable: "Boolean",
-    showPageSizeSelection: "Boolean",
-    shrink: "Boolean",
-    tbody: "Node",
-    thead: "Node",
-    totalRecords: "String"
+    actions: 'Array',
+    currentPage: 'String',
+    children: 'Node',
+    className: 'String',
+    filter: 'Object',
+    highlightable: 'Boolean',
+    onChange: 'Function',
+    onHighlight: 'Function',
+    onPageSizeChange: 'Function',
+    onSelect: 'Function',
+    pageSize: 'String',
+    pageSizeSelectionOptions: 'Object',
+    paginate: 'Boolean',
+    selectable: 'Boolean',
+    showPageSizeSelection: 'Boolean',
+    shrink: 'Boolean',
+    sortOrder: 'String',
+    sortedColumn: 'String',
+    tbody: 'Node',
+    thead: 'Node',
+    totalRecords: 'String'
   });
   definition.propDescriptions = assign({}, definition.propDescriptions, {
-    currentPage: "Controls the current page number of a paginated data set.",
+    actions: 'The actions to display in the toolbar',
+    currentPage: 'Controls the current page number of a paginated data set.',
+    children: 'This component supports children.',
+    className: 'Classes to apply to the component.',
     filter: "An object of filtered data. Each key in the object should match with the key of one of the table's columns.",
-    highlightable: "Makes each row clickable/highlightable. Works well with the onHighlight callback.",
+    highlightable: 'Makes each row clickable/highlightable. Works well with the onHighlight callback.',
     onChange: "Triggered whenever any of the table's display is updated - for example if sort order changes, pagination changes or the filter changes. It will trigger your callback with all of the information required to manually filter/sort your data in your external data source.",
-    onHighlight: "Triggered when a row is highlighted via the highlightable prop. It will provide you with the row index.",
-    onPageSizeChange: "Triggered when the page size is changed.",
-    onSelect: "Triggered when a row is selected via the selectable prop. It will provide you with an array of all of the currently selected rows.",
-    pageSize: "Controls the current page size of a paginated data set.",
-    pageSizeSelectionOptions: "Defines the page size selection options. By default this is defined as 10, 25 and 50.",
-    paginate: "Turns pagination on/off.",
-    selectable: "Makes each row selectable using a checkbox. It will also turn on a select all checkbox if you have a header.",
-    showPageSizeSelection: "Will show the page size selection options if turned on.",
-    shrink: "If you move from one page with 10 results to a second page with only 5 results, the table will not shrink to maintain a consistent height. Turn this on if you want your table to shrink in these circumstances.",
-    tbody: "Instead of passing children, define your tbody as a prop.",
-    thead: "Instead of passing children, define your thead as a prop. Using this prop will put your header inside an HTML thead element.",
-    totalRecords: "Tracks the total number of records of a paginated data set."
+    onHighlight: 'Triggered when a row is highlighted via the highlightable prop. It will provide you with the row index.',
+    onPageSizeChange: 'Triggered when the page size is changed.',
+    onSelect: 'Triggered when a row is selected via the selectable prop. It will provide you with an array of all of the currently selected rows.',
+    pageSize: 'Controls the current page size of a paginated data set.',
+    pageSizeSelectionOptions: 'Defines the page size selection options. By default this is defined as 10, 25 and 50.',
+    paginate: 'Turns pagination on/off.',
+    selectable: 'Makes each row selectable using a checkbox. It will also turn on a select all checkbox if you have a header.',
+    showPageSizeSelection: 'Will show the page size selection options if turned on.',
+    shrink: 'If you move from one page with 10 results to a second page with only 5 results, the table will not shrink to maintain a consistent height. Turn this on if you want your table to shrink in these circumstances.',
+    sortOrder: 'The current sort order applied.',
+    sortedColumn: 'The currently sorted column.',
+    tbody: 'Instead of passing children, define your tbody as a prop.',
+    thead: 'Instead of passing children, define your thead as a prop. Using this prop will put your header inside an HTML thead element.',
+    totalRecords: 'Tracks the total number of records of a paginated data set.'
   });
-}
+};

--- a/src/components/action-toolbar/README.md
+++ b/src/components/action-toolbar/README.md
@@ -11,14 +11,18 @@ import ActionToolbar from 'carbon/lib/components/action-toolbar';
 *  To render a Alert:
 
 ```javascript
-  let actions = [{
-    text: "Add Subscriptions",
-    icon: "basket",
-    onClick: () => {}
-  }, {
-    text: "Delete",
-    icon: "bin"
-  }];
+  let actions = {
+    subscription: {
+      text: 'Add Subscriptions',
+      icon: 'basket',
+      onClick: (selected, event) => { }
+    },
+    delete: {
+      text: 'Delete',
+      icon: 'bin',
+      onClick: (selected, event) => { }
+    }
+  };
 
   <ActionToolbar actions={ actions } />
 ```

--- a/src/components/action-toolbar/__spec__.js
+++ b/src/components/action-toolbar/__spec__.js
@@ -51,14 +51,18 @@ describe('action toolbar', () => {
 
   describe('buildAction', () => {
     it('returns a link with props', () => {
-      let action = instance.buildAction({
-        onClick: () => {},
+      const spy = jasmine.createSpy('onClick');
+      const event = jasmine.createSpy('event');
+      instance.setState({selected: true});
+      const action = instance.buildAction({
+        onClick: (event, selected) => { spy(selected, event) },
         text: 'foo',
         className: 'bar'
       }, 1);
-
       expect(action.props.className).toEqual('carbon-action-toolbar__action bar');
       expect(action.props.children).toEqual('foo');
+      action.props.onClick(event)
+      expect(spy).toHaveBeenCalledWith(event, instance.state.selected)
     });
   });
 

--- a/src/components/action-toolbar/action-toolbar.js
+++ b/src/components/action-toolbar/action-toolbar.js
@@ -119,6 +119,15 @@ class ActionToolbar extends React.Component {
   }
 
   /**
+   * @method handleOnClick
+   * @return {Function}
+   */
+  handleOnClick = (onClick, selected) => {
+    if (!onClick) { return null; }
+    return event => onClick(selected, event);
+  }
+
+  /**
    * @method isActive
    * @return {Boolean}
    */
@@ -147,8 +156,7 @@ class ActionToolbar extends React.Component {
    * @return {Object} JSX
    */
   buildAction(action, index) {
-    let { onClick, className, text, ...props } = action;
-    onClick = onClick ? onClick.bind(this, this.state.selected) : null;
+    const { onClick, className, text, ...props } = action;
 
     return (
       <Link
@@ -156,7 +164,7 @@ class ActionToolbar extends React.Component {
         data-element='action'
         disabled={ !this.isActive() }
         key={ index }
-        onClick={ onClick }
+        onClick={ this.handleOnClick(onClick, this.state.selected) }
         { ...props }
       >
         { text }

--- a/src/components/action-toolbar/action-toolbar.js
+++ b/src/components/action-toolbar/action-toolbar.js
@@ -183,7 +183,7 @@ class ActionToolbar extends React.Component {
           <strong data-element='total'>
             { this.state.total }
           </strong>
-          { I18n.t('action_toolbar.selected', { defaultValue: 'Selected' }) }
+          &nbsp;{ I18n.t('action_toolbar.selected', { defaultValue: 'Selected' }) }
         </div>
 
         <div className='carbon-action-toolbar__actions'>

--- a/src/components/action-toolbar/action-toolbar.js
+++ b/src/components/action-toolbar/action-toolbar.js
@@ -19,11 +19,11 @@ import { tagComponent } from '../../utils/helpers/tags';
  *   let actions = [{
  *     text: "Add Subscriptions",
  *     icon: "basket",
- *     onClick: onClickHandler() => {}
+ *     onClick: onClickHandler(event, selected) => {}
  *   }, {
  *     text: "Delete",
  *     icon: "bin",
- *     onClick: onClickHandler() => {}
+ *     onClick: onClickHandler(event, selected) => {}
  *   }];
  *
  *   <ActionToolbar total={ count } actions={ actions } />
@@ -104,24 +104,6 @@ class ActionToolbar extends React.Component {
   }
 
   /**
-   * @method render
-   * @return {Object} JSX
-   */
-  render() {
-    return (
-      <div className={ this.mainClasses() } { ...tagComponent('action-toolbar', this.props) } >
-        <div className='carbon-action-toolbar__total'>
-          <strong data-element='total'>{ this.state.total }</strong> { I18n.t('action_toolbar.selected', { defaultValue: 'Selected' }) }
-        </div>
-
-        <div className='carbon-action-toolbar__actions'>
-          { this.actions() }
-        </div>
-      </div>
-    );
-  }
-
-  /**
    * @method actions
    * @return {Array}
    */
@@ -153,17 +135,24 @@ class ActionToolbar extends React.Component {
   }
 
   /**
+   * @method linkClasses
+   * @return {String}
+   */
+  linkClasses(className) {
+    return classNames('carbon-action-toolbar__action', className);
+  }
+
+  /**
    * @method buildAction
    * @return {Object} JSX
    */
   buildAction(action, index) {
     let { onClick, className, text, ...props } = action;
-    className = classNames('carbon-action-toolbar__action', className);
     onClick = onClick ? onClick.bind(this, this.state.selected) : null;
 
     return (
       <Link
-        className={ className }
+        className={ this.linkClasses(className) }
         data-element='action'
         disabled={ !this.isActive() }
         key={ index }
@@ -172,6 +161,27 @@ class ActionToolbar extends React.Component {
       >
         { text }
       </Link>
+    );
+  }
+
+  /**
+   * @method render
+   * @return {Object} JSX
+   */
+  render() {
+    return (
+      <div className={ this.mainClasses() } { ...tagComponent('action-toolbar', this.props) } >
+        <div className='carbon-action-toolbar__total'>
+          <strong data-element='total'>
+            { this.state.total }
+          </strong>
+          { I18n.t('action_toolbar.selected', { defaultValue: 'Selected' }) }
+        </div>
+
+        <div className='carbon-action-toolbar__actions'>
+          { this.actions() }
+        </div>
+      </div>
     );
   }
 }

--- a/src/components/table-ajax/table-ajax.js
+++ b/src/components/table-ajax/table-ajax.js
@@ -23,11 +23,6 @@ import { Table, TableRow, TableCell, TableHeader, TableSubheader } from './../ta
  *
  */
 class TableAjax extends Table {
-
-  constructor(...args) {
-    super(...args);
-  }
-
   /**
    * Timeout for firing ajax request
    *
@@ -170,7 +165,7 @@ class TableAjax extends Table {
   componentWillReceiveProps(nextProps) {
     super.componentWillReceiveProps(nextProps);
     if (this.props.pageSize !== nextProps.pageSize) {
-      this.setState({pageSize: nextProps.pageSize});
+      this.setState({ pageSize: nextProps.pageSize });
     }
   }
 
@@ -279,11 +274,11 @@ class TableAjax extends Table {
       this.selectAllComponent = null;
     }
 
-    let resetHeight = Number(options.pageSize) < Number(this.pageSize),
-        currentPage = (element === "filter") ? "1" : options.currentPage;
+    const resetHeight = Number(options.pageSize) < Number(this.pageSize),
+        currentPage = (element === 'filter') ? '1' : options.currentPage;
 
     this.setState({
-      currentPage: currentPage,
+      currentPage,
       pageSize: options.pageSize,
       sortOrder: options.sortOrder,
       sortedColumn: options.sortedColumn
@@ -329,7 +324,7 @@ class TableAjax extends Table {
    */
   handleResponse = (err, response) => {
     if (!err) {
-      let data = response.body;
+      const data = response.body;
       this.props.onChange(data);
       this.setState({ totalRecords: String(data.records) });
     }
@@ -344,8 +339,8 @@ class TableAjax extends Table {
    * @return {Object} params for query
    */
   queryParams = (element, options) => {
-    let query = options.filter || {};
-    query.page = (element === "filter") ? "1" : options.currentPage;
+    const query = options.filter || {};
+    query.page = (element === 'filter') ? '1' : options.currentPage;
     query.rows = options.pageSize;
     if (options.sortOrder) { query.sord = options.sortOrder; }
     if (options.sortedColumn) { query.sidx = options.sortedColumn; }

--- a/src/components/table/table-cell/definition.js
+++ b/src/components/table/table-cell/definition.js
@@ -4,11 +4,15 @@ import Definition from './../../../../demo/utils/definition';
 let definition = new Definition('table-cell', TableCell, {
   propTypes: {
     align: "String",
-    action: "Boolean"
+    action: "Boolean",
+    children: "Node",
+    className: "String"
   },
   propDescriptions: {
     align: "Aligns the text in the cell. Can be set to left, center or right.",
     action: "Defines if this cell is used for actions, such as the delete or select action (it makes the column more narrow).",
+    children: "This component supports children.",
+    className: "Classes to apply to the component."
   }
 });
 

--- a/src/components/table/table-cell/table-cell.js
+++ b/src/components/table/table-cell/table-cell.js
@@ -24,6 +24,14 @@ class TableCell extends React.Component {
 
   static propTypes = {
     /**
+     * Defines the cell type to be an action - used for the delete cell.
+     *
+     * @property action
+     * @type {Boolean}
+     */
+    action: PropTypes.bool,
+
+    /**
      * Defines the alignment of the cell (eg "left", "center" or "right").
      *
      * @property align
@@ -32,12 +40,20 @@ class TableCell extends React.Component {
     align: PropTypes.string,
 
     /**
-     * Defines the cell type to be an action - used for the delete cell.
+     * Children elements
      *
-     * @property action
-     * @type {Boolean}
+     * @property children
+     * @type {Node}
      */
-    action: PropTypes.bool
+    children: PropTypes.node,
+
+    /**
+     * Custom className
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string
   }
 
   /**
@@ -48,10 +64,10 @@ class TableCell extends React.Component {
    */
   get tableCellClasses() {
     return classNames(
-      "carbon-table-cell",
+      'carbon-table-cell',
       this.props.className,
       { [`carbon-table-cell--align-${this.props.align}`]: this.props.align },
-      { [`carbon-table-cell--action`]: this.props.action }
+      { 'carbon-table-cell--action': this.props.action }
     );
   }
 
@@ -62,7 +78,7 @@ class TableCell extends React.Component {
    * @return {Object}
    */
   get tableCellProps() {
-    let { ...props } = validProps(this);
+    const { ...props } = validProps(this);
 
     delete props.children;
 

--- a/src/components/table/table-header/__spec__.js
+++ b/src/components/table/table-header/__spec__.js
@@ -127,7 +127,7 @@ describe('TableHeader', () => {
     describe('if a column is sortable', () => {
       describe('before a sortable header is clicked', () => {
         it('does not display an icon', () => {
-          expect(sortableHeader.sortIconHTML).not.toBeDefined();
+          expect(sortableHeader.sortIconHTML).toEqual(null);
         });
       });
 
@@ -154,7 +154,7 @@ describe('TableHeader', () => {
     describe('if a column is not sortable', () => {
       it('does not return an icon', () => {
         let nonSortableHeader = TestUtils.scryRenderedComponentsWithType(instance, TableHeader)[0];
-        expect(nonSortableHeader.sortIconHTML).not.toBeDefined();
+        expect(nonSortableHeader.sortIconHTML).toEqual(null);
       });
     });
   });

--- a/src/components/table/table-header/definition.js
+++ b/src/components/table/table-header/definition.js
@@ -4,11 +4,15 @@ import Definition from './../../../../demo/utils/definition';
 let definition = new Definition('table-header', TableHeader, {
   propTypes: {
     align: "String",
+    children: "Node",
+    className: "String",
     name: "String",
     sortable: "Boolean"
   },
   propDescriptions: {
     align: "Aligns the text in the cell. Can be set to left, center or right.",
+    children: "This component supports children.",
+    className: "Classes to apply to the component.",
     name: "This will normally match the key for data displayed in this column, it is used to identify the sort column in the table.",
     sortable: "Turn sortable on/off for this column."
   }

--- a/src/components/table/table-header/table-header.js
+++ b/src/components/table/table-header/table-header.js
@@ -42,12 +42,28 @@ class TableHeader extends React.Component {
     align: PropTypes.string,
 
     /**
+     * The body of the content component.
+     *
+     * @property children
+     * @type {Object}
+     */
+    children: PropTypes.node,
+
+    /**
+     * Custom className
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    /**
      * Name of the column to sort. Should correspond to name in database.
      *
      * @property name
      * @type {String}
      */
-    name: function(props, propName) {
+    name(props, propName) {
       if (props.sortable) {
         if (!props[propName]) {
           throw new Error('Sortable columns require a prop of name of type String');
@@ -113,9 +129,10 @@ class TableHeader extends React.Component {
    */
   get sortIconHTML() {
     if (this.sorted) {
-      let type = this.context.sortOrder === 'desc' ? 'sort-down' : 'sort-up';
+      const type = this.context.sortOrder === 'desc' ? 'sort-down' : 'sort-up';
       return <Icon type={ type } className={ this.sortIconClasses } />;
     }
+    return null;
   }
 
   /**
@@ -128,7 +145,7 @@ class TableHeader extends React.Component {
     return classNames(
       'carbon-table-header__icon',
       {
-        [`carbon-table-header__icon--align-${ this.props.align }`]: this.props.align
+        [`carbon-table-header__icon--align-${this.props.align}`]: this.props.align
       }
     );
   }
@@ -141,7 +158,7 @@ class TableHeader extends React.Component {
    */
   tableHeaderClasses() {
     return classNames(
-      "carbon-table-header",
+      'carbon-table-header',
       this.props.className,
       {
         [`carbon-table-header--align-${this.props.align}`]: this.props.align,
@@ -157,7 +174,7 @@ class TableHeader extends React.Component {
    * @return {Object}
    */
   get tableHeaderProps() {
-    let { ...props } = validProps(this);
+    const { ...props } = validProps(this);
 
     delete props.children;
 
@@ -165,6 +182,14 @@ class TableHeader extends React.Component {
     props.onClick = this.props.sortable ? this.emitSortEvent.bind(this) : '';
 
     return props;
+  }
+
+  componentTags(props) {
+    return {
+      'data-component': 'table-header',
+      'data-element': props['data-element'],
+      'data-role': props['data-role']
+    };
   }
 
   /**
@@ -179,14 +204,6 @@ class TableHeader extends React.Component {
         { this.sortIconHTML }
       </th>
     );
-  }
-
-  componentTags(props) {
-    return {
-      'data-component': 'table-header',
-      'data-element': props['data-element'],
-      'data-role': props['data-role']
-    };
   }
 }
 

--- a/src/components/table/table-row/definition.js
+++ b/src/components/table/table-row/definition.js
@@ -4,9 +4,12 @@ import Definition from './../../../../demo/utils/definition';
 let definition = new Definition('table-row', TableRow, {
   propTypes: {
     as: "String",
+    children: "Node",
+    className: "String",
     hideMultiSelect: "Boolean",
     highlightable: "Boolean",
     highlighted: "Boolean",
+    onClick: "Function",
     onHighlight: "Function",
     onSelect: "Function",
     selectAll: "Boolean",
@@ -16,9 +19,12 @@ let definition = new Definition('table-row', TableRow, {
   },
   propDescriptions: {
     as: "Defines what this row is for. For your header row set this to 'header' to ensure it behaves correctly.",
+    children: "This component supports children.",
+    className: "Classes to apply to the component.",
     hideMultiSelect: "Option to hide the checkbox for a row that is selectable. Useful if you have set your table to be selectable but you do not want a particular row to be selectable.",
     highlightable: "Controls if this particular row is highlightable.",
     highlighted: "Controls the highlighted state of the row.",
+    onClick: "Callback called after the row is clicked.",
     onHighlight: "Triggered when a row is highlighted.",
     onSelect: "Triggered when a row is selected.",
     selectAll: "Defines if the row's checkbox should be used to select all rows.",

--- a/src/components/table/table-row/table-row.js
+++ b/src/components/table/table-row/table-row.js
@@ -25,6 +25,30 @@ class TableRow extends React.Component {
 
   static propTypes = {
     /**
+     * Children elements
+     *
+     * @property children
+     * @type {Node}
+     */
+    children: PropTypes.node,
+
+    /**
+     * A custom class name for the component.
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    /**
+     * Allows developers to specify a callback after the row is clicked.
+     *
+     * @property onClick
+     * @type {Function}
+     */
+    onClick: PropTypes.func,
+
+    /**
      * Enables multi-selectable table rows.
      *
      * @property selectable
@@ -103,6 +127,8 @@ class TableRow extends React.Component {
     onSelect: PropTypes.func
   }
 
+  static safeProps = ['onClick']
+
   /**
    * Sort handler passed from table context
    *
@@ -146,7 +172,7 @@ class TableRow extends React.Component {
    */
   componentWillMount() {
     if (this.requiresUniqueID && !this.props.uniqueID) {
-      throw new Error("A TableRow which is selectable or highlightable should provide a uniqueID.");
+      throw new Error('A TableRow which is selectable or highlightable should provide a uniqueID.');
     }
 
     if (this.context.attachToTable && this.props.uniqueID && !this.props.selectAll && !this.isHeader) {
@@ -170,16 +196,6 @@ class TableRow extends React.Component {
   }
 
   /**
-   * @method componentWillUnmount
-   * @return {Void}
-   */
-  componentWillUnmount() {
-    if (this.context.detachFromTable) {
-      this.context.detachFromTable(this.rowID);
-    }
-  }
-
-  /**
    * @method componentWillReceiveProps
    * @return {Void}
    */
@@ -197,6 +213,16 @@ class TableRow extends React.Component {
     if (this.props.highlighted != nextProps.highlighted) {
       // if developer is controlling highlighted state - set it
       this.setState({ highlighted: nextProps.highlighted });
+    }
+  }
+
+  /**
+   * @method componentWillUnmount
+   * @return {Void}
+   */
+  componentWillUnmount() {
+    if (this.context.detachFromTable) {
+      this.context.detachFromTable(this.rowID);
     }
   }
 
@@ -224,7 +250,6 @@ class TableRow extends React.Component {
       // trigger highlightRow method on the table
       this.context.highlightRow(this.props.uniqueID, this);
     }
-
     // trigger any custom onClick event the developer may have set
     if (this.props.onClick) { this.props.onClick(...args); }
   }
@@ -268,8 +293,7 @@ class TableRow extends React.Component {
    * @return {Object}
    */
   get rowProps() {
-    let { ...props } = validProps(this);
-
+    const { ...props } = validProps(this);
     props.className = this.mainClasses;
 
     if (this.context.highlightable || this.props.highlightable) {
@@ -286,7 +310,7 @@ class TableRow extends React.Component {
    * @return {Boolean}
    */
   get isHeader() {
-    return this.props.as === "header";
+    return this.props.as === 'header';
   }
 
   /**
@@ -297,10 +321,10 @@ class TableRow extends React.Component {
    */
   get multiSelectCell() {
     // renders a TableHeader if row is flagged as a header.
-    let cell = this.isHeader ? TableHeader : TableCell;
+    const cell = this.isHeader ? TableHeader : TableCell;
 
     return React.createElement(cell, {
-      key: "select", className: "carbon-table-cell--select"
+      key: 'select', className: 'carbon-table-cell--select'
     }, this.multiSelect);
   }
 
@@ -314,9 +338,15 @@ class TableRow extends React.Component {
     if (this.props.hideMultiSelect) { return null; }
 
     // determines which action to use (multi-select or select-all)
-    let action = (this.props.selectAll || this.isHeader) ? this.onSelectAll : this.onSelect;
+    const action = (this.props.selectAll || this.isHeader) ? this.onSelectAll : this.onSelect;
 
-    return <Checkbox onClick={ (ev) => ev.stopPropagation() } onChange={ action } checked={ this.state.selected } />;
+    return (
+      <Checkbox
+        onClick={ ev => ev.stopPropagation() }
+        onChange={ action }
+        checked={ this.state.selected }
+      />
+    );
   }
 
   /**
@@ -344,7 +374,8 @@ class TableRow extends React.Component {
    * @return {Boolean}
    */
   get requiresUniqueID() {
-    let highlightable = this.props.highlightable !== false && (this.props.highlightable || this.context.highlightable),
+    const highlightable = this.props.highlightable !== false &&
+                          (this.props.highlightable || this.context.highlightable),
         selectable = this.props.selectable !== false && (this.props.selectable || this.context.selectable);
 
     return highlightable || selectable;
@@ -356,7 +387,7 @@ class TableRow extends React.Component {
    * @method render
    */
   render() {
-    let content = [this.props.children];
+    const content = [this.props.children];
 
     if (this.shouldHaveMultiSelectColumn) {
       content.unshift(this.multiSelectCell);

--- a/src/components/table/table-subheader/definition.js
+++ b/src/components/table/table-subheader/definition.js
@@ -4,11 +4,15 @@ import Definition from './../../../../demo/utils/definition';
 let definition = new Definition('table-subheader', TableSubheader, {
   propTypes: {
     align: "String",
+    children: "Node",
+    className: "String",
     name: "String",
     sortable: "Boolean"
   },
   propDescriptions: {
     align: "Aligns the text in the cell. Can be set to left, center or right.",
+    children: "This component supports children.",
+    className: "Classes to apply to the component.",
     name: "This will normally match the key for data displayed in this column, it is used to identify the sort column in the table.",
     sortable: "Turn sortable on/off for this column."
   }

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -84,7 +84,7 @@ class Table extends React.Component {
      * The actions to display in the toolbar
      *
      * @property actions - each action is object with the action attributes
-     * @type {Array}
+     * @type {Object}
      */
     actions: PropTypes.object,
 

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -81,6 +81,30 @@ class Table extends React.Component {
 
   static propTypes = {
     /**
+     * The actions to display in the toolbar
+     *
+     * @property actions - each action is object with the action attributes
+     * @type {Array}
+     */
+    actions: PropTypes.object,
+
+    /**
+     * Children elements
+     *
+     * @property children
+     * @type {Node}
+     */
+    children: PropTypes.node,
+
+    /**
+     * Custom className
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    /**
      * Data used to filter the data
      *
      * @property filter
@@ -199,6 +223,22 @@ class Table extends React.Component {
     shrink: PropTypes.bool,
 
     /**
+     * The currently sorted column.
+     *
+     * @property sortedColumn
+     * @type {String}
+     */
+    sortedColumn: PropTypes.string,
+
+    /**
+     * The current sort order applied.
+     *
+     * @property sortOrder
+     * @type {String}
+     */
+    sortOrder: PropTypes.string,
+
+    /**
      * TableRows to be wrapped in <thead>
      *
      * @property thead
@@ -213,6 +253,57 @@ class Table extends React.Component {
      * @type {Object}
      */
     tbody: PropTypes.bool
+  }
+
+  static childContextTypes = {
+    /**
+     * Defines a context object for child components of the table component.
+     * https://facebook.github.io/react/docs/context.html
+     *
+     * @property childContextTypes
+     * @type {Object}
+     */
+    attachActionToolbar: PropTypes.func, // tracks the action toolbar component
+    detachActionToolbar: PropTypes.func, // tracks the action toolbar component
+    attachToTable: PropTypes.func, // attach the row to the table
+    checkSelection: PropTypes.func, // a function to check if the row is currently selected
+    detachFromTable: PropTypes.func, // detach the row from the table
+    highlightRow: PropTypes.func, // highlights the row
+    selectable: PropTypes.bool, // table can enable all rows to be multi-selectable
+    onSort: PropTypes.func, // a callback function for when a sort order is updated
+    selectAll: PropTypes.func, // a callback function for when all visible rows are selected
+    selectRow: PropTypes.func, // a callback function for when a row is selected
+    highlightable: PropTypes.bool, // table can enable all rows to be highlightable
+    sortOrder: PropTypes.string, // the current sort order applied
+    sortedColumn: PropTypes.string // the currently sorted column
+  }
+
+  state = {
+    selectedCount: 0
+  }
+
+  /**
+   * Returns table object to child components.
+   *
+   * @method getChildContext
+   * @return {void}
+   */
+  getChildContext = () => {
+    return {
+      attachActionToolbar: this.attachActionToolbar,
+      detachActionToolbar: this.detachActionToolbar,
+      attachToTable: this.attachToTable,
+      detachFromTable: this.detachFromTable,
+      checkSelection: this.checkSelection,
+      highlightRow: this.highlightRow,
+      onSort: this.onSort,
+      highlightable: this.props.highlightable,
+      selectable: this.props.selectable,
+      selectAll: this.selectAll,
+      selectRow: this.selectRow,
+      sortedColumn: this.sortedColumn,
+      sortOrder: this.sortOrder
+    };
   }
 
   /**
@@ -244,9 +335,9 @@ class Table extends React.Component {
     }
 
     if (this.props.selectable && nextProps.selectable === false) {
-      for (let key in this.rows) {
+      for (const key in this.rows) {
         // update all the rows with the new state
-        let row = this.rows[key];
+        const row = this.rows[key];
         this.selectRow(row.props.uniqueID, row, false);
       }
       this.selectedRows = {};
@@ -269,107 +360,88 @@ class Table extends React.Component {
     }
   }
 
-  static childContextTypes = {
-    /**
-     * Defines a context object for child components of the table component.
-     * https://facebook.github.io/react/docs/context.html
-     *
-     * @property childContextTypes
-     * @type {Object}
-     */
-    attachActionToolbar: PropTypes.func, // tracks the action toolbar component
-    detachActionToolbar: PropTypes.func, // tracks the action toolbar component
-    attachToTable: PropTypes.func, // attach the row to the table
-    checkSelection: PropTypes.func, // a function to check if the row is currently selected
-    detachFromTable: PropTypes.func, // detach the row from the table
-    highlightRow: PropTypes.func, // highlights the row
-    selectable: PropTypes.bool, // table can enable all rows to be multi-selectable
-    onSort: PropTypes.func, // a callback function for when a sort order is updated
-    selectAll: PropTypes.func, // a callback function for when all visible rows are selected
-    selectRow: PropTypes.func, // a callback function for when a row is selected
-    highlightable: PropTypes.bool, // table can enable all rows to be highlightable
-    sortOrder: PropTypes.string, // the current sort order applied
-    sortedColumn: PropTypes.string // the currently sorted column
+  /**
+   * Handles what happens on sort.
+   *
+   * @method onSort
+   * @param {String} sortedColumn
+   * @param {String} sortOrder
+   */
+  onSort = (sortedColumn, sortOrder) => {
+    const options = this.emitOptions();
+    options.sortedColumn = sortedColumn;
+    options.sortOrder = sortOrder;
+    this.emitOnChangeCallback('table', options);
   }
 
   /**
-   * Returns table object to child components.
+   * Handles when the pager emits a onChange event
+   * Passes data to emitOnChangeCallback in the correct
+   * format
    *
-   * @method getChildContext
-   * @return {void}
+   * @method onPagination
+   * @param {String} currentPage
+   * @param {String} pageSize
+   * @return {Void}
    */
-  getChildContext = () => {
-    return {
-      attachActionToolbar: this.attachActionToolbar,
-      detachActionToolbar: this.detachActionToolbar,
-      attachToTable: this.attachToTable,
-      detachFromTable: this.detachFromTable,
-      checkSelection: this.checkSelection,
-      highlightRow: this.highlightRow,
-      onSort: this.onSort,
-      highlightable: this.props.highlightable,
-      selectable: this.props.selectable,
-      selectAll: this.selectAll,
-      selectRow: this.selectRow,
-      sortedColumn: this.sortedColumn,
-      sortOrder: this.sortOrder
-    };
-  }
-
-  state = {
-    selectedCount: 0
+  onPagination = (currentPage, pageSize, element) => {
+    if (this.props.onPageSizeChange && element === 'size') {
+      this.props.onPageSizeChange(pageSize);
+    }
+    const options = this.emitOptions();
+    options.currentPage = currentPage;
+    options.pageSize = pageSize;
+    this.emitOnChangeCallback('pager', options);
   }
 
   /**
-   * Maintains the height of the table
+   * Returns the currently sorted column.
    *
-   * @property tableHeight
-   * @type {Number}
+   * @method sortedColumn
+   * @return {String}
    */
-  tableHeight = 0;
+  get sortedColumn() {
+    return this.props.sortedColumn;
+  }
 
   /**
-   * The rows currently attached to the table.
+   * Returns the current sort order.
    *
-   * @property rows
-   * @type {Object}
+   * @method sortOrder
+   * @return {String}
    */
-  rows = {};
+  get sortOrder() {
+    return this.props.sortOrder;
+  }
 
   /**
-   * Tracks the currently highlighted row.
+   * Get pageSize for table
    *
-   * @property highlightedRow
-   * @type {String}
+   * @method pageSize
+   * @return {String} table page size
    */
-  highlightedRow = {
-    id: null,
-    row: null
-  };
+  get pageSize() {
+    return this.props.pageSize;
+  }
 
   /**
-   * Tracks the rows which are currently selected.
+   * Emit onChange event with options
+   * needed to fetch the new data
    *
-   * @property selectedRows
-   * @type {Object}
+   * @method emitOnChangeCallback
+   * @param {String} element changed element
+   * @param {Object} options base and updated options
+   * @return {Void}
    */
-  selectedRows = {};
+  emitOnChangeCallback = (element, options) => {
+    if (this.selectAllComponent) {
+      // reset the select all component
+      this.selectAllComponent.setState({ selected: false });
+      this.selectAllComponent = null;
+    }
 
-  /**
-   * Tracks the component used for select all.
-   *
-   * @property selectAllComponent
-   * @type {Object}
-   */
-  selectAllComponent = null;
-
-  /**
-   * Tracks the action toolbar component.
-   *
-   * @property actionToolbarComponent
-   * @type {Object}
-   */
-  actionToolbarComponent = null;
+    this.props.onChange(element, options);
+  }
 
   /**
    * Attaches action toolbar to the table.
@@ -430,8 +502,8 @@ class Table extends React.Component {
       });
     }
 
-    for (let key in this.rows) {
-      let _row = this.rows[key];
+    for (const key in this.rows) {
+      const _row = this.rows[key];
       _row.setState({ selected: false });
     }
     this.emitOnChangeCallback('refresh', this.emitOptions());
@@ -480,8 +552,8 @@ class Table extends React.Component {
 
     // update the current highlighted row
     this.highlightedRow = {
-      id: id,
-      row: row
+      id,
+      row
     };
 
     if (this.props.onHighlight) {
@@ -501,7 +573,7 @@ class Table extends React.Component {
    * @return {Void}
    */
   selectRow = (id, row, state, skipCallback) => {
-    let isSelected = this.selectedRows[id] !== undefined;
+    const isSelected = this.selectedRows[id] !== undefined;
 
     // if row state has not changed - return early
     if (state === isSelected) { return; }
@@ -524,7 +596,7 @@ class Table extends React.Component {
     row.setState({ selected: state });
 
     if (this.actionToolbarComponent && !skipCallback) {
-      let keys = Object.keys(this.selectedRows);
+      const keys = Object.keys(this.selectedRows);
 
       // update action toolbar
       this.actionToolbarComponent.setState({
@@ -547,11 +619,11 @@ class Table extends React.Component {
    * @return {Void}
    */
   selectAll = (row) => {
-    let selectState = !row.state.selected;
+    const selectState = !row.state.selected;
 
-    for (let key in this.rows) {
+    for (const key in this.rows) {
       // update all the rows with the new state
-      let _row = this.rows[key];
+      const _row = this.rows[key];
       if (_row.shouldHaveMultiSelectColumn) {
         this.selectRow(_row.props.uniqueID, _row, selectState, true);
       }
@@ -565,7 +637,7 @@ class Table extends React.Component {
 
 
     if (this.actionToolbarComponent) {
-      let keys = Object.keys(this.selectedRows);
+      const keys = Object.keys(this.selectedRows);
 
       // update action toolbar
       this.actionToolbarComponent.setState({
@@ -590,7 +662,7 @@ class Table extends React.Component {
    * @return {Void}
    */
   checkSelection = (id, row) => {
-    let isSelected = this.selectedRows[id] !== undefined,
+    const isSelected = this.selectedRows[id] !== undefined,
         isHighlighted = this.highlightedRow.id === id;
 
     if (isSelected !== row.state.selected) {
@@ -624,11 +696,11 @@ class Table extends React.Component {
    * @return {Void}
    */
   resizeTable() {
-    let shrink = this.props.shrink && this._table.offsetHeight < this.tableHeight;
+    const shrink = this.props.shrink && this._table.offsetHeight < this.tableHeight;
 
     if (shrink || this._table.offsetHeight > this.tableHeight) {
       this.tableHeight = this._table.offsetHeight;
-      this._wrapper.style.minHeight = this.tableHeight + 'px';
+      this._wrapper.style.minHeight = `${this.tableHeight}px`;
     }
   }
 
@@ -644,87 +716,55 @@ class Table extends React.Component {
   }
 
   /**
-   * Get pageSize for table
+   * Tracks the component used for select all.
    *
-   * @method pageSize
-   * @return {String} table page size
+   * @property selectAllComponent
+   * @type {Object}
    */
-  get pageSize() {
-    return this.props.pageSize;
-  }
+  selectAllComponent = null;
 
   /**
-   * Emit onChange event with options
-   * needed to fetch the new data
+   * Tracks the action toolbar component.
    *
-   * @method emitOnChangeCallback
-   * @param {String} element changed element
-   * @param {Object} options base and updated options
-   * @return {Void}
+   * @property actionToolbarComponent
+   * @type {Object}
    */
-  emitOnChangeCallback = (element, options) => {
-    if (this.selectAllComponent) {
-      // reset the select all component
-      this.selectAllComponent.setState({ selected: false });
-      this.selectAllComponent = null;
-    }
-
-    this.props.onChange(element, options);
-  }
+  actionToolbarComponent = null;
 
   /**
-   * Handles when the pager emits a onChange event
-   * Passes data to emitOnChangeCallback in the correct
-   * format
+   * Tracks the rows which are currently selected.
    *
-   * @method onPagination
-   * @param {String} currentPage
-   * @param {String} pageSize
-   * @return {Void}
+   * @property selectedRows
+   * @type {Object}
    */
-  onPagination = (currentPage, pageSize, element) => {
-    if (this.props.onPageSizeChange && element === 'size') {
-      this.props.onPageSizeChange(pageSize);
-    }
-    let options = this.emitOptions();
-    options.currentPage = currentPage;
-    options.pageSize = pageSize;
-    this.emitOnChangeCallback('pager', options);
-  }
+  selectedRows = {};
 
   /**
-   * Returns the currently sorted column.
+   * Tracks the currently highlighted row.
    *
-   * @method sortedColumn
-   * @return {String}
+   * @property highlightedRow
+   * @type {String}
    */
-  get sortedColumn() {
-    return this.props.sortedColumn;
-  }
+  highlightedRow = {
+    id: null,
+    row: null
+  };
 
   /**
-   * Returns the current sort order.
+   * The rows currently attached to the table.
    *
-   * @method sortOrder
-   * @return {String}
+   * @property rows
+   * @type {Object}
    */
-  get sortOrder() {
-    return this.props.sortOrder;
-  }
+  rows = {};
 
   /**
-   * Handles what happens on sort.
+   * Maintains the height of the table
    *
-   * @method onSort
-   * @param {String} sortedColumn
-   * @param {String} sortOrder
+   * @property tableHeight
+   * @type {Number}
    */
-  onSort = (sortedColumn, sortOrder) => {
-    let options = this.emitOptions();
-    options.sortedColumn = sortedColumn;
-    options.sortOrder = sortOrder;
-    this.emitOnChangeCallback('table', options);
-  }
+  tableHeight = 0;
 
   /**
    * Base Options to be emitted by onChange
@@ -736,12 +776,12 @@ class Table extends React.Component {
     let currentPage = props.currentPage || '';
 
     if (Number(props.currentPage) > Number(props.pageSize)) {
-      currentPage = "1";
+      currentPage = '1';
     }
 
     return {
       // What if paginate if false - think about when next change functionality is added
-      currentPage: currentPage,
+      currentPage,
       filter: props.filter ? props.filter.toJS() : {},
       pageSize: props.pageSize || '',
       sortOrder: props.sortOrder || '',
@@ -791,6 +831,7 @@ class Table extends React.Component {
     if (this.props.paginate) {
       return (<Pager { ...this.pagerProps } />);
     }
+    return null;
   }
 
   /**
@@ -816,7 +857,7 @@ class Table extends React.Component {
     return classNames(
       'carbon-table__wrapper',
       this.props.className,
-      { [`carbon-table--pager`]: this.props.paginate }
+      { 'carbon-table--pager': this.props.paginate }
     );
   }
 
@@ -839,11 +880,12 @@ class Table extends React.Component {
   get thead() {
     if (this.props.thead) {
       return (
-        <thead className="carbon-table__header">
+        <thead className='carbon-table__header'>
           { this.props.thead }
         </thead>
       );
     }
+    return null;
   }
 
   /**
@@ -868,16 +910,16 @@ class Table extends React.Component {
    */
   get loadingRow() {
     return (
-      <TableRow key="__loading__" selectable={ false } highlightable={ false } hideMultiSelect={ true }>
-        <TableCell colSpan="42" align="center">
+      <TableRow key='__loading__' selectable={ false } highlightable={ false } hideMultiSelect>
+        <TableCell colSpan='42' align='center'>
           <ReactCSSTransitionGroup
-            transitionName="table-loading"
+            transitionName='table-loading'
             transitionEnterTimeout={ 300 }
             transitionLeaveTimeout={ 300 }
             transitionAppearTimeout={ 300 }
-            transitionAppear={ true }
+            transitionAppear
           >
-            <Spinner size="small" />
+            <Spinner size='small' />
           </ReactCSSTransitionGroup>
         </TableCell>
       </TableRow>
@@ -892,9 +934,9 @@ class Table extends React.Component {
    */
   get emptyRow() {
     return (
-      <TableRow key="__loading__" selectable={ false } highlightable={ false }>
-        <TableCell colSpan="42" align="center">
-          { I18n.t("table.no_data", { defaultValue: "No results to display" }) }
+      <TableRow key='__loading__' selectable={ false } highlightable={ false }>
+        <TableCell colSpan='42' align='center'>
+          { I18n.t('table.no_data', { defaultValue: 'No results to display' }) }
         </TableCell>
       </TableRow>
     );
@@ -912,8 +954,8 @@ class Table extends React.Component {
 
     // if using immutable js we can count the children
     if (children && children.count) {
-      let numOfChildren = children.count(),
-          onlyChildIsHeader = numOfChildren === 1 && children.first().props.as === "header";
+      const numOfChildren = children.count(),
+          onlyChildIsHeader = numOfChildren === 1 && children.first().props.as === 'header';
 
       if (onlyChildIsHeader) {
         if (this._hasRetreivedData) {
@@ -933,9 +975,8 @@ class Table extends React.Component {
       return children;
     } else if (this._hasRetreivedData) {
       return this.emptyRow;
-    } else {
-      return this.loadingRow;
     }
+    return this.loadingRow;
   }
 
   /**
@@ -947,13 +988,20 @@ class Table extends React.Component {
   get tbody() {
     if (this.props.tbody === false) {
       return this.tableContent;
-    } else {
-      return (
-        <tbody>
-          { this.tableContent }
-        </tbody>
-      );
     }
+    return (
+      <tbody>
+        { this.tableContent }
+      </tbody>
+    );
+  }
+
+  componentTags(props) {
+    return {
+      'data-component': 'table',
+      'data-element': props['data-element'],
+      'data-role': props['data-role']
+    };
   }
 
   /**
@@ -974,14 +1022,6 @@ class Table extends React.Component {
         { this.pager }
       </div>
     );
-  }
-
-  componentTags(props) {
-    return {
-      'data-component': 'table',
-      'data-element': props['data-element'],
-      'data-role': props['data-role']
-    };
   }
 }
 


### PR DESCRIPTION
To prepare for the future upgrade of [carbon-factory](https://github.com/Sage/carbon-factory), that will introduce stricter linting rules, this PR updates the `table` components to pre-emptively resolve the errors.

Updated components:
- ActionToolbar 
- Table
- TableAjax
- TableCell
- TableHeader
- TableRow
- TableSubHeader (no linting errors)

#### Notes
The biggest change is removing the usage of `.bind` in `ActionToolbar`. I added a spec to test the existing behaviour as the onClick handler allowed as part of the actions prop was not currently tested. I then added a separate commit to refactor out the usage of `.bind`.