### PR TITLE
Fixed validation error in modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.5
+
+* `Validations`: fixes an error from being thrown for non-Textbox validations when situated inside a Modal.
+
 # 1.4.4
 
 * `Date`: Fixes missing background color on validation errors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "A library of reusable React components and an interface for easily building user interfaces based on Flux.",
   "engineStrict": true,
   "engines": {

--- a/src/utils/decorators/input-validation/input-validation.js
+++ b/src/utils/decorators/input-validation/input-validation.js
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { assign } from 'lodash';
 import Icon from './../../../components/icon';
 import chainFunctions from './../../helpers/chain-functions';
@@ -273,7 +274,8 @@ const InputValidation = ComposedComponent => class Component extends ComposedCom
         if (this.context.modal && this.context.modal.getDialog()) {
           // if in a modal check its position relative to that
           const dialog = this.context.modal.getDialog();
-          shouldFlip = (message.offsetLeft + this._target.offsetLeft + messageOffsetWidth) > dialog.offsetWidth;
+          const domNode = ReactDOM.findDOMNode(this);
+          shouldFlip = (message.offsetLeft + domNode.offsetLeft + messageOffsetWidth) > dialog.offsetWidth;
         } else {
           // otherwise check relative to the window
           shouldFlip = messageScreenPosition > this._window.innerWidth;


### PR DESCRIPTION
`this._target` was only defined on Textboxes - so instead we lookup the dom node using ReactDOM.