### PR TITLE
test(sidebar, showeditpod): add missing tests

### DIFF
--- a/cypress/features/regression/showEditPod.feature
+++ b/cypress/features/regression/showEditPod.feature
@@ -10,6 +10,11 @@ Feature: Show Edit Pod component
     Then Show Edit Pod component has proper content inside itself
 
   @positive
+  Scenario: Verify color of the edit icon
+    # When I open "ShowEditPod" component page
+    Then Edit icon has color "rgb(0, 128, 93)"
+
+  @positive
   Scenario Outline: Set Show Edit Pod as to <as>
     When I select as to "<as>"
     Then Show Edit Pod as value is set to "<as>"
@@ -28,8 +33,8 @@ Feature: Show Edit Pod component
 
   @positive
   Scenario: Enable and disable border checkbox for a Show Edit Pod component
-    When I check border checkbox
-      And I uncheck border checkbox
+    Given I check border checkbox
+    When I uncheck border checkbox
     Then Show Edit Pod component has no border property
 
   @positive
@@ -40,8 +45,8 @@ Feature: Show Edit Pod component
 
   @positive
   Scenario: Enable and disable border on a edit dialog view for a Show Edit Pod component
-    When I check border checkbox
-      And I uncheck border checkbox
+    Given I check border checkbox
+    When I uncheck border checkbox
       And I click edit Show Edit Pod component
     Then Show Edit Pod component has no border property
 
@@ -74,12 +79,12 @@ Feature: Show Edit Pod component
   Scenario: Enable cancel checkbox for a Show Edit Pod component
     When I check cancel checkbox
       And I click edit Show Edit Pod component
-    Then Show Edit Pod component has a cancel button
+    Then Show Edit Pod component cancel button has color "rgb(0, 128, 93)" and borderColor "rgb(0, 128, 93)"
 
   @positive
   Scenario: Enable and disable cancel checkbox for a Show Edit Pod component
-    When I check cancel checkbox
-      And I uncheck cancel checkbox
+    Given I check cancel checkbox
+    When I uncheck cancel checkbox
       And I click edit Show Edit Pod component
     Then Show Edit Pod component hasn't a cancel button
 
@@ -121,8 +126,8 @@ Feature: Show Edit Pod component
 
   @positive
   Scenario: Enable and disable saving checkbox for a Show Edit Pod component
-    When I check saving checkbox
-      And I uncheck saving checkbox
+    Given I check saving checkbox
+    When I uncheck saving checkbox
       And I click edit Show Edit Pod component
     Then Show Edit Pod component has no saving property
 

