### PR TITLE
DropdownFilter/Ajax Improvements: Add additional prop to filter ajax and allow clearing of selection

### DIFF
--- a/change_log/next/add-ability-to-clear-dropdown-filter.yml
+++ b/change_log/next/add-ability-to-clear-dropdown-filter.yml
@@ -1,0 +1,1 @@
+New Features: "DropdownFilter/Ajax improvement: When clearing the dropdown in full, it now clears the selection."

--- a/change_log/next/add-ability-to-clear-dropdown-filter.yml
+++ b/change_log/next/add-ability-to-clear-dropdown-filter.yml
@@ -1,1 +1,1 @@
-New Features: "DropdownFilter/Ajax improvement: When clearing the dropdown in full, it now clears the selection."
+New Features: "DropdownFilter and DropdownFilterAjax improvement: When clearing the dropdown in full, it now clears the selection."

--- a/change_log/next/add-option-to-pass-cookies.yml
+++ b/change_log/next/add-option-to-pass-cookies.yml
@@ -1,0 +1,1 @@
+New Features: "DropdownFilterAjax improvement: Add the ability to pass cookies when making an ajax request."

--- a/src/components/dropdown-filter-ajax/__definition__.js
+++ b/src/components/dropdown-filter-ajax/__definition__.js
@@ -27,7 +27,8 @@ let definition = new Definition('dropdown-filter-ajax', DropdownFilterAjax, {
     path: "String",
     rowsPerRequest: "String",
     visibleValue: "String",
-    additionalRequestParams: "Object"
+    additionalRequestParams: "Object",
+    withCredentials: "Boolean"
   },
   propValues: {
     path: '/countries'

--- a/src/components/dropdown-filter-ajax/__definition__.js
+++ b/src/components/dropdown-filter-ajax/__definition__.js
@@ -45,7 +45,8 @@ let definition = new Definition('dropdown-filter-ajax', DropdownFilterAjax, {
     path: "The path to make ajax requests to.",
     rowsPerRequest: "How many items to get per request.",
     visibleValue: "The visible value to display in the input.",
-    additionalRequestParams: "Add additional params to the server request"
+    additionalRequestParams: "Add additional params to the server request",
+    withCredentials: "Enable the ability to send cookies from the origin"
   }
 });
 

--- a/src/components/dropdown-filter-ajax/__spec__.js
+++ b/src/components/dropdown-filter-ajax/__spec__.js
@@ -291,6 +291,30 @@ describe('DropdownFilterAjax', () => {
         });
       });
     });
