### PR TITLE
FE-2077 Storybook - Tables -> downArrow has no theming color

### DIFF
--- a/change_log/next/FE-2077-tables-downArrow-missing-color.yml
+++ b/change_log/next/FE-2077-tables-downArrow-missing-color.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Fixes table bug where multi action buttons arrow has no theme color applied (Component: Table) ."

--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.js.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.js.snap
@@ -4,12 +4,12 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
 .c5 {
   display: inline-block;
   position: relative;
-  color: rgba(0,0,0,0.65);
+  color: #26A826;
   background-color: transparent;
 }
 
 .c5:hover {
-  color: rgba(0,0,0,0.90);
+  color: #1E861E;
   background-color: transparent;
 }
 
@@ -168,14 +168,14 @@ exports[`MultiActionButton when rendered with "classic" theme should match the s
 .c6 {
   display: inline-block;
   position: relative;
-  color: rgba(0,0,0,0.65);
+  color: #00805D;
   background-color: transparent;
   color: rgba(0,0,0,0.85);
   background-color: transparent;
 }
 
 .c6:hover {
-  color: rgba(0,0,0,0.90);
+  color: #00664A;
   background-color: transparent;
 }
 

--- a/src/components/multi-action-button/multi-action-button.component.js
+++ b/src/components/multi-action-button/multi-action-button.component.js
@@ -32,7 +32,7 @@ class MultiActionButton extends SplitButton {
         <Icon
           type='dropdown'
           bgTheme='none'
-          iconColor={ this.getIconColor(this.props.buttonType) }
+          iconColor={ this.getIconColor(this.props.buttonType || this.props.as) }
           disabled={ this.toggleButtonProps.disabled }
         />
       </Button>

--- a/src/components/split-button/split-button.component.js
+++ b/src/components/split-button/split-button.component.js
@@ -126,14 +126,11 @@ class SplitButton extends Component {
   }
 
   getIconColor(buttonType) {
-    switch (buttonType) {
-      case 'primary':
-        return 'on-dark-background';
-      case 'secondary':
-        return 'business-color';
-      default:
-        return null;
-    }
+    const colorsMap = {
+      primary: 'on-dark-background',
+      secondary: 'business-color'
+    };
+    return colorsMap[buttonType];
   }
 
   /**


### PR DESCRIPTION
# Description
Currently downArrow color does not change to the corresponding theme color when theme is changed.

# Screenshots / Gifs
![ThemeLarge](https://user-images.githubusercontent.com/20651022/66122825-007b6580-e5e1-11e9-828c-5d61a42bd1d0.jpg)
![ThemeMedium](https://user-images.githubusercontent.com/20651022/66122826-007b6580-e5e1-11e9-9dbb-e02f535c7736.jpg)
![ThemeNone](https://user-images.githubusercontent.com/20651022/66122827-0113fc00-e5e1-11e9-96f8-b1517af815c1.jpg)
![ThemeSmall](https://user-images.githubusercontent.com/20651022/66122828-0113fc00-e5e1-11e9-8629-f8197ab8ddad.jpg)
