### PR TITLE
remove uneeded carbon-todo

### DIFF
--- a/src/components/inline-inputs/inline-inputs.js
+++ b/src/components/inline-inputs/inline-inputs.js
@@ -23,7 +23,7 @@ const columnWrapper = (children) => {
   }
 
   return inputs.map((input, index) => {
-    // TODO: CarbonV2 Add unique requirement for inlineInputs to use as keys
+    // Input is never going to be re-ordered so we don't require a defined key
     /* eslint-disable react/no-array-index-key */
     return (
       <Column key={ index }>

--- a/src/components/multi-step-wizard/multi-step-wizard.js
+++ b/src/components/multi-step-wizard/multi-step-wizard.js
@@ -277,9 +277,6 @@ class MultiStepWizard extends React.Component {
     return this.props.steps.map((step, index) => {
       return (
         // Step is never going to be re-ordered or changed so index is safe to use
-        // TODO: CarbonV2 Add requirement to pass unique id to each step for key value
-        // OR we could change the api so they have to supply the steps as children rather
-        // than via an array
         /* eslint-disable react/no-array-index-key */
         <Step stepNumber={ index + 1 } key={ `multi-step-wizard-step-${index}` } { ...step.props }>
           { step }


### PR DESCRIPTION
# Description

Looking for opinions if this is ok. Originally i added these as TODO's and wanted to add some deprecations so the user had to provide a key.

After some investigation it seems that keys are only really needed if the items are going to be re-ordered in some way or there might be issues when dynamically pushing/unsetting. With these two components i very much doubt there will be any re-ordering however there may be a case of dynamically adding fields to the inline inputs set?
