### PR TITLE
UX improvement to address padding in dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.4.0
+
+## UX Improvements
+
+* `Dialog` Ensure the heading used within a dialog has 15px padding instead of 20px.
+
 # 2.3.0
 
 ## CSS Changes

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -105,6 +105,7 @@ $dialog-sizes: (
 
   .carbon-heading__header {
     margin-bottom: 0;
+    padding-bottom: 15px;
   }
 }
 


### PR DESCRIPTION
# Description
A UX request to reduce the spacing between the dialog header and the line spacer.

# Screenshots / Gifs
_**Original**_
![screen shot 2017-11-16 at 11 31 26](https://user-images.githubusercontent.com/3584292/32889189-cb643642-cac1-11e7-96c3-f1588443f6d2.png)

_**New**_
![screen shot 2017-11-16 at 11 31 45](https://user-images.githubusercontent.com/3584292/32889188-cb4c5c2a-cac1-11e7-9543-d8825aa3d83a.png)

# Testing
At desk demonstration done with UX.


