### PR TITLE
FE-2267 experimental docgeninfo updates

### DIFF
--- a/src/__experimental__/components/decimal/decimal.stories.js
+++ b/src/__experimental__/components/decimal/decimal.stories.js
@@ -11,6 +11,17 @@ import Textbox, { OriginalTextbox } from '../textbox';
 import getTextboxStoryProps from '../textbox/textbox.stories';
 import OptionsHelper from '../../../utils/helpers/options-helper';
 import { info, notes } from './documentation';
+import getDocGenInfo from '../../../utils/helpers/docgen-info';
+
+OriginalTextbox.__docgenInfo = getDocGenInfo(
+  require('../textbox/docgenInfo.json'),
+  /textbox\.component(?!spec)/
+);
+
+Decimal.__docgenInfo = getDocGenInfo(
+  require('./docgenInfo.json'),
+  /decimal\.component(?!spec)/
+);
 
 const store = new Store({
   value: Decimal.defaultProps.value

--- a/src/__experimental__/components/decimal/docgenInfo.json
+++ b/src/__experimental__/components/decimal/docgenInfo.json
@@ -1,0 +1,151 @@
+{
+  "src/__experimental__/components/decimal/decimal.component.js": [
+    {
+      "description": "",
+      "displayName": "Decimal",
+      "methods": [
+        {
+          "name": "getValue",
+          "docblock": null,
+          "modifiers": [],
+          "params": [],
+          "returns": null
+        },
+        {
+          "name": "getUndelimitedValue",
+          "docblock": null,
+          "modifiers": [],
+          "params": [],
+          "returns": null
+        },
+        {
+          "name": "formatValue",
+          "docblock": null,
+          "modifiers": [],
+          "params": [],
+          "returns": null
+        },
+        {
+          "name": "validatePrecision",
+          "docblock": null,
+          "modifiers": [],
+          "params": [],
+          "returns": null
+        },
+        {
+          "name": "isValidDecimal",
+          "docblock": null,
+          "modifiers": [],
+          "params": [
+            {
+              "name": "value",
+              "type": null
+            }
+          ],
+          "returns": null
+        },
+        {
+          "name": "onChange",
+          "docblock": null,
+          "modifiers": [],
+          "params": [
+            {
+              "name": "ev",
+              "type": null
+            }
+          ],
+          "returns": null
+        },
+        {
+          "name": "onBlur",
+          "docblock": null,
+          "modifiers": [],
+          "params": [
+            {
+              "name": "ev",
+              "type": null
+            }
+          ],
+          "returns": null
+        },
+        {
+          "name": "dataComponent",
+          "docblock": null,
+          "modifiers": [],
+          "params": [],
+          "returns": null
+        }
+      ],
+      "props": {
+        "align": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "The default value alignment on the input",
+          "defaultValue": {
+            "value": "'right'",
+            "computed": false
+          }
+        },
+        "precision": {
+          "type": {
+            "name": "number"
+          },
+          "required": false,
+          "description": "The decimal precision of the value in the input",
+          "defaultValue": {
+            "value": "2",
+            "computed": false
+          }
+        },
+        "inputWidth": {
+          "type": {
+            "name": "number"
+          },
+          "required": false,
+          "description": "The width of the input as a percentage"
+        },
+        "defaultValue": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "The default value of the input if it's meant to be used as an uncontrolled component"
+        },
+        "value": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "The value of the input if it's used as a controlled component"
+        },
+        "onChange": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "Handler for change event if input is meant to be used as a controlled component"
+        },
+        "onBlur": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "Handler for blur event"
+        },
+        "maxPrecision": {
+          "type": {
+            "name": "number"
+          },
+          "required": false,
+          "description": "Maximum value for precision",
+          "defaultValue": {
+            "value": "15",
+            "computed": false
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/__experimental__/components/form/docgenInfo.json
+++ b/src/__experimental__/components/form/docgenInfo.json
@@ -5,13 +5,6 @@
       "displayName": "FormWithoutValidations",
       "methods": [
         {
-          "name": "getChildContext",
-          "docblock": null,
-          "modifiers": [],
-          "params": [],
-          "returns": null
-        },
-        {
           "name": "getActiveInput",
           "docblock": null,
           "modifiers": [],
@@ -80,6 +73,14 @@
           "returns": null
         },
         {
+          "name": "checkFormDataExists",
+          "docblock": "Returns true if any input has value",
+          "modifiers": [],
+          "params": [],
+          "returns": null,
+          "description": "Returns true if any input has value"
+        },
+        {
           "name": "checkIsFormDirty",
           "docblock": null,
           "modifiers": [],
@@ -131,9 +132,7 @@
         {
           "name": "submitControlledForm",
           "docblock": null,
-          "modifiers": [
-            "async"
-          ],
+          "modifiers": [],
           "params": [],
           "returns": null
         },
@@ -155,18 +154,6 @@
           "modifiers": [],
           "params": [],
           "returns": null
-        },
-        {
-          "name": "serialize",
-          "docblock": "Serializes the inputs in the form ready for submission via AJAX\nhttps://www.npmjs.com/package/form-serialize",
-          "modifiers": [],
-          "params": [
-            {
-              "name": "opts"
-            }
-          ],
-          "returns": null,
-          "description": "Serializes the inputs in the form ready for submission via AJAX\nhttps://www.npmjs.com/package/form-serialize"
         },
         {
           "name": "htmlProps",
@@ -237,24 +224,12 @@
           "description": "Returns the footer for the form"
         },
         {
-          "name": "mainClasses",
-          "docblock": "Main class getter",
-          "modifiers": [
-            "get"
-          ],
+          "name": "orderFormButtons",
+          "docblock": "Orders the Save and Cancel Buttons based on alignment prop",
+          "modifiers": [],
           "params": [],
           "returns": null,
-          "description": "Main class getter"
-        },
-        {
-          "name": "footerClasses",
-          "docblock": "Button class getter",
-          "modifiers": [
-            "get"
-          ],
-          "params": [],
-          "returns": null,
-          "description": "Button class getter"
+          "description": "Orders the Save and Cancel Buttons based on alignment prop"
         },
         {
           "name": "addInputDataToState",
@@ -270,6 +245,26 @@
           ],
           "returns": null,
           "description": "Store children controlled data in state"
+        },
+        {
+          "name": "getContext",
+          "docblock": "Returns form object to child components.",
+          "modifiers": [],
+          "params": [],
+          "returns": null,
+          "description": "Returns form object to child components."
+        },
+        {
+          "name": "isHTMLElement",
+          "docblock": null,
+          "modifiers": [],
+          "params": [
+            {
+              "name": "child",
+              "type": null
+            }
+          ],
+          "returns": null
         },
         {
           "name": "renderChildren",
@@ -319,7 +314,9 @@
         },
         "buttonAlign": {
           "type": {
-            "name": "string"
+            "name": "enum",
+            "computed": true,
+            "value": "OptionsHelper.alignBinary"
           },
           "required": false,
           "description": "Alignment of submit button",
@@ -456,13 +453,6 @@
             "computed": false
           }
         },
-        "className": {
-          "type": {
-            "name": "string"
-          },
-          "required": false,
-          "description": "A custom class name for the component."
-        },
         "children": {
           "type": {
             "name": "node"
@@ -546,23 +536,21 @@
             "name": "string"
           },
           "required": false,
-          "description": ""
-        }
-      },
-      "context": {
-        "modal": {
+          "description": "Path to redirect after submit"
+        },
+        "fixedBottom": {
           "type": {
-            "name": "object"
+            "name": "bool"
           },
-          "required": false
-        }
-      },
-      "childContext": {
-        "form": {
+          "required": false,
+          "description": "Passed down when Form parent is dialog"
+        },
+        "isLabelRightAligned": {
           "type": {
-            "name": "object"
+            "name": "bool"
           },
-          "required": false
+          "required": false,
+          "description": "Sets children's label alignment"
         }
       }
     },

