### PR TITLE
Bug fix for ISSUE 1856

### DIFF
--- a/change_log/next/ISSUE_1856.yml
+++ b/change_log/next/ISSUE_1856.yml
@@ -1,0 +1,1 @@
+Bug Fixes: 'ISSUE-1856: Updating textarea CSS to fix bug with error icons being displaced.'

--- a/src/__deprecated__/components/textarea/textarea.scss
+++ b/src/__deprecated__/components/textarea/textarea.scss
@@ -7,6 +7,10 @@
   vertical-align: top;
 }
 
+.carbon-textarea:not(.common-input--label-inline) .carbon-icon.common-input__icon {
+  top: 37px;
+}
+
 .carbon-textarea__input {
   height: auto;
   min-height: $input-common-height;


### PR DESCRIPTION
# Description

- A potential fix for issue #1856
- Updating the textarea css to prevent error icons becoming displaced
- The suggested change on #1856 did not work for all situations. I found that it interfered with textareas using the labelInline prop, see screenshot below. My suggested css change only affects text areas not using the labelInline prop since for me textareas using the labelInline prop do not exhibit the displaced error icon issue in the first place.

# TODO
- [x] Release notes

# Related Issues
https://github.com/Sage/carbon/issues/1856

# Screenshots

**Without any style changes the normal textarea error icon is displaced. Textarea using labelInline is not affected**
<img width="1048" alt="Screenshot 2019-08-14 at 15 25 40" src="https://user-images.githubusercontent.com/11958620/63029080-dbebf280-bea7-11e9-9d10-bd8bc115e4dc.png">

**With the suggested change from 1856 the error icon on the normal textarea is no longer displaced, however the error icon for the textarea using labelInline is now displaced**
<img width="1045" alt="Screenshot 2019-08-14 at 15 25 29" src="https://user-images.githubusercontent.com/11958620/63029108-e908e180-bea7-11e9-890b-acb60ebee40e.png">

**With my own suggested change neither of the error icons are displaced**
<img width="1049" alt="Screenshot 2019-08-14 at 15 25 09" src="https://user-images.githubusercontent.com/11958620/63029137-f2924980-bea7-11e9-9ba3-d94fc0ccd6ad.png">
