### PR TITLE
update Create action to use Link component with Icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.1.1
 
-TBD
+* DropdownFilter now uses a stylized Link component for the Create button.
+* DropdownFilter now has `createText` & `createIconType` props for customizable create button text and create button Icons (limited to current Carbon Icon types).
 
 # 2.1.0
 

--- a/src/components/dropdown-filter/__definition__.js
+++ b/src/components/dropdown-filter/__definition__.js
@@ -51,6 +51,8 @@ let definition = new Definition('dropdown-filter', DropdownFilter, {
     cacheVisibleValue: "Boolean",
     value: "String",
     create: "Function",
+    createText: "String",
+    createIconType: "String",
     freetext: "Boolean",
     suggest: "Boolean"
   },
@@ -62,6 +64,8 @@ let definition = new Definition('dropdown-filter', DropdownFilter, {
     options: "The options for the dropdown. This needs to be an Immutable Map.",
     value: "The currently selected value of the input.",
     create: "When defined will show a create button, which on click will trigger this callback with currently typed value.",
+    createText: "When defined this prop will customize the text 'Create New' inside the create button.",
+    createIconType: "Leave alone for default 'add' Icon, choose any Icon type available in the Icon component, or set to 'none' to hide the Icon.",
     freetext: "When enabled will allow the user to type freely into the field, without their filter having to match a result.",
     suggest: "When enabled will enforce that the user needs to type something before they will see any results."
   }

--- a/src/components/dropdown-filter/__spec__.js
+++ b/src/components/dropdown-filter/__spec__.js
@@ -551,7 +551,12 @@ describe('DropdownFilter', () => {
     describe('if in create mode', () => {
       beforeEach(() => {
         instance = TestUtils.renderIntoDocument(
-          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" create={ function() {} } />
+          <DropdownFilter
+            name='foo'
+            options={ Immutable.fromJS([]) }
+            value='1'
+            create={ function() {} }
+          />
         );
       });
 
@@ -562,20 +567,93 @@ describe('DropdownFilter', () => {
       });
 
       describe('if open', () => {
+        let createIconType, createText;
+
         beforeEach(() => {
+          instance = TestUtils.renderIntoDocument(
+            <DropdownFilter
+              name='foo'
+              options={ Immutable.fromJS([]) }
+              value='1'
+              create={ function() {} }
+              createText={ createText }
+              createIconType={ createIconType }
+            />
+          );
           instance.setState({ open: true });
         });
 
-        describe('if there is a filter', () => {
-          it('adds create option with correct text', () => {
-            instance.setState({ filter: "foo" });
-            expect(instance.listHTML[1].props.children).toEqual('Create "foo"');
+        describe('if no createText string is provided', () => {
+          beforeAll(() => {
+            createText = null;
+          });
+
+          describe('if there is a createIconType string provided', () => {
+            beforeAll(() => { createIconType = 'attach'; });
+
+            it('adds create option with correct icon type', () => {
+              expect(instance.listHTML[1].props.icon).toEqual('attach');
+            });
+          });
+
+          describe('if there is no createIconType string provided', () => {
+            beforeAll(() => { createIconType = null; });
+
+            it('adds create option with the add icon', () => {
+              expect(instance.listHTML[1].props.icon).toEqual('add');
+            });
+          });
+
+          describe('if there is a filter', () => {
+            it('adds create option with correct text', () => {
+              instance.setState({ filter: 'foo' });
+              expect(instance.listHTML[1].props.children).toEqual('Create "foo"');
+            });
+          });
+
+          describe('if there is no filter', () => {
+            it('adds create option with correct text', () => {
+              expect(instance.listHTML[1].props.children).toEqual('Create New');
+            });
           });
         });
 
-        describe('if there is no filter', () => {
+        describe('if createText string is provided', () => {
+          beforeAll(() => {
+            createText = 'add foobar';
+          });
+
           it('adds create option with correct text', () => {
-            expect(instance.listHTML[1].props.children).toEqual('Create New');
+            expect(instance.listHTML[1].props.children).toEqual('add foobar');
+          });
+
+          describe('if there is a createIconType string provided', () => {
+            beforeAll(() => { createIconType = 'attach'; });
+
+            it('adds create option with correct icon type', () => {
+              expect(instance.listHTML[1].props.icon).toEqual('attach');
+            });
+          });
+
+          describe('if there is no createIconType string provided', () => {
+            beforeAll(() => { createIconType = null; });
+
+            it('adds create option with the add icon', () => {
+              expect(instance.listHTML[1].props.icon).toEqual('add');
+            });
+          });
+
+          describe('if there is a filter', () => {
+            it('adds create option with correct text', () => {
+              instance.setState({ filter: 'foo' });
+              expect(instance.listHTML[1].props.children).toEqual('add foobar');
+            });
+          });
+
+          describe('if there is no filter', () => {
+            it('adds create option with correct text', () => {
+              expect(instance.listHTML[1].props.children).toEqual('add foobar');
+            });
           });
         });
       });

--- a/src/components/dropdown-filter/dropdown-filter.js
+++ b/src/components/dropdown-filter/dropdown-filter.js
@@ -5,6 +5,7 @@ import I18n from 'i18n-js';
 import classNames from 'classnames';
 import escapeStringRegexp from 'escape-string-regexp';
 import Dropdown from './../dropdown';
+import Link from './../link';
 
 /**
  * A dropdown filter widget.
@@ -108,6 +109,22 @@ class DropdownFilter extends Dropdown {
      * @type {Function}
      */
     create: PropTypes.func,
+
+    /**
+     * Customizes text for the create functionality of the dropdown.
+     *
+     * @property createText
+     * @type {String}
+     */
+    createText: PropTypes.string,
+
+    /**
+     * Customizes the Carbon Icon type for the create functionality of the dropdown.
+     *
+     * @property createIconType
+     * @type {String}
+     */
+    createIconType: PropTypes.string,
 
     /**
      * Should the dropdown act and look like a suggestable input instead.
@@ -328,23 +345,27 @@ class DropdownFilter extends Dropdown {
         html = [original];
 
     if (this.state.open && this.props.create) {
-      let text = 'Create ';
+      let createText = I18n.t('dropdown_filter.create_text', { defaultValue: 'Create' });
 
-      if (this.state.filter) {
-        text += `"${this.state.filter}"`;
+      if (this.props.createText) {
+        createText = this.props.createText;
+      } else if (this.state.filter) {
+        createText += ` "${this.state.filter}"`;
       } else {
-        text += 'New';
+        createText += I18n.t('dropdown_filter.new_text', { defaultValue: ' New' });
       }
 
       html.push(
-        <a
+        <Link
+          icon={ this.props.createIconType || 'add' }
+          iconAlign='left'
           className='carbon-dropdown__action'
           data-element='create'
           key='dropdown-action'
           onClick={ this.handleCreate }
         >
-          { text }
-        </a>
+          { createText }
+        </Link>
       );
     }
 

--- a/src/components/dropdown-filter/dropdown-filter.scss
+++ b/src/components/dropdown-filter/dropdown-filter.scss
@@ -22,13 +22,22 @@
   box-sizing: border-box;
   cursor: pointer;
   left: 0;
-  padding: 5px 6px;
+  padding: 6px 6px 5px 6px;
   position: absolute;
   width: 100%;
   z-index: $z-dropdown-list;
 
-  &:hover {
-    background-color: $blue-bright;
-    color: $white;
+  .carbon-link__content {
+    color: $grey-dark-blue;
+  }
+
+  &.carbon-link__anchor {
+    &:hover {
+      background-color: #E6E9E7;
+
+      .carbon-link__content {
+        text-decoration: none;
+      }
+    }
   }
 }


### PR DESCRIPTION
# Description
Update the Create functionality of the Dropdown Filter component.
Use a Link component inside of the Create action button.
Allow customized create-text to be added via props on Dropdown Filter.
Allow customized icon-type to be added via props on Dropdown Filter.
Create button styling has subtle highlighting on hover, grey-dark-blue text and a blue icon.
Update `__spec__` and `__definition__` with these changes.

# TODO
- [x] Release notes

# Screenshots / Gifs
![sj-1094-carbondropdownfilterchanges-2](https://user-images.githubusercontent.com/24529339/31943779-d28b1c92-b897-11e7-91fa-705791b045f7.gif)

# Testing Instructions
just pull down this branch and run `gulp`, then go to Dropdown Filter component in the Demo site and click "create" checkbox.