### PR TITLE
updated Alert to render a Dialog instead of extend it

### DIFF
--- a/change_log/next/CARBON-1818.yml
+++ b/change_log/next/CARBON-1818.yml
@@ -1,0 +1,1 @@
+Other: "[CARBON-1818](https://github.com/Sage/carbon/issues/1818) - Updated Alert to not extend Dialog, but render a Dialog instead."

--- a/src/components/alert/__definition__.js
+++ b/src/components/alert/__definition__.js
@@ -21,7 +21,6 @@ let definition = new Definition('alert', Alert, {
     size: OptionsHelper.sizesFull
   },
   propValues: {
-    ariaRole: 'alertdialog',
     title: 'Attention!',
     children: 'This is an example of a alert.'
   },

--- a/src/components/alert/__snapshots__/__spec__.js.snap
+++ b/src/components/alert/__snapshots__/__spec__.js.snap
@@ -1,87 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Alert include correct component, element and role data tags 1`] = `
-<Portal
-  key="1"
->
-  <div
-    className="carbon-dialog"
-    data-component="alert"
-    data-element="bar"
-    data-role="baz"
-    data-state="open"
-  >
-    <CSSTransitionGroup
-      component="div"
-      transitionAppear={true}
-      transitionAppearTimeout={500}
-      transitionEnter={true}
-      transitionEnterTimeout={500}
-      transitionLeave={true}
-      transitionLeaveTimeout={500}
-      transitionName="modal-background"
-    >
-      <div
-        className="carbon-modal__background"
-      />
-    </CSSTransitionGroup>
-    <CSSTransitionGroup
-      component="div"
-      transitionAppear={true}
-      transitionAppearTimeout={500}
-      transitionEnter={true}
-      transitionEnterTimeout={500}
-      transitionLeave={true}
-      transitionLeaveTimeout={500}
-      transitionName="modal"
-    >
-      <div
-        aria-describedby="carbon-dialog-subtitle"
-        aria-labelledby="carbon-dialog-title"
-        className="carbon-dialog__dialog carbon-dialog__dialog--extra-small carbon-alert__alert"
-        data-component="alert"
-        data-element="bar"
-        data-role="baz"
-        onBlur={[Function]}
-        role="dialog"
-        style={
-          Object {
-            "minHeight": undefined,
-          }
-        }
-        tabIndex={0}
-      >
-        <div
-          className="carbon-dialog__title carbon-dialog__title--has-subheader"
-        >
-          <Heading
-            divider={true}
-            separator={false}
-            subheader="Alert Subtitle"
-            subtitleId="carbon-dialog-subtitle"
-            title="Alert title"
-            titleId="carbon-dialog-title"
-          />
-        </div>
-        <div
-          className="carbon-dialog__content"
-        >
-          <div
-            className="carbon-dialog__inner-content"
-            style={Object {}}
-          />
-        </div>
-        <Icon
-          bgSize="small"
-          className="carbon-dialog__close"
-          data-element="close"
-          onBlur={[Function]}
-          onClick={[Function]}
-          tabIndex="0"
-          type="close"
-        />
-      </div>
-    </CSSTransitionGroup>
-  </div>
-</Portal>
+<Dialog
+  ariaRole="dialog"
+  autoFocus={true}
+  className="carbon-alert"
+  componentTag="alert"
+  data-element="bar"
+  data-role="baz"
+  onCancel={[Function]}
+  open={true}
+  showCloseIcon={true}
+  size="extra-small"
+  subtitle="Alert Subtitle"
+  title="Alert title"
+/>
 `;

--- a/src/components/alert/__spec__.js
+++ b/src/components/alert/__spec__.js
@@ -1,67 +1,22 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import Alert from './alert';
-import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
-
-/* global jest */
 
 describe('Alert', () => {
-  let wrapper;
-  let onCancel = jasmine.createSpy('cancel');
-
-  beforeEach(() => {
-    wrapper = shallow(
+  const renderShallow = () => (
+    shallow(
       <Alert
         open
-        onCancel={ onCancel }
+        onCancel={ () => {} }
         title='Alert title'
         subtitle='Alert Subtitle'
         data-element='bar'
         data-role='baz'
       />
-    );
-  });
+    )
+  );
 
   it('include correct component, element and role data tags', () => {
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  describe('keyboard focus', () => {
-    let wrapper;
-    let mockEvent;
-
-    beforeEach(() => {
-      wrapper = mount(
-        <Alert open title='Test' subtitle='Test' showCloseIcon={ false } />
-      );
-
-      mockEvent = {
-        preventDefault() {}
-      };
-
-      jest.useFakeTimers();
-    });
-
-    it('remains on the dialog if open and no close icon is shown', () => {
-      const instance = wrapper.instance();
-      spyOn(mockEvent, 'preventDefault');
-      spyOn(instance, 'focusDialog');
-
-      instance.onDialogBlur(mockEvent);
-      jest.runTimersToTime(10);
-      expect(mockEvent.preventDefault).toHaveBeenCalled();
-      expect(instance.focusDialog).toHaveBeenCalled();
-    });
-
-    it('does not remain on the dialog if close icon is shown', () => {
-      wrapper.setProps({
-        showCloseIcon: true
-      });
-
-      spyOn(mockEvent, 'preventDefault');
-
-      wrapper.instance().onDialogBlur(mockEvent);
-      expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-    });
+    expect(renderShallow()).toMatchSnapshot();
   });
 });

--- a/src/components/alert/alert.js
+++ b/src/components/alert/alert.js
@@ -1,82 +1,21 @@
+import React from 'react';
 import classNames from 'classnames';
-import { assign } from 'lodash';
 import Dialog from '../dialog';
 
 /**
- * A Alert widget.
- *
- * == How to use a Alert in a component:
- *
- * In your file
- *
- *   import Alert from 'carbon/lib/components/alert';
- *
- * To render a Alert:
- *
- *   <Alert onCancel={ customEventHandler } open={ false }/>
- *
- * The component rendering the Alert must pass down a prop of 'open' in order to open the alert.
- *
- * You need to provide a custom cancel event handler to handle a close event.
- *
- * @class Alert
- * @constructor
+ * Alert component - used to display system messages, similar to a JavaScript `alert('message')`.
  */
-class Alert extends Dialog {
-  static defaultProps = assign({}, Dialog.defaultProps, {
-    role: 'alertdialog',
-    size: 'extra-small'
-  })
+const Alert = props => (
+  <Dialog
+    { ...props }
+    className={ classNames('carbon-alert', props.className) }
+    componentTag='alert'
+  />
+);
 
-  constructor(props) {
-    super(props);
-    // focusDialog is called via setTimeout in onDialogBlur,
-    // so it needs binding to this
-    // From the React docs: "Generally, if you refer to a method without () after
-    // it, such as onClick={this.handleClick}, you should bind that method."
-    this.focusDialog = this.focusDialog.bind(this);
-  }
-
-  /**
-   * Returns classes for the alert, combines with dialog class names..
-   *
-   * @method dialogClasses
-   */
-  get dialogClasses() {
-    return classNames(
-      super.dialogClasses,
-      'carbon-alert__alert'
-    );
-  }
-
-  componentTags(props) {
-    return {
-      'data-component': 'alert',
-      'data-element': props['data-element'],
-      'data-role': props['data-role']
-    };
-  }
-
-  /**
-   * Handles keyboard focus leaving the dialog
-   * element.
-   *
-   * Assumes that, if no close icon is displayed,
-   * no other element can receive keyboard focus.
-   * Therefore focus should remain on the dialog
-   * element while it is open.
-   *
-   * @override
-   * @return {Void}
-   */
-  onDialogBlur(ev) {
-    if (!this.props.showCloseIcon) {
-      ev.preventDefault();
-      // Firefox loses focus unless we wrap the call to
-      // this.focusDialog in setTimeout
-      setTimeout(this.focusDialog);
-    }
-  }
-}
+Alert.defaultProps = {
+  'data-role': 'alertdialog',
+  size: 'extra-small'
+};
 
 export default Alert;

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -335,7 +335,7 @@ class Dialog extends Modal {
 
   componentTags(props) {
     return {
-      'data-component': 'dialog',
+      'data-component': props['componentTag'] || 'dialog',
       'data-element': props['data-element'],
       'data-role': props['data-role']
     };

--- a/src/components/flash/__snapshots__/__spec__.js.snap
+++ b/src/components/flash/__snapshots__/__spec__.js.snap
@@ -74,14 +74,11 @@ exports[` 1`] = `
       </CSSTransitionGroup>
     </div>
     <Alert
-      ariaRole="dialog"
-      autoFocus={true}
       data-element="info-dialog"
+      data-role="alertdialog"
       key="bun"
       onCancel={[Function]}
       open={false}
-      role="alertdialog"
-      showCloseIcon={true}
       size="extra-small"
       title="bun"
     >


### PR DESCRIPTION
Alert now renders a Dialog, instead of extending it - see https://github.com/Sage/carbon/issues/1818