### PR TITLE
Update configurable-items pattern to use utils flux Dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pattern Enhancements
 
-* `ConfigurableItems` now accepts an `onReset` prop to be passed in.
+* `ConfigurableItems` now accepts an `onReset` prop to be passed in and uses the Carbon dispatcher.
 
 ### npm
 

--- a/src/dispatcher/index.js
+++ b/src/dispatcher/index.js
@@ -1,3 +1,0 @@
-import { Dispatcher } from 'flux';
-
-export default new Dispatcher();

--- a/src/patterns/configurable-items/actions/__spec__.js
+++ b/src/patterns/configurable-items/actions/__spec__.js
@@ -1,4 +1,4 @@
-import Dispatcher from 'dispatcher';
+import { Dispatcher } from './../../../utils/flux';
 import Constants from './../constants';
 import Actions from './actions.js';
 

--- a/src/patterns/configurable-items/actions/actions.js
+++ b/src/patterns/configurable-items/actions/actions.js
@@ -1,4 +1,4 @@
-import Dispatcher from 'dispatcher';
+import { Dispatcher } from './../../../utils/flux';
 import Constants from './../constants';
 
 const ConfigurableItemsActions = {

--- a/src/patterns/configurable-items/store/store.js
+++ b/src/patterns/configurable-items/store/store.js
@@ -1,4 +1,4 @@
-import Dispatcher from 'dispatcher';
+import { Dispatcher } from './../../../utils/flux';
 import Store from './../../../utils/flux/store';
 import ImmutableHelper from './../../../utils/helpers/immutable';
 import ConfigurableItemsConstants from './../constants';


### PR DESCRIPTION
Ticket: CARBON-925

The dispatcher used by the configurable-items pattern was temporary. This has been switched to use the one provided in utils/flux.

**Testing** 
The Configurable Items pattern just needs a sanity check. No functional changes.