### PR TITLE
Add react-addons-perf to devDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * `TooltipDecorator` now uses the new `Portal` component for layout. This effects `Help` and `Icon` components.
 * `Date` now uses the new `Portal` component to render the DatePicker
 
+## Package Updates
+
+* The `react-addons-perf` package is now included in `devDependencies`.
+
 # 2.0.0
 
 ## Breaking Changes

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ncp": "~2.0.0",
     "node-inspector": "^1.1.1",
     "react": "~15.6.1",
+    "react-addons-perf": "^15.4.2",
     "react-addons-test-utils": "~15.6.0",
     "react-dnd-test-backend": "~2.4.0",
     "react-dom": "~15.6.1",


### PR DESCRIPTION
Add the `react-addons-perf` to devDependencies. This will give us access to the `Perf` object in development mode, which we can use to profile / analyse Carbon's performance.
