### PR TITLE
Fix Flash component not opening on initial render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.2.5
+
+## Bug Fixes
+
+* Fixed [#1741](https://github.com/Sage/carbon/issues/1741): `Flash` component will now open on initial render when its `open` prop is set to `true`.
+
 # 3.2.4
 
 ## Bug fixes

--- a/src/components/flash/__spec__.js
+++ b/src/components/flash/__spec__.js
@@ -44,6 +44,36 @@ describe('Flash', () => {
     );
   });
 
+  describe('constructor', () => {
+    const commonProps = {
+      message: 'Should set state',
+      onDismiss: dismissHandler
+    };
+    describe('when this.props.open is true', () => {
+      it('sets this.state.open to true', () => {
+        const wrapper = shallow(
+          <Flash
+            open
+            { ...commonProps }
+          />
+        );
+        expect(wrapper.state().open).toBe(true);
+      });
+    });
+
+    describe('when this.props.open is false', () => {
+      it('sets this.state.open to false', () => {
+        const wrapper = shallow(
+          <Flash
+            open={ false }
+            { ...commonProps }
+          />
+        );
+        expect(wrapper.state().open).toBe(false);
+      });
+    })
+  });
+
   describe('componentWillReceiveProps', () => {
     beforeEach(() => {
       spyOn(defaultInstance, 'setState');

--- a/src/components/flash/flash.js
+++ b/src/components/flash/flash.js
@@ -136,6 +136,14 @@ class Flash extends React.Component {
     open: false
   }
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      dialogs: {},
+      open: this.props.open
+    };
+  }
+
   /**
    * Resets the dialog open states if flash is opened/closed.
    *

--- a/src/components/flash/flash.js
+++ b/src/components/flash/flash.js
@@ -118,28 +118,22 @@ class Flash extends React.Component {
     timeout: 0
   }
 
-  state = {
-    /**
-     * Keeps track on the open state of each dialog
-     *
-     * @property dialogs
-     * @type {Object}
-     */
-    dialogs: {},
-
-    /**
-     * Keeps track of the open state of the Flash Component
-     *
-     * @property open
-     * @type {Boolean}
-     */
-    open: false
-  }
-
   constructor(props) {
     super(props);
     this.state = {
+      /**
+       * Keeps track of the open state of each dialog
+       *
+       * @property dialogs
+       * @type {Object}
+       */
       dialogs: {},
+      /**
+       * Keeps track of the open state of the Flash Component
+       *
+       * @property open
+       * @type {Boolean}
+       */
       open: this.props.open
     };
   }

--- a/src/components/flash/flash.js
+++ b/src/components/flash/flash.js
@@ -134,7 +134,7 @@ class Flash extends React.Component {
        * @property open
        * @type {Boolean}
        */
-      open: this.props.open
+      open: this.props.open || false
     };
   }
 


### PR DESCRIPTION
Resolves #1741.

Set `this.state.open` to `this.props.open` in the constructor, so that if `this.props.open` is set to `true` the `Flash` component will open on initial render.