### PR TITLE
Fe 2076 dc flickering

### DIFF
--- a/src/components/drag-and-drop/draggable-context/__spec__.js
+++ b/src/components/drag-and-drop/draggable-context/__spec__.js
@@ -61,9 +61,10 @@ describe('DraggableContext', () => {
 
     describe('handleBeginDrag', () => {
       it('returns the index of the props passed in', () => {
-        expect(instance.handleBeginDrag({ index: 3, foo: 'bar' })).toEqual({
+        expect(instance.handleBeginDrag({ index: 3, foo: 'bar', offsetDiffY: 0 })).toEqual({
           index: 3,
-          foo: 'bar'
+          foo: 'bar',
+          offsetDiffY: 0
         });
       });
     });

--- a/src/components/drag-and-drop/draggable-context/draggable-context.js
+++ b/src/components/drag-and-drop/draggable-context/draggable-context.js
@@ -183,6 +183,7 @@ class DraggableContext extends React.Component {
   handleBeginDrag = (props) => {
     return {
       index: props.index,
+      offsetDiffY: 0,
       ...props
     };
   }

--- a/src/components/drag-and-drop/with-drop/with-drop.js
+++ b/src/components/drag-and-drop/with-drop/with-drop.js
@@ -29,7 +29,8 @@ class WithDrop extends React.Component {
   }
 
   state = {
-    isDraggedElementOver: false
+    isDraggedElementOver: false,
+    inDeadZone: false
   }
 
   componentWillReceiveProps(nextProps) {
@@ -50,7 +51,10 @@ class WithDrop extends React.Component {
     // below
     const { children, connectDropTarget, droppableNode } = this.props; // eslint-disable-line react/prop-types
 
-    const childrenWithProps = React.cloneElement(children, { isDraggedElementOver: this.state.isDraggedElementOver });
+    const childrenWithProps = React.cloneElement(children, {
+      isDraggedElementOver: this.state.isDraggedElementOver,
+      inDeadZone: this.state.inDeadZone
+    });
 
     if (droppableNode) {
       connectDropTarget(droppableNode());

--- a/src/components/table/draggable-table-cell/draggable-table-cell.spec.js
+++ b/src/components/table/draggable-table-cell/draggable-table-cell.spec.js
@@ -47,7 +47,7 @@ describe('DraggableTableCell', () => {
   it('styles the icon cursor', () => {
     const component = TestRenderer.create(<StyledDraggableTableCell identifier='foo' />);
     assertStyleMatch({
-      cursor: 'move'
+      cursor: 'grab'
     }, component.toJSON(), { modifier: css`${StyledIcon}` });
   });
 

--- a/src/components/table/draggable-table-cell/draggable-table-cell.style.js
+++ b/src/components/table/draggable-table-cell/draggable-table-cell.style.js
@@ -13,7 +13,7 @@ const StyledDraggableTableCell = styled(StyledTableCell)`
   }
 
   ${StyledIcon} {
-    cursor: move;
+    cursor: grab;
   }
 `;
 

--- a/src/components/table/table-row/__snapshots__/table-row.spec.js.snap
+++ b/src/components/table/table-row/__snapshots__/table-row.spec.js.snap
@@ -272,6 +272,18 @@ exports[`TableRow render if is not classic theme renders a row to match the snap
   background-color: #255BC7;
 }
 
+.c10 .c3 {
+  border-top: 1px solid transparent;
+}
+
+.c10 .c3:first-child {
+  border-left: 1px solid transparent;
+}
+
+.c10 .c3:last-child {
+  border-right: 1px solid transparent;
+}
+
 .c11 .c3 {
   background-color: #FFFFFF;
 }
@@ -342,6 +354,18 @@ exports[`TableRow render if is not classic theme renders a row to match the snap
 
 .c12.c12.c12.c12:hover .c3 {
   background-color: #D0E3FA;
+}
+
+.c12 .c3 {
+  border-top: 1px solid transparent;
+}
+
+.c12 .c3:first-child {
+  border-left: 1px solid transparent;
+}
+
+.c12 .c3:last-child {
+  border-right: 1px solid transparent;
 }
 
 .c13 .c3 {

--- a/src/components/table/table-row/table-row-classic.style.js
+++ b/src/components/table/table-row/table-row-classic.style.js
@@ -61,7 +61,7 @@ function applyClassicHighlightStyling() {
  * instead of being `import`ed, to avoid a dependency cycle
  * between `table-row.style.js` and `table-row-classic.style.js`.
  */
-function applyClassicDraggedStyling(StyledTableRow) {
+function applyClassicDraggedStyling() {
   return css`
     ${StyledTableCell} {
       background-color: #F2F4F5;

--- a/src/components/table/table-row/table-row-classic.style.js
+++ b/src/components/table/table-row/table-row-classic.style.js
@@ -64,25 +64,14 @@ function applyClassicHighlightStyling() {
 function applyClassicDraggedStyling(StyledTableRow) {
   return css`
     ${StyledTableCell} {
-      visibility: hidden;
-    }
-    
-    + ${StyledTableRow} {
-      ${StyledTableCell} {
-        border-top: 1px solid #000A0E;
-      }
+      background-color: #F2F4F5;
     }
   `;
-}
-
-function applyClassicDropTargetStyling(isDraggedElementOver) {
-  return isDraggedElementOver ? css`visibility: hidden;` : css``;
 }
 
 export {
   applyClassicDraggedStyling,
   applyClassicRowStyling,
   applyClassicSelectedStyling,
-  applyClassicHighlightStyling,
-  applyClassicDropTargetStyling
+  applyClassicHighlightStyling
 };

--- a/src/components/table/table-row/table-row-modern.style.js
+++ b/src/components/table/table-row/table-row-modern.style.js
@@ -39,11 +39,11 @@ function applyModernSelectedStyling({ table }) {
   `;
 }
 
-function applyModernDropTargetStyling(isDraggedElementOver, { table }) {
+function applyModernDropTargetStyling(isDraggedElementOver, { table }, inDeadZone) {
   const border = `1px solid ${isDraggedElementOver ? table.header : 'transparent'}`;
 
   return css`
-    ${isDraggedElementOver && `
+    ${isDraggedElementOver && !inDeadZone && `
       background-color: ${table.dragging};
       border-bottom:    ${border} !important;
     `}
@@ -57,6 +57,21 @@ function applyModernDropTargetStyling(isDraggedElementOver, { table }) {
     &:last-child {
       border-right: ${border};
     }
+
+    ${isDraggedElementOver && inDeadZone && `
+      background-color: none;
+      border-bottom: 1px solid ${table.selected} !important;
+
+      border-top: none;
+
+      &:first-child {
+        border-left: none;
+      }
+
+      &:last-child {
+        border-right: none;
+      }
+    `}
   `;
 }
 

--- a/src/components/table/table-row/table-row.spec.js
+++ b/src/components/table/table-row/table-row.spec.js
@@ -664,6 +664,26 @@ describe('TableRow', () => {
           { modifier: `${StyledTableCell}` }
         );
       });
+
+      describe('when isDraggedElementOver is true and inDeadZone is true', () => {
+        it('renders the correct styles for a drop-target row for the Modern theme', () => {
+          wrapper = mount(
+            <StyledTableRow
+              theme={ SmallTheme }
+              isDraggedElementOver
+              inDeadZone
+            />
+          );
+          assertStyleMatch(
+            {
+              backgroundColor: 'none',
+              borderTop: 'none'
+            },
+            wrapper,
+            { modifier: `${StyledTableCell}` }
+          );
+        });
+      });
     });
   });
 });

--- a/src/components/table/table-row/table-row.spec.js
+++ b/src/components/table/table-row/table-row.spec.js
@@ -636,7 +636,7 @@ describe('TableRow', () => {
         row1.setContext({ dragAndDropActiveIndex: 0 });
 
         assertStyleMatch(
-          { visibility: 'hidden' },
+          { backgroundColor: '#F2F4F5' },
           row1.find(StyledTableRow),
           { modifier: `&&&&& ${StyledTableCell}` }
         );
@@ -647,7 +647,7 @@ describe('TableRow', () => {
       it('renders the correct styles for a drop-target row for the Classic theme', () => {
         wrapper = mount(<StyledTableRow theme={ ClassicTheme } isDraggedElementOver />);
         assertStyleMatch(
-          { visibility: 'hidden' },
+          { backgroundColor: '#E5EAEC' },
           wrapper,
           { modifier: `${StyledTableCell}` }
         );

--- a/src/components/table/table-row/table-row.style.js
+++ b/src/components/table/table-row/table-row.style.js
@@ -124,7 +124,7 @@ function dragRowStyling({
 
     ${isDragged && css`
       &&&&& {
-        ${isClassic(theme) && applyClassicDraggedStyling(StyledTableRow)}
+        ${isClassic(theme) && applyClassicDraggedStyling()}
       }
     `}
 

--- a/src/components/table/table-row/table-row.style.js
+++ b/src/components/table/table-row/table-row.style.js
@@ -107,7 +107,8 @@ function dragRowStyling({
   isDragged,
   isDragging,
   theme,
-  isDraggedElementOver
+  isDraggedElementOver,
+  inDeadZone
 }) {
   return css`
     ${StyledIcon} {
@@ -127,9 +128,9 @@ function dragRowStyling({
         ${isClassic(theme) && applyClassicDraggedStyling()}
       }
     `}
-
+    
     ${StyledTableCell} {
-      ${applyModernDropTargetStyling(isDraggedElementOver, theme)}
+      ${applyModernDropTargetStyling(isDraggedElementOver, theme, inDeadZone)}
     }
   `;
 }

--- a/src/components/table/table-row/table-row.style.js
+++ b/src/components/table/table-row/table-row.style.js
@@ -6,8 +6,7 @@ import {
   applyClassicDraggedStyling,
   applyClassicRowStyling,
   applyClassicSelectedStyling,
-  applyClassicHighlightStyling,
-  applyClassicDropTargetStyling
+  applyClassicHighlightStyling
 } from './table-row-classic.style';
 import {
   applyModernRowStyling,
@@ -130,8 +129,7 @@ function dragRowStyling({
     `}
 
     ${StyledTableCell} {
-      ${isClassic(theme) && applyClassicDropTargetStyling(isDraggedElementOver)}
-      ${!isClassic(theme) && applyModernDropTargetStyling(isDraggedElementOver, theme)}
+      ${applyModernDropTargetStyling(isDraggedElementOver, theme)}
     }
   `;
 }

--- a/src/utils/helpers/dnd/item-target/__spec__.js
+++ b/src/utils/helpers/dnd/item-target/__spec__.js
@@ -14,6 +14,7 @@ describe('ItemTargetHelper', () => {
 
     beforeEach(() => {
       component = document.createElement('div');
+      component.setState = () => {};
       rect = {
         bottom: 100,
         height: 50, 
@@ -117,10 +118,12 @@ describe('ItemTargetHelper', () => {
           monitorItem.offsetDiffY = 10;
           offsetDiff.y = 11;
 
+          spyOn(component, 'setState');
           spyOn(props, 'onDrag');
           ItemTargetHelper.onHoverUpDown(props, monitor, component);
 
           expect(props.onDrag).not.toHaveBeenCalled();
+          expect(component.setState).toHaveBeenCalled();
         });
       });
 

--- a/src/utils/helpers/dnd/item-target/__spec__.js
+++ b/src/utils/helpers/dnd/item-target/__spec__.js
@@ -9,7 +9,8 @@ describe('ItemTargetHelper', () => {
         monitor = {},
         monitorItem,
         props,
-        clientOffset;
+        clientOffset,
+        offsetDiff;
 
     beforeEach(() => {
       component = document.createElement('div');
@@ -39,12 +40,20 @@ describe('ItemTargetHelper', () => {
         index: 0
       };
 
+      offsetDiff = {
+        x: 0,
+        y: 0
+      };
+
       monitor = {
         getItem: () => {
           return monitorItem;
         },
         getClientOffset: () => {
           return clientOffset;
+        },
+        getDifferenceFromInitialOffset: () => {
+          return offsetDiff;
         }
       };
     });
@@ -53,6 +62,18 @@ describe('ItemTargetHelper', () => {
       it('item dragged downwards and below 50% of item height', () => {
         props.index = 1;
         clientOffset.y = 76; // over the halfway point when dragging downwards
+
+        spyOn(props, 'onDrag');
+        ItemTargetHelper.onHoverUpDown(props, monitor, component);
+
+        expect(props.onDrag).toHaveBeenCalled();
+      });
+
+      it('item dragged upwards and above 50% of item height', () => {
+        props.index = 0;
+
+        clientOffset.y = 51;
+        monitorItem.index = 1;
 
         spyOn(props, 'onDrag');
         ItemTargetHelper.onHoverUpDown(props, monitor, component);
@@ -86,6 +107,36 @@ describe('ItemTargetHelper', () => {
 
         ItemTargetHelper.onHoverUpDown(props, monitor, component);
         expect(contextSpy).toHaveBeenCalled();
+      });
+
+      describe('when difference between item offset y and initial offset y is less than 1', () => {
+        it('it does not run onDrag', () => {
+          props.index = 0;
+          clientOffset.y = 51;
+          monitorItem.index = 1;
+          monitorItem.offsetDiffY = 10;
+          offsetDiff.y = 11;
+
+          spyOn(props, 'onDrag');
+          ItemTargetHelper.onHoverUpDown(props, monitor, component);
+
+          expect(props.onDrag).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('when difference between item offset y and initial offset y is greater than 1', () => {
+        it('it does not run onDrag', () => {
+          props.index = 0;
+          monitorItem.index = 1;
+          clientOffset.y = 51;
+          monitorItem.offsetDiffY = 10;
+          offsetDiff.y = 12;
+
+          spyOn(props, 'onDrag');
+          ItemTargetHelper.onHoverUpDown(props, monitor, component);
+
+          expect(props.onDrag).toHaveBeenCalled();
+        });
       });
     });
 

--- a/src/utils/helpers/dnd/item-target/item-target.js
+++ b/src/utils/helpers/dnd/item-target/item-target.js
@@ -16,7 +16,7 @@ const ItemTargetHelper = {
 
     const newOffsetDiff = monitor.getDifferenceFromInitialOffset();
 
-    //prevents flickering
+    // prevents flickering
     if (item.offsetDiffY && Math.abs(item.offsetDiffY - newOffsetDiff.y) <= 1) {
       return;
     }

--- a/src/utils/helpers/dnd/item-target/item-target.js
+++ b/src/utils/helpers/dnd/item-target/item-target.js
@@ -18,6 +18,7 @@ const ItemTargetHelper = {
 
     // prevents flickering
     if (item.offsetDiffY && Math.abs(item.offsetDiffY - newOffsetDiff.y) <= 1) {
+      component.setState({ inDeadZone: true });
       return;
     }
 

--- a/src/utils/helpers/dnd/item-target/item-target.js
+++ b/src/utils/helpers/dnd/item-target/item-target.js
@@ -1,12 +1,12 @@
 const ItemTargetHelper = {
-
   /**
    * Helper method for when drag and drop is enabled for
    * items grouped together vertically e.g. a list, or
    * a table.
    */
   onHoverUpDown(props, monitor, component) {
-    const dragIndex = monitor.getItem().index;
+    const item = monitor.getItem();
+    const dragIndex = item.index;
     const hoverIndex = props.index;
 
     // Don't replace items with themselves
@@ -14,14 +14,23 @@ const ItemTargetHelper = {
       return;
     }
 
+    const newOffsetDiff = monitor.getDifferenceFromInitialOffset();
+
+    //prevents flickering
+    if (item.offsetDiffY && Math.abs(item.offsetDiffY - newOffsetDiff.y) <= 1) {
+      return;
+    }
+
     // Time to actually perform the action
     const onDrag = props.onDrag || component.context.dragAndDropOnDrag;
     onDrag(dragIndex, hoverIndex);
+
     // Note: we're mutating the monitor item here!
     // Generally it's better to avoid mutations,
     // but it's good here for the sake of performance
     // to avoid expensive index searches.
-    monitor.getItem().index = hoverIndex;
+    item.index = hoverIndex;
+    item.offsetDiffY = newOffsetDiff.y;
   }
 
 };


### PR DESCRIPTION
# Description
attempts to resolve the React DnD flickering issue

Resolves flicker issue with crossover of draggable items by measuring difference of the  "Y" distance from the moment of cross over and pointer Y (cursor traveled distance). = offsetDrifferenceY

Currently 1px is used for divider line that acts as point of crossover between two list items.
For as long as offsetDrifferenceY is <= 1px the onDrag will not switch over allowing for 1px "dead zone".

Crossover zone of 1px causes flicker of two items. This happens if drag is in crosover zone and drag continues on X-axis (horizontal) as item A and B are alternated for every pixel of mouse move. 

Depending on different implementation cases two draggable items overlap each other (elements touch) as they share border space (divider line) to resolve the problem I am introducing 1px space that will act as no action zone/dead zone in which dragIndex and hoverIndex properties will not be set while during drag/hover action.