### PR TITLE
[CARBON-938] Update the DatePicker to use a new library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ New invocation:
  - `service.get('1', { onSuccess: onSuccessFunc, onError: onErrorFunc })`
  - `service.get('1', { onSuccess: onSuccessFunc, onError: onErrorFunc, params: { key1: 'val1', key2: 'val2'} })`
 
+ ### DatePicker
+
+* The Date Picker library has changed from react-date-picker to react-day-picker as the old library is no longer maintained.
+* This will effect the `Date` and `DateRange` components but functionally they have remained the same.
+
 # 1.5.2
 
 ## Bug Fixes

--- a/demo/i18n/config.js
+++ b/demo/i18n/config.js
@@ -1,0 +1,10 @@
+import I18n from 'i18n-js';
+
+const setupI18n = () => {
+  I18n.fallbacks = true; // Show english if the translation does not exist
+  const match = window.location.href.match(/locale=(.[^&]*)/);
+  const locale = match ? match[1] : 'en';
+  I18n.locale = locale; // Allow testing locales e.g. http://localhost:8095/components/date-input?locale=fr
+};
+
+export default setupI18n;

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,9 +1,12 @@
 import React from 'react';
-import config from './config';
-import 'utils/css';
 import { Route } from 'react-router';
 import { startRouter } from 'utils/router';
+import 'moment/locale/fr'; // For testing the date picker
+import 'utils/css';
+import Highcharts from 'highcharts';
+import config from './config';
 import { enableMock } from './xhr-mock';
+import setupI18n from './i18n/config';
 
 // Languages
 import './i18n/en';
@@ -17,16 +20,16 @@ import Home from './views/pages/home';
 
 import SiteMap from './site-map';
 
-import Highcharts from 'highcharts';
 global.Highcharts = Highcharts;
 
 global.imagePath = config.imagePath;
 
+setupI18n();
 enableMock();
 
 const routes = (
   <Route component={ Chrome }>
-    <Route path="/" component={ Home } />
+    <Route path='/' component={ Home } />
 
     <Route component={ SubPageChrome }>
       { SiteMap.generateRoutes() }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7339,11 +7339,6 @@
         "lodash.escape": "3.2.0"
       }
     },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
-    },
     "lodash.toarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
@@ -8774,7 +8769,8 @@
     "performance-now": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
@@ -9009,14 +9005,6 @@
       "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
       "dev": true
     },
-    "raf": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.2.0.tgz",
-      "integrity": "sha1-KrqaCbtw+MLpCU3GCs58N0+t7H4=",
-      "requires": {
-        "performance-now": "0.2.0"
-      }
-    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -9112,35 +9100,13 @@
       "integrity": "sha1-Bi02EX/o0Y87peBuszODsLhepbk=",
       "dev": true
     },
-    "react-class": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-class/-/react-class-2.0.0.tgz",
-      "integrity": "sha1-WlL9wV1NmXOOvyv2nbN0zoJzd5c=",
+    "react-day-picker": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-6.1.0.tgz",
+      "integrity": "sha1-gRIsNL+07uwojsMXCeiqbUvBYcw=",
       "requires": {
-        "object-assign": "4.1.1"
-      }
-    },
-    "react-date-picker": {
-      "version": "5.3.28",
-      "resolved": "https://registry.npmjs.org/react-date-picker/-/react-date-picker-5.3.28.tgz",
-      "integrity": "sha1-t7ru4mHFyNy5CZc/uXiJFO8H9Rg=",
-      "requires": {
-        "lodash.throttle": "4.1.1",
-        "object-assign": "4.0.1",
-        "raf": "3.2.0",
-        "react-class": "2.0.0",
-        "react-field": "2.0.2",
-        "react-flex": "2.2.7",
-        "react-inline-block": "2.0.0",
-        "react-notify-resize": "1.0.3",
-        "react-style-normalizer": "1.2.8"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-          "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
-        }
+        "object-assign": "4.1.1",
+        "prop-types": "15.5.10"
       }
     },
     "react-deep-force-update": {
@@ -9192,23 +9158,6 @@
         "prop-types": "15.5.10"
       }
     },
