### PR TITLE
reverted menu alternate prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.2
+
+* `Menu`: removed `alternate` prop, can use `SubMenuBlock` instead which achieves the same thing.
+
 # 1.4.1
 
 * `Dropdown`: validation fail now allows the dropdown arrow to be visible

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A library of reusable React components and an interface for easily building user interfaces based on Flux.",
   "engineStrict": true,
   "engines": {

--- a/src/components/menu/__definition__.js
+++ b/src/components/menu/__definition__.js
@@ -62,7 +62,7 @@ definition.addChildByDefinition(menuItemDefinition, {
   </SubmenuBlock>
   <MenuItem href="#">Sub Menu Item Four</MenuItem>
   <MenuItem href="#">Sub Menu Item Five</MenuItem>
-  <MenuItem href="#" alternate={ true }>Sub Menu Item Six</MenuItem>
+  <MenuItem href="#">Sub Menu Item Six</MenuItem>
   <MenuItem href="#">Sub Menu Item Seven</MenuItem>
   <MenuItem href="#" divide={ true }>Sub Menu Item Eight</MenuItem>`,
   href: "#",

--- a/src/components/menu/menu-item/__definition__.js
+++ b/src/components/menu/menu-item/__definition__.js
@@ -5,7 +5,6 @@ let definition = new Definition('menu-item', MenuItem, {
   description: '[content needed] Basic example of the component',
   designerNotes: '[content needed] Basic designs description for the component',
   propTypes: {
-    alternate: "Boolean",
     children: "Node",
     className: "String",
     divide: "Boolean",
@@ -18,7 +17,6 @@ let definition = new Definition('menu-item', MenuItem, {
     to: "String"
   },
   propDescriptions: {
-    alternate: "Applies an alternate styling for the item.",
     children: "This component supports children.",
     className: "Classes for the component.",
     divide: "Applies a dividing line above an item.",

--- a/src/components/menu/menu-item/__spec__.js
+++ b/src/components/menu/menu-item/__spec__.js
@@ -42,24 +42,17 @@ describe('MenuItem', () => {
   describe('Boolean props', () => {
     beforeEach(() => {
       wrapper = shallow(
-        <MenuItem selected={ true } divide={ true } alternate={ true }>
+        <MenuItem selected={ true } divide={ true }>
           foo
         </MenuItem>
       );
     });
 
-    it('selected, divide and alternate', () => {
+    it('selected and divide', () => {
       let submenuItem = wrapper.find(Link);
       expect(submenuItem.hasClass('carbon-menu-item--divide')).toEqual(true);
       expect(submenuItem.hasClass('carbon-menu-item--selected')).toEqual(true);
-      expect(submenuItem.hasClass('carbon-menu-item--alternate')).toEqual(true);
     });
-
-    it("alternate-off if 'alternate' Boolean is not set", () => {
-      wrapper = shallow(<MenuItem>foo</MenuItem>);
-      let submenuItem = wrapper.find(Link);
-      expect(submenuItem.hasClass('carbon-menu-item--alternate-off')).toEqual(true);
-    })
   });
 
   describe("tags on component", () => {

--- a/src/components/menu/menu-item/menu-item.js
+++ b/src/components/menu/menu-item/menu-item.js
@@ -12,15 +12,6 @@ class MenuItem extends React.Component {
 
   static propTypes = {
     /**
-     * Defines whether alternate row styling should be applied
-     * 0..n blocks of 1..n menu items can be marked as `alternate` which adds a secondary style
-     *
-     * @property alternate
-     * @type {Boolean}
-     */
-    alternate: PropTypes.bool,
-
-    /**
      * Children elements
      *
      * @property children
@@ -146,8 +137,6 @@ class MenuItem extends React.Component {
     return classNames(
       'carbon-menu-item',
       this.props.className, {
-        'carbon-menu-item--alternate': this.props.alternate,
-        'carbon-menu-item--alternate-off': !this.props.alternate,
         'carbon-menu-item--divide': this.props.divide,
         'carbon-menu-item--has-link': this.props.href || this.props.to || this.props.onClick,
         'carbon-menu-item--has-submenu': this.props.submenu,

--- a/src/components/menu/menu-item/menu-item.scss
+++ b/src/components/menu/menu-item/menu-item.scss
@@ -111,12 +111,13 @@
   box-shadow: 0 4px 8px rgba($black, 0.2);
   display: none;
   min-width: 100%;
-  padding: 0;
+  padding: 0 0 5px;
   position: absolute;
   z-index: $z-dropdown-list;
 
   .carbon-menu--primary & {
     background-color: $white;
+    padding-top: 5px;
 
     .carbon-menu-item--selected {
       color: $green-bright-dull;
@@ -153,14 +154,6 @@
     line-height: 30px;
     white-space: nowrap;
 
-    &:first-of-type {
-      padding-top: 5px;
-    }
-
-    &:last-of-type {
-      padding-bottom: 5px;
-    }
-
     .carbon-menu--primary & {
       background-color: $white;
     }
@@ -168,14 +161,6 @@
     .carbon-menu--secondary & {
       background-color: $grey-dark-blue;
     }
-  }
-
-  .carbon-menu-item--alternate.carbon-menu-item--alternate {
-    background-color: $grey-dark-blue-10;
-  }
-  .carbon-menu-item--alternate-off + .carbon-menu-item--alternate,
-  .carbon-menu-item--alternate + .carbon-menu-item--alternate-off {
-    border-top: 1px solid $grey-dark-blue-25;
   }
 }
 

--- a/src/components/menu/submenu-block/submenu-block.scss
+++ b/src/components/menu/submenu-block/submenu-block.scss
@@ -1,8 +1,7 @@
 @import "./../../../style-config/colors";
 
 .carbon-submenu-block {
-  padding: 5px 0 !important;
-  margin: 10px 0 5px;
+  padding:  0 !important;
 
   .carbon-menu--primary & {
     background-color: $grey-dark-blue-10;


### PR DESCRIPTION
reverts the alternate prop work done in this PR https://github.com/Sage/carbon/pull/936

this was because the original PR introduces some regressions with the original functionality, and essentially achieves the same as `SubMenuBlock` which is already supported.