### PR TITLE
Fixes #1868 - boolean warning from Form component

### DIFF
--- a/change_log/next/1868.yml
+++ b/change_log/next/1868.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "[#1868](https://github.com/Sage/carbon/issues/1868) - Fixes a boolean warning error that `Form` was rendering incorrectly."

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -886,7 +886,7 @@ function generateCSRFToken(doc) {
   return (
     <input
       type='hidden' name={ csrfAttr }
-      value={ csrfValue } readOnly='true'
+      value={ csrfValue } readOnly
     />
   );
 }

--- a/src/components/show-edit-pod/__snapshots__/__spec__.js.snap
+++ b/src/components/show-edit-pod/__snapshots__/__spec__.js.snap
@@ -111,7 +111,7 @@ exports[`ShowEditPod edit form props where onDelete is provided should get throu
                           >
                             <input
                               name=""
-                              readOnly="true"
+                              readOnly={true}
                               type="hidden"
                               value=""
                             />


### PR DESCRIPTION
Fixes #1868 

Fixes a warning from triggering in development where a boolean value was being used a string.