### PR TITLE
FE-2062 fixed checkbox icon focus outline on modern theme

### DIFF
--- a/src/components/validations/validation-icon.style.js
+++ b/src/components/validations/validation-icon.style.js
@@ -23,8 +23,15 @@ const ValidationIconStyle = styled.div`
     ${StyledIcon}:before {
       font-size: 20px;
     }
+
     ${StyledIcon}:focus {
       outline: none;
+    }
+  `}
+  
+  ${({ theme }) => !isClassic(theme) && css`
+    ${StyledIcon}:focus {
+      outline: solid 2px ${theme.colors.focus};
     }
   `}
 `;


### PR DESCRIPTION
# Description
![image-2019-09-25-10-56-07-456](https://user-images.githubusercontent.com/47245766/66475373-1bd7ec00-ea8b-11e9-916b-0153a3bbd2e9.png)

Fixes checkbox icon focus outline for modern theme.
