### PR TITLE
Cypress - fix for stickyFormFooter, fix for Confirm component

### DIFF
--- a/cypress/features/regression/confirm.feature
+++ b/cypress/features/regression/confirm.feature
@@ -136,29 +136,12 @@ Feature: Confirm component
       And I open component preview
     Then Close icon is not visible
 
-  # Tests are disabled until the stickyFormFooter will be fixed
-  # doesn't work on Carbon Site
-  @ignore
-  @positive
-  Scenario: StickyFormFooter enabled
-    When I check stickyFormFooter checkbox
-      And I open component preview
-    Then Confirm dialog has stickyFormFooter parameter enabled
-
-  @ignore
-  @negative
-  Scenario: StickyFormFooter disabled
-    When I uncheck stickyFormFooter checkbox
-      And I open component preview
-    Then Confirm dialog has no stickyFormFooter parameter
-
   @positive
   Scenario: Confirm dialog should dissapear after click onto cancelButton
     When I open component preview
       And I click on a cancelButton
     Then Confirm dialog is not visible
 
-  @ignore @FE-1487
   @positive
   Scenario: Confirm dialog should dissapear after click onto confirmButton
     When I open component preview

--- a/cypress/features/regression/dialog.feature
+++ b/cypress/features/regression/dialog.feature
@@ -86,8 +86,6 @@ Feature: Dialog component
     Then closeIcon is not visible
 
   @positive
-  @FE-1918
-  @ignore
   Scenario: Enable StickyFormFooter
     When I check stickyFormFooter checkbox
       And I open component preview

--- a/cypress/locators/dialog/locators.js
+++ b/cypress/locators/dialog/locators.js
@@ -2,4 +2,4 @@
 export const ALERT_DIALOG = '[data-element="dialog"]';
 export const DIALOG_TITLE = '#carbon-dialog-title';
 export const DIALOG_SUBTITLE = '#carbon-dialog-subtitle';
-export const STICKY_FORM_FOOTER_ELEMENT = 'div[class="carbon-form__footer-wrapper"]';
+export const STICKY_FORM_FOOTER_ELEMENT = '[data-element="form-footer"]';

--- a/cypress/support/step-definitions/confirm-steps.js
+++ b/cypress/support/step-definitions/confirm-steps.js
@@ -59,17 +59,3 @@ Then('Confirm dialog input height is {string}', (height) => {
 Then('Confirm dialog size property on preview is {string}', (size) => {
   dialogPreview().should('have.css', 'width', `${size}px`);
 });
-
-Then('Confirm dialog has stickyFormFooter parameter enabled', () => {
-  /*
-  stickyFormFooter - the functionality exists, but doesn't work on Storybook / Carbon demo site.
-  will be fixed on the next impementation phase
-  */
-});
-
-Then('Confirm dialog has no stickyFormFooter parameter', () => {
-  /*
-  stickyFormFooter - the functionality exists, but doesn't work on Storybook / Carbon demo site.
-  will be fixed on the next impementation phase
-  */
-});

--- a/cypress/support/step-definitions/dialog-steps.js
+++ b/cypress/support/step-definitions/dialog-steps.js
@@ -35,6 +35,7 @@ Then('Dialog is not visible', () => {
 });
 
 Then('stickyFormFooter is enabled', () => {
+  cy.wait(500); // storybook needs time to render properly stickyFormFooter
   dialogStickyFormFooter().should('be.visible');
 });
 


### PR DESCRIPTION
Cypress tests:
- fix for stickyFormFooter for `Dialog` component;
- fix for `Confirm` component (deleted tests with stickyFormFooter, enabled test for confirm button)