### PR TITLE
Update Portrait and Profile CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Improvements
 
+* Improve the contrast of the text in the `Profile` component, and the `Portrait` component when `darkBackground={ true }`.
 * Changed type of prop `tooltipMessage` of `tooltip-decorator` from string to node to allow children.
 
 ## Fixes

--- a/src/components/portrait/__spec__.js
+++ b/src/components/portrait/__spec__.js
@@ -181,7 +181,7 @@ describe('Portrait', () => {
         );
         const context = { fillRect: () => {} };
         instance.applyBackground(context);
-        expect(context.fillStyle).toEqual('#4E545F');
+        expect(context.fillStyle).toEqual('#8A8E95');
       });
     });
   });

--- a/src/components/portrait/portrait.js
+++ b/src/components/portrait/portrait.js
@@ -206,7 +206,7 @@ class Portrait extends React.Component {
    * @return {Object}
    */
   applyBackground = (context, size) => {
-    const color = this.props.darkBackground ? '#4E545F' : '#D8D9DC';
+    const color = this.props.darkBackground ? '#8A8E95' : '#D8D9DC';
 
     context.fillStyle = color;
     context.fillRect(0, 0, size, size);
@@ -223,7 +223,7 @@ class Portrait extends React.Component {
   applyText = (context, size) => {
     const letters = this.props.initials ? this.props.initials.slice(0, 3) : '';
 
-    context.fillStyle = '#636872';
+    context.fillStyle = '#FFFFFF';
     context.fillText(letters.toUpperCase(), size / 2, size / 1.5);
 
     return context;

--- a/src/components/profile/__spec__.js
+++ b/src/components/profile/__spec__.js
@@ -83,6 +83,7 @@ describe('PortraitContainer', () => {
       it('returns the portrait component', () => {
         expect(TestUtils.isElementOfType(instance.avatar, Portrait)).toBeTruthy();
         expect(instance.avatar.props.className).toEqual("carbon-profile__avatar");
+        expect(instance.avatar.props.darkBackground).toEqual(true);
       });
     });
 

--- a/src/components/profile/profile.js
+++ b/src/components/profile/profile.js
@@ -88,6 +88,7 @@ class Profile extends React.Component {
   get avatar() {
     return (
       <Portrait
+        darkBackground={ true }
         initials={ this.initials }
         gravatar={ this.props.email }
         className='carbon-profile__avatar'

--- a/src/components/profile/profile.js
+++ b/src/components/profile/profile.js
@@ -88,7 +88,7 @@ class Profile extends React.Component {
   get avatar() {
     return (
       <Portrait
-        darkBackground={ true }
+        darkBackground
         initials={ this.initials }
         gravatar={ this.props.email }
         className='carbon-profile__avatar'

--- a/src/components/profile/profile.scss
+++ b/src/components/profile/profile.scss
@@ -16,8 +16,13 @@
   line-height: $app-line-height;
 }
 
+.carbon-profile__name,
 .carbon-profile__email {
-  color: $grey-mid;
+  color: $onyx;
+}
+
+.carbon-profile__name {
+  font-weight: bold;
 }
 
 .carbon-profile--large .carbon-profile__name {


### PR DESCRIPTION
Update the text colour for `Profile`,  and the background colour used for `darkBackground={ true }` in the `Portrait` component, to `$onyx`.

Update the `Portrait` component used by `Profile` to use `darkBackground={ true }`.

## Screenshots
![profile](https://user-images.githubusercontent.com/52329/33844756-345da544-de99-11e7-917b-4fcec28605aa.png)

![portrait](https://user-images.githubusercontent.com/52329/33844822-71711dc6-de99-11e7-9c5a-5b016f45299f.png)