--- a/src/__experimental__/components/radio-button/docgenInfo.json
+++ b/src/__experimental__/components/radio-button/docgenInfo.json
@@ -1,0 +1,239 @@
+{
+  "src/__experimental__/components/radio-button/radio-button-group.component.js": [
+    {
+      "description": "",
+      "displayName": "RadioButtonGroup",
+      "methods": [],
+      "props": {
+        "children": {
+          "type": {
+            "name": "node"
+          },
+          "required": true,
+          "description": "The RadioButton objects to be rendered in the group"
+        },
+        "name": {
+          "type": {
+            "name": "string"
+          },
+          "required": true,
+          "description": "Specifies the name prop to be applied to each button in the group"
+        },
+        "legend": {
+          "type": {
+            "name": "string"
+          },
+          "required": true,
+          "description": "The content for the RadioGroup Legend"
+        },
+        "labelHelp": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Help text"
+        },
+        "hasError": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Prop to indicate that an error has occurred",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        },
+        "hasWarning": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Prop to indicate that a warning has occurred",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        },
+        "hasInfo": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Prop to indicate additional information",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        },
+        "onBlur": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "The onBlur event"
+        },
+        "onChange": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "The onChange event"
+        },
+        "value": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "The formatted value"
+        },
+        "tooltipMessage": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "String to be displayed in a Tooltip"
+        }
+      }
+    }
+  ],
+  "src/__experimental__/components/radio-button/radio-button-svg.component.js": [
+    {
+      "description": "",
+      "displayName": "RadioButtonSvg",
+      "methods": []
+    }
+  ],
+  "src/__experimental__/components/radio-button/radio-button.component.js": [
+    {
+      "description": "",
+      "displayName": "RadioButton",
+      "methods": [],
+      "props": {
+        "checked": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Set the value of the radio button"
+        },
+        "disabled": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Toggles disabling of input"
+        },
+        "fieldHelpInline": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Displays fieldHelp inline with the radio button"
+        },
+        "id": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Unique Identifier for the input. Will use a randomly generated GUID if none is provided"
+        },
+        "inputWidth": {
+          "type": {
+            "name": "union",
+            "value": [
+              {
+                "name": "number"
+              },
+              {
+                "name": "string"
+              }
+            ]
+          },
+          "required": false,
+          "description": "Sets percentage-based input width"
+        },
+        "label": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "The content of the label for the input"
+        },
+        "labelAlign": {
+          "type": {
+            "name": "enum",
+            "computed": true,
+            "value": "OptionsHelper.alignBinary"
+          },
+          "required": false,
+          "description": "Sets label alignment - accepted values: 'left' (default), 'right'"
+        },
+        "labelWidth": {
+          "type": {
+            "name": "union",
+            "value": [
+              {
+                "name": "number"
+              },
+              {
+                "name": "string"
+              }
+            ]
+          },
+          "required": false,
+          "description": "Sets percentage-based label width"
+        },
+        "name": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "The name of the the RadioButton (can also be set via the 'name' prop of the RadioButtonGroup component)"
+        },
+        "onChange": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "Accepts a callback function which can be used to update parent state on change"
+        },
+        "reverse": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Reverses label and radio button display",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        },
+        "size": {
+          "type": {
+            "name": "enum",
+            "computed": true,
+            "value": "OptionsHelper.sizesBinary"
+          },
+          "required": false,
+          "description": "Set the size of the radio button to 'small' (16x16 - default) or 'large' (24x24).\nNo effect when using Classic theme."
+        },
+        "value": {
+          "type": {
+            "name": "string"
+          },
+          "required": true,
+          "description": "the value of the Radio Button, passed on form submit"
+        },
+        "children": {
+          "type": {
+            "name": "custom",
+            "raw": "(props, propName, componentName) => {\n  if (props[propName]) {\n    return new Error(\n      `Forbidden prop \\`${propName}\\` supplied to \\`${componentName}\\`. `\n        + 'This component is meant to be used as a self-closing tag. '\n        + 'You should probably use the label prop instead.'\n    );\n  }\n  return null;\n}"
+          },
+          "required": false,
+          "description": ""
+        }
+      }
+    }
+  ]
+}

