### PR TITLE
[CARBON-948] Add the Portal component and apply to the Tooltip decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,10 +109,14 @@ import { Row, Column } from 'carbon/lib/components/row';
 </Row>
 ```
 
+## New Components
+* `Portal` is a component that wraps the [react-portal](https://github.com/tajo/react-portal) library.
+
 ## Component Enhancements
 
 * `Browser` has been updated so that `getWindow()` will work when run in a node environment
 * `ButtonToggle` now lets you add a `size` and a `grouped` prop.
+* `TooltipDecorator` now uses the new `Portal` component for layout. This effects `Help` and `Icon` components.
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 * Button - Ensure that the button text is always aligned centrally by default. Resolves an issue where the Button text may wrap where translated text occurs.
 
+## New Components
+
+* `Portal` is a component that wraps the [react-portal](https://github.com/tajo/react-portal) library.
+
+## Component Enhancements
+
+* `TooltipDecorator` now uses the new `Portal` component for layout. This effects `Help` and `Icon` components.
+
 # 2.0.0
 
 ## Breaking Changes
@@ -115,14 +123,10 @@ import { Row, Column } from 'carbon/lib/components/row';
 </Row>
 ```
 
-## New Components
-* `Portal` is a component that wraps the [react-portal](https://github.com/tajo/react-portal) library.
-
 ## Component Enhancements
 
 * `Browser` has been updated so that `getWindow()` will work when run in a node environment
 * `ButtonToggle` now lets you add a `size` and a `grouped` prop.
-* `TooltipDecorator` now uses the new `Portal` component for layout. This effects `Help` and `Icon` components.
 
 ## Bug Fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9285,6 +9285,14 @@
         "react-dom": "15.6.1"
       }
     },
+    "react-portal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-3.1.0.tgz",
+      "integrity": "sha1-hlxE+3Kh2hBsZJIGk2VZzoke6Jk=",
+      "requires": {
+        "prop-types": "15.5.10"
+      }
+    },
     "react-proxy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-dnd": "~2.4.0",
     "react-dnd-touch-backend": "0.2.7",
     "react-highcharts": "~11.5.0",
+    "react-portal": "^3.1.0",
     "react-router": "^3.0.0",
     "react-transition-group": "~1.1.3",
     "superagent": "~2.2.0"

--- a/src/components/help/__definition__.js
+++ b/src/components/help/__definition__.js
@@ -19,6 +19,9 @@ let definition = new Definition('help', Help, {
     tooltipAlign: 'children',
     tooltipPosition: 'children'
   },
+  propValues: {
+    children: 'This is an example of help.'
+  },
   propTypes: {
     children: "Node",
     className: "String",

--- a/src/components/icon/__spec__.js
+++ b/src/components/icon/__spec__.js
@@ -151,9 +151,9 @@ describe('Icon', () => {
 
   describe('when passed a tooltipMessage', () => {
     it('renders a tooltip', () => {
-      let helpInstance = TestUtils.renderIntoDocument(<Icon type='info' tooltipMessage='Helpful content' />);
-      let tooltip = TestUtils.findRenderedComponentWithType(helpInstance, Tooltip);
-      expect(tooltip).toBeDefined();
+      const wrapper = shallow(<Icon type='info' tooltipMessage='Helpful content'/>);
+      const tooltip = wrapper.find(Tooltip);
+      expect(tooltip.length).toEqual(1);
     });
   });
 

--- a/src/components/portal/__spec__.js
+++ b/src/components/portal/__spec__.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Portal from './portal';
+import ReactPortal from 'react-portal';
+
+describe('Portal', () => {
+  let child, wrapper, reactPortal;
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <Portal open>
+        <p className='child-element'></p>
+      </Portal>
+    );
+  });
+
+  it('renders an instance of ReactPortal', () => {
+    reactPortal = wrapper.find(ReactPortal);
+    expect(reactPortal.length).toEqual(1);
+    expect(reactPortal.props().isOpened).toBeTruthy();
+  });
+
+  it('renders children props', () => {
+    child = wrapper.find('.child-element');
+    expect(child.length).toEqual(1);
+  });
+});

--- a/src/components/portal/package.json
+++ b/src/components/portal/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "./portal.js"
+}

