### PR TITLE
fix(pager): add I18n translation to First option 

### DIFF
--- a/src/components/pager/pager-navigation.component.js
+++ b/src/components/pager/pager-navigation.component.js
@@ -80,7 +80,7 @@ const PagerNavigation = (props) => {
     const currentPage = Number(props.currentPage);
     const navLinkConfig = {
       first: {
-        text: 'First',
+        text: I18n.t('pager.first', { defaultValue: 'First' }),
         destination: '1'
       },
       last: {


### PR DESCRIPTION
### Proposed behaviour
Fixes https://github.com/Sage/carbon/issues/2584 where Pager does not use I18n for the "First" label. This change is backwards compatible as it maintains a defaultValue of 'First'.

### Current behaviour
Currently the Pager navLinkConfig object contains labels for first/last/next/previous but the first label does not use I18n.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes
<del>- [ ] Unit tests</del>
<del>- [ ] <del>Cypress automation tests</del>
<del>- [ ] <del>Storybook added or updated</del>
<del>- [ ] <del>Theme support</del>
<del>- [ ] <del>Typescript `d.ts` file added or updated</del>

### Additional context
https://github.com/Sage/carbon/issues/2584

### Testing instructions
<!-- How can a reviewer test this PR? -->
