### PR TITLE
CARBON-968 - Adding Portal component to input-validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 * DropdownFilter now uses a stylized Link component for the Create button.
 * DropdownFilter now has `createText` & `createIconType` props for customizable create button text and create button Icons (limited to current Carbon Icon types).
+* Portal has been added to the `input-validation` messages, meaning they no longer suffer from boundary issues on parent container.
 
 ## Fixes
 
-Ensures that `displayName` is set to the original component's name when connecting to a store using Carbon's flux helper. We have noticed Jest snapshot's have started to default to `View` when connected to a store using our flux connector, this change will ensure the display name is maintained.
+* Ensures that `displayName` is set to the original component's name when connecting to a store using Carbon's flux helper. We have noticed Jest snapshot's have started to default to `View` when connected to a store using our flux connector, this change will ensure the display name is maintained.
+* The `Date` component and input validation message no longer stick in position when scrolling within a Modal.
 
 # 2.2.1
 

--- a/src/components/date/__spec__.js
+++ b/src/components/date/__spec__.js
@@ -99,6 +99,59 @@ describe('Date', () => {
         });
       });
     });
+
+    describe('componentWillUpdate', () => {
+      beforeAll(() => {
+        instance = TestUtils.renderIntoDocument(
+          <Date name='date' label='Date' value='foo' />
+        );
+      });
+
+      describe('when the if condition is true', () => {
+        let listenSpy = jasmine.createSpy('listenSpy');
+        let contextSpy = jasmine.createSpy('contextSpy')
+          .and.returnValue({ addEventListener: listenSpy });
+
+        beforeEach(() => {
+          const modalContext =  {
+            modal: {
+              getDialogContent: contextSpy
+            }
+          };
+          instance.componentWillUpdate({}, {}, modalContext);
+        });
+
+        it('fetches the modal dialog context', () => {
+          expect(contextSpy).toHaveBeenCalled();
+        });
+
+        it('sets the scroll listener', () => {
+          expect(listenSpy).toHaveBeenCalledWith('scroll', instance.updateDatePickerPosition);
+        });
+      });
+    });
+
+    describe('componentWillUnmount', () => {
+      beforeAll(() => {
+        instance = TestUtils.renderIntoDocument(
+          <Date name='date' label='Date' value='foo' />
+        );
+      });
+
+      describe('when the if condition is true', () => {
+        let listenSpy = jasmine.createSpy('listenSpy');
+
+        beforeEach(() => {
+          instance.componentWillUnmount();
+          instance.dialogModalNode = { removeEventListener: listenSpy };
+          instance.componentWillUnmount();
+        });
+
+        it('removes the scroll listener', () => {
+          expect(listenSpy).toHaveBeenCalledWith('scroll', instance.updateDatePickerPosition);
+        });
+      });
+    });
   });
 
   describe('datePickerValueChanged', () => {

--- a/src/components/date/date.js
+++ b/src/components/date/date.js
@@ -180,6 +180,21 @@ class Date extends React.Component {
   }
 
   /**
+   * A lifecycle method for when the component is removed from the page.
+   *
+   * @method componentWillUnmount
+   * @return {void}
+   */
+  componentWillUnmount() {
+    /* istanbul ignore if */
+    if (super.componentWillUnmount) { super.componentWillUnmount(); }
+
+    if (this.dialogModalNode) {
+      this.dialogModalNode.removeEventListener('scroll', this.updateDatePickerPosition);
+    }
+  }
+
+  /**
    * A lifecycle method to update the visible value with a formatted version,
    * only when the field is not the active element.
    *
@@ -191,6 +206,20 @@ class Date extends React.Component {
     if (this._document.activeElement !== this._input) {
       const date = this.formatVisibleValue(nextProps.value);
       this.setState({ visibleValue: date });
+    }
+  }
+
+  /**
+   * @method componentWillUpdate
+   * @return {Void}
+   */
+  componentWillUpdate(nextProps, nextState, nextContext) {
+    /* istanbul ignore if */
+    if (super.componentWillUpdate) { super.componentWillUpdate(nextProps, nextState, nextContext); }
+
+    if (!this.dialogModalNode && nextContext.modal && nextContext.modal.getDialogContent()) {
+      this.dialogModalNode = nextContext.modal.getDialogContent();
+      this.dialogModalNode.addEventListener('scroll', this.updateDatePickerPosition);
     }
   }
 

--- a/src/components/date/date.js
+++ b/src/components/date/date.js
@@ -186,9 +186,6 @@ class Date extends React.Component {
    * @return {void}
    */
   componentWillUnmount() {
-    /* istanbul ignore if */
-    if (super.componentWillUnmount) { super.componentWillUnmount(); }
-
     if (this.dialogModalNode) {
       this.dialogModalNode.removeEventListener('scroll', this.updateDatePickerPosition);
     }
@@ -214,9 +211,6 @@ class Date extends React.Component {
    * @return {Void}
    */
   componentWillUpdate(nextProps, nextState, nextContext) {
-    /* istanbul ignore if */
-    if (super.componentWillUpdate) { super.componentWillUpdate(nextProps, nextState, nextContext); }
-
     if (!this.dialogModalNode && nextContext.modal && nextContext.modal.getDialogContent()) {
       this.dialogModalNode = nextContext.modal.getDialogContent();
       this.dialogModalNode.addEventListener('scroll', this.updateDatePickerPosition);

--- a/src/components/modal/__spec__.js
+++ b/src/components/modal/__spec__.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Modal from './modal';
 import Events from './../../utils/helpers/events';
 import Browser from './../../utils/helpers/browser';
@@ -49,6 +49,11 @@ describe('Modal', () => {
           expect(mockWindow.addEventListener.calls.count()).toEqual(0);
           expect(mockWindow.addEventListener).not.toHaveBeenCalled();
         });
+      });
+
+      it('correctly fetches the reference to the dialog', () => {
+        wrapper.instance()._dialog = 'ref';
+        expect(wrapper.instance().getDialog()).toEqual('ref');
       });
     });
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -125,7 +125,8 @@ class Modal extends React.Component {
     return {
       modal: {
         onCancel: this.props.onCancel,
-        getDialog: this.getDialog
+        getDialog: this.getDialog,
+        getDialogContent: this.getDialogContent
       }
     };
   }
@@ -138,6 +139,16 @@ class Modal extends React.Component {
    */
   getDialog = () => {
     return this._dialog;
+  }
+
+  /**
+   * Returns the reference to the dialog content if it exists.
+   *
+   * @method getDialogContent
+   * @return {HTMLElement}
+   */
+  getDialogContent = () => {
+    return this._content;
   }
 
   /**

--- a/src/components/tabs/__spec__.js
+++ b/src/components/tabs/__spec__.js
@@ -133,9 +133,6 @@ describe('Tabs', () => {
     });
   });
 
-
-
-
   describe('Change in tab prop', () => {
     let instance, tabs, unique1Tab, unique2Tab;
     beforeEach(() => {
@@ -143,7 +140,9 @@ describe('Tabs', () => {
         history: {
           replaceState: () => {}
         },
-        location: ""
+        location: "",
+        addEventListener: () => {},
+        removeEventListener: () => {}
       });
 
       let TestParent = React.createFactory(React.createClass({

--- a/src/components/textarea/__spec__.js
+++ b/src/components/textarea/__spec__.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
-import { shallow, mount } from 'enzyme';
+import { shallow, mount, ReactWrapper } from 'enzyme';
 import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
+import ReactPortal from 'react-portal';
 import Textarea from './textarea';
 
 describe('Textarea', () => {
@@ -90,7 +91,8 @@ describe('Textarea', () => {
         spyOn(window, 'addEventListener');
         spyOn(baseInstance, 'expandTextarea');
         baseInstance.componentDidMount();
-        expect(window.addEventListener).not.toHaveBeenCalled();
+        expect(window.addEventListener)
+          .not.toHaveBeenCalledWith('resize', baseInstance.expandTextarea);
         expect(baseInstance.expandTextarea).not.toHaveBeenCalled();
       });
     });
@@ -123,7 +125,7 @@ describe('Textarea', () => {
     });
 
     describe('when textarea cannot be expanded', () => {
-      let wrapper = shallow(
+      let wrapper = mount(
         <Textarea
           id='Dummy Area'
           value={ 'foo' }
@@ -133,10 +135,13 @@ describe('Textarea', () => {
           onChange={ spy }
         />
       );
+      let instance = wrapper.instance();
 
       it('does not remove event listener from the window', () => {
+        spyOn(instance, 'expandTextarea');
         wrapper.unmount();
-        expect(window.removeEventListener).not.toHaveBeenCalled();
+        expect(window.removeEventListener)
+          .not.toHaveBeenCalledWith('resize', instance.expandTextarea);
       });
     });
   });
@@ -272,9 +277,12 @@ describe('Textarea', () => {
     });
 
     it('is decorated with a validation if a error is present', () => {
-      baseInstance.setState({errorMessage: 'Error', valid: false});
-      let errorDiv = TestUtils.findRenderedDOMComponentWithClass(baseInstance, 'common-input__message--error')
-      expect(errorDiv.textContent).toEqual('Error')
+      baseInstance.setState({ errorMessage: 'Error', valid: false });
+      const portalContent = new ReactWrapper(
+        baseWrapper.find(ReactPortal).prop('children')
+      );
+      expect(portalContent.find('.common-input__message--error').text())
+        .toEqual('Error');
     });
 
     describe('when characterLimit is set', () => {

--- a/src/components/textbox/__snapshots__/__spec__.js.snap
+++ b/src/components/textbox/__snapshots__/__spec__.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Textbox render renders correctly  1`] = `
+Array [
+  <div
+    className="carbon-textbox common-input"
+    data-component="textbox"
+    data-element="bar"
+    data-role="baz"
+>
+    <label
+        className="common-input__label"
+        data-element="label"
+        htmlFor="my-unique-textbox"
+        style={null}
+    >
+        Label
+    </label>
+    <div
+        className="common-input__field"
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+    >
+        <input
+            autoComplete="off"
+            className="carbon-textbox__input common-input__input"
+            data-element="input"
+            id="my-unique-textbox"
+            name="my-textbox-name"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onPaste={undefined}
+            value="foo"
+        />
+    </div>
+</div>,
+]
+`;

--- a/src/components/textbox/__spec__.js
+++ b/src/components/textbox/__spec__.js
@@ -1,81 +1,45 @@
 import React from 'react';
-import TestUtils from 'react-dom/test-utils';
-import { shallow } from 'enzyme';
-import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
+import { shallow, ReactWrapper } from 'enzyme';
+import ReactPortal from 'react-portal';
 import Textbox from './textbox';
 
 describe('Textbox', () => {
-  let instance;
+  let wrapper;
   let spy = jasmine.createSpy('spy')
 
   beforeEach(() => {
-    instance = TestUtils.renderIntoDocument(
+    wrapper = shallow(
       <Textbox
-        name='Dummy Box'
-        id='Dummy Box'
+        name='my-textbox-name'
+        id='my-unique-textbox'
         value={ 'foo' }
         label={ 'Label' }
+        data-element='bar'
+        data-role='baz'
         onChange={ spy }
       />
     );
   });
 
   describe('render', () => {
-    it('renders a parent div', () => {
-      let textboxNode = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'div')[0];
-      expect(textboxNode.classList[0]).toEqual('carbon-textbox');
-    });
-
-    it('renders with a visible input', () => {
-      let input = TestUtils.findRenderedDOMComponentWithTag(instance, 'input');
-      expect(input.getAttribute('name')).toBe('Dummy Box');
-    });
-
-    it('is decorated with a label', () => {
-      let label = TestUtils.findRenderedDOMComponentWithTag(instance, 'label')
-      expect(label.getAttribute('for')).toEqual('Dummy Box');
+    it('renders correctly ', () => {
+      expect(wrapper.nodes).toMatchSnapshot();
     });
 
     it('is decorated with a validation if a error is present', () => {
-      instance.setState({errorMessage: 'Error', valid: false});
-      let errorDiv = TestUtils.findRenderedDOMComponentWithClass(instance, 'common-input__message--error')
-      expect(errorDiv.textContent).toEqual('Error')
-    });
-  });
-
-  describe('mainClasses', () => {
-    it('returns carbon-textbox and additional decorated classes', () => {
-      expect(instance.mainClasses).toEqual('carbon-textbox common-input');
-    });
-  });
-
-  describe('inputClasses', () => {
-    it('returns carbon-textbox__input and additional decorated classes', () => {
-      expect(instance.inputClasses).toEqual('carbon-textbox__input common-input__input');
+      wrapper.instance().setState({errorMessage: 'Error', valid: false});
+      const portalContent = new ReactWrapper(
+        wrapper.find(ReactPortal).prop('children')
+      );
+      expect(portalContent.find('.common-input__message--error').text())
+        .toEqual('Error');
     });
   });
 
   describe('Passing a custom onChange', () => {
     it('triggers the custom function', () => {
-      let input = TestUtils.findRenderedDOMComponentWithTag(instance, 'input');
-      TestUtils.Simulate.change(input);
+      wrapper.find('input').simulate('change');
       expect(spy).toHaveBeenCalled();
-    });
-  });
-
-  describe('tags on component', () => {
-    let wrapper = shallow(
-      <Textbox
-        value={ 'foo' }
-        label={ 'Label' }
-        onChange={ spy }
-        data-element='bar'
-        data-role='baz'
-      />
-    );
-
-    it('include correct component, element and role data tags', () => {
-      rootTagTest(wrapper, 'textbox', 'bar', 'baz');
     });
   });
 });

--- a/src/style-config/z-index.scss
+++ b/src/style-config/z-index.scss
@@ -2,7 +2,7 @@ $z-animate-menu-button:     310 !default;
 $z-dropdown-list:           10 !default;
 $z-datepicker:              1002 !default;
 $z-split-button:            10 !default;
-$z-validation-message:      50 !default;
+$z-validation-message:      1002 !default;
 $z-full-screen-dialog:      1000 !default;
 $z-modal-background:        1001 !default;
 $z-sidebar:                 1002 !default;

--- a/src/utils/decorators/input-validation/__snapshots__/__spec__.js.snap
+++ b/src/utils/decorators/input-validation/__snapshots__/__spec__.js.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InputValidation validationHTML there is an error renders the error correctly  1`] = `
+<div
+  className="common-input__validation"
+>
+  <Icon
+    bgSize="small"
+    className="common-input__icon common-input__icon--error"
+    style={Object {}}
+    type="error"
+  />
+  <Portal
+    isOpened={true}
+    onClose={[Function]}
+    onOpen={[Function]}
+    onUpdate={[Function]}
+  >
+    <div
+      className="common-input__message-wrapper"
+    >
+      <div
+        className="common-input__message common-input__message--error common-input__message--locked common-input__message--flipped"
+      >
+        foo
+      </div>
+    </div>
+  </Portal>
+</div>
+`;
+
+exports[`InputValidation validationHTML there is an warning renders the warning correctly 1`] = `
+<div
+  className="common-input__validation"
+>
+  <Icon
+    bgSize="small"
+    className="common-input__icon common-input__icon--warning"
+    style={Object {}}
+    type="warning"
+  />
+  <Portal
+    isOpened={true}
+    onClose={[Function]}
+    onOpen={[Function]}
+    onUpdate={[Function]}
+  >
+    <div
+      className="common-input__message-wrapper"
+    >
+      <div
+        className="common-input__message common-input__message--warning common-input__message--locked"
+      >
+        foo
+      </div>
+    </div>
+  </Portal>
+</div>
+`;
+
+exports[`InputValidation validationHTML there is info renders the info correctly 1`] = `
+<div
+  className="common-input__validation"
+>
+  <Icon
+    bgSize="small"
+    className="common-input__icon common-input__icon--info"
+    style={Object {}}
+    type="info"
+  />
+  <Portal
+    isOpened={true}
+    onClose={[Function]}
+    onOpen={[Function]}
+    onUpdate={[Function]}
+  >
+    <div
+      className="common-input__message-wrapper"
+    >
+      <div
+        className="common-input__message common-input__message--info common-input__message--locked"
+      >
+        foo
+      </div>
+    </div>
+  </Portal>
+</div>
+`;

--- a/src/utils/decorators/input-validation/__spec__.js
+++ b/src/utils/decorators/input-validation/__spec__.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import TestUtils from 'react-dom/test-utils';
 import InputValidation from './input-validation';
 import InputLabel from './../input-label';
 import Form from 'components/form';
@@ -378,7 +377,6 @@ describe('InputValidation', () => {
             spyOn(instance, 'getIcon').and.returnValue(icon);
             instance.setState({ valid: false, errorMessage: 'foo' });
             instance.positionElements();
-            instance.positionElements();
 
             expect(message.style.top).toEqual('20px');
             expect(message.style.left).toEqual('55px');
@@ -475,7 +473,7 @@ describe('InputValidation', () => {
   describe('componentWillMount', () => {
     describe('when the component does not have a componentWillMount method', () => {
       it('still works', () => {
-        let simpleInstance = TestUtils.renderIntoDocument(React.createElement(SimpleComponent));
+        let simpleInstance = shallow(<SimpleComponent/>).instance();
         expect(simpleInstance.componentWillMount()).toBe(undefined);
       });
     });
@@ -490,9 +488,11 @@ describe('InputValidation', () => {
 
     describe('When validations are present on the input', () => {
       it('attaches the input to the form', () => {
-        instance = TestUtils.renderIntoDocument(React.createElement(Component, {
-          validations: [validationOne]
-        }));
+        instance = shallow(
+          <Component
+            validations={ [validationOne] }
+          />
+        ).instance();
         instance.context.form = form;
         spyOn(instance.context.form, 'attachToForm');
         instance.componentWillMount();
@@ -513,7 +513,7 @@ describe('InputValidation', () => {
   describe('componentWillUnmount', () => {
     describe('when the component does not have a componentWillUnmount method', () => {
       it('still works', () => {
-        let simpleInstance = TestUtils.renderIntoDocument(React.createElement(SimpleComponent));
+        let simpleInstance = shallow(<SimpleComponent/>).instance();
         expect(simpleInstance.componentWillUnmount()).toBe(undefined);
       });
     });
@@ -528,9 +528,11 @@ describe('InputValidation', () => {
 
     describe('When validations are present on the input', () => {
       beforeEach(() => {
-        instance = TestUtils.renderIntoDocument(React.createElement(Component, {
-          validations: [validationOne]
-        }));
+        instance = shallow(
+          <Component
+            validations={ [validationOne] }
+          />
+        ).instance();
       });
 
       describe('when the input is invalid', () => {
@@ -588,10 +590,12 @@ describe('InputValidation', () => {
     describe('when validations are present on the input', () => {
       describe('when the input has a value', () => {
         beforeEach(() => {
-          instance = TestUtils.renderIntoDocument(React.createElement(Component, {
-            validations: [validationOne, validationTwo, validationThree],
-            value: 'foo'
-          }));
+          instance = shallow(
+            <Component
+              validations={ [validationOne, validationTwo, validationThree] }
+              value='foo'
+            />
+          ).instance();
           instance.context.form = form;
           spyOn(validationOne, 'validate').and.callThrough();
           spyOn(validationTwo, 'validate').and.callThrough();
@@ -607,10 +611,12 @@ describe('InputValidation', () => {
 
         describe('when the second validation fails', () => {
           it('stops validating', () => {
-            instance = TestUtils.renderIntoDocument(React.createElement(Component, {
-              validations: [validationOne, validationThree, validationTwo],
-              value: 'foo'
-            }));
+            instance = shallow(
+              <Component
+                validations={ [validationOne, validationThree, validationTwo] }
+                value='foo'
+              />
+            ).instance();
             instance.validate();
             expect(validationOne.validate).toHaveBeenCalledWith(instance.props.value, instance.props, instance.updateValidation);
             expect(validationThree.validate).toHaveBeenCalledWith(instance.props.value, instance.props, instance.updateValidation);
@@ -815,10 +821,12 @@ describe('InputValidation', () => {
     describe('when warnings are present on the input', () => {
       describe('when the input has a value', () => {
         beforeEach(() => {
-          instance = TestUtils.renderIntoDocument(React.createElement(Component, {
-            warnings: [warningTwo, warningOne],
-            value: 'foo'
-          }));
+          instance = shallow(
+            <Component
+              warnings={ [warningTwo, warningOne] }
+              value='foo'
+            />
+          ).instance();
           instance.context.form = form;
           spyOn(warningOne, 'validate').and.callThrough();
           spyOn(warningTwo, 'validate').and.callThrough();
@@ -832,10 +840,12 @@ describe('InputValidation', () => {
 
         describe('when the first warning fails', () => {
           it('stops warning', () => {
-            instance = TestUtils.renderIntoDocument(React.createElement(Component, {
-              warnings: [warningOne, validationTwo],
-              value: 'foo'
-            }));
+            instance = shallow(
+              <Component
+                warnings={ [warningOne, validationTwo] }
+                value='foo'
+              />
+            ).instance();
             instance.warning();
             expect(warningOne.validate).toHaveBeenCalledWith(instance.props.value, instance.props, instance.updateWarning);
             expect(warningTwo.validate).not.toHaveBeenCalled();
@@ -1216,11 +1226,12 @@ describe('InputValidation', () => {
   describe('mainClasses', () => {
     describe('when there is an error', () => {
       beforeEach(() => {
-        instance = TestUtils.renderIntoDocument(React.createElement(Component, {
-          validations: [validationThree],
-          value: 'foo'
-        }));
-
+        instance = shallow(
+          <Component
+            validations={ [validationThree] }
+            value='foo'
+          />
+        ).instance();
         instance.validate();
       });
 
@@ -1243,11 +1254,12 @@ describe('InputValidation', () => {
   describe('inputClasses', () => {
     describe('when there is an error', () => {
       beforeEach(() => {
-        instance = TestUtils.renderIntoDocument(React.createElement(Component, {
-          validations: [validationThree],
-          value: 'foo'
-        }));
-
+        instance = shallow(
+          <Component
+            validations={ [validationThree] }
+            value='foo'
+          />
+        ).instance();
         instance.validate();
       });
 
@@ -1270,7 +1282,7 @@ describe('InputValidation', () => {
   describe('inputProps', () => {
     describe('with no super inputProps', () => {
       it('still works', () => {
-        let simpleInstance = TestUtils.renderIntoDocument(React.createElement(SimpleComponent));
+        let simpleInstance = shallow(<SimpleComponent/>).instance();
         expect(simpleInstance.inputProps).toBeDefined();
       });
     });

--- a/src/utils/decorators/input-validation/input-validation.scss
+++ b/src/utils/decorators/input-validation/input-validation.scss
@@ -1,0 +1,19 @@
+.common-input__message-wrapper {
+  .common-input__message {
+    opacity: 0;
+    transition: opacity 0.2s 1.3s, visibility 0s 1.5s;
+    visibility: hidden;
+  }
+
+  .common-input--message-hidden {
+    opacity: 0;
+    transition: none;
+    visibility: hidden;
+  }
+
+  .common-input--message-shown {
+    opacity: 1;
+    transition: opacity 0s 0s, visibility 0s 0s;
+    visibility: visible;
+  }
+}

--- a/src/utils/decorators/input-validation/package.json
+++ b/src/utils/decorators/input-validation/package.json
@@ -1,4 +1,5 @@
 {
   "name": "input-validation",
+  "style": "input-validation.scss",
   "main": "./input-validation.js"
 }

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -7,24 +7,6 @@
 .common-input {
   position: relative;
 
-  .common-input__message {
-    opacity: 0;
-    transition: opacity 0.2s 1.3s, visibility 0s 1.5s;
-    visibility: hidden;
-  }
-
-  &--message-hidden .common-input__message {
-    opacity: 0;
-    transition: none;
-    visibility: hidden;
-  }
-
-  &--message-shown .common-input__message.common-input__message {
-    opacity: 1;
-    transition: opacity 0s 0s, visibility 0s 0s;
-    visibility: visible;
-  }
-
   .carbon-fieldset + &,
   + .carbon-fieldset,
   + .common-input {
@@ -189,7 +171,7 @@
 }
 
 .carbon-icon.common-input__icon {
-  height: 15px;
+  height: 20px;
   position: absolute;
   right: 5px;
   top: 28px;
@@ -279,7 +261,7 @@
 .common-input--error,
 .common-input--warning {
   .carbon-icon {
-    z-index: 1;
+    z-index: $z-validation-message;
   }
 }
 


### PR DESCRIPTION
At the moment I just want to get some feedback as this was quite a big change, as the inclusion of `Portal` broken quite a large part of the validation/state functionality which I am slowly getting back.

# TODO
- [x] Specs and coverage
- [x] Release notes

# Related Issues / Pull Requests

Jira Ticket: CARBON-968

# Screenshots / Gifs
![scroll](https://user-images.githubusercontent.com/2031/32104648-44b838ea-bb1d-11e7-99bd-697d47f77866.gif)

# Testing Instructions

  