### PR TITLE
Swap version text for npm shields image

### DIFF
--- a/demo/i18n/en.js
+++ b/demo/i18n/en.js
@@ -47,8 +47,7 @@ I18n.translations['en'] = {
 
     page_header_large: {
       heading1: 'Carbon is a library of React components for building great web applications.',
-      heading2: 'Carbon is Open Source. It’s hosted, developed, and maintained on Github.',
-      version: 'Currently: v1.0.0-rc4'
+      heading2: 'Carbon is Open Source. It’s hosted, developed, and maintained on Github.'
     },
 
     sage_loves_carbon: {

--- a/demo/views/common/page-header-large/page-header-large.js
+++ b/demo/views/common/page-header-large/page-header-large.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import I18n from 'i18n-js';
 
+import Link from 'components/link';
+
 // Demo Site
 import GetCodeButtons from './../../../components/get-code-buttons';
 import InfoTile from './../../../components/info-tile';
@@ -25,7 +27,9 @@ class PageHeaderLarge extends React.Component {
               { GetCodeButtons.pair() }
 
               <div className='page-header-large__version'>
-                { I18n.t('homepage.page_header_large.version') }
+                <Link href='https://www.npmjs.com/package/carbon-react' target='_blank'>
+                  <img src='https://img.shields.io/npm/v/carbon-react.svg' alt='npm' />
+                </Link>
               </div>
             </div>
           </div>


### PR DESCRIPTION
# Description

Swaps the hard coded text for the current version of `carbon-react` for a http://shields.io/ badge.

# Screenshots / Gifs

### Before

<img width="844" alt="screen shot 2017-05-27 at 00 33 01" src="https://cloud.githubusercontent.com/assets/145826/26515599/162948f6-4274-11e7-8dbc-d5acc2fc2df0.png">

### After

<img width="843" alt="screen shot 2017-05-27 at 00 30 30" src="https://cloud.githubusercontent.com/assets/145826/26515564/da3188a4-4273-11e7-8407-6bc9ee25137d.png">

# Testing Instructions

* Run demo site locally
* Observe change present as per screenshot above.