### PR TITLE
FE-2503 adds support for value or defaultValue being an object

### DIFF
--- a/change_log/next/FE-2503-update-selct-to-support-object-value.yml
+++ b/change_log/next/FE-2503-update-selct-to-support-object-value.yml
@@ -1,0 +1,3 @@
+New Features: "Loosens the prop-typing for `value` and `defaultValue`. The component now supports being initialized\n
+ with string and object (`{ value '', text: ''}`), to support projects that only populate the option list when the\n
+ component is interacted with. (Component: Select)"

--- a/src/__experimental__/components/select/index.d.ts
+++ b/src/__experimental__/components/select/index.d.ts
@@ -1,0 +1,4 @@
+import Select from './select.component';
+import Option from './option.component';
+
+export { Select, Option };

--- a/src/__experimental__/components/select/option.d.ts
+++ b/src/__experimental__/components/select/option.d.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+export interface OptionProps {
+  children?: React.ReactNode;
+  text: string;
+  value: string;
+  options: object
+}
+declare const Option: React.ComponentType<OptionProps>;
+export default Option;

--- a/src/__experimental__/components/select/select-list.component.js
+++ b/src/__experimental__/components/select/select-list.component.js
@@ -156,7 +156,7 @@ SelectList.propTypes = {
   customFilter: PropTypes.func,
   /** The value to filter the children by */
   filterValue: PropTypes.string,
-  /** Flag to indicite whether select list is loopable while traversing using up and down keys */
+  /** Flag to indicate whether select list is loopable while traversing using up and down keys */
   isLoopable: PropTypes.bool,
   /** A custom callback for when more data needs to be lazy-loaded when the user scrolls the dropdown menu list */
   onLazyLoad: PropTypes.func,

--- a/src/__experimental__/components/select/select-list.d.ts
+++ b/src/__experimental__/components/select/select-list.d.ts
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+export interface SelectListProps {
+  alwaysHighlight?: boolean;
+  customFilter?: () => void; 
+  children?: React.ReactNode;
+  filterValue?: string;
+  id?: string;
+  isLoopable?: boolean;
+  name?: string;
+  leftChildren?: React.ReactNode;
+  onLazyLoad? : () => void;
+  onMouseDown? : () => void;
+  onMouseEnter? : () => void;
+  onMouseLeave? : () => void;
+  onSelect? : () => void;
+  target?: object;
+}
+declare const SelectList: React.ComponentType<SelectListProps>;
+export default SelectList;

--- a/src/__experimental__/components/select/select.d.ts
+++ b/src/__experimental__/components/select/select.d.ts
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+interface valueObject {
+  value: string;
+  text: string;
+};
+
+export interface SelectProps {
+  ariaLabel?: string;
+  children?: React.ReactNode;
+  defaultValue?: string | valueObject | string[] | valueObject[];
+  'data-component': string;
+  disabled?: boolean;
+  enableMultiSelect?: boolean;
+  fieldHelp?: string;
+  filterable?: boolean;
+  label?: string;
+  id?: string;
+  isAnyValueSelected?: boolean;
+  isLoopable?: boolean;
+  name?: string;
+  leftChildren?: React.ReactNode;
+  onBlur?(): void;
+  onChange?(): void;
+  onFocus?(): void;
+  onFilter?(): void;
+  onOpen?(): void;
+  onLazyLoad?(): void;
+  placeholder?: string;
+  preventFocusAutoOpen?: boolean;
+  readOnly?: boolean;
+  size?: 'small' | 'medium' | 'large';
+  typeAhead?: boolean;
+  value?: string | valueObject | string[] | valueObject[];
+}
+declare const Select: React.ComponentType<SelectProps>;
+export default Select;

--- a/src/__experimental__/components/select/select.d.ts
+++ b/src/__experimental__/components/select/select.d.ts
@@ -20,12 +20,12 @@ export interface SelectProps {
   isLoopable?: boolean;
   name?: string;
   leftChildren?: React.ReactNode;
-  onBlur?(): void;
-  onChange?(): void;
-  onFocus?(): void;
-  onFilter?(): void;
-  onOpen?(): void;
-  onLazyLoad?(): void;
+  onBlur?: () => void;
+  onChange?: () => void;
+  onFocus?: () => void;
+  onFilter?: () => void;
+  onOpen?: () => void;
+  onLazyLoad?: () => void;
   placeholder?: string;
   preventFocusAutoOpen?: boolean;
   readOnly?: boolean;

--- a/src/__spec_helper__/test-utils.js
+++ b/src/__spec_helper__/test-utils.js
@@ -29,6 +29,7 @@ const keyMap = {
   Escape: '27',
   End: '35',
   Home: '36',
+  BackSpace: '8',
   D: '68',
   E: '69',
   P: '80',


### PR DESCRIPTION
### Proposed behaviour
Proposed to add support for allowing the Select to be passed either a string, an object formatted like
`{ value: '', text: '' }`, an array of strings or an array of the above object format when the component is in multi-select mode

### Current behaviour
Currently the  Select component only supports being passed string or array of strings as a value or defaultValue

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ /] Release notes (renogen)
- [ /] Unit tests
<del>- [ /] Cypress automation tests</del>
<del>- [ /] Storybook added or updated</del>
<del>- [ /] Theme support</del>
- [ /] Typescript `d.ts` file added or updated

### Additional context
The proposed change is to support projects who do not populate the option list unless the a user performs an action to indicate they wish to change the initial value, at that point the values or lazy loaded via a call to an api.

### Testing instructions
<!-- How can a reviewer test this PR? -->
I have created `test-branch-for-FE-2503` to allow it to be tested, the fixtures for the Select component have been adjusted to simulate the component being initialised with values but no options and then a button can be clicked to simulate an api call being made
https://github.com/Sage/carbon/tree/test-branch-for-FE-2503