### PR TITLE
FE-1806 implements axios post instead of fetch

### DIFF
--- a/src/__experimental__/components/form/form.component.js
+++ b/src/__experimental__/components/form/form.component.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import axios from 'axios';
 import PropTypes from 'prop-types';
 import I18n from 'i18n-js';
 import Serialize from 'form-serialize';
@@ -221,23 +222,20 @@ class FormWithoutValidations extends React.Component {
   }
 
   async submitControlledForm() {
-    const response = await fetch(
-      this.props.formAction, {
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json'
-        },
-        method: 'post',
-        body: JSON.stringify(this.state.formInputs)
-      }
-    );
-    return this.clearFormData(await response.json());
+    const response = await axios.post(this.props.formAction, {
+      ...this.state.formInputs
+    }, {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    });
+    const { data } = await response;
+    return this.clearFormData(data);
   }
 
-  clearFormData(json) {
+  clearFormData(data) {
     // stop gap solution to prevent double submission for the time being
     this._window.location.href = this.redirectPath;
-    return json;
+    return data;
   }
 
   /* enables a form which has been disabled after being submitted. */

--- a/src/__experimental__/components/form/form.stories.js
+++ b/src/__experimental__/components/form/form.stories.js
@@ -34,7 +34,6 @@ storiesOf('Experimental/Form', module)
     const leftAlignedActions = text('leftAlignedActions', '');
     const rightAlignedActions = text('rightAlignedActions', '');
     const showSummary = boolean('showSummary', false);
-    const formAction = text('formAction', 'https://jsonplaceholder.typicode.com/posts');
 
     return (
       <Form
@@ -52,7 +51,9 @@ storiesOf('Experimental/Form', module)
         leftAlignedActions={ leftAlignedActions }
         rightAlignedActions={ rightAlignedActions }
         showSummary={ showSummary }
-        formAction={ formAction }
+        onSubmit={ () => {
+          window.location.href = window.location.href;
+        } }
       >
         <Textbox
           key='0'


### PR DESCRIPTION
# Description
Replaces the `fetch` post call with `axios` as it is not supported by IE11
Refactors test and story to fit with the above changes