### PR TITLE
Tabs ARIA updates

### DIFF
--- a/src/components/tabs/__spec__.js
+++ b/src/components/tabs/__spec__.js
@@ -595,87 +595,184 @@ describe('Tabs', () => {
 
   describe('Keyboard navigation', () => {
     let wrapper, replaceSpy
-    beforeEach(() => {
-      wrapper = mount(
-        <Tabs>
-          <Tab tabId='tab1' title='Test 1' />
-          <Tab tabId='tab2' title='Test 2' />
-          <Tab tabId='tab3' title='Test 3' />
-        </Tabs>
-      );
-      replaceSpy = jest.fn(); //jasmine.createSpy('replaceState');
-      wrapper.instance()._window = {
-        history: {
-          replaceState: replaceSpy
-        },
-        location: {
-          origin: 'foo',
-          pathname: 'bar'
-        }
-      };
-    });
 
-    describe('when pressing the right arrow', () => {
-      it('can handle multiple presses and remains focused on the right most tab', () => {
-        wrapper.setState({ selectedTabId: "tab1" });
-        wrapper.find('.carbon-tabs__headers__header--selected').node.focus();
-        expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab1')
-        wrapper.find('.carbon-tabs__headers__header--selected').simulate(
-          'keyDown', { key: 'ArrowRight', which: 39, stopPropagation: () => {}}
+    describe('when the orientation is horizontal', () => {
+      beforeEach(() => {
+        wrapper = mount(
+          <Tabs>
+            <Tab tabId='tab1' title='Test 1' />
+            <Tab tabId='tab2' title='Test 2' />
+            <Tab tabId='tab3' title='Test 3' />
+          </Tabs>
         );
-        expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab2')
-        expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab2');
-        wrapper.find('.carbon-tabs__headers__header--selected').simulate(
-          'keyDown', { key: 'ArrowRight', which: 39, stopPropagation: () => {}}
-        );
-        expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
-        expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab3');
-        wrapper.find('.carbon-tabs__headers__header--selected').simulate(
-          'keyDown', { key: 'ArrowRight', which: 39, stopPropagation: () => {}}
-        );
-        expect(replaceSpy.mock.calls.length).toEqual(2);
-        expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
+        replaceSpy = jest.fn();
+        wrapper.instance()._window = {
+          history: {
+            replaceState: replaceSpy
+          },
+          location: {
+            origin: 'foo',
+            pathname: 'bar'
+          }
+        };
+      });
+
+      describe('when pressing the right arrow', () => {
+        it('can handle multiple presses and remains focused on the right most tab', () => {
+          wrapper.setState({ selectedTabId: "tab1" });
+          wrapper.find('.carbon-tabs__headers__header--selected').node.focus();
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab1')
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'ArrowRight', which: 39, stopPropagation: () => {}}
+          );
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab2')
+          expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab2');
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'ArrowRight', which: 39, stopPropagation: () => {}}
+          );
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
+          expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab3');
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'ArrowRight', which: 39, stopPropagation: () => {}}
+          );
+          expect(replaceSpy.mock.calls.length).toEqual(2);
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
+        });
+      });
+
+      describe('when pressing the left arrow', () => {
+        it('changes the url focuses on the adjacent left tab', () => {
+          wrapper.setState({ selectedTabId: "tab3" });
+          wrapper.find('.carbon-tabs__headers__header--selected').node.focus();
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'ArrowLeft', which: 37, stopPropagation: () => {}}
+          );
+          expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab2');
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab2')
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'ArrowLeft', which: 37, stopPropagation: () => {}}
+          );
+          expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab1');
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'ArrowLeft', which: 37, stopPropagation: () => {}}
+          );
+          expect(replaceSpy.mock.calls.length).toEqual(2);
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab1')
+        });
+      });
+
+      describe('when pressing the enter key', () => {
+        it('changes url to the one currently selected', () => {
+          wrapper.setState({ selectedTabId: "tab2" });
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'Enter', which: 13, stopPropagation: () => {}}
+          );
+          expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab2');
+        });
+      });
+
+      describe('when pressing the up key', () => {
+        it('doesnt do anything', () => {
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'UpArrow', which: 38, stopPropagation: () => {}}
+          );
+          expect(replaceSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('when pressing the down key', () => {
+        it('doesnt do anything', () => {
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'DownArrow', which: 40, stopPropagation: () => {}}
+          );
+          expect(replaceSpy).not.toHaveBeenCalled();
+        });
       });
     });
 
