### PR TITLE
CARBON-696 Fix Table component props warning in carbon demo

### DIFF
--- a/src/components/table/definition.js
+++ b/src/components/table/definition.js
@@ -30,7 +30,12 @@ let definition = new Definition('table', Table, {
   ],
   dataVariable: 'tableData',
   propValues: {
+    highlightable: false,
     onChange: ComponentActions.updateTable,
+    paginate: false,
+    selectable: false,
+    shrink: false,
+    showPageSizeSelection: false
   }
 });
 


### PR DESCRIPTION
Resolved the following warning that appeared in the console when viewing the Table component on the Carbon demo site:

```
Warning: Failed prop type: Invalid prop `value` of type `string` supplied to `Checkbox`, expected `boolean`.
```

Note the error only appeared when running the app locally in development mode.