### PR TITLE
[1767] CustomDragLayer can now take className prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Improvements
 
 * `Menu` now outputs semantic HTML. Links are rendered in HTML lists, with submenus rendered with nested lists.
+* `CustomDragLayer` component can now take className prop. 
 
 # 4.1.0
 

--- a/src/components/drag-and-drop/custom-drag-layer/__spec__.js
+++ b/src/components/drag-and-drop/custom-drag-layer/__spec__.js
@@ -230,4 +230,22 @@ describe('CustomDragLayer', () => {
       })
     })
   });
+  describe('customDragLayer with custom className', () => {
+    beforeEach(() => {
+      wrapper = mount(
+        <UndecoratedCustomDragLayer
+          draggableNode={draggableNode}
+          isDragging={false}
+          className='Foo'
+        />
+      );
+      wrapper.setProps({ isDragging: true })
+      instance = wrapper.find(UndecoratedCustomDragLayer);
+    });
+
+    it('sets the default className + one from the props', () => {
+      expect(instance.hasClass('Foo')).toBeTruthy;
+      expect(instance.hasClass('custom-drag-layer')).toBeTruthy;
+    });
+  });
 });

--- a/src/components/drag-and-drop/custom-drag-layer/custom-drag-layer.js
+++ b/src/components/drag-and-drop/custom-drag-layer/custom-drag-layer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { DragLayer } from 'react-dnd';
 
 const collect = (monitor) => {
@@ -62,6 +63,10 @@ class CustomDragLayer extends React.Component {
     };
   }
 
+  getClassName = (props) => {
+    return classNames('custom-drag-layer', props.className);
+  }
+
   setClonedChildWidth(props) {
     this.width = props.draggableNode.getBoundingClientRect().width;
   }
@@ -82,7 +87,7 @@ class CustomDragLayer extends React.Component {
 
   render() {
     return (
-      <div className='custom-drag-layer'>
+      <div className={ this.getClassName(this.props) }>
         <div
           className='custom-drag-layer__container'
           ref={ (node) => { this._container = node; } }


### PR DESCRIPTION
# Description
For draggable lines work I require to extend to apply className to customDragLayer component - this would be a neat feature to have in Carbon to make customLayer even more custom.

# TODO
- [x] Release notes


# Screenshots / Gifs

# Testing Instructions
