### PR TITLE
fix: dialog should not render falsey children FE-2024

### DIFF
--- a/src/components/dialog/dialog.component.js
+++ b/src/components/dialog/dialog.component.js
@@ -192,7 +192,7 @@ class Dialog extends Modal {
     const childrenArray = Array.isArray(children) ? children : [children];
     this.childKeys = generateKeysForChildren(childrenArray);
 
-    return childrenArray.map((child, index) => {
+    return childrenArray.filter(Boolean).map((child, index) => {
       return React.cloneElement(child, {
         ...child.props,
         key: this.childKeys[index],

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -197,6 +197,25 @@ describe('Dialog', () => {
     });
   });
 
+  it('renders when a child is undefined', () => {
+    expect(() => {
+      shallow(
+        <Dialog
+          onCancel={ () => { } }
+          onConfirm={ () => { } }
+          showCloseIcon
+          open
+          subtitle='Test'
+          title='Test'
+          ariaRole='dialog'
+        >
+          {undefined}
+          Hello world
+        </Dialog>
+      );
+    }).not.toThrow();
+  });
+
   describe('renders children when they are a JSX component', () => {
     it('should render matched snpashot', () => {
       const wrapper = shallow(


### PR DESCRIPTION
This fixes the issue in the release candidate where dialogs with one or more falsey children failes to render.
