### PR TITLE
#1374 alternate table theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ A new helper object is available in `utils/helpers/text`. Currently it only cont
 
 * `Table` can now receive an `caption` prop which renders a `<caption>` element as a child of the table element. Note that the caption is hidden by default, but still accessible to screen readers and assistive technologies.
 * `Table` has a new prop of onConfigure. Displays a configure icon to the left of the table header that triggers the callback onClick.
+* `Table` has a new prop of `theme` that allows primary (dark) or secondary (light) styling.
 
 ## Bug Fixes
 

--- a/demo/utils/definition/table-definition/table-definition.js
+++ b/demo/utils/definition/table-definition/table-definition.js
@@ -1,4 +1,5 @@
 import ComponentActions from './../../../actions/component';
+import OptionsHelper from '../../../../src/utils/helpers/options-helper';
 import { assign } from 'lodash';
 
 export default (definition) => {
@@ -61,6 +62,7 @@ function buildRows() {
     sortedColumn: 'String',
     tbody: 'Node',
     thead: 'Node',
+    theme: 'String',
     totalRecords: 'String'
   });
   definition.propDescriptions = assign({}, definition.propDescriptions, {
@@ -86,6 +88,10 @@ function buildRows() {
     sortedColumn: 'The currently sorted column.',
     tbody: 'Instead of passing children, define your tbody as a prop.',
     thead: 'Instead of passing children, define your thead as a prop. Using this prop will put your header inside an HTML thead element.',
+    theme: 'Allows the table to be set to primary or secondary. Primary is darker and more bold, while secondary is lighter and doesn\'t use tiger stripes',
     totalRecords: 'Tracks the total number of records of a paginated data set.'
   });
+  definition.propOptions = {
+    theme: OptionsHelper.themesBinary,
+  };
 };

--- a/src/components/table/__spec__.js
+++ b/src/components/table/__spec__.js
@@ -955,7 +955,7 @@ describe('Table', () => {
     it('renders a table with correct classes', () => {
       let parent = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'div')[0];
       expect(parent).toBeDefined();
-      expect(parent.className).toEqual('carbon-table foo');
+      expect(parent.className).toEqual('carbon-table foo carbon-table--primary');
     });
 
     it('renders a caption tag when a caption prop is given', () => {
@@ -998,6 +998,22 @@ describe('Table', () => {
 
     it('include correct component, element and role data tags', () => {
       rootTagTest(wrapper, 'table', 'bar', 'baz');
+    });
+  });
+
+  describe("theme", () => {
+    it("renders a --secondary if the theme is set to 'secondary'", () => {
+      const wrapper = shallow(
+        <Table theme='secondary' />
+      );
+      expect(wrapper.find('.carbon-table--secondary').exists()).toBeTruthy();
+    });
+
+    it("renders a --primary if the theme is missing (default)", () => {
+      const wrapper = shallow(
+        <Table />
+      );
+      expect(wrapper.find('.carbon-table--primary').exists()).toBeTruthy();
     });
   });
 });

--- a/src/components/table/package.json
+++ b/src/components/table/package.json
@@ -1,5 +1,8 @@
 {
   "main": "./table.js",
   "name": "Table",
-  "style": "./table.scss"
+  "style": [
+    "./table.scss",
+    "./table--secondary-theme.scss"
+  ]
 }

--- a/src/components/table/table--secondary-theme.scss
+++ b/src/components/table/table--secondary-theme.scss
@@ -1,0 +1,21 @@
+@import "./../../style-config/colors";
+
+.carbon-table--secondary {
+  .carbon-table-cell {
+    background-color: $white;
+  }
+
+  .carbon-table-header {
+    background-color: $grey-dark-blue-20;
+    color: $grey-dark-blue;
+
+    &--sort {
+      &:link,
+      &:visited,
+      &:hover,
+      &:active {
+        color: $grey-dark-blue;
+      }
+    }
+  }
+}

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -306,6 +306,10 @@ class Table extends React.Component {
     sortedColumn: PropTypes.string // the currently sorted column
   }
 
+  static defaultProps = {
+    theme: 'primary'
+  }
+
   state = {
     selectedCount: 0
   }
@@ -872,7 +876,7 @@ class Table extends React.Component {
     return classNames(
       'carbon-table',
       this.props.className,
-      `carbon-table--${this.props.theme || 'primary'}`
+      `carbon-table--${this.props.theme}`
     );
   }
 

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -271,7 +271,16 @@ class Table extends React.Component {
      * @property caption
      * @type string
      */
-    caption: React.PropTypes.string
+    caption: React.PropTypes.string,
+
+    /**
+     * Renders as light or dark
+     * Uses common theme definition of 'primary' (dark, default) and 'secondary' (light)
+     *
+     * @property theme
+     * @type string
+     */
+    theme: React.PropTypes.string
   }
 
   static childContextTypes = {
@@ -862,7 +871,8 @@ class Table extends React.Component {
   get mainClasses() {
     return classNames(
       'carbon-table',
-      this.props.className
+      this.props.className,
+      `carbon-table--${this.props.theme || 'primary'}`
     );
   }
 


### PR DESCRIPTION
## Description

* Uses primary and secondary as the theme names to keep it consistent with Buttons
* Uses prop name of `theme` unlike Button because `as` is ambiguous and used elsewhere - this should be addressed with https://github.com/Sage/carbon/issues/1005

Also, this demonstrates how an issue can link up to a PR as a way to do our work in the open source context - see how the commits tag the issue and the issue itself links to the PR and commits. Our proprietary ticketing system links into this and keeps app specific QA instructions there.

## TODO
- [x] Release notes

## Related Issues / Pull Requests
#1374 

# Screenshots / Gifs
![theme](https://user-images.githubusercontent.com/10499070/27682020-f578675e-5cb8-11e7-99bd-f6825b65062a.gif)

# Testing Instructions
* Use the demo site
