### PR TITLE
revert formatter

### DIFF
--- a/change_log/v7_0_1/revert-date-formatter.yml
+++ b/change_log/v7_0_1/revert-date-formatter.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Reverts date formatter back as using utc forces it to default to UK locale"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "A library of reusable React components and an interface for easily building user interfaces based on Flux.",
   "engineStrict": true,
   "engines": {

--- a/release_notes/v7_0_1.html.md
+++ b/release_notes/v7_0_1.html.md
@@ -1,0 +1,5 @@
+# v7.0.1 (2019-04-02)
+### Bug Fixes
+* Reverts date formatter back as using utc forces it to default to UK locale
+
+

--- a/src/utils/helpers/date/date.js
+++ b/src/utils/helpers/date/date.js
@@ -66,7 +66,7 @@ const DateHelper = {
    */
   formatDateString: (value, formatTo) => {
     return (
-      moment.utc(new Date(value).getTime()).format(formatTo)
+      moment(new Date(value).getTime()).format(formatTo)
     );
   },
 


### PR DESCRIPTION
# Description

Reverts formatter back as `utc` function is forcing locale to format to UK
