### PR TITLE
Ensures close icon positioning in dialog #1450

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
   directories:
   - node_modules
 node_js:
-  - '7'
+  - '6.10.2'
 install:
   - npm install -g npm
   - npm install -g gulp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.6
+
+## Bug Fix
+
+* `Dialog`: ensures close icon positioning regardless of CSS load order
+
 # 1.3.5
 
 ## Bug Fixes

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -97,13 +97,15 @@ $dialog-sizes: (
 .carbon-dialog__close {
   color: $grey-dark-blue-60;
   cursor: pointer;
-  position: absolute;
   right: $dialog-padding;
   top: 25px;
   z-index: 1;
 
   &:hover {
     color: $blue;
+  }
+  &.carbon-icon {
+    position: absolute;
   }
 }
 


### PR DESCRIPTION
# Description
* This specificity is introduced to ensure that the Dialog maintains the layout of it's close icon even if the CSS loads in a different order

# TODO
- [x] Release notes

# Related Issues / Pull Requests
https://github.com/Sage/carbon/issues/1450

# Screenshots / Gifs
Demostrate the fix in our app:
![screen shot 2017-07-31 at 12 20 09](https://user-images.githubusercontent.com/10499070/28776565-01d263e8-75ef-11e7-954c-6c36bf453d52.png)
![screen shot 2017-07-31 at 12 47 34](https://user-images.githubusercontent.com/10499070/28776566-01d635fe-75ef-11e7-994c-b080c759cd75.png)

# Testing Instructions
* The above screen shots should demonstrate that it's fixed in our app, so I've checked that as done on the issue
* There should be no change to demo site functionality
