### PR TITLE
FE-1355 - InputIconToggle Classic styling

### DIFF
--- a/src/__experimental__/components/form-field/__snapshots__/form-field.spec.js.snap
+++ b/src/__experimental__/components/form-field/__snapshots__/form-field.spec.js.snap
@@ -47,7 +47,18 @@ exports[`FormField default renders children with styling 1`] = `
 `;
 
 exports[`FormField with a label renders the label component above the childen 1`] = `
-Array [
+<ContextProvider
+  value={
+    Object {
+      "hasFocus": false,
+      "hasHover": false,
+      "onBlur": [Function],
+      "onFocus": [Function],
+      "onMouseOut": [Function],
+      "onMouseOver": [Function],
+    }
+  }
+>
   <Label
     align="left"
     help="Help me!"
@@ -56,19 +67,30 @@ Array [
     labelWidth={20}
   >
     Name
-  </Label>,
-  <input />,
-]
+  </Label>
+  <input />
+</ContextProvider>
 `;
 
 exports[`FormField with fieldHelp renders the FieldHelp component below the childen 1`] = `
-Array [
-  <input />,
+<ContextProvider
+  value={
+    Object {
+      "hasFocus": false,
+      "hasHover": false,
+      "onBlur": [Function],
+      "onFocus": [Function],
+      "onMouseOut": [Function],
+      "onMouseOver": [Function],
+    }
+  }
+>
+  <input />
   <FieldHelp
     labelInline={true}
     labelWidth={20}
   >
     Help me!
-  </FieldHelp>,
-]
+  </FieldHelp>
+</ContextProvider>
 `;

--- a/src/__experimental__/components/form-field/form-field.component.js
+++ b/src/__experimental__/components/form-field/form-field.component.js
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import FormFieldStyle from './form-field.style';
 import Label from '../label';
 import FieldHelp from '../field-help';
 import OptionsHelper from '../../../utils/helpers/options-helper';