--- a/src/__experimental__/components/radio-button/index.js
+++ b/src/__experimental__/components/radio-button/index.js
@@ -1,5 +1,5 @@
-import RadioButton from './radio-button.component';
+import RadioButton, { OriginalRadioButton } from './radio-button.component';
 import RadioButtonGroup from './radio-button-group.component';
 
-export { RadioButton, RadioButtonGroup };
+export { RadioButton, RadioButtonGroup, OriginalRadioButton };
 export default RadioButton;

--- a/src/__experimental__/components/radio-button/index.js
+++ b/src/__experimental__/components/radio-button/index.js
@@ -1,5 +1,5 @@
-import RadioButton, { OriginalRadioButton } from './radio-button.component';
+import RadioButton, { PrivateRadioButton } from './radio-button.component';
 import RadioButtonGroup from './radio-button-group.component';
 
-export { RadioButton, RadioButtonGroup, OriginalRadioButton };
+export { RadioButton, RadioButtonGroup, PrivateRadioButton };
 export default RadioButton;

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -97,7 +97,7 @@ RadioButtonGroup.propTypes = {
   onChange: PropTypes.func,
   /** value of the selected RadioButton */
   value: PropTypes.string,
-  /** String to be displayed in a Tooltip */
+  /** Message to be displayed in a Tooltip when the user hovers over the help icon */
   tooltipMessage: PropTypes.string
 };
 

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -91,9 +91,13 @@ RadioButtonGroup.propTypes = {
   hasWarning: PropTypes.bool,
   /** Prop to indicate additional information  */
   hasInfo: PropTypes.bool,
+  /** The onBlur event */
   onBlur: PropTypes.func,
+  /** The onChange event */
   onChange: PropTypes.func,
+  /** The formatted value */
   value: PropTypes.string,
+  /** String to be displayed in a Tooltip */
   tooltipMessage: PropTypes.string
 };
 

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -95,7 +95,7 @@ RadioButtonGroup.propTypes = {
   onBlur: PropTypes.func,
   /** The onChange event */
   onChange: PropTypes.func,
-  /** The formatted value */
+  /** value of the selected RadioButton */
   value: PropTypes.string,
   /** String to be displayed in a Tooltip */
   tooltipMessage: PropTypes.string

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -91,7 +91,7 @@ RadioButtonGroup.propTypes = {
   hasWarning: PropTypes.bool,
   /** Prop to indicate additional information  */
   hasInfo: PropTypes.bool,
-  /** The onBlur event */
+  /** Callback fired when each RadioButton is blurred */
   onBlur: PropTypes.func,
   /** The onChange event */
   onChange: PropTypes.func,

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -93,7 +93,7 @@ RadioButtonGroup.propTypes = {
   hasInfo: PropTypes.bool,
   /** Callback fired when each RadioButton is blurred */
   onBlur: PropTypes.func,
-  /** The onChange event */
+  /** Callback fired when the user selects a RadioButton */
   onChange: PropTypes.func,
   /** value of the selected RadioButton */
   value: PropTypes.string,

--- a/src/__experimental__/components/radio-button/radio-button.component.js
+++ b/src/__experimental__/components/radio-button/radio-button.component.js
@@ -92,4 +92,5 @@ RadioButton.defaultProps = {
   reverse: false
 };
 
+export { RadioButton as OriginalRadioButton };
 export default React.memo(RadioButton);

--- a/src/__experimental__/components/radio-button/radio-button.component.js
+++ b/src/__experimental__/components/radio-button/radio-button.component.js
@@ -92,5 +92,5 @@ RadioButton.defaultProps = {
   reverse: false
 };
 
-export { RadioButton as OriginalRadioButton };
+export { RadioButton as PrivateRadioButton };
 export default React.memo(RadioButton);

--- a/src/__experimental__/components/radio-button/radio-button.stories.js
+++ b/src/__experimental__/components/radio-button/radio-button.stories.js
@@ -7,7 +7,7 @@ import { action } from '@storybook/addon-actions';
 import { State, Store } from '@sambego/storybook-state';
 import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/theme-selectors';
 import OptionsHelper from '../../../utils/helpers/options-helper';
-import { RadioButton, RadioButtonGroup, OriginalRadioButton } from '.';
+import { RadioButton, RadioButtonGroup, PrivateRadioButton } from '.';
 import { info, infoValidations, notes } from './documentation';
 import getDocGenInfo from '../../../utils/helpers/docgen-info';
 
@@ -16,7 +16,7 @@ RadioButtonGroup.__docgenInfo = getDocGenInfo(
   /radio-button-group\.component(?!spec)/
 );
 
-OriginalRadioButton.__docgenInfo = getDocGenInfo(
+PrivateRadioButton.__docgenInfo = getDocGenInfo(
   require('./docgenInfo.json'),
   /radio-button\.component.(?!spec)/
 );

--- a/src/__experimental__/components/radio-button/radio-button.stories.js
+++ b/src/__experimental__/components/radio-button/radio-button.stories.js
@@ -7,8 +7,19 @@ import { action } from '@storybook/addon-actions';
 import { State, Store } from '@sambego/storybook-state';
 import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/theme-selectors';
 import OptionsHelper from '../../../utils/helpers/options-helper';
-import { RadioButton, RadioButtonGroup } from '.';
+import { RadioButton, RadioButtonGroup, OriginalRadioButton } from '.';
 import { info, infoValidations, notes } from './documentation';
+import getDocGenInfo from '../../../utils/helpers/docgen-info';
+
+RadioButtonGroup.__docgenInfo = getDocGenInfo(
+  require('./docgenInfo.json'),
+  /radio-button-group\.component(?!spec)/
+);
+
+OriginalRadioButton.__docgenInfo = getDocGenInfo(
+  require('./docgenInfo.json'),
+  /radio-button\.component.(?!spec)/
+);
 
 const radioToggleGroupStore = new Store({ value: null });
 const validationRadioToggleGroupStore = new Store({ value: null });

--- a/src/__experimental__/components/select/docgenInfo.json
+++ b/src/__experimental__/components/select/docgenInfo.json
@@ -10,28 +10,28 @@
             "name": "string"
           },
           "required": true,
-          "description": ""
+          "description": "used to filter the item"
         },
         "children": {
           "type": {
             "name": "node"
           },
           "required": false,
-          "description": ""
+          "description": "optional, if different to props.text"
         },
         "value": {
           "type": {
             "name": "string"
           },
           "required": true,
-          "description": ""
+          "description": "sent on select of an item"
         },
         "options": {
           "type": {
             "name": "object"
           },
           "required": false,
-          "description": ""
+          "description": "optional additional params to be sent on select"
         }
       }
     }

