### PR TITLE
1778: Date Input component - info prop not working.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@
 
 * Add a blue background to fix a 'white text on a white background' issue when selecting rows in the `Table` component with the secondary theme applied.
 * No longer render a `type` attribute for the `Icon` component, as this produced invalid HTML (the `Icon` component still accepts a `type` prop).
-* Fixed [#1778](https://github.com/Sage/carbon/issues/1778): `Date-Input` component will now open display the `info` prop when used.
 
 # 4.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Bug Fixes
+
+* Fixed [#1778](https://github.com/Sage/carbon/issues/1778): `Date-Input` component will now open display the `info` prop when used.
+
+
 # 4.1.0
 
 ## npm audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,25 @@
+# 4.2.0
+
+## Improvements
+
+* `Browser` now has a `redirectAfter` method that redirects to the given URL after the given number of seconds.
+* `Menu` now outputs semantic HTML. Links are rendered in HTML lists, with submenus rendered with nested lists.
+* `CustomDragLayer` component can now take className prop.
+
+## Upgrades
+
+* Upgraded carbon-factory to v4.2.2 to support Window environments.
+
+## Build
+
+* Travis CI now sets --maxWorkers=2 for npm test to reduce chance of timeouts
+* Remove `gulp` as Carbon now uses webpack.
+
 ## Bug Fixes
 
+* Add a blue background to fix a 'white text on a white background' issue when selecting rows in the `Table` component with the secondary theme applied.
+* No longer render a `type` attribute for the `Icon` component, as this produced invalid HTML (the `Icon` component still accepts a `type` prop).
 * Fixed [#1778](https://github.com/Sage/carbon/issues/1778): `Date-Input` component will now open display the `info` prop when used.
-
 
 # 4.1.0
 

--- a/change_log/next/date_input_info.yml
+++ b/change_log/next/date_input_info.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "`Date-Input` Component will now show the info prop when used"

--- a/src/components/date/__spec__.js
+++ b/src/components/date/__spec__.js
@@ -325,6 +325,13 @@ describe('Date', () => {
         invalidDate.setState({ warning: true });
         expect(invalidDate.inputIconHTML).toHaveBeenCalledWith('warning');
       });
+
+      it("calls inputIconHTML with info in order to correctly generate the info icon", () => {
+        let invalidDate = TestUtils.renderIntoDocument(<Date value='' />);
+        spyOn(invalidDate, 'inputIconHTML');
+        invalidDate.setState({ info: true });
+        expect(invalidDate.inputIconHTML).toHaveBeenCalledWith('info');
+      });
     });
   });
 

--- a/src/components/date/date.js
+++ b/src/components/date/date.js
@@ -471,6 +471,8 @@ const Date = Input(InputIcon(InputLabel(InputValidation(class Date extends React
       return this.inputIconHTML('error');
     } else if (this.state.warning) {
       return this.inputIconHTML('warning');
+    } else if (this.state.info) {
+      return this.inputIconHTML('info');
     }
     return this.inputIconHTML('calendar');
   }

--- a/src/components/date/date.scss
+++ b/src/components/date/date.scss
@@ -169,6 +169,11 @@ $date__picker__background-color: $white;
   top: 5px;
 }
 
+.carbon-date.common-input--with-icon .common-input__icon--info {
+  right: 5px;
+  top: 5px;
+}
+
 .carbon-date.common-input--with-icon .common-input__icon--warning {
   right: 3px;
   top: 6px;

--- a/src/utils/decorators/input-icon/input-icon.js
+++ b/src/utils/decorators/input-icon/input-icon.js
@@ -58,7 +58,7 @@ const InputIcon = (ComposedComponent) => {
 
       let icon = <Icon type={ iconType } className='carbon-input-icon' />;
 
-      if (['error', 'warning'].indexOf(iconType) > -1) {
+      if (['error', 'warning', 'info'].indexOf(iconType) > -1) {
         icon = (
           <span className={ `carbon-input-icon carbon-input-icon--${iconType}` }>
             { this.validationHTML }

--- a/src/utils/decorators/input-icon/input-icon.scss
+++ b/src/utils/decorators/input-icon/input-icon.scss
@@ -28,15 +28,15 @@
 
 .common-input__input:hover ~ label .carbon-input-icon--error,
 .common-input__input:hover ~ label .carbon-input-icon--error:hover {
-  border-color: $error;
   background-color: $error;
+  border-color: $error;
   .carbon-icon:before {
     color: $white;
   }
 }
 .common-input__input:focus ~ label .carbon-input-icon--error {
-  border-color: $red-dark;
   background-color: $red-dark;
+  border-color: $red-dark;
   .carbon-icon:before {
     color: $white;
   }
@@ -44,15 +44,15 @@
 
 .common-input__input:hover ~ label .carbon-input-icon--warning,
 .common-input__input:hover ~ label .carbon-input-icon--warning:hover {
-  border-color: $warning;
   background-color: $warning;
+  border-color: $warning;
   .carbon-icon:before  {
     fill: $white;
   }
 }
 .common-input__input:focus ~ label .carbon-input-icon--warning {
-  border-color: $warning-hover;
   background-color: $warning-hover;
+  border-color: $warning-hover;
   .carbon-icon:before  {
     fill: $white;
   }
@@ -60,15 +60,15 @@
 
 .common-input__input:hover ~ label .carbon-input-icon--info,
 .common-input__input:hover ~ label .carbon-input-icon--info:hover {
-  border-color: $info;
   background-color: $info;
+  border-color: $info;
   .carbon-icon:before  {
     color: $white;
   }
 }
 .common-input__input:focus ~ label .carbon-input-icon--info {
-  border-color: $info-hover;
   background-color: $info-hover;
+  border-color: $info-hover;
   .carbon-icon:before  {
     color: $white;
   }

--- a/src/utils/decorators/input-icon/input-icon.scss
+++ b/src/utils/decorators/input-icon/input-icon.scss
@@ -58,6 +58,22 @@
   }
 }
 
+.common-input__input:hover ~ label .carbon-input-icon--info,
+.common-input__input:hover ~ label .carbon-input-icon--info:hover {
+  border-color: $info;
+  background-color: $info;
+  .carbon-icon:before  {
+    color: $white;
+  }
+}
+.common-input__input:focus ~ label .carbon-input-icon--info {
+  border-color: $info-hover;
+  background-color: $info-hover;
+  .carbon-icon:before  {
+    color: $white;
+  }
+}
+
 .carbon-input-icon {
   $button-border-radius: $input-border-radius - 1;
   background-color: $grey-light;


### PR DESCRIPTION
# Description

DateInput component not displaying `info` prop when used. 

# TODO
- [x] Release notes

# Related Issues / Pull Requests

https://github.com/Sage/carbon/issues/1778

# Screenshots / Gifs

before:
![screen shot 2018-07-05 at 10 02 10](https://user-images.githubusercontent.com/32830770/42329237-20b89dd4-8068-11e8-8e2a-d0c5ad2b6cf7.png)

after:
<img width="314" alt="screen shot 2018-07-05 at 12 15 01" src="https://user-images.githubusercontent.com/32830770/42329241-24ff8394-8068-11e8-9338-a0337633f788.png">

# Testing Instructions
