### PR TITLE
Amend min & max width to avoid fixed width bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.1
+
+## Bug Fixes
+
+* A bug was found in the new Dialog behaviour in Safari 9.x which rendered the sticky footer incorrectly. This solves it rendering incorrectly on page load for Safari 9.x. There remains a wider issue around Safari logged [here](https://github.com/Sage/carbon/issues/1432).
+
 # 1.3.0
 
 ## Component Ehancements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A library of reusable React components and an interface for easily building user interfaces based on Flux.",
   "engineStrict": true,
   "engines": {

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -65,8 +65,8 @@
 .carbon-form:not(.carbon-form--sticky-footer),
 .carbon-dialog__dialog--fixed-bottom {
   .carbon-form__buttons {
-    max-width: auto;
-    min-width: auto;
+    max-width: initial;
+    min-width: initial;
     padding: 0;
   }
 }


### PR DESCRIPTION
# Description

A bug was found in the new `Dialog` behaviour in Safari `9.x` which rendered the sticky footer incorrectly. This solves it rendering incorrectly on page load for Safari `9.x`. There remains a wider issue around Safari logged [here](https://github.com/Sage/carbon/issues/1432)
