### PR TITLE
DLS Checkbox component, with classic & new themes - specs TODO

### DIFF
--- a/src/__experimental__/components/checkbox/checkbox.component.js
+++ b/src/__experimental__/components/checkbox/checkbox.component.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import tagComponent from '../../../utils/helpers/tags';
+import { validProps } from '../../../utils/ether';
+import FormField from '../form-field';
+import CheckboxStyle from './checkbox.style';
+
+class Checkbox extends React.Component {
+  get checkboxStyleProps() {
+    return {
+      checked: this.props.checked,
+      disabled: this.props.disabled,
+      error: this.props.error,
+      fieldHelpInline: this.props.fieldHelpInline,
+      inputWidth: this.props.inputWidth,
+      labelAlign: this.props.labelAlign,
+      labelWidth: this.props.labelWidth,
+      reverse: this.props.reverse,
+      size: this.props.size
+    };
+  }
+
+  get formFieldProps() {
+    const { ...props } = validProps(this, ['fieldHelpInline']);
+
+    props.reverse = !this.props.reverse;
+
+    return props;
+  }
+
+  get inputProps() {
+    const { ...props } = validProps(this, ['disabled', 'onChange']);
+    // React uses checked instead of value to define the state of a checkbox
+    props.className = this.inputClasses;
+    props.type = 'checkbox';
+    delete props.children;
+    delete props.fieldHelp;
+    delete props.labelHelp;
+    return props;
+  }
+
+  get checkboxSprite() {
+    return (
+      <svg
+        width='12' height='10'
+        viewBox='0 0 12 10'
+      >
+        <path
+          d={ 'M.237 6.477A.752.752 0 0 1 .155 5.47l.851-1.092a.63.63 0 0 1 .934-.088l2.697 1.964, '
+            + '4.674-6a.63.63 0 0 1 .933-.088l1.015.917c.28.254.317.703.081 1.005L6.353 8.492a.725.725, '
+            + '0 0 1-.095.16l-.85 1.093a.637.637 0 0 1-.626.244.638.638 0 0 1-.335-.16L.237 6.476z' }
+          className='checkbox-check'
+          fill='#FFFFFF'
+          fillRule='evenodd'
+        />
+      </svg>
+    );
+  }
+
+  render() {
+    return (
+      <CheckboxStyle
+        { ...tagComponent('checkbox', this.props) }
+        { ...this.checkboxStyleProps }
+      >
+        <FormField
+          labelHelpIcon='info'
+          { ...this.formFieldProps }
+        >
+          <div className='carbon-checkbox__input'>
+            <input
+              aria-checked={ this.props.checked }
+              role='checkbox'
+              { ...this.inputProps }
+            />
+            {this.checkboxSprite}
+          </div>
+        </FormField>
+      </CheckboxStyle>
+    );
+  }
+}
+
+Checkbox.propTypes = {
+  checked: PropTypes.bool,
+  children: PropTypes.node,
+  disabled: PropTypes.bool,
+  error: PropTypes.bool,
+  fieldHelpInline: PropTypes.bool,
+  inputWidth: PropTypes.number,
+  labelAlign: PropTypes.string,
+  labelWidth: PropTypes.number,
+  onChange: PropTypes.func,
+  reverse: PropTypes.bool,
+  size: PropTypes.string
+};
+
+Checkbox.defaultProps = {
+  reverse: false
+};
+
+export default Checkbox;

