### PR TITLE
Extend table ajax for post

### DIFF
--- a/__mocks__/superagent.js
+++ b/__mocks__/superagent.js
@@ -27,12 +27,8 @@ var Request = (method, url) => {
   return Request;
 }
 
-Request.post = () => {
-  return Request;
-};
-Request.get = () => {
-  return Request;
-};
+Request.post = jest.fn().mockReturnThis();
+Request.get = jest.fn().mockReturnThis();
 Request.send = () => {
   return Request;
 };

--- a/change_log/next/extend-table-ajax-for-post-requests.yml
+++ b/change_log/next/extend-table-ajax-for-post-requests.yml
@@ -1,0 +1,1 @@
+New Features: "Extends the TableAjax component with a prop `postAction` providing the ability to override the default get request with a post request."

--- a/src/components/table-ajax/__definition__.js
+++ b/src/components/table-ajax/__definition__.js
@@ -23,20 +23,23 @@ const definition = new Definition('table-ajax', TableAjax, {
     formatResponse: 'Function',
     formatRequest: 'Function',
     onAjaxError: 'Function',
-    path: 'String'
+    path: 'String',
+    postAction: 'Boolean'
   },
   propDescriptions: {
     formatResponse: 'Callback function for formatting the data received via Ajax requests into the format required by the table',
     formatRequest: 'Callback function for formatting the query data to be sent via Ajax to the defined path',
     onAjaxError: 'Callback function to handle XHR request errors',
-    path: 'The path to make XHR requests to.'
+    path: 'The path to make XHR requests to.',
+    postAction: 'This provides an option to override the default get request with post.'
   },
   requiredProps: ['path'],
   hiddenProps: [
     'formatResponse',
     'formatRequest',
     'onAjaxError',
-    'path'
+    'path',
+    'postAction'
   ]
 });
 

--- a/src/components/table-ajax/__spec__.js
+++ b/src/components/table-ajax/__spec__.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Immutable from 'immutable';
 import { TableAjax, TableRow } from './table-ajax';
 import { shallow, mount } from 'enzyme';
-import { elementsTagTest, rootTagTest } from '../../utils/helpers/tags/tags-specs';
+import { rootTagTest } from '../../utils/helpers/tags/tags-specs';
 import Pager from './../pager';
 
 import Request from 'superagent';
@@ -277,8 +277,60 @@ describe('TableAjax', () => {
 
         instance.emitOnChangeCallback('data', options);
         jest.runTimersToTime(251);
-
+        expect(Request.get).toHaveBeenLastCalledWith('/test');
         expect(instance.resetTableHeight).toBeCalled();
+      });
+    });
+
+    describe('when postAction is true', () => {
+      beforeEach(() => {
+        spy = jasmine.createSpy('onChange spy');
+        wrapper = mount(
+          <TableAjax
+            onAjaxError={ () => {} }
+            className="foo"
+            path='/test'
+            onChange={ spy }
+            postAction
+          >
+            <TableRow />
+          </TableAjax>
+        );
+        instance = wrapper.instance();
+      });
+
+      it('resets the select all component', () => {
+        let selectAllComponent = {
+          setState: jasmine.createSpy()
+        };
+        instance.selectAllComponent = selectAllComponent;
+        instance.emitOnChangeCallback('data', options);
+        expect(selectAllComponent.setState).toHaveBeenCalledWith({ selected: false });
+        expect(instance.selectAllComponent).toBe(null);
+      });
+
+      describe('when page size is less than previous page size', () => {
+        it('calls resetTableHeight on successful response', () => {
+          instance.resetTableHeight = jest.fn();
+          options = { currentPage: '1', pageSize: '5' }
+
+          Request.__setMockResponse({
+            status() {
+              return 200;
+            },
+            ok() {
+              return true;
+            },
+            body: {
+              data: 'foo'
+            }
+          });
+
+          instance.emitOnChangeCallback('data', options);
+          jest.runTimersToTime(251);
+          expect(Request.post).toHaveBeenLastCalledWith('/test');
+          expect(instance.resetTableHeight).toBeCalled();
+        });
       });
     });
   });
