### PR TITLE
Sticky dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   * Dialog will attach to the bottom of the browser if it gets too tall, and it's content will become scrollable.
   * If a dialog has a form, the form buttons will become sticky to the bottom of the dialog while the dialog is attached to the bottom of the browser.
   * Dialog can now use a prop called `height`, allowing developers to specify a set height for the dialog (the dialog will still attach to the bottom of the browser if it is taller than the browser's height).
+* Form
+  * Now has a prop of `stickyFooter` which when `true` will enable a sticky footer when it is off the screen.
+  * Now has a prop of `stickyFooterPadding` which will add additional padding to the form buttons when they are sticky (useful for aligning the form buttons between sticky and non-sticky states).
 
 # 1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.3.0
+
+## Component Ehancements
+
+* Dialog
+  * Screen is no longer scrollable when a dialog is open.
+  * Dialog will attach to the bottom of the browser if it gets too tall, and it's content will become scrollable.
+  * If a dialog has a form, the form buttons will become sticky to the bottom of the dialog while the dialog is attached to the bottom of the browser.
+  * Dialog can now use a prop called `height`, allowing developers to specify a set height for the dialog (the dialog will still attach to the bottom of the browser if it is taller than the browser's height).
+
 # 1.2.1
 
 ## Bug Fixes

--- a/src/components/app-wrapper/__spec__.js
+++ b/src/components/app-wrapper/__spec__.js
@@ -8,7 +8,7 @@ describe('app wrapper', () => {
   let instance, wrapper;
 
   beforeEach(() => {
-    instance = TestUtils.renderIntoDocument( <AppWrapper className='foobar'>foo</AppWrapper>);
+    instance = TestUtils.renderIntoDocument(<AppWrapper className='foobar'>foo</AppWrapper>);
     wrapper = shallow(<AppWrapper className='foobar' data-element='app-wrapper' data-role='contacts'>foo</AppWrapper>);
   });
 
@@ -20,6 +20,12 @@ describe('app wrapper', () => {
   it('renders with correct classes', () => {
     let div = TestUtils.findRenderedDOMComponentWithTag(instance, 'div');
     expect(div.className).toEqual('carbon-app-wrapper foobar');
+  });
+
+  it('renders with additional html attributes', () => {
+    instance = TestUtils.renderIntoDocument(<AppWrapper style={{ color: 'red' }}>foo</AppWrapper>);
+    let div = TestUtils.findRenderedDOMComponentWithTag(instance, 'div');
+    expect(div.style.color).toEqual('red');
   });
 
   describe("tags", () => {

--- a/src/components/app-wrapper/app-wrapper.js
+++ b/src/components/app-wrapper/app-wrapper.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import tagComponent from '../../utils/helpers/tags';
+import { validProps } from '../../utils/ether';
 
 /**
  * Manages the width and containment of your application.
@@ -48,7 +49,7 @@ class AppWrapper extends React.Component {
    */
   render() {
     return (
-      <div className={ this.classes() } { ...tagComponent('app-wrapper', this.props) }>
+      <div { ...validProps(this) } className={ this.classes() } { ...tagComponent('app-wrapper', this.props) }>
         { this.props.children }
       </div>
     );

--- a/src/components/confirm/__spec__.js
+++ b/src/components/confirm/__spec__.js
@@ -32,6 +32,11 @@ describe('Confirm', () => {
   describe('confirmButtons', () => {
     let yes, no, yesButton, noButton;
 
+    it('renders with the buttons and clearfix classes', () => {
+      let buttons = TestUtils.findRenderedDOMComponentWithClass(instance, 'carbon-confirm__buttons');
+      expect(buttons.classList).toMatch('clearfix');
+    });
+
     describe('yes button', () => {
       beforeEach(() => {
         yes = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'carbon-confirm__button')[1]

--- a/src/components/confirm/confirm.js
+++ b/src/components/confirm/confirm.js
@@ -5,6 +5,7 @@ import { assign } from 'lodash';
 import PropTypes from 'prop-types';
 import Dialog from '../dialog';
 import Button from '../button';
+import CSS from './../../utils/css';
 
 /**
  * A Confirm widget.
@@ -100,9 +101,11 @@ class Confirm extends Dialog {
    * @method confirmButtons
    * @return {Object} JSX yes and no buttons
    */
-  get confirmButtons() {
+  additionalContent() {
+    const classes = `carbon-confirm__buttons ${CSS.clearfix}`;
+
     return (
-      <div key='confirm-buttons' className='carbon-confirm__buttons' >
+      <div key='confirm-buttons' className={ classes }>
         <div className='carbon-confirm__button carbon-confirm__no'>
           <Button as='secondary' onClick={ this.props.onCancel } data-element='cancel'>
             { this.props.cancelLabel || I18n.t('confirm.no', { defaultValue: 'No' }) }
@@ -116,18 +119,6 @@ class Confirm extends Dialog {
         </div>
       </div>
     );
-  }
-
-  /**
-   * Returns HTML and text for the confirm body. Appends the two
-   * confirm buttons to super dialogHTML
-   *
-   * @method dialogTitle
-   */
-  get modalHTML() {
-    const dialog = super.modalHTML,
-        children = [].concat(dialog.props.children, this.confirmButtons);
-    return React.cloneElement(dialog, {}, children);
   }
 
   componentTags(props) {

--- a/src/components/dialog-full-screen/__spec__.js
+++ b/src/components/dialog-full-screen/__spec__.js
@@ -90,7 +90,7 @@ describe('DialogFullScreen', () => {
 
     it('adds a carbon-dialog-full-screen--open class to the body', () => {
       const html = wrapper.instance().document.documentElement;
-      expect(html.className).toEqual('carbon-dialog-full-screen--open');
+      expect(html.className).toMatch('carbon-dialog-full-screen--open');
     });
   });
 
@@ -102,9 +102,9 @@ describe('DialogFullScreen', () => {
 
     it('removes a carbon-dialog-full-screen--open class to the body', () => {
       const html = wrapper.instance().document.documentElement;
-      expect(html.className).toEqual('carbon-dialog-full-screen--open');
+      expect(html.className).toMatch('carbon-dialog-full-screen--open');
       wrapper.setProps({ open: false });
-      expect(html.className).toEqual('');
+      expect(html.className).not.toMatch('carbon-dialog-full-screen--open');
     });
   });
 

--- a/src/components/dialog/__spec__.js
+++ b/src/components/dialog/__spec__.js
@@ -75,7 +75,8 @@ describe('Dialog', () => {
       beforeEach(() => {
         mockWindow = {
           addEventListener() {},
-          removeEventListener() {}
+          removeEventListener() {},
+          getComputedStyle() { return {} }
         };
 
         spyOn(Browser, 'getWindow').and.returnValue(mockWindow);

--- a/src/components/dialog/__spec__.js
+++ b/src/components/dialog/__spec__.js
@@ -7,6 +7,7 @@ import Dialog from './dialog';
 import Button from './../button';
 import { Row, Column } from './../row';
 import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
+import ElementResize from './../../utils/helpers/element-resize';
 
 describe('Dialog', () => {
   let instance, onCancel;
@@ -95,12 +96,15 @@ describe('Dialog', () => {
         });
 
         it('sets up event listeners to resize and close the dialog', () => {
+          const instance = wrapper.instance();
+          spyOn(ElementResize, 'addListener');
           spyOn(mockWindow, 'addEventListener');
 
           wrapper.setProps({ title: 'Dialog title' });
           expect(mockWindow.addEventListener.calls.count()).toEqual(2);
           expect(mockWindow.addEventListener).toHaveBeenCalledWith('resize', instance.centerDialog);
           expect(mockWindow.addEventListener).toHaveBeenCalledWith('keyup', instance.closeModal);
+          expect(ElementResize.addListener).toHaveBeenCalledWith(instance._innerContent, instance.applyFixedBottom);
         });
 
         describe('when the dialog is already listening', () => {
@@ -120,18 +124,21 @@ describe('Dialog', () => {
       describe('when the dialog is closed', () => {
         beforeEach(() => {
           wrapper = mount(
-            <Dialog open={ false } onCancel={ onCancel } />
+            <Dialog open={ true } onCancel={ onCancel } />
           );
           instance = wrapper.instance();
         });
 
         it('removes event listeners for resize and closing', () => {
+          const instance = wrapper.instance();
+          spyOn(ElementResize, 'removeListener');
           spyOn(mockWindow, 'removeEventListener');
-          wrapper.setProps({ title: 'Dialog closed' });
+          wrapper.setProps({ open: false });
 
           expect(mockWindow.removeEventListener.calls.count()).toEqual(2);
           expect(mockWindow.removeEventListener).toHaveBeenCalledWith('resize', instance.centerDialog);
           expect(mockWindow.removeEventListener).toHaveBeenCalledWith('keyup', instance.closeModal);
+          expect(ElementResize.removeListener).toHaveBeenCalledWith(instance._innerContent, instance.applyFixedBottom);
         });
       });
     });
@@ -173,11 +180,108 @@ describe('Dialog', () => {
       });
     });
 
-    describe('when ios', () => {
-      it('does not remove page y offset', () => {
-        Bowser.ios = true;
+    describe('when there is no content', () => {
+      it('does not apply height to the content', () => {
+        instance._content = undefined;
         instance.centerDialog();
-        expect(instance._dialog.style.top).toEqual('150px');
+        expect(instance._content).toEqual(undefined);
+      });
+    });
+
+    describe('when there is content and no title', () => {
+      it('applies height to content with 0 title', () => {
+        instance._content = { style: {}};
+        instance.centerDialog();
+        expect(instance._content.style.height).toEqual('calc(100% - 0px)');
+      });
+    });
+
+    describe('when there is content and a title', () => {
+      it('applies height to content based on title', () => {
+        instance._title = { offsetHeight: '100'};
+        instance._content = { style: {}};
+        instance.centerDialog();
+        expect(instance._content.style.height).toEqual('calc(100% - 100px)');
+      });
+    });
+
+    describe('when animating', () => {
+      beforeEach(() => {
+        jasmine.clock().install();
+      });
+
+      afterEach(() => {
+        jasmine.clock().uninstall();
+      });
+
+      it('applies the fixed bottom after 500ms', () => {
+        spyOn(instance, 'applyFixedBottom');
+        instance.centerDialog(true);
+        jasmine.clock().tick(500);
+        expect(instance.applyFixedBottom).toHaveBeenCalled();
+      });
+    });
+
+    describe('when not animating', () => {
+      it('applies the fixed bottom immediately', () => {
+        spyOn(instance, 'applyFixedBottom');
+        instance.centerDialog();
+        expect(instance.applyFixedBottom).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('applyFixedBottom', () => {
+    beforeEach(() => {
+      const wrapper = mount(
+        <Dialog onCancel={ onCancel } open />
+      );
+      instance = wrapper.instance();
+      spyOn(instance, 'forceUpdate');
+    });
+
+    describe('when it should have a fixed bottom', () => {
+      it('sets appliedFixedBottom and calls forceUpdate', () => {
+        instance._innerContent = {
+          offsetHeight: 100,
+          offsetTop: 100
+        };
+        instance._dialog = {
+          offsetTop: 10
+        };
+        instance.window = {
+          innerHeight: 100
+        };
+        instance.applyFixedBottom();
+        expect(instance.appliedFixedBottom).toBeTruthy();
+        expect(instance.forceUpdate).toHaveBeenCalled();
+      });
+    });
+
+    describe('when it should not have a fixed bottom', () => {
+      it('resets appliedFixedBottom and calls forceUpdate', () => {
+        instance._innerContent = {
+          offsetHeight: 10,
+          offsetTop: 10
+        };
+        instance._dialog = {
+          offsetTop: 10
+        };
+        instance.window = {
+          innerHeight: 100
+        };
+        instance.appliedFixedBottom = true;
+        instance.applyFixedBottom();
+        expect(instance.appliedFixedBottom).toBeFalsy();
+        expect(instance.forceUpdate).toHaveBeenCalled();
+      });
+
+      it('resets appliedFixedBottom and calls forceUpdate', () => {
+        instance._innerContent = undefined;
+        instance.appliedFixedBottom = true;
+        instance.applyFixedBottom();
+        expect(instance.appliedFixedBottom).toBeFalsy();
+        expect(instance.forceUpdate).toHaveBeenCalled();
       });
     });
   });
@@ -332,6 +436,14 @@ describe('Dialog', () => {
         'subtitle',
         'title'
       ]);
+    });
+  });
+
+  describe('height', () => {
+    it('adds the height as css', () => {
+      const wrapper = mount(<Dialog height="500" open />);
+      const div = wrapper.instance()._innerContent;
+      expect(div.style.minHeight).toEqual("calc(500px - 40px)");
     });
   });
 

--- a/src/components/dialog/definition.js
+++ b/src/components/dialog/definition.js
@@ -21,7 +21,7 @@ const definition = new Definition('dialog', Dialog, {
   },
   propValues: {
     title: 'Example Title for a Dialog',
-    children: '<Form><Textarea /></Form>'
+    children: '<Form>This is an example of a dialog.</Form>'
   },
   propTypes: {
     height: 'String',

--- a/src/components/dialog/definition.js
+++ b/src/components/dialog/definition.js
@@ -21,7 +21,7 @@ const definition = new Definition('dialog', Dialog, {
   },
   propValues: {
     title: 'Example Title for a Dialog',
-    children: '<Form><Tabs><Tab tabId="1" title="Tab 1"><Textarea rows="37"></Tab><Tab tabId="2" title="Tab 2"><Textarea rows="40" /></Tab></Tabs></Form>',
+    children: '<Form><Tabs><Tab tabId="1" title="Tab 1"><Textarea rows="37" /></Tab><Tab tabId="2" title="Tab 2"><Textarea rows="40" /></Tab></Tabs></Form>',
     height: "900px"
   },
   propTypes: {

--- a/src/components/dialog/definition.js
+++ b/src/components/dialog/definition.js
@@ -21,7 +21,7 @@ const definition = new Definition('dialog', Dialog, {
   },
   propValues: {
     title: 'Example Title for a Dialog',
-    children: '<Form><Textarea /></Form>'
+    children: '<Form>This is an example of a dialog.</Form>'
   },
   propTypes: {
     autoFocus: 'Boolean',

--- a/src/components/dialog/definition.js
+++ b/src/components/dialog/definition.js
@@ -21,7 +21,7 @@ const definition = new Definition('dialog', Dialog, {
   },
   propValues: {
     title: 'Example Title for a Dialog',
-    children: '<Form>An Example of a dialog.</Form>'
+    children: '<Form><Textarea /></Form>'
   },
   propTypes: {
     height: 'String',

--- a/src/components/dialog/definition.js
+++ b/src/components/dialog/definition.js
@@ -21,16 +21,17 @@ const definition = new Definition('dialog', Dialog, {
   },
   propValues: {
     title: 'Example Title for a Dialog',
-    children: '<Form><Tabs><Tab tabId="1" title="Tab 1"><div style={{ height: "400px", backgroundColor: "red"}} /></Tab><Tab tabId="2" title="Tab 2"><div style={{ height: "600px", backgroundColor: "red"}} /></Tab></Tabs></Form>',
-    height: "845px"
+    children: '<Form>An Example of a dialog.</Form>'
   },
   propTypes: {
+    height: 'String',
     title: 'String',
     size: 'String',
     showCloseIcon: 'Boolean',
     subtitle: 'String'
   },
   propDescriptions: {
+    height: 'Sets a value for a specific height the dialog should take (for example "500px").',
     showCloseIcon: 'Set this prop to false to hide the close icon within the dialog.',
     size: `Change this prop to set the dialog to a specific size. Possible values include:
      ${OptionsHelper.sizesFull.join(', ')}`,

--- a/src/components/dialog/definition.js
+++ b/src/components/dialog/definition.js
@@ -21,8 +21,8 @@ const definition = new Definition('dialog', Dialog, {
   },
   propValues: {
     title: 'Example Title for a Dialog',
-    children: '<Form><Tabs><Tab tabId="1" title="Tab 1"><Textarea rows="37" /></Tab><Tab tabId="2" title="Tab 2"><Textarea rows="40" /></Tab></Tabs></Form>',
-    height: "900px"
+    children: '<Form><Tabs><Tab tabId="1" title="Tab 1"><div style={{ height: "400px", backgroundColor: "red"}} /></Tab><Tab tabId="2" title="Tab 2"><div style={{ height: "600px", backgroundColor: "red"}} /></Tab></Tabs></Form>',
+    height: "845px"
   },
   propTypes: {
     title: 'String',

--- a/src/components/dialog/definition.js
+++ b/src/components/dialog/definition.js
@@ -21,7 +21,8 @@ const definition = new Definition('dialog', Dialog, {
   },
   propValues: {
     title: 'Example Title for a Dialog',
-    children: 'This is an example of a dialog.'
+    children: '<Tabs><Tab tabId="1" title="Tab 1"><Textarea /></Tab><Tab tabId="2" title="Tab 2"><Textarea rows="40" /></Tab></Tabs>',
+    minHeight: "825px"
   },
   propTypes: {
     title: 'String',

--- a/src/components/dialog/definition.js
+++ b/src/components/dialog/definition.js
@@ -21,8 +21,8 @@ const definition = new Definition('dialog', Dialog, {
   },
   propValues: {
     title: 'Example Title for a Dialog',
-    children: '<Tabs><Tab tabId="1" title="Tab 1"><Textarea /></Tab><Tab tabId="2" title="Tab 2"><Textarea rows="40" /></Tab></Tabs>',
-    minHeight: "825px"
+    children: '<Form><Tabs><Tab tabId="1" title="Tab 1"><Textarea rows="37"></Tab><Tab tabId="2" title="Tab 2"><Textarea rows="40" /></Tab></Tabs></Form>',
+    height: "900px"
   },
   propTypes: {
     title: 'String',

--- a/src/components/dialog/definition.js
+++ b/src/components/dialog/definition.js
@@ -21,7 +21,7 @@ const definition = new Definition('dialog', Dialog, {
   },
   propValues: {
     title: 'Example Title for a Dialog',
-    children: '<Form>This is an example of a dialog.</Form>'
+    children: '<Form><Textarea /></Form>'
   },
   propTypes: {
     autoFocus: 'Boolean',

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Bowser from 'bowser';
 import classNames from 'classnames';
 import { assign } from 'lodash';
 import PropTypes from 'prop-types';
@@ -7,7 +6,7 @@ import Browser from './../../utils/helpers/browser';
 import Icon from './../icon';
 import Modal from './../modal';
 import Heading from './../heading';
-import { addResizeListener, removeResizeListener } from './../../utils/helpers/element-resize';
+import ElementResize from './../../utils/helpers/element-resize';
 
 const DIALOG_OPEN_HTML_CLASS = 'carbon-dialog--open';
 
@@ -153,7 +152,7 @@ class Dialog extends Modal {
   get onOpening() {
     this.document.documentElement.classList.add(DIALOG_OPEN_HTML_CLASS);
     this.centerDialog(true);
-    addResizeListener(this._innerContent, this.applyFixedBottom);
+    ElementResize.addListener(this._innerContent, this.applyFixedBottom);
     this.window.addEventListener('resize', this.centerDialog);
 
     if (this.props.autoFocus) {
@@ -173,7 +172,7 @@ class Dialog extends Modal {
     this.appliedFixedBottom = false;
     this.document.documentElement.classList.remove(DIALOG_OPEN_HTML_CLASS);
     this.window.removeEventListener('resize', this.centerDialog);
-    removeResizeListener(this._innerContent, this.applyFixedBottom);
+    ElementResize.removeListener(this._innerContent, this.applyFixedBottom);
   }
 
   /**
@@ -185,8 +184,8 @@ class Dialog extends Modal {
    */
   centerDialog = (animating) => {
     const height = this._dialog.offsetHeight / 2,
-          width = this._dialog.offsetWidth / 2,
-          win = this.window;
+        width = this._dialog.offsetWidth / 2,
+        win = this.window;
 
     let midPointY = win.innerHeight / 2,
         midPointX = win.innerWidth / 2;
@@ -204,8 +203,8 @@ class Dialog extends Modal {
 
     if (this._content) {
       // apply height to content based on height of title
-      const height = this._title ? this._title.offsetHeight : '0';
-      this._content.style.height = `calc(100% - ${height}px)`;
+      const titleHeight = this._title ? this._title.offsetHeight : '0';
+      this._content.style.height = `calc(100% - ${titleHeight}px)`;
     }
 
     this._dialog.style.top = `${midPointY}px`;
@@ -214,7 +213,7 @@ class Dialog extends Modal {
     if (animating === true) {
       // cause timeout to accommodate dialog animating in
       setTimeout(() => {
-        this.applyFixedBottom(true);
+        this.applyFixedBottom();
       }, 500);
     } else {
       this.applyFixedBottom();
@@ -245,7 +244,7 @@ class Dialog extends Modal {
     if (!this._innerContent) { return false; }
 
     const contentHeight = this._innerContent.offsetHeight + this._innerContent.offsetTop,
-          windowHeight = this.window.innerHeight - this._dialog.offsetTop - 1;
+        windowHeight = this.window.innerHeight - this._dialog.offsetTop - 1;
 
     return contentHeight > windowHeight;
   }
@@ -259,8 +258,8 @@ class Dialog extends Modal {
   get dialogTitle() {
     if (!this.props.title) { return null; }
 
-    let title = this.props.title,
-        classes = classNames(
+    let title = this.props.title;
+    const classes = classNames(
           'carbon-dialog__title', {
             'carbon-dialog__title--has-subheader': this.props.subtitle
           }
@@ -278,7 +277,7 @@ class Dialog extends Modal {
     }
 
     return (
-      <div className={ classes } ref={ (c) => this._title = c }>{ title }</div>
+      <div className={ classes } ref={ (c) => { this._title = c; } }>{ title }</div>
     );
   }
 
@@ -361,7 +360,9 @@ class Dialog extends Modal {
       style: {
         minHeight: height
       }
-    }, style = {};
+    };
+
+    const style = {};
 
     if (this.props.ariaRole) {
       dialogProps.role = this.props.ariaRole;
@@ -388,8 +389,8 @@ class Dialog extends Modal {
       >
         { this.dialogTitle }
 
-        <div className='carbon-dialog__content' ref={ (c) => this._content = c }>
-          <div className='carbon-dialog__inner-content' ref={ (c) => this._innerContent = c } style={ style }>
+        <div className='carbon-dialog__content' ref={ (c) => { this._content = c; } }>
+          <div className='carbon-dialog__inner-content' ref={ (c) => { this._innerContent = c; } } style={ style }>
             { this.props.children }
             { this.additionalContent() }
           </div>

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -214,22 +214,19 @@ class Dialog extends Modal {
     this._dialog.style.left = `${midPointX}px`;
 
     if (animating === true) {
+      // cause timeout to accommodate dialog animating in
       setTimeout(() => {
         this.applyFixedBottom(true);
-      }, 0);
+      }, 500);
     } else {
       this.applyFixedBottom();
     }
   }
 
-  applyFixedBottom = (animating) => {
+  applyFixedBottom = () => {
     if (!this.appliedFixedBottom && this.shouldHaveFixedBottom()) {
       this.appliedFixedBottom = true;
-      let timeout = (animating === true) ? 500 : 0;
-      // cause timeout to accommodate dialog animating in
-      setTimeout(() => {
-        this.forceUpdate();
-      }, timeout);
+      this.forceUpdate();
     } else if (this.appliedFixedBottom && !this.shouldHaveFixedBottom()) {
       this.appliedFixedBottom = false;
       this.forceUpdate();

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -7,73 +7,7 @@ import Browser from './../../utils/helpers/browser';
 import Icon from './../icon';
 import Modal from './../modal';
 import Heading from './../heading';
-
-
-(function(){
-  var attachEvent = document.attachEvent;
-  var isIE = navigator.userAgent.match(/Trident/);
-  console.log(isIE);
-  var requestFrame = (function(){
-    var raf = window.requestAnimationFrame || window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame ||
-        function(fn){ return window.setTimeout(fn, 20); };
-    return function(fn){ return raf(fn); };
-  })();
-  
-  var cancelFrame = (function(){
-    var cancel = window.cancelAnimationFrame || window.mozCancelAnimationFrame || window.webkitCancelAnimationFrame ||
-           window.clearTimeout;
-    return function(id){ return cancel(id); };
-  })();
-  
-  function resizeListener(e){
-    var win = e.target || e.srcElement;
-    if (win.__resizeRAF__) cancelFrame(win.__resizeRAF__);
-    win.__resizeRAF__ = requestFrame(function(){
-      var trigger = win.__resizeTrigger__;
-      trigger.__resizeListeners__.forEach(function(fn){
-        fn.call(trigger, e);
-      });
-    });
-  }
-  
-  function objectLoad(e){
-    this.contentDocument.defaultView.__resizeTrigger__ = this.__resizeElement__;
-    this.contentDocument.defaultView.addEventListener('resize', resizeListener);
-  }
-  
-  window.addResizeListener = function(element, fn){
-    if (!element.__resizeListeners__) {
-      element.__resizeListeners__ = [];
-      if (attachEvent) {
-        element.__resizeTrigger__ = element;
-        element.attachEvent('onresize', resizeListener);
-      }
-      else {
-        if (getComputedStyle(element).position == 'static') element.style.position = 'relative';
-        var obj = element.__resizeTrigger__ = document.createElement('object'); 
-        obj.setAttribute('style', 'display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;');
-        obj.__resizeElement__ = element;
-        obj.onload = objectLoad;
-        obj.type = 'text/html';
-        if (isIE) element.appendChild(obj);
-        obj.data = 'about:blank';
-        if (!isIE) element.appendChild(obj);
-      }
-    }
-    element.__resizeListeners__.push(fn);
-  };
-  
-  window.removeResizeListener = function(element, fn){
-    element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1);
-    if (!element.__resizeListeners__.length) {
-      if (attachEvent) element.detachEvent('onresize', resizeListener);
-      else {
-        element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener);
-        element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__);
-      }
-    }
-  }
-})();
+import { addResizeListener, removeResizeListener } from './../../utils/helpers/element-resize';
 
 const DIALOG_OPEN_HTML_CLASS = 'carbon-dialog--open';
 
@@ -158,6 +92,7 @@ class Dialog extends Modal {
     this.onDialogBlur = this.onDialogBlur.bind(this);
     this.onCloseIconBlur = this.onCloseIconBlur.bind(this);
     this.document = Browser.getDocument();
+    this.window = Browser.getWindow();
     // create a function to be called specifically when the browser is resized,
     // so it can pass true as an arg
     this.centerOnResize = this.centerDialog.bind(this, true);
@@ -209,7 +144,8 @@ class Dialog extends Modal {
     this.document.documentElement.classList.add(DIALOG_OPEN_HTML_CLASS);
     this.centerDialog();
     this.focusDialog();
-    this.window().addEventListener('resize', this.centerOnResize);
+    this.window.addEventListener('resize', this.centerOnResize);
+    addResizeListener(this._innerContent, this.applyFixedBottom);
   }
 
   /**
@@ -222,18 +158,11 @@ class Dialog extends Modal {
    */
   get onClosing() {
     this.document.documentElement.classList.remove(DIALOG_OPEN_HTML_CLASS);
-    this.window().removeEventListener('resize', this.centerOnResize);
+    this.window.removeEventListener('resize', this.centerOnResize);
+    if (this._innerContent) {
+      removeResizeListener(this._innerContent, this.applyFixedBottom);
+    }
     this.appliedFixedBottom = false;
-  }
-
-  /**
-   * Returns the current window
-   *
-   * @method window
-   * @return {Object}
-   */
-  window = () => {
-    return Browser.getWindow();
   }
 
   /**
@@ -246,7 +175,7 @@ class Dialog extends Modal {
   centerDialog = (notRender) => {
     const height = this._dialog.offsetHeight / 2,
           width = this._dialog.offsetWidth / 2,
-          win = this.window();
+          win = this.window;
 
     let midPointY = win.innerHeight / 2,
         midPointX = win.innerWidth / 2;
@@ -262,25 +191,6 @@ class Dialog extends Modal {
       midPointX = 20;
     }
 
-    const f = (notRender) => {
-      if (!this.appliedFixedBottom && this.shouldHaveFixedBottom()) {
-        this.appliedFixedBottom = true;
-        let timeout = notRender ? 0 : 500;
-        // cause timeout to accommodate dialog animating in
-        setTimeout(() => {
-          this.forceUpdate();
-        }, timeout);
-      } else if (this.appliedFixedBottom && !this.shouldHaveFixedBottom()) {
-        this.appliedFixedBottom = false;
-        this.forceUpdate();
-      }
-    }
-    f(notRender);
-    if (this._dialog && !this.added) {
-      this.added = true;
-      addResizeListener(this._innerContent, f);
-    }
-
     if (this._content) {
       // apply height to content based on height of title
       const height = this._title ? this._title.offsetHeight : '0';
@@ -289,6 +199,22 @@ class Dialog extends Modal {
 
     this._dialog.style.top = `${midPointY}px`;
     this._dialog.style.left = `${midPointX}px`;
+
+    this.applyFixedBottom(notRender);
+  }
+
+  applyFixedBottom = (notRender) => {
+    if (!this.appliedFixedBottom && this.shouldHaveFixedBottom()) {
+      this.appliedFixedBottom = true;
+      let timeout = notRender ? 0 : 500;
+      // cause timeout to accommodate dialog animating in
+      setTimeout(() => {
+        this.forceUpdate();
+      }, timeout);
+    } else if (this.appliedFixedBottom && !this.shouldHaveFixedBottom()) {
+      this.appliedFixedBottom = false;
+      this.forceUpdate();
+    }
   }
 
   focusDialog() {
@@ -305,7 +231,7 @@ class Dialog extends Modal {
     if (!this._innerContent) { return false; }
 
     const contentHeight = this._innerContent.offsetHeight + this._innerContent.offsetTop,
-          windowHeight = this.window().innerHeight - this._dialog.offsetTop - 1;
+          windowHeight = this.window.innerHeight - this._dialog.offsetTop - 1;
 
     return contentHeight > windowHeight;
   }
@@ -405,13 +331,19 @@ class Dialog extends Modal {
    * @return {Object} JSX for dialog
    */
   get modalHTML() {
+    let height = this.props.height;
+
+    if (height && !height.match(/px$/)) {
+      height = `${height}px`;
+    }
+
     const dialogProps = {
       className: this.dialogClasses,
       tabIndex: 0,
       style: {
-        minHeight: this.props.height
+        minHeight: height
       }
-    };
+    }, style = {};
 
     if (this.props.ariaRole) {
       dialogProps.role = this.props.ariaRole;
@@ -425,9 +357,8 @@ class Dialog extends Modal {
       dialogProps['aria-describedby'] = 'carbon-dialog-subtitle';
     }
 
-    let s = {};
     if (this.props.height) {
-      s = { minHeight: `calc(${this.props.height} - 40px)` }
+      style.minHeight = `calc(${height} - 40px)`;
     }
 
     return (
@@ -442,7 +373,7 @@ class Dialog extends Modal {
         { this.dialogTitle }
 
         <div className='carbon-dialog__content' ref={ (c) => this._content = c }>
-          <div className='carbon-dialog__inner-content' ref={ (c) => this._innerContent = c } style={ s }>
+          <div className='carbon-dialog__inner-content' ref={ (c) => this._innerContent = c } style={ style }>
             { this.props.children }
           </div>
         </div>

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -8,6 +8,8 @@ import Icon from './../icon';
 import Modal from './../modal';
 import Heading from './../heading';
 
+const DIALOG_OPEN_HTML_CLASS = 'carbon-dialog--open';
+
 /**
  * A Dialog widget.
  *
@@ -80,6 +82,8 @@ class Dialog extends Modal {
     this.componentTags = this.componentTags.bind(this);
     this.onDialogBlur = this.onDialogBlur.bind(this);
     this.onCloseIconBlur = this.onCloseIconBlur.bind(this);
+    this.document = Browser.getDocument();
+    this.centerOnResize = this.centerDialog.bind(this, true);
   }
 
   /**
@@ -125,9 +129,10 @@ class Dialog extends Modal {
    * @return {Void}
    */
   get onOpening() {
+    this.document.documentElement.classList.add(DIALOG_OPEN_HTML_CLASS);
     this.centerDialog();
     this.focusDialog();
-    this.window().addEventListener('resize', this.centerDialog);
+    this.window().addEventListener('resize', this.centerOnResize);
   }
 
   /**
@@ -139,7 +144,9 @@ class Dialog extends Modal {
    * @return {Void}
    */
   get onClosing() {
-    this.window().removeEventListener('resize', this.centerDialog);
+    this.document.documentElement.classList.remove(DIALOG_OPEN_HTML_CLASS);
+    this.window().removeEventListener('resize', this.centerOnResize);
+    this.appliedFixedBottom = false;
   }
 
   /**
@@ -150,6 +157,7 @@ class Dialog extends Modal {
    */
   window = () => {
     return Browser.getWindow();
+    console.log(this._dialog);
   }
 
   /**
@@ -158,26 +166,35 @@ class Dialog extends Modal {
    * @method centerDialog
    * @return {void}
    */
-  centerDialog = () => {
+  centerDialog = (notRender) => {
     const height = this._dialog.offsetHeight / 2,
         width = this._dialog.offsetWidth / 2;
 
     const win = this.window();
 
-    let midPointY = (win.innerHeight / 2) + win.pageYOffset,
-        midPointX = (win.innerWidth / 2) + win.pageXOffset;
+    let midPointY = win.innerHeight / 2,
+        midPointX = win.innerWidth / 2;
 
     midPointY -= height;
     midPointX -= width;
 
     if (midPointY < 20) {
       midPointY = 20;
-    } else if (Bowser.ios) {
-      midPointY -= win.pageYOffset;
     }
 
     if (midPointX < 20) {
       midPointX = 20;
+    }
+
+    if (this.isFixedBottom() && !this.appliedFixedBottom) {
+      this.appliedFixedBottom = true;
+      let timeout = notRender ? 0 : 500;
+      setTimeout(() => {
+        this.forceUpdate();
+      }, timeout);
+    } else if (!this.isFixedBottom() && this.appliedFixedBottom) {
+      this.appliedFixedBottom = false;
+      this.forceUpdate();
     }
 
     this._dialog.style.top = `${midPointY}px`;
@@ -186,6 +203,10 @@ class Dialog extends Modal {
 
   focusDialog() {
     this._dialog.focus();
+  }
+
+  isFixedBottom = () => {
+    return !!this._dialog && (this.x.offsetHeight + this.x.offsetTop) > (this.window().innerHeight - 20);
   }
 
   /**
@@ -240,7 +261,9 @@ class Dialog extends Modal {
     return classNames(
       'carbon-dialog__dialog',
       {
-        [`carbon-dialog__dialog--${this.props.size}`]: typeof this.props.size !== 'undefined'
+        [`carbon-dialog__dialog--${this.props.size}`]: typeof this.props.size !== 'undefined',
+        'carbon-dialog__dialog--fixed-bottom': this.isFixedBottom(),
+        'carbon-dialog__dialog--min-height': this.props.minHeight
       }
     );
   }
@@ -278,7 +301,10 @@ class Dialog extends Modal {
   get modalHTML() {
     const dialogProps = {
       className: this.dialogClasses,
-      tabIndex: 0
+      tabIndex: 0,
+      style: {
+        maxHeight: this.props.minHeight
+      }
     };
 
     if (this.props.ariaRole) {
@@ -305,7 +331,9 @@ class Dialog extends Modal {
         { this.dialogTitle }
 
         <div className='carbon-dialog__content'>
-          { this.props.children }
+          <div className='carbon-dialog__inner-content' ref={ (c) => this.x = c }>
+            { this.props.children }
+          </div>
         </div>
       </div>
     );

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -8,6 +8,73 @@ import Icon from './../icon';
 import Modal from './../modal';
 import Heading from './../heading';
 
+
+(function(){
+  var attachEvent = document.attachEvent;
+  var isIE = navigator.userAgent.match(/Trident/);
+  console.log(isIE);
+  var requestFrame = (function(){
+    var raf = window.requestAnimationFrame || window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame ||
+        function(fn){ return window.setTimeout(fn, 20); };
+    return function(fn){ return raf(fn); };
+  })();
+  
+  var cancelFrame = (function(){
+    var cancel = window.cancelAnimationFrame || window.mozCancelAnimationFrame || window.webkitCancelAnimationFrame ||
+           window.clearTimeout;
+    return function(id){ return cancel(id); };
+  })();
+  
+  function resizeListener(e){
+    var win = e.target || e.srcElement;
+    if (win.__resizeRAF__) cancelFrame(win.__resizeRAF__);
+    win.__resizeRAF__ = requestFrame(function(){
+      var trigger = win.__resizeTrigger__;
+      trigger.__resizeListeners__.forEach(function(fn){
+        fn.call(trigger, e);
+      });
+    });
+  }
+  
+  function objectLoad(e){
+    this.contentDocument.defaultView.__resizeTrigger__ = this.__resizeElement__;
+    this.contentDocument.defaultView.addEventListener('resize', resizeListener);
+  }
+  
+  window.addResizeListener = function(element, fn){
+    if (!element.__resizeListeners__) {
+      element.__resizeListeners__ = [];
+      if (attachEvent) {
+        element.__resizeTrigger__ = element;
+        element.attachEvent('onresize', resizeListener);
+      }
+      else {
+        if (getComputedStyle(element).position == 'static') element.style.position = 'relative';
+        var obj = element.__resizeTrigger__ = document.createElement('object'); 
+        obj.setAttribute('style', 'display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;');
+        obj.__resizeElement__ = element;
+        obj.onload = objectLoad;
+        obj.type = 'text/html';
+        if (isIE) element.appendChild(obj);
+        obj.data = 'about:blank';
+        if (!isIE) element.appendChild(obj);
+      }
+    }
+    element.__resizeListeners__.push(fn);
+  };
+  
+  window.removeResizeListener = function(element, fn){
+    element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1);
+    if (!element.__resizeListeners__.length) {
+      if (attachEvent) element.detachEvent('onresize', resizeListener);
+      else {
+        element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener);
+        element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__);
+      }
+    }
+  }
+})();
+
 const DIALOG_OPEN_HTML_CLASS = 'carbon-dialog--open';
 
 /**
@@ -195,16 +262,23 @@ class Dialog extends Modal {
       midPointX = 20;
     }
 
-    if (!this.appliedFixedBottom && this.shouldHaveFixedBottom()) {
-      this.appliedFixedBottom = true;
-      let timeout = notRender ? 0 : 500;
-      // cause timeout to accommodate dialog animating in
-      setTimeout(() => {
+    const f = (notRender) => {
+      if (!this.appliedFixedBottom && this.shouldHaveFixedBottom()) {
+        this.appliedFixedBottom = true;
+        let timeout = notRender ? 0 : 500;
+        // cause timeout to accommodate dialog animating in
+        setTimeout(() => {
+          this.forceUpdate();
+        }, timeout);
+      } else if (this.appliedFixedBottom && !this.shouldHaveFixedBottom()) {
+        this.appliedFixedBottom = false;
         this.forceUpdate();
-      }, timeout);
-    } else if (this.appliedFixedBottom && !this.shouldHaveFixedBottom()) {
-      this.appliedFixedBottom = false;
-      this.forceUpdate();
+      }
+    }
+    f(notRender);
+    if (this._dialog && !this.added) {
+      this.added = true;
+      addResizeListener(this._innerContent, f);
     }
 
     if (this._content) {
@@ -231,7 +305,7 @@ class Dialog extends Modal {
     if (!this._innerContent) { return false; }
 
     const contentHeight = this._innerContent.offsetHeight + this._innerContent.offsetTop,
-          windowHeight = this.window().innerHeight - 20;
+          windowHeight = this.window().innerHeight - this._dialog.offsetTop - 1;
 
     return contentHeight > windowHeight;
   }
@@ -335,7 +409,7 @@ class Dialog extends Modal {
       className: this.dialogClasses,
       tabIndex: 0,
       style: {
-        maxHeight: this.props.height
+        minHeight: this.props.height
       }
     };
 
@@ -351,6 +425,11 @@ class Dialog extends Modal {
       dialogProps['aria-describedby'] = 'carbon-dialog-subtitle';
     }
 
+    let s = {};
+    if (this.props.height) {
+      s = { minHeight: `calc(${this.props.height} - 40px)` }
+    }
+
     return (
       <div
         ref={ (d) => { this._dialog = d; } }
@@ -363,7 +442,7 @@ class Dialog extends Modal {
         { this.dialogTitle }
 
         <div className='carbon-dialog__content' ref={ (c) => this._content = c }>
-          <div className='carbon-dialog__inner-content' ref={ (c) => this._innerContent = c }>
+          <div className='carbon-dialog__inner-content' ref={ (c) => this._innerContent = c } style={ s }>
             { this.props.children }
           </div>
         </div>

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -218,7 +218,12 @@ class Dialog extends Modal {
   get dialogTitle() {
     if (!this.props.title) { return null; }
 
-    let title = this.props.title;
+    let title = this.props.title,
+        classes = classNames(
+          'carbon-dialog__title', {
+            'carbon-dialog__title--has-subheader': this.props.subtitle
+          }
+        );
 
     if (typeof title === 'string') {
       title = (
@@ -232,7 +237,7 @@ class Dialog extends Modal {
     }
 
     return (
-      <div className='carbon-dialog__title'>{ title }</div>
+      <div className={ classes }>{ title }</div>
     );
   }
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -104,9 +104,6 @@ class Dialog extends Modal {
     this.onCloseIconBlur = this.onCloseIconBlur.bind(this);
     this.document = Browser.getDocument();
     this.window = Browser.getWindow();
-    // create a function to be called specifically when the browser is resized,
-    // so it can pass true as an arg
-    this.centerOnResize = this.centerDialog.bind(this, true);
   }
 
   /**
@@ -155,9 +152,9 @@ class Dialog extends Modal {
    */
   get onOpening() {
     this.document.documentElement.classList.add(DIALOG_OPEN_HTML_CLASS);
-    this.centerDialog();
+    this.centerDialog(true);
     addResizeListener(this._innerContent, this.applyFixedBottom);
-    this.window.addEventListener('resize', this.centerOnResize);
+    this.window.addEventListener('resize', this.centerDialog);
 
     if (this.props.autoFocus) {
       this.focusDialog();
@@ -173,12 +170,12 @@ class Dialog extends Modal {
    * @return {Void}
    */
   get onClosing() {
+    this.appliedFixedBottom = false;
     this.document.documentElement.classList.remove(DIALOG_OPEN_HTML_CLASS);
-    this.window.removeEventListener('resize', this.centerOnResize);
+    this.window.removeEventListener('resize', this.centerDialog);
     if (this._innerContent) {
       removeResizeListener(this._innerContent, this.applyFixedBottom);
     }
-    this.appliedFixedBottom = false;
   }
 
   /**
@@ -188,7 +185,7 @@ class Dialog extends Modal {
    * @param {Boolean} notRender - declares that the method was called not as part of the component lifecycle
    * @return {void}
    */
-  centerDialog = (notRender) => {
+  centerDialog = (animating) => {
     const height = this._dialog.offsetHeight / 2,
           width = this._dialog.offsetWidth / 2,
           win = this.window;
@@ -216,13 +213,19 @@ class Dialog extends Modal {
     this._dialog.style.top = `${midPointY}px`;
     this._dialog.style.left = `${midPointX}px`;
 
-    this.applyFixedBottom(notRender);
+    if (animating === true) {
+      setTimeout(() => {
+        this.applyFixedBottom(true);
+      }, 0);
+    } else {
+      this.applyFixedBottom();
+    }
   }
 
-  applyFixedBottom = (notRender) => {
+  applyFixedBottom = (animating) => {
     if (!this.appliedFixedBottom && this.shouldHaveFixedBottom()) {
       this.appliedFixedBottom = true;
-      let timeout = notRender ? 0 : 500;
+      let timeout = (animating === true) ? 500 : 0;
       // cause timeout to accommodate dialog animating in
       setTimeout(() => {
         this.forceUpdate();
@@ -310,7 +313,7 @@ class Dialog extends Modal {
       'carbon-dialog__dialog',
       {
         [`carbon-dialog__dialog--${this.props.size}`]: typeof this.props.size !== 'undefined',
-        'carbon-dialog__dialog--fixed-bottom': this.shouldHaveFixedBottom(),
+        'carbon-dialog__dialog--fixed-bottom': this.appliedFixedBottom,
         'carbon-dialog__dialog--has-height': this.props.height
       }
     );

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -33,6 +33,8 @@ const DIALOG_OPEN_HTML_CLASS = 'carbon-dialog--open';
 class Dialog extends Modal {
 
   static propTypes = assign({}, Modal.propTypes, {
+    height: PropTypes.string,
+
     /**
      * Title displayed at top of dialog
      *

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -263,7 +263,7 @@ class Dialog extends Modal {
       {
         [`carbon-dialog__dialog--${this.props.size}`]: typeof this.props.size !== 'undefined',
         'carbon-dialog__dialog--fixed-bottom': this.isFixedBottom(),
-        'carbon-dialog__dialog--min-height': this.props.minHeight
+        'carbon-dialog__dialog--has-height': this.props.height
       }
     );
   }
@@ -303,7 +303,7 @@ class Dialog extends Modal {
       className: this.dialogClasses,
       tabIndex: 0,
       style: {
-        maxHeight: this.props.minHeight
+        maxHeight: this.props.height
       }
     };
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -199,6 +199,12 @@ class Dialog extends Modal {
       this.forceUpdate();
     }
 
+    if (this._content) {
+      // apply height to content based on height of title
+      const height = this._title ? this._title.offsetHeight : '0';
+      this._content.style.height = `calc(100% - ${height}px)`;
+    }
+
     this._dialog.style.top = `${midPointY}px`;
     this._dialog.style.left = `${midPointX}px`;
   }
@@ -208,7 +214,12 @@ class Dialog extends Modal {
   }
 
   isFixedBottom = () => {
-    return !!this._dialog && (this.x.offsetHeight + this.x.offsetTop) > (this.window().innerHeight - 20);
+    if (!this._innerContent) { return false; }
+
+    const contentHeight = this._innerContent.offsetHeight + this._innerContent.offsetTop,
+          windowHeight = this.window().innerHeight - 20;
+
+    return contentHeight > windowHeight;
   }
 
   /**
@@ -239,7 +250,7 @@ class Dialog extends Modal {
     }
 
     return (
-      <div className={ classes }>{ title }</div>
+      <div className={ classes } ref={ (c) => this._title = c }>{ title }</div>
     );
   }
 
@@ -337,8 +348,8 @@ class Dialog extends Modal {
 
         { this.dialogTitle }
 
-        <div className='carbon-dialog__content'>
-          <div className='carbon-dialog__inner-content' ref={ (c) => this.x = c }>
+        <div className='carbon-dialog__content' ref={ (c) => this._content = c }>
+          <div className='carbon-dialog__inner-content' ref={ (c) => this._innerContent = c }>
             { this.props.children }
           </div>
         </div>

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -173,9 +173,7 @@ class Dialog extends Modal {
     this.appliedFixedBottom = false;
     this.document.documentElement.classList.remove(DIALOG_OPEN_HTML_CLASS);
     this.window.removeEventListener('resize', this.centerDialog);
-    if (this._innerContent) {
-      removeResizeListener(this._innerContent, this.applyFixedBottom);
-    }
+    removeResizeListener(this._innerContent, this.applyFixedBottom);
   }
 
   /**
@@ -340,6 +338,10 @@ class Dialog extends Modal {
     };
   }
 
+  additionalContent() {
+    return null;
+  }
+
   /**
    * Returns the computed HTML for the dialog.
    *
@@ -389,6 +391,7 @@ class Dialog extends Modal {
         <div className='carbon-dialog__content' ref={ (c) => this._content = c }>
           <div className='carbon-dialog__inner-content' ref={ (c) => this._innerContent = c } style={ style }>
             { this.props.children }
+            { this.additionalContent() }
           </div>
         </div>
         { this.closeIcon }

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -73,10 +73,11 @@ $dialog-sizes: (
 .carbon-dialog__dialog--fixed-bottom {
   border-radius: 5px 5px 0 0;
   bottom: 0;
+  min-height: 0px !important;
 
   .carbon-form .carbon-form__footer-wrapper {
     margin-left: -($dialog-padding);
-    left: initial;
+    left: auto;
     padding-left: $dialog-padding;
     padding-right: $dialog-padding;
   }

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -51,11 +51,9 @@ $dialog-sizes: (
 .carbon-dialog__inner-content {
   padding: $dialog-padding;
   position: relative;
-  min-height: calc(100% - #{$dialog-padding * 2});
 }
 
 .carbon-dialog__dialog--has-height {
-  height: calc(100% - #{$dialog-padding - 1}); // remove 1 pixel so to prevent jutter
 
   .carbon-form {
     padding-bottom: 80px;
@@ -66,6 +64,10 @@ $dialog-sizes: (
     bottom: $dialog-padding;
     width: calc(100% - #{$dialog-padding * 2});
   }
+  //
+  // .carbon-dialog__inner-content {
+  //   min-height: calc(100% - #{$dialog-padding * 2});
+  // }
 }
 
 @keyframes form-buttons-animate-in {

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -2,6 +2,35 @@
 @import "./../../style-config/z-index";
 
 $dialog-padding: 20px;
+$dialog-sizes: (
+  ('extra-small', 300px),
+  ('small', 380px),
+  ('medium-small', 540px),
+  ('medium', 750px),
+  ('medium-large', 850px),
+  ('large', 960px),
+  ('extra-large', 1080px)
+);
+
+@mixin dialog-size-css($name, $size) {
+  .carbon-dialog__dialog--#{$name} {
+    width: $size;
+
+    $form-buttons-width: $size - ($dialog-padding * 2);
+    &.carbon-dialog__dialog--fixed-bottom .carbon-form__buttons {
+      width: $form-buttons-width;
+
+      // IE10+ fix (caters for scrollbar width)
+      @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+        width: $form-buttons-width - 16;
+      }
+    }
+  }
+}
+
+@each $size in $dialog-sizes {
+  @include dialog-size-css($size...);
+}
 
 .carbon-dialog__dialog {
   background-color: $grey-light;
@@ -13,24 +42,18 @@ $dialog-padding: 20px;
   transition: top 0.25s;
 }
 
-.carbon-dialog__dialog--extra-small   { width: 300px; }
-.carbon-dialog__dialog--small         { width: 380px; }
-.carbon-dialog__dialog--medium-small  { width: 540px; }
-.carbon-dialog__dialog--medium        { width: 750px; }
-.carbon-dialog__dialog--medium-large  { width: 850px; }
-.carbon-dialog__dialog--large         { width: 960px; }
-.carbon-dialog__dialog--extra-large   { width: 1080px; }
-
-
-@-webkit-keyframes NAME-YOUR-ANIMATION {
-  0%   { bottom: -50px; }
-  100% { bottom: 0; }
-}
-
 .carbon-dialog__content {
+  height: 100%;
   overflow-y: auto;
   width: 100%;
-  height: calc(100% - 63px);
+
+  .carbon-dialog__title + & {
+    height: calc(100% - 63px); // not great - hardcodes what we think the title height is
+  }
+
+  .carbon-dialog__title--has-subheader + & {
+    height: calc(100% - 85px); // not great - hardcodes what we think the title height is
+  }
 }
 
 .carbon-dialog__inner-content {
@@ -40,10 +63,10 @@ $dialog-padding: 20px;
 }
 
 .carbon-dialog__dialog--has-height {
-  height: calc(100% - #{$dialog-padding - 1});
+  height: calc(100% - #{$dialog-padding - 1}); // remove 1 pixel so to prevent jutter
 
   .carbon-form {
-    padding-bottom: 77px;
+    padding-bottom: 77px; // not great - hardcodes what we think the form buttons height is
   }
 
   .carbon-form__buttons {
@@ -53,22 +76,26 @@ $dialog-padding: 20px;
   }
 }
 
+@keyframes form-buttons-animate-in {
+  0%   { bottom: -50px; }
+  100% { bottom: 0; }
+}
+
 .carbon-dialog__dialog--fixed-bottom {
   border-radius: 5px 5px 0 0;
   bottom: 0;
 
   .carbon-form__buttons {
-    -webkit-animation: NAME-YOUR-ANIMATION 0.25s ease-out;
-    box-shadow: 0 -2px 4px rgba(0,0,0,0.1);
-    position: fixed;
-    bottom: 0;
-    width: 710px;
-    padding-left: 20px;
+    animation: form-buttons-animate-in 0.25s ease-out;
     background-color: white;
-    padding-right: 20px;
-    margin-left: -20px;
-    padding-top: 15px;
+    bottom: 0;
+    box-shadow: 0 -2px 4px rgba(0,0,0,0.1);
+    margin-left: -($dialog-padding);
     padding-bottom: 15px;
+    padding-left: $dialog-padding;
+    padding-right: $dialog-padding;
+    padding-top: 15px;
+    position: fixed;
   }
 }
 
@@ -98,4 +125,11 @@ $dialog-padding: 20px;
 
 .carbon-dialog--open {
   overflow: hidden;
+}
+
+// IE10+ Fix (always shows scrollbar)
+@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+  .carbon-dialog__dialog--fixed-bottom .carbon-dialog__content {
+    overflow-y: scroll;
+  }
 }

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -7,10 +7,10 @@ $dialog-padding: 20px;
   background-color: $grey-light;
   border-radius: 5px;
   box-shadow: 0 4px 8px #555;
-  padding: $dialog-padding;
-  position: absolute;
+  position: fixed;
   top: 50%;
   z-index: $z-dialog;
+  transition: top 0.25s;
 }
 
 .carbon-dialog__dialog--extra-small   { width: 300px; }
@@ -21,12 +21,35 @@ $dialog-padding: 20px;
 .carbon-dialog__dialog--large         { width: 960px; }
 .carbon-dialog__dialog--extra-large   { width: 1080px; }
 
-.carbon-dialog__content {
-  width: 100%;
+.carbon-dialog__dialog--min-height {
+  height: calc(100% - #{$dialog-padding});
 }
 
-.carbon-dialog__title .carbon-heading {
-  padding-top: 0;
+.carbon-dialog__content {
+  overflow-y: auto;
+  width: 100%;
+  height: calc(100% - 63px);
+}
+
+.carbon-dialog__inner-content {
+  padding: $dialog-padding;
+  min-height: calc(100% - #{$dialog-padding * 2});
+}
+
+.carbon-dialog__dialog--fixed-bottom {
+  border-radius: 5px 5px 0 0;
+  bottom: 0;
+}
+
+.carbon-dialog__title {
+  .carbon-heading {
+    padding-top: $dialog-padding;
+    margin: 0 $dialog-padding;
+  }
+
+  .carbon-heading__header {
+    margin-bottom: 0;
+  }
 }
 
 .carbon-dialog__close {
@@ -40,4 +63,8 @@ $dialog-padding: 20px;
   &:hover {
     color: $blue;
   }
+}
+
+.carbon-dialog--open {
+  overflow: hidden;
 }

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -21,8 +21,10 @@ $dialog-padding: 20px;
 .carbon-dialog__dialog--large         { width: 960px; }
 .carbon-dialog__dialog--extra-large   { width: 1080px; }
 
-.carbon-dialog__dialog--min-height {
-  height: calc(100% - #{$dialog-padding});
+
+@-webkit-keyframes NAME-YOUR-ANIMATION {
+  0%   { bottom: -50px; }
+  100% { bottom: 0; }
 }
 
 .carbon-dialog__content {
@@ -33,12 +35,41 @@ $dialog-padding: 20px;
 
 .carbon-dialog__inner-content {
   padding: $dialog-padding;
+  position: relative;
   min-height: calc(100% - #{$dialog-padding * 2});
+}
+
+.carbon-dialog__dialog--has-height {
+  height: calc(100% - #{$dialog-padding - 1});
+
+  .carbon-form {
+    padding-bottom: 77px;
+  }
+
+  .carbon-form__buttons {
+    position: absolute;
+    bottom: $dialog-padding;
+    width: calc(100% - #{$dialog-padding * 2});
+  }
 }
 
 .carbon-dialog__dialog--fixed-bottom {
   border-radius: 5px 5px 0 0;
   bottom: 0;
+
+  .carbon-form__buttons {
+    -webkit-animation: NAME-YOUR-ANIMATION 0.25s ease-out;
+    box-shadow: 0 -2px 4px rgba(0,0,0,0.1);
+    position: fixed;
+    bottom: 0;
+    width: 710px;
+    padding-left: 20px;
+    background-color: white;
+    padding-right: 20px;
+    margin-left: -20px;
+    padding-top: 15px;
+    padding-bottom: 15px;
+  }
 }
 
 .carbon-dialog__title {

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -46,14 +46,6 @@ $dialog-sizes: (
   height: 100%;
   overflow-y: auto;
   width: 100%;
-
-  .carbon-dialog__title + & {
-    height: calc(100% - 63px); // not great - hardcodes what we think the title height is
-  }
-
-  .carbon-dialog__title--has-subheader + & {
-    height: calc(100% - 85px); // not great - hardcodes what we think the title height is
-  }
 }
 
 .carbon-dialog__inner-content {
@@ -66,7 +58,7 @@ $dialog-sizes: (
   height: calc(100% - #{$dialog-padding - 1}); // remove 1 pixel so to prevent jutter
 
   .carbon-form {
-    padding-bottom: 77px; // not great - hardcodes what we think the form buttons height is
+    padding-bottom: 80px;
   }
 
   .carbon-form__buttons {
@@ -89,7 +81,7 @@ $dialog-sizes: (
     animation: form-buttons-animate-in 0.25s ease-out;
     background-color: white;
     bottom: 0;
-    box-shadow: 0 -2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 -4px 12px 0 rgba(0, 0, 0, 0.05);
     margin-left: -($dialog-padding);
     padding-bottom: 15px;
     padding-left: $dialog-padding;

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -77,17 +77,23 @@ $dialog-sizes: (
   border-radius: 5px 5px 0 0;
   bottom: 0;
 
+  .carbon-form {
+    padding-bottom: 80px;
+  }
+
   .carbon-form__buttons {
     animation: form-buttons-animate-in 0.25s ease-out;
     background-color: white;
     bottom: 0;
     box-shadow: 0 -4px 12px 0 rgba(0, 0, 0, 0.05);
+    box-sizing: content-box;
     margin-left: -($dialog-padding);
     padding-bottom: 15px;
     padding-left: $dialog-padding;
     padding-right: $dialog-padding;
     padding-top: 15px;
     position: fixed;
+    z-index: 5;
   }
 }
 

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -17,7 +17,7 @@ $dialog-sizes: (
     width: $size;
 
     $form-buttons-width: $size - ($dialog-padding * 2);
-    &.carbon-dialog__dialog--fixed-bottom .carbon-form__buttons {
+    &.carbon-dialog__dialog--fixed-bottom .carbon-form__footer-wrapper {
       width: $form-buttons-width;
 
       // IE10+ fix (caters for scrollbar width)
@@ -54,20 +54,15 @@ $dialog-sizes: (
 }
 
 .carbon-dialog__dialog--has-height {
-
   .carbon-form {
     padding-bottom: 80px;
   }
 
-  .carbon-form__buttons {
+  .carbon-form__footer-wrapper {
     position: absolute;
     bottom: $dialog-padding;
     width: calc(100% - #{$dialog-padding * 2});
   }
-  //
-  // .carbon-dialog__inner-content {
-  //   min-height: calc(100% - #{$dialog-padding * 2});
-  // }
 }
 
 @keyframes form-buttons-animate-in {
@@ -79,23 +74,11 @@ $dialog-sizes: (
   border-radius: 5px 5px 0 0;
   bottom: 0;
 
-  .carbon-form {
-    padding-bottom: 80px;
-  }
-
-  .carbon-form__buttons {
-    animation: form-buttons-animate-in 0.25s ease-out;
-    background-color: white;
-    bottom: 0;
-    box-shadow: 0 -4px 12px 0 rgba(0, 0, 0, 0.05);
-    box-sizing: content-box;
+  .carbon-form .carbon-form__footer-wrapper {
     margin-left: -($dialog-padding);
-    padding-bottom: 15px;
+    left: initial;
     padding-left: $dialog-padding;
     padding-right: $dialog-padding;
-    padding-top: 15px;
-    position: fixed;
-    z-index: 5;
   }
 }
 

--- a/src/components/form/__spec__.js
+++ b/src/components/form/__spec__.js
@@ -12,6 +12,7 @@ import SaveButton from './save-button';
 import FormSummary from './form-summary';
 import Button from './../button';
 import MultiActionButton from './../multi-action-button';
+import ElementResize from './../../utils/helpers/element-resize';
 
 import { mount, shallow } from 'enzyme';
 import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
@@ -31,6 +32,26 @@ describe('Form', () => {
     });
   });
 
+  describe('componentWillReceiveProps', () => {
+    describe('when stickyFooter is enabled', () => {
+      it('adds the listeners', () => {
+        wrapper = shallow(<Form />);
+        spyOn(wrapper.instance(), 'addStickyFooterListeners');
+        wrapper.setProps({ stickyFooter: true });
+        expect(wrapper.instance().addStickyFooterListeners).toHaveBeenCalled();
+      });
+    });
+
+    describe('when stickyFooter is disabled', () => {
+      it('adds the listeners', () => {
+        wrapper = shallow(<Form stickyFooter />);
+        spyOn(wrapper.instance(), 'removeStickyFooterListeners');
+        wrapper.setProps({ stickyFooter: false });
+        expect(wrapper.instance().removeStickyFooterListeners).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('componentDidMount', () => {
     it('does not validate by default', () => {
       spyOn(instance, 'validate');
@@ -45,6 +66,118 @@ describe('Form', () => {
         instance.componentDidMount();
         expect(instance.validate).toHaveBeenCalled();
       });
+    });
+
+    it('adds sticky footer listeners is enabled', () => {
+      wrapper = shallow(<Form stickyFooter />);
+      spyOn(wrapper.instance(), 'addStickyFooterListeners');
+      wrapper.instance().componentDidMount();
+      expect(wrapper.instance().addStickyFooterListeners).toHaveBeenCalled();
+    });
+  });
+
+  describe('componentWillUnmount', () => {
+    it('does not remove sticky footer listeners if not enabled', () => {
+      wrapper = shallow(<Form />);
+      spyOn(wrapper.instance(), 'removeStickyFooterListeners');
+      wrapper.instance().componentWillUnmount();
+      expect(wrapper.instance().removeStickyFooterListeners).not.toHaveBeenCalled();
+    });
+
+    it('removes sticky footer listeners if enabled', () => {
+      wrapper = shallow(<Form stickyFooter />);
+      spyOn(wrapper.instance(), 'removeStickyFooterListeners');
+      wrapper.instance().componentWillUnmount();
+      expect(wrapper.instance().removeStickyFooterListeners).toHaveBeenCalled();
+    });
+  });
+
+  describe('addStickyFooterListeners', () => {
+    beforeEach(() => {
+      wrapper = shallow(<Form />);
+      instance = wrapper.instance();
+      instance._form = {};
+      spyOn(instance, 'checkStickyFooter');
+      spyOn(ElementResize, 'addListener');
+      spyOn(instance._window, 'addEventListener');
+    });
+
+    it('calls checkStickyFooter', () => {
+      instance.addStickyFooterListeners();
+      expect(instance.checkStickyFooter).toHaveBeenCalled();
+    });
+
+    it('sets up listeners', () => {
+      instance.addStickyFooterListeners();
+      expect(ElementResize.addListener).toHaveBeenCalledWith(instance._form, instance.checkStickyFooter);
+      expect(instance._window.addEventListener).toHaveBeenCalledWith('resize', instance.checkStickyFooter);
+      expect(instance._window.addEventListener).toHaveBeenCalledWith('scroll', instance.checkStickyFooter);
+    });
+  });
+
+  describe('removeStickyFooterListeners', () => {
+    beforeEach(() => {
+      wrapper = shallow(<Form />);
+      instance = wrapper.instance();
+      instance._form = {};
+      spyOn(ElementResize, 'removeListener');
+      spyOn(instance._window, 'removeEventListener');
+    });
+
+    it('removes listeners', () => {
+      instance.removeStickyFooterListeners();
+      expect(ElementResize.removeListener).toHaveBeenCalledWith(instance._form, instance.checkStickyFooter);
+      expect(instance._window.removeEventListener).toHaveBeenCalledWith('resize', instance.checkStickyFooter);
+      expect(instance._window.removeEventListener).toHaveBeenCalledWith('scroll', instance.checkStickyFooter);
+    });
+  });
+
+  describe('checkStickyFooter', () => {
+    beforeEach(() => {
+      wrapper = shallow(<Form />);
+    });
+
+    it('sets stickyFooter state to true if form is bigger than window', () => {
+      wrapper.setState({ stickyFooter: false });
+      wrapper.instance()._form = {
+        offsetTop: 10,
+        offsetHeight: 10
+      };
+      wrapper.instance()._window = {
+        pageYOffset: 10,
+        innerHeight: 1
+      };
+
+      wrapper.instance().checkStickyFooter();
+      expect(wrapper.state().stickyFooter).toBeTruthy();
+    });
+
+    it('sets stickyFooter state to false if form is smaller than window', () => {
+      wrapper.setState({ stickyFooter: true });
+      wrapper.instance()._form = {
+        offsetTop: 10,
+        offsetHeight: 10
+      };
+      wrapper.instance()._window = {
+        pageYOffset: 10,
+        innerHeight: 100
+      };
+      wrapper.instance().checkStickyFooter();
+      expect(wrapper.state().stickyFooter).toBeFalsy();
+    });
+
+    it('does not change stickyFooter state if it does not need to change', () => {
+      wrapper.setState({ stickyFooter: false });
+      wrapper.instance()._form = {
+        offsetTop: 10,
+        offsetHeight: 10
+      };
+      wrapper.instance()._window = {
+        pageYOffset: 10,
+        innerHeight: 100
+      };
+      wrapper.instance().checkStickyFooter();
+      expect(wrapper.state().stickyFooter).toBeFalsy();
     });
   });
 
@@ -344,6 +477,14 @@ describe('Form', () => {
   describe('mainClasses', () => {
     it('returns the carbon-form class', () => {
       expect(instance.mainClasses).toEqual('carbon-form');
+    });
+  });
+
+  describe('stickyFooterPadding', () => {
+    it('adds padding if defined', () => {
+      wrapper = shallow(<Form stickyFooterPadding="500" />);
+      const footer = wrapper.find('.carbon-form__buttons');
+      expect(footer.props().style.borderWidth).toEqual('500px');
     });
   });
 

--- a/src/components/form/definition.js
+++ b/src/components/form/definition.js
@@ -69,7 +69,7 @@ let definition = new Definition('form', Form, {
   propValues: {
     activeInput: '',
     cancelText: '',
-    children: `<Textarea
+    children: `<Textbox
     label="Name"
     validations={[ new PresenceValidation() ]}
   />`,

--- a/src/components/form/definition.js
+++ b/src/components/form/definition.js
@@ -39,6 +39,7 @@ let definition = new Definition('form', Form, {
     saveButtonProps: "Object",
     onCancel: "Function",
     save: "Boolean",
+    stickyFooter: "Boolean",
     additionalActions: "Node",
     onSubmit: "Function",
     iterative: "Boolean",
@@ -59,6 +60,7 @@ let definition = new Definition('form', Form, {
     saveButtonProps: "Supply custom props for the save button.",
     onCancel: "A callback triggered when the form is cancelled.",
     save: "Set to false to hide the save button.",
+    stickyFooter: "Enables the form buttons to become sticky when off the screen.",
     additionalActions: "Supply additional buttons alongside the form's buttons.",
     onSubmit: "A callback triggered when the form is submitted with passing validation.",
     iterative: "A flag for when the user should be able to repeatedly save & re-use a form.",
@@ -67,7 +69,7 @@ let definition = new Definition('form', Form, {
   propValues: {
     activeInput: '',
     cancelText: '',
-    children: `<Textbox
+    children: `<Textarea
     label="Name"
     validations={[ new PresenceValidation() ]}
   />`,

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -659,10 +659,15 @@ class Form extends React.Component {
    */
   formFooter = () => {
     const save = this.props.showSummary ? this.saveButtonWithSummary() : this.saveButton();
+    let padding = this.props.stickyFooterPadding;
+
+    if (padding && !padding.match(/px$/)) {
+      padding = `${padding}px`;
+    }
 
     return (
       <div className="carbon-form__footer-wrapper">
-        <AppWrapper className={ this.footerClasses } style={{ borderWidth: this.props.stickyFooterPadding }}>
+        <AppWrapper className={ this.footerClasses } style={{ borderWidth: padding }}>
           { save }
           { this.cancelButton() }
           { this.additionalActions }

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import Serialize from 'form-serialize';
 
 import CancelButton from './cancel-button';
@@ -10,6 +11,7 @@ import AppWrapper from './../app-wrapper';
 
 import { validProps } from '../../utils/ether';
 import tagComponent from '../../utils/helpers/tags';
+import Browser from './../../utils/helpers/browser';
 
 import { addResizeListener, removeResizeListener } from './../../utils/helpers/element-resize';
 
@@ -39,6 +41,7 @@ import { addResizeListener, removeResizeListener } from './../../utils/helpers/e
  */
 class Form extends React.Component {
   static propTypes = {
+    stickyFooterPadding: PropTypes.string,
     stickyFooter: PropTypes.bool,
 
     /**
@@ -296,29 +299,29 @@ class Form extends React.Component {
   addStickyFooterListeners = () => {
     this.checkStickyFooter();
     addResizeListener(this._form, this.checkStickyFooter);
-    window.addEventListener('resize', this.checkStickyFooter);
-    window.addEventListener('scroll', this.checkStickyFooter);
+    this._window.addEventListener('resize', this.checkStickyFooter);
+    this._window.addEventListener('scroll', this.checkStickyFooter);
   }
 
   removeStickyFooterListeners = () => {
     removeResizeListener(this._form, this.checkStickyFooter);
-    window.removeEventListener('resize', this.checkStickyFooter);
-    window.removeEventListener('scroll', this.checkStickyFooter);
+    this._window.removeEventListener('resize', this.checkStickyFooter);
+    this._window.removeEventListener('scroll', this.checkStickyFooter);
   }
 
   checkStickyFooter = () => {
-    let x = 0,
-        ele = this._form;
+    let offsetTop = 0,
+        element = this._form;
 
-    while(ele){
-       x += ele.offsetTop;
-       ele = ele.offsetParent;
+    while(element){
+       offsetTop += element.offsetTop;
+       element = element.offsetParent;
     }
-    const formHeight = x + this._form.offsetHeight - window.scrollY;
+    const formHeight = offsetTop + this._form.offsetHeight - this._window.pageYOffset;
 
-    if (!this.state.stickyFooter && formHeight > window.innerHeight) {
+    if (!this.state.stickyFooter && formHeight > this._window.innerHeight) {
       this.setState({ stickyFooter: true });
-    } else if (this.state.stickyFooter && formHeight < window.innerHeight) {
+    } else if (this.state.stickyFooter && formHeight < this._window.innerHeight) {
       this.setState({ stickyFooter: false });
     }
   }
@@ -355,7 +358,7 @@ class Form extends React.Component {
    * @property _document
    * @type {document}
    */
-  _document = document;
+  _document = Browser.getDocument();
 
   /**
    * stores the window - allows us to override it different contexts, such as
@@ -364,7 +367,7 @@ class Form extends React.Component {
    * @property _window
    * @type {window}
    */
-  _window = window;
+  _window = Browser.getWindow();
 
   /**
    * @method activeInputHasValidation
@@ -659,7 +662,7 @@ class Form extends React.Component {
 
     return (
       <div className="carbon-form__footer-wrapper">
-        <AppWrapper className={ this.footerClasses }>
+        <AppWrapper className={ this.footerClasses } style={{ borderWidth: this.props.stickyFooterPadding }}>
           { save }
           { this.cancelButton() }
           { this.additionalActions }

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -43,6 +43,8 @@
     border-left-color: white;
     border-right-style: solid;
     border-right-color: white;
+    border-width: 0;
+    box-sizing: border-box;
   }
 
   .carbon-form__footer-wrapper {

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -27,3 +27,40 @@
 .carbon-form-save--invalid {
   background-color: $grey-dark-blue-5;
 }
+
+@keyframes form-buttons-animate-in {
+  0%   { bottom: -50px; }
+  100% { bottom: 0; }
+}
+
+.carbon-dialog__dialog--fixed-bottom .carbon-form,
+.carbon-form--sticky-footer {
+  padding-bottom: 80px;
+
+  .carbon-form__buttons {
+    margin-top: 0;
+  }
+
+  .carbon-form__footer-wrapper {
+    animation: form-buttons-animate-in 0.25s ease-out;
+    background-color: white;
+    bottom: 0;
+    box-shadow: 0 -4px 12px 0 rgba(0, 0, 0, 0.05);
+    box-sizing: content-box;
+    left: 0;
+    padding-bottom: 13px;
+    padding-top: 15px;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+  }
+}
+
+.carbon-form:not(.carbon-form--sticky-footer),
+.carbon-dialog__dialog--fixed-bottom {
+  .carbon-form__buttons {
+    max-width: initial;
+    min-width: initial;
+    padding: 0;
+  }
+}

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -39,6 +39,10 @@
 
   .carbon-form__buttons {
     margin-top: 0;
+    border-left-style: solid;
+    border-left-color: white;
+    border-right-style: solid;
+    border-right-color: white;
   }
 
   .carbon-form__footer-wrapper {
@@ -59,8 +63,8 @@
 .carbon-form:not(.carbon-form--sticky-footer),
 .carbon-dialog__dialog--fixed-bottom {
   .carbon-form__buttons {
-    max-width: initial;
-    min-width: initial;
+    max-width: auto;
+    min-width: auto;
     padding: 0;
   }
 }

--- a/src/components/textarea/textarea.scss
+++ b/src/components/textarea/textarea.scss
@@ -2,7 +2,6 @@
 
 .carbon-textarea__input {
   height: auto;
-  resize: none;
 }
 
 .carbon-textarea__character-limit {

--- a/src/components/textarea/textarea.scss
+++ b/src/components/textarea/textarea.scss
@@ -2,6 +2,7 @@
 
 .carbon-textarea__input {
   height: auto;
+  resize: none;
 }
 
 .carbon-textarea__character-limit {

--- a/src/utils/helpers/element-resize/__spec__.js
+++ b/src/utils/helpers/element-resize/__spec__.js
@@ -1,0 +1,120 @@
+import Bowser from 'bowser';
+import Browser from './../browser';
+import ElementResize from './element-resize';
+
+describe('ElementResize', () => {
+  let element, callback;
+
+  beforeEach(() => {
+    element = document.createElement('div'),
+    callback = jasmine.createSpy('callback');
+  });
+
+  describe('addListener', () => {
+    describe('no listener yet set', () => {
+      it('creates an object to watch', () => {
+        ElementResize.addListener(element, callback);
+        expect(element.children[0].tagName).toEqual("OBJECT");
+      });
+    });
+
+    describe('listener already setup', () => {
+      it('adds the callback to the array', () => {
+        ElementResize.addListener(element, callback);
+        ElementResize.addListener(element, callback);
+        expect(element.__resizeListenerCallbacks__.length).toEqual(2);
+      });
+    });
+
+    describe('when position is static', () => {
+      it('sets it to relative', () => {
+        spyOn(Browser, 'getWindow').and.returnValue({
+          getComputedStyle: (element) => {
+            return { position: 'static' };
+          }
+        });
+        ElementResize.addListener(element, callback);
+        expect(element.style.position).toEqual('relative');
+      });
+    });
+
+    describe('objectLoad', () => {
+      it('sets the listener', () => {
+        const addSpy = jasmine.createSpy('add listener');
+        spyOn(ElementResize, 'getDefaultView').and.returnValue({
+          addEventListener: addSpy
+        });
+        ElementResize.addListener(element, callback);
+        element.children[0].onload();
+        expect(addSpy).toHaveBeenCalled();
+        expect(addSpy.calls.mostRecent().args[0]).toEqual('resize');
+        expect(typeof addSpy.calls.mostRecent().args[1]).toEqual('function');
+      });
+    });
+
+    describe('resizeListener', () => {
+      it('triggers each callback', () => {
+        const trigger = {
+          __resizeListenerCallbacks__: [callback]
+        };
+        const ev = {
+          target: {
+            __resizeTrigger__: trigger
+          }
+        };
+        const addSpy = jasmine.createSpy('add listener');
+        spyOn(ElementResize, 'getDefaultView').and.returnValue({
+          addEventListener: addSpy
+        });
+        ElementResize.addListener(element, callback);
+        element.children[0].onload();
+        addSpy.calls.mostRecent().args[1](ev);
+        expect(callback).toHaveBeenCalledWith(ev);
+      });
+    });
+
+    it('sets data attribute', () => {
+      Bowser.msie = true;
+      ElementResize.addListener(element, callback);
+      expect(element.children[0].data).toEqual("about:blank");
+    });
+  });
+
+  describe('removeListener', () => {
+    it('does not remove callbacks if there are none', () => {
+      ElementResize.removeListener(element, callback);
+      expect(element.__resizeListenerCallbacks__).toBe(undefined);
+    });
+
+    it('removes the callback if it exists (and the listener if it was last callback)', () => {
+      const removeSpy = jasmine.createSpy('remove listener');
+      spyOn(ElementResize, 'getDefaultView').and.returnValue({
+        removeEventListener: removeSpy
+      });
+      ElementResize.addListener(element, callback);
+      ElementResize.addListener(element, callback);
+      ElementResize.removeListener(element, callback);
+      expect(element.__resizeListenerCallbacks__.length).toEqual(1);
+    });
+
+    it('removes the callback if it exists (and the listener if it was last callback)', () => {
+      const removeSpy = jasmine.createSpy('remove listener');
+      spyOn(ElementResize, 'getDefaultView').and.returnValue({
+        removeEventListener: removeSpy
+      });
+      ElementResize.addListener(element, callback);
+      ElementResize.removeListener(element, callback);
+      expect(element.__resizeListenerCallbacks__.length).toEqual(0);
+      expect(removeSpy).toHaveBeenCalled();
+      expect(element.__resizeTrigger__).toBeFalsy();
+    });
+  });
+
+  describe('getDefaultView', () => {
+    it('returns the defaultView of the given element', () => {
+      expect(ElementResize.getDefaultView({
+        contentDocument: { defaultView: 'foo' }
+      })).toEqual('foo');
+    })
+  });
+});

--- a/src/utils/helpers/element-resize/element-resize.js
+++ b/src/utils/helpers/element-resize/element-resize.js
@@ -1,71 +1,4 @@
-import Browser from './../browser';
 import Bowser from 'bowser';
-
-/**
- * Creates a child 'object' or document which mimics the size of the given element and is
- * able to use the browser 'resize' event listener to trigger a callback.
- *
- * Adapted from http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
- *
- *   __resizeListenerCallbacks__ - an array of callbacks to trigger on this element when it is resized
- *   __resizeTrigger__ - the element to listen for resize events. The browser creates a fake object
- *   which supports resize events.
- */
-
-/**
- * Sets up an event listener for when an element is resized.
- *
- * @method addResizeListener
- * @param {HTMLElement} element - the html element to watch
- * @param {Function} fn - the callback
- */
-const addResizeListener = (element, callback) => {
-
-  // if there is no resize listener on this element yet, create an object to apply the listener to
-  if (!element.__resizeTrigger__) {
-    element.__resizeListenerCallbacks__ = [];
-
-    // ensure that the element has position relative for the child object to work properly
-    if (getComputedStyle(element).position == 'static') {
-      element.style.position = 'relative';
-    }
-
-    // creates an object which will support the resize event listener
-    const obj = element.__resizeTrigger__ = document.createElement('object'); 
-    obj.setAttribute('style', 'display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;');
-    // when the object is ready, add the event listener
-    obj.onload = objectLoad(obj, element);
-    obj.type = 'text/html';
-
-    const isMS = Bowser.msie || Bowser.msedge;
-
-    if (isMS) {
-      element.appendChild(obj);
-    }
-
-    obj.data = 'about:blank';
-
-    if (!isMS) {
-      element.appendChild(obj);
-    }
-  }
-
-  // add the callback to the array of listeners
-  element.__resizeListenerCallbacks__.push(callback);
-};
-
-const removeResizeListener = (element, callback) => {
-  // remove the event listener from the array
-  element.__resizeListenerCallbacks__.splice(element.__resizeListenerCallbacks__.indexOf(callback), 1);
-
-  // if there are no event listeners left, time to detach the event
-  if (!element.__resizeListenerCallbacks__.length) {
-    // remove the event listener on the object
-    element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener);
-    // remove the fake object
-    element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__);
-  }
-}
 
 /**
  * The event listener to be triggered.
@@ -77,7 +10,7 @@ const resizeListener = (ev) => {
   trigger.__resizeListenerCallbacks__.forEach((fn) => {
     fn.call(trigger, ev);
   });
-}
+};
 
 /**
  * Return a function to be triggered when the fake object has been loaded into the DOM.
@@ -88,10 +21,92 @@ const objectLoad = (obj, element) => {
     obj.contentDocument.defaultView.__resizeTrigger__ = element;
     // apply the event listener to the new object's document
     obj.contentDocument.defaultView.addEventListener('resize', resizeListener);
-  }
-}
+  };
+};
 
-export {
-  addResizeListener,
-  removeResizeListener
-}
+/**
+ * Creates a child 'object' or document which mimics the size of the given element and is
+ * able to use the browser 'resize' event listener to trigger a callback.
+ *
+ * Adapted from http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
+ *
+ *   __resizeListenerCallbacks__ - an array of callbacks to trigger on this element when it is resized
+ *   __resizeTrigger__ - the element to listen for resize events. The browser creates a fake object
+ *   which supports resize events.
+ */
+const ElementResize = {
+  /**
+   * Sets up an event listener for when an element is resized.
+   *
+   * @method addListener
+   * @param {HTMLElement} element - the html element to watch
+   * @param {Function} fn - the callback
+   */
+  addListener: (element, callback) => {
+    // if there is no resize listener on this element yet, create an object to apply the listener to
+    if (!element.__resizeTrigger__) {
+      element.__resizeListenerCallbacks__ = [];
+
+      // ensure that the element has position relative for the child object to work properly
+      if (getComputedStyle(element).position === 'static') {
+        element.style.position = 'relative';
+      }
+
+      // creates an object which will support the resize event listener
+      const obj = element.__resizeTrigger__ = document.createElement('object');
+      obj.setAttribute('style', `
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        overflow: hidden;
+        pointer-events: none;
+        z-index: -1;
+      `);
+      // when the object is ready, add the event listener
+      obj.onload = objectLoad(obj, element);
+      obj.type = 'text/html';
+
+      const isMS = Bowser.msie || Bowser.msedge;
+
+      if (isMS) {
+        element.appendChild(obj);
+      }
+
+      obj.data = 'about:blank';
+
+      if (!isMS) {
+        element.appendChild(obj);
+      }
+    }
+
+    // add the callback to the array of listeners
+    element.__resizeListenerCallbacks__.push(callback);
+  },
+
+  /**
+   * Removes event listeners for when an element is resized.
+   *
+   * @method removeListener
+   * @param {HTMLElement} element - the html element to watch
+   * @param {Function} fn - the callback
+   */
+  removeListener: (element, callback) => {
+    if (element.__resizeListenerCallbacks__) {
+      // remove the event listener from the array
+      element.__resizeListenerCallbacks__.splice(element.__resizeListenerCallbacks__.indexOf(callback), 1);
+
+      // if there are no event listeners left, time to detach the event
+      if (!element.__resizeListenerCallbacks__.length) {
+        // remove the event listener on the object
+        element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener);
+        // remove the fake object
+        element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__);
+      }
+    }
+  }
+};
+
+export default ElementResize;

--- a/src/utils/helpers/element-resize/element-resize.js
+++ b/src/utils/helpers/element-resize/element-resize.js
@@ -22,7 +22,7 @@ import Bowser from 'bowser';
 const addResizeListener = (element, callback) => {
 
   // if there is no resize listener on this element yet, create an object to apply the listener to
-  if (!element.__resizeListenerCallbacks__) {
+  if (!element.__resizeTrigger__) {
     element.__resizeListenerCallbacks__ = [];
 
     // ensure that the element has position relative for the child object to work properly

--- a/src/utils/helpers/element-resize/element-resize.js
+++ b/src/utils/helpers/element-resize/element-resize.js
@@ -33,6 +33,7 @@ const ElementResize = {
       const obj = element.__resizeTrigger__ = Browser.getDocument().createElement('object');
       obj.setAttribute('style', `
         display: block;
+        opacity: 0;
         position: absolute;
         top: 0;
         left: 0;

--- a/src/utils/helpers/element-resize/element-resize.js
+++ b/src/utils/helpers/element-resize/element-resize.js
@@ -1,0 +1,143 @@
+import Browser from './../browser';
+import Bowser from 'bowser';
+
+/**
+ * Creates a child 'object' or document which mimics the size of the given element and is
+ * able to use the browser 'resize' event listener to trigger a callback.
+ *
+ * Adapted from http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
+ *
+ *   __resizeListenerCallbacks__ - an array of callbacks to trigger on this element when it is resized
+ *   __resizeTrigger__ - the element to listen for resize events. If the browser supports 'attachEvent' then
+ *   this will be the original element. If the browser does not support 'attachEvent' then this will be a
+ *   fake object element which supports resize events.
+ *
+ * NOTE: requestAnimationFrame is used for performance (runs the callback less frequently) - https://www.html5rocks.com/en/tutorials/speed/rendering/
+ */
+
+/**
+ * Sets up an event listener for when an element is resized.
+ *
+ * @method addResizeListener
+ * @param {HTMLElement} element - the html element to watch
+ * @param {Function} fn - the callback
+ */
+const addResizeListener = (element, callback) => {
+  // if there is no resize listener on this element yet, create an object to apply the listener to
+  if (!element.__resizeListenerCallbacks__) {
+    element.__resizeListenerCallbacks__ = [];
+
+    if (attachEvent) {
+      // if browser supports 'attachEvent' then use it's API (IE10 and below)
+      element.__resizeTrigger__ = element;
+      element.attachEvent('onresize', resizeListener);
+    } else {
+      // ensure that the element has position relative for the child object to work properly
+      if (getComputedStyle(element).position == 'static') {
+        element.style.position = 'relative';
+      }
+
+      // creates an object which will support the resize event listener
+      const obj = element.__resizeTrigger__ = document.createElement('object'); 
+      obj.setAttribute('style', 'display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;');
+      // when the object is ready, add the event listener
+      obj.onload = objectLoad(obj, element);
+      obj.type = 'text/html';
+
+      if (isIE) {
+        element.appendChild(obj);
+      }
+
+      obj.data = 'about:blank';
+
+      if (!isIE) {
+        element.appendChild(obj);
+      }
+    }
+  }
+
+  // add the callback to the array of listeners
+  element.__resizeListenerCallbacks__.push(callback);
+};
+
+const removeResizeListener = (element, callback) => {
+  // remove the event listener from the array
+  element.__resizeListenerCallbacks__.splice(element.__resizeListenerCallbacks__.indexOf(callback), 1);
+
+  // if there are no event listeners left, time to detach the event
+  if (!element.__resizeListenerCallbacks__.length) {
+    if (attachEvent) {
+      // if the browser supports 'attachEvent' then use it's API (IE 10 and below)
+      element.detachEvent('onresize', resizeListener);
+    } else {
+      // remove the event listener on the object
+      element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener);
+      // remove the fake object
+      element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__);
+    }
+  }
+}
+
+const _document = Browser.getDocument(),
+      _window = Browser.getWindow(),
+      attachEvent = _document.attachEvent,
+      isIE = Bowser.msie;
+
+/**
+ * Returns a supported requestAnimationFrame for the current browser.
+ */
+const requestFrame = (() => {
+  const rafFake = (fn) => _window.setTimeout(fn, 20),
+        raf = _window.requestAnimationFrame ||
+              _window.mozRequestAnimationFrame ||
+              _window.webkitRequestAnimationFrame ||
+              rafFake;
+
+  return (fn) => { return raf(fn); };
+})();
+
+/**
+ * Returns a supported cancelAnimationFrame for the current browser.
+ */
+const cancelFrame = (() => {
+  const cancel = _window.cancelAnimationFrame || _window.mozCancelAnimationFrame || _window.webkitCancelAnimationFrame || _window.clearTimeout;
+
+  return (id) => { return cancel(id); };
+})();
+
+/**
+ * The event listener to be triggered.
+ */
+const resizeListener = (e) => {
+  const win = e.target || e.srcElement;
+
+  if (win.__resizeRAF__) {
+    // if there is an animation frame in progress then cancel it
+    cancelFrame(win.__resizeRAF__);
+  }
+
+  // create a new animation frame which will trigger each resize listener currently assigned
+  win.__resizeRAF__ = requestFrame(() => {
+    // using the reference to the source element, retrieve the array of callbacks and trigger them all
+    win.__resizeTrigger__.__resizeListenerCallbacks__.forEach((fn) => {
+      fn.call(win.__resizeTrigger__, e);
+    });
+  });
+}
+
+/**
+ * Return a function to be triggered when the fake object has been loaded into the DOM.
+ */
+const objectLoad = (obj, element) => {
+  return (e) => {
+    // assign a reference back to the source element in the new object's document
+    obj.contentDocument.defaultView.__resizeTrigger__ = element;
+    // apply the event listener to the new object's document
+    obj.contentDocument.defaultView.addEventListener('resize', resizeListener);
+  }
+}
+
+export {
+  addResizeListener,
+  removeResizeListener
+}

--- a/src/utils/helpers/element-resize/element-resize.js
+++ b/src/utils/helpers/element-resize/element-resize.js
@@ -8,11 +8,8 @@ import Bowser from 'bowser';
  * Adapted from http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
  *
  *   __resizeListenerCallbacks__ - an array of callbacks to trigger on this element when it is resized
- *   __resizeTrigger__ - the element to listen for resize events. If the browser supports 'attachEvent' then
- *   this will be the original element. If the browser does not support 'attachEvent' then this will be a
- *   fake object element which supports resize events.
- *
- * NOTE: requestAnimationFrame is used for performance (runs the callback less frequently) - https://www.html5rocks.com/en/tutorials/speed/rendering/
+ *   __resizeTrigger__ - the element to listen for resize events. The browser creates a fake object
+ *   which supports resize events.
  */
 
 /**
@@ -23,36 +20,33 @@ import Bowser from 'bowser';
  * @param {Function} fn - the callback
  */
 const addResizeListener = (element, callback) => {
+
   // if there is no resize listener on this element yet, create an object to apply the listener to
   if (!element.__resizeListenerCallbacks__) {
     element.__resizeListenerCallbacks__ = [];
 
-    if (attachEvent) {
-      // if browser supports 'attachEvent' then use it's API (IE10 and below)
-      element.__resizeTrigger__ = element;
-      element.attachEvent('onresize', resizeListener);
-    } else {
-      // ensure that the element has position relative for the child object to work properly
-      if (getComputedStyle(element).position == 'static') {
-        element.style.position = 'relative';
-      }
+    // ensure that the element has position relative for the child object to work properly
+    if (getComputedStyle(element).position == 'static') {
+      element.style.position = 'relative';
+    }
 
-      // creates an object which will support the resize event listener
-      const obj = element.__resizeTrigger__ = document.createElement('object'); 
-      obj.setAttribute('style', 'display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;');
-      // when the object is ready, add the event listener
-      obj.onload = objectLoad(obj, element);
-      obj.type = 'text/html';
+    // creates an object which will support the resize event listener
+    const obj = element.__resizeTrigger__ = document.createElement('object'); 
+    obj.setAttribute('style', 'display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;');
+    // when the object is ready, add the event listener
+    obj.onload = objectLoad(obj, element);
+    obj.type = 'text/html';
 
-      if (isIE) {
-        element.appendChild(obj);
-      }
+    const isMS = Bowser.msie || Bowser.msedge;
 
-      obj.data = 'about:blank';
+    if (isMS) {
+      element.appendChild(obj);
+    }
 
-      if (!isIE) {
-        element.appendChild(obj);
-      }
+    obj.data = 'about:blank';
+
+    if (!isMS) {
+      element.appendChild(obj);
     }
   }
 
@@ -66,62 +60,22 @@ const removeResizeListener = (element, callback) => {
 
   // if there are no event listeners left, time to detach the event
   if (!element.__resizeListenerCallbacks__.length) {
-    if (attachEvent) {
-      // if the browser supports 'attachEvent' then use it's API (IE 10 and below)
-      element.detachEvent('onresize', resizeListener);
-    } else {
-      // remove the event listener on the object
-      element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener);
-      // remove the fake object
-      element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__);
-    }
+    // remove the event listener on the object
+    element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener);
+    // remove the fake object
+    element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__);
   }
 }
-
-const _document = Browser.getDocument(),
-      _window = Browser.getWindow(),
-      attachEvent = _document.attachEvent,
-      isIE = Bowser.msie;
-
-/**
- * Returns a supported requestAnimationFrame for the current browser.
- */
-const requestFrame = (() => {
-  const rafFake = (fn) => _window.setTimeout(fn, 20),
-        raf = _window.requestAnimationFrame ||
-              _window.mozRequestAnimationFrame ||
-              _window.webkitRequestAnimationFrame ||
-              rafFake;
-
-  return (fn) => { return raf(fn); };
-})();
-
-/**
- * Returns a supported cancelAnimationFrame for the current browser.
- */
-const cancelFrame = (() => {
-  const cancel = _window.cancelAnimationFrame || _window.mozCancelAnimationFrame || _window.webkitCancelAnimationFrame || _window.clearTimeout;
-
-  return (id) => { return cancel(id); };
-})();
 
 /**
  * The event listener to be triggered.
  */
-const resizeListener = (e) => {
-  const win = e.target || e.srcElement;
+const resizeListener = (ev) => {
+  const trigger = ev.target.__resizeTrigger__;
 
-  if (win.__resizeRAF__) {
-    // if there is an animation frame in progress then cancel it
-    cancelFrame(win.__resizeRAF__);
-  }
-
-  // create a new animation frame which will trigger each resize listener currently assigned
-  win.__resizeRAF__ = requestFrame(() => {
-    // using the reference to the source element, retrieve the array of callbacks and trigger them all
-    win.__resizeTrigger__.__resizeListenerCallbacks__.forEach((fn) => {
-      fn.call(win.__resizeTrigger__, e);
-    });
+  // using the reference to the source element, retrieve the array of callbacks and trigger them all
+  trigger.__resizeListenerCallbacks__.forEach((fn) => {
+    fn.call(trigger, ev);
   });
 }
 
@@ -129,7 +83,7 @@ const resizeListener = (e) => {
  * Return a function to be triggered when the fake object has been loaded into the DOM.
  */
 const objectLoad = (obj, element) => {
-  return (e) => {
+  return () => {
     // assign a reference back to the source element in the new object's document
     obj.contentDocument.defaultView.__resizeTrigger__ = element;
     // apply the event listener to the new object's document

--- a/src/utils/helpers/element-resize/package.json
+++ b/src/utils/helpers/element-resize/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "./element-resize.js"
+}


### PR DESCRIPTION
* Screen is no longer scrollable when a dialog is open.
* Dialog will attach to the bottom of the browser if it gets too tall, and it's content will become scrollable.
* If a dialog has a form, the form buttons will become sticky to the bottom of the dialog while the dialog is attached to the bottom of the browser.
* Dialog can now use a prop called `height`, allowing developers to specify a set height for the dialog (the dialog will still attach to the bottom of the browser if it is taller than the browser's height).

![sticky-footer](https://user-images.githubusercontent.com/1668080/28059410-1c94813a-661c-11e7-85c2-4f5daf3a1818.gif)
