### PR TITLE
Change type of prop tooltipMessage

### DIFF
--- a/src/utils/decorators/tooltip-decorator/tooltip-decorator.js
+++ b/src/utils/decorators/tooltip-decorator/tooltip-decorator.js
@@ -88,9 +88,9 @@ const TooltipDecorator = ComposedComponent => class Component extends ComposedCo
      * The message for this tooltip
      *
      * @property
-     * @type {String}
+     * @type {Node}
      */
-    tooltipMessage: PropTypes.string,
+    tooltipMessage: PropTypes.node,
 
     /**
      * The position of this tooltip: top, bottom, left or right


### PR DESCRIPTION
The Tooltip component accepts children. So the decorator should do the same.

# Description

# TODO
- [ ] Release notes

# Related Issues / Pull Requests

# Screenshots / Gifs

# Testing Instructions
