### PR TITLE
refactor: removes title attribute from Tab StyledDiv to remove obtrusive tooltip

### DIFF
--- a/change_log/next/FE-2281-remove-tabs-child-tooltip.yml
+++ b/change_log/next/FE-2281-remove-tabs-child-tooltip.yml
@@ -1,0 +1,1 @@
+New Features: "Removes title attribute from StyledDiv to remove obtrusive tooltip (Component: Tab)"

--- a/src/components/tabs/tab/tab.component.js
+++ b/src/components/tabs/tab/tab.component.js
@@ -53,13 +53,12 @@ class Tab extends React.Component {
 
   render() {
     const {
-      className, children, isTabSelected, position, title, ariaLabelledby, role
+      className, children, isTabSelected, position, ariaLabelledby, role
     } = this.props;
     return (
       <StyledTab
         className={ className }
         role={ role }
-        title={ title }
         isTabSelected={ isTabSelected }
         aria-labelledby={ ariaLabelledby }
         position={ position }
@@ -77,7 +76,6 @@ Tab.defaultProps = {
 };
 
 Tab.propTypes = {
-  title: PropTypes.string.isRequired,
   tabId: PropTypes.string.isRequired,
   className: PropTypes.string,
   children: PropTypes.node,


### PR DESCRIPTION
# Description
There is a tooltip on the child of a Tab that has the Tab title as content, which should not be visible. This refactor removes the title attribute from the StyledDiv which causes this behaviour.

# TODO
- [x] Release notes