### PR TITLE
Fix for Split Button when children are undefined

### DIFF
--- a/src/components/split-button/split-button.component.js
+++ b/src/components/split-button/split-button.component.js
@@ -177,7 +177,7 @@ class SplitButton extends Component {
     const { children } = this.props;
     const childArray = Array.isArray(children) ? children : [children];
 
-    return childArray.map((child, index) => {
+    return childArray.filter(Boolean).map((child, index) => {
       const props = {
         key: index.toString(),
         role: 'menu-item',

--- a/src/components/split-button/split-button.spec.js
+++ b/src/components/split-button/split-button.spec.js
@@ -71,6 +71,17 @@ const renderWithTheme = (mainProps = {}, childButtons = singleButton, renderer =
   );
 };
 
+const renderWithNoChildren = (mainProps = {}, renderer = shallow) => {
+  return renderer(
+    <SplitButton
+      { ...mainProps }
+      text='Split button'
+      data-element='bar'
+      data-role='baz'
+    />
+  );
+};
+
 const buildSizeConfig = (name, size) => {
   const sizeObj = {};
   sizeObj.fontSizze = size === 'large' ? '16px' : '14px';
@@ -117,6 +128,12 @@ describe('SplitButton', () => {
 
     afterEach(() => {
       wrapper.unmount();
+    });
+  });
+
+  describe('when there are no children', () => {
+    it('does not throw an error', () => {
+      expect(() => renderWithNoChildren()).not.toThrow();
     });
   });
 


### PR DESCRIPTION
# Description
Tests fail in GAC when children are undefined for split and multi action buttons, adds filter to fix
