### PR TITLE
Layout components linting updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,26 @@
 
 The following components have had minor internal changes to satisfy the introduction of stricter linting rules:
 
+* AppWrapper
 * Carousel
+* Column
+* Content
 * Date
 * DateRange
+* Detail
+* Heading
+* I18n
 * Link
 * Menu
 * MenuItem
 * MenuList
 * MenuListItem
+* MountInApp
 * NavigationBar
+* Pod
+* Row
+* SettingsRow
+* ShowEditPod
 * SubmenuBlock
 * Tabs
 

--- a/src/components/app-wrapper/app-wrapper.js
+++ b/src/components/app-wrapper/app-wrapper.js
@@ -31,17 +31,6 @@ class AppWrapper extends React.Component {
   }
 
   /**
-   * @method render
-   */
-  render() {
-    return (
-      <div className={ this.classes() } { ...tagComponent('app-wrapper', this.props) }>
-        { this.props.children }
-      </div>
-    );
-  }
-
-  /**
    * Returns the classes for the component.
    *
    * @method classes
@@ -51,6 +40,17 @@ class AppWrapper extends React.Component {
     return classNames(
       'carbon-app-wrapper',
       this.props.className
+    );
+  }
+
+  /**
+   * @method render
+   */
+  render() {
+    return (
+      <div className={ this.classes() } { ...tagComponent('app-wrapper', this.props) }>
+        { this.props.children }
+      </div>
     );
   }
 }

--- a/src/components/content/content.js
+++ b/src/components/content/content.js
@@ -83,10 +83,10 @@ class Content extends React.Component {
   }
 
   static defaultProps = {
-    align:         'left',
-    as:            'primary',
+    align: 'left',
+    as: 'primary',
     bodyFullWidth: false,
-    inline:        false
+    inline: false
   }
 
   constructor(args) {
@@ -95,35 +95,6 @@ class Content extends React.Component {
     this.titleStyle = this.titleStyle.bind(this);
     this.bodyStyle = this.bodyStyle.bind(this);
     this.classes = this.classes.bind(this);
-  }
-
-  /**
-   * @method render
-   * @return {Object} JSX
-   */
-  render() {
-    if (this.props.children) {
-      return (
-        <div className={ this.classes() } { ...tagComponent('content', this.props) }>
-          <div
-            className='carbon-content__title'
-            data-element='title'
-            style={ this.titleStyle() }
-          >
-            { this.props.title }
-          </div>
-
-          <div
-            className='carbon-content__body'
-            data-element='body'
-            style={ this.bodyStyle() }
-          >
-            { this.props.children }
-          </div>
-        </div>
-      );
-    }
-    return null;
   }
 
   /**
@@ -138,7 +109,7 @@ class Content extends React.Component {
       this.props.className,
       `carbon-content--${this.props.as}`,
       `carbon-content--align-${this.props.align}`, {
-        'carbon-content--inline':          this.props.inline,
+        'carbon-content--inline': this.props.inline,
         'carbon-content--body-full-width': this.props.bodyFullWidth
       }
     );
@@ -178,6 +149,35 @@ class Content extends React.Component {
     }
 
     return style;
+  }
+
+  /**
+   * @method render
+   * @return {Object} JSX
+   */
+  render() {
+    if (this.props.children) {
+      return (
+        <div className={ this.classes() } { ...tagComponent('content', this.props) }>
+          <div
+            className='carbon-content__title'
+            data-element='title'
+            style={ this.titleStyle() }
+          >
+            { this.props.title }
+          </div>
+
+          <div
+            className='carbon-content__body'
+            data-element='body'
+            style={ this.bodyStyle() }
+          >
+            { this.props.children }
+          </div>
+        </div>
+      );
+    }
+    return null;
   }
 }
 