-    "react-field": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-field/-/react-field-2.0.2.tgz",
-      "integrity": "sha1-dOZXlENy3sD4ycjjQHhue7dh0rU=",
-      "requires": {
-        "object-assign": "4.1.1"
-      }
-    },
-    "react-flex": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/react-flex/-/react-flex-2.2.7.tgz",
-      "integrity": "sha1-XITmw6/8vcNm7d5AiPjQcwMxj6g=",
-      "requires": {
-        "object-assign": "4.1.1",
-        "react-class": "2.0.0"
-      }
-    },
     "react-highcharts": {
       "version": "11.5.0",
       "resolved": "https://registry.npmjs.org/react-highcharts/-/react-highcharts-11.5.0.tgz",
@@ -9226,22 +9175,6 @@
         "highlight.js": "9.6.0",
         "react": "15.6.1",
         "react-dom": "15.6.1"
-      }
-    },
-    "react-inline-block": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-inline-block/-/react-inline-block-2.0.0.tgz",
-      "integrity": "sha1-fbes1hVwW1RZhwLxhiLehK+An/o=",
-      "requires": {
-        "object-assign": "4.1.1"
-      }
-    },
-    "react-notify-resize": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/react-notify-resize/-/react-notify-resize-1.0.3.tgz",
-      "integrity": "sha1-oddQOu79J+7LaztbNcdwe+lCL0g=",
-      "requires": {
-        "react-class": "2.0.0"
       }
     },
     "react-proxy": {
@@ -9266,11 +9199,6 @@
         "loose-envify": "1.3.1",
         "warning": "3.0.0"
       }
