### PR TITLE
ensure displayName is maintained when connecting to a store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 2.2.2
 
+* DropdownFilter now uses a stylized Link component for the Create button.
+* DropdownFilter now has `createText` & `createIconType` props for customizable create button text and create button Icons (limited to current Carbon Icon types).
+
 ## Fixes
 
 Ensures that `displayName` is set to the original component's name when connecting to a store using Carbon's flux helper. We have noticed Jest snapshot's have started to default to `View` when connected to a store using our flux connector, this change will ensure the display name is maintained.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.2.2
+
+## Fixes
+
+Ensures that `displayName` is set to the original component's name when connecting to a store using Carbon's flux helper. We have noticed Jest snapshot's have started to default to `View` when connected to a store using our flux connector, this change will ensure the display name is maintained.
+
 # 2.2.1
 
 ## Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A library of reusable React components and an interface for easily building user interfaces based on Flux.",
   "engineStrict": true,
   "engines": {

--- a/src/utils/flux/__spec__.js
+++ b/src/utils/flux/__spec__.js
@@ -15,7 +15,6 @@ class SimpleView extends React.Component {
 }
 
 class View extends React.Component {
-
   componentDidMount() {
     this.extraFunction();
   }
@@ -29,7 +28,6 @@ class View extends React.Component {
   }
 
   render() {
-
     let value = this.state.BaseStore1.get('text');
 
     return(
@@ -37,6 +35,8 @@ class View extends React.Component {
     );
   }
 }
+
+View.displayName = 'CustomName';
 
 let baseStore1 = new BaseStore1('BaseStore1', { text: 'text' });
 let baseStore2 = new BaseStore2('BaseStore2', {});
@@ -153,6 +153,18 @@ describe('Connect', () => {
         instance._onChange('BaseStore1')
         expect(instance.setState).toHaveBeenCalledWith({ BaseStore1: { text: 'text' } });
       });
+    });
+  });
+
+  describe('displayName', () => {
+    it('uses the original class name', () => {
+      const connectedView = connect(SimpleView, baseStore1);
+      expect(connectedView.displayName).toEqual('SimpleView');
+    });
+
+    it('uses the any custom display name', () => {
+      const connectedView = connect(View, baseStore1);
+      expect(connectedView.displayName).toEqual('CustomName');
     });
   });
 });

--- a/src/utils/flux/flux.js
+++ b/src/utils/flux/flux.js
@@ -133,5 +133,8 @@ export function connect(ComposedView, stores) {
     }
   }
 
+  // ensures that the new component has the original component's name
+  View.displayName = ComposedView.displayName || ComposedView.name;
+
   return View;
 }


### PR DESCRIPTION
Ensures that `displayName` is set to the original component's name when connecting to a store using Carbon's flux helper. We have noticed Jest snapshot's have started to default to `View` when connected to a store using our flux connector, this change will ensure the display name is maintained.