### PR TITLE
Modal js refactor

### DIFF
--- a/src/components/dialog/__spec__.js
+++ b/src/components/dialog/__spec__.js
@@ -120,6 +120,35 @@ describe('Dialog', () => {
           });
         });
       });
+
+      describe('when Dialog is closed and listening', () => {
+        beforeEach(() => {
+          jest.useFakeTimers();
+          mockWindow = {
+            addEventListener() {},
+            removeEventListener() {},
+            getComputedStyle() { return {} }
+          };
+          wrapper = mount(
+            <Dialog onCancel={ onCancel } />
+          );
+          instance = wrapper.instance();
+        });
+
+        afterEach(() => {
+          jest.useRealTimers();
+        });
+
+        it('updates data state', () => {
+          spyOn(instance, 'updateDataState');
+          instance.listening = true;
+          instance._innerContent = {};
+          wrapper.setProps({ title: 'Dialog title' });
+          jest.runAllTimers();
+          expect(instance.updateDataState).toHaveBeenCalled();
+        });
+
+      });
     });
   });
 

--- a/src/components/dialog/__spec__.js
+++ b/src/components/dialog/__spec__.js
@@ -106,18 +106,6 @@ describe('Dialog', () => {
           expect(instance.centerDialog).toHaveBeenCalled();
         });
 
-        it('sets up event listeners to resize and close the dialog', () => {
-          const instance = wrapper.instance();
-          spyOn(ElementResize, 'addListener');
-          spyOn(mockWindow, 'addEventListener');
-
-          wrapper.setProps({ title: 'Dialog title' });
-          jest.runAllTimers();
-          expect(mockWindow.addEventListener.calls.count()).toEqual(2);
-          expect(mockWindow.addEventListener).toHaveBeenCalledWith('resize', instance.centerDialog);
-          expect(mockWindow.addEventListener).toHaveBeenCalledWith('keyup', instance.closeModal);
-          expect(ElementResize.addListener).toHaveBeenCalledWith(instance._innerContent, instance.applyFixedBottom);
-        });
 
         describe('when the dialog is already listening', () => {
           it('does not set up event listeners', () => {
@@ -130,28 +118,6 @@ describe('Dialog', () => {
             expect(mockWindow.addEventListener).not.toHaveBeenCalled();
             expect(mockWindow.addEventListener).not.toHaveBeenCalled();
           });
-        });
-      });
-
-      describe('when the dialog is closed', () => {
-        beforeEach(() => {
-          wrapper = mount(
-            <Dialog open={ true } onCancel={ onCancel } stickyFormFooter />
-          );
-          instance = wrapper.instance();
-          instance.listening = true;
-        });
-
-        it('removes event listeners for resize and closing', () => {
-          const instance = wrapper.instance();
-          spyOn(ElementResize, 'removeListener');
-          spyOn(mockWindow, 'removeEventListener');
-          wrapper.setProps({ open: false });
-
-          expect(mockWindow.removeEventListener.calls.count()).toEqual(2);
-          expect(mockWindow.removeEventListener).toHaveBeenCalledWith('resize', instance.centerDialog);
-          expect(mockWindow.removeEventListener).toHaveBeenCalledWith('keyup', instance.closeModal);
-          expect(ElementResize.removeListener).toHaveBeenCalledWith(instance._innerContent, instance.applyFixedBottom);
         });
       });
     });

