### PR TITLE
Allow consumers to set custom headers when using DropdownFilterAjax and TableAjax

### DIFF
--- a/src/components/dropdown-filter-ajax/__spec__.js
+++ b/src/components/dropdown-filter-ajax/__spec__.js
@@ -531,6 +531,27 @@ describe('DropdownFilterAjax', () => {
       });
     });
 
+    describe('when setting headers', () => {
+      it('sets headers using getCustomHeaders prop', () => {
+        const headers = { 'Accepts': 'application/json', 'jwt': 'very secret stuff' };
+        const mockGetCustomHeaders = () => { return headers };
+
+        wrapper.setProps({
+          getCustomHeaders: mockGetCustomHeaders
+        });
+
+        expect(
+          wrapper.instance().getHeaders()
+        ).toEqual(headers)
+      });
+
+      it('sets default accept header without getCustomHeaders prop', () => {
+        expect(
+          wrapper.instance().getHeaders()
+        ).toEqual({"Accept": "application/json"})
+      });
+    });
+
     describe('when props contains a formatResponse function', () => {
       it('calls formatResponse', () => {
         let expectedResponse = {

--- a/src/components/dropdown-filter-ajax/dropdown-filter-ajax.js
+++ b/src/components/dropdown-filter-ajax/dropdown-filter-ajax.js
@@ -168,6 +168,22 @@ class DropdownFilterAjax extends DropdownFilter {
     formatRequest: PropTypes.func,
 
     /**
+     * A callback function used to set the Ajax
+     * headers using custom ones provided by the consumer
+     *
+     * Expected return object format
+     * {
+        'Accepts': 'application/json',
+        'jwt': 'secret',
+        ...
+       }
+     *
+     * @property getCustomHeaders
+     * @type {Function}
+     */
+    getCustomHeaders: PropTypes.func,
+
+    /**
      * Should the dropdown act and look like a suggestable input instead.
      *
      * @property suggest
@@ -292,7 +308,7 @@ class DropdownFilterAjax extends DropdownFilter {
       .get(this.props.path)
       .query(this.getParams(query, page))
       .query(this.props.additionalRequestParams)
-      .set('Accept', this.props.acceptHeader);
+      .set(this.getHeaders());
 
     if (this.props.withCredentials) this.pendingRequest.withCredentials();
     this.pendingRequest.end(this.ajaxUpdateList);
@@ -312,6 +328,15 @@ class DropdownFilterAjax extends DropdownFilter {
       return this.props.formatRequest(params);
     }
     return params;
+  }
+
+  /**
+   * Retrieve headers to use for the request
+   *
+   * @method getHeaders
+   */
+  getHeaders = () => {
+    return this.props.getCustomHeaders ? this.props.getCustomHeaders() : { 'Accept': this.props.acceptHeader };
   }
 
   /**

--- a/src/components/table-ajax/__spec__.js
+++ b/src/components/table-ajax/__spec__.js
@@ -385,6 +385,27 @@ describe('TableAjax', () => {
         ).toEqual('foo=bar')
       });
     });
+
+    describe('when setting headers', () => {
+      it('sets headers using getCustomHeaders prop', () => {
+        const headers = { 'Accepts': 'application/json', 'jwt': 'very secret stuff' };
+        const mockGetCustomHeaders = () => { return headers };
+
+        wrapper.setProps({
+          getCustomHeaders: mockGetCustomHeaders
+        });
+
+        expect(
+          wrapper.instance().getHeaders()
+        ).toEqual(headers)
+      });
+
+      it('sets default accept header without getCustomHeaders prop', () => {
+        expect(
+          wrapper.instance().getHeaders()
+        ).toEqual({"Accept": "application/json"})
+      });
+    });
   });
 
   describe('handleResponse', () => {

--- a/src/components/table-ajax/table-ajax.js
+++ b/src/components/table-ajax/table-ajax.js
@@ -59,6 +59,22 @@ class TableAjax extends Table {
     formatRequest: PropTypes.func,
 
     /**
+     * A callback function used to set the Ajax
+     * headers using custom ones provided by the consumer
+     *
+     * Expected return object format
+     * {
+        'Accepts': 'application/json',
+        'jwt': 'secret',
+        ...
+       }
+     *
+     * @property getCustomHeaders
+     * @type {Function}
+     */
+    getCustomHeaders: PropTypes.func,
+
+    /**
      * A callback function used to format the Ajax
      * response into the format required by the table
      *
@@ -329,7 +345,7 @@ class TableAjax extends Table {
       });
       this._request = Request
         .get(this.props.path)
-        .set('Accept', 'application/json')
+        .set(this.getHeaders())
         .query(this.queryParams(element, options))
         .end((err, response) => {
           this._hasRetreivedData = true;
@@ -399,6 +415,15 @@ class TableAjax extends Table {
       return serialize(this.props.formatRequest(query));
     }
     return serialize(query);
+  }
+
+  /**
+   * Retrieve headers to use for the request
+   *
+   * @method getHeaders
+   */
+  getHeaders = () => {
+    return this.props.getCustomHeaders ? this.props.getCustomHeaders() : { 'Accept': 'application/json' };
   }
 
   /**


### PR DESCRIPTION
# Description
- Allow custom headers to be set when using `DropdownFilterAjax` or `TableAjax`.
- Useful for consumers that require more headers to be set when using the components, for example a `JWT` header.
- Falls back to the default `Accept: application/json` header if no override is provided.
- `Superagent` supports setting headers using a Javascript object, therefore the override expects an object to be returned.

# TODO
- [x] Release notes
- [x] Integration test in demo site
