### PR TITLE
Switch fieldHelp prop to type Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * `TooltipDecorator` now uses the new `Portal` component for layout. This effects `Help` and `Icon` components.
 * `Date` now uses the new `Portal` component to render the DatePicker
+* `InputLabel` now allows fieldHelp to be a node type.
 
 ## Package Updates
 

--- a/demo/utils/definition/input-definition/input-definition.js
+++ b/demo/utils/definition/input-definition/input-definition.js
@@ -31,7 +31,7 @@ export default (definition) => {
   });
 
   definition.propDescriptions = assign({}, definition.propDescriptions, {
-    fieldHelp: "Displays additional text below the input to provide help to the user.",
+    fieldHelp: "Displays additional information below the input to provide help to the user.",
     fieldHelpInline: "Displays fieldHelp inline with the checkbox/radio button.",
     inputWidth: "A number representing the percentage/ratio of width with the label. Works best with inline labels.",
     label: "Outputs a label for the input.",

--- a/demo/utils/definition/input-definition/input-definition.js
+++ b/demo/utils/definition/input-definition/input-definition.js
@@ -18,7 +18,7 @@ export default (definition) => {
   definition.stubAction('onChange', 'value');
 
   definition.propTypes = assign({}, definition.propTypes, {
-    fieldHelp: "String",
+    fieldHelp: "Node",
     fieldHelpInline: "Boolean",
     inputWidth: "Number",
     label: "String",

--- a/src/utils/decorators/input-label/input-label.js
+++ b/src/utils/decorators/input-label/input-label.js
@@ -116,9 +116,9 @@ const InputLabel = ComposedComponent => class Component extends ComposedComponen
      * A string representing a help message
      *
      * @property
-     * @type {String}
+     * @type {Node}
      */
-    fieldHelp: PropTypes.string,
+    fieldHelp: PropTypes.node,
 
     /**
      * Boolean to determine whether the help message should be inline


### PR DESCRIPTION
# Description
Updated input-label to change fieldHelp prop from type String to type Node to allow the input to include JSX.

# TODO
- [x] Release notes