--- a/cypress/features/regression/showEditPod.feature
+++ b/cypress/features/regression/showEditPod.feature
@@ -1,0 +1,161 @@
+Feature: Show Edit Pod component
+  I want to test Show Edit Pod component properties
+
+  Background: Open ShowEditPod component page
+    Given I open "ShowEditPod" component page
+
+  @positive
+  Scenario: Verify the inner content of the component
+    # When I open "ShowEditPod" component page
+    Then Show Edit Pod component has proper content inside itself
+
+  @positive
+  Scenario Outline: Set Show Edit Pod as to <as>
+    When I select as to "<as>"
+    Then Show Edit Pod as value is set to "<as>"
+    Examples:
+      | as          |
+      | primary     |
+      | secondary   |
+      | tertiary    |
+      | tile        |
+      | transparent |
+
+  @positive
+  Scenario: Enable border checkbox for a Show Edit Pod component
+    When I check border checkbox
+    Then Show Edit Pod component has border property
+
+  @positive
+  Scenario: Enable and disable border checkbox for a Show Edit Pod component
+    When I check border checkbox
+      And I uncheck border checkbox
+    Then Show Edit Pod component has no border property
+
+  @positive
+  Scenario: Enable border on a edit dialog view for a Show Edit Pod component
+    When I check border checkbox
+      And I click edit Show Edit Pod component
+    Then Show Edit Pod component has border property
+
+  @positive
+  Scenario: Enable and disable border on a edit dialog view for a Show Edit Pod component
+    When I check border checkbox
+      And I uncheck border checkbox
+      And I click edit Show Edit Pod component
+    Then Show Edit Pod component has no border property
+
+  @positive
+  Scenario Outline: Set Show Edit Pod buttonAlign to <position>
+    When I select buttonAlign to "<position>"
+      And I click edit Show Edit Pod component
+    Then Show Edit Pod buttons are aligned to "<position>"
+    Examples:
+      | position |
+      | left     |
+      | right    |
+
+  @positive
+  Scenario Outline: Change Show Edit Pod cancelText to <cancelText>
+    When I set cancelText to "<cancelText>"
+      And I click edit Show Edit Pod component
+    Then Show Edit Pod cancelText on preview is set to "<cancelText>"
+    Examples:
+      | cancelText              |
+      | Sample text             |
+      | 1234567890              |
+      | áéíóú¿¡üñ               |
+      | !@#$%^*()_+-=~[];:.,?{} |
+      | ÄÖÜßäöüß                |
+  # @ignore because of FE-1447
+  # | <>                       |
+
+  @positive
+  Scenario: Enable cancel checkbox for a Show Edit Pod component
+    When I check cancel checkbox
+      And I click edit Show Edit Pod component
+    Then Show Edit Pod component has a cancel button
+
+  @positive
+  Scenario: Enable and disable cancel checkbox for a Show Edit Pod component
+    When I check cancel checkbox
+      And I uncheck cancel checkbox
+      And I click edit Show Edit Pod component
+    Then Show Edit Pod component hasn't a cancel button
+
+  @positive
+  Scenario Outline: Change Show Edit Pod deleteText to <deleteText>
+    When I set deleteText to "<deleteText>"
+      And I click edit Show Edit Pod component
+    Then Show Edit Pod deleteText on preview is set to "<deleteText>"
+    Examples:
+      | deleteText              |
+      | Sample text             |
+      | 1234567890              |
+      | áéíóú¿¡üñ               |
+      | !@#$%^*()_+-=~[];:.,?{} |
+      | ÄÖÜßäöüß                |
+  # @ignore because of FE-1447
+  # | <>                       |
+
+  @positive
+  Scenario Outline: Change Show Edit Pod saveText to <saveText>
+    When I set saveText to "<saveText>"
+      And I click edit Show Edit Pod component
+    Then Show Edit Pod saveText on preview is set to "<saveText>"
+    Examples:
+      | saveText                |
+      | Sample text             |
+      | 1234567890              |
+      | áéíóú¿¡üñ               |
+      | !@#$%^*()_+-=~[];:.,?{} |
+      | ÄÖÜßäöüß                |
+  # @ignore because of FE-1447
+  # | <>                       |
+
+  @positive
+  Scenario: Enable saving checkbox for a Show Edit Pod component
+    When I check saving checkbox
+      And I click edit Show Edit Pod component
+    Then Show Edit Pod component has saving property
+
+  @positive
+  Scenario: Enable and disable saving checkbox for a Show Edit Pod component
+    When I check saving checkbox
+      And I uncheck saving checkbox
+      And I click edit Show Edit Pod component
+    Then Show Edit Pod component has no saving property
+
+  @positive
+  Scenario Outline: Change Show Edit Pod title to <title>
+    When I set title to "<title>"
+    Then Show Edit Pod title on preview is set to "<title>"
+    Examples:
+      | title                   |
+      | Sample text             |
+      | 1234567890              |
+      | áéíóú¿¡üñ               |
+      | !@#$%^*()_+-=~[];:.,?{} |
+      | ÄÖÜßäöüß                |
+  # @ignore because of FE-1447
+  # | <>                       |
+
+  @positive
+  Scenario: Edit action was called
+    Given clear all actions in Actions Tab
+    When I click edit Show Edit Pod component
+    Then edit action was called in Actions Tab
+
+  @ignore
+  Scenario: Delete action was called
+    Given I click edit Show Edit Pod component
+    When clear all actions in Actions Tab
+      And I click delete button
+    Then delete action was called in Actions Tab
+
+  @positive
+  Scenario: Cancel action was called
+    Given I click edit Show Edit Pod component
+    When clear all actions in Actions Tab
+      And I click cancel button
+    Then cancel action was called in Actions Tab

