### PR TITLE
Fixes ImmutableHelper edge case when passing object with length field to parseJSON fails

### DIFF
--- a/src/utils/helpers/immutable/__spec__.js
+++ b/src/utils/helpers/immutable/__spec__.js
@@ -99,5 +99,14 @@ describe('Immutable Helper', () => {
         });
       });
     });
+
+    describe('when passed an object containing "length" field', () => {
+      it('returns immutable map containing that field', () => {
+        const data = { length: 5 };
+        const expectedData = Immutable.Map({ length: '5' });
+        const result = ImmutableHelper.parseJSON(data);
+        expect(result.toJS()).toEqual(expectedData.toJS());
+      });
+    });
   });
 });

--- a/src/utils/helpers/immutable/immutable.js
+++ b/src/utils/helpers/immutable/immutable.js
@@ -30,7 +30,7 @@ const ImmutableHelper = {
       return Immutable.Seq(js).map(ImmutableHelper.parseJSON).toList();
     }
 
-    return Immutable.Seq(js).map(ImmutableHelper.parseJSON).toMap();
+    return Immutable.Map(js).map(ImmutableHelper.parseJSON);
   }
 };
 


### PR DESCRIPTION
# Description
When passing object that contains _length_ field to ImmutableHelper.parseJSON, it returns an array of undefined elements, whose count is equal to length field value. It's because ImmutableHelper uses  Immutable.Seq underneath even for objects (which is possible, but doesn't work well when we pass an object like `{ foo: 1, bar: 2, length: 3 }`). 

This PR fixes it by changing last Seq to Map instead. I also added relevant test to the spec.

# TODO
- [ ] Release notes

# Related Issues / Pull Requests

# Screenshots / Gifs

# Testing Instructions
