### PR TITLE
Enable Table component to scroll horizontally

### DIFF
--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -15,7 +15,9 @@
   border-collapse: separate;
   border-radius: $tables__border-radius;
   border-spacing: 0;
+  display: block;
   min-width: 100%;
+  overflow-x: auto;
   table-layout: fixed;
   width: auto;
   word-break: break-all;


### PR DESCRIPTION
# Description
When the `<Table>` content is too wide the browser has a horizontal scroll-bar. Instead it should add a horizontal scroll-bar to the table itself.

**Before**
![table-scroll-before](https://user-images.githubusercontent.com/4964/29961637-2bebe74a-8ef8-11e7-9748-660e5209974d.gif)

**After**
![table-scroll](https://user-images.githubusercontent.com/4964/29961646-3060eb18-8ef8-11e7-95bc-cc929c8d6a20.gif)

### TODO
- [ ] Changelog
- [ ] Check how this works with a dropdown at the bottom of the table

### Testing
One way to test this would be to open the dev tools in your browser and edit the markup to add a bunch of `<th>`'s as shown in the gifs above.
