### PR TITLE
Do not apply hover CSS to table rows if they are selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.2
+
+## Bug Fixes
+* Selected table rows no longer have highlights applied on hover.
+
+
 # 1.2.1
 
 ## Linting Updates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A library of reusable React components and an interface for easily building user interfaces based on Flux.",
   "engineStrict": true,
   "engines": {

--- a/src/components/table/table-cell/table-cell.scss
+++ b/src/components/table/table-cell/table-cell.scss
@@ -46,9 +46,8 @@
     background-color: $white;
   }
 
-
   .carbon-table-row.carbon-table-row--dragged &,
-  .carbon-table-row:hover:not(.carbon-table-row--dragging) & {
+  .carbon-table-row:hover:not(.carbon-table-row--dragging):not(.carbon-table-row--selected) & {
     background-color: $row-hover-color;
   }
 


### PR DESCRIPTION


# Description

This fixes a regression in tables where highlights are incorrectly applied to table rows when hovered.

# TODO
- [x] Release notes

# Screenshots / Gifs

This gif illustrates the bug:
![si-395](https://user-images.githubusercontent.com/1702055/28318173-aefbe932-6bc1-11e7-9351-9ab90657a1e2.gif)

This shows the bug fixed:

![carbon2](https://user-images.githubusercontent.com/1702055/28318670-832e14c2-6bc3-11e7-8c91-92cdb5afaf97.gif)

# Testing Instructions
Verify that drag and drop behaviour is not affected.
