### PR TITLE
CARBON-903 Add autoFocus prop to Dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # 1.2.1
 
-## Bug Fixes
-
-* `Dialog Full screen`: The `carbon-dialog-full-screen--open` class is now applied to the `html` element instead of the `body`.
-
 ## Linting Updates
 
 The following have had minor internal changes to satisfy the introduction of stricter linting rules:
@@ -22,7 +18,9 @@ The following have had minor internal changes to satisfy the introduction of str
 * Text
 
 ## Bug Fixes
-* Input prefix was hidden when error was present
+* `Dialog` now has a `autoFocus` boolean property. You can set this to `false` if you don't want the dialog to receive keyboard focus when it opens e.g. if your dialog contains form fields that you want to set the focus on instead.
+* `Dialog Full screen`: The `carbon-dialog-full-screen--open` class is now applied to the `html` element instead of the `body`.
+* `Input`: the prefix was hidden when an error was present on the input element.
 
 # 1.2.0
 

--- a/src/components/dialog/__spec__.js
+++ b/src/components/dialog/__spec__.js
@@ -27,12 +27,32 @@ describe('Dialog', () => {
           expect(instance.centerDialog).toHaveBeenCalled();
         });
 
-        it('focuses on the dialog', () => {
-          spyOn(Dialog.prototype, 'focusDialog');
-          mount(
-            <Dialog open onCancel={ onCancel } />
-          );
-          expect(Dialog.prototype.focusDialog).toHaveBeenCalled();
+        describe('when autoFocus is true', () => {
+          it('focuses on the dialog', () => {
+            spyOn(Dialog.prototype, 'focusDialog');
+            mount(
+              <Dialog
+                open
+                onCancel={ onCancel }
+                autoFocus
+              />
+            );
+            expect(Dialog.prototype.focusDialog).toHaveBeenCalled();
+          });
+        });
+
+        describe('when autoFocus is false', () => {
+          it('does not focus on the dialog', () => {
+            spyOn(Dialog.prototype, 'focusDialog');
+            mount(
+              <Dialog
+                open
+                onCancel={ onCancel }
+                autoFocus={ false }
+              />
+            );
+            expect(Dialog.prototype.focusDialog).not.toHaveBeenCalled();
+          });
         });
       });
 
@@ -372,17 +392,36 @@ describe('Dialog', () => {
       });
     });
 
-    it('focuses on the dialog when opened', () => {
-      wrapper.setProps({
-        open: false
-      });
-      instance = wrapper.instance();
-      spyOn(instance, 'focusDialog');
+    describe('when autoFocus is true', () => {
+      it('focuses on the dialog when opened', () => {
+        wrapper.setProps({
+          open: false,
+          autoFocus: true
+        });
+        instance = wrapper.instance();
+        spyOn(instance, 'focusDialog');
 
-      wrapper.setProps({
-        open: true
+        wrapper.setProps({
+          open: true
+        });
+        expect(instance.focusDialog).toHaveBeenCalled();
       });
-      expect(instance.focusDialog).toHaveBeenCalled();
+    });
+
+    describe('when autoFocus is false', () => {
+      it('does not focus on the dialog when opened', () => {
+        wrapper.setProps({
+          open: false,
+          autoFocus: false
+        });
+        instance = wrapper.instance();
+        spyOn(instance, 'focusDialog');
+
+        wrapper.setProps({
+          open: true
+        });
+        expect(instance.focusDialog).not.toHaveBeenCalled();
+      });
     });
 
     it('returns focus to the dialog element when focus leaves the close icon', () => {

--- a/src/components/dialog/definition.js
+++ b/src/components/dialog/definition.js
@@ -24,12 +24,14 @@ const definition = new Definition('dialog', Dialog, {
     children: 'This is an example of a dialog.'
   },
   propTypes: {
+    autoFocus: 'Boolean',
     title: 'String',
     size: 'String',
     showCloseIcon: 'Boolean',
     subtitle: 'String'
   },
   propDescriptions: {
+    autoFocus: 'When set to true the dialog will receive keyboard focus when it opens.',
     showCloseIcon: 'Set this prop to false to hide the close icon within the dialog.',
     size: `Change this prop to set the dialog to a specific size. Possible values include:
      ${OptionsHelper.sizesFull.join(', ')}`,

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -60,16 +60,27 @@ class Dialog extends Modal {
     size: PropTypes.string,
 
     /**
-     * Determins if the close icon is shown
+     * Determines if the close icon is shown
      *
      * @property showCloseIcon
      * @type {Boolean}
      * @default true
      */
-    showCloseIcon: PropTypes.bool
+    showCloseIcon: PropTypes.bool,
+
+    /**
+     * If true then the dialog receives focus
+     * when it opens
+     *
+     * @property autoFocus
+     * @type {Boolean}
+     * @default false
+     */
+    autoFocus: PropTypes.bool
   })
 
   static defaultProps = {
+    autoFocus: true,
     size: 'medium',
     showCloseIcon: true,
     ariaRole: 'dialog'
@@ -91,7 +102,9 @@ class Dialog extends Modal {
   componentDidMount() {
     if (this.props.open) {
       this.centerDialog();
-      this.focusDialog();
+      if (this.props.autoFocus) {
+        this.focusDialog();
+      }
     }
   }
 
@@ -126,7 +139,9 @@ class Dialog extends Modal {
    */
   get onOpening() {
     this.centerDialog();
-    this.focusDialog();
+    if (this.props.autoFocus) {
+      this.focusDialog();
+    }
     this.window().addEventListener('resize', this.centerDialog);
   }
 
@@ -300,13 +315,12 @@ class Dialog extends Modal {
         { ...this.componentTags(this.props) }
         onBlur={ this.onDialogBlur }
       >
-        { this.closeIcon }
-
         { this.dialogTitle }
 
         <div className='carbon-dialog__content'>
           { this.props.children }
         </div>
+        { this.closeIcon }
       </div>
     );
   }


### PR DESCRIPTION
Add a `autoFocus` prop to `Dialog`. This helps control how focus is handled by the dialog:

* If `autoFocus` is true then the dialog element receives keyboard focus when the dialog opens

* If `autoFocus` is false then the dialog element doesn't receive keyboard focus when the dialog opens. Instead the developer is free to set the focus on e.g. a form field within the dialog.

In addition the close icon has been moved so it is the last child of the dialog. This should help manage the focus within the dialog better, as when focus leaves the close icon you should be safe to return focus to the dialog element without skipping any other child elements that can receive keyboard focus.

