### PR TITLE
Initial look at step sequence components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
   "globals": {
     "jest": false,
     "global": false,
-    "process": false
+    "process": false,
+    "test": false
   }
 }

--- a/demo/actions/component/component.js
+++ b/demo/actions/component/component.js
@@ -51,15 +51,18 @@ const ComponentActions = {
       .end((err, res) => {
         const data = res.body;
 
-        window.Dispatcher.dispatch({
-          actionType: window.ComponentConstants.UPDATE_TABLE,
-          items: data.rows,
-          records: String(data.records),
-          sortOrder: opts.sortOrder,
-          sortedColumn: opts.sortedColumn,
-          page: String(data.current_page),
-          pageSize
-        });
+        if (data) {
+          window.Dispatcher.dispatch({
+            actionType: window.ComponentConstants.UPDATE_TABLE,
+            items: data.rows,
+            records: String(data.records),
+            sortOrder: opts.sortOrder,
+            sortedColumn: opts.sortedColumn,
+            page: String(data.current_page),
+            pageSize
+          });
+        }
+
       });
   },
 

--- a/demo/main.js
+++ b/demo/main.js
@@ -20,6 +20,7 @@ import SubPageChrome from './views/chrome/sub-page-chrome';
 import Home from './views/pages/home';
 import Sandbox from './views/pages/sandbox';
 import News from './views/pages/news';
+import PlayArea from './views/pages/play-area';
 import SiteMap from './site-map';
 
 global.Carbon = {
@@ -36,6 +37,8 @@ const routes = (
 
     <Route component={ Chrome }>
       <Route path='/' component={ Home } />
+
+      <Route path='/play-area' component={ PlayArea } />
 
       <Route component={ SubPageChrome }>
         { SiteMap.generateRoutes() }

--- a/demo/views/pages/play-area/__snapshots__/play-area.spec.js.snap
+++ b/demo/views/pages/play-area/__snapshots__/play-area.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PlayArea /> basic render 1`] = `
+<div
+  className="carbon-play-area"
+/>
+`;

--- a/demo/views/pages/play-area/package.json
+++ b/demo/views/pages/play-area/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./play-area.js",
+  "style": "./play-area.scss"
+}

--- a/demo/views/pages/play-area/play-area.js
+++ b/demo/views/pages/play-area/play-area.js
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import WizardWrapperStub from './wizard-wrapper-stub';
+
+import './play-area.scss';
+
+const PlayArea = props => (
+  <div className='carbon-play-area'>
+    <WizardWrapperStub />
+  </div>
+);
+
+PlayArea.propTypes = {};
+
+export default PlayArea;

--- a/demo/views/pages/play-area/play-area.scss
+++ b/demo/views/pages/play-area/play-area.scss
@@ -1,0 +1,9 @@
+.carbon-play-area {
+  height: 90vh;
+}
+
+.demo-footer,
+.demo-menu,
+.demo-header {
+  display: none;
+}

--- a/demo/views/pages/play-area/play-area.spec.js
+++ b/demo/views/pages/play-area/play-area.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import PlayArea from './play-area';
+
+describe('<PlayArea />', () => {
+  let playArea;
+
+  beforeAll(() => {
+    playArea = shallow(
+      <PlayArea />
+    );
+  });
+
+  test('basic render', () => {
+    expect(playArea).toMatchSnapshot();
+  });
+});

--- a/demo/views/pages/play-area/wizard-wrapper-stub/__snapshots__/wizard-wrapper-stub.spec.js.snap
+++ b/demo/views/pages/play-area/wizard-wrapper-stub/__snapshots__/wizard-wrapper-stub.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<WizardWrapperStub /> basic render 1`] = `
+<div
+  className="demo-wizard-wrapper-stub"
+>
+  <Wizard />
+</div>
+`;

--- a/demo/views/pages/play-area/wizard-wrapper-stub/package.json
+++ b/demo/views/pages/play-area/wizard-wrapper-stub/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./wizard-wrapper-stub.js",
+  "style": "./wizard-wrapper-stub.scss"
+}

