### PR TITLE
Adds intersections to component types

### DIFF
--- a/change_log/next/FE-1399 extend type defintitions.yml
+++ b/change_log/next/FE-1399 extend type defintitions.yml
@@ -1,0 +1,3 @@
+Bug Fixes: |
+  Fixes issue that prevented html element events being passed to components by adding intersection types
+  to the definitons for any component that rneders an html input element

--- a/src/components/button/button.d.ts
+++ b/src/components/button/button.d.ts
@@ -7,5 +7,5 @@ export interface ButtonProps {
   subtext?: string;
   children?: React.ReactNode;
 }
-declare const Button: React.ComponentType<ButtonProps>;
+declare const Button: React.ComponentType<ButtonProps & React.HTMLProps<HTMLButtonElement>>;
 export default Button;

--- a/src/components/decimal/decimal.d.ts
+++ b/src/components/decimal/decimal.d.ts
@@ -23,5 +23,5 @@ export interface DecimalProps extends InputProps {
 /**
  * A decimal widget.
  */
-declare const Decimal: React.Component<DecimalProps, {}>;
+declare const Decimal: React.ComponentType<DecimalProps>;
 export default Decimal;

--- a/src/components/flash/flash.d.ts
+++ b/src/components/flash/flash.d.ts
@@ -28,7 +28,7 @@ export interface FlashProps {
    * Sets the time in Milliseconds the flash remains on the screen. After the timeout it will call the onDimiss
    * callback. This will remove the close icon when set.
    */
-  timeout?: number;
+  timeout?: string | number;
 }
 
 /**
@@ -36,5 +36,5 @@ export interface FlashProps {
  *
  * The flash is rendered in two sections: a ventral message 'flash', and a dorsal coloured, expanding 'slider'.
  */
-declare const Flash: React.Component<FlashProps, {}>;
+declare const Flash: React.ComponentType<FlashProps>;
 export default Flash;

--- a/src/components/link/link.d.ts
+++ b/src/components/link/link.d.ts
@@ -17,5 +17,5 @@ export interface LinkProps {
   children?: React.ReactNode;
 }
 
-declare const Link: React.ComponentType<LinkProps>;
+declare const Link: React.ComponentType<LinkProps & React.HTMLProps<HTMLLinkElement>>;
 export default Link;

--- a/src/components/textbox/textbox.d.ts
+++ b/src/components/textbox/textbox.d.ts
@@ -8,5 +8,6 @@ export interface TextboxProps extends InputProps {
 /**
  * A textbox widget.
  */
-declare const Textbox: React.ComponentType<TextboxProps>;
+declare const Textbox:
+    React.ComponentType<TextboxProps & React.HTMLProps<HTMLInputElement> & React.HTMLProps<HTMLLabelElement>>;
 export default Textbox;


### PR DESCRIPTION
# Description

Addresses https://github.com/Sage/carbon/issues/1968 where type definitions were missing the default html events (onclick etc) which blocked Carbon being used in any strict Typescript projects