### PR TITLE
Fe 1424 - Google Analytics Double Counting

### DIFF
--- a/change_log/next/FE-1424-google-analytics-bug.yml
+++ b/change_log/next/FE-1424-google-analytics-bug.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "prvent Google Analytics double counting"

--- a/change_log/next/FE-1424-google-analytics-bug.yml
+++ b/change_log/next/FE-1424-google-analytics-bug.yml
@@ -1,1 +1,1 @@
-Bug Fixes: "prvent Google Analytics double counting"
+Bug Fixes: "prevent Google Analytics double counting"

--- a/src/utils/router/__spec__.js
+++ b/src/utils/router/__spec__.js
@@ -37,7 +37,13 @@ describe('startRouter', () => {
       expect(window.screenY).toEqual(0);
     });
 
-    it('sets the router onUpdate to track analytics', () => {
+    it('does not track analytics when unavailable', () => {
+      let gaSpy = jasmine.createSpy('ga');
+      router.props.onUpdate();
+      expect(gaSpy).not.toHaveBeenCalledWith();
+    });
+
+    it('sets the router onUpdate to track analytics when available', () => {
       let gaSpy = jasmine.createSpy('ga');
       global.ga = gaSpy;
 

--- a/src/utils/router/__spec__.js
+++ b/src/utils/router/__spec__.js
@@ -40,7 +40,7 @@ describe('startRouter', () => {
     it('does not track analytics when unavailable', () => {
       let gaSpy = jasmine.createSpy('ga');
       router.props.onUpdate();
-      expect(gaSpy).not.toHaveBeenCalledWith();
+      expect(gaSpy).not.toHaveBeenCalled();
     });
 
     it('sets the router onUpdate to track analytics when available', () => {

--- a/src/utils/router/router.js
+++ b/src/utils/router/router.js
@@ -2,8 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, browserHistory } from 'react-router';
 
+let isInitial = true;
 const onRouteUpdate = () => {
   global.window.scrollTo(0, 0);
+
+  if (isInitial) {
+    isInitial = false;
+    return;
+  }
 
   if (global.ga) {
     global.ga('set', 'page', global.location.pathname);


### PR DESCRIPTION
# Description
Analytics is tracked only when React Router triggers the URL change (not a true page load, just a SPA page load).
