### PR TITLE
FE-2405 move validation array out of render method

### DIFF
--- a/change_log/next/FE-2405-move-validation-array-out-of-render.yml
+++ b/change_log/next/FE-2405-move-validation-array-out-of-render.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Moves validation concatenation out of render method and into state and handles on update as well. (Component: Date)"

--- a/src/__experimental__/components/date-range/date-range.component.js
+++ b/src/__experimental__/components/date-range/date-range.component.js
@@ -178,11 +178,13 @@ class DateRange extends React.Component {
           { ...this.startDateProps() } onFocus={ this.focusStart }
           data-element='start-date'
           ref={ this.startDateInputRef }
+          isDateRange
         />
         <DateInput
           { ...this.endDateProps() } onFocus={ this.focusEnd }
           data-element='end-date'
           ref={ this.endDateInputRef }
+          isDateRange
         />
       </StyledDateRange>
     );

--- a/src/__experimental__/components/date-range/date-range.stories.js
+++ b/src/__experimental__/components/date-range/date-range.stories.js
@@ -20,7 +20,7 @@ const store = new Store({
 const handleChange = (evt) => {
   const newValue = [evt.target.value[0].rawValue, evt.target.value[1].rawValue];
   store.set({ value: newValue });
-  action('changed')(newValue);
+  action('changed')(evt.target.value);
 };
 
 function makeStory(name, themeSelector) {

--- a/src/__experimental__/components/date/date.component.js
+++ b/src/__experimental__/components/date/date.component.js
@@ -46,7 +46,7 @@ class BaseDateInput extends React.Component {
       this.input.focus();
       this.openDatePicker(true);
     }
-    this.handleValidationUpdate(this.inputProps());
+    this.handleValidationUpdate();
   }
 
   componentDidUpdate(prevProps) {
@@ -55,7 +55,7 @@ class BaseDateInput extends React.Component {
     }
 
     if (this.hasValidationsChanged()) {
-      this.handleValidationUpdate(this.inputProps());
+      this.handleValidationUpdate();
     }
   }
 
@@ -77,16 +77,15 @@ class BaseDateInput extends React.Component {
       return true;
     }
 
-    for (let i = validationsArray.length; i--;) {
-      if (validationsArray[i] !== currentValidations[i]) {
-        return true;
-      }
+    if (validationsArray.some((val, index) => val !== currentValidations[index])) {
+      return true;
     }
 
     return false;
   }
 
-  handleValidationUpdate = (inputProps) => {
+  handleValidationUpdate = () => {
+    const inputProps = this.inputProps();
     this.setState({ validationsArray: concatAllValidations(inputProps) });
   }
 
@@ -391,7 +390,9 @@ BaseDateInput.propTypes = {
   /** The current date YYYY-MM-DD */
   value: PropTypes.string,
   /** Triggers textbox validation when it's boolean value changes */
-  forceUpdateTriggerToggle: PropTypes.bool
+  forceUpdateTriggerToggle: PropTypes.bool,
+  /** Temporary flag to indeicate if input is part of DateRange */
+  isDateRange: PropTypes.bool
 };
 
 BaseDateInput.defaultProps = {

--- a/src/__experimental__/components/date/date.component.js
+++ b/src/__experimental__/components/date/date.component.js
@@ -391,7 +391,7 @@ BaseDateInput.propTypes = {
   value: PropTypes.string,
   /** Triggers textbox validation when it's boolean value changes */
   forceUpdateTriggerToggle: PropTypes.bool,
-  /** Temporary flag to indeicate if input is part of DateRange */
+  /** Temporary flag to indicate if input is part of DateRange */
   isDateRange: PropTypes.bool
 };
 

--- a/src/__experimental__/components/date/date.component.js
+++ b/src/__experimental__/components/date/date.component.js
@@ -46,17 +46,49 @@ class BaseDateInput extends React.Component {
       this.input.focus();
       this.openDatePicker(true);
     }
+    this.handleValidationUpdate(this.inputProps());
   }
 
   componentDidUpdate(prevProps) {
     if (this.isControlled && !this.inputHasFocus && this.hasValueChanged(prevProps)) {
       this.updateSelectedDate(this.props.value);
     }
+
+    if (this.hasValidationsChanged()) {
+      this.handleValidationUpdate(this.inputProps());
+    }
+  }
+
+  inputProps = () => {
+    const { minDate, maxDate, ...inputProps } = this.props;
+    return inputProps;
   }
 
   hasValueChanged = (prevProps) => {
     return this.props.value && prevProps.value !== this.props.value;
   };
+
+  hasValidationsChanged = () => {
+    const { validationsArray } = this.state;
+
+    const currentValidations = concatAllValidations(this.inputProps());
+
+    if (validationsArray.length !== currentValidations.length) {
+      return true;
+    }
+
+    for (let i = validationsArray.length; i--;) {
+      if (validationsArray[i] !== currentValidations[i]) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  handleValidationUpdate = (inputProps) => {
+    this.setState({ validationsArray: concatAllValidations(inputProps) });
+  }
 
   assignInput = (input) => {
     this.input = input.current;
@@ -291,8 +323,6 @@ class BaseDateInput extends React.Component {
     delete inputProps.defaultValue;
     delete inputProps.value;
 
-    inputProps.validations = concatAllValidations(inputProps);
-
     events = {
       onBlur: this.handleBlur,
       onChange: this.handleVisibleInputChange,
@@ -309,6 +339,7 @@ class BaseDateInput extends React.Component {
       >
         <Textbox
           { ...inputProps }
+          validations={ this.state.validationsArray }
           inputIcon='calendar'
           value={ this.state.visibleValue }
           rawValue={ isoFormattedValueString(this.state.visibleValue) }

--- a/src/__experimental__/components/date/date.component.js
+++ b/src/__experimental__/components/date/date.component.js
@@ -317,7 +317,10 @@ class BaseDateInput extends React.Component {
   }
 
   render() {
-    const { minDate, maxDate, ...inputProps } = this.props;
+    const {
+      minDate, maxDate, isDateRange, ...inputProps
+    } = this.props;
+
     let events = {};
     delete inputProps.autoFocus;
     delete inputProps.defaultValue;
@@ -330,6 +333,8 @@ class BaseDateInput extends React.Component {
       onKeyDown: this.handleTabKeyDown
     };
 
+    const validations = isDateRange ? concatAllValidations(inputProps) : this.state.validationsArray;
+
     return (
       <StyledDateInput
         onClick={ this.markCurrentDatepicker }
@@ -339,7 +344,7 @@ class BaseDateInput extends React.Component {
       >
         <Textbox
           { ...inputProps }
-          validations={ this.state.validationsArray }
+          validations={ validations }
           inputIcon='calendar'
           value={ this.state.visibleValue }
           rawValue={ isoFormattedValueString(this.state.visibleValue) }

--- a/src/__experimental__/components/date/date.spec.js
+++ b/src/__experimental__/components/date/date.spec.js
@@ -475,6 +475,7 @@ describe('Date', () => {
 
   describe('when additional validations are provided with the "validations" prop', () => {
     const mockValidationFunction = () => {};
+    const mockValidationFunction2 = () => {};
 
     describe('as a function', () => {
       it('then these validations should be passed with internal validations to the Textbox Component', () => {
@@ -490,6 +491,22 @@ describe('Date', () => {
         const { internalValidations } = wrapper.find(BaseDateInput).instance().props;
         expect(wrapper.find(Textbox).props().validations).toEqual([mockValidationFunction, ...internalValidations]);
       });
+    });
+
+    describe('when the validations update', () => {
+      it('appends the new validator to the validations array', () => {
+        wrapper = render({ validations: [mockValidationFunction] });
+        wrapper.setProps({ validations: [mockValidationFunction, mockValidationFunction2] });
+
+        expect(wrapper.find(BaseDateInput).state().validationsArray.length).toEqual(3);
+      });
+    });
+
+    it('updates the validation array in state when there is a difference', () => {
+      wrapper = render({ validations: [mockValidationFunction] });
+      wrapper.setProps({ validations: [mockValidationFunction2] });
+
+      expect(wrapper.find(BaseDateInput).state().validationsArray.length).toEqual(2);
     });
   });
 });


### PR DESCRIPTION
# Description
The current implementation assigns the validation array on each render which causes it to infinite loop when in a form. To fix this the validation array is now stored in state unless it is part of a `date-range`. The array is only updated when a change is detected in `componentDidUpdate`
