### PR TITLE
Scrollable full screen dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,34 @@ The `TableRow` component now supports drag and drop. To enable it you need to ad
 
 A new helper object is available in `utils/helpers/text`. Currently it only contains one method `clearSelection`, which clears any selected text on the page.
 
+## Pages and page
+
+Pages and Page are new components to enable paginated content for full screen views.
+See an example with a full screen dialog:
+```
+const headingOne = (
+  <Heading title="My First Page" />
+);
+
+const headingTwo = (
+  <Heading title="My Second Page" />
+);
+
+return (
+  <DialogFullScreen>
+    <Pages slideIndex={ 0 }>
+      <Page title={ headingOne }>
+        Content for the first page.
+      </Page>
+
+      <Page title={ headingTwo }>
+        Content for the second page.
+      </Page>
+    </Pages>
+  </DialogFullScreen>
+);
+```
+
 ## Component Improvements
 
 * `Alert` now alerts itself to screen readers.
@@ -151,6 +179,7 @@ A new helper object is available in `utils/helpers/text`. Currently it only cont
   * has a new prop `onSlideChange`, which is an action to be called on slide change. It will receive the slide index and the transition direction as params.
   * animation between slides enhanced.
 * `Dialog` is now using the `Heading` component to render its title and subtitle.
+* `DialogFullScreen` is now scrollable if the content goes beyond the height of the browser.
 * `Form` now has default `SaveButton` and `CancelButton` functional stateless components. The former can be overridden with a new prop of `customSaveButton`.
 * `Heading` backLink prop can now be a string or a function.
 * `InlineInputs` children are now wrapped by Columns by the component.

--- a/demo/definitions.js
+++ b/demo/definitions.js
@@ -41,6 +41,7 @@ export default {
   'navigation-bar':       require('components/navigation-bar/definition').default,
   'number-input':         require('components/number/definition').default,
   'pager':                require('components/pager/definition').default,
+  'pages':                require('components/pages/definition').default,
   'pill':                 require('components/pill/definition').default,
   'pod':                  require('components/pod/definition').default,
   'portrait':             require('components/portrait/definition').default,

--- a/demo/utils/component-code-builder/component-code-builder.js
+++ b/demo/utils/component-code-builder/component-code-builder.js
@@ -52,12 +52,12 @@ class ComponentCodeBuilder {
         js = definition.get('js'),
         wrap = definition.get('wrap');
 
-    if (wrap && wrapProps.count()) {
+    if (wrap && wrapProps && wrapProps.count()) {
       props = props.filter((prop, key) => {
         return wrapProps.includes(key);
       });
       children = null;
-    } else if (wrapProps.count()) {
+    } else if (wrapProps && wrapProps.count()) {
       props = props.filter((prop, key) => {
         return !wrapProps.includes(key);
       });

--- a/demo/utils/component-code-builder/component-code-builder.js
+++ b/demo/utils/component-code-builder/component-code-builder.js
@@ -5,7 +5,7 @@ class ComponentCodeBuilder {
   constructor(name, withEvents) {
     let definition;
 
-    if (typeof name !== "string") {
+    if (typeof name !== 'string') {
       definition = name;
       this.wrap = definition.get('wrap');
       name = definition.get('topLevelComponent') || definition.get('name');
@@ -45,10 +45,10 @@ class ComponentCodeBuilder {
   // adds multiple props to the code based on a definition
   addProps = (definition, withEvents) => {
     let props = definition.get('propValues'),
-        propTypes = definition.get('propTypes'),
+        children = props.get('children');
+    const propTypes = definition.get('propTypes'),
         wrapProps = definition.get('wrapProps'),
         toggleFunctions = definition.get('toggleFunctions'),
-        children = props.get('children'),
         js = definition.get('js'),
         wrap = definition.get('wrap');
 
@@ -66,19 +66,19 @@ class ComponentCodeBuilder {
     this.openPreview = definition.get('openPreview');
 
     props.forEach((value, prop) => {
-      if (prop !== "children" && !toggleFunctions.includes(prop)) {
-        if (withEvents || (prop !== "data-binding" && typeof value !== "function")) {
+      if (prop !== 'children' && !toggleFunctions.includes(prop)) {
+        if (withEvents || (prop !== 'data-binding' && typeof value !== 'function')) {
           this.addProp(prop, value, propTypes.get(prop));
         }
       } else if (toggleFunctions.includes(prop) && value) {
-        this.addProp(prop, `() => { alert("${prop}"); }`, "Function");
+        this.addProp(prop, `() => { alert("${prop}"); }`, 'Function');
       }
     });
 
     if (children) {
-      if (typeof children === "object") {
+      if (typeof children === 'object') {
         children.forEach((child) => {
-          let childCode = new ComponentCodeBuilder(child);
+          const childCode = new ComponentCodeBuilder(child);
           this.addChild(childCode);
         });
       } else {
@@ -94,7 +94,8 @@ class ComponentCodeBuilder {
   // adds a prop to the code
   addProp = (prop, value, type) => {
     if (this.hasChildren || this.isClosed) {
-      throw new Error(`You cannot add props after you have added children or closed your component! See the ComponentCodeBuilder for '${this.name}'.\n\nCurrent markup:\n\n${this.code}`);
+      throw new Error(`You cannot add props after you have added children or closed your component!
+         See the ComponentCodeBuilder for '${this.name}'.\n\nCurrent markup:\n\n${this.code}`);
     }
 
     if (value || value === '' || value === false) {
@@ -116,25 +117,26 @@ class ComponentCodeBuilder {
   // adds children to the component
   addChild = (child) => {
     if (this.isClosed) {
-      throw new Error(`You cannot add children after you have closed your component! See the ComponentCodeBuilder for '${this.name}'.\n\nCurrent markup:\n\n${this.code}`);
+      throw new Error(`You cannot add children after you have closed your component!
+         See the ComponentCodeBuilder for '${this.name}'.\n\nCurrent markup:\n\n${this.code}`);
     }
 
-    let spaces = "  ";
+    let spaces = '  ';
 
     // add spaces to child with code
     if (child.code) {
       child.close();
       child.code = child.code.replace(/^/gm, spaces);
-      spaces = "";
+      spaces = '';
     }
 
     if (this.hasChildren) {
       this.code += `\n${spaces}${child}`;
     } else {
       if (this.hasProps) {
-        this.code += `\n>\n`;
+        this.code += '\n>\n';
       } else {
-        this.code += `>\n`;
+        this.code += '>\n';
       }
       this.code += `${spaces}${child}`;
       this.hasChildren = true;
@@ -143,7 +145,7 @@ class ComponentCodeBuilder {
 
   // adds javascript making it available before the JSX
   addJS = (js) => {
-    this.code = js + "\n\n" + this.code
+    this.code = js + '\n\n' + this.code
   }
 
   // closes the component tag
@@ -153,9 +155,9 @@ class ComponentCodeBuilder {
     if (this.hasChildren) {
       this.code += `\n</${this.wrap || this.name}>`;
     } else if (this.hasProps) {
-      this.code += "\n/>";
+      this.code += '\n/>';
     } else {
-      this.code += " />";
+      this.code += ' />';
     }
 
     this.isClosed = true;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,5 +50,5 @@ gulp.task('deploy', ['prepare-demo', 'build', 'run-deploy']);
 
 gulp.task('test', SpecTask({
   path: '/src/***/**/!(__spec__|definition).js',
-  eslintThreshold: 55
+  eslintThreshold: 52
 }));

--- a/src/components/dialog-full-screen/__spec__.js
+++ b/src/components/dialog-full-screen/__spec__.js
@@ -104,7 +104,7 @@ describe('DialogFullScreen', () => {
       const body = wrapper.instance().document.body;
       expect(body.className).toEqual('carbon-dialog-full-screen--open');
       wrapper.setProps({ open: false });
-      expect(body.className).toEqual(' ');
+      expect(body.className).toEqual('');
     });
   });
 

--- a/src/components/dialog-full-screen/__spec__.js
+++ b/src/components/dialog-full-screen/__spec__.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import DialogFullScreen from './dialog-full-screen';
+import FullScreenHeading from './full-screen-heading';
 import Button from './../button';
 import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
 import Icon from './../icon';
@@ -8,16 +9,17 @@ import Heading from './../heading';
 
 describe('DialogFullScreen', () => {
   let instance,
-      wrapper,
-      onCancel = jasmine.createSpy('cancel');
+      wrapper;
+  const onCancel = jasmine.createSpy('cancel');
 
   beforeEach(() => {
     wrapper = shallow(
       <DialogFullScreen
         onCancel={ onCancel }
         className='foo'
-        open={ true }
+        open
         title='my title'
+        subtitle='my subtitle'
       >
         <Button>Button</Button>
         <Button>Button</Button>
@@ -50,7 +52,7 @@ describe('DialogFullScreen', () => {
         <DialogFullScreen
           onCancel={ onCancel }
           className='foo'
-          open={ true }
+          open
           title='my title'
         >
           <Button>Button</Button>
@@ -70,7 +72,7 @@ describe('DialogFullScreen', () => {
     });
 
     it('closes when the exit icon is click', () => {
-      let closeIcon = wrapper.find(Icon);
+      const closeIcon = wrapper.find(Icon);
       closeIcon.simulate('click');
       expect(onCancel).toHaveBeenCalled();
     });
@@ -80,23 +82,51 @@ describe('DialogFullScreen', () => {
     });
   });
 
-  describe('title', () => {
+  describe('onOpening', () => {
+    beforeEach(() => {
+      wrapper = mount(<DialogFullScreen open={ false } />);
+      wrapper.setProps({ open: true });
+    });
+
+    it('adds a carbon-dialog-full-screen--open class to the body', () => {
+      const body = wrapper.instance().document.body;
+      expect(body.className).toEqual('carbon-dialog-full-screen--open');
+    });
+  });
+
+  describe('onClosing', () => {
+    beforeEach(() => {
+      wrapper = mount(<DialogFullScreen open={ false } />);
+      wrapper.setProps({ open: true });
+    });
+
+    it('removes a carbon-dialog-full-screen--open class to the body', () => {
+      const body = wrapper.instance().document.body;
+      expect(body.className).toEqual('carbon-dialog-full-screen--open');
+      wrapper.setProps({ open: false });
+      expect(body.className).toEqual(' ');
+    });
+  });
+
+  describe('dialogTitle', () => {
     describe('is a string', () => {
-      it('renders the title within a h2', () => {
-        let titleNode = wrapper.find('h2.carbon-dialog-full-screen__title');
-        expect(titleNode.length).toEqual(1);
-        expect(titleNode.text()).toEqual('my title');
+      it('renders the title within a heading', () => {
+        const heading = wrapper.find(Heading);
+        expect(heading.props().title).toEqual('my title');
+        expect(heading.props().subheader).toEqual('my subtitle');
+        expect(heading.props().titleId).toEqual('carbon-dialog-title');
+        expect(heading.props().subtitleId).toEqual('carbon-dialog-subtitle');
       });
     });
 
     describe('is an object', () => {
       beforeEach(() => {
-        let titleHeading = <Heading title='my custom heading' />;
+        const titleHeading = <Heading title='my custom heading' />;
         wrapper = shallow(
           <DialogFullScreen
             onCancel={ onCancel }
             className='foo'
-            open={ true }
+            open
             title={ titleHeading }
           >
             <Button>Button</Button>
@@ -105,43 +135,45 @@ describe('DialogFullScreen', () => {
         );
       });
 
-      it('renders the component directly', () => {
-        let heading = wrapper.find(Heading)
+      it('renders the component in a full screen heading', () => {
+        const fullScrenHeading = wrapper.find(FullScreenHeading),
+            heading = fullScrenHeading.children().first();
+
         expect(heading.props().title).toEqual('my custom heading');
       });
     });
   });
 
-  describe("tags", () => {
-    describe("on component", () => {
-      let wrapper = shallow(
-        <DialogFullScreen
-          data-element='bar'
-          onCancel={ () => {} }
-          onConfirm={ () => {} }
-          open={ true }
-          data-role='baz'
-        />
-      );
-
+  describe('tags', () => {
+    describe('on component', () => {
       it('include correct component, element and role data tags', () => {
+        wrapper = shallow(
+          <DialogFullScreen
+            data-element='bar'
+            onCancel={ () => {} }
+            onConfirm={ () => {} }
+            open
+            data-role='baz'
+          />
+        );
+
         rootTagTest(wrapper, 'dialog-full-screen', 'bar', 'baz');
       });
     });
 
-    describe("on internal elements", () => {
-      let wrapper = shallow(
+    describe('on internal elements', () => {
+      const dialog = shallow(
         <DialogFullScreen
           onCancel={ () => {} }
           onConfirm={ () => {} }
-          open={ true }
+          open
           title='Test'
         />
       );
 
-      elementsTagTest(wrapper, [
+      elementsTagTest(dialog, [
         'close',
-        'title'
+        'content'
       ]);
     });
   });

--- a/src/components/dialog-full-screen/definition.js
+++ b/src/components/dialog-full-screen/definition.js
@@ -1,12 +1,14 @@
 import DialogFullScreen from './';
 import Definition from './../../../demo/utils/definition';
 
-let definition = new Definition('dialog-full-screen', DialogFullScreen, {
-  description: `A full-width and full-height dialog overlaid on top of any page.`,
+const definition = new Definition('dialog-full-screen', DialogFullScreen, {
+  description: 'A full-width and full-height dialog overlaid on top of any page.',
   designerNotes: `
 * Useful to perform an action in context without navigating the user to a separate page.
-* Whilst a standard Dialog component’s width might constrain what you can do, the full screen dialog uses the full width and height available.
-* A good example could be importing a large volume of data, and checking for errors, in the context of an underlying Table of data.
+* Whilst a standard Dialog component’s width might constrain what you can do, the full screen dialog uses the full width
+ and height available.
+* A good example could be importing a large volume of data, and checking for errors, in the context of an underlying
+ Table of data.
   `,
   relatedComponentsNotes: `
 * Simple task in context? [Try Dialog](/components/dialog).
@@ -15,7 +17,7 @@ let definition = new Definition('dialog-full-screen', DialogFullScreen, {
  `,
   propValues: {
     title: 'Example Title for a DialogFullScreen',
-    children: 'This is an example of a dialog full screen.',
+    children: 'This is an example of a dialog full screen.'
   }
 });
 

--- a/src/components/dialog-full-screen/dialog-full-screen-variables.scss
+++ b/src/components/dialog-full-screen/dialog-full-screen-variables.scss
@@ -1,0 +1,5 @@
+$padding-left-right: 5% !default;
+$padding-top-bottom: 30px !default;
+$title-margin-bottom: $padding-top-bottom !default;
+$title-height: 106px !default;
+$title-total-height: $padding-top-bottom + $title-height + $title-margin-bottom;

--- a/src/components/dialog-full-screen/dialog-full-screen.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.js
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import Icon from './../icon';
 import Modal from './../modal';
+import Heading from './../heading';
 
 /**
  * A DialogFullScreen widget.
@@ -73,17 +74,15 @@ class DialogFullScreen extends Modal {
         className={ this.dialogClasses }
         { ...this.componentTags(this.props) }
       >
-        <div className='carbon-dialog-full-screen__header'>
-          { this.renderTitle() }
-          <Icon
-            className='carbon-dialog-full-screen__close'
-            data-element='close'
-            onClick={ this.props.onCancel }
-            type='close'
-          />
-        </div>
+        <Icon
+          className='carbon-dialog-full-screen__close'
+          data-element='close'
+          onClick={ this.props.onCancel }
+          type='close'
+        />
 
         <div className='carbon-dialog-full-screen__content' data-element='content'>
+          { this.dialogTitle() }
           { this.props.children }
         </div>
       </div>
@@ -91,16 +90,24 @@ class DialogFullScreen extends Modal {
   }
 
   /**
-   * Returns title prop wrapped in <h2> if title is a string otherwise returns the title prop directly.
-   * Dialog main classes.
+   * Returns HTML and text for the dialog title.
    *
-   * @return {Object} JSX
+   * @method dialogTitle
+   * @return {String} title to display
    */
-  renderTitle = () => {
-    if (typeof (this.props.title) === 'string' || this.props.title instanceof String) {
-      return <h2 className='carbon-dialog-full-screen__title' data-element='title'>{ this.props.title }</h2>;
+  dialogTitle = () => {
+    if (this.props.title) {
+      return (
+        <Heading
+          title={ this.props.title }
+          titleId='carbon-dialog-title'
+          subheader={ this.props.subtitle }
+          subtitleId='carbon-dialog-subtitle'
+        />
+      );
     }
-    return this.props.title;
+
+    return null;
   }
 }
 

--- a/src/components/dialog-full-screen/dialog-full-screen.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.js
@@ -6,7 +6,7 @@ import Heading from './../heading';
 import FullScreenHeading from './full-screen-heading';
 import Browser from './../../utils/helpers/browser';
 
-const DIALOG_OPEN_ATTRIBUTE = 'carbonFullScreenDialogOpen';
+const DIALOG_OPEN_BODY_CLASS = 'carbon-dialog-full-screen--open';
 
 /**
  * A DialogFullScreen widget.
@@ -31,6 +31,10 @@ const DIALOG_OPEN_ATTRIBUTE = 'carbonFullScreenDialogOpen';
 class DialogFullScreen extends Modal {
   constructor(props) {
     super(props);
+
+    /**
+     * Caches a reference to the document.
+     */
     this.document = Browser.getDocument();
   }
 
@@ -98,19 +102,25 @@ class DialogFullScreen extends Modal {
     );
   }
 
+  /**
+   * Overrides the original function to disable the document's scroll.
+   */
   get onOpening() {
-    Browser.addClass(this.document.body, 'foo');
+    Browser.addClass(this.document.body, DIALOG_OPEN_BODY_CLASS);
   }
 
+  /**
+   * Overrides the original function to enable the document's scroll.
+   */
   get onClosing() {
-    Browser.removeClass(this.document.body, 'foo');
+    Browser.removeClass(this.document.body, DIALOG_OPEN_BODY_CLASS);
   }
 
   /**
    * Returns HTML and text for the dialog title.
    *
    * @method dialogTitle
-   * @return {String} title to display
+   * @return {Object} title to display
    */
   dialogTitle = () => {
     if (!this.props.title) { return null; }

--- a/src/components/dialog-full-screen/dialog-full-screen.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.js
@@ -3,6 +3,27 @@ import classNames from 'classnames';
 import Icon from './../icon';
 import Modal from './../modal';
 import Heading from './../heading';
+import FullScreenHeading from './full-screen-heading';
+import Browser from './../../utils/helpers/browser';
+
+let hasClassName = function(elem, name) {
+  return new RegExp("(?:^|\\s+)" + name + "(?:\\s+|$)").test(elem.className);
+};
+
+let addClass = function(elem, name) {
+  if (!hasClassName(elem, name)) {
+    elem.className = elem.className ? [elem.className, name].join(' ') : name;
+  }
+};
+
+let removeClass = function(elem, name) {
+  if (hasClassName(elem, name)) {
+    var c = elem.className;
+    elem.className = c.replace(new RegExp("(?:^|\\s+)" + name + "(?:\\s+|$)", "g"), "");
+  }
+};
+
+const DIALOG_OPEN_ATTRIBUTE = 'carbonFullScreenDialogOpen';
 
 /**
  * A DialogFullScreen widget.
@@ -25,6 +46,10 @@ import Heading from './../heading';
  * @constructor
  */
 class DialogFullScreen extends Modal {
+  constructor(props) {
+    super(props);
+    this.document = Browser.getDocument();
+  }
 
   static defaultProps = {
     open: false,
@@ -81,13 +106,24 @@ class DialogFullScreen extends Modal {
           type='close'
         />
 
+        { this.dialogTitle() }
+
         <div className='carbon-dialog-full-screen__content' data-element='content'>
-          { this.dialogTitle() }
           { this.props.children }
         </div>
       </div>
     );
   }
+
+  get onOpening() {
+    addClass(this.document.body, 'foo');
+  }
+
+  get onClosing() {
+    removeClass(this.document.body, 'foo');
+  }
+
+
 
   /**
    * Returns HTML and text for the dialog title.
@@ -96,10 +132,14 @@ class DialogFullScreen extends Modal {
    * @return {String} title to display
    */
   dialogTitle = () => {
-    if (this.props.title) {
-      return (
+    if (!this.props.title) { return null; }
+
+    let title = this.props.title;
+
+    if (typeof title === "string") {
+      title = (
         <Heading
-          title={ this.props.title }
+          title={ title }
           titleId='carbon-dialog-title'
           subheader={ this.props.subtitle }
           subtitleId='carbon-dialog-subtitle'
@@ -107,7 +147,9 @@ class DialogFullScreen extends Modal {
       );
     }
 
-    return null;
+    return (
+      <FullScreenHeading>{ title }</FullScreenHeading>
+    );
   }
 }
 

--- a/src/components/dialog-full-screen/dialog-full-screen.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.js
@@ -106,14 +106,14 @@ class DialogFullScreen extends Modal {
    * Overrides the original function to disable the document's scroll.
    */
   get onOpening() {
-    Browser.addClass(this.document.body, DIALOG_OPEN_BODY_CLASS);
+    this.document.body.classList.add(DIALOG_OPEN_BODY_CLASS);
   }
 
   /**
    * Overrides the original function to enable the document's scroll.
    */
   get onClosing() {
-    Browser.removeClass(this.document.body, DIALOG_OPEN_BODY_CLASS);
+    this.document.body.classList.remove(DIALOG_OPEN_BODY_CLASS);
   }
 
   /**

--- a/src/components/dialog-full-screen/dialog-full-screen.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.js
@@ -6,23 +6,6 @@ import Heading from './../heading';
 import FullScreenHeading from './full-screen-heading';
 import Browser from './../../utils/helpers/browser';
 
-let hasClassName = function(elem, name) {
-  return new RegExp("(?:^|\\s+)" + name + "(?:\\s+|$)").test(elem.className);
-};
-
-let addClass = function(elem, name) {
-  if (!hasClassName(elem, name)) {
-    elem.className = elem.className ? [elem.className, name].join(' ') : name;
-  }
-};
-
-let removeClass = function(elem, name) {
-  if (hasClassName(elem, name)) {
-    var c = elem.className;
-    elem.className = c.replace(new RegExp("(?:^|\\s+)" + name + "(?:\\s+|$)", "g"), "");
-  }
-};
-
 const DIALOG_OPEN_ATTRIBUTE = 'carbonFullScreenDialogOpen';
 
 /**
@@ -116,14 +99,12 @@ class DialogFullScreen extends Modal {
   }
 
   get onOpening() {
-    addClass(this.document.body, 'foo');
+    Browser.addClass(this.document.body, 'foo');
   }
 
   get onClosing() {
-    removeClass(this.document.body, 'foo');
+    Browser.removeClass(this.document.body, 'foo');
   }
-
-
 
   /**
    * Returns HTML and text for the dialog title.

--- a/src/components/dialog-full-screen/dialog-full-screen.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.js
@@ -127,7 +127,7 @@ class DialogFullScreen extends Modal {
 
     let title = this.props.title;
 
-    if (typeof title === "string") {
+    if (typeof title === 'string') {
       title = (
         <Heading
           title={ title }

--- a/src/components/dialog-full-screen/dialog-full-screen.scss
+++ b/src/components/dialog-full-screen/dialog-full-screen.scss
@@ -30,7 +30,7 @@
   position: absolute;
   right: $padding-left-right;
   top: $title-height / 2;
-  z-index: 1;
+  z-index: $z-dialog;
 
   &:before {
     font-size: 24px;
@@ -41,6 +41,6 @@
   }
 }
 
-.foo {
+.carbon-dialog-full-screen--open {
   overflow: hidden;
 }

--- a/src/components/dialog-full-screen/dialog-full-screen.scss
+++ b/src/components/dialog-full-screen/dialog-full-screen.scss
@@ -1,11 +1,11 @@
 @import "./../../style-config/colors";
 @import "./../../style-config/z-index";
+@import "./dialog-full-screen-variables";
 
 .carbon-dialog-full-screen__dialog {
   background-color: $grey-light;
   height: 100%;
   left: 0;
-  overflow-y: scroll;
   position: fixed;
   top: 0;
   width: 100%;
@@ -13,25 +13,12 @@
 }
 
 .carbon-dialog-full-screen__content {
-  padding: 30px 5%;
+  padding: $padding-top-bottom $padding-left-right;
   overflow-y: auto;
-  height: calc(100% - 60px);
+  height: calc(100% - #{$padding-top-bottom * 2});
 
-  .carbon-heading {
-    height: 85px;
-  }
-
-  .carbon-heading__header {
-    align-items: center;
-    background-color: $grey-light;
-    display: flex;
-    height: 106px;
-    left: 0;
-    padding-left: 5%;
-    padding-right: 5%;
-    position: absolute;
-    top: 0;
-    width: 100%;
+  .carbon-full-screen-heading + & {
+    height: calc(100% - #{$title-total-height});
   }
 }
 
@@ -41,8 +28,8 @@
   display: block;
   margin-top: -8px;
   position: absolute;
-  right: 5%;
-  top: 52px;
+  right: $padding-left-right;
+  top: $title-height / 2;
   z-index: 1;
 
   &:before {
@@ -52,4 +39,8 @@
   &:hover {
     color: $blue;
   }
+}
+
+.foo {
+  overflow: hidden;
 }

--- a/src/components/dialog-full-screen/dialog-full-screen.scss
+++ b/src/components/dialog-full-screen/dialog-full-screen.scss
@@ -14,22 +14,25 @@
 
 .carbon-dialog-full-screen__content {
   padding: 30px 5%;
-}
-
-.carbon-dialog-full-screen__header {
-  border-bottom: 1px solid $border-color;
-  margin: 0;
-  padding: 25px 5%;
-  position: relative;
+  overflow-y: auto;
+  height: calc(100% - 60px);
 
   .carbon-heading {
-    padding: 0;
+    height: 85px;
   }
-}
 
-.carbon-dialog-full-screen__title {
-  font-size: 26px;
-  margin: 0;
+  .carbon-heading__header {
+    align-items: center;
+    background-color: $grey-light;
+    display: flex;
+    height: 106px;
+    left: 0;
+    padding-left: 5%;
+    padding-right: 5%;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
 }
 
 .carbon-dialog-full-screen__close {
@@ -39,10 +42,11 @@
   margin-top: -8px;
   position: absolute;
   right: 5%;
-  top: 50%;
+  top: 52px;
+  z-index: 1;
 
   &:before {
-    font-size: 25px;
+    font-size: 24px;
   }
 
   &:hover {

--- a/src/components/dialog-full-screen/full-screen-heading/full-screen-heading.js
+++ b/src/components/dialog-full-screen/full-screen-heading/full-screen-heading.js
@@ -1,13 +1,11 @@
 import React from 'react';
+import classNames from 'classnames';
+import tagComponent from '../../../utils/helpers/tags';
 
-class FullScreenHeading extends React.Component {
-  render() {
-    return (
-      <div className="carbon-full-screen-heading">
-        { this.props.children }
-      </div>
-    );
-  }
-}
+export default (props) => {
+  const classes = classNames("carbon-full-screen-heading", props.className);
 
-export default FullScreenHeading;
+  return (
+    <div { ...props } className={ classes } { ...tagComponent('full-screen-heading', props) } />
+  );
+};

--- a/src/components/dialog-full-screen/full-screen-heading/full-screen-heading.js
+++ b/src/components/dialog-full-screen/full-screen-heading/full-screen-heading.js
@@ -1,11 +1,18 @@
 import React from 'react';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import tagComponent from '../../../utils/helpers/tags';
 
-export default (props) => {
-  const classes = classNames("carbon-full-screen-heading", props.className);
-
-  return (
-    <div { ...props } className={ classes } { ...tagComponent('full-screen-heading', props) } />
-  );
+const fullScrenHeadingClasses = (props) => {
+  return classNames('carbon-full-screen-heading', props.className);
 };
+
+const FullScrenHeading = props =>
+  <div { ...props } className={ fullScrenHeadingClasses(props) } { ...tagComponent('full-screen-heading', props) } />
+;
+
+FullScrenHeading.propTypes = {
+  className: PropTypes.string
+};
+
+export default FullScrenHeading;

--- a/src/components/dialog-full-screen/full-screen-heading/full-screen-heading.js
+++ b/src/components/dialog-full-screen/full-screen-heading/full-screen-heading.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+class FullScreenHeading extends React.Component {
+  render() {
+    return (
+      <div className="carbon-full-screen-heading">
+        { this.props.children }
+      </div>
+    );
+  }
+}
+
+export default FullScreenHeading;

--- a/src/components/dialog-full-screen/full-screen-heading/full-screen-heading.scss
+++ b/src/components/dialog-full-screen/full-screen-heading/full-screen-heading.scss
@@ -6,7 +6,6 @@
 
   .carbon-heading__header {
     align-items: center;
-    background-color: $grey-light;
     display: flex;
     height: $title-height;
     left: 0;
@@ -25,6 +24,10 @@
     .carbon-heading__back {
       margin-top: -7px;
       margin-left: -40px;
+    }
+
+    .carbon-dialog-full-screen & {
+      background-color: $grey-light;
     }
   }
 

--- a/src/components/dialog-full-screen/full-screen-heading/full-screen-heading.scss
+++ b/src/components/dialog-full-screen/full-screen-heading/full-screen-heading.scss
@@ -1,0 +1,21 @@
+@import "./../../../style-config/colors";
+@import "./../dialog-full-screen-variables";
+
+.carbon-full-screen-heading {
+  height: $title-height;
+
+  .carbon-heading__header {
+    align-items: center;
+    background-color: $grey-light;
+    display: flex;
+    height: $title-height;
+    left: 0;
+    margin-bottom: 0;
+    padding-bottom: 0;
+    padding-left: $padding-left-right;
+    padding-right: $padding-left-right;
+    position: absolute;
+    top: 0;
+    width: 100% - ($padding-left-right * 2);
+  }
+}

--- a/src/components/dialog-full-screen/full-screen-heading/full-screen-heading.scss
+++ b/src/components/dialog-full-screen/full-screen-heading/full-screen-heading.scss
@@ -17,5 +17,18 @@
     position: absolute;
     top: 0;
     width: 100% - ($padding-left-right * 2);
+
+    .icon-chevron_left:before {
+      font-size: 24px;
+    }
+
+    .carbon-heading__back {
+      margin-top: -7px;
+      margin-left: -40px;
+    }
+  }
+
+  .carbon-heading--has-back .carbon-heading__headers {
+    margin-left: 0;
   }
 }

--- a/src/components/dialog-full-screen/full-screen-heading/package.json
+++ b/src/components/dialog-full-screen/full-screen-heading/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./full-screen-heading.js",
+  "style": "./full-screen-heading.scss"
+}

--- a/src/components/dialog/__spec__.js
+++ b/src/components/dialog/__spec__.js
@@ -29,8 +29,8 @@ describe('Dialog', () => {
 
         it('focuses on the dialog', () => {
           spyOn(Dialog.prototype, 'focusDialog');
-          const wrapper = mount(
-            <Dialog open={ true } onCancel={ onCancel } />
+          mount(
+            <Dialog open onCancel={ onCancel } />
           );
           expect(Dialog.prototype.focusDialog).toHaveBeenCalled();
         });
@@ -49,9 +49,7 @@ describe('Dialog', () => {
     });
 
     describe('componentDidUpdate', () => {
-      let mockWindow;
-      let wrapper;
-      let instance;
+      let mockWindow, wrapper;
 
       beforeEach(() => {
         mockWindow = {
@@ -184,7 +182,7 @@ describe('Dialog', () => {
     });
 
     describe('when a props object title is passed', () => {
-      it('sets a dialog header', () => {
+      it('wraps it within a div', () => {
         const wrapper = mount(
           <Dialog
             onCancel={ onCancel }
@@ -197,7 +195,7 @@ describe('Dialog', () => {
             }
           />
         ),
-            title = wrapper.find('[data-element="title"]'),
+            title = wrapper.find('.carbon-dialog__title'),
             columns = title.find(Column);
 
         expect(columns.first().props().children).toEqual('Row1');
@@ -325,11 +323,11 @@ describe('Dialog', () => {
         <Dialog
           onCancel={ () => {} }
           onConfirm={ () => {} }
-          open={ true }
-          showCloseIcon={ true }
+          open
+          showCloseIcon
           subtitle='Test'
           title='Test'
-          ariaRole="dialog"
+          ariaRole='dialog'
         />
       );
     });
@@ -354,9 +352,9 @@ describe('Dialog', () => {
           <Dialog
             onCancel={ () => {} }
             onConfirm={ () => {} }
-            open={ true }
-            showCloseIcon={ true }
-            ariaRole=""
+            open
+            showCloseIcon
+            ariaRole=''
           />
         );
       });
@@ -378,7 +376,7 @@ describe('Dialog', () => {
       wrapper.setProps({
         open: false
       });
-      const instance = wrapper.instance();
+      instance = wrapper.instance();
       spyOn(instance, 'focusDialog');
 
       wrapper.setProps({

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -195,10 +195,14 @@ class Dialog extends Modal {
    * @return {String} title to display
    */
   get dialogTitle() {
-    if (this.props.title) {
-      return (
+    if (!this.props.title) { return null; }
+
+    let title = this.props.title;
+
+    if (typeof title === "string") {
+      title = (
         <Heading
-          title={ this.props.title }
+          title={ title }
           titleId='carbon-dialog-title'
           subheader={ this.props.subtitle }
           subtitleId='carbon-dialog-subtitle'
@@ -206,7 +210,9 @@ class Dialog extends Modal {
       );
     }
 
-    return null;
+    return (
+      <div className="carbon-dialog__title">{ title }</div>
+    );
   }
 
   /**
@@ -294,10 +300,9 @@ class Dialog extends Modal {
         { ...this.componentTags(this.props) }
         onBlur={ this.onDialogBlur }
       >
-        <div className="carbon-dialog__title">
-          { this.dialogTitle }
-          { this.closeIcon }
-        </div>
+        { this.closeIcon }
+
+        { this.dialogTitle }
 
         <div className='carbon-dialog__content'>
           { this.props.children }

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -199,7 +199,7 @@ class Dialog extends Modal {
 
     let title = this.props.title;
 
-    if (typeof title === "string") {
+    if (typeof title === 'string') {
       title = (
         <Heading
           title={ title }
@@ -211,7 +211,7 @@ class Dialog extends Modal {
     }
 
     return (
-      <div className="carbon-dialog__title">{ title }</div>
+      <div className='carbon-dialog__title'>{ title }</div>
     );
   }
 
@@ -276,13 +276,13 @@ class Dialog extends Modal {
    * @return {Object} JSX for dialog
    */
   get modalHTML() {
-    let dialogProps = {
+    const dialogProps = {
       className: this.dialogClasses,
       tabIndex: 0
     };
 
     if (this.props.ariaRole) {
-      dialogProps['role'] = this.props.ariaRole;
+      dialogProps.role = this.props.ariaRole;
     }
 
     if (this.props.title) {

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -294,10 +294,12 @@ class Dialog extends Modal {
         { ...this.componentTags(this.props) }
         onBlur={ this.onDialogBlur }
       >
-        { this.closeIcon }
+        <div className="carbon-dialog__title">
+          { this.dialogTitle }
+          { this.closeIcon }
+        </div>
 
         <div className='carbon-dialog__content'>
-          { this.dialogTitle }
           { this.props.children }
         </div>
       </div>

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -23,10 +23,10 @@ $dialog-padding: 20px;
 
 .carbon-dialog__content {
   width: 100%;
+}
 
-  > .carbon-heading {
-    padding-top: 0;
-  }
+.carbon-dialog__title .carbon-heading {
+  padding-top: 0;
 }
 
 .carbon-dialog__close {

--- a/src/components/pages/__spec__.js
+++ b/src/components/pages/__spec__.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Pages, Page } from './pages';
+import { Carousel } from './../carousel';
+
+describe('Pages', () => {
+  it('renders a carousel with the right props', () => {
+    const wrapper = shallow(
+      <Pages>
+        <Page />
+        <Page />
+      </Pages>
+    );
+
+    expect(wrapper.type()).toEqual(Carousel);
+    expect(wrapper.props().className).toEqual('carbon-pages');
+    expect(wrapper.props().enableSlideSelector).toBeFalsy();
+    expect(wrapper.props().enablePreviousButton).toBeFalsy();
+    expect(wrapper.props().enableNextButton).toBeFalsy();
+    expect(wrapper.props()['data-component']).toEqual('pages');
+  });
+});

--- a/src/components/pages/definition.js
+++ b/src/components/pages/definition.js
@@ -1,0 +1,50 @@
+import { Pages } from './';
+import Definition from './../../../demo/utils/definition';
+import pageDefinition from './page/definition';
+
+global.goToPage = (ev) => {
+  window.Dispatcher.dispatch({
+    actionType: window.ComponentConstants.UPDATE_DEFINITION,
+    name: 'pages',
+    prop: 'slideIndex',
+    value: ev.target.name || "0"
+  });
+};
+
+const definition = new Definition('pages', Pages, {
+  description: 'Allows to slide to different pages in a full screen dialog.',
+  designerNotes: ``,
+  associatedDefinitions: [pageDefinition],
+  propTypes: {
+    children: 'Node',
+    className: 'String',
+    slideIndex: 'Number || String',
+  },
+  propDescriptions: {
+    children: 'This component supports children.',
+    className: 'Classes to apply to the component.',
+    slideIndex: 'Set this prop to change slide',
+  },
+  wrap: 'DialogFullScreen',
+  wrapProps: ['open', 'onCancel'],
+  props: ['slideIndex'],
+  propValues: {
+    children: `<Page title={ <Heading title='My First Page' /> }>
+    <Button onClick={ window.goToPage } name="1">
+      Go to next page.
+    </Button>
+  </Page>
+
+  <Page title={ <Heading title='My Second Page' backLink={ window.goToPage } /> }>
+    <Button onClick={ window.goToPage } name="0">
+      Go to previous page.
+    </Button>
+  </Page>`,
+    slideIndex: 0
+  },
+  openPreview: true
+});
+
+definition.stubAction('onCancel', 'open', false);
+
+export default definition;

--- a/src/components/pages/definition.js
+++ b/src/components/pages/definition.js
@@ -7,23 +7,23 @@ global.goToPage = (ev) => {
     actionType: window.ComponentConstants.UPDATE_DEFINITION,
     name: 'pages',
     prop: 'slideIndex',
-    value: ev.target.name || "0"
+    value: ev.target.name || '0'
   });
 };
 
 const definition = new Definition('pages', Pages, {
   description: 'Allows to slide to different pages in a full screen dialog.',
-  designerNotes: ``,
+  designerNotes: '',
   associatedDefinitions: [pageDefinition],
   propTypes: {
     children: 'Node',
     className: 'String',
-    slideIndex: 'Number || String',
+    slideIndex: 'Number || String'
   },
   propDescriptions: {
     children: 'This component supports children.',
     className: 'Classes to apply to the component.',
-    slideIndex: 'Set this prop to change slide',
+    slideIndex: 'Set this prop to change slide'
   },
   wrap: 'DialogFullScreen',
   wrapProps: ['open', 'onCancel'],

--- a/src/components/pages/package.json
+++ b/src/components/pages/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./pages.js",
+  "style": "./pages.scss"
+}

--- a/src/components/pages/page/__spec__.js
+++ b/src/components/pages/page/__spec__.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Page } from './../pages';
+import FullScreenHeading from './../../dialog-full-screen/full-screen-heading';
+
+describe('Pages', () => {
+  it('renders a page with a full screen heading', () => {
+    const wrapper = shallow(
+      <Page title={ 'My Title' }>
+        My Content
+      </Page>
+    );
+    const fullScrenHeading = wrapper.find(FullScreenHeading),
+        content = wrapper.find('.carbon-page__content');
+
+    expect(wrapper.props().className).toEqual('carbon-page');
+    expect(wrapper.props()['data-component']).toEqual('page');
+    expect(fullScrenHeading.props().children).toEqual('My Title');
+    expect(content.props().children).toEqual('My Content');
+  });
+});

--- a/src/components/pages/page/definition.js
+++ b/src/components/pages/page/definition.js
@@ -1,8 +1,8 @@
 import Page from './';
 import Definition from './../../../../demo/utils/definition';
 
-let definition = new Definition('page', Page, {
-  props: [ 'children', 'title' ],
+const definition = new Definition('page', Page, {
+  props: ['children', 'title'],
   propTypes: {
     title: 'Node',
     children: 'Node'

--- a/src/components/pages/page/definition.js
+++ b/src/components/pages/page/definition.js
@@ -1,0 +1,16 @@
+import Page from './';
+import Definition from './../../../../demo/utils/definition';
+
+let definition = new Definition('page', Page, {
+  props: [ 'children', 'title' ],
+  propTypes: {
+    title: 'Node',
+    children: 'Node'
+  },
+  propDescriptions: {
+    title: 'The title for the page, normally a Heading component.',
+    children: 'This component supports children.'
+  }
+});
+
+export default definition;

--- a/src/components/pages/page/package.json
+++ b/src/components/pages/page/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./page.js",
+  "style": "./page.scss"
+}

--- a/src/components/pages/page/page.js
+++ b/src/components/pages/page/page.js
@@ -1,20 +1,35 @@
 import React from 'react';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import tagComponent from './../../../utils/helpers/tags';
 import FullScreenHeading from './../../dialog-full-screen/full-screen-heading';
 
-export default (props) => {
-  const classes = classNames("carbon-page", props.className);
-
-  return (
-    <div className={ classes } { ...tagComponent('page', props) }>
-      <FullScreenHeading>
-        { props.title }
-      </FullScreenHeading>
-
-      <div className="carbon-page__content">
-        { props.children }
-      </div>
-    </div>
-  );
+const pageClasses = (props) => {
+  return classNames('carbon-page', props.className);
 };
+
+const Page = props =>
+  <div className={ pageClasses(props) } { ...tagComponent('page', props) }>
+    <FullScreenHeading>
+      { props.title }
+    </FullScreenHeading>
+
+    <div className='carbon-page__content'>
+      { props.children }
+    </div>
+  </div>
+;
+
+Page.propTypes = {
+  className: PropTypes.string,
+  title: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]),
+  children: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ])
+};
+
+export default Page;

--- a/src/components/pages/page/page.js
+++ b/src/components/pages/page/page.js
@@ -1,20 +1,20 @@
 import React from 'react';
+import classNames from 'classnames';
+import tagComponent from './../../../utils/helpers/tags';
 import FullScreenHeading from './../../dialog-full-screen/full-screen-heading';
 
-class Page extends React.Component {
-  render() {
-    return (
-      <div className="carbon-page">
-        <FullScreenHeading>
-          { this.props.title }
-        </FullScreenHeading>
+export default (props) => {
+  const classes = classNames("carbon-page", props.className);
 
-        <div className="carbon-page__content">
-          { this.props.children }
-        </div>
+  return (
+    <div className={ classes } { ...tagComponent('page', props) }>
+      <FullScreenHeading>
+        { props.title }
+      </FullScreenHeading>
+
+      <div className="carbon-page__content">
+        { props.children }
       </div>
-    );
-  }
-}
-
-export default Page;
+    </div>
+  );
+};

--- a/src/components/pages/page/page.js
+++ b/src/components/pages/page/page.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import FullScreenHeading from './../../dialog-full-screen/full-screen-heading';
+
+class Page extends React.Component {
+  render() {
+    return (
+      <div className="carbon-page">
+        <FullScreenHeading>
+          { this.props.title }
+        </FullScreenHeading>
+
+        <div className="carbon-page__content">
+          { this.props.children }
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Page;

--- a/src/components/pages/page/page.js
+++ b/src/components/pages/page/page.js
@@ -9,7 +9,7 @@ const pageClasses = (props) => {
 };
 
 const Page = props =>
-  <div className={ pageClasses(props) } { ...tagComponent('page', props) }>
+  <article className={ pageClasses(props) } { ...tagComponent('page', props) }>
     <FullScreenHeading>
       { props.title }
     </FullScreenHeading>
@@ -17,7 +17,7 @@ const Page = props =>
     <div className='carbon-page__content'>
       { props.children }
     </div>
-  </div>
+  </article>
 ;
 
 Page.propTypes = {

--- a/src/components/pages/page/page.scss
+++ b/src/components/pages/page/page.scss
@@ -1,0 +1,11 @@
+.carbon-page {
+  width: 100%;
+  height: 100%;
+}
+
+.carbon-page__content {
+  padding: 30px 5%;
+  width: 90%;
+  height: calc(100% - 169px);
+  overflow-y: auto;
+}

--- a/src/components/pages/page/page.scss
+++ b/src/components/pages/page/page.scss
@@ -1,11 +1,13 @@
+@import "./../../dialog-full-screen/dialog-full-screen-variables";
+
 .carbon-page {
   width: 100%;
   height: 100%;
 }
 
 .carbon-page__content {
-  padding: 30px 5%;
-  width: 90%;
-  height: calc(100% - 169px);
+  padding: $padding-top-bottom $padding-left-right;
+  width: 100% - ($padding-left-right * 2);
+  height: calc(100% - #{($title-height + ($padding-top-bottom * 2))});
   overflow-y: auto;
 }

--- a/src/components/pages/pages.js
+++ b/src/components/pages/pages.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Carousel } from './../carousel';
+import Page from './page';
+
+class Pages extends React.Component {
+  render() {
+    return (
+      <Carousel
+        className="carbon-pages"
+        enableSlideSelector={ false }
+        enablePreviousButton={ false }
+        enableNextButton={ false }
+        { ...this.props }
+      >
+        { this.props.children }
+      </Carousel>
+    );
+  }
+}
+
+export { Pages, Page };

--- a/src/components/pages/pages.js
+++ b/src/components/pages/pages.js
@@ -5,7 +5,7 @@ import { Carousel } from './../carousel';
 import Page from './page';
 
 const Pages = (props) => {
-  const classes = classNames("carbon-pages", props.className);
+  const classes = classNames('carbon-pages', props.className);
 
   return (
     <Carousel

--- a/src/components/pages/pages.js
+++ b/src/components/pages/pages.js
@@ -1,24 +1,33 @@
 import React from 'react';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import tagComponent from './../../utils/helpers/tags';
 import { Carousel } from './../carousel';
 import Page from './page';
 
-const Pages = (props) => {
-  const classes = classNames('carbon-pages', props.className);
+const pagesClasses = (props) => {
+  return classNames('carbon-pages', props.className);
+};
 
-  return (
-    <Carousel
-      className={ classes }
-      enableSlideSelector={ false }
-      enablePreviousButton={ false }
-      enableNextButton={ false }
-      { ...tagComponent('pages', props) }
-      { ...props }
-    >
-      { props.children }
-    </Carousel>
-  );
+const Pages = props =>
+  <Carousel
+    className={ pagesClasses(props) }
+    enableSlideSelector={ false }
+    enablePreviousButton={ false }
+    enableNextButton={ false }
+    { ...tagComponent('pages', props) }
+    { ...props }
+  >
+    { props.children }
+  </Carousel>
+;
+
+Pages.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ])
 };
 
 export { Pages, Page };

--- a/src/components/pages/pages.js
+++ b/src/components/pages/pages.js
@@ -1,21 +1,24 @@
 import React from 'react';
+import classNames from 'classnames';
+import tagComponent from './../../utils/helpers/tags';
 import { Carousel } from './../carousel';
 import Page from './page';
 
-class Pages extends React.Component {
-  render() {
-    return (
-      <Carousel
-        className="carbon-pages"
-        enableSlideSelector={ false }
-        enablePreviousButton={ false }
-        enableNextButton={ false }
-        { ...this.props }
-      >
-        { this.props.children }
-      </Carousel>
-    );
-  }
-}
+const Pages = (props) => {
+  const classes = classNames("carbon-pages", props.className);
+
+  return (
+    <Carousel
+      className={ classes }
+      enableSlideSelector={ false }
+      enablePreviousButton={ false }
+      enableNextButton={ false }
+      { ...tagComponent('pages', props) }
+      { ...props }
+    >
+      { props.children }
+    </Carousel>
+  );
+};
 
 export { Pages, Page };

--- a/src/components/pages/pages.scss
+++ b/src/components/pages/pages.scss
@@ -1,0 +1,11 @@
+.carbon-pages {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+
+  .carbon-carousel__content {
+    height: 100%;
+  }
+}

--- a/src/utils/helpers/browser/__spec__.js
+++ b/src/utils/helpers/browser/__spec__.js
@@ -14,7 +14,7 @@ describe('Browser', () => {
 
   describe('redirectTo', () => {
     describe('when url is passed', () => {
-      let urlsample = 'http://bla';
+      const urlsample = 'http://bla';
 
       it('redirects to url', () => {
         spyOn(Browser, 'getWindow').and.returnValue(_window);
@@ -45,7 +45,7 @@ describe('Browser', () => {
 
   describe('reload', () => {
     it('calls the windows location relaod method', () => {
-      let spy = jasmine.createSpy('reload');
+      const spy = jasmine.createSpy('reload');
       _window = { location: { reload: spy } };
 
       spyOn(Browser, 'getWindow').and.returnValue(_window);
@@ -57,7 +57,7 @@ describe('Browser', () => {
 
   describe('edit-focus', () => {
     it('focuses on the input field of the passed in ref', () => {
-      let node = jasmine.createSpyObj(['focus', 'select']);
+      const node = jasmine.createSpyObj(['focus', 'select']);
       spyOn(ReactDOM, 'findDOMNode').and.returnValue(node);
       Browser.editFocus('fakeRef');
       expect(node.focus).toHaveBeenCalled();
@@ -67,8 +67,8 @@ describe('Browser', () => {
 
   describe('setInputFocus', () => {
     it('focuses on the input field of the passed in ref but doesnot select text', () => {
-      let node = jasmine.createSpyObj(['focus']);
-      let fakeComponent = { _input: {} };
+      const node = jasmine.createSpyObj(['focus']);
+      const fakeComponent = { _input: {} };
       spyOn(ReactDOM, 'findDOMNode').and.returnValue(node);
       Browser.setInputFocus(fakeComponent);
       expect(node.focus).toHaveBeenCalled();
@@ -90,7 +90,7 @@ describe('Browser', () => {
       describe('options', () => {
         describe('when expires is passed', () => {
           it('adds expires date to the cookie', () => {
-            let date = new Date();
+            const date = new Date();
             date.setDate(date.getDate() + 1);
             Browser.setCookie('foo', 'bar', { expires: date });
             // Cannot check expiration date from document api
@@ -98,7 +98,7 @@ describe('Browser', () => {
           });
 
           it('does not add a cookie when expiration is in the passed', () => {
-            let date = new Date();
+            const date = new Date();
             date.setDate(date.getDate() - 1);
             Browser.setCookie('foo', 'bar', { expires: date });
             // Cannot check expiration date from document api
@@ -182,8 +182,14 @@ describe('Browser', () => {
     it('renders a hidden input for each data member', () => {
       spyOn(React, 'createElement').and.callThrough();
       Browser.postToNewWindow(url, data);
-      expect(React.createElement).toHaveBeenCalledWith('input', { type: 'hidden', key: key1, name: key1, value: value1 });
-      expect(React.createElement).toHaveBeenCalledWith('input', { type: 'hidden', key: key2, name: key2, value: value2 });
+      expect(React.createElement).toHaveBeenCalledWith(
+        'input',
+        { type: 'hidden', key: key1, name: key1, value: value1 }
+      );
+      expect(React.createElement).toHaveBeenCalledWith(
+        'input',
+        { type: 'hidden', key: key2, name: key2, value: value2 }
+      );
     });
 
     it('submits the rendered form', () => {
@@ -203,11 +209,11 @@ describe('Browser', () => {
     describe('when target option is passed', () => {
       it('sets the form target', () => {
         spyOn(React, 'createElement').and.callThrough();
-        let target = 'some_window';
+        const target = 'some_window';
 
         Browser.postToNewWindow(url, data, target);
         expect(React.createElement).toHaveBeenCalledWith(Form, {
-          action: url, method: 'post', target: target, save: false, cancel: false
+          action: url, method: 'post', target, save: false, cancel: false
         }, jasmine.anything());
       });
     });
@@ -221,10 +227,56 @@ describe('Browser', () => {
       expect(submitSpy).toHaveBeenCalled();
     });
   });
+
+  describe('hasClass', () => {
+    it('return true when the element has the name classe', () => {
+      const elem = { className: 'foo bar baz' },
+          name = 'bar';
+
+      expect(Browser.hasClass(elem, name)).toBeTruthy();
+    });
+
+    it('return false when the element does not have the name classe', () => {
+      const elem = { className: 'foo bar baz' },
+          name = 'qux';
+
+      expect(Browser.hasClass(elem, name)).toBeFalsy();
+    });
+  });
+
+  describe('addClass', () => {
+    it('adds the name class to the elem', () => {
+      const elem = { className: 'foo bar baz' },
+          name = 'qux';
+
+      Browser.addClass(elem, name);
+      expect(elem.className).toEqual('foo bar baz qux');
+    });
+  });
+
+  describe('removeClass', () => {
+    it('removes the name class to the elem', () => {
+      const elem = { className: 'foo bar baz' },
+          name = 'bar';
+
+      Browser.removeClass(elem, name);
+      expect(elem.className).toEqual('foo baz');
+    });
+
+    describe('when the elem does not have the name class', () => {
+      it('does not remove the name class to the elem', () => {
+        const elem = { className: 'foo bar baz' },
+            name = 'qux';
+
+        Browser.removeClass(elem, name);
+        expect(elem.className).toEqual('foo bar baz');
+      });
+    });
+  });
 });
 
 function addPostFormDiv() {
-  const div = document.createElement("div");
+  const div = document.createElement('div');
   div.setAttribute('id', 'carbonPostFormContainer');
   document.body.appendChild(div);
 }

--- a/src/utils/helpers/browser/__spec__.js
+++ b/src/utils/helpers/browser/__spec__.js
@@ -1,10 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { mount } from 'enzyme';
 import Form from './../../../components/form';
 import Browser from './browser.js';
 
 describe('Browser', () => {
   let _window;
+  const elem = mount(
+    <div className='foo bar baz' />
+  );
 
   beforeEach(() => {
     _window = {
@@ -225,52 +229,6 @@ describe('Browser', () => {
       const form = { submit: submitSpy };
       Browser.submitForm(form);
       expect(submitSpy).toHaveBeenCalled();
-    });
-  });
-
-  describe('hasClass', () => {
-    it('return true when the element has the name classe', () => {
-      const elem = { className: 'foo bar baz' },
-          name = 'bar';
-
-      expect(Browser.hasClass(elem, name)).toBeTruthy();
-    });
-
-    it('return false when the element does not have the name classe', () => {
-      const elem = { className: 'foo bar baz' },
-          name = 'qux';
-
-      expect(Browser.hasClass(elem, name)).toBeFalsy();
-    });
-  });
-
-  describe('addClass', () => {
-    it('adds the name class to the elem', () => {
-      const elem = { className: 'foo bar baz' },
-          name = 'qux';
-
-      Browser.addClass(elem, name);
-      expect(elem.className).toEqual('foo bar baz qux');
-    });
-  });
-
-  describe('removeClass', () => {
-    it('removes the name class to the elem', () => {
-      const elem = { className: 'foo bar baz' },
-          name = 'bar';
-
-      Browser.removeClass(elem, name);
-      expect(elem.className).toEqual('foo baz');
-    });
-
-    describe('when the elem does not have the name class', () => {
-      it('does not remove the name class to the elem', () => {
-        const elem = { className: 'foo bar baz' },
-            name = 'qux';
-
-        Browser.removeClass(elem, name);
-        expect(elem.className).toEqual('foo bar baz');
-      });
     });
   });
 });

--- a/src/utils/helpers/browser/browser.js
+++ b/src/utils/helpers/browser/browser.js
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom';
 import { keys } from 'lodash';
 import Form from './../../../components/form';
 
+const DOCUMENT_SCROLL = 'disable-scroll';
+
 /**
 * Browser Helper
 

--- a/src/utils/helpers/browser/browser.js
+++ b/src/utils/helpers/browser/browser.js
@@ -4,16 +4,6 @@ import { keys } from 'lodash';
 import Form from './../../../components/form';
 
 /**
- * Returns regex for finding a class name in a string.
- *
- * @param {String} name
- * @return {Regex}
- */
-const classRegex = (name) => {
-  return `(?:^|\\s+)${name}(?:\\s+|$)`;
-};
-
-/**
 * Browser Helper
 
 *
@@ -172,43 +162,6 @@ const Browser = {
    */
   submitForm: (form) => {
     form.submit();
-  },
-
-  /**
-   * Determines if a class is present on an element.
-   *
-   * @param {Element} elem - the element to inspect
-   * @param {String} name - the class name to look for
-   * @return {Boolean}
-   */
-  hasClass: (elem, name) => {
-    return new RegExp(classRegex(name)).test(elem.className);
-  },
-
-  /**
-   * Adds a class to an element if it is not already present.
-   *
-   * @param {Element} elem - the element to add the class to
-   * @param {String} name - the class name to add
-   * @return {Boolean}
-   */
-  addClass: (elem, name) => {
-    if (!Browser.hasClass(elem, name)) {
-      elem.className = elem.className ? [elem.className, name].join(' ') : name;
-    }
-  },
-
-  /**
-   * Removes a class from an element if it exists.
-   *
-   * @param {Element} elem - the element to remove the class from
-   * @param {String} name - the class name to remove
-   * @return {Boolean}
-   */
-  removeClass: (elem, name) => {
-    if (Browser.hasClass(elem, name)) {
-      elem.className = elem.className.replace(new RegExp(classRegex(name), 'g'), ' ');
-    }
   }
 };
 

--- a/src/utils/helpers/browser/browser.js
+++ b/src/utils/helpers/browser/browser.js
@@ -3,7 +3,9 @@ import ReactDOM from 'react-dom';
 import { keys } from 'lodash';
 import Form from './../../../components/form';
 
-const DOCUMENT_SCROLL = 'disable-scroll';
+const classRegex = (name) => {
+  return `(?:^|\\s+)${name}(?:\\s+|$)`;
+}
 
 /**
 * Browser Helper
@@ -164,6 +166,22 @@ const Browser = {
    */
   submitForm: (form) => {
     form.submit();
+  },
+
+  hasClass: (elem, name) => {
+    return new RegExp(classRegex(name)).test(elem.className);
+  },
+
+  addClass: (elem, name) => {
+    if (!Browser.hasClass(elem, name)) {
+      elem.className = elem.className ? [elem.className, name].join(' ') : name;
+    }
+  },
+
+  removeClass: (elem, name) => {
+    if (Browser.hasClass(elem, name)) {
+      elem.className = elem.className.replace(new RegExp(classRegex(name), "g"), "");
+    }
   }
 };
 

--- a/src/utils/helpers/browser/browser.js
+++ b/src/utils/helpers/browser/browser.js
@@ -11,7 +11,7 @@ import Form from './../../../components/form';
  */
 const classRegex = (name) => {
   return `(?:^|\\s+)${name}(?:\\s+|$)`;
-}
+};
 
 /**
 * Browser Helper
@@ -45,7 +45,7 @@ const Browser = {
    * @return HTMLElement
    */
   getActiveElement: () => {
-    let doc = Browser.getDocument();
+    const doc = Browser.getDocument();
     return doc.activeElement;
   },
 
@@ -207,7 +207,7 @@ const Browser = {
    */
   removeClass: (elem, name) => {
     if (Browser.hasClass(elem, name)) {
-      elem.className = elem.className.replace(new RegExp(classRegex(name), "g"), "");
+      elem.className = elem.className.replace(new RegExp(classRegex(name), 'g'), ' ');
     }
   }
 };

--- a/src/utils/helpers/browser/browser.js
+++ b/src/utils/helpers/browser/browser.js
@@ -3,6 +3,12 @@ import ReactDOM from 'react-dom';
 import { keys } from 'lodash';
 import Form from './../../../components/form';
 
+/**
+ * Returns regex for finding a class name in a string.
+ *
+ * @param {String} name
+ * @return {Regex}
+ */
 const classRegex = (name) => {
   return `(?:^|\\s+)${name}(?:\\s+|$)`;
 }
@@ -168,16 +174,37 @@ const Browser = {
     form.submit();
   },
 
+  /**
+   * Determines if a class is present on an element.
+   *
+   * @param {Element} elem - the element to inspect
+   * @param {String} name - the class name to look for
+   * @return {Boolean}
+   */
   hasClass: (elem, name) => {
     return new RegExp(classRegex(name)).test(elem.className);
   },
 
+  /**
+   * Adds a class to an element if it is not already present.
+   *
+   * @param {Element} elem - the element to add the class to
+   * @param {String} name - the class name to add
+   * @return {Boolean}
+   */
   addClass: (elem, name) => {
     if (!Browser.hasClass(elem, name)) {
       elem.className = elem.className ? [elem.className, name].join(' ') : name;
     }
   },
 
+  /**
+   * Removes a class from an element if it exists.
+   *
+   * @param {Element} elem - the element to remove the class from
+   * @param {String} name - the class name to remove
+   * @return {Boolean}
+   */
   removeClass: (elem, name) => {
     if (Browser.hasClass(elem, name)) {
       elem.className = elem.className.replace(new RegExp(classRegex(name), "g"), "");


### PR DESCRIPTION
* Makes `DialogFullScreen` scrollable if the content goes beyond the height of the browser.
* Adds `Pages` and `Page` components to enable paginated content for full screen views.

```
const headingOne = (
  <Heading title="My First Page" />
);

const headingTwo = (
  <Heading title="My Second Page" />
);

return (
  <DialogFullScreen>
    <Pages slideIndex={ 0 }>
      <Page title={ headingOne }>
        Content for the first page.
      </Page>

      <Page title={ headingTwo }>
        Content for the second page.
      </Page>
    </Pages>
  </DialogFullScreen>
);
```