### PR TITLE
data-component is now over-ridden if provided by the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.2
+
+## Component Enhancements
+
+* ALL: `data-component` will now be over-ridden if it's provided as a prop by the user
+
 # 1.1.1
 
 ## Component Enhancements

--- a/src/utils/helpers/tags/__spec__.js
+++ b/src/utils/helpers/tags/__spec__.js
@@ -7,6 +7,12 @@ describe('tagComponent', () => {
     });
   });
 
+  describe("when a data-component tag is sent", () => {
+    it("uses this over the Carbon component tag", () => {
+      expect(tagComponent('my-component', { ['data-component']: 'specific'})).toEqual({ ['data-component']: 'specific' });
+    });
+  });
+
   describe('when role and element props are sent', () => {
     it('adds those to the tagProps object', () => {
       expect(tagComponent('my-component', { ['data-element']: 'my-component', ['data-role']: 'contacts'}))

--- a/src/utils/helpers/tags/tags.js
+++ b/src/utils/helpers/tags/tags.js
@@ -6,10 +6,9 @@
  * @return {Object} dataTagProps
  */
 function tagComponent(component, props) {
-  const tagProps = {
-    ['data-component']: component
-  };
+  const tagProps = {};
 
+  tagProps['data-component'] = props['data-component'] ? props['data-component'] : component;
   if (props['data-element']) { tagProps['data-element'] = props['data-element']; }
   if (props['data-role']) { tagProps['data-role'] = props['data-role']; }
 


### PR DESCRIPTION
## Description

* The root of the component is the correct place for a `data-component` tag, but if the user provides one, the Carbon defaults will be applied instead.

In the following example:

```
<Wrapper>
  <AppComp data-role='x'/>
  <AppComp data-role='x'/>
  <AppComp data-role='z/>

  <OtherComp data-role='1' />
  <OtherComp data-role='2' />
</Wrapper>
```

If all five child components had `Pod` at their root level then they would all show up as `data-component='pod'` when `data-component='app-comp'` and `data-component='other-comp'` makes more sense.

The role needs to be kept unique, for identifying each individually and the element relates to the component's position within it's parent, so neither are correct.

Therefore, the `data-component` on the Carbon component should be over-ridden by a user provided prop.

## TODO
- [x] Release notes