### PR TITLE
CARBON-887 move error state to form-summary from save-button

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,5 +50,5 @@ gulp.task('deploy', ['prepare-demo', 'build', 'run-deploy']);
 
 gulp.task('test', SpecTask({
   path: '/src/***/**/!(__spec__|definition).js',
-  eslintThreshold: 55
+  eslintThreshold: 46
 }));

--- a/src/components/form/__spec__.js
+++ b/src/components/form/__spec__.js
@@ -447,8 +447,6 @@ describe('Form', () => {
             expect(saveButton.prop('saveText')).toEqual('Some custom save text');
             expect(saveButton.prop('saving')).toBeFalsy();
             expect(saveButton.prop('saveButtonProps')).toEqual({ theme: 'red' })
-            expect(saveButton.prop('errors')).toEqual(2);
-            expect(saveButton.prop('warnings')).toEqual(3);
           });
 
           it('renders a form summary with expected props', () => {

--- a/src/components/form/cancel-button/cancel-button.js
+++ b/src/components/form/cancel-button/cancel-button.js
@@ -3,14 +3,6 @@ import React from 'react';
 import tagComponent from '../../../utils/helpers/tags';
 import Button from './../../button';
 
-const CancelButton = props =>
-  <div className='carbon-form-cancel' { ...tagComponent('cancel', props) }>
-    <Button { ...cancelButtonProps(props) } data-element='cancel'>
-      { cancelText(props) }
-    </Button>
-  </div>
-;
-
 const cancelButtonProps = (props) => {
   return ({
     onClick: props.cancelClick,
@@ -23,5 +15,13 @@ const cancelButtonProps = (props) => {
 const cancelText = (props) => {
   return props.cancelText || I18n.t('actions.cancel', { defaultValue: 'Cancel' });
 };
+
+const CancelButton = props =>
+  <div className='carbon-form-cancel' { ...tagComponent('cancel', props) }>
+    <Button { ...cancelButtonProps(props) } data-element='cancel'>
+      { cancelText(props) }
+    </Button>
+  </div>
+;
 
 export default CancelButton;

--- a/src/components/form/form-summary/__spec__.js
+++ b/src/components/form/form-summary/__spec__.js
@@ -67,6 +67,11 @@ describe('<FormSummary />', () => {
       expect(text).toContain('There is 1 error');
       expect(text).toContain('and 1 warning');
     });
+
+    it('renders with a default and invalid class', () => {
+      expect(wrapper.hasClass('carbon-form-save')).toBeTruthy();
+      expect(wrapper.hasClass('carbon-form-save--invalid')).toBeTruthy();
+    });
   });
 
   describe("tags", () => {

--- a/src/components/form/form-summary/form-summary.js
+++ b/src/components/form/form-summary/form-summary.js
@@ -1,30 +1,10 @@
-import I18n from 'i18n-js';
 import React from 'react';
+import I18n from 'i18n-js';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import tagComponent from '../../../utils/helpers/tags';
 
 import Icon from './../../icon';
-
-const FormSummary = props =>
-  <div className='carbon-form-summary' { ...tagComponent('form-summary', props) }>
-    { summary(props, 'error') }
-    { summary(props, 'warning') }
-    { props.children }
-  </div>
-;
-
-FormSummary.propTypes = {
-  children: PropTypes.node,
-  errors: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number
-  ]),
-  warnings: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number
-  ])
-};
-
 /**
  * Adds an 's' to pluralise (keys will always be error or warning)
  *
@@ -33,6 +13,28 @@ FormSummary.propTypes = {
  */
 const pluralize = (key) => {
   return `${key}s`;
+};
+
+/**
+ * decides whether the warning message should be appended to the sentence or output as a sentence on it's own
+ *
+ * @param {object} props
+ * @param {string} key
+ * @return {boolean} true if the warning message needs to be appended
+ */
+const warningAppend = (props, key) => {
+  return props.errors > 0 && props.warnings > 0 && key === 'warning';
+};
+
+/**
+ * finds the correct translation key
+ *
+ * @param {object} props
+ * @param {string} key
+ * @return {string} correct key
+ */
+const translationKey = (props, key) => {
+  return warningAppend(props, key) ? 'errors_and_warnings' : pluralize(key);
 };
 
 /**
@@ -66,28 +68,6 @@ const defaultTranslations = (errorCount, warningCount) => {
       count: parseInt(warningCount, 10)
     }
   };
-};
-
-/**
- * decides whether the warning message should be appended to the sentence or output as a sentence on it's own
- *
- * @param {object} props
- * @param {string} key
- * @return {boolean} true if the warning message needs to be appended
- */
-const warningAppend = (props, key) => {
-  return props.errors > 0 && props.warnings > 0 && key === 'warning';
-};
-
-/**
- * finds the correct translation key
- *
- * @param {object} props
- * @param {string} key
- * @return {string} correct key
- */
-const translationKey = (props, key) => {
-  return warningAppend(props, key) ? 'errors_and_warnings' : pluralize(key);
 };
 
 /**
@@ -128,5 +108,35 @@ const summary = (props, key) => {
   }
   return null;
 };
+
+const summaryClasses = (props) => {
+  return classNames(
+    'carbon-form-summary',
+    'carbon-form-save', {
+      'carbon-form-save--invalid': props.errors || props.warnings
+    }
+  );
+};
+
+const FormSummary = props =>
+  <div className={ summaryClasses(props) } { ...tagComponent('form-summary', props) }>
+    { summary(props, 'error') }
+    { summary(props, 'warning') }
+    { props.children }
+  </div>
+;
+
+FormSummary.propTypes = {
+  children: PropTypes.node,
+  errors: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]),
+  warnings: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ])
+};
+
 
 export default FormSummary;

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -558,8 +558,6 @@ class Form extends React.Component {
         saveButtonProps={ this.props.saveButtonProps }
         saveText={ this.props.saveText }
         saving={ this.props.saving }
-        errors={ this.state.errorCount }
-        warnings={ this.state.warningCount }
       />
     );
   }

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -20,7 +20,8 @@
 }
 
 .carbon-form-save {
-  padding: 8px;
+  padding: 4px 4px 4px 8px;
+  border-radius: 4px;
 }
 
 .carbon-form-save--invalid {

--- a/src/components/form/save-button/__spec__.js
+++ b/src/components/form/save-button/__spec__.js
@@ -55,25 +55,6 @@ describe('SaveButton', () => {
     });
   });
 
-  describe('when there are errors or warnings', () => {
-    beforeEach(() => {
-      let errors = 2;
-      let warnings = 1;
-       wrapper = shallow(
-         <SaveButton
-           errors={ errors }
-           warnings={ warnings }
-           saving={ false }
-         />
-       );
-     });
-
-    it('renders with a default and invalid class', () => {
-      expect(wrapper.hasClass('carbon-form-save')).toBeTruthy();
-      expect(wrapper.hasClass('carbon-form-save--invalid')).toBeTruthy();
-    });
-  });
-
   it('the button is enabled when the form is not saving', () => {
     expect(wrapper.props.disabled).toBeFalsy();
   });

--- a/src/components/form/save-button/save-button.js
+++ b/src/components/form/save-button/save-button.js
@@ -1,25 +1,8 @@
-import classNames from 'classnames';
 import I18n from 'i18n-js';
 import React from 'react';
 import PropTypes from 'prop-types';
 import tagComponent from '../../../utils/helpers/tags';
 import Button from './../../button';
-
-const SaveButton = props =>
-  <div className={ saveClasses(props) } { ...tagComponent('save', props) }>
-    <Button { ...saveButtonProps(props) } data-element='save'>
-      { saveText(props) }
-    </Button>
-  </div>
-;
-
-const saveClasses = (props) => {
-  return classNames(
-    'carbon-form-save', {
-      'carbon-form-save--invalid': props.errors || props.warnings
-    }
-  );
-};
 
 const saveButtonProps = (props) => {
   return ({
@@ -33,6 +16,14 @@ const saveButtonProps = (props) => {
 const saveText = (props) => {
   return props.saveText || I18n.t('actions.save', { defaultValue: 'Save' });
 };
+
+const SaveButton = props =>
+  <div className='carbon-form-save' { ...tagComponent('save', props) }>
+    <Button { ...saveButtonProps(props) } data-element='save'>
+      { saveText(props) }
+    </Button>
+  </div>
+;
 
 SaveButton.propTypes = {
   errors: PropTypes.oneOfType([


### PR DESCRIPTION
# Description

**BEFORE**:

![screen shot 2017-06-30 at 15 07 36](https://user-images.githubusercontent.com/9549240/27739272-e0da93b0-5da5-11e7-956f-629874ecc19e.png)

**AFTER**

![screen shot 2017-07-03 at 14 57 00](https://user-images.githubusercontent.com/9549240/27795916-eab421c4-5fff-11e7-8885-803440e5f384.png)

Puts grey background around summary rather than just save button.

* Also fixes some linter warnings by re-ordering methods. lowers errors to 46.