-    },
-    "react-style-normalizer": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/react-style-normalizer/-/react-style-normalizer-1.2.8.tgz",
-      "integrity": "sha1-foSz0lzqYiVUXFr2iWOyJYhTRKI="
     },
     "react-test-renderer": {
       "version": "15.6.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "marked": "~0.3.6",
     "moment": "~2.15.1",
     "prop-types": "~15.5.8",
-    "react-date-picker": "~5.3.28",
+    "react-day-picker": "~6.1.0",
     "react-dnd": "~2.4.0",
     "react-dnd-touch-backend": "0.2.7",
     "react-highcharts": "~11.5.0",

--- a/src/components/date/__definition__.js
+++ b/src/components/date/__definition__.js
@@ -13,9 +13,6 @@ let definition = new Definition('date-input', DateInput, {
 * Entering or picking a start and end date together? [Try Date Range](/components/date-range).
  `,
   type: 'form',
-  propValues: {
-    minDate: moment().subtract(1, 'days').format('YYYY-MM-DD')
-  },
   propTypes: {
     autoFocus: "Boolean",
     disabled: "Boolean",

--- a/src/components/date/__definition__.js
+++ b/src/components/date/__definition__.js
@@ -1,5 +1,6 @@
 import DateInput from './';
 import Definition from './../../../demo/utils/definition';
+import moment from 'moment';
 
 let definition = new Definition('date-input', DateInput, {
   description: `Captures a single date.`,
@@ -12,7 +13,9 @@ let definition = new Definition('date-input', DateInput, {
 * Entering or picking a start and end date together? [Try Date Range](/components/date-range).
  `,
   type: 'form',
-  hiddenProps: ['minDate', 'maxDate'],
+  propValues: {
+    minDate: moment().subtract(1, 'days').format('YYYY-MM-DD')
+  },
   propTypes: {
     autoFocus: "Boolean",
     disabled: "Boolean",

--- a/src/components/date/__spec__.js
+++ b/src/components/date/__spec__.js
@@ -211,7 +211,7 @@ describe('Date', () => {
 
   describe('handleVisibleInputChange', () => {
     beforeEach(() => {
-      spyOn(instance, 'setState');
+      spyOn(instance, 'setState').and.callThrough();
     });
 
     it('is triggered when visible input changes', () => {
@@ -221,7 +221,7 @@ describe('Date', () => {
       expect(instance.emitOnChangeCallback).toHaveBeenCalledWith(hiddenToday);
       expect(instance.setState).toHaveBeenCalledWith({
         visibleValue: today,
-        datePickerValue: hiddenToday
+        datePickerValue: DateHelper.stringToDate(hiddenToday)
       });
     });
 
@@ -231,54 +231,76 @@ describe('Date', () => {
 
       it('accepts the format DD MMM YYYY', () => {
         let date = moment().add(noOfDays, 'days').format('DD MMM YYYY');
-        instance.handleVisibleInputChange({ target: { value: date } })
+        instance.handleVisibleInputChange({ target: { value: date } });
         expect(instance.setState).toHaveBeenCalledWith({
           visibleValue: date,
-          datePickerValue: hiddenDate
+          datePickerValue: DateHelper.stringToDate(hiddenDate)
         });
       });
 
       it('accepts the format DD-MM', () => {
         let date = moment().format('DD-MM');
-        instance.handleVisibleInputChange({ target: { value: date } })
+        instance.handleVisibleInputChange({ target: { value: date } });
         expect(instance.setState).toHaveBeenCalledWith({
           visibleValue: date,
-          datePickerValue: hiddenToday
+          datePickerValue: DateHelper.stringToDate(hiddenToday)
         });
       });
 
       it('accepts the format DD.MM.YYYY', () => {
         let date = moment().add(noOfDays, 'days').format('DD.MM.YYYY');
-        instance.handleVisibleInputChange({ target: { value: date } })
+        instance.handleVisibleInputChange({ target: { value: date } });
         expect(instance.setState).toHaveBeenCalledWith({
           visibleValue: date,
-          datePickerValue: hiddenDate
+          datePickerValue: DateHelper.stringToDate(hiddenDate)
         });
       });
 
       it('accepts the format DD-MM-YYYY', () => {
         let date = moment().add(noOfDays, 'days').format('DD-MM-YYYY');
-        instance.handleVisibleInputChange({ target: { value: date } })
+        instance.handleVisibleInputChange({ target: { value: date } });
         expect(instance.setState).toHaveBeenCalledWith({
           visibleValue: date,
-          datePickerValue: hiddenDate
+          datePickerValue: DateHelper.stringToDate(hiddenDate)
+        });
+      });
+
+      describe('if the month changes and datepicker is open', () => {
+        it('updates the month of the datepicker', () => {
+          instance.setState({ open: true });
+          spyOn(instance.datepicker, 'showMonth');
+          let date = moment().add(1, 'months').format('DD-MM-YYYY');
+          instance.handleVisibleInputChange({ target: { value: date } });
+          expect(instance.datepicker.showMonth).toHaveBeenCalledWith(instance.state.datePickerValue);
+        });
+      });
+
+      describe('if the year changes and datepicker is open', () => {
+        it('updates the year of the datepicker', () => {
+          instance.setState({ open: true });
+          spyOn(instance.datepicker, 'showMonth');
+          let date = moment().add(1, 'years').format('DD-MM-YYYY');
+          instance.handleVisibleInputChange({ target: { value: date } });
+          expect(instance.datepicker.showMonth).toHaveBeenCalledWith(instance.state.datePickerValue);
         });
       });
     });
 
     describe('when a invalid date is entered', () => {
       it('does not update the hidden value', () => {
-        instance.handleVisibleInputChange({ target: { value: 'abc' } })
+        instance.handleVisibleInputChange({ target: { value: 'abc' } });
         expect(instance.setState).toHaveBeenCalledWith({
           visibleValue: 'abc'
         });
       });
+
       it("calls inputIconHTML with error in order to correctly generate the error icon", () => {
         let invalidDate = TestUtils.renderIntoDocument(<Date value='' />);
         spyOn(invalidDate, 'inputIconHTML');
         invalidDate.setState({ valid: false });
         expect(invalidDate.inputIconHTML).toHaveBeenCalledWith('error');
       });
+
       it("calls inputIconHTML with warning in order to correctly generate the warning icon", () => {
         let invalidDate = TestUtils.renderIntoDocument(<Date value='' />);
         spyOn(invalidDate, 'inputIconHTML');
@@ -394,14 +416,6 @@ describe('Date', () => {
       it('sets the input as readonly', () => {
         expect(instance._input.readOnly).toEqual(true);
       });
-    });
-  });
-
-  describe('handleViewDateChange', () => {
-    it('sets the state of the datePickerValue', () => {
-      spyOn(instance, 'setState');
-      instance.handleViewDateChange(123);
-      expect(instance.setState).toHaveBeenCalledWith({ datePickerValue: 123 });
     });
   });
 

--- a/src/components/date/__spec__.js
+++ b/src/components/date/__spec__.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import moment from 'moment';
+import LocaleUtils from 'react-day-picker/moment';
+import I18n from 'i18n-js';
+import DateHelper from './../../utils/helpers/date';
 import Date from './date';
 import Events from './../../utils/helpers/events';
 import { shallow } from 'enzyme';
@@ -153,11 +156,13 @@ describe('Date', () => {
       describe('when a valid date', () => {
         it('calls set state setting the datePickerValue to be the valid date', () => {
           instance = TestUtils.renderIntoDocument(
-            <Date name='date' value='2015/01/01' label='Date' />
+            <Date name='date' value='2015-01-01' label='Date' />
           );
           spyOn(instance, 'setState');
           instance.openDatePicker();
-          expect(instance.setState).toHaveBeenCalledWith({ datePickerValue: '2015/01/01' });
+          expect(instance.setState).toHaveBeenCalledWith(
+            { datePickerValue: DateHelper.stringToDate('2015-01-01') }
+          );
         });
       });
 
@@ -170,7 +175,7 @@ describe('Date', () => {
           instance.openDatePicker();
           expect(instance.setState).not.toHaveBeenCalledWith({ datePickerValue: 'x' });
         });
-      })
+      });
     });
   });
 
@@ -289,28 +294,28 @@ describe('Date', () => {
     });
 
     it('sets blockBlur to true', () => {
-      let cell = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'dp-day')[1];
+      let cell = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'DayPicker-Day')[1];
       TestUtils.Simulate.click(cell, { nativeEvent: { stopImmediatePropagation: () => {} } } );
       expect(instance.blockBlur).toBeTruthy();
     });
 
     it('closes the date picker', () => {
       let spy = spyOn(instance, 'closeDatePicker');
-      let cell = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'dp-day')[1];
+      let cell = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'DayPicker-Day')[1];
       TestUtils.Simulate.click(cell, { nativeEvent: { stopImmediatePropagation: () => {} } } );
       expect(instance.closeDatePicker).toHaveBeenCalled();
     });
 
     it('emits a onChange callback', () => {
       spyOn(instance, 'emitOnChangeCallback')
-      let cell = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'dp-day')[1];
+      let cell = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'DayPicker-Day')[1];
       TestUtils.Simulate.click(cell, { nativeEvent: { stopImmediatePropagation: () => {} } } );
       expect(instance.emitOnChangeCallback).toHaveBeenCalled();
     });
 
     it('updates the visible value', () => {
       spyOn(instance, 'updateVisibleValue')
-      let cell = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'dp-day')[1];
+      let cell = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'DayPicker-Day')[1];
       TestUtils.Simulate.click(cell, { nativeEvent: { stopImmediatePropagation: () => {} } } );
       expect(instance.updateVisibleValue).toHaveBeenCalled();
     });
