### PR TITLE
Dropdown component linting fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 The following components have had minor internal changes to satisfy the introduction of stricter linting rules:
 
 * AppWrapper
+* Dropdown
+* DropdownFilter
+* DropdownFilterAjax
 * Carousel
 * Column
 * Content

--- a/src/components/dropdown-filter-ajax/__spec__.js
+++ b/src/components/dropdown-filter-ajax/__spec__.js
@@ -180,7 +180,7 @@ describe('DropdownFilterAjax', () => {
 
         describe('if scroll top is less than scroll trigger position', () => {
           it('does not get data', () => {
-            instance.refs.list = {
+            instance.list = {
               scrollHeight: 200,
               offsetHeight: 75,
               scrollTop: 100
@@ -192,7 +192,7 @@ describe('DropdownFilterAjax', () => {
 
         describe('if scroll top is more than scroll trigger position', () => {
           it('calls get data', () => {
-            instance.refs.list = {
+            instance.list = {
               scrollHeight: 200,
               offsetHeight: 76,
               scrollTop: 100
@@ -272,12 +272,12 @@ describe('DropdownFilterAjax', () => {
 
     describe('when list is open', () => {
       it('should reset the scroll top', () => {
-        instance.refs.list = {
+        instance.list = {
           scrollTop: 100
         };
         instance.setState({ open: true });
         instance.resetScroll();
-        expect(instance.refs.list.scrollTop).toEqual(0);
+        expect(instance.list.scrollTop).toEqual(0);
       });
     });
   });

--- a/src/components/dropdown-filter-ajax/__spec__.js
+++ b/src/components/dropdown-filter-ajax/__spec__.js
@@ -155,7 +155,7 @@ describe('DropdownFilterAjax', () => {
       it('does not get data', () => {
         instance.listeningToScroll = false;
         instance.setState({ open: true });
-        TestUtils.Simulate.scroll(instance.refs.list);
+        TestUtils.Simulate.scroll(instance.list);
         expect(instance.getData).not.toHaveBeenCalled();
       });
     });

--- a/src/components/dropdown-filter-ajax/dropdown-filter-ajax.js
+++ b/src/components/dropdown-filter-ajax/dropdown-filter-ajax.js
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import Request from 'superagent';
-import { cloneDeep } from 'lodash';
+import { omit, assign, cloneDeep } from 'lodash';
 import DropdownFilter from './../dropdown-filter';
-import { omit, assign } from 'lodash';
 
 /**
  * A dropdown filter widget using ajax.
@@ -160,9 +159,9 @@ class DropdownFilterAjax extends DropdownFilter {
    */
   handleBlur = () => {
     if (!this.blockBlur) {
-      let filter = this.props.create ? this.state.filter : null;
+      const filter = this.props.create ? this.state.filter : null;
       // close list and reset filter
-      this.setState({ open: false, filter: filter });
+      this.setState({ open: false, filter });
 
       if (this.props.onBlur) {
         this.props.onBlur();
@@ -177,7 +176,7 @@ class DropdownFilterAjax extends DropdownFilter {
    */
   handleFocus = () => {
     if (!this.props.suggest && !this.blockFocus) {
-      this.getData("", 1);
+      this.getData('', 1);
     } else {
       this.blockFocus = false;
     }
@@ -193,8 +192,8 @@ class DropdownFilterAjax extends DropdownFilter {
   handleScroll = () => {
     if (this.listeningToScroll) {
       if (this.state.page < this.state.pages) {
-        let list = this.refs.list;
-        let scrollTriggerPosition = list.scrollHeight - list.offsetHeight - 25;
+        const list = this.list;
+        const scrollTriggerPosition = list.scrollHeight - list.offsetHeight - 25;
 
         if (list.scrollTop > scrollTriggerPosition) {
           this.listeningToScroll = false;
@@ -211,12 +210,12 @@ class DropdownFilterAjax extends DropdownFilter {
    * @param {String} query The search term
    * @param {Object} page The page number to get
    */
-  getData = (query = "", page = 1) => {
-    this.setState({ 'requesting': true });
+  getData = (query = '', page = 1) => {
+    this.setState({ requesting: true });
     Request
       .get(this.props.path)
       .query({
-        page: page,
+        page,
         rows: this.props.rowsPerRequest,
         value: query
       })
@@ -229,7 +228,7 @@ class DropdownFilterAjax extends DropdownFilter {
    */
   ajaxUpdateList = (err, response) => {
     this.updateList(response.body.data[0]);
-    this.setState({ 'requesting': false });
+    this.setState({ requesting: false });
   }
 
   /**
@@ -239,10 +238,8 @@ class DropdownFilterAjax extends DropdownFilter {
    */
   resetScroll = () => {
     this.listeningToScroll = false;
-
-    if (this.state.open) {
-      let list = this.refs.list;
-      list.scrollTop = 0;
+    if (this.state.open && this.list) {
+      this.list.scrollTop = 0;
     }
   }
 
@@ -254,8 +251,8 @@ class DropdownFilterAjax extends DropdownFilter {
    */
   updateList = (data) => {
     // Default page size is 25 records
-    let pages = Math.ceil(data.records / this.props.rowsPerRequest),
-        records = data.items;
+    const pages = Math.ceil(data.records / this.props.rowsPerRequest);
+    let records = data.items;
 
     // Adds next set of records as page scrolled down
     if (data.page > 1) {
@@ -268,7 +265,7 @@ class DropdownFilterAjax extends DropdownFilter {
       open: true,
       options: records,
       page: data.page,
-      pages: pages
+      pages
     });
 
     this.listeningToScroll = true;
@@ -280,7 +277,7 @@ class DropdownFilterAjax extends DropdownFilter {
    * @method listProps
    */
   get listProps() {
-    let props = super.listProps;
+    const props = super.listProps;
 
     props.onScroll = this.handleScroll;
 
@@ -309,7 +306,7 @@ class DropdownFilterAjax extends DropdownFilter {
    * @method inputProps
    */
   get inputProps() {
-    let props = super.inputProps;
+    const props = super.inputProps;
 
     if (typeof this.state.filter !== 'string') {
       props.value = this.props.visibleValue;

--- a/src/components/dropdown-filter/dropdown-filter.js
+++ b/src/components/dropdown-filter/dropdown-filter.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Dropdown from './../dropdown';
+import { assign } from 'lodash';
 import I18n from 'i18n-js';
 import classNames from 'classnames';
 import escapeStringRegexp from 'escape-string-regexp';
-import { assign } from 'lodash';
+import Dropdown from './../dropdown';
 
 /**
  * A dropdown filter widget.
@@ -143,7 +143,7 @@ class DropdownFilter extends Dropdown {
    */
   componentWillUpdate(nextProps, nextState) {
     // if list is being opened, set boolean
-    if (this.state.open != nextState.open) {
+    if (this.state.open !== nextState.open) {
       this.openingList = true;
     }
   }
@@ -155,9 +155,9 @@ class DropdownFilter extends Dropdown {
    * @param {String} val
    */
   selectValue(val, visibleVal) {
-    let filter = this.props.freetext ? visibleVal : null;
+    const filter = this.props.freetext ? visibleVal : null;
     super.selectValue(val, visibleVal);
-    this.setState({ filter: filter });
+    this.setState({ filter });
   }
 
   /*
@@ -167,7 +167,7 @@ class DropdownFilter extends Dropdown {
    * @param {Object} ev event
    */
   handleVisibleChange(ev) {
-    let state = {
+    const state = {
       filter: ev.target.value,
       highlighted: null
     };
@@ -184,7 +184,7 @@ class DropdownFilter extends Dropdown {
 
     if (this.props.create) {
       // if create is enabled then empty the selected value so the filter persists
-      this.emitOnChangeCallback("", ev.target.value);
+      this.emitOnChangeCallback('', ev.target.value);
     }
   }
 
@@ -198,16 +198,17 @@ class DropdownFilter extends Dropdown {
       let filter = null;
 
       if (this.props.create || this.props.freetext) { filter = this.state.filter; }
-      this.setState({ open: false, filter: filter });
+      this.setState({ open: false, filter });
 
       if (this.props.freetext) {
         let opt;
 
         if (this.state.filter) {
-          opt = this.props.options.find((opt) => {
-            if (opt.get('name')) {
-              return opt.get('name').toLowerCase() === this.state.filter.toLowerCase();
+          opt = this.props.options.find((option) => {
+            if (option.get('name')) {
+              return option.get('name').toLowerCase() === this.state.filter.toLowerCase();
             }
+            return null;
           });
         }
 
@@ -256,20 +257,22 @@ class DropdownFilter extends Dropdown {
    * @param {Object} options Immutable map of list options
    */
   prepareList = (options) => {
+    let filteredOptions;
     if ((this.writeable || !this.openingList) && typeof this.state.filter === 'string') {
-      let filter = this.state.filter;
-      let regex = new RegExp(escapeStringRegexp(filter), 'i');
+      const filter = this.state.filter;
+      const regex = new RegExp(escapeStringRegexp(filter), 'i');
 
       // if user has entered a search filter
-      options = options.filter((option) => {
+      filteredOptions = options.filter((option) => {
         if (option.name && option.name.search(regex) > -1) {
           option.name = this.highlightMatches(option.name, filter);
           return option;
         }
+        return null;
       });
     }
 
-    return options;
+    return filteredOptions || options;
   }
 
   /**
@@ -284,8 +287,8 @@ class DropdownFilter extends Dropdown {
       items = (
         <li className={ 'carbon-dropdown__list-item carbon-dropdown__list-item--no-results' }>
           {
-            I18n.t("dropdownlist.no_results", {
-              defaultValue: "No results match \"%{term}\"",
+            I18n.t('dropdownlist.no_results', {
+              defaultValue: 'No results match "%{term}"',
               term: this.state.filter
             })
           }
@@ -306,12 +309,10 @@ class DropdownFilter extends Dropdown {
 
     if (this.state.highlighted) {
       highlighted = this.state.highlighted;
-    } else {
-      if (!this.state.filter && this.props.value) {
-        highlighted = this.props.value;
-      } else if (this.state.filter && options.length) {
-        highlighted = options[0].id;
-      }
+    } else if (!this.state.filter && this.props.value) {
+      highlighted = this.props.value;
+    } else if (this.state.filter && options.length) {
+      highlighted = options[0].id;
     }
 
     return highlighted;
@@ -323,26 +324,26 @@ class DropdownFilter extends Dropdown {
    * @method listHTML
    */
   get listHTML() {
-    let original = super.listHTML,
+    const original = super.listHTML,
         html = [original];
 
     if (this.state.open && this.props.create) {
-      let text = "Create ";
+      let text = 'Create ';
 
       if (this.state.filter) {
-        text += '"' + this.state.filter + '"';
+        text += `"${this.state.filter}"`;
       } else {
-        text += "New";
+        text += 'New';
       }
 
       html.push(
         <a
-          className="carbon-dropdown__action"
+          className='carbon-dropdown__action'
           data-element='create'
-          key="dropdown-action"
+          key='dropdown-action'
           onClick={ this.handleCreate }
         >
-            { text }
+          { text }
         </a>
       );
     }
@@ -388,7 +389,7 @@ class DropdownFilter extends Dropdown {
    * @method inputClasses
    */
   get inputClasses() {
-    let filtered = !this.props.create && !this.props.freetext && typeof this.state.filter === 'string';
+    const filtered = !this.props.create && !this.props.freetext && typeof this.state.filter === 'string';
     return classNames(super.inputClasses, { 'carbon-dropdown__input--filtered': filtered });
   }
 
@@ -398,7 +399,7 @@ class DropdownFilter extends Dropdown {
    * @method inputProps
    */
   get inputProps() {
-    let props = super.inputProps;
+    const props = super.inputProps;
 
     let value = props.value;
 
@@ -421,9 +422,9 @@ class DropdownFilter extends Dropdown {
    * @return {Object}
    */
   get alternateHiddenInputProps() {
-    let props = {
-      ref: "altHidden",
-      type: "hidden",
+    const props = {
+      ref: 'altHidden',
+      type: 'hidden',
       readOnly: true,
       name: this.props.freetextName,
       value: this.props.visibleValue
@@ -455,18 +456,16 @@ class DropdownFilter extends Dropdown {
   highlightMatches = (optionText, value) => {
     if (!value.length) { return optionText; }
 
-    let beginning, end, middle, newValue, parsedOptionText, valIndex;
-
-    parsedOptionText = optionText.toLowerCase();
-    valIndex = parsedOptionText.indexOf(value);
+    const parsedOptionText = optionText.toLowerCase();
+    const valIndex = parsedOptionText.indexOf(value);
 
     if (valIndex === -1) {
       return optionText;
     }
 
-    beginning = optionText.substr(0, valIndex);
-    middle = optionText.substr(valIndex, value.length);
-    end = optionText.substr(valIndex + value.length, optionText.length);
+    const beginning = optionText.substr(0, valIndex);
+    const middle = optionText.substr(valIndex, value.length);
+    let end = optionText.substr(valIndex + value.length, optionText.length);
 
     // find end of string recursively
     if (end.indexOf(value) !== -1) {
@@ -474,10 +473,10 @@ class DropdownFilter extends Dropdown {
     }
 
     // build JSX object
-    newValue = [
-      <span   key="beginning">{ beginning }</span>,
-      <strong key="middle"><u>{ middle }</u></strong>,
-      <span   key="end">{ end }</span>
+    const newValue = [
+      <span key='beginning'>{ beginning }</span>,
+      <strong key='middle'><u>{ middle }</u></strong>,
+      <span key='end'>{ end }</span>
     ];
 
     return newValue;

--- a/src/components/dropdown/__spec__.js
+++ b/src/components/dropdown/__spec__.js
@@ -189,7 +189,7 @@ describe('Dropdown', () => {
   describe('handleMouseEnterList', () => {
     it('sets blockBlur to true', () => {
       instance.blockBlur = false;
-      TestUtils.Simulate.mouseEnter(instance.refs.listBlock);
+      TestUtils.Simulate.mouseEnter(instance.listBlock);
       expect(instance.blockBlur).toBeTruthy;
     });
   });
@@ -197,7 +197,7 @@ describe('Dropdown', () => {
   describe('handleMouseLeaveList', () => {
     it('sets blockBlur to true', () => {
       instance.blockBlur = true;
-      TestUtils.Simulate.mouseLeave(instance.refs.listBlock);
+      TestUtils.Simulate.mouseLeave(instance.listBlock);
       expect(instance.blockBlur).toBeFalsy;
     });
   });
@@ -214,8 +214,8 @@ describe('Dropdown', () => {
 
     describe('if target is the list', () => {
       it('calls focus on the input after a timeout', () => {
-        TestUtils.Simulate.mouseDown(instance.refs.listBlock, {
-          target: instance.refs.list
+        TestUtils.Simulate.mouseDown(instance.listBlock, {
+          target: instance.list
         });
         jasmine.clock().tick();
         expect(instance._input.focus).toHaveBeenCalled();
@@ -224,7 +224,7 @@ describe('Dropdown', () => {
 
     describe('if target is not the list', () => {
       it('does not call focus on the input', () => {
-        TestUtils.Simulate.mouseDown(instance.refs.listBlock, {
+        TestUtils.Simulate.mouseDown(instance.listBlock, {
           target: 'foo'
         });
         jasmine.clock().tick();
@@ -576,6 +576,27 @@ describe('Dropdown', () => {
           });
         });
       });
+
+      describe('unknown key', () => {
+        let spy, opts;
+
+        beforeEach(() => {
+          spy = jasmine.createSpy();
+          opts = { which: 0, preventDefault: spy };
+        });
+
+        it('does not prevent default', () => {
+          TestUtils.Simulate.keyDown(instance._input, opts);
+          expect(spy).not.toHaveBeenCalled();
+        });
+
+        it('sets highlighted to null', () => {
+          instance.setState({ highlighted: 2 });
+          spyOn(instance, 'setState');
+          TestUtils.Simulate.keyDown(instance._input, opts);
+          expect(instance.setState).toHaveBeenCalledWith({ highlighted: null });
+        });
+      });
     });
   });
 
@@ -593,7 +614,7 @@ describe('Dropdown', () => {
 
     describe('if the list was closed', () => {
       it('returns the value of the last item in the list', () => {
-        list = instance.refs.list;
+        list = instance.list;
         let nextValue = instance.onUpArrow(list, null);
         expect(nextValue).toEqual(list.lastChild.getAttribute('value'));
       });
@@ -602,7 +623,7 @@ describe('Dropdown', () => {
     describe('if the element is the first in the list', () => {
       it('it calls updateScroll with the list and the last list element', () => {
         instance.setState({ highlighted: 1 });
-        list = instance.refs.list;
+        list = instance.list;
         element = list.getElementsByClassName('carbon-dropdown__list-item--highlighted')[0];
         instance.onUpArrow(list, element);
         expect(instance.updateScroll).toHaveBeenCalledWith(list, list.lastChild);
@@ -610,7 +631,7 @@ describe('Dropdown', () => {
 
       it('returns the next highlighted value', () => {
         instance.setState({ highlighted: 1 });
-        list = instance.refs.list;
+        list = instance.list;
         element = list.getElementsByClassName('carbon-dropdown__list-item--highlighted')[0];
         let nextValue = instance.onUpArrow(list, element);
         expect(nextValue).toEqual(list.lastChild.getAttribute('value'));
@@ -620,7 +641,7 @@ describe('Dropdown', () => {
     describe('if there is a next sibling', () => {
       it('it calls updateScroll with the list and the last list element', () => {
         instance.setState({ highlighted: 2 });
-        list = instance.refs.list;
+        list = instance.list;
         element = list.getElementsByClassName('carbon-dropdown__list-item--highlighted')[0];
         instance.onUpArrow(list, element);
         expect(instance.updateScroll).toHaveBeenCalledWith(list, element.previousElementSibling);
@@ -628,7 +649,7 @@ describe('Dropdown', () => {
 
       it('returns the next highlighted value', () => {
         instance.setState({ highlighted: 2 });
-        list = instance.refs.list;
+        list = instance.list;
         element = list.getElementsByClassName('carbon-dropdown__list-item--highlighted')[0];
         let nextValue = instance.onUpArrow(list, element);
         expect(nextValue).toEqual(element.previousElementSibling.getAttribute('value'));
@@ -650,7 +671,7 @@ describe('Dropdown', () => {
 
     describe('if the list was closed', () => {
       it('returns the value of the last item in the list', () => {
-        list = instance.refs.list;
+        list = instance.list;
         let nextValue = instance.onDownArrow(list, null);
         expect(nextValue).toEqual(list.firstChild.getAttribute('value'));
       });
@@ -659,7 +680,7 @@ describe('Dropdown', () => {
     describe('if the element is the last in the list', () => {
       it('it calls updateScroll with the list and the previous sibling', () => {
         instance.setState({ highlighted: 2 });
-        list = instance.refs.list;
+        list = instance.list;
         element = list.getElementsByClassName('carbon-dropdown__list-item--highlighted')[0];
         instance.onDownArrow(list, element);
         expect(instance.updateScroll).toHaveBeenCalledWith(list, list.firstChild);
@@ -669,7 +690,7 @@ describe('Dropdown', () => {
     describe('if there is a next sibling', () => {
       it('it calls updateScroll with the list and next element', () => {
         instance.setState({ highlighted: 1 });
-        list = instance.refs.list;
+        list = instance.list;
         element = list.getElementsByClassName('carbon-dropdown__list-item--highlighted')[0];
         instance.onDownArrow(list, element);
         expect(instance.updateScroll).toHaveBeenCalledWith(list, element.nextElementSibling);

--- a/src/components/dropdown/definition.js
+++ b/src/components/dropdown/definition.js
@@ -44,16 +44,26 @@ let definition = new Definition('dropdown', Dropdown, {
   }]);
 };`,
   propTypes: {
-    options: "Object",
+    autoFocus: "Boolean",
     cacheVisibleValue: "Boolean",
+    disabled: "Boolean",
+    name: "String",
+    onBlur: "Function",
+    options: "Object",
+    readOnly: "Boolean",
     value: "String"
   },
   propValues: {
     options: `getOptions()`
   },
   propDescriptions: {
+    autoFocus: "Automatically focus the input.",
     cacheVisibleValue: "The dropdown will continually find the name during re-render, set this to true to only re-find the name if the value has actually changed.",
+    disabled: "Disable all user interaction.",
+    name: "Set the name of the corresponding hidden input.",
+    onBlur: "A custom onBlur handler",
     options: "The options for the dropdown. This needs to be an Immutable Map.",
+    readOnly: "Display the currently selected value without displaying the dropdown.",
     value: "The currently selected value of the input."
   }
 });

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import Input from './../../utils/decorators/input';
 import InputLabel from './../../utils/decorators/input-label';
 import InputValidation from './../../utils/decorators/input-validation';
 import InputIcon from './../../utils/decorators/input-icon';
-import classNames from 'classnames';
 import Events from './../../utils/helpers/events';
 import { validProps } from '../../utils/ether';
 
@@ -64,15 +64,36 @@ class Dropdown extends React.Component {
 
   static propTypes = {
     /**
-     * The ID value for the component
+     * Automatically focus the input.
      *
-     * @property value
-     * @type {String}
+     * @property autoFocus
+     * @type {boolean}
      */
-    value: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
+    autoFocus: PropTypes.bool,
+
+    /**
+     * Determines if the visibleValue will be cached or not.
+     *
+     * @property cacheVisibleValue
+     * @type {boolean}
+     */
+    cacheVisibleValue: PropTypes.bool,
+
+    /**
+     * Disable all user interaction.
+     *
+     * @property disabled
+     * @type {boolean}
+     */
+    disabled: PropTypes.bool,
+
+   /**
+    * A custom onBlur handler.
+    *
+    * @property onBlur
+    * @type {function}
+    */
+    onBlur: PropTypes.func,
 
     /**
      * The options to be displayed in the dropdown. Should be set in the store and passed from the parent component.
@@ -85,12 +106,31 @@ class Dropdown extends React.Component {
     options: PropTypes.object.isRequired,
 
     /**
-     * Determines if the visibleValue will be cached or not.
+     * Set the name of the corresponding hidden input.
      *
-     * @property cacheVisibleValue
+     * @property name
+     * @type {string}
+     */
+    name: PropTypes.string,
+
+    /**
+     * Display the currently selected value without displaying the dropdown.
+     *
+     * @property readOnly
      * @type {boolean}
      */
-    cacheVisibleValue: PropTypes.bool
+    readOnly: PropTypes.bool,
+
+    /**
+     * The ID value for the component
+     *
+     * @property value
+     * @type {String}
+     */
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ])
   }
 
   static defaultProps = {
@@ -170,12 +210,12 @@ class Dropdown extends React.Component {
    */
   emitOnChangeCallback = (value, visibleValue) => {
     // To be consistent, always return string
-    value = String(value);
+    const valueAsString = String(value);
     // mock a standard input event return, with target and value
     this._handleOnChange({
       target: {
-        value: value,
-        visibleValue: visibleValue
+        value: valueAsString,
+        visibleValue
       }
     });
   }
@@ -231,7 +271,7 @@ class Dropdown extends React.Component {
   handleMouseDownOnList = (ev) => {
     // if mouse down was on list (not list item), ensure the input retains focus
     // NOTE: this is an IE11 fix
-    if (ev.target === this.refs.list) {
+    if (ev.target === this.list) {
       setTimeout(() => {
         this._input.focus();
       }, 0);
@@ -293,7 +333,7 @@ class Dropdown extends React.Component {
       if (!this.props.value) { return this.visibleValue; }
 
       // Match selected id to corresponding list option
-      let option = this.props.options.find((item) => {
+      const option = this.props.options.find((item) => {
         return item.get('id') == this.props.value;
       });
       // If match is found, set visibleValue to option's name;
@@ -324,11 +364,11 @@ class Dropdown extends React.Component {
       return;
     }
 
-    let list = this.refs.list,
-        element = list.getElementsByClassName('carbon-dropdown__list-item--highlighted')[0],
-        nextVal;
+    const list = this.list,
+        element = list.getElementsByClassName('carbon-dropdown__list-item--highlighted')[0];
+    let nextVal;
 
-    switch(ev.which) {
+    switch (ev.which) {
       case 13: // return
         if (element) {
           ev.preventDefault();
@@ -343,6 +383,8 @@ class Dropdown extends React.Component {
         ev.preventDefault();
         nextVal = this.onDownArrow(list, element);
         break;
+      default:
+        nextVal = null;
     }
     this.setState({ highlighted: nextVal });
   }
@@ -398,7 +440,7 @@ class Dropdown extends React.Component {
    * @return {Void}
    */
   updateScroll(list, nextItem) {
-    let firstTop = list.firstChild.offsetTop,
+    const firstTop = list.firstChild.offsetTop,
         itemHeight = nextItem.offsetHeight,
         listHeight = list.offsetHeight;
 
@@ -416,15 +458,15 @@ class Dropdown extends React.Component {
    * @return {String}
    */
   highlighted = () => {
-    let highlighted = null;
+    const highlighted = null;
 
     if (this.state.highlighted) {
       return this.state.highlighted;
-    } else {
-      if (this.props.value) {
-        return this.props.value;
-      }
     }
+    if (this.props.value) {
+      return this.props.value;
+    }
+
 
     return highlighted;
   }
@@ -447,7 +489,7 @@ class Dropdown extends React.Component {
    * @return {Object}
    */
   get inputProps() {
-    let { ...props } = validProps(this);
+    const { ...props } = validProps(this);
 
     delete props.autoFocus;
 
@@ -471,10 +513,10 @@ class Dropdown extends React.Component {
    * @return {Object}
    */
   get hiddenInputProps() {
-    let props = {
-      ['data-element']: 'hidden-input',
+    const props = {
+      'data-element': 'hidden-input',
       ref: 'hidden',
-      type: "hidden",
+      type: 'hidden',
       readOnly: true,
       name: this.props.name,
       // Using this to prevent `null` and `uncontrolled` warnings from React
@@ -492,7 +534,7 @@ class Dropdown extends React.Component {
    */
   get listBlockProps() {
     return {
-      key: "listBlock",
+      key: 'listBlock',
       ref: 'listBlock',
       onMouseDown: this.handleMouseDownOnList,
       onMouseLeave: this.handleMouseLeaveList,
@@ -513,8 +555,8 @@ class Dropdown extends React.Component {
    */
   get listProps() {
     return {
-      key: "list",
-      ref: "list",
+      key: 'list',
+      ref: 'list',
       className: 'carbon-dropdown__list'
     };
   }
@@ -550,7 +592,7 @@ class Dropdown extends React.Component {
    */
   get listHTML() {
     return (
-      <ul { ...this.listProps }>
+      <ul { ...this.listProps } ref={ (node) => { this.list = node; } }>
         { this.results(this.options) }
       </ul>
     );
@@ -563,10 +605,10 @@ class Dropdown extends React.Component {
    * @return {Array}
    */
   results(options) {
-    let className = 'carbon-dropdown__list-item',
+    const className = 'carbon-dropdown__list-item',
         highlighted = this.highlighted(options);
 
-    let results = options.map((option) => {
+    const results = options.map((option) => {
       let klass = className;
 
       // add highlighted class
@@ -586,8 +628,9 @@ class Dropdown extends React.Component {
           value={ option.id }
           onClick={ this.handleSelect }
           onMouseOver={ this.handleMouseOverListItem }
-          className={ klass }>
-            { option.name }
+          className={ klass }
+        >
+          { option.name }
         </li>
       );
     });
@@ -602,14 +645,14 @@ class Dropdown extends React.Component {
    * @return {Object} JSX
    */
   get additionalInputContent() {
-    let content = [];
+    const content = [];
 
     if (this.showArrow()) {
-      content.push(this.inputIconHTML("dropdown"));
+      content.push(this.inputIconHTML('dropdown'));
     }
 
     content.push(
-      <div { ...this.listBlockProps }>
+      <div { ...this.listBlockProps } ref={ (node) => { this.listBlock = node; } }>
         { this.listHTML }
       </div>
     );
@@ -649,7 +692,7 @@ class Dropdown extends React.Component {
    * Stubbed function allows this to be called on the parent without causign a console error
    * This funciton is used by DropdownFilterAjax
    */
-  requestingState = () => { return; }
+  requestingState = () => { }
 
   /**
    * Renders the component.


### PR DESCRIPTION
To prepare for the future upgrade of [carbon-factory](https://github.com/Sage/carbon-factory), that will introduce stricter linting rules, this PR updates the `dropdown` components to pre-emptively resolve the errors.

- [x] Dropdown
- [x] DropdownFilter
- [x] DropdownFilterAjax

There are no functional changes to the components.

#### Notes
The Dropdown component was not specifically handling key presses other than `up`, `down` and `return`. The linter wanted a default case added to the case statement, so I've set it to set highlighted as null (previously it was setting it to undefined). This should not change the behaviour but I did need to add a spec to keep the coverage at 100%.
