### PR TITLE
FE-2468 - Fixed invalid animation behaviour on Decimal

### DIFF
--- a/change_log/next/FE-2468-decimal-wiggle-readOnly-animation.yml
+++ b/change_log/next/FE-2468-decimal-wiggle-readOnly-animation.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Fixes issue with wiggle animation starting even when component has readOnly prop passed as true. (Component: Decimal)"

--- a/src/__experimental__/components/decimal/decimal.component.js
+++ b/src/__experimental__/components/decimal/decimal.component.js
@@ -56,7 +56,11 @@ class Decimal extends React.Component {
     }
   }
 
-  startAnimation = () => this.setState({ isAnimating: true })
+  startAnimation = () => {
+    if (!this.props.readOnly) {
+      this.setState({ isAnimating: true });
+    }
+  }
 
   stopAnimation = () => this.setState({ isAnimating: false })
 
@@ -294,6 +298,10 @@ Decimal.propTypes = {
    * The width of the input as a percentage
    */
   inputWidth: PropTypes.number,
+  /**
+   * If true, the component will be read-only
+   */
+  readOnly: PropTypes.bool,
   /**
    * The default value of the input if it's meant to be used as an uncontrolled component
    */

--- a/src/__experimental__/components/decimal/decimal.spec.js
+++ b/src/__experimental__/components/decimal/decimal.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import TestRenderer from 'react-test-renderer';
 import { mount as enzymeMount } from 'enzyme';
 import I18n from 'i18n-js';
 import { assertStyleMatch } from '../../../__spec_helper__/test-utils';

--- a/src/__experimental__/components/decimal/decimal.spec.js
+++ b/src/__experimental__/components/decimal/decimal.spec.js
@@ -173,6 +173,14 @@ describe('Decimal', () => {
       );
     });
 
+    it('is not triggered when Decimal has readOnly prop', () => {
+      render({ readOnly: true });
+      paste({ key: 'invalid' }, '0.|00');
+      expect(wrapper.current.find(StyledWiggle).prop('isAnimating')).toBe(false);
+      press({ key: '-' }, '0.|00');
+      expect(wrapper.current.find(StyledWiggle).prop('isAnimating')).toBe(false);
+    });
+
     it('turns off the animation after finishing', () => {
       render();
       paste({ key: 'invalid' }, '0.|00');

--- a/src/__experimental__/components/decimal/decimal.spec.js
+++ b/src/__experimental__/components/decimal/decimal.spec.js
@@ -147,47 +147,37 @@ describe('Decimal', () => {
   });
 
   describe('Wiggle animation', () => {
+    const animation = `0.4s ${wiggleAnimation.name} 1 ease-in forwards`;
+
     it('is triggered by invalid keypress', () => {
       render();
       press({ key: '-' }, '0.|00');
-      expect(wrapper.current.find(StyledWiggle).prop('isAnimating')).toBe(true);
-      const WiggleWrapper = TestRenderer.create(<StyledWiggle isAnimating />);
-      assertStyleMatch(
-        {
-          animation: `0.4s ${wiggleAnimation.name} 1 ease-in forwards`
-        },
-        WiggleWrapper.toJSON()
-      );
+      assertStyleMatch({ animation }, wrapper.current.find(StyledWiggle));
     });
 
     it('is triggered by pasting an invalid value', () => {
       render();
-      paste({ key: 'invalid' }, '0.|00');
-      expect(wrapper.current.find(StyledWiggle).prop('isAnimating')).toBe(true);
-      const WiggleWrapper = TestRenderer.create(<StyledWiggle isAnimating />);
-      assertStyleMatch(
-        {
-          animation: `0.4s ${wiggleAnimation.name} 1 ease-in forwards`
-        },
-        WiggleWrapper.toJSON()
-      );
+      paste({ key: 'a' }, '0.|00');
+      assertStyleMatch({ animation }, wrapper.current.find(StyledWiggle));
     });
 
     it('is not triggered when Decimal has readOnly prop', () => {
       render({ readOnly: true });
-      paste({ key: 'invalid' }, '0.|00');
-      expect(wrapper.current.find(StyledWiggle).prop('isAnimating')).toBe(false);
+
+      paste({ key: 'a' }, '0.|00');
+      expect(wrapper.current.find(StyledWiggle)).not.toHaveStyleRule('animation');
+
       press({ key: '-' }, '0.|00');
-      expect(wrapper.current.find(StyledWiggle).prop('isAnimating')).toBe(false);
+      expect(wrapper.current.find(StyledWiggle)).not.toHaveStyleRule('animation');
     });
 
     it('turns off the animation after finishing', () => {
       render();
-      paste({ key: 'invalid' }, '0.|00');
-      expect(wrapper.current.find(StyledWiggle).prop('isAnimating')).toBe(true);
+      paste({ key: 'a' }, '0.|00');
+      assertStyleMatch({ animation }, wrapper.current.find(StyledWiggle));
       wrapper.current.find(StyledWiggle).props().onAnimationEnd();
       wrapper.current.update();
-      expect(wrapper.current.find(StyledWiggle).prop('isAnimating')).toBe(false);
+      expect(wrapper.current.find(StyledWiggle)).not.toHaveStyleRule('animation');
     });
   });
 


### PR DESCRIPTION
# Description
Fixed an issue where wiggle animation started even when `readOnly` prop was passed as true to the component.