--- a/src/components/portal/portal.js
+++ b/src/components/portal/portal.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactPortal from 'react-portal';
+import PropTypes from 'prop-types';
+
+const Portal = ({ open, children }) => (
+  <ReactPortal isOpened={ open }>
+    { children }
+  </ReactPortal>
+);
+
+Portal.propTypes = {
+  open: PropTypes.bool,
+  children: PropTypes.node
+};
+
+export default Portal;

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -49,10 +49,11 @@
 
 .carbon-tooltip--pointer-align-center.carbon-tooltip--position-bottom .carbon-tooltip__pointer {
   @include calc(left, "50% - #{$app-tooltip-pointer-size}");
-  top: -15px;
+  top: -7.5px;
 
   &:before {
     @include arrow(up, $app-tooltip-pointer-size, $grey-dark-plus);
+    border-top: none;
     position: absolute;
   }
 }
@@ -63,16 +64,18 @@
 
   &:before {
     @include arrow(down, $app-tooltip-pointer-size, $grey-dark-plus);
+    border-bottom: none;
     position: absolute;
   }
 }
 
 .carbon-tooltip--pointer-align-left.carbon-tooltip--position-bottom .carbon-tooltip__pointer {
-  top: -15px;
+  top: -7.5px;
   left: 10px;
 
   &:before {
     @include arrow(up, $app-tooltip-pointer-size, $grey-dark-plus);
+    border-top: none;
     position: absolute;
   }
 }
@@ -84,16 +87,18 @@
 
   &:before {
     @include arrow(down, $app-tooltip-pointer-size, $grey-dark-plus);
+    border-bottom: none;
     position: absolute;
   }
 }
 
 .carbon-tooltip--pointer-align-right.carbon-tooltip--position-bottom .carbon-tooltip__pointer {
-  top: -15px;
+  top: -7.5px;
   right: 25px;
 
   &:before {
     @include arrow(up, $app-tooltip-pointer-size, $grey-dark-plus);
+    border-top: none;
     position: absolute;
   }
 }
@@ -104,6 +109,7 @@
 
   &:before {
     @include arrow(down, $app-tooltip-pointer-size, $grey-dark-plus);
+    border-bottom: none;
     position: absolute;
   }
 }
@@ -114,16 +120,18 @@
 
   &:before {
     @include arrow(right, $app-tooltip-pointer-size, $grey-dark-plus);
+    border-right: none;
     position: absolute;
   }
 }
 
 .carbon-tooltip--pointer-align-center.carbon-tooltip--position-right .carbon-tooltip__pointer {
   @include calc(top, "50% - #{$app-tooltip-pointer-size}");
-  left: -15px;
+  left: -7.5px;
 
   &:before {
     @include arrow(left, $app-tooltip-pointer-size, $grey-dark-plus);
+    border-left: none;
     position: absolute;
   }
 }
@@ -134,16 +142,18 @@
 
   &:before {
     @include arrow(right, $app-tooltip-pointer-size, $grey-dark-plus);
+    border-right: none;
     position: absolute;
   }
 }
 
 .carbon-tooltip--pointer-align-bottom.carbon-tooltip--position-right .carbon-tooltip__pointer {
-  left: -15px;
+  left: -7.5px;
   bottom: 25px;
 
   &:before {
     @include arrow(left, $app-tooltip-pointer-size, $grey-dark-plus);
+    border-left: none;
     position: absolute;
   }
 }
@@ -154,16 +164,18 @@
 
   &:before {
     @include arrow(right, $app-tooltip-pointer-size, $grey-dark-plus);
+    border-right: none;
     position: absolute;
   }
 }
 
 .carbon-tooltip--pointer-align-top.carbon-tooltip--position-right .carbon-tooltip__pointer {
-  left: -15px;
+  left: -7.5px;
   top: 10px;
 
   &:before {
     @include arrow(left, $app-tooltip-pointer-size, $grey-dark-plus);
+    border-left: none;
     position: absolute;
   }
 }

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -1,11 +1,12 @@
 @import "./../../style-config/colors";
 @import "./../../style-config/general";
 @import "./../../style-config/mixins";
+@import "./../../style-config/z-index";
 
 .carbon-tooltip {
   position: absolute;
   width: 300px;
-  z-index: 20;
+  z-index: $z-dialog + 1;
 }
 
 .carbon-tooltip__container {

--- a/src/utils/decorators/tooltip-decorator/__spec__.js
+++ b/src/utils/decorators/tooltip-decorator/__spec__.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import TooltipDecorator from './tooltip-decorator';
+import { shallow } from 'enzyme';
 
 /* global jest */
 
@@ -49,19 +50,18 @@ class StrippedClass extends React.Component {
   }
 }
 
