### PR TITLE
Fix ESLint errors in Help component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following components have had minor internal changes to satisfy the introduc
 * Fieldset
 * GroupedCharacter
 * Heading
+* Help
 * I18n
 * Link
 * Menu

--- a/src/components/help/definition.js
+++ b/src/components/help/definition.js
@@ -21,6 +21,7 @@ let definition = new Definition('help', Help, {
   },
   propTypes: {
     children: "Node",
+    className: "String",
     href: "String",
     tooltipAlign: "String",
     tooltipPosition: "String",
@@ -28,6 +29,7 @@ let definition = new Definition('help', Help, {
   },
   propDescriptions: {
     children: "This component supports children.",
+    className: "Classes to apply to the component.",
     href: "Set's a href to link this help icon to.",
     tooltipAlign: "Aligns the tooltip.",
     tooltipPosition: "Positions the tooltip with the icon.",

--- a/src/components/help/help.js
+++ b/src/components/help/help.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Icon from './../icon';
 import classNames from 'classnames';
+import Icon from './../icon';
 import TooltipDecorator from './../../utils/decorators/tooltip-decorator';
 import { tagComponent } from '../../utils/helpers/tags';
 
@@ -24,9 +24,18 @@ import { tagComponent } from '../../utils/helpers/tags';
  * @constructor
  * @decorators {TooltipDecorator}
  */
-const Help = TooltipDecorator(class Help extends React.Component{
+const Help = TooltipDecorator(class Help extends React.Component {
 
   static propTypes = {
+
+    /**
+     * A custom class name for the component.
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
     /**
      * Message to display in tooltip
      *
@@ -76,7 +85,7 @@ const Help = TooltipDecorator(class Help extends React.Component{
   get mainClasses() {
     return classNames(
       'carbon-help',
-      {'carbon-help__href': this.props.href },
+      { 'carbon-help__href': this.props.href },
       this.props.className
     );
   }
@@ -92,7 +101,8 @@ const Help = TooltipDecorator(class Help extends React.Component{
       <a
         className={ this.mainClasses }
         href={ this.props.href }
-        target="_blank"
+        target='_blank'
+        rel='noopener noreferrer'
         { ...tagComponent('help', this.props) }
       >
         <Icon


### PR DESCRIPTION
Add `className` to props, add spaces before curly braces, replace double quotes with single quotes, and add `rel="noopener noreferrer"` to the link that opens in a new window.