### PR TITLE
FE-1835 RadioButton SVG bug on IE/Edge/Firefox

### DIFF
--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -905,6 +905,7 @@ exports[`RadioButton styles base renders as expected 1`] = `
                 cx="7.5"
                 cy="7.5"
                 fill="#FFFFFF"
+                r="5"
               />
             </g>
           </svg>

--- a/src/__experimental__/components/radio-button/radio-button-svg.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-svg.component.js
@@ -18,6 +18,7 @@ const RadioButtonSvg = () => {
             fill='#FFFFFF'
             cx='7.5'
             cy='7.5'
+            r='5'
           />
         </g>
       </svg>


### PR DESCRIPTION
# Description

Chrome and Safari allow an [SVG `circle`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/circle) to be created without an initial radius:
```svg
<circle cx='7.5' cy='7.5' />
```
and then the [radius](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/r) can be set later via CSS:
```css
circle {
  r: 5;
}
```
But in IE, Edge and Firefox, if an initial radius isn't supplied, then the `circle` will never render, even if the radius is later set via CSS :warning:

This PR fixes the bug by supplying an initial radius.