### PR TITLE
Update default text alignment on Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.0
+
+## Styling Improvements
+
+* Button - Ensure that the button text is always aligned centrally by default. Resolves an issue where the Button text may wrap where translated text occurs.
+
 # 2.0.0
 
 ## Breaking Changes

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -20,6 +20,7 @@
   margin-right: 0;
   padding: $carbon-button__padding;
   outline: none;
+  text-align: center;
   text-decoration: none;
 
   &:focus {


### PR DESCRIPTION
# Description
Default alignment of text on buttons should always be center. This change resolves an issue where Button would inherit the text-align of the parent component.

# Related Issues / Pull Requests
https://github.com/Sage/carbon/issues/1561

# Screenshots / Gifs
_**Before**_
![screen shot 2017-09-18 at 14 16 53](https://user-images.githubusercontent.com/3584292/30546161-b8e148f0-9c83-11e7-90eb-89c160526bd6.png)
_**After**_
![screen shot 2017-09-18 at 14 17 20](https://user-images.githubusercontent.com/3584292/30546162-b8f4440a-9c83-11e7-8683-fd50f328764b.png)