### PR TITLE
AnimatedMenuButton Accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * `Table` now lets you add an `aria-describedby` prop.
 * `ConfigurableItemRow` is vertically centered correctly.
+* ARIA role of `button` added to the `AnimatedMenu` close button
+* `AnimatedMenu` close button is now tabbable
 
 ## Pattern Enhancements
 

--- a/src/components/animated-menu-button/__spec__.js
+++ b/src/components/animated-menu-button/__spec__.js
@@ -221,6 +221,14 @@ describe('AnimatedMenuButton', () => {
     it('returns the HTML for the close Icon', () => {
       expect(basicWidget.closeIcon().props.children.props.type).toEqual('close');
     });
+
+    it('has the role button', () => {
+      expect(basicWidget.closeIcon().props.role).toEqual('button');
+    });
+
+    it('has the tabIndex 0', () => {
+      expect(basicWidget.closeIcon().props.tabIndex).toEqual(0);
+    });
   });
 
   describe('render', () => {

--- a/src/components/animated-menu-button/animated-menu-button.js
+++ b/src/components/animated-menu-button/animated-menu-button.js
@@ -219,6 +219,8 @@ class AnimatedMenuButton extends React.Component {
         key='close'
         onClick={ this.closeHandler }
         ref={ (comp) => { this._closeIcon = comp; } }
+        role='button'
+        tabIndex={ 0 }
       >
         <Icon type='close' />
       </div>


### PR DESCRIPTION
### Added ARIA role 'button' to the animated menu button close icon
The wrapper for the icon is a Non-interactive HTML element and thus requires a role to tell screen-readers how it can be interacted with.

Note the icon only displays on touch devices. A tabIndex is required for interactive elements so they can be focused.

### AnimatedMenu close button is now tabbable