### PR TITLE
FE-2075 Bug: table row icons rotated

### DIFF
--- a/src/components/table/draggable-table-cell/draggable-table-cell.component.js
+++ b/src/components/table/draggable-table-cell/draggable-table-cell.component.js
@@ -1,16 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { ThemeContext } from 'styled-components';
 import WithDrag from '../../drag-and-drop/with-drag';
 import Icon from '../../icon';
+import { isClassic } from '../../../utils/helpers/style-helper';
 import StyledDraggableTableCell from './draggable-table-cell.style';
-
-const iconHTML = (
-  <div>
-    <Icon
-      type='drag_vertical'
-    />
-  </div>
-);
 
 /**
  * Creates a draggable table cell using WithDrag.
@@ -18,25 +12,41 @@ const iconHTML = (
  */
 const DraggableTableCell = (props) => {
   const canDrag = props.canDrag !== false;
+  const theme = React.useContext(ThemeContext) || props.theme;
 
+  /**
+   * Note: the <div> wrapper is required, otherwise ReactDnD throws an error:
+   * "Only native element nodes can now be passed to ReactDnD connectors."
+   */
   const icon = (
+    <div>
+      <Icon
+        type={ isClassic(theme) ? 'drag_vertical' : 'drag' }
+      />
+    </div>
+  );
+
+  const iconWithDrag = (
     <WithDrag
       identifier={ props.identifier }
       draggableNode={ props.draggableNode }
       canDrag={ () => { return canDrag; } }
     >
-      {canDrag ? iconHTML : <span />}
+      {canDrag ? icon : <span />}
     </WithDrag>
   );
 
   return (
     <StyledDraggableTableCell className='draggable-table-cell'>
-      {icon}
+      {iconWithDrag}
     </StyledDraggableTableCell>
   );
 };
 
 DraggableTableCell.propTypes = {
+  /** Theme to use when rendering the DraggableTableCell */
+  theme: PropTypes.object,
+
   /** used to associate WithDrags and WithDrops */
   identifier: PropTypes.string,
 

--- a/src/components/table/draggable-table-cell/draggable-table-cell.spec.js
+++ b/src/components/table/draggable-table-cell/draggable-table-cell.spec.js
@@ -8,13 +8,15 @@ import StyledDraggableTableCell from './draggable-table-cell.style';
 import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
 import Icon from '../../icon';
 import StyledIcon from '../../icon/icon.style';
+import smallTheme from '../../../style/themes/small';
+import classicTheme from '../../../style/themes/classic';
 
 describe('DraggableTableCell', () => {
   let wrapper;
 
   beforeEach(() => {
     wrapper = shallow(
-      <DraggableTableCell identifier='foo' />
+      <DraggableTableCell identifier='foo' theme={ smallTheme } />
     );
   });
 
@@ -29,7 +31,15 @@ describe('DraggableTableCell', () => {
     expect(wd.props().canDrag()).toEqual(true);
   });
 
-  it('renders an icon', () => {
+  it('renders the correct icon for Modern theme', () => {
+    const icon = wrapper.find(Icon);
+    expect(icon.props().type).toEqual('drag');
+  });
+
+  it('renders the correct icon for Classic theme', () => {
+    wrapper = shallow(
+      <DraggableTableCell identifier='foo' theme={ classicTheme } />
+    );
     const icon = wrapper.find(Icon);
     expect(icon.props().type).toEqual('drag_vertical');
   });
@@ -43,7 +53,11 @@ describe('DraggableTableCell', () => {
 
   it('does not render on last row', () => {
     wrapper = shallow(
-      <DraggableTableCell identifier='foo' canDrag={ false } />
+      <DraggableTableCell
+        identifier='foo'
+        canDrag={ false }
+        theme={ smallTheme }
+      />
     );
     const icon = wrapper.find(Icon);
     expect(icon.exists()).toEqual(false);

--- a/src/components/table/table-row/__snapshots__/table-row.spec.js.snap
+++ b/src/components/table/table-row/__snapshots__/table-row.spec.js.snap
@@ -24,12 +24,6 @@ exports[`TableRow render if is not classic theme renders a row to match the snap
   background-color: #FFFFFF;
 }
 
-.c2 .c3 .c14::before {
-  -webkit-transform: rotate(90deg);
-  -ms-transform: rotate(90deg);
-  transform: rotate(90deg);
-}
-
 .c2 .c15 {
   padding: 10px 8px;
 }
@@ -76,12 +70,6 @@ exports[`TableRow render if is not classic theme renders a row to match the snap
   background-color: #FFFFFF;
 }
 
-.c5 .c3 .c14::before {
-  -webkit-transform: rotate(90deg);
-  -ms-transform: rotate(90deg);
-  transform: rotate(90deg);
-}
-
 .custom-drag-layer .c5.c5 .c3 {
   background-color: #E5EAEC;
   border: none;
@@ -105,12 +93,6 @@ exports[`TableRow render if is not classic theme renders a row to match the snap
 
 .c6 .c3 {
   background-color: #FFFFFF;
-}
-
-.c6 .c3 .c14::before {
-  -webkit-transform: rotate(90deg);
-  -ms-transform: rotate(90deg);
-  transform: rotate(90deg);
 }
 
 .custom-drag-layer .c6.c6 .c3 {
@@ -140,12 +122,6 @@ exports[`TableRow render if is not classic theme renders a row to match the snap
 
 .c7 .c3 {
   background-color: #FFFFFF;
-}
-
-.c7 .c3 .c14::before {
-  -webkit-transform: rotate(90deg);
-  -ms-transform: rotate(90deg);
-  transform: rotate(90deg);
 }
 
 .custom-drag-layer .c7.c7 .c3 {
@@ -178,12 +154,6 @@ exports[`TableRow render if is not classic theme renders a row to match the snap
 
 .c8 .c3 {
   background-color: #FFFFFF;
-}
-
-.c8 .c3 .c14::before {
-  -webkit-transform: rotate(90deg);
-  -ms-transform: rotate(90deg);
-  transform: rotate(90deg);
 }
 
 .custom-drag-layer .c8.c8 .c3 {
@@ -228,12 +198,6 @@ exports[`TableRow render if is not classic theme renders a row to match the snap
 
 .c9 .c3 {
   background-color: #FFFFFF;
-}
-
-.c9 .c3 .c14::before {
-  -webkit-transform: rotate(90deg);
-  -ms-transform: rotate(90deg);
-  transform: rotate(90deg);
 }
 
 .custom-drag-layer .c9.c9 .c3 {
@@ -312,12 +276,6 @@ exports[`TableRow render if is not classic theme renders a row to match the snap
   background-color: #FFFFFF;
 }
 
-.c11 .c3 .c14::before {
-  -webkit-transform: rotate(90deg);
-  -ms-transform: rotate(90deg);
-  transform: rotate(90deg);
-}
-
 .custom-drag-layer .c11.c11 .c3 {
   background-color: #E5EAEC;
   border: none;
@@ -388,12 +346,6 @@ exports[`TableRow render if is not classic theme renders a row to match the snap
 
 .c13 .c3 {
   background-color: #FFFFFF;
-}
-
-.c13 .c3 .c14::before {
-  -webkit-transform: rotate(90deg);
-  -ms-transform: rotate(90deg);
-  transform: rotate(90deg);
 }
 
 .custom-drag-layer .c13.c13 .c3 {

--- a/src/components/table/table-row/table-row-modern.style.js
+++ b/src/components/table/table-row/table-row-modern.style.js
@@ -1,16 +1,11 @@
 import { css } from 'styled-components';
 import StyledTableCell from '../table-cell/table-cell.style';
 import StyledTableHeader from '../table-header/table-header.style';
-import StyledIcon from '../../icon/icon.style';
 
 function applyModernRowStyling(isPassive, { colors, table }) {
   return css`   
     ${StyledTableCell} {
       background-color: ${colors.white};
-
-      ${StyledIcon}::before {
-        transform: rotate(90deg);
-      }
     }
 
     ${StyledTableHeader} {


### PR DESCRIPTION
# Description

In commit 23a1e4a in branch [`FE-1569-react-dnd-and-dls-table-row`](https://github.com/Sage/carbon/commits/FE-1569-react-dnd-and-dls-table-row), some CSS code was added to `src/components/table/table-row/table-row-modern.style.js` for the styling of icons in table cells. That approach was incorrect.

This PR reverts that change (4c542bf) and then implements the correct functionality (8411478) by selecting the DraggableTableCell's icon according to the current theme.