### PR TITLE
onReset prop can be passed into ConfigurableItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.5.0
+
+## Pattern Enhancements
+
+* `ConfigurableItems` now accepts an `onReset` prop to be passed in.
+
 # 1.4.2
 
 * `Menu`: removed `alternate` prop, can use `SubMenuBlock` instead which achieves the same thing.

--- a/src/patterns/configurable-items/__definition__.js
+++ b/src/patterns/configurable-items/__definition__.js
@@ -11,6 +11,7 @@ let definition = new Definition('configurable-items-pattern', ConfigurableItemsP
   hiddenProps: ['itemsData'],
   propValues: {
     itemsData: `configurableItemsData`,
+    onReset: `resetConfigurableItemsData`,
     onSave: `configurableItemsOnSave`,
     title: 'Configure Items'
   },
@@ -18,13 +19,15 @@ let definition = new Definition('configurable-items-pattern', ConfigurableItemsP
     className: 'String',
     itemsData: 'Object',
     onCancel: 'Function',
+    onReset: 'Function',
     onSave: 'Function',
     title: 'String'
   },
   propDescriptions: {
     itemsData: 'Data to define the items that can be configured',
-    className : 'Classes to apply to the component.',
+    className: 'Classes to apply to the component.',
     onCancel: 'Callback triggered when the form is cancelled.',
+    onReset: 'Callback triggered when the reset button is pressed',
     onSave: 'Callback triggered when the form is saved.',
     title: 'Title to display as heading'
   },

--- a/src/patterns/configurable-items/__spec__.js
+++ b/src/patterns/configurable-items/__spec__.js
@@ -12,6 +12,7 @@ describe('ConfigurableItemsPattern', () => {
   let wrapper;
   const onCancel = jasmine.createSpy('onCancel');
   const onSave = jasmine.createSpy('onSave');
+  const onReset = jasmine.createSpy('onReset');
 
   const itemsData = ImmutableHelper.parseJSON(
     [
@@ -89,6 +90,7 @@ describe('ConfigurableItemsPattern', () => {
           <ConfigurableItemsPattern
             itemsData={ { data: 'configurableItemsData' } }
             onCancel={ onCancel }
+            onReset={ onReset }
             onSave={ onSave }
             title='Configure Items'
             data-element='bar'
@@ -166,12 +168,12 @@ describe('ConfigurableItemsPattern', () => {
           expect(ConfigurableItemsActions.reorderItems).toHaveBeenCalledWith(1, 2);
         });
 
-        it('triggers ConfigurableItemsActions.updateData onReset', () => {
-          spyOn(ConfigurableItemsActions, 'updateData');
-          patternProps.onReset();
-          expect(ConfigurableItemsActions.updateData).toHaveBeenCalledWith(
-            { data: 'configurableItemsData' }
-          );
+        it('triggers toggleDialogOpen and the onReset prop when onReset is called', () => {
+          spyOn(ConfigurableItemsActions, 'toggleDialogOpen');
+          const event = {};
+          patternProps.onReset(event);
+          expect(ConfigurableItemsActions.toggleDialogOpen).toHaveBeenCalled();
+          expect(onReset).toHaveBeenCalledWith(event);
         });
 
         it('calls the onSave prop with the event and items data from configurableItemsStore', () => {
@@ -235,7 +237,30 @@ describe('ConfigurableItemsPattern', () => {
         spyOn(ConfigurableItemsActions, 'toggleDialogOpen')
         patternProps.onCancel();
         expect(ConfigurableItemsActions.toggleDialogOpen).toHaveBeenCalled();
-      })
-    })
+      });
+    });
+
+    describe('when the onReset prop is not provided', () => {
+      let pattern, patternProps
+      beforeEach(() => {
+        ConfigurableItemsStore.data = ConfigurableItemsStore.data.set(
+          'items_data', itemsData
+        );
+        wrapper = shallow(
+          <ConfigurableItemsPattern
+            itemsData={ { data: 'configurableItemsData' } }
+            onSave={ onSave }
+          />
+        );
+        pattern = wrapper.find(ConfigurableItemsContent);
+        patternProps = pattern.props();
+      });
+
+      it('does not try and call the onReset prop', () => {
+        spyOn(ConfigurableItemsActions, 'toggleDialogOpen')
+        patternProps.onReset();
+        expect(ConfigurableItemsActions.toggleDialogOpen).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/patterns/configurable-items/configurable-items.js
+++ b/src/patterns/configurable-items/configurable-items.js
@@ -35,6 +35,14 @@ class ConfigurableItemsPattern extends React.Component {
     onCancel: PropTypes.func,
 
     /**
+     * Callback triggered when the form reset button is pressed.
+     *
+     * @property onReset
+     * @type {Function}
+     */
+    onReset: PropTypes.func,
+
+    /**
      * Callback triggered when the form is saved.
      *
      * @property onSave
@@ -75,8 +83,11 @@ class ConfigurableItemsPattern extends React.Component {
     ConfigurableItemsActions.reorderItems(dragIndex, hoverIndex);
   }
 
-  onReset = () => {
-    ConfigurableItemsActions.updateData(this.props.itemsData);
+  onReset = (event) => {
+    ConfigurableItemsActions.toggleDialogOpen();
+    if (this.props.onReset) {
+      this.props.onReset(event);
+    }
   }
 
   onSave = (event) => {


### PR DESCRIPTION
# Description
This prop means the functionality of the reset button can be specified and is no longer hard-coded. It will first close the dialog and then execute the callback. Previously it would reset the ConfigurableItems pattern store from the point the dialog was opened.

# Testing Instructions
In the ConfigurableItems pattern demo, the dialog will close when the reset button is pressed.
