### PR TITLE
fix(flash): icon is too close to the text in IE FE-2406

### DIFF
--- a/change_log/next/flash_icon_ie.yml
+++ b/change_log/next/flash_icon_ie.yml
@@ -1,0 +1,1 @@
+Bug Fixes: "Fix icon alignment when the `as` prop is set (Component: Classic Flash)"

--- a/src/components/flash/flash-legacy.style.js
+++ b/src/components/flash/flash-legacy.style.js
@@ -87,8 +87,8 @@ const FlashIconStyle = styled(Icon)`
   display: flex;
   left: 0;
   position: absolute;
-  width: 70px;
   top: -3px;
+  padding-left: 23px;
 
   &:before {
     color: rgba(0, 0, 0, 0.85);


### PR DESCRIPTION
# Description
When the **Classic Flash** is displayed with the **as** prop set, the icon alignment is wrong in IE.
# TODO
- [ ] Release notes

# Related Issues / Pull Requests
FE-2406
# Screenshots / Gifs
## Before
<img width="1444" alt="Screenshot 2019-12-18 at 16 12 08" src="https://user-images.githubusercontent.com/2328042/71103068-61aee000-21b1-11ea-980c-401faaa17c18.png">

## After
<img width="1444" alt="Screenshot 2019-12-18 at 16 13 08" src="https://user-images.githubusercontent.com/2328042/71103069-62477680-21b1-11ea-9544-28bdcaada35b.png">

# Testing Instructions
This issue only occurs in IE
You can replicate in [this story](http://localhost:9001/?path=/story/flash--classic) by setting the `as` prop.