--- a/cypress/features/regression/showEditPodClassic.feature
+++ b/cypress/features/regression/showEditPodClassic.feature
@@ -10,10 +10,13 @@ Feature: Show Edit Pod classic component
     Then Edit icon has color "rgb(37, 91, 199)"
 
   @positive
-  Scenario: Enable cancel checkbox for a Show Edit Pod classic component
+  Scenario Outline: Enable cancel checkbox for a Show Edit Pod classic component
     When I check cancel checkbox
       And I click edit Show Edit Pod component
-    Then Show Edit Pod component cancel button has color "rgb(37, 91, 199)" and borderColor "rgb(37, 91, 199)"
+    Then Show Edit Pod component cancel button has color "<color>" and borderColor "<color>"
+    Examples:
+      | color            |
+      | rgb(37, 91, 199) |
 
   @positive
   Scenario: Enable saving checkbox for a Show Edit Pod classic component

--- a/cypress/features/regression/showEditPodClassic.feature
+++ b/cypress/features/regression/showEditPodClassic.feature
@@ -1,155 +1,17 @@
-Feature: Show Edit Pod component
-  I want to test Show Edit Pod component
+Feature: Show Edit Pod classic component
+  I want to test Show Edit Pod classic component
 
   Background: Open ShowEditPod component page classic
     Given I open "ShowEditPod" component page classic
 
   @positive
-  Scenario: Verify the inner content of the component
-    # When I open "ShowEditPod" component page
-    Then Show Edit Pod component has proper content inside itself
-
-  @positive
-  Scenario Outline: Change Show Edit Pod cancelText to <cancelText>
-    When I set cancelText to "<cancelText>"
-      And I edit Show Edit Pod component
-    Then Show Edit Pod cancelText on preview is set to "<cancelText>"
-    Examples:
-      | cancelText              |
-      | Sample text             |
-      | 1234567890              |
-      | áéíóú¿¡üñ               |
-      | !@#$%^*()_+-=~[];:.,?{} |
-      | ÄÖÜßäöüß                |
-  # @ignore because of FE-1447
-  # | <>                       |
-
-  @positive
-  Scenario Outline: Change Show Edit Pod deleteText to <deleteText>
-    When I set deleteText to "<deleteText>"
-      And I edit Show Edit Pod component
-    Then Show Edit Pod deleteText on preview is set to "<deleteText>"
-    Examples:
-      | deleteText              |
-      | Sample text             |
-      | 1234567890              |
-      | áéíóú¿¡üñ               |
-      | !@#$%^*()_+-=~[];:.,?{} |
-      | ÄÖÜßäöüß                |
-  # @ignore because of FE-1447
-  # | <>                       |
-
-  @positive
-  Scenario Outline: Change Show Edit Pod saveText to <saveText>
-    When I set saveText to "<saveText>"
-      And I edit Show Edit Pod component
-    Then Show Edit Pod saveText on preview is set to "<saveText>"
-    Examples:
-      | saveText                |
-      | Sample text             |
-      | 1234567890              |
-      | áéíóú¿¡üñ               |
-      | !@#$%^*()_+-=~[];:.,?{} |
-      | ÄÖÜßäöüß                |
-  # @ignore because of FE-1447
-  # | <>                       |
-
-  @positive
-  Scenario Outline: Change Show Edit Pod title to <title>
-    When I set title to "<title>"
-    Then Show Edit Pod title on preview is set to "<title>"
-    Examples:
-      | title                   |
-      | Sample text             |
-      | 1234567890              |
-      | áéíóú¿¡üñ               |
-      | !@#$%^*()_+-=~[];:.,?{} |
-      | ÄÖÜßäöüß                |
-  # @ignore because of FE-1447
-  # | <>                       |
-
-  @positive
-  Scenario: Enable border checkbox for a Show Edit Pod component
-    When I check border checkbox
-    Then Show Edit Pod component has border property
-
-  @positive
-  Scenario: Enable and disable border checkbox for a Show Edit Pod component
-    When I check border checkbox
-      And I uncheck border checkbox
-    Then Show Edit Pod component has no border property
-
-  @positive
-  Scenario: Enable border checkbox on a secondary block for a Show Edit Pod component
-    When I check border checkbox
-      And I edit Show Edit Pod component
-    Then Show Edit Pod component has border property
-
-  @positive
-  Scenario: Enable and disable border checkbox on a secondary block for a Show Edit Pod component
-    When I check border checkbox
-      And I uncheck border checkbox
-      And I edit Show Edit Pod component
-    Then Show Edit Pod component has no border property
-
-  @positive
-  Scenario: Enable cancel checkbox for a Show Edit Pod component
+  Scenario: Enable cancel checkbox for a Show Edit Pod classic component
     When I check cancel checkbox
