### PR TITLE
Fix ESLint errors in the Icon component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The following components have had minor internal changes to satisfy the introduc
 * GroupedCharacter
 * Heading
 * I18n
+* Icon
 * Link
 * Menu
 * MenuItem

--- a/src/components/icon/__spec__.js
+++ b/src/components/icon/__spec__.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
-import Icon from './icon';
-import Tooltip from 'components/tooltip'
 import { shallow } from 'enzyme';
+import Tooltip from 'components/tooltip'
+import Icon from './icon';
 import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
 
 describe('Icon', () => {

--- a/src/components/icon/definition.js
+++ b/src/components/icon/definition.js
@@ -1,9 +1,9 @@
+import OptionsHelper from 'utils/helpers/options-helper';
 import Icon from './';
 import Definition from './../../../demo/utils/definition';
-import OptionsHelper from 'utils/helpers/options-helper';
 
-let definition = new Definition('icon', Icon, {
-  description: `An eye catching icon associated with a UI element or content item.`,
+const definition = new Definition('icon', Icon, {
+  description: 'An eye catching icon associated with a UI element or content item.',
   designerNotes: `
 * Carbon comes with about 50 standard icons to choose from. See the Icons page in the Style section.
 * A tooltip option is available within this component.
@@ -16,39 +16,41 @@ let definition = new Definition('icon', Icon, {
 * After an image? [View Icons](/style/icons).
  `,
   propRequires: {
-    bgShape: "bgTheme",
-    bgSize: "bgTheme",
-    tooltipPosition: "tooltipMessage",
-    tooltipAlign: "tooltipMessage",
+    bgShape: 'bgTheme',
+    bgSize: 'bgTheme',
+    tooltipAlign: 'tooltipMessage',
+    tooltipPosition: 'tooltipMessage'
   },
   propValues: {
-    type: "tick"
+    type: 'tick'
   },
   propOptions: {
-    type: OptionsHelper.icons,
-    bgSize: OptionsHelper.sizesRestricted,
     bgShape: OptionsHelper.shapes,
+    bgSize: OptionsHelper.sizesRestricted,
     bgTheme: OptionsHelper.colors,
     tooltipAlign: OptionsHelper.alignAroundEdges,
     tooltipPosition: OptionsHelper.positions,
+    type: OptionsHelper.icons
   },
   propTypes: {
-    type: "String",
-    bgSize: "String",
-    bgShape: "String",
-    bgTheme: "String",
-    tooltipMessage: "String",
-    tooltipPosition: "String",
-    tooltipAlign: "String"
+    bgShape: 'String',
+    bgSize: 'String',
+    bgTheme: 'String',
+    className: 'String',
+    tooltipAlign: 'String',
+    tooltipMessage: 'String',
+    tooltipPosition: 'String',
+    type: 'String'
   },
   propDescriptions: {
-    type: "The icon to render.",
-    bgSize: "The size of the background.",
-    bgShape: "The shape of the background.",
-    bgTheme: "The color/theme of the background.",
-    tooltipMessage: "A message to display as a tooltip to the icon.",
-    tooltipPosition: "The position of the tooltip.",
-    tooltipAlign: "The alignment of the tooltip."
+    bgShape: 'The shape of the background.',
+    bgSize: 'The size of the background.',
+    bgTheme: 'The color/theme of the background.',
+    className: 'Set custom classes on the component',
+    tooltipAlign: 'The alignment of the tooltip.',
+    tooltipMessage: 'A message to display as a tooltip to the icon.',
+    tooltipPosition: 'The position of the tooltip.',
+    type: 'The icon to render.'
   }
 });
 

--- a/src/components/icon/icon.js
+++ b/src/components/icon/icon.js
@@ -21,7 +21,8 @@ import { tagComponent } from '../../utils/helpers/tags';
  *
  * 'type' is a required prop
  *
- * This widget follows this pattern: https://facebook.github.io/react/blog/2015/09/10/react-v0.14-rc1.html#stateless-function-components
+ * This widget follows this pattern:
+ * https://facebook.github.io/react/blog/2015/09/10/react-v0.14-rc1.html#stateless-function-components
  *
  * For information on how to use the Tooltip Decorator see the decorator docs.
  *
@@ -30,6 +31,14 @@ import { tagComponent } from '../../utils/helpers/tags';
  */
 const Icon = TooltipDecorator(class Icon extends React.Component {
   static propTypes = {
+    /**
+     * Add classes to this component
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
     /**
      * Icon type
      *
@@ -86,7 +95,7 @@ const Icon = TooltipDecorator(class Icon extends React.Component {
    * @return {Object} props
    */
   get componentProps() {
-    let { ...props } = validProps(this);
+    const { ...props } = validProps(this);
 
     delete props.className;
     delete props.bgSize;
@@ -104,10 +113,10 @@ const Icon = TooltipDecorator(class Icon extends React.Component {
    * @return {String} classes
    */
   get mainClasses() {
-    let icon = this.renderIcon,
-        hasShape = this.props.bgShape || this.props.bgTheme;
+    const icon = this.renderIcon;
+    const hasShape = this.props.bgShape || this.props.bgTheme;
 
-    let classes = classNames(
+    const classes = classNames(
       'carbon-icon',
       this.props.className, {
         [`icon-${this.type}`]: !icon
@@ -129,12 +138,12 @@ const Icon = TooltipDecorator(class Icon extends React.Component {
    */
   get type() {
     // switch tweaks icon names for actual icons in the set
-    switch(this.props.type) {
-      case 'help':        return 'question';
+    switch (this.props.type) {
+      case 'help': return 'question';
       case 'maintenance': return 'settings';
-      case 'new':         return 'gift';
-      case 'success':     return 'tick';
-      default:            return this.props.type;
+      case 'new': return 'gift';
+      case 'success': return 'tick';
+      default: return this.props.type;
     }
   }
 
@@ -150,7 +159,7 @@ const Icon = TooltipDecorator(class Icon extends React.Component {
         className={ this.mainClasses }
         { ...this.componentProps }
         { ...tagComponent('icon', this.props) }
-        ref={ (comp) => this._target = comp }
+        ref={ (comp) => { this._target = comp; } }
       >
         { this.iconSvgHTML() }
         { this.tooltipHTML }
@@ -159,9 +168,16 @@ const Icon = TooltipDecorator(class Icon extends React.Component {
   }
 
   iconSvgHTML = () => {
-    if (this.renderIcon) {
-      return (<span className="carbon-icon__svg-icon" dangerouslySetInnerHTML={ this.renderIcon } />);
+    const icon = this.renderIcon;
+    if (icon) {
+      /* eslint-disable react/no-danger */
+      return (
+        <span className='carbon-icon__svg-icon' dangerouslySetInnerHTML={ icon } />
+      );
+      /* eslint-enable react/no-danger */
     }
+
+    return null;
   }
 });
 


### PR DESCRIPTION
Absolute imports before relative, missing props, whitespace, `const` over `let`, and line length.

Disabled the `react/no-danger` rule when using `dangerouselySetInnerHtml` when rendering the icon.