### PR TITLE
FE-1196 fixes timezone bug with datepickers

### DIFF
--- a/change_log/next/FE-1196_bug_fix.yml
+++ b/change_log/next/FE-1196_bug_fix.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Fixes bug FE-1196 where date inputs display incorrect date when in different timezones"

--- a/src/utils/helpers/date/date.js
+++ b/src/utils/helpers/date/date.js
@@ -66,7 +66,7 @@ const DateHelper = {
    */
   formatDateString: (value, formatTo) => {
     return (
-      moment(new Date(value).getTime()).format(formatTo)
+      moment.utc(new Date(value).getTime()).format(formatTo)
     );
   },
 


### PR DESCRIPTION
# Description

Fixes Bug FE-1196 where users in western timezones would see date and date range components display values for the day before when using the text input and tabbing out.
