### PR TITLE
fixes styling defects

### DIFF
--- a/src/components/table/table-cell/table-cell.style.js
+++ b/src/components/table/table-cell/table-cell.style.js
@@ -105,8 +105,8 @@ function applyModernInputStyling(isTextArea, inputHeight, fontSize) {
       padding-bottom: 0px;
     }
     
-    .carbon-icon {
-      font-size: 13px !important;
+    && .carbon-icon {
+      font-size: 13px;
     }
   `;
 }

--- a/src/components/table/table-cell/table-cell.style.js
+++ b/src/components/table/table-cell/table-cell.style.js
@@ -63,6 +63,7 @@ function applyModernPresentationStyling(size, isTextArea) {
       padding-left: ${paddingSize};
       padding-right: ${paddingSize};
       position: relative;
+      ${size === 'large' ? 'width: 150px;' : ''}
       ${additionalPresentationStyling(isTextArea, inputHeight)}
     }
     ${applyModernInputStyling(isTextArea, inputHeight, fontSize)}
@@ -102,6 +103,10 @@ function applyModernInputStyling(isTextArea, inputHeight, fontSize) {
       height: ${inputHeight}px;
       padding-top: 0px;
       padding-bottom: 0px;
+    }
+    
+    .carbon-icon {
+      font-size: 13px !important;
     }
   `;
 }

--- a/src/components/table/table.style.js
+++ b/src/components/table/table.style.js
@@ -56,6 +56,7 @@ export const StyledInternalTableWrapper = styled.div`
   border-radius: 0px;
   overflow: visible;
   position: relative;
+  border-bottom: none;
   
   ${({ onConfigure, theme }) => onConfigure && css`
     ${StyledTable} {


### PR DESCRIPTION
# Description
Fixes the styling defects found in the base PR: removes the border on the table wrapper, sets a width for the date input when the table is `large` and adjusts the date picker icon so it is aligned vertically in the input