### PR TITLE
FE-1830 / FE-1833 RadioButton Help accessibility and tabbing

### DIFF
--- a/src/__experimental__/components/checkable-input/__snapshots__/hidden-checkable-input.spec.js.snap
+++ b/src/__experimental__/components/checkable-input/__snapshots__/hidden-checkable-input.spec.js.snap
@@ -10,6 +10,14 @@ exports[`HiddenCheckableInput renders as expected 1`] = `
 }
 
 <input
+  aria-checked={true}
+  aria-describedby="test-help"
+  checked={true}
   className="c0"
+  name="test-name"
+  role="test-type"
+  tabIndex="0"
+  type="test-type"
+  value="test-value"
 />
 `;

--- a/src/__experimental__/components/checkable-input/checkable-input.component.js
+++ b/src/__experimental__/components/checkable-input/checkable-input.component.js
@@ -18,7 +18,7 @@ class CheckableInput extends React.Component {
     const id = this.inputId;
 
     const formFieldProps = {
-      ...validProps(this, ['fieldHelpInline', 'helpTabIndex', 'labelHelp', 'helpTag', 'reverse']),
+      ...validProps(this, ['fieldHelpInline', 'labelHelp', 'reverse']),
       helpId,
       label: rest.inputLabel,
       labelHelpIcon: 'info',
@@ -28,7 +28,7 @@ class CheckableInput extends React.Component {
     const {
       fieldHelp, labelHelp, ...inputProps
     } = {
-      ...validProps(this, ['checked', 'disabled', 'groupLabelId', 'inputName', 'inputType', 'onChange', 'tabindex']),
+      ...validProps(this, ['checked', 'disabled', 'inputType', 'onChange', 'tabindex']),
       helpId,
       id
     };
@@ -55,6 +55,8 @@ CheckableInput.propTypes = {
   disabled: PropTypes.bool,
   /** Toggles error styles */
   error: PropTypes.bool,
+  /** The fieldHelp content to display for the input */
+  fieldHelp: PropTypes.node,
   /** Displays fieldHelp inline with the CheckableInput */
   fieldHelpInline: PropTypes.bool,
   /** Unique Identifier for the input. Will use a randomly generated GUID if none is provided */

--- a/src/__experimental__/components/checkable-input/checkable-input.component.js
+++ b/src/__experimental__/components/checkable-input/checkable-input.component.js
@@ -12,34 +12,33 @@ class CheckableInput extends React.Component {
     this.inputId = props.inputId || guid();
   }
 
-  formFieldProps = () => {
-    return {
-      ...validProps(this, ['fieldHelpInline', 'reverse']),
-      labelHelpIcon: 'info',
-      name: this.inputId
-    };
-  }
-
-  inputProps = () => {
-    const {
-      children, fieldHelp, labelHelp, ...inputProps
-    } = {
-      ...validProps(this, ['checked', 'disabled', 'onChange', 'tabindex', 'type']),
-      id: this.inputId
-    };
-
-    return inputProps;
-  };
-
   render() {
-    const { onChange, ...rest } = this.props;
+    const { children, onChange, ...rest } = this.props;
+    const helpId = rest.labelHelp ? `${this.inputId}-help` : undefined;
+    const id = this.inputId;
+
+    const formFieldProps = {
+      ...validProps(this, ['fieldHelpInline', 'helpTabIndex', 'labelHelp', 'helpTag', 'reverse']),
+      helpId,
+      label: rest.inputLabel,
+      labelHelpIcon: 'info',
+      name: id
+    };
+
+    const {
+      fieldHelp, labelHelp, ...inputProps
+    } = {
+      ...validProps(this, ['checked', 'disabled', 'groupLabelId', 'inputName', 'inputType', 'onChange', 'tabindex']),
+      helpId,
+      id
+    };
 
     return (
       <StyledCheckableInputWrapper { ...rest }>
-        <FormField { ...this.formFieldProps() }>
+        <FormField { ...formFieldProps }>
           <StyledCheckableInput>
-            <HiddenCheckableInput { ...this.inputProps() } />
-            {this.props.children}
+            <HiddenCheckableInput { ...inputProps } />
+            {children}
           </StyledCheckableInput>
         </FormField>
       </StyledCheckableInputWrapper>
@@ -60,10 +59,14 @@ CheckableInput.propTypes = {
   fieldHelpInline: PropTypes.bool,
   /** Unique Identifier for the input. Will use a randomly generated GUID if none is provided */
   inputId: PropTypes.string,
+  /** The content for the Label to apply to the input */
+  inputLabel: PropTypes.node,
   /** Sets percentage-based input width */
   inputWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /** Sets label alignment - accepted values: 'left' (default), 'right' */
   labelAlign: PropTypes.string,
+  /** The content for the help tooltip, to appear next to the Label */
+  labelHelp: PropTypes.node,
   /** Sets percentage-based label width */
   labelWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /** Accepts a callback function which can be used to update parent state on change */
@@ -71,7 +74,7 @@ CheckableInput.propTypes = {
   /** Reverses label and CheckableInput display */
   reverse: PropTypes.bool,
   /** Specifies input type, 'checkbox' or 'switch' */
-  type: PropTypes.string.isRequired
+  inputType: PropTypes.string.isRequired
 };
 
 CheckableInput.defaultProps = {

--- a/src/__experimental__/components/checkable-input/checkable-input.spec.js
+++ b/src/__experimental__/components/checkable-input/checkable-input.spec.js
@@ -1,15 +1,36 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 import 'jest-styled-components';
 import { css } from 'styled-components';
 import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
+import CheckableInput from '.';
 import FieldHelpStyle from '../field-help/field-help.style';
 import FormFieldStyle from '../form-field/form-field.style';
+import Help from '../../../components/help';
 import HiddenCheckableInputStyle from './hidden-checkable-input.style';
 import LabelStyle from '../label/label.style';
 import { StyledCheckableInput, StyledCheckableInputWrapper } from './checkable-input.style';
 import StyledHelp from '../../../components/help/help.style';
 import baseTheme from '../../../style/themes/base';
+
+describe('CheckableInput', () => {
+  function mountInput(props) {
+    return mount(<CheckableInput { ...props } />);
+  }
+
+  describe('helpId', () => {
+    describe('when inputLabel and labelHelp props are present', () => {
+      it('returns an appropriate helpId property', () => {
+        const helpButton = mountInput({ inputId: 'foo', inputLabel: 'bar', labelHelp: 'baz' })
+          .find(Help)
+          .find('button');
+
+        expect(helpButton.props().id).toBe('foo-help');
+      });
+    });
+  });
+});
 
 function render(props) {
   return TestRenderer.create(<StyledCheckableInputWrapper { ...props } />);

--- a/src/__experimental__/components/checkable-input/hidden-checkable-input.component.js
+++ b/src/__experimental__/components/checkable-input/hidden-checkable-input.component.js
@@ -3,14 +3,17 @@ import PropTypes from 'prop-types';
 import HiddenCheckableInputStyle from './hidden-checkable-input.style';
 
 const HiddenCheckableInput = ({
-  role, tabindex, type, ...props
+  helpId, inputName, inputType, inputValue, role, tabindex, ...props
 }) => {
   return (
     <HiddenCheckableInputStyle
       aria-checked={ props.checked }
-      role={ role || type }
+      aria-describedby={ helpId }
+      name={ inputName }
+      role={ role || inputType }
       tabIndex={ tabindex }
-      type={ type }
+      type={ inputType }
+      value={ inputValue }
       { ...props }
     />
   );
@@ -18,9 +21,12 @@ const HiddenCheckableInput = ({
 
 HiddenCheckableInput.propTypes = {
   checked: PropTypes.bool,
+  helpId: PropTypes.string,
+  inputName: PropTypes.string,
+  inputType: PropTypes.string.isRequired,
+  inputValue: PropTypes.string.isRequired,
   role: PropTypes.string,
-  tabindex: PropTypes.number,
-  type: PropTypes.string.isRequired
+  tabindex: PropTypes.number
 };
 
 export default HiddenCheckableInput;

--- a/src/__experimental__/components/checkable-input/hidden-checkable-input.spec.js
+++ b/src/__experimental__/components/checkable-input/hidden-checkable-input.spec.js
@@ -9,6 +9,13 @@ function render(props) {
 
 describe('HiddenCheckableInput', () => {
   it('renders as expected', () => {
-    expect(render()).toMatchSnapshot();
+    expect(render({
+      checked: true,
+      helpId: 'test-help',
+      inputName: 'test-name',
+      inputType: 'test-type',
+      inputValue: 'test-value',
+      tabindex: '0'
+    })).toMatchSnapshot();
   });
 });

--- a/src/__experimental__/components/checkbox/__snapshots__/checkbox.spec.js.snap
+++ b/src/__experimental__/components/checkbox/__snapshots__/checkbox.spec.js.snap
@@ -590,7 +590,6 @@ exports[`Checkbox base theme renders as expected 1`] = `
 >
   <div
     className="c1"
-    type="checkbox"
   >
     <div
       className="c2 c3"
@@ -603,6 +602,7 @@ exports[`Checkbox base theme renders as expected 1`] = `
           id="guid-12345"
           role="checkbox"
           type="checkbox"
+          value="test"
         />
         <div
           className="c8 "

--- a/src/__experimental__/components/checkbox/checkbox.component.js
+++ b/src/__experimental__/components/checkbox/checkbox.component.js
@@ -5,13 +5,17 @@ import CheckboxStyle from './checkbox.style';
 import CheckableInput from '../checkable-input/checkable-input.component';
 import CheckboxSvg from './checkbox-svg.component';
 
-const Checkbox = (props) => {
+const Checkbox = ({
+  id, label, onChange, value, ...props
+}) => {
   const inputProps = {
     ...props,
+    inputId: id,
+    inputLabel: label,
+    inputValue: value,
+    inputType: 'checkbox',
     reverse: !props.reverse
   };
-
-  const { onChange, ...rest } = inputProps;
 
   return (
     <CheckboxStyle
@@ -19,9 +23,8 @@ const Checkbox = (props) => {
       { ...props }
     >
       <CheckableInput
-        type='checkbox'
-        { ...rest }
-        onChange={ props.onChange }
+        { ...inputProps }
+        onChange={ onChange }
       >
         <CheckboxSvg />
       </CheckableInput>
@@ -38,8 +41,12 @@ Checkbox.propTypes = {
   error: PropTypes.bool,
   /** Displays fieldHelp inline with the checkbox */
   fieldHelpInline: PropTypes.bool,
+  /** Unique Identifier for the input. Will use a randomly generated GUID if none is provided */
+  id: PropTypes.string,
   /** Sets percentage-based input width */
   inputWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /** The content of the label for the input */
+  label: PropTypes.string,
   /** Sets label alignment - accepted values: 'left' (default), 'right' */
   labelAlign: PropTypes.string,
   /** Sets percentage-based label width */
@@ -52,7 +59,9 @@ Checkbox.propTypes = {
    * Set the size of the checkbox to 'small' (16x16 - default) or 'large' (24x24).
    * No effect when using Classic theme.
    */
-  size: PropTypes.string
+  size: PropTypes.string,
+  /** the value of the checkbox, passed on form submit */
+  value: PropTypes.string.isRequired
 };
 
 Checkbox.defaultProps = {

--- a/src/__experimental__/components/checkbox/checkbox.spec.js
+++ b/src/__experimental__/components/checkbox/checkbox.spec.js
@@ -21,7 +21,7 @@ jest.mock('../../../utils/helpers/guid');
 guid.mockImplementation(() => 'guid-12345');
 
 function render(props) {
-  return TestRenderer.create(<Checkbox { ...props } />);
+  return TestRenderer.create(<Checkbox value='test' { ...props } />);
 }
 
 describe('Checkbox', () => {

--- a/src/__experimental__/components/checkbox/checkbox.stories.js
+++ b/src/__experimental__/components/checkbox/checkbox.stories.js
@@ -61,6 +61,7 @@ function defaultKnobs() {
       OptionsHelper.alignBinary,
       OptionsHelper.alignBinary[0]
     ),
-    size: select('size', OptionsHelper.sizesBinary, 'small')
+    size: select('size', OptionsHelper.sizesBinary, 'small'),
+    value: text('value', 'test-value')
   });
 }

--- a/src/__experimental__/components/form-field/form-field.component.js
+++ b/src/__experimental__/components/form-field/form-field.component.js
@@ -11,6 +11,9 @@ const FormField = ({
   fieldHelp,
   fieldHelpInline,
   hasError,
+  helpId,
+  helpTag,
+  helpTabIndex,
   label,
   labelAlign,
   labelHelp,
@@ -30,6 +33,9 @@ const FormField = ({
         disabled={ disabled }
         hasError={ hasError }
         help={ labelHelp }
+        helpId={ helpId }
+        helpTag={ helpTag }
+        helpTabIndex={ helpTabIndex }
         htmlFor={ name }
         helpIcon={ labelHelpIcon }
         inline={ labelInline }
@@ -66,6 +72,9 @@ FormField.propTypes = {
   fieldHelp: PropTypes.node,
   fieldHelpInline: PropTypes.bool,
   hasError: PropTypes.bool,
+  helpId: PropTypes.string,
+  helpTag: PropTypes.string,
+  helpTabIndex: PropTypes.string,
   label: PropTypes.node,
   labelAlign: PropTypes.oneOf(OptionsHelper.alignBinary),
   labelHelp: PropTypes.node,

--- a/src/__experimental__/components/label/label.component.js
+++ b/src/__experimental__/components/label/label.component.js
@@ -7,6 +7,9 @@ const Label = ({
   children,
   help,
   helpIcon,
+  helpId,
+  helpTag,
+  helpTabIndex,
   ...props
 }) => (
   <LabelStyle
@@ -14,14 +17,25 @@ const Label = ({
     { ...props }
   >
     {children}
-    {help && <Help type={ helpIcon }>{help}</Help>}
+    {help && (
+      <Help
+        helpId={ helpId }
+        tagTypeOverride={ helpTag }
+        tabIndexOverride={ helpTabIndex }
+        type={ helpIcon }
+      >
+        {help}
+      </Help>)}
   </LabelStyle>
 );
 
 Label.propTypes = {
   children: PropTypes.node,
   help: PropTypes.string,
-  helpIcon: PropTypes.string
+  helpIcon: PropTypes.string,
+  helpId: PropTypes.string,
+  helpTag: PropTypes.string,
+  helpTabIndex: PropTypes.string
 };
 
 export default Label;

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -867,12 +867,9 @@ exports[`RadioButton styles base renders as expected 1`] = `
 <div
   className="c0"
   data-component="radio-button"
-  value="test"
 >
   <div
     className="c1"
-    type="radio"
-    value="test"
   >
     <div
       className="c2 c3"

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -16,6 +16,8 @@ const RadioButtonGroup = (props) => {
   const { children, groupName, label } = props;
   const [selectedValue, setSelectedValue] = useState(null);
 
+  const groupLabelId = `${groupName}-label`;
+
   const buttons = React.Children.map(children, (child, index) => {
     const key = child.props.key || child.props.value;
     const checked = selectedValue === child.props.value;
@@ -30,23 +32,22 @@ const RadioButtonGroup = (props) => {
       child,
       {
         checked,
+        inputName: groupName,
         key,
-        name: groupName,
         onChange: handleChange,
         tabindex
       }
     );
   });
 
-  const labelId = `${groupName}-label`;
 
   return (
     <StyledRadioButtonGroup
-      aria-labelledby={ labelId }
+      aria-labelledby={ groupLabelId }
       role='radiogroup'
       { ...tagComponent('radiogroup', props) }
     >
-      <Label id={ labelId }>
+      <Label id={ groupLabelId }>
         {label}
       </Label>
       {buttons}

--- a/src/__experimental__/components/radio-button/radio-button-group.spec.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.spec.js
@@ -57,7 +57,10 @@ describe('RadioButtonGroup', () => {
 
       describe('name', () => {
         it('is set using the RadioButtonGroup groupName prop', () => {
-          expect(button.props.name).toEqual(groupName);
+          const buttonWrapper = buttons.at(buttonArray.indexOf(button));
+          const input = getInputWrapper(buttonWrapper).instance();
+
+          expect(input.name).toEqual(groupName);
         });
       });
     });

--- a/src/__experimental__/components/radio-button/radio-button.component.js
+++ b/src/__experimental__/components/radio-button/radio-button.component.js
@@ -18,28 +18,32 @@ function setTabIndex({ tabindex, checked }) {
   return tabindexOverride;
 }
 
-const RadioButton = ({ id, ...props }) => {
-  const { onChange, ...rest } = props;
-
+const RadioButton = ({
+  id, label, onChange, value, ...props
+}) => {
   const inputProps = {
-    ...rest,
+    ...props,
+    helpTabIndex: '-1',
+    helpTag: 'span',
+    inputId: id,
+    inputLabel: label,
+    inputValue: value,
+    inputType: 'radio',
     /**
      * Invert the reverse prop, to ensure the FormField component renders the components
      * in the desired order (other elements which use FormField render their sub-components the
      * opposite way around by default)
-    */
+     */
     reverse: !props.reverse
   };
 
   return (
     <RadioButtonStyle
       { ...tagComponent('radio-button', props) }
-      { ...rest }
+      { ...props }
     >
       <CheckableInput
-        type='radio'
         { ...inputProps }
-        inputId={ id }
         onChange={ onChange }
         tabindex={ setTabIndex(inputProps) }
       >
@@ -62,6 +66,8 @@ RadioButton.propTypes = {
   id: PropTypes.string,
   /** Sets percentage-based input width */
   inputWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /** The content of the label for the input */
+  label: PropTypes.string,
   /** Sets label alignment - accepted values: 'left' (default), 'right' */
   labelAlign: PropTypes.oneOf(OptionsHelper.alignBinary),
   /** Sets percentage-based label width */

--- a/src/__experimental__/components/switch/__snapshots__/switch.spec.js.snap
+++ b/src/__experimental__/components/switch/__snapshots__/switch.spec.js.snap
@@ -514,7 +514,6 @@ exports[`Switch base theme renders as expected 1`] = `
 >
   <div
     className="c1"
-    type="checkbox"
   >
     <div
       className="c2 c3"
@@ -527,6 +526,7 @@ exports[`Switch base theme renders as expected 1`] = `
           id="guid-12345"
           role="checkbox"
           type="checkbox"
+          value="test"
         />
         <span
           className="c8 c9"

--- a/src/__experimental__/components/switch/switch.component.js
+++ b/src/__experimental__/components/switch/switch.component.js
@@ -6,7 +6,9 @@ import CheckableInput from '../checkable-input';
 import SwitchSlider from './switch-slider.component';
 import { isClassic } from '../../../utils/helpers/style-helper';
 
-const Switch = (props) => {
+const Switch = ({
+  id, label, onChange, value, ...props
+}) => {
   const classicDisabled = props.theme && isClassic(props.theme) && props.loading;
 
   const switchProps = {
@@ -14,14 +16,23 @@ const Switch = (props) => {
     ...props
   };
 
+  const inputProps = {
+    ...switchProps,
+    disabled: props.disabled || classicDisabled,
+    inputId: id,
+    inputLabel: label,
+    inputValue: value,
+    inputType: 'checkbox'
+  };
+
   return (
     <SwitchStyle
-      { ...tagComponent('Switch', switchProps) }
+      { ...tagComponent('Switch', props) }
       { ...switchProps }
     >
       <CheckableInput
-        type='checkbox'
-        { ...switchProps }
+        { ...inputProps }
+        onChange={ onChange }
       >
         <SwitchSlider { ...switchProps } />
       </CheckableInput>
@@ -38,8 +49,12 @@ Switch.propTypes = {
   fieldHelp: PropTypes.string,
   /** Displays fieldHelp inline with the checkbox */
   fieldHelpInline: PropTypes.bool,
+  /** Unique Identifier for the input. Will use a randomly generated GUID if none is provided */
+  id: PropTypes.string,
   /** Sets percentage-based input width */
   inputWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /** The content of the label for the input */
+  label: PropTypes.string,
   /** Sets label alignment - accepted values: 'left' (default), 'right' */
   labelAlign: PropTypes.string,
   /** Displays label inline with the Switch */
@@ -57,7 +72,9 @@ Switch.propTypes = {
    * No effect when using Classic theme.
    */
   size: PropTypes.string,
-  theme: PropTypes.object
+  theme: PropTypes.object,
+  /** the value of the checkbox, passed on form submit */
+  value: PropTypes.string.isRequired
 };
 
 Switch.defaultProps = {

--- a/src/__experimental__/components/switch/switch.spec.js
+++ b/src/__experimental__/components/switch/switch.spec.js
@@ -20,7 +20,7 @@ jest.mock('../../../utils/helpers/guid');
 guid.mockImplementation(() => 'guid-12345');
 
 function render(props) {
-  return TestRenderer.create(<Switch { ...props } />);
+  return TestRenderer.create(<Switch value='test' { ...props } />);
 }
 
 describe('Switch', () => {

--- a/src/__experimental__/components/switch/switch.stories.js
+++ b/src/__experimental__/components/switch/switch.stories.js
@@ -85,7 +85,8 @@ function commonKnobs() {
       OptionsHelper.alignBinary,
       OptionsHelper.alignBinary[0]
     ),
-    reverse: boolean('reverse', Switch.defaultProps.reverse)
+    reverse: boolean('reverse', Switch.defaultProps.reverse),
+    value: text('value', 'test-value')
   });
 }
 

--- a/src/components/help/help.component.js
+++ b/src/components/help/help.component.js
@@ -11,7 +11,10 @@ const Help = (props) => {
   const {
     className,
     href,
+    helpId,
     children,
+    tabIndexOverride,
+    tagTypeOverride,
     tooltipPosition,
     tooltipAlign
   } = props;
@@ -29,6 +32,8 @@ const Help = (props) => {
     tagType = 'a';
   }
 
+  tagType = tagTypeOverride || tagType;
+
   function handleKeyPress(ev) {
     if (Events.isEscKey(ev)) {
       helpElement.current.blur();
@@ -41,12 +46,15 @@ const Help = (props) => {
       className={ className }
       as={ tagType }
       href={ href }
+      id={ helpId }
       target='_blank'
       rel='noopener noreferrer'
       ref={ helpElement }
       onFocus={ () => updateTooltipVisible(true) }
       onBlur={ () => updateTooltipVisible(false) }
       { ...tagComponent('help', props) }
+      tabIndex={ tabIndexOverride }
+      value={ children }
     >
       <Icon
         type='help'
@@ -64,6 +72,12 @@ Help.propTypes = {
   className: PropTypes.string,
   /** Message to display in tooltip */
   children: PropTypes.string,
+  /** The unique id of the component (used with aria-describedby for accessibility) */
+  helpId: PropTypes.string,
+  /** Overrides the default tabindex of the component */
+  tabIndexOverride: PropTypes.string,
+  /** Overrides the default 'as' attribute of the Help component */
+  tagTypeOverride: PropTypes.string,
   /** Position of tooltip relative to target */
   tooltipPosition: PropTypes.string,
   /** Aligment of pointer */


### PR DESCRIPTION
- updates to Help, when used within a RadioButton group, as discussed with UX
- to preserve normal RadioButtonGroup UX, it has been agreed that the Help component will NOT be tabbable when it appears alongside a RadioButton
- in these cases, it is made accessible via aria-describedby instead. To facilitate this, overrides for the tabIndex and tag type have been added to the Help component, along with an id prop
- this commit also makes some refactors to the CheckableInput, and the components which use this, to ensure that props such as value, label and type are only applied to the input element (the HiddenCheckableInput)