### PR TITLE
Allow Row to have null column in V2

### DIFF
--- a/src/components/row/__snapshots__/__spec__.js.snap
+++ b/src/components/row/__snapshots__/__spec__.js.snap
@@ -20,6 +20,15 @@ exports[`Row columnDivide when columnDivide is true passes columnDivide to its c
 </div>
 `;
 
+exports[`Row columns when a null column is passed ignores the null child 1`] = `
+<div
+  className="carbon-row carbon-row--gutter-medium carbon-row--columns-2"
+>
+  <Column />
+  <Column />
+</div>
+`;
+
 exports[`Row columns when column number is not passed determines the columns from the number of children 1`] = `
 <div
   className="carbon-row carbon-row--gutter-medium carbon-row--columns-4"

--- a/src/components/row/__spec__.js
+++ b/src/components/row/__spec__.js
@@ -37,6 +37,20 @@ describe('Row', () => {
         expect(wrapper).toMatchSnapshot();
       });
     });
+
+    describe('when a null column is passed', () => {
+      it('ignores the null child', () => {
+        const columns = [<Column />, <Column />, null];
+
+        wrapper = shallow(
+          <Row>
+            { columns }
+          </Row>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+      });
+    });
   });
 
   describe('gutter', () => {

--- a/src/components/row/row.js
+++ b/src/components/row/row.js
@@ -94,7 +94,7 @@ class Row extends React.Component {
    * @return {Array} array of built columns
    */
   buildColumns = () => {
-    return React.Children.map(this.props.children, (child) => {
+    return React.Children.toArray(this.props.children).map((child) => {
       return React.cloneElement(
         child, {
           columnClasses: this.props.columnClasses,
@@ -112,7 +112,7 @@ class Row extends React.Component {
    * @return {String} Main className
    */
   get mainClasses() {
-    const columns = this.props.columns || React.Children.count(this.props.children);
+    const columns = this.props.columns || React.Children.toArray(this.props.children).length;
 
     return classNames(
       'carbon-row',


### PR DESCRIPTION
React.Children.map(this.props.children) does not strip out null children.
React.Children.toArray(this.props.children).map does.

Do we include release notes for RC changes. 
