### PR TITLE
SelectAsync default Accept header

### DIFF
--- a/change_log/v6_3_2/select-async-defaults.yml
+++ b/change_log/v6_3_2/select-async-defaults.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Sets default Accept header for SelectAsync requests to 'application/json'."

--- a/release_notes/v6_3_2.html.md
+++ b/release_notes/v6_3_2.html.md
@@ -1,3 +1,4 @@
 # v6.3.2 (2019-03-19)
 ### Bug Fixes
 * AC-3964 - Fixes event listeners from not being set up correctly on dialog mount.
+* Sets default Accept header for SelectAsync requests to 'application/json'.

--- a/src/__experimental__/components/select-async/select-async.component.js
+++ b/src/__experimental__/components/select-async/select-async.component.js
@@ -100,6 +100,9 @@ class SelectAsync extends React.Component {
         page,
         items_per_page: itemsPerPage,
         search
+      },
+      headers: {
+        Accept: 'application/json'
       }
     };
 

--- a/src/__experimental__/components/select-async/select-async.spec.js
+++ b/src/__experimental__/components/select-async/select-async.spec.js
@@ -26,6 +26,9 @@ const validRequest = ({ search, page, extra }) => ({
     page,
     search
   },
+  headers: {
+    Accept: 'application/json'
+  },
   ...extra
 });
 const mockResponse = (response) => {


### PR DESCRIPTION
Sets default Accept header for SelectAsync requests to 'application/json'.