### PR TITLE
chore: add bug template FE-2023

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,12 +24,12 @@ assignees: ''
 
 ### Your environment
 <!-- PLEASE FILL THIS OUT -->
-| Software               | Version(s) |
-| ----------------- | ---------- |
-| carbon-react        |
-| carbon-factory     |
-| react-scripts         | 
-| React                     |
-| Browser                 |
-| npm                        |
+| Software         | Version(s) |
+| ---------------- | ---------- |
+| carbon-react     |
+| carbon-factory   |
+| react-scripts    | 
+| React            |
+| Browser          |
+| npm              |
 | Operating System |

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve carbon
+title: ''
+labels: Bug, triage
+assignees: ''
+
+---
+
+### Current Behavior
+<!-- If applicable, add screenshots to help explain your problem. You can paste these directly into GitHub. -->
+
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+### Reproducible example
+<!-- Please fork this CodeSandbox (https://codesandbox.io/s/carbon-quickstart-xi5jc) and include any required steps to reproduce -->
+
+### Suggested solution(s)
+<!-- How could we solve this bug? What changes would need to make to carbon? -->
+
+### Additional context
+<!-- Add any other context about the problem here.  -->
+
+### Your environment
+<!-- PLEASE FILL THIS OUT -->
+| Software               | Version(s) |
+| ----------------- | ---------- |
+| carbon-react        |
+| carbon-factory     |
+| react-scripts         | 
+| React                     |
+| Browser                 |
+| npm                        |
+| Operating System |

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ assignees: ''
 <!-- Please fork this CodeSandbox (https://codesandbox.io/s/carbon-quickstart-xi5jc) and include any required steps to reproduce -->
 
 ### Suggested solution(s)
-<!-- How could we solve this bug? What changes would need to make to carbon? -->
+<!-- How could we solve this bug? What changes would need to be made to carbon? -->
 
 ### Additional context
 <!-- Add any other context about the problem here.  -->


### PR DESCRIPTION
This PR adds a bug template. When users create a new issue they can choose from this template or a blank one.