### PR TITLE
Prevents error when Form children undefined

### DIFF
--- a/src/__experimental__/components/form/form.component.js
+++ b/src/__experimental__/components/form/form.component.js
@@ -418,7 +418,7 @@ class FormWithoutValidations extends React.Component {
       this.childKeys = generateKeysForChildren(childrenArray);
     }
 
-    return childrenArray.map((child, index) => {
+    return childrenArray.filter(Boolean).map((child, index) => {
       if (typeof child.type !== 'function') return child;
 
       return React.cloneElement((child), {

--- a/src/__experimental__/components/form/form.spec.js
+++ b/src/__experimental__/components/form/form.spec.js
@@ -915,6 +915,12 @@ describe('Form', () => {
     });
   });
 
+  describe('when children are undefined', () => {
+    it('it does not throw an error', () => {
+      expect(() => shallow(<Form validate={ () => true } formAction='foo' />)).not.toThrow();
+    });
+  });
+
   describe('tags', () => {
     describe('on component', () => {
       const wrapper2 = shallow(

--- a/src/components/form/form.component.js
+++ b/src/components/form/form.component.js
@@ -367,7 +367,7 @@ class FormWithoutValidations extends React.Component {
       this.childKeys = generateKeysForChildren(childrenArray);
     }
 
-    return childrenArray.map((child, index) => {
+    return childrenArray.filter(Boolean).map((child, index) => {
       if (typeof child.type !== 'function') return child;
 
       return React.cloneElement((child), {

--- a/src/components/form/form.spec.js
+++ b/src/components/form/form.spec.js
@@ -502,6 +502,12 @@ describe('Form', () => {
       });
     });
 
+    describe('when children are undefined', () => {
+      it('it does not throw an error', () => {
+        expect(() => shallow(<Form validate={ () => true } formAction='foo' />)).not.toThrow();
+      });
+    });
+
     describe('when an onCancel prop is passed', () => {
       it('calls onCancel', () => {
         const spy = jasmine.createSpy('spy');


### PR DESCRIPTION
# Description
GAC tests break when Form children are undefined, PR adds a guard and tests functions as expected
