### PR TITLE
feat: Added gutter prop to InlineInputs component

### DIFF
--- a/change_log/next/FE-2452-gutter-prop.yml
+++ b/change_log/next/FE-2452-gutter-prop.yml
@@ -1,0 +1,1 @@
+New Features: "Adds gutter prop. Adds gutter size select to Storybook knob. (Component: InlineInputs)"

--- a/src/components/inline-inputs/__definition__.js
+++ b/src/components/inline-inputs/__definition__.js
@@ -3,6 +3,7 @@ import TextboxDefinition from '../../__deprecated__/components/textbox/__definit
 import DecimalDefinition from '../../__deprecated__/components/decimal/__definition__';
 import DropdownFilterAjaxDefintion from '../../__deprecated__/components/dropdown-filter-ajax/__definition__';
 import Definition from '../../../demo/utils/definition';
+import OptionsHelper from 'utils/helpers/options-helper';
 
 let definition = new Definition('inline-inputs', InlineInputs, {
   description: 'Edits a set of closely related inputs that are grouped together.',
@@ -10,7 +11,8 @@ let definition = new Definition('inline-inputs', InlineInputs, {
     label: 'String',
     children: 'Node',
     className: 'String',
-    htmlFor: 'String'
+    htmlFor: 'String',
+    gutter: 'String'
   },
   propValues: {
     label: 'Inline Inputs'
@@ -20,8 +22,12 @@ let definition = new Definition('inline-inputs', InlineInputs, {
     label: 'Label applied to set of inputs',
     htmlFor: 'label for property',
     className: 'Classes applied to the inline inputs component',
-    children: 'Supports all inputs as children'
+    children: 'Supports all inputs as children',
+    gutter: 'Define how wide the gutter between the inputs should be.'
   },
+  propOptions: {
+    gutter: OptionsHelper.sizesFull
+  }
 });
 
 const inputProps = {

--- a/src/components/inline-inputs/docgenInfo.json
+++ b/src/components/inline-inputs/docgenInfo.json
@@ -40,6 +40,17 @@
           },
           "required": false,
           "description": "The id of the corresponding input control for the label"
+        },
+        "gutter": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Defines how wide the gutter between the input fields should be.",
+          "defaultValue": {
+            "value": "'none'",
+            "computed": false
+          }
         }
       }
     }

--- a/src/components/inline-inputs/inline-inputs.component.js
+++ b/src/components/inline-inputs/inline-inputs.component.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import OptionsHelper from '../../utils/helpers/options-helper';
 import { Row, Column } from '../row';
 import Label from '../../__experimental__/components/label';
 import StyledInlineInputs from './inline-inputs.style';
