### PR TITLE
fix(date): support for runtime value update FE-2514

### DIFF
--- a/src/__experimental__/components/date-range/date-range.component.js
+++ b/src/__experimental__/components/date-range/date-range.component.js
@@ -31,6 +31,31 @@ class DateRange extends React.Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.hasUpdated(prevProps)) {
+      this.updateValues(this.props.value);
+    }
+  }
+
+  hasUpdated(prevProps) {
+    return (
+      this.isControlled && (this.props.value[0] !== prevProps.value[0] || this.props.value[1] !== prevProps.value[1])
+    );
+  }
+
+  updateValues() {
+    this.setState({
+      startDateValue: {
+        formattedValue: DateHelper.formatDateToCurrentLocale(this.startDate),
+        rawValue: DateHelper.formatValue(this.startDate || this.today)
+      },
+      endDateValue: {
+        formattedValue: DateHelper.formatDateToCurrentLocale(this.endDate),
+        rawValue: DateHelper.formatValue(this.endDate || this.today)
+      }
+    });
+  }
+
   /** onChange function -triggers validations on both fields and updates opposing field when one changed. */
   _onChange = (changedDate, ev) => {
     this.setState({ [`${changedDate}Value`]: { ...ev.target.value } },
@@ -220,9 +245,9 @@ DateRange.propTypes = {
   startDateProps: PropTypes.shape({ ...DateInput.propTypes, value: PropTypes.string }),
   /** Props for the child end Date component */
   endDateProps: PropTypes.shape({ ...DateInput.propTypes, value: PropTypes.string }),
-  /** An optional string prop to privide a name to the component */
+  /** An optional string prop to provide a name to the component */
   name: PropTypes.string,
-  /** An optional string prop to privide an id to the component */
+  /** An optional string prop to provide an id to the component */
   id: PropTypes.string
 };
 

--- a/src/__experimental__/components/date-range/date-range.spec.js
+++ b/src/__experimental__/components/date-range/date-range.spec.js
@@ -107,7 +107,7 @@ describe('DateRange', () => {
         expect(customOnBlur).not.toHaveBeenCalled();
       });
 
-      it('does not fire an onBlur event when the endtDate is focused', () => {
+      it('does not fire an onBlur event when the endDate is focused', () => {
         wrapper.instance().focusEnd();
         wrapper.instance()._onBlur();
         expect(customOnBlur).not.toHaveBeenCalled();
@@ -368,6 +368,33 @@ describe('DateRange', () => {
       endInput = wrapper.find(BaseDateInput).at(1);
       expect(startInput.props().value).toEqual('2016-10-10');
       expect(endInput.props().value).toEqual('2016-11-11');
+    });
+
+    it('supports value update dynamically at runtime', () => {
+      wrapper = renderDateRange({
+        onChange: customOnChange,
+        value: ['2012-12-12', '2012-12-13']
+      }, mount);
+      wrapper.setProps({ value: ['2016-10-10', '2016-11-11'] });
+      wrapper.update();
+      startInput = wrapper.find(BaseDateInput).at(0);
+      endInput = wrapper.find(BaseDateInput).at(1);
+      expect(startInput.props().value).toEqual('2016-10-10');
+      expect(endInput.props().value).toEqual('2016-11-11');
+    });
+
+    it('supports value update dynamically at runtime and defaults to today if new value is undefined', () => {
+      MockDate.set('2020-01-21');
+      wrapper = renderDateRange({
+        onChange: customOnChange,
+        value: ['2012-12-12', '2012-12-13']
+      }, mount);
+      wrapper.setProps({ value: [] });
+      wrapper.update();
+      startInput = wrapper.find(BaseDateInput).at(0);
+      endInput = wrapper.find(BaseDateInput).at(1);
+      expect(startInput.props().value).toEqual('2020-01-21');
+      expect(endInput.props().value).toEqual('2020-01-21');
     });
 
     it('class names can be added to dates by passing startDateProps and endDateProps to DateRange', () => {

--- a/src/__experimental__/components/date/date.component.js
+++ b/src/__experimental__/components/date/date.component.js
@@ -289,7 +289,7 @@ class BaseDateInput extends React.Component {
   updateSelectedDate = (newValue) => {
     const newDate = this.getDateObject(newValue);
 
-    this.setState({ selectedDate: newDate });
+    this.setState({ selectedDate: newDate, visibleValue: DateHelper.formatDateToCurrentLocale(newValue) });
   };
 
   getDateObject = (newValue) => {

--- a/src/__experimental__/components/date/date.spec.js
+++ b/src/__experimental__/components/date/date.spec.js
@@ -566,6 +566,13 @@ describe('Date', () => {
         expect(wrapper.find(BaseDateInput).instance().isControlled).toEqual(true);
         expect(wrapper.find(BaseDateInput).instance().initialVisibleValue).toEqual('27/02/2001');
       });
+
+      it('supports being used as an controlled input allows the value to dynamically updated at runtime', () => {
+        wrapper = render({ value: '2001-02-27' });
+        wrapper.setProps({ value: '2012-12-12' });
+        wrapper.update();
+        expect(wrapper.find(Textbox).props().value).toEqual('12/12/2012');
+      });
     });
   });
 


### PR DESCRIPTION
# Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
The component should support runtime updates of the value when used in controlled manner and display the new value formatted in the both the input and calendar

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Only the selected date value is updated in the calendar/ date picker, the visible value does not update

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
<del>- [ ] Cypress automation tests</del>
<del>- [ ] Storybook added or updated</del>
<del>- [ ] Theme support</del>
<del>- [ ] Typescript `d.ts` file added or updated</del>

### Additional context
<!-- Add any other context or links about the pull request here. -->
Fixes #2604, FE-2514

### Testing instructions
<!-- How can a reviewer test this PR? -->
Test experimental date and date range components in storybook
