### PR TITLE
Fix ESLint errors in Decimal component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The following components have had minor internal changes to satisfy the introduc
 * Content
 * Date
 * DateRange
+* Decimal
 * Detail
 * Fieldset
 * GroupedCharacter

--- a/src/components/decimal/__spec__.js
+++ b/src/components/decimal/__spec__.js
@@ -1,9 +1,8 @@
 import React from 'react';
+import I18n from "i18n-js";
+import { shallow } from 'enzyme';
 import TestUtils from 'react-dom/test-utils';
 import Decimal from './decimal';
-import I18n from "i18n-js";
-import ReactDOM from 'react-dom';
-import { shallow } from 'enzyme';
 import Events from './../../utils/helpers/events';
 import I18nHelper from './../../utils/helpers/i18n';
 import PropTypesHelper from '../../utils/helpers/prop-types';
@@ -51,7 +50,8 @@ describe('Decimal', () => {
 
     describe('handleBlur using default value', () => {
       it('calls set state with the formatted value', () => {
-        instance.refs.hidden.value = "9999";
+        const wrapper = shallow(<Decimal value="9999" name="total" />);
+        const instance = wrapper.instance();
         spyOn(instance, 'setState');
         instance.handleBlur();
         expect(instance.setState).toHaveBeenCalledWith({ visibleValue: "9,999.00" });
@@ -168,11 +168,11 @@ describe('Decimal', () => {
       });
 
       it('sets the hiddenField value as if it had been changed', () => {
-        expect(instance.refs.hidden.value).toEqual('100');
+        expect(instance._hiddenInput.value).toEqual('100');
       });
 
       it('calls _handleOnChange with a dummy event', () => {
-        expect(instance._handleOnChange).toHaveBeenCalledWith({ target: instance.refs.hidden });
+        expect(instance._handleOnChange).toHaveBeenCalledWith({ target: instance._hiddenInput });
       });
     });
 
@@ -456,11 +456,12 @@ describe('Decimal', () => {
 
     describe('hiddenInputProps', () => {
       it('sets type and readOnly', () => {
-        expect(instance.refs.hidden.type).toEqual("hidden");
-        expect(instance.refs.hidden.readOnly).toBeTruthy();
-        expect(instance.refs.hidden.value).toEqual("1000.00");
-        expect(instance.refs.hidden.defaultValue).toEqual("1000.00");
-        expect(instance.refs.hidden.name).toEqual("total");
+        const hiddenInput = instance._hiddenInput;
+        expect(hiddenInput.type).toEqual("hidden");
+        expect(hiddenInput.readOnly).toBeTruthy();
+        expect(hiddenInput.value).toEqual("1000.00");
+        expect(hiddenInput.defaultValue).toEqual("1000.00");
+        expect(hiddenInput.name).toEqual("total");
       });
     });
 

--- a/src/components/decimal/definition.js
+++ b/src/components/decimal/definition.js
@@ -2,8 +2,8 @@ import Decimal from './';
 import Definition from './../../../demo/utils/definition';
 import OptionsHelper from './../../utils/helpers/options-helper';
 
-let definition = new Definition('decimal', Decimal, {
-  description: `Captures a number with a decimal point, or a currency value.`,
+const definition = new Definition('decimal', Decimal, {
+  description: 'Captures a number with a decimal point, or a currency value.',
   designerNotes: `
 * For currency values, show currency symbols outside the field rather than inserting one for the user dynamically.
 * Carbon offers a Precision configuration, so you can choose how many decimal places to show.
@@ -15,14 +15,19 @@ let definition = new Definition('decimal', Decimal, {
 * Entering whole numbers without a decimal point? [Try Number Input](/components/number-input).
  `,
   type: 'form',
-  hiddenProps: ['onBlur', 'onKeyDown'],
+  hiddenProps: [
+    'name',
+    'onBlur',
+    'onKeyDown',
+    'value'
+  ],
   propTypes: {
-    align: "String",
-    precision: "String || Number"
+    align: 'String',
+    precision: 'String || Number'
   },
   propDescriptions: {
-    align: "Sets the alignment of the text within the decimal component",
-    precision: "Sets the precision of the decimal"
+    align: 'Sets the alignment of the text within the decimal component',
+    precision: 'Sets the precision of the decimal'
   },
   propOptions: {
     align: OptionsHelper.alignBinary

--- a/src/components/decimal/definition.js
+++ b/src/components/decimal/definition.js
@@ -15,6 +15,7 @@ let definition = new Definition('decimal', Decimal, {
 * Entering whole numbers without a decimal point? [Try Number Input](/components/number-input).
  `,
   type: 'form',
+  hiddenProps: ['onBlur', 'onKeyDown'],
   propTypes: {
     align: "String",
     precision: "String || Number"


### PR DESCRIPTION
Add `name`, `value`, `onBlur`, and `onKeyDown` to props, and add `onBlur` and
`onKeyDown` to the definition's `hiddenProps`.

Fix whitespace issues.

Use `const` over `let`.

Disable the warning about the unused align prop, as it is used by the `Input`
decorator that is applied to this component.

Changes to some props, and how `refs` are referenced, caused some tests to
fail. These have been fixed.
