### PR TITLE
Add redirectAfter method to Browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Improvements
 
+* `Browser` now has a `redirectAfter` method that redirects to the given URL after the given number of seconds.
 * `Menu` now outputs semantic HTML. Links are rendered in HTML lists, with submenus rendered with nested lists.
 * `CustomDragLayer` component can now take className prop. 
 

--- a/src/utils/helpers/browser/__spec__.js
+++ b/src/utils/helpers/browser/__spec__.js
@@ -16,15 +16,40 @@ describe('Browser', () => {
     };
   });
 
-  describe('redirectTo', () => {
-    describe('when url is passed', () => {
-      const urlsample = 'http://bla';
+  describe('redirects', () => {
+    const urlSample = 'http://bla';
 
-      it('redirects to url', () => {
-        spyOn(Browser, 'getWindow').and.returnValue(_window);
+    beforeEach(() => {
+      spyOn(Browser, 'getWindow').and.returnValue(_window);
+    });
 
-        Browser.redirectTo(urlsample);
-        expect(_window.location).toEqual(urlsample);
+    describe('redirectTo', () => {
+      describe('when url is passed', () => {
+        it('redirects to url', () => {
+          Browser.redirectTo(urlSample);
+          expect(_window.location).toEqual(urlSample);
+        });
+      });
+    });
+
+    describe('redirectAfter', () => {
+      const seconds = 5;
+
+      beforeEach(() => {
+        jest.useFakeTimers();
+      });
+
+      it('redirects to the url after the given number of seconds', () => {
+        Browser.redirectAfter(urlSample, seconds);
+
+        expect(_window.location).toBeNull();
+        jest.advanceTimersByTime(seconds * 1000);
+        expect(_window.location).toEqual(urlSample);
+      });
+
+      it('returns the timeout ID', () => {
+        const timeoutId = Browser.redirectAfter(urlSample, seconds);
+        expect(timeoutId).toBeGreaterThan(0);
       });
     });
   });

--- a/src/utils/helpers/browser/browser.js
+++ b/src/utils/helpers/browser/browser.js
@@ -58,6 +58,17 @@ const Browser = {
   },
 
   /**
+   * Redirects to URL after the given number of seconds have elapsed
+   *
+   * @method redirectAfter
+   * @param url => URL string format
+   * @param seconds => the number of seconds to wait before redirecting
+   */
+  redirectAfter: (url, seconds) => {
+    return setTimeout(() => Browser.redirectTo(url), seconds);
+  },
+
+  /**
    * Reload the current page
    *
    * @method reload

--- a/src/utils/helpers/browser/browser.js
+++ b/src/utils/helpers/browser/browser.js
@@ -65,7 +65,7 @@ const Browser = {
    * @param seconds => the number of seconds to wait before redirecting
    */
   redirectAfter: (url, seconds) => {
-    return setTimeout(() => Browser.redirectTo(url), seconds);
+    return setTimeout(() => Browser.redirectTo(url), seconds * 1000);
   },
 
   /**


### PR DESCRIPTION
Add `redirectAfter` to the `Browser` class. This method takes 2 arguments: url, and seconds.

It redirects to the given URL after the given number of seconds have elapsed e.g. if you need to redirect after displaying a `Flash` message.
