### PR TITLE
[CARBON-962] Dropdown ARIA updates

### DIFF
--- a/src/components/dropdown-filter/__spec__.js
+++ b/src/components/dropdown-filter/__spec__.js
@@ -5,6 +5,7 @@ import Immutable from 'immutable';
 import { shallow } from 'enzyme';
 import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
 import ImmutableHelper from './../../utils/helpers/immutable';
+import BrowserHelper from './../../utils/helpers/browser';
 
 
 describe('DropdownFilter', () => {
@@ -836,6 +837,143 @@ describe('DropdownFilter', () => {
           'label',
           'option'
         ]);
+      });
+    });
+  });
+
+  describe('the create link', () => {
+    let createLink, wrapper, createLinkProps;
+
+    beforeEach(() => {
+      wrapper = shallow(
+        <DropdownFilter
+          create={function() {}}
+          fieldHelp='test'
+          label='test'
+          options={ ImmutableHelper.parseJSON([ { id: 1, name: 'bun' } ]) }
+          path='test'
+        />
+      );
+      wrapper.setState({ open: true })
+      createLink = wrapper.find('.carbon-dropdown__action');
+      expect(createLink.length).toEqual(1);
+      createLinkProps = createLink.props();
+    });
+
+    it('calls handleCreate onClick', () => {
+      expect(createLinkProps.onClick).toEqual(wrapper.instance().handleCreate);
+    });
+
+    it('calls handleCreate onKeyPress', () => {
+      expect(createLinkProps.onKeyPress).toEqual(wrapper.instance().handleCreate);
+    });
+
+    it('calls handleCreateBlur onBlur', () => {
+      expect(createLinkProps.onBlur).toEqual(wrapper.instance().handleCreateBlur);
+      createLinkProps.onBlur();
+      expect(wrapper.state.open).toBeFalsy();
+      expect(wrapper.instance().blockBlur).toBeFalsy();
+    });
+
+    it('has a tabIndex of 0', () => {
+      expect(createLinkProps.tabIndex).toEqual('0');
+    });
+  });
+
+  describe('onUpArrow', () => {
+    let createLink, wrapper, createLinkProps;
+
+    describe('when the create prop is set', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <DropdownFilter
+            create={function() {}}
+            fieldHelp='test'
+            label='test'
+            options={ ImmutableHelper.parseJSON([ { id: 1, name: 'bun' } ]) }
+            path='test'
+          />
+        );
+        wrapper.setState({ open: true })
+      });
+
+      it('sets blockBlur to true', () => {
+        const list = BrowserHelper.getDocument().createElement('ul');
+        const li = BrowserHelper.getDocument().createElement('li')
+        list.appendChild(li)
+        let nextValue = wrapper.instance().onUpArrow(list, null);
+        expect(wrapper.instance().blockBlur).toBeTruthy();
+      });
+    });
+
+    describe('when the create prop is not set', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <DropdownFilter
+            fieldHelp='test'
+            label='test'
+            options={ ImmutableHelper.parseJSON([ { id: 1, name: 'bun' } ]) }
+            path='test'
+          />
+        );
+        wrapper.setState({ open: true })
+      });
+
+      it('it does not set blockBlur to true', () => {
+        const list = BrowserHelper.getDocument().createElement('ul');
+        const li = BrowserHelper.getDocument().createElement('li')
+        list.appendChild(li)
+        let nextValue = wrapper.instance().onUpArrow(list, null);
+        expect(wrapper.instance().blockBlur).toBeFalsy();
+      });
+    });
+  });
+
+  describe('onDownArrow', () => {
+    let createLink, wrapper, createLinkProps;
+
+    describe('when the create prop is set', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <DropdownFilter
+            create={function() {}}
+            fieldHelp='test'
+            label='test'
+            options={ ImmutableHelper.parseJSON([ { id: 1, name: 'bun' } ]) }
+            path='test'
+          />
+        );
+        wrapper.setState({ open: true })
+      });
+
+      it('sets blockBlur to true', () => {
+        const list = BrowserHelper.getDocument().createElement('ul');
+        const li = BrowserHelper.getDocument().createElement('li')
+        list.appendChild(li)
+        let nextValue = wrapper.instance().onDownArrow(list, null);
+        expect(wrapper.instance().blockBlur).toBeTruthy();
+      });
+    });
+
+    describe('when the create prop is not set', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <DropdownFilter
+            fieldHelp='test'
+            label='test'
+            options={ ImmutableHelper.parseJSON([ { id: 1, name: 'bun' } ]) }
+            path='test'
+          />
+        );
+        wrapper.setState({ open: true })
+      });
+
+      it('it does not set blockBlur to true', () => {
+        const list = BrowserHelper.getDocument().createElement('ul');
+        const li = BrowserHelper.getDocument().createElement('li')
+        list.appendChild(li)
+        let nextValue = wrapper.instance().onDownArrow(list, null);
+        expect(wrapper.instance().blockBlur).toBeFalsy();
       });
     });
   });

