### PR TITLE
feat(Form): add data-element attribute. Fixes FE-2486

### DIFF
--- a/src/__experimental__/components/form/__snapshots__/form.spec.js.snap
+++ b/src/__experimental__/components/form/__snapshots__/form.spec.js.snap
@@ -328,6 +328,7 @@ exports[`Form When child is an html element it renders the child 1`] = `
   </div>
   <div
     className="c1 c2"
+    data-element="sticky-footer"
   >
     <div
       className="c3 c4"

--- a/src/__experimental__/components/form/form.component.js
+++ b/src/__experimental__/components/form/form.component.js
@@ -353,7 +353,10 @@ class FormWithoutValidations extends React.Component {
     }
 
     return (
-      <StyledFormFooter ref={ this.formFooterRef } buttonAlign={ this.props.buttonAlign }>
+      <StyledFormFooter
+        data-element='sticky-footer' ref={ this.formFooterRef }
+        buttonAlign={ this.props.buttonAlign }
+      >
         <StyledResponsiveFooterWrapper
           buttonAlign={ this.props.buttonAlign }
           showSummary={ this.props.showSummary }

--- a/src/__experimental__/components/form/form.spec.js
+++ b/src/__experimental__/components/form/form.spec.js
@@ -41,6 +41,11 @@ describe('Form', () => {
     );
   });
 
+  it('has a data-element attribute that locates the sticky footer', () => {
+    wrapper = shallow(<Form formAction='foo' />);
+    expect(wrapper.find('[data-element="sticky-footer"]').exists()).toBeTruthy();
+  });
+
   describe('componentWillReceiveProps', () => {
     describe('the StyledFormFooter attribute check', () => {
       it('checks that the correct data-element exist', () => {

--- a/src/__experimental__/components/form/form.spec.js
+++ b/src/__experimental__/components/form/form.spec.js
@@ -42,6 +42,13 @@ describe('Form', () => {
   });
 
   describe('componentWillReceiveProps', () => {
+    describe('the StyledFormFooter attribute check', () => {
+      it('checks that the correct data-element exist', () => {
+        wrapper = shallow(<Form formAction='foo' />);
+        expect(wrapper.find('[data-element="sticky-footer"]').exists()).toBeTruthy();
+      });
+    });
+
     describe('when stickyFooter is enabled', () => {
       it('adds the listeners', () => {
         wrapper = shallow(<Form formAction='foo' />);


### PR DESCRIPTION
### Proposed behaviour
`data-element` has been added to `StyledFormFooter`, part of the `Form` component. This is to allow the user to access the element within Selenium, then scroll the page by the hight of the sticky footer.

### Current behaviour
The sticky footer can obscure other controls rendered on the form which then prevents Selenium from selecting them.

### Checklist
- [ ] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [ ] Unit tests
<del>- [ ] Cypress automation tests
<del>- [ ] Storybook added or updated
<del>- [ ] Theme support
<del>- [ ] Typescript `d.ts` file added or updated

### Related Issues / Pull Requests
FE-2486

### Testing instructions
You can see the attribute `data-element="sticky-footer"` in the DOM when running the `Form` stories in storybook.
