### PR TITLE
Fix ESLint errors in Create component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 The following components have had minor internal changes to satisfy the introduction of stricter linting rules:
 
 * AppWrapper
+* Create
 * Dropdown
 * DropdownFilter
 * DropdownFilterAjax

--- a/src/components/create/create.js
+++ b/src/components/create/create.js
@@ -37,6 +37,25 @@ class Create extends React.Component {
   }
 
   /**
+   * Returns the props for the component.
+   *
+   * @method linkProps
+   * @return {Object}
+   */
+  linkProps() {
+    const className = this.props.className;
+    const { ...props } = this.props;
+
+    props.className = classNames(
+      'carbon-create', className
+    );
+
+    props.iconAlign = 'right';
+    props.icon = 'add';
+    return props;
+  }
+
+  /**
    * @method render
    * @return {Object} JSX
    */
@@ -46,25 +65,6 @@ class Create extends React.Component {
         { this.props.children }
       </Link>
     );
-  }
-
-  /**
-   * Returns the props for the component.
-   *
-   * @method linkProps
-   * @return {Object}
-   */
-  linkProps() {
-    const className = this.props.className;
-    let { ...props } = this.props;
-
-    props.className = classNames(
-      'carbon-create', className
-    );
-
-    props.iconAlign = 'right';
-    props.icon = 'add';
-    return props;
   }
 }
 


### PR DESCRIPTION
Move `render` function to the end of the component, and use `const` over `let`.

Update release notes.