### PR TITLE
upgraded to carbon-factory v2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,12 +66,6 @@
         }
       }
     },
-    "after": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
-      "dev": true
-    },
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
@@ -1326,32 +1320,6 @@
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
-    "biased-opener": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/biased-opener/-/biased-opener-0.2.8.tgz",
-      "integrity": "sha1-FZpJualxTB+xAvLg7RkG+rakUPQ=",
-      "dev": true,
-      "requires": {
-        "browser-launcher2": "0.4.6",
-        "minimist": "1.2.0",
-        "x-default-browser": "0.3.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
-    "big-integer": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.25.tgz",
-      "integrity": "sha1-HeRan1dUKsIBIcaC+NZCIgo06CM=",
-      "dev": true,
-      "optional": true
-    },
     "bignumber.js": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.0.4.tgz",
@@ -1427,16 +1395,6 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.5.0.tgz",
       "integrity": "sha1-uXQUusvGMfGfHi4RRmVm7BkySYM="
     },
-    "bplist-parser": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
-      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "big-integer": "1.6.25"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -1463,36 +1421,6 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
-    },
-    "browser-launcher2": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/browser-launcher2/-/browser-launcher2-0.4.6.tgz",
-      "integrity": "sha1-UVmECKE/TJxbIOukRVSywLCuQHQ=",
-      "dev": true,
-      "requires": {
-        "headless": "0.1.7",
-        "lodash": "2.4.2",
-        "mkdirp": "0.5.1",
-        "osenv": "0.1.4",
-        "plist": "1.2.0",
-        "rimraf": "2.2.8",
-        "uid": "0.0.2",
-        "win-detect-browsers": "1.0.2"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-          "dev": true
-        }
-      }
     },
     "browser-pack": {
       "version": "6.0.2",
@@ -1752,9 +1680,9 @@
       }
     },
     "carbon-factory": {
-      "version": "2.0.0-rc4",
-      "resolved": "https://registry.npmjs.org/carbon-factory/-/carbon-factory-2.0.0-rc4.tgz",
-      "integrity": "sha1-DTdCT2jYUrHXbt2MSGpdde+Dm8Y=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/carbon-factory/-/carbon-factory-2.2.0.tgz",
+      "integrity": "sha1-0loynOvdhoQ3m28zzssG6Kx3T64=",
       "dev": true,
       "requires": {
         "aliasify": "1.7.2",
@@ -1788,7 +1716,6 @@
         "jest-cli": "20.0.4",
         "livereactload": "3.1.2",
         "mkdirp": "0.5.1",
-        "node-inspector": "1.1.1",
         "node-notifier": "4.6.1",
         "parcelify": "2.1.0",
         "promptly": "2.1.0",
@@ -2547,35 +2474,11 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
-    },
-    "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-      "dev": true
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
-    },
-    "default-browser-id": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-1.0.4.tgz",
-      "integrity": "sha1-5Z0JpdFXuCi4dsJoFuYcPSosIDo=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bplist-parser": "0.1.1",
-        "meow": "3.7.0",
-        "untildify": "2.1.0"
-      }
     },
     "default-require-extensions": {
       "version": "1.0.0",
@@ -3890,15 +3793,6 @@
         "stream-consume": "0.1.0"
       }
     },
-    "for-each": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
-      "dev": true,
-      "requires": {
-        "is-function": "1.0.1"
-      }
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -4893,17 +4787,6 @@
         "rimraf": "2.6.1"
       }
     },
-    "fstream-ignore": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "dev": true,
-      "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4"
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5521,12 +5404,6 @@
         "sntp": "1.0.9"
       }
     },
-    "headless": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/headless/-/headless-0.1.7.tgz",
-      "integrity": "sha1-bmL65miUf4gYTVwVbt58VpWn6cg=",
-      "dev": true
-    },
     "highcharts": {
       "version": "5.0.14",
       "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-5.0.14.tgz",
@@ -5904,12 +5781,6 @@
       "requires": {
         "number-is-nan": "1.0.1"
       }
-    },
-    "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
-      "dev": true
     },
     "is-glob": {
       "version": "2.0.1",
@@ -7983,69 +7854,6 @@
         }
       }
     },
