### PR TITLE
Add .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "files.exclude": {
+    "**/.git": true,
+    "**/coverage": true,
+    "**/lib": true,
+    "**/node_modules": true
+  }
+}


### PR DESCRIPTION
Exclude the `.git`, `coverage`, `lib`, and `node_modules` from displaying in the project explorer.
