### PR TITLE
MenuListItem SCSS import fix

### DIFF
--- a/change_log/next/menu-list-item-style-fix.yml
+++ b/change_log/next/menu-list-item-style-fix.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Fixes an SCSS error in menu list item"

--- a/src/components/menu-list/menu-list-item/menu-list-item.scss
+++ b/src/components/menu-list/menu-list-item/menu-list-item.scss
@@ -1,4 +1,4 @@
-@import 'colors.scss';
+@import "./../../../style-config/colors";
 
 .carbon-menu-list-item {
   font-size: 16px;


### PR DESCRIPTION
# Description
When I tried to import the MenuListItem component I got the following error from Webpack:
```ERROR in projectDir/node_modules/carbon-react/lib/components/menu-list/menu-list-item/menu-list-item.scss (projectDir/node_modules/css-loader!projectDir/node_modules/sass-loader/lib/loader.js!projectDir/node_modules/carbon-react/lib/components/menu-list/menu-list-item/menu-list-item.scss)
Module build failed (from projectDir/node_modules/sass-loader/lib/loader.js):

@import 'colors.scss';
^
      File to import not found or unreadable: colors.scss.
      in projectDir/node_modules/carbon-react/lib/components/menu-list/menu-list-item/menu-list-item.scss (line 1, column 1)
 @ projectDir/node_modules/carbon-react/lib/components/menu-list/menu-list-item/menu-list-item.scss 2:14-124
 @ projectDir/node_modules/carbon-react/lib/components/menu-list/menu-list-item/menu-list-item.js
 @ ./src/component/left-list.tsx
 @ ./src/component/index.tsx
 @ ./src/index.tsx
 @ multi (webpack)-dev-server/client?http://localhost:3000 ./src/index.tsx
```

The menu-list-item.scss file imported colors file in a different way the other scss files, so I changed it to the "standard" way to make it work.

# TODO
- [x] Release notes

# Testing Instructions
Regression test