--- a/src/__experimental__/components/checkbox/checkbox.stories.js
+++ b/src/__experimental__/components/checkbox/checkbox.stories.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import {
+  boolean, text, number, select
+} from '@storybook/addon-knobs';
+import { Store, State } from '@sambego/storybook-state';
+import OptionsHelper from '../../../utils/helpers/options-helper';
+import Checkbox from '.';
+
+const formStore = new Store({
+  checked: false
+});
+
+storiesOf('Experimental/Checkbox', module)
+  .add('default', () => {
+    return (
+      <State store={ formStore }>
+        <Checkbox
+          onChange={ handleChange }
+          { ...defaultKnobs() }
+        />
+      </State>
+    );
+  });
+
+function handleChange(ev) {
+  formStore.set({ checked: ev.target.checked });
+}
+
+function defaultKnobs() {
+  return ({
+    disabled: boolean('disabled', false),
+    error: boolean('error', false),
+    fieldHelp: text('fieldHelp', 'This text provides help for the input.'),
+    fieldHelpInline: boolean('fieldHelpInline', false),
+    reverse: boolean('reverse', false),
+    label: text('label', 'Example Checkbox'),
+    labelHelp: text('labelHelp', 'This text provides more information for the label.'),
+    inputWidth: number('inputWidth', 0, {
+      range: true,
+      min: 0,
+      max: 50,
+      step: 1
+    }),
+    labelWidth: number('labelWidth', 0, {
+      range: true,
+      min: 0,
+      max: 50,
+      step: 1
+    }),
+    labelAlign: select(
+      'labelAlign',
+      OptionsHelper.alignBinary,
+      OptionsHelper.alignBinary[0]
+    ),
+    name: text('name', 'inputName'),
+    size: select('size', OptionsHelper.sizesBinary, 'small')
+  });
+}

--- a/src/__experimental__/components/checkbox/checkbox.style.js
+++ b/src/__experimental__/components/checkbox/checkbox.style.js
@@ -1,0 +1,198 @@
+import styled, { css } from 'styled-components';
+import PropTypes from 'prop-types';
+import baseTheme from '../../../style/themes/base';
+import FieldHelpStyle from '../field-help/field-help.style';
+import LabelStyle from '../label/label.style';
+import StyledHelp from '../help/help.style';
+import { THEMES } from '../../../style/themes';
+
+const StyledCheckbox = styled.div`
+  padding-top: 8px;
+
+  input[type=checkbox] {
+    cursor: pointer;
+    opacity: 0;
+    margin: 0;
+    z-index: 999;
+  }
+
+  svg {
+    background-color: #ffffff;
+    border: solid 1px #668592;
+  }
+
+  input[type=checkbox],
+  svg {
+    position: absolute;
+  }
+
+  .carbon-checkbox__input,
+  input[type=checkbox],
+  svg {
+    box-sizing: border-box;
+    display: inline-block;
+    height: 16px;
+    padding: 1px;
+    vertical-align: middle;
+    width: 16px;
+  }
+
+  input[type=checkbox]:not([disabled]) {
+    &:focus + svg,
+    &:hover + svg {
+      outline: solid 2px #ffb403;
+    }
+  }
+
+  ${LabelStyle} {
+    padding: 0 6px;
+    text-align: ${({ labelAlign }) => labelAlign || 'left'};
+    width: auto;
+
+    & ${StyledHelp} {
+      color: rgba(0, 0, 0, 0.65);
+      vertical-align: bottom;
+
+      &:hover, &:focus {
+        color: rgba(0, 0, 0, 0.9);
+      }
+    }
+  }
+
+  label:hover + .carbon-checkbox__input input[type=checkbox]:not([disabled]) + svg { outline: solid 2px #ffb403; }
+
+  ${FieldHelpStyle} {
+    margin-left: 16px;
+    margin-top: 0;
+    padding-left: 6px;
+  }
+
+  ${({ size, fieldHelpInline }) => size === 'large' && css`
+    .carbon-checkbox__input,
+    input[type=checkbox],
+    input[type=checkbox] + svg {
+      height: 24px;
+      padding: 2px;
+      width: 24px;
+    }
+
+    ${FieldHelpStyle} {
+      margin-left: 24px;
+    }
+
+    ${fieldHelpInline && `${FieldHelpStyle},`}
+    ${LabelStyle} {
+      padding-top: 4px;
+      padding-bottom: 4px;
+    }
+  `}
+
+  ${({ checked }) => checked && css`
+    svg path {
+      fill: ${({ theme }) => theme.colors.primary};
+    }
+  `}
+
+  ${({ disabled }) => disabled && css`
+    ${LabelStyle} {
+      &, & ${StyledHelp} {
+        color: rgba(0, 0, 0, 0.55);
+      }
+    }
+
+    svg {
+      background-color: #f2f5f6;
+      border: 1px solid #ccd6db;
+    }
+
+    svg .checkbox-check { fill: ${({ checked }) => (checked ? '#ccd6db' : '#f2f5f6')}; }
+
+    input[type=checkbox],
+    svg,
+    ${LabelStyle} {
+      &:hover, &:focus {
+        outline: none;
+        cursor: not-allowed;
+      }
+    }
+  `}
+
+  ${({ error }) => error && css`
+    svg {
+      border: 1px solid #c7384f;
+    }
+  `}
+
+  ${({ fieldHelpInline }) => fieldHelpInline && css`
+    ${FieldHelpStyle} {
+      display: inline;
+      margin: 0;
+      width: auto;
+    }
+  `}
+
+  ${({ inputWidth, reverse }) => inputWidth !== 0 && css`
+    .carbon-checkbox__input {
+      width: ${inputWidth}%;
+    }
+
+    ${FieldHelpStyle} {
+      ${reverse ? 'margin-right' : 'margin-left'}: ${inputWidth}%;
+    }
+  `}
+
+  ${({ labelWidth }) => labelWidth !== 0 && css`
+    ${LabelStyle} {
+      width: ${labelWidth}%;
+    }
+  `}
+
+  ${({ reverse }) => reverse && css`
+    ${FieldHelpStyle} {
+      margin-left: 0;
+    }
+  `}
+
+  ${({ reverse, fieldHelpInline }) => reverse && fieldHelpInline && css`
+    .carbon-checkbox__input { padding-left: 6px; }
+  `}
+
+  ${({ theme }) => theme.name === THEMES.classic && css`
+    .carbon-checkbox__input,
+    input[type=checkbox],
+    input[type=checkbox] + svg {
+      height: 15px;
+      padding: 1px;
+      width: 15px;
+    }
+
+    input[type=checkbox]:not([disabled]) {
+      &:focus + svg,
+      &:hover + svg {
+        border: 1px solid #1963f6;
+        outline: none;
+      }
+    }
+
+    label:hover + .carbon-checkbox__input input[type=checkbox]:not([disabled]) + svg {
+      border: 1px solid #1963f6;
+      outline: none;
+    }
+  `}
+`;
+
+StyledCheckbox.defaultProps = {
+  theme: baseTheme
+};
+
+StyledCheckbox.propTypes = {
+  disabled: PropTypes.bool,
+  error: PropTypes.bool,
+  fieldHelpInline: PropTypes.bool,
+  inputWidth: PropTypes.number,
+  labeLAlign: PropTypes.string,
+  labelWidth: PropTypes.number,
+  size: PropTypes.string
+};
+
+export default StyledCheckbox;

