### PR TITLE
Store formatted value in state for grouped character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,10 @@ import { Row, Column } from 'carbon/lib/components/row';
 
 * `ButtonToggle` now lets you add a `size` and a `grouped` prop.
 
+## Bug Fixes
+
+* Grouped character adds separators to value on first render.
+
 # 1.7.0
 
 ## Component Enhancements

--- a/src/components/grouped-character/__spec__.js
+++ b/src/components/grouped-character/__spec__.js
@@ -26,7 +26,7 @@ describe('GroupedCharacter', () => {
       beforeEach(() => {
         spyOn(console, 'error');
         let badWrapper = mount(
-          <GroupedCharacter separator={ 22 } onChange={ jasmine.createSpy('onChange') } groups={ [2, 2, 2] } />
+          <GroupedCharacter separator={ 22 } groups={ [2, 2, 2] } />
         );
       });
 
@@ -60,6 +60,16 @@ describe('GroupedCharacter', () => {
       it('renders the value with custom separator', () => {
         input.simulate('change', { target: { value: '123456789', selectionEnd: 8 } });
         expect(input.nodes[0].value).toEqual('12/3456/789');
+      });
+    });
+
+    describe('on initial render when a value is passed in', () => {
+      it('renders the value with separators', () => {
+        wrapper = mount(
+          <GroupedCharacter groups={ [2, 2, 2] } value='123456' />
+        );
+        input = wrapper.find('.carbon-grouped-character__input');
+        expect(input.nodes[0].value).toEqual('12-34-56');
       });
     });
   });

--- a/src/components/grouped-character/grouped-character.js
+++ b/src/components/grouped-character/grouped-character.js
@@ -17,7 +17,6 @@ class GroupedCharacter extends React.Component {
     super(...args);
 
     this.state = {};
-    this.state.value = this.props.value;
     this.maxLength = this.calculateMaxLength();
     this.insertionIndices = this.insertionIndices();
     this.onKeyDown = this.onKeyDown.bind(this);
@@ -28,6 +27,7 @@ class GroupedCharacter extends React.Component {
     this.getPlainValue = this.getPlainValue.bind(this);    // value without separators
     this.lastPosition = 0;                                // last position of cursor 1-indexed
     this.keyPressed = { which: null };                  // track key pressed outside of React synthetic event
+    this.state.value = this.setVisibleValue(this.props.value);
   }
 
 


### PR DESCRIPTION
# Description
* Store formatted value in state so value always displayed with separators. This means values passed in from a store on first render will be correctly formatted.
