### PR TITLE
Portal ie fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.3
+
+Stops incorrect Dirty Form warning from showing in Safari/IE on a clean form
+
 # 3.1.2
 
 Fixes auto-deployment of tags using Travis CI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A library of reusable React components and an interface for easily building user interfaces based on Flux.",
   "engineStrict": true,
   "engines": {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -658,9 +658,9 @@ const Dropdown = Input(InputIcon(InputLabel(InputValidation(class Dropdown exten
    */
   calculatePosition = () => {
     const inputBoundingRect = this._input.getBoundingClientRect();
-    const top = `${inputBoundingRect.y + (inputBoundingRect.height) + window.scrollY}px`;
+    const top = `${inputBoundingRect.top + (inputBoundingRect.height) + window.scrollY}px`;
     const width = `${inputBoundingRect.width}px`;
-    const left = `${inputBoundingRect.x}px`;
+    const left = `${inputBoundingRect.left}px`;
     this.listBlock.setAttribute('style', `left: ${left}; top: ${top}; width: ${width};`);
   }
 

--- a/src/components/form/__spec__.js
+++ b/src/components/form/__spec__.js
@@ -363,7 +363,7 @@ describe('Form', () => {
 
     it("if form is clean, return an empty string", () => {
       instance.resetIsDirty();
-      expect(instance.checkIsFormDirty(Event)).toEqual("");
+      expect(instance.checkIsFormDirty(Event)).toBeUndefined();
     });
   });
 

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -469,16 +469,18 @@ class Form extends React.Component {
     this._window.removeEventListener('beforeunload', this.checkIsFormDirty);
   }
 
+  // This must return undefined for IE and Safari if we don't want a warning
+  /* eslint-disable consistent-return */
   checkIsFormDirty = (ev) => {
-    let confirmationMessage = '';
     if (this.state.isDirty) {
       // Confirmation message is usually overridden by browsers with a similar message
-      confirmationMessage = I18n.t('form.save_prompt',
+      const confirmationMessage = I18n.t('form.save_prompt',
         { defaultValue: 'Do you want to leave this page? Changes that you made may not be saved.' });
       ev.returnValue = confirmationMessage; // Gecko + IE
+      return confirmationMessage; // Gecko + Webkit, Safari, Chrome etc.
     }
-    return confirmationMessage; // Gecko + Webkit, Safari, Chrome etc.
   }
+  /* eslint-enable consistent-return */
 
   /**
    * stores the document - allows us to override it different contexts, such as


### PR DESCRIPTION
* The code was using `x` and `y` instead of `left` and `top` and those two values are not reported by the IE's none standard object returned by `getBoundingClientRect` - switching to `left` and `top` fixes the problem.

* https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect