### PR TITLE
New ConfigurableItems component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 * The `Poller` helper has been refactored to no longer use promises
 
+## New Components
+
+* `ConfigurableItems` Drag & Drop and check/uncheck a list of items
+* `ConfigurableItemRow` Used with ConfigurableItems to build the list of configurable items
+
 # 1.3.0
 
 ## Component Ehancements

--- a/demo/actions/component/component.js
+++ b/demo/actions/component/component.js
@@ -78,10 +78,34 @@ const ComponentActions = {
       dragIndex,
       hoverIndex,
     });
+  },
+
+  updateConfigurableItemsData: (dragIndex, hoverIndex) => {
+    window.Dispatcher.dispatch({
+      actionType: window.ComponentConstants.UPDATE_CONFIGURABLE_ITEMS,
+      dragIndex,
+      hoverIndex,
+    });
+  },
+
+  updateConfigurableItem: (rowIndex) => {
+    window.Dispatcher.dispatch({
+      actionType: window.ComponentConstants.UPDATE_CONFIGURABLE_ITEM,
+      rowIndex
+    });
+  },
+
+  resetConfigurableItemsData: () => {
+    window.Dispatcher.dispatch({
+      actionType: window.ComponentConstants.RESET_CONFIGURABLE_ITEM_DATA
+    });
   }
 };
 
 // required for dnd demo:
 global.updateDndData = ComponentActions.updateDndData;
+global.updateConfigurableItemsData = ComponentActions.updateConfigurableItemsData;
+global.updateConfigurableItem = ComponentActions.updateConfigurableItem;
+global.resetConfigurableItemsData = ComponentActions.resetConfigurableItemsData;
 
 export default ComponentActions;

--- a/demo/constants/component/component.js
+++ b/demo/constants/component/component.js
@@ -4,5 +4,8 @@ export default {
   UPDATE_SIMPLE_COLOR_PICKER_SELECTED: 'updateSimpleColorPickerSelected',
   UPDATE_TABLE: 'updateTable',
   UPDATE_TABLE_AJAX: 'updateTableAjax',
-  UPDATE_TABLE_DND: 'updateTableDnD'
+  UPDATE_TABLE_DND: 'updateTableDnD',
+  UPDATE_CONFIGURABLE_ITEMS: 'updateConfigurableItems',
+  UPDATE_CONFIGURABLE_ITEM: 'updateConfigurableItem',
+  RESET_CONFIGURABLE_ITEM_DATA: 'resetConfigurableItemData'
 };

