### PR TITLE
FE-1915 - fix Configurable Items component in the storybook

### DIFF
--- a/change_log/next/FE-1915-configurable-items.yml
+++ b/change_log/next/FE-1915-configurable-items.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Fixes issue with component not being visible in the storybook"

--- a/change_log/next/FE-1915-configurable-items.yml
+++ b/change_log/next/FE-1915-configurable-items.yml
@@ -1,1 +1,1 @@
-Bug Fixes: "Fixes issue with component not being visible in the storybook"
+Bug Fixes: "Fixes issue with ConfigurableItems component not being visible in the storybook"

--- a/src/components/configurable-items/configurable-items.stories.js
+++ b/src/components/configurable-items/configurable-items.stories.js
@@ -7,7 +7,7 @@ import notes from './documentation';
 import { ConfigurableItems, ConfigurableItemRow } from '.';
 import getDocGenInfo from '../../utils/helpers/docgen-info';
 
-const ConfigurableItemsWrapper = () => (<ConfigurableItems />);
+const ConfigurableItemsWrapper = props => (<ConfigurableItems { ...props } />);
 ConfigurableItemsWrapper.__docgenInfo = getDocGenInfo(
   require('./docgenInfo.json'),
   /configurable-items\.component(?!spec)/

--- a/src/components/configurable-items/configurable-items.style.js
+++ b/src/components/configurable-items/configurable-items.style.js
@@ -5,6 +5,7 @@ import {
   ConfigurableItemRowIconStyle,
   ConfigurableItemRowStyle
 } from './configurable-item-row/configurable-item-row.style';
+import StyledFormField from '../../__experimental__/components/form-field/form-field.style';
 import baseTheme from '../../style/themes/base';
 
 const ConfigurableItemsButtonReset = styled(Button)`
@@ -16,6 +17,10 @@ const ConfigurableItemsWrapper = styled.ol`
   list-style: none;
   margin: 0;
   padding: 0;
+
+  && ${StyledFormField}{
+    margin-bottom: 0px;
+  }
 `;
 
 const ConfigurableItemsStyle = styled.div`


### PR DESCRIPTION
# Description
- fix visibility of component in the storybook
- fix for styling of the component

# Important Information
- The issue with `Accessibility` (`ul` ,`li`) is familiar but we have to omit it because it is caused by DnD library specifications