--- a/src/components/modal/__spec__.js
+++ b/src/components/modal/__spec__.js
@@ -5,11 +5,61 @@ import Events from './../../utils/helpers/events';
 import Browser from './../../utils/helpers/browser';
 
 describe('Modal', () => {
-  let wrapper, onCancel;
+  let wrapper, onCancel, mockWindow;
+
+  describe('componentDidMount', () => {
+    beforeEach(() => {
+      mockWindow = {
+        addEventListener() {},
+        removeEventListener() {}
+      };
+      jest.useFakeTimers();
+      wrapper = shallow(
+        <Modal open onCancel={ onCancel } />
+      );
+      spyOn(Browser, 'getWindow').and.returnValue(mockWindow);
+      spyOn(mockWindow, 'addEventListener');
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('binds the key event listener to the window', () => {
+      wrapper.instance().componentDidMount();
+          expect(mockWindow.addEventListener.calls.count()).toEqual(1);
+          expect(mockWindow.addEventListener).toHaveBeenCalled();
+    });
+
+  });
+  
+  describe('componentWillUnmount', () => {
+    beforeEach(() => {
+      mockWindow = {
+        addEventListener() {},
+        removeEventListener() {}
+      };
+      jest.useFakeTimers();
+      wrapper = shallow(
+        <Modal open onCancel={ onCancel } />
+      );
+      spyOn(Browser, 'getWindow').and.returnValue(mockWindow);
+      spyOn(mockWindow, 'removeEventListener');
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('binds the key event listener to the window', () => {
+      wrapper.instance().componentWillUnmount();
+          expect(mockWindow.removeEventListener.calls.count()).toEqual(1);
+          expect(mockWindow.removeEventListener).toHaveBeenCalled();
+    });
+
+  });
 
   describe('componentDidUpdate', () => {
-    let mockWindow;
-
     beforeEach(() => {
       mockWindow = {
         addEventListener() {},
@@ -30,15 +80,6 @@ describe('Modal', () => {
 
       afterEach(() => {
         jest.useRealTimers();
-      });
-
-      it('sets up event listeners to resize and close the modal', () => {
-        spyOn(mockWindow, 'addEventListener');
-
-        wrapper.instance().componentDidUpdate();
-        jest.runAllTimers();
-        expect(mockWindow.addEventListener.calls.count()).toEqual(1);
-        expect(mockWindow.addEventListener).toHaveBeenCalledWith('keyup', wrapper.instance().closeModal);
       });
 
       it('clears the opentimeout and sets data state to open', () => {
@@ -67,14 +108,6 @@ describe('Modal', () => {
         wrapper = shallow(
           <Modal onCancel={ onCancel } />
         );
-      });
-
-      it('removes event listeners for resize and closing', () => {
-        spyOn(mockWindow, 'removeEventListener');
-        wrapper.instance().listening = true;
-        wrapper.instance().componentDidUpdate();
-        expect(mockWindow.removeEventListener.calls.count()).toEqual(1);
-        expect(mockWindow.removeEventListener).toHaveBeenCalledWith('keyup', wrapper.instance().closeModal);
       });
 
       it('clears the opentimeout and sets data state to closed', () => {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -153,24 +153,41 @@ class Modal extends React.Component {
   }
 
   /**
+   * A lifecycle method to update the component after it is mounted
+   *
+   * @method componentWillMount
+   * @return {void}
+   */
+  componentWillMount() {
+    Browser.getWindow().addEventListener('keyup', this.closeModal);
+  }
+
+  /**
+   * A lifecycle method to update the component after it is unmounted
+   *
+   * @method componentWillUnmount
+   * @return {void}
+   */
+  componentWillUnmount() {
+    Browser.getWindow().removeEventListener('keyup', this.closeModal);
+  }
+
+
+  /**
    * A lifecycle method to update the component after it is re-rendered
    *
    * @method componentDidUpdate
    * @return {void}
    */
   componentDidUpdate() {
-    const _window = Browser.getWindow();
-
     if (this.props.open && !this.listening) {
       this.listening = true;
       this.updateDataState();
       this.onOpening; // eslint-disable-line no-unused-expressions
-      _window.addEventListener('keyup', this.closeModal);
     } else if (!this.props.open && this.listening) {
       this.listening = false;
       this.updateDataState();
       this.onClosing; // eslint-disable-line no-unused-expressions
-      _window.removeEventListener('keyup', this.closeModal);
     }
   }
 
@@ -182,7 +199,7 @@ class Modal extends React.Component {
    * @return {void}
    */
   closeModal = (ev) => {
-    if (this.props.onCancel && !this.props.disableEscKey && Events.isEscKey(ev)) {
+    if (this.props.open && this.props.onCancel && !this.props.disableEscKey && Events.isEscKey(ev)) {
       this.props.onCancel();
     }
   }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -155,15 +155,15 @@ class Modal extends React.Component {
   /**
    * A lifecycle method to update the component after it is mounted
    *
-   * @method componentWillMount
+   * @method componentDidMount
    * @return {void}
    */
-  componentWillMount() {
+  componentDidMount() {
     Browser.getWindow().addEventListener('keyup', this.closeModal);
   }
 
   /**
-   * A lifecycle method to update the component after it is unmounted
+   * A lifecycle method to update the component when it is unmounted
    *
    * @method componentWillUnmount
    * @return {void}

--- a/src/components/sidebar/__spec__.js
+++ b/src/components/sidebar/__spec__.js
@@ -50,14 +50,6 @@ describe('Sidebar', () => {
         instance = wrapper.instance();
       });
 
-      it('sets up event listeners to resize and close the Sidebar', () => {
-        spyOn(mockWindow, 'addEventListener');
-        wrapper.setProps({ title: 'Sidebar title' });
-
-        expect(mockWindow.addEventListener.calls.count()).toEqual(1);
-        expect(mockWindow.addEventListener).toHaveBeenCalledWith('keyup', instance.closeModal);
-      });
-
       describe('when the Sidebar is already listening', () => {
         it('does not set up event listeners', () => {
           spyOn(mockWindow, 'addEventListener');
@@ -67,23 +59,6 @@ describe('Sidebar', () => {
           expect(mockWindow.addEventListener.calls.count()).toEqual(0);
           expect(mockWindow.addEventListener).not.toHaveBeenCalled();
         });
-      });
-    });
-
-    describe('when the Sidebar is closed', () => {
-      beforeEach(() => {
-        wrapper = mount(
-          <Sidebar onCancel={ spy } />
-        );
-        instance = wrapper.instance();
-        instance.listening = true;
-      });
-
-      it('removes event listeners for resize and closing', () => {
-        spyOn(mockWindow, 'removeEventListener');
-        wrapper.setProps({ title: 'Remove event handlers' });
-        expect(mockWindow.removeEventListener.calls.count()).toEqual(1);
-        expect(mockWindow.removeEventListener).toHaveBeenCalledWith('keyup', instance.closeModal);
       });
     });
   });


### PR DESCRIPTION
# Description

The modal element was refactored to simplify its event binding mechnanisms. Previously it was handled in `componentDidUpdate` method which proved to be stable for most, but not all cases.
Now the binding of 'keyup' event was split into `componentDidMount` & `componentWillUnmount` to make sure that the binding is there regardless of the props. The check that assured that only opened component is closed was moved to `closeModal` method.

# TODO
- [ ] Release notes

# Related Issues / Pull Requests

# Screenshots / Gifs

# Testing Instructions
