### PR TITLE
CARBON-937 Allow decimals without a leading leading zero

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ cache:
   directories:
   - node_modules
 node_js:
-  - '6.10.2'
+  - '6.11.2'
 install:
-  - npm install -g npm
+  - npm install -g npm@4.6.1
   - npm install -g gulp
   - npm install
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.7
+
+## Bug Fix
+
+* `Decimal`: fix an issue where values entered without a leading zero were incorrectly failing numerical validation
+
 # 1.3.6
 
 ## Bug Fix

--- a/src/components/decimal/__spec__.js
+++ b/src/components/decimal/__spec__.js
@@ -371,6 +371,17 @@ describe('Decimal', () => {
         });
       });
 
+      describe('when the value does not have a leading zero', () => {
+        it('calls setState with the value formatted with a leading zero', () => {
+          const wrapper = shallow(
+            <Decimal name='total' value='.9' />
+          );
+
+          wrapper.find('input').at(0).simulate('blur');
+          expect(wrapper.state().visibleValue).toBe('0.90');
+        });
+      })
+
       describe('when onBlur is passed', () => {
         it('calls onBlur', () => {
           let onBlur = jasmine.createSpy();

--- a/src/components/decimal/__spec__.js
+++ b/src/components/decimal/__spec__.js
@@ -380,7 +380,18 @@ describe('Decimal', () => {
           wrapper.find('input').at(0).simulate('blur');
           expect(wrapper.state().visibleValue).toBe('0.90');
         });
-      })
+      });
+
+      describe('when the value has a decimal point but no trailing zero', () => {
+        it('calls setState with the value formatted with a trailing zero', () => {
+          const wrapper = shallow(
+            <Decimal name='total' value='9.' />
+          );
+
+          wrapper.find('input').at(0).simulate('blur');
+          expect(wrapper.state().visibleValue).toBe('9.00');
+        });
+      });
 
       describe('when onBlur is passed', () => {
         it('calls onBlur', () => {

--- a/src/components/decimal/decimal.js
+++ b/src/components/decimal/decimal.js
@@ -379,7 +379,7 @@ function getDefaultValue(scope) {
 function canConvertToBigNumber(value) {
   // single `-` sign will raise an exception during formatDecimal()
   // as it cannot be convert to BigNumber()
-  return /^-?\d+(\.\d+)?$/.test(value);
+  return /^-?(\d+(\.\d+)?|\.\d+)$/.test(value);
 }
 
 export default Decimal;

--- a/src/components/decimal/decimal.js
+++ b/src/components/decimal/decimal.js
@@ -379,7 +379,7 @@ function getDefaultValue(scope) {
 function canConvertToBigNumber(value) {
   // single `-` sign will raise an exception during formatDecimal()
   // as it cannot be convert to BigNumber()
-  return /^-?(\d+(\.\d+)?|\.\d+)$/.test(value);
+  return /^-?(\d+(\.\d+)?|\.\d+|\d+\.)$/.test(value);
 }
 
 export default Decimal;

--- a/src/utils/validations/numeral/__spec__.js
+++ b/src/utils/validations/numeral/__spec__.js
@@ -22,9 +22,22 @@ describe('Numeral Validator', () => {
 
   describe('getDescriptiveMessage', () => {
     describe('when passed nothing', () => {
+      let numeralValidator;
+
+      beforeEach(() => {
+        numeralValidator = new Validator();
+      });
+
       it('validates the decimal', () => {
-        let numeralValidator = new Validator();
         expect(numeralValidator.validate(1.1)).toBeTruthy();
+      });
+
+      it('validates the decimal with a leading zero', () => {
+        expect(numeralValidator.validate(0.1)).toBeTruthy();
+      });
+
+      it('validates the decimal without a leading zero', () => {
+        expect(numeralValidator.validate('.1')).toBeTruthy();
       });
     });
 

--- a/src/utils/validations/numeral/__spec__.js
+++ b/src/utils/validations/numeral/__spec__.js
@@ -39,6 +39,10 @@ describe('Numeral Validator', () => {
       it('validates the decimal without a leading zero', () => {
         expect(numeralValidator.validate('.1')).toBeTruthy();
       });
+
+      it('validates the decimal with a decimal point but no trailing zero', () => {
+        expect(numeralValidator.validate('1.')).toBeTruthy();
+      });
     });
 
     describe('when passed a message', () => {

--- a/src/utils/validations/numeral/numeral-type/numeral-type.js
+++ b/src/utils/validations/numeral/numeral-type/numeral-type.js
@@ -96,7 +96,7 @@ function validateDecimal() {
      * @return {Boolean} true if value is valid
      */
     validate(value) {
-      return (!value || /^-?\d+(\.\d+)?$/.test(value));
+      return (!value || /^-?(\d+(\.\d+)?|\.\d+)$/.test(value));
     },
 
     /**

--- a/src/utils/validations/numeral/numeral-type/numeral-type.js
+++ b/src/utils/validations/numeral/numeral-type/numeral-type.js
@@ -96,7 +96,7 @@ function validateDecimal() {
      * @return {Boolean} true if value is valid
      */
     validate(value) {
-      return (!value || /^-?(\d+(\.\d+)?|\.\d+)$/.test(value));
+      return (!value || /^-?(\d+(\.\d+)?|\.\d+|\d+\.)$/.test(value));
     },
 
     /**


### PR DESCRIPTION
Update the regex used for decimal validation to allow values that are
entered _without_ a leading zero.

The regex has been updated in both `Decimal` and `NumeralTypeValidator`.

Update release notes.
