### PR TITLE
Fix drag and drop text selection issue in IE11

### DIFF
--- a/src/components/drag-and-drop/with-drag/with-drag.js
+++ b/src/components/drag-and-drop/with-drag/with-drag.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import ItemTypes from './../../../utils/helpers/dnd/item-types';
-import Text from './../../../utils/helpers/text';
 
 class WithDrag extends React.Component {
   static propTypes = {
@@ -36,7 +35,6 @@ const ItemSource = {
 
   endDrag(props, monitor, component) {
     const endDrag = props.endDrag || component.context.dragAndDropEndDrag;
-    Text.clearSelection();
     return endDrag(props, monitor, component);
   }
 };

--- a/src/components/drag-and-drop/with-drop/with-drop.js
+++ b/src/components/drag-and-drop/with-drop/with-drop.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { DropTarget } from 'react-dnd';
 import ItemTypes from './../../../utils/helpers/dnd/item-types';
+import Text from './../../../utils/helpers/text';
 
 class WithDrop extends React.Component {
   static propTypes = {
@@ -23,6 +24,7 @@ class WithDrop extends React.Component {
 
 const ItemTarget = {
   hover(props, monitor, component) {
+    Text.clearSelection();
     const hover = props.hover || component.context.dragAndDropHover;
     hover(props, monitor, component);
   }

--- a/src/components/table/draggable-table-cell/draggable-table-cell.scss
+++ b/src/components/table/draggable-table-cell/draggable-table-cell.scss
@@ -1,16 +1,24 @@
+// Remove the padding from the table cell
+// and apply it to the drag icon instead.
+// This gives us a bigger 'click' area on
+// the drag icon for both mouse and touch.
 .draggable-table-cell {
+  padding: 0;
   width: 21px;
+
+  &.carbon-table-cell:first-child {
+    padding-left: 0;
+  }
 }
 
 .draggable-table-cell__icon {
-  cursor: move; /* fallback if grab cursor is unsupported */
-  cursor: grab;
-  cursor: -moz-grab;
-  cursor: -webkit-grab;
-}
+  cursor: move;
+  padding: 8.5px 14px;
 
-.draggable-table-cell__icon:active {
-  cursor: grabbing;
-  cursor: -moz-grabbing;
-  cursor: -webkit-grabbing;
+  .carbon-table-row--dragging &,
+  .carbon-table-row--dragged {
+    cursor: grabbing;
+    cursor: -moz-grabbing;
+    cursor: -webkit-grabbing;
+  }
 }


### PR DESCRIPTION
Clear the selected text in the drop target `hover` function, instead of in the drag source `endDrag` function. This fixes the issue where text was still selected during the drag operation in IE11.

Also increased the size of the drag handle: removed the padding from the `.draggable-table-cell` and applied it to the drag icon instead.

**NB** QA for this will be done on the main `dnd` branch