-
-
 describe('tooltip-decorator', () => {
-  let topTooltip, bottomTooltip, rightTooltip, leftTooltip, noTooltip, strippedTooltip;
+  let topTooltip, bottomTooltip, rightTooltip, leftTooltip, noTooltip, strippedTooltip,
+      DecoratedClassOne, DecoratedClassTwo;
 
   beforeEach(() => {
-    let DecoratedClassOne = TooltipDecorator(BasicClass);
-    let DecoratedClassTwo = TooltipDecorator(StrippedClass);
+    DecoratedClassOne = TooltipDecorator(BasicClass);
+    DecoratedClassTwo = TooltipDecorator(StrippedClass);
 
-    topTooltip = TestUtils.renderIntoDocument(<DecoratedClassOne tooltipMessage='Hello'/>);
-    bottomTooltip = TestUtils.renderIntoDocument(<DecoratedClassOne tooltipMessage='Hello' tooltipPosition='bottom'/>);
-    rightTooltip = TestUtils.renderIntoDocument(<DecoratedClassOne tooltipMessage='Hello' tooltipPosition='right'/>);
-    leftTooltip = TestUtils.renderIntoDocument(<DecoratedClassOne tooltipMessage='Hello' tooltipPosition='left'/>);
+    topTooltip = TestUtils.renderIntoDocument(<DecoratedClassOne tooltipMessage='Hello' />);
+    bottomTooltip = TestUtils.renderIntoDocument(<DecoratedClassOne tooltipMessage='Hello' tooltipPosition='bottom' />);
+    rightTooltip = TestUtils.renderIntoDocument(<DecoratedClassOne tooltipMessage='Hello' tooltipPosition='right' />);
+    leftTooltip = TestUtils.renderIntoDocument(<DecoratedClassOne tooltipMessage='Hello' tooltipPosition='left' />);
     noTooltip = TestUtils.renderIntoDocument(<DecoratedClassOne/>);
 
     strippedTooltip = TestUtils.renderIntoDocument(<DecoratedClassTwo />);
@@ -177,14 +177,21 @@ describe('tooltip-decorator', () => {
   });
 
   describe('positionTooltip', () => {
+    let getTarget;
+
+    beforeEach(() => {
+      getTarget = {
+        offsetWidth: 30,
+        offsetHeight: 30,
+        getBoundingClientRect: () => ({ top: 100, bottom: 100, left: 100, right: 100 })
+      }
+    });
+
+
     describe('when positioned above the target', () => {
       beforeEach(()  => {
-        spyOn(topTooltip, 'getTarget').and.returnValue(
-          {
-            offsetWidth: 30,
-            offsetHeight: 30
-          }
-        );
+        topTooltip = shallow(<DecoratedClassOne tooltipMessage='Hello' />).instance();
+        spyOn(topTooltip, 'getTarget').and.returnValue(getTarget);
 
         spyOn(topTooltip, 'getTooltip').and.returnValue(
           {
@@ -208,8 +215,8 @@ describe('tooltip-decorator', () => {
         let tooltip = topTooltip.getTooltip();
         let target = topTooltip.getTarget();
         topTooltip.positionTooltip(tooltip, target);
-        expect(tooltip.style.left).toEqual('-35px');
-        expect(tooltip.style.top).toEqual('-57.5px');
+        expect(tooltip.style.left).toEqual('65px');
+        expect(tooltip.style.top).toEqual('42.5px');
       });
 
       describe('when the pointer is aligned to the right', () => {
@@ -217,16 +224,11 @@ describe('tooltip-decorator', () => {
 
         beforeEach(()  => {
           let DecoratedClass = TooltipDecorator(BasicClass);
-          rightTopTooltip = TestUtils.renderIntoDocument(
+          rightTopTooltip = shallow(
             <DecoratedClass tooltipMessage='Hello' tooltipPosition='top' tooltipAlign='right'/>
-          );
+          ).instance();
 
-          spyOn(rightTopTooltip, 'getTarget').and.returnValue(
-            {
-              offsetWidth: 30,
-              offsetHeight: 30
-            }
-          );
+          spyOn(rightTopTooltip, 'getTarget').and.returnValue(getTarget);
 
           spyOn(rightTopTooltip, 'getTooltip').and.returnValue(
             {
@@ -250,8 +252,8 @@ describe('tooltip-decorator', () => {
           let alignedTooltip = rightTopTooltip.getTooltip();
           let target = rightTopTooltip.getTarget();
           rightTopTooltip.positionTooltip(alignedTooltip, target);
-          expect(alignedTooltip.style.left).toEqual('-74px');
-          expect(alignedTooltip.style.top).toEqual('-57.5px');
+          expect(alignedTooltip.style.left).toEqual('26px');
+          expect(alignedTooltip.style.top).toEqual('42.5px');
         });
       });
 
@@ -260,16 +262,11 @@ describe('tooltip-decorator', () => {
 
         beforeEach(()  => {
           let DecoratedClass = TooltipDecorator(BasicClass);
-          leftTopTooltip = TestUtils.renderIntoDocument(
+          leftTopTooltip = shallow(
             <DecoratedClass tooltipMessage='Hello' tooltipPosition='top' tooltipAlign='left'/>
-          );
+          ).instance();
 
-          spyOn(leftTopTooltip, 'getTarget').and.returnValue(
-            {
-              offsetWidth: 30,
-              offsetHeight: 30
-            }
-          );
+          spyOn(leftTopTooltip, 'getTarget').and.returnValue(getTarget);
 
           spyOn(leftTopTooltip, 'getTooltip').and.returnValue(
             {
@@ -293,20 +290,19 @@ describe('tooltip-decorator', () => {
           let alignedTooltip = leftTopTooltip.getTooltip();
           let target = leftTopTooltip.getTarget();
           leftTopTooltip.positionTooltip(alignedTooltip, target);
-          expect(alignedTooltip.style.left).toEqual('-7.5px');
-          expect(alignedTooltip.style.top).toEqual('-57.5px');
+          expect(alignedTooltip.style.left).toEqual('92.5px');
+          expect(alignedTooltip.style.top).toEqual('42.5px');
         });
       });
     });
 
     describe('when positioned below the target', () => {
       beforeEach(()  => {
-        spyOn(bottomTooltip, 'getTarget').and.returnValue(
-            {
-              offsetWidth: 30,
-              offsetHeight: 30
-            }
-        );
+        let DecoratedClass = TooltipDecorator(BasicClass);
+        bottomTooltip = shallow(
+          <DecoratedClass tooltipMessage='Hello' tooltipPosition='bottom'/>
+        ).instance();
+        spyOn(bottomTooltip, 'getTarget').and.returnValue(getTarget);
 
         spyOn(bottomTooltip, 'getTooltip').and.returnValue(
             {
@@ -330,20 +326,18 @@ describe('tooltip-decorator', () => {
         let tooltip = bottomTooltip.getTooltip();
         let target = bottomTooltip.getTarget();
         bottomTooltip.positionTooltip(tooltip, target);
-        expect(tooltip.style.left).toEqual('-35px');
-        expect(tooltip.style.bottom).toEqual('-57.5px');
+        expect(tooltip.style.left).toEqual('65px');
+        expect(tooltip.style.bottom).toEqual('auto');
       });
-
     });
 
     describe('when positioned right of the target', () => {
       beforeEach(()  => {
-        spyOn(rightTooltip, 'getTarget').and.returnValue(
-            {
-              offsetWidth: 30,
-              offsetHeight: 30
-            }
-        );
+        let DecoratedClass = TooltipDecorator(BasicClass);
+        rightTooltip = shallow(
+          <DecoratedClass tooltipMessage='Hello' tooltipPosition='right'/>
+        ).instance();
+        spyOn(rightTooltip, 'getTarget').and.returnValue(getTarget);
 
         spyOn(rightTooltip, 'getTooltip').and.returnValue(
             {
@@ -367,8 +361,8 @@ describe('tooltip-decorator', () => {
         let tooltip = rightTooltip.getTooltip();
         let target = rightTooltip.getTarget();
         rightTooltip.positionTooltip(tooltip, target);
-        expect(tooltip.style.left).toEqual('37.5px');
-        expect(tooltip.style.top).toEqual('-10px');
+        expect(tooltip.style.left).toEqual('107.5px');
+        expect(tooltip.style.top).toEqual('90px');
       });
 
       describe('when the pointer is aligned to the top', () => {
@@ -380,12 +374,7 @@ describe('tooltip-decorator', () => {
             <DecoratedClass tooltipMessage='Hello' tooltipPosition='right' tooltipAlign='top'/>
           );
 
-          spyOn(topRightTooltip, 'getTarget').and.returnValue(
-            {
-              offsetWidth: 30,
-              offsetHeight: 30
-            }
-          );
+          spyOn(topRightTooltip, 'getTarget').and.returnValue(getTarget);
 
           spyOn(topRightTooltip, 'getTooltip').and.returnValue(
             {
@@ -409,8 +398,8 @@ describe('tooltip-decorator', () => {
           let alignedTooltip = topRightTooltip.getTooltip();
           let target = topRightTooltip.getTarget();
           topRightTooltip.positionTooltip(alignedTooltip, target);
-          expect(alignedTooltip.style.left).toEqual('37.5px');
-          expect(alignedTooltip.style.top).toEqual('-11px');
+          expect(alignedTooltip.style.left).toEqual('107.5px');
+          expect(alignedTooltip.style.top).toEqual('89px');
         });
       });
 
@@ -419,16 +408,11 @@ describe('tooltip-decorator', () => {
 
         beforeEach(()  => {
           let DecoratedClass = TooltipDecorator(BasicClass);
-          bottomRightTooltip = TestUtils.renderIntoDocument(
+          bottomRightTooltip = shallow(
             <DecoratedClass tooltipMessage='Hello' tooltipPosition='right' tooltipAlign='bottom'/>
-          );
+          ).instance();
 
-          spyOn(bottomRightTooltip, 'getTarget').and.returnValue(
-            {
-              offsetWidth: 30,
-              offsetHeight: 30
-            }
-          );
+          spyOn(bottomRightTooltip, 'getTarget').and.returnValue(getTarget);
 
           spyOn(bottomRightTooltip, 'getTooltip').and.returnValue(
             {
@@ -452,20 +436,19 @@ describe('tooltip-decorator', () => {
           let alignedTooltip = bottomRightTooltip.getTooltip();
           let target = bottomRightTooltip.getTarget();
           bottomRightTooltip.positionTooltip(alignedTooltip, target);
-          expect(alignedTooltip.style.left).toEqual('37.5px');
-          expect(alignedTooltip.style.top).toEqual('-9px');
+          expect(alignedTooltip.style.left).toEqual('107.5px');
+          expect(alignedTooltip.style.top).toEqual('91px');
         });
       });
-    });
+     });
 
     describe('when positioned left of the target', () => {
       beforeEach(()  => {
-        spyOn(leftTooltip, 'getTarget').and.returnValue(
-            {
-              offsetWidth: 30,
-              offsetHeight: 30
-            }
-        );
+        let DecoratedClass = TooltipDecorator(BasicClass);
+        leftTooltip = shallow(
+          <DecoratedClass tooltipMessage='Hello' tooltipPosition='left' />
+        ).instance();
+        spyOn(leftTooltip, 'getTarget').and.returnValue(getTarget);
 
         spyOn(leftTooltip, 'getTooltip').and.returnValue(
             {
@@ -489,14 +472,14 @@ describe('tooltip-decorator', () => {
         let tooltip = leftTooltip.getTooltip();
         let target = leftTooltip.getTarget();
         leftTooltip.positionTooltip(tooltip, target);
-        expect(tooltip.style.left).toEqual('-107.5px');
-        expect(tooltip.style.top).toEqual('-10px');
+        expect(tooltip.style.left).toEqual('-7.5px');
+        expect(tooltip.style.top).toEqual('90px');
       });
     });
 
     describe('when isVisible is set to false', () => {
       it('does not try to position the tooltip', () => {
-        spyOn(topTooltip, 'getTooltip');
+        spyOn(topTooltip, 'getTooltip')
         topTooltip.onHide();
         topTooltip.positionTooltip();
         expect(topTooltip.getTooltip).not.toHaveBeenCalled();


### PR DESCRIPTION
# Description
The Portal component pulls a component out into the top level of the DOM. The benefit of this is so that it is not effected by it’s position in the markup and cascading styles.

I have set the z-index of the tooltip to 1 + `z-dialog` to ensure it appears above modals.

The underlying functionality is provided by the library: https://github.com/tajo/react-portal

# TODO
- [x] Release notes
- [x] Specs for the new `<Portal>` component

# Related Issues / Pull Requests
CARBON-948

# Testing Instructions
Test that the Help and Icon tooltips remain positioned in the same way when tweaking the props for the position of the tooltip.