--- a/demo/definitions.js
+++ b/demo/definitions.js
@@ -9,6 +9,7 @@ export default {
   'button-toggle':        require('components/button-toggle/definition').default,
   'carousel':             require('components/carousel/definition').default,
   'checkbox':             require('components/checkbox/definition').default,
+  'configurable-items':   require('components/configurable-items/definition').default,
   'confirm':              require('components/confirm/definition').default,
   'content':              require('components/content/definition').default,
   'create':               require('components/create/definition').default,

--- a/demo/stores/component/component.js
+++ b/demo/stores/component/component.js
@@ -9,7 +9,7 @@ import ComponentConstants from './../../constants/component';
 
 import definitions from './../../definitions';
 
-let data = ImmutableHelper.parseJSON(definitions);
+const data = ImmutableHelper.parseJSON(definitions);
 
 // expose tableData for the table component demo
 global.tableData = ImmutableHelper.parseJSON([]);
@@ -27,6 +27,13 @@ global.dndData = ImmutableHelper.parseJSON([
   { id: 10, name: 'Austria', value: 'AT' }
 ]);
 
+const initialConfigurableItemsData = [
+  { id: 1, name: 'Foo', locked: true, enabled: true },
+  { id: 2, name: 'Bar', locked: false, enabled: true },
+  { id: 3, name: 'Baz', locked: false, enabled: false }
+];
+global.configurableItemsData = ImmutableHelper.parseJSON(initialConfigurableItemsData);
+
 class ComponentStore extends Store {
   [ComponentConstants.UPDATE_DEFINITION](data) {
     let value = data.value;
@@ -40,7 +47,7 @@ class ComponentStore extends Store {
       this.data = this.data.setIn([data.name, 'propValues', 'visibleValue'], data.visibleValue);
     }
 
-    if (data.name === "table") {
+    if (data.name === 'table') {
       ComponentActions.updateTable('manual', this.data.getIn(['table', 'propValues']).toJS());
     }
   }
@@ -54,35 +61,56 @@ class ComponentStore extends Store {
   }
 
   [ComponentConstants.UPDATE_TABLE](action) {
-    let data = ImmutableHelper.parseJSON(action.items);
+    const data = ImmutableHelper.parseJSON(action.items);
     this.data = this.data.setIn(['table', 'data'], data);
     this.data = this.data.setIn(['table', 'propValues', 'currentPage'], action.page);
-    this.data = this.data.setIn(['table', 'propValues', "totalRecords"], action.records);
-    this.data = this.data.setIn(['table', 'propValues', "pageSize"], action.pageSize);
-    if (action.sortOrder) { this.data = this.data.setIn(['table', 'propValues', "sortOrder"], action.sortOrder); }
-    if (action.sortedColumn) { this.data = this.data.setIn(['table', 'propValues', "sortedColumn"], action.sortedColumn); }
+    this.data = this.data.setIn(['table', 'propValues', 'totalRecords'], action.records);
+    this.data = this.data.setIn(['table', 'propValues', 'pageSize'], action.pageSize);
+    if (action.sortOrder) { this.data = this.data.setIn(['table', 'propValues', 'sortOrder'], action.sortOrder); }
+    if (action.sortedColumn) { this.data = this.data.setIn(['table', 'propValues', 'sortedColumn'], action.sortedColumn); }
 
     // update the global object
     global.tableData = data;
   }
 
   [ComponentConstants.UPDATE_TABLE_AJAX](action) {
-    let data = ImmutableHelper.parseJSON(action.items);
+    const data = ImmutableHelper.parseJSON(action.items);
     this.data = this.data.setIn(['table', 'data'], data);
     this.data = this.data.setIn(['table', 'propValues', 'currentPage'], action.page);
-    this.data = this.data.setIn(['table', 'propValues', "totalRecords"], action.records);
+    this.data = this.data.setIn(['table', 'propValues', 'totalRecords'], action.records);
 
     // update the global object
     global.tableAjaxData = data;
   }
 
   [ComponentConstants.UPDATE_TABLE_DND](action) {
-    let data = global.dndData.toArray();
-    let { dragIndex, hoverIndex } = action;
-    let dragItem = data.splice(dragIndex, 1)[0];
+    const data = global.dndData.toArray();
+    const { dragIndex, hoverIndex } = action;
+    const dragItem = data.splice(dragIndex, 1)[0];
     data.splice(hoverIndex, 0, dragItem);
 
     global.dndData = ImmutableHelper.parseJSON(data);
+  }
+
+  [ComponentConstants.UPDATE_CONFIGURABLE_ITEMS](action) {
+    const columnData = global.configurableItemsData.toArray();
+    const { dragIndex, hoverIndex } = action;
+    const dragItem = columnData.splice(dragIndex, 1)[0];
+    columnData.splice(hoverIndex, 0, dragItem);
+
+    global.configurableItemsData = ImmutableHelper.parseJSON(columnData);
+  }
+
+  [ComponentConstants.UPDATE_CONFIGURABLE_ITEM](action) {
+    const updatedData = global.configurableItemsData.update(
+      action.rowIndex,
+      (column) => { return column.set('enabled', !column.get('enabled')); }
+    );
+    global.configurableItemsData = updatedData;
+  }
+
+  [ComponentConstants.RESET_CONFIGURABLE_ITEM_DATA]() {
+    global.configurableItemsData = ImmutableHelper.parseJSON(initialConfigurableItemsData);
   }
 }
 

--- a/src/components/configurable-items/README.md
+++ b/src/components/configurable-items/README.md
@@ -1,0 +1,49 @@
+## Configurable Items.
+
+This component renders a list of items that can be checked/unchecked and re-ordered.
+
+### How to use the Configurable Items component:
+
+* In your file:
+
+```javascript
+import { ConfigurableItems, ConfigurableItemRow } from 'carbon-react/lib/components/configurable-items';
+```
+
+* To render the Rows:
+
+```javascript
+
+rows(data) {
+  return (
+    data.map((item, rowIndex) => {
+      return (
+        <ConfigurableItemRow
+          enabled={item.get('enabled')}
+          key={rowIndex}
+          locked={item.get('locked')}
+          name={item.get('name')}
+          rowIndex={rowIndex}
+          onChange={onChange(rowIndex)}
+        />
+      );
+    })
+  );
+}
+
+onChange(rowIndex) {
+  return (event) => {
+    Actions.onChange(rowIndex)
+  }
+}
+
+<ConfigurableItems
+  onCancel={ Actions.onCancel }
+  onDrag={ Actions.onDrag }
+  onReset={ Actions.onReset }
+  onSave={ Actions.onSave }
+  title='Configure Items'
+>
+  { this.rows(data) }
+</ConfigurableItems>
+```

--- a/src/components/configurable-items/__spec__.js
+++ b/src/components/configurable-items/__spec__.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ConfigurableItems } from './configurable-items';
+import Button from './../button';
+import { DraggableContext } from './../drag-and-drop';
+import Form from './../form';
+import Heading from './../heading';
+import { rootTagTest } from '../../utils/helpers/tags/tags-specs';
+
+describe('ConfigurableItems', () => {
+  let wrapper
+  const onCancel = () => { }
+  const onClick = () => { }
+  const onDrag = () => { }
+  const onSave = () => { }
+
+  describe('children', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <ConfigurableItems
+          onCancel={onCancel}
+          onClick={onClick}
+          onDrag={onDrag}
+          onSave={onSave}
+        >
+          <p className='child-node'>Foo</p>
+        </ConfigurableItems>
+      );
+    });
+    it('renders child nodes', () => {
+      const childNode = wrapper.find('.child-node');
+      expect(childNode.length).toEqual(1);
+    });
+  });
+
+  describe('onCancel', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <ConfigurableItems
+          onCancel={onCancel}
+          onClick={onClick}
+          onDrag={onDrag}
+          onSave={onSave}
+        />
+      );
+    });
+    it('passes the onCancel prop through to the Form onCancel prop', () => {
+      expect(wrapper.find(Form).props().onCancel).toEqual(onCancel);
+    });
+  });
+
+  describe('onDrag', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <ConfigurableItems
+          onCancel={onCancel}
+          onClick={onClick}
+          onDrag={onDrag}
+          onSave={onSave}
+        />
+      );
+    });
+    it('passes the onDrag prop through to the DraggableContext', () => {
+      expect(wrapper.find(DraggableContext).props().onDrag).toEqual(onDrag);
+    });
+  });
+
+  describe('onSave', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <ConfigurableItems
+          onCancel={onCancel}
+          onClick={onClick}
+          onDrag={onDrag}
+          onSave={onSave}
+        />
+      );
+    });
+    it('passes the onSave prop through to the Form onSubmit prop', () => {
+      expect(wrapper.find(Form).props().onSubmit).toEqual(onSave);
+    });
+  });
+
+  describe('onReset', () => {
+    let form, resetButton
+    let onResetSpy = jasmine.createSpy('onResetSpy')
+    let onReset = () => { onResetSpy() }
+
+    describe('when the onReset prop is provided', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <ConfigurableItems
+            onCancel={onCancel}
+            onClick={onClick}
+            onDrag={onDrag}
+            onReset={onReset}
+            onSave={onSave}
+          />
+        );
+        form = wrapper.find(Form);
+        resetButton = shallow(form.props().additionalActions).find('.carbon-button--reset')
+      });
+
+      it('passes a reset button, with an onClick prop, as additionalActions to the form', () => {
+        expect(resetButton.length).toEqual(1);
+        resetButton.simulate('click', { preventDefault: () => {} })
+        expect(onResetSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('when the onReset prop is not provided', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <ConfigurableItems
+            onCancel={onCancel}
+            onClick={onClick}
+            onDrag={onDrag}
+            onSave={onSave}
+          />
+        );
+        form = wrapper.find(Form);
+      });
+
+      it('does not pass additionalActions to the form', () => {
+        expect(form.props().additionalActions).toBeNull();
+      });
+    })
+  });
+
+  describe("tags", () => {
+    describe("on component", () => {
+      let wrapper = shallow(
+        <ConfigurableItems
+          data-element='bar'
+          data-role='baz'
+          onCancel={onCancel}
+          onClick={onClick}
+          onDrag={onDrag}
+          onSave={onSave}
+        />
+      );
+
+      it('includes the correct component, element and role data tags', () => {
+        rootTagTest(wrapper, 'configurable-items', 'bar', 'baz');
+      });
+    });
+  });
+});

