### PR TITLE
Resolve warnings appearing in console and test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,5 +50,5 @@ gulp.task('deploy', ['prepare-demo', 'build', 'run-deploy']);
 
 gulp.task('test', SpecTask({
   path: '/src/***/**/!(__spec__|definition).js',
-  eslintThreshold: 17
+  eslintThreshold: 11
 }));

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -263,7 +263,7 @@ class Table extends React.Component {
      * @property tbody
      * @type {Object}
      */
-    tbody: React.PropTypes.bool,
+    tbody: PropTypes.bool,
 
     /**
      * A string to render as the table's caption
@@ -271,7 +271,7 @@ class Table extends React.Component {
      * @property caption
      * @type string
      */
-    caption: React.PropTypes.string,
+    caption: PropTypes.string,
 
     /**
      * Renders as light or dark
@@ -280,7 +280,7 @@ class Table extends React.Component {
      * @property theme
      * @type string
      */
-    theme: React.PropTypes.string
+    theme: PropTypes.string
   }
 
   static childContextTypes = {

--- a/src/utils/decorators/tooltip-decorator/tooltip-decorator.js
+++ b/src/utils/decorators/tooltip-decorator/tooltip-decorator.js
@@ -206,7 +206,7 @@ const TooltipDecorator = ComposedComponent => class Component extends ComposedCo
    * @return {DOM node}
    */
   getTarget = () => {
-    return ReactDOM.findDOMNode(this._target); // eslint-disable-line no-find-dom-node
+    return ReactDOM.findDOMNode(this._target); // eslint-disable-line react/no-find-dom-node
   }
 
   /**
@@ -216,7 +216,7 @@ const TooltipDecorator = ComposedComponent => class Component extends ComposedCo
    * @return {DOM node}
    */
   getTooltip = () => {
-    return ReactDOM.findDOMNode(this._tooltip); // eslint-disable-line no-find-dom-node
+    return ReactDOM.findDOMNode(this._tooltip); // eslint-disable-line react/no-find-dom-node
   }
 
   /**

--- a/src/utils/flux/store/store.js
+++ b/src/utils/flux/store/store.js
@@ -7,7 +7,7 @@ import { EventEmitter } from 'events';
  * @type String
  * @final
  */
-const CHANGE_EVENT = "change";
+const CHANGE_EVENT = 'change';
 
 /**
  * A base class that can be used to extend a store with boilerplate to work with
@@ -59,12 +59,16 @@ export default class Store extends EventEmitter {
 
     // tell the developer if they have not defined the name property.
     if (!name) {
-      throw new Error(`You need to initialize your store with a name. Check the initialization of ${this.constructor.name}.`);
+      throw new Error(
+        `You need to initialize your store with a name. Check the initialization of ${this.constructor.name}.`
+      );
     }
 
     // tell the developer if they have not defined the data property.
     if (!data) {
-      throw new Error(`You need to initialize your store with data. Check the initialization of ${this.constructor.name}.`);
+      throw new Error(
+        `You need to initialize your store with data. Check the initialization of ${this.constructor.name}.`
+      );
     }
 
     // it is required to initialize the store with the dispatcher so we can register
@@ -157,7 +161,7 @@ export default class Store extends EventEmitter {
    */
   dispatcherCallback = (action) => {
     if (!action.actionType) {
-      throw new Error("You are dispatching an invalid action (maybe the constant is incorrect or missing)");
+      throw new Error('You are dispatching an invalid action (maybe the constant is incorrect or missing)');
     }
 
     // We determine if the store has the actionType available as a function.


### PR DESCRIPTION
# Description
When the table component is being loaded, there were warnings appearing in the console and test logs due to using react.proptypes. This removes them and a couple others.