### PR TITLE
Fix issue with hover styles on readonly and disabled inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.2.2
+
+## Bugs
+
+* Prevent hover styles being applied when hovering over a readonly `input` element.
+
 # 3.2.1
 
 Merged in v3.1.3 and v3.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.2.2
 
-## Bugs
+## Bug Fixes
 
 * Prevent hover styles being applied when hovering over a readonly or a disabled `input` element.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bugs
 
-* Prevent hover styles being applied when hovering over a readonly `input` element.
+* Prevent hover styles being applied when hovering over a readonly or a disabled `input` element.
 
 # 3.2.1
 

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -97,7 +97,8 @@
     border-color: $grey !important; // this is the correct use of !important
 
     &:active,
-    &:focus {
+    &:focus,
+    &:hover {
       box-shadow: none;
     }
   }

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -20,7 +20,8 @@
     border: none;
 
     &:active,
-    &:focus {
+    &:focus,
+    &:hover {
       box-shadow: none;
     }
   }


### PR DESCRIPTION
Prevent the hover styles being applied to readonly and disabled inputs.
