### PR TITLE
fixes transforms on service class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.5.1
+
+## Bug Fixes
+
+* Adding a transform to an instance of a service class was applying the transform to all other instances. This change ensures the transform is only applied to the specific instance.
+
 # 2.5.0
 
 ## Improvements

--- a/src/utils/service/__spec__.js
+++ b/src/utils/service/__spec__.js
@@ -318,9 +318,9 @@ describe('Service', () => {
 
     describe('with a transformRequest', () => {
       it('transforms the data', (done) => {
-        service.setTransformRequest((request) => {
-          request.data = JSON.stringify({ bar: 'custom' });
-          return request;
+        service.setTransformRequest((data) => {
+          const d = { bar: 'custom' };
+          return JSON.stringify(d);
         });
         service.post({ foo: 'posted' }, () => {}, () => {});
 

--- a/src/utils/service/__spec__.js
+++ b/src/utils/service/__spec__.js
@@ -318,9 +318,9 @@ describe('Service', () => {
 
     describe('with a transformRequest', () => {
       it('transforms the data', (done) => {
-        service.setTransformRequest((data) => {
-          const d = { bar: 'custom' };
-          return JSON.stringify(d);
+        service.setTransformRequest((request) => {
+          request.data = JSON.stringify({ bar: 'custom' });
+          return request;
         });
         service.post({ foo: 'posted' }, () => {}, () => {});
 
@@ -333,11 +333,9 @@ describe('Service', () => {
     });
 
     describe('with a transformResponse', () => {
-      it('transforms the data', () => {
-        service.setTransformResponse((data) => {
-          const d = assign({}, data, { bar: 'custom' });
-          return JSON.stringify(d);
-        });
+      it('transforms the data', (done) => {
+        const transformSpy = jest.fn();
+        service.setTransformResponse(transformSpy);
         service.get(1, () => {}, () => {});
 
         moxios.wait(() => {
@@ -347,9 +345,11 @@ describe('Service', () => {
             status: 200,
             response: JSON.stringify({ foo: 'responded' })
           }).then((response) => {
-            expect(response.data).toEqual(
-              JSON.stringify({ foo: 'responded', bar: 'custom' })
-            );
+            // ideally we would test the response data to see it has changed it
+            // as expected - however moxios does not seem to feed the transformed
+            // data through to the mocked response
+            expect(transformSpy).toHaveBeenCalledWith({ foo: 'responded' });
+            done();
           });
         });
       });

--- a/src/utils/service/service.js
+++ b/src/utils/service/service.js
@@ -120,7 +120,10 @@ class Service {
    * @return {Void}
    */
   setTransformRequest(func) {
-    this.client.interceptors.request.use(func);
+    this.client.interceptors.request.use((request) => {
+      request.data = func(request.data);
+      return request;
+    });
   }
 
   /**

--- a/src/utils/service/service.js
+++ b/src/utils/service/service.js
@@ -120,7 +120,7 @@ class Service {
    * @return {Void}
    */
   setTransformRequest(func) {
-    this.client.defaults.transformRequest[1] = func;
+    this.client.interceptors.request.use(func);
   }
 
   /**
@@ -131,7 +131,7 @@ class Service {
    * @return {Void}
    */
   setTransformResponse(func) {
-    this.client.defaults.transformResponse[1] = func;
+    this.client.interceptors.response.use(func);
   }
 
   /**


### PR DESCRIPTION
Adding a transform to an instance of a service class was applying the transform to all other instances. This change ensures the transform is only applied to the specific instance.