### PR TITLE
Fix release notes to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.2.1
+# 1.3.0
 
 ## Linting Updates
 


### PR DESCRIPTION
Linting updates that are not yet released don't need to be in a patch