### PR TITLE
Re-enable endLabel and startLabel prop types on DateRange

### DIFF
--- a/src/components/date-range/date-range.js
+++ b/src/components/date-range/date-range.js
@@ -10,6 +10,14 @@ import tagComponent from '../../utils/helpers/tags';
 
 class DateRange extends React.Component {
   static propTypes = {
+    /**
+     * Optional label for endDate field
+     * eslint is disabled because the prop is used to determine the label in the dateProps function
+     *
+     * @property endDate
+     * @type {String}
+     */
+    endLabel: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
 
     /**
      * Custom callback - receives array of startDate and endDate
@@ -26,6 +34,15 @@ class DateRange extends React.Component {
      * @type {Array}
      */
     value: PropTypes.array.isRequired,
+
+    /**
+     * Optional label for startDate field
+     * eslint is disabled because the prop is used to determine the label in the dateProps function
+     *
+     * @property startLabel
+     * @type {String}
+     */
+    startLabel: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
 
     /**
      * Custom message for startDate field


### PR DESCRIPTION
These were accidentally removed as part of linting updates.

Note I have disabled eslint check because of the way the prop names are used dynamically and thus the linter doesn't detect that they are actually used in the code.

![date-range-labels](https://user-images.githubusercontent.com/4964/27532234-7964df70-5a57-11e7-89b0-cea6815fc3f7.gif)

