### PR TITLE
added .vscode/ directory to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ lib
 src/style-config/assets.scss
 cypress/fixtures/example*
 cypress/screenshots
+./vscode/


### PR DESCRIPTION
# Description
.vscode/ is a store for local configuration of visual studio code and should not be committed to the repo.