@@ -429,10 +434,12 @@ describe('Date', () => {
     });
 
     it('sets the weekDays and format', () => {
-      expect(datepicker.props.weekDayNames).toEqual(
-        ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
-      );
-      expect(datepicker.props.dateFormat).toEqual('YYYY-MM-DD');
+      const datepickerProps = datepicker.props
+      expect(datepickerProps.fixedWeeks).toBeTruthy();
+      expect(datepickerProps.enableOutsideDays).toBeTruthy();
+      expect(datepickerProps.inline).toBeTruthy();
+      expect(datepickerProps.locale).toEqual(I18n.locale);
+      expect(datepickerProps.localeUtils).toEqual(LocaleUtils);
     });
   });
 
@@ -488,7 +495,7 @@ describe('Date', () => {
       });
 
       it('sets the minDate to the correct value', () => {
-        expect(date.props.minDate).toEqual(minDate);
+        expect(date.props.disabledDays[0].before).toEqual(DateHelper.stringToDate(minDate));
       });
     });
 
@@ -505,7 +512,13 @@ describe('Date', () => {
       });
 
       it('sets the maxDate to the correct value', () => {
-        expect(date.props.maxDate).toEqual(maxDate);
+        expect(date.props.disabledDays[0].after).toEqual(DateHelper.stringToDate(maxDate));
+      });
+
+      it('does not close the date picker when a disabled day is clicked', () => {
+        let cell = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'DayPicker-Day--disabled')[1];
+        TestUtils.Simulate.click(cell, { nativeEvent: { stopImmediatePropagation: () => {} } } );
+        expect(instance.state.open).toBeTruthy();
       });
     });
   });

