### PR TITLE
css updates for button, message and base-text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## CSS Changes
 
-* Adds an app wide `line-height` default of `16px`.
+* Adds an app wide `line-height` default of `18px`.
 * Fixes `Message` to remove excess padding right when not dismissable.
 * Updates `Button` so inline siblings have a default `10px` gap.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.5.0
+
+## CSS Changes
+
+* Adds an app wide `line-height` default of `16px`.
+* Fixes `Message` to remove excess padding right when not dismissable.
+* Updates `Button` so inline siblings have a default `10px` gap.
+
 # 2.4.0
 
 ## Improvements

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -23,6 +23,10 @@
   text-align: center;
   text-decoration: none;
 
+  + .carbon-button {
+    margin-left: 10px;
+  }
+
   &:focus {
     @include transition(box-shadow linear 0.1s);
 

--- a/src/components/message/message.scss
+++ b/src/components/message/message.scss
@@ -66,8 +66,12 @@ $message-width: 300px !default;
 }
 
 .carbon-message__content {
-  padding: 15px 50px;
+  padding: 15px 20px 15px 50px;
   white-space: pre-wrap;
+
+  .carbon-message--dismissable {
+    padding-right: 50px;
+  }
 }
 
 .carbon-message__title {

--- a/src/style-config/general.scss
+++ b/src/style-config/general.scss
@@ -16,7 +16,7 @@ $app-font-family: 'Lato', 'Helvetica Neue', Arial, sans-serif !default;
 $app-light-font-family: 'HelveticaNeue-Light', 'Helvetica Neue', Arial, sans-serif !default;
 $app-medium-font-family: 'HelveticaNeue-Medium', 'Helvetica Neue', Arial, sans-serif !default;
 $app-font-size: 14px !default;
-$app-line-height: 16px !default;
+$app-line-height: 18px !default;
 $app-text-color: $grey-dark-blue !default;
 $grid-margin: 15px !default;
 $grid-margin-extra-small: 2px !default;

--- a/src/utils/css/modules/base-text.scss
+++ b/src/utils/css/modules/base-text.scss
@@ -3,6 +3,7 @@ body {
   color: $app-text-color;
   font-family: $app-font-family;
   font-size: $app-font-size;
+  line-height: $app-line-height;
   text-rendering: optimizeLegibility;
 }
 


### PR DESCRIPTION
## CSS Changes

* Adds an app wide `line-height` default of `18px`.
* Fixes `Message` to remove excess padding right when not dismissable.
* Updates `Button` so inline siblings have a default `10px` gap.