--- a/src/__experimental__/components/checkbox/index.js
+++ b/src/__experimental__/components/checkbox/index.js
@@ -1,0 +1,1 @@
+export { default } from './checkbox.component';

--- a/src/__experimental__/components/form-field/form-field.component.js
+++ b/src/__experimental__/components/form-field/form-field.component.js
@@ -8,33 +8,45 @@ import OptionsHelper from '../../../utils/helpers/options-helper';
 const FormField = ({
   children,
   fieldHelp,
+  fieldHelpInline,
   label,
   labelAlign,
   labelHelp,
+  labelHelpIcon,
   labelInline,
   labelWidth,
+  reverse,
   size
 }) => (
   <FormFieldStyle>
-    { label && (
+    {reverse && children}
+
+    {label && (
       <Label
         align={ labelAlign }
         help={ labelHelp }
+        helpIcon={ labelHelpIcon }
         inline={ labelInline }
         inputSize={ size }
         width={ labelWidth }
       >
-        { label }
+        {label}
       </Label>
-    ) }
+    )}
 
-    { children }
-
-    { fieldHelp && (
+    {fieldHelp && fieldHelpInline && (
       <FieldHelp labelInline={ labelInline } labelWidth={ labelWidth }>
-        { fieldHelp }
+        {fieldHelp}
       </FieldHelp>
-    ) }
+    )}
+
+    {!reverse && children}
+
+    {fieldHelp && !fieldHelpInline && (
+      <FieldHelp labelInline={ labelInline } labelWidth={ labelWidth }>
+        {fieldHelp}
+      </FieldHelp>
+    )}
   </FormFieldStyle>
 );
 
