### PR TITLE
Add an 'info' prop in input to display info-styled icon and message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## Component Enhancements
 
 * ALL: `data-component` will now be over-ridden if it's provided as a prop by the user
-* `Dropdown` now accepts a new optional function prop `renderItem` which will be called to render each option in the list
-* `InputValidation`: now accepts a `warningType` prop which customizes the style of warning icon and message attached to an input.
+* `InputValidation`: now accepts a `info` prop to display info-styled icon and message attached to an input.
 
 # 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.1.3
+# 1.3.0
 
 ## Component Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Component Enhancements
 
 * ALL: `data-component` will now be over-ridden if it's provided as a prop by the user
+* `InputValidation`: now accepts a `warningType` prop which customizes the style of warning icon and message attached to an input.
 
 # 1.1.1
 

--- a/src/utils/decorators/input-validation/__spec__.js
+++ b/src/utils/decorators/input-validation/__spec__.js
@@ -473,7 +473,7 @@ describe('InputValidation', () => {
         });
       });
 
-      describe('when the input has the info state', () => {
+      describe('when the input has an info state', () => {
         it('calls handleContentChange', () => {
           instance.state.info = true;
           spyOn(instance, '_handleContentChange');
@@ -845,7 +845,7 @@ describe('InputValidation', () => {
           expect(infoTwo.validate).toHaveBeenCalledWith(instance.props.value, instance.props, instance.updateInfo);
         });
 
-        describe('when calling info function on the first element fails', () => {
+        describe('when calling the info function on the first element fails', () => {
           it('stops info', () => {
             wrapper = shallow(React.createElement(Component, {
               info: [infoOne, infoTwo],
@@ -1053,7 +1053,7 @@ describe('InputValidation', () => {
   describe('validationHTML', () => {
     describe('the field is valid', () => {
       it('returns null', () => {
-        instance.setState({ valid: true, warning: false});
+        instance.setState({ valid: true, warning: false, info: false});
         expect(instance.validationHTML).toBe(null);
       });
     });

--- a/src/utils/decorators/input-validation/__spec__.js
+++ b/src/utils/decorators/input-validation/__spec__.js
@@ -4,7 +4,7 @@ import TestUtils from 'react-dom/test-utils';
 import InputValidation from './input-validation';
 import InputLabel from './../input-label';
 import Form from 'components/form';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 let validationOne = {
   validate: function() {
@@ -48,6 +48,26 @@ let warningOne = {
 
 let warningTwo = {
   validate: function(value, props, updateWarning) {
+    return true;
+  },
+
+  message: function() {
+    return 'foo';
+  }
+};
+
+let infoOne = {
+  validate: function(value, props, updateInfo) {
+    return false;
+  },
+
+  message: function() {
+    return 'foo';
+  }
+};
+
+let infoTwo = {
+  validate: function(value, props, updateInfo) {
     return true;
   },
 
@@ -126,15 +146,17 @@ describe('InputValidation', () => {
     it('instatiates state with some defaults', () => {
       expect(instance.state.valid).toBeTruthy();
       expect(instance.state.warning).toBeFalsy();
+      expect(instance.state.info).toBeFalsy();
       expect(instance.state.errorMessage).toBe(null);
       expect(instance.state.warningMessage).toBe(null);
+      expect(instance.state.infoMessage).toBe(null);
     });
   });
 
   describe('componentWillReceiveProps', () => {
     describe('when invalid', () => {
       beforeEach(() => {
-        instance.setState({ valid: false, warning: true});
+        instance.setState({ valid: false, warning: true, info: true});
         spyOn(instance, 'setState').and.callThrough();
         spyOn(instance, '_handleContentChange');
       });
@@ -185,6 +207,12 @@ describe('InputValidation', () => {
           expect(instance.warning).toHaveBeenCalledWith('foo');
         });
 
+        it('calls info with the next value', () => {
+          spyOn(instance, 'info');
+          instance.componentWillReceiveProps({ value: 'foo' });
+          expect(instance.info).toHaveBeenCalledWith('foo');
+        });
+
         describe('when it returns valid', () => {
           it('resets valid to be truthy', () => {
             spyOn(instance, 'validate').and.returnValue(true);
@@ -216,7 +244,7 @@ describe('InputValidation', () => {
           });
 
           describe('when no longer has a warning state', () => {
-            it('set warning to be truthy', () => {
+            it('set warning to be false', () => {
               spyOn(instance, 'validate').and.returnValue(true);
               spyOn(instance, 'warning').and.returnValue(false);
               instance.componentWillReceiveProps({ value: 'foo' });
@@ -230,6 +258,39 @@ describe('InputValidation', () => {
               instance.setState.calls.reset();
               spyOn(instance, 'validate').and.returnValue(true);
               spyOn(instance, 'warning').and.returnValue(true);
+              instance.componentWillReceiveProps({ value: 'foo' });
+              expect(instance.setState).not.toHaveBeenCalled();
+              expect(instance._handleContentChange).not.toHaveBeenCalled();
+            });
+          });
+        });
+
+        describe('when it is valid but has an info state', () => {
+          beforeEach(() => {
+            instance.setState({ valid: true, info: true});
+          });
+
+          it('calls info with the next value', () => {
+            spyOn(instance, 'info');
+            instance.componentWillReceiveProps({ value: 'foo' });
+            expect(instance.info).toHaveBeenCalledWith('foo');
+          });
+
+          describe('when it no longer has an info state', () => {
+            it('set the info state to be false', () => {
+              spyOn(instance, 'validate').and.returnValue(true);
+              spyOn(instance, 'info').and.returnValue(false);
+              instance.componentWillReceiveProps({ value: 'foo' });
+              expect(instance.setState).toHaveBeenCalledWith({ info: false });
+              expect(instance._handleContentChange).toHaveBeenCalled();
+            });
+          });
+
+          describe('when it still has an info state', () => {
+            it('does not modify the validity', () => {
+              instance.setState.calls.reset();
+              spyOn(instance, 'validate').and.returnValue(true);
+              spyOn(instance, 'info').and.returnValue(true);
               instance.componentWillReceiveProps({ value: 'foo' });
               expect(instance.setState).not.toHaveBeenCalled();
               expect(instance._handleContentChange).not.toHaveBeenCalled();
@@ -410,7 +471,16 @@ describe('InputValidation', () => {
             instance.componentWillUnmount();
             expect(instance._handleContentChange).toHaveBeenCalled();
         });
-      })
+      });
+
+      describe('when the input has the info state', () => {
+        it('calls handleContentChange', () => {
+          instance.state.info = true;
+          spyOn(instance, '_handleContentChange');
+          instance.componentWillUnmount();
+          expect(instance._handleContentChange).toHaveBeenCalled();
+        });
+      });
 
       describe('when the input is in a form', () => {
         beforeEach(() => {
@@ -557,6 +627,20 @@ describe('InputValidation', () => {
           instance.setState({
             valid: true,
             warning: true
+          });
+          spyOn(instance, 'setState');
+          instance.showMessage();
+          expect(instance.setState).toHaveBeenCalledWith({
+            messageShown: true,
+            immediatelyHideMessage: false
+          });
+          expect(instance.context.form.setActiveInput).toHaveBeenCalledWith(instance);
+        });
+
+        it("if info", () => {
+          instance.setState({
+            valid: true,
+            info: true
           });
           spyOn(instance, 'setState');
           instance.showMessage();
@@ -739,6 +823,76 @@ describe('InputValidation', () => {
     });
   });
 
+  describe('info', () => {
+    describe('when the info prop is present on the input', () => {
+      describe('when the input has a value', () => {
+        let wrapper;
+
+        beforeEach(() => {
+          wrapper = shallow(React.createElement(Component, {
+            info: [infoTwo, infoOne],
+            value: 'foo'
+          }));
+          instance = wrapper.instance();
+          instance.context.form = form;
+          spyOn(infoTwo, 'validate').and.callThrough();
+          spyOn(infoOne, 'validate').and.callThrough();
+        });
+
+        it('calls the info function for each element inside the info prop array', () => {
+          instance.info();
+          expect(infoOne.validate).toHaveBeenCalledWith(instance.props.value, instance.props, instance.updateInfo);
+          expect(infoTwo.validate).toHaveBeenCalledWith(instance.props.value, instance.props, instance.updateInfo);
+        });
+
+        describe('when calling info function on the first element fails', () => {
+          it('stops info', () => {
+            wrapper = shallow(React.createElement(Component, {
+              info: [infoOne, infoTwo],
+              value: 'foo'
+            }));
+            instance = wrapper.instance();
+            instance.info();
+            expect(infoOne.validate).toHaveBeenCalledWith(instance.props.value, instance.props, instance.updateInfo);
+            expect(infoTwo.validate).not.toHaveBeenCalled();
+          });
+        });
+
+        describe('when called with a custom value', () => {
+          it('calls the info function for each element inside the info prop array', () => {
+            instance.info('bar');
+            expect(infoOne.validate).toHaveBeenCalledWith('bar', instance.props, instance.updateInfo);
+            expect(infoTwo.validate).toHaveBeenCalledWith('bar', instance.props, instance.updateInfo);
+          });
+        });
+
+        describe('when the input state has no info', () => {
+          it('calls setState', () => {
+            spyOn(instance, 'setState');
+            instance.info();
+            expect(instance.setState).toHaveBeenCalledWith({ infoMessage: 'foo', info: true });
+          });
+        });
+
+        describe('when the input state has info', () => {
+          it('does not call setState', () => {
+            instance.setState({ warning: true });
+            spyOn(instance, 'setState');
+            instance.warning();
+            expect(instance.setState).not.toHaveBeenCalled();
+          });
+        });
+      });
+    });
+
+    describe('when no info prop is present on the input', () => {
+      it('defaults the input info to true', () => {
+        let valid = instance.info();
+        expect(valid).toBeTruthy();
+      });
+    });
+  });
+
   describe('_handleBlur', () => {
     beforeEach(() => {
       jasmine.clock().install();
@@ -825,7 +979,7 @@ describe('InputValidation', () => {
         instance.setState({ valid: false, warning: true });
         spyOn(instance, 'setState');
         instance._handleContentChange();
-        expect(instance.setState).toHaveBeenCalledWith({ errorMessage: null, valid: true, warning: false });
+        expect(instance.setState).toHaveBeenCalledWith({ errorMessage: null, valid: true, warning: false, info: false });
       });
     });
 
@@ -1004,6 +1158,36 @@ describe('InputValidation', () => {
       });
     });
 
+    describe('there is info', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = mount(React.createElement(Component, {
+          info: [infoOne],
+          value: 'foo'
+        }));
+        instance = wrapper.instance();
+        instance.info();
+      });
+
+      it('returns an info icon', () => {
+        expect(instance.validationHTML[0].props.type).toEqual('info');
+        expect(wrapper.find('.common-input__icon.common-input__icon--info').exists()).toBeTruthy();
+      });
+
+      it('returns a div for the info message', () => {
+        expect(wrapper.find('.common-input__message-wrapper').exists()).toBeTruthy();
+        expect(wrapper.find('.common-input__message.common-input__message--info').exists()).toBeTruthy();
+        expect(instance.validationHTML[1].props.children.props.children).toEqual('foo');
+      });
+
+      describe('when the message is locked', () => {
+        it('adds a locked class', () => {
+          instance.setState({ messageLocked: true });
+          expect(instance.refs.validationMessage.classList).toContain('common-input__message--locked');
+        });
+      });
+    });
   });
 
   describe('mainClasses', () => {

--- a/src/utils/decorators/input-validation/input-validation.js
+++ b/src/utils/decorators/input-validation/input-validation.js
@@ -134,7 +134,20 @@ let InputValidation = (ComposedComponent) => class Component extends ComposedCom
      * @property
      * @type {Array}
      */
-    warnings: PropTypes.array
+    warnings: PropTypes.array,
+
+    /**
+     * The warning type
+     *
+     * @property
+     * @type {String}
+     * @default 'warning'
+     */
+    warningType: PropTypes.string
+  });
+
+  static defaultProps = assign({}, ComposedComponent.defaultProps, {
+    warningType: 'warning'
   });
 
   /**
@@ -520,7 +533,7 @@ let InputValidation = (ComposedComponent) => class Component extends ComposedCom
   get validationHTML() {
     if (this.state.valid && !this.state.warning) { return null; }
 
-    let type = !this.state.valid ? "error" : "warning";
+    let type = !this.state.valid ? "error" : this.props.warningType;
 
     let messageClasses = `common-input__message common-input__message--${type}`,
         iconClasses = `common-input__icon common-input__icon--${type}`;
@@ -553,7 +566,7 @@ let InputValidation = (ComposedComponent) => class Component extends ComposedCom
     return classNames(
       super.mainClasses, {
         'common-input--error': !this.state.valid,
-        'common-input--warning': this.state.warning,
+        [`common-input--${this.props.warningType}`]: this.state.warning,
         'common-input--message-hidden': this.state.immediatelyHideMessage,
         'common-input--message-shown': this.state.messageShown
       }
@@ -570,7 +583,7 @@ let InputValidation = (ComposedComponent) => class Component extends ComposedCom
     return classNames(
       super.inputClasses, {
         'common-input__input--error': !this.state.valid,
-        'common-input__input--warning': this.state.warning
+        [`common-input__input--${this.props.warningType}`]: this.state.warning
       }
     );
   }

--- a/src/utils/decorators/input-validation/input-validation.js
+++ b/src/utils/decorators/input-validation/input-validation.js
@@ -312,13 +312,8 @@ let InputValidation = (ComposedComponent) => class Component extends ComposedCom
    * @return {void}
    */
   updateInfo = (valid, value, info) => {
-    // if validation fails
-    if (!valid) {
-      // if input currently thinks it is valid
-      if (!this.state.info) {
-        // tell the input it is invalid
-        this.setState({ infoMessage: info.message(value, this.props), info: true });
-      }
+    if (!valid && !this.state.info) {
+      this.setState({ infoMessage: info.message(value, this.props), info: true });
     }
   }
 

--- a/src/utils/decorators/input-validation/input-validation.js
+++ b/src/utils/decorators/input-validation/input-validation.js
@@ -185,8 +185,8 @@ let InputValidation = (ComposedComponent) => class Component extends ComposedCom
       if (this.messageExists() && (nextProps.value !== this.props.value)) {
         let contentChanged = false;
 
-        if (this.state.info && !this.info(nextProps.value)) {
-          this.setState({ info: false });
+        if (!this.state.valid && this.validate(nextProps.value)) {
+          this.setState({ valid: true });
           contentChanged = true;
         }
 
@@ -195,8 +195,8 @@ let InputValidation = (ComposedComponent) => class Component extends ComposedCom
           contentChanged = true;
         }
 
-        if (!this.state.valid && this.validate(nextProps.value)) {
-          this.setState({ valid: true });
+        if (this.state.info && !this.info(nextProps.value)) {
+          this.setState({ info: false });
           contentChanged = true;
         }
 
@@ -595,10 +595,12 @@ let InputValidation = (ComposedComponent) => class Component extends ComposedCom
 
     if (this.state.valid && !this.state.warning && !this.state.info) { return null; }
 
-    if (this.state.info) {
-      type = "info";
+    if (!this.state.valid) {
+      type = 'error';
+    } else if (this.state.warning) {
+      type = 'warning';
     } else {
-      type = !this.state.valid ? "error" : "warning";
+      type = 'info';
     }
 
     let messageClasses = `common-input__message common-input__message--${type}`,

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -195,7 +195,8 @@
   height: 15px;
   position: absolute;
   right: 5px;
-  top: 28px;
+  top: 6px;
+  z-index: 2;
 
   &:before {
     font-size: 20px;
@@ -280,6 +281,15 @@
 
 }
 
-@each $set in $colorIconSets {
+/**
+ * Color and Icon sets used for inputs with themes.
+ */
+$inputColorIconSets: (
+  ("warning", $warning),
+  ("error", $error),
+  ("info", $info)
+);
+
+@each $set in $inputColorIconSets {
   @include common-input-theme($set...);
 }

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -252,7 +252,7 @@
   right: -24px;
 }
 
-@mixin common-input-theme($type, $color, $border, $background, $color-hover) {
+@mixin common-input-theme($type, $color) {
   .carbon-icon.common-input__icon.common-input__icon--#{$type} {
     color: $color;
   }
@@ -267,7 +267,7 @@
     }
   }
 
-  .common-input__message--#{type}:before {
+  .common-input__message--#{$type}:before {
     border-top-color: $color;
   }
 

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -170,19 +170,6 @@
   }
 }
 
-.common-input__message--warning .carbon-link__anchor {
-  color: white;
-  text-decoration: underline;
-}
-
-.common-input__message--warning:before {
-  border-top-color: $warning;
-}
-
-.common-input__message--error:before {
-  border-top-color: $error;
-}
-
 .common-input__message--hidden {
   display: none;
 }
@@ -213,10 +200,6 @@
   &:before {
     font-size: 20px;
   }
-
-  &.common-input__icon--warning {
-    color: $warning;
-  }
 }
 
 .common-input--label-inline {
@@ -229,28 +212,6 @@
 .common-input--error .common-input__label,
 .common-input__icon {
   color: $error;
-}
-
-.common-input__input--warning,
-.common-input__input--warning:hover {
-  border-color: $warning !important; // this is the correct use of !important
-  position: relative;
-  z-index: 1;
-}
-
-.common-input__input--error,
-.common-input__input--error:hover {
-  border-color: $error !important; // this is the correct use of !important
-}
-
-.common-input__message--warning {
-  background-color: $warning;
-  color: $white;
-}
-
-.common-input__message--error {
-  background-color: $error;
-  color: $white;
 }
 
 .common-input__prefix {
@@ -289,4 +250,36 @@
   position: absolute;
   top: 6px;
   right: -24px;
+}
+
+@mixin common-input-theme($type, $color, $border, $background, $color-hover) {
+  .carbon-icon.common-input__icon.common-input__icon--#{$type} {
+    color: $color;
+  }
+
+  .common-input__message--#{$type} {
+    background-color: $color;
+    color: $white;
+
+    .carbon-link__anchor {
+      color: $white;
+      text-decoration: underline;
+    }
+  }
+
+  .common-input__message--#{type}:before {
+    border-top-color: $color;
+  }
+
+  .common-input__input--#{$type},
+  .common-input__input--#{$type}:hover {
+    border-color: $color !important; // this is the correct use of !important
+    position: relative;
+    z-index: 1;
+  }
+
+}
+
+@each $set in $colorIconSets {
+  @include common-input-theme($set...);
 }


### PR DESCRIPTION
# Description
`InputValidation`: now accepts a `info` prop to display info-styled icon and message attached to an input.

# TODO
- [x] Release notes

# Related Issues / Pull Requests
https://github.com/Sage/sage_one_advanced/pull/12325

# Screenshots / Gifs
![screen shot 2017-06-20 at 6 10 33 pm 2](https://user-images.githubusercontent.com/1891722/27362545-f0e99310-55e3-11e7-901b-f70af7ce512f.png)
![screen shot 2017-06-20 at 7 23 02 pm 2](https://user-images.githubusercontent.com/1891722/27364211-f3ce034a-55ed-11e7-88c4-21994781f1ea.png)




