### PR TITLE
Input prefix disappears on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The following have had minor internal changes to satisfy the introduction of str
 * ItemTarget
 * Text
 
+## Bug Fixes
+* Input prefix was hidden when error was present
+
 # 1.2.0
 
 ## Dependency Upgrade

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -221,6 +221,7 @@
   left: 7px;
   position: absolute;
   top: 8px;
+  z-index: 3;
 }
 
 .common-input__input-icon {


### PR DESCRIPTION
# Description
Prefix was hidden when there was a error present on the input. I have also fixed #1230 in the process

![prefix](https://user-images.githubusercontent.com/5382335/27866454-518d881a-618e-11e7-81aa-f0dd85073239.gif)
