### PR TITLE
Ensure table-ajax data state sets loaded on last update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.3
+
+* Fix table-ajax to only set data-state to loaded once all of the data has been set. This resolves an issue when automating user scenarios allowing us to reliabliy wait for the loaded state to be set, before moving on.
+
 # 2.2.2
 
 * DropdownFilter now uses a stylized Link component for the Create button.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A library of reusable React components and an interface for easily building user interfaces based on Flux.",
   "engineStrict": true,
   "engines": {

--- a/src/components/table-ajax/table-ajax.js
+++ b/src/components/table-ajax/table-ajax.js
@@ -343,12 +343,10 @@ class TableAjax extends Table {
    * @param {Object} response
    */
   handleResponse = (err, response) => {
-    this.setState({ ariaBusy: false });
     if (!err) {
-      this.setComponentTagsLoaded();
       const data = response.body;
       this.props.onChange(data);
-      this.setState({ totalRecords: String(data.records) });
+      this.setState({ totalRecords: String(data.records), dataState: 'loaded', ariaBusy: false });
     } else if (this.props.onAjaxError) {
       this.setComponentTagsErrored();
       this.props.onAjaxError(err, response);
@@ -357,13 +355,8 @@ class TableAjax extends Table {
       Logger.warn(`${err.status} - ${response}`);
     }
   }
-
-  setComponentTagsLoaded() {
-    this.setState({ dataState: 'loaded' });
-  }
-
   setComponentTagsErrored() {
-    this.setState({ dataState: 'errored' });
+    this.setState({ dataState: 'errored', ariaBusy: false });
   }
 
   /**


### PR DESCRIPTION
# Description
The data state on a table-ajax component is being set to loaded before the on change event is happening. 
This is causing random failures when running automation and the response is a little slow.

Moving the update of the data state to when the total records are set ensures this is set at at a point when the table is fully loaded.
