### PR TITLE
Change type of prop tooltipMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.5.0
+
+## Improvements
+
+* Changed type of prop `tooltipMessage` of `tooltip-decorator` from string to node to allow children.
+
 # 2.4.0
 
 ## Improvements


### PR DESCRIPTION
The Tooltip component accepts children. So the decorator should do the same.

# Description

# TODO
- [x] Release notes

# Related Issues / Pull Requests

# Screenshots / Gifs

# Testing Instructions