--- a/demo/views/pages/play-area/wizard-wrapper-stub/wizard-wrapper-stub.js
+++ b/demo/views/pages/play-area/wizard-wrapper-stub/wizard-wrapper-stub.js
@@ -1,0 +1,65 @@
+import Button from 'components/button';
+import React from 'react';
+import Wizard from 'components/wizard';
+
+class WizardWrapperStub extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      steps: [
+        { label: 'foo', state: 'complete' },
+        { label: 'bar', state: 'current' },
+        { label: 'baz', state: 'incomplete' }
+      ],
+      current: 2
+    };
+  }
+
+  setStepState = current => (step, i) => {
+    let state = 'incomplete';
+    if (current === i) { state = 'current'; }
+    if (current > i) { state = 'complete'; }
+    console.log({ state, label: step.label });
+    return { state, label: step.label };
+  };
+
+  previous = () => {
+    let { current, steps } = this.state;
+
+    current = current === 0 ? 0 : current - 1;
+
+    steps = steps.map(this.setStepState(current));
+
+    this.setState({ current, steps });
+  }
+
+  next = () => {
+    let { current } = this.state;
+    let { steps } = this.state;
+
+    current = current === steps.length - 1 ? current : current + 1;
+
+    steps = steps.map(this.setStepState(current));
+
+    this.setState({ current, steps });
+  }
+
+  render() {
+    return (
+      <div className='demo-wizard-wrapper-stub'>
+        <Wizard { ...this.state }>
+          <div>Step 1</div>
+          <div>Step 2</div>
+          <div>Step 3</div>
+        </Wizard>
+
+        <div className='demo-wizard-wrapper-stub__buttons'>
+          <Button onClick={ this.previous }>Previous</Button>
+          <Button onClick={ this.next }>Next</Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default WizardWrapperStub;

--- a/demo/views/pages/play-area/wizard-wrapper-stub/wizard-wrapper-stub.scss
+++ b/demo/views/pages/play-area/wizard-wrapper-stub/wizard-wrapper-stub.scss
@@ -1,0 +1,11 @@
+.demo-wizard-wrapper-stub {
+  > * {
+    margin-bottom: 30px;
+  }
+
+  &__buttons {
+    > * {
+      margin-right: 50px;
+    }
+  }
+}

--- a/demo/views/pages/play-area/wizard-wrapper-stub/wizard-wrapper-stub.spec.js
+++ b/demo/views/pages/play-area/wizard-wrapper-stub/wizard-wrapper-stub.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import WizardWrapperStub from './wizard-wrapper-stub';
+
+describe('<WizardWrapperStub />', () => {
+  let wizardWrapperStub;
+
+  beforeAll(() => {
+    wizardWrapperStub = shallow(
+      <WizardWrapperStub />
+    );
+  });
+
+  test('basic render', () => {
+    expect(wizardWrapperStub).toMatchSnapshot();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -4970,12 +4970,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4990,17 +4992,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5117,7 +5122,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5129,6 +5135,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5143,6 +5150,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5150,12 +5158,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5174,6 +5184,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5254,7 +5265,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5266,6 +5278,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5387,6 +5400,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/components/wizard/__snapshots__/wizard.spec.js.snap
+++ b/src/components/wizard/__snapshots__/wizard.spec.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Wizard /> basic render 1`] = `
+<div
+  className="carbon-wizard"
+>
+  <div
+    className="carbon-wizard__steps"
+  >
+    <StepSequence
+      current="1"
+      steps={
+        Array [
+          Object {
+            "label": "foo",
+            "state": "complete",
+          },
+          Object {
+            "label": "bar",
+            "state": "current",
+          },
+          Object {
+            "label": "baz",
+            "state": "incomplete",
+          },
+        ]
+      }
+    />
+  </div>
+  <div
+    className="carbon-wizard__content"
+  >
+    <div>
+      Step 2
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/wizard/package.json
+++ b/src/components/wizard/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "./wizard.js"
+}

--- a/src/components/wizard/step-sequence-item/__snapshots__/step-sequence-item.spec.js.snap
+++ b/src/components/wizard/step-sequence-item/__snapshots__/step-sequence-item.spec.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<StepSequenceItem /> basic render 1`] = `
+<li
+  className="carbon-step-sequence-item"
+>
+  <span>
+    2
+  </span>
+  <span>
+    bar
+  </span>
+</li>
+`;
+
+exports[`<StepSequenceItem /> completed render 1`] = `
+<li
+  className="carbon-step-sequence-item"
+>
+  <span>
+    <Icon
+      bgSize="small"
+      type="tick"
+    />
+  </span>
+  <span>
+    bar
+  </span>
+</li>
+`;

--- a/src/components/wizard/step-sequence-item/package.json
+++ b/src/components/wizard/step-sequence-item/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./step-sequence-item.js",
+  "style": "./step-sequence-item.scss"
+}

--- a/src/components/wizard/step-sequence-item/step-sequence-item.js
+++ b/src/components/wizard/step-sequence-item/step-sequence-item.js
@@ -1,0 +1,22 @@
+import Icon from 'components/icon';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const stepMarker = (state, number) => {
+  return state === 'complete' ? <Icon type='tick' /> : number;
+};
+
+const StepSequenceItem = ({ label, state, stepNumber }) => (
+  <li className='carbon-step-sequence-item'>
+    <span>{ stepMarker(state, stepNumber) }</span>
+    <span>{ label }</span>
+  </li>
+);
+
+StepSequenceItem.propTypes = {
+  label: PropTypes.string,
+  state: PropTypes.string,
+  stepNumber: PropTypes.number
+};
+
+export default StepSequenceItem;

--- a/src/components/wizard/step-sequence-item/step-sequence-item.scss
+++ b/src/components/wizard/step-sequence-item/step-sequence-item.scss
@@ -1,0 +1,3 @@
+.carbon-step-sequence-item {
+
+}

--- a/src/components/wizard/step-sequence-item/step-sequence-item.spec.js
+++ b/src/components/wizard/step-sequence-item/step-sequence-item.spec.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import StepSequenceItem from './step-sequence-item';
+
+describe('<StepSequenceItem />', () => {
+  let stepSequenceItem;
+
+  beforeAll(() => {
+    stepSequenceItem = shallow(
+      <StepSequenceItem
+        state='foo'
+        label='bar'
+        stepNumber={ 2 }
+      />
+    );
+  });
+
+  test('basic render', () => {
+    expect(stepSequenceItem).toMatchSnapshot();
+  });
+
+  test('completed render', () => {
+    stepSequenceItem.setProps({ state: 'complete' });
+    expect(stepSequenceItem).toMatchSnapshot();
+  });
+});

--- a/src/components/wizard/step-sequence/__snapshots__/step-sequence.spec.js.snap
+++ b/src/components/wizard/step-sequence/__snapshots__/step-sequence.spec.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<StepSequence /> basic render 1`] = `
+<ol
+  className="carbon-step-sequence"
+>
+  <StepSequenceItem
+    key="foo0"
+    label="foo"
+    state="complete"
+    stepNumber={1}
+  />
+  <StepSequenceItem
+    key="bar1"
+    label="bar"
+    state="current"
+    stepNumber={2}
+  />
+  <StepSequenceItem
+    key="baz2"
+    label="baz"
+    state="incomplete"
+    stepNumber={3}
+  />
+</ol>
+`;

--- a/src/components/wizard/step-sequence/package.json
+++ b/src/components/wizard/step-sequence/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./step-sequence.js",
+  "style": "./step-sequence.scss"
+}

--- a/src/components/wizard/step-sequence/step-sequence.js
+++ b/src/components/wizard/step-sequence/step-sequence.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import StepSequenceItem from '../step-sequence-item';
+
+const stepSequenceItems = (step, index) => {
+  const { label, state } = step;
+  const props = {
+    label,
+    state,
+    stepNumber: index + 1,
+    key: label + index
+  };
+  return <StepSequenceItem { ...props } />;
+};
+
+const StepSequence = ({ steps }) => (
+  <ol className='carbon-step-sequence'>
+    { steps.map(stepSequenceItems) }
+  </ol>
+);
+
+StepSequence.propTypes = {
+  steps: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      state: PropTypes.string
+    })
+  )
+};
+
+export default StepSequence;