-    describe('when pressing the left arrow', () => {
-      it('changes the url focuses on the adjacent left tab', () => {
-        wrapper.setState({ selectedTabId: "tab3" });
-        wrapper.find('.carbon-tabs__headers__header--selected').node.focus();
-        expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
-        wrapper.find('.carbon-tabs__headers__header--selected').simulate(
-          'keyDown', { key: 'ArrowLeft', which: 37, stopPropagation: () => {}}
+    describe('when the orientation is vertical', () => {
+      beforeEach(() => {
+        wrapper = mount(
+          <Tabs position='left'>
+            <Tab tabId='tab1' title='Test 1' />
+            <Tab tabId='tab2' title='Test 2' />
+            <Tab tabId='tab3' title='Test 3' />
+          </Tabs>
         );
-        expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab2');
-        expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab2')
-        wrapper.find('.carbon-tabs__headers__header--selected').simulate(
-          'keyDown', { key: 'ArrowLeft', which: 37, stopPropagation: () => {}}
-        );
-        expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab1');
-        wrapper.find('.carbon-tabs__headers__header--selected').simulate(
-          'keyDown', { key: 'ArrowLeft', which: 37, stopPropagation: () => {}}
-        );
-        expect(replaceSpy.mock.calls.length).toEqual(2);
-        expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab1')
+        replaceSpy = jest.fn();
+        wrapper.instance()._window = {
+          history: {
+            replaceState: replaceSpy
+          },
+          location: {
+            origin: 'foo',
+            pathname: 'bar'
+          }
+        };
       });
-    });
 
-    describe('when pressing the enter key', () => {
-      it('changes url to the one currently selected', () => {
-        wrapper.setState({ selectedTabId: "tab2" });
-        wrapper.find('.carbon-tabs__headers__header--selected').simulate(
-          'keyDown', { key: 'Enter', which: 13, stopPropagation: () => {}}
-        );
-        expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab2');
+      describe('when pressing the down arrow', () => {
+        it('can handle multiple presses and remains focused on the bottom most tab', () => {
+          wrapper.setState({ selectedTabId: "tab1" });
+          wrapper.find('.carbon-tabs__headers__header--selected').node.focus();
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab1')
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'ArrowDown', which: 40, stopPropagation: () => {}}
+          );
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab2')
+          expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab2');
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'ArrowDown', which: 40, stopPropagation: () => {}}
+          );
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
+          expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab3');
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'ArrowDown', which: 40, stopPropagation: () => {}}
+          );
+          expect(replaceSpy.mock.calls.length).toEqual(2);
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
+        });
       });
-    });
 
-    describe('when pressing an unregistered key', () => {
-      it('doesnt do anything', () => {
-        wrapper.find('.carbon-tabs__headers__header--selected').simulate(
-          'keyDown', { key: 'UpArrow', which: 38, stopPropagation: () => {}}
-        );
-        expect(replaceSpy).not.toHaveBeenCalled();
+      describe('when pressing the up arrow', () => {
+        it('changes the url focuses on the adjacent above tab', () => {
+          wrapper.setState({ selectedTabId: "tab3" });
+          wrapper.find('.carbon-tabs__headers__header--selected').node.focus();
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'ArrowUp', which: 38, stopPropagation: () => {}}
+          );
+          expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab2');
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab2')
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'ArrowUp', which: 38, stopPropagation: () => {}}
+          );
+          expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab1');
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'ArrowUp', which: 38, stopPropagation: () => {}}
+          );
+          expect(replaceSpy.mock.calls.length).toEqual(2);
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab1')
+        });
+      });
+
+      describe('when pressing the left key', () => {
+        it('doesnt do anything', () => {
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'LeftArrow', which: 37, stopPropagation: () => {}}
+          );
+          expect(replaceSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('when pressing the right key', () => {
+        it('doesnt do anything', () => {
+          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
+            'keyDown', { key: 'RightArrow', which: 39, stopPropagation: () => {}}
+          );
+          expect(replaceSpy).not.toHaveBeenCalled();
+        });
       });
     });
   });

