### PR TITLE
Renamed tutorial numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 3.1.3
 
-### Fixes
+### Demo Site
 
-Tutorials are now numbered incorrectly in the Carbon Demo sidebar.
+Tutorials are now numbered correctly in the Carbon Demo sidebar.
 
 # 3.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.1.3
+
+### Fixes
+
+Tutorials are now numbered incorrectly in the Carbon Demo sidebar.
+
 # 3.1.2
 
 Fixes auto-deployment of tags using Travis CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.2.0
 
-### Demo Site
+## Demo Site
 
 Tutorials are now numbered correctly in the Carbon Demo sidebar.
 

--- a/demo/site-map.js
+++ b/demo/site-map.js
@@ -55,7 +55,7 @@ export default new SiteMapHelper({
     items: {
       'rails-part-1:-hello-world': `${tutorialsPath}/carbon-rails/hello-world.md`,
       'rails-part-2:-introducing-data': `${tutorialsPath}/carbon-rails/introducing-data.md`,
-      'rails-part-2:-updating-data': `${tutorialsPath}/carbon-rails/updating-data.md`
+      'rails-part-3:-updating-data': `${tutorialsPath}/carbon-rails/updating-data.md`
     }
   }
 });


### PR DESCRIPTION
# Description
Tutorials are numbered incorrectly in the Carbon sidebar.

### Bug location
http://carbon.sage.com

### Testing Instructions
Navigate to specified area.
Expand "Tutorials" section in sidebar.

### Expected Behaviour
Rails Part 1
Rails Part 2
Rails Part 3

### Actual Behaviour
Rails Part 1
Rails Part 2
Rails Part 2