--- a/src/components/configurable-items/__spec__.js
+++ b/src/components/configurable-items/__spec__.js
@@ -98,10 +98,10 @@ describe('ConfigurableItems', () => {
           />
         );
         form = wrapper.find(Form);
-        resetButton = shallow(form.props().additionalActions).find('.carbon-button--reset')
+        resetButton = shallow(form.props().leftAlignedActions).find('.carbon-button--reset')
       });
 
-      it('passes a reset button, with an onClick prop, as additionalActions to the form', () => {
+      it('passes a reset button, with an onClick prop, as leftAlignedActions to the form', () => {
         expect(resetButton.length).toEqual(1);
         resetButton.simulate('click', { preventDefault: () => {} })
         expect(onResetSpy).toHaveBeenCalled();
@@ -121,8 +121,8 @@ describe('ConfigurableItems', () => {
         form = wrapper.find(Form);
       });
 
-      it('does not pass additionalActions to the form', () => {
-        expect(form.props().additionalActions).toBeNull();
+      it('does not pass leftAlignedActions to the form', () => {
+        expect(form.props().leftAlignedActions).toBeNull();
       });
     })
   });

--- a/src/components/configurable-items/configurable-item-row/__spec__.js
+++ b/src/components/configurable-items/configurable-item-row/__spec__.js
@@ -1,0 +1,164 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ConfigurableItemRow from './configurable-item-row';
+import Checkbox from './../../checkbox';
+import Icon from './../../icon';
+import { WithDrag, WithDrop } from './../../drag-and-drop';
+import { rootTagTest } from './../../../utils/helpers/tags/tags-specs';
+
+describe('ConfigurableItemRow', () => {
+  let wrapper
+  const onChange = () => { }
+
+  describe('classNames', () => {
+    beforeEach(() => {
+      wrapper = shallow(<ConfigurableItemRow className='my-custom-class-name' />);
+      wrapper.instance().context = { dragAndDropActiveIndex: 1 }
+    })
+
+    it('adds the className to the row', () => {
+      expect(wrapper.find('.my-custom-class-name').length).toEqual(1);
+    })
+
+    describe('when the dragAndDropActiveIndex is the same as the rowIndex', () =>{
+      beforeEach(() => {
+        wrapper.setProps({rowIndex: 1})
+      });
+      it('adds configurable-item-row--dragged to the classes', () => {
+        expect(wrapper.find('.configurable-item-row--dragged').length).toEqual(1);
+      });
+    });
+
+    describe('when the dragAndDropActiveIndex is the same as the rowIndex', () =>{
+      beforeEach(() => {
+        wrapper.setProps({rowIndex: 2})
+      });
+      it('does not add configurable-item-row--dragged to the classes', () => {
+        expect(wrapper.find('.configurable-item-row--dragged').length).toEqual(0);
+      });
+    });
+  });
+
+  describe("tags", () => {
+    describe("on component", () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <ConfigurableItemRow data-element='bar' data-role='baz' />
+        );
+      });
+      it('includes the correct component, element and role data tags', () => {
+        rootTagTest(wrapper, 'configurable-item-row', 'bar', 'baz');
+      });
+    });
+  });
+
+  describe('onChange', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <ConfigurableItemRow onChange={onChange} />
+      );
+    });
+    it('passes the onChange prop through to the Checkbox onChange prop', () => {
+      expect(wrapper.find(Checkbox).props().onChange).toEqual(onChange);
+    });
+  });
+
+  describe('enabled', () => {
+    describe('when the row is enabled', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <ConfigurableItemRow enabled={true} />
+        );
+      });
+
+      it('sets the Checkbox value to true', () => {
+        expect(wrapper.find(Checkbox).props().value).toBeTruthy();
+      });
+    });
+
+    describe('when the row is not enabled', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <ConfigurableItemRow enabled={false} />
+        );
+      });
+
+      it('sets the Checkbox value to false', () => {
+        expect(wrapper.find(Checkbox).props().value).toBeFalsy();
+      });
+    });
+  });
+
+  describe('locked', () => {
+    describe('when the row is locked', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <ConfigurableItemRow locked={true} />
+        );
+      });
+
+      it('sets the Checkbox as disabled', () => {
+        expect(wrapper.find(Checkbox).props().disabled).toBeTruthy();
+      });
+    });
+
+    describe('when the row is not locked', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <ConfigurableItemRow locked={false} />
+        );
+      });
+
+      it('does not set the Checkbox as disabled', () => {
+        expect(wrapper.find(Checkbox).props().disabled).toBeFalsy();
+      });
+    });
+  });
+
+  describe('name', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <ConfigurableItemRow name='Foo' />
+      );
+    });
+
+    it('sets the Checkbox label prop', () => {
+      expect(wrapper.find(Checkbox).props().label).toEqual('Foo')
+    });
+  });
+
+  describe('rowIndex', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <ConfigurableItemRow rowIndex={2} />
+      );
+    });
+    it('sets the index prop on the WithDrop component', () => {
+      expect(wrapper.find(WithDrop).props().index).toEqual(2)
+    });
+  });
+
+  describe('icon', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <ConfigurableItemRow name='Foo' />
+      );
+    });
+
+    it('renders a drag vertical icon', () => {
+      expect(wrapper.find(Icon).props().type).toEqual('drag_vertical')
+    });
+  });
+
+  describe('list item markup', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <ConfigurableItemRow name='Foo' />
+      );
+    });
+
+    it('renders an <li>', () => {
+      expect(wrapper.find('li').length).toEqual(1)
+    });
+  })
+});

