### PR TITLE
FE-2167 Decimal does not implement onBlur

### DIFF
--- a/src/__experimental__/components/decimal/decimal.component.js
+++ b/src/__experimental__/components/decimal/decimal.component.js
@@ -16,10 +16,15 @@ class Decimal extends React.Component {
 
   isControlled = this.props.value !== undefined
 
-  formatValue = () => {
+  getValue = () => {
     const { value: propValue = '0.00' } = this.props;
     const { value: stateValue = '0.00' } = this.state;
     const value = this.isControlled ? propValue : stateValue;
+    return value;
+  }
+
+  formatValue = () => {
+    const value = this.getValue();
 
     const { input } = this;
 

--- a/src/__experimental__/components/decimal/decimal.component.js
+++ b/src/__experimental__/components/decimal/decimal.component.js
@@ -23,6 +23,15 @@ class Decimal extends React.Component {
     return value;
   }
 
+  getUndelimitedValue = () => {
+    const value = this.getValue();
+    const format = I18nHelper.format();
+    const delimiter = `\\${format.delimiter}`;
+    const delimiterMatcher = new RegExp(`[${delimiter}]*`, 'g');
+    const noDelimiters = value.replace(delimiterMatcher, '');
+    return noDelimiters;
+  }
+
   formatValue = () => {
     const value = this.getValue();
 
@@ -39,10 +48,7 @@ class Decimal extends React.Component {
 
     // Only format value if input is not active
     // Strip delimiters otherwise formatDecimal Helper goes nuts
-    const format = I18nHelper.format();
-    const delimiter = `\\${format.delimiter}`;
-    const delimiterMatcher = new RegExp(`[${delimiter}]*`, 'g');
-    const noDelimiters = value.replace(delimiterMatcher, '');
+    const noDelimiters = this.getUndelimitedValue();
 
     return I18nHelper.formatDecimal(
       noDelimiters,

--- a/src/__experimental__/components/decimal/decimal.component.js
+++ b/src/__experimental__/components/decimal/decimal.component.js
@@ -102,8 +102,11 @@ class Decimal extends React.Component {
     }
   }
 
-  onBlur = () => {
+  onBlur = (ev) => {
     this.forceUpdate();
+    if (this.props.onBlur) {
+      this.props.onBlur(ev, this.getUndelimitedValue());
+    }
   }
 
   dataComponent = () => {
@@ -151,6 +154,10 @@ Decimal.propTypes = {
    * Handler for change event if input is meant to be used as a controlled component
    */
   onChange: PropTypes.func,
+  /**
+   * Handler for blur event
+   */
+  onBlur: PropTypes.func,
   /**
    * Maximum value for precision
    */

--- a/src/__experimental__/components/decimal/decimal.spec.js
+++ b/src/__experimental__/components/decimal/decimal.spec.js
@@ -36,6 +36,14 @@ describe('Decimal', () => {
       expect(onChange).toHaveBeenCalledWith({ target: { value: '14.79' } });
     });
 
+    it('invokes onBlur passed as a prop', () => {
+      const onBlur = jest.fn();
+      const wrapper = shallow(<Decimal onBlur={ onBlur } onChange={ () => true } />);
+      const input = wrapper.find(Textbox);
+      input.simulate('blur', { target: { value: '0.00' } });
+      expect(onBlur).toHaveBeenCalledWith({ target: { value: '0.00' } }, '0.00');
+    });
+
     it('input value defaults to 0.00 if none provided', () => {
       const wrapper = render({});
       assertCorrectTextboxVal(wrapper, '0.00');

--- a/src/__experimental__/components/decimal/decimal.stories.js
+++ b/src/__experimental__/components/decimal/decimal.stories.js
@@ -44,6 +44,7 @@ function makeStory(name, themeSelector) {
           precision={ precision }
           value={ store.get('value') }
           onChange={ setValue }
+          onBlur={ (ev, undelimitedValue) => action('onBlur')(ev, undelimitedValue) }
         />
       </State>
     );


### PR DESCRIPTION
# Description

Implemented a new `onBlur()` prop for the Experimental Decimal component. The callback receives two arguments:

1. The React `SyntheticEvent` object for the `blur` event.
2. The undelimited value (as a string). For example, if the component's displayed value is `"1,000.0"`, then the undelimited value is `"1000.0"`.