--- a/src/__experimental__/components/select/docgenInfo.json
+++ b/src/__experimental__/components/select/docgenInfo.json
@@ -10,28 +10,28 @@
             "name": "string"
           },
           "required": true,
-          "description": "used to filter the item"
+          "description": "if children is undefined, text will be rendered as the Option content"
         },
         "children": {
           "type": {
             "name": "node"
           },
           "required": false,
-          "description": "optional, if different to props.text"
+          "description": "if defined, children will be rendered as the Option content"
         },
         "value": {
           "type": {
             "name": "string"
           },
           "required": true,
-          "description": "sent on select of an item"
+          "description": "the value of the Option"
         },
         "options": {
           "type": {
             "name": "object"
           },
           "required": false,
-          "description": "optional additional params to be sent on select"
+          "description": "if defined, this object can be used to provide optional extra properties"
         }
       }
     }

--- a/src/__experimental__/components/select/option.component.js
+++ b/src/__experimental__/components/select/option.component.js
@@ -8,10 +8,14 @@ const Option = ({ text, children, ...props }) => (
 );
 
 Option.propTypes = {
-  text: PropTypes.string.isRequired, // used to filter the item
-  children: PropTypes.node, // optional, if different to props.text
-  value: PropTypes.string.isRequired, // sent on select of an item
-  options: PropTypes.object // optional additional params to be sent on select
+  /** used to filter the item */
+  text: PropTypes.string.isRequired,
+  /** optional, if different to props.text */
+  children: PropTypes.node,
+  /** sent on select of an item */
+  value: PropTypes.string.isRequired,
+  /** optional additional params to be sent on select */
+  options: PropTypes.object
 };
 
 export default Option;