-      And I edit Show Edit Pod component
-    Then Show Edit Pod component has a cancel button
+      And I click edit Show Edit Pod component
+    Then Show Edit Pod classic component has a cancel button
 
   @positive
-  Scenario: Enable and disable cancel checkbox for a Show Edit Pod component
-    When I check cancel checkbox
-      And I uncheck cancel checkbox
-      And I edit Show Edit Pod component
-    Then Show Edit Pod component hasn't a cancel button
-
-  @positive
-  Scenario: Enable saving checkbox for a Show Edit Pod component
+  Scenario: Enable saving checkbox for a Show Edit Pod classic component
     When I check saving checkbox
-      And I edit Show Edit Pod component
-    Then Show Edit Pod component has saving property
-
-  @positive
-  Scenario: Enable and disable saving checkbox for a Show Edit Pod component
-    When I check saving checkbox
-      And I uncheck saving checkbox
-      And I edit Show Edit Pod component
-    Then Show Edit Pod component has no saving property
-
-  @positive
-  Scenario Outline: Set Show Edit Pod as to <as>
-    When I select as to "<as>"
-    Then Show Edit Pod as value is set to "<as>"
-    Examples:
-      | as          |
-      | primary     |
-      | secondary   |
-      | tertiary    |
-      | tile        |
-      | transparent |
-
-  @positive
-  Scenario Outline: Set Show Edit Pod buttonAlign to <position>
-    When I select buttonAlign to "<position>"
-      And I edit Show Edit Pod component
-    Then Show Edit Pod buttons are aligned to "<position>"
-    Examples:
-      | position |
-      | left     |
-      | right    |
-
-  @ignore
-  Scenario: Delete action was called
-    When I edit Show Edit Pod component
-      And clear all actions in Actions Tab
-      And I click delete button
-    Then delete action was called in Actions Tab
-
-  @positive
-  Scenario: Cancel action was called
-    When I edit Show Edit Pod component
-      And clear all actions in Actions Tab
-      And I click cancel button
-    Then cancel action was called in Actions Tab
+      And I click edit Show Edit Pod component
+    Then Show Edit Pod classic component has saving property

--- a/cypress/features/regression/showEditPodClassic.feature
+++ b/cypress/features/regression/showEditPodClassic.feature
@@ -5,10 +5,15 @@ Feature: Show Edit Pod classic component
     Given I open "ShowEditPod" component page classic
 
   @positive
+  Scenario: Verify color of the edit icon
+    # When I open "ShowEditPod" component page classic
+    Then Edit icon has color "rgb(37, 91, 199)"
+
+  @positive
   Scenario: Enable cancel checkbox for a Show Edit Pod classic component
     When I check cancel checkbox
       And I click edit Show Edit Pod component
-    Then Show Edit Pod classic component has a cancel button
+    Then Show Edit Pod component cancel button has color "rgb(37, 91, 199)" and borderColor "rgb(37, 91, 199)"
 
   @positive
   Scenario: Enable saving checkbox for a Show Edit Pod classic component

