### PR TITLE
Will need Retarget - Safari dirty form was always being triggered

### DIFF
--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -470,7 +470,7 @@ class Form extends React.Component {
   }
 
   checkIsFormDirty = (ev) => {
-    let confirmationMessage = '';
+    let confirmationMessage = null;
     if (this.state.isDirty) {
       // Confirmation message is usually overridden by browsers with a similar message
       confirmationMessage = I18n.t('form.save_prompt',

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -470,14 +470,13 @@ class Form extends React.Component {
   }
 
   checkIsFormDirty = (ev) => {
-    let confirmationMessage = null;
     if (this.state.isDirty) {
       // Confirmation message is usually overridden by browsers with a similar message
-      confirmationMessage = I18n.t('form.save_prompt',
+      const confirmationMessage = I18n.t('form.save_prompt',
         { defaultValue: 'Do you want to leave this page? Changes that you made may not be saved.' });
       ev.returnValue = confirmationMessage; // Gecko + IE
+      return confirmationMessage; // Gecko + Webkit, Safari, Chrome etc.
     }
-    return confirmationMessage; // Gecko + Webkit, Safari, Chrome etc.
   }
 
   /**


### PR DESCRIPTION
Inspiration from - http://jonathonhill.net/2011-03-04/catching-the-javascript-beforeunload-event-the-cross-browser-way/

`and then return it for Safari (use null instead to allow normal behavior):`

So returning an empty string from the beforeunload method in safari assumes you want the default message to be displayed? Returning null fixes this

Will need testing across all browsers including IE.
