### PR TITLE
Extending DropdownFilterAjax component to accept additional http headers

### DIFF
--- a/change_log/next/dropdown_filter_ajax_header.yml
+++ b/change_log/next/dropdown_filter_ajax_header.yml
@@ -1,0 +1,1 @@
+Improvement: "DropdownFilterAjax: Allow to use the “Accept: application/json” HTTP header when making requests"

--- a/src/components/dropdown-filter-ajax/dropdown-filter-ajax.js
+++ b/src/components/dropdown-filter-ajax/dropdown-filter-ajax.js
@@ -241,6 +241,7 @@ class DropdownFilterAjax extends DropdownFilter {
       .get(this.props.path)
       .query(this.getParams(query, page))
       .query(this.props.additionalRequestParams)
+      .set('Accept', 'application/json')
       .end(this.ajaxUpdateList);
   }
 


### PR DESCRIPTION
# Description
Extending the DropdownFilterAjax component to allow the use of the “Accept: application/json” HTTP header when making requests. 

# TODO
- [ ] Release notes

# Related Issues / Pull Requests
https://github.com/Sage/carbon/pull/1796 PR

# Testing Instructions
Was sanity tested as part of - https://github.com/Sage/carbon/pull/1796