### PR TITLE
Fix ESLint errors in Number component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The following components have had minor internal changes to satisfy the introduc
 * MenuListItem
 * MountInApp
 * NavigationBar
+* NumberInput
 * Pod
 * RadioButton
 * Row

--- a/src/components/number/definition.js
+++ b/src/components/number/definition.js
@@ -1,8 +1,8 @@
 import NumberInput from './';
 import Definition from './../../../demo/utils/definition';
 
-let definition = new Definition('number-input', NumberInput, {
-  description: `Captures a whole number (not a decimal or currency value).`,
+const definition = new Definition('number-input', NumberInput, {
+  description: 'Captures a whole number (not a decimal or currency value).',
   designerNotes: `
 * Where it’s clear a field only accepts numerals, you could disable entry of other characters. But, remember than for some regions, phone numbers and postcodes might contain dashes, and remember to cater for a minus sign if necessary.
   `,
@@ -10,7 +10,20 @@ let definition = new Definition('number-input', NumberInput, {
 * Entering a number including a decimal point? [Try Decimal](/components/decimal).
 * Entering numbers, symbols, and letters, or handling various formats? [Try Textbox](/components/textbox).
  `,
-
+  hiddenProps: [
+    'onKeyDown',
+    'value'
+  ],
+  propDescriptions: {
+    className: 'Classes to apply to the component.',
+    onKeyDown: 'Callback function called in response to the keydown event',
+    value: 'Controls the value of the NumberInput component'
+  },
+  propTypes: {
+    className: 'String',
+    onKeyDown: 'Function',
+    value: 'String'
+  },
   type: 'form',
   propValues: {
     value: ''

--- a/src/components/number/number.js
+++ b/src/components/number/number.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Input from './../../utils/decorators/input';
 import InputLabel from './../../utils/decorators/input-label';
@@ -26,6 +27,32 @@ import { tagComponent } from '../../utils/helpers/tags';
  */
 const Number = Input(InputLabel(InputValidation(
 class Number extends React.Component {
+
+  static propTypes = {
+    /**
+     * A custom class name for the component.
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    /**
+     * The value of the Number input element
+     *
+     * @property value
+     * @type {String}
+     */
+    value: PropTypes.string,
+
+    /**
+     * Event handler for the keyDown event
+     *
+     * @property onKeyDown
+     * @type {Function}
+     */
+    onKeyDown: PropTypes.func
+  }
 
   /**
    * Main Class getter
@@ -94,7 +121,7 @@ class Number extends React.Component {
    * @return {Object} props for the input
    */
   get inputProps() {
-    let { ...props } = validProps(this);
+    const { ...props } = validProps(this);
     props.className = this.inputClasses;
     props.onChange = this.handleOnChange;
     props.onKeyDown = this.handleKeyDown;
@@ -131,9 +158,8 @@ class Number extends React.Component {
  * @return {Boolean} true if value is valid number
  */
 function isValidNumber(value) {
-  let regex, result;
-  regex = new RegExp('^[-]?[0-9]*$');
-  result = regex.test(value);
+  const regex = new RegExp('^[-]?[0-9]*$');
+  const result = regex.test(value);
 
   return result;
 }


### PR DESCRIPTION
Add missing props, use `const` over `let`, fix whitespace issues.

Add `hiddenProps`, and `propDescriptions` to definition.

Update release notes.
