### PR TITLE
Dropdown list item renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Component Enhancements
 
 * ALL: `data-component` will now be over-ridden if it's provided as a prop by the user
+* `Dropdown` now accepts a new optional function prop `renderItem` which will be called to render each option in the list
 
 # 1.1.1
 

--- a/src/components/dropdown/__spec__.js
+++ b/src/components/dropdown/__spec__.js
@@ -164,7 +164,7 @@ describe('Dropdown', () => {
       spyOn(instance, 'selectValue');
       instance.handleSelect({
         currentTarget: {
-          getAttribute: function() { return 'foo' },
+          getAttribute: function() { return 'foo'; },
           textContent: 'bar'
         }
       });
@@ -178,7 +178,7 @@ describe('Dropdown', () => {
       spyOn(instance, 'setState');
       instance.handleMouseOverListItem({
         currentTarget: {
-          getAttribute: function() { return 'foo' }
+          getAttribute: function() { return 'foo'; }
         }
       });
 
@@ -849,23 +849,42 @@ describe('Dropdown', () => {
   });
 
   describe('results', () => {
-    beforeEach(() => {
-      instance = TestUtils.renderIntoDocument(
-        <Dropdown name="foo" options={ Immutable.fromJS([{id: 1, name: 'foo'}, { id: 2, name: 'bar' }]) } value="1" />
-      );
+    describe('when there is no render item prop', () => {
+      beforeEach(() => {
+        instance = TestUtils.renderIntoDocument(
+          <Dropdown name="foo" options={ Immutable.fromJS([{id: 1, name: 'foo'}, { id: 2, name: 'bar' }]) } value="1" />
+        );
+      });
+
+      it('returns list of items', () => {
+        expect(instance.results(instance.options).length).toEqual(2);
+      });
+
+      it('adds selected class', () => {
+        expect(instance.results(instance.options)[0].props.className).toEqual('carbon-dropdown__list-item carbon-dropdown__list-item--highlighted carbon-dropdown__list-item--selected');
+      });
+
+      it('adds highlighted class', () => {
+        instance.setState({ highlighted: 2 });
+        expect(instance.results(instance.options)[1].props.className).toEqual('carbon-dropdown__list-item carbon-dropdown__list-item--highlighted');
+      });
     });
 
-    it('returns list of items', () => {
-      expect(instance.results(instance.options).length).toEqual(2);
-    });
+    describe('when there is render item prop', () => {
+      beforeEach(() => {
+        const renderItem = (option) => {
+          return `the ${option.name}`;
+        };
+        instance = TestUtils.renderIntoDocument(
+          <Dropdown name="foo" options={ Immutable.fromJS([{id: 1, name: 'foo'}, { id: 2, name: 'bar' }]) } renderItem={ renderItem } value="1" />
+        );
+      });
 
-    it('adds selected class', () => {
-      expect(instance.results(instance.options)[0].props.className).toEqual('carbon-dropdown__list-item carbon-dropdown__list-item--highlighted carbon-dropdown__list-item--selected');
-    });
-
-    it('adds highlighted class', () => {
-      instance.setState({ highlighted: 2 });
-      expect(instance.results(instance.options)[1].props.className).toEqual('carbon-dropdown__list-item carbon-dropdown__list-item--highlighted');
+      it('returns list of items', () => {
+        const results = instance.results(instance.options);
+        expect(results[0].props.children).toEqual('the foo');
+        expect(results[1].props.children).toEqual('the bar');
+      });
     });
   });
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -586,8 +586,9 @@ class Dropdown extends React.Component {
           value={ option.id }
           onClick={ this.handleSelect }
           onMouseOver={ this.handleMouseOverListItem }
-          className={ klass }>
-            { option.name }
+          className={ klass }
+        >
+          { this.props.renderItem ? this.props.renderItem(option) : option.name }
         </li>
       );
     });

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -90,7 +90,15 @@ class Dropdown extends React.Component {
      * @property cacheVisibleValue
      * @type {boolean}
      */
-    cacheVisibleValue: PropTypes.bool
+    cacheVisibleValue: PropTypes.bool,
+
+    /**
+     * An optional function to be passed that will render each of the dropdown's items.
+     *
+     * @property renderItem
+     * @type {Function}
+     */
+    renderItem: PropTypes.func
   }
 
   static defaultProps = {


### PR DESCRIPTION
Link to original PR: https://github.com/Sage/carbon/pull/1336

Allowing dropdown list to use a function passed as a prop to render list items if prop present.
Otherwise option.name will be used