### PR TITLE
updated tooltip to support types and offscreen

### DIFF
--- a/change_log/next/tooltip-update.yml
+++ b/change_log/next/tooltip-update.yml
@@ -1,0 +1,1 @@
+Improvements: "Tooltip now supports 'type' prop to add color, it also now repositions itself automatically if rendered off screen."

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -101,8 +101,15 @@ class Tooltip extends React.Component {
      * @property onMouseLeave
      * @type {Function}
      */
-    onMouseLeave: PropTypes.func
+    onMouseLeave: PropTypes.func,
 
+    /**
+     * Defines the message type
+     *
+     * @property type
+     * @type {String}
+     */
+    type: PropTypes.string
   };
 
   static defaultProps = {
@@ -123,6 +130,7 @@ class Tooltip extends React.Component {
       'carbon-tooltip',
       `carbon-tooltip--position-${this.props.position}`,
       `carbon-tooltip--pointer-align-${this.props.align}`,
+      `carbon-tooltip--type-${this.props.type}`,
       this.props.className
     );
   }

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -19,6 +19,10 @@
   max-width: 300px;
   word-break: normal;
   white-space: pre-wrap;
+
+  .carbon-tooltip--type-error & {
+    background-color: $error;
+  }
 }
 
 .carbon-tooltip__pointer {
@@ -54,6 +58,10 @@
     @include arrow(up, $app-tooltip-pointer-size, $grey-dark-plus);
     border-top: none;
     position: absolute;
+
+    @at-root .carbon-tooltip--type-error#{&} {
+      border-bottom-color: $error;
+    }
   }
 }
 
@@ -65,6 +73,10 @@
     @include arrow(down, $app-tooltip-pointer-size, $grey-dark-plus);
     border-bottom: none;
     position: absolute;
+
+    @at-root .carbon-tooltip--type-error#{&} {
+      border-top-color: $error;
+    }
   }
 }
 
@@ -76,6 +88,10 @@
     @include arrow(up, $app-tooltip-pointer-size, $grey-dark-plus);
     border-top: none;
     position: absolute;
+
+    @at-root .carbon-tooltip--type-error#{&} {
+      border-bottom-color: $error;
+    }
   }
 }
 
@@ -88,6 +104,10 @@
     @include arrow(down, $app-tooltip-pointer-size, $grey-dark-plus);
     border-bottom: none;
     position: absolute;
+
+    @at-root .carbon-tooltip--type-error#{&} {
+      border-top-color: $error;
+    }
   }
 }
 
@@ -99,6 +119,10 @@
     @include arrow(up, $app-tooltip-pointer-size, $grey-dark-plus);
     border-top: none;
     position: absolute;
+
+    @at-root .carbon-tooltip--type-error#{&} {
+      border-bottom-color: $error;
+    }
   }
 }
 
@@ -110,6 +134,10 @@
     @include arrow(down, $app-tooltip-pointer-size, $grey-dark-plus);
     border-bottom: none;
     position: absolute;
+
+    @at-root .carbon-tooltip--type-error#{&} {
+      border-top-color: $error;
+    }
   }
 }
 
@@ -121,6 +149,10 @@
     @include arrow(right, $app-tooltip-pointer-size, $grey-dark-plus);
     border-right: none;
     position: absolute;
+
+    @at-root .carbon-tooltip--type-error#{&} {
+      border-left-color: $error;
+    }
   }
 }
 
@@ -132,6 +164,10 @@
     @include arrow(left, $app-tooltip-pointer-size, $grey-dark-plus);
     border-left: none;
     position: absolute;
+
+    @at-root .carbon-tooltip--type-error#{&} {
+      border-right-color: $error;
+    }
   }
 }
 
@@ -143,6 +179,10 @@
     @include arrow(right, $app-tooltip-pointer-size, $grey-dark-plus);
     border-right: none;
     position: absolute;
+
+    @at-root .carbon-tooltip--type-error#{&} {
+      border-left-color: $error;
+    }
   }
 }
 
@@ -154,6 +194,10 @@
     @include arrow(left, $app-tooltip-pointer-size, $grey-dark-plus);
     border-left: none;
     position: absolute;
+
+    @at-root .carbon-tooltip--type-error#{&} {
+      border-right-color: $error;
+    }
   }
 }
 
@@ -165,6 +209,10 @@
     @include arrow(right, $app-tooltip-pointer-size, $grey-dark-plus);
     border-right: none;
     position: absolute;
