### PR TITLE
added new package to download on Ubuntu for cypress tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ cache:
 node_js:
   - 8.11.3
 
+addons:
+   apt:
+     packages:
+       # Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves
+       - libgconf-2-4
+
 install:
   - npm install -g npm@6.1.0
   - npm install -g gulp


### PR DESCRIPTION
Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves so we need to add new package to download on Ubuntu for cypress tests