### PR TITLE
FE-2217 Select list looping / Select home and end buttons support

### DIFF
--- a/change_log/next/FE-2217-select-list-loop.yml
+++ b/change_log/next/FE-2217-select-list-loop.yml
@@ -1,0 +1,2 @@
+Breaking Changes: "Changes behaviour of select list where previously traversing using up and down keyboard arrows led to looping of the whole list when reaching end or start of the list. (Old behaviour still achievable by passing isLoopable prop to the component). (Components: Select)"
+New Features: "Adds `home` and `end` keyboard button support while traversing the select options list. (Components: Select)"

--- a/src/__experimental__/components/select/__snapshots__/select.spec.js.snap
+++ b/src/__experimental__/components/select/__snapshots__/select.spec.js.snap
@@ -119,6 +119,7 @@ Object {
   "customFilter": undefined,
   "filterValue": undefined,
   "id": "listbox-2",
+  "isLoopable": undefined,
   "onLazyLoad": undefined,
   "onSelect": [Function],
   "open": true,

--- a/src/__experimental__/components/select/select-list.component.js
+++ b/src/__experimental__/components/select/select-list.component.js
@@ -86,6 +86,7 @@ class SelectList extends React.Component {
   render() {
     const {
       id,
+      isLoopable,
       alwaysHighlight,
       children,
       customFilter,
@@ -112,6 +113,7 @@ class SelectList extends React.Component {
             onLazyLoad={ onLazyLoad }
             onSelect={ onSelect }
             alwaysHighlight={ alwaysHighlight }
+            isLoopable={ isLoopable }
             keyNavigation
           >
             {
@@ -154,6 +156,8 @@ SelectList.propTypes = {
   customFilter: PropTypes.func,
   /** The value to filter the children by */
   filterValue: PropTypes.string,
+  /** Flag to indicite whether select list is loopable while traversing using up and down keys */
+  isLoopable: PropTypes.bool,
   /** A custom callback for when more data needs to be lazy-loaded when the user scrolls the dropdown menu list */
   onLazyLoad: PropTypes.func,
   /** A custom callback for the parent <div>'s MouseDown event */

--- a/src/__experimental__/components/select/select.component.js
+++ b/src/__experimental__/components/select/select.component.js
@@ -408,6 +408,7 @@ class Select extends React.Component {
       placeholder,
       value,
       defaultValue,
+      isLoopable,
       onLazyLoad,
       onFilter,
       onOpen,
@@ -445,6 +446,7 @@ class Select extends React.Component {
               customFilter={ customFilter }
               filterValue={ filter }
               onLazyLoad={ onLazyLoad }
+              isLoopable={ isLoopable }
               onSelect={ this.handleChange }
               open={ open }
               target={ this.input.current && this.input.current.parentElement }
@@ -475,6 +477,8 @@ Select.propTypes = {
   disabled: PropTypes.bool,
   /** Label text for the <Textbox> */
   label: PropTypes.string,
+  /** Flag to indicite whether select list is loopable while traversing using up and down keys */
+  isLoopable: PropTypes.bool,
   /** A custom callback for the <Textbox>'s Blur event */
   onBlur: PropTypes.func,
   /** A custom callback for when changes occur */

--- a/src/__experimental__/components/select/select.stories.js
+++ b/src/__experimental__/components/select/select.stories.js
@@ -32,6 +32,7 @@ const commonKnobs = (store, enableMultiSelect = false) => {
   const filterable = boolean('filterable', Select.defaultProps.filterable);
   const typeAhead = filterable && boolean('typeAhead', Select.defaultProps.typeAhead);
   const label = text('label', '');
+  const isLoopable = boolean('isLoopable', false);
 
   const knobs = {
     disabled: boolean('disabled', false),
@@ -50,7 +51,8 @@ const commonKnobs = (store, enableMultiSelect = false) => {
     size: select('size', OptionsHelper.sizesRestricted, OptionsHelper.sizesRestricted[1]),
     filterable,
     typeAhead,
-    label
+    label,
+    isLoopable
   };
 
   if (label.length) {

--- a/src/__spec_helper__/test-utils.js
+++ b/src/__spec_helper__/test-utils.js
@@ -82,8 +82,10 @@ const assertCorrectTraversal = method => expect => ({ num, nonSelectables = [] }
   const array = makeArrayKeys(num);
   const validIndexes = array.filter(isSelectableGiven(nonSelectables));
 
+
+  const selectedItem = selectedItemOf(wrapper);
   const indexesThatWereSelected = array
-    .reduce(selectedItemReducer(method)(wrapper), [])
+    .reduce(selectedItemReducer(method)(wrapper), [selectedItem])
     .filter(isUnique);
   expect(arraysEqual(validIndexes, indexesThatWereSelected)).toBeTruthy();
 };

--- a/src/components/scrollable-list/scrollable-list.component.js
+++ b/src/components/scrollable-list/scrollable-list.component.js
@@ -10,6 +10,7 @@ import ScrollableListContainer from './scrollable-list.style';
 class ScrollableList extends Component {
   static propTypes = {
     alwaysHighlight: PropTypes.bool, // ensures an item is always highlighted
+    isLoopable: PropTypes.bool,
     children: PropTypes.node,
     keyNavigation: PropTypes.bool,
     maxHeight: PropTypes.string,
@@ -84,26 +85,41 @@ class ScrollableList extends Component {
   buildHeightReducer(acc, { offsetHeight }) { return acc + offsetHeight; }
 
   nextSelectable(direction, position) {
-    if (!this.props.children) return null;
+    const { isLoopable, children } = this.props;
+    if (!children) return null;
 
-    const limit = this.props.children.length;
+    const limit = children.length;
 
     if (!limit) return null;
 
-    const change = direction === 'down' ? 1 : -1,
-        testIndex = position + change;
 
-    if (testIndex <= -1) return this.nextSelectable(direction, limit);
+    const change = direction === 'down' ? 1 : -1;
+    const nextPosition = position + change;
 
-    if (testIndex === limit) return this.nextSelectable(direction, -1);
+    if (nextPosition <= -1) {
+      return isLoopable ? this.nextSelectable(direction, limit) : this.nextSelectable('down', -1);
+    }
 
-    const testNode = this.props.children[testIndex];
+    if (nextPosition === limit) {
+      return isLoopable ? this.nextSelectable(direction, -1) : this.nextSelectable('up', limit);
+    }
 
-    return this.isSelectable(testNode) ? testIndex : this.nextSelectable(direction, testIndex);
+    const testNode = children[nextPosition];
+
+    return this.isSelectable(testNode) ? nextPosition : this.nextSelectable(direction, nextPosition);
   }
 
   isSelectable(node) {
     return node.props.isSelectable;
+  }
+
+  selectLastItem() {
+    const limit = this.props.children.length;
+    return this.nextSelectable('up', limit);
+  }
+
+  selectFirstItem() {
+    return this.nextSelectable('down', -1);
   }
 
   renderChildren(children) {
@@ -137,6 +153,12 @@ class ScrollableList extends Component {
     } else if (Events.isDownKey(e)) {
       e.preventDefault();
       newPos = this.nextSelectable('down', newPos);
+    } else if (Events.isEndKey(e)) {
+      e.preventDefault();
+      newPos = this.selectLastItem();
+    } else if (Events.isHomeKey(e)) {
+      e.preventDefault();
+      newPos = this.selectFirstItem();
     } else if (Events.isEnterKey(e)) {
       e.preventDefault();
       this.selectItem(selectedItem);

--- a/src/components/scrollable-list/scrollable-list.spec.js
+++ b/src/components/scrollable-list/scrollable-list.spec.js
@@ -15,17 +15,17 @@ import renderListItems from './test-utils';
 import 'jest-styled-components';
 
 describe('ScrollableList', () => {
-  const initialItem = 0,
-      childCount = 20,
-      lastItem = childCount - 1,
-      onLazyLoad = jest.fn();
+  const initialItem = 0;
+  const childCount = 20;
+  const lastItem = childCount - 1;
+  const onLazyLoad = jest.fn();
 
-  let scrollableList,
-      listMakeup = { num: childCount },
-      hoverListItem,
-      assertMouseOverAll,
-      assertKeyboardOverAll,
-      onSelect;
+  let scrollableList;
+  let listMakeup = { num: childCount };
+  let hoverListItem;
+  let assertMouseOverAll;
+  let assertKeyboardOverAll;
+  let onSelect;
 
   const mountComponent = (props, children) => {
     let childrenToRender = children;
@@ -150,6 +150,17 @@ describe('ScrollableList', () => {
         expect(selectedItemOf(scrollableList)).toEqual(initialItem);
       });
 
+      it('supports home button navigation', () => {
+        scrollableList.setState({ selectedItem: 5 });
+        keyboard.pressHome();
+        expect(selectedItemOf(scrollableList)).toEqual(initialItem);
+      });
+
+      it('supports end button navigation', () => {
+        keyboard.pressEnd();
+        expect(selectedItemOf(scrollableList)).toEqual(19);
+      });
+
       it('does not throw error trying to update scroll if list is not present', () => {
         scrollableList.instance().scrollBox.current = undefined;
         expect(() => keyboard.pressUpArrow()).not.toThrowError();
@@ -160,37 +171,79 @@ describe('ScrollableList', () => {
         expect(() => keyboard.pressUpArrow()).not.toThrowError();
       });
 
-      it('scrolls as the selected item goes beyond the max-height of the list', () => {
-        const numOfItems = 20;
-        const listHeight = 100;
-        const itemHeight = 10;
-        const list = {
-          offsetHeight: listHeight,
-          children: [...Array(numOfItems).keys()].map(() => {
-            return { offsetHeight: itemHeight, offsetTop: 0 };
-          }),
-          scrollTop: 0
-        };
-        list.children[lastItem].offsetTop = listHeight + 1;
-        scrollableList.instance().scrollBox.current = list;
+      describe('when is loopable', () => {
+        it('scrolls as the selected item goes beyond the max-height of the list', () => {
+          scrollableList.setProps({ isLoopable: true });
+          const numOfItems = 20;
+          const listHeight = 100;
+          const itemHeight = 10;
+          const list = {
+            offsetHeight: listHeight,
+            children: [...Array(numOfItems).keys()].map(() => {
+              return { offsetHeight: itemHeight, offsetTop: 0 };
+            }),
+            scrollTop: 0
+          };
+          list.children[lastItem].offsetTop = listHeight + 1;
+          scrollableList.instance().scrollBox.current = list;
 
-        keyboard.pressUpArrow();
-        expect(list.scrollTop).toEqual(numOfItems * itemHeight - listHeight);
+          keyboard.pressUpArrow();
+          expect(list.scrollTop).toEqual(numOfItems * itemHeight - listHeight);
+        });
+
+        it('jumps to the bottom of list when up key pressed at first item', () => {
+          scrollableList.setProps({ isLoopable: true });
+          keyboard.pressUpArrow();
+          expect(selectedItemOf(scrollableList)).toEqual(lastItem);
+        });
+
+        it('jumps back to the top of list when down key pressed at last item', () => {
+          scrollableList.setProps({ isLoopable: true });
+          scrollableList.setState({ selectedItem: lastItem });
+          keyboard.pressDownArrow();
+          expect(selectedItemOf(scrollableList)).toEqual(initialItem);
+        });
+
+        it('keyboard events reliably traverse the list', () => {
+          scrollableList.setProps({ isLoopable: true });
+          assertKeyboardOverAll(scrollableList);
+        });
       });
 
-      it('jumps to the bottom of list when up key pressed at first item', () => {
-        keyboard.pressUpArrow();
-        expect(selectedItemOf(scrollableList)).toEqual(lastItem);
-      });
+      describe('when is not loopable', () => {
+        it('scrolls as the selected item goes beyond the max-height of the list', () => {
+          const numOfItems = 20;
+          const listHeight = 100;
+          const itemHeight = 10;
+          const list = {
+            offsetHeight: listHeight,
+            children: [...Array(numOfItems).keys()].map(() => {
+              return { offsetHeight: itemHeight, offsetTop: 0 };
+            }),
+            scrollTop: 0
+          };
+          list.children[lastItem].offsetTop = listHeight + 1;
+          scrollableList.instance().scrollBox.current = list;
+          for (let index = 0; index < numOfItems; index++) {
+            keyboard.pressDownArrow();
+          }
+          expect(list.scrollTop).toEqual(numOfItems * itemHeight - listHeight);
+        });
 
-      it('jumps back to the top of list when down key pressed at last item', () => {
-        scrollableList.setState({ selectedItem: lastItem });
-        keyboard.pressDownArrow();
-        expect(selectedItemOf(scrollableList)).toEqual(initialItem);
-      });
+        it('does nothing when up key pressed at first item', () => {
+          keyboard.pressUpArrow();
+          expect(selectedItemOf(scrollableList)).toEqual(initialItem);
+        });
 
-      it('keyboard events reliably traverse the list', () => {
-        assertKeyboardOverAll(scrollableList);
+        it('does nothing when down key pressed at last item', () => {
+          scrollableList.setState({ selectedItem: lastItem });
+          keyboard.pressDownArrow();
+          expect(selectedItemOf(scrollableList)).toEqual(lastItem);
+        });
+
+        it('keyboard events reliably traverse the list', () => {
+          assertKeyboardOverAll(scrollableList);
+        });
       });
 
       it('calls an onSelect callback on pressing the enter key', () => {
@@ -271,8 +324,9 @@ describe('ScrollableList', () => {
     });
 
     it('skips non-selectable items on keyboard up navigation', () => {
+      scrollableList.setState({ selectedItem: 3 });
       keyboard.pressUpArrow();
-      expect(selectedItemOf(scrollableList)).toEqual(3);
+      expect(selectedItemOf(scrollableList)).toEqual(1);
     });
   });
 


### PR DESCRIPTION
# Description

This PR fixes incorrect Select list behaviour where traversing the list with `up` and `down` keyboard arrow buttons resulted in looping the whole list without stopping at the last or first item. However to enable this behaviour in case someone wants the Select to work like that there is a `isLoopable` prop available to be passed to the `Select` component.

Also in this PR I've implemented support for traversing the Select list using `home` and `end` button to select either first or the last selectable item.