### PR TITLE
docs: update action-popover keyboard information

### DIFF
--- a/src/components/action-popover/documentation/info.js
+++ b/src/components/action-popover/documentation/info.js
@@ -22,7 +22,7 @@ const Info = (
           <li>ActionPopover
             <ul>
               <li>DownArrow, Space, Enter opens the menu and selects the first item</li>
-              <li>UpArrow opens the menu and selects the previously selected item</li>
+              <li>UpArrow opens the menu and selects the last item</li>
             </ul>
           </li>
           <li>ActionPopoverItem


### PR DESCRIPTION
# Description
Minor update to keyboard documentation for action-popover.
Functionality is correct and the description is wrong.