### PR TITLE
i18n peer dep

### DIFF
--- a/change_log/next/FE-1279-i18n-peer-dep.yml
+++ b/change_log/next/FE-1279-i18n-peer-dep.yml
@@ -1,1 +1,6 @@
-Dependency Updates: "We have changed i18n-js into a peer dependency. This means developers will need to install and manage which version of i18n-js they want to use in their own applications. We have done this as some applications using Carbon require an older version of i18n-js, while some would like to use newer versions."
+Dependency Updates: |
+  We have changed i18n-js into a peer dependency. This means developers will need to install and manage which version of i18n-js they want to use in their own applications. We have done this as some applications using Carbon require an older version of i18n-js, while some would like to use newer versions.
+
+  To use the version previously supplied by Carbon, add the following to your `package.json`
+
+  "i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc12.tar.gz"

--- a/change_log/next/FE-1279-i18n-peer-dep.yml
+++ b/change_log/next/FE-1279-i18n-peer-dep.yml
@@ -1,0 +1,1 @@
+Dependency Updates: "We have changed i18n-js into a peer dependency. This means developers will need to install and manage which version of i18n-js they want to use in their own applications. We have done this as some applications using Carbon require an older version of i18n-js, while some would like to use newer versions."

--- a/package-lock.json
+++ b/package-lock.json
@@ -9554,7 +9554,8 @@
     },
     "i18n-js": {
       "version": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc12.tar.gz",
-      "integrity": "sha512-XTmESzet0wu29yhGkl6VA9OpvXRtDOKI7jSNJNmkiR9FNdcHU8euwieqh5SLktIqOlMe1uYaqo3rjpedZE2QLA=="
+      "integrity": "sha512-XTmESzet0wu29yhGkl6VA9OpvXRtDOKI7jSNJNmkiR9FNdcHU8euwieqh5SLktIqOlMe1uYaqo3rjpedZE2QLA==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/Sage/carbon#readme",
   "peerDependencies": {
     "flux": "^3.1.1",
+    "i18n-js": "^3.0.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"
   },
@@ -64,6 +65,7 @@
     "enzyme-adapter-react-16": "1.7.1",
     "flux": "^3.1.1",
     "highlight.js": "~9.6.0",
+    "i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc12.tar.gz",
     "jest-styled-components": "^6.3.1",
     "moxios": "^0.4.0",
     "raf": "^3.4.0",
@@ -86,7 +88,6 @@
     "events": "~1.1.1",
     "form-serialize": "~0.7.0",
     "highcharts": "~5.0.2",
-    "i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc12.tar.gz",
     "immutable": "~3.8.1",
     "lodash": "^4.17.11",
     "marked": "~0.3.9",


### PR DESCRIPTION
We have changed i18n-js into a peer dependency. This means developers will need to install and manage which version of i18n-js they want to use in their own applications. We have done this as some applications using Carbon require an older version of i18n-js, while some would like to use newer versions.