### PR TITLE
fixes 2556 ActionPopover having conditional children

### DIFF
--- a/change_log/next/issue-2556.yml
+++ b/change_log/next/issue-2556.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "ActionPopover: Handle when an ActionPopoverItem is being conditionally removed."

--- a/src/components/action-popover/action-popover.component.js
+++ b/src/components/action-popover/action-popover.component.js
@@ -136,7 +136,7 @@ const ActionPopover = ({
   useEffect(() => {
     const itemsWithRef = [];
     // childrenWith a clone of children with refs added so we can focus the dom element
-    setChildrenWithRef(React.Children.map(children, (child) => {
+    setChildrenWithRef(React.Children.toArray(children).map((child) => {
       if (child.type === ActionPopoverItem) {
         const itemWithRef = React.cloneElement(child, { ref: React.createRef() });
         itemsWithRef.push(itemWithRef);
@@ -196,6 +196,7 @@ ActionPopover.propTypes = {
     const prop = props[propName];
 
     React.Children.forEach(prop, (child) => {
+      if (child === null) { return; }
       if (![ActionPopoverItem.displayName, ActionPopoverDivider.displayName].includes(child.type.displayName)) {
         error = new Error(`\`${componentName}\` only accepts children of type \`${ActionPopoverItem.displayName}\``
         + ` and \`${ActionPopoverDivider.displayName}\`.`);

--- a/src/components/action-popover/action-popover.spec.js
+++ b/src/components/action-popover/action-popover.spec.js
@@ -43,7 +43,9 @@ describe('ActionPopover', () => {
         >Download PDF
         </ActionPopoverItem>,
         <ActionPopoverDivider />,
-        <ActionPopoverItem icon='csv' { ...{ onClick: onClickWrapper('csv') } }>Download CSV</ActionPopoverItem>
+        <ActionPopoverItem icon='csv' { ...{ onClick: onClickWrapper('csv') } }>Download CSV</ActionPopoverItem>,
+        null,
+        undefined
       ],
       onOpen,
       onClose,


### PR DESCRIPTION
# Description

When conditionally removing an ActionPopoverItem, a javascript error was occurring.
This ensures we handle when the child object is null.

# Related Issues / Pull Requests

[GitHub issue](https://github.com/Sage/carbon/issues/2556)

# Testing Instructions