--- a/src/components/configurable-items/configurable-item-row/configurable-item-row.js
+++ b/src/components/configurable-items/configurable-item-row/configurable-item-row.js
@@ -1,0 +1,135 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import tagComponent from './../../../utils/helpers/tags';
+import { WithDrag, WithDrop } from './../../drag-and-drop';
+import Checkbox from './../../checkbox';
+import Icon from './../../icon';
+
+class ConfigurableItemRow extends React.Component {
+  static propTypes = {
+    /**
+     * A custom class name for the component.
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    /**
+     * The checked value for the checkbox.
+     *
+     * @property enabled
+     * @type {Boolean}
+     */
+    enabled: PropTypes.bool,
+
+    /**
+     * The disabled value for the checkbox.
+     *
+     * @property locked
+     * @type {Boolean}
+     */
+    locked: PropTypes.bool,
+
+    /**
+     * The label for the row.
+     *
+     * @property name
+     * @type {String}
+     */
+    name: PropTypes.string,
+
+    /**
+     * Callback triggered when the checkbox checked value is updated.
+     *
+     * @property onChange
+     * @type {Function}
+     */
+    onChange: PropTypes.func,
+
+    /**
+     * The unique index for the row.
+     *
+     * @property rowIndex
+     * @type {Number}
+     */
+    rowIndex: PropTypes.number
+  };
+
+  static contextTypes = {
+    dragDropManager: PropTypes.object, // the React DND DragDropManager
+    dragAndDropActiveIndex: PropTypes.number // tracks the currently active index
+  }
+
+  checkbox(enabled, locked, name, onChange) {
+    return (
+      <Checkbox
+        value={ enabled }
+        disabled={ locked }
+        label={ name }
+        onChange={ onChange }
+      />
+    );
+  }
+
+  icon() {
+    return (
+      <Icon
+        className='configurable-item-row__icon'
+        type='drag_vertical'
+      />
+    );
+  }
+
+  classes = (dragAndDropActiveIndex, index) => {
+    return (
+      classNames(
+        'configurable-item-row',
+        this.props.className,
+        {
+          'configurable-item-row--dragged': this.dragged(dragAndDropActiveIndex, index),
+          'configurable-item-row--dragging': (this.draggingIsOccurring(dragAndDropActiveIndex))
+        }
+      )
+    );
+  }
+
+  /**
+   * Determines if the item has been dragged.
+   *
+   * @method dragged
+   * @return {Boolean}
+   */
+  dragged(dragAndDropActiveIndex, index) {
+    return (this.draggingIsOccurring(dragAndDropActiveIndex) && dragAndDropActiveIndex === index);
+  }
+
+  /**
+   * Determines if dragging is occurring within the current draggable context.
+   *
+   * @method draggingIsOccurring
+   * @return {Boolean}
+   */
+  draggingIsOccurring(dragAndDropActiveIndex) {
+    return typeof (dragAndDropActiveIndex) === 'number';
+  }
+
+  render() {
+    const { rowIndex, enabled, locked, name, onChange } = this.props;
+    return (
+      <WithDrop index={ rowIndex } { ...tagComponent('configurable-item-row', this.props) }>
+        <li className={ this.classes(this.context.dragAndDropActiveIndex, rowIndex) }>
+          <WithDrag>
+            <div className='configurable-item-row__content-wrapper'>
+              { this.icon() }
+              { this.checkbox(enabled, locked, name, onChange) }
+            </div>
+          </WithDrag>
+        </li>
+      </WithDrop>
+    );
+  }
+}
+
+export default ConfigurableItemRow;

