### PR TITLE
[blue-icon-fix] SCSS adjustment to disable helplink Icon color change

### DIFF
--- a/change_log/next/blue-icon.yml
+++ b/change_log/next/blue-icon.yml
@@ -1,0 +1,1 @@
+Minor Improvements: "Disabled the icon color change on helplink"

--- a/src/components/help/help.scss
+++ b/src/components/help/help.scss
@@ -17,4 +17,8 @@
     color: $blue;
     text-decoration: underline;
   }
+  
+  &:visited {
+    color: $grey-dark-blue-50;
+  }
 }


### PR DESCRIPTION
# Description

The Icon with a href had a misbehaviour of changing color, when the link it has has been clicked. I was told it was undesirable, so I applied this small SCSS patch to make the Icon color constant. 

# TODO
- [x] Release notes
- [ ] UX Approval
- [ ] Review
- [ ] QA

# Screenshots / Gifs
Before:
![before blue](https://user-images.githubusercontent.com/29885246/49146538-a8117280-f302-11e8-831c-f47d5965177a.gif)

After:
![icon after](https://user-images.githubusercontent.com/29885246/49146544-aa73cc80-f302-11e8-9d18-110c50ed0b99.gif)
