### PR TITLE
Address padding based on UX changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.3.0
+
+## UX Improvements
+
+* Dialog - Padding fix
+
 # 2.2.3
 
 * Fix table-ajax to only set data-state to loaded once all of the data has been set. This resolves an issue when automating user scenarios allowing us to reliabliy wait for the loaded state to be set, before moving on.

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -53,7 +53,7 @@ $dialog-sizes: (
   box-sizing: border-box;
   height: 100%;
   overflow-y: auto;
-  padding: 0px 35px 22px;
+  padding: 0px 35px 30px;
   width: 100%;
 }
 


### PR DESCRIPTION
# Description
Discussions with members of UX, the bottom of the dialog should have 30px bottom padding.
_**Old dialog with less bottom padding**_
<img width="869" alt="screen shot 2017-11-10 at 20 57 12" src="https://user-images.githubusercontent.com/3584292/32678354-e6aa43ae-c659-11e7-818f-bb3e6f4ea750.png">
_**New dialog with more bottom padding**_
<img width="904" alt="screen shot 2017-11-10 at 20 56 53" src="https://user-images.githubusercontent.com/3584292/32678356-e6c4b478-c659-11e7-8699-6044b0d2f8ce.png">



