### PR TITLE
Portal ie fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.4
+
+Fixes incorrect dropdown placement in IE.
+
 # 3.1.3
 
 Stops incorrect Dirty Form warning from showing in Safari/IE on a clean form

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "A library of reusable React components and an interface for easily building user interfaces based on Flux.",
   "engineStrict": true,
   "engines": {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -658,9 +658,9 @@ const Dropdown = Input(InputIcon(InputLabel(InputValidation(class Dropdown exten
    */
   calculatePosition = () => {
     const inputBoundingRect = this._input.getBoundingClientRect();
-    const top = `${inputBoundingRect.y + (inputBoundingRect.height) + window.scrollY}px`;
+    const top = `${inputBoundingRect.top + (inputBoundingRect.height) + window.scrollY}px`;
     const width = `${inputBoundingRect.width}px`;
-    const left = `${inputBoundingRect.x}px`;
+    const left = `${inputBoundingRect.left}px`;
     this.listBlock.setAttribute('style', `left: ${left}; top: ${top}; width: ${width};`);
   }
 


### PR DESCRIPTION
* The code was using `x` and `y` instead of `left` and `top` and those two values are not reported by the IE's none standard object returned by `getBoundingClientRect` - switching to `left` and `top` fixes the problem.

* https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect