### PR TITLE
Add missing release step

### DIFF
--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -9,15 +9,15 @@
 * Commit and push changes.
 
 * If releasing a minor version:
-*   Open a PR to `master`.
-*   Merge PR into `master`
-*   Raise PR to merge `master` into `release`
-*   Merge PR into `release`
-*   Cut new version from `release`
+    * Open a PR to `master`.
+    * Merge PR into `master`
+    * Raise PR to merge `master` into `release`
+    * Merge PR into `release`
+    * Cut new version from `release`
 
 * If releasing a patch version, open a PR to `release`.
-*   Open a PR to `release`.
-*   Merge PR into `release`
+    * Open a PR to `release`.
+    * Merge PR into `release`
 
 * Once merged, publish a release in GitHub using the new version number as the tag. Make sure to target the correct branch (`release`). This will auto-deploy to npm. (relase should be published from `release`)
 * If you have released from a branch other than `master`, open a PR to merge that branch back into `master`.

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -9,14 +9,14 @@
 * Commit and push changes.
 
 * If releasing a minor version:
-    * Open a PR to `master`.
+    * Open a PR to `master`
     * Merge PR into `master`
     * Raise PR to merge `master` into `release`
     * Merge PR into `release`
     * Cut new version from `release`
 
-* If releasing a patch version, open a PR to `release`.
-    * Open a PR to `release`.
+* If releasing a patch version:
+    * Open a PR to `release`
     * Merge PR into `release`
 
 * Once merged, publish a release in GitHub using the new version number as the tag. Make sure to target the correct branch (`release`). This will auto-deploy to npm. (relase should be published from `release`)

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -7,7 +7,17 @@
 * Bump the version in `package.json`.
 * Generate Release Notes using the provided script `./script/generate-release-notes.sh` - please note this relies on [renogen](https://github.com/DDAZZA/renogen).
 * Commit and push changes.
-* If releasing a minor version, open a PR to `master`.
+
+* If releasing a minor version:
+*   Open a PR to `master`.
+*   Merge PR into `master`
+*   Raise PR to merge `master` into `release`
+*   Merge PR into `release`
+*   Cut new version from `release`
+
 * If releasing a patch version, open a PR to `release`.
-* Once merged, publish a release in GitHub using the new version number as the tag. Make sure to target the correct branch (`master` or `release`). This will auto-deploy to npm.
+*   Open a PR to `release`.
+*   Merge PR into `release`
+
+* Once merged, publish a release in GitHub using the new version number as the tag. Make sure to target the correct branch (`release`). This will auto-deploy to npm. (relase should be published from `release`)
 * If you have released from a branch other than `master`, open a PR to merge that branch back into `master`.


### PR DESCRIPTION
# Description

After doing a minor version release, @chrisbarber86 and me noticed that there is a missing step in release step document.

Missing step was `PR to merge master into release` after release a minor version from master.

Also we think that releases should be always cut from `release`