### PR TITLE
Addressing erroneous title attribute in Pod component

### DIFF
--- a/change_log/next/CARBON-1079.yml
+++ b/change_log/next/CARBON-1079.yml
@@ -1,0 +1,1 @@
+  Bug Fixes: "the Pod component was refactored to resolve the issue of its title property being incorrectly applied as an attribute to the containing div element in the Pod component"

--- a/src/components/pod/__spec__.js
+++ b/src/components/pod/__spec__.js
@@ -355,17 +355,6 @@ describe('Pod', () => {
     });
   });
 
-  describe("titleIsString", () => {
-    it("returns false if title is not a string", () => {
-      instance = TestUtils.renderIntoDocument(<Pod title={ undefined } />);
-      expect(instance.titleIsString()).toEqual(false);
-    });
-    it("returns true if title is object", () => {
-      instance = TestUtils.renderIntoDocument(<Pod title='testing' />);
-      expect(instance.titleIsString()).toEqual(true);
-    });
-  });
-
   describe('render', () => {
     it('applies all props to the pod', () => {
       instance = TestUtils.renderIntoDocument(<Pod data-foo="bar" />);
@@ -375,8 +364,7 @@ describe('Pod', () => {
 
     it('does not apply title prop to containing elements', () => {
       const wrapper = shallow(<Pod title="some-title" />);
-      const re = /title=\"some-title\"/;
-      expect(wrapper.html().match(re)).toBeNull();
+      expect(wrapper.is('[title]')).toBe(false);
     });
 
     describe('pod content', () => {

--- a/src/components/pod/__spec__.js
+++ b/src/components/pod/__spec__.js
@@ -373,6 +373,12 @@ describe('Pod', () => {
       expect(div.attributes['data-foo'].value).toEqual("bar");
     });
 
+    it('does not apply title prop to containing elements', () => {
+      const wrapper = shallow(<Pod title="some-title" />);
+      const re = /title=\"some-title\"/;
+      expect(wrapper.html().match(re)).toBeNull();
+    });
+
     describe('pod content', () => {
       describe('when pod is closed', () => {
         it('does not render the pods content', () => {

--- a/src/components/pod/pod.js
+++ b/src/components/pod/pod.js
@@ -285,15 +285,6 @@ class Pod extends React.Component {
     );
   }
 
-  /**
-   * Checks that the title is a string rather than something else as it can be JSX
-   *
-   * @method titleIsString
-   * @return {Boolean}
-   */
-  titleIsString = () => {
-    return typeof this.props.title === 'string';
-  }
 
   /**
    * Toggles the opening and closing of the pod

--- a/src/components/pod/pod.js
+++ b/src/components/pod/pod.js
@@ -525,10 +525,6 @@ class Pod extends React.Component {
 
     delete props.className;
 
-    if (this.titleIsString()) {
-      props.title = this.props.title;
-    }
-
     if (!this.state.collapsed) { content = this.podContent; }
 
     if (this.shouldContentHaveEditProps) {


### PR DESCRIPTION
# Description
This PR is a fix for issue #1709.  There were a few lines of code in the render function that was causing a title attribute, equal to the title prop passed to the Pod component, to be added to the Pod component's containing div element.  I removed that bit of code and added a test case that ensures none of the html elements that are rendered has a title attribute equal to that of the title property passed to the Pod component.  

# TODO
N/A

# Related Issues / Pull Requests
N/A

# Screenshots / Gifs
N/A

# Testing Instructions
Either run npm test or run npm start and go to http://localhost:8095/components/pod .  Fill out the title field in the Pod form.  Hover mouse above the generated pod component to ensure the title attribute tooltip does not appear.  

# Important note
When I pulled master and ran tests there was one failing test case from commit 12d43b7f89031a6d739fe78fd5f93cb6677e9b23 .  It was a test case in the spec for the Date component.  Here is the output, 

Summary of all failing tests
 FAIL  src/components/date/__spec__.js (8.844s)
  ● Date › emitOnChangeCallback › on valid value › sets the hiddenField to the new date

    expect(received).toEqual(expected)

    Expected value to equal:
      "2018-08-09"
    Received:
      "2018-08-08"

      130 | 
      131 |       it('sets the hiddenField to the new date', () => {
    > 132 |         expect(instance.hidden.value).toEqual(date);
          |                                       ^
      133 |       });
      134 | 
      135 |       it('triggers the onChange handler in the input decorator', () => {

      at Object.<anonymous> (src/components/date/__spec__.js:132:39)