--- a/src/__experimental__/components/select/option.component.js
+++ b/src/__experimental__/components/select/option.component.js
@@ -8,13 +8,13 @@ const Option = ({ text, children, ...props }) => (
 );
 
 Option.propTypes = {
-  /** used to filter the item */
+  /** if children is undefined, text will be rendered as the Option content */
   text: PropTypes.string.isRequired,
-  /** optional, if different to props.text */
+  /** if defined, children will be rendered as the Option content */
   children: PropTypes.node,
-  /** sent on select of an item */
+  /** the value of the Option */
   value: PropTypes.string.isRequired,
-  /** optional additional params to be sent on select */
+  /** if defined, this object can be used to provide optional extra properties */
   options: PropTypes.object
 };
 

--- a/src/__experimental__/components/switch/docgenInfo.json
+++ b/src/__experimental__/components/switch/docgenInfo.json
@@ -51,7 +51,14 @@
             "name": "bool"
           },
           "required": false,
-          "description": "Set the value of the Switch"
+          "description": "Set the value of the Switch if component is meant to be used as controlled"
+        },
+        "defaultChecked": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Set the default value of the Switch if component is meant to be used as uncontrolled"
         },
         "disabled": {
           "type": {
@@ -74,12 +81,41 @@
           "required": false,
           "description": "Displays fieldHelp inline with the checkbox"
         },
+        "id": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Unique Identifier for the input. Will use a randomly generated GUID if none is provided"
+        },
         "inputWidth": {
           "type": {
-            "name": "number"
+            "name": "union",
+            "value": [
+              {
+                "name": "number"
+              },
+              {
+                "name": "string"
+              }
+            ]
           },
           "required": false,
           "description": "Sets percentage-based input width"
+        },
+        "label": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "The content of the label for the input"
+        },
+        "labelHelp": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Help text"
         },
         "labelAlign": {
           "type": {
@@ -101,10 +137,37 @@
         },
         "labelWidth": {
           "type": {
-            "name": "number"
+            "name": "union",
+            "value": [
+              {
+                "name": "number"
+              },
+              {
+                "name": "string"
+              }
+            ]
           },
           "required": false,
           "description": "Sets percentage-based label width"
+        },
+        "helpTabIndex": {
+          "type": {
+            "name": "union",
+            "value": [
+              {
+                "name": "number"
+              },
+              {
+                "name": "string"
+              }
+            ]
+          },
+          "required": false,
+          "description": "Override tab index on the validation and help icon",
+          "defaultValue": {
+            "value": "0",
+            "computed": false
+          }
         },
         "loading": {
           "type": {
@@ -143,7 +206,47 @@
             "name": "object"
           },
           "required": false,
-          "description": ""
+          "description": "Current theme"
+        },
+        "value": {
+          "type": {
+            "name": "string"
+          },
+          "required": true,
+          "description": "the value of the checkbox, passed on form submit"
+        },
+        "hasError": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Prop to indicate that an error has occurred",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        },
+        "hasWarning": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Prop to indicate that a warning has occurred",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        },
+        "hasInfo": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Prop to indicate additional information",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
         }
       }
     }
