### PR TITLE
dirty form warning fix for safari/IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.3
+
+Stops incorrect Dirty Form warning from showing in Safari/IE on a clean form
+
 # 3.1.2
 
 Fixes auto-deployment of tags using Travis CI.

--- a/src/components/form/__spec__.js
+++ b/src/components/form/__spec__.js
@@ -363,7 +363,7 @@ describe('Form', () => {
 
     it("if form is clean, return an empty string", () => {
       instance.resetIsDirty();
-      expect(instance.checkIsFormDirty(Event)).toEqual("");
+      expect(instance.checkIsFormDirty(Event)).toBeUndefined();
     });
   });
 

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -469,16 +469,18 @@ class Form extends React.Component {
     this._window.removeEventListener('beforeunload', this.checkIsFormDirty);
   }
 
+  // This must return undefined for IE and Safari if we don't want a warning
+  /* eslint-disable consistent-return */
   checkIsFormDirty = (ev) => {
-    let confirmationMessage = '';
     if (this.state.isDirty) {
       // Confirmation message is usually overridden by browsers with a similar message
-      confirmationMessage = I18n.t('form.save_prompt',
+      const confirmationMessage = I18n.t('form.save_prompt',
         { defaultValue: 'Do you want to leave this page? Changes that you made may not be saved.' });
       ev.returnValue = confirmationMessage; // Gecko + IE
+      return confirmationMessage; // Gecko + Webkit, Safari, Chrome etc.
     }
-    return confirmationMessage; // Gecko + Webkit, Safari, Chrome etc.
   }
+  /* eslint-enable consistent-return */
 
   /**
    * stores the document - allows us to override it different contexts, such as


### PR DESCRIPTION
# Description

Returning an empty string from the beforeunload method in safari/IE assumes you want the default message to be displayed? Returning null fixes Safari but not IE. Returning undefined or not returning fixes IE

# TODO
- [x] Release notes