+
+const FormFieldContext = React.createContext();
 
 const FormField = ({
   children,
@@ -14,29 +16,47 @@ const FormField = ({
   labelInline,
   labelWidth,
   size
-}) => (
-  <FormFieldStyle>
-    { label && (
-      <Label
-        align={ labelAlign }
-        help={ labelHelp }
-        inline={ labelInline }
-        inputSize={ size }
-        labelWidth={ labelWidth }
-      >
-        { label }
-      </Label>
-    ) }
+}) => {
+  const [hasHover, setHasHover] = useState(false),
+      [hasFocus, setHasFocus] = useState(false);
 
-    { children }
+  const contextForFormField = () => {
+    return {
+      hasFocus,
+      hasHover,
+      onFocus: () => setHasFocus(true),
+      onBlur: () => setHasFocus(false),
+      onMouseOver: () => setHasHover(true),
+      onMouseOut: () => setHasHover(false)
+    };
+  };
 
-    { fieldHelp && (
-      <FieldHelp labelInline={ labelInline } labelWidth={ labelWidth }>
-        { fieldHelp }
-      </FieldHelp>
-    ) }
-  </FormFieldStyle>
-);
+  return (
+    <FormFieldStyle>
+      <FormFieldContext.Provider value={ contextForFormField() }>
+        {label && (
+          <Label
+            align={ labelAlign }
+            help={ labelHelp }
+            inline={ labelInline }
+            inputSize={ size }
+            labelWidth={ labelWidth }
+          >
+            {label}
+          </Label>
+        )}
+
+        {children}
+
+        {fieldHelp && (
+          <FieldHelp labelInline={ labelInline } labelWidth={ labelWidth }>
+            {fieldHelp}
+          </FieldHelp>
+        )}
+      </FormFieldContext.Provider>
+    </FormFieldStyle>
+  );
+};
 
 FormField.defaultProps = {
   size: 'medium'
@@ -53,4 +73,4 @@ FormField.propTypes = {
   size: PropTypes.oneOf(OptionsHelper.sizesRestricted)
 };
 
-export default FormField;
+export { FormField, FormFieldContext };

--- a/src/__experimental__/components/form-field/form-field.spec.js
+++ b/src/__experimental__/components/form-field/form-field.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import 'jest-styled-components';
 import { shallow } from 'enzyme';
-import FormField from '.';
+import { FormField } from '.';
 import FormFieldStyle from './form-field.style';
 import classicTheme from '../../../style/themes/classic';
 

--- a/src/__experimental__/components/form-field/index.js
+++ b/src/__experimental__/components/form-field/index.js
@@ -1,1 +1,1 @@
-export { default } from './form-field.component';
+export { FormField, FormFieldContext } from './form-field.component';

--- a/src/__experimental__/components/input-icon-toggle/__snapshots__/input-icon-toggle.spec.js.snap
+++ b/src/__experimental__/components/input-icon-toggle/__snapshots__/input-icon-toggle.spec.js.snap
@@ -23,6 +23,7 @@ exports[`InputIconToggle when initiated with children renders as expected 1`] = 
 <span
   className="c0"
   size="medium"
+  type="settings"
 >
   mock content
 </span>

--- a/src/__experimental__/components/input-icon-toggle/input-icon-toggle-classic.style.js
+++ b/src/__experimental__/components/input-icon-toggle/input-icon-toggle-classic.style.js
@@ -1,0 +1,26 @@
+import { css } from 'styled-components';
+import { THEMES } from '../../../style/themes';
+
+export default ({
+  inputFocus, inputHover, theme, type
+}) => theme.name === THEMES.classic && css`
+  background-color: #e6ebed;
+  border-left: 1px solid #bfccd2;
+  box-sizing: border-box;
+  color: #003349;
+  cursor: pointer;
+  margin-right: -6.5px;
+  width: ${type === 'dropdown' ? '20px' : '31px'};
+
+  ${(inputHover || inputFocus) ? '' : '&:hover'} { color: #fff };
+
+  ${inputFocus ? '' : '&:hover'} {
+    background-color: #004b87;
+    border-color: #004b87;
+  }
+
+  ${inputHover && css`
+    background-color: #1963f6;
+    border-color: #1963f6;
+  `}
+`;

--- a/src/__experimental__/components/input-icon-toggle/input-icon-toggle-classic.style.js
+++ b/src/__experimental__/components/input-icon-toggle/input-icon-toggle-classic.style.js
@@ -8,7 +8,6 @@ export default ({
   border-left: 1px solid #bfccd2;
   box-sizing: border-box;
   color: #003349;
-  cursor: pointer;
   margin-right: -6.5px;
   width: ${type === 'dropdown' ? '20px' : '31px'};
 

--- a/src/__experimental__/components/input-icon-toggle/input-icon-toggle.component.js
+++ b/src/__experimental__/components/input-icon-toggle/input-icon-toggle.component.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../../../components/icon';
 import InputIconToggleStyle from './input-icon-toggle.style';
+import { InputPresentationContext } from '../input/input-presentation.component';
 
 const InputIconToggle = ({
   type,
@@ -12,9 +13,27 @@ const InputIconToggle = ({
 }) => {
   if (disabled || readOnly) return null;
 
+  const inputPresentationContext = useContext(InputPresentationContext);
+
+  const hasFocus = () => {
+    if (inputPresentationContext && inputPresentationContext.hasFocus) return inputPresentationContext.hasFocus;
+    return false;
+  };
+
+  const hasHover = () => {
+    if (inputPresentationContext && inputPresentationContext.hasHover) return inputPresentationContext.hasHover;
+    return false;
+  };
+
   return (
-    <InputIconToggleStyle key='label-icon' { ...props }>
-      { children || <Icon type={ type } /> }
+    <InputIconToggleStyle
+      key='label-icon'
+      inputFocus={ hasFocus() }
+      inputHover={ hasHover() }
+      type={ type }
+      { ...props }
+    >
+      {children || <Icon type={ type } />}
     </InputIconToggleStyle>
   );
 };

--- a/src/__experimental__/components/input-icon-toggle/input-icon-toggle.spec.js
+++ b/src/__experimental__/components/input-icon-toggle/input-icon-toggle.spec.js
@@ -1,18 +1,40 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import TestRenderer from 'react-test-renderer';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import 'jest-styled-components';
 import Icon from 'components/icon';
 import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
 import BaseTheme from '../../../style/themes/base';
 
 import InputIconToggle from './input-icon-toggle.component';
+import { InputPresentationContext } from '../input/input-presentation.component';
 
-function render(props, renderer = shallow) {
-  return renderer(
-    <InputIconToggle type='settings' { ...props } />
+const ToggleWithContext = ({ value, ...props }) => {
+  return (
+    <InputPresentationContext.Provider value={ value }>
+      <InputIconToggle type='settings' { ...props } />
+    </InputPresentationContext.Provider>
   );
-}
+};
+
+ToggleWithContext.propTypes = {
+  value: PropTypes.object
+};
+
+const render = (props, renderer = shallow, contextValue = {}) => {
+  let content;
+
+  if (renderer === shallow) {
+    content = <InputIconToggle type='settings' { ...props } />;
+  } else {
+    content = <ToggleWithContext value={ contextValue } { ...props } />;
+  }
+
+  return renderer(content);
+};
+
+const mountRender = (props, contextValue = {}) => mount(<ToggleWithContext value={ contextValue } { ...props } />);
 
 describe('InputIconToggle', () => {
   describe('when initiated with the disabled prop set to true', () => {
@@ -29,7 +51,7 @@ describe('InputIconToggle', () => {
 
   describe('when initiated without children', () => {
     it('renders an Icon component with an icon type that was specified in the props', () => {
-      expect(render({ type: 'settings' }).contains(<Icon type='settings' />)).toBeTruthy();
+      expect(mountRender({ type: 'settings' }).contains(<Icon type='settings' />)).toBeTruthy();
     });
   });
 

--- a/src/__experimental__/components/input-icon-toggle/input-icon-toggle.style.js
+++ b/src/__experimental__/components/input-icon-toggle/input-icon-toggle.style.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import BaseTheme from '../../../style/themes/base';
 import OptionsHelper from '../../../utils/helpers/options-helper';
 import sizes from '../input/input-sizes.style';
+import InputIconToggleClassicStyling from './input-icon-toggle-classic.style';
 
 const InputIconToggleStyle = styled.span`
   align-items: center;
@@ -26,6 +27,8 @@ const InputIconToggleStyle = styled.span`
     if (size === 'large') return css`width: 48px;`;
     return css`width: 40px;`;
   }}
+
+  ${InputIconToggleClassicStyling}
 `;
 
 InputIconToggleStyle.defaultProps = {
@@ -36,7 +39,10 @@ InputIconToggleStyle.defaultProps = {
 InputIconToggleStyle.propTypes = {
   error: PropTypes.string,
   info: PropTypes.string,
+  inputFocus: PropTypes.bool,
+  inputHover: PropTypes.bool,
   size: PropTypes.oneOf(OptionsHelper.sizesRestricted),
+  type: PropTypes.string,
   warning: PropTypes.string
 };
 

--- a/src/__experimental__/components/input/__snapshots__/input.spec.js.snap
+++ b/src/__experimental__/components/input/__snapshots__/input.spec.js.snap
@@ -4,12 +4,14 @@ exports[`Input renders with an input 1`] = `
 .c0 {
   background: transparent;
   border: none;
+  box-sizing: border-box;
   color: rgba(0,0,0,0.9);
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
   font-size: 14px;
+  height: 100%;
   outline: none;
   width: 30px;
 }
@@ -35,5 +37,7 @@ exports[`Input renders with an input 1`] = `
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
 />
 `;

--- a/src/__experimental__/components/input/input-presentation.component.js
+++ b/src/__experimental__/components/input/input-presentation.component.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { filterOutInputEvents } from '../../../utils/ether/ether';
 import InputPresentationStyle from './input-presentation.style';
+import { FormFieldContext } from '../form-field';
 
 const InputPresentationContext = React.createContext();
 
@@ -18,8 +19,11 @@ class InputPresentation extends React.Component {
     children: PropTypes.node
   }
 
+  static contextType = FormFieldContext;
+
   state = {
-    hasFocus: false
+    hasFocus: false,
+    hasHover: false
   }
 
   input = {}
@@ -30,13 +34,20 @@ class InputPresentation extends React.Component {
 
   onBlur = () => this.setState({ hasFocus: false })
 
+  onMouseOver = () => this.setState({ hasHover: true })
+
+  onMouseOut = () => this.setState({ hasHover: false })
+
   assignInput = (input) => { this.input = input; }
 
   contextForInput() {
     return {
-      hasFocus: this.state.hasFocus,
+      hasFocus: (this.context && this.context.hasFocus) || this.state.hasFocus,
+      hasHover: (this.context && this.context.hasHover) || this.state.hasHover,
       onFocus: this.onFocus,
       onBlur: this.onBlur,
+      onMouseOver: this.onMouseOver,
+      onMouseOut: this.onMouseOut,
       inputRef: this.assignInput
     };
   }
@@ -60,7 +71,7 @@ class InputPresentation extends React.Component {
         { ...filteredProps }
       >
         <InputPresentationContext.Provider value={ this.contextForInput() }>
-          { children }
+          {children}
         </InputPresentationContext.Provider>
       </InputPresentationStyle>
     );

--- a/src/__experimental__/components/input/input.component.js
+++ b/src/__experimental__/components/input/input.component.js
@@ -16,7 +16,9 @@ class Input extends React.Component {
     inputRef: PropTypes.func, // a callback to retrieve the input reference
     onBlur: PropTypes.func,
     onClick: PropTypes.func,
-    onFocus: PropTypes.func
+    onFocus: PropTypes.func,
+    onMouseOver: PropTypes.func,
+    onMouseOut: PropTypes.func
   }
 
   static contextType = InputPresentationContext
@@ -44,6 +46,16 @@ class Input extends React.Component {
     if (this.context && this.context.onBlur) this.context.onBlur(ev);
   };
 
+  handleMouseOver = (ev) => {
+    if (this.props.onMouseOver) this.props.onMouseOver(ev);
+    if (this.context && this.context.onMouseOver) this.context.onMouseOver(ev);
+  };
+
+  handleMouseOut = (ev) => {
+    if (this.props.onMouseOut) this.props.onMouseOut(ev);
+    if (this.context && this.context.onMouseOut) this.context.onMouseOut(ev);
+  };
+
   render() {
     const {
       inputRef,
@@ -57,6 +69,8 @@ class Input extends React.Component {
         onFocus={ this.handleFocus }
         onBlur={ this.handleBlur }
         onClick={ this.handleClick }
+        onMouseOver={ this.handleMouseOver }
+        onMouseOut={ this.handleMouseOut }
       />
     );
   }

--- a/src/__experimental__/components/input/input.style.js
+++ b/src/__experimental__/components/input/input.style.js
@@ -5,9 +5,11 @@ import baseTheme from '../../../style/themes/base';
 const StyledInput = styled.input`
   background: transparent;
   border: none;
+  box-sizing: border-box;
   color: ${({ theme }) => theme.text.color};
   flex-grow: 1;
   font-size: ${({ theme }) => theme.text.size};
+  height: 100%;
   outline: none;
   width: 30px;
 

--- a/src/__experimental__/components/label/label.component.js
+++ b/src/__experimental__/components/label/label.component.js
@@ -1,21 +1,30 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Help from '../../../components/help/help';
 import LabelStyle from './label.style';
+import { FormFieldContext } from '../form-field';
 
 const Label = ({
   children,
   help,
   ...props
-}) => (
-  <LabelStyle
-    data-element='label'
-    { ...props }
-  >
-    { children }
-    { help && <Help>{ help }</Help> }
-  </LabelStyle>
-);
+}) => {
+  const formFieldContext = useContext(FormFieldContext);
+
+  return (
+    <LabelStyle
+      data-element='label'
+      onBlur={ formFieldContext.onBlur }
+      onFocus={ formFieldContext.onFocus }
+      onMouseOver={ formFieldContext.onMouseOver }
+      onMouseOut={ formFieldContext.onMouseOut }
+      { ...props }
+    >
+      {children}
+      {help && <Help>{help}</Help>}
+    </LabelStyle>
+  );
+};
 
 Label.propTypes = {
   children: PropTypes.node,

--- a/src/__experimental__/components/label/label.spec.js
+++ b/src/__experimental__/components/label/label.spec.js
@@ -1,20 +1,46 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import PropTypes from 'prop-types';
+import { shallow, mount } from 'enzyme';
 import TestRenderer from 'react-test-renderer';
 import 'jest-styled-components';
 
 import Help from '../../../components/help/help';
 import Label from './label.component';
+import { FormFieldContext } from '../form-field';
 import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
 import classicTheme from '../../../style/themes/classic';
 
-function render(props, renderer = shallow) {
-  return renderer(
-    <Label { ...props }>
-      Name:
-    </Label>
+const LabelWithContext = ({ value, ...props }) => {
+  return (
+    <FormFieldContext.Provider value={ value }>
+      <Label { ...props }>
+        Name:
+      </Label>
+    </FormFieldContext.Provider>
   );
-}
+};
+
+LabelWithContext.propTypes = {
+  value: PropTypes.object
+};
+
+const render = (props, renderer = shallow, contextValue = {}) => {
+  let content;
+
+  if (renderer === shallow) {
+    content = (
+      <Label { ...props }>
+        Name:
+      </Label>
+    );
+  } else {
+    content = <LabelWithContext value={ contextValue } { ...props } />;
+  }
+
+  return renderer(content);
+};
+
+const mountRender = (props, contextValue = {}) => mount(<LabelWithContext value={ contextValue } { ...props } />);
 
 describe('Label', () => {
   it('renders the label', () => {
@@ -23,7 +49,7 @@ describe('Label', () => {
 
   describe('when initiated with the help prop', () => {
     it('contains Help component with the content specified in that prop', () => {
-      const wrapper = render({ help: 'Help me!' });
+      const wrapper = mountRender({ help: 'Help me!' });
       expect(wrapper.contains(<Help>Help me!</Help>)).toBeTruthy();
     });
   });

--- a/src/__experimental__/components/select/__snapshots__/select.spec.js.snap
+++ b/src/__experimental__/components/select/__snapshots__/select.spec.js.snap
@@ -82,7 +82,7 @@ Object {
   >
     <input
       autocomplete="off"
-      class="sc-bxivhb wHvcT"
+      class="sc-bZQynM cOAzzL"
       data-element="input"
       value=""
     />
@@ -91,8 +91,9 @@ Object {
     />
     <span
       autocomplete="off"
-      class="sc-ifAKCX jaOJuD"
+      class="sc-gzVnrw gxqCdh"
       data-element="input"
+      type="dropdown"
       value=""
     >
       <span

--- a/src/__experimental__/components/textbox/textbox.component.js
+++ b/src/__experimental__/components/textbox/textbox.component.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Input, InputPresentation } from '../input';
 import InputIconToggle from '../input-icon-toggle';
-import FormField from '../form-field';
+import { FormField } from '../form-field';
 
 // This component is a working example of what a Textbox might look like
 // using only the new input componentry. It is still under development with
@@ -17,10 +17,10 @@ const Textbox = ({
   return (
     <FormField { ...props }>
       <InputPresentation type='text' { ...props }>
-        { leftChildren }
+        {leftChildren}
         <Input { ...props } />
-        { children }
-        { inputIcon && <InputIconToggle { ...props } type={ inputIcon } /> }
+        {children}
+        {inputIcon && <InputIconToggle { ...props } type={ inputIcon } />}
       </InputPresentation>
     </FormField>
   );

--- a/src/__experimental__/components/textbox/textbox.stories.js
+++ b/src/__experimental__/components/textbox/textbox.stories.js
@@ -12,6 +12,8 @@ storiesOf('Experimental/Textbox', module)
         errorMessage={ text('errorMessage') }
         fieldHelp={ text('fieldHelp') }
         infoMessage={ text('infoMessage') }
+        info={ text('info') }
+        inputIcon={ select('inputIcon', OptionsHelper.icons) }
         label={ text('label') }
         labelAlign={ select('labelAlign', OptionsHelper.alignBinary) }
         labelHelp={ text('labelHelp') }


### PR DESCRIPTION
- adds classic styles for InputIconToggle, with variations for focus / hover states, and the dropdown icon type
- adds supporting functionality to InputPresentation and input, to set state required for styling the toggle
- subscribes InputIconToggle to the InputContext using Hooks so that this info can be used for toggle styling

# Description

# TODO
- [ ] Release notes

# Related Issues / Pull Requests

# Screenshots / Gifs

# Testing Instructions