--- a/cypress/features/regression/sidebarWithButton.feature
+++ b/cypress/features/regression/sidebarWithButton.feature
@@ -1,0 +1,17 @@
+Feature: Sidebar With Button component
+  I want to check Sidebar With Button component properties
+
+  Background: Open Sidebar With Button component page
+    Given I open "Sidebar" component page with button
+      And I open component preview
+
+  @positive
+  Scenario: Open Sidebar With Button
+    # When I open component preview
+    Then Sidebar component is visible
+
+  @positive
+  Scenario: Close Sidebar With Button by closeIcon
+    # Given I open component preview
+    When I close Sidebar
+    Then Sidebar component is not visible

--- a/cypress/locators/show-edit-pod/locators.js
+++ b/cypress/locators/show-edit-pod/locators.js
@@ -1,5 +1,5 @@
 // component preview locators
-export const SHOW_EDIT_POD_PREVIEW = 'div[data-component="pod"]';
+export const SHOW_EDIT_POD_PREVIEW = '[data-component="pod"]';
 export const SHOW_EDIT_POD_TITLE = 'h4[data-element=title]';
 export const SHOW_EDIT_POD_COLLAPSIBLE_CONTENT = 'div[class="carbon-pod__collapsible-content"] > div > div > div';
 export const SHOW_EDIT_SAVE_BUTTON = 'button[data-element="save"]';
@@ -8,4 +8,4 @@ export const SHOW_EDIT_DELETE_BUTTON = '.carbon-link__content';
 export const SHOW_EDIT_POD_EDIT = '[data-element="edit"]';
 export const SHOW_EDIT_POD_SECONDARY_BLOCK = 'div[class="carbon-pod__block--secondary"]';
 export const SHOW_EDIT_POD_SECONDARY_WRAPPER = 'div[data-component="app-wrapper"]';
-export const SHOW_EDIT_POD_FOOTER = 'div[data-element="form-footer"]';
+export const SHOW_EDIT_POD_FOOTER = '[data-element="form-footer"]';

--- a/cypress/locators/sidebar/locators.js
+++ b/cypress/locators/sidebar/locators.js
@@ -1,3 +1,3 @@
 // component preview locators
 // export const SIDEBAR_PREVIEW = 'body > div.carbon-portal > div > div:nth-child(2) > div';
-export const SIDEBAR_PREVIEW = 'div[data-element="sidebar"]';
+export const SIDEBAR_PREVIEW = '[data-element="sidebar"]';

--- a/cypress/support/step-definitions/show-edit-pod-steps.js
+++ b/cypress/support/step-definitions/show-edit-pod-steps.js
@@ -30,7 +30,7 @@ Then('Show Edit Pod title on preview is set to {string}', (text) => {
   showEditPodTitle().should('have.text', text);
 });
 
