### PR TITLE
FE-2261 Fix GroupedCharacter validation

### DIFF
--- a/src/__experimental__/components/grouped-character/grouped-character.component.js
+++ b/src/__experimental__/components/grouped-character/grouped-character.component.js
@@ -97,6 +97,7 @@ const GroupedCharacter = ({
   return (
     <Textbox
       { ...rest }
+      value={ value }
       formattedValue={ formatValue(value) }
       onChange={ handleChange }
       onBlur={ handleBlur }


### PR DESCRIPTION
# Description

It seems that this functionality broke in commit 7b94f1e in #2405 (FE-2175).

In that commit, the props of `<GroupedCharacter>` became destructured like this:

```diff
- const GroupedCharacter = (props) => {
+ const GroupedCharacter = ({
+   groups,
+   value: externalValue,
+   defaultValue,
+   onChange,
+   separator: rawSeparator,
+   ...rest
+ }) => {
```

This meant the `value` prop became excluded from `...rest`, so the `value` prop is no longer passed to `<Textbox>` (where the `withValidation` HOC is applied):

```diff
- <Textbox { ...props }
+ <Textbox { ...rest }
```

Since `withValidation` is no longer receiving the `value` prop, it can't run the validations.

This PR resolves the issue by simply restoring the `value` prop to the `<Textbox>`.