### PR TITLE
FE-2216 fixes issue with input.focus and autoFocus behaviour across b…

### DIFF
--- a/src/__experimental__/components/date/date.component.js
+++ b/src/__experimental__/components/date/date.component.js
@@ -162,6 +162,7 @@ class BaseDateInput extends React.Component {
         event.target.value = visibleValue;
         this.emitOnChangeCallback(event, date);
         this.input.focus();
+        this.isAutoFocused = true;
         this.closeDatePicker();
       }
     });
@@ -243,6 +244,7 @@ class BaseDateInput extends React.Component {
 
   markCurrentDatepicker = () => {
     this.isOpening = true;
+    this.openDatePicker();
   }
 
   render() {


### PR DESCRIPTION
# Description

onClick will now trigger openDatePicker
resolved auto focus issue across browsers that was causing the date picker to be open when returning to the browser tab.