--- a/src/components/date/date.js
+++ b/src/components/date/date.js
@@ -283,12 +283,33 @@ class Date extends React.Component {
     // Updates the hidden value after first formatting to default hidden format
     if (validDate) {
       const hiddenValue = DateHelper.formatValue(input, this.hiddenFormat());
-      newState.datePickerValue = hiddenValue;
+      newState.datePickerValue = DateHelper.stringToDate(hiddenValue);
+
+      if (this.datepicker && this.monthOrYearHasChanged(newState.datePickerValue)) {
+        this.datepicker.showMonth(newState.datePickerValue);
+      }
+
       this.emitOnChangeCallback(hiddenValue);
     } else {
       this.emitOnChangeCallback(ev.target.value);
     }
     this.setState(newState);
+  }
+
+  /**
+   * Determines if the new date's month or year has changed from the currently selected.
+   *
+   * @method monthOrYearHasChanged
+   * @param {Date}
+   * @return {Boolean}
+   */
+  monthOrYearHasChanged = (newDate) => {
+    const currentDate = this.datepicker.state.currentMonth;
+
+    return (
+      (currentDate.getMonth() !== newDate.getMonth()) ||
+      (currentDate.getYear() !== newDate.getYear())
+    );
   }
 
   /**
@@ -343,18 +364,6 @@ class Date extends React.Component {
     } else {
       this.openDatePicker();
     }
-  }
-
-
-  /**
-   * Updates datePickerValue as hidden input changes.
-   *
-   * @method handleViewDateChange
-   * @param {String} val hidden input value
-   * @return {void}
-   */
-  handleViewDateChange = (val) => {
-    this.setState({ datePickerValue: val });
   }
 
   /**
@@ -483,6 +492,7 @@ class Date extends React.Component {
       inline: true,
       locale: I18n.locale,
       localeUtils: LocaleUtils,
+      navbarElement: <Navbar />,
       onDayClick: this.handleDateSelect,
       ref: (input) => { this.datepicker = input; },
       selectedDays: [this.state.datePickerValue]
@@ -497,9 +507,7 @@ class Date extends React.Component {
    */
   renderDatePicker() {
     if (!this.state.open) { return null; }
-    return (
-      <DayPicker { ...this.datePickerProps } navbarElement={ <Navbar /> } />
-    );
+    return <DayPicker { ...this.datePickerProps } />;
   }
 
   renderHiddenInput() {

--- a/src/components/date/date.scss
+++ b/src/components/date/date.scss
@@ -41,6 +41,11 @@ $date__picker__background-color: $white;
   &:focus {
     outline: none;
   }
+
+  abbr[title] {
+    border: none;
+    cursor: initial;
+  }
 }
 
 .DayPicker-wrapper {

--- a/src/components/date/date.scss
+++ b/src/components/date/date.scss
@@ -2,7 +2,6 @@
 @import "./../../style-config/z-index";
 @import "./../../style-config/mixins";
 
-$date__picker__width: 334px;
 $date__picker__header-color: $grey-dark-blue-70;
 $date__picker__header-height: 40px;
 $date__picker__header-border-color: $grey-dark-blue-80;
@@ -17,20 +16,16 @@ $date__picker__background-color: $white;
 }
 
 .DayPicker {
-  color: $date__picker__header-color;
-}
-
-.DayPicker {
   background-color: $date__picker__background-color;
   border-radius: 3px;
   box-shadow: 0 20px 30px rgba($grey-shadow, 0.2);
+  color: $date__picker__header-color;
   display: block;
   font-size: 14px;
   font-weight: 700;
   overflow: hidden;
   position: absolute;
   text-align: center;
-  width: $date__picker__width;
   z-index: $z-datepicker;
 
   -webkit-user-select: none;
@@ -130,21 +125,24 @@ $date__picker__background-color: $white;
   width: percentage(1/7);
 }
 
-.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-  background-color: $blue;
+.DayPicker-Day--selected, .DayPicker-Day--selected.DayPicker-Day--outside {
+  background-color: $blue !important;
   color: $white;
+  font-weight: 700;
 }
 
