### PR TITLE
Remove space from clearfix psuedos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 * Adding a transform to an instance of a service class was applying the transform to all other instances. This change ensures the transform is only applied to the specific instance.
+* Remove space from clearfix psuedoclasses that was creating a space character that was pushing layouts out of line
 
 # 2.5.1
 

--- a/src/utils/css/modules/utility-classes.scss
+++ b/src/utils/css/modules/utility-classes.scss
@@ -13,7 +13,7 @@
 .clearfix {
   &:before,
   &:after {
-    content: " ";
+    content: "";
     display: table;
   }
 


### PR DESCRIPTION
* This results in a space being added which pushes layouts out of line as it has a measurable size
* Not being exhibited in the demo site, but a space is not needed to make the clearfix effective and we can't be sure that it won't be rendered as a space in different contexts
# Description

# TODO
- [x] Release notes

# Screenshots / Gifs
**Before:**
![screen shot 2017-12-15 at 11 56 28](https://user-images.githubusercontent.com/20279205/34041168-e92eaac0-e18e-11e7-9407-24f1a45d5d2c.png)
![screen shot 2017-12-15 at 11 55 28](https://user-images.githubusercontent.com/20279205/34041141-cc3a76f6-e18e-11e7-9a3a-1bcaa3371751.png)

**After:** 
![screen shot 2017-12-15 at 11 55 19](https://user-images.githubusercontent.com/20279205/34041156-db7c88ac-e18e-11e7-940b-7e8df2a29dd0.png)


