### PR TITLE
feat: leftchildren property added to select

### DIFF
--- a/change_log/next/select-left-children.yml
+++ b/change_log/next/select-left-children.yml
@@ -1,0 +1,1 @@
+New Features: "Adds `leftChildren` property to select component."

--- a/src/__experimental__/components/select/select.component.js
+++ b/src/__experimental__/components/select/select.component.js
@@ -376,7 +376,7 @@ class Select extends React.Component {
   }
 
   textboxProps() {
-    const { typeAhead, placeholder } = this.props;
+    const { typeAhead, placeholder, leftChildren } = this.props;
 
     const value = this.getValue();
 
@@ -391,6 +391,10 @@ class Select extends React.Component {
       value,
       formattedValue: this.formattedValue(this.state.filter, value)
     };
+
+    if (leftChildren) {
+      props.leftChildren = props.leftChildren ? [leftChildren, ...props.leftChildren] : leftChildren;
+    }
 
     return props;
   }
@@ -507,7 +511,9 @@ Select.propTypes = {
   typeAhead: PropTypes.bool,
   /** Can the user type a value in the <Textbox> to filter the dropdown menu options? */
   filterable: PropTypes.bool,
-  isAnyValueSelected: PropTypes.bool
+  isAnyValueSelected: PropTypes.bool,
+  /** Add additional child elements before the input */
+  leftChildren: PropTypes.node
 };
 
 Select.defaultProps = {

--- a/src/__experimental__/components/select/select.spec.js
+++ b/src/__experimental__/components/select/select.spec.js
@@ -174,6 +174,18 @@ describe('Select', () => {
         target: { value: [multiValueReturn[0], multiValueReturn[2]] }
       });
     });
+
+    it('supports leftChildren property', () => {
+      const props = {
+        value: multiValueProp,
+        enableMultiSelect: true,
+        leftChildren: <span className='my-test-element'>Text</span>
+      };
+
+      const wrapper = renderWrapper({ props });
+      expect(wrapper.find('.my-test-element')).toHaveLength(1);
+      expect(wrapper.find('.my-test-element').text()).toEqual('Text');
+    });
   });
 
   describe('when backspace is pressed and is single select', () => {
@@ -270,6 +282,13 @@ describe('Select', () => {
       const props = { value: singleValue };
       const list = listOf(openList(renderWrapper({ props })));
       expect(() => list.props().onSelect({ value: 'new!' })).not.toThrowError();
+    });
+
+    it('supports leftChildren property', () => {
+      const props = { leftChildren: <span className='my-test-element'>Text</span> };
+      const wrapper = renderWrapper({ props });
+      expect(wrapper.find('.my-test-element')).toHaveLength(1);
+      expect(wrapper.find('.my-test-element').text()).toEqual('Text');
     });
   });
 

--- a/src/__experimental__/components/select/select.spec.js
+++ b/src/__experimental__/components/select/select.spec.js
@@ -183,8 +183,13 @@ describe('Select', () => {
       };
 
       const wrapper = renderWrapper({ props });
+
+      // Check custom left children
       expect(wrapper.find('.my-test-element')).toHaveLength(1);
       expect(wrapper.find('.my-test-element').text()).toEqual('Text');
+
+      // Check pills
+      expect(pillsOf(wrapper)).toHaveLength(3);
     });
   });
 


### PR DESCRIPTION
# Description
This is either a bug fix or a feature: In the select component the `leftChildren` property was overridden by the multi-select pills and was not forwarded to the textbox. I changed the code so now the provided leftChildren and the multi select generated pills can coexist.

# TODO
- [X] Release notes

# Related Issues / Pull Requests

# Screenshots / Gifs

# Testing Instructions
