### PR TITLE
Ensure response data is an object #1631

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Fixes
 
 * Set the `Component.displayName` on all decorators. **NB** You may need to update your snapshots as a result of this to change the component name to something more accurate
+* Handles an empty body (such as that with a 204) more robustly ([#1631](https://github.com/Sage/carbon/issues/1631))
 
 # 2.4.0
 

--- a/src/utils/flux/__spec__.js
+++ b/src/utils/flux/__spec__.js
@@ -36,7 +36,7 @@ class View extends React.Component {
   }
 }
 
-View.displayName = 'CustomName';
+View.displayName = 'CustomDisplayName';
 
 let baseStore1 = new BaseStore1('BaseStore1', { text: 'text' });
 let baseStore2 = new BaseStore2('BaseStore2', {});
@@ -158,13 +158,15 @@ describe('Connect', () => {
 
   describe('displayName', () => {
     it('uses the original class name', () => {
+      SimpleView.displayName = null;
+
       const connectedView = connect(SimpleView, baseStore1);
       expect(connectedView.displayName).toEqual('SimpleView');
     });
 
-    it('uses the any custom display name', () => {
+    it('uses the custom display name', () => {
       const connectedView = connect(View, baseStore1);
-      expect(connectedView.displayName).toEqual('CustomName');
+      expect(connectedView.displayName).toEqual('CustomDisplayName');
     });
   });
 

--- a/src/utils/service/__spec__.js
+++ b/src/utils/service/__spec__.js
@@ -54,13 +54,6 @@ describe('Service', () => {
       });
     });
 
-    describe('when the body is empty', () => {
-      it('returns a stringified empty object', () => {
-        let data = '';
-        expect(service.handleSuccess({ data })).toEqual({});
-      });
-    });
-
     describe('when there is a message in the response', () => {
       describe('if the status is error', () => {
         let response;
@@ -294,6 +287,30 @@ describe('Service', () => {
             }
           );
           testEndpoint(done, 200, successSpy);
+        });
+      });
+
+      describe('DELETE with no_content response', () => {
+        it('calls the DELETE endpoint', (done) => {
+
+          service.delete(1,
+            {
+              onSuccess: successSpy,
+              onError: errorSpy
+            });
+          moxios.wait(() => {
+            let request = moxios.requests.mostRecent(),
+              data = { data: {} };
+
+            request.respondWith({
+              status: 204,
+              response: ''
+            }).then((response) => {
+              expect(successSpy).toHaveBeenCalled();
+              expect(errorSpy).not.toHaveBeenCalled();
+              done();
+            });
+          });
         });
       });
     });

--- a/src/utils/service/__spec__.js
+++ b/src/utils/service/__spec__.js
@@ -1,6 +1,6 @@
+import { assign } from 'lodash';
 import moxios from 'moxios';
 import Service from './service';
-import { assign } from 'lodash';
 
 describe('Service', () => {
   let service, onSuccessSpy, onErrorSpy;
@@ -15,13 +15,13 @@ describe('Service', () => {
       onError: onErrorSpy
     });
     // init an instance of the service
-    service = new Service;
+    service = new Service();
   });
 
   describe('constructor', () => {
     it('sets the headers of the axios client', () => {
-      let headers = service.client.defaults.headers;
-      expect(headers['Accept']).toEqual('application/json');
+      const headers = service.client.defaults.headers;
+      expect(headers.Accept).toEqual('application/json');
       expect(headers['Content-Type']).toEqual('application/json');
     });
 
@@ -49,7 +49,7 @@ describe('Service', () => {
   describe('handleSuccess', () => {
     describe('when there is no message in the response', () => {
       it('returns the data', () => {
-        let data = { foo: true };
+        const data = { foo: true };
         expect(service.handleSuccess({ data })).toEqual(data);
       });
     });
@@ -57,16 +57,17 @@ describe('Service', () => {
     describe('when there is a message in the response', () => {
       describe('if the status is error', () => {
         let response;
+        const data = { message: 'message', status: 'error' };
 
         beforeEach(() => {
           spyOn(Promise, 'reject');
-          response = { data: { message: 'message', status: 'error' } };
+          response = { data };
         });
 
         describe('if global callbacks are enabled', () => {
           it('calls onError', () => {
             service.handleSuccess(response);
-            expect(onErrorSpy).toHaveBeenCalledWith('message');
+            expect(onErrorSpy).toHaveBeenCalledWith(data);
             expect(Promise.reject).toHaveBeenCalledWith(response);
           });
         });
@@ -83,10 +84,12 @@ describe('Service', () => {
       });
 
       describe('if the status is not error', () => {
+        const data = { message: 'message', status: 'ok' };
+
         describe('if global callbacks are enabled', () => {
           it('calls onSuccess', () => {
-            service.handleSuccess({ data: { message: 'message' } });
-            expect(onSuccessSpy).toHaveBeenCalledWith('message');
+            service.handleSuccess({ data });
+            expect(onSuccessSpy).toHaveBeenCalledWith(data);
           });
         });
 
@@ -160,12 +163,12 @@ describe('Service', () => {
       moxios.uninstall(service.client);
     });
 
-    let testEndpoint = (done, status, spy) => {
+    const testEndpoint = (done, status, spy) => {
       moxios.wait(() => {
-        let request = moxios.requests.mostRecent(),
+        const request = moxios.requests.mostRecent(),
             data = { data: {} };
         request.respondWith({
-          status: status,
+          status,
           response: JSON.stringify(data)
         }).then((response) => {
           expect(spy).toHaveBeenCalled();
@@ -262,7 +265,7 @@ describe('Service', () => {
       it('without an error callback', (done) => {
         service.delete(1, successSpy);
         moxios.wait(() => {
-          let request = moxios.requests.mostRecent(),
+          const request = moxios.requests.mostRecent(),
               data = { data: {} };
 
           request.respondWith({
@@ -292,15 +295,13 @@ describe('Service', () => {
 
       describe('DELETE with no_content response', () => {
         it('calls the DELETE endpoint', (done) => {
-
           service.delete(1,
             {
               onSuccess: successSpy,
               onError: errorSpy
             });
           moxios.wait(() => {
-            let request = moxios.requests.mostRecent(),
-              data = { data: {} };
+            const request = moxios.requests.mostRecent();
 
             request.respondWith({
               status: 204,
@@ -318,13 +319,13 @@ describe('Service', () => {
     describe('with a transformRequest', () => {
       it('transforms the data', (done) => {
         service.setTransformRequest((data) => {
-          let d = { bar: 'custom' };
+          const d = { bar: 'custom' };
           return JSON.stringify(d);
         });
-        service.post({ foo: "posted" }, () => {}, () => {});
+        service.post({ foo: 'posted' }, () => {}, () => {});
 
         moxios.wait(() => {
-          let request = moxios.requests.mostRecent();
+          const request = moxios.requests.mostRecent();
           expect(request.config.data).toEqual(JSON.stringify({ bar: 'custom' }));
           done();
         });
@@ -334,13 +335,13 @@ describe('Service', () => {
     describe('with a transformResponse', () => {
       it('transforms the data', () => {
         service.setTransformResponse((data) => {
-          let d = assign({}, data, { bar: 'custom' });
+          const d = assign({}, data, { bar: 'custom' });
           return JSON.stringify(d);
         });
         service.get(1, () => {}, () => {});
 
         moxios.wait(() => {
-          let request = moxios.requests.mostRecent();
+          const request = moxios.requests.mostRecent();
 
           request.respondWith({
             status: 200,

--- a/src/utils/service/__spec__.js
+++ b/src/utils/service/__spec__.js
@@ -54,6 +54,13 @@ describe('Service', () => {
       });
     });
 
+    describe('when the body is empty', () => {
+      it('returns a stringified empty object', () => {
+        let data = '';
+        expect(service.handleSuccess({ data })).toEqual({});
+      });
+    });
+
     describe('when there is a message in the response', () => {
       describe('if the status is error', () => {
         let response;

--- a/src/utils/service/service.js
+++ b/src/utils/service/service.js
@@ -71,11 +71,6 @@ class Service {
    * @return {Object} the response data
    */
   handleSuccess(response) {
-    if (response.data === '') {
-      response.data = {};
-      return response.data;
-    }
-
     if (!response.data.message) {
       return response.data;
     }
@@ -260,7 +255,7 @@ class Service {
    * @return {Void}
    */
   responseTransform(response) {
-    return JSON.parse(response);
+    return JSON.parse(!response ? '{}' : response);
   }
 
   /**

--- a/src/utils/service/service.js
+++ b/src/utils/service/service.js
@@ -71,6 +71,11 @@ class Service {
    * @return {Object} the response data
    */
   handleSuccess(response) {
+    if (response.data === '') {
+      response.data = {};
+      return response.data;
+    }
+
     if (!response.data.message) {
       return response.data;
     }

--- a/src/utils/service/service.js
+++ b/src/utils/service/service.js
@@ -71,22 +71,16 @@ class Service {
    * @return {Object} the response data
    */
   handleSuccess(response) {
-    if (!response.data.message) {
-      return response.data;
-    }
-
-    if (response.data.status === 'error') {
-      // respond with an error if the server responds with an error status
+    if (response.data && response.data.status === 'error') {
       if (this.shouldTriggerCallback(config.onError)) {
-        config.onError(response.data.message);
+        config.onError(response.data);
       }
 
       return Promise.reject(response);
     }
 
-    // in other cases, default to 'success'
     if (this.shouldTriggerCallback(config.onSuccess)) {
-      config.onSuccess(response.data.message);
+      config.onSuccess(response.data);
     }
 
     return response.data;
@@ -255,7 +249,8 @@ class Service {
    * @return {Void}
    */
   responseTransform(response) {
-    return JSON.parse(!response ? '{}' : response);
+    if (!response) { return undefined; }
+    return JSON.parse(response);
   }
 
   /**


### PR DESCRIPTION
# Description

* We take an empty string in response data and convert it to an object
* This ensures 204 responses with empty data will still be correctly parsed

# TODO
- [x] Release notes

# Related Issues / Pull Requests
https://github.com/Sage/carbon/issues/1631

# Testing Instructions
