### PR TITLE
upgrade react-highlight for demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ The following updates have been made to Carbon components to align with design u
 
 * Fix typo in FullScreenHeading
 
+## Demo Site
+
+* Upgrades `react-highlight`, which removes the last `createClass` warning from React.
+
 # 2.1.0
 
 * DialogFullScreen and Pages now have a max width applied.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9275,14 +9275,22 @@
       }
     },
     "react-highlight": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/react-highlight/-/react-highlight-0.9.0.tgz",
-      "integrity": "sha1-1e3udEzLhon3k4eUtqG1VLsVDrc=",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/react-highlight/-/react-highlight-0.10.0.tgz",
+      "integrity": "sha1-04b53Oq4Z9wNzCNkFT+xzHZF0EY=",
       "dev": true,
       "requires": {
-        "highlight.js": "9.6.0",
+        "highlight.js": "9.12.0",
         "react": "15.6.1",
         "react-dom": "15.6.1"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "9.12.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+          "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+          "dev": true
+        }
       }
     },
     "react-proxy": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-addons-test-utils": "~15.6.0",
     "react-dnd-test-backend": "~2.4.0",
     "react-dom": "~15.6.1",
-    "react-highlight": "~0.9.0",
+    "react-highlight": "~0.10.0",
     "react-test-renderer": "~15.6.1",
     "underscore.string": "~3.3.4",
     "xhr-mock": "git://github.com/resin-io-modules/xhr-mock.git#improvements"


### PR DESCRIPTION
This removes the last createClass warning from the demo site.

Just a devDependency so can go in anywhere. No release notes required?