### PR TITLE
ci: parallelize travis FE-2511

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,30 +7,45 @@ addons:
        # Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves
        - libgconf-2-4
 
-script:
-  - npm run storybook-ci </dev/null &>/dev/null &
-  - npm run test-carbon-build
-  - npm run lint && npm test -- --maxWorkers=2
-  - npm run test-storybook-smoke
-  - wait-on http://localhost:9001
-  - npm run test-cypress-build
+stages:
+  - test
+  - deploy
 
-before_deploy: if [ "$TRAVIS_BRANCH" == "master" ]; then ASSETS_PREFIX=https://carbon.sage.com npm run build; fi
-
-deploy:
-  - provider: s3
-    bucket: carbon.sage.com
-    skip_cleanup: true
-    local_dir: deploy
-    detect_encoding: true
-    on:
-      branch: master
-    access_key_id:
-      secure: iZx7SkuMjUMXLVQNO5LSjF6EfQeqGbgdGtPg0hfzVIEcS5s/79j5aq8aQJ7EjCXM+yPRDZMaXB+StXOZjNhEbKLYt2mZDyMki3gAII2QM2MAeI5YtltgJHlXClsMjFiomTbRPo/F9CnIerRBdAFUmQXh2BVSdz86ptsLWs9SrcSjgN/RM6bWSaFYbyckyRVQZVipHYN1vmbEw8ZNZGSQTEPyi3Pw4nXMJ+9ro/72Pt5Ioo3a/praWJL9I5hEc6uBAfFZTtsg70txARaSOycoHxQT8S/xfIzfPQXSmj3n4MTMMCOi3CyJFJfTOdHnQ2ylSllae3zLgIJv1dPQoRuPrB0A1loG2BA+1PXA7KZrwBzYty20XMM2o2tB4mlkKh8p1gOjdsAyRT415kDkEvGpw/b+jFPQ+mAg67ELCJz/HTvBvrKF8nAGsoiG0A1Bi89wxi2riMjAZ2VzbTHrTq/Lp/MlJYt4Z44CXVSKXlKBVKwlDVS7+OIp5QAC0AggtJGFb4kvS/6zUnoykM/lsRBX99lsMURlpGq/EKC5B4iU26NWvF4L+sO9UUesN7LMr8C6oSc7wVrhLHiQbJx55UZTjT4+H/Y4VOFOiEhVKKJTk0/jt/QOOxZbuyhMitLOMBTQQ9tEICv7fIFSUIfePD3bG6FR3vXvod0ct/H7/DhNM0A=
-    secret_access_key:
-      secure: qdS1pq1ZXvw6lXLrGtSaZTpx7OLREvV/7UCwPFbfQkuQBLbxLe32qlzOkkEQWd7sHwadSgvVTKvX4HKaAIx+QZ2XXFbXGx4HIOCws6ynAVVa2kV5SSHKMwiy+R6Ypttu3GD6uKEhPMUULCYuCLzIIvAOKoCaDIzzKlxzK+g/tCe94J+fKU0DS6U23FFxW51UADgTxn7opg3mkhsteaRyAtDkurAeobEzfQpTFKPNXJ3YcFjpGUf9Z5zxcXXNohKZQP4wODgYU+OZuif/cAeETChWxVThk0PMIIk9/lmwyX1UKIpWpyVTDEKXzwnO2COVWOxtVCpTB0uwfZTZ8MhVXRvFj8Dk/iw+2NN/W55fQ44xx0h6mvhMle98jKTWi6AR/F0LJMpCkZeNTVCdiDz7Ow1g23HlBIRx/seYxph2vLSLkh63kU8ygaOFWhCNdCGOOPLHi8m8X8vlLRvN9ETWY/sMWkvY/S9bXIGw8lv5Bk4lIxAmjoU05XJceq5rOlSax46d1fsicJ5gF6tcxvMau2bFGMCgeZJEpRYChqTEt284woFc8+maa4SwMVrim6J8R53Xfx8mtgCnRlgZmXymzyxu8wCVnAza24iQ4kWmx+fDw70iU5Q3nxSwjN4Q922QZiAFLGpAK0nRDFhE7NPftubYOgsisNCFOnTTTBGJghI=
-  - provider: script
-    skip_cleanup: true
-    script: npx semantic-release
-    on:
-      branch: master
+jobs:
+  include:
+    - stage: test
+      name: "lint"
+      script: npm run lint
+    - name: "unit tests"
+      script: npm test
+    - name: "test build"
+      script: npm run test-carbon-build
+      if: type = pull_request # we only need to test this in a pull, on a push to master we will be running the build in the deploy step
+    - name: "test storybook with cypress"
+      script: 
+        - npm run storybook-ci </dev/null &>/dev/null &
+        - wait-on http://localhost:9001
+        - npm run test-cypress-build
+    - stage: deploy
+      name: "s3"
+      before_deploy: ASSETS_PREFIX=https://carbon.sage.com npm run build
+      deploy:
+          provider: s3
+          on:
+            branch: master
+          bucket: carbon.sage.com
+          skip_cleanup: true
+          local_dir: deploy
+          detect_encoding: true
+          access_key_id:
+            secure: iZx7SkuMjUMXLVQNO5LSjF6EfQeqGbgdGtPg0hfzVIEcS5s/79j5aq8aQJ7EjCXM+yPRDZMaXB+StXOZjNhEbKLYt2mZDyMki3gAII2QM2MAeI5YtltgJHlXClsMjFiomTbRPo/F9CnIerRBdAFUmQXh2BVSdz86ptsLWs9SrcSjgN/RM6bWSaFYbyckyRVQZVipHYN1vmbEw8ZNZGSQTEPyi3Pw4nXMJ+9ro/72Pt5Ioo3a/praWJL9I5hEc6uBAfFZTtsg70txARaSOycoHxQT8S/xfIzfPQXSmj3n4MTMMCOi3CyJFJfTOdHnQ2ylSllae3zLgIJv1dPQoRuPrB0A1loG2BA+1PXA7KZrwBzYty20XMM2o2tB4mlkKh8p1gOjdsAyRT415kDkEvGpw/b+jFPQ+mAg67ELCJz/HTvBvrKF8nAGsoiG0A1Bi89wxi2riMjAZ2VzbTHrTq/Lp/MlJYt4Z44CXVSKXlKBVKwlDVS7+OIp5QAC0AggtJGFb4kvS/6zUnoykM/lsRBX99lsMURlpGq/EKC5B4iU26NWvF4L+sO9UUesN7LMr8C6oSc7wVrhLHiQbJx55UZTjT4+H/Y4VOFOiEhVKKJTk0/jt/QOOxZbuyhMitLOMBTQQ9tEICv7fIFSUIfePD3bG6FR3vXvod0ct/H7/DhNM0A=
+          secret_access_key:
+            secure: qdS1pq1ZXvw6lXLrGtSaZTpx7OLREvV/7UCwPFbfQkuQBLbxLe32qlzOkkEQWd7sHwadSgvVTKvX4HKaAIx+QZ2XXFbXGx4HIOCws6ynAVVa2kV5SSHKMwiy+R6Ypttu3GD6uKEhPMUULCYuCLzIIvAOKoCaDIzzKlxzK+g/tCe94J+fKU0DS6U23FFxW51UADgTxn7opg3mkhsteaRyAtDkurAeobEzfQpTFKPNXJ3YcFjpGUf9Z5zxcXXNohKZQP4wODgYU+OZuif/cAeETChWxVThk0PMIIk9/lmwyX1UKIpWpyVTDEKXzwnO2COVWOxtVCpTB0uwfZTZ8MhVXRvFj8Dk/iw+2NN/W55fQ44xx0h6mvhMle98jKTWi6AR/F0LJMpCkZeNTVCdiDz7Ow1g23HlBIRx/seYxph2vLSLkh63kU8ygaOFWhCNdCGOOPLHi8m8X8vlLRvN9ETWY/sMWkvY/S9bXIGw8lv5Bk4lIxAmjoU05XJceq5rOlSax46d1fsicJ5gF6tcxvMau2bFGMCgeZJEpRYChqTEt284woFc8+maa4SwMVrim6J8R53Xfx8mtgCnRlgZmXymzyxu8wCVnAza24iQ4kWmx+fDw70iU5Q3nxSwjN4Q922QZiAFLGpAK0nRDFhE7NPftubYOgsisNCFOnTTTBGJghI=
+    - name: "npm & GitHub"
+      before_deploy: npm run build
+      deploy:
+        provider: script
+        script: npx semantic-release
+        on:
+          all_branches: true # semantic-release has a regex that allows us to publish maintenance releases
+          

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ jobs:
     - name: "test build"
       script: npm run test-carbon-build
       if: type = pull_request # we only need to test this in a pull, on a push to master we will be running the build in the deploy step
