### PR TITLE
[CARBON-865] Re-enable html5 backend for desktop ghost row drag and drop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
     - node_modules
 
 node_js:
-  - "7"
+  - '6.10.2'
 
 install:
   - npm install -g npm

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "prop-types": "~15.5.8",
     "react-date-picker": "~5.3.28",
     "react-dnd": "~2.4.0",
+    "react-dnd-html5-backend": "~2.4.1",
     "react-dnd-touch-backend": "0.2.7",
     "react-highcharts": "~11.5.0",
     "superagent": "~2.2.0"

--- a/src/components/drag-and-drop/drag-and-drop.js
+++ b/src/components/drag-and-drop/drag-and-drop.js
@@ -1,9 +1,11 @@
 import DraggableContext from './draggable-context';
 import WithDrag from './with-drag';
 import WithDrop from './with-drop';
+import WithDragDrop from './with-drag-drop';
 
 export {
   DraggableContext,
   WithDrag,
-  WithDrop
+  WithDrop,
+  WithDragDrop
 };

--- a/src/components/drag-and-drop/draggable-context/__spec__.js
+++ b/src/components/drag-and-drop/draggable-context/__spec__.js
@@ -1,7 +1,17 @@
 import React from 'react';
+import Bowser from 'bowser';
+import TouchBackend from 'react-dnd-touch-backend';
+import HTML5Backend from 'react-dnd-html5-backend';
+import { isEqual } from 'underscore';
 import DraggableContext from './draggable-context';
 import { mount } from 'enzyme';
 import ItemTargetHelper from './../../../utils/helpers/dnd/item-target';
+import { backend } from './draggable-context';
+
+// Used to compare complex functions
+const stringify = (func) => {
+  return JSON.stringify(func.toString()).replace(/(\\t|\\n)/g,'')
+}
 
 describe('DraggableContext', () => {
   let wrapper, instance, onDragSpy;
@@ -75,6 +85,37 @@ describe('DraggableContext', () => {
     it('renders this.props.children', () => {
       expect(wrapper.find('div').length).toEqual(1);
       expect(wrapper.find('p').length).toEqual(2);
+    });
+  });
+
+  describe('backend()', () => {
+    describe('when Bowser detects the device is a mobile', () => {
+      beforeEach(() => {
+        Bowser.mobile = true
+      })
+      it('renders the TouchBackend', () => {
+        expect(stringify(backend())).toEqual(stringify(TouchBackend({ enableMouseEvents: true })))
+      });
+    });
+
+    describe('when Bowser detects the device is a tablet', () => {
+      beforeEach(() => {
+        Bowser.mobile = false
+        Bowser.tablet = true
+      })
+      it('renders the TouchBackend', () => {
+        expect(stringify(backend())).toEqual(stringify(TouchBackend({ enableMouseEvents: true })))
+      });
+    });
+
+    describe('when Bowser detects the device is not mobile or tablet', () => {
+      beforeEach(() => {
+        Bowser.mobile = false
+        Bowser.tablet = false
+      })
+      it('renders the HTML5Backend', () => {
+        expect(stringify(backend())).toEqual(stringify(HTML5Backend))
+      });
     });
   });
 });

--- a/src/components/drag-and-drop/draggable-context/definition.js
+++ b/src/components/drag-and-drop/draggable-context/definition.js
@@ -4,9 +4,10 @@ import ComponentActions from './../../../../demo/actions/component';
 import Definition from './../../../../demo/utils/definition';
 import WithDragDefinition from './../with-drag/definition';
 import WithDropDefinition from './../with-drop/definition';
