### PR TITLE
Allow itemsData to be undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.2.0
+
+## Improvements
+
+* `ConfigurableItemsPattern`'s prop `itemsData` is no longer required
+
 # 2.1.0
 
 ## Styling Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
-# 2.2.0
-
-## Improvements
-
-* `ConfigurableItemsPattern`'s prop `itemsData` is no longer required
-
 # 2.1.0
 
 ## Styling Improvements
 
 * Button - Ensure that the button text is always aligned centrally by default. Resolves an issue where the Button text may wrap where translated text occurs.
+
+## Improvements
+
+* `ConfigurableItemsPattern`'s prop `itemsData` is no longer required
 
 ## New Components
 

--- a/src/patterns/configurable-items/__spec__.js
+++ b/src/patterns/configurable-items/__spec__.js
@@ -75,6 +75,25 @@ describe('ConfigurableItemsPattern', () => {
         expect(ConfigurableItemsActions.updateData).not.toHaveBeenCalled();
       });
     });
+
+    describe('when itemsData is not provided', () => {
+      beforeEach(() => {
+        ConfigurableItemsStore.data = ConfigurableItemsStore.data.set('open', false)
+        wrapper = shallow(
+          <ConfigurableItemsPattern
+            onCancel={ onCancel }
+            onSave={ onSave }
+          />,
+          { lifecycleExperimental: true }
+        );
+        spyOn(ConfigurableItemsActions, 'updateData');
+        let data = wrapper.state().configurableItemsStore.set('open', true);
+        wrapper.setState({ configurableItemsStore: data });
+      });
+      it('does not try to update the itemsData', () => {
+        expect(ConfigurableItemsActions.updateData).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('render', () => {

--- a/src/patterns/configurable-items/configurable-items.js
+++ b/src/patterns/configurable-items/configurable-items.js
@@ -24,7 +24,7 @@ class ConfigurableItemsPattern extends React.Component {
      * @property itemsData
      * @type {Object}
      */
-    itemsData: PropTypes.object.isRequired,
+    itemsData: PropTypes.object,
 
     /**
      * Callback triggered when the form is cancelled.
@@ -63,7 +63,7 @@ class ConfigurableItemsPattern extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.open && (this.open !== prevState.configurableItemsStore.get('open'))) {
+    if (this.props.itemsData && this.open && (this.open !== prevState.configurableItemsStore.get('open'))) {
       ConfigurableItemsActions.updateData(this.props.itemsData);
     }
   }


### PR DESCRIPTION
`ConfigurableItemsPattern` current requires the `itemsData` prop whereas GAC does not always provide it and it's causes a warning in the console. This fix makes the prop optional and only applies it when it's provided.

### TODO
- [x] Release notes
