### PR TITLE
Hot fix to allow default checked radio

### DIFF
--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -20,7 +20,8 @@ const RadioButtonGroup = (props) => {
 
   const buttons = React.Children.map(children, (child, index) => {
     const key = child.props.key || child.props.value;
-    const checked = selectedValue === child.props.value;
+    const isDefaultChecked = child.props.checked && !selectedValue;
+    const checked = isDefaultChecked || selectedValue === child.props.value;
     const tabindex = selectedValue ? checkedTabIndex(checked) : initialTabIndex(index);
 
     const handleChange = (ev) => {

--- a/src/__experimental__/components/radio-button/radio-button-group.spec.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import 'jest-styled-components';
 import { css } from 'styled-components';
 import { RadioButton, RadioButtonGroup } from '.';
@@ -71,6 +71,22 @@ describe('RadioButtonGroup', () => {
           buttonArray.forEach((button) => {
             expect(button.props.checked).toBe(false);
           });
+        });
+      });
+
+      describe('defaultChecked', () => {
+        it('sets a child radio button to checked when the prop is set programatically', () => {
+          const radioGroup = shallow(
+            <RadioButtonGroup
+              groupName={ groupName }
+              label='Test RadioButtonGroup Label'
+            >
+              <RadioButton checked value='foo' />
+            </RadioButtonGroup>
+          );
+
+          const button = getButtons(radioGroup);
+          expect(button.props().checked).toBe(true);
         });
       });
 

--- a/src/__experimental__/components/radio-button/radio-button.stories.js
+++ b/src/__experimental__/components/radio-button/radio-button.stories.js
@@ -20,6 +20,7 @@ function makeStory(name, themeSelector) {
       >
         <RadioButton
           id='input-1'
+          checked
           label={ text('radioOneLabel', 'Example Weekly Radio Button') }
           value={ text('radioOneValue', 'weekly') }
           { ...knobs }


### PR DESCRIPTION
# Description
Currently setting a RadioButton to `checked` is ignored when it is in a RadioButtonGroup, I have added some code to ensure it is respected and applied when it is passed
