### PR TITLE
Date component now keeps an invalid value and throw a validation error on the input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.0.0
+
+## Bug fixes
+
+* `Date`: Previously this component would not retain an invalid date value, we now keep the value and throw a validation error on the input.
+
 # 2.6.4
 
 * Upgrade marked package from v0.3.6 to 0.3.9 to address security vulnerabilities

--- a/src/components/date/__spec__.js
+++ b/src/components/date/__spec__.js
@@ -121,18 +121,32 @@ describe('Date', () => {
   describe('emitOnChangeCallback', () => {
     let date;
 
-    beforeEach(() => {
-      spyOn(instance, '_handleOnChange');
-      date = moment().add(10, 'days').format('YYYY-MM-DD');
-      instance.emitOnChangeCallback(date);
+    describe('on valid value', () => {
+      beforeEach(() => {
+        spyOn(instance, '_handleOnChange');
+        date = moment().add(10, 'days').format('YYYY-MM-DD');
+        instance.emitOnChangeCallback(date);
+      });
+
+      it('sets the hiddenField to the new date', () => {
+        expect(instance.hidden.value).toEqual(date);
+      });
+
+      it('triggers the onChange handler in the input decorator', () => {
+        expect(instance._handleOnChange).toHaveBeenCalledWith({ target: instance.hidden });
+      });
     });
 
-    it('sets the hiddenField to the new date', () => {
-      expect(instance.hidden.value).toEqual(date);
-    });
+    describe('on invalid date input', () => {
+      beforeEach(() => {
+        spyOn(instance, '_handleOnChange');
+        instance.emitOnChangeCallback('abc');
+      });
 
-    it('triggers the onChange handler in the input decorator', () => {
-      expect(instance._handleOnChange).toHaveBeenCalledWith({ target: instance.hidden });
+      it('triggers _handleOnChange with the invalid value', () => {
+        const value = instance._handleOnChange.calls.mostRecent().args[0].target.value;
+        expect(value).toEqual('abc');
+      });
     });
   });
 

--- a/src/components/date/date.js
+++ b/src/components/date/date.js
@@ -237,7 +237,8 @@ class Date extends React.Component {
    */
   emitOnChangeCallback = (val) => {
     const hiddenField = this.hidden;
-    hiddenField.value = DateHelper.formatDateString(val, this.hiddenFormat());
+    const isValid = DateHelper.isValidDate(val, { sanitize: (typeof val === 'string') });
+    hiddenField.value = isValid ? DateHelper.formatDateString(val, this.hiddenFormat()) : val;
     this._handleOnChange({ target: hiddenField });
   }
 


### PR DESCRIPTION
# Description

Previously this component would not retain an invalid date value, we now keep the value and throw a validation error on the input.

# Screenshots / Gifs

![carbon](https://user-images.githubusercontent.com/32830770/35108711-2733c5f6-fc6c-11e7-8b27-9870f33bc0e7.png)