+    - name: "storybook smoketest"
+      script: npm run test-storybook-smoke
     - name: "test storybook with cypress"
       script: 
         - npm run storybook-ci </dev/null &>/dev/null &

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
       deploy:
         provider: script
         script: npx semantic-release
+        skip_cleanup: true
         on:
           all_branches: true # semantic-release has a regex that allows us to publish maintenance releases
           

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
         - npm run test-cypress-build
     - stage: deploy
       name: "s3"
+      script: skip
       before_deploy: ASSETS_PREFIX=https://carbon.sage.com npm run build
       deploy:
           provider: s3
@@ -42,7 +43,7 @@ jobs:
           secret_access_key:
             secure: qdS1pq1ZXvw6lXLrGtSaZTpx7OLREvV/7UCwPFbfQkuQBLbxLe32qlzOkkEQWd7sHwadSgvVTKvX4HKaAIx+QZ2XXFbXGx4HIOCws6ynAVVa2kV5SSHKMwiy+R6Ypttu3GD6uKEhPMUULCYuCLzIIvAOKoCaDIzzKlxzK+g/tCe94J+fKU0DS6U23FFxW51UADgTxn7opg3mkhsteaRyAtDkurAeobEzfQpTFKPNXJ3YcFjpGUf9Z5zxcXXNohKZQP4wODgYU+OZuif/cAeETChWxVThk0PMIIk9/lmwyX1UKIpWpyVTDEKXzwnO2COVWOxtVCpTB0uwfZTZ8MhVXRvFj8Dk/iw+2NN/W55fQ44xx0h6mvhMle98jKTWi6AR/F0LJMpCkZeNTVCdiDz7Ow1g23HlBIRx/seYxph2vLSLkh63kU8ygaOFWhCNdCGOOPLHi8m8X8vlLRvN9ETWY/sMWkvY/S9bXIGw8lv5Bk4lIxAmjoU05XJceq5rOlSax46d1fsicJ5gF6tcxvMau2bFGMCgeZJEpRYChqTEt284woFc8+maa4SwMVrim6J8R53Xfx8mtgCnRlgZmXymzyxu8wCVnAza24iQ4kWmx+fDw70iU5Q3nxSwjN4Q922QZiAFLGpAK0nRDFhE7NPftubYOgsisNCFOnTTTBGJghI=
     - name: "npm & GitHub"