@@ -45,11 +57,14 @@ FormField.defaultProps = {
 FormField.propTypes = {
   children: PropTypes.node,
   fieldHelp: PropTypes.node,
+  fieldHelpInline: PropTypes.bool,
   label: PropTypes.node,
   labelAlign: PropTypes.oneOf(OptionsHelper.alignBinary),
   labelHelp: PropTypes.node,
+  labelHelpIcon: PropTypes.string,
   labelInline: PropTypes.bool,
   labelWidth: PropTypes.number,
+  reverse: PropTypes.bool,
   size: PropTypes.oneOf(OptionsHelper.sizesRestricted)
 };
 

--- a/src/__experimental__/components/help/help.component.js
+++ b/src/__experimental__/components/help/help.component.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import Icon from '../../../components/icon';
+import tagComponent from '../../../utils/helpers/tags';
+import StyledHelp from './help.style';
+
+class Help extends React.Component {
+  static propTypes = {
+    className: PropTypes.string,
+    children: PropTypes.string,
+    type: PropTypes.string,
+    tooltipPosition: PropTypes.string,
+    tooltipAlign: PropTypes.string,
+    href: PropTypes.string
+  };
+
+  static defaultProps = {
+    tooltipPosition: 'top',
+    tooltipAlign: 'center'
+  }
+
+  get mainClasses() {
+    return classNames(
+      'carbon-help',
+      { 'carbon-help__href': this.props.href },
+      this.props.className
+    );
+  }
+
+  render() {
+    return (
+      <StyledHelp
+        className={ this.mainClasses }
+        href={ this.props.href }
+        target='_blank'
+        rel='noopener noreferrer'
+        { ...tagComponent('help', this.props) }
+      >
+        <Icon
+          type={ this.props.type ? this.props.type : 'help' }
+          tooltipMessage={ this.props.children }
+          tooltipPosition={ this.props.tooltipPosition }
+          tooltipAlign={ this.props.tooltipAlign }
+        />
+      </StyledHelp>
+    );
+  }
+}
+
+export default Help;

--- a/src/__experimental__/components/help/help.style.js
+++ b/src/__experimental__/components/help/help.style.js
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import baseTheme from '../../../style/themes/base';
+
+const StyledHelp = styled.a`
+  cursor: pointer;
+  display: inline-block;
+  position: relative;
+  margin-left: 8px;
+  text-decoration: none;
+  top: -1px;
+
+  &:hover {
+    color: $blue;
+    text-decoration: underline;
+  }
+`;
+
+StyledHelp.defaultProps = {
+  theme: baseTheme
+};
+
+StyledHelp.propTypes = {
+  disabled: PropTypes.bool,
+  error: PropTypes.bool,
+  size: PropTypes.string
+};
+
+export default StyledHelp;

--- a/src/__experimental__/components/label/label.component.js
+++ b/src/__experimental__/components/label/label.component.js
@@ -1,25 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Help from '../../../components/help/help';
+import Help from '../help/help.component';
 import LabelStyle from './label.style';
 
 const Label = ({
   children,
   help,
+  helpIcon,
   ...props
 }) => (
   <LabelStyle
     data-element='label'
     { ...props }
   >
-    { children }
-    { help && <Help>{ help }</Help> }
+    {children}
+    {help && <Help type={ helpIcon }>{help}</Help>}
   </LabelStyle>
 );
 
 Label.propTypes = {
   children: PropTypes.node,
-  help: PropTypes.string
+  help: PropTypes.string,
+  helpIcon: PropTypes.string
 };
 
 export default Label;


### PR DESCRIPTION
# Description
Creates a new experimental Checkbox component for the DLS.
Added a new Help component as well, making it configurable to allow passing in a different icon (new Checkbox uses `i` rather than `?`

# TODO
- Release notes
- Specs
- some accessibility failures to resolve (reported by Storybook)
