### PR TITLE
Stop rendering a type attribute for the Icon's type prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.1.1
+
+## Bug Fixes
+
+* No longer render a `type` attribute for the `Icon` component, as this produced invalid HTML (the `Icon` component still accepts a `type` prop).
+
 # 4.1.0
 
 ## npm audit

--- a/src/components/dialog-full-screen/__snapshots__/__spec__.js.snap
+++ b/src/components/dialog-full-screen/__snapshots__/__spec__.js.snap
@@ -104,7 +104,6 @@ exports[`DialogFullScreen tags on component include correct component, elements 
                               data-element="close"
                               key="icon"
                               onClick={[Function]}
-                              type="close"
                             />
                           </Icon>
                           <Heading

--- a/src/components/icon/icon.js
+++ b/src/components/icon/icon.js
@@ -101,7 +101,6 @@ const Icon = TooltipDecorator(class Icon extends React.Component {
     delete props.bgSize;
     delete props.bgShape;
     delete props.bgTheme;
-    props.type = this.type;
 
     return props;
   }

--- a/src/components/portal/__snapshots__/__spec__.js.snap
+++ b/src/components/portal/__snapshots__/__spec__.js.snap
@@ -23,11 +23,10 @@ exports[`Portal when using default node to match snapshot  1`] = `
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
         onTouchEnd={[Function]}
-        type="tick"
       />
     </Icon>
   </span>
 </Portal>
 `;
 
-exports[`Portal when using default node will mount correctly on document 1`] = `"<div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><span class=\\"carbon-icon icon-tick\\" type=\\"tick\\" data-component=\\"icon\\"></span></div>"`;
+exports[`Portal when using default node will mount correctly on document 1`] = `"<div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><span class=\\"carbon-icon icon-tick\\" data-component=\\"icon\\"></span></div>"`;

--- a/src/utils/helpers/browser/__spec__.js
+++ b/src/utils/helpers/browser/__spec__.js
@@ -173,9 +173,16 @@ describe('Browser', () => {
     const key2 = 'bar';
     const value2 = 'bar';
     const data = { [key1]: value1, [key2]: value2 };
+    let origSubmitForm;
 
     beforeEach(() => {
+      origSubmitForm = Browser.submitForm;
+      Browser.submitForm = jest.fn();
       spyOn(Browser, 'getDocument').and.returnValue(document);
+    });
+
+    afterEach(() => {
+      Browser.submitForm = origSubmitForm;
     });
 
     describe('when container not found', () => {
@@ -227,9 +234,11 @@ describe('Browser', () => {
     });
 
     it('submits the rendered form', () => {
-      spyOn(Browser, 'submitForm');
+      const spy = jest.spyOn(Browser, 'submitForm');
       Browser.postToNewWindow(url, data);
-      expect(Browser.submitForm).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalled();
+
+      spy.mockRestore();
     });
 
     it('unmounts the rendered form', () => {
@@ -255,10 +264,11 @@ describe('Browser', () => {
 
   describe('submitForm', () => {
     it('calls submit on the passed form', () => {
-      const submitSpy = jasmine.createSpy('form-submit');
-      const form = { submit: submitSpy };
-      Browser.submitForm(form);
-      expect(submitSpy).toHaveBeenCalled();
+      const mockForm = {
+        submit: jest.fn()
+      };
+      Browser.submitForm(mockForm);
+      expect(mockForm.submit).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Do not render the `type` prop as a `type` attribute, as this is invalid HTML.
