### PR TITLE
Remove manual interpolation on FormSummary to allow override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Using the `loading` prop:
 ## Bug Fixes
 
 * `AnimatedMenuButton`, `Carousel`, `Flash`, `ShowEditPod`, `Table`, and `Toast` all pass the `component='div'` prop to their respective `CSSTransitionGroup` components. This fixes incorrectly nested HTML e.g. `<div>` tags nested within `<span>` tags.
+* Allow localisation override by removing manual interpolation on `FormSummary`.
 
 ## Demo Site
 

--- a/src/components/form/form-summary/form-summary.js
+++ b/src/components/form/form-summary/form-summary.js
@@ -48,22 +48,22 @@ const defaultTranslations = (errorCount, warningCount) => {
   return {
     errors: {
       defaultValue: {
-        one: `There is ${errorCount} error`,
-        other: `There are ${errorCount} errors`
+        one: 'There is %{count} error',
+        other: 'There are %{count} errors'
       },
       count: parseInt(errorCount, 10)
     },
     warnings: {
       defaultValue: {
-        one: `There is ${warningCount} warning`,
-        other: `There are ${warningCount} warnings`
+        one: 'There is %{count} warning',
+        other: 'There are %{count} warnings'
       },
       count: parseInt(warningCount, 10)
     },
     errors_and_warnings: {
       defaultValue: {
-        one: `and ${warningCount} warning`,
-        other: `and ${warningCount} warnings`
+        one: 'and %{count} warning',
+        other: 'and %{count} warnings'
       },
       count: parseInt(warningCount, 10)
     }


### PR DESCRIPTION
Currently the `FormSummary` component uses manual interpolation to set the default translations. This stops us from being able to add localisation for these translations. The fix allows `I18n` to handle that stuff so we can add override localisations as normal.

### TODO
- [x] Release notes
