### PR TITLE
fix: radio button keyboard control FE-2060

### DIFF
--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
@@ -286,6 +286,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
               className="c11 "
             >
               <svg
+                focusable="false"
                 viewBox="0 0 15 15"
               >
                 <g
@@ -342,6 +343,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
               className="c11 "
             >
               <svg
+                focusable="false"
                 viewBox="0 0 15 15"
               >
                 <g

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
@@ -279,7 +279,6 @@ exports[`RadioButtonGroup renders as expected 1`] = `
               name="radio-name-test-1"
               onChange={[Function]}
               role="radio"
-              tabIndex={0}
               type="radio"
               value="test-1"
             />
@@ -336,7 +335,6 @@ exports[`RadioButtonGroup renders as expected 1`] = `
               name="radio-name-test-2"
               onChange={[Function]}
               role="radio"
-              tabIndex={-1}
               type="radio"
               value="test-2"
             />

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -37,9 +37,9 @@ exports[`RadioButton styles base renders as expected 1`] = `
 }
 
 .c11 .c7:hover,
-.c11 .c25:hover,
+.c11 .c24:hover,
 .c11 .c7:focus,
-.c11 .c25:focus {
+.c11 .c24:focus {
   outline: none;
   cursor: not-allowed;
 }
@@ -54,24 +54,24 @@ exports[`RadioButton styles base renders as expected 1`] = `
   flex-wrap: wrap;
 }
 
