### PR TITLE
1543 Message props updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.7.0
+
+## Component Enhancements
+
+* `Message` - `children` prop is now optional. [#1543](https://github.com/Sage/carbon/issues/1543)
+* `Message` - `title` prop type has been changed from string to node. [#1543](https://github.com/Sage/carbon/issues/1543)
+
 # 1.6.0
 
 ## Component Enhancements

--- a/src/components/message/message.js
+++ b/src/components/message/message.js
@@ -55,7 +55,7 @@ class Message extends React.Component {
      * @property children
      * @type {Node}
      */
-    children: PropTypes.node.isRequired,
+    children: PropTypes.node,
 
     /**
      * Add classes to the component.
@@ -95,9 +95,9 @@ class Message extends React.Component {
      * Add a title to this component
      *
      * @property title
-     * @type {String}
+     * @type {Node}
      */
-    title: PropTypes.string,
+    title: PropTypes.node,
 
     /**
      * Determines if the message background is transparent or filled defined by the as property.


### PR DESCRIPTION
- `children` prop is now optional
- `title` prop type changed from string to node

# Description

# TODO
- [x] Release notes

# Related Issues / Pull Requests
https://github.com/Sage/carbon/issues/1543
