### PR TITLE
More ARIA updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `Table` now lets you add an `aria-describedby` prop.
 * `ConfigurableItemRow` is vertically centered correctly.
+* `AnimatedMenuButton` uses the native `<button>` instead of a div for the close button.
 
 ## Pattern Enhancements
 

--- a/src/components/animated-menu-button/__spec__.js
+++ b/src/components/animated-menu-button/__spec__.js
@@ -117,7 +117,10 @@ describe('AnimatedMenuButton', () => {
 
   describe('close handler', () => {
     it('closes the menu', () => {
-      basicWidget.closeHandler();
+      let event = { preventDefault: () => {} }
+      spyOn(event, 'preventDefault')
+      basicWidget.closeHandler(event);
+      expect(event.preventDefault).toHaveBeenCalled();
       expect(basicWidget.setState).toHaveBeenCalled();
       expect(basicWidget.blockBlur).toBeFalsy();
     });
@@ -220,6 +223,7 @@ describe('AnimatedMenuButton', () => {
   describe('closeIcon', () => {
     it('returns the HTML for the close Icon', () => {
       expect(basicWidget.closeIcon().props.children.props.type).toEqual('close');
+      expect(basicWidget.closeIcon().type).toEqual('button');
     });
   });
 

--- a/src/components/animated-menu-button/animated-menu-button.js
+++ b/src/components/animated-menu-button/animated-menu-button.js
@@ -214,17 +214,17 @@ class AnimatedMenuButton extends React.Component {
    */
   closeIcon() {
     return (
-      <div
+      <button
+        className='carbon-animated-menu-button__close-button'
         data-element='close'
         key='close'
         onClick={ this.closeHandler }
         ref={ (comp) => { this._closeIcon = comp; } }
       >
         <Icon type='close' />
-      </div>
+      </button>
     );
   }
-
 
   /**
    * Opens handler on event.
@@ -243,7 +243,8 @@ class AnimatedMenuButton extends React.Component {
    * @method closeHandler
    * @return {void}
    */
-  closeHandler () {
+  closeHandler(event) {
+    event.preventDefault();
     this.setState({ open: false });
     this.blockBlur = false;
   }

--- a/src/components/animated-menu-button/animated-menu-button.scss
+++ b/src/components/animated-menu-button/animated-menu-button.scss
@@ -123,9 +123,18 @@
       }
     }
 
-    .icon-close {
+    .carbon-animated-menu-button__close-button {
+      background: none;
+      border: none;
+      color: $white;
+      display: block;
       float: right;
-      outline: none;
+      margin: 0;
+      padding: 0;
+
+      .icon-close {
+        outline: none;
+      }
     }
   }
 }

--- a/src/utils/decorators/input-validation/input-validation.js
+++ b/src/utils/decorators/input-validation/input-validation.js
@@ -642,12 +642,7 @@ const InputValidation = ComposedComponent => class Component extends ComposedCom
         className={ iconClasses }
         style={ iconStyle }
       />,
-      <div
-        key='1'
-        className='common-input__message-wrapper'
-        onMouseOver={ this.showMessage }
-        onMouseOut={ this.hideMessage }
-      >
+      <div key='1' className='common-input__message-wrapper'>
         <div
           ref={ (validationMessage) => { this.validationMessage = validationMessage; } }
           className={ messageClasses }


### PR DESCRIPTION
# Description
Following on from https://github.com/Sage/carbon/pull/1513 This PR resolves more of the a11y linting errors that would be raised by the `eslint-plugin-jsx-a11y` plugin if it was turned on for Carbon.

- The `AnimatedMenuButton` will now close when pressing the enter key.
- Removed `onMouseOver` and `onMouseOut` from validation message itself in the input validation decorator

# TODO
- [x] Release notes

# Related Issues / Pull Requests
https://github.com/Sage/carbon/pull/1513

# Testing Instructions
- The AnimatedMenuButton close button has keyboard support (press enter to close) but this is only visible on touch devices.

