### PR TITLE
test(configurable items, confirm, content): add new tests for configurable items, confirm and content Classic files

### DIFF
--- a/cypress/features/regression/configurableItemsClassic.feature
+++ b/cypress/features/regression/configurableItemsClassic.feature
@@ -1,12 +1,10 @@
 Feature: Configurable Items component
   I want to change Configurable Items component
 
-  Background: Open Configurable Items component iframe
-    Given I open "Configurable Items" component iframe
+  Background: Open Configurable Items component page classic
+    Given I open "Configurable Items" component page classic
 
   @positive
-  @ignore
-  @FE-1915
   Scenario Outline: Drag record inside Configurable Items to <destinationId> position
     When I drag Configurable Items "<record>" to <destinationId>
     Then Configurable Items "<record>" is dragged to <destinationId>

--- a/cypress/features/regression/contentClassic.feature
+++ b/cypress/features/regression/contentClassic.feature
@@ -1,8 +1,8 @@
-Feature: Content component
-  I want to change Content component properties
+Feature: Content classic component
+  I want to change Content classic component properties
 
-  Background: Open Content component page
-    Given I open "Content" component page
+  Background: Open Content component page classic
+    Given I open "Content" component page classic
 
   @positive
   Scenario Outline: Change children in Content dialog to <children>

--- a/cypress/locators/configurable-items/index.js
+++ b/cypress/locators/configurable-items/index.js
@@ -1,10 +1,10 @@
 import { COMMON_INPUT_LABEL, ITEMS_WRAPPER } from './locators';
 
 // component preview locators
-export const draggableItemByText = text => cy.get(COMMON_INPUT_LABEL)
+export const draggableItemByText = text => cy.iFrame(COMMON_INPUT_LABEL)
   .contains(text).parent().parent()
-  .find('.icon-drag_vertical');
-export const draggableItemByPosition = position => cy.get(ITEMS_WRAPPER)
+  .find('[data-element="drag_vertical"]');
+export const draggableItemByPosition = position => cy.iFrame(ITEMS_WRAPPER)
   .find(`div:nth-child(${position})`)
   .find('li[data-element="configurable-item-row"] > div[data-element="configurable-item-row-content-wrapper"]')
   .find('label');


### PR DESCRIPTION
### Proposed behaviour
Allow feature files to run in Cypress for configurableItems and content components Classic stories.

### Current behaviour
The configurableItems file currently fails and the content file does not specify the classic story.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del> [ ] Unit tests<del>
- [x] Cypress automation tests
<del> [ ] Storybook added or updated<del>
<del> [ ] Theme support<del>
<del> [ ] Typescript `d.ts` file added or updated<del>

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
Run the feature files in Cypress
Tests run successfully with no errors
