### PR TITLE
CARBON-686 MultiActionButton – update secondary button hover style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ A new helper object is available in `utils/helpers/text`. Currently it only cont
 * `InlineInputs` children are now wrapped in Columns by the component.
 * `Menu` has been updated to use a `<nav>` tag as its root element.
 * `MenuItem`: focus outline is now fully visible when an item is focused.
+* `MultiActionButton`: Secondary button hover style has been updated to not change on hover.
 * `Table` has a new prop of onConfigure. Displays a configure icon to the left of the table header that triggers the callback onClick.
 * `TableHeader`: improve accessibility of sortable columns. They can now receive focus via the keyboard, and include `aria-sort` and `aria-label` attributes to indicate they are sortable, the current sort direction, and which direction the column will be sorted when sorting is next activated.
 

--- a/src/components/multi-action-button/multi-action-button.scss
+++ b/src/components/multi-action-button/multi-action-button.scss
@@ -1,6 +1,7 @@
 @import "./../../style-config/colors";
 @import "./../../style-config/buttons";
 @import "./../../style-config/z-index";
+@import "./../../style-config/mixins";
 
 .carbon-multi-action-button--align-right {
   .carbon-multi-action-button__additional-buttons {
@@ -31,6 +32,19 @@
     &--primary {
       border: none;
     }
+  }
+
+  @mixin button-theme($theme, $color, $hover, $active, $text-color) {
+    .carbon-button--#{$theme}.carbon-multi-action-button__toggle--secondary{
+      &:not(.carbon-button--disabled) {
+        background-color: transparent;
+        color: $color;
+      }
+    }
+  }
+
+  @each $set in $buttonColorSets {
+    @include button-theme($set...);
   }
 
   .carbon-multi-action-button__additional-buttons {


### PR DESCRIPTION
## MultiActionButton component

Ticket: CARBON-686

The Primary button does not change colour on hover. However, the Secondary style button was changing colour on hover.

The Secondary button has now been updated so it does not change colour on hover.

**Before:**
![multi-action-before](https://user-images.githubusercontent.com/4964/27576002-67a8468e-5b13-11e7-83d1-007fd00b7944.gif)

**After:**
![multi-action-after](https://user-images.githubusercontent.com/4964/27576005-692bc260-5b13-11e7-9bd7-47f5166f05d4.gif)