### PR TITLE
Fix bug with focus outline on MenuItem component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The following utils have had minor internal changes to satisfy the introduction 
 * `InlineInputs` children are now wrapped by Columns by the component
 * `TableHeader`: improve accessibility of sortable columns. They can now receive focus via the keyboard, and include `aria-sort` and `aria-label` attributes to indicate they are sortable, the current sort direction, and which direction the column will be sorted when sorting is next activated.
 * `Browser`: add a new method `setInputFocus` to focus on the input field of passed in ref but does not select text
+* `MenuItem`: focus outline is now fully visible when an item is focused.
 
 ## Deployment Changes
 

--- a/src/components/menu/menu-item/menu-item.scss
+++ b/src/components/menu/menu-item/menu-item.scss
@@ -11,6 +11,10 @@
   font-size: 13px;
   font-weight: 700;
 
+  &:focus {
+    z-index: 1;
+  }
+
   .carbon-menu--primary & {
     background-color: $white;
     color: $grey-dark-blue;
@@ -86,7 +90,7 @@
     top: 50%;
     margin-top: -2px;
     position: absolute;
-    z-index: 1;
+    z-index: 2;
 
     .carbon-menu--primary & {
       @include arrow("down", 4px, $grey-dark-blue);


### PR DESCRIPTION
**Before:** 
![menu-item-before](https://user-images.githubusercontent.com/4964/27231078-41ef1e30-52a9-11e7-9cce-3d45949563c9.gif)

**After:**
![menu-item-after](https://user-images.githubusercontent.com/4964/27231079-4612c2f0-52a9-11e7-81fb-9207c05d75b4.gif)
