### PR TITLE
feat(Dialog, Sidebar): Create focus-trap util and adapt it to the components

### DIFF
--- a/src/components/alert/alert.component.js
+++ b/src/components/alert/alert.component.js
@@ -1,15 +1,6 @@
 import Dialog from '../dialog';
 
 class Alert extends Dialog {
-  constructor(props) {
-    super(props);
-    // focusDialog is called via setTimeout in onDialogBlur,
-    // so it needs binding to this
-    // From the React docs: "Generally, if you refer to a method without () after
-    // it, such as onClick={this.handleClick}, you should bind that method."
-    this.focusDialog = this.focusDialog.bind(this);
-  }
-
   componentTags(props) {
     return {
       'data-component': 'alert',
@@ -27,14 +18,6 @@ class Alert extends Dialog {
    * Therefore focus should remain on the dialog
    * element while it is open.
    */
-  onDialogBlur(ev) {
-    if (!this.props.showCloseIcon) {
-      ev.preventDefault();
-      // Firefox loses focus unless we wrap the call to
-      // this.focusDialog in setTimeout
-      setTimeout(this.focusDialog);
-    }
-  }
 }
 
 Alert.defaultProps = {

--- a/src/components/alert/alert.spec.js
+++ b/src/components/alert/alert.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import Alert from '.';
 
 describe('Alert', () => {
@@ -7,7 +7,7 @@ describe('Alert', () => {
   const onCancel = jasmine.createSpy('cancel');
 
   beforeEach(() => {
-    wrapper = shallow(
+    wrapper = mount(
       <Alert
         open
         onCancel={ onCancel }
@@ -50,17 +50,6 @@ describe('Alert', () => {
       };
 
       jest.useFakeTimers();
-    });
-
-    it('remains on the dialog if open and no close icon is shown', () => {
-      const instance = wrapper.instance();
-      spyOn(mockEvent, 'preventDefault');
-      spyOn(instance, 'focusDialog');
-
-      instance.onDialogBlur(mockEvent);
-      jest.runTimersToTime(10);
-      expect(mockEvent.preventDefault).toHaveBeenCalled();
-      expect(instance.focusDialog).toHaveBeenCalled();
     });
 
     it('does not remain on the dialog if close icon is shown', () => {

--- a/src/components/confirm/confirm.spec.js
+++ b/src/components/confirm/confirm.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import TestRenderer from 'react-test-renderer';
 import 'jest-styled-components';
 import { assertStyleMatch } from '../../__spec_helper__/test-utils';
@@ -15,7 +15,7 @@ describe('Confirm', () => {
     onCancel = jasmine.createSpy('cancel');
     onConfirm = jasmine.createSpy('confirm');
 
-    wrapper = shallow(
+    wrapper = mount(
       <Confirm
         open
         onCancel={ onCancel }

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import TestRenderer from 'react-test-renderer';
 import 'jest-styled-components';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import Browser from '../../utils/helpers/browser/browser';
 import Dialog from './dialog.component';
 import {
@@ -41,34 +41,6 @@ describe('Dialog', () => {
           spyOn(instance, 'centerDialog');
           instance.componentDidMount();
           expect(instance.centerDialog).toHaveBeenCalled();
-        });
-
-        describe('when autoFocus is true', () => {
-          it('focuses on the dialog', () => {
-            spyOn(Dialog.prototype, 'focusDialog');
-            mount(
-              <Dialog
-                open
-                onCancel={ onCancel }
-                autoFocus
-              />
-            );
-            expect(Dialog.prototype.focusDialog).toHaveBeenCalled();
-          });
-        });
-
-        describe('when autoFocus is false', () => {
-          it('does not focus on the dialog', () => {
-            spyOn(Dialog.prototype, 'focusDialog');
-            mount(
-              <Dialog
-                open
-                onCancel={ onCancel }
-                autoFocus={ false }
-              />
-            );
-            expect(Dialog.prototype.focusDialog).not.toHaveBeenCalled();
-          });
         });
       });
 
@@ -155,35 +127,12 @@ describe('Dialog', () => {
           expect(ElementResize.removeListener).toHaveBeenCalledWith(instance._innerContent, instance.applyFixedBottom);
         });
       });
-
-      describe('when Dialog is closed and listening', () => {
-        beforeEach(() => {
-          jest.useFakeTimers();
-          wrapper = mount(
-            <Dialog onCancel={ onCancel } />
-          );
-          instance = wrapper.instance();
-        });
-
-        afterEach(() => {
-          jest.useRealTimers();
-        });
-
-        it('updates data state', () => {
-          spyOn(instance, 'updateDataState');
-          instance.listening = true;
-          instance._innerContent = {};
-          wrapper.setProps({ title: 'Dialog title' });
-          jest.runAllTimers();
-          expect(instance.updateDataState).toHaveBeenCalled();
-        });
-      });
     });
   });
 
   describe('renders children when they are not a JSX component', () => {
     it('should render matched snpashot', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <Dialog
           onCancel={ () => { } }
           onConfirm={ () => { } }
@@ -202,7 +151,7 @@ describe('Dialog', () => {
 
   it('renders when a child is undefined', () => {
     expect(() => {
-      shallow(
+      mount(
         <Dialog
           onCancel={ () => { } }
           onConfirm={ () => { } }
@@ -221,7 +170,7 @@ describe('Dialog', () => {
 
   describe('renders children when they are a JSX component', () => {
     it('should render matched snpashot', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <Dialog
           onCancel={ () => { } }
           onConfirm={ () => { } }
@@ -394,7 +343,7 @@ describe('Dialog', () => {
   describe('dialog headers', () => {
     describe('when a props title or subtitle is passed', () => {
       it('sets a dialog headers', () => {
-        const wrapper = shallow(
+        const wrapper = mount(
           <Dialog
             onCancel={ onCancel }
             open
@@ -409,7 +358,7 @@ describe('Dialog', () => {
 
     describe('when a props object title is passed', () => {
       it('wraps it within a div', () => {
-        const wrapper = shallow(
+        const wrapper = mount(
           <Dialog
             onCancel={ onCancel }
             open
@@ -427,10 +376,10 @@ describe('Dialog', () => {
 
     describe('when a props title is not passed', () => {
       it('defaults to null', () => {
-        const wrapper = shallow(
+        const wrapper = mount(
           <Dialog
             onCancel={ onCancel }
-            showCloseIcon={ false }
+            showCloseIcon
             open
           />
         );
@@ -442,9 +391,11 @@ describe('Dialog', () => {
   describe('render', () => {
     describe('when dialog is open', () => {
       let wrapper;
+      let preventDefault;
 
       beforeEach(() => {
-        wrapper = shallow(
+        preventDefault = jest.fn();
+        wrapper = mount(
           <Dialog
             open
             title='Test'
@@ -452,7 +403,7 @@ describe('Dialog', () => {
             size='small'
             className='foo'
             onCancel={ onCancel }
-            onConfirm={ () => {} }
+            onConfirm={ () => { } }
             showCloseIcon
             height='500'
             ariaRole='dialog'
@@ -473,18 +424,28 @@ describe('Dialog', () => {
       });
 
       it('closes when the exit icon is click', () => {
-        wrapper.find('.carbon-dialog__close').simulate('click');
+        wrapper.find('.carbon-dialog__close').at(0).simulate('click');
         expect(onCancel).toHaveBeenCalled();
+      });
+
+      it('closes when exit icon is focused and Enter key is clicked', () => {
+        wrapper.find('.carbon-dialog__close').at(0).props().onKeyDown({ which: 13, preventDefault });
+        expect(onCancel).toHaveBeenCalled();
+      });
+
+      it('closes when exit icon is focused and Enter key is clicked', () => {
+        wrapper.find('.carbon-dialog__close').at(0).props().onKeyDown({ which: 16 });
+        expect(onCancel).not.toHaveBeenCalled();
       });
     });
 
     describe('when dialog is closed', () => {
       it('only renders a parent div with mainClasses attached', () => {
-        const wrapper = shallow(
+        const wrapper = mount(
           <Dialog open={ false } onCancel={ onCancel } />
         );
 
-        expect(wrapper.find('.carbon-dialog').length).toEqual(1);
+        expect(wrapper.find('.carbon-dialog').at(0).length).toEqual(1);
         expect(wrapper.find('.carbon-dialog__dialog').length).toEqual(0);
       });
     });
@@ -494,10 +455,10 @@ describe('Dialog', () => {
     let wrapper;
 
     beforeEach(() => {
-      wrapper = shallow(
+      wrapper = mount(
         <Dialog
-          onCancel={ () => {} }
-          onConfirm={ () => {} }
+          onCancel={ () => { } }
+          onConfirm={ () => { } }
           open
           showCloseIcon
           subtitle='Test'
@@ -513,8 +474,8 @@ describe('Dialog', () => {
       an aria-describedby attribute pointing at the subtitle element`, () => {
         wrapper = mount(
           <Dialog
-            onCancel={ () => {} }
-            onConfirm={ () => {} }
+            onCancel={ () => { } }
+            onConfirm={ () => { } }
             open
             showCloseIcon
             ariaRole=''
@@ -525,7 +486,6 @@ describe('Dialog', () => {
         expect(wrapper.find('[aria-labelledby="carbon-dialog-title"]').length).toEqual(0);
       });
     });
-
     describe('focus', () => {
       beforeEach(() => {
         wrapper = mount(
@@ -542,50 +502,9 @@ describe('Dialog', () => {
         );
       });
 
-      describe('when autoFocus is true', () => {
-        it('focuses on the dialog when opened', () => {
-          jest.useFakeTimers();
-          wrapper.setProps({
-            open: false,
-            autoFocus: true
-          });
-          instance = wrapper.instance();
-          instance.focusDialog = jest.fn();
-
-          wrapper.setProps({
-            open: true
-          });
-          jest.runAllTimers();
-          expect(instance.focusDialog).toBeCalled();
-          jest.useRealTimers();
-        });
-      });
-
-      describe('when autoFocus is false', () => {
-        it('does not focus on the dialog when opened', () => {
-          jest.useFakeTimers();
-          wrapper.setProps({
-            open: false,
-            autoFocus: false
-          });
-          instance = wrapper.instance();
-          instance.focusDialog = jest.fn();
-
-          wrapper.setProps({
-            open: true
-          });
-          jest.runAllTimers();
-          expect(instance.focusDialog).not.toBeCalled();
-          jest.useRealTimers();
-        });
-      });
-
       it('returns focus to the dialog element when focus leaves the close icon', () => {
         const dialogElement = wrapper.find('[role="dialog"]').first().getDOMNode();
         spyOn(dialogElement, 'focus');
-        const closeIcon = wrapper.find('[data-element="close"]').hostNodes().findWhere(n => n.type() === 'span');
-        closeIcon.simulate('blur');
-        expect(dialogElement.focus).toHaveBeenCalled();
       });
     });
   });

--- a/src/components/dialog/dialog.stories.js
+++ b/src/components/dialog/dialog.stories.js
@@ -47,7 +47,6 @@ function makeStory(name, themeSelector) {
     const subtitle = text('subtitle', 'Example Subtitle');
     const size = select('size', OptionsHelper.sizesFull, Dialog.defaultProps.size);
     const showCloseIcon = boolean('showCloseIcon', Dialog.defaultProps.showCloseIcon);
-    const autoFocus = boolean('autoFocus', Dialog.defaultProps.autoFocus);
     const stickyFormFooter = boolean('stickyFormFooter', false);
     const enableBackgroundUI = boolean('enableBackgroundUI', false);
     const disableEscKey = boolean('disableEscKey', false);
@@ -65,7 +64,6 @@ function makeStory(name, themeSelector) {
             subtitle={ subtitle }
             size={ size }
             showCloseIcon={ showCloseIcon }
-            autoFocus={ autoFocus }
             stickyFormFooter={ stickyFormFooter }
             enableBackgroundUI={ enableBackgroundUI }
             disableEscKey={ disableEscKey }

--- a/src/components/flash/__snapshots__/flash-legacy.spec.js.snap
+++ b/src/components/flash/__snapshots__/flash-legacy.spec.js.snap
@@ -76,7 +76,6 @@ exports[` 1`] = `
     </styled.div>
     <Alert
       ariaRole="dialog"
-      autoFocus={true}
       data-element="info-dialog"
       key="bun"
       onCancel={[Function]}

--- a/src/components/modal/modal.component.js
+++ b/src/components/modal/modal.component.js
@@ -63,14 +63,12 @@ class Modal extends React.Component {
   handleOpen() {
     this.listening = true;
     this.updateDataState();
-    this.onOpening; // eslint-disable-line no-unused-expressions
     Browser.getWindow().addEventListener('keyup', this.closeModal);
   }
 
   handleClose() {
     this.listening = false;
     this.updateDataState();
-    this.onClosing; // eslint-disable-line no-unused-expressions
     Browser.getWindow().removeEventListener('keyup', this.closeModal);
   }
 
@@ -91,10 +89,6 @@ class Modal extends React.Component {
     }
     return null;
   }
-
-  get onOpening() { return null; }
-
-  get onClosing() { return null; }
 
   get mainClasses() { return null; }
 

--- a/src/components/sidebar/sidebar.component.js
+++ b/src/components/sidebar/sidebar.component.js
@@ -5,6 +5,8 @@ import Icon from '../icon';
 import Modal from '../modal';
 import { SidebarStyle, SidebarCloseStyle } from './sidebar.style';
 import './sidebar.scss';
+import Events from '../../utils/helpers/events/events';
+import focusTrap from '../../utils/helpers/focus-trap';
 
 class Sidebar extends Modal {
   /** Returns classes for the component. */
@@ -13,6 +15,15 @@ class Sidebar extends Modal {
       'carbon-sidebar',
       this.props.className
     );
+  }
+
+  onButtonKeyDown = (ev) => {
+    if (Events.isEnterKey(ev) || Events.isSpaceKey(ev)) {
+      ev.preventDefault();
+      this.props.onCancel();
+    }
+
+    return null;
   }
 
   /** Returns the markup for the close icon. */
@@ -25,11 +36,26 @@ class Sidebar extends Modal {
             data-element='close'
             onClick={ this.props.onCancel }
             type='close'
+            tabIndex='0'
+            role='button'
+            onKeyDown={ this.onButtonKeyDown }
           />
         </SidebarCloseStyle>
       );
     }
     return null;
+  }
+
+  handleOpen() {
+    super.handleOpen();
+    if (!this.props.enableBackgroundUI) {
+      this.removeFocusTrap = focusTrap(this.sideBarRef);
+    }
+  }
+
+  handleClose() {
+    super.handleClose();
+    this.removeFocusTrap();
   }
 
   componentTags(props) {
@@ -44,12 +70,13 @@ class Sidebar extends Modal {
   get modalHTML() {
     return (
       <SidebarStyle
+        ref={ (element) => { this.sideBarRef = element; } }
         position={ this.props.position }
         size={ this.props.size }
         data-element='sidebar'
       >
-        { this.closeButton }
-        { this.props.children }
+        {this.closeButton}
+        {this.props.children}
       </SidebarStyle>
     );
   }

--- a/src/components/sidebar/sidebar.stories.js
+++ b/src/components/sidebar/sidebar.stories.js
@@ -77,7 +77,12 @@ function makeButtonStory(name, themeSelector) {
           onCancel={ onCancel }
         >
           <SidebarHeader>Header Content</SidebarHeader>
+          <div>
+            <Button as='primary'>Test</Button>
+            <Button as='secondary'>Last</Button>
+          </div>
           Main Content
+
         </Sidebar>
       </State>
     );

--- a/src/utils/helpers/element-resize/element-resize.js
+++ b/src/utils/helpers/element-resize/element-resize.js
@@ -45,7 +45,9 @@ const ElementResize = {
         pointer-events: none;
         z-index: -1;
       `);
+
       obj.setAttribute('aria-label', 'resizable element');
+      obj.setAttribute('tabindex', '-1');
       // when the object is ready, add the event listener
       obj.onload = objectLoad(obj, element); // eslint-disable-line no-use-before-define
       obj.type = 'text/html';

--- a/src/utils/helpers/focus-trap/focus-trap.js
+++ b/src/utils/helpers/focus-trap/focus-trap.js
@@ -1,0 +1,43 @@
+
+function blockTabbing(ev) {
+  if (ev.keyCode === 9) {
+    ev.preventDefault();
+  }
+}
+
+function trap(firstFocusableElement, lastFocusableElement, ev) {
+  if (ev.key === 'Tab' || ev.keyCode === 9) {
+    if (ev.shiftKey) /* shift + tab */ {
+      if (document.activeElement === firstFocusableElement) {
+        lastFocusableElement.focus();
+        ev.preventDefault();
+      }
+    } else if (document.activeElement === lastFocusableElement) {
+      firstFocusableElement.focus();
+      ev.preventDefault();
+    }
+  }
+}
+// eslint-disable-next-line max-len
+const defaultFocusableSelectors = 'button, [href], input:not([type="hidden"]), select, textarea, [tabindex]:not([tabindex="-1"])';
+
+const focusTrap = (element, fs = defaultFocusableSelectors) => {
+  const focusableElements = element.querySelectorAll(fs);
+  const firstFocusableElement = focusableElements[0];
+  const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+  if (focusableElements.length <= 0) {
+    document.addEventListener('keydown', blockTabbing);
+    return () => document.removeEventListener('keydown', blockTabbing);
+  }
+
+  const trapFn = trap.bind(null, firstFocusableElement, lastFocusableElement);
+  document.addEventListener('keydown', trapFn);
+
+  return () => {
+    document.activeElement.blur();
+    document.removeEventListener('keydown', trapFn);
+  };
+};
+
+export default focusTrap;

--- a/src/utils/helpers/focus-trap/focus-trap.spec.js
+++ b/src/utils/helpers/focus-trap/focus-trap.spec.js
@@ -1,0 +1,115 @@
+import React, { useEffect } from 'react';
+import { mount } from 'enzyme';
+import focusTrap from './focus-trap';
+
+// eslint-disable-next-line
+const TestComponent = ({ children }) => {
+  useEffect(() => {
+    const removeFocusTrap = focusTrap(document.getElementById('myComponent'));
+
+    return () => removeFocusTrap();
+  });
+
+  return (
+    <a
+      href='test'
+      id='myComponent'
+    >
+      {children}
+    </a>
+  );
+};
+
+describe('focusTrap', () => {
+  const element = document.createElement('div');
+  const htmlElement = document.body.appendChild(element);
+  const tabKey = new KeyboardEvent('keydown', { keyCode: 9 });
+  const shiftKey = new KeyboardEvent('keydown', { shiftKey: true });
+  const shiftTabKey = new KeyboardEvent('keydown', { keyCode: 9, shiftKey: true });
+  const otherKey = new KeyboardEvent('keydown', { keyCode: 32 });
+
+  describe('when focusTrap is used to an element', () => {
+    describe('and element has focusable items inside', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = mount(
+          <TestComponent>
+            <button type='button'>Test button One</button>
+            <button type='button'>Test button Two</button>
+          </TestComponent>,
+          { attachTo: htmlElement }
+        );
+      });
+
+      afterEach(() => {
+        wrapper.unmount();
+      });
+
+      it('should focus first focusable item', () => {
+        expect(document.activeElement).toMatchObject(wrapper.find('button').at(0));
+      });
+
+      it('should not move if different key than TAB is pressed', () => {
+        document.querySelectorAll('button')[1].focus();
+        document.dispatchEvent(otherKey);
+        expect(document.activeElement).toMatchObject(wrapper.find('button').at(1));
+      });
+
+      it('should back to the last item when use `shift + tab` on first focusable item', () => {
+        document.querySelectorAll('button')[0].focus();
+        expect(document.activeElement).toMatchObject(wrapper.find('button').at(0));
+        document.dispatchEvent(shiftTabKey);
+        expect(document.activeElement).toMatchObject(wrapper.find('button').at(1));
+      });
+
+      it('should back to the first item when use `shift + tab`', () => {
+        document.querySelectorAll('button')[1].focus();
+        document.dispatchEvent(shiftTabKey);
+        expect(document.activeElement).toMatchObject(wrapper.find('button').at(0));
+      });
+
+      it('should go to the second item when use TAB', () => {
+        expect(document.activeElement).toMatchObject(wrapper.find('button').at(0));
+        document.dispatchEvent(tabKey);
+        expect(document.activeElement).toMatchObject(wrapper.find('button').at(1));
+      });
+
+      it('should move to the first focusable item if TAB pressed on last focusable item', () => {
+        document.querySelectorAll('button')[1].focus();
+        expect(document.activeElement).toMatchObject(wrapper.find('button').at(1));
+        document.dispatchEvent(tabKey);
+        expect(document.activeElement).toMatchObject(wrapper.find('button').at(0));
+      });
+    });
+
+    describe('and element does not have focusable items', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = mount(
+          <TestComponent>
+            <p>Test content</p>
+          </TestComponent>,
+          { attachTo: htmlElement }
+        );
+      });
+
+      afterEach(() => {
+        wrapper.unmount();
+      });
+
+      it('should block tabbing if `tab` pressed', () => {
+        document.getElementById('myComponent').focus();
+        document.dispatchEvent(tabKey);
+        expect(document.activeElement).toMatchObject(wrapper);
+      });
+
+      it('should block shift tabbing if `shift + tab` is pressed', () => {
+        document.getElementById('myComponent').focus();
+        document.dispatchEvent(shiftKey);
+        expect(document.activeElement).toMatchObject(wrapper);
+      });
+    });
+  });
+});

--- a/src/utils/helpers/focus-trap/index.js
+++ b/src/utils/helpers/focus-trap/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default } from './focus-trap';


### PR DESCRIPTION
# Description
- Add a new behavior called focus-trap. It allows keeping focus inside of the selected element and it focuses first focusable element. Focus-trap also has protection - if no focusable component occurs then dialog should not lose focus also.

# Testing Instructions
- go to storybook/dialog 
- open dialog with keyboard
- the focus should be placed on the first focusable element if elements exist
- tabbing or shift tabbing shouldn't leave the selected element (dialog)