### PR TITLE
CARBON-935 TableAjax component now uses the data-state attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 # Component Enhancements
 
-* `TableAjax` component now uses the data-state attribute.
+* `TableAjax` component now uses the data-state attribute and `aria-busy`.
 
 # 1.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 * To upgrade your version of npm, run `npm install npm@latest`.
 * Then, before running `npm install` in your project folder, run `npm verify cache` to update your cache.
 
+# Component Enhancements
+
+* `TableAjax` component now uses the data-state attribute.
+
 # 1.4.4
 
 * `Date`: Fixes missing background color on validation errors.

--- a/src/components/table-ajax/__spec__.js
+++ b/src/components/table-ajax/__spec__.js
@@ -246,8 +246,11 @@ describe('TableAjax', () => {
       jest.runTimersToTime(251);
       const pager = wrapper.find(Pager);
       expect(pager.props().totalRecords).toEqual('1');
-      expect(wrapper.find('.carbon-table').length).toEqual(1);
+      const table = wrapper.find('.carbon-table')
+      expect(table.length).toEqual(1);
       expect(wrapper.find('[data-state="loaded"]').length).toEqual(1);
+      expect(table.props().ariaBusy).toBeFalsy();
+      expect(table.prop('aria-busy')).toBeFalsy();
     });
 
     describe('when page size is less than previous page size', () => {
@@ -380,6 +383,8 @@ describe('TableAjax', () => {
         jest.runTimersToTime(251);
         expect(onError).toBeCalledWith(error, response);
         expect(wrapper.find('[data-state="errored"]').length).toEqual(1);
+        const table = wrapper.find('.carbon-table');
+        expect(table.prop('aria-busy')).toBeFalsy();
       });
     });
 
@@ -394,6 +399,8 @@ describe('TableAjax', () => {
 
         expect(console.warn).toBeCalled();
         expect(wrapper.find('[data-state="errored"]').length).toEqual(1);
+        const table = wrapper.find('.carbon-table');
+        expect(table.prop('aria-busy')).toBeFalsy();
       });
     });
   });

--- a/src/components/table-ajax/table-ajax.js
+++ b/src/components/table-ajax/table-ajax.js
@@ -303,8 +303,10 @@ class TableAjax extends Table {
     this.stopTimeout();
     this.timeout = setTimeout(() => {
       // track the request incase we need to abort it
-      this.setState({ dataState: 'requested' });
-      this.setState({ ariaBusy: true });
+      this.setState({
+        dataState: 'requested',
+        ariaBusy: true
+      });
       this._request = Request
         .get(this.props.path)
         .set('Accept', 'application/json')

--- a/src/components/table-ajax/table-ajax.js
+++ b/src/components/table-ajax/table-ajax.js
@@ -97,6 +97,14 @@ class TableAjax extends Table {
     currentPage: this.props.currentPage || '1',
 
     /**
+     * The current value of the data-state property
+     *
+     * @property dataState
+     * @type {String}
+     */
+    dataState: 'idle',
+
+    /**
      * Pagination
      * Page Size of grid (number of visible records)
      *
@@ -296,6 +304,7 @@ class TableAjax extends Table {
     this.stopTimeout();
     this.timeout = setTimeout(() => {
       // track the request incase we need to abort it
+      this.setState({ dataState: 'requested' });
       this._request = Request
         .get(this.props.path)
         .set('Accept', 'application/json')
@@ -333,12 +342,15 @@ class TableAjax extends Table {
    */
   handleResponse = (err, response) => {
     if (!err) {
+      this.setState({ dataState: 'loaded' });
       const data = response.body;
       this.props.onChange(data);
       this.setState({ totalRecords: String(data.records) });
     } else if (this.props.onAjaxError) {
+      this.setState({ dataState: 'errored' });
       this.props.onAjaxError(err, response);
     } else {
+      this.setState({ dataState: 'errored' });
       Logger.warn(`${err.status} - ${response}`);
     }
   }
@@ -395,13 +407,17 @@ class TableAjax extends Table {
     };
   }
 
-  componentTags(props) {
-    return {
-      'data-component': 'table-ajax',
-      'data-element': props['data-element'],
-      'data-role': props['data-role']
-    };
+  /**
+   * Returns the data-state string used in componentTags
+   */
+  dataState = () => {
+    return this.state.dataState;
   }
+
+  /**
+   * The name used for the data-component attribute
+   */
+  get dataComponent() { return 'table-ajax'; }
 }
 
 export {

--- a/src/components/table-ajax/table-ajax.js
+++ b/src/components/table-ajax/table-ajax.js
@@ -86,7 +86,6 @@ class TableAjax extends Table {
   }
 
   state = {
-
     /**
      * Pagination
      * Current Visible Page
@@ -305,6 +304,7 @@ class TableAjax extends Table {
     this.timeout = setTimeout(() => {
       // track the request incase we need to abort it
       this.setState({ dataState: 'requested' });
+      this.setState({ ariaBusy: true });
       this._request = Request
         .get(this.props.path)
         .set('Accept', 'application/json')
@@ -341,18 +341,27 @@ class TableAjax extends Table {
    * @param {Object} response
    */
   handleResponse = (err, response) => {
+    this.setState({ ariaBusy: false });
     if (!err) {
-      this.setState({ dataState: 'loaded' });
+      this.setComponentTagsLoaded();
       const data = response.body;
       this.props.onChange(data);
       this.setState({ totalRecords: String(data.records) });
     } else if (this.props.onAjaxError) {
-      this.setState({ dataState: 'errored' });
+      this.setComponentTagsErrored();
       this.props.onAjaxError(err, response);
     } else {
-      this.setState({ dataState: 'errored' });
+      this.setComponentTagsErrored();
       Logger.warn(`${err.status} - ${response}`);
     }
+  }
+
+  setComponentTagsLoaded() {
+    this.setState({ dataState: 'loaded' });
+  }
+
+  setComponentTagsErrored() {
+    this.setState({ dataState: 'errored' });
   }
 
   /**

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1044,11 +1044,25 @@ class Table extends React.Component {
     );
   }
 
+  /**
+   * Placeholder function for defining the data state, intended to be overriden in subclasses
+   */
+  dataState = () => { }
+
+  /**
+   * The name used for the data-component attribute
+   */
+  get dataComponent() { return 'table'; }
+
+  /**
+   * Data tags used for the data-component attribute
+   */
   componentTags(props) {
     return {
-      'data-component': 'table',
+      'data-component': this.dataComponent,
       'data-element': props['data-element'],
-      'data-role': props['data-role']
+      'data-role': props['data-role'],
+      'data-state': this.dataState()
     };
   }
 

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1062,7 +1062,8 @@ class Table extends React.Component {
       'data-component': this.dataComponent,
       'data-element': props['data-element'],
       'data-role': props['data-role'],
-      'data-state': this.dataState()
+      'data-state': this.dataState(),
+      'aria-busy': this.state.ariaBusy
     };
   }
 


### PR DESCRIPTION
**Data Attributes**
The data-state attribute has been added to track the current state of the process of loading data for the table. This will help with writing automated tests that can rely on a data attribute that should remain more constant and robust than relying on class names or markup structure.

The states for the attribute are:
- idle _(before the component has requested data)_
- requested
- loaded
- errored

**Aria Busy**
The `aria-busy` attribute is now set to true when the ajax request is processing and set to false after the request has finished.

Ticket: CARBON-935

#### TODO
- [x] Release notes