### PR TITLE
SI-395 - Revert hover rule

### DIFF
--- a/src/components/table/table-cell/table-cell.scss
+++ b/src/components/table/table-cell/table-cell.scss
@@ -46,9 +46,7 @@
     background-color: $white;
   }
 
-
-  .carbon-table-row.carbon-table-row--dragged &,
-  .carbon-table-row:hover:not(.carbon-table-row--dragging) & {
+  .carbon-table-row:hover & {
     background-color: $row-hover-color;
   }
 


### PR DESCRIPTION
A bug has been introduced where hovering on a TableCell makes the highlighted text unreadable. This PR reverts that CSS change. NOTE I need review of this as whilst this fixes the bug I'm not sure of the consequences of the change, or whether it can be best served with an updated rule.

# Screenshots / Gifs
![si-395](https://user-images.githubusercontent.com/2031/28317398-97263bbc-6bbe-11e7-850c-62de0df3cb8c.gif)

