### PR TITLE
FE-2428 Enzyme Snapshot Helper

### DIFF
--- a/src/__spec_helper__/enzyme-snapshot-helper.js
+++ b/src/__spec_helper__/enzyme-snapshot-helper.js
@@ -1,0 +1,29 @@
+import toJson from 'enzyme-to-json';
+
+function snapshotWithoutProps(enzymeWrapper, propNames) {
+  let propNameList = propNames;
+
+  if (!Array.isArray(propNames)) {
+    propNameList = [propNames];
+  }
+
+  const snapshotOptions = {
+    map: (json) => {
+      propNameList.forEach((prop) => {
+        if (json.props[prop]) {
+          json.props[prop] = `[ ${prop} object ]`;
+        }
+      });
+
+      return json;
+    }
+  };
+
+  return toJson(enzymeWrapper, snapshotOptions);
+}
+
+function noThemeSnapshot(enzymeWrapper) {
+  return snapshotWithoutProps(enzymeWrapper, 'theme');
+}
+
+export { snapshotWithoutProps, noThemeSnapshot };


### PR DESCRIPTION
When generating a snapshot of an Enzyme wrapper with an object passed as a prop, that object will be rendered in a snapshot, obfuscating the result.
With this helper we could render snapshots with these objects replaced by `[ <prop name> object ]`.

Previously we have avoided this issue by using `TestRenderer.Create`, this helper will allow us to not mix various test tools.

To remove theme object:
`expect(noThemeSnapshot(wrapper)).toMatchSnapshot()`

To remove a custom object/objects:
`expect(snapshotWithoutProps(wrapper, 'propName')).toMatchSnapshot()`
`expect(snapshotWithoutProps(wrapper, ['firstProp', 'secondProp'])).toMatchSnapshot()`