### PR TITLE
FE-1844 Select component validation bug

### DIFF
--- a/src/__experimental__/components/select/select.component.js
+++ b/src/__experimental__/components/select/select.component.js
@@ -168,7 +168,6 @@ class Select extends React.Component {
 
   // returns the correct value to feed into the textbox component
   value(value) {
-    if (!this.props.filterable) return undefined;
     if (this.isMultiValue(value)) {
       return value; // if multi value the returns the full array
     }

--- a/src/components/validations/with-validation.hoc.js
+++ b/src/components/validations/with-validation.hoc.js
@@ -264,7 +264,10 @@ const withValidation = (WrappedComponent) => {
   WithValidation.propTypes = {
     children: PropTypes.node, // Children elements
     name: PropTypes.string.isRequired, // Name to uniquely identify the component
-    value: PropTypes.string, // The current value of the component
+    value: PropTypes.oneOfType([ // The current value of the component
+      PropTypes.string,
+      PropTypes.array
+    ]),
     onBlur: PropTypes.func, // Custom function to be called when the component blurs
     onChange: PropTypes.func, // Custom function called when component value changes
     validations: validationsPropTypes,


### PR DESCRIPTION
# Description

[This line](https://github.com/Sage/carbon/blob/c84f4d7/src/__experimental__/components/select/select.component.js#L171):

```js
if (!this.props.filterable) return undefined;
```

was added to `<Select>`'s `value()` method in https://github.com/Sage/carbon/pull/2163 for FE-1420 (see [commit `f0bbf4e`](https://github.com/Sage/carbon/pull/2163/commits/f0bbf4e#diff-c3877e0d6c511e983d6356c0354b2c8eR159) on 1st July).

It looks like this has broken [the `withValidation()` functionality](https://github.com/Sage/carbon/blob/4e046b7/src/__experimental__/components/textbox/textbox.component.js#L99) of [`<Select>`'s `<Textbox>`](https://github.com/Sage/carbon/blob/4e046b7/src/__experimental__/components/select/select.component.js#L289) when `this.props.filterable === false` :warning:

Specifically, when `this.props.filterable === false`, then [`value()` will always return `undefined`](https://github.com/Sage/carbon/blob/c84f4d7/src/__experimental__/components/select/select.component.js#L170-L171), and so the [`value`](https://github.com/Sage/carbon/blob/c84f4d7/src/__experimental__/components/select/select.component.js#L248) prop [passed to `<Textbox>`](https://github.com/Sage/carbon/blob/c84f4d7/src/__experimental__/components/select/select.component.js#L293) will always be `undefined`.  `<Textbox>` is [wrapped in a `withValidation()` HOC](https://github.com/Sage/carbon/blob/4e046b7/src/__experimental__/components/textbox/textbox.component.js#L99) which [passes the `value` prop to validation callbacks](https://github.com/Sage/carbon/blob/4e046b7/src/components/validations/with-validation.hoc.js#L148).  Since `value` is always `undefined`, the validation callbacks always receive `undefined` :warning:

This PR fixes the bug by removing the problematic line from `value()`.

This PR also fixes FE-1848 (a related bug).  When `<Select>` is operating in "multi-value" mode, the `value` prop it passes to `<Textbox>` is an array.  [`<Textbox>`'s `value` prop type](https://github.com/Sage/carbon/blob/4e046b7/src/__experimental__/components/textbox/textbox.component.js#L55-L58) is correctly `oneOfType: string, array`, but [`withValidation()`'s `value` prop type](https://github.com/Sage/carbon/blob/4e046b7/src/components/validations/with-validation.hoc.js#L267) is just `string` :warning:  This PR makes the necessary correction to `withValidation()`'s `value` prop type.
