### PR TITLE
FE-2153 Focus on icon is visible after the third click tab button

### DIFF
--- a/change_log/next/FE-2153-focus-icon-third-click.yml
+++ b/change_log/next/FE-2153-focus-icon-third-click.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Fixes IE11 bug where checkbox help icon get's focused on 3rd tab instead of 2nd (Component: Checkbox)."

--- a/src/__experimental__/components/checkbox/__snapshots__/checkbox-group.spec.js.snap
+++ b/src/__experimental__/components/checkbox/__snapshots__/checkbox-group.spec.js.snap
@@ -230,6 +230,7 @@ exports[`CheckboxGroup renders as expected 1`] = `
               className="c12 "
             >
               <svg
+                focusable="false"
                 height="10"
                 viewBox="0 0 12 10"
                 width="12"
@@ -278,6 +279,7 @@ exports[`CheckboxGroup renders as expected 1`] = `
               className="c12 "
             >
               <svg
+                focusable="false"
                 height="10"
                 viewBox="0 0 12 10"
                 width="12"

--- a/src/__experimental__/components/checkbox/__snapshots__/checkbox.spec.js.snap
+++ b/src/__experimental__/components/checkbox/__snapshots__/checkbox.spec.js.snap
@@ -627,6 +627,7 @@ exports[`Checkbox base theme renders as expected 1`] = `
           className="c8 "
         >
           <svg
+            focusable="false"
             height="10"
             viewBox="0 0 12 10"
             width="12"

--- a/src/__experimental__/components/checkbox/checkbox-svg.component.js
+++ b/src/__experimental__/components/checkbox/checkbox-svg.component.js
@@ -5,6 +5,7 @@ const CheckboxSvg = () => {
   return (
     <StyledCheckableInputSvgWrapper>
       <svg
+        focusable='false'
         width='12'
         height='10'
         viewBox='0 0 12 10'


### PR DESCRIPTION
# Description
Fixes IE11 bug where checkbox help icon get's focused on 3rd tab instead of 2nd