### PR TITLE
added additional form actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.3.0
+# 1.4.0
 
 ## Dependency Update
 
@@ -6,7 +6,8 @@
 
 ## Component Improvements
 
-* The `Poller` helper has been refactored to no longer use promises
+* The `Poller` helper has been refactored to no longer use promises.
+* `Form` now has additional props of `leftAlignedActions` and `rightAlignedActions` which allows developers to add additional nodes in line with the default form actions.
 
 # 1.2.2
 

--- a/src/components/form/__spec__.js
+++ b/src/components/form/__spec__.js
@@ -532,18 +532,31 @@ describe('Form', () => {
       describe('if none defined', () => {
         it('returns null', () => {
           let instance = TestUtils.renderIntoDocument(<Form />);
-          expect(instance.additionalActions).toBe(null);
+          expect(instance.additionalActions('additionalActions')).toBe(null);
         });
       });
 
       describe('if defined', () => {
         it('returns the action', () => {
           let instance = TestUtils.renderIntoDocument(<Form additionalActions={ <span /> } />);
-          expect(instance.additionalActions.props.className).toEqual("carbon-form__additional-actions");
+          expect(instance.additionalActions('additionalActions').props.className).toEqual("carbon-form__additional-actions");
+        });
+      });
+
+      describe('leftAlignedActions', () => {
+        it('returns the action', () => {
+          let instance = TestUtils.renderIntoDocument(<Form leftAlignedActions={ <span /> } />);
+          expect(instance.additionalActions('leftAlignedActions').props.className).toEqual("carbon-form__left-aligned-actions");
+        });
+      });
+
+      describe('rightAlignedActions', () => {
+        it('returns the action', () => {
+          let instance = TestUtils.renderIntoDocument(<Form rightAlignedActions={ <span /> } />);
+          expect(instance.additionalActions('rightAlignedActions').props.className).toEqual("carbon-form__right-aligned-actions");
         });
       });
     });
-
   });
 
   describe("tags", () => {

--- a/src/components/form/definition.js
+++ b/src/components/form/definition.js
@@ -24,7 +24,6 @@ let definition = new Definition('form', Form, {
     buttonAlign: OptionsHelper.alignBinary
   },
   propTypes: {
-    additionalActions: "Node",
     cancel: "Boolean",
     children: "Node",
     className: "String",

--- a/src/components/form/definition.js
+++ b/src/components/form/definition.js
@@ -39,7 +39,6 @@ let definition = new Definition('form', Form, {
     saveButtonProps: "Object",
     onCancel: "Function",
     save: "Boolean",
-    additionalActions: "Node",
     onSubmit: "Function",
     iterative: "Boolean",
     summary: "Boolean",

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Serialize from 'form-serialize';
+import { kebabCase } from 'lodash';
 
 import CancelButton from './cancel-button';
 import FormSummary from './form-summary';
@@ -147,6 +148,22 @@ class Form extends React.Component {
      * @type {String|JSX}
      */
     additionalActions: PropTypes.node,
+
+    /**
+     * Additional actions rendered and aligned left to the save and cancel buttons
+     *
+     * @property additionalActions
+     * @type {String|JSX}
+     */
+    leftAlignedActions: PropTypes.node,
+
+    /**
+     * Additional actions rendered and aligned right to the save and cancel buttons
+     *
+     * @property additionalActions
+     * @type {String|JSX}
+     */
+    rightAlignedActions: PropTypes.node,
 
     /**
      * Custom callback for when form will submit
@@ -536,12 +553,12 @@ class Form extends React.Component {
    * @method additionalActions
    * @return {Object} JSX
    */
-  get additionalActions() {
-    if (!this.props.additionalActions) { return null; }
+  additionalActions = (type) => {
+    if (!this.props[type]) { return null; }
 
     return (
-      <div className='carbon-form__additional-actions' >
-        { this.props.additionalActions }
+      <div className={ `carbon-form__${kebabCase(type)}` } >
+        { this.props[type] }
       </div>
     );
   }
@@ -603,9 +620,11 @@ class Form extends React.Component {
     const save = this.props.showSummary ? this.saveButtonWithSummary() : this.saveButton();
     return (
       <div className={ this.footerClasses }>
+        { this.additionalActions('leftAlignedActions') }
+        { this.additionalActions('rightAlignedActions') }
         { save }
         { this.cancelButton() }
-        { this.additionalActions }
+        { this.additionalActions('additionalActions') }
       </div>
     );
   }

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -147,7 +147,7 @@ class Form extends React.Component {
      * @property additionalActions
      * @type {String|JSX}
      */
-    additionalActions: PropTypes.node,
+    additionalActions: PropTypes.node, // eslint-disable-line react/no-unused-prop-types
 
     /**
      * Additional actions rendered and aligned left to the save and cancel buttons
@@ -155,7 +155,7 @@ class Form extends React.Component {
      * @property additionalActions
      * @type {String|JSX}
      */
-    leftAlignedActions: PropTypes.node,
+    leftAlignedActions: PropTypes.node, // eslint-disable-line react/no-unused-prop-types
 
     /**
      * Additional actions rendered and aligned right to the save and cancel buttons
@@ -163,7 +163,7 @@ class Form extends React.Component {
      * @property additionalActions
      * @type {String|JSX}
      */
-    rightAlignedActions: PropTypes.node,
+    rightAlignedActions: PropTypes.node, // eslint-disable-line react/no-unused-prop-types
 
     /**
      * Custom callback for when form will submit

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -2,11 +2,28 @@
 
 .carbon-form__left-aligned-actions {
   flex-grow: 1;
+
+  .carbon-button {
+    margin-left: 15px;
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
 }
 
+.carbon-form__right-aligned-actions,
 .carbon-form__additional-actions {
-  padding-left: 10px;
+  padding-left: 15px;
   display: inline-block;
+
+  .carbon-button {
+    margin-left: 15px;
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
 }
 
 .carbon-form__buttons {
@@ -30,6 +47,7 @@
 
 .carbon-form-save--invalid {
   background-color: $grey-dark-blue-5;
+  margin-left: 15px;
 }
 
 @keyframes form-buttons-animate-in {

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -1,5 +1,9 @@
 @import "./../../style-config/colors";
 
+.carbon-form__left-aligned-actions {
+  flex-grow: 1;
+}
+
 .carbon-form__additional-actions {
   padding-left: 10px;
   display: inline-block;


### PR DESCRIPTION
`Form` now has additional props of `leftAlignedActions` and `rightAlignedActions` which allows developers to add additional nodes in line with the default form actions.

![screen shot 2017-07-20 at 17 44 03](https://user-images.githubusercontent.com/1668080/28429042-3eb6f852-6d73-11e7-8132-55a8e16e1d80.png)