--- a/src/components/dropdown-filter/dropdown-filter.js
+++ b/src/components/dropdown-filter/dropdown-filter.js
@@ -250,6 +250,11 @@ class DropdownFilter extends Dropdown {
     this.props.create(ev, this);
   }
 
+  handleCreateBlur = () => {
+    this.blockBlur = false;
+    this.setState({ open: false });
+  }
+
   /**
    * Prepares list options by converting to JSON and formatting filtered options.
    *
@@ -341,7 +346,11 @@ class DropdownFilter extends Dropdown {
           className='carbon-dropdown__action'
           data-element='create'
           key='dropdown-action'
+          onBlur={ this.handleCreateBlur }
           onClick={ this.handleCreate }
+          onKeyPress={ this.handleCreate }
+          role='button'
+          tabIndex='0'
         >
           { text }
         </a>
@@ -508,6 +517,20 @@ class DropdownFilter extends Dropdown {
       'data-element': props['data-element'],
       'data-role': props['data-role']
     };
+  }
+
+  onUpArrow = (list, element) => {
+    if (this.props.create) {
+      this.blockBlur = true;
+    }
+    return super.onUpArrow(list, element);
+  }
+
+  onDownArrow = (list, element) => {
+    if (this.props.create) {
+      this.blockBlur = true;
+    }
+    return super.onDownArrow(list, element);
   }
 }
 

--- a/src/components/dropdown/__spec__.js
+++ b/src/components/dropdown/__spec__.js
@@ -857,6 +857,7 @@ describe('Dropdown', () => {
       expect(instance.listProps.key).toEqual('list');
       expect(instance.listProps.ref).toEqual('list');
       expect(instance.listProps.className).toEqual('carbon-dropdown__list');
+      expect(instance.listProps.role).toEqual('listbox');
     });
   });
 
@@ -885,6 +886,15 @@ describe('Dropdown', () => {
       it('adds highlighted class', () => {
         instance.setState({ highlighted: 2 });
         expect(instance.results(instance.options)[1].props.className).toEqual('carbon-dropdown__list-item carbon-dropdown__list-item--highlighted');
+      });
+
+      it('sets aria-selected', () => {
+        expect(instance.results(instance.options)[0].props['aria-selected']).toBeTruthy();
+        expect(instance.results(instance.options)[1].props['aria-selected']).toBeFalsy();
+      });
+
+      it('sets the role as option', () => {
+        expect(instance.results(instance.options)[0].props.role).toEqual('option');
       });
     });
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -703,9 +703,11 @@ class Dropdown extends React.Component {
 
   componentTags(props) {
     return {
+      'aria-expanded': this.state.open,
       'data-component': 'dropdown',
       'data-element': props['data-element'],
-      'data-role': props['data-role']
+      'data-role': props['data-role'],
+      role: 'combobox'
     };
   }
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -60,6 +60,8 @@ class Dropdown extends React.Component {
     // recalled with the use of super
     this.selectValue = this.selectValue.bind(this);
     this.results = this.results.bind(this);
+    this.onDownArrow = this.onDownArrow.bind(this);
+    this.onUpArrow = this.onUpArrow.bind(this);
   }
 
   static propTypes = {
@@ -292,7 +294,7 @@ class Dropdown extends React.Component {
    * Handles touch events.
    *
    * @method handleTouchEvent
-   **/
+   */
   handleTouchEvent = () => {
     // blocking blurring like this stops a bug on mobile when touch doesn't trigger until after blur, we want to
     // update the input before blurring
@@ -407,7 +409,7 @@ class Dropdown extends React.Component {
    * @param {HTML} element current li element
    * @return {HTML} nextVal next li element to be selected
    */
-  onUpArrow = (list, element) => {
+  onUpArrow(list, element) {
     let nextVal = list.lastChild.getAttribute('value');
 
     if (element === list.firstChild) {
@@ -428,7 +430,7 @@ class Dropdown extends React.Component {
    * @param {HTML} element current li element
    * @return {HTML} nextVal next li element to be selected
    */
-  onDownArrow = (list, element) => {
+  onDownArrow(list, element) {
     let nextVal = list.firstChild.getAttribute('value');
 
     if (element === list.lastChild) {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -567,7 +567,8 @@ class Dropdown extends React.Component {
     return {
       key: 'list',
       ref: 'list',
-      className: 'carbon-dropdown__list'
+      className: 'carbon-dropdown__list',
+      role: 'listbox'
     };
   }
 
@@ -628,17 +629,20 @@ class Dropdown extends React.Component {
       }
 
       // add selected class
-      if (String(this.props.value) === optionId) {
+      const selected = String(this.props.value) === optionId;
+      if (selected) {
         klass += ` ${className}--selected`;
       }
 
       return (
         <li
+          aria-selected={ selected }
           data-element='option'
           key={ option.name + option.id }
           value={ option.id }
           onClick={ this.handleSelect }
           onMouseOver={ this.handleMouseOverListItem }
+          role='option'
           className={ klass }
         >
           { this.props.renderItem ? this.props.renderItem(option) : option.name }

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -634,6 +634,8 @@ class Dropdown extends React.Component {
         klass += ` ${className}--selected`;
       }
 
+      /* eslint-disable jsx-a11y/mouse-events-have-key-events */
+      /* eslint-disable jsx-a11y/click-events-have-key-events */
       return (
         <li
           aria-selected={ selected }
@@ -648,6 +650,8 @@ class Dropdown extends React.Component {
           { this.props.renderItem ? this.props.renderItem(option) : option.name }
         </li>
       );
+      /* eslint-enable jsx-a11y/click-events-have-key-events */
+      /* eslint-enable jsx-a11y/mouse-events-have-key-events */
     });
 
     return results;


### PR DESCRIPTION
# Description

**Add listbox, combobox and option roles to Dropdown component**

The role of `combobox` has been added to the wrapper div for the Dropdown component. `aria-expanded` attribute has also been added and it set to true when the dropdown is open showing the options.
https://www.w3.org/TR/wai-aria-1.1/#combobox

The li now has a role of `option`. It is a Non-interactive HTML element and thus requires a role to tell screen-readers how it can be interacted with.
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_listbox_role

The role of `listbox` for the container and option for the items identify the element that creates a list from which a user may select one item.
https://www.w3.org/TR/wai-aria/states_and_properties#aria-selected
aria-selected indicates the current "selected" state and should be used
in tandem with the role option.

**Add ARIA role button to the DropdownFilter component**
This component allows a create button to be added at the bottom. The role of `button` has been added because an onClick is present on the anchor.

https://www.w3.org/TR/wai-aria/roles#button
An input that allows for user-triggered actions when clicked or pressed.

# TODO
- [ ] Release notes
- [ ] Allow create button to be focused in the DropdownFilter (not using tab)

# Related Issues / Pull Requests
Issue: https://github.com/Sage/carbon/issues/1471
Ticket CARBON-962