### PR TITLE
DropdownFilterAjax: Add the option to pass cookies with ajax call

### DIFF
--- a/change_log/next/add-option-to-pass-cookies.yml
+++ b/change_log/next/add-option-to-pass-cookies.yml
@@ -1,0 +1,1 @@
+New Features: "DropdownFilterAjax improvement: Add the ability to pass cookies when making an ajax request."

--- a/change_log/next/add-withCredentials-dropdownfilterajax.yml
+++ b/change_log/next/add-withCredentials-dropdownfilterajax.yml
@@ -1,0 +1,1 @@
+New Features: "DropdownFilterAjax improvement: Add the ability to pass cookies when making an ajax request."

--- a/src/components/dropdown-filter-ajax/__definition__.js
+++ b/src/components/dropdown-filter-ajax/__definition__.js
@@ -27,7 +27,8 @@ let definition = new Definition('dropdown-filter-ajax', DropdownFilterAjax, {
     path: "String",
     rowsPerRequest: "String",
     visibleValue: "String",
-    additionalRequestParams: "Object"
+    additionalRequestParams: "Object",
+    withCredentials: "Boolean"
   },
   propValues: {
     path: '/countries'

--- a/src/components/dropdown-filter-ajax/__spec__.js
+++ b/src/components/dropdown-filter-ajax/__spec__.js
@@ -291,6 +291,30 @@ describe('DropdownFilterAjax', () => {
         });
       });
     });
+
+    describe('when the param withCredentials is passed', () => {
+      beforeEach(() => {
+        instance = TestUtils.renderIntoDocument(
+          <DropdownFilterAjax
+            name="foo"
+            value="1"
+            path="/foobar"
+            create={ function() {} }
+            withCredentials
+            additionalRequestParams={ {foo: 'bar'} }
+          />
+        );
+      });
+
+      it('calls with credentials', () => {
+        Request.query = jest.fn().mockReturnThis();
+        Request.withCredentials = jest.fn();
+        instance.ajaxUpdateList = jest.fn();
+
+        instance.getData("foo", 1);
+        expect(Request.withCredentials).toHaveBeenCalled();
+      });
+    });
   });
 
   describe('resetScroll', () => {

--- a/src/components/dropdown-filter-ajax/dropdown-filter-ajax.js
+++ b/src/components/dropdown-filter-ajax/dropdown-filter-ajax.js
@@ -165,7 +165,15 @@ class DropdownFilterAjax extends DropdownFilter {
      * @property suggest
      * @type {Boolean}
      */
-    suggest: PropTypes.bool
+    suggest: PropTypes.bool,
+
+    /**
+     * Enable the ability to send cookies from the origin.
+     *
+     * @property withCredentials
+     * @type: {Boolean}
+     */
+    withCredentials: PropTypes.bool
   }), 'options');
 
   static defaultProps = {
@@ -246,12 +254,14 @@ class DropdownFilterAjax extends DropdownFilter {
    */
   getData = (query = '', page = 1) => {
     this.setState({ requesting: true });
-    Request
+    const request = Request
       .get(this.props.path)
       .query(this.getParams(query, page))
       .query(this.props.additionalRequestParams)
-      .set('Accept', this.props.acceptHeader)
-      .end(this.ajaxUpdateList);
+      .set('Accept', this.props.acceptHeader);
+
+    if (this.props.withCredentials) request.withCredentials();
+    request.end(this.ajaxUpdateList);
   }
 
   /**


### PR DESCRIPTION
# Description
Add withCredentials prop to DropdownFilterAjax to allow for the passing of cookies in the request.

# Testing Instructions
Testing to be done as part of the integration within an application as the demo site mocks the api call.