### PR TITLE
[CARBON-1045] Demo Site - fix typo to run in production mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 script:
   - gulp test --build --runInBand
 
-before_deploy: if [ "$TRAVIS_BRANCH" == "release" ]; then gulp deploy --build -—production; fi
+before_deploy: if [ "$TRAVIS_BRANCH" == "release" ]; then gulp deploy --build --production; fi
 
 deploy:
   - provider: s3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Flash component now uses Portal
 
 ## Demo Site
 
-Tutorials are now numbered correctly in the Carbon Demo sidebar.
+* Tutorials are now numbered correctly in the Carbon Demo sidebar.
+* Demo Site should now correctly deploy in production mode
 
 ## Preview Component
 
@@ -33,11 +34,6 @@ Using the `loading` prop:
 ## Bug Fixes
 
 * `AnimatedMenuButton`, `Carousel`, `Flash`, `ShowEditPod`, `Table`, and `Toast` all pass the `component='div'` prop to their respective `CSSTransitionGroup` components. This fixes incorrectly nested HTML e.g. `<div>` tags nested within `<span>` tags.
-* Demo Site should now correctly deploy in production mode
-
-## Demo Site
-
-Tutorials are now numbered correctly in the Carbon Demo sidebar.
 
 # 3.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Using the `loading` prop:
 ## Bug Fixes
 
 * `AnimatedMenuButton`, `Carousel`, `Flash`, `ShowEditPod`, `Table`, and `Toast` all pass the `component='div'` prop to their respective `CSSTransitionGroup` components. This fixes incorrectly nested HTML e.g. `<div>` tags nested within `<span>` tags.
+* Demo Site should now correctly deploy in production mode
 
 ## Demo Site
 


### PR DESCRIPTION
# Description
https://jira-sage.valiantyscloud.net/browse/CARBON-1045
> We're getting console errors/warnings on the demo site in prod. These should be disabled when running with `--production`. Need to look into why this is happening and resolve it.

# TODO
- [x] Release notes

# Testing Instructions
Locally run `gulp deploy --build --production`
`npm install http-server -g`
`cd deploy`
`http-server`
Navigate to `http://127.0.0.1:8080`
Ensure warnings / errors don't appear in inspector-console