-When('I edit Show Edit Pod component', () => {
+When('I click edit Show Edit Pod component', () => {
   showEditPodEdit().first().click();
 });
 
@@ -60,7 +60,7 @@ Then('Show Edit Pod component on a secondary block has no border property', () =
     .should('have.css', 'border', '0px none rgba(0, 0, 0, 0.85)');
 });
 
-Then('Show Edit Pod component has a cancel button', () => {
+Then('Show Edit Pod classic component has a cancel button', () => {
   showEditPodCancelButton()
     .should('be.visible')
     .and('have.css', 'background', 'rgba(0, 0, 0, 0) none repeat scroll 0% 0% / auto padding-box border-box')
@@ -68,11 +68,19 @@ Then('Show Edit Pod component has a cancel button', () => {
     .and('have.css', 'color', 'rgb(37, 91, 199)');
 });
 
+Then('Show Edit Pod component has a cancel button', () => {
+  showEditPodCancelButton()
+    .should('be.visible')
+    .and('have.css', 'background', 'rgba(0, 0, 0, 0) none repeat scroll 0% 0% / auto padding-box border-box')
+    .and('have.css', 'border-color', 'rgb(0, 128, 93)')
+    .and('have.css', 'color', 'rgb(0, 128, 93)');
+});
+
 Then('Show Edit Pod component hasn\'t a cancel button', () => {
   showEditPodCancelButton().should('not.exist');
 });
 
-Then('Show Edit Pod component has saving property', () => {
+Then('Show Edit Pod classic component has saving property', () => {
   showEditPodSaveButton()
     .should('be.disabled');
   showEditPodSaveButton()
@@ -81,6 +89,17 @@ Then('Show Edit Pod component has saving property', () => {
     .should('have.css', 'background', 'rgb(230, 235, 237) none repeat scroll 0% 0% / auto padding-box border-box')
     .and('have.css', 'border', '1px solid rgba(0, 0, 0, 0)')
     .and('have.css', 'color', 'rgba(0, 0, 0, 0.2)');
+});
+
+Then('Show Edit Pod component has saving property', () => {
+  showEditPodSaveButton()
+    .should('be.disabled');
+  showEditPodSaveButton()
+    .should('have.attr', 'disabled');
+  showEditPodSaveButton()
+    .should('have.css', 'background', 'rgb(229, 234, 236) none repeat scroll 0% 0% / auto padding-box border-box')
+    .and('have.css', 'border', '2px solid rgba(0, 0, 0, 0)')
+    .and('have.css', 'color', 'rgba(0, 0, 0, 0.3)');
 });
 
 Then('Show Edit Pod component has no saving property', () => {

--- a/cypress/support/step-definitions/show-edit-pod-steps.js
+++ b/cypress/support/step-definitions/show-edit-pod-steps.js
@@ -3,7 +3,6 @@ import {
   showEditPodTitle, showEditPodPreview, showEditPodSecondaryBlock,
   showEditPodCollapsibleInnerContent, showEditPodFooter,
 } from '../../locators/show-edit-pod';
-
 import { icon } from '../../locators';
 
 const SHOW_EDIT_POD_BLOCK_CONTENT = 'carbon-pod__block--';
@@ -14,7 +13,6 @@ const SECOND_DIV = 2;
 const THIRD_DIV = 3;
 const INNER_CONTENT_TITLE = 'title';
 const INNER_CONTENT_BODY = 'body';
-
 
 Then('Show Edit Pod saveText on preview is set to {string}', (text) => {
   showEditPodSaveButton().should('have.text', text);
@@ -57,13 +55,11 @@ Then('Show Edit Pod component has no border property', () => {
 });
 
 Then('Show Edit Pod component on a secondary block has border property', () => {
-  showEditPodSecondaryBlock()
-    .should('have.css', 'border', '1px solid rgb(204, 214, 219)');
+  showEditPodSecondaryBlock().should('have.css', 'border', '1px solid rgb(204, 214, 219)');
 });
 
 Then('Show Edit Pod component on a secondary block has no border property', () => {
-  showEditPodSecondaryBlock()
-    .should('have.css', 'border', '0px none rgba(0, 0, 0, 0.85)');
+  showEditPodSecondaryBlock().should('have.css', 'border', '0px none rgba(0, 0, 0, 0.85)');
 });
 
 Then('Show Edit Pod component cancel button has color {string} and borderColor {string}', (color, borderColor) => {
@@ -79,10 +75,8 @@ Then('Show Edit Pod component hasn\'t a cancel button', () => {
 });
 
 Then('Show Edit Pod classic component has saving property', () => {
-  showEditPodSaveButton()
-    .should('be.disabled');
-  showEditPodSaveButton()
-    .should('have.attr', 'disabled');
+  showEditPodSaveButton().should('be.disabled');
+  showEditPodSaveButton().should('have.attr', 'disabled');
   showEditPodSaveButton()
     .should('have.css', 'background', 'rgb(230, 235, 237) none repeat scroll 0% 0% / auto padding-box border-box')
     .and('have.css', 'border', '1px solid rgba(0, 0, 0, 0)')
@@ -90,10 +84,8 @@ Then('Show Edit Pod classic component has saving property', () => {
 });
 
 Then('Show Edit Pod component has saving property', () => {
-  showEditPodSaveButton()
-    .should('be.disabled');
-  showEditPodSaveButton()
-    .should('have.attr', 'disabled');
+  showEditPodSaveButton().should('be.disabled');
+  showEditPodSaveButton().should('have.attr', 'disabled');
   showEditPodSaveButton()
     .should('have.css', 'background', 'rgb(229, 234, 236) none repeat scroll 0% 0% / auto padding-box border-box')
     .and('have.css', 'border', '2px solid rgba(0, 0, 0, 0)')
@@ -101,8 +93,7 @@ Then('Show Edit Pod component has saving property', () => {
 });
 
 Then('Show Edit Pod component has no saving property', () => {
-  showEditPodSaveButton()
-    .should('not.have.attr', 'disabled');
+  showEditPodSaveButton().should('not.have.attr', 'disabled');
 });
 
 Then('Show Edit Pod as value is set to {string}', (property) => {

--- a/cypress/support/step-definitions/show-edit-pod-steps.js
+++ b/cypress/support/step-definitions/show-edit-pod-steps.js
@@ -4,6 +4,8 @@ import {
   showEditPodCollapsibleInnerContent, showEditPodFooter,
 } from '../../locators/show-edit-pod';
 
+import { icon } from '../../locators';
+
 const SHOW_EDIT_POD_BLOCK_CONTENT = 'carbon-pod__block--';
 const SHOW_EDIT_POD_CONTENT = 'carbon-pod__content--';
 const SHOW_EDIT_POD_NO_BORDER_CONTENT = 'carbon-pod--no-border';
@@ -34,6 +36,10 @@ When('I click edit Show Edit Pod component', () => {
   showEditPodEdit().first().click();
 });
 
+When('Edit icon has color {string}', (color) => {
+  icon().should('have.css', 'color', color);
+});
+
 Then('Show Edit Pod component has border property', () => {
   showEditPodPreview()
     .should('not.have.class', `${SHOW_EDIT_POD_BLOCK_CONTENT}no-border`)
@@ -60,20 +66,12 @@ Then('Show Edit Pod component on a secondary block has no border property', () =
     .should('have.css', 'border', '0px none rgba(0, 0, 0, 0.85)');
 });
 
-Then('Show Edit Pod classic component has a cancel button', () => {
+Then('Show Edit Pod component cancel button has color {string} and borderColor {string}', (color, borderColor) => {
   showEditPodCancelButton()
     .should('be.visible')
     .and('have.css', 'background', 'rgba(0, 0, 0, 0) none repeat scroll 0% 0% / auto padding-box border-box')
-    .and('have.css', 'border-color', 'rgb(37, 91, 199)')
-    .and('have.css', 'color', 'rgb(37, 91, 199)');
-});
-
-Then('Show Edit Pod component has a cancel button', () => {
-  showEditPodCancelButton()
-    .should('be.visible')
-    .and('have.css', 'background', 'rgba(0, 0, 0, 0) none repeat scroll 0% 0% / auto padding-box border-box')
-    .and('have.css', 'border-color', 'rgb(0, 128, 93)')
-    .and('have.css', 'color', 'rgb(0, 128, 93)');
+    .and('have.css', 'border-color', borderColor)
+    .and('have.css', 'color', color);
 });
 
 Then('Show Edit Pod component hasn\'t a cancel button', () => {


### PR DESCRIPTION
Add missing tests for Sidebar With Button and Show Edit Pod default. Refactor Show Edit Pod Classic

FE-2357

### Proposed behaviour
Add missing features for Sidebar With Button, Show Edit Pod default.
Refactor Show Edit Pod classic

### Current behaviour
Missing Sidebar With Button component and Show Edit Pod default component

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ --></del>
<del> - [ ] Unit tests </del>
- [x] Cypress automation tests

<del> - [ ] Storybook added or updated </del>
<del> - [ ] Theme support </del>
<del> - [ ] Typescript `d.ts` file added or updated </del>

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->

run: `./node_modules/.bin/cypress run --spec './cypress/features/regression/showEditPod*.feature', './cypress/features/regression/sidebar*.feature' --reporter spec`
