### PR TITLE
Add subtitle prop type and descriptions for demo site

### DIFF
--- a/src/components/alert/definition.js
+++ b/src/components/alert/definition.js
@@ -28,10 +28,12 @@ let definition = new Definition('alert', Alert, {
     title: "String",
     size: "String",
     showCloseIcon: "Boolean",
+    subtitle: "String"
   },
   propDescriptions: {
     showCloseIcon: "Set this prop to false to hide the close icon within the dialog.",
     size: "Change this prop to set the dialog to a specific size. Possible values include: " + OptionsHelper.sizesFull.join(", "),
+    subtitle: "Controls the subtitle of the dialog.",
     title: "Controls the main title of the dialog."
   }
 });

--- a/src/components/confirm/definition.js
+++ b/src/components/confirm/definition.js
@@ -26,20 +26,22 @@ let definition = new Definition('confirm', Confirm, {
     children: 'This is an example of a confirm.'
   },
   propTypes: {
-    title: "String",
-    size: "String",
-    showCloseIcon: "Boolean",
-    onConfirm: "Function",
     cancelLabel: "String",
-    confirmLabel: "String"
+    confirmLabel: "String",
+    onConfirm: "Function",
+    showCloseIcon: "Boolean",
+    size: "String",
+    subtitle: "String",
+    title: "String"
   },
   propDescriptions: {
+    cancelLabel: "Define custom text for the cancel button.",
+    confirmLabel: "Define custom text for the confirm button.",
+    onConfirm: "A callback when the user selects confirm.",
     showCloseIcon: "Set this prop to false to hide the close icon within the dialog.",
     size: "Change this prop to set the dialog to a specific size. Possible values include: " + OptionsHelper.sizesFull.join(", "),
-    title: "Controls the main title of the dialog.",
-    onConfirm: "A callback when the user selects confirm.",
-    cancelLabel: "Define custom text for the cancel button.",
-    confirmLabel: "Define custom text for the confirm button."
+    subtitle: "Controls the subtitle of the dialog.",
+    title: "Controls the main title of the dialog."
   }
 });
 

--- a/src/components/dialog/definition.js
+++ b/src/components/dialog/definition.js
@@ -25,10 +25,12 @@ let definition = new Definition('dialog', Dialog, {
     title: "String",
     size: "String",
     showCloseIcon: "Boolean",
+    subtitle: "String"
   },
   propDescriptions: {
     showCloseIcon: "Set this prop to false to hide the close icon within the dialog.",
     size: "Change this prop to set the dialog to a specific size. Possible values include: " + OptionsHelper.sizesFull.join(", "),
+    subtitle: "Controls the subtitle of the dialog.",
     title: "Controls the main title of the dialog."
   }
 });


### PR DESCRIPTION
Add the prop type and description for `subtitle` to the `Alert`, `Confirm`, and `Dialog` components.

Also sorted the prop types and descriptions in `Confirm`.