### PR TITLE
Add Portal to the Date component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Component Enhancements
 
 * `TooltipDecorator` now uses the new `Portal` component for layout. This effects `Help` and `Icon` components.
+* `Date` now uses the new `Portal` component to render the DatePicker
 
 # 2.0.0
 

--- a/src/components/portal/portal.js
+++ b/src/components/portal/portal.js
@@ -2,15 +2,34 @@ import React from 'react';
 import ReactPortal from 'react-portal';
 import PropTypes from 'prop-types';
 
-const Portal = ({ open, children }) => (
-  <ReactPortal isOpened={ open }>
-    { children }
-  </ReactPortal>
-);
+class Portal extends React.Component {
+  static propTypes = {
+    /**
+     * Determine if the portal is visible or not
+     *
+     * @property open
+     * @type {Boolean}
+    */
+    open: PropTypes.bool,
 
-Portal.propTypes = {
-  open: PropTypes.bool,
-  children: PropTypes.node
-};
+    /**
+     * The content of the portal.
+     *
+     * @property children
+     * @type {Node}
+     */
+    children: PropTypes.node
+  }
+
+  render() {
+    return (
+      <ReactPortal isOpened={ this.props.open }>
+        <div ref={ (node) => { this._portal = node; } }>
+          { this.props.children }
+        </div>
+      </ReactPortal>
+    );
+  }
+}
 
 export default Portal;


### PR DESCRIPTION
# Description
The Date Picker now uses Portal to handle the layout.

Note that in order to write the specs I needed to add a ref to the Portal component itself. This is so that the content inside the Portal can be found using Enzyme as the content has been pulled out of the dom tree of the parent component.

# TODO
- [x] Release notes
- [x] Repoint this branch to master

# Related Issues / Pull Requests
PR that introduces Portal: https://github.com/Sage/carbon/pull/1542
CARBON-967

# Testing Instructions
No visible changes, ensure the date picker behaves as it currently does.