### PR TITLE
ConfigurableItems tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Component Enhancements
 
 * `Table` now lets you add an `aria-describedby` prop.
+* `ConfigurableItemRow` is vertically centered correctly.
+
+## Pattern Enhancements
+
+* `ConfigurableItems` has `stickyFormFooter` enabled
 
 ## Draggable Ghost Row
 

--- a/src/components/configurable-items/configurable-item-row/configurable-item-row.scss
+++ b/src/components/configurable-items/configurable-item-row/configurable-item-row.scss
@@ -3,7 +3,7 @@
 .configurable-item-row {
   border-bottom: 1px solid $border-color;
   font-weight: bold;
-  padding: 0.5em;
+  padding: 0.5em 0.5em 0.7em;
 }
 
 .configurable-item-row--dragging,

--- a/src/patterns/configurable-items/__spec__.js
+++ b/src/patterns/configurable-items/__spec__.js
@@ -122,6 +122,10 @@ describe('ConfigurableItemsPattern', () => {
           expect(dialogProps.title).toEqual('Configure Items');
         });
 
+        it('renders a dialog with stickyFormFooter prop set to true', () => {
+          expect(dialogProps.stickyFormFooter).toBeTruthy();
+        });
+
         it('includes the correct component, element and role data tags', () => {
           rootTagTest(wrapper, 'configurable-items-pattern', 'bar', 'baz');
         });

--- a/src/patterns/configurable-items/configurable-items.js
+++ b/src/patterns/configurable-items/configurable-items.js
@@ -144,6 +144,7 @@ class ConfigurableItemsPattern extends React.Component {
         onCancel={ this.onCancel }
         open={ this.isDialogOpen }
         title={ this.props.title }
+        stickyFormFooter
       >
         { this.content() }
       </Dialog>


### PR DESCRIPTION
# Description
- ConfigurableItems pattern dialog now uses stickyFormFooter
- Make Configurable Item Row vertically centered

![screen shot 2017-09-01 at 11 56 17](https://user-images.githubusercontent.com/4964/29967087-caff5ba0-8f0c-11e7-9dde-e719a43d6fe9.png)

![screen shot 2017-09-01 at 11 58 15](https://user-images.githubusercontent.com/4964/29967111-eaea82dc-8f0c-11e7-8f9e-68e691077889.png)



Ticket: PF-3381