### PR TITLE
Five more linting files in Utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ The following components have had minor internal changes to satisfy the introduc
 * Textarea
 * Textbox
 
+The following utils have had minor internal changes to satisfy the introduction of stricter linting rules:
+
+* Flux
+* Logger
+* Promises
+* Router
+* Service
+
+
 ## Component Improvements
 
 * `Menu` has been updated to use a `<nav>` tag as its root element.

--- a/src/utils/flux/__spec__.js
+++ b/src/utils/flux/__spec__.js
@@ -19,7 +19,7 @@ class SimpleView extends React.Component {
 class View extends React.Component {
 
   componentDidMount() {
-    this.extraFunction(); 
+    this.extraFunction();
   }
 
   componentWillUnmount() {
@@ -30,12 +30,12 @@ class View extends React.Component {
     // Nothing
   }
 
-  render() { 
-    
+  render() {
+
     let value = this.state.BaseStore1.get('text');
 
     return(
-      <Textbox name="Test" value={ value } />    
+      <Textbox name="Test" value={ value } />
     );
   }
 }
@@ -87,7 +87,7 @@ describe('Connect', () => {
           instance.componentDidMount();
           expect(instance.extraFunction).toHaveBeenCalled();
         });
-      
+
         it('adds events listeners', () => {
           spyOn(baseStore1, 'addChangeListener');
           spyOn(baseStore2, 'addChangeListener');

--- a/src/utils/flux/flux.js
+++ b/src/utils/flux/flux.js
@@ -26,12 +26,11 @@ import { assign } from 'lodash';
  * @param {Object|Array} stores The store(s) you want to connect to the ComposedView.
  * @return {Class} An enhanced version of the ComposedView to work with flux stores.
  */
-export function connect(ComposedView, stores) {
-
+export function connect(ComposedView, stores) { // eslint-disable-line import/prefer-default-export
   // Build an object mapping any stores passed to the connect function, using
   // the store's class name as the key.
 
-  let _stores = {};
+  const _stores = {};
 
   function _addStore(store) {
     _stores[store.name] = store;
@@ -79,7 +78,7 @@ export function connect(ComposedView, stores) {
       if (super.componentDidMount) { super.componentDidMount(); }
 
       // listen to each store when the view component mounts
-      for (let key in _stores) {
+      for (const key in _stores) {
         _stores[key].addChangeListener(this._onChange);
       }
     }
@@ -95,7 +94,7 @@ export function connect(ComposedView, stores) {
       if (super.componentWillUnmount) { super.componentWillUnmount(); }
 
       // unlisten to each store when the view component unmounts
-      for (let key in _stores) {
+      for (const key in _stores) {
         _stores[key].removeChangeListener(this._onChange);
       }
     }
@@ -119,9 +118,9 @@ export function connect(ComposedView, stores) {
      * @return {Object} A collection of each store and it's data.
      */
     _getStoreStates = () => {
-      let states = {};
+      const states = {};
 
-      for (let key in _stores) {
+      for (const key in _stores) {
         states[key] = _stores[key].getState();
       }
 

--- a/src/utils/logger/logger.js
+++ b/src/utils/logger/logger.js
@@ -55,7 +55,7 @@ const Logger = {
   },
 
   deprecate: (message) => {
-    log(`[Deprecation] ${ message }`, 'warn');
+    log(`[Deprecation] ${message}`, 'warn');
   }
 };
 

--- a/src/utils/promises/promises.js
+++ b/src/utils/promises/promises.js
@@ -1,2 +1,3 @@
 import promise from 'es6-promise';
+
 promise.polyfill();

--- a/src/utils/router/router.js
+++ b/src/utils/router/router.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, browserHistory } from 'react-router';
 
-let onRouteUpdate = () => {
+const onRouteUpdate = () => {
   global.window.scrollTo(0, 0);
 
   if (global.ga) {

--- a/src/utils/service/service.js
+++ b/src/utils/service/service.js
@@ -4,7 +4,7 @@ import { assign } from 'lodash';
 /**
  * Global configuration for all service classes.
  */
-let config = {
+const config = {
   csrfToken: null, // defines the CSRF token if required by your web application
   onSuccess: null, // defines a callback to trigger on every successful response
   onError: null    // defines a callback to trigger on every erroneous response
@@ -31,10 +31,10 @@ class Service {
     this.client = axios.create({
       headers: {
         'X-CSRF-Token': config.csrfToken,
-        'Accept': 'application/json',
+        Accept: 'application/json',
         'Content-Type': 'application/json'
       },
-      transformResponse: [ this.responseTransform ]
+      transformResponse: [this.responseTransform]
     });
 
     // applies the default axios interceptors used for manipulating the data
@@ -59,21 +59,21 @@ class Service {
       return response.data;
     }
 
-    if (response.data.status === "error") {
+    if (response.data.status === 'error') {
       // respond with an error if the server responds with an error status
       if (this.shouldTriggerCallback(config.onError)) {
         config.onError(response.data.message);
       }
 
       return Promise.reject(response);
-    } else {
-      // otherwise respond with a success
-      if (this.shouldTriggerCallback(config.onSuccess)) {
-        config.onSuccess(response.data.message);
-      }
-
-      return response.data;
     }
+
+    // in other cases, default to 'success'
+    if (this.shouldTriggerCallback(config.onSuccess)) {
+      config.onSuccess(response.data.message);
+    }
+
+    return response.data;
   }
 
   /**


### PR DESCRIPTION
## Description

* In the flux.js there was a clash with the way the file is built (and used amongst the user base) that meant a line had to be over-ridden

## QA Notes

* Point at the branch in an app like GAC and sense check a carbon area of the app, such as 'contacts' (this will cover the flux updates which aren't used in the demo site)
* Use this branch in s1_artefact_ui in order to test the services object (again, sense check)
* The rest can be covered by GAC / demo site sen checking