### PR TITLE
Validations in demo site

### DIFF
--- a/demo/components/validations/definition.js
+++ b/demo/components/validations/definition.js
@@ -1,0 +1,28 @@
+import Validations from './';
+import Definition from './../../utils/definition';
+import ComponentActions from './../../actions/component';
+
+let definition = new Definition('validations', Validations, {
+  propValues: {
+    value: '',
+    validator: 'length',
+    onOptionsChange: ComponentActions.updateValidationOption
+  },
+  propOptions: {
+    validator: [
+      'blank',
+      'email',
+      'exclusion',
+      'inclusion',
+      'length',
+      'numeral',
+      'presence',
+      'regex',
+    ]
+  },
+  hiddenProps: [ 'value' ]
+});
+
+definition.stubAction('onChange', 'value');
+
+export default definition;

--- a/demo/components/validations/package.json
+++ b/demo/components/validations/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "./validations.js"
+}

--- a/demo/components/validations/validations.js
+++ b/demo/components/validations/validations.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import Dropdown from 'components/dropdown';
+import Textbox from 'components/textbox';
+import { Row, Column } from 'components/row';
+
+import DateRangeValidator from 'utils/validations/date-range';
+import DateValidator from 'utils/validations/date';
+import DateWithinRangeValidator from 'utils/validations/date-within-range';
+
+import BlankValidator from 'utils/validations/blank';
+import EmailValidator from 'utils/validations/email';
+import ExclusionValidator from 'utils/validations/exclusion';
+import InclusionValidator from 'utils/validations/inclusion';
+import LengthValidator from 'utils/validations/length';
+import NumeralValidator from 'utils/validations/numeral';
+import PresenceValidator from 'utils/validations/presence';
+import RegexValidator from 'utils/validations/regex';
+
+const Validators = {
+  blank: { validator: BlankValidator, component: Textbox, options: {} },
+  email: { validator: EmailValidator, component: Textbox, options: {} },
+  exclusion: { validator: ExclusionValidator, component: Textbox, options: { disallowedValues: "['foo', 'bar' ]" } },
+  inclusion: { validator: InclusionValidator, component: Textbox, options: { allowedValues: "['foo', 'bar' ]" } },
+  length: { validator: LengthValidator, component: Textbox, options: { min: '2', max: '5' } },
+  numeral: { validator: NumeralValidator, component: Textbox, options: { min: '10', max: '100' } },
+  presence: { validator: PresenceValidator, component: Textbox, options: {} },
+  regex: { validator: RegexValidator, component: Textbox, options: { format: /[0-9]/ } }
+}
+
+class Validations extends React.Component {
+
+  static propTypes = {
+    value: React.PropTypes.string,
+    validator: React.PropTypes.string
+  }
+
+  static defaultProps = {
+    value: ''
+  }
+
+  state = {
+    options: Validators[this.props.validator].options || Validators['length'].options
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.validator !== this.props.validator) {
+      const options = Validators[nextProps.validator].options || Validators['length'].options
+      this.setState({ options });
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.validator !== this.props.validator) {
+      this._input._handleContentChange();
+    }
+  }
+
+  optionChange(prop) {
+    return ((ev) => {
+      let options = this.state.options;
+      options[prop] = ev.target.value;
+      this.setState({ options });
+    });
+  }
+
+  generateOptions() {
+    const options = Validators[this.props.validator].options;
+    let fields = Object.keys(options).map((key) => {
+      return (
+        <Column>
+          <Textbox
+            label={ key }
+            value={ this.state.options[key] }
+            onChange={ this.optionChange(key) }
+          />
+        </Column>
+      );
+    });
+    return <Row>{ fields }</Row>;
+  }
+
+  render() {
+    const validator = Validators[this.props.validator] || Validators['length'];
+
+    let element = React.createElement(
+      validator.component,
+      {
+        validations: [ new validator.validator(this.state.options) ],
+        value: this.props.value,
+        onChange: this.props.onChange,
+        ref: (input) => { this._input = input }
+      }
+    );
+
+
+    return (
+      <div>
+        <div>
+          { element }
+        </div>
+        <div>
+          { this.generateOptions() }
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Validations;

--- a/demo/definitions.js
+++ b/demo/definitions.js
@@ -61,5 +61,6 @@ export default {
   'textarea':             require('components/textarea/definition').default,
   'textbox':              require('components/textbox/definition').default,
   'toast':                require('components/toast/definition').default,
-  'tooltip':              require('components/tooltip/definition').default
+  'tooltip':              require('components/tooltip/definition').default,
+  'validations':          require('./components/validations/definition').default
 };


### PR DESCRIPTION
Added a separate demo site component for handling the validations and changing them via props.

This however does not correctly show the controls or the code for each validation. (Styles also pending)

![screen shot 2017-07-19 at 09 09 37](https://user-images.githubusercontent.com/5382335/28357038-026adfe2-6c62-11e7-82c8-f289226c176f.png)


Other options could include

Completely custom validations set up without a validations component/definition file

A more custom definition file that contains the logic?

Separate screen for each validation in a new area?