### PR TITLE
FE-1876 - add missing outline to the Help Component

### DIFF
--- a/change_log/next/FE-1876-help-component.yml
+++ b/change_log/next/FE-1876-help-component.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Fix issue with outline border not being visible when component is focused"

--- a/change_log/next/FE-1876-help-component.yml
+++ b/change_log/next/FE-1876-help-component.yml
@@ -1,1 +1,1 @@
-Bug Fixes: "Fix issue with outline border not being visible when component is focused"
+Bug Fixes: "Fix issue with outline border not being visible when Help component is focused"

--- a/src/components/help/help.component.js
+++ b/src/components/help/help.component.js
@@ -56,6 +56,7 @@ const Help = (props) => {
       { ...tagComponent('help', props) }
       tabIndex={ tabIndexOverride }
       value={ children }
+      aria-label='additional help information'
     >
       <Icon
         type='help'

--- a/src/components/help/help.style.js
+++ b/src/components/help/help.style.js
@@ -16,6 +16,7 @@ const StyledHelp = styled.button`
   margin-left: 8px;
   margin-top: 0;
   top: -1px;
+  padding: 1px;
 
   ${({ href }) => href && css`
     cursor: pointer;
@@ -28,12 +29,20 @@ const StyledHelp = styled.button`
     text-decoration: underline;
   }
 
+  &:focus{
+    outline: 2px solid ${({ theme }) => theme.colors.focus}
+  }
+
   ${({ theme }) => isClassic(theme) && css`
     color: rgb(128, 153, 164);
 
     &:focus,
     &:hover {
       color: rgb(128, 153, 164);
+    }
+
+    &:focus{
+      outline: none;
     }
   `}
 `;

--- a/src/components/help/help.style.js
+++ b/src/components/help/help.style.js
@@ -30,7 +30,11 @@ const StyledHelp = styled.button`
   }
 
   &:focus{
-    outline: 2px solid ${({ theme }) => theme.colors.focus}
+    outline: 2px solid ${({ theme }) => theme.colors.focus};
+
+    ::-moz-focus-inner{
+      border: 0;
+    }
   }
 
   ${({ theme }) => isClassic(theme) && css`
@@ -43,6 +47,10 @@ const StyledHelp = styled.button`
 
     &:focus{
       outline: none;
+
+      ::-moz-focus-inner{
+        border: 1px dotted black;
+      }
     }
   `}
 `;

--- a/src/components/toast/toast.stories.js
+++ b/src/components/toast/toast.stories.js
@@ -29,7 +29,7 @@ storiesOf('Toast', module)
       propTablesExclude: [ThemeProvider, StyledToastStory]
     }
   })
-  .add('Classic', () => {
+  .add('classic', () => {
     const variant = select('as', OptionsHelper.colors, OptionsHelper.colors[2]);
     const children = text('children', 'Talkie\'s the name, toasting\'s the game. Anyone like any toast?');
     const open = boolean('open', true);
@@ -49,7 +49,7 @@ storiesOf('Toast', module)
         </StyledToastStory>
       </ThemeProvider>
     );
-  }).add('Default', () => {
+  }).add('default', () => {
     const variant = select('variant', OptionsHelper.toast, OptionsHelper.toast[0]);
     const children = text('children', 'Talkie\'s the name, toasting\'s the game. Anyone like any toast?');
     const open = boolean('open', true);


### PR DESCRIPTION
# Description
- added missing outline

# Testing Instructions
- Open storybook
- Open Help component
- Change the theme to S/M/L
- Press twice Tab button

