### PR TITLE
Apply :hover style to input rather than container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,16 @@
 Form autoDisables after submit when the prop `autoDisable` is set to true. The props `afterFormValidation` and `onSubmit` are passed a `enableForm` callback function which can be used to reactivate the form.
 
 ### Example Code
-  ``` 
+  ```
   <Form
     onSubmit={ this.saveContact }
     autoDisable
   >
-    {children} 
+    {children}
   </Form>
   ```
-  
-  ``` 
+
+  ```
   saveContact = (ev, valid, enableForm) => {
     ...
     Actions.submitForm(...);
@@ -36,6 +36,7 @@ Form autoDisables after submit when the prop `autoDisable` is set to true. The p
 ## Bug Fixes
 
 * `mapToProps` takes precedence over props passed to HOC in `connect` function.
+* `inputs` border-color change `:hover` is now applied to input rather than input container
 
 ## Changes
 

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -13,7 +13,7 @@
     margin-top: 10px;
   }
 
-  &:hover .common-input__field .common-input__input {
+  .common-input__field .common-input__input:hover {
     border-color: $input-active-border-color;
   }
 }

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -12,10 +12,6 @@
   + .common-input {
     margin-top: 10px;
   }
-
-  .common-input__field .common-input__input:hover {
-    border-color: $input-active-border-color;
-  }
 }
 
 .common-input--readonly {
@@ -89,6 +85,7 @@
   }
 
   &:active,
+  &:hover,
   &:focus {
     @include input-outline($input-active-border-color);
   }


### PR DESCRIPTION
Sometimes the input width is not 100% which means the border hover is being applied when the user is not actually over the input.

Ticket: PF-3737

## TODO
- [x] Release notes

## Screenshots / Gifs
### Before
![before](https://user-images.githubusercontent.com/2031/36422506-38b448e6-1634-11e8-8af3-896ee9cf5cba.gif)

### After
![hover](https://user-images.githubusercontent.com/2031/36475088-86bed5e8-16f1-11e8-854b-614aa5831ec2.gif)