-      before_deploy: npm run build
+      script: skip
       deploy:
         provider: script
         script: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "npm run gen-colors && npm run gen-docs && cross-env NODE_ENV=production npm run webpack && npm run prep-deploy && npm run build-storybook",
     "test": "jest --config=./jest.conf.json",
     "test-update": "jest --config=./jest.conf.json --updateSnapshot",
-    "test-carbon-build": "npm run gen-colors && npm run gen-docs && npm run webpack",
+    "test-carbon-build": "npm run gen-colors && npm run gen-docs && cross-env NODE_ENV=production npm run webpack",
     "test-cypress": "cypress open",
     "test-cypress-build": "cypress run --spec ./cypress/features/build/build*.feature --browser chrome --reporter spec",
     "test-cypress-accessibility": "cypress run --spec ./cypress/features/accessibility/accessibility.feature --browser chrome --reporter spec",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint ./src ./fixtures",
     "lint-ts": "./node_modules/.bin/tslint 'src/**/*.ts'",
     "precompile": "npm run clean-lib && npm run copy-files && npm run babel",
-    "prepublishOnly": "node check-version.js && npm install && npm run precompile",
+    "prepublishOnly": "node check-version.js && npm run precompile",
     "watch": "npm run clean-lib && npm run copy-files -- --watch & npm run babel -- --watch",
     "storybook": "./node_modules/.bin/start-storybook -p 9001 -s .assets -c .storybook",
     "storybook-ci": "./node_modules/.bin/start-storybook -p 9001 -c .storybook --ci",


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
I have parallelised many of the stages in the Travis build reducing the time from 14 mins to 6.

![image](https://user-images.githubusercontent.com/2328042/72359716-b0836300-36e6-11ea-8a16-f2708e1041b0.png)

- Only `pr` check is important for PR's the `push` one is not because we only care about the condition of the code after the merge.
- `push` is not important for PR's we could make some more time savings here but it wouldn't help the speed of the `pr` check. 
- I looked to prevent the double builds that we see in a PR, but this would mean we have to explicitly state which branches to build. This would make it difficult to do a maintenance release so for now we still have two builds for each PR.
- `npm run test-carbon-build` only runs on `pull_request` because on the `push` job we will be doing it in the `deploy` stage.

### Current behaviour
All steps are run in sequence, but they do not depend upon each other.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>- [ ] Unit tests</del>
<del>- [ ] Cypress automation tests</del>
<del>- [ ] Storybook added or updated</del>
<del>- [ ] Theme support</del>
<del>- [ ] Typescript `d.ts` file added or updated</del>

### Additional context
<!-- Add any other context or links about the pull request here. -->
FE-2511
### Testing instructions
See the Travis checks on this PR.
