### PR TITLE
Extending Draggable Context functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * `Browser` now has a `redirectAfter` method that redirects to the given URL after the given number of seconds.
 * `Menu` now outputs semantic HTML. Links are rendered in HTML lists, with submenus rendered with nested lists.
 * `CustomDragLayer` component can now take className prop.
+* `Draggable Context` extending functionality to determine if a an item can be dropped on.
 
 ## Upgrades
 

--- a/src/components/drag-and-drop/with-drop/__spec__.js
+++ b/src/components/drag-and-drop/with-drop/__spec__.js
@@ -102,7 +102,8 @@ describe('WithDrop', () => {
     beforeEach(() => {
       createWrapper({
         index: 1,
-        hover: hoverPropSpy
+        hover: hoverPropSpy,
+        canDrop: hoverPropSpy
       });
     });
 

--- a/src/components/drag-and-drop/with-drop/with-drop.js
+++ b/src/components/drag-and-drop/with-drop/with-drop.js
@@ -21,7 +21,8 @@ class WithDrop extends React.Component {
     identifier: PropTypes.string, // identifies an association between WithDrag and WithDrop
     index: PropTypes.number.isRequired, // identifies the index for this item
     hover: PropTypes.func, // an optional callback to trigger when the item is hovered
-    onDrag: PropTypes.func // an optional callback to trigger when dragging occurs
+    onDrag: PropTypes.func, // an optional callback to trigger when dragging occurs
+    canDrop: PropTypes.func // an optional callback to determine if this item can be dropped on
     /* eslint-enable react/no-unused-prop-types */
   }
 
@@ -39,7 +40,13 @@ class WithDrop extends React.Component {
 }
 
 const ItemTarget = {
+  canDrop(props, monitor) {
+    return (props.canDrop) ? props.canDrop(props, monitor) : true;
+  },
+
   hover(props, monitor, component) {
+    if (!monitor.canDrop()) return false;
+
     Text.clearSelection();
     const hover = props.hover || component.context.dragAndDropHover;
     hover(props, monitor, component);

--- a/src/components/drag-and-drop/with-drop/with-drop.js
+++ b/src/components/drag-and-drop/with-drop/with-drop.js
@@ -49,7 +49,7 @@ const ItemTarget = {
 
     Text.clearSelection();
     const hover = props.hover || component.context.dragAndDropHover;
-    hover(props, monitor, component);
+    return hover(props, monitor, component);
   }
 };
 

--- a/src/components/table/draggable-table-cell/__spec__.js
+++ b/src/components/table/draggable-table-cell/__spec__.js
@@ -22,6 +22,7 @@ describe('DraggableTableCell', () => {
   it('renders a WithDrag component', () => {
     let wd = wrapper.find(WithDrag);
     expect(wd.props().identifier).toEqual('foo');
+    expect(wd.props().canDrag()).toEqual(true);
   });
 
   it('renders an icon', () => {

--- a/src/components/table/draggable-table-cell/__spec__.js
+++ b/src/components/table/draggable-table-cell/__spec__.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import DraggableTableCell from './draggable-table-cell';
 import TableCell from './../table-cell';
 import WithDrag from './../../drag-and-drop/with-drag';
@@ -34,9 +34,6 @@ describe('DraggableTableCell', () => {
       <DraggableTableCell identifier="foo" canDrag={ false }/>
     );
     let icon = wrapper.find(Icon);
-    //expect(icon.props().type).toEqual(true);
-    //expect(icon.props().className).toEqual('<span />');
-    //expect(wrapper.isEmptyRender()).toEqual(false);
     expect(icon.exists()).toEqual(false);
   });
 });

--- a/src/components/table/draggable-table-cell/__spec__.js
+++ b/src/components/table/draggable-table-cell/__spec__.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import DraggableTableCell from './draggable-table-cell';
 import TableCell from './../table-cell';
 import WithDrag from './../../drag-and-drop/with-drag';
@@ -27,5 +27,16 @@ describe('DraggableTableCell', () => {
   it('renders an icon', () => {
     let icon = wrapper.find(Icon);
     expect(icon.props().type).toEqual('drag_vertical');
+  });
+
+  it('does not render on last row', () => {
+    wrapper = shallow(
+      <DraggableTableCell identifier="foo" canDrag={ false }/>
+    );
+    let icon = wrapper.find(Icon);
+    //expect(icon.props().type).toEqual(true);
+    //expect(icon.props().className).toEqual('<span />');
+    //expect(wrapper.isEmptyRender()).toEqual(false);
+    expect(icon.exists()).toEqual(false);
   });
 });

--- a/src/components/table/draggable-table-cell/draggable-table-cell.js
+++ b/src/components/table/draggable-table-cell/draggable-table-cell.js
@@ -25,7 +25,7 @@ const DraggableTableCell = (props) => {
     <WithDrag
       identifier={ props.identifier }
       draggableNode={ props.draggableNode }
-      canDrag={ canDrag }
+      canDrag={ () => { return canDrag; } }
     >
       { canDrag ? iconHTML : <span /> }
     </WithDrag>

--- a/src/components/table/draggable-table-cell/draggable-table-cell.js
+++ b/src/components/table/draggable-table-cell/draggable-table-cell.js
@@ -25,7 +25,7 @@ const DraggableTableCell = (props) => {
     <WithDrag
       identifier={ props.identifier }
       draggableNode={ props.draggableNode }
-      canDrag={ () => { return canDrag; } }
+      canDrag={ canDrag }
     >
       { canDrag ? iconHTML : <span /> }
     </WithDrag>

--- a/src/components/table/draggable-table-cell/draggable-table-cell.js
+++ b/src/components/table/draggable-table-cell/draggable-table-cell.js
@@ -40,7 +40,8 @@ const DraggableTableCell = (props) => {
 
 DraggableTableCell.propTypes = {
   identifier: PropTypes.string, // used to associate WithDrags and WithDrops
-  draggableNode: PropTypes.func // A function that returns the dom node used as the ghost layer when dragging
+  draggableNode: PropTypes.func, // A function that returns the dom node used as the ghost layer when dragging
+  canDrag: PropTypes.func // used to specify whether the dragging is currently allowed
 };
 
 export default DraggableTableCell;

--- a/src/components/table/draggable-table-cell/draggable-table-cell.js
+++ b/src/components/table/draggable-table-cell/draggable-table-cell.js
@@ -41,7 +41,7 @@ const DraggableTableCell = (props) => {
 DraggableTableCell.propTypes = {
   identifier: PropTypes.string, // used to associate WithDrags and WithDrops
   draggableNode: PropTypes.func, // A function that returns the dom node used as the ghost layer when dragging
-  canDrag: PropTypes.func // used to specify whether the dragging is currently allowed
+  canDrag: PropTypes.bool // used to specify whether the dragging is currently allowed
 };
 
 export default DraggableTableCell;

--- a/src/components/table/draggable-table-cell/draggable-table-cell.js
+++ b/src/components/table/draggable-table-cell/draggable-table-cell.js
@@ -19,12 +19,15 @@ const iconHTML = (
  * @constructor
  */
 const DraggableTableCell = (props) => {
+  const canDrag = props.canDrag !== false;
+
   const icon = (
     <WithDrag
       identifier={ props.identifier }
       draggableNode={ props.draggableNode }
+      canDrag={ () => { return canDrag; } }
     >
-      { iconHTML }
+      { canDrag ? iconHTML : <span /> }
     </WithDrag>
   );
 

--- a/src/components/table/table-row/__spec__.js
+++ b/src/components/table/table-row/__spec__.js
@@ -472,7 +472,7 @@ describe('TableRow', () => {
     describe('with drag and drop context', () => {
       beforeEach(() => {
         wrapper = mount(
-          <DraggableContext onDrag={ () => {} }>
+          <DraggableContext onDrag={ () => {} } canDrop={ () => { return true } }>
             <Table>
               <TableRow index={ 0 } dragAndDropIdentifier="foo">
                 <TableCell>foo</TableCell>
@@ -486,12 +486,14 @@ describe('TableRow', () => {
         let cell = wrapper.find(TableRow).find(DraggableTableCell);
         expect(cell.props().identifier).toEqual("foo");
         expect(cell.props().draggableNode().getAttribute('class')).toEqual('carbon-table-row');
+        expect(cell.props().canDrag).toEqual(true);
       });
 
       it('renders a WithDrop component', () => {
         let wd = wrapper.find(WithDrop);
         expect(wd.props().index).toEqual(0);
         expect(wd.props().identifier).toEqual("foo");
+        expect(wd.props().canDrop()).toEqual(true);
       });
 
       it('renders a dragging class', () => {

--- a/src/components/table/table-row/table-row.js
+++ b/src/components/table/table-row/table-row.js
@@ -141,7 +141,15 @@ class TableRow extends React.Component {
      * @property dragAndDropIdentifier
      * @type {String}
      */
-    dragAndDropIdentifier: PropTypes.string
+    dragAndDropIdentifier: PropTypes.string,
+
+    /**
+     * Used to determine if line is empty or not
+     *
+     * @property hideDrag
+     * @type {Boolean}
+     */
+    hideDrag: PropTypes.bool
   }
 
   static safeProps = ['onClick']

--- a/src/components/table/table-row/table-row.js
+++ b/src/components/table/table-row/table-row.js
@@ -428,6 +428,7 @@ class TableRow extends React.Component {
       <DraggableTableCell
         identifier={ this.props.dragAndDropIdentifier }
         draggableNode={ () => { return this._row; } }
+        canDrag={ !this.props.hideDrag }
       />
     );
   }
@@ -448,6 +449,7 @@ class TableRow extends React.Component {
       <WithDrop
         identifier={ this.props.dragAndDropIdentifier }
         index={ this.props.index }
+        canDrop={ () => { return !this.props.hideDrag; } }
       >
         { row }
       </WithDrop>


### PR DESCRIPTION
# Description
Extending functionality to determine if a an item can be dropped on. This fixes an issue where line items could be dragged below the last existing line item, causing an issue shown in the screenshot below.

Before:
![screen shot 2018-06-27 at 10 33 54](https://user-images.githubusercontent.com/32874307/41979739-b5821d34-7a1c-11e8-9bf3-92896d50a5eb.png)

After:
![screen shot 2018-06-27 at 15 16 55](https://user-images.githubusercontent.com/32874307/41980032-65d4bc0a-7a1d-11e8-8db2-40f3d2be743c.png)


# TODO
- [x] Release notes

# Testing Instructions