### PR TITLE
Allow ButtonToggle to be toggled via the keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The following have had minor internal changes to satisfy the introduction of str
 * `Form` now has additional props of `leftAlignedActions` and `rightAlignedActions` which allows developers to add additional nodes in line with the default form actions.
 * `Button`: Makes large button text the same as the medium button
 * `Button`: Allows secondary text under main text [#1385](https://github.com/Sage/carbon/issues/1385)
+* `ButtonToggle`: The buttons can now be toggled using the keyboard
 
 ## Minor Improvments
 

--- a/src/components/button-toggle/__spec__.js
+++ b/src/components/button-toggle/__spec__.js
@@ -22,7 +22,7 @@ describe('ButtonToggle', () => {
 
   describe('input classes', () => {
     it('returns the classes for the input', () => {
-      expect(instance.inputClasses).toEqual('carbon-button-toggle__input hidden common-input__input');
+      expect(instance.inputClasses).toEqual('carbon-button-toggle__input common-input__input');
     });
   });
 

--- a/src/components/button-toggle/button-toggle.js
+++ b/src/components/button-toggle/button-toggle.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Icon from './../icon';
-import css from './../../utils/css';
 import Input from './../../utils/decorators/input';
 import { validProps } from './../../utils/ether';
 import tagComponent from '../../utils/helpers/tags';
@@ -63,7 +62,7 @@ class ButtonToggle extends React.Component {
    * @return {String} input className
    */
   get inputClasses() {
-    return classNames('carbon-button-toggle__input', css.hidden);
+    return classNames('carbon-button-toggle__input');
   }
 
   /**
@@ -96,7 +95,7 @@ class ButtonToggle extends React.Component {
   get inputProps() {
     const { ...props } = validProps(this);
     delete props.children;
-    props.className = this.inputClasses;
+    props.className = 'carbon-button-toggle__input';
     props.type = 'radio';
     if (!props.id) {
       props.id = this._guid;

--- a/src/components/button-toggle/button-toggle.scss
+++ b/src/components/button-toggle/button-toggle.scss
@@ -1,5 +1,7 @@
 @import "./../../style-config/colors";
 @import "./../../style-config/buttons";
+@import "./../../style-config/input-field";
+@import "./../../style-config/mixins";
 
 .carbon-button-toggle {
   display: inline-block;
@@ -30,6 +32,14 @@
   background-color: $carbon-button__background-color--disabled !important;
   color: $carbon-button__color--disabled !important;
   cursor: initial;
+}
+
+.carbon-button-toggle__input {
+  @include visually-hidden();
+
+  &:focus:not(:checked) + label {
+    @include input-outline($input-active-border-color);
+  }
 }
 
 .carbon-button-toggle__input:checked ~ .carbon-button-toggle__label {

--- a/src/style-config/mixins.scss
+++ b/src/style-config/mixins.scss
@@ -258,3 +258,9 @@
   -ms-user-select: none;
   user-select: none;
 }
+
+@mixin input-outline($border-color) {
+  border-color: $border-color;
+  box-shadow: 0 0 6px rgba(25, 99, 246, 0.6);
+  @include transition(box-shadow linear 0.1s);
+}

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -108,9 +108,7 @@
 
   &:active,
   &:focus {
-    border-color: $input-active-border-color;
-    box-shadow: 0 0 6px rgba(25, 99, 246, 0.6);
-    @include transition(box-shadow linear 0.1s);
+    @include input-outline($input-active-border-color);
   }
 
   .common-input--disabled &,


### PR DESCRIPTION
Change the CSS used to hide the radio buttons so the radio buttons are
still accessible to screen readers, and can be tabbed via the keyboard:
instead of using `display: none` the `visually-hidden` mixin is applied
instead.

Add CSS outline to the ButtonToggle so users can see visually that the
component has received focus:

* The outline effect is the same as that used on existing input elements
* The existing CSS for the outline has been moved to a mixin

## Screenshots / Gifs
![btn-tgl](https://user-images.githubusercontent.com/52329/28674046-206afb3c-72dc-11e7-871b-138be26111de.gif)
