### PR TITLE
Increase maxListeners #1700

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Form autoDisables after submit when the prop `autoDisable` is set to true. The p
 
 * `mapToProps` takes precedence over props passed to HOC in `connect` function.
 * `inputs` border-color change `:hover` is now applied to input rather than input container
+* `Store`: sets the `maxListeners` to handle more complex store arrangements 
 
 ## Changes
 

--- a/src/utils/flux/store/__spec__.js
+++ b/src/utils/flux/store/__spec__.js
@@ -2,6 +2,7 @@ import Store from './store';
 import Flux from 'flux';
 import Logger from './../../logger';
 import { Dispatcher } from './../../flux';
+import { EventEmitter } from 'events';
 
 describe('Store', () => {
   let instance;
@@ -52,6 +53,14 @@ describe('Store', () => {
       it('sets trackHistory to true', () => {
         instance = new Store('foo', {}, { history: true });
         expect(instance.trackHistory).toBeTruthy();
+      });
+    });
+
+    describe('max event listeners', () => {
+      it('set to 50', () => {
+        spyOn(EventEmitter.prototype, 'setMaxListeners');
+        instance = new Store('foo', 'some data');
+        expect(EventEmitter.prototype.setMaxListeners).toHaveBeenCalledWith(50);
       });
     });
   });

--- a/src/utils/flux/store/store.js
+++ b/src/utils/flux/store/store.js
@@ -56,6 +56,8 @@ export default class Store extends EventEmitter {
   constructor(name, data, opts = {}) {
     super(name, data, opts);
 
+    this.setMaxListeners(50);
+
     const suffix = `Check the initialization of ${this.constructor.name}.`;
 
     // tell the developer if they have not defined the name property.


### PR DESCRIPTION
 ## Description

* I chose 50, which would allow for a complex layout with several store on some of it's children, this should be enough room to manoeuvre for a varied array of applications without allowing anything really silly to happen with exponentials

## TODO
- [x] Release notes

## Related Issues / Pull Requests
https://github.com/Sage/carbon/issues/1700

## Testing Instructions
* Has been dev checked in the context where it was happening 