+
+    describe('when the param withCredentials is passed', () => {
+      beforeEach(() => {
+        instance = TestUtils.renderIntoDocument(
+          <DropdownFilterAjax
+            name="foo"
+            value="1"
+            path="/foobar"
+            create={ function() {} }
+            withCredentials
+            additionalRequestParams={ {foo: 'bar'} }
+          />
+        );
+      });
+
+      it('calls with credentials', () => {
+        Request.query = jest.fn().mockReturnThis();
+        Request.withCredentials = jest.fn();
+        instance.ajaxUpdateList = jest.fn();
+
+        instance.getData("foo", 1);
+        expect(Request.withCredentials).toHaveBeenCalled();
+      });
+    });
   });
 
   describe('resetScroll', () => {

--- a/src/components/dropdown-filter-ajax/__spec__.js
+++ b/src/components/dropdown-filter-ajax/__spec__.js
@@ -301,7 +301,7 @@ describe('DropdownFilterAjax', () => {
             path="/foobar"
             create={ function() {} }
             withCredentials
-            additionalRequestParams={ {foo: 'bar'} }
+            additionalRequestParams={ { foo: 'bar' } }
           />
         );
       });

--- a/src/components/dropdown-filter-ajax/dropdown-filter-ajax.js
+++ b/src/components/dropdown-filter-ajax/dropdown-filter-ajax.js
@@ -165,7 +165,15 @@ class DropdownFilterAjax extends DropdownFilter {
      * @property suggest
      * @type {Boolean}
      */
-    suggest: PropTypes.bool
+    suggest: PropTypes.bool,
+
+    /**
+     * Enable the ability to send cookies from the origin.
+     *
+     * @property withCredentials
+     * @type: {Boolean}
+     */
+    withCredentials: PropTypes.bool
   }), 'options');
 
   static defaultProps = {
@@ -246,12 +254,14 @@ class DropdownFilterAjax extends DropdownFilter {
    */
   getData = (query = '', page = 1) => {
     this.setState({ requesting: true });
-    Request
+    const request = Request
       .get(this.props.path)
       .query(this.getParams(query, page))
       .query(this.props.additionalRequestParams)
-      .set('Accept', this.props.acceptHeader)
-      .end(this.ajaxUpdateList);
+      .set('Accept', this.props.acceptHeader);
+
+    if (this.props.withCredentials) request.withCredentials();
+    request.end(this.ajaxUpdateList);
   }
 
   /**

--- a/src/components/dropdown-filter/__spec__.js
+++ b/src/components/dropdown-filter/__spec__.js
@@ -185,9 +185,35 @@ describe('DropdownFilter', () => {
         );
         spyOn(instance, 'emitOnChangeCallback');
         TestUtils.Simulate.change(instance._input, {
-          target: { value: 'foo' }
+          target: { value: '' }
         });
-        expect(instance.emitOnChangeCallback).toHaveBeenCalledWith("", 'foo');
+        expect(instance.emitOnChangeCallback).toHaveBeenCalledWith("", '');
+      });
+    });
+
+    describe('when the value is cleared by the user', () => {
+      it('triggers emitOnChangeCallback', () => {
+        instance = TestUtils.renderIntoDocument(
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="1" />
+        );
+        spyOn(instance, 'emitOnChangeCallback');
+        TestUtils.Simulate.change(instance._input, {
+          target: { value: '' }
+        });
+        expect(instance.emitOnChangeCallback).toHaveBeenCalledWith('', '');
+      });
+    });
+
+    describe('when the value is partially cleared by the user', () => {
+      it('does not trigger emitOnChangeCallback', () => {
+        instance = TestUtils.renderIntoDocument(
+          <DropdownFilter name="foo" options={ Immutable.fromJS([]) } value="Foo bar" />
+        );
+        spyOn(instance, 'emitOnChangeCallback');
+        TestUtils.Simulate.change(instance._input, {
+          target: { value: 'Foo b' }
+        });
+        expect(instance.emitOnChangeCallback).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/components/dropdown-filter/__spec__.js
+++ b/src/components/dropdown-filter/__spec__.js
@@ -185,9 +185,9 @@ describe('DropdownFilter', () => {
         );
         spyOn(instance, 'emitOnChangeCallback');
         TestUtils.Simulate.change(instance._input, {
-          target: { value: '' }
+          target: { value: 'foo' }
         });
-        expect(instance.emitOnChangeCallback).toHaveBeenCalledWith("", '');
+        expect(instance.emitOnChangeCallback).toHaveBeenCalledWith("", 'foo');
       });
     });
 

--- a/src/components/dropdown-filter/dropdown-filter.js
+++ b/src/components/dropdown-filter/dropdown-filter.js
@@ -199,13 +199,8 @@ class DropdownFilter extends Dropdown {
 
     this.openingList = false;
 
-    if (this.props.create) {
+    if (this.props.create || !ev.target.value.length) {
       // if create is enabled then empty the selected value so the filter persists
-      this.emitOnChangeCallback('', ev.target.value);
-    }
-
-    if (ev.target.value.length <= 0) {
-      // When the input is cleared, remove the selection.
       this.emitOnChangeCallback('', ev.target.value);
     }
   }

--- a/src/components/dropdown-filter/dropdown-filter.js
+++ b/src/components/dropdown-filter/dropdown-filter.js
@@ -203,6 +203,11 @@ class DropdownFilter extends Dropdown {
       // if create is enabled then empty the selected value so the filter persists
       this.emitOnChangeCallback('', ev.target.value);
     }
+
+    if (ev.target.value.length <= 0) {
+      // When the input is cleared, remove the selection.
+      this.emitOnChangeCallback('', ev.target.value);
+    }
   }
 
   /*


### PR DESCRIPTION
# Description
### Additional prop
When making network requests using the dropdown-filter-ajax component, we require the ability to pass cookies in the network request.
To allow developers to control this during implementation, we have added a Boolean prop of withCredentials.

### Ability to clear selected value
When a user clears the selected value in the dropdown filter or dropdown filter ajax it should trigger the onchange event to clear the selection.

# Testing Instructions
Testing to be done during an integration with another application.
Due to the way the mock is setup for drop down filter ajax, it is not doing successful network requests on selection.