### PR TITLE
Extending Dropdown component to allow auto completion with tab key press

### DIFF
--- a/change_log/next/dropdown-tab-autocomplete.yml
+++ b/change_log/next/dropdown-tab-autocomplete.yml
@@ -1,0 +1,1 @@
+Improvements: "Extending dropdown component to allow for autocompletion with tab"

--- a/src/components/dropdown/__spec__.js
+++ b/src/components/dropdown/__spec__.js
@@ -500,6 +500,39 @@ describe('Dropdown', () => {
         });
       });
 
+      describe('if tab key', () => {
+        let spy, opts;
+
+        beforeEach(() => {
+          spyOn(instance, 'selectValue');
+          spy = jasmine.createSpy();
+          opts = { which: 9, preventDefault: spy };
+        });
+
+        describe('if something is highlighted', () => {
+          beforeEach(() => {
+            instance.setState({ highlighted: 1 });
+            TestUtils.Simulate.keyDown(instance._input, opts);
+          });
+
+          it('prevents default', () => {
+            expect(spy).toHaveBeenCalled();
+          });
+
+          it('calls setValue', () => {
+            expect(instance.selectValue).toHaveBeenCalledWith('1', 'foo');
+          });
+        });
+
+        describe('if something is not highlighted', () => {
+          it('does not prevent default', () => {
+            instance.setState({ highlighted: 'abc' }); // value which does not exist
+            TestUtils.Simulate.keyDown(instance._input, opts);
+            expect(spy).not.toHaveBeenCalled();
+          });
+        });
+      });
+
       describe('up arrow', () => {
         let spy, opts;
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -382,7 +382,7 @@ const Dropdown = Input(InputIcon(InputLabel(InputValidation(class Dropdown exten
     let nextVal;
 
     switch (ev.which) {
-      case 13: // return
+      case 9: case 13: // tab key or return key
         if (element) {
           ev.preventDefault();
           this.selectValue(element.getAttribute('value'), element.textContent);


### PR DESCRIPTION
# Description
Extending Dropdown component to allow users auto completion of selected items within the dropdown with the press of a tab button

# TODO
- [x] Release notes

# Screenshots / Gifs
Autocompletion of Ledger Accounts with tab presses
![tab](https://user-images.githubusercontent.com/32874307/49218435-559a8980-f3c8-11e8-8c2c-c5f3900faf5e.gif)


# Testing Instructions
Test Dropdown/Dropdown Filter/ Dropdown Filter Ajax components to see if the tab key autocompletes selected items.