### PR TITLE
fixes uniqueID error

### DIFF
--- a/src/components/table/table.stories.js
+++ b/src/components/table/table.stories.js
@@ -46,6 +46,7 @@ const buildRows = (pageSize, totalRecords) => {
       <TableRow
         key='header'
         as='header'
+        uniqueID='header'
       >
         <TableHeader
           sortable name='name'


### PR DESCRIPTION
# Description
Fixes the error being thrown when theme is toggled to none in storybook and a row was missing the required `uniqueID`
