### PR TITLE
FE-1397 - Renames Filter Story to Prevent Storybook Error

### DIFF
--- a/src/components/filter/filter.stories.js
+++ b/src/components/filter/filter.stories.js
@@ -5,7 +5,7 @@ import OptionsHelper from '../../utils/helpers/options-helper';
 import Filter from './filter';
 import Textbox from '../textbox';
 
-storiesOf('Filter', module)
+storiesOf('Filter Component', module)
   .addParameters({
     info: {
       propTablesExclude: [Textbox]


### PR DESCRIPTION
Renames the `Filter` story in Storybook as a workaround for the following error:

![Screenshot 2019-03-21 at 14 39 46](https://user-images.githubusercontent.com/4471057/54813481-8bb88d80-4c85-11e9-8f95-e15775ba8bd6.png)

