### PR TITLE
MenuItem supports icon prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## CSS Changes
 
-* `Menu` has been updated based on slightly new designs. `secondary` menus now support `Icon` components as children.
+* `Menu` has been updated based on slightly new designs. `MenuItem` now supports the `icon` prop.
 * `Portrait` size `extra-small` has reduced from `26px` to `25px`.
 * `Portrait` size `medium-small` has reduced from `50px` to `40px`.
 * `Profile` has increased margin between the image and text.

--- a/src/components/menu/__definition__.js
+++ b/src/components/menu/__definition__.js
@@ -55,7 +55,7 @@ definition.addChildByDefinition(menuItemDefinition, {
 });
 
 definition.addChildByDefinition(menuItemDefinition, {
-  children: `<MenuItem href="#"><Icon type='settings'/>Sub Menu Item One</MenuItem>
+  children: `<MenuItem href="#" icon='settings'>Sub Menu Item One</MenuItem>
   <SubmenuBlock>
     <MenuItem href="#">Sub Menu Item Two</MenuItem>
     <MenuItem href="#">Sub Menu Item Three</MenuItem>

--- a/src/components/menu/menu-item/menu-item.js
+++ b/src/components/menu/menu-item/menu-item.js
@@ -36,6 +36,14 @@ class MenuItem extends React.Component {
     onClick: PropTypes.func,
 
     /**
+     * Adds an icon to the menu item.
+     *
+     * @property icon
+     * @type {String}
+     */
+    icon: PropTypes.string,
+
+    /**
      * Defines which direction the submenu will hang eg. left/right
      *
      * @property submenuDirection
@@ -155,7 +163,8 @@ class MenuItem extends React.Component {
       href: this.props.href,
       to: this.props.to,
       target: this.props.target,
-      onClick: this.props.onClick
+      onClick: this.props.onClick,
+      icon: this.props.icon
     };
 
     props = assign({}, props, tagComponent('menu-item', this.props));


### PR DESCRIPTION
As well as a child, pass on the `icon` prop to the `Link` so it can be used in that way.