### PR TITLE
Apply overflow hidden to <html> when dialog open

### DIFF
--- a/src/components/dialog-full-screen/__spec__.js
+++ b/src/components/dialog-full-screen/__spec__.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+import Browser from '../../utils/helpers/browser';
 import DialogFullScreen from './dialog-full-screen';
 import Button from './../button';
 import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
@@ -36,7 +37,7 @@ describe('DialogFullScreen', () => {
     describe('when the open prop is true', () => {
       it('returns the full screen dialog class and the open class', () => {
         expect(instance.dialogClasses).toEqual(
-          'carbon-dialog-full-screen__dialog carbon-dialog-full-screen__dialog--open'
+          'carbon-dialog-full-screen__dialog'
         );
       });
     });
@@ -48,6 +49,41 @@ describe('DialogFullScreen', () => {
       });
     });
   });
+
+  describe('onOpening', () => {
+    it('adds a data-fullscreendialogopen attribute to the <html> tag', () => {
+      const mockDocElement = document.createElement('html');
+      const mockDocument = {
+        documentElement: mockDocElement
+      };
+      spyOn(Browser, 'getDocument').and.returnValue(mockDocument);
+
+      wrapper = shallow(
+        <DialogFullScreen open={ false } />
+      );
+      wrapper.instance().onOpening();
+      expect(mockDocument.documentElement.dataset['fullscreendialogopen']).toBeTruthy();
+    });
+  });
+
+  describe('onClosing', () => {
+    it('removes the data-fullscreendialogopen attribute from the <html> tag', () => {
+      const mockDocElement = document.createElement('html');
+      mockDocElement.dataset.fullscreendialogopen = true;
+
+      const mockDocument = {
+        documentElement: mockDocElement
+      };
+      spyOn(Browser, 'getDocument').and.returnValue(mockDocument);
+
+      wrapper = shallow(
+        <DialogFullScreen open={ true } />
+      );
+
+      wrapper.instance().onClosing();
+      expect(mockDocument.documentElement.dataset.fullscreendialogopen).toBeUndefined();
+    });
+  })
 
   describe('mainClasses', () => {
     it('returns the full screen dialog class and custom class', () => {
@@ -78,7 +114,7 @@ describe('DialogFullScreen', () => {
     it('renders the dialog', () => {
       expect(instance._dialog).toBeTruthy();
       expect(instance._dialog.className).toEqual(
-        'carbon-dialog-full-screen__dialog carbon-dialog-full-screen__dialog--open'
+        'carbon-dialog-full-screen__dialog'
       );
     });
 

--- a/src/components/dialog-full-screen/dialog-full-screen.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
+
+import Browser from '../../utils/helpers/browser';
 import Icon from './../icon';
 import Modal from './../modal';
 import Heading from './../heading';
+
+const dialogOpenAttribute = 'fullscreendialogopen';
 
 /**
  * A DialogFullScreen widget.
@@ -25,6 +29,12 @@ import Heading from './../heading';
  * @constructor
  */
 class DialogFullScreen extends Modal {
+
+  constructor(props) {
+    super(props);
+    this.document = Browser.getDocument();
+  }
+
   static defaultProps = {
     open: false,
     enableBackgroundUI: true
@@ -37,8 +47,7 @@ class DialogFullScreen extends Modal {
    */
   get dialogClasses() {
     return classNames(
-      'carbon-dialog-full-screen__dialog',
-      { 'carbon-dialog-full-screen__dialog--open': this.props.open }
+      'carbon-dialog-full-screen__dialog'
     );
   }
 
@@ -53,6 +62,14 @@ class DialogFullScreen extends Modal {
       this.props.className,
       'carbon-dialog-full-screen'
     );
+  }
+
+  onOpening() {
+    this.document.documentElement.dataset[dialogOpenAttribute] = true;
+  }
+
+  onClosing() {
+    delete this.document.documentElement.dataset[dialogOpenAttribute];
   }
 
   componentTags(props) {

--- a/src/components/dialog-full-screen/dialog-full-screen.scss
+++ b/src/components/dialog-full-screen/dialog-full-screen.scss
@@ -35,8 +35,6 @@
   }
 }
 
-.carbon-dialog-full-screen__dialog--open {
-  body & {
-    overflow: hidden;
-  }
+[data-fullscreendialogopen] {
+  overflow: hidden;
 }

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -123,7 +123,7 @@ class Dialog extends Modal {
    * @method onOpening
    * @return {Void}
    */
-  get onOpening() {
+  onOpening() {
     this.centerDialog();
     this.focusDialog();
     this.window().addEventListener('resize', this.centerDialog);
@@ -137,7 +137,7 @@ class Dialog extends Modal {
    * @method onClosing
    * @return {Void}
    */
-  get onClosing() {
+  onClosing() {
     this.window().removeEventListener('resize', this.centerDialog);
   }
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -22,8 +22,8 @@ import Browser from './../../utils/helpers/browser';
  *
  * Override several methods
  *
- * get onOpening() // Called by componentDidUpdate when dialog opens
- * get onClosing() // Called by componentDidUpdate when dialog closes
+ * onOpening() // Called by componentDidUpdate when dialog opens
+ * onClosing() // Called by componentDidUpdate when dialog closes
  * get mainClasses() // Classes to apply to parent div
  * get modalHTML() // JSX displayed when open
  * get transitionName() // Transisition name for ReactCSSTransitionGroup
@@ -140,11 +140,11 @@ class Modal extends React.Component {
 
     if (this.props.open && !this.listening) {
       this.listening = true;
-      this.onOpening; // eslint-disable-line no-unused-expressions
+      this.onOpening(); // eslint-disable-line no-unused-expressions
       _window.addEventListener('keyup', this.closeModal);
     } else if (!this.props.open) {
       this.listening = false;
-      this.onClosing; // eslint-disable-line no-unused-expressions
+      this.onClosing(); // eslint-disable-line no-unused-expressions
       _window.removeEventListener('keyup', this.closeModal);
     }
   }
@@ -180,9 +180,9 @@ class Modal extends React.Component {
   }
 
   // Called after the modal opens
-  get onOpening() { return null; }
+  onOpening() { return null; }
   // Called after the modal closes
-  get onClosing() { return null; }
+  onClosing() { return null; }
   // Classes for parent div
   get mainClasses() { return null; }
   // Modal HTML shown when open


### PR DESCRIPTION
Use the dialog `onOpening` and `onClosing` functions to add and remove
a `data-fullscreendialogopen` attribute to the `<html>` tag: the data
attribute is added when the dialog is open, and removed when the dialog
is closed.

Add the CSS to set `overflow: hidden` using the
`[data-fullscreendialogopen]` selector.

Change the `onOpening` and `onClosing` getters defined in `Modal` to
functions, as they aren't really getters.

Remove the `carbon-dialog-full-screen__dialog--open` code and CSS.

**NB** merging into SE-2333_dialog_full_screen, so no QA required here (QA will be done in SE-2333_dialog_full_screen). Also no release notes required here for the same reason.