### PR TITLE
Fix invalid HTML when using CSSTransitionGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.1.3
+
+## Bug Fixes
+
+* `AnimatedMenuButton`, `Carousel`, `Flash`, `ShowEditPod`, `Table`, and `Toast` all pass the `component='div'` prop to their respective `CSSTransitionGroup` components. This fixes incorrectly nested HTML e.g. `<div>` tags nested within `<span>` tags.
+
 # 3.1.2
 
 Fixes auto-deployment of tags using Travis CI.

--- a/demo/views/pages/document/document.js
+++ b/demo/views/pages/document/document.js
@@ -60,6 +60,7 @@ class Document extends React.Component {
 
           <CSSTransitionGroup
             className={ this.loadingClasses() }
+            component='div'
             transitionName="demo-document__loading"
             transitionAppear={ true }
             transitionAppearTimeout={ 300 }

--- a/src/components/animated-menu-button/animated-menu-button.js
+++ b/src/components/animated-menu-button/animated-menu-button.js
@@ -276,6 +276,7 @@ class AnimatedMenuButton extends React.Component {
         <Icon type='add' data-element='open' />
 
         <CSSTransitionGroup
+          component='div'
           transitionEnterTimeout={ 500 }
           transitionLeaveTimeout={ 500 }
           transitionName='carbon-animated-menu-button'

--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -494,6 +494,7 @@ class Carousel extends React.Component {
           { this.previousButton() }
 
           <CSSTransitionGroup
+            component='div'
             transitionName={ this.transitionName() }
             transitionEnterTimeout={ TRANSITION_TIME }
             transitionLeaveTimeout={ TRANSITION_TIME }

--- a/src/components/flash/flash.js
+++ b/src/components/flash/flash.js
@@ -467,12 +467,14 @@ class Flash extends React.Component {
       <div { ...tagComponent('flash', this.props) }>
         <div className={ this.classes }>
           <CSSTransitionGroup
+            component='div'
             transitionName='carbon-flash__slider'
             transitionEnterTimeout={ 600 }
             transitionLeaveTimeout={ 600 }
           >
             { sliderHTML }
             <CSSTransitionGroup
+              component='div'
               transitionName='carbon-flash__content'
               transitionEnterTimeout={ 800 }
               transitionLeaveTimeout={ 500 }

--- a/src/components/flash/flash.scss
+++ b/src/components/flash/flash.scss
@@ -11,8 +11,8 @@
   width: 100%;
   z-index: $z-flash;
 
-  // span added by CSSTransitionGroup
-  > span {
+  // tag added by CSSTransitionGroup
+  > div {
     display: inline-block;
     height: 100%;
     width: 100%;

--- a/src/components/show-edit-pod/show-edit-pod.js
+++ b/src/components/show-edit-pod/show-edit-pod.js
@@ -352,6 +352,7 @@ class ShowEditPod extends React.Component {
         { ...tagComponent('show-edit-pod', this.props) }
       >
         <CSSTransitionGroup
+          component='div'
           transitionName={ this.props.transitionName }
           transitionEnterTimeout={ 300 }
           transitionLeaveTimeout={ 50 }

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -986,6 +986,7 @@ class Table extends React.Component {
       >
         <TableCell colSpan='42' align='center'>
           <CSSTransitionGroup
+            component='div'
             transitionName='table-loading'
             transitionEnterTimeout={ 300 }
             transitionLeaveTimeout={ 300 }

--- a/src/components/toast/__snapshots__/__spec__.js.snap
+++ b/src/components/toast/__snapshots__/__spec__.js.snap
@@ -12,6 +12,7 @@ exports[`Toast when toast is closed renders null 1`] = `
       data-portal-entrance="guid-12345"
     >
       <CSSTransitionGroup
+        component="div"
         transitionAppear={true}
         transitionAppearTimeout={1600}
         transitionEnter={true}
@@ -22,7 +23,7 @@ exports[`Toast when toast is closed renders null 1`] = `
       >
         <TransitionGroup
           childFactory={[Function]}
-          component="span"
+          component="div"
           transitionAppear={true}
           transitionAppearTimeout={1600}
           transitionEnter={true}
@@ -31,7 +32,7 @@ exports[`Toast when toast is closed renders null 1`] = `
           transitionLeaveTimeout={500}
           transitionName="toast"
         >
-          <span />
+          <div />
         </TransitionGroup>
       </CSSTransitionGroup>
     </span>

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -146,6 +146,7 @@ class Toast extends React.Component {
     return (
       <Portal>
         <CSSTransitionGroup
+          component='div'
           transitionAppear
           transitionName='toast'
           transitionAppearTimeout={ 1600 }


### PR DESCRIPTION
Pass the `component='div'` prop to all instances of `CSSTransitionGroup` that contain block-level content.

By default `CSSTransitionGroup` uses a `<span>` tag, which can lead to invalid HTML such as:

```html
<span>
  <div>
    My component
  </div>
</span>
```

By setting the `component` prop to the string `div` we ensure that the component HTML is valid HTML and doesn't include incorrectly nested tags.