--- a/src/components/wizard/step-sequence/step-sequence.scss
+++ b/src/components/wizard/step-sequence/step-sequence.scss
@@ -1,0 +1,3 @@
+.carbon-step-sequence {
+
+}

--- a/src/components/wizard/step-sequence/step-sequence.spec.js
+++ b/src/components/wizard/step-sequence/step-sequence.spec.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import StepSequence from './step-sequence';
+
+describe('<StepSequence />', () => {
+  let stepSequence;
+
+  beforeAll(() => {
+    stepSequence = shallow(
+      <StepSequence
+        current='1'
+        steps={ [
+          { label: 'foo', state: 'complete' },
+          { label: 'bar', state: 'current' },
+          { label: 'baz', state: 'incomplete' }
+        ] }
+      />
+    );
+  });
+
+  test('basic render', () => {
+    expect(stepSequence).toMatchSnapshot();
+  });
+});

--- a/src/components/wizard/wizard.js
+++ b/src/components/wizard/wizard.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import StepSequence from './step-sequence';
+
+const Wizard = ({ children, current, steps }) => (
+  <div className='carbon-wizard'>
+    <div className='carbon-wizard__steps'>
+      <StepSequence { ...{ current, steps } } />
+    </div>
+    <div className='carbon-wizard__content'>
+      { children[current] }
+    </div>
+  </div>
+);
+
+Wizard.propTypes = {
+  children: PropTypes.array,
+  current: PropTypes.number,
+  steps: PropTypes.array
+};
+
+export default Wizard;

--- a/src/components/wizard/wizard.spec.js
+++ b/src/components/wizard/wizard.spec.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Wizard from './wizard';
+
+describe('<Wizard />', () => {
+  let wizard;
+
+  beforeAll(() => {
+    wizard = shallow(
+      <Wizard
+        steps={ [
+          { label: 'foo', state: 'complete' },
+          { label: 'bar', state: 'current' },
+          { label: 'baz', state: 'incomplete' }
+        ] }
+        current='1'
+      >
+        <div>Step 1</div>
+        <div>Step 2</div>
+        <div>Step 3</div>
+      </Wizard>
+    );
+  });
+
+  test('basic render', () => {
+    expect(wizard).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Step sequence component wrapped in a wizard, with a demo site page 'play-area' into which it's been added.

There's also some basic state management so it should react to clicks of the buttons

Intending to help with the [issue about step sequences](https://github.com/Sage/carbon/issues/1865)

![steps](https://user-images.githubusercontent.com/10499070/48784337-623d2480-ecda-11e8-85c7-59b97e53268a.gif)

Load carbon and visit: http://0.0.0.0:8095/play-area to see