### PR TITLE
Fe 2444 fix allowEmptyValue prop in every story

### DIFF
--- a/change_log/next/FE-2444-remove-allowEmptyValue-knob-from-every-story.yml
+++ b/change_log/next/FE-2444-remove-allowEmptyValue-knob-from-every-story.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Fixes bug where `allowEmptyValue` knob was present in every component story. (Component: DateInput Story)"

--- a/src/__experimental__/components/date/date.stories.js
+++ b/src/__experimental__/components/date/date.stories.js
@@ -71,7 +71,6 @@ function makeStory(name, themeSelector) {
 }
 
 function makeValidationsStory(name, themeSelector) {
-  const allowEmptyValue = boolean('allowEmptyValue', false);
   const component = () => {
     return (
       <State store={ store }>
@@ -83,7 +82,7 @@ function makeValidationsStory(name, themeSelector) {
           info={ [isNotThirdApr] }
           onChange={ setValue }
           onBlur={ ev => action('onBlur')(ev) }
-          allowEmptyValue={ allowEmptyValue }
+          allowEmptyValue={ boolean('allowEmptyValue', false) }
         />
       </State>
     );


### PR DESCRIPTION
# Description
Fixes bug where `allowEmptyValue` knob was present in every component story. (Component: DateInput Story)
