### PR TITLE
CheckBox inline bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 
-* Checkbox no longer overlays the end of the Help field text when the Reverse box is ticked
+* Checkbox no longer overlays the end of the Help field text when the reverse prop is set to true
 
 # 2.6.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.0.0
+
+## Bug Fixes
+
+* Checkbox no longer overlays the end of the Help field text when the Reverse box is ticked
+
 # 2.6.4
 
 * Upgrade marked package from v0.3.6 to 0.3.9 to address security vulnerabilities

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -98,6 +98,7 @@
     display: inline;
     margin-right: 5px;
     position: relative;
+    margin-left: 0;
     top: -2px;
   }
 }

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -96,10 +96,9 @@
 
   &.carbon-checkbox__help-text--inline {
     display: inline;
-    left: 21px;
-    margin-left: -21px;
-    margin-right: 24px;
+    left: 0;
     padding-left: 0;
+    margin-right: 5px;
     position: relative;
     top: -2px;
   }

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -98,7 +98,7 @@
     display: inline;
     left: 21px;
     margin-left: -21px;
-    margin-right: 5px;
+    margin-right: 24px;
     padding-left: 0;
     position: relative;
     top: -2px;

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -96,8 +96,6 @@
 
   &.carbon-checkbox__help-text--inline {
     display: inline;
-    left: 0;
-    padding-left: 0;
     margin-right: 5px;
     position: relative;
     top: -2px;


### PR DESCRIPTION
# Description
Checkbox should not cover the last two letters and the full stop of the Help field text (see screenshots).