### PR TITLE
CARBON-918 Fix Form tests coverage in Jest

### DIFF
--- a/src/components/form/__spec__.js
+++ b/src/components/form/__spec__.js
@@ -16,6 +16,8 @@ import MultiActionButton from './../multi-action-button';
 import { mount, shallow } from 'enzyme';
 import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
 
+/* global jest */
+
 describe('Form', () => {
   let instance, wrapper;
 
@@ -375,12 +377,18 @@ describe('Form', () => {
       let csrf;
 
       beforeEach(() => {
-        let fakeMeta1 = { getAttribute() {} },
+        const fakeMeta1 = { getAttribute() {} },
             fakeMeta2 = { getAttribute() {} };
 
-        spyOn(fakeMeta1, 'getAttribute').and.returnValue('csrf-param')
-        spyOn(fakeMeta2, 'getAttribute').and.returnValue('csrf-token')
-        spyOn(instance._document, 'getElementsByTagName').and.returnValue( [ fakeMeta1, fakeMeta2 ] );
+        fakeMeta1.getAttribute = jest.fn();
+        fakeMeta2.getAttribute = jest.fn();
+        fakeMeta1.getAttribute.mockReturnValue('csrf-param');
+        fakeMeta2.getAttribute.mockReturnValue('csrf-token');
+
+        instance._document.querySelector = jest.fn();
+        instance._document.querySelector
+          .mockReturnValueOnce(fakeMeta1)
+          .mockReturnValue(fakeMeta2);
 
         instance = TestUtils.renderIntoDocument(<Form />);
 

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -669,18 +669,11 @@ class Form extends React.Component {
  * @return {Object} JSX hidden CSRF token
  */
 function generateCSRFToken(doc) {
-  const meta = doc.getElementsByTagName('meta');
-  let csrfAttr, csrfValue;
+  const csrfParam = doc.querySelector('meta[name="csrf-param"]');
+  const csrfToken = doc.querySelector('meta[name="csrf-token"]');
 
-  for (let i = 0; i < meta.length; i++) {
-    const item = meta[i];
-
-    if (item.getAttribute('name') === 'csrf-param') {
-      csrfAttr = item.getAttribute('content');
-    } else if (item.getAttribute('name') === 'csrf-token') {
-      csrfValue = item.getAttribute('content');
-    }
-  }
+  const csrfAttr = csrfParam ? csrfParam.getAttribute('content') : '';
+  const csrfValue = csrfToken ? csrfToken.getAttribute('content') : '';
 
   return <input type='hidden' name={ csrfAttr } value={ csrfValue } readOnly='true' />;
 }


### PR DESCRIPTION
Refactor the `generateCSRFToken` function to use `querySelector` instead of `getElementsByTagName`. This means we don't need the `for` loop any longer, and can remove the `if` statement that was causing the code coverage to fail.