### PR TITLE
Date component now keeps an invalid value and throw a validation error on the input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ Both `react` and `react-dom` will need to be updated to version 16.2.0
 npm install react@^16.2.0 react-dom@^16.2.0 --save
 ```
 
+### Hydrate Deprecation
+
+Hydrating a server-rendered container now has an explicit API. If you’re reviving server-rendered HTML, use `ReactDOM.hydrate` instead of `ReactDOM.render`. Keep using `ReactDOM.render` if you’re just doing client-side rendering.
+
 ## React Portal
 
 We have updated the `Portal` component to use React's own version of portal which is available with React 16, removing the `react-portal` dependency.
@@ -88,10 +92,7 @@ We have updated the `Portal` component to use React's own version of portal whic
 ## Bug Fixes
 
 * The DatePicker element will now reposition itself when the DateInput is scrolled.
-
-### Hydrate Deprecation
-
-Hydrating a server-rendered container now has an explicit API. If you’re reviving server-rendered HTML, use `ReactDOM.hydrate` instead of `ReactDOM.render`. Keep using `ReactDOM.render` if you’re just doing client-side rendering.
+* `Date`: Previously this component would not retain an invalid date value, we now keep the value and throw a validation error on the input.
 
 # 2.6.4
 

--- a/src/components/date/__spec__.js
+++ b/src/components/date/__spec__.js
@@ -121,18 +121,32 @@ describe('Date', () => {
   describe('emitOnChangeCallback', () => {
     let date;
 
-    beforeEach(() => {
-      spyOn(instance, '_handleOnChange');
-      date = moment().add(10, 'days').format('YYYY-MM-DD');
-      instance.emitOnChangeCallback(date);
+    describe('on valid value', () => {
+      beforeEach(() => {
+        spyOn(instance, '_handleOnChange');
+        date = moment().add(10, 'days').format('YYYY-MM-DD');
+        instance.emitOnChangeCallback(date);
+      });
+
+      it('sets the hiddenField to the new date', () => {
+        expect(instance.hidden.value).toEqual(date);
+      });
+
+      it('triggers the onChange handler in the input decorator', () => {
+        expect(instance._handleOnChange).toHaveBeenCalledWith({ target: instance.hidden });
+      });
     });
 
-    it('sets the hiddenField to the new date', () => {
-      expect(instance.hidden.value).toEqual(date);
-    });
+    describe('on invalid date input', () => {
+      beforeEach(() => {
+        spyOn(instance, '_handleOnChange');
+        instance.emitOnChangeCallback('abc');
+      });
 
-    it('triggers the onChange handler in the input decorator', () => {
-      expect(instance._handleOnChange).toHaveBeenCalledWith({ target: instance.hidden });
+      it('triggers _handleOnChange with the invalid value', () => {
+        const value = instance._handleOnChange.calls.mostRecent().args[0].target.value;
+        expect(value).toEqual('abc');
+      });
     });
   });
 

--- a/src/components/date/date.js
+++ b/src/components/date/date.js
@@ -228,7 +228,8 @@ class Date extends React.Component {
    */
   emitOnChangeCallback = (val) => {
     const hiddenField = this.hidden;
-    hiddenField.value = DateHelper.formatDateString(val, this.hiddenFormat());
+    const isValid = DateHelper.isValidDate(val, { sanitize: (typeof val === 'string') });
+    hiddenField.value = isValid ? DateHelper.formatDateString(val, this.hiddenFormat()) : val;
     this._handleOnChange({ target: hiddenField });
   }
 


### PR DESCRIPTION
# Description

Previously this component would not retain an invalid date value, we now keep the value and throw a validation error on the input.

# Screenshots / Gifs

![carbon](https://user-images.githubusercontent.com/32830770/35108711-2733c5f6-fc6c-11e7-8b27-9870f33bc0e7.png)

