### PR TITLE
Fix i18nhelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.4
+* Update I18nhelper to respect the locale for the delimiter and separator.
+
 # 1.1.3
 
 * Fix bug with Date Range date pickers not closing correctly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A library of reusable React components and an interface for easily building user interfaces based on Flux.",
   "engineStrict": true,
   "engines": {

--- a/src/utils/helpers/i18n/__spec__.js
+++ b/src/utils/helpers/i18n/__spec__.js
@@ -76,11 +76,11 @@ describe('I18n Helper', () => {
     it("creates the correct abbreviation", () => {
       expect(Helper.abbreviateCurrency('-345')).toEqual('£-345.00');
       expect(Helper.abbreviateCurrency('345')).toEqual('£345.00');
-      expect(Helper.abbreviateCurrency('678', { locale: 'fr', unit: '€' })).toEqual('678.00 €');
+      expect(Helper.abbreviateCurrency('678', { locale: 'fr', unit: '€' })).toEqual('678,00 €');
       expect(Helper.abbreviateCurrency('123456', { locale: 'en', unit: '£' })).toEqual('£123.5k');
-      expect(Helper.abbreviateCurrency('567890', { locale: 'fr', unit: '€' })).toEqual('567.9k €');
+      expect(Helper.abbreviateCurrency('567890', { locale: 'fr', unit: '€' })).toEqual('567,9k €');
       expect(Helper.abbreviateCurrency('987654321', { locale: 'en', unit: '£' })).toEqual('£987.7m');
-      expect(Helper.abbreviateCurrency('234567890', { locale: 'fr', unit: '€' })).toEqual('234.6m €');
+      expect(Helper.abbreviateCurrency('234567890', { locale: 'fr', unit: '€' })).toEqual('234,6m €');
     });
 
     describe('when locale is different to the provided locale', () => {
@@ -96,9 +96,9 @@ describe('I18n Helper', () => {
         expect(Helper.abbreviateCurrency('-345')).toEqual('-345,00 €');
         expect(Helper.abbreviateCurrency('345')).toEqual('345,00 €');
         expect(Helper.abbreviateCurrency('678', { locale: 'fr', unit: '€' })).toEqual('678,00 €');
-        expect(Helper.abbreviateCurrency('123456', { locale: 'en', unit: '£' })).toEqual('£123,5k');
+        expect(Helper.abbreviateCurrency('123456', { locale: 'en', unit: '£' })).toEqual('£123.5k');
         expect(Helper.abbreviateCurrency('567890', { locale: 'fr', unit: '€' })).toEqual('567,9k €');
-        expect(Helper.abbreviateCurrency('987654321', { locale: 'en', unit: '£' })).toEqual('£987,7m');
+        expect(Helper.abbreviateCurrency('987654321', { locale: 'en', unit: '£' })).toEqual('£987.7m');
         expect(Helper.abbreviateCurrency('234567890', { locale: 'fr', unit: '€' })).toEqual('234,6m €');
       });
     });
@@ -183,7 +183,7 @@ describe('I18n Helper', () => {
 
     describe('when a value is provided with a set locale', () => {
       it('returns a formatted value based on locale', () => {
-        expect(Helper.formatCurrency(1337, { locale: 'fr' })).toEqual('1,337.00 €');
+        expect(Helper.formatCurrency(1337, { locale: 'fr' })).toEqual('1.337,00 €');
       });
     });
 

--- a/src/utils/helpers/i18n/i18n.js
+++ b/src/utils/helpers/i18n/i18n.js
@@ -19,8 +19,8 @@ const I18nHelper = {
    */
   format: (locale) => {
     return {
-      delimiter: I18n.t("number.format.delimiter", { defaultValue: "," }),
-      separator: I18n.t("number.format.separator", { defaultValue: "." }),
+      delimiter: I18n.t("number.format.delimiter", { locale: locale, defaultValue: "," }),
+      separator: I18n.t("number.format.separator", { locale: locale, defaultValue: "." }),
       unit: I18n.t("number.currency.format.unit", { locale: locale, defaultValue: '£' }),
       format: I18n.t("number.currency.format.format", { locale: locale, defaultValue: '%u%n' })
     };


### PR DESCRIPTION
# Description
This PR resolves the i18nhelper to use the locale for the separator and delimiter values, in the same way that unit and format already do.