--- a/src/components/detail/definition.js
+++ b/src/components/detail/definition.js
@@ -21,11 +21,13 @@ let definition = new Definition('detail', Detail, {
     footnote: "This detail may require a footnote."
   },
   propTypes: {
+    className: "String",
     footnote: "String",
     icon: "String",
     children: "Node"
   },
   propDescriptions: {
+    className: "Classes to apply to the component.",
     footnote: "Some additional notes for this detail.",
     icon: "Render a specific icon alongside your detail.",
     children: "This component supports children."

--- a/src/components/detail/detail.js
+++ b/src/components/detail/detail.js
@@ -7,6 +7,14 @@ import Icon from './../icon';
 class Detail extends React.Component {
   static propTypes = {
     /**
+     * Custom className
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    /**
      * The type of icon to use.
      *
      * @property icon

--- a/src/components/heading/definition.js
+++ b/src/components/heading/definition.js
@@ -13,6 +13,8 @@ let definition = new Definition('heading', Heading, {
  `,
   type: 'layout',
   propTypes: {
+    children: "Node",
+    className: "String",
     title: "String",
     subheader: "String",
     help: "String",
@@ -22,6 +24,8 @@ let definition = new Definition('heading', Heading, {
     separator: "Boolean"
   },
   propDescriptions: {
+    children: "This component supports children.",
+    className: "Classes to apply to the component.",
     title: "Sets the title for the heading.",
     subheader: "Sets the subheader for the heading.",
     help: "Sets the help text for the heading.",

--- a/src/components/heading/heading.js
+++ b/src/components/heading/heading.js
@@ -12,6 +12,22 @@ import { tagComponent } from '../../utils/helpers/tags';
 class Heading extends React.Component {
   static propTypes = {
     /**
+     * Children elements
+     *
+     * @property children
+     * @type {Node}
+     */
+    children: PropTypes.node,
+
+    /**
+     * Custom className
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    /**
      * Defines the title for the heading.
      *
      * @property title
@@ -92,7 +108,7 @@ class Heading extends React.Component {
 
     return (
       <Help
-        className="carbon-heading__help"
+        className='carbon-heading__help'
         data-element='help'
         tooltipAlign='center'
         tooltipPosition='right'
@@ -114,11 +130,11 @@ class Heading extends React.Component {
 
     return (
       <Link
-        className="carbon-heading__back"
+        className='carbon-heading__back'
         data-element='back'
         href={ this.props.backLink }
       >
-        <Icon type="chevron" />
+        <Icon type='chevron' />
       </Link>
     );
   }
@@ -133,7 +149,7 @@ class Heading extends React.Component {
     if (!this.props.subheader) { return null; }
 
     return (
-      <div className="carbon-heading__subheader" data-element='subtitle'>
+      <div className='carbon-heading__subheader' data-element='subtitle'>
         { this.props.subheader }
       </div>
     );
@@ -147,10 +163,10 @@ class Heading extends React.Component {
    */
   get classes() {
     return classNames(
-      "carbon-heading", this.props.className, {
-        ["carbon-heading--has-subheader"]: this.props.subheader,
-        ["carbon-heading--has-back"]: this.props.backLink,
-        ["carbon-heading--has-divider"]: this.props.divider
+      'carbon-heading', this.props.className, {
+        'carbon-heading--has-subheader': this.props.subheader,
+        'carbon-heading--has-back': this.props.backLink,
+        'carbon-heading--has-divider': this.props.divider
       }
     );
   }
@@ -174,12 +190,12 @@ class Heading extends React.Component {
 
     return (
       <div className={ this.classes } { ...tagComponent('heading', this.props) }>
-        <div className="carbon-heading__header">
+        <div className='carbon-heading__header'>
           { this.back }
 
-          <div className="carbon-heading__headers">
-            <div className="carbon-heading__main-header">
-              <h1 className="carbon-heading__title" data-element='title'>
+          <div className='carbon-heading__headers'>
+            <div className='carbon-heading__main-header'>
+              <h1 className='carbon-heading__title' data-element='title'>
                 { this.props.title }
               </h1>
 

--- a/src/components/i18n/i18n.js
+++ b/src/components/i18n/i18n.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from 'i18n-js';
 import _marked from 'marked';
-import { tagComponent } from '../../utils/helpers/tags';
 import { assign } from 'lodash';
+import { tagComponent } from '../../utils/helpers/tags';
 
 /**
  * A widget for internationalisation of text.
@@ -68,14 +68,25 @@ class I18n extends React.Component {
     inline: true
   }
 
+  marked(inline) {
+    // Make sure that we sanitize html markup in the MD compiler
+    _marked.setOptions({ sanitize: true });
+    return inline ? str => _marked.inlineLexer(str, []) : _marked;
+  }
+
+  renderMarkup(inline, props, translation) {
+    const el = inline ? 'span' : 'div';
+    return React.createElement(el, props, translation);
+  }
+
   /**
    * Renders the component.
    *
    * @method render
    */
   render() {
-    let { markdown, inline, scope, options, ...props } = { ...this.props },
-        translation = i18n.t(scope, options);
+    const { markdown, inline, scope, options, ...props } = this.props;
+    let translation = i18n.t(scope, options);
 
     if (markdown) {
       props.dangerouslySetInnerHTML = {
@@ -84,20 +95,9 @@ class I18n extends React.Component {
       translation = null;
     }
 
-    props = assign({}, props, tagComponent('i18n', this.props));
+    const markupProps = assign({}, props, tagComponent('i18n', this.props));
 
-    return this.renderMarkup(inline, props, translation);
-  }
-
-  renderMarkup(inline, props, translation) {
-    let el = inline ? 'span' : 'div';
-    return React.createElement(el, props, translation);
-  }
-
-  marked(inline) {
-    // Make sure that we sanitize html markup in the MD compiler
-    _marked.setOptions({ sanitize: true });
-    return inline ? str => _marked.inlineLexer(str, []) : _marked;
+    return this.renderMarkup(inline, markupProps, translation);
   }
 }
 

--- a/src/components/mount-in-app/mount-in-app.js
+++ b/src/components/mount-in-app/mount-in-app.js
@@ -26,7 +26,20 @@ import ReactDOM from 'react-dom';
  */
 class MountInApp extends React.Component {
   static propTypes = {
-    // the ID of the element in which the children components will be rendered.
+    /**
+     * Children elements
+     *
+     * @property children
+     * @type {Node}
+     */
+    children: PropTypes.node,
+
+    /**
+     * ID of the element in which the children components will be rendered.
+     *
+     * @property targetId
+     * @type {String}
+     */
     targetId: PropTypes.string
   }
 

--- a/src/components/pod/__spec__.js
+++ b/src/components/pod/__spec__.js
@@ -61,7 +61,7 @@ describe('Pod', () => {
     describe('when title is not passed as a prop', () => {
       it('returns null', () => {
         instance = TestUtils.renderIntoDocument(<Pod/>);
-        expect(instance.podHeader).toBeUndefined();
+        expect(instance.podHeader).toBeNull();
       });
     });
 

--- a/src/components/pod/definition.js
+++ b/src/components/pod/definition.js
@@ -37,6 +37,8 @@ let definition = new Definition('pod', Pod, {
   },
   propTypes: {
     border: "Boolean",
+    children: "Node",
+    className: "String",
     padding: "String",
     as: "String",
     collapsed: "Boolean",
@@ -53,6 +55,8 @@ let definition = new Definition('pod', Pod, {
   },
   propDescriptions: {
     border: "Shows/hides the border of the Pod.",
+    children: "This component supports children.",
+    className: "Classes to apply to the component.",
     padding: "Controls the size of the padding on the Pod.",
     as: "Controls what theme the Pod should use.",
     collapsed: "Enables and controls the collapsed state of the Pod. This needs to be defined on initialise to work.",

--- a/src/components/pod/pod.js
+++ b/src/components/pod/pod.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import I18n from 'i18n-js';
 import Icon from './../icon';
 import Link from './../link';
-import classNames from 'classnames';
 import Event from './../../utils/helpers/events';
 import { validProps } from '../../utils/ether';
 import { tagComponent } from '../../utils/helpers/tags';
@@ -37,6 +38,22 @@ class Pod extends React.Component {
      * @default true
      */
     border: PropTypes.bool,
+
+    /**
+     * Children elements
+     *
+     * @property children
+     * @type {Node}
+     */
+    children: PropTypes.node,
+
+    /**
+     * Custom className
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
 
     /**
      * Determines the padding around the pod.
@@ -203,9 +220,10 @@ class Pod extends React.Component {
    * @method podHeader
    */
   get podHeader() {
-    if (!this.props.title) { return; }
+    if (!this.props.title) { return null; }
 
-    let pod, subtitle, headerProps = {};
+    const headerProps = {};
+    let pod, subtitle;
 
     if (this.state.collapsed !== undefined) {
       pod = this.podCollapsible;
@@ -235,9 +253,8 @@ class Pod extends React.Component {
   get podDescription() {
     if (this.props.description) {
       return <div className='carbon-pod__description'>{ this.props.description }</div>;
-    } else {
-      return null;
     }
+    return null;
   }
 
   /**
@@ -246,9 +263,9 @@ class Pod extends React.Component {
    * @method podCollapsible
    */
   get podCollapsible() {
-    let className = 'carbon-pod__arrow carbon-pod__arrow--' + this.state.collapsed;
+    const className = `carbon-pod__arrow carbon-pod__arrow--${this.state.collapsed}`;
 
-    return(
+    return (
       <Icon type='dropdown' className={ className } />
     );
   }
@@ -259,7 +276,7 @@ class Pod extends React.Component {
    * @method podContent
    */
   get podContent() {
-    return(
+    return (
       <div className='carbon-pod__collapsible-content'>
         { this.podDescription }
         <div className='carbon-pod__content'>
@@ -290,7 +307,7 @@ class Pod extends React.Component {
 
   get mainClasses() {
     return classNames('carbon-pod', this.props.className,
-      `carbon-pod--${ this.props.alignTitle }`, {
+      `carbon-pod--${this.props.alignTitle}`, {
         'carbon-pod--editable': this.props.onEdit,
         'carbon-pod--is-hovered': this.state.hoverEdit,
         'carbon-pod--content-triggers-edit': this.shouldContentHaveEditProps,
@@ -325,10 +342,10 @@ class Pod extends React.Component {
    */
   get headerClasses() {
     return classNames(
-      `carbon-pod__header`,
-      `carbon-pod__header--${ this.props.alignTitle }`,
+      'carbon-pod__header',
+      `carbon-pod__header--${this.props.alignTitle}`,
       {
-        [`carbon-pod__header--${ this.state.collapsed }`]: this.state.collapsed !== undefined
+        [`carbon-pod__header--${this.state.collapsed}`]: this.state.collapsed !== undefined
       }
     );
   }
@@ -410,7 +427,9 @@ class Pod extends React.Component {
 
     return (
       <div className='carbon-pod__edit-button-container' { ...this.hoverOverEditEvents } >
-        <Link icon='edit' className={ this.editActionClasses } { ...this.linkProps() }/>
+        <Link icon='edit' className={ this.editActionClasses } { ...this.linkProps() }>
+          {I18n.t('actions.edit', { defaultValue: 'Edit' })}
+        </Link>
       </div>
     );
   }
@@ -442,7 +461,7 @@ class Pod extends React.Component {
    * @return {Object}
    */
   get hoverOverEditEvents() {
-    let props = {
+    const props = {
       onMouseEnter: this.toggleHoverState.bind(this, true),
       onMouseLeave: this.toggleHoverState.bind(this, false),
       onFocus: this.toggleHoverState.bind(this, true),
@@ -498,8 +517,8 @@ class Pod extends React.Component {
    */
   render() {
     let content,
-        { ...props } = validProps(this),
         hoverOverEditEvents = {};
+    const { ...props } = validProps(this);
 
     delete props.className;
 

--- a/src/components/pod/pod.scss
+++ b/src/components/pod/pod.scss
@@ -16,6 +16,11 @@
   width: 15px;
   height: 15px;
   vertical-align: top;
+
+  .carbon-link__content {
+    clip: rect(1px, 1px, 1px, 1px);
+    position: absolute;
+  }
 }
 
 .carbon-pod--content-triggers-edit .carbon-pod__block:hover {

--- a/src/components/row/column/column.js
+++ b/src/components/row/column/column.js
@@ -11,26 +11,22 @@ const Column = (props) => {
 
 Column.isColumn = true;
 
-Column.PropTypes = {
-  columnAlign: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string
-  ]),
+Column.propTypes = {
+  /**
+   * Children elements
+   *
+   * @property children
+   * @type {Node}
+   */
+  children: PropTypes.node,
 
-  columnOffset: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string
-  ]),
-
-  columnSpan: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string
-  ]),
-
-  columnDivide: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string
-  ])
+  /**
+   * Custom className
+   *
+   * @property className
+   * @type {String}
+   */
+  className: PropTypes.string
 };
 
 export default Column;

--- a/src/components/row/column/definition.js
+++ b/src/components/row/column/definition.js
@@ -4,12 +4,14 @@ import Definition from './../../../../demo/utils/definition';
 let definition = new Definition('column', Column, {
   type: 'layout',
   propTypes: {
+    className: "String",
     columnOffset: "String",
     columnSpan: "String",
     columnAlign: "String",
     children: "Node"
   },
   propDescriptions: {
+    className: "Classes to apply to the component.",
     columnOffset: "Offset this column by a certain number of columns.",
     columnSpan: "Span this column by a certain number of columns.",
     columnAlign: "Align the content of this column.",

--- a/src/components/row/definition.js
+++ b/src/components/row/definition.js
@@ -17,11 +17,13 @@ let definition = new Definition('row', Row, {
  `,
   hiddenProps: ['children'],
   propTypes: {
+    className: "String",
     gutter: "String",
     columnDivide: "Boolean",
     columns: "String"
   },
   propDescriptions: {
+    className: "Classes to apply to the component.",
     gutter: "Define how wide the gutter between the rows and columns should be.",
     columnDivide: "Enable a divider between each column.",
     columns: "Define a certain amount of columns, instead of basing it on the number of children.",

--- a/src/components/row/row.js
+++ b/src/components/row/row.js
@@ -40,6 +40,14 @@ class Row extends React.Component {
     ]),
 
     /**
+     * Custom className
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    /**
      * Pass a custom value for the gutter
      * (extra-small, small, medium, large or extra-large)
      *
@@ -66,7 +74,7 @@ class Row extends React.Component {
   }
 
   static defaultProps = {
-    gutter: "medium"
+    gutter: 'medium'
   };
 
   /**
@@ -78,7 +86,7 @@ class Row extends React.Component {
   buildColumns = () => {
     if (!this.props.children) { return null; }
 
-    let columns = [],
+    const columns = [],
         children = (this.props.children.constructor === Array) ? compact(this.props.children) : this.props.children;
 
     if ((children.constructor === Array && children.length) || (Immutable.Iterable.isIterable(children))) {
@@ -114,12 +122,12 @@ class Row extends React.Component {
      * TODO: CarbonV2
      */
     let columnClasses = classNames(
-      "carbon-row__column",
+      'carbon-row__column',
       child.props.columnClasses, {
         [`carbon-row__column--offset-${child.props.columnOffset}`]: child.props.columnOffset,
         [`carbon-row__column--span-${child.props.columnSpan}`]: child.props.columnSpan,
         [`carbon-row__column--align-${child.props.columnAlign}`]: child.props.columnAlign,
-        "carbon-row__column--column-divide": this.props.columnDivide
+        'carbon-row__column--column-divide': this.props.columnDivide
       }
     );
 
@@ -127,18 +135,17 @@ class Row extends React.Component {
       columnClasses = classNames(columnClasses, child.props.className);
       return React.cloneElement(
         child,
-        { className: columnClasses, key: key },
+        { className: columnClasses, key },
         child.props.children
       );
-    } else {
-      Logger.deprecate('Row Component should only have an immediate child of type Column');
-
-      return (
-        <div key={ key } className={ columnClasses }>
-          { child }
-        </div>
-      );
     }
+    Logger.deprecate('Row Component should only have an immediate child of type Column');
+
+    return (
+      <div key={ key } className={ columnClasses }>
+        { child }
+      </div>
+    );
   }
 
   /**

--- a/src/components/settings-row/settings-row.js
+++ b/src/components/settings-row/settings-row.js
@@ -41,6 +41,14 @@ class SettingsRow extends React.Component {
     children: PropTypes.node,
 
     /**
+     * Custom className
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    /**
      * Heading title
      *
      * @property  title
@@ -77,7 +85,11 @@ class SettingsRow extends React.Component {
    * @return  {String}
    */
   get classes() {
-    return classNames('carbon-settings-row', { 'carbon-settings-row--has-divider': this.props.divider }, this.props.className);
+    return classNames(
+      'carbon-settings-row',
+      { 'carbon-settings-row--has-divider': this.props.divider },
+      this.props.className
+    );
   }
 
   /**

--- a/src/components/show-edit-pod/definition.js
+++ b/src/components/show-edit-pod/definition.js
@@ -25,7 +25,7 @@ let definition = new Definition('show-edit-pod', ShowEditPod, {
 * Viewing content that’s grouped together visually? [Try Pod](/components/pod).
 * Creating a new entity that is usually presented in a pod? [Try Create](/components/create).
  `,
-  hiddenProps: ['editing', 'validateOnMount', 'transitionName'],
+  hiddenProps: ['children', 'editing', 'validateOnMount', 'transitionName'],
   toggleFunctions: ['onDelete'],
   propOptions: assign({}, formDefinition.propOptions, {
     as: OptionsHelper.themesFull

--- a/src/components/show-edit-pod/definition.js
+++ b/src/components/show-edit-pod/definition.js
@@ -32,6 +32,8 @@ let definition = new Definition('show-edit-pod', ShowEditPod, {
   }),
   defaultProps: assign({}, formDefinition.defaultProps, ShowEditPod.defaultProps),
   propTypes: assign({}, formDefinition.propTypes, {
+    children: "Node",
+    className: "String",
     editing: "Boolean",
     onEdit: "Function",
     onDelete: "Function",
@@ -56,6 +58,8 @@ let definition = new Definition('show-edit-pod', ShowEditPod, {
   propDescriptions: assign({}, formDefinition.propDescriptions, {
     as: "Set a theme for the Pod.",
     border: "Enabled/disable the border on the Pod.",
+    children: "This component supports children.",
+    className: "Classes to apply to the component.",
     deleteText: "Define custom text for the delete button.",
     editFields: "Define fields to be rendered in the edit state.",
     editing: "Allows developers to control the editing state manually.",

--- a/src/components/show-edit-pod/show-edit-pod.js
+++ b/src/components/show-edit-pod/show-edit-pod.js
@@ -1,24 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import I18n from 'i18n-js';
+import ReactDOM from 'react-dom';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import Pod from './../pod';
 import Form from './../form';
 import Link from './../link';
-import classNames from 'classnames';
-import I18n from 'i18n-js';
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import Events from './../../utils/helpers/events';
 import { validProps } from '../../utils/ether';
 import { tagComponent } from '../../utils/helpers/tags';
 
-import ReactDOM from 'react-dom';
-
 class ShowEditPod extends React.Component {
-
-  // Determines if controlled internally via state
-  // Or externally via props
-  control = 'props';
-
   static propTypes = {
+    /**
+     * Children elements
+     *
+     * @property children
+     * @type {Node}
+     */
+    children: PropTypes.node,
+
+    /**
+     * Custom className
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
 
     /**
      * Determines the editing state of the show edit pod
@@ -59,17 +68,6 @@ class ShowEditPod extends React.Component {
     editFields: PropTypes.node,
 
     /**
-     * Title to display in pod
-     *
-     * @property title
-     * @type {String}
-     */
-    title: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.object
-    ]),
-
-    /**
      * Transition Name, Override for custom state transition
      *
      * @property transitionName
@@ -88,12 +86,7 @@ class ShowEditPod extends React.Component {
     saveText: PropTypes.string,
     deleteText: PropTypes.string,
     saving: PropTypes.bool,
-    validateOnMount: PropTypes.bool,
-    additionalActions: PropTypes.node,
-
-    // Props passed to Pod
-    as: PropTypes.string,
-    border: PropTypes.bool
+    validateOnMount: PropTypes.bool
   }
 
   static defaultProps = {
@@ -198,6 +191,10 @@ class ShowEditPod extends React.Component {
     }
   }
 
+  // Determines if controlled internally via state
+  // Or externally via props
+  control = 'props';
+
   /**
    * True if the component is controlled by state
    *
@@ -264,9 +261,10 @@ class ShowEditPod extends React.Component {
    * @method content
    */
   get content() {
-    return this[this.control].editing ?
-      <div key='edit'>{ this.editContent }</div> :
-      <div key='show'>{ this.props.children }</div>;
+    if (this[this.control].editing) {
+      return <div key='edit'>{ this.editContent }</div>;
+    }
+    return <div key='show'>{ this.props.children }</div>;
   }
 
   /**
@@ -275,7 +273,7 @@ class ShowEditPod extends React.Component {
    * @method content
    */
   get contentProps() {
-    let { ...props } = validProps(this, Object.keys(Pod.propTypes));
+    const { ...props } = validProps(this, Object.keys(Pod.propTypes));
 
     delete props.onEdit;
     delete props.className;
@@ -293,7 +291,7 @@ class ShowEditPod extends React.Component {
    * @method content
    */
   get editingProps() {
-    let { ...props } = validProps(this, Object.keys(Pod.propTypes));
+    const { ...props } = validProps(this, Object.keys(Pod.propTypes));
 
     delete props.onEdit;
     delete props.className;
@@ -314,29 +312,35 @@ class ShowEditPod extends React.Component {
   }
 
   /**
-   * @method render
-   */
-  render() {
-    return (
-      <Pod className={ this.mainClasses } { ...this.podProps } ref='podFocus' tabIndex='-1' { ...tagComponent('show-edit-pod', this.props) }>
-        <ReactCSSTransitionGroup
-          transitionName={ this.props.transitionName }
-          transitionEnterTimeout={ 300 }
-          transitionLeaveTimeout={ 50 }
-        >
-        { this.content }
-        </ReactCSSTransitionGroup>
-      </Pod>
-    );
-  }
-
-  /**
    * Focuses on the pod component.
    *
    * @method __focusOnPod
    */
   __focusOnPod = () => {
-    ReactDOM.findDOMNode(this.refs.podFocus).focus();
+    ReactDOM.findDOMNode(this.pod).focus(); // eslint-disable-line react/no-find-dom-node
+  }
+
+  /**
+   * @method render
+   */
+  render() {
+    return (
+      <Pod
+        className={ this.mainClasses }
+        { ...this.podProps }
+        ref={ (node) => { this.pod = node; } }
+        tabIndex='-1'
+        { ...tagComponent('show-edit-pod', this.props) }
+      >
+        <ReactCSSTransitionGroup
+          transitionName={ this.props.transitionName }
+          transitionEnterTimeout={ 300 }
+          transitionLeaveTimeout={ 50 }
+        >
+          { this.content }
+        </ReactCSSTransitionGroup>
+      </Pod>
+    );
   }
 }
 


### PR DESCRIPTION
To prepare for the future upgrade of [carbon-factory](https://github.com/Sage/carbon-factory), that will introduce stricter linting rules, this PR updates the `layout` components to pre-emptively resolve the errors.

#### Updated components
- [x] AppWrapper
- [x] Column
- [x] Content
- [x] Heading
- [x] Detail
- [x] I18n
- [x] MountInApp
- [x] Pod
- [x] Row
- [x] SettingsRow
- [x] ShowEditPod

#### NOTES
**Column**
The `column` component had `columnAlign`, `columnOffset`, `columnSpan` and `columnDivide` prop types all declared but these were not used.

**ShowEditPod**
After exploring the alternatives, I have ignored the rule for using `ReactDOM.findDOMNode`. In this instance the inputs are passed in as a prop and thus would need to be interrogated to pull out the first one to call focus on it. This feels more fragile than using `findDOMNode` to call focus on the Pod component.

Arguably setting auto focus on the inputs passed in should not be the responsibility of this component. In an ideal world, the developer would set `autofocus` on the input they want to be focused. However, this would be a breaking change to existing implementation and has been discussed with @SeanArmstrong that could possibly form part of a future 2.0 release.

