### PR TITLE
removed top padding from heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.3
+
+* `Heading`: Removed default top padding.
+
 # 1.4.2
 
 * `Menu`: removed `alternate` prop, can use `SubMenuBlock` instead which achieves the same thing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A library of reusable React components and an interface for easily building user interfaces based on Flux.",
   "engineStrict": true,
   "engines": {

--- a/src/components/heading/heading.scss
+++ b/src/components/heading/heading.scss
@@ -2,10 +2,6 @@
 @import "./../../style-config/general";
 @import "./../../style-config/z-index";
 
-.carbon-heading {
-  padding: 24px 0 0;
-}
-
 .carbon-heading__header {
   position: relative;
 


### PR DESCRIPTION
Top padding was interfering with the layout in various use cases of heading. Checked dialogs etc where heading is used, they all override this value anyway.

This is required for a fix in global navigation.