@@ -27,7 +28,8 @@ const InlineInputs = (props) => {
     label,
     htmlFor,
     children,
-    className
+    className,
+    gutter
   } = props;
 
   function renderLabel() {
@@ -39,7 +41,7 @@ const InlineInputs = (props) => {
   return (
     <StyledInlineInputs data-component='inline-inputs' className={ className }>
       { renderLabel() }
-      <Row gutter='none'>
+      <Row gutter={ gutter }>
         { columnWrapper(children) }
       </Row>
     </StyledInlineInputs>
@@ -55,12 +57,15 @@ InlineInputs.propTypes = {
   /** Defines the label text for the heading. */
   label: PropTypes.string,
   /** The id of the corresponding input control for the label */
-  htmlFor: PropTypes.string
+  htmlFor: PropTypes.string,
+  /** Gutter prop gets passed down to Row component if false gutter value is "none" */
+  gutter: PropTypes.oneOf(['none', ...OptionsHelper.sizesFull])
 };
 
 InlineInputs.defaultProps = {
   children: null,
-  className: ''
+  className: '',
+  gutter: 'none'
 };
 
 export default InlineInputs;

--- a/src/components/inline-inputs/inline-inputs.spec.js
+++ b/src/components/inline-inputs/inline-inputs.spec.js
@@ -94,6 +94,28 @@ describe('Inline Inputs', () => {
     });
   });
 
+  describe('when a gutter prop is passed in', () => {
+    const gutterValue = 'medium';
+
+    beforeEach(() => {
+      wrapper = render({ gutter: gutterValue }, mount);
+    });
+
+    it('then the gutter prop should be passed down to the row component', () => {
+      expect(wrapper.find('Row').props().gutter).toEqual(gutterValue);
+    });
+  });
+
+  describe('when no gutter prop is passed in', () => {
+    beforeEach(() => {
+      wrapper = render();
+    });
+
+    it('then the gutter prop on the row component should be "none"', () => {
+      expect(wrapper.find('Row').props().gutter).toEqual('none');
+    });
+  });
+
   it('contains a row', () => {
     wrapper = render();
     const row = wrapper.find(Row);

--- a/src/components/inline-inputs/inline-inputs.stories.js
+++ b/src/components/inline-inputs/inline-inputs.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text } from '@storybook/addon-knobs';
+import { text, select } from '@storybook/addon-knobs';
 import { State, Store } from '@sambego/storybook-state';
 import { dlsThemeSelector, classicThemeSelector } from '../../../.storybook/theme-selectors';
 import InlineInputs from '.';
@@ -8,6 +8,7 @@ import Textbox from '../../__experimental__/components/textbox';
 import Decimal from '../../__experimental__/components/decimal';
 import { Select, Option } from '../../__experimental__/components/select';
 import getDocGenInfo from '../../utils/helpers/docgen-info';
+import OptionsHelper from '../../utils/helpers/options-helper';
 
 InlineInputs.__docgenInfo = getDocGenInfo(
   require('./docgenInfo.json'),
@@ -34,11 +35,12 @@ const handleSelectChange = (ev) => {
 function makeStory(name, themeSelector) {
   const component = () => {
     const label = text('label', 'Inline Inputs');
+    const gutter = select('gutter size', ['none', ...OptionsHelper.sizesFull], InlineInputs.defaultProps.gutter);
 
     return (
       <State store={ singleSelectStore }>
         { state => (
-          <InlineInputs label={ label }>
+          <InlineInputs label={ label } gutter={ gutter }>
             <Textbox />
             <Decimal value={ state.decimalValue } onChange={ handleDecimalChange } />
             <Select value={ state.selectValue } onChange={ handleSelectChange }>

--- a/src/components/inline-inputs/inline-inputs.style.js
+++ b/src/components/inline-inputs/inline-inputs.style.js
@@ -38,6 +38,76 @@ const StyledInlineInputs = styled.div`
       flex-grow: 0;
     }
   `}
+
+  .carbon-row.carbon-row--gutter-extra-small {
+    margin-bottom: 0;
+    margin-left: -8px;
+
+    > .carbon-column {
+      margin-bottom: 0;
+      padding-left: 8px;
+    }
+  }
+
+  .carbon-row.carbon-row--gutter-small {
+    margin-bottom: 0;
+    margin-left: -16px;
+
+    > .carbon-column {
+      margin-bottom: 0;
+      padding-left: 16px;
+    }
+  }
+
+  .carbon-row.carbon-row--gutter-medium-small {
+    margin-bottom: 0;
+    margin-left: -20px;
+
+    > .carbon-column {
+      margin-bottom: 0;
+      padding-left: 20px;
+    }
+  }
+
+  .carbon-row.carbon-row--gutter-medium {
+    margin-bottom: 0;
+    margin-left: -24px;
+
+    > .carbon-column {
+      margin-bottom: 0;
+      padding-left: 24px;
+    }
+  }
+
+  .carbon-row.carbon-row--gutter-medium-large {
+    margin-bottom: 0;
+    margin-left: -28px;
+
+    > .carbon-column {
+      margin-bottom: 0;
+      padding-left: 28px;
+    }
+  }
+
+  .carbon-row.carbon-row--gutter-large {
+    margin-bottom: 0;
+    margin-left: -32px;
+
+    > .carbon-column {
+      margin-bottom: 0;
+      padding-left: 32px;
+    }
+  }
+
+  .carbon-row.carbon-row--gutter-extra-large {
+    margin-bottom: 0;
+    margin-left: -40px;
+
+    > .carbon-column {
+      margin-bottom: 0;
+      padding-left: 40px;
+    }
+  }
 `;
 
 StyledInlineInputs.defaultProps = {


### PR DESCRIPTION
# Description
Added gutter prop to InlineInputs component to provide gutter support. The prop is directly passed down to the Row component. 

# TODO
- [x] Release notes
- [x] Implement gutter into definition files
- [x] Implement gutter into testing files
- [x] Review 

# Screenshots
![screenshot-working](https://user-images.githubusercontent.com/30438094/66306928-426b1b00-e903-11e9-8c51-b1fc6e1bab6e.PNG)

# Use case
![screenshot-use-case](https://user-images.githubusercontent.com/30438094/66312787-8fee8480-e911-11e9-84d2-84f62677875e.PNG)

In this case the gutter is visually demonstrating that the **values relate to each other but differ in behaviour and input type.**

_There are other cases where the UI might look better when there is a gap between the input fields._