### PR TITLE
Apply carbon-dialog-full-screen--open to html instead of body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 1.2.1
 
-## Dialog Full screen
-The `carbon-dialog-full-screen--open` class is now applied to the `html` element instead of the `body`.
+## Bug Fixes
+
+* `Dialog Full screen`: The `carbon-dialog-full-screen--open` class is now applied to the `html` element instead of the `body`.
 
 ## Linting Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.1
+
+## Dialog Full screen
+The `carbon-dialog-full-screen--open` class is now applied to the `html` element instead of the `body`.
+
 # 1.2.0
 
 ## Dependency Upgrade

--- a/src/components/dialog-full-screen/__spec__.js
+++ b/src/components/dialog-full-screen/__spec__.js
@@ -89,8 +89,8 @@ describe('DialogFullScreen', () => {
     });
 
     it('adds a carbon-dialog-full-screen--open class to the body', () => {
-      const body = wrapper.instance().document.body;
-      expect(body.className).toEqual('carbon-dialog-full-screen--open');
+      const html = wrapper.instance().document.documentElement;
+      expect(html.className).toEqual('carbon-dialog-full-screen--open');
     });
   });
 
@@ -101,10 +101,10 @@ describe('DialogFullScreen', () => {
     });
 
     it('removes a carbon-dialog-full-screen--open class to the body', () => {
-      const body = wrapper.instance().document.body;
-      expect(body.className).toEqual('carbon-dialog-full-screen--open');
+      const html = wrapper.instance().document.documentElement;
+      expect(html.className).toEqual('carbon-dialog-full-screen--open');
       wrapper.setProps({ open: false });
-      expect(body.className).toEqual('');
+      expect(html.className).toEqual('');
     });
   });
 

--- a/src/components/dialog-full-screen/dialog-full-screen.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.js
@@ -6,7 +6,7 @@ import Heading from './../heading';
 import FullScreenHeading from './full-screen-heading';
 import Browser from './../../utils/helpers/browser';
 
-const DIALOG_OPEN_BODY_CLASS = 'carbon-dialog-full-screen--open';
+const DIALOG_OPEN_HTML_CLASS = 'carbon-dialog-full-screen--open';
 
 /**
  * A DialogFullScreen widget.
@@ -106,14 +106,14 @@ class DialogFullScreen extends Modal {
    * Overrides the original function to disable the document's scroll.
    */
   get onOpening() {
-    this.document.body.classList.add(DIALOG_OPEN_BODY_CLASS);
+    this.document.documentElement.classList.add(DIALOG_OPEN_HTML_CLASS);
   }
 
   /**
    * Overrides the original function to enable the document's scroll.
    */
   get onClosing() {
-    this.document.body.classList.remove(DIALOG_OPEN_BODY_CLASS);
+    this.document.documentElement.classList.remove(DIALOG_OPEN_HTML_CLASS);
   }
 
   /**


### PR DESCRIPTION
# Description
The `carbon-dialog-full-screen--open` class is now applied to the `html` element instead of the `body`.

# TODO
- [x] Release notes

# Related Issues / Pull Requests

# Screenshots / Gifs

# Testing Instructions
https://jira-sage.valiantyscloud.net/secure/ViewSession.jspa?testSessionId=42734