@@ -151,7 +254,17 @@
   "src/__experimental__/components/switch/switch.stories.js": [
     {
       "description": "",
-      "displayName": "SwitchWrapper",
+      "displayName": "switchWrapper",
+      "methods": []
+    },
+    {
+      "description": "",
+      "displayName": "switchClassic",
+      "methods": []
+    },
+    {
+      "description": "",
+      "displayName": "switchComponent",
       "methods": []
     }
   ]

--- a/src/__experimental__/components/switch/switch.component.js
+++ b/src/__experimental__/components/switch/switch.component.js
@@ -106,6 +106,7 @@ Switch.propTypes = {
    * No effect when using Classic theme.
    */
   size: PropTypes.string,
+  /** Current theme */
   theme: PropTypes.object,
   /** the value of the checkbox, passed on form submit */
   value: PropTypes.string.isRequired,

--- a/src/__experimental__/components/switch/switch.component.js
+++ b/src/__experimental__/components/switch/switch.component.js
@@ -106,7 +106,7 @@ Switch.propTypes = {
    * No effect when using Classic theme.
    */
   size: PropTypes.string,
-  /** Current theme */
+  /** Theme to apply */
   theme: PropTypes.object,
   /** the value of the checkbox, passed on form submit */
   value: PropTypes.string.isRequired,

--- a/src/__experimental__/components/textarea/docgenInfo.json
+++ b/src/__experimental__/components/textarea/docgenInfo.json
@@ -85,6 +85,13 @@
           "returns": null
         },
         {
+          "name": "renderValidation",
+          "docblock": null,
+          "modifiers": [],
+          "params": [],
+          "returns": null
+        },
+        {
           "name": "overLimit",
           "docblock": null,
           "modifiers": [
@@ -175,28 +182,28 @@
             "name": "string"
           },
           "required": false,
-          "description": ""
+          "description": "The content of the label for the input"
         },
         "name": {
           "type": {
             "name": "string"
           },
           "required": false,
-          "description": ""
+          "description": "Name of the input"
         },
         "onChange": {
           "type": {
             "name": "func"
           },
           "required": false,
-          "description": ""
+          "description": "Specify a callback triggered on change"
         },
         "placeholder": {
           "type": {
             "name": "string"
           },
           "required": false,
-          "description": ""
+          "description": "Placeholder text for the component"
         },
         "readOnly": {
           "type": {
@@ -242,6 +249,41 @@
             "value": "false",
             "computed": false
           }
+        },
+        "hasError": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Status of error validations"
+        },
+        "hasWarning": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Status of warnings"
+        },
+        "hasInfo": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Status of info"
+        },
+        "inputIcon": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Icon associated with this component"
+        },
+        "tooltipMessage": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "A message to display as a tooltip to the component."
         }
       }
     }

