### PR TITLE
CARBON-903 Fix Dialog focus issue that triggered validation error on form field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ The following have had minor internal changes to satisfy the introduction of str
 * ItemTarget
 * Text
 
+## Component Enhancements
+
+* `Alert` no longer inherits from `Dialog`, but is composed of a `Dialog`.
+* `Dialog` has new props: `autoFocusCloseIcon`, `onCloseKeyDown`, `onClosing`, `onOpening`.
+
+## Bug Fixes
+
+* `Dialog`: fixed an issue where the dialog would steal focus from a child `Textbox` with `autoFocus`, and trigger a presence validation error.
+
 # 1.2.0
 
 ## Dependency Upgrade

--- a/src/components/alert/__spec__.js
+++ b/src/components/alert/__spec__.js
@@ -1,39 +1,36 @@
 import React from 'react';
-import TestUtils from 'react-dom/test-utils';
 import { shallow, mount } from 'enzyme';
 import Alert from './alert';
 import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
 
 describe('Alert', () => {
-  let instance;
-  let onCancel = jasmine.createSpy('cancel');
-
-  beforeEach(() => {
-    instance = TestUtils.renderIntoDocument(
-      <Alert
-        onCancel={ onCancel }
-        open={ true }
-        title="Alert title" />
-    );
-  });
-
   describe('dialogClasses', () => {
     it('returns the dialog class along with the alert class', () => {
-      expect(instance.dialogClasses).toEqual('carbon-dialog__dialog carbon-dialog__dialog--extra-small carbon-alert__alert');
+      const wrapper = mount(
+        <Alert
+          title='Alert'
+          open
+        />
+      );
+
+      expect(wrapper
+        .find('.carbon-dialog.carbon-dialog--alert')
+        .exists())
+        .toBe(true);
     });
   });
 
-  describe("tags", () => {
-    describe("on component", () => {
-      let wrapper = shallow(<Alert open={ true } data-element='bar' data-role='baz' />);
+  describe('tags', () => {
+    describe('on component', () => {
+      const wrapper = shallow(<Alert open data-element='bar' data-role='baz' />);
 
       it('include correct component, element and role data tags', () => {
         rootTagTest(wrapper, 'alert', 'bar', 'baz');
       });
     });
 
-    describe("on internal elements", () => {
-      let wrapper = mount(<Alert open={ true } title='Test' subtitle='Test' showCloseIcon={ true } />);
+    describe('on internal elements', () => {
+      const wrapper = mount(<Alert open title='Test' subtitle='Test' showCloseIcon />);
 
       elementsTagTest(wrapper, [
         'close',
@@ -45,16 +42,11 @@ describe('Alert', () => {
 
   describe('keyboard focus', () => {
     let wrapper;
-    let mockEvent;
 
     beforeEach(() => {
       wrapper = mount(
-        <Alert open={ true } title='Test' subtitle='Test' showCloseIcon={ false } />
+        <Alert open title='Test' subtitle='Test' showCloseIcon={ false } />
       );
-
-      mockEvent = {
-        preventDefault() {}
-      };
 
       jasmine.clock().install();
     });
@@ -63,26 +55,29 @@ describe('Alert', () => {
       jasmine.clock().uninstall();
     });
 
-    it('remains on the dialog if open and no close icon is shown', () => {
-      const instance = wrapper.instance();
-      spyOn(mockEvent, 'preventDefault');
-      spyOn(instance, 'focusDialog');
+    describe('keydown', () => {
+      let ev;
 
-      instance.onDialogBlur(mockEvent);
-      jasmine.clock().tick(10);
-      expect(mockEvent.preventDefault).toHaveBeenCalled();
-      expect(instance.focusDialog).toHaveBeenCalled();
-    });
+      beforeEach(() => {
+        ev = {
+          key: 'Tab',
+          preventDefault() {}
+        };
 
-    it('does not remain on the dialog if close icon is shown', () => {
-      wrapper.setProps({
-        showCloseIcon: true
+        spyOn(ev, 'preventDefault');
       });
 
-      spyOn(mockEvent, 'preventDefault');
+      it('calls preventDefault when the Tab key is pressed', () => {
+        wrapper.instance().onCloseKeyDown(ev);
+        expect(ev.preventDefault).toHaveBeenCalled();
+      });
 
-      wrapper.instance().onDialogBlur(mockEvent);
-      expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+      it('does not call preventDefault when the Tab key is not pressed', () => {
+        ev.key = 'Enter';
+        wrapper.instance().onCloseKeyDown(ev);
+
+        expect(ev.preventDefault).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/components/alert/alert.js
+++ b/src/components/alert/alert.js
@@ -69,6 +69,7 @@ class Alert extends React.Component {
       <Dialog
         className='carbon-dialog--alert'
         { ...this.props }
+        autoFocusCloseIcon={ this.props.showCloseIcon }
         onCloseKeyDown={ this.onCloseKeyDown }
         { ...this.componentTags(this.props) }
       />

--- a/src/components/alert/alert.js
+++ b/src/components/alert/alert.js
@@ -31,18 +31,33 @@ class Alert extends React.Component {
   })
 
   static propTypes = {
-    size: PropTypes.string,
+    /*
+     * The following props are the same as
+     * the props defined on the Dialog component -
+     * they are defined here then passed through
+     * to the Dialog that the Alert renders.
+     *
+     * Therefore the ESLint react/no-unused-prop=types
+     * rule is disabled for these prop types
+     */
+    /* eslint-disable react/no-unused-prop-types */
+    disableEscKey: PropTypes.bool,
 
-    title: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.object
-    ]),
+    enableBackgroundUI: PropTypes.bool,
 
     open: PropTypes.bool,
 
+    showCloseIcon: PropTypes.bool,
+
+    size: PropTypes.string,
+
     subtitle: PropTypes.string,
 
-    showCloseIcon: PropTypes.bool
+    title: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.string
+    ])
+    /* eslint-enable react/no-unused-prop-types */
   }
 
   constructor(props) {

--- a/src/components/alert/alert.js
+++ b/src/components/alert/alert.js
@@ -1,4 +1,5 @@
-import classNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { assign } from 'lodash';
 import Dialog from '../dialog';
 
@@ -22,32 +23,37 @@ import Dialog from '../dialog';
  * @class Alert
  * @constructor
  */
-class Alert extends Dialog {
+class Alert extends React.Component {
 
   static defaultProps = assign({}, Dialog.defaultProps, {
-    role: 'alertdialog',
+    ariaRole: 'alertdialog',
     size: 'extra-small'
   })
 
-  constructor(props) {
-    super(props);
-    // focusDialog is called via setTimeout in onDialogBlur,
-    // so it needs binding to this
-    // From the React docs: "Generally, if you refer to a method without () after
-    // it, such as onClick={this.handleClick}, you should bind that method."
-    this.focusDialog = this.focusDialog.bind(this);
+  static propTypes = {
+    size: PropTypes.string,
+
+    title: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
+    ]),
+
+    open: PropTypes.bool,
+
+    subtitle: PropTypes.string,
+
+    showCloseIcon: PropTypes.bool
   }
 
-  /**
-   * Returns classes for the alert, combines with dialog class names..
-   *
-   * @method dialogClasses
-   */
-  get dialogClasses() {
-    return classNames(
-      super.dialogClasses,
-      'carbon-alert__alert'
-    );
+  constructor(props) {
+    super(props);
+    this.onCloseKeyDown = this.onCloseKeyDown.bind(this);
+  }
+
+  onCloseKeyDown(ev) {
+    if (ev.key === 'Tab') {
+      ev.preventDefault();
+    }
   }
 
   componentTags(props) {
@@ -58,25 +64,15 @@ class Alert extends Dialog {
     };
   }
 
-  /**
-   * Handles keyboard focus leaving the dialog
-   * element.
-   *
-   * Assumes that, if no close icon is displayed,
-   * no other element can receive keyboard focus.
-   * Therefore focus should remain on the dialog
-   * element while it is open.
-   *
-   * @override
-   * @return {Void}
-   */
-  onDialogBlur(ev) {
-    if (!this.props.showCloseIcon) {
-      ev.preventDefault();
-      // Firefox loses focus unless we wrap the call to
-      // this.focusDialog in setTimeout
-      setTimeout(this.focusDialog);
-    }
+  render() {
+    return (
+      <Dialog
+        className='carbon-dialog--alert'
+        { ...this.props }
+        onCloseKeyDown={ this.onCloseKeyDown }
+        { ...this.componentTags(this.props) }
+      />
+    );
   }
 }
 

--- a/src/components/dialog-full-screen/dialog-full-screen.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.js
@@ -105,14 +105,14 @@ class DialogFullScreen extends Modal {
   /**
    * Overrides the original function to disable the document's scroll.
    */
-  get onOpening() {
+  onOpening() {
     this.document.body.classList.add(DIALOG_OPEN_BODY_CLASS);
   }
 
   /**
    * Overrides the original function to enable the document's scroll.
    */
-  get onClosing() {
+  onClosing() {
     this.document.body.classList.remove(DIALOG_OPEN_BODY_CLASS);
   }
 

--- a/src/components/dialog/__spec__.js
+++ b/src/components/dialog/__spec__.js
@@ -26,14 +26,6 @@ describe('Dialog', () => {
           instance.componentDidMount();
           expect(instance.centerDialog).toHaveBeenCalled();
         });
-
-        it('focuses on the dialog', () => {
-          spyOn(Dialog.prototype, 'focusDialog');
-          mount(
-            <Dialog open onCancel={ onCancel } />
-          );
-          expect(Dialog.prototype.focusDialog).toHaveBeenCalled();
-        });
       });
 
       describe('when dialog is closed', () => {
@@ -315,6 +307,97 @@ describe('Dialog', () => {
     });
   });
 
+  describe('onOpening', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = mount(
+        <Dialog
+          onCancel={ () => {} }
+          onConfirm={ () => {} }
+          showCloseIcon
+          subtitle='Test'
+          title='Test'
+          ariaRole='dialog'
+        />
+      );
+    });
+
+    it('calls this.props.onOpening if defined', () => {
+      const onOpening = jasmine.createSpy('onOpening');
+      wrapper.setProps({
+        onOpening
+      });
+
+      wrapper.setProps({ open: true });
+
+      expect(wrapper.props().onOpening).toHaveBeenCalled();
+    });
+
+    describe('when showCloseIcon is true', () => {
+      describe('when autoFocusCloseIcon is true', () => {
+        it('give focus to the close icon', () => {
+          wrapper.setProps({
+            open: true,
+            showCloseIcon: true,
+            autoFocusCloseIcon: true
+          });
+
+          const closeLink = wrapper.find('[title="Close"]').first().getDOMNode();
+          spyOn(closeLink, 'focus');
+
+          wrapper.instance().onOpening();
+          expect(closeLink.focus).toHaveBeenCalled();
+        });
+      });
+
+      describe('when autoFocusCloseIcon is false', () => {
+        it('does not give focus to the close icon', () => {
+          wrapper.setProps({
+            open: true,
+            autoFocusCloseIcon: true
+          });
+
+          const closeLink = wrapper.find('[title="Close"]').first().getDOMNode();
+          spyOn(closeLink, 'focus');
+
+          wrapper.setProps({ showCloseIcon: false });
+
+          wrapper.instance().onOpening();
+          expect(closeLink.focus).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('when autoFocusCloseIcon is true', () => {
+      it('does not set focus on close icon if no close icon shown', () => {
+      });
+    });
+  });
+
+  describe('onClosing', () => {
+    it('calls this.props.onClosing if defined', () => {
+      const wrapper = mount(
+        <Dialog
+          onCancel={ () => {} }
+          onConfirm={ () => {} }
+          showCloseIcon
+          subtitle='Test'
+          title='Test'
+          ariaRole='dialog'
+        />
+      );
+      const onClosing = jasmine.createSpy('onClosing');
+      wrapper.setProps({
+        onClosing
+      });
+
+      wrapper.setProps({ open: true });
+
+      expect(wrapper.props().onClosing).toHaveBeenCalled();
+    });
+  });
+
   describe('a11y', () => {
     let wrapper;
 
@@ -370,28 +453,6 @@ describe('Dialog', () => {
       it('renders an aria-describedby attribute pointing at the subtitle element', () => {
         expect(wrapper.find('[aria-describedby="carbon-dialog-subtitle"]').exists()).toBe(false);
       });
-    });
-
-    it('focuses on the dialog when opened', () => {
-      wrapper.setProps({
-        open: false
-      });
-      instance = wrapper.instance();
-      spyOn(instance, 'focusDialog');
-
-      wrapper.setProps({
-        open: true
-      });
-      expect(instance.focusDialog).toHaveBeenCalled();
-    });
-
-    it('returns focus to the dialog element when focus leaves the close icon', () => {
-      const dialogElement = wrapper.find('[role="dialog"]').first().getDOMNode();
-      spyOn(dialogElement, 'focus');
-
-      const closeIcon = wrapper.find('[data-element="close"]');
-      closeIcon.simulate('blur');
-      expect(dialogElement.focus).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/dialog/__spec__.js
+++ b/src/components/dialog/__spec__.js
@@ -398,6 +398,39 @@ describe('Dialog', () => {
     });
   });
 
+  describe('onCloseClick', () => {
+    const mockEvent = {
+      preventDefault() {}
+    };
+
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = mount(
+        <Dialog 
+          open
+        />
+      );
+    });
+
+    it('prevents the default click action', () => {
+      spyOn(mockEvent, 'preventDefault');
+
+      wrapper.instance().onCloseClick(mockEvent);
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+    });
+
+    it('calls this.props.onCancel if passed via props', () => {
+      const onCancel = jasmine.createSpy('onCancel');
+      wrapper.setProps({
+        onCancel
+      });
+
+      wrapper.instance().onCloseClick(mockEvent);
+      expect(wrapper.props().onCancel).toHaveBeenCalled();
+    });
+  });
+
   describe('a11y', () => {
     let wrapper;
 

--- a/src/components/dialog/definition.js
+++ b/src/components/dialog/definition.js
@@ -23,13 +23,29 @@ const definition = new Definition('dialog', Dialog, {
     title: 'Example Title for a Dialog',
     children: 'This is an example of a dialog.'
   },
+  hiddenProps: [
+    'ariaRole',
+    'onCloseKeyDown',
+    'onClosing',
+    'onOpening'
+  ],
   propTypes: {
-    title: 'String',
-    size: 'String',
+    ariaRole: 'String',
+    autoFocusCloseIcon: 'Boolean',
+    onCloseKeyDown: 'Function',
+    onClosing: 'Function',
+    onOpening: 'Function',
     showCloseIcon: 'Boolean',
-    subtitle: 'String'
+    size: 'String',
+    subtitle: 'String',
+    title: 'String'
   },
   propDescriptions: {
+    ariaRole: 'The ARIA role to apply to the dialog. Defaults to dialog.',
+    autoFocusCloseIcon: 'If set to true then the close icon receives keyboard focus when the dialog opens',
+    onCloseKeyDown: 'Callback function for the close icon keydown event',
+    onClosing: 'Callback function for when the dialog closes',
+    onOpening: 'Callback function for when the dialog opens',
     showCloseIcon: 'Set this prop to false to hide the close icon within the dialog.',
     size: `Change this prop to set the dialog to a specific size. Possible values include:
      ${OptionsHelper.sizesFull.join(', ')}`,

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -116,6 +116,7 @@ class Dialog extends Modal {
   constructor(args) {
     super(args);
     this.componentTags = this.componentTags.bind(this);
+    this.onCloseClick = this.onCloseClick.bind(this);
   }
 
   /**
@@ -271,7 +272,7 @@ class Dialog extends Modal {
       const closeProps = {
         className: 'carbon-dialog__close',
         'data-element': 'close',
-        onClick: this.props.onCancel,
+        onClick: this.onCloseClick,
         title: 'Close',
         onKeyDown: this.props.onCloseKeyDown
       };
@@ -288,6 +289,17 @@ class Dialog extends Modal {
       );
     }
     return null;
+  }
+
+  /**
+   * Event handler to handle clicks on
+   * the close icon.
+   */
+  onCloseClick(ev) {
+    ev.preventDefault();
+    if (this.props.onCancel) {
+      this.props.onCancel(ev);
+    }
   }
 
   componentTags(props) {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -22,8 +22,8 @@ import Browser from './../../utils/helpers/browser';
  *
  * Override several methods
  *
- * get onOpening() // Called by componentDidUpdate when dialog opens
- * get onClosing() // Called by componentDidUpdate when dialog closes
+ * onOpening() // Called by componentDidUpdate when dialog opens
+ * onClosing() // Called by componentDidUpdate when dialog closes
  * get mainClasses() // Classes to apply to parent div
  * get modalHTML() // JSX displayed when open
  * get transitionName() // Transisition name for CSSTransitionGroup
@@ -140,11 +140,11 @@ class Modal extends React.Component {
 
     if (this.props.open && !this.listening) {
       this.listening = true;
-      this.onOpening; // eslint-disable-line no-unused-expressions
+      this.onOpening(); // eslint-disable-line no-unused-expressions
       _window.addEventListener('keyup', this.closeModal);
     } else if (!this.props.open) {
       this.listening = false;
-      this.onClosing; // eslint-disable-line no-unused-expressions
+      this.onClosing(); // eslint-disable-line no-unused-expressions
       _window.removeEventListener('keyup', this.closeModal);
     }
   }
@@ -180,9 +180,9 @@ class Modal extends React.Component {
   }
 
   // Called after the modal opens
-  get onOpening() { return null; }
+  onOpening() { return null; }
   // Called after the modal closes
-  get onClosing() { return null; }
+  onClosing() { return null; }
   // Classes for parent div
   get mainClasses() { return null; }
   // Modal HTML shown when open


### PR DESCRIPTION
An issue was found in Dialog where the changes made in #1340 conflicted with trying to set the focus to the first form field in a Dialog: it would the focus to the form field, then change the focus to the dialog element and trigger a validation error if the form field was a required field.

The fix involved:

* Removing the `focusDialog` from `Dialog`, and adding props for `onOpening`, `onClosing`, `onCloseKeyDown`, and `autoFocusCloseIcon`.

* Making `Alert` no longer inherit from `Dialog`. Instead it is composed of a `Dialog` with the props set accordingly.

The `autoFocusCloseIcon` prop takes a boolean value:

* if true then the close icon receives focus when the dialog opens

* if false then the close icon does not receive focus when the dialog opens (the develop is then free to set focus as they see fit).

A further change was made to the close icon in the `Dialog`. It renders an `Icon` wrapped in an `<a>` tag. This fixes an issue where if the close icon had keyboard focus, you couldn't close the dialog by pressing the Enter key: now you can.

# TODO
- [x] Release notes