--- a/src/components/tabs/__spec__.js
+++ b/src/components/tabs/__spec__.js
@@ -618,7 +618,7 @@ describe('Tabs', () => {
       });
 
       describe('when pressing the right arrow', () => {
-        it('can handle multiple presses and remains focused on the right most tab', () => {
+        it('focuses on the next right tab and loops back round to the first tab', () => {
           wrapper.setState({ selectedTabId: "tab1" });
           wrapper.find('.carbon-tabs__headers__header--selected').node.focus();
           expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab1')
@@ -635,13 +635,13 @@ describe('Tabs', () => {
           wrapper.find('.carbon-tabs__headers__header--selected').simulate(
             'keyDown', { key: 'ArrowRight', which: 39, stopPropagation: () => {}}
           );
-          expect(replaceSpy.mock.calls.length).toEqual(2);
-          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
+          expect(replaceSpy.mock.calls.length).toEqual(3);
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab1')
         });
       });
 
       describe('when pressing the left arrow', () => {
-        it('changes the url focuses on the adjacent left tab', () => {
+        it('focuses on the next left tab and loops back round to the last tab', () => {
           wrapper.setState({ selectedTabId: "tab3" });
           wrapper.find('.carbon-tabs__headers__header--selected').node.focus();
           expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
@@ -657,8 +657,8 @@ describe('Tabs', () => {
           wrapper.find('.carbon-tabs__headers__header--selected').simulate(
             'keyDown', { key: 'ArrowLeft', which: 37, stopPropagation: () => {}}
           );
-          expect(replaceSpy.mock.calls.length).toEqual(2);
-          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab1')
+          expect(replaceSpy.mock.calls.length).toEqual(3);
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
         });
       });
 
@@ -713,7 +713,7 @@ describe('Tabs', () => {
       });
 
       describe('when pressing the down arrow', () => {
-        it('can handle multiple presses and remains focused on the bottom most tab', () => {
+        it('focuses on the next below tab and loops back round to the top tab', () => {
           wrapper.setState({ selectedTabId: "tab1" });
           wrapper.find('.carbon-tabs__headers__header--selected').node.focus();
           expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab1')
@@ -730,13 +730,13 @@ describe('Tabs', () => {
           wrapper.find('.carbon-tabs__headers__header--selected').simulate(
             'keyDown', { key: 'ArrowDown', which: 40, stopPropagation: () => {}}
           );
-          expect(replaceSpy.mock.calls.length).toEqual(2);
-          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
+          expect(replaceSpy.mock.calls.length).toEqual(3);
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab1')
         });
       });
 
       describe('when pressing the up arrow', () => {
-        it('changes the url focuses on the adjacent above tab', () => {
+        it('focuses on the next above tab and loops back round to the bottom tab', () => {
           wrapper.setState({ selectedTabId: "tab3" });
           wrapper.find('.carbon-tabs__headers__header--selected').node.focus();
           expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
@@ -752,8 +752,8 @@ describe('Tabs', () => {
           wrapper.find('.carbon-tabs__headers__header--selected').simulate(
             'keyDown', { key: 'ArrowUp', which: 38, stopPropagation: () => {}}
           );
-          expect(replaceSpy.mock.calls.length).toEqual(2);
-          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab1')
+          expect(replaceSpy.mock.calls.length).toEqual(3);
+          expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
         });
       });
 

--- a/src/components/tabs/__spec__.js
+++ b/src/components/tabs/__spec__.js
@@ -336,6 +336,10 @@ describe('Tabs', () => {
           </Tabs>);
 
         expect(instance.mainClasses).toEqual('carbon-tabs carbon-tabs__position-left');
+        const tablist = TestUtils.findRenderedDOMComponentWithClass(
+          instance, 'carbon-tabs__headers'
+        );
+        expect(tablist.getAttribute('aria-orientation')).toEqual('vertical');
       });
     });
   });

--- a/src/components/tabs/__spec__.js
+++ b/src/components/tabs/__spec__.js
@@ -416,12 +416,26 @@ describe('Tabs', () => {
       expect(instance.tabHeaders.type).toBe('ul');
     });
 
+    it('has the role of tablist', () => {
+      expect(instance.tabHeaders.props.role).toEqual('tablist');
+    });
+
     it('renders a list item for each tab passed to the tabs', () => {
       expect(instance.tabHeaders.props.children.length).toEqual(3);
     });
 
     it('adds a data-tabid to each list item', () => {
       expect(instance.tabHeaders.props.children[0].props['data-tabid']).toEqual('uniqueid1');
+    });
+
+    it('adds a role of tab to each list item', () => {
+      expect(instance.tabHeaders.props.children[0].props.role).toEqual('tab');
+    });
+
+    it('sets aria-selected to true for the selected tab', () => {
+      expect(instance.tabHeaders.props.children[0].props['aria-selected']).toBeTruthy();
+      expect(instance.tabHeaders.props.children[1].props['aria-selected']).toBeFalsy();
+      expect(instance.tabHeaders.props.children[2].props['aria-selected']).toBeFalsy();
     });
 
     describe('when passed a null child', () => {

--- a/src/components/tabs/__spec__.js
+++ b/src/components/tabs/__spec__.js
@@ -336,10 +336,6 @@ describe('Tabs', () => {
           </Tabs>);
 
         expect(instance.mainClasses).toEqual('carbon-tabs carbon-tabs__position-left');
-        const tablist = TestUtils.findRenderedDOMComponentWithClass(
-          instance, 'carbon-tabs__headers'
-        );
-        expect(tablist.getAttribute('aria-orientation')).toEqual('vertical');
       });
     });
   });
@@ -659,16 +655,6 @@ describe('Tabs', () => {
           );
           expect(replaceSpy.mock.calls.length).toEqual(3);
           expect(Browser.getActiveElement().getAttribute('data-tabid')).toEqual('tab3')
-        });
-      });
-
-      describe('when pressing the enter key', () => {
-        it('changes url to the one currently selected', () => {
-          wrapper.setState({ selectedTabId: "tab2" });
-          wrapper.find('.carbon-tabs__headers__header--selected').simulate(
-            'keyDown', { key: 'Enter', which: 13, stopPropagation: () => {}}
-          );
-          expect(replaceSpy).toHaveBeenCalledWith(null, 'change-tab', 'foobar#tab2');
         });
       });
 

--- a/src/components/tabs/tab/__definition__.js
+++ b/src/components/tabs/tab/__definition__.js
@@ -9,7 +9,6 @@ let definition = new Definition('tab', Tab, {
     title: "String"
   },
   propDescriptions: {
-    'aria-expanded': 'Is the tab open or closed.',
     'aria-labelledby': 'The id of the corresponding control that must be activated to show the tab.',
     role: 'The ARIA role of the component.',
     tabId: "A unique ID to identify this specific tab.",

--- a/src/components/tabs/tab/__definition__.js
+++ b/src/components/tabs/tab/__definition__.js
@@ -9,7 +9,11 @@ let definition = new Definition('tab', Tab, {
     title: "String"
   },
   propDescriptions: {
+    'aria-expanded': 'Is the tab open or closed.',
+    'aria-labelledby': 'The id of the corresponding control that must be activated to show the tab.',
+    role: 'The ARIA role of the component.',
     tabId: "A unique ID to identify this specific tab.",
+    tabIndex: "Determines if the tab is tabbable using the keyboard.",
     title: "The title for this tab and it's button."
   }
 });

--- a/src/components/tabs/tab/tab.js
+++ b/src/components/tabs/tab/tab.js
@@ -15,6 +15,42 @@ class Tab extends React.Component {
 
   static propTypes = {
     /**
+     * Is the tab expanded or not
+     *
+     * @property aria-expanded
+     * @type {Boolean}
+     *
+     */
+    'aria-expanded': PropTypes.bool.isRequired,
+
+    /**
+     * The id of the corresponding control that must be activated to show the tab
+     *
+     * @property aria-expanded
+     * @type {String}
+     *
+     */
+    'aria-labelledby': PropTypes.string.isRequired,
+
+    /**
+     * The role of the component
+     *
+     * @property role
+     * @type {String}
+     *
+     */
+    role: PropTypes.string,
+
+    /**
+     * The tabIndex of the component
+     *
+     * @property tabIndex
+     * @type {Number}
+     *
+     */
+    tabIndex: PropTypes.number,
+
+    /**
      * Visible title in tabs header
      * Consumed within tabs component
      *
@@ -52,7 +88,8 @@ class Tab extends React.Component {
 
   static defaultProps = {
     className: '',
-    children: null
+    children: null,
+    role: 'tabPanel'
   }
 
   static contextTypes = {
@@ -157,7 +194,13 @@ class Tab extends React.Component {
    */
   render() {
     return (
-      <div className={ this.mainClasses }>
+      <div
+        aria-expanded={ this.props['aria-expanded'] }
+        aria-labelledby={ this.props['aria-labelledby'] }
+        className={ this.mainClasses }
+        role={ this.props.role }
+        tabIndex={ this.props.tabIndex }
+      >
         { this.props.children }
       </div>
     );

--- a/src/components/tabs/tab/tab.js
+++ b/src/components/tabs/tab/tab.js
@@ -15,18 +15,9 @@ class Tab extends React.Component {
 
   static propTypes = {
     /**
-     * Is the tab expanded or not
-     *
-     * @property aria-expanded
-     * @type {Boolean}
-     *
-     */
-    'aria-expanded': PropTypes.bool,
-
-    /**
      * The id of the corresponding control that must be activated to show the tab
      *
-     * @property aria-expanded
+     * @property aria-labelledby
      * @type {String}
      *
      */
@@ -186,7 +177,6 @@ class Tab extends React.Component {
   render() {
     return (
       <div
-        aria-expanded={ this.props['aria-expanded'] }
         aria-labelledby={ this.props['aria-labelledby'] }
         className={ this.mainClasses }
         role={ this.props.role }

--- a/src/components/tabs/tab/tab.js
+++ b/src/components/tabs/tab/tab.js
@@ -21,7 +21,7 @@ class Tab extends React.Component {
      * @type {Boolean}
      *
      */
-    'aria-expanded': PropTypes.bool.isRequired,
+    'aria-expanded': PropTypes.bool,
 
     /**
      * The id of the corresponding control that must be activated to show the tab
@@ -30,7 +30,7 @@ class Tab extends React.Component {
      * @type {String}
      *
      */
-    'aria-labelledby': PropTypes.string.isRequired,
+    'aria-labelledby': PropTypes.string,
 
     /**
      * The role of the component

--- a/src/components/tabs/tab/tab.js
+++ b/src/components/tabs/tab/tab.js
@@ -42,15 +42,6 @@ class Tab extends React.Component {
     role: PropTypes.string,
 
     /**
-     * The tabIndex of the component
-     *
-     * @property tabIndex
-     * @type {Number}
-     *
-     */
-    tabIndex: PropTypes.number,
-
-    /**
      * Visible title in tabs header
      * Consumed within tabs component
      *
@@ -199,7 +190,6 @@ class Tab extends React.Component {
         aria-labelledby={ this.props['aria-labelledby'] }
         className={ this.mainClasses }
         role={ this.props.role }
-        tabIndex={ this.props.tabIndex }
       >
         { this.props.children }
       </div>

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -292,14 +292,68 @@ class Tabs extends React.Component {
       event.stopPropagation();
       if (Event.isEnterKey(event)) {
         this.updateVisibleTab(this.tabIds[index]);
-      } else if (Event.isLeftKey(event)) {
-        this.updateVisibleTab(this.tabIds[index - 1]);
-        this.focusTab(this[this.tabRefs[index - 1]]);
-      } else if (Event.isRightKey(event)) {
-        this.updateVisibleTab(this.tabIds[index + 1]);
-        this.focusTab(this[this.tabRefs[index + 1]]);
+      } else if (this.isVertical(this.props.position)) {
+        this.handleUpDownKeys(event, index);
+      } else {
+        this.handleLeftRightKeys(event, index);
       }
     };
+  }
+
+  /**
+   * Handles the keyboard navigation of tabs when responding to up/down arrow keys
+   *
+   * @method handleUpDownKeys
+   * @param {Object} event The onKeyDown event
+   * @param {Number} index Index of the current visible tab
+   */
+  handleUpDownKeys(event, index) {
+    if (Event.isUpKey(event)) {
+      this.focusPreviousTab(event, index);
+    } else if (Event.isDownKey(event)) {
+      this.focusNextTab(event, index);
+    }
+  }
+
+  /**
+   * Handles the keyboard navigation of tabs when responding to left/right arrow keys
+   *
+   * @method handleLeftRightKeys
+   * @param {Object} event The onKeyDown event
+   * @param {Number} index Index of the current visible tab
+   */
+  handleLeftRightKeys(event, index) {
+    if (Event.isLeftKey(event)) {
+      this.focusPreviousTab(event, index);
+    } else if (Event.isRightKey(event)) {
+      this.focusNextTab(event, index);
+    }
+  }
+
+  /**
+   * Focus the previous tab
+   *
+   * @method focusPreviousTab
+   * @param {Object} event The onKeyDown event
+   * @param {Number} index Index of the current visible tab
+   */
+  focusPreviousTab(event, index) {
+    event.preventDefault();
+    this.updateVisibleTab(this.tabIds[index - 1]);
+    this.focusTab(this[this.tabRefs[index - 1]]);
+  }
+
+  /**
+   * Focus the next tab
+   *
+   * @method focusNextTab
+   * @param {Object} event The onKeyDown event
+   * @param {Number} index Index of the current visible tab
+   */
+  focusNextTab(event, index) {
+    event.preventDefault();
+    this.updateVisibleTab(this.tabIds[index + 1]);
+    this.focusTab(this[this.tabRefs[index + 1]]);
   }
 
   /**
@@ -369,10 +423,22 @@ class Tabs extends React.Component {
 
   isTabSelected = tabId => tabId === this.state.selectedTabId;
 
+  /**
+   * The children nodes converted into an Array
+   *
+   * @method children
+   * @return {Array} Ordered array of children
+   */
   get children() {
     return compact(React.Children.toArray(this.props.children));
   }
 
+  /**
+   * Array of the tabIds for the child nodes
+   *
+   * @method tabIds
+   * @return {Array} Ordered array of tabIds for the child nodes
+   */
   get tabIds() {
     return this.children.map(child => child.props.tabId);
   }

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -408,7 +408,7 @@ class Tabs extends React.Component {
     });
 
     return (
-      <ul className={ this.tabsHeaderClasses() } role='tablist'>
+      <ul className={ this.tabsHeaderClasses() } role='tablist' aria-orientation={ this.ariaOrientation() }>
         { tabTitles }
       </ul>
     );
@@ -459,6 +459,15 @@ class Tabs extends React.Component {
     });
 
     return tabs;
+  }
+
+  isVertical(position) {
+    return position === 'left';
+  }
+
+  ariaOrientation() {
+    if (this.isVertical(this.props.position)) { return 'vertical'; }
+    return null;
   }
 
   /**

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -339,8 +339,10 @@ class Tabs extends React.Component {
    */
   focusPreviousTab(event, index) {
     event.preventDefault();
-    this.updateVisibleTab(this.tabIds[index - 1]);
-    this.focusTab(this[this.tabRefs[index - 1]]);
+    const previousTabId = this.tabIds[index - 1] || this.tabIds[this.tabIds.length - 1];
+    const previousRef = this.tabRefs[index - 1] || this.tabRefs[this.tabRefs.length - 1];
+    this.updateVisibleTab(previousTabId);
+    this.focusTab(this[previousRef]);
   }
 
   /**
@@ -352,8 +354,10 @@ class Tabs extends React.Component {
    */
   focusNextTab(event, index) {
     event.preventDefault();
-    this.updateVisibleTab(this.tabIds[index + 1]);
-    this.focusTab(this[this.tabRefs[index + 1]]);
+    const nextTabId = this.tabIds[index + 1] || this.tabIds[0];
+    const nextRef = this.tabRefs[index + 1] || this.tabRefs[0];
+    this.updateVisibleTab(nextTabId);
+    this.focusTab(this[nextRef]);
   }
 
   /**

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -501,13 +501,12 @@ class Tabs extends React.Component {
 
     const tabs = this.children.map((child, index) => {
       let klass = 'hidden';
-      const selected = this.isTabSelected(child.props.tabId);
-      if (selected) {
+
+      if (this.isTabSelected(child.props.tabId)) {
         klass = 'carbon-tab--selected';
       }
 
       const props = {
-        'aria-expanded': selected,
         'aria-labelledby': this.tabRefs[index],
         className: klass,
         role: 'tabPanel'

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -323,10 +323,12 @@ class Tabs extends React.Component {
       {
         'carbon-tabs__headers__header--error': tabHasError,
         'carbon-tabs__headers__header--warning': tabHasWarning,
-        'carbon-tabs__headers__header--selected': tab.props.tabId === this.state.selectedTabId
+        'carbon-tabs__headers__header--selected': this.isTabSelected(tab.props.tabId)
       }
     );
   }
+
+  isTabSelected = tabId => tabId === this.state.selectedTabId;
 
   /**
    * Build the headers for the tab component
@@ -338,6 +340,7 @@ class Tabs extends React.Component {
     const tabTitles = compact(React.Children.toArray(this.props.children)).map((child) => {
       return (
         <li
+          aria-selected={ this.isTabSelected(child.props.tabId) }
           className={ this.tabHeaderClasses(child) }
           data-element='select-tab'
           data-tabid={ child.props.tabId }
@@ -345,7 +348,8 @@ class Tabs extends React.Component {
           onClick={ this.handleTabClick }
           onKeyDown={ this.handleTabClick }
           ref={ `${child.props.tabId}-tab` }
-          tabIndex='0'
+          role='tab'
+          tabIndex={ this.isTabSelected(child.props.tabId) ? '0' : '-1' }
         >
           { child.props.title }
         </li>
@@ -353,7 +357,7 @@ class Tabs extends React.Component {
     });
 
     return (
-      <ul className={ this.tabsHeaderClasses() } >
+      <ul className={ this.tabsHeaderClasses() } role='tablist'>
         { tabTitles }
       </ul>
     );
@@ -369,7 +373,7 @@ class Tabs extends React.Component {
     let visibleTab;
 
     compact(React.Children.toArray(this.props.children)).forEach((child) => {
-      if (child.props.tabId === this.state.selectedTabId) {
+      if (this.isTabSelected(child.props.tabId)) {
         visibleTab = child;
       }
     });
@@ -388,12 +392,15 @@ class Tabs extends React.Component {
 
     const tabs = compact(React.Children.toArray(this.props.children)).map((child) => {
       let klass = 'hidden';
-
-      if (child.props.tabId === this.state.selectedTabId) {
+      const selected = this.isTabSelected(child.props.tabId);
+      if (selected) {
         klass = 'carbon-tab--selected';
       }
 
-      return React.cloneElement(child, { className: klass });
+      return React.cloneElement(
+        child,
+        { className: klass, role: 'tabPanel', tabIndex: selected ? '0' : '-1' }
+      );
     });
 
     return tabs;

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -394,6 +394,7 @@ class Tabs extends React.Component {
           className={ this.tabHeaderClasses(child) }
           data-element='select-tab'
           data-tabid={ child.props.tabId }
+          id={ ref }
           key={ child.props.tabId }
           onClick={ this.handleTabClick }
           onKeyDown={ this.handleKeyDown(index) }
@@ -422,7 +423,7 @@ class Tabs extends React.Component {
   get visibleTab() {
     let visibleTab;
 
-    compact(React.Children.toArray(this.props.children)).forEach((child) => {
+    this.children.forEach((child) => {
       if (this.isTabSelected(child.props.tabId)) {
         visibleTab = child;
       }
@@ -440,17 +441,21 @@ class Tabs extends React.Component {
   get tabs() {
     if (!this.props.renderHiddenTabs) { return this.visibleTab; }
 
-    const tabs = compact(React.Children.toArray(this.props.children)).map((child) => {
+    const tabs = this.children.map((child, index) => {
       let klass = 'hidden';
       const selected = this.isTabSelected(child.props.tabId);
       if (selected) {
         klass = 'carbon-tab--selected';
       }
 
-      return React.cloneElement(
-        child,
-        { className: klass, role: 'tabPanel', tabIndex: selected ? '0' : '-1' }
-      );
+      const props = {
+        'aria-expanded': selected,
+        'aria-labelledby': this.tabRefs[index],
+        className: klass,
+        role: 'tabPanel'
+      };
+      if (selected) { props.tabIndex = 0; }
+      return React.cloneElement(child, props);
     });
 
     return tabs;


### PR DESCRIPTION
- The element that serves as the container for the set of tabs has role `tablist`
- The `tablist` has `aria-orientation` set to `vertical` when the tabs aligned left of the content.
- Each element that serves as a tab has role `tab`
- Each tab has the `aria-selected` attribute true/false based on the selected state
- Each tab content container has a role of `tabpanel`
- Each tabpanel has the `aria-labelledby` attribute pointing at the relevant `tab` id
- Left and right arrow keyboard support added to move focus between tabs (see gif below).
- Up and down arrow keyboard support added to move focus between vertical tabs.
- When using keys to navigate between tabs, it will loop back around as per the w3 spec.
- The currently visible `tabpanel` has a `tabIndex` added to make it tabbable by keyboard.

**Specification**
https://www.w3.org/TR/wai-aria/roles#tablist
https://www.w3.org/TR/wai-aria/roles#tab

**Example implementation:**
https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html

![tabs-arrows](https://user-images.githubusercontent.com/4964/30111810-0eb46752-9307-11e7-8e9a-29bd66128e5f.gif)

![up-down-tabs](https://user-images.githubusercontent.com/4964/30120844-ec6d7bdc-9321-11e7-9b3e-bb9e7f465e94.gif)

### TODO
- [ ] Release notes
- [x] Additional keyboard support

### Related Issues / Pull Requests
https://github.com/Sage/carbon/issues/1470