### PR TITLE
Fix table configure cog layout

### DIFF
--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -68,6 +68,7 @@
     border: 1px solid $border-color;
     border-right: none;
     border-radius: 25px 0 0 25px;
+    box-sizing: content-box;
     color: $white;
     display: flex;
     height: 100%;


### PR DESCRIPTION
Because this component relies on calculating the height accurately to match the header, we need to fix the box-sizing to content-box to ensure it remains consistent.

More info on box-sizing: https://developer.mozilla.org/en/docs/Web/CSS/box-sizing

**Before**
![before_onconfigure](https://user-images.githubusercontent.com/4964/27694008-ca22c7a0-5ce2-11e7-900b-80ed108a8b52.png)

**After**
![after_onconfigure](https://user-images.githubusercontent.com/4964/27694017-ce9dd25c-5ce2-11e7-9668-9d584aaad244.png)