+import WithDragDropDefinition from './../with-drag-drop/definition';
 
 let definition = new Definition('draggable-context', DraggableContext, {
-  associatedDefinitions: [WithDropDefinition, WithDragDefinition],
+  associatedDefinitions: [WithDropDefinition, WithDragDefinition, WithDragDropDefinition],
 
   hiddenProps: ['children', 'onDrag'],
 
@@ -24,12 +25,7 @@ let definition = new Definition('draggable-context', DraggableContext, {
 
   propValues: {
     tbody: false,
-    children: `<thead>
-    <TableRow as="header">
-      <TableHeader />
-      <TableHeader>Country</TableHeader>
-    </TableRow>
-  </thead>
+    children: `
   <DraggableContext onDrag={ updateDndData }>
     <tbody>
       { buildRows() }
@@ -42,9 +38,11 @@ let definition = new Definition('draggable-context', DraggableContext, {
 
   dndData.forEach((row, index) => {
     rows.push(
-      <TableRow key={ row.get('id') } uniqueID={ row.get('id') } index={ index }>
-        <TableCell>{ row.get('name') }</TableCell>
-      </TableRow>
+      <WithDragDrop index={ index }>
+        <TableRow key={ row.get('id') } uniqueID={ row.get('id') } index={ index }>
+          <TableCell>{ row.get('name') }</TableCell>
+        </TableRow>
+      </WithDragDrop>
     );
   });
 

--- a/src/components/drag-and-drop/draggable-context/draggable-context.js
+++ b/src/components/drag-and-drop/draggable-context/draggable-context.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import Bowser from 'bowser';
 import { DragDropContext } from 'react-dnd';
 import PropTypes from 'prop-types';
 import TouchBackend from 'react-dnd-touch-backend';
+import HTML5Backend from 'react-dnd-html5-backend';
 import ItemTargetHelper from './../../../utils/helpers/dnd/item-target';
 
 /**
@@ -150,4 +152,11 @@ class DraggableContext extends React.Component {
   }
 }
 
-export default DragDropContext(TouchBackend({ enableMouseEvents: true }))(DraggableContext);
+export const backend = () => {
+  if (Bowser.mobile || Bowser.tablet) {
+    return TouchBackend({ enableMouseEvents: true });
+  }
+  return HTML5Backend;
+};
+
+export default DragDropContext(backend())(DraggableContext);

--- a/src/components/drag-and-drop/with-drag-drop/__spec__.js
+++ b/src/components/drag-and-drop/with-drag-drop/__spec__.js
@@ -1,0 +1,185 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { mount } from 'enzyme';
+import { DragDropContext } from 'react-dnd';
+import TestBackend from 'react-dnd-test-backend';
+import WithDragDrop from './with-drag-drop';
+import DraggableContext from './../draggable-context';
+import Text from './../../../utils/helpers/text';
+
+describe('WithDragDrop', () => {
+  let wrapper, wrapper2;
+
+  const DummyComponent = () => <div>Test</div>;
+
+  describe('render', () => {
+    let connectDragSource
+    beforeEach(() => {
+      connectDragSource = (bar) => { foo: bar }
+      wrapper = mount(
+        <DraggableContext onDrag={ () => {} }>
+          <WithDragDrop>
+            <DummyComponent />
+          </WithDragDrop>
+        </DraggableContext>
+      )
+    })
+    it('clones the children with props passed through', () => {
+      const child = wrapper.find(DummyComponent)
+      expect(child.props().connectDragSource).toEqual(expect.any(Function))
+      expect(child.props().connectDragPreview).toEqual(expect.any(Function))
+    });
+  });
+
+  describe('Drag and drop', () => {
+    let backend, handlerId, targetId, beginDragContextSpy, beginDragPropSpy,
+    endDragContextSpy, endDragPropSpy, hoverContextSpy, hoverPropSpy,
+    component, component2;
+
+    const TestComponent = (props) => {
+      return(
+        props.connectDragPreview(
+          props.connectDragSource(
+            <div>foo</div>
+          )
+        )
+      )
+    }
+
+    function createWrapper(props = {}) {
+      let DnD = wrapInTestContext(WithDragDrop);
+      wrapper = mount(
+        <DnD { ...props } index={1}>
+          <TestComponent index={1} />
+        </DnD>
+      );
+
+      wrapper2 = mount(
+        <DnD { ...props } index={2}>
+          <TestComponent index={2} />
+        </DnD>
+      );
+
+      component = wrapper.find(WithDragDrop).getNode();
+      handlerId = component.getDecoratedComponentInstance().getHandlerId();
+      component2 = wrapper2.find(WithDragDrop).getNode();
+      targetId = component2.getHandlerId();
+      backend = wrapper.getNode().getManager().backend;
+    }
+
+    function wrapInTestContext(DecoratedComponent) {
+      return DragDropContext(TestBackend)(
+        class TestContextContainer extends React.Component {
+          static childContextTypes = {
+            dragAndDropBeginDrag: PropTypes.func,
+            dragAndDropEndDrag: PropTypes.func,
+            dragAndDropHover: PropTypes.func
+          }
+
+          getChildContext() {
+            return {
+              dragAndDropBeginDrag: beginDragContextSpy,
+              dragAndDropEndDrag: endDragContextSpy,
+              dragAndDropHover: hoverContextSpy
+            };
+          }
+
+          render() {
+            return <DecoratedComponent {...this.props} />;
+          }
+        }
+      );
+    }
+
+    beforeEach(() => {
+      jest.spyOn(Text, 'clearSelection').mockImplementation(() => {});
+      hoverContextSpy = jest.fn();
+      hoverPropSpy = jest.fn();
+      beginDragContextSpy = jest.fn(() => ({ index: 1 }))
+      beginDragPropSpy = jest.fn(() => ({ index: 1 }))
+      endDragContextSpy = jest.fn();
+      endDragPropSpy = jest.fn();
+    });
+
+    describe('without custom props', () => {
+      beforeEach(() => {
+        createWrapper();
+      });
+
+      describe('beginDrag', () => {
+        it('calls the beginDrag from context', () => {
+          backend.simulateBeginDrag([handlerId]);
+          expect(beginDragPropSpy).not.toHaveBeenCalled();
+          expect(beginDragContextSpy).toHaveBeenCalled();
+        });
+      });
+
+      describe('endDrag', () => {
+        it('calls the endDrag from context', () => {
+          backend.simulateBeginDrag([handlerId]);
+          backend.simulateEndDrag([handlerId]);
+          expect(endDragPropSpy).not.toHaveBeenCalled();
+          expect(endDragContextSpy).toHaveBeenCalled();
+        });
+      });
+
+      describe('hover', () => {
+        it('calls the hover from context', () => {
+          backend.simulateBeginDrag([handlerId]);
+          backend.simulateHover([targetId]);
+          expect(hoverPropSpy).not.toHaveBeenCalled();
+          expect(hoverContextSpy).toHaveBeenCalled();
+        });
+      });
+    })
+
+    describe('with custom props', () => {
+      beforeEach(() => {
+        createWrapper({
+          hover: hoverPropSpy,
+          beginDrag: beginDragPropSpy,
+          endDrag: endDragPropSpy
+        });
+      });
+
+      describe('hover', () => {
+        it('calls the hover from props', () => {
+          backend.simulateBeginDrag([handlerId]);
+          backend.simulateHover([targetId]);
+          expect(hoverPropSpy).toHaveBeenCalled();
+          expect(hoverContextSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('beginDrag', () => {
+        it('calls the beginDrag from context', () => {
+          backend.simulateBeginDrag([handlerId]);
+          expect(beginDragPropSpy).toHaveBeenCalled();
+          expect(beginDragContextSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('endDrag', () => {
+        it('calls the endDrag from context', () => {
+          backend.simulateBeginDrag([handlerId]);
+          backend.simulateEndDrag([handlerId]);
+          expect(endDragPropSpy).toHaveBeenCalled();
+          expect(endDragContextSpy).not.toHaveBeenCalled();
+        });
+      });
+    })
+
+    describe('when the canDrag prop is a function that returns false', () => {
+      beforeEach(() => {
+        createWrapper({
+          canDrag: () => false
+        });
+      });
+
+      it('it does not trigger begin drag', () => {
+        backend.simulateBeginDrag([handlerId]);
+        expect(beginDragContextSpy).not.toHaveBeenCalled();
+      });
+    })
+  });
+});

--- a/src/components/drag-and-drop/with-drag-drop/definition.js
+++ b/src/components/drag-and-drop/with-drag-drop/definition.js
@@ -1,0 +1,20 @@
+import WithDrag from './';
+import Definition from './../../../../demo/utils/definition';
+
+let definition = new Definition('with-drag-drop', WithDrag, {
+  props: ['identifier', 'canDrag', 'beginDrag', 'endDrag'],
+  propTypes: {
+    identifier: "String",
+    canDrag: "Function",
+    beginDrag: "Function",
+    endDrag: "Function"
+  },
+  propDescriptions: {
+    identifier: "Associates an instance of WithDrag with an instance of WithDrop, so multiple DraggableContexts can work independently.",
+    canDrag: "An optional callback which can be used to determine if this item is draggable.",
+    beginDrag: "An optional callback triggered when dragging begins.",
+    endDrag: "An optional callback triggered when dragging ends."
+  }
+});
+
+export default definition;

--- a/src/components/drag-and-drop/with-drag-drop/package.json
+++ b/src/components/drag-and-drop/with-drag-drop/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "./with-drag-drop.js"
+}

--- a/src/components/drag-and-drop/with-drag-drop/with-drag-drop.js
+++ b/src/components/drag-and-drop/with-drag-drop/with-drag-drop.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { DropTarget, DragSource } from 'react-dnd';
+import { findDOMNode } from 'react-dom';
+import ItemTypes from './../../../utils/helpers/dnd/item-types';
+import Text from './../../../utils/helpers/text';
+
+class WithDragDrop extends React.Component {
+  static propTypes = {
+    /**
+     * Children elements
+     *
+     * @property children
+     * @type {Node}
+     */
+    children: PropTypes.node,
+
+    /**
+     * Provided by DragSource
+     *
+     * @property connectDragPreview
+     * @type {Func}
+     */
+    connectDragPreview: PropTypes.func,
+
+    /**
+     * Provided by DragSource
+     *
+     * @property connectDragPreview
+     * @type {Func}
+     */
+    connectDragSource: PropTypes.func,
+
+    /**
+     * Provided by DropTarget
+     *
+     * @property connectDropTarget
+     * @type {Func}
+     */
+    connectDropTarget: PropTypes.func
+  }
+
+  static contextTypes = {
+    dragDropManager: PropTypes.object, // the React DND DragDropManager
+    dragAndDropActiveIndex: PropTypes.number, // tracks the currently active index
+    dragAndDropBeginDrag: PropTypes.func,
+    dragAndDropEndDrag: PropTypes.func,
+    dragAndDropOnDrag: PropTypes.func,
+    dragAndDropHover: PropTypes.func
+  }
+
+  render() {
+    return (
+      React.cloneElement(
+        this.props.children,
+        {
+          connectDragSource: this.props.connectDragSource,
+          connectDragPreview: this.props.connectDragPreview,
+          ref: (instance) => {
+            const node = findDOMNode(instance);
+            this.props.connectDropTarget(node);
+          }
+        }
+      )
+    );
+  }
+}
+
+const ItemTarget = {
+  hover(props, monitor, component) {
+    const decoratedComponent = component.getDecoratedComponentInstance();
+    Text.clearSelection();
+    const hover = props.hover || decoratedComponent.context.dragAndDropHover;
+    hover(decoratedComponent.props, monitor, decoratedComponent);
+  }
+};
+
+const ItemSource = {
+  canDrag(props, monitor) {
+    return (props.canDrag) ? props.canDrag(props, monitor) : true;
+  },
+
+  beginDrag: (props, monitor, component) => {
+    const beginDrag = props.beginDrag || component.context.dragAndDropBeginDrag;
+    return beginDrag(props, monitor, component);
+  },
+
+  endDrag: (props, monitor, component) => {
+    const endDrag = props.endDrag || component.context.dragAndDropEndDrag;
+    return endDrag(props, monitor, component);
+  }
+};
+
+export default DropTarget(
+  ItemTypes.getItemType,
+  ItemTarget,
+  connect => ({
+    connectDropTarget: connect.dropTarget()
+  })
+)(
+  DragSource(
+    ItemTypes.getItemType,
+    ItemSource,
+    connect => ({
+      connectDragSource: connect.dragSource(),
+      connectDragPreview: connect.dragPreview()
+    })
+  )(WithDragDrop)
+);

--- a/src/components/table/draggable-table-cell/__spec__.js
+++ b/src/components/table/draggable-table-cell/__spec__.js
@@ -2,26 +2,25 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import DraggableTableCell from './draggable-table-cell';
 import TableCell from './../table-cell';
-import WithDrag from './../../drag-and-drop/with-drag';
 import Icon from './../../icon';
 
 describe('DraggableTableCell', () => {
-  let wrapper;
+  let wrapper, connectDragSource;
 
   beforeEach(() => {
+    connectDragSource = jasmine.createSpy().and.callFake((component) => component);
     wrapper = shallow(
-      <DraggableTableCell identifier="foo" />
+      <DraggableTableCell connectDragSource={connectDragSource} />
     );
+  });
+
+  it('calls connectDragSource', () => {
+    expect(connectDragSource).toHaveBeenCalled();
   });
 
   it('renders a table cell', () => {
     let cell = wrapper.find(TableCell);
     expect(cell.props().className).toEqual('draggable-table-cell');
-  });
-
-  it('renders a WithDrag component', () => {
-    let wd = wrapper.find(WithDrag);
-    expect(wd.props().identifier).toEqual('foo');
   });
 
   it('renders an icon', () => {

--- a/src/components/table/draggable-table-cell/draggable-table-cell.js
+++ b/src/components/table/draggable-table-cell/draggable-table-cell.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import WithDrag from './../../drag-and-drop/with-drag';
 import Icon from './../../icon';
 import TableCell from './../table-cell';
 
@@ -12,20 +11,23 @@ import TableCell from './../table-cell';
 const DraggableTableCell = (props) => {
   return (
     <TableCell className='draggable-table-cell'>
-      <WithDrag identifier={ props.identifier }>
-        <div>
-          <Icon
-            className='draggable-table-cell__icon'
-            type='drag_vertical'
-          />
-        </div>
-      </WithDrag>
+      {
+          props.connectDragSource(
+            <div>
+              <Icon
+                className='draggable-table-cell__icon'
+                draggable
+                type='drag_vertical'
+              />
+            </div>
+          )
+        }
     </TableCell>
   );
 };
 
 DraggableTableCell.propTypes = {
-  identifier: PropTypes.string // used to associate WithDrags and WithDrops
+  connectDragSource: PropTypes.func.isRequired // Provided by DragSource
 };
 
 export default DraggableTableCell;

--- a/src/components/table/table-row/__spec__.js
+++ b/src/components/table/table-row/__spec__.js
@@ -9,7 +9,7 @@ import Icon from './../../icon';
 import Checkbox from './../../checkbox';
 import { rootTagTest } from '../../../utils/helpers/tags/tags-specs';
 import { shallow, mount } from 'enzyme';
-import { DraggableContext, WithDrop } from './../../drag-and-drop';
+import { DraggableContext, WithDragDrop } from './../../drag-and-drop';
 
 describe('TableRow', () => {
   let instance, clickableInstance, row;
@@ -448,11 +448,6 @@ describe('TableRow', () => {
         let cell = wrapper.find(TableRow).find(DraggableTableCell);
         expect(cell.length).toEqual(0);
       });
-
-      it('does not render a WithDrop component', () => {
-        let wd = wrapper.find(WithDrop);
-        expect(wd.length).toEqual(0);
-      });
     });
 
     describe('ensuring index is provided', () => {
@@ -479,9 +474,11 @@ describe('TableRow', () => {
           <Table tbody={ false }>
             <DraggableContext onDrag={ () => {} }>
               <tbody>
-                <TableRow index={ 0 } dragAndDropIdentifier="foo">
-                  <TableCell>foo</TableCell>
-                </TableRow>
+                <WithDragDrop index={ 0 }>
+                  <TableRow index={ 0 } dragAndDropIdentifier="foo">
+                    <TableCell>foo</TableCell>
+                  </TableRow>
+                </WithDragDrop>
               </tbody>
             </DraggableContext>
           </Table>
@@ -491,12 +488,6 @@ describe('TableRow', () => {
       it('renders a draggable cell', () => {
         let cell = wrapper.find(TableRow).find(DraggableTableCell);
         expect(cell.props().identifier).toEqual("foo");
-      });
-
-      it('renders a WithDrop component', () => {
-        let wd = wrapper.find(WithDrop);
-        expect(wd.props().index).toEqual(0);
-        expect(wd.props().identifier).toEqual("foo");
       });
 
       it('renders a dragging class', () => {

--- a/src/components/table/table-row/table-row.js
+++ b/src/components/table/table-row/table-row.js
@@ -5,7 +5,6 @@ import TableCell from './../table-cell';
 import TableHeader from './../table-header';
 import Checkbox from './../../checkbox';
 import guid from './../../../utils/helpers/guid';
-import WithDrop from './../../drag-and-drop/with-drop';
 import DraggableTableCell from './../draggable-table-cell';
 import { validProps } from '../../../utils/ether';
 import tagComponent from '../../../utils/helpers/tags';
@@ -420,12 +419,16 @@ class TableRow extends React.Component {
    * @method renderDraggableCell
    * @return {Object} JSX
    */
-  renderDraggableCell = () => {
+  renderDraggableCell = (connectDragSource) => {
     if (!this.context.dragDropManager) {
       return null;
     }
-
-    return <DraggableTableCell identifier={ this.props.dragAndDropIdentifier } />;
+    return (
+      <DraggableTableCell
+        identifier={ this.props.dragAndDropIdentifier }
+        connectDragSource={ connectDragSource }
+      />
+    );
   }
 
   /**
@@ -435,19 +438,12 @@ class TableRow extends React.Component {
    * @param {Object} JSX
    * @return {Object} JSX
    */
-  renderDraggableRow = (row) => {
+  renderDraggableRow = (row, connectDragPreview) => {
     if (!this.context.dragDropManager) {
       return row;
     }
 
-    return (
-      <WithDrop
-        identifier={ this.props.dragAndDropIdentifier }
-        index={ this.props.index }
-      >
-        { row }
-      </WithDrop>
-    );
+    return connectDragPreview(row);
   }
 
   /**
@@ -457,17 +453,21 @@ class TableRow extends React.Component {
    */
   render() {
     const content = [this.props.children];
+    const { connectDragPreview, connectDragSource, ...rowProps } = this.rowProps;
 
     if (this.shouldHaveMultiSelectColumn) {
       content.unshift(this.multiSelectCell);
     }
 
     return this.renderDraggableRow(
-      <tr { ...this.rowProps } { ...tagComponent('table-row', this.props) }>
-        { this.renderDraggableCell() }
+      (
+        <tr { ...rowProps } { ...tagComponent('table-row', this.props) }>
+          { this.renderDraggableCell(connectDragSource) }
 
-        { content }
-      </tr>
+          { content }
+        </tr>
+      ),
+      connectDragPreview
     );
   }
 }


### PR DESCRIPTION
This PR re-enables the html5 backend for drag and drop functionality when not on a mobile or tablet device. The logic for this is held in `<DraggableContext>`

The goal is to have a ui where, for example, a table row is draggable (with the entire row displayed as the 'ghost layer' that appears when dragging) yet only allowing the user to drag by dragging an icon (not by just dragging anywhere on the row itself).

I have introduced a new `<WithDragDrop>` component. This component defines the `DragSource` around the entire child (e.g. the TableRow) and then allows the developer to mark which element in the child is used for the preview via `connectDragPreview`. The element to be dragged (for example an Icon) is then wrapped in `connectDragSource`.

The existing implementation uses WithDrag to wrap the draggable Icon. But this means the preview cannot be defined in the parent via `connectDragPreview`. Thus when the row is dragged, only the icon follows the mouse cursor and not the entire row.

![drag-drop-html5](https://user-images.githubusercontent.com/4964/28875500-ab2fb716-778d-11e7-8110-8d852d89c6b0.gif)
