### PR TITLE
Add keys to top-level MenuListItem components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Form autoDisables after submit when the prop `autoDisable` is set to true. The p
 
 * Resolved new ESLint errors from carbon-factory upgrade.
 
+## Demo Site
+
+* Add a `key` to the top-level `MenuListItem` components in the sidebar, which removes the 'Each child in an array or iterator should have a unique "key" prop' warning.
+
 # 3.0.0
 
 ## Package Updates

--- a/demo/utils/site-map-helper/generate-menu/generate-menu.js
+++ b/demo/utils/site-map-helper/generate-menu/generate-menu.js
@@ -52,8 +52,13 @@ const createSubmenu = (url, value) => {
   }
 
   return (
-    <MenuListItem>
-      <MenuList title={ title } initiallyOpen={ initiallyOpen } filter={ value.filter } filterPlaceholder="Filter Components">
+    <MenuListItem key={ title }>
+      <MenuList
+        title={ title }
+        initiallyOpen={ initiallyOpen }
+        filter={ value.filter }
+        filterPlaceholder='Filter Components'
+      >
         { submenuItems }
       </MenuList>
     </MenuListItem>


### PR DESCRIPTION
Add keys to the top-level `MenuListItem` components used in the sidebar. This removes the warning 'Each child in an array or iterator should have a unique "key" prop' that was appearing in the browser console.
