### PR TITLE
Date linting updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.2.0
+
+## Linting Updates
+
+The following components have had minor internal changes to satisfy the introduction of stricter linting rules:
+
+* Date
+* DateRange
+
 # 1.1.0
 
 ## Package Updates

--- a/src/components/date-range/date-range.js
+++ b/src/components/date-range/date-range.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import I18n from 'i18n-js';
-import Date from './../date';
-import DateRangeValidator from './../../utils/validations/date-range';
-import DateHelper from  './../../utils/helpers/date';
 import { assign } from 'lodash';
 import classNames from 'classnames';
+import Date from './../date';
+import DateRangeValidator from './../../utils/validations/date-range';
+import DateHelper from './../../utils/helpers/date';
 import { tagComponent } from '../../utils/helpers/tags';
 
 class DateRange extends React.Component {
@@ -26,22 +26,6 @@ class DateRange extends React.Component {
      * @type {Array}
      */
     value: PropTypes.array.isRequired,
-
-    /**
-     * Optional label for startDate field
-     *
-     * @property startLabel
-     * @type {String}
-     */
-    startLabel: PropTypes.string,
-
-    /**
-     * Optional label for endDate field
-     *
-     * @property endDate
-     * @type {String}
-     */
-    endLabel: PropTypes.string,
 
     /**
      * Custom message for startDate field
@@ -93,7 +77,7 @@ class DateRange extends React.Component {
    * @param{Object} ev the event containing the new date value
    */
   _onChange = (changedDate, ev) => {
-    let newValue = ev.target.value;
+    const newValue = ev.target.value;
 
     if (changedDate === 'startDate') {
       this.props.onChange([newValue, this.endDate]);
@@ -125,9 +109,10 @@ class DateRange extends React.Component {
    * @return {String} the value of the start date
    */
   get startDate() {
-    return this.props.startDateProps && this.props.startDateProps.value ?
-      this.props.startDateProps.value :
-      this.props.value[0];
+    if (this.props.startDateProps && this.props.startDateProps.value) {
+      return this.props.startDateProps.value;
+    }
+    return this.props.value[0];
   }
 
   /**
@@ -137,9 +122,10 @@ class DateRange extends React.Component {
    * @return {String} the value of the end date
    */
   get endDate() {
-    return this.props.endDateProps && this.props.endDateProps.value ?
-      this.props.endDateProps.value :
-      this.props.value[1];
+    if (this.props.endDateProps && this.props.endDateProps.value) {
+      return this.props.endDateProps.value;
+    }
+    return this.props.value[1];
   }
 
   /**
@@ -222,32 +208,32 @@ class DateRange extends React.Component {
    * @return {Object} the props that are applied to the child Date components
    */
   dateProps(propsKey, defaultValidations) {
-    let props = assign({}, {
-      label: this.props[`${ propsKey }Label`],
+    const props = assign({}, {
+      label: this.props[`${propsKey}Label`],
       labelInline: this.props.labelsInline,
-      onChange: this._onChange.bind(null, `${ propsKey }Date`),
+      onChange: this._onChange.bind(null, `${propsKey}Date`),
       onFocus: this.focusEnd,
-      ref: (c) => { this[`_${ propsKey }Date`] = c; },
-      value: this[`${ propsKey }Date`]
-    }, this.props[`${ propsKey }DateProps`]);
+      ref: (c) => { this[`_${propsKey}Date`] = c; },
+      value: this[`${propsKey}Date`]
+    }, this.props[`${propsKey}DateProps`]);
 
     props.className = classNames(
       'carbon-date-range',
-      `carbon-date-range__${ propsKey }`,
-      (this.props[`${ propsKey }DateProps`] || {}).className : null
+      `carbon-date-range__${propsKey}`,
+      (this.props[`${propsKey}DateProps`] || {}).className : null
     );
 
     props.validations = defaultValidations.concat(
-      (this.props[`${ propsKey }DateProps`] || {}).validations || []
+      (this.props[`${propsKey}DateProps`] || {}).validations || []
     );
     return props;
   }
 
   render () {
-    return(
+    return (
       <div { ...tagComponent('date-range', this.props) }>
-        <Date { ...this.startDateProps() } data-element='start-date'/>
-        <Date { ...this.endDateProps() } data-element='end-date'/>
+        <Date { ...this.startDateProps() } data-element='start-date' />
+        <Date { ...this.endDateProps() } data-element='end-date' />
       </div>
     );
   }

--- a/src/components/date/__spec__.js
+++ b/src/components/date/__spec__.js
@@ -367,6 +367,10 @@ describe('Date', () => {
       it('does not open the date picker', () => {
         expect(instance.openDatePicker).not.toHaveBeenCalled();
       });
+
+      it('sets the input as disabled', () => {
+        expect(instance._input.disabled).toEqual(true);
+      })
     });
 
     describe('when readOnly', () => {
@@ -380,6 +384,10 @@ describe('Date', () => {
 
       it('does not open the date picker', () => {
         expect(instance.openDatePicker).not.toHaveBeenCalled();
+      });
+
+      it('sets the input as readonly', () => {
+        expect(instance._input.readOnly).toEqual(true);
       });
     });
   });

--- a/src/components/date/__spec__.js
+++ b/src/components/date/__spec__.js
@@ -122,11 +122,11 @@ describe('Date', () => {
     });
 
     it('sets the hiddenField to the new date', () => {
-      expect(instance.refs.hidden.value).toEqual(date);
+      expect(instance.hidden.value).toEqual(date);
     });
 
     it('triggers the onChange handler in the input decorator', () => {
-      expect(instance._handleOnChange).toHaveBeenCalledWith({ target: instance.refs.hidden });
+      expect(instance._handleOnChange).toHaveBeenCalledWith({ target: instance.hidden });
     });
   });
 
@@ -440,13 +440,13 @@ describe('Date', () => {
 
   describe('hiddenInputProps', () => {
     it('sets the input as a hidden readOnly field', () => {
-      expect(instance.refs.hidden.type).toEqual('hidden');
-      expect(instance.refs.hidden.readOnly).toEqual(true);
+      expect(instance.hidden.type).toEqual('hidden');
+      expect(instance.hidden.readOnly).toEqual(true);
     });
 
     describe('when value is not passed', () => {
       it('uses the defaultValue', () => {
-        expect(instance.refs.hidden.defaultValue).toEqual(hiddenToday);
+        expect(instance.hidden.defaultValue).toEqual(hiddenToday);
       });
     });
 
@@ -463,7 +463,7 @@ describe('Date', () => {
       });
 
       it('sets the hidden value to props.value', () => {
-        expect(instance.refs.hidden.defaultValue).toEqual(value);
+        expect(instance.hidden.defaultValue).toEqual(value);
       });
     });
 

--- a/src/components/date/date.js
+++ b/src/components/date/date.js
@@ -381,6 +381,8 @@ class Date extends React.Component {
     props.onBlur = this.handleBlur;
     props.value = this.state.visibleValue;
     props.onKeyDown = this.handleKeyDown;
+    props.disabled = this.props.disabled;
+    props.readOnly = this.props.readOnly;
 
     delete props.autoFocus;
     delete props.internalValidations;

--- a/src/components/date/date.js
+++ b/src/components/date/date.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+// https://github.com/zippyui/react-date-picker
+import { MonthView, NavBar } from 'react-date-picker';
+import I18n from 'i18n-js';
 import Input from './../../utils/decorators/input';
 import InputLabel from './../../utils/decorators/input-label';
 import InputValidation from './../../utils/decorators/input-validation';
 import InputIcon from './../../utils/decorators/input-icon';
-// https://github.com/zippyui/react-date-picker
-import { MonthView, NavBar } from 'react-date-picker';
-import I18n from "i18n-js";
 import Events from './../../utils/helpers/events';
 import DateHelper from './../../utils/helpers/date';
 import DateValidator from './../../utils/validations/date';
@@ -21,7 +21,7 @@ import { tagComponent } from '../../utils/helpers/tags';
  * @property _today
  * @type {string}
  */
-const today = DateHelper.todayFormatted("YYYY-MM-DD");
+const today = DateHelper.todayFormatted('YYYY-MM-DD');
 /**
  * A Date widget.
  *
@@ -54,6 +54,22 @@ class Date extends React.Component {
   // Required for validProps function
   static propTypes = {
     /**
+     * Automatically focus on component mount
+     *
+     * @property autoFocus
+     * @type {Boolean}
+    */
+    autoFocus: PropTypes.bool,
+
+    /**
+     * Disable all user interaction.
+     *
+     * @property disabled
+     * @type {boolean}
+     */
+    disabled: PropTypes.bool,
+
+    /**
      * Minimum possible date
      *
      * @property minDate
@@ -67,7 +83,31 @@ class Date extends React.Component {
      * @property maxDate
      * @type {String}
      */
-    maxDate: PropTypes.string
+    maxDate: PropTypes.string,
+
+    /**
+     * Specify a callback triggered on blur
+     *
+     * @property onBlur
+     * @type {Function}
+     */
+    onBlur: PropTypes.func,
+
+    /**
+     * Display the currently selected value without displaying the input
+     *
+     * @property readOnly
+     * @type {Boolean}
+     */
+    readOnly: PropTypes.bool,
+
+    /**
+     * The current date
+     *
+     * @property value
+     * @type {String}
+     */
+    value: PropTypes.string
   };
 
   static defaultProps = {
@@ -87,7 +127,7 @@ class Date extends React.Component {
     * @type {Array}
     * @default DateValidator
     */
-    internalValidations: [ new DateValidator ]
+    internalValidations: [new DateValidator()]
   }
 
   state = {
@@ -140,8 +180,8 @@ class Date extends React.Component {
    * @return {void}
    */
   componentWillReceiveProps(nextProps) {
-    if (this._document.activeElement != this._input) {
-      let date = this.formatVisibleValue(nextProps.value);
+    if (this._document.activeElement !== this._input) {
+      const date = this.formatVisibleValue(nextProps.value);
       this.setState({ visibleValue: date });
     }
   }
@@ -179,7 +219,7 @@ class Date extends React.Component {
    * @return {void}
    */
   emitOnChangeCallback = (val) => {
-    let hiddenField = this.refs.hidden;
+    const hiddenField = this.hidden;
     hiddenField.value = val;
 
     this._handleOnChange({ target: hiddenField });
@@ -192,7 +232,7 @@ class Date extends React.Component {
    * @return {void}
    */
   openDatePicker = () => {
-    this._document.addEventListener("click", this.closeDatePicker);
+    this._document.addEventListener('click', this.closeDatePicker);
     this.setState({ open: true });
 
     if (DateHelper.isValidDate(this.props.value)) {
@@ -207,7 +247,7 @@ class Date extends React.Component {
    * @return {void}
    */
   closeDatePicker = () => {
-    this._document.removeEventListener("click", this.closeDatePicker);
+    this._document.removeEventListener('click', this.closeDatePicker);
     this.setState({
       open: false
     });
@@ -220,7 +260,7 @@ class Date extends React.Component {
    * @return {void}
    */
   updateVisibleValue = () => {
-    let date = this.formatVisibleValue(this.props.value);
+    const date = this.formatVisibleValue(this.props.value);
     this.setState({
       visibleValue: date
     });
@@ -234,13 +274,13 @@ class Date extends React.Component {
    * @return {void}
    */
   handleVisibleInputChange = (ev) => {
-    let input = DateHelper.sanitizeDateInput(ev.target.value),
+    const input = DateHelper.sanitizeDateInput(ev.target.value),
         validDate = DateHelper.isValidDate(input),
         newState = { visibleValue: ev.target.value };
 
     // Updates the hidden value after first formatting to default hidden format
     if (validDate) {
-      let hiddenValue = DateHelper.formatValue(input, this.hiddenFormat());
+      const hiddenValue = DateHelper.formatValue(input, this.hiddenFormat());
       newState.datePickerValue = hiddenValue;
       this.emitOnChangeCallback(hiddenValue);
     } else {
@@ -303,7 +343,6 @@ class Date extends React.Component {
   }
 
 
-
   /**
    * Updates datePickerValue as hidden input changes.
    *
@@ -336,7 +375,7 @@ class Date extends React.Component {
    * @return {Object} props for the visible input
    */
   get inputProps() {
-    let { ...props } = validProps(this);
+    const { ...props } = validProps(this);
     props.className = this.inputClasses;
     props.onChange = this.handleVisibleInputChange;
     props.onBlur = this.handleBlur;
@@ -360,7 +399,7 @@ class Date extends React.Component {
    * @return {Object} props for the hidden input
    */
   get hiddenInputProps() {
-    let props = {
+    const props = {
       ref: 'hidden',
       type: 'hidden',
       readOnly: true,
@@ -399,12 +438,11 @@ class Date extends React.Component {
    */
   get additionalInputContent() {
     if (!this.state.valid) {
-      return this.inputIconHTML("error");
+      return this.inputIconHTML('error');
     } else if (this.state.warning) {
-      return this.inputIconHTML("warning");
-    } else {
-      return this.inputIconHTML("calendar");
+      return this.inputIconHTML('warning');
     }
+    return this.inputIconHTML('calendar');
   }
 
  /**
@@ -464,14 +502,14 @@ class Date extends React.Component {
    */
   render() {
     // TODO: Pull datepicker into own component to wrap third party
-    let datePicker = this.state.open ? this.renderDatePicker() : null;
+    const datePicker = this.state.open ? this.renderDatePicker() : null;
 
     return (
       <div className={ this.mainClasses } onClick={ this.handleWidgetClick } { ...tagComponent('date', this.props) }>
 
         { this.labelHTML }
         { this.inputHTML }
-        <input { ...this.hiddenInputProps } />
+        <input { ...this.hiddenInputProps } ref={ (node) => { this.hidden = node; } } />
         { datePicker }
 
         { this.fieldHelpHTML }
@@ -487,7 +525,7 @@ class Date extends React.Component {
   * @return {String} formatted date string
   */
   visibleFormat() {
-    return I18n.t('date.formats.javascript', { defaultValue: "DD/MM/YYYY" }).toUpperCase();
+    return I18n.t('date.formats.javascript', { defaultValue: 'DD/MM/YYYY' }).toUpperCase();
   }
 
   /**
@@ -497,7 +535,7 @@ class Date extends React.Component {
    * @return {String} formatted date string
    */
   hiddenFormat() {
-    return "YYYY-MM-DD";
+    return 'YYYY-MM-DD';
   }
 
   /**
@@ -508,9 +546,12 @@ class Date extends React.Component {
    * @return {String} formatted visible value
    */
   formatVisibleValue(value) {
-    value = value || today;
     // Don't sanitize so it accepts the hidden format (with dash separators)
-    return DateHelper.formatValue(value, this.visibleFormat(), { formats: this.hiddenFormat(), sanitize: false });
+    return DateHelper.formatValue(
+      value || today,
+      this.visibleFormat(),
+      { formats: this.hiddenFormat(), sanitize: false }
+    );
   }
 }
 ))));

--- a/src/components/date/definition.js
+++ b/src/components/date/definition.js
@@ -14,12 +14,20 @@ let definition = new Definition('date-input', DateInput, {
   type: 'form',
   hiddenProps: ['minDate', 'maxDate'],
   propTypes: {
+    autoFocus: "Boolean",
+    disabled: "Boolean",
     minDate: "String",
-    maxDate: "String"
+    maxDate: "String",
+    onBlur: "Function",
+    value: "String"
   },
   propDescriptions: {
+    autoFocus: "Automatically focus on component mount.",
+    disabled: "Disable all user interaction.",
     minDate: "Set a minimum value for date.",
-    maxDate: "Set a maximum value for date."
+    maxDate: "Set a maximum value for date.",
+    onBlur: "Specify a callback triggered on blur.",
+    value: "The selected date."
   }
 });
 

--- a/src/components/date/definition.js
+++ b/src/components/date/definition.js
@@ -19,6 +19,7 @@ let definition = new Definition('date-input', DateInput, {
     minDate: "String",
     maxDate: "String",
     onBlur: "Function",
+    readOnly: "Boolean",
     value: "String"
   },
   propDescriptions: {
@@ -27,6 +28,7 @@ let definition = new Definition('date-input', DateInput, {
     minDate: "Set a minimum value for date.",
     maxDate: "Set a maximum value for date.",
     onBlur: "Specify a callback triggered on blur.",
+    readOnly: "Display the currently selected value without displaying the input.",
     value: "The selected date."
   }
 });


### PR DESCRIPTION
To prepare for the future upgrade of [carbon-factory](https://github.com/Sage/carbon-factory), that will introduce stricter linting rules, this PR updates the `date` components to pre-emptively resolve the errors.

Updated components:
- Date
- DateRange

#### Functional changes
After QA feedback I have updated the props of the input to set disabled to true on the input if either `disabled` or `readOnly` are set to true by the developer.

**BEFORE**
![date-disabled-before](https://cloud.githubusercontent.com/assets/4964/26777787/6c2d34b0-49d6-11e7-87f5-a038e9ce6390.gif)

**AFTER**
![date-disabled-after](https://cloud.githubusercontent.com/assets/4964/26777794/70c53aea-49d6-11e7-82fe-21211aedf115.gif)