-.c4 .c25 {
+.c4 .c24 {
   text-align: left;
   width: auto;
   white-space: nowrap;
   margin-top: -2px;
 }
 
-.c4 .c25 .c23,
-.c4 .c25 .c24 {
+.c4 .c24 .c22,
+.c4 .c24 .c23 {
   color: rgba(0,0,0,0.65);
   vertical-align: middle;
   top: -1px;
 }
 
-.c4 .c25 .c23:hover,
-.c4 .c25 .c24:hover,
-.c4 .c25 .c23:focus,
-.c4 .c25 .c24:focus {
+.c4 .c24 .c22:hover,
+.c4 .c24 .c23:hover,
+.c4 .c24 .c22:focus,
+.c4 .c24 .c23:focus {
   color: rgba(0,0,0,0.9);
 }
 
@@ -86,9 +86,9 @@ exports[`RadioButton styles base renders as expected 1`] = `
 }
 
 .c12 .c7:hover,
-.c12 .c25:hover,
+.c12 .c24:hover,
 .c12 .c7:focus,
-.c12 .c25:focus {
+.c12 .c24:focus {
   outline: none;
   cursor: not-allowed;
 }
@@ -770,59 +770,6 @@ exports[`RadioButton styles base renders as expected 1`] = `
   margin-left: 6px;
 }
 
-.c21 .c5 {
-  padding-top: 1px;
-}
-
-.c21 .c9 {
-  height: 16px;
-}
-
-.c21 .c7,
-.c21 svg {
-  height: 16px;
-  position: absolute;
-  padding: 1px;
-}
-
-.c21 .c5,
-.c21 .c7,
-.c21 .c9,
-.c21 svg {
-  box-sizing: border-box;
-  width: 16px;
-}
-
-.c21 .c7:not([disabled]):focus + .c9,
-.c21 .c7:not([disabled]):hover + .c9 {
-  box-shadow: 0 0 0 3px #FFB500;
-}
-
-.c21 .c5 {
-  margin-right: 16px;
-}
-
-.c21 .c9 {
-  padding: 0;
-}
-
-.c21 .c9,
-.c21 svg {
-  border-radius: 50%;
-}
-
-.c21 .c5,
-.c21 .c7,
-.c21 .c9,
-.c21 svg {
-  height: 16px;
-  width: 16px;
-}
-
-.c21 .c7:checked + .c9 circle {
-  fill: #00805D;
-}
-
 .c3 {
   padding-top: 8px;
   margin-bottom: 12px;
@@ -861,18 +808,18 @@ exports[`RadioButton styles base renders as expected 1`] = `
   box-shadow: 0 0 0 3px #FFB500;
 }
 
-.c3 .c25 {
+.c3 .c24 {
   padding: 0 6px;
   width: auto;
 }
 
-.c3 .c22 {
+.c3 .c21 {
   margin-left: 16px;
   margin-top: 0;
   padding-left: 6px;
 }
 
-.c3 .c22 {
+.c3 .c21 {
   margin-left: 32px;
 }
 
@@ -909,23 +856,23 @@ exports[`RadioButton styles base renders as expected 1`] = `
   fill: #00805D;
 }
 
-.c0 > .c1 > .c25 {
+.c0 > .c1 > .c24 {
   cursor: default;
   margin-bottom: 16px;
   padding: 0;
 }
 
-.c0 > .c1 > .c25 > label {
+.c0 > .c1 > .c24 > label {
   vertical-align: middle;
 }
 
-.c0 > .c1 > .c25 .c24 {
+.c0 > .c1 > .c24 .c23 {
   margin-top: 0;
   margin-right: 0;
   display: inline-block;
 }
 
-.c0 > .c1 > .c25 .c24 ::before {
+.c0 > .c1 > .c24 .c23 ::before {
   font-size: 16px;
 }
 
@@ -965,7 +912,6 @@ exports[`RadioButton styles base renders as expected 1`] = `
               name="my-radio"
               onChange={[Function]}
               role="radio"
-              tabIndex={0}
               type="radio"
               value="test"
             />

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -919,6 +919,7 @@ exports[`RadioButton styles base renders as expected 1`] = `
               className="c9 "
             >
               <svg
+                focusable="false"
                 viewBox="0 0 15 15"
               >
                 <g

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -5,14 +5,6 @@ import { StyledRadioButtonGroup } from './radio-button.style';
 import withValidation from '../../../components/validations/with-validation.hoc';
 import FormField from '../form-field';
 
-function initialTabIndex(childIndex) {
-  return (childIndex > 0) ? -1 : 0;
-}
-
-function checkedTabIndex(checked) {
-  return checked ? 0 : -1;
-}
-
 const RadioButtonGroup = (props) => {
   const {
     children,
@@ -40,29 +32,26 @@ const RadioButtonGroup = (props) => {
   const [checkedValue, setCheckedValue] = useState(false);
   const onChangeProp = useCallback((e) => {
     onChange(e);
-    setCheckedValue(e.target.value);
-  }, [onChange, setCheckedValue]);
+    if (!isControled) {
+      setCheckedValue(e.target.value);
+    }
+  }, [onChange, setCheckedValue, isControled]);
 
-  const buttons = React.Children.map(children, (child, index) => {
-    let tabindex;
+  const buttons = React.Children.map(children, (child) => {
     let checked;
     if (isControled) {
       // The user is controlling the input via the value prop
       checked = value === child.props.value;
-      tabindex = checkedTabIndex(checked);
     } else if (!checkedValue && anyChecked) {
       // Uncontrolled and the user has not made a selection, but at least one has a checked prop
       checked = child.props.checked || false;
-      tabindex = checkedTabIndex(checked);
     } else {
       // Uncontrolled, existing selection or none marked as checked
       checked = checkedValue === child.props.value;
-      tabindex = initialTabIndex(index);
     }
 
     return React.cloneElement(child, {
       checked,
-      tabindex,
       inputName: groupName,
       onChange: onChangeProp
     });

--- a/src/__experimental__/components/radio-button/radio-button-svg.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-svg.component.js
@@ -5,6 +5,7 @@ const RadioButtonSvg = () => {
   return (
     <StyledCheckableInputSvgWrapper>
       <svg
+        focusable='false'
         viewBox='0 0 15 15'
       >
         <g

--- a/src/__experimental__/components/radio-button/radio-button.component.js
+++ b/src/__experimental__/components/radio-button/radio-button.component.js
@@ -11,7 +11,7 @@ const RadioButton = ({
 }) => {
   const inputProps = {
     ...props,
-    helpTabIndex: -1,
+    helpTabIndex: 0,
     helpTag: 'span',
     inputId: id,
     inputLabel: label,

--- a/src/__experimental__/components/radio-button/radio-button.spec.js
+++ b/src/__experimental__/components/radio-button/radio-button.spec.js
@@ -6,7 +6,6 @@ import TestRenderer from 'react-test-renderer';
 import { RadioButton, RadioButtonGroup } from '.';
 import FieldHelpStyle from '../field-help/field-help.style';
 import LabelStyle from '../label/label.style';
-import CheckableInput from '../checkable-input/checkable-input.component';
 import HiddenCheckableInputStyle from '../checkable-input/hidden-checkable-input.style';
 import { StyledCheckableInput } from '../checkable-input/checkable-input.style';
 import StyledCheckableInputSvgWrapper from '../checkable-input/checkable-input-svg-wrapper.style';

--- a/src/__experimental__/components/radio-button/radio-button.spec.js
+++ b/src/__experimental__/components/radio-button/radio-button.spec.js
@@ -47,25 +47,6 @@ const renderClassic = props => render(props, classic);
 const validationTypes = ['hasError', 'hasWarning', 'hasInfo'];
 
 describe('RadioButton', () => {
-  describe('tabindex', () => {
-    describe('when checked === true', () => {
-      it('sets the tabindex attribute to 0', () => {
-        const input = render({ checked: true }).find(CheckableInput);
-
-        expect(input.props().tabindex).toEqual(0);
-      });
-    });
-
-    describe('when checked === false', () => {
-      it('sets the tabindex attribute to -1', () => {
-        const wrapper = render({ checked: false });
-        const input = wrapper.find(CheckableInput);
-
-        expect(input.props().tabindex).toEqual(-1);
-      });
-    });
-  });
-
   describe('default props', () => {
     it('onChange', () => {
       const button = getRadioButton(render());

--- a/src/__experimental__/components/radio-button/radio-button.stories.js
+++ b/src/__experimental__/components/radio-button/radio-button.stories.js
@@ -11,8 +11,8 @@ import { RadioButton, RadioButtonGroup } from '.';
 import { info, infoValidations, notes } from './documentation';
 
 const trueBool = true;
-const radioToggleGroupStore = new Store({ value: undefined });
-const validationRadioToggleGroupStore = new Store({ value: undefined });
+const radioToggleGroupStore = new Store({ value: null });
+const validationRadioToggleGroupStore = new Store({ value: null });
 const handleGroupChangeFactory = store => (event) => {
   const { value } = event.target;
 
@@ -20,7 +20,6 @@ const handleGroupChangeFactory = store => (event) => {
 
   action('Selected')(value);
 };
-
 
 function makeStory(name, themeSelector, component) {
   const metadata = {

--- a/src/__experimental__/components/radio-button/radio-button.stories.js
+++ b/src/__experimental__/components/radio-button/radio-button.stories.js
@@ -11,7 +11,16 @@ import { RadioButton, RadioButtonGroup } from '.';
 import { info, infoValidations, notes } from './documentation';
 
 const trueBool = true;
-const radioToggleGroupStore = new Store({ value: '' });
+const radioToggleGroupStore = new Store({ value: undefined });
+const validationRadioToggleGroupStore = new Store({ value: undefined });
+const handleGroupChangeFactory = store => (event) => {
+  const { value } = event.target;
+
+  store.set({ value });
+
+  action('Selected')(value);
+};
+
 
 function makeStory(name, themeSelector, component) {
   const metadata = {
@@ -63,31 +72,26 @@ const radioComponent = themeName => () => {
   const labelHelp = text('labelHelp', 'Group label helper');
 
   return (
-    <RadioButtonGroup
-      labelHelp={ labelHelp }
-      groupName='frequency'
-      label={ text('groupLabel', 'Please select a frequency from the options below') }
-      name='radio-button-group'
-    >
-      <RadioButton
-        id='input-1'
-        name='input-1'
-        checked
-        onChange={ handleChange }
-        { ...groupedKnobs('weekly', themeName) }
-      />
-      <RadioButton
-        name='input-2'
-        onChange={ handleChange }
-        { ...groupedKnobs('monthly', themeName) }
-      />
-      <RadioButton
+    <State store={ radioToggleGroupStore }>
+      <RadioButtonGroup
+        labelHelp={ labelHelp }
+        groupName='frequency'
+        label={ text('groupLabel', 'Please select a frequency from the options below') }
+        onChange={ handleGroupChangeFactory(radioToggleGroupStore) }
+      >
+        <RadioButton
+          id='input-1'
+          { ...groupedKnobs('weekly', themeName) }
+        />
+        <RadioButton
+          { ...groupedKnobs('monthly', themeName) }
+        />
+        <RadioButton
         // id prop intentionally left off here, to demonstrate automatic GUID generation
-        name='input-2'
-        onChange={ handleChange }
-        { ...groupedKnobs('yearly', themeName) }
-      />
-    </RadioButtonGroup>
+          { ...groupedKnobs('yearly', themeName) }
+        />
+      </RadioButtonGroup>
+    </State>
   );
 };
 
@@ -117,23 +121,21 @@ const radioComponentWithValidation = themeName => () => {
   }
 
   return (
-    <State store={ radioToggleGroupStore }>
+    <State store={ validationRadioToggleGroupStore }>
       <RadioButtonGroup
-        groupName='my-event'
+        groupName='radio-button-group'
         label={ label }
         labelHelp={ labelHelp }
         validations={ testValidation('valid') }
         warnings={ testValidation('warn') }
         info={ testValidation('info') }
-        name='radio-button-group'
         useValidationIcon={ trueBool }
-        onChange={ handleGroupChange }
+        onChange={ handleGroupChangeFactory(validationRadioToggleGroupStore) }
       >
         {validationTypes.map(vType => (
           <RadioButton
             { ...groupedKnobs(vType, themeName) }
             id={ `id-${vType}` }
-            name={ vType }
           />
         ))}
       </RadioButtonGroup>
@@ -146,16 +148,3 @@ storiesOf('Experimental/RadioButton', module)
   .add(...makeStory('classic', classicThemeSelector, radioComponent('classic')))
   .add(...makeStory('validations', dlsThemeSelector, radioComponentWithValidation()))
   .add(...makeStory('validations classic', classicThemeSelector, radioComponentWithValidation('classic')));
-
-function handleChange(event) {
-  const { value } = event.target;
-  action('Selected')(value);
-}
-
-function handleGroupChange(event) {
-  const { value } = event.target;
-
-  radioToggleGroupStore.set({ value });
-
-  action('Selected')(value);
-}


### PR DESCRIPTION
# Description
A defect was raised for missing keyboard control. However, this is supported natively by the browser and was a defect in the story implementation.

The `tabIndex` code was also removed to allow the browser to control the tab index. The browser changes the tab order depending on which way the user is tabbing (`Tab` vs `Shift+Tab`). There was a bug where using a `falsey` value would incorrectly set the tab index on the first item. This bug is no longer present as we're not controlling `tabIndex` you can see this in the storybook as the default value has changed from `undefined` to `null`.

# Testing Instructions
The experimental radio button stories should now support keyboard control.