### PR TITLE
Add data-state to modal

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "./node_modules/carbon-factory/.eslintrc",
   "globals": {
+    "jest": true,
     "global": true,
     "process": true
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 * `Portrait` size `extra-small` has reduced from `26px` to `25px`.
 * `Portrait` size `medium-small` has reduced from `50px` to `40px`.
 * `Profile` has increased margin between the image and text.
-* `Dialog` - bottom padding has increased by 8px.
+* `Dialog` bottom padding has increased by 8px.
+
+## Improvements
+* `Modal` now has a data-state element that begins as default, set to open once transition to open is complete and is set to closed once the transition to closed is complete.
 
 ## New Components
 

--- a/src/components/alert/__snapshots__/__spec__.js.snap
+++ b/src/components/alert/__snapshots__/__spec__.js.snap
@@ -6,6 +6,7 @@ exports[`Alert include correct component, element and role data tags 1`] = `
   data-component="alert"
   data-element="bar"
   data-role="baz"
+  data-state="default"
 >
   <CSSTransitionGroup
     component="div"

--- a/src/components/alert/__snapshots__/__spec__.js.snap
+++ b/src/components/alert/__snapshots__/__spec__.js.snap
@@ -6,7 +6,7 @@ exports[`Alert include correct component, element and role data tags 1`] = `
   data-component="alert"
   data-element="bar"
   data-role="baz"
-  data-state="default"
+  data-state="open"
 >
   <CSSTransitionGroup
     component="div"

--- a/src/components/confirm/__snapshots__/__spec__.js.snap
+++ b/src/components/confirm/__snapshots__/__spec__.js.snap
@@ -6,7 +6,7 @@ exports[`Confirm default snapshot renders as expected 1`] = `
   data-component="confirm"
   data-element="bar"
   data-role="baz"
-  data-state="default"
+  data-state="open"
 >
   <CSSTransitionGroup
     component="div"

--- a/src/components/confirm/__snapshots__/__spec__.js.snap
+++ b/src/components/confirm/__snapshots__/__spec__.js.snap
@@ -6,6 +6,7 @@ exports[`Confirm default snapshot renders as expected 1`] = `
   data-component="confirm"
   data-element="bar"
   data-role="baz"
+  data-state="default"
 >
   <CSSTransitionGroup
     component="div"

--- a/src/components/dialog/__snapshots__/__spec__.js.snap
+++ b/src/components/dialog/__snapshots__/__spec__.js.snap
@@ -23,6 +23,7 @@ exports[`Dialog render when dialog is open has the correct content, tags, elemen
   data-component="dialog"
   data-element="bar"
   data-role="baz"
+  data-state="default"
 >
   <CSSTransitionGroup
     component="div"

--- a/src/components/dialog/__snapshots__/__spec__.js.snap
+++ b/src/components/dialog/__snapshots__/__spec__.js.snap
@@ -23,7 +23,7 @@ exports[`Dialog render when dialog is open has the correct content, tags, elemen
   data-component="dialog"
   data-element="bar"
   data-role="baz"
-  data-state="default"
+  data-state="open"
 >
   <CSSTransitionGroup
     component="div"

--- a/src/components/modal/__snapshots__/__spec__.js.snap
+++ b/src/components/modal/__snapshots__/__spec__.js.snap
@@ -3,6 +3,7 @@
 exports[`Modal backgroundHTML when enableBackgroundUI is false renders children 1`] = `
 <div
   className={null}
+  data-state="default"
 >
   <CSSTransitionGroup
     component="div"
@@ -32,6 +33,7 @@ exports[`Modal backgroundHTML when enableBackgroundUI is false renders children 
 exports[`Modal backgroundHTML when enableBackgroundUI is true renders children 1`] = `
 <div
   className={null}
+  data-state="default"
 >
   <CSSTransitionGroup
     component="div"

--- a/src/components/modal/__snapshots__/__spec__.js.snap
+++ b/src/components/modal/__snapshots__/__spec__.js.snap
@@ -3,7 +3,7 @@
 exports[`Modal backgroundHTML when enableBackgroundUI is false renders children 1`] = `
 <div
   className={null}
-  data-state="default"
+  data-state="open"
 >
   <CSSTransitionGroup
     component="div"
@@ -33,7 +33,7 @@ exports[`Modal backgroundHTML when enableBackgroundUI is false renders children 
 exports[`Modal backgroundHTML when enableBackgroundUI is true renders children 1`] = `
 <div
   className={null}
-  data-state="default"
+  data-state="open"
 >
   <CSSTransitionGroup
     component="div"

--- a/src/components/modal/__spec__.js
+++ b/src/components/modal/__spec__.js
@@ -24,7 +24,7 @@ describe('Modal', () => {
         jest.useFakeTimers();
         onCancel = jasmine.createSpy('cancel');
         wrapper = shallow(
-          <Modal open={ true } onCancel={ onCancel } />
+          <Modal open onCancel={ onCancel } />
         );
       });
 
@@ -39,6 +39,16 @@ describe('Modal', () => {
         jest.runAllTimers();
         expect(mockWindow.addEventListener.calls.count()).toEqual(1);
         expect(mockWindow.addEventListener).toHaveBeenCalledWith('keyup', wrapper.instance().closeModal);
+      });
+
+      it('clears the opentimeout and sets datas tate to open', () => {
+        spyOn(mockWindow, 'removeEventListener');
+        spyOn(window, 'setTimeout');
+        jest.useFakeTimers();
+        wrapper.instance().componentDidUpdate();
+        jest.runTimersToTime(500);
+        expect(clearTimeout).toHaveBeenCalled();
+        expect(wrapper.state()).toEqual({ state: 'open' });
       });
 
       describe('when the modal is already listening', () => {
@@ -66,6 +76,17 @@ describe('Modal', () => {
         expect(mockWindow.removeEventListener.calls.count()).toEqual(1);
         expect(mockWindow.removeEventListener).toHaveBeenCalledWith('keyup', wrapper.instance().closeModal);
       });
+
+      it('clears the opentimeout and sets data state to closed', () => {
+        spyOn(mockWindow, 'removeEventListener');
+        spyOn(window, 'setTimeout');
+        jest.useFakeTimers();
+        wrapper.instance().listening = true;
+        wrapper.instance().componentDidUpdate();
+        jest.runTimersToTime(500);
+        expect(clearTimeout).toHaveBeenCalled();
+        expect(wrapper.state()).toEqual({ state: 'closed' });
+      });
     });
   });
 
@@ -74,7 +95,7 @@ describe('Modal', () => {
       beforeEach(() => {
         onCancel = jasmine.createSpy('cancel');
         wrapper = shallow(
-          <Modal open={ true } onCancel={ onCancel } />
+          <Modal open onCancel={ onCancel } />
         );
       });
 
@@ -98,7 +119,7 @@ describe('Modal', () => {
     describe('when disableEscKey is true', () => {
       onCancel = jasmine.createSpy('cancel');
       wrapper = shallow(
-        <Modal disableEscKey={ true } open={ true } onCancel={ onCancel } />
+        <Modal disableEscKey open onCancel={ onCancel } />
       );
 
       it('does not call onCancel', () => {
@@ -111,11 +132,11 @@ describe('Modal', () => {
   describe('backgroundHTML', () => {
     describe('when enableBackgroundUI is false', () => {
       it('renders children', () => {
-        let wrapper = shallow(
+        wrapper = shallow(
           <Modal
             onCancel={ () => {} }
             onConfirm={ () => {} }
-            open={ true }
+            open
             enableBackgroundUI={ false }
           />
         );
@@ -125,12 +146,12 @@ describe('Modal', () => {
 
     describe('when enableBackgroundUI is true', () => {
       it('renders children', () => {
-        let wrapper = shallow(
+        wrapper = shallow(
           <Modal
             onCancel={ () => {} }
             onConfirm={ () => {} }
-            open={ true }
-            enableBackgroundUI={ true }
+            open
+            enableBackgroundUI
           />
         );
         expect(wrapper).toMatchSnapshot();

--- a/src/components/modal/__spec__.js
+++ b/src/components/modal/__spec__.js
@@ -41,7 +41,7 @@ describe('Modal', () => {
         expect(mockWindow.addEventListener).toHaveBeenCalledWith('keyup', wrapper.instance().closeModal);
       });
 
-      it('clears the opentimeout and sets datas tate to open', () => {
+      it('clears the opentimeout and sets data state to open', () => {
         spyOn(mockWindow, 'removeEventListener');
         spyOn(window, 'setTimeout');
         jest.useFakeTimers();

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -5,6 +5,7 @@ import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import Events from './../../utils/helpers/events';
 import Browser from './../../utils/helpers/browser';
 
+const TIMEOUT = 500;
 /**
  * A Modal Component
  *
@@ -102,8 +103,8 @@ class Modal extends React.Component {
     modal: PropTypes.object
   }
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     /**
      * Tracks if event listeners are on for modal
@@ -112,7 +113,29 @@ class Modal extends React.Component {
      * @type {Boolean}
      */
     this.listening = false;
-    this.state = { state: 'default' };
+
+    this.state = {
+      /**
+       * Sets the initial data-state of the modal
+       * @property state
+       * @type {String}
+       */
+      state: this.props.open ? 'open' : 'closed'
+    };
+  }
+
+  /**
+   * Updates the value used for the css data-state. This uses a timeout to match the length of any transition to ensure
+   * UI automation is able to target elements once they are visually ready.
+   * @method updateDataState
+   * @return {void}
+   *
+   */
+  updateDataState = () => {
+    clearTimeout(this.openTimeout);
+    this.openTimeout = setTimeout(() => {
+      this.setState({ state: this.props.open ? 'open' : 'closed' });
+    }, TIMEOUT);
   }
 
 
@@ -156,15 +179,13 @@ class Modal extends React.Component {
       // it was added as the Portal library we use messes up the callstack
       // when assigning the ref and triggering componentDidUpdate
       setTimeout(() => {
-        clearTimeout(this.openTimeout);
-        this.openTimeout = setTimeout(() => { this.setState({ state: 'open' }); }, 500);
+        this.updateDataState();
         this.onOpening; // eslint-disable-line no-unused-expressions
       });
       _window.addEventListener('keyup', this.closeModal);
     } else if (!this.props.open && this.listening) {
-      clearTimeout(this.openTimeout);
-      this.openTimeout = setTimeout(() => { this.setState({ state: 'closed' }); }, 500);
       this.listening = false;
+      this.updateDataState();
       this.onClosing; // eslint-disable-line no-unused-expressions
       _window.removeEventListener('keyup', this.closeModal);
     }
@@ -241,8 +262,8 @@ class Modal extends React.Component {
         <CSSTransitionGroup
           component='div'
           transitionName={ this.transitionName }
-          transitionEnterTimeout={ 500 }
-          transitionLeaveTimeout={ 500 }
+          transitionEnterTimeout={ TIMEOUT }
+          transitionLeaveTimeout={ TIMEOUT }
         >
           { modalHTML }
         </CSSTransitionGroup>
@@ -250,8 +271,8 @@ class Modal extends React.Component {
         <CSSTransitionGroup
           component='div'
           transitionName={ this.backgroundTransitionName }
-          transitionEnterTimeout={ 500 }
-          transitionLeaveTimeout={ 500 }
+          transitionEnterTimeout={ TIMEOUT }
+          transitionLeaveTimeout={ TIMEOUT }
         >
           { backgroundHTML }
         </CSSTransitionGroup>

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -112,6 +112,7 @@ class Modal extends React.Component {
      * @type {Boolean}
      */
     this.listening = false;
+    this.state = { state: 'default' };
   }
 
 
@@ -155,10 +156,14 @@ class Modal extends React.Component {
       // it was added as the Portal library we use messes up the callstack
       // when assigning the ref and triggering componentDidUpdate
       setTimeout(() => {
+        clearTimeout(this.openTimeout);
+        this.openTimeout = setTimeout(() => { this.setState({ state: 'open' }); }, 500);
         this.onOpening; // eslint-disable-line no-unused-expressions
       });
       _window.addEventListener('keyup', this.closeModal);
     } else if (!this.props.open && this.listening) {
+      clearTimeout(this.openTimeout);
+      this.openTimeout = setTimeout(() => { this.setState({ state: 'closed' }); }, 500);
       this.listening = false;
       this.onClosing; // eslint-disable-line no-unused-expressions
       _window.removeEventListener('keyup', this.closeModal);
@@ -231,6 +236,7 @@ class Modal extends React.Component {
       <div
         className={ this.mainClasses }
         { ...this.componentTags(this.props) }
+        data-state={ this.state.state }
       >
         <CSSTransitionGroup
           component='div'

--- a/src/components/sidebar/__snapshots__/__spec__.js.snap
+++ b/src/components/sidebar/__snapshots__/__spec__.js.snap
@@ -6,7 +6,7 @@ exports[`Sidebar sidebarClasses returns a base sidebar 1`] = `
   data-component="sidebar"
   data-element="bar"
   data-role="baz"
-  data-state="default"
+  data-state="open"
 >
   <CSSTransitionGroup
     component="div"

--- a/src/components/sidebar/__snapshots__/__spec__.js.snap
+++ b/src/components/sidebar/__snapshots__/__spec__.js.snap
@@ -6,6 +6,7 @@ exports[`Sidebar sidebarClasses returns a base sidebar 1`] = `
   data-component="sidebar"
   data-element="bar"
   data-role="baz"
+  data-state="default"
 >
   <CSSTransitionGroup
     component="div"


### PR DESCRIPTION
# Description

Add data state to modal to aid in test running.
This change ensures the data state is updated once all transitions have fininshed.
Selenium was attempting to select dialogs before they had finished rendering on the page, causing false failures.