-.DayPicker-Day--today {
-  background: $grey-dark-blue-70;
+.DayPicker-Day--today, .DayPicker-Day--today.DayPicker-Day--outside {
+  background-color: $grey-dark-blue-70;
   color: $white;
+  font-weight: 700;
 }
 
 .DayPicker-Day--outside {
   background-color: $date__picker__background-color;
+  color: $grey-dark-blue-50;
 
   &:hover {
-    background-color: $blue;
+    background-color: $azul;
     color: $white;
   }
 }

--- a/src/components/date/date.scss
+++ b/src/components/date/date.scss
@@ -2,10 +2,11 @@
 @import "./../../style-config/z-index";
 @import "./../../style-config/mixins";
 
-$date__picker__border: $grey-light;
+$date__picker__width: 334px;
 $date__picker__header-color: $grey-dark-blue-70;
+$date__picker__header-height: 40px;
 $date__picker__header-border-color: $grey-dark-blue-80;
-$date__picker__cell-border-color: white;
+$date__picker__background-color: $white;
 
 .carbon-date {
   .icon-calendar:before {
@@ -15,11 +16,12 @@ $date__picker__cell-border-color: white;
   }
 }
 
-.react-date-picker__month-view {
+.DayPicker {
   color: $date__picker__header-color;
 }
 
-.react-date-picker__month-view {
+.DayPicker {
+  background-color: $date__picker__background-color;
   border-radius: 3px;
   box-shadow: 0 20px 30px rgba($grey-shadow, 0.2);
   display: block;
@@ -28,7 +30,7 @@ $date__picker__cell-border-color: white;
   overflow: hidden;
   position: absolute;
   text-align: center;
-  width: 334px;
+  width: $date__picker__width;
   z-index: $z-datepicker;
 
   -webkit-user-select: none;
@@ -46,57 +48,56 @@ $date__picker__cell-border-color: white;
   }
 }
 
-.react-date-picker__month-view-cell {
-  display: inline-block;
+.DayPicker-wrapper {
+  padding: 0;
+}
+
+.DayPicker-Month {
+  margin: 0 0 2px;
+}
+
+.DayPicker-Body, .DayPicker-Week {
+  width: 100%;
+}
+
+.DayPicker-Day, .DayPicker-Weekday {
   padding: 10px 12px;
+  border-color: $date__picker__background-color;
+  border-style: solid;
+  border-width: 0 3px 3px 3px;
+}
+
+.DayPicker-Day {
   width: percentage(1/7);
 }
 
-.react-date-picker__nav-bar {
+.DayPicker-Weekday {
+  width: percentage(1/7);
+}
+
+.DayPicker-Caption {
   background-color: $date__picker__header-color;
-  border-radius: 3px 3px 0 0;
-  color: white;
-  cursor: pointer;
+  color: $white;
+  height: $date__picker__header-height;
+  line-height: $date__picker__header-height;
 
-  >.react-date-picker__nav-bar-arrow,
-  >.react-date-picker__nav-bar-date {
-    display: inline-block;
-    padding: 8px 0px 12px;
-
-    &:active {
-      background-color: $grey-dark;
-    }
-  }
-
-  .react-date-picker__nav-bar-arrow {
-    font-size: 20px;
-    line-height: 20px;
-    width: 12%;
-  }
-
-  .react-date-picker__nav-bar-date {
-    text-align: center;
-    text-transform: capitalize;
-    width: 76%;
+  >div {
+    margin: 0 auto;
+    width: 80%;
   }
 }
 
-.react-date-picker__month-view-week-day-name {
-  background-color: $date__picker__cell-border-color;
+.DayPicker-Weekday {
+  background-color: $date__picker__background-color;
   color: $grey-dark;
   font-size: 14px;
   font-weight: 700;
-  padding: 10px 12px;
+  text-align: center;
+  text-transform: capitalize;
 }
 
-.dp-year,
-.dp-month,
-.dp-day,
-.react-date-picker__footer button {
+.DayPicker-Day {
   background-color: $grey-dark-blue-10;
-  border-style: solid;
-  border-color: $date__picker__cell-border-color;
-  border-width: 0 3px 3px 3px;
   color: $blue;
   cursor: pointer;
 
@@ -110,24 +111,44 @@ $date__picker__cell-border-color: white;
   }
 }
 
-.react-date-picker__month-view-day--active {
+.DayPicker-Day, .DayPicker-Weekday {
+  padding: 10px 12px;
+  border-color: $date__picker__background-color;
+  border-style: solid;
+  border-width: 0 3px 3px 3px;
+}
+
+.DayPicker-Day {
+  width: percentage(1/7);
+}
+
+.DayPicker-Weekday {
+  width: percentage(1/7);
+}
+
+.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
   background-color: $blue;
   color: $white;
 }
 
-.react-date-picker__month-view-day--today {
+.DayPicker-Day--today {
   background: $grey-dark-blue-70;
-  color: white;
+  color: $white;
 }
 
-.react-date-picker__month-view-day--prev-month,
-.react-date-picker__month-view-day--next-month {
-  background-color: white;
+.DayPicker-Day--outside {
+  background-color: $date__picker__background-color;
 
   &:hover {
     background-color: $blue;
-    color: white;
+    color: $white;
   }
+}
+
+.DayPicker-Day--disabled, .DayPicker-Day--disabled:hover {
+  background-color: $white;
+  color: $grey-dark-blue-30;
+  cursor: default;
 }
 
 .carbon-date .common-input__field {

--- a/src/components/date/date.scss
+++ b/src/components/date/date.scss
@@ -65,6 +65,10 @@ $date__picker__background-color: $white;
   border-color: $date__picker__background-color;
   border-style: solid;
   border-width: 0 3px 3px 3px;
+
+  abbr {
+    text-decoration: none;
+  }
 }
 
 .DayPicker-Day {

--- a/src/components/date/navbar/__spec__.js
+++ b/src/components/date/navbar/__spec__.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Navbar from './navbar';
+import { shallow } from 'enzyme';
+
+describe('Navbar', () => {
+  let wrapper, onPreviousClick, onNextClick
+  describe('render', () => {
+    beforeEach(() => {
+      onPreviousClick = jest.fn();
+      onNextClick = jest.fn();
+      wrapper = shallow(
+        <Navbar
+          onPreviousClick={onPreviousClick}
+          onNextClick={onNextClick}
+          className='custom-class'
+        />
+      )
+    });
+
+    it('returns a previous button that calls onPreviousClick', () => {
+      const prevButton = wrapper.find('.DayPicker-NavButton--prev');
+      prevButton.simulate('click');
+      expect(onPreviousClick.mock.calls.length).toEqual(1);
+    });
+
+    it('returns a next button that calls onNextClick', () => {
+      const prevButton = wrapper.find('.DayPicker-NavButton--next');
+      prevButton.simulate('click');
+      expect(onNextClick.mock.calls.length).toEqual(1);
+    });
+
+    it('applies the custom class name', () => {
+      expect(wrapper.find('.custom-class').length).toEqual(1);
+    });
+  });
+});

--- a/src/components/date/navbar/navbar.js
+++ b/src/components/date/navbar/navbar.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Navbar = ({
+  onPreviousClick,
+  onNextClick,
+  className
+}) => {
+  return (
+    <div className={ className }>
+      <button
+        className='DayPicker-NavButton DayPicker-NavButton--prev'
+        onClick={ () => { onPreviousClick(); } }
+      >
+        <span className='DayPicker-NavButton__arrow'>‹</span>
+      </button>
+      <button
+        className='DayPicker-NavButton DayPicker-NavButton--next'
+        onClick={ () => { onNextClick(); } }
+      >
+        <span className='DayPicker-NavButton__arrow'>›</span>
+      </button>
+    </div>
+  );
+};
+
+Navbar.propTypes = {
+  onPreviousClick: PropTypes.func,
+  onNextClick: PropTypes.func,
+  className: PropTypes.string
+};
+
+export default Navbar;

--- a/src/components/date/navbar/navbar.js
+++ b/src/components/date/navbar/navbar.js
@@ -10,13 +10,13 @@ const Navbar = ({
     <div className={ className }>
       <button
         className='DayPicker-NavButton DayPicker-NavButton--prev'
-        onClick={ () => { onPreviousClick(); } }
+        onClick={ () => onPreviousClick() }
       >
         <span className='DayPicker-NavButton__arrow'>‹</span>
       </button>
       <button
         className='DayPicker-NavButton DayPicker-NavButton--next'
-        onClick={ () => { onNextClick(); } }
+        onClick={ () => onNextClick() }
       >
         <span className='DayPicker-NavButton__arrow'>›</span>
       </button>

--- a/src/components/date/navbar/navbar.scss
+++ b/src/components/date/navbar/navbar.scss
@@ -32,6 +32,10 @@ $date__picker__header-height: 40px;
       &:active {
         background-color: $grey-dark;
       }
+
+      &:focus {
+        outline-offset: -3px;
+      }
     }
 
     .DayPicker-NavButton__arrow {

--- a/src/components/date/navbar/navbar.scss
+++ b/src/components/date/navbar/navbar.scss
@@ -1,0 +1,50 @@
+@import "./../../../style-config/colors";
+
+$date__picker__header-height: 40px;
+
+.DayPicker {
+  .DayPicker-NavBar {
+    border-radius: 3px 3px 0 0;
+    color: $white;
+    cursor: pointer;
+    height: $date__picker__header-height;
+    top: 0;
+    width: 100%;
+
+    .DayPicker-NavButton {
+      align-items: center;
+      border:none;
+      background-image:none;
+      background-color:transparent;
+      -webkit-box-shadow: none;
+      -moz-box-shadow: none;
+      box-shadow: none;
+      color: $white;
+      display: flex;
+      font-size: 20px;
+      height: $date__picker__header-height;
+      justify-content: center;
+      line-height: 15px;
+      padding: 0;
+      top: 0;
+      width: 12%;
+
+      &:active {
+        background-color: $grey-dark;
+      }
+    }
+
+    .DayPicker-NavButton__arrow {
+      height: 20px;
+      width: 100%;
+    }
+
+    .DayPicker-NavButton--prev {
+      left: 0;
+    }
+
+    .DayPicker-NavButton--next {
+      right: 0;
+    }
+  }
+}

--- a/src/components/date/navbar/navbar.scss
+++ b/src/components/date/navbar/navbar.scss
@@ -6,7 +6,6 @@ $date__picker__header-height: 40px;
   .DayPicker-NavBar {
     border-radius: 3px 3px 0 0;
     color: $white;
-    cursor: pointer;
     height: $date__picker__header-height;
     top: 0;
     width: 100%;
@@ -20,6 +19,7 @@ $date__picker__header-height: 40px;
       -moz-box-shadow: none;
       box-shadow: none;
       color: $white;
+      cursor: pointer;
       display: flex;
       font-size: 20px;
       height: $date__picker__header-height;

--- a/src/components/date/navbar/navbar.scss
+++ b/src/components/date/navbar/navbar.scss
@@ -36,6 +36,10 @@ $date__picker__header-height: 40px;
       &:focus {
         outline-offset: -3px;
       }
+
+      &:hover {
+        background-color: $azul;
+      }
     }
 
     .DayPicker-NavButton__arrow {

--- a/src/components/date/navbar/package.json
+++ b/src/components/date/navbar/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "navbar",
+  "main": "./navbar.js",
+  "style": "./navbar.scss"
+}

--- a/src/utils/helpers/date/__spec__.js
+++ b/src/utils/helpers/date/__spec__.js
@@ -77,6 +77,20 @@ describe('DateHelper', () => {
     });
   });
 
+  describe('stringToDate', () => {
+    it('converts a value such as "2017-08-23" into a Javascript Date object', () => {
+      const date = new Date(2017, 7, 23) // js Date month is zero indexed
+      expect(DateHelper.stringToDate("2017-08-23")).toEqual(date);
+    });
+  });
+
+  describe('formatDateString', () => {
+    it('Formats the given date string to a specified format', () => {
+      const dateString = 'Wed Aug 23 2017 12:00:00 GMT+0100 (BST)'
+      expect(DateHelper.formatDateString(dateString, 'YYYY-MM-DD')).toEqual('2017-08-23')
+    });
+  });
+
   describe('todayFormatted', () => {
     it('returns todays date in a in a set format', () => {
       expect(DateHelper.todayFormatted('DD-MM-YYYY')).toEqual(moment().format('DD-MM-YYYY'));

--- a/src/utils/helpers/date/date.js
+++ b/src/utils/helpers/date/date.js
@@ -47,6 +47,30 @@ const DateHelper = {
   },
 
   /**
+   * Convert a value such as '2017-08-23' into a Javascript Date object
+   *
+   * @method stringToDate
+   * @param {String} value current value e.g. 2017-08-23
+   * @return {Oject} The Date object
+   */
+  stringToDate: value => moment(value).toDate(),
+
+  /**
+   * Formats the given date string to the specified format
+   * Moment will not format the standard Javascript Date string format
+   *
+   * @method formatDateString
+   * @param {String} value current value e.g. Wed Aug 23 2017 12:00:00 GMT+0100 (BST)
+   * @param {String} formatTo Desired format e.g. YYYY-MM-DD
+   * @return {String} formatted date
+   */
+  formatDateString: (value, formatTo) => {
+    return (
+      moment(new Date(value).getTime()).format(formatTo)
+    );
+  },
+
+  /**
    * Returns todays date formatted
    *
    * @param {String} format - format of date


### PR DESCRIPTION
### New Date Picker library
Switched from `react-date-picker` to `react-day-picker` as the old library is no longer being maintained.
- http://react-day-picker.js.org
- https://github.com/gpbl/react-day-picker

![date-picker](https://user-images.githubusercontent.com/4964/29613101-4ded435a-87fc-11e7-8e63-2b6e0ac7ddb1.gif)

### TODO
- [x] Style for disabled days
- [x] Update the nav bar left/right arrows to match design
- [x] Release notes
- [x] Cross browser check of css
- [x] Possibly add a locale switcher to show translated version on Carbon demo
- [x] Fix specs & coverage

### QA
- Check keyboard support is the same (hitting tab closes the picker rather than giving it focus)
- Visit http://localhost:8095/components/date-input?locale=fr to test the picker showing the months in French. Note French is the only locale other than English supported on the Carbon demo site.
- Carbon demo has been updated so maxDate and minDate can be set to test the disabled dates functionality.