### PR TITLE
revert footer classname

### DIFF
--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -633,8 +633,8 @@ class Form extends React.Component {
    */
   get footerClasses() {
     return classNames(
-      'carbon-form__footer',
-      `carbon-form__footer--${this.props.buttonAlign}`
+      'carbon-form__buttons',
+      `carbon-form__buttons--${this.props.buttonAlign}`
     );
   }
 

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -5,13 +5,13 @@
   display: inline-block;
 }
 
-.carbon-form__footer {
+.carbon-form__buttons {
   align-items: center;
   display: flex;
   margin-top: 20px;
 }
 
-.carbon-form__footer--right {
+.carbon-form__buttons--right {
   justify-content: flex-end;
 }
 


### PR DESCRIPTION
this reverts the footer class name made in a recent PR, this is because some applications use this class to apply custom CSS and it was breaking.