@@ -353,16 +405,9 @@ describe('TableAjax', () => {
   });
 
   describe('handleRequest', () => {
-    let wrapper,
-        response;
+    let wrapper;
 
     beforeEach(() => {
-      response = {
-        body: {
-          records: 1
-        }
-      };
-
       wrapper = mount(
         <TableAjax
           path='/test'

--- a/src/components/table-ajax/table-ajax.js
+++ b/src/components/table-ajax/table-ajax.js
@@ -114,7 +114,15 @@ class TableAjax extends Table {
      * @property onAjaxError
      * @type {Function}
      */
-    onAjaxError: PropTypes.func
+    onAjaxError: PropTypes.func,
+
+    /**
+     * A prop to allow the override of the default get request and perform a post.
+     * @property postAction
+     * @type {Boolean}
+
+     */
+    postAction: PropTypes.bool
   }
 
   static defaultProps = {
@@ -343,15 +351,27 @@ class TableAjax extends Table {
         dataState: 'requested',
         ariaBusy: true
       });
-      this._request = Request
-        .get(this.props.path)
-        .set(this.getHeaders())
-        .query(this.queryParams(element, options))
-        .end((err, response) => {
-          this._hasRetreivedData = true;
-          this.handleResponse(err, response);
-          if (resetHeight) { this.resetTableHeight(); }
-        });
+      if (this.props.postAction) {
+        this._request = Request
+          .post(this.props.path)
+          .set(this.getHeaders())
+          .query(this.queryParams(element, options))
+          .end((err, response) => {
+            this._hasRetreivedData = true;
+            this.handleResponse(err, response);
+            if (resetHeight) { this.resetTableHeight(); }
+          });
+      } else {
+        this._request = Request
+          .get(this.props.path)
+          .set(this.getHeaders())
+          .query(this.queryParams(element, options))
+          .end((err, response) => {
+            this._hasRetreivedData = true;
+            this.handleResponse(err, response);
+            if (resetHeight) { this.resetTableHeight(); }
+          });
+      }
     }, timeout);
   }
 

--- a/src/components/table-ajax/table-ajax.js
+++ b/src/components/table-ajax/table-ajax.js
@@ -351,27 +351,16 @@ class TableAjax extends Table {
         dataState: 'requested',
         ariaBusy: true
       });
-      if (this.props.postAction) {
-        this._request = Request
-          .post(this.props.path)
-          .set(this.getHeaders())
-          .query(this.queryParams(element, options))
-          .end((err, response) => {
-            this._hasRetreivedData = true;
-            this.handleResponse(err, response);
-            if (resetHeight) { this.resetTableHeight(); }
-          });
-      } else {
-        this._request = Request
-          .get(this.props.path)
-          .set(this.getHeaders())
-          .query(this.queryParams(element, options))
-          .end((err, response) => {
-            this._hasRetreivedData = true;
-            this.handleResponse(err, response);
-            if (resetHeight) { this.resetTableHeight(); }
-          });
-      }
+
+      const verb = this.props.postAction ? 'post' : 'get';
+      this._request = Request[verb](this.props.path)
+        .set(this.getHeaders())
+        .query(this.queryParams(element, options))
+        .end((err, response) => {
+          this._hasRetreivedData = true;
+          this.handleResponse(err, response);
+          if (resetHeight) { this.resetTableHeight(); }
+        });
     }, timeout);
   }
 


### PR DESCRIPTION
# Description

Extends TableAjax to allow for post requests.

Followed pattern of mocking superagent for post and get based on another Sage repository. Pending comments from reviewers, I could change the mocks to match? Unless there is another way of testing `Request.post` was called.