### PR TITLE
Position textarea label at the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# next
+
+## Bug fixes
+
+* Position textarea label at the top of the component
+
 # 3.2.1
 
 Merged in v3.1.3 and v3.1.4

--- a/src/components/textarea/textarea.scss
+++ b/src/components/textarea/textarea.scss
@@ -1,8 +1,8 @@
 @import 'colors';
 
 .carbon-textarea .common-input__label {
-  vertical-align: top;
   margin-top: 9px;
+  vertical-align: top;
 }
 
 .carbon-textarea__input {

--- a/src/components/textarea/textarea.scss
+++ b/src/components/textarea/textarea.scss
@@ -1,5 +1,10 @@
 @import 'colors';
 
+.carbon-textarea .common-input__label {
+  vertical-align: top;
+  margin-top: 9px;
+}
+
 .carbon-textarea__input {
   height: auto;
   resize: none;


### PR DESCRIPTION
#1718

Moves the label for the textarea to the top of the component.

![screen shot 2018-04-23 at 17 14 03](https://user-images.githubusercontent.com/8832592/39135702-d6d4d99e-4719-11e8-933d-8a38555be3a5.png)

# TODO
- [x] Release notes

