### PR TITLE
CARBON-700 Fix mis-aligned sort icon in IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ A new helper object is available in `utils/helpers/text`. Currently it only cont
 ## Bug Fixes
 
 * `DialogFullScreen` now scrolls vertically if it contains content taller than the dialog height.
+* `TableHeader`: fix alignment of sort icon in IE11.
 
 ## Dependency Switch
 

--- a/src/components/table/table-header/table-header.js
+++ b/src/components/table/table-header/table-header.js
@@ -276,8 +276,8 @@ class TableHeader extends React.Component {
           aria-label={ this.sortDescription }
           onClick={ this.onSortableColumnClick }
         >
-          { this.props.children }
           { this.sortIconHTML }
+          { this.props.children }
         </a>
       );
     } else {

--- a/src/components/table/table-header/table-header.scss
+++ b/src/components/table/table-header/table-header.scss
@@ -67,10 +67,7 @@
 }
 
 .carbon-table-header__icon {
-  margin: -5px 10px 0;
-  position: absolute;
-  right: 0;
-  top: 50%;
+  float: right;
 
   .carbon-icon__svg--sort-down,
   .carbon-icon__svg--sort-up {

--- a/src/components/table/table-header/table-header.scss
+++ b/src/components/table/table-header/table-header.scss
@@ -77,8 +77,7 @@
 }
 
 .carbon-table-header__icon--align-right {
-  position: relative;
-  top: 0;
+  float: left;
 }
 
 .carbon-table-header--sortable {


### PR DESCRIPTION
Replace absolute positioning with float.

Re-order the HTML so the icon comes first inside the `<th>`, otherwise
the mis-alignment got worse in Firefox.

Update release notes.

# Related Issues / Pull Requests
#1132 