--- a/src/__experimental__/components/textarea/textarea.component.js
+++ b/src/__experimental__/components/textarea/textarea.component.js
@@ -184,7 +184,7 @@ Textarea.propTypes = {
   hasInfo: PropTypes.bool,
   /** Icon associated with this component */
   inputIcon: PropTypes.string,
-  /** A message to display as a tooltip to the component. */
+  /** Message to be displayed in a Tooltip when the user hovers over the help icon */
   tooltipMessage: PropTypes.string
 };
 

--- a/src/__experimental__/components/textarea/textarea.component.js
+++ b/src/__experimental__/components/textarea/textarea.component.js
@@ -162,7 +162,7 @@ Textarea.propTypes = {
   label: PropTypes.string,
   /** Name of the input */
   name: PropTypes.string,
-  /** Specify a callback triggered on change */
+  /** Callback fired when the user types in the Textarea */
   onChange: PropTypes.func,
   /** Placeholder text for the component */
   placeholder: PropTypes.string,

--- a/src/__experimental__/components/textarea/textarea.component.js
+++ b/src/__experimental__/components/textarea/textarea.component.js
@@ -158,9 +158,13 @@ Textarea.propTypes = {
   enforceCharacterLimit: PropTypes.bool,
   /** Allows the Textareas Height to change based on user input */
   expandable: PropTypes.bool,
+  /** The content of the label for the input */
   label: PropTypes.string,
+  /** Name of the input */
   name: PropTypes.string,
+  /** Specify a callback triggered on change */
   onChange: PropTypes.func,
+  /** Placeholder text for the component */
   placeholder: PropTypes.string,
   /** Adds readOnly property */
   readOnly: PropTypes.bool,
@@ -178,7 +182,9 @@ Textarea.propTypes = {
   hasWarning: PropTypes.bool,
   /** Status of info */
   hasInfo: PropTypes.bool,
+  /** Icon associated with this component */
   inputIcon: PropTypes.string,
+  /** A message to display as a tooltip to the component. */
   tooltipMessage: PropTypes.string
 };
 

--- a/src/__experimental__/components/textarea/textarea.component.js
+++ b/src/__experimental__/components/textarea/textarea.component.js
@@ -182,7 +182,7 @@ Textarea.propTypes = {
   hasWarning: PropTypes.bool,
   /** Status of info */
   hasInfo: PropTypes.bool,
-  /** Icon associated with this component */
+  /** Icon to display inside of the Textarea */
   inputIcon: PropTypes.string,
   /** Message to be displayed in a Tooltip when the user hovers over the help icon */
   tooltipMessage: PropTypes.string

--- a/src/__experimental__/components/textbox/docgenInfo.json
+++ b/src/__experimental__/components/textbox/docgenInfo.json
@@ -25,21 +25,21 @@
             ]
           },
           "required": false,
-          "description": ""
+          "description": "The formatted value of the field"
         },
         "disabled": {
           "type": {
             "name": "bool"
           },
           "required": false,
-          "description": ""
+          "description": "Flag indicating disabled state"
         },
         "readOnly": {
           "type": {
             "name": "bool"
           },
           "required": false,
-          "description": ""
+          "description": "Flag indicting read-only state"
         },
         "onChange": {
           "type": {
@@ -131,14 +131,14 @@
             "name": "string"
           },
           "required": false,
-          "description": ""
+          "description": "Icon associated with this component"
         },
         "leftChildren": {
           "type": {
             "name": "node"
           },
           "required": false,
-          "description": ""
+          "description": "Adds additional child elements before the input"
         },
         "validations": {
           "type": {
@@ -163,6 +163,61 @@
           },
           "required": false,
           "description": "List of info validation functions"
+        },
+        "childOfForm": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Flag to configure component when in a Form"
+        },
+        "isOptional": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Flag to configure component as optional in Form"
+        },
+        "hasError": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Status of error validations"
+        },
+        "hasWarning": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Status of warnings"
+        },
+        "hasInfo": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Status of info"
+        },
+        "size": {
+          "type": {
+            "name": "enum",
+            "computed": true,
+            "value": "OptionsHelper.sizesRestricted"
+          },
+          "required": false,
+          "description": "Size of an input",
+          "defaultValue": {
+            "value": "'medium'",
+            "computed": false
+          }
+        },
+        "placeholder": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Placeholder string to be displayed in input"
         }
       }
     }

--- a/src/__experimental__/components/textbox/docgenInfo.json
+++ b/src/__experimental__/components/textbox/docgenInfo.json
@@ -32,14 +32,14 @@
             "name": "bool"
           },
           "required": false,
-          "description": "Flag indicating disabled state"
+          "description": "If true, the component will be disabled"
         },
         "readOnly": {
           "type": {
             "name": "bool"
           },
           "required": false,
-          "description": "Flag indicting read-only state"
+          "description": "If true, the component will be read-only"
         },
         "onChange": {
           "type": {

--- a/src/__experimental__/components/textbox/textbox.component.js
+++ b/src/__experimental__/components/textbox/textbox.component.js
@@ -94,7 +94,7 @@ Textbox.propTypes = {
   children: PropTypes.node,
   /** Icon to display inside of the Textbox */
   inputIcon: PropTypes.string,
-  /** Adds additional child elements before the input */
+  /** Additional child elements to display before the input */
   leftChildren: PropTypes.node,
   /** List of error validation functions */
   validations: validationsPropTypes,

--- a/src/__experimental__/components/textbox/textbox.component.js
+++ b/src/__experimental__/components/textbox/textbox.component.js
@@ -66,9 +66,9 @@ Textbox.propTypes = {
     PropTypes.string,
     PropTypes.array // Allows the textbox to be used in the Multi-Select component
   ]),
-  /** Flag indicating disabled state */
+  /** If true, the component will be disabled */
   disabled: PropTypes.bool,
-  /** Flag indicting read-only state */
+  /** If true, the component will be read-only */
   readOnly: PropTypes.bool,
   /** Event handler for the change event */
   onChange: PropTypes.func,

--- a/src/__experimental__/components/textbox/textbox.component.js
+++ b/src/__experimental__/components/textbox/textbox.component.js
@@ -92,7 +92,7 @@ Textbox.propTypes = {
   fieldHelp: PropTypes.node,
   /** Type of the icon that will be rendered next to the input */
   children: PropTypes.node,
-  /** Icon associated with this component */
+  /** Icon to display inside of the Textbox */
   inputIcon: PropTypes.string,
   /** Adds additional child elements before the input */
   leftChildren: PropTypes.node,

--- a/src/__experimental__/components/textbox/textbox.component.js
+++ b/src/__experimental__/components/textbox/textbox.component.js
@@ -61,11 +61,14 @@ Textbox.propTypes = {
    * real value is an ID but you want to show a human-readable version.
    */
   formattedValue: PropTypes.string,
+  /** The formatted value of the field */
   value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.array // Allows the textbox to be used in the Multi-Select component
   ]),
+  /** Flag indicating disabled state */
   disabled: PropTypes.bool,
+  /** Flag indicting read-only state */
   readOnly: PropTypes.bool,
   /** Event handler for the change event */
   onChange: PropTypes.func,
@@ -89,7 +92,9 @@ Textbox.propTypes = {
   fieldHelp: PropTypes.node,
   /** Type of the icon that will be rendered next to the input */
   children: PropTypes.node,
+  /** Icon associated with this component */
   inputIcon: PropTypes.string,
+  /** Adds additional child elements before the input */
   leftChildren: PropTypes.node,
   /** List of error validation functions */
   validations: validationsPropTypes,

--- a/src/__experimental__/components/textbox/textbox.component.js
+++ b/src/__experimental__/components/textbox/textbox.component.js
@@ -61,7 +61,7 @@ Textbox.propTypes = {
    * real value is an ID but you want to show a human-readable version.
    */
   formattedValue: PropTypes.string,
-  /** The formatted value of the field */
+  /** The value of the Textbox */
   value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.array // Allows the textbox to be used in the Multi-Select component


### PR DESCRIPTION
# Description
Updates and repairs to docgenInfo and story js files to correct Prop Types tables in storybook. Only the RadioButton is worthy of noting as here as I exported the component as a named variable in a state before it was wrapped by the React.memo HOC. This was necessary for the react-docgen module to see the component.
Release notes not required IMO.