### PR TITLE
FE-1906 Pill close button

### DIFF
--- a/change_log/next/FE-1906-pill.yml
+++ b/change_log/next/FE-1906-pill.yml
@@ -1,1 +1,0 @@
-Bug Fixes: "Fixed visual inconsistency on the Pill component where the close button had margins in Safari."

--- a/change_log/next/FE-1906-pill.yml
+++ b/change_log/next/FE-1906-pill.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Fixed visual inconsistency on the Pill component where the close button had margins in Safari."

--- a/src/components/pill/pill.style.js
+++ b/src/components/pill/pill.style.js
@@ -61,6 +61,7 @@ const PillStyle = styled.span`
           right: 0;
           top: 0;
           width: 20px;
+          margin: 0;
 
           ${inFill && css`
             background-color: ${styleSet[variety].color};


### PR DESCRIPTION
# Description

Added CSS margin to equal 0 on the Pill close button, to resolve the stylistic mismatch on Safari compared with other browsers.