### PR TITLE
FE-2471 - Fixed incorrect onBlur behaviour on checkable input

### DIFF
--- a/change_log/next/FE-2471-checkable-input-onBlur-fired-3-times.yml
+++ b/change_log/next/FE-2471-checkable-input-onBlur-fired-3-times.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Fixes issue with onBlur event fired multiple times instead of only once. (Components: Switch, Checkbox, RadioButton)"

--- a/src/__experimental__/components/checkable-input/checkable-input.component.js
+++ b/src/__experimental__/components/checkable-input/checkable-input.component.js
@@ -13,7 +13,9 @@ class CheckableInput extends React.Component {
   }
 
   render() {
-    const { children, onChange, ...rest } = this.props;
+    const {
+      children, onChange, onBlur, ...rest
+    } = this.props;
     const id = this.inputId;
     const labelId = `${id}-label`;
     const helpId = `${id}-help`;
@@ -30,7 +32,7 @@ class CheckableInput extends React.Component {
     const {
       fieldHelp, labelHelp, ...inputProps
     } = {
-      ...validProps(this, ['checked', 'disabled', 'inputType', 'onChange', 'tabindex']),
+      ...validProps(this, ['checked', 'disabled', 'inputType', 'onChange', 'onBlur', 'tabindex']),
       labelId,
       helpId,
       id
@@ -76,6 +78,8 @@ CheckableInput.propTypes = {
   labelWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /** Accepts a callback function which can be used to update parent state on change */
   onChange: PropTypes.func,
+  /** Accepts a callback function which is triggered on blur event */
+  onBlur: PropTypes.func,
   /** Reverses label and CheckableInput display */
   reverse: PropTypes.bool,
   /** Specifies input type, 'checkbox' or 'switch' */

--- a/src/__experimental__/components/checkbox/__snapshots__/checkbox-group.spec.js.snap
+++ b/src/__experimental__/components/checkbox/__snapshots__/checkbox-group.spec.js.snap
@@ -216,12 +216,10 @@ exports[`CheckboxGroup renders as expected 1`] = `
         className="c7 c8"
         data-component="checkbox"
         name="check-required"
-        onBlur={[Function]}
       >
         <div
           className="c9"
           name="check-required"
-          onBlur={[Function]}
         >
           <div
             className="c1 c2"
@@ -269,12 +267,10 @@ exports[`CheckboxGroup renders as expected 1`] = `
         className="c7 c8"
         data-component="checkbox"
         name="check-optional"
-        onBlur={[Function]}
       >
         <div
           className="c9"
           name="check-optional"
-          onBlur={[Function]}
         >
           <div
             className="c1 c2"

--- a/src/__experimental__/components/checkbox/__snapshots__/checkbox.spec.js.snap
+++ b/src/__experimental__/components/checkbox/__snapshots__/checkbox.spec.js.snap
@@ -638,12 +638,10 @@ exports[`Checkbox base theme renders as expected 1`] = `
   className="c0"
   data-component="checkbox"
   name="my-checkbox"
-  onBlur={[Function]}
 >
   <div
     className="c1"
     name="my-checkbox"
-    onBlur={[Function]}
   >
     <div
       className="c2 c3"

--- a/src/__experimental__/components/checkbox/checkbox.component.js
+++ b/src/__experimental__/components/checkbox/checkbox.component.js
@@ -7,10 +7,13 @@ import CheckboxSvg from './checkbox-svg.component';
 import withValidations from '../../../components/validations/with-validation.hoc';
 
 const Checkbox = ({
-  id, label, onChange, value, ...props
+  id, label, onChange, onBlur, value, ...props
 }) => {
   const inputProps = {
     ...props,
+    onChange,
+    onBlur,
+    labelInline: true,
     inputId: id,
     inputLabel: label,
     inputValue: value,
@@ -23,11 +26,7 @@ const Checkbox = ({
       { ...tagComponent('checkbox', props) }
       { ...props }
     >
-      <CheckableInput
-        { ...inputProps }
-        onChange={ onChange }
-        labelInline
-      >
+      <CheckableInput { ...inputProps }>
         <CheckboxSvg />
       </CheckableInput>
     </CheckboxStyle>
@@ -53,6 +52,8 @@ Checkbox.propTypes = {
   labelWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /** Accepts a callback function which can be used to update parent state on change */
   onChange: PropTypes.func,
+  /** Accepts a callback function which is triggered on blur event */
+  onBlur: PropTypes.func,
   /** Reverses label and checkbox display */
   reverse: PropTypes.bool,
   /**

--- a/src/__experimental__/components/checkbox/checkbox.stories.js
+++ b/src/__experimental__/components/checkbox/checkbox.stories.js
@@ -94,6 +94,7 @@ function defaultKnobs(type) {
     reverse: boolean(nameWithGroup('reverse'), false, knobGroup),
     label,
     labelHelp: text(nameWithGroup('labelHelp'), 'This text provides more information for the label.', knobGroup),
+    onBlur: action('onBlur'),
     inputWidth: number(nameWithGroup('inputWidth'), 0, {
       range: true,
       min: 0,

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
@@ -224,13 +224,11 @@ exports[`RadioButtonGroup renders as expected 1`] = `
     className="c4 c5"
     data-component="radio-button"
     name="test-group"
-    onBlur={[Function]}
   >
     <div
       checked={false}
       className="c6"
       name="test-group"
-      onBlur={[Function]}
     >
       <div
         className="c7 c8"
@@ -288,13 +286,11 @@ exports[`RadioButtonGroup renders as expected 1`] = `
     className="c4 c5"
     data-component="radio-button"
     name="test-group"
-    onBlur={[Function]}
   >
     <div
       checked={false}
       className="c6"
       name="test-group"
-      onBlur={[Function]}
     >
       <div
         className="c7 c8"

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-mapper.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-mapper.spec.js.snap
@@ -216,13 +216,11 @@ Array [
     className="c0"
     data-component="radio-button"
     name="test-group"
-    onBlur={[MockFunction]}
   >
     <div
       checked={false}
       className="c1"
       name="test-group"
-      onBlur={[MockFunction]}
     >
       <div
         className="c2 c3"
@@ -489,13 +487,11 @@ Array [
     className="c0"
     data-component="radio-button"
     name="test-group"
-    onBlur={[MockFunction]}
   >
     <div
       checked={false}
       className="c1"
       name="test-group"
-      onBlur={[MockFunction]}
     >
       <div
         className="c2 c3"

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -922,12 +922,10 @@ exports[`RadioButton styles base renders as expected 1`] = `
     checked={false}
     className="c2 c3"
     data-component="radio-button"
-    onBlur={[Function]}
   >
     <div
       checked={false}
       className="c4"
-      onBlur={[Function]}
     >
       <div
         className="c5 c6"

--- a/src/__experimental__/components/radio-button/radio-button.component.js
+++ b/src/__experimental__/components/radio-button/radio-button.component.js
@@ -7,10 +7,18 @@ import RadioButtonSvg from './radio-button-svg.component';
 import OptionsHelper from '../../../utils/helpers/options-helper';
 
 const RadioButton = ({
-  id, label, onChange, value, ...props
+  id, label, onChange, onBlur, value, ...props
 }) => {
+  const handleChange = useCallback((ev) => {
+    onChange(ev);
+    // specifically trigger focus, as Safari doesn't focus radioButtons on click by default
+    ev.target.focus();
+  }, [onChange]);
+
   const inputProps = {
     ...props,
+    onChange: handleChange,
+    onBlur,
     helpTabIndex: 0,
     helpTag: 'span',
     inputId: id,
@@ -25,21 +33,13 @@ const RadioButton = ({
     reverse: !props.reverse
   };
 
-  const handleChange = useCallback((ev) => {
-    onChange(ev);
-    // specifically trigger focus, as Safari doesn't focus radioButtons on click by default
-    ev.target.focus();
-  }, [onChange]);
 
   return (
     <RadioButtonStyle
       { ...tagComponent('radio-button', props) }
       { ...props }
     >
-      <CheckableInput
-        { ...inputProps }
-        onChange={ handleChange }
-      >
+      <CheckableInput { ...inputProps }>
         <RadioButtonSvg />
       </CheckableInput>
     </RadioButtonStyle>
@@ -67,6 +67,8 @@ RadioButton.propTypes = {
   name: PropTypes.string,
   /** Accepts a callback function which can be used to update parent state on change */
   onChange: PropTypes.func,
+  /** Accepts a callback function which is triggered on blur event */
+  onBlur: PropTypes.func,
   /** Reverses label and radio button display */
   reverse: PropTypes.bool,
   /**

--- a/src/__experimental__/components/switch/__snapshots__/switch.spec.js.snap
+++ b/src/__experimental__/components/switch/__snapshots__/switch.spec.js.snap
@@ -798,13 +798,11 @@ exports[`Switch base theme renders as expected 1`] = `
   className="c0"
   data-component="Switch"
   name="my-switch"
-  onBlur={[Function]}
 >
   <div
     checked={false}
     className="c1"
     name="my-switch"
-    onBlur={[Function]}
   >
     <div
       className="c2 c3"

--- a/src/__experimental__/components/switch/switch.component.js
+++ b/src/__experimental__/components/switch/switch.component.js
@@ -10,6 +10,7 @@ const Switch = ({
   id,
   label,
   onChange,
+  onBlur,
   value,
   checked,
   defaultChecked,
@@ -39,6 +40,7 @@ const Switch = ({
 
   const inputProps = {
     ...switchProps,
+    onBlur,
     onChange: isControlled ? onChange : onChangeInternal,
     inputId: id,
     inputLabel: label,
@@ -96,6 +98,8 @@ Switch.propTypes = {
   loading: PropTypes.bool,
   /** Accepts a callback function which can be used to update parent state on change */
   onChange: PropTypes.func,
+  /** Accepts a callback function which is triggered on blur event */
+  onBlur: PropTypes.func,
   /** Reverses label and Switch display */
   reverse: PropTypes.bool,
   /**

--- a/src/__experimental__/components/switch/switch.stories.js
+++ b/src/__experimental__/components/switch/switch.stories.js
@@ -149,6 +149,7 @@ function commonKnobs() {
     labelHelp: text('labelHelp', 'Switch off and on this component.'),
     labelInline: boolean('labelInline', false),
     loading: boolean('loading', false),
+    onBlur: action('onBlur'),
     inputWidth: number('inputWidth', 0, {
       range: true,
       min: 0,


### PR DESCRIPTION
# Description

Fixed onBlur event on inputs using CheckableInput (Checkbox, Switch, RadioButton) which was incorrectly invoked multiple times instead of just once.

# Testing Instructions

Can be easily checked in either fixtures on component stories.