### PR TITLE
Update guides to use `carbon-react` in imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-# NEXT
-
-## Guide Updates
-Minor changes to guides to reference `carbon-react` in imports.
-
 # 1.2.0
 
 ## Linting Updates
@@ -144,6 +139,9 @@ A new helper object is available in `utils/helpers/text`. Currently it only cont
 ## Deployment Changes
 
 You can now pass `--cdn` to the gulp task to bundle assets pointing towards the CDN.
+
+## Other
+Minor changes to guides to reference `carbon-react` in imports.
 
 # 1.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# NEXT
+
+## Guide Updates
+Minor changes to guides to reference `carbon-react` in imports.
+
 # 1.2.0
 
 ## Linting Updates

--- a/docs/guides/a-basic-example.md
+++ b/docs/guides/a-basic-example.md
@@ -75,8 +75,8 @@ The store handles the data for a particular model. It defines functions which su
 
 import Dispatcher from 'dispatcher';
 import ContactConstants from 'constants/contact';
-import Store from 'carbon/lib/utils/flux/store';
-import ImmutableHelper from 'carbon/lib/utils/helpers/immutable';
+import Store from 'carbon-react/lib/utils/flux/store';
+import ImmutableHelper from 'carbon-react/lib/utils/helpers/immutable';
 
 // data to init your store with
 let data = ImmutableHelper.parseJSON({
@@ -110,8 +110,8 @@ The component connects to a store, setting up listeners for when the store's dat
 // ./src/views/contact/index.js
 
 import React from 'react';
-import { connect } from 'carbon/lib/utils/flux';
-import Textbox from 'carbon/lib/components/textbox';
+import { connect } from 'carbon-react/lib/utils/flux';
+import Textbox from 'carbon-react/lib/components/textbox';
 import ContactStore from 'stores/contact';
 import ContactActions from 'actions/contact';
 
@@ -144,7 +144,7 @@ The router defines which component to render for a given route.
 
 import React from 'react';
 import { Route } from 'react-router';
-import { startRouter } from 'carbon/lib/utils/router';
+import { startRouter } from 'carbon-react/lib/utils/router';
 import Contact from 'views/contact';
 
 let routes = (

--- a/docs/guides/decorators.md
+++ b/docs/guides/decorators.md
@@ -8,9 +8,9 @@ This means we can extend as many decorators as we like - for example, a typical 
 
 ```js
 import React from 'react';
-import Input from 'carbon/lib/utils/decorators/input';
-import InputLabel from 'carbon/lib/utils/decorators/input-label';
-import InputValidation from 'carbon/lib/utils/decorators/input-validation';
+import Input from 'carbon-react/lib/utils/decorators/input';
+import InputLabel from 'carbon-react/lib/utils/decorators/input-label';
+import InputValidation from 'carbon-react/lib/utils/decorators/input-validation';
 
 const Textbox = Input(InputLabel(InputValidation(
 class Textbox extends React.Component {

--- a/docs/guides/flux.md
+++ b/docs/guides/flux.md
@@ -32,8 +32,8 @@ Carbon provides a base class for creating a store. This should be used to extend
 ```js
 // ./src/stores/user/index.js
 
-import Store from 'carbon/lib/utils/flux/store';
-import ImmutableHelper from 'carbon/lib/utils/helpers/immutable';
+import Store from 'carbon-react/lib/utils/flux/store';
+import ImmutableHelper from 'carbon-react/lib/utils/helpers/immutable';
 import Dispatcher from 'dispatcher';
 
 // our store!
@@ -96,8 +96,8 @@ So now we can update the store to subscribe to this event by using the same cons
 ```js
 // ./src/stores/user/index.js
 
-import Store from 'carbon/lib/utils/flux/store';
-import ImmutableHelper from 'carbon/lib/utils/helpers/immutable';
+import Store from 'carbon-react/lib/utils/flux/store';
+import ImmutableHelper from 'carbon-react/lib/utils/helpers/immutable';
 import Dispatcher from 'dispatcher';
 import UserConstants from 'constants/user';
 
@@ -126,7 +126,7 @@ The store is now updating its data - but we have no React components connected t
 
 import React from 'react';
 import { connect } from 'utils/flux';
-import Textbox from 'carbon/lib/components/textbox';
+import Textbox from 'carbon-react/lib/components/textbox';
 import UserStore from 'stores/user';
 import UserActions from 'actions/user';
 

--- a/docs/guides/handlers.md
+++ b/docs/guides/handlers.md
@@ -58,7 +58,7 @@ We could render the application like this:
 
 import React from 'react';
 import { Route } from 'react-router';
-import { startRouter } from 'carbon/lib/utils/router';
+import { startRouter } from 'carbon-react/lib/utils/router';
 import App from './app';
 import MyView from './views/dummy';
 
@@ -80,7 +80,7 @@ Let's create a handler registry for the footer links:
 ```js
 // ./footer-links-registry.js
 
-import BaseRegistry from 'carbon/lib/utils/handlers/base-registry';
+import BaseRegistry from 'carbon-react/lib/utils/handlers/base-registry';
 
 class FooterLinksRegistry extends BaseRegistry {
 }
@@ -187,7 +187,7 @@ The app should *still* work, however the links will not have been updated. This 
 
 import React from 'react';
 import { Route } from 'react-router';
-import { startRouter } from 'carbon/lib/utils/router';
+import { startRouter } from 'carbon-react/lib/utils/router';
 import App from './app';
 import MyView from './my-view';
 

--- a/docs/guides/immutable.md
+++ b/docs/guides/immutable.md
@@ -15,7 +15,7 @@ Some of our components require immutable data to function correctly - so we reco
 We have provided an object of helper functions when working with Immutable.js, which parses your data in a recommended format:
 
 ```js
-import ImmutableHelper from 'carbon/lib/utils/helpers/immutable';
+import ImmutableHelper from 'carbon-react/lib/utils/helpers/immutable';
 ```
 
 Available functions:

--- a/docs/guides/retrieving-data.md
+++ b/docs/guides/retrieving-data.md
@@ -34,7 +34,7 @@ let data = {
 If you are using Immutable data this initial data should be wrapped in a parseJSON function:
 
 ```js
-import ImmutableHelper from 'carbon/lib/utils/helpers/immutable';
+import ImmutableHelper from 'carbon-react/lib/utils/helpers/immutable';
 
 let data = ImmutableHelper.parseJSON({
   contact: global.VIEW_DATA.contact

--- a/docs/guides/validations.md
+++ b/docs/guides/validations.md
@@ -6,8 +6,8 @@ The Carbon library provides a [selection of validations](https://github.com/Sage
 
 ```js
 import React from 'react';
-import Textbox from 'carbon/lib/components/textbox';
-import Presence from 'carbon/lib/utils/validations/presence';
+import Textbox from 'carbon-react/lib/components/textbox';
+import Presence from 'carbon-react/lib/utils/validations/presence';
 
 class MyComponent extends React.Component {
   render() {
@@ -32,9 +32,9 @@ Usually, your inputs will sit inside a form component. The Carbon form component
 
 ```js
 import React from 'react';
-import Form from 'carbon/lib/components/form';
-import Textbox from 'carbon/lib/components/textbox';
-import Presence from 'carbon/lib/utils/validations/presence';
+import Form from 'carbon-react/lib/components/form';
+import Textbox from 'carbon-react/lib/components/textbox';
+import Presence from 'carbon-react/lib/utils/validations/presence';
 
 class MyComponent extends React.Component {
   render() {


### PR DESCRIPTION
Due to open sourcing, import statements must refer to `carbon-react`.  This PR updates the getting started guides to reflect this.
