### PR TITLE
Allow Portrait to render an empty alt attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Improvements
 
+* `Portrait` can now render an empty string for the alt attribute.
 * Changed type of prop `tooltipMessage` of `tooltip-decorator` from string to node to allow children.
 
 ## Fixes

--- a/src/components/portrait/__spec__.js
+++ b/src/components/portrait/__spec__.js
@@ -353,6 +353,32 @@ describe('Portrait', () => {
         });
       });
     });
+
+    describe('when alt is an empty string', () => {
+      it('renders avatar alt attribute with an empty string', () => {
+        wrapper = shallow(<Portrait initials='FF' src='test' alt='' />);
+        expect(wrapper.find('.carbon-portrait__avatar[alt=""]').exists()).toEqual(true);
+      });
+
+      describe('when rendering the initials image', () => {
+        it('renders the alt attribute with an empty string', () => {
+          wrapper = shallow(<Portrait initials='FF' alt='' />);
+          expect(wrapper.find('.carbon-portrait__initials[alt=""]').exists()).toEqual(true);
+        });
+      });
+    });
+
+    describe('when the alt prop is not given', () => {
+      it('renders the avatar image with an empty alt attribute', () => {
+        wrapper = shallow(<Portrait src='test' />);
+        expect(wrapper.find('.carbon-portrait__avatar[alt=""]').exists()).toEqual(true);
+      });
+
+      it('renders the initials image with an empty alt attribute', () => {
+        wrapper = shallow(<Portrait initials='FF' />);
+        expect(wrapper.find('.carbon-portrait__initials[alt=""]').exists()).toEqual(true);
+      });
+    });
   });
 
   describe('tags', () => {

--- a/src/components/portrait/portrait.js
+++ b/src/components/portrait/portrait.js
@@ -280,7 +280,7 @@ class Portrait extends React.Component {
         data-element='initials'
         className='carbon-portrait__img carbon-portrait__initials'
         src={ this.generateInitials }
-        alt={ this.props.alt || '' }
+        alt={ this.props.alt }
       />
     );
   }
@@ -297,7 +297,7 @@ class Portrait extends React.Component {
         data-element='user-image'
         className='carbon-portrait__img carbon-portrait__avatar'
         src={ this.imgSrc }
-        alt={ this.props.alt || '' }
+        alt={ this.props.alt }
       />
     );
   }

--- a/src/components/portrait/portrait.js
+++ b/src/components/portrait/portrait.js
@@ -111,6 +111,7 @@ class Portrait extends React.Component {
   }
 
   static defaultProps = {
+    alt: '',
     size: 'medium',
     shape: 'standard'
   };
@@ -279,7 +280,7 @@ class Portrait extends React.Component {
         data-element='initials'
         className='carbon-portrait__img carbon-portrait__initials'
         src={ this.generateInitials }
-        alt={ this.props.alt }
+        alt={ this.props.alt || '' }
       />
     );
   }
@@ -296,7 +297,7 @@ class Portrait extends React.Component {
         data-element='user-image'
         className='carbon-portrait__img carbon-portrait__avatar'
         src={ this.imgSrc }
-        alt={ this.props.alt }
+        alt={ this.props.alt || '' }
       />
     );
   }


### PR DESCRIPTION
Update the `Portrait` component so that can render empty `alt` attributes: when it receives the empty string for the `alt` prop it will render it as an empty `alt` attribute on the `<img>` tag.

Set the `defaultValue` for the `alt` prop to `''`.
