### PR TITLE
Form linting updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ The following components have had minor internal changes to satisfy the introduc
 
 * AppWrapper
 * Carousel
+* Checkbox
 * Column
 * Content
 * Date
 * DateRange
 * Detail
+* Fieldset
+* GroupedCharacter
 * Heading
 * I18n
 * Link
@@ -21,11 +24,14 @@ The following components have had minor internal changes to satisfy the introduc
 * MountInApp
 * NavigationBar
 * Pod
+* RadioButton
 * Row
 * SettingsRow
 * ShowEditPod
 * SubmenuBlock
 * Tabs
+* Textarea
+* Textbox
 
 ## Component Improvements
 

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import Input from './../../utils/decorators/input';
 import InputLabel from './../../utils/decorators/input-label';
 import InputValidation from './../../utils/decorators/input-validation';
-import classNames from 'classnames';
 import { tagComponent } from '../../utils/helpers/tags';
 import { validProps } from '../../utils/ether';
 
@@ -29,13 +29,37 @@ class Checkbox extends React.Component {
 
   static propTypes = {
     /**
+     * Set the value of the checkbox
+     *
+     * @property checked
+     * @type {Boolean}
+     */
+    checked: PropTypes.boolean,
+
+    /**
+     * Displays fieldHelp inline with the checkbox
+     *
+     * @property fieldHelpInline
+     * @type {Boolean}
+     */
+    fieldHelpInline: PropTypes.bool,
+
+    /**
      * Reverses label and checkbox display
      *
      * @property reverse
      * @type {Boolean}
      * @default false
      */
-    reverse: PropTypes.bool
+    reverse: PropTypes.bool,
+
+    /**
+     * Set the value of the checkbox
+     *
+     * @property value
+     * @type {Boolean}
+     */
+    value: PropTypes.boolean
   }
 
   static defaultProps = {
@@ -52,7 +76,7 @@ class Checkbox extends React.Component {
   handleOnChange = (ev) => {
     // we handle the change event manually here, as we pass the checked param
     // instead of value
-    this._handleOnChange({ target: { value: ev.target.checked }});
+    this._handleOnChange({ target: { value: ev.target.checked } });
   }
 
   /**
@@ -83,13 +107,13 @@ class Checkbox extends React.Component {
    * @return {Object} Props to be applied to the input
    */
   get inputProps() {
-    let { ...props } = validProps(this);
+    const { ...props } = validProps(this);
     // React uses checked instead of value to define the state of a checkbox
-    props.checked   = this.props.checked !== undefined ? this.props.checked : this.props.value;
+    props.checked = this.props.checked !== undefined ? this.props.checked : this.props.value;
     props.className = this.inputClasses;
-    props.onChange  = this.handleOnChange;
-    props.type      = 'checkbox';
-    props.value     = '1';
+    props.onChange = this.handleOnChange;
+    props.type = 'checkbox';
+    props.value = '1';
     return props;
   }
 
@@ -100,12 +124,12 @@ class Checkbox extends React.Component {
    * @return {Object} Props to be applied to the hidden input
    */
   get hiddenInputProps() {
-    let props = {
-      name:           this.inputProps.name,
-      readOnly:       true,
-      ref:            'hidden',
-      type:           'hidden',
-      value:          '0',
+    const props = {
+      name: this.inputProps.name,
+      readOnly: true,
+      ref: 'hidden',
+      type: 'hidden',
+      value: '0',
       'data-element': 'hidden-input'
     };
 
@@ -118,19 +142,21 @@ class Checkbox extends React.Component {
    * @return {Object} JSX svg
    */
   get checkboxSprite() {
-    return(
+    return (
       <svg width='15' height='15' viewBox='0 0 15 15'>
-        <rect className='checkbox-outline' fill='#AFAFAF' x='0' y='0' width='15' height='15'></rect>
-        <rect className='checkbox-fill' fill='#FFFFFF' x='1' y='1' width='13' height='13'></rect>
-        <path d="M5.06079081,11.805307 L2.2548404,9.4508351 C1.95287351,9.19745479 1.91372172,
-        8.74748731 2.16708208,8.44554418 L3.08395978,7.35285189 C3.3376225,7.05054844 3.78738919,
-        7.01144632 4.08921714,7.26471004 L6.46118447,9.25502694 L11.4959248,3.25485701 C11.7492184,
-        2.95299356 12.1993451,2.91365198 12.5012882,3.16701234 L13.5939805,4.08389004 C13.896284,
-        4.33755276 13.9353536,4.78735811 13.6820499,5.08923375 L8.30934217,11.4921775 C8.28333213,
-        11.5485068 8.24949267,11.6023543 8.20769039,11.6521724 L7.2908127,12.7448647 C7.12011041,
-        12.9482997 6.86060017,13.032541 6.61713008,12.9887006 C6.48855215,12.9709764 6.36324771,
-        12.9179844 6.25647356,12.8283903 L5.16378128,11.9115126 C5.12512704,11.8790778 5.09077658,
-        11.8434362 5.06079081,11.805307 L5.06079081,11.805307 Z" className='checkbox-check' fill='#FFFFFF'></path>
+        <rect className='checkbox-outline' fill='#AFAFAF' x='0' y='0' width='15' height='15' />
+        <rect className='checkbox-fill' fill='#FFFFFF' x='1' y='1' width='13' height='13' />
+        <path
+          d={ 'M5.06079081,11.805307 L2.2548404,9.4508351 C1.95287351,9.19745479 1.91372172,' +
+        '8.74748731 2.16708208,8.44554418 L3.08395978,7.35285189 C3.3376225,7.05054844 3.78738919,' +
+        '7.01144632 4.08921714,7.26471004 L6.46118447,9.25502694 L11.4959248,3.25485701 C11.7492184,' +
+        '2.95299356 12.1993451,2.91365198 12.5012882,3.16701234 L13.5939805,4.08389004 C13.896284,' +
+        '4.33755276 13.9353536,4.78735811 13.6820499,5.08923375 L8.30934217,11.4921775 C8.28333213,' +
+        '11.5485068 8.24949267,11.6023543 8.20769039,11.6521724 L7.2908127,12.7448647 C7.12011041,' +
+        '12.9482997 6.86060017,13.032541 6.61713008,12.9887006 C6.48855215,12.9709764 6.36324771,' +
+        '12.9179844 6.25647356,12.8283903 L5.16378128,11.9115126 C5.12512704,11.8790778 5.09077658,' +
+        '11.8434362 5.06079081,11.805307 L5.06079081,11.805307 Z' } className='checkbox-check' fill='#FFFFFF'
+        />
       </svg>
     );
   }
@@ -181,7 +207,7 @@ class Checkbox extends React.Component {
       labelRight = this.labelHTML;
     }
 
-    return(
+    return (
       <div className={ this.mainClasses } { ...tagComponent('checkbox', this.props) }>
         { labelLeft }
         { fieldHelpLeft }

--- a/src/components/checkbox/definition.js
+++ b/src/components/checkbox/definition.js
@@ -19,10 +19,14 @@ let definition = new Definition('checkbox', Checkbox, {
     value: false
   },
   propTypes: {
-    reverse: 'Boolean'
+    checked: 'Boolean',
+    reverse: 'Boolean',
+    value: 'Boolean'
   },
   propDescriptions: {
-    reverse: 'Flips the input and label render order'
+    checked: 'Set the checkbox as checked',
+    reverse: 'Flips the input and label render order',
+    value: 'Set the value of the checkbox'
   }
 });
 

--- a/src/components/fieldset/fieldset.js
+++ b/src/components/fieldset/fieldset.js
@@ -13,6 +13,14 @@ class Fieldset extends React.Component {
 
   static propTypes = {
     /**
+     * Children elements
+     *
+     * @property children
+     * @type {Node}
+     */
+    children: PropTypes.node,
+
+    /**
      * A label for the fieldset.
      *
      * @property legend
@@ -32,7 +40,7 @@ class Fieldset extends React.Component {
     if (!this.props.legend) { return null; }
 
     return (
-      <legend className="carbon-fieldset__legend common-input__label" data-element='legend'>
+      <legend className='carbon-fieldset__legend common-input__label' data-element='legend'>
         { this.props.legend }
       </legend>
     );
@@ -42,8 +50,8 @@ class Fieldset extends React.Component {
    * @method render
    */
   render() {
-    let { className, ...props } = validProps(this),
-        classes = classNames("carbon-fieldset", className);
+    const { className, ...props } = validProps(this);
+    const classes = classNames('carbon-fieldset', className);
 
     return (
       <fieldset className={ classes } { ...props } { ...tagComponent('fieldset', this.props) }>

--- a/src/components/grouped-character/definition.js
+++ b/src/components/grouped-character/definition.js
@@ -4,14 +4,18 @@ import Definition from './../../../demo/utils/definition';
 let definition = new Definition('grouped-character', GroupedCharacter, {
   hiddenProps: ["groups"],
   propTypes: {
+    className: "String",
     groups: "Array",
     separator: "String",
-    inputWidth: "String"
+    inputWidth: "String",
+    value: "String"
   },
   propDescriptions: {
+    className: "Classes to apply to the component.",
     groups: "Determine groups of characters e.g. [1, 2, 3] would create the following text in the input 'A-BC-DEF'",
     separator: "Separator to split the character groups. Defaulted to a dash '-'. Must be a non alpha-numeric character",
-    inputWidth: "Inline style to set the width of the component. Used if you want the with to match the character length"
+    inputWidth: "Inline style to set the width of the component. Used if you want the width to match the character length",
+    value: "The value of the input"
   },
   propValues: {
     groups: '[2,4,4]'

--- a/src/components/grouped-character/grouped-character.js
+++ b/src/components/grouped-character/grouped-character.js
@@ -17,30 +17,47 @@ class GroupedCharacter extends React.Component {
     super(...args);
 
     this.state = {};
-    this.state.value          = this.props.value;
-    this.maxLength            = this.calculateMaxLength();
-    this.insertionIndices     = this.insertionIndices();
-    this.onKeyDown            = this.onKeyDown.bind(this);
-    this.onChange             = this.onChange.bind(this);
-    this.getCursorPosition    = this.getCursorPosition.bind(this);
-    this.getNewPosition       = this.getNewPosition.bind(this);
-    this.sliceUpToSeparator   = this.sliceUpToSeparator.bind(this);
-    this.getPlainValue        = this.getPlainValue.bind(this);    // value without separators
-    this.lastPosition         = 0;                                // last position of cursor 1-indexed
-    this.keyPressed           = { which: null };                  // track key pressed outside of React synthetic event
+    this.state.value = this.props.value;
+    this.maxLength = this.calculateMaxLength();
+    this.insertionIndices = this.insertionIndices();
+    this.onKeyDown = this.onKeyDown.bind(this);
+    this.onChange = this.onChange.bind(this);
+    this.getCursorPosition = this.getCursorPosition.bind(this);
+    this.getNewPosition = this.getNewPosition.bind(this);
+    this.sliceUpToSeparator = this.sliceUpToSeparator.bind(this);
+    this.getPlainValue = this.getPlainValue.bind(this);    // value without separators
+    this.lastPosition = 0;                                // last position of cursor 1-indexed
+    this.keyPressed = { which: null };                  // track key pressed outside of React synthetic event
   }
 
 
   static propTypes = {
-    groups:     PropTypes.array.isRequired,            // an array of  group sizes
+    /**
+     * A custom class name for the component.
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    groups: PropTypes.array.isRequired,            // an array of  group sizes
     inputWidth: PropTypes.string,                      // pixel value that sets inputWidth
-    separator:  ((props, propName, componentName) => { // a separator character to insert between number groups
+    separator: ((props, propName, componentName) => { // a separator character to insert between number groups
       if ((props[propName]).length > 1 || typeof props[propName] !== 'string') {
         return new Error(
           `Invalid prop ${propName} supplied to ${componentName}. Must be string of length 1.`
         );
       }
-    })
+      return null;
+    }),
+
+    /**
+     * The value of the Input
+     *
+     * @property value
+     * @type {String}
+     */
+    value: PropTypes.string
   };
 
   static defaultProps = {
@@ -49,7 +66,7 @@ class GroupedCharacter extends React.Component {
   };
 
   componentDidUpdate() {
-    let newPosition = this.getCursorPosition();
+    const newPosition = this.getCursorPosition();
     this._input.setSelectionRange(newPosition, newPosition);
   }
 
@@ -58,12 +75,12 @@ class GroupedCharacter extends React.Component {
   }
 
   calculateMaxLength = () => {
-    return sum(this.props.groups) + this.props.groups.length - 1;
+    return sum(this.props.groups) + (this.props.groups.length - 1);
   }
 
   // delete value after separator
   deleteAfterSeparator = (value) => {
-    let upToSeparator =  this.sliceUpToSeparator();
+    const upToSeparator = this.sliceUpToSeparator();
     return value.slice(0, upToSeparator) + value.slice(upToSeparator + 1);
   }
 
@@ -84,7 +101,7 @@ class GroupedCharacter extends React.Component {
   }
 
   getNewPosition() {
-    let leftPosition = this.lastPosition - 1;
+    const leftPosition = this.lastPosition - 1;
     // adjust position for presence of separator
     if (includes(this.insertionIndices, leftPosition)) {
       // move cursor 1 space left if backspacing character
@@ -105,7 +122,7 @@ class GroupedCharacter extends React.Component {
 
   // Get indices at which to insert separator
   insertionIndices = () => {
-    let indices = [this.props.groups[0]];
+    const indices = [this.props.groups[0]];
 
     for (let i = 1; i < this.props.groups.length; i++) {
       indices.push(indices[i - 1] + this.props.groups[i] + 1);
@@ -145,7 +162,7 @@ class GroupedCharacter extends React.Component {
     // return early if no separators needed yet
     if (this.separatorsNotNeeded(plainValue)) { return plainValue; }
 
-    let valueWithSeparators = insertAt(
+    const valueWithSeparators = insertAt(
       plainValue,
       { insertionIndices: this.insertionIndices, separator: this.props.separator }
     );
@@ -153,7 +170,7 @@ class GroupedCharacter extends React.Component {
     return this.enforceMaxLength(valueWithSeparators);
   }
 
-  //gets value up to separator for current group
+  // gets value up to separator for current group
   sliceUpToSeparator() {
     let upToSeparator = 1;
 
@@ -169,8 +186,8 @@ class GroupedCharacter extends React.Component {
   onChange(ev) {
     this.lastPosition = ev.target.selectionEnd;
 
-    let plainValue    = this.getPlainValue(ev),
-        visibleValue  = this.setVisibleValue(plainValue);
+    const plainValue = this.getPlainValue(ev),
+        visibleValue = this.setVisibleValue(plainValue);
 
     this.setState({ value: visibleValue });
     this._hidden.value = plainValue;
@@ -184,22 +201,22 @@ class GroupedCharacter extends React.Component {
   }
 
   get inputProps() {
-    let { ...props } = validProps(this);
-    props.className  = this.inputClasses;
-    props.onChange   = this.onChange;
-    props.maxLength  = this.maxLength;
-    props.onKeyDown  = this.onKeyDown;
-    props.style      = { width: `${this.props.inputWidth}px` };
-    props.value      = this.state.value;
+    const { ...props } = validProps(this);
+    props.className = this.inputClasses;
+    props.onChange = this.onChange;
+    props.maxLength = this.maxLength;
+    props.onKeyDown = this.onKeyDown;
+    props.style = { width: `${this.props.inputWidth}px` };
+    props.value = this.state.value;
     return props;
   }
 
   get hiddenInputProps() {
     return {
-      value:          this.props.value,
-      ref:            (c) => { this._hidden = c; },
-      type:           'hidden',
-      readOnly:       true,
+      value: this.props.value,
+      ref: (c) => { this._hidden = c; },
+      type: 'hidden',
+      readOnly: true,
       'data-element': 'hidden-input'
     };
   }
@@ -207,7 +224,7 @@ class GroupedCharacter extends React.Component {
   get mainClasses() {
     return classNames(
       this.props.className,
-      `carbon-grouped-character`
+      'carbon-grouped-character'
     );
   }
 
@@ -220,7 +237,7 @@ class GroupedCharacter extends React.Component {
       <div className={ this.mainClasses } { ...tagComponent('grouped-character', this.props) }>
         { this.labelHTML }
         { this.inputHTML }
-        <input { ...this.hiddenInputProps }/>
+        <input { ...this.hiddenInputProps } />
         { this.validationHTML }
         { this.fieldHelpHTML }
       </div>

--- a/src/components/radio-button/definition.js
+++ b/src/components/radio-button/definition.js
@@ -16,12 +16,14 @@ let definition = new Definition('radio-button', RadioButton, {
   type: 'form',
   numberOfExamples: 2,
   propTypes: {
+    className: "String",
     reverse: 'Boolean'
   },
   propValues: {
     name: "example"
   },
   propDescriptions: {
+    className: "Classes to apply to the component.",
     reverse: 'Flips the input and label render order'
   }
 });

--- a/src/components/radio-button/radio-button.js
+++ b/src/components/radio-button/radio-button.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Input from './../../utils/decorators/input';
 import InputLabel from './../../utils/decorators/input-label';
@@ -30,6 +31,24 @@ import { tagComponent } from '../../utils/helpers/tags';
  */
 const RadioButton = Input(InputLabel(InputValidation(
 class RadioButton extends React.Component {
+  static propTypes = {
+    /**
+     * A custom class name for the component.
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    /**
+     * Displays fieldHelp inline with the radio button.
+     *
+     * @property fieldHelpInline
+     * @type {Boolean}
+     */
+    fieldHelpInline: PropTypes.bool
+  }
+
   /**
    * Uses the mainClasses method provided by the decorator to add additional classes.
    *
@@ -37,7 +56,7 @@ class RadioButton extends React.Component {
    * @return {String} Main className
    */
   get mainClasses() {
-    return classNames (
+    return classNames(
       'carbon-radio-button',
       this.props.className
     );
@@ -75,9 +94,9 @@ class RadioButton extends React.Component {
    * @return {Object} Props to be applied to the input
    */
   get inputProps() {
-    let { ...props } = validProps(this);
+    const { ...props } = validProps(this);
     props.className = this.inputClasses;
-    props.type = "radio";
+    props.type = 'radio';
     return props;
   }
 
@@ -117,7 +136,12 @@ class RadioButton extends React.Component {
    * @return {Object} JSX additional content inline with input
    */
   get additionalInputContent() {
-    return <div className="carbon-radio-button__sprite" dangerouslySetInnerHTML={{ __html: this.radiobuttonSprite }}></div>;
+    return (
+      <div
+        className='carbon-radio-button__sprite'
+        dangerouslySetInnerHTML={ { __html: this.radiobuttonSprite } }
+      />
+    );
   }
 
   /**
@@ -127,7 +151,7 @@ class RadioButton extends React.Component {
    * @return {Object} JSX
    */
   render() {
-    return(
+    return (
       <div className={ this.mainClasses } { ...tagComponent('radio-button', this.props) }>
         { this.inputHTML }
         { this.labelHTML }

--- a/src/components/textarea/__spec__.js
+++ b/src/components/textarea/__spec__.js
@@ -249,7 +249,7 @@ describe('Textarea', () => {
 
     describe('when characterLimit is not set', () => {
       it('returns null', () => {
-        expect(baseInstance.characterCount).toBeUndefined();
+        expect(baseInstance.characterCount).toBeNull();
       });
     });
   });

--- a/src/components/textarea/definition.js
+++ b/src/components/textarea/definition.js
@@ -20,12 +20,14 @@ let definition = new Definition('textarea', Textarea, {
     characterLimit: "Displays a character count to inform the user how many characters they have used from a recommended amount.",
     enforceCharacterLimit: "Enforces the maximum number of characters.",
     expandable: "Makes the textarea automatically expand depending on the amount of text the user inputs.",
+    value: "The value of the textarea.",
     warnOverLimit: "When the character limit is exceeded the chracter count text will turn red."
   },
   propTypes: {
     characterLimit: "String",
     enforceCharacterLimit: "Boolean",
     expandable: "Boolean",
+    value: "String",
     warnOverLimit: "Boolean"
   }
 });

--- a/src/components/textarea/textarea.js
+++ b/src/components/textarea/textarea.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import I18n from 'i18n-js';
 import Input from './../../utils/decorators/input';
 import InputLabel from './../../utils/decorators/input-label';
 import InputValidation from './../../utils/decorators/input-validation';
-import I18n from 'i18n-js';
 import { validProps } from '../../utils/ether';
 import { tagComponent } from '../../utils/helpers/tags';
 
@@ -34,6 +34,31 @@ class Textarea extends React.Component {
 
   static propTypes = {
     /**
+     * Character limit of the textarea
+     *
+     * @property characterLimit
+     * @type {String}
+     */
+    characterLimit: PropTypes.string,
+
+    /**
+     * The visible width of the text control, in average character widths.
+     *
+     * @property cols
+     * @type {Integer}
+     */
+    cols: PropTypes.integer,
+
+    /**
+     * Stop the user typing over the characterLimit
+     *
+     * @property enforceCharacterLimit
+     * @type {Boolean}
+     * @default true
+     */
+    enforceCharacterLimit: PropTypes.bool,
+
+    /**
      * Allows the Textareas Height to change based on user input
      * Width of the textarea will remain static
      *
@@ -44,21 +69,20 @@ class Textarea extends React.Component {
     expandable: PropTypes.bool,
 
     /**
-     * Character limit of the textarea
+     * The number of visible text lines for the control.
      *
-     * @property characterLimit
-     * @type {String}
+     * @property rows
+     * @type {Integer}
      */
-    characterLimit: PropTypes.string,
+    rows: PropTypes.integer,
 
     /**
-     * Stop the user typing over the characterLimit
+     * The value of the Textarea
      *
-     * @property enforceCharacterLimit
-     * @type {Boolean}
-     * @default true
+     * @property value
+     * @type {String}
      */
-    enforceCharacterLimit: PropTypes.bool,
+    value: PropTypes.string,
 
     /**
      * Whether to display the character count message in red
@@ -130,13 +154,13 @@ class Textarea extends React.Component {
    * @return {void}
    */
   expandTextarea = () => {
-    let textarea = this._input;
+    const textarea = this._input;
 
     if (textarea.scrollHeight > this.minHeight) {
       // Reset height to zero - IE specific
       textarea.style.height = '0px';
       // Set the height so all content is shown
-      textarea.style.height = Math.max(textarea.scrollHeight, this.minHeight) + 'px';
+      textarea.style.height = `${Math.max(textarea.scrollHeight, this.minHeight)}px`;
     }
   }
 
@@ -157,7 +181,7 @@ class Textarea extends React.Component {
    * @return {String} input className
    */
   get inputClasses() {
-    return classNames (
+    return classNames(
       'carbon-textarea__input',
       { 'carbon-textarea__input--disable-scroll': this.props.expandable }
     );
@@ -170,7 +194,7 @@ class Textarea extends React.Component {
    * @return {String} textarea className
    */
   get textAreaClasses() {
-    return classNames (
+    return classNames(
       'carbon-textarea__character-limit',
       { 'over-limit': this.props.warnOverLimit && this.overLimit }
     );
@@ -184,7 +208,7 @@ class Textarea extends React.Component {
    */
   get overLimit() {
     const value = this.props.value || '';
-    return value.length > parseInt(this.props.characterLimit);
+    return value.length > parseInt(this.props.characterLimit, 10);
   }
 
   /**
@@ -195,7 +219,7 @@ class Textarea extends React.Component {
    * @return {Object} props for the input
    */
   get inputProps() {
-    let { ...props } = validProps(this);
+    const { ...props } = validProps(this);
     props.className = this.inputClasses;
     props.rows = this.props.rows;
     props.cols = this.props.cols;
@@ -236,21 +260,20 @@ class Textarea extends React.Component {
   get characterCount() {
     const value = this.props.value || '';
 
-    if (this.props.characterLimit) {
-      return (
-        <div className={ this.textAreaClasses } data-element='character-limit'>
-          { I18n.t('textarea.limit.prefix', { defaultValue: 'You have used ' } ) }
-          <span className='carbon-textarea__limit-used'>
-            { I18n.toNumber(value.length, this.i18nNumberOpts) }
-          </span>
-          { I18n.t('textarea.limit.middle', { defaultValue: ' of ' } ) }
-          <span className='carbon-textarea__limit-max'>
-            { I18n.toNumber(this.props.characterLimit, this.i18nNumberOpts) }
-          </span>
-          { I18n.t('textarea.limit.suffix', { defaultValue: ' characters' } ) }
-        </div>
-      );
-    }
+    if (!this.props.characterLimit) { return null; }
+    return (
+      <div className={ this.textAreaClasses } data-element='character-limit'>
+        { I18n.t('textarea.limit.prefix', { defaultValue: 'You have used ' }) }
+        <span className='carbon-textarea__limit-used'>
+          { I18n.toNumber(value.length, this.i18nNumberOpts) }
+        </span>
+        { I18n.t('textarea.limit.middle', { defaultValue: ' of ' }) }
+        <span className='carbon-textarea__limit-max'>
+          { I18n.toNumber(this.props.characterLimit, this.i18nNumberOpts) }
+        </span>
+        { I18n.t('textarea.limit.suffix', { defaultValue: ' characters' }) }
+      </div>
+    );
   }
 
 

--- a/src/components/textbox/textbox.js
+++ b/src/components/textbox/textbox.js
@@ -52,7 +52,7 @@ class Textbox extends React.Component {
    * @return {Object} props for the input
    */
   get inputProps() {
-    let { ...props } = validProps(this);
+    const { ...props } = validProps(this);
     props.className = this.inputClasses;
     return props;
   }
@@ -67,7 +67,7 @@ class Textbox extends React.Component {
     return (
       <div
         className={ this.mainClasses }
-        ref={ (comp) => this._target = comp }
+        ref={ (comp) => { this._target = comp; } }
         { ...tagComponent('textbox', this.props) }
       >
         { this.labelHTML }


### PR DESCRIPTION
To prepare for the future upgrade of [carbon-factory](https://github.com/Sage/carbon-factory), that will introduce stricter linting rules, this PR updates the `form` components to pre-emptively resolve the errors.

#### Updated components
- [x] Checkbox
- [x] Fieldset
- [x] Filter (no changes required)
- [x] GroupedCharacter
- [x] RadioButton
- [x] Textarea
- [x] Textbox

#### Notes
- I've set Checkbox `checked` and `value` prop types as boolean. Not 100% sure that is correct as it feels like some developers might have set them as strings.

#### Components specifically not included
- Form
- FormSummary

Linting updates for these components have been included in commit https://github.com/Sage/carbon/pull/1243/commits/92600a999d9acf09444ca7583e97614621e0fc97 which is in a separate PR.
