### PR TITLE
S1T-1897 - Add withCredentials support to TableAjax

### DIFF
--- a/change_log/next/S1T-1897.yml
+++ b/change_log/next/S1T-1897.yml
@@ -1,0 +1,1 @@
+Improvements: "Adds `withCredentials` prop to the TableAjax component"

--- a/src/components/table-ajax/__definition__.js
+++ b/src/components/table-ajax/__definition__.js
@@ -24,14 +24,16 @@ const definition = new Definition('table-ajax', TableAjax, {
     formatRequest: 'Function',
     onAjaxError: 'Function',
     path: 'String',
-    postAction: 'Boolean'
+    postAction: 'Boolean',
+    withCredentials: 'Boolean'
   },
   propDescriptions: {
     formatResponse: 'Callback function for formatting the data received via Ajax requests into the format required by the table',
     formatRequest: 'Callback function for formatting the query data to be sent via Ajax to the defined path',
     onAjaxError: 'Callback function to handle XHR request errors',
     path: 'The path to make XHR requests to.',
-    postAction: 'This provides an option to override the default get request with post.'
+    postAction: 'This provides an option to override the default get request with post.',
+    withCredentials: 'Makes your browser include cookies and authentication headers in your XHR request.'
   },
   requiredProps: ['path'],
   hiddenProps: [

--- a/src/components/table-ajax/__spec__.js
+++ b/src/components/table-ajax/__spec__.js
@@ -314,6 +314,7 @@ describe('TableAjax', () => {
         it('calls resetTableHeight on successful response', () => {
           instance.resetTableHeight = jest.fn();
           options = { currentPage: '1', pageSize: '5' }
+          Request.withCredentials = jest.fn();
           Request.__setMockResponse({
             status() {
               return 200;
@@ -331,7 +332,46 @@ describe('TableAjax', () => {
           expect(Request.post).toHaveBeenLastCalledWith('/test');
           expect(Request.send).toHaveBeenLastCalledWith({ page: '1', rows: '5' });
           expect(instance.resetTableHeight).toBeCalled();
+          expect(Request.withCredentials).not.toHaveBeenCalled();
         });
+      });
+    });
+
+    describe('when withCredentials is true', () => {
+      beforeEach(() => {
+        spy = jasmine.createSpy('onChange spy');
+        wrapper = mount(
+          <TableAjax
+            withCredentials
+            onAjaxError={ () => {} }
+            className="foo"
+            path='/test'
+            onChange={ spy }
+          >
+            <TableRow />
+          </TableAjax>
+        );
+        instance = wrapper.instance();
+      });
+
+      it('calls withCredentials', () => {
+        options = { currentPage: '1', pageSize: '5' }
+        Request.withCredentials = jest.fn();
+        Request.__setMockResponse({
+          status() {
+            return 200;
+          },
+          ok() {
+            return true;
+          },
+          body: {
+            data: 'foo'
+          }
+        });
+
+        instance.emitOnChangeCallback('data', options);
+        jest.runTimersToTime(251);
+        expect(Request.withCredentials).toHaveBeenCalled();
       });
     });
   });

--- a/src/components/table-ajax/table-ajax.js
+++ b/src/components/table-ajax/table-ajax.js
@@ -122,7 +122,15 @@ class TableAjax extends Table {
      * @type {Boolean}
 
      */
-    postAction: PropTypes.bool
+    postAction: PropTypes.bool,
+
+    /**
+     * Enable the ability to send cookies from the origin.
+     *
+     * @property withCredentials
+     * @type: {Boolean}
+     */
+    withCredentials: PropTypes.bool
   }
 
   static defaultProps = {
@@ -355,22 +363,20 @@ class TableAjax extends Table {
       if (this.props.postAction) {
         this._request = Request.post(this.props.path)
           .set(this.getHeaders())
-          .send(this.queryParams(element, options))
-          .end((err, response) => {
-            this._hasRetreivedData = true;
-            this.handleResponse(err, response);
-            if (resetHeight) { this.resetTableHeight(); }
-          });
+          .send(this.queryParams(element, options));
       } else {
         this._request = Request.get(this.props.path)
           .set(this.getHeaders())
-          .query(this.queryParams(element, options))
-          .end((err, response) => {
-            this._hasRetreivedData = true;
-            this.handleResponse(err, response);
-            if (resetHeight) { this.resetTableHeight(); }
-          });
+          .query(this.queryParams(element, options));
       }
+
+      if (this.props.withCredentials) this._request.withCredentials();
+
+      this._request.end((err, response) => {
+        this._hasRetreivedData = true;
+        this.handleResponse(err, response);
+        if (resetHeight) { this.resetTableHeight(); }
+      });
     }, timeout);
   }
 


### PR DESCRIPTION
### Description

Adding `withCredentials` support to the TableAjax component.

> *withCredentials()* makes your browser include cookies and authentication headers in your XHR request. If your service depends on any cookie (including session cookies), it will only work with this option set.

### TODO

- [x] Release notes
