### PR TITLE
docs: remove codeship badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Carbon [![Codeship Status](https://img.shields.io/codeship/dd2c7bd0-6c4e-0133-1f77-72bb5571e5ad/master.svg)](https://app.codeship.com/projects/115478) [![Travis Status](https://travis-ci.org/Sage/carbon.svg?branch=master)](https://travis-ci.org/Sage/carbon) [![npm](https://img.shields.io/npm/v/carbon-react.svg)](https://www.npmjs.com/package/carbon-react)
+# Carbon [![Travis Status](https://travis-ci.org/Sage/carbon.svg?branch=master)](https://travis-ci.org/Sage/carbon) [![npm](https://img.shields.io/npm/v/carbon-react.svg)](https://www.npmjs.com/package/carbon-react)
 
 <img src="https://raw.githubusercontent.com/Sage/carbon/master/logo/carbon-logo.png" width="50">
 


### PR DESCRIPTION
### Proposed behaviour
Remove Codeship badge from Github README. We have disabled the Codeship integration in favour of Travis.

### Current behaviour
There is a status bade on the Github README.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del> - [ ] Release notes (renogen)</del>
<del> - [ ] Unit tests</del>
<del> - [ ] Cypress automation tests</del>
<del> - [ ] Storybook added or updated</del>
<del> - [ ] Theme support</del>
<del> - [ ] Typescript `d.ts` file added or updated</del>

### Additional context
Codeship is faster but does not run pull requests from forks. For this reason, we're going to use Travis which does run pull requests from forks. We will look to parallelise some of the Travis steps to speed up the build.

### Testing instructions
View the README.md file.