-    "node-inspector": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/node-inspector/-/node-inspector-1.1.1.tgz",
-      "integrity": "sha1-54UeuXPzgFQ8BY21ZKmBIFXqxkA=",
-      "dev": true,
-      "requires": {
-        "async": "0.9.2",
-        "biased-opener": "0.2.8",
-        "debug": "2.6.8",
-        "express": "4.14.1",
-        "glob": "5.0.15",
-        "path-is-absolute": "1.0.1",
-        "rc": "1.2.1",
-        "semver": "4.3.6",
-        "serve-favicon": "2.4.3",
-        "strong-data-uri": "1.0.4",
-        "v8-debug": "1.0.1",
-        "v8-profiler": "5.7.0",
-        "which": "1.3.0",
-        "ws": "1.1.1",
-        "yargs": "3.32.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "window-size": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "string-width": "1.0.2",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
-          }
-        }
-      }
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8073,32 +7881,6 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
-          "dev": true
-        }
-      }
-    },
-    "node-pre-gyp": {
-      "version": "0.6.37",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.37.tgz",
-      "integrity": "sha1-PIcrI2suJm5BQFeP4e6I9pMyOgU=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1",
-        "nopt": "4.0.1",
-        "npmlog": "4.1.2",
-        "rc": "1.2.1",
-        "request": "2.81.0",
-        "rimraf": "2.6.1",
-        "semver": "5.4.1",
-        "tape": "4.8.0",
-        "tar": "2.2.1",
-        "tar-pack": "3.4.0"
-      },
-      "dependencies": {
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -8179,16 +7961,6 @@
         }
       }
     },
-    "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.1.0",
-        "osenv": "0.1.4"
-      }
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -8259,12 +8031,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "object-inspect": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
-      "integrity": "sha1-Wx645nQuLugzQqY3A02ESSi6L20=",
-      "dev": true
     },
     "object-is": {
       "version": "1.0.1",
@@ -8922,26 +8688,6 @@
         "readable-stream": "2.3.3"
       }
     },
-    "plist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
-      "integrity": "sha1-CEtQk93JJQbiWfh0uNmxr7jHlZM=",
-      "dev": true,
-      "requires": {
-        "base64-js": "0.0.8",
-        "util-deprecate": "1.0.2",
-        "xmlbuilder": "4.0.0",
-        "xmldom": "0.1.27"
-      },
-      "dependencies": {
-        "base64-js": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
-          "dev": true
-        }
-      }
-    },
     "pluralize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
@@ -9170,26 +8916,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
-    },
-    "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-      "dev": true,
-      "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.4",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
     },
     "react": {
       "version": "15.6.1",
@@ -9712,15 +9438,6 @@
         "onetime": "1.1.0"
       }
     },
-    "resumer": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
-      }
-    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -10015,39 +9732,6 @@
       "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
       "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
       "dev": true
-    },
-    "serve-favicon": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.3.tgz",
-      "integrity": "sha1-WYaxewUCZCtkHCH4GLGszjICXSM=",
-      "dev": true,
-      "requires": {
-        "etag": "1.8.0",
-        "fresh": "0.5.0",
-        "ms": "2.0.0",
-        "parseurl": "1.3.1",
-        "safe-buffer": "5.0.1"
-      },
-      "dependencies": {
-        "etag": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-          "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
-          "dev": true
-        },
-        "fresh": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-          "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true
-        }
-      }
     },
     "serve-static": {
       "version": "1.11.2",
@@ -10379,17 +10063,6 @@
         "strip-ansi": "3.0.1"
       }
     },
-    "string.prototype.trim": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.8.2",
-        "function-bind": "1.1.1"
-      }
-    },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -10428,15 +10101,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
-    },
-    "strong-data-uri": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/strong-data-uri/-/strong-data-uri-1.0.4.tgz",
-      "integrity": "sha1-E2dl66+OD0rWDEsUZ3nwYsKdGPA=",
-      "dev": true,
-      "requires": {
-        "truncate": "1.0.5"
-      }
     },
     "subarg": {
       "version": "1.0.0",
@@ -10553,49 +10217,6 @@
         }
       }
     },
-    "tape": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
-      "integrity": "sha1-9qn+xBzFCh3lD6M2A6tYCZH2Bo4=",
-      "dev": true,
-      "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.2",
-        "function-bind": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "object-inspect": "1.3.0",
-        "resolve": "1.4.0",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
     "tar": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
@@ -10605,22 +10226,6 @@
         "block-stream": "0.0.9",
         "fstream": "1.0.11",
         "inherits": "2.0.3"
-      }
-    },
-    "tar-pack": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-      "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "fstream": "1.0.11",
-        "fstream-ignore": "1.0.5",
-        "once": "1.4.0",
-        "readable-stream": "2.3.3",
-        "rimraf": "2.6.1",
-        "tar": "2.2.1",
-        "uid-number": "0.0.6"
       }
     },
     "ternary-stream": {
@@ -10769,12 +10374,6 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
-    "truncate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/truncate/-/truncate-1.0.5.tgz",
-      "integrity": "sha1-xjbGwfUO7XySevBsHb/6tTx6vig=",
-      "dev": true
-    },
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
@@ -10917,18 +10516,6 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true
     },
-    "uid": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/uid/-/uid-0.0.2.tgz",
-      "integrity": "sha1-XkpdS3gTi09w+J/Tx2/FmqnS8QM=",
-      "dev": true
-    },
-    "uid-number": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-      "dev": true
-    },
     "ultron": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
@@ -10974,16 +10561,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
-    },
-    "untildify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
-      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
     },
     "url": {
       "version": "0.11.0",
@@ -11052,26 +10629,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
       "dev": true
-    },
-    "v8-debug": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/v8-debug/-/v8-debug-1.0.1.tgz",
-      "integrity": "sha1-auHG2uRHe7PO15tSPk0WDB2GZ/4=",
-      "dev": true,
-      "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.37"
-      }
-    },
-    "v8-profiler": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/v8-profiler/-/v8-profiler-5.7.0.tgz",
-      "integrity": "sha1-6DgcvrtbX9DKjSsJ9qAYGhWNs00=",
-      "dev": true,
-      "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.37"
-      }
     },
     "v8flags": {
       "version": "2.1.1",
@@ -11403,27 +10960,6 @@
         "string-width": "1.0.2"
       }
     },
-    "win-detect-browsers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/win-detect-browsers/-/win-detect-browsers-1.0.2.tgz",
-      "integrity": "sha1-9F8Q0UEIbF2UrhTAOyCYRAp+cbA=",
-      "dev": true,
-      "requires": {
-        "after": "0.8.2",
-        "debug": "2.6.8",
-        "which": "1.3.0",
-        "xtend": "4.0.1",
-        "yargs": "1.3.3"
-      },
-      "dependencies": {
-        "yargs": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
-          "integrity": "sha1-BU3oth8i7v23IHBZ6u+da4P7kxo=",
-          "dev": true
-        }
-      }
-    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -11481,15 +11017,6 @@
         "ultron": "1.0.2"
       }
     },
-    "x-default-browser": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/x-default-browser/-/x-default-browser-0.3.1.tgz",
-      "integrity": "sha1-f2GUFU/ReGzyYeaLVIjEcSegSXc=",
-      "dev": true,
-      "requires": {
-        "default-browser-id": "1.0.4"
-      }
-    },
     "xhr-mock": {
       "version": "git://github.com/resin-io-modules/xhr-mock.git#b1a8e6f6abc9da3a9425d6fcb6e6bb6a13987925",
       "dev": true,
@@ -11502,29 +11029,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
-      "dev": true
-    },
-    "xmlbuilder": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
-      "integrity": "sha1-mLj2UcowqmJANvEn0RzGbce5B6M=",
-      "dev": true,
-      "requires": {
-        "lodash": "3.10.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
-      }
-    },
-    "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   },
   "scripts": {
     "test": "jest",
-    "debug:listen": "node --debug-brk ./node_modules/.bin/jest --runInBand",
-    "debug:start": "node-inspector",
+    "debug": "node --inspect ./node_modules/.bin/jest --watch",
     "release-version": "node check-version.js && npm install && npm publish",
     "prepublishOnly": "rm -rf ./lib && node -e \"require('ncp').ncp('./src', './lib', { filter: new RegExp('^((?!__spec__.js|.md).)*$') }, function() { })\" && NODE_ENV=production babel --stage 0 ./src --out-dir ./lib --ignore '**/*/__spec__.js' --quiet"
   },
@@ -30,7 +29,7 @@
   },
   "devDependencies": {
     "babel-standalone": "~6.17.0",
-    "carbon-factory": "v2.0.0-rc4",
+    "carbon-factory": "v2.2.0",
     "enzyme": "~2.8.2",
     "express": "~4.14.0",
     "flux": "^3.1.1",
@@ -39,7 +38,6 @@
     "jest": "^20.0.4",
     "moxios": "^0.4.0",
     "ncp": "~2.0.0",
-    "node-inspector": "^1.1.1",
     "react": "~15.6.1",
     "react-addons-perf": "^15.4.2",
     "react-addons-test-utils": "~15.6.0",


### PR DESCRIPTION
Upgraded to Carbon Factory v2.2.0
* Sourcemaps are now available.
* Node v8 is now supported.

Added a new script to debug tests `npm run debug` - requires Node v8 (also recommend [installing NiM](https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj))