### PR TITLE
CARBON-964 Remove explicit window reference from input validation decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ import { Row, Column } from 'carbon/lib/components/row';
 
 ## Component Enhancements
 
+* `Browser` has been updated so that `getWindow()` will work when run in a node environment
 * `ButtonToggle` now lets you add a `size` and a `grouped` prop.
 
 # 1.6.0

--- a/src/utils/decorators/input-validation/input-validation.js
+++ b/src/utils/decorators/input-validation/input-validation.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { assign } from 'lodash';
+import Browser from './../../helpers/browser';
 import Icon from './../../../components/icon';
 import chainFunctions from './../../helpers/chain-functions';
 
@@ -41,10 +42,10 @@ import chainFunctions from './../../helpers/chain-functions';
  */
 const InputValidation = ComposedComponent => class Component extends ComposedComponent {
 
-  _window = window;
-
   constructor(...args) {
     super(...args);
+
+    this._window = Browser.getWindow();
 
     // use the super components state, or create an empty object
     this.state = this.state || {};

--- a/src/utils/helpers/browser/__spec__.js
+++ b/src/utils/helpers/browser/__spec__.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { mount } from 'enzyme';
 import Form from './../../../components/form';
-import Browser from './browser.js';
+import Browser from './browser';
 
 describe('Browser', () => {
   let _window;

--- a/src/utils/helpers/browser/browser.js
+++ b/src/utils/helpers/browser/browser.js
@@ -17,11 +17,7 @@ const Browser = {
    * @return window
    */
   getWindow: () => {
-    if (typeof window !== 'undefined') {
-      return window;
-    } else {
-      return {};
-    }
+    return global.window;
   },
 
   /**

--- a/src/utils/helpers/browser/browser.js
+++ b/src/utils/helpers/browser/browser.js
@@ -17,7 +17,11 @@ const Browser = {
    * @return window
    */
   getWindow: () => {
-    return window;
+    if (typeof window !== 'undefined') {
+      return window;
+    } else {
+      return {};
+    }
   },
 
   /**

--- a/src/utils/helpers/browser/node/__spec__.js
+++ b/src/utils/helpers/browser/node/__spec__.js
@@ -1,0 +1,18 @@
+/**
+ * @jest-environment node
+ */
+
+import Browser from '../browser';
+
+/* global test */
+
+describe('Browser', () => {
+  describe('getWindow()', () => {
+    describe('when window is not defined', () => {
+      it('returns an empty object', () => {
+        const emptyObj = {};
+        expect(Browser.getWindow()).toEqual(emptyObj);
+      });
+    });
+  });
+});

--- a/src/utils/helpers/browser/node/__spec__.js
+++ b/src/utils/helpers/browser/node/__spec__.js
@@ -10,8 +10,7 @@ describe('Browser', () => {
   describe('getWindow()', () => {
     describe('when window is not defined', () => {
       it('returns an empty object', () => {
-        const emptyObj = {};
-        expect(Browser.getWindow()).toEqual(emptyObj);
+        expect(Browser.getWindow()).toBeUndefined();
       });
     });
   });


### PR DESCRIPTION
Update `Browser.getWindow()` to return `global.window`. This should return the browser `window` object in a browser environment, and return `undefined` in a node environment.

This is tested using the `testEnvironment` setting, which can be set per
file using the [`@jest-environment` docblock](https://github.com/facebook/jest/blob/master/docs/en/Configuration.md#testenvironment-string).

Update the input validation decorator to use `Browser.getWindow()` to get its `window` reference, rather than reference `window` directly.

## Related Issues / Pull Requests
#1540 