### PR TITLE
max-width on setting-row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * `Table`'s `resizeTable` method won't attempt to run if the table isn't present
 * Fixed tests broken by Enzyme major version bump.
 
+## CSS Changes
+
+* `SettingRow` - the left hand segment now has a `max-width` of 300px.
+
 # 2.5.3
 
 ## Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -4839,7 +4839,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "stringstream": {

--- a/src/components/settings-row/settings-row.scss
+++ b/src/components/settings-row/settings-row.scss
@@ -42,7 +42,7 @@
   box-sizing: border-box;
   clear: both;
   float: left;
-  max-width: 300px;
+  max-width: 325px;
   width: 35%;
 }
 
@@ -50,6 +50,6 @@
   box-sizing: border-box;
   clear: both;
   float: left;
-  margin-left: 20px;
+  margin-left: 50px;
   width: 100%;
 }

--- a/src/components/settings-row/settings-row.scss
+++ b/src/components/settings-row/settings-row.scss
@@ -42,12 +42,14 @@
   box-sizing: border-box;
   clear: both;
   float: left;
-  width: calc(35% - 20px);
+  max-width: 300px;
+  width: 35%;
 }
 
 .carbon-settings-row__input {
   box-sizing: border-box;
   clear: both;
   float: left;
-  width: 65%;
+  margin-left: 20px;
+  width: 100%;
 }


### PR DESCRIPTION
Sets a max-width on the left hand segment of the SettingRow component, to ensure the content has the majority of the width of larger screens.

### Before

![screen shot 2017-12-21 at 14 10 34](https://user-images.githubusercontent.com/1668080/34259086-c22da20e-e658-11e7-9f3c-b5878843ef14.png)

### After
![screen shot 2017-12-21 at 14 09 36](https://user-images.githubusercontent.com/1668080/34259087-c474801e-e658-11e7-9a06-5730d385df18.png)

