### PR TITLE
FE-1196 - Fix timezone date format bug by adding conditional formatting

### DIFF
--- a/change_log/next/FE-1196-add-conditional-boolean-to-formatDateString.yml
+++ b/change_log/next/FE-1196-add-conditional-boolean-to-formatDateString.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Makes formatDateString configurable with a boolean paramater, to allow for utc locale formatting in date picker components"

--- a/src/components/date/date.js
+++ b/src/components/date/date.js
@@ -237,7 +237,7 @@ const Date = Input(InputIcon(InputLabel(InputValidation(class Date extends React
   emitOnChangeCallback = (val) => {
     const hiddenField = this.hidden;
     const isValid = DateHelper.isValidDate(val, { sanitize: (typeof val === 'string') });
-    hiddenField.value = isValid ? DateHelper.formatDateString(val, this.hiddenFormat()) : val;
+    hiddenField.value = isValid ? DateHelper.formatDateString(val, this.hiddenFormat(), false) : val;
     this._handleOnChange({ target: hiddenField });
   }
 

--- a/src/utils/helpers/date/date.js
+++ b/src/utils/helpers/date/date.js
@@ -62,12 +62,12 @@ const DateHelper = {
    * @method formatDateString
    * @param {String} value current value e.g. Wed Aug 23 2017 12:00:00 GMT+0100 (BST)
    * @param {String} formatTo Desired format e.g. YYYY-MM-DD
+   * @param {boolean} utcFormat set whether date should be utc formatted
    * @return {String} formatted date
    */
-  formatDateString: (value, formatTo) => {
-    return (
-      moment(new Date(value).getTime()).format(formatTo)
-    );
+  formatDateString: (value, formatTo, utcFormat = true) => {
+    const momentMethod = utcFormat ? moment.utc : moment;
+    return momentMethod(new Date(value).getTime()).format(formatTo);
   },
 
   /**


### PR DESCRIPTION
# Description
The original attempt to format the date correctly based on locale caused issue elsewhere. Therefore, I have added a boolean condition to `formatDateString` that fixes the original bug and prevents the issues it attempted fix created


