### PR TITLE
chore: define rfc process FE-2234

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ When reporting an issue, please provide as much information and context as possi
 
 For any feature requests, please use the [issue tracker](https://github.com/sage/carbon/issues). When you raise the feature request, please provide as much information as possible to describe the feature required, as well as examples of how you would like the feature to work.
 
+## Defining Features
+
+For features that you have a proposed solution for, please write a [RFC](./rfcs/README.md).
+
 ## Pull Request Guidelines
 
 * Before submitting a pull request, check the [issue tracker](https://github.com/sage/carbon/issues) to see if the feature or bug has already been discussed. If it has, check with us before beginning work on it to avoid duplicated effort.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ For any feature requests, please use the [issue tracker](https://github.com/sage
 
 ## Defining Features
 
-For features that you have a proposed solution for, please write a [RFC](./rfcs/README.md).
+For features that you have a proposed solution for, please write an [RFC](./rfcs/README.md).
 
 ## Pull Request Guidelines
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -86,7 +86,7 @@ become 'active'.
 Once an RFC becomes active, then authors may implement it and submit the
 feature as a pull request to the Carbon repo. Becoming 'active' is not a rubber
 stamp, and in particular still does not mean the feature will ultimately
-be merged; it does mean that the core team has agreed to it in principle
+be merged; it does mean that the Carbon core team has agreed to it in principle
 and are amenable to merging it.
 
 Furthermore, the fact that a given RFC has been accepted and is
@@ -113,11 +113,9 @@ feel free to ask (e.g. by leaving a comment on the associated issue).
 
 ## Reviewing RFCs
 
-Each week the team will attempt to review some set of open RFC
-pull requests.
+Every two weeks the Carbon core team will attempt to review some set of open RFC pull requests.
 
-Every accepted feature should have a core team champion,
-who will represent the feature and its progress.
+Every accepted feature should have a Carbon core team champion, who will represent the feature and its progress.
 
 **Carbon's RFC process owes its inspiration to the [React RFC process], [Yarn RFC process], [Rust RFC process], and [Ember RFC process]**.
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -58,7 +58,7 @@ into Carbon.
 * * If you have access, you may clone the repo and submit a PR from a branch.
 * Copy `rfcs/template.md` to `rfcs/text/my-feature.md` (where 'my-feature' is descriptive).
 * Fill in the RFC. Put care into the details: **RFCs that do not
-present convincing motivation, demonstrate understanding of the
+present convincing motivation, do not demonstrate understanding of the
 impact of the design, or are disingenuous about the drawbacks or
 alternatives, tend to be poorly-received**.
 * Submit a pull request. The RFC will receive design

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,6 +1,6 @@
 # Carbon RFCs
 
-Many changes, including bug fixes and documentation improvements can be
+Many changes, including bug fixes and documentation improvements, can be
 implemented and reviewed via the normal GitHub pull request workflow.
 
 Some changes though are "substantial", and we ask that these be put
@@ -24,10 +24,10 @@ from an RFC are:
 
    - A new component
    - The removal of a component that has been shipped
-   - Modification the interface/props of a component that would be a breaking change
-   - The additon of runtime exceptions
-   - Changes to the way carbon is imported
-   - Changes to the way carbon is built
+   - Breaking changes to the interface/props of a component
+   - The addition of runtime exceptions
+   - Changes to the way Carbon is imported
+   - Changes to the way Carbon is built
 
 The RFC process is a great opportunity to get more eyeballs on your proposal
 before it becomes a part of a released version of Carbon. Quite often, even
@@ -41,7 +41,7 @@ implemented.
 
 Some changes do not require an RFC:
 
-  - Rephrasing, reorganizing or refactoring carbon internals
+  - Rephrasing, reorganising or refactoring Carbon internals
   - Addition or removal of warnings
   - Additions or modifications that don't change the external Carbon interface
   - Additions only likely to be _noticed by_ other implementors-of-Carbon,
@@ -54,14 +54,14 @@ the RFC merged into the repo as a markdown file. At that point the RFC
 is 'active' and may be implemented with the goal of eventual inclusion
 into Carbon.
 
-* Fork the repo http://github.com/sage/carbon
-* * If you have access you may clone the repo and submit a PR from a branch
+* Fork the repo – http://github.com/sage/carbon
+* * If you have access, you may clone the repo and submit a PR from a branch.
 * Copy `rfcs/template.md` to `rfcs/text/my-feature.md` (where 'my-feature' is descriptive).
 * Fill in the RFC. Put care into the details: **RFCs that do not
 present convincing motivation, demonstrate understanding of the
 impact of the design, or are disingenuous about the drawbacks or
-alternatives tend to be poorly-received**.
-* Submit a pull request. As a pull request the RFC will receive design
+alternatives, tend to be poorly-received**.
+* Submit a pull request. The RFC will receive design
 feedback from the larger community, and the author should be prepared
 to revise it in response.
 * Build consensus and integrate feedback. RFCs that have broad support
@@ -71,14 +71,14 @@ comments.
 for inclusion in Carbon.
 * RFCs that are candidates for inclusion in Carbon will enter a "final comment
 period" lasting 3 calendar days. The beginning of this period will be signaled with a
-comment and tag on the RFCs pull request.
+comment and tag on the RFC's pull request.
 * An RFC can be modified based upon feedback from the team and community.
-Significant modifications may trigger a new final comment period.
+Significant modifications may trigger a new "final comment period".
 * An RFC may be rejected by the team after public discussion has settled
-and comments have been made summarizing the rationale for rejection. A member of
-the team should then close the RFCs associated pull request.
+and comments have been made summarising the rationale for rejection. A member of
+the team should then close the RFC's associated pull request.
 * An RFC may be accepted at the close of its final comment period. A team
-member will merge the RFCs associated pull request, at which point the RFC will
+member will merge the RFC's associated pull request, at which point the RFC will
 become 'active'.
 
 ## The RFC life-cycle
@@ -94,7 +94,7 @@ Furthermore, the fact that a given RFC has been accepted and is
 implementation, nor whether anybody is currently working on it.
 
 Modifications to active RFCs can be done in followup PRs. We strive
-to write each RFC in a manner that it will reflect the final design of
+to write each RFC in a manner that will reflect the final design of
 the feature; but the nature of the process means that we cannot expect
 every merged RFC to actually reflect what the end result will be at
 the time of the next major release; therefore we try to keep each RFC
@@ -119,9 +119,9 @@ pull requests.
 Every accepted feature should have a core team champion,
 who will represent the feature and its progress.
 
-**Carbons's RFC process owes its inspiration to the [React RFC process], [Yarn RFC process], [Rust RFC process], and [Ember RFC process]**.
+**Carbon's RFC process owes its inspiration to the [React RFC process], [Yarn RFC process], [Rust RFC process], and [Ember RFC process]**.
 
-[React RFC process]: https://github.com/react/rfcs
+[React RFC process]: https://github.com/reactjs/rfcs
 [Yarn RFC process]: https://github.com/yarnpkg/rfcs
 [Rust RFC process]: https://github.com/rust-lang/rfcs
 [Ember RFC process]: https://github.com/emberjs/rfcs

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,127 @@
+# Carbon RFCs
+
+Many changes, including bug fixes and documentation improvements can be
+implemented and reviewed via the normal GitHub pull request workflow.
+
+Some changes though are "substantial", and we ask that these be put
+through a bit of a design process and produce a consensus among the Carbon
+core team.
+
+The "RFC" (request for comments) process is intended to provide a
+consistent and controlled path for new features to enter the project.
+
+[Active RFC List](https://github.com/Sage/carbon/pulls?q=is%3Apr+is%3Aopen+label%3A%22RFC%22)
+
+Carbon is still **actively developing** this process, and it will still change as
+more features are implemented and the community settles on specific approaches
+to feature development.
+
+## When to follow this process
+
+You should consider using this process if you intend to make "substantial"
+changes to Carbon or its documentation. Some examples that would benefit
+from an RFC are:
+
+   - A new component
+   - The removal of a component that has been shipped
+   - Modification the interface/props of a component that would be a breaking change
+   - The additon of runtime exceptions
+   - Changes to the way carbon is imported
+   - Changes to the way carbon is built
+
+The RFC process is a great opportunity to get more eyeballs on your proposal
+before it becomes a part of a released version of Carbon. Quite often, even
+proposals that seem "obvious" can be significantly improved once a wider
+group of interested people have a chance to weigh in.
+
+The RFC process can also be helpful to encourage discussions about a proposed
+feature as it is being designed, and incorporate important constraints into
+the design while it's easier to change, before the design has been fully
+implemented.
+
+Some changes do not require an RFC:
+
+  - Rephrasing, reorganizing or refactoring carbon internals
+  - Addition or removal of warnings
+  - Additions or modifications that don't change the external Carbon interface
+  - Additions only likely to be _noticed by_ other implementors-of-Carbon,
+  invisible to users-of-Carbon.
+
+## What the process is
+
+In short, to get a major feature added to Carbon, one usually first gets
+the RFC merged into the repo as a markdown file. At that point the RFC
+is 'active' and may be implemented with the goal of eventual inclusion
+into Carbon.
+
+* Fork the repo http://github.com/sage/carbon
+* * If you have access you may clone the repo and submit a PR from a branch
+* Copy `rfcs/template.md` to `rfcs/text/my-feature.md` (where 'my-feature' is descriptive).
+* Fill in the RFC. Put care into the details: **RFCs that do not
+present convincing motivation, demonstrate understanding of the
+impact of the design, or are disingenuous about the drawbacks or
+alternatives tend to be poorly-received**.
+* Submit a pull request. As a pull request the RFC will receive design
+feedback from the larger community, and the author should be prepared
+to revise it in response.
+* Build consensus and integrate feedback. RFCs that have broad support
+are much more likely to make progress than those that don't receive any
+comments.
+* Eventually, the team will decide whether the RFC is a candidate
+for inclusion in Carbon.
+* RFCs that are candidates for inclusion in Carbon will enter a "final comment
+period" lasting 3 calendar days. The beginning of this period will be signaled with a
+comment and tag on the RFCs pull request.
+* An RFC can be modified based upon feedback from the team and community.
+Significant modifications may trigger a new final comment period.
+* An RFC may be rejected by the team after public discussion has settled
+and comments have been made summarizing the rationale for rejection. A member of
+the team should then close the RFCs associated pull request.
+* An RFC may be accepted at the close of its final comment period. A team
+member will merge the RFCs associated pull request, at which point the RFC will
+become 'active'.
+
+## The RFC life-cycle
+
+Once an RFC becomes active, then authors may implement it and submit the
+feature as a pull request to the Carbon repo. Becoming 'active' is not a rubber
+stamp, and in particular still does not mean the feature will ultimately
+be merged; it does mean that the core team has agreed to it in principle
+and are amenable to merging it.
+
+Furthermore, the fact that a given RFC has been accepted and is
+'active' implies nothing about what priority is assigned to its
+implementation, nor whether anybody is currently working on it.
+
+Modifications to active RFCs can be done in followup PRs. We strive
+to write each RFC in a manner that it will reflect the final design of
+the feature; but the nature of the process means that we cannot expect
+every merged RFC to actually reflect what the end result will be at
+the time of the next major release; therefore we try to keep each RFC
+document somewhat in sync with the language feature as planned,
+tracking such changes via followup pull requests to the document.
+
+## Implementing an RFC
+
+The author of an RFC is not obligated to implement it. Of course, the
+RFC author (like any other developer) is welcome to post an
+implementation for review after the RFC has been accepted.
+
+If you are interested in working on the implementation for an 'active'
+RFC, but cannot determine if someone else is already working on it,
+feel free to ask (e.g. by leaving a comment on the associated issue).
+
+## Reviewing RFCs
+
+Each week the team will attempt to review some set of open RFC
+pull requests.
+
+Every accepted feature should have a core team champion,
+who will represent the feature and its progress.
+
+**Carbons's RFC process owes its inspiration to the [React RFC process], [Yarn RFC process], [Rust RFC process], and [Ember RFC process]**.
+
+[React RFC process]: https://github.com/react/rfcs
+[Yarn RFC process]: https://github.com/yarnpkg/rfcs
+[Rust RFC process]: https://github.com/rust-lang/rfcs
+[Ember RFC process]: https://github.com/emberjs/rfcs

--- a/rfcs/template.md
+++ b/rfcs/template.md
@@ -31,9 +31,9 @@ defined here.
 
 Why should we *not* do this? Please consider:
 
-- implementation cost, both in term of code size and complexity
+- implementation cost, both in terms of code size and complexity
 - whether the proposed feature can be implemented in user space
-- the impact on teaching people Carbon
+- the impact on teaching people how to use Carbon
 - integration of this feature with other existing and planned features
 - cost of migrating existing Carbon applications (is it a breaking change?)
 

--- a/rfcs/template.md
+++ b/rfcs/template.md
@@ -1,0 +1,66 @@
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+
+# Summary
+
+Brief explanation of the feature.
+
+# Basic example
+
+If the proposal involves a new or changed API, include a basic code example.
+Omit this section if it's not applicable.
+
+# Motivation
+
+Why are we doing this? What use cases does it support? What is the expected
+outcome?
+
+Please focus on explaining the motivation so that if this RFC is not accepted,
+the motivation could be used to develop alternative solutions. In other words,
+enumerate the constraints you are trying to solve without coupling them too
+closely to the solution you have in mind.
+
+# Detailed design
+
+This is the bulk of the RFC. Explain the design in enough detail for somebody
+familiar with Carbon to understand, and for somebody familiar with the
+implementation to implement. This should get into specifics and corner-cases,
+and include examples of how the feature is used. Any new terminology should be
+defined here.
+
+# Drawbacks
+
+Why should we *not* do this? Please consider:
+
+- implementation cost, both in term of code size and complexity
+- whether the proposed feature can be implemented in user space
+- the impact on teaching people Carbon
+- integration of this feature with other existing and planned features
+- cost of migrating existing Carbon applications (is it a breaking change?)
+
+There are tradeoffs to choosing any path. Attempt to identify them here.
+
+# Alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+# Adoption strategy
+
+If we implement this proposal, how will existing Carbon developers adopt it? Is
+this a breaking change? Can we write a codemod? Should we coordinate with
+other projects or libraries?
+
+# How we teach this
+
+What names and terminology work best for these concepts and why? How is this
+idea best presented? As a continuation of existing Carbon patterns?
+
+Would the acceptance of this proposal mean the Carbon documentation must be
+re-organized or altered? Does it change how Carbon is taught to new developers
+at any level?
+
+How should this feature be taught to existing Carbon developers?
+
+# Unresolved questions
+
+Optional, but suggested for first drafts. What parts of the design are still
+TBD?


### PR DESCRIPTION
To define clear channels for collaboration, we have introduced a "request for comments" process.

This will streamline the process for making any substantial changes that require input from the wider audience.