### PR TITLE
S1T-1852: Removes search text on multi select dropdown after selecting item

### DIFF
--- a/change_log/next/S1T-1852.yml
+++ b/change_log/next/S1T-1852.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Removes the search filter text on multi select dropdown, when an item has been selected."

--- a/src/__experimental__/components/select/select.component.js
+++ b/src/__experimental__/components/select/select.component.js
@@ -149,9 +149,10 @@ class Select extends React.Component {
     if (!this.isMultiValue(value)) {
       // only closes the dropdown if not multi-value
       newState.open = false;
-      newState.filter = undefined;
       this.unblockBlur();
     }
+
+    newState.filter = undefined;
     this.setState(newState);
     this.bridge.current._handleContentChange(); // temporary - resets validation on the old bridge component
 


### PR DESCRIPTION
# Description

When a search filter was applied to the multi select dropdown component and an item was selected, the search text was not being cleared. The changes made here now clear the text once an item has been selected. The items will stay filtered until a new filter is applied, or deselecting and selecting the dropdown again.

# Related Issues / Pull Requests

https://jira.sage.com/browse/S1T-1852