--- a/src/components/configurable-items/configurable-item-row/configurable-item-row.js
+++ b/src/components/configurable-items/configurable-item-row/configurable-item-row.js
@@ -75,10 +75,14 @@ class ConfigurableItemRow extends React.Component {
 
   icon() {
     return (
-      <Icon
-        className='configurable-item-row__icon'
-        type='drag_vertical'
-      />
+      <WithDrag>
+        <div>
+          <Icon
+            className='configurable-item-row__icon'
+            type='drag_vertical'
+          />
+        </div>
+      </WithDrag>
     );
   }
 
@@ -120,12 +124,10 @@ class ConfigurableItemRow extends React.Component {
     return (
       <WithDrop index={ rowIndex } { ...tagComponent('configurable-item-row', this.props) }>
         <li className={ this.classes(this.context.dragAndDropActiveIndex, rowIndex) }>
-          <WithDrag>
-            <div className='configurable-item-row__content-wrapper'>
-              { this.icon() }
-              { this.checkbox(enabled, locked, name, onChange) }
-            </div>
-          </WithDrag>
+          <div className='configurable-item-row__content-wrapper'>
+            { this.icon() }
+            { this.checkbox(enabled, locked, name, onChange) }
+          </div>
         </li>
       </WithDrop>
     );

--- a/src/components/configurable-items/configurable-item-row/configurable-item-row.scss
+++ b/src/components/configurable-items/configurable-item-row/configurable-item-row.scss
@@ -1,0 +1,24 @@
+@import "./../../../style-config/colors";
+
+.configurable-item-row {
+  border-bottom: 1px solid $border-color;
+  font-weight: bold;
+  padding: 0.5em;
+}
+
+.configurable-item-row--dragging,
+.configurable-item-row--dragged {
+  cursor: grabbing;
+  cursor: -moz-grabbing;
+  cursor: -webkit-grabbing;
+}
+
+.configurable-item-row__content-wrapper {
+  align-items: center;
+  display: flex;
+  justify-content: left;
+}
+
+.configurable-item-row__icon {
+  cursor: move;
+}

--- a/src/components/configurable-items/configurable-item-row/definition.js
+++ b/src/components/configurable-items/configurable-item-row/definition.js
@@ -1,0 +1,6 @@
+import ConfigurableItemRow from './';
+import Definition from './../../../../demo/utils/definition';
+
+const definition = new Definition('configurable-item-row', ConfigurableItemRow, {});
+
+export default definition;

--- a/src/components/configurable-items/configurable-item-row/package.json
+++ b/src/components/configurable-items/configurable-item-row/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./configurable-item-row.js",
+  "style": "./configurable-item-row.scss"
+}

--- a/src/components/configurable-items/configurable-items.js
+++ b/src/components/configurable-items/configurable-items.js
@@ -95,7 +95,7 @@ class ConfigurableItems extends React.Component {
       <div className={ this.classes } { ...tagComponent('configurable-items', this.props) }>
         <DraggableContext onDrag={ this.props.onDrag }>
           <Form
-            additionalActions={ this.additionalActions() }
+            leftAlignedActions={ this.additionalActions() }
             onSubmit={ this.props.onSave }
             onCancel={ this.props.onCancel }
           >

--- a/src/components/configurable-items/configurable-items.js
+++ b/src/components/configurable-items/configurable-items.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import I18n from 'i18n-js';
+import tagComponent from '../../utils/helpers/tags';
+import { DraggableContext } from './../drag-and-drop';
+import Button from './../button';
+import ConfigurableItemRow from './configurable-item-row';
+import Form from './../form';
+
+class ConfigurableItems extends React.Component {
+  static propTypes = {
+    /**
+     * Children elements.
+     *
+     * @property children
+     * @type {Node}
+     */
+    children: PropTypes.node,
+
+    /**
+     * A custom class name for the component.
+     *
+     * @property className
+     * @type {String}
+     */
+    className: PropTypes.string,
+
+    /**
+     * Callback triggered when the form is canceled.
+     *
+     * @property onCancel
+     * @type {Function}
+     */
+    onCancel: PropTypes.func.isRequired,
+
+    /**
+     * Callback triggered when an item is dragged.
+     *
+     * @property onDrag
+     * @type {Function}
+     */
+    onDrag: PropTypes.func.isRequired,
+
+    /**
+     * Callback triggered when when the reset button is pressed.
+     *
+     * @property onReset
+     * @type {Function}
+     */
+    onReset: PropTypes.func,
+
+    /**
+     * Callback triggered when the form is saved.
+     *
+     * @property onSave
+     * @type {Function}
+     */
+    onSave: PropTypes.func.isRequired
+  }
+
+  onReset = (event) => {
+    event.preventDefault();
+    this.props.onReset();
+  }
+
+  additionalActions = () => {
+    if (!this.props.onReset) { return null; }
+    return (
+      <Button onClick={ this.onReset } className='carbon-button--reset'>
+        { I18n.t('actions.reset', { defaultValue: 'Reset' }) }
+      </Button>
+    );
+  }
+
+  rows = () => {
+    return (
+      <ol className='carbon-configurable-items__items-wrapper'>
+        { this.props.children }
+      </ol>
+    );
+  }
+
+  get classes() {
+    return (
+      classNames(
+        'carbon-configurable-items',
+        this.props.className
+      )
+    );
+  }
+
+  render() {
+    return (
+      <div className={ this.classes } { ...tagComponent('configurable-items', this.props) }>
+        <DraggableContext onDrag={ this.props.onDrag }>
+          <Form
+            additionalActions={ this.additionalActions() }
+            onSubmit={ this.props.onSave }
+            onCancel={ this.props.onCancel }
+          >
+            { this.rows() }
+          </Form>
+        </DraggableContext>
+      </div>
+    );
+  }
+}
+
+export {
+  ConfigurableItems,
+  ConfigurableItemRow
+};

--- a/src/components/configurable-items/configurable-items.scss
+++ b/src/components/configurable-items/configurable-items.scss
@@ -1,14 +1,3 @@
-.carbon-configurable-items {
-  .carbon-form__buttons {
-    position: relative;
-  }
-
-  .carbon-form__additional-actions {
-    position: absolute;
-    left: 0;
-  }
-}
-
 .carbon-configurable-items__items-wrapper {
   list-style: none;
   margin: 0;

--- a/src/components/configurable-items/configurable-items.scss
+++ b/src/components/configurable-items/configurable-items.scss
@@ -1,0 +1,16 @@
+.carbon-configurable-items {
+  .carbon-form__buttons {
+    position: relative;
+  }
+
+  .carbon-form__additional-actions {
+    position: absolute;
+    left: 0;
+  }
+}
+
+.carbon-configurable-items__items-wrapper {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}

--- a/src/components/configurable-items/definition.js
+++ b/src/components/configurable-items/definition.js
@@ -1,0 +1,66 @@
+import { ConfigurableItems } from './';
+import Definition from './../../../demo/utils/definition';
+import configurableItemRowDefinition from './configurable-item-row/definition';
+
+let definition = new Definition('configurable-items', ConfigurableItems, {
+  associatedDefinition: [configurableItemRowDefinition],
+  dataVariable: 'configurableItemsData',
+  description: `Allow a list of items to be checked/unchecked and re-ordered.`,
+  designerNotes: `
+* Designed to be used in tandem with the onConfigure prop in the table component so that columns can be enabled/disabled and re-ordered.
+  `,
+  hiddenProps: ['children'],
+  js: `
+    function rows(data) {
+      return (
+        data.map((column, rowIndex) => {
+          return (
+            <ConfigurableItemRow
+              enabled={column.get('enabled')}
+              key={rowIndex}
+              locked={column.get('locked')}
+              name={column.get('name')}
+              rowIndex={rowIndex}
+              onChange={onChange(rowIndex)}
+            />
+          );
+        })
+      );
+    }
+
+    function onChange(rowIndex) {
+      return (event) => {
+        updateConfigurableItem(rowIndex)
+      }
+    }
+  `,
+  propValues: {
+    children: `{ rows(configurableItemsData) }`,
+    onCancel: `() => {}`,
+    onDrag: `updateConfigurableItemsData`,
+    onReset: `resetConfigurableItemsData`,
+    onSave: `() => {}`
+  },
+  propTypes: {
+    children: 'Node',
+    className: 'String',
+    onCancel: 'Function',
+    onDrag: 'Function',
+    onReset: 'Function',
+    onSave: 'Function',
+  },
+  propDescriptions: {
+    children: 'This component supports children',
+    className : 'Classes to apply to the component.',
+    onCancel: 'Callback triggered when the form is canceled.',
+    onDrag: 'Callback triggered when an item is dragged.',
+    onReset: 'Callback triggered when the reset button is pressed',
+    onSave: 'Callback triggered when the form is saved.'
+  },
+  relatedComponentsNotes: `
+* [Table component](/components/table)
+ `,
+  requiredProps: ['onCancel', 'onDrag', 'onSave', 'title'],
+});
+
+export default definition;

--- a/src/components/configurable-items/package.json
+++ b/src/components/configurable-items/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./configurable-items.js",
+  "style": "./configurable-items.scss"
+}

--- a/src/utils/helpers/poller/__spec__.js
+++ b/src/utils/helpers/poller/__spec__.js
@@ -206,8 +206,7 @@ describe('poller', () => {
           });
         });
 
-        it('calls the handleError with the error', (done) => {
-          done();
+        it('calls the handleError with the error', () => {
           expect(functions.handleError.calls.mostRecent().args.toString()).toEqual('Error: Unsuccessful HTTP response');
         });
       });
@@ -228,9 +227,8 @@ describe('poller', () => {
           });
         });
 
-        it('logs the error', (done) => {
+        it('logs the error', () => {
           Poller({ url }, functions, { interval: 1000 });
-          done();
           expect(console.error).toHaveBeenCalledWith( // eslint-disable-line no-console
             'Unsuccessful HTTP response');
         });


### PR DESCRIPTION
Introduces new `ConfigurableItems` and `ConfigurableItemRow` components.

These can be combined to form a list of Items with checkboxes that can be dragged and dropped. Designed to be used in tandem with the onConfigure prop in the table component.

Ticket: CARBON-828

![config-items](https://user-images.githubusercontent.com/4964/28419135-07e2eb46-6d56-11e7-921b-0acf2d601cf4.gif)