+
+    @at-root .carbon-tooltip--type-error#{&} {
+      border-left-color: $error;
+    }
   }
 }
 
@@ -176,5 +224,9 @@
     @include arrow(left, $app-tooltip-pointer-size, $grey-dark-plus);
     border-left: none;
     position: absolute;
+
+    @at-root .carbon-tooltip--type-error#{&} {
+      border-right-color: $error;
+    }
   }
 }

--- a/src/utils/decorators/tooltip-decorator/__spec__.js
+++ b/src/utils/decorators/tooltip-decorator/__spec__.js
@@ -8,6 +8,7 @@ import { shallow } from 'enzyme';
 class BasicClass extends React.Component {
   componentWillUpdate() {}
   componentDidUpdate() {}
+  componentDidMount() {}
   componentWillReceiveProps() {}
   onBlur = () => {}
   onFocus = () => {}
@@ -35,6 +36,7 @@ class BasicClass extends React.Component {
 class StrippedClass extends React.Component {
   componentWillUpdate() {}
   componentDidUpdate() {}
+  componentDidMount() {}
   componentWillReceiveProps() {}
   onBlur = () => {}
   onFocus = () => {}
@@ -87,6 +89,21 @@ describe('tooltip-decorator', () => {
         topTooltip.componentWillReceiveProps();
         expect(topTooltip.setState).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('componentDidMount', () => {
+    it('positions the tooltip if visible', () => {
+      const visibleTooltip = TestUtils.renderIntoDocument(<DecoratedClassOne tooltipMessage='Hello' tooltipVisible />);
+      spyOn(visibleTooltip, 'positionTooltip');
+      visibleTooltip.componentDidMount();
+      expect(visibleTooltip.positionTooltip).toHaveBeenCalled();
+    });
+    
+    it('does not position the tooltip if not visible', () => {
+      spyOn(topTooltip, 'positionTooltip');
+      topTooltip.componentDidMount();
+      expect(topTooltip.positionTooltip).not.toHaveBeenCalled();
     });
   });
 
@@ -197,7 +214,6 @@ describe('tooltip-decorator', () => {
       }
     });
 
-
     describe('when positioned above the target', () => {
       beforeEach(()  => {
         topTooltip = shallow(<DecoratedClassOne tooltipMessage='Hello' />).instance();
@@ -227,6 +243,20 @@ describe('tooltip-decorator', () => {
         topTooltip.positionTooltip(tooltip, target);
         expect(tooltip.style.left).toEqual('65px');
         expect(tooltip.style.top).toEqual('42.5px');
+      });
+
+      describe('when the tooltip is offscreen', () => {
+        it('realigns to the right', () => {
+          topTooltip.onShow();
+          jest.runTimersToTime(100);
+          const tooltip = topTooltip.getTooltip();
+          const target = topTooltip.getTarget();
+          const innerWidth = window.innerWidth;
+          window.innerWidth = 0;
+          topTooltip.positionTooltip(tooltip, target);
+          expect(topTooltip.state.tooltipAlign).toEqual('right');
+          window.innerWidth = innerWidth;
+        });
       });
 
       describe('when the pointer is aligned to the right', () => {
@@ -623,7 +653,7 @@ describe('tooltip-decorator', () => {
   describe('tooltipHTML', () => {
     describe('when a tooltipMessage is defined', () => {
       it('returns a Tooltip', () => {
-        expect(topTooltip.tooltipHTML).toBeDefined();
+        expect(topTooltip.getTooltip()).toBeDefined();
       });
     });
   });

--- a/src/utils/decorators/tooltip-decorator/tooltip-decorator.js
+++ b/src/utils/decorators/tooltip-decorator/tooltip-decorator.js
@@ -132,6 +132,11 @@ const TooltipDecorator = (ComposedComponent) => {
      */
     _memoizedShifts = null;
 
+    componentDidMount() {
+      if (super.componentDidMount) super.componentDidMount();
+      if (this.props.tooltipVisible) this.positionTooltip();
+    }
+
     /**
      * @method componentWillUpdate
      * @return {Void}
@@ -153,7 +158,7 @@ const TooltipDecorator = (ComposedComponent) => {
     componentDidUpdate(prevProps) {
       if (super.componentDidUpdate) { super.componentDidUpdate(prevProps); }
 
-      if (this.props.tooltipMessage && !this._memoizedShifts && this.state.isVisible) {
+      if (this.props.tooltipMessage && !this._memoizedShifts && this.isVisible()) {
         this.positionTooltip();
       }
     }
@@ -167,7 +172,7 @@ const TooltipDecorator = (ComposedComponent) => {
     componentWillReceiveProps(nextProps) {
       if (super.componentWillReceiveProps) { super.componentWillReceiveProps(nextProps); }
 
-      if (this.state.isVisible) {
+      if (this.isVisible()) {
         this.setState({ isVisible: false });
       }
     }
@@ -182,6 +187,10 @@ const TooltipDecorator = (ComposedComponent) => {
        */
       isVisible: false
     };
+
+    isVisible = () => {
+      return this.state.isVisible || this.props.tooltipVisible;
+    }
 
     /**
      * Shows tooltip
@@ -257,7 +266,7 @@ const TooltipDecorator = (ComposedComponent) => {
           targetLeft = targetRect.left,
           targetRight = targetRect.right;
 
-      return {
+      const shifts = {
         verticalY: targetTop - tooltipHeight - (pointerDimension * 0.5),
         verticalBottomY: targetBottom + (pointerDimension * 0.5),
         verticalCenter: (targetLeft - (tooltipWidth * 0.5)) + (targetWidth * 0.5),
@@ -269,7 +278,25 @@ const TooltipDecorator = (ComposedComponent) => {
         sideBottom: (targetTop - tooltipHeight) + targetHeight + pointerOffset,
         sideCenter: (targetTop + (targetHeight * 0.5)) - (tooltipHeight * 0.5)
       };
+
+      this.realignOffscreenTooltip(shifts, tooltipWidth);
+
+      return shifts;
     };
+
+    realignOffscreenTooltip = (shifts, tooltipWidth) => {
+      if (this.props.tooltipAlign === 'right' || this.state.tooltipAlign === 'right') return;
+
+      const position = this.props.tooltipPosition || 'top';
+      const alignment = this.props.tooltipAlign || 'center';
+
+      if (position === 'top' || position === 'bottom') {
+        const horizontalPosition = shifts[`vertical${startCase(alignment)}`];
+        if (window.innerWidth < (horizontalPosition + tooltipWidth)) {
+          this.setState({ tooltipAlign: 'right' });
+        }
+      }
+    }
 
     /**
      * Positions tooltip relative to target
@@ -280,16 +307,16 @@ const TooltipDecorator = (ComposedComponent) => {
      * @return {Void}
      */
     positionTooltip = () => {
-      if (this.state.isVisible) {
+      if (this.isVisible()) {
         const tooltip = this.getTooltip(),
             target = this.getTarget();
         if (!tooltip || !target) {
           // Can't find the tooltip or target so hide
-          this.setState({ isVisible: false });
+          if (this.state.isVisible) this.setState({ isVisible: false });
           return;
         }
 
-        const alignment = this.props.tooltipAlign || 'center',
+        const alignment = this.state.tooltipAlign || this.props.tooltipAlign || 'center',
             position = this.props.tooltipPosition || 'top',
             shifts = this.calculatePosition(tooltip, target);
 
@@ -336,7 +363,7 @@ const TooltipDecorator = (ComposedComponent) => {
         props.onMouseLeave = chainFunctions(this.onHide, props.onMouseLeave);
         props.onFocus = chainFunctions(this.onShow, props.onFocus);
         props.onBlur = chainFunctions(this.onHide, props.onBlur);
-        props.onTouchEnd = this.state.isVisible ? this.onHide : this.onShow;
+        props.onTouchEnd = this.isVisible() ? this.onHide : this.onShow;
       }
       return props;
     }
@@ -349,16 +376,17 @@ const TooltipDecorator = (ComposedComponent) => {
      */
     get tooltipHTML() {
       return (
-        (this.props.tooltipMessage && this.state.isVisible) && (
+        (this.props.tooltipMessage && this.isVisible()) && (
           <Portal key='tooltip'>
             <Tooltip
-              align={ this.props.tooltipAlign }
+              align={ this.state.tooltipAlign || this.props.tooltipAlign }
               data-element='tooltip'
-              isVisible={ this.state.isVisible }
+              isVisible={ this.isVisible() }
               onMouseEnter={ this.onShow }
               onMouseLeave={ this.onHide }
               position={ this.props.tooltipPosition }
               ref={ (comp) => { this._tooltip = comp; } }
+              type={ this.props.tooltipType }
             >
               { this.props.tooltipMessage }
             </Tooltip>


### PR DESCRIPTION
Tooltip now supports 'type' prop to add color, it also now repositions itself automatically if rendered off screen.

No QA required as this is part of a feature branch that will be tested together (`validation-branch`).