### PR TITLE
CARBON-913 Refactor Poller to no longer use promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * React has been upgraded to 15.6.1 - https://facebook.github.io/react/blog/2017/06/13/react-v15.6.0.html
 
+## Component Improvements
+
+* The `Poller` helper has been refactored to no longer use promises
+
 # 1.2.1
 
 ## Linting Updates

--- a/src/utils/helpers/poller/__spec__.js
+++ b/src/utils/helpers/poller/__spec__.js
@@ -189,12 +189,10 @@ describe('poller', () => {
 
     describe('if there is an error', () => {
       describe('if a handleError function is provided', () => {
-        let promise;
-
         beforeEach(() => {
           functions.handleError = jasmine.createSpy('handleError');
 
-          promise = Poller({ url }, functions, { interval: 1000 });
+          Poller({ url }, functions, { interval: 1000 });
 
           const request = jasmine.Ajax.requests.mostRecent();
           request.respondWith({
@@ -209,16 +207,14 @@ describe('poller', () => {
         });
 
         it('calls the handleError with the error', (done) => {
-          promise.then(done, done);
+          done();
           expect(functions.handleError.calls.mostRecent().args.toString()).toEqual('Error: Unsuccessful HTTP response');
         });
       });
 
       describe('if no custom handleError function is avaliable', () => {
-        let promise;
-
         beforeEach(() => {
-          promise = Poller({ url }, functions, { interval: 1000 });
+          Poller({ url }, functions, { interval: 1000 });
 
           const request = jasmine.Ajax.requests.mostRecent();
           request.respondWith({
@@ -233,7 +229,8 @@ describe('poller', () => {
         });
 
         it('logs the error', (done) => {
-          promise.then(done, done);
+          Poller({ url }, functions, { interval: 1000 });
+          done();
           expect(console.error).toHaveBeenCalledWith( // eslint-disable-line no-console
             'Unsuccessful HTTP response');
         });

--- a/src/utils/helpers/poller/poller.js
+++ b/src/utils/helpers/poller/poller.js
@@ -49,45 +49,41 @@ export default (queryOptions, functions, options) => {
   const funcs = getFunctions(functions);
   const opts = getOptions(options);
 
-  return new Promise((resolve, reject) => {
-    // pollCount for use if retries option passed
-    let pollCount = 1;
+  // pollCount for use if retries option passed
+  let pollCount = 1;
 
-    (function poll() {
-      if (pollCount > opts.retries || Number(new Date()) > opts.endTime) {
-        console.warn('The poller has made too many requests - terminating poll'); // eslint-disable-line no-console
-        return;
-      }
-      Request
-        .get(queryOpts.url)
-        .query(queryOpts.data)
-        .set(queryOpts.headers)
-        .end((err, response) => {
-          let result;
+  (function poll() {
+    const now = Date.now();
+    if (pollCount > opts.retries || now > opts.endTime) {
+      console.warn('The poller has made too many requests - terminating poll'); // eslint-disable-line no-console
+      return;
+    }
+    Request
+      .get(queryOpts.url)
+      .query(queryOpts.data)
+      .set(queryOpts.headers)
+      .end((err, response) => {
+        let result;
 
-          if (err) {
-            if (funcs.handleError) {
-              result = reject(funcs.handleError(err));
-            } else {
-              result = reject(console.error(err.message)); // eslint-disable-line no-console
-            }
-          } else if (funcs.terminate(response)) {
-            result = resolve(response);
-          } else if (funcs.conditionMet(response)) {
-            result = resolve(funcs.callback(response));
+        if (err) {
+          if (funcs.handleError) {
+            result = funcs.handleError(err);
           } else {
-            funcs.conditionNotMetCallback(response);
-            pollCount += 1;
-            setTimeout(poll, opts.interval);
+            result = console.error(err.message); // eslint-disable-line no-console
           }
+        } else if (funcs.terminate(response)) {
+          result = response;
+        } else if (funcs.conditionMet(response)) {
+          result = funcs.callback(response);
+        } else {
+          funcs.conditionNotMetCallback(response);
+          pollCount += 1;
+          setTimeout(poll, opts.interval);
+        }
 
-          return result;
-        });
-    }());
-  })
-    .catch((err) => {
-      console.error(err); // eslint-disable-line no-console
-    });
+        return result;
+      });
+  }());
 };
 
 /**

--- a/src/utils/helpers/poller/poller.js
+++ b/src/utils/helpers/poller/poller.js
@@ -41,7 +41,7 @@ import './../../promises';
  */
 export default (queryOptions, functions, options) => {
   if (!setupValid(queryOptions, functions)) {
-    return undefined;
+    return;
   }
 
   // set default options for unprovided options


### PR DESCRIPTION
Poller helper no longer uses promises. Instead, it just calls itself via `setTimeout` as before __without__ being wrapped in a `Promise`.

Fix Poller tests so they work without promises.

## TODO
- [x] Release notes
