### PR TITLE
Change default text-align for common input message

### DIFF
--- a/change_log/next/common-input-message.yml
+++ b/change_log/next/common-input-message.yml
@@ -1,0 +1,1 @@
+Styling Changes: 'Update text-align default for .common-input__message to left'

--- a/src/utils/decorators/input/input.scss
+++ b/src/utils/decorators/input/input.scss
@@ -136,7 +136,7 @@
   min-width: 50px;
   padding: 10px;
   position: absolute;
-  text-align: center;
+  text-align: left;
   width: 100%;
   width: fit-content;
   z-index: $z-validation-message;


### PR DESCRIPTION
# Description

Currently the `.common-input__message` style that is applied to all inputs is set to `text-align: center;`. This PR changes that to `left`. Applies to `error`, `warning` and `info` validation messages.

# TODO
- [ ] Release notes

# Screenshots / Gifs

#### Before:
<img width="550" alt="Screenshot 2019-03-18 15 40 10" src="https://user-images.githubusercontent.com/2031/54546592-e7d89480-499b-11e9-9c98-4d084f21a1af.png">

#### After:
<img width="578" alt="Screenshot 2019-03-18 16 00 24" src="https://user-images.githubusercontent.com/2031/54546625-f6bf4700-499b-11e9-9af2-c2f01e51407d.png">

# Testing Instructions
