### PR TITLE
feat(textbox): add icon onclick prop to textbox

### DIFF
--- a/cypress/features/regression/experimental/textbox.feature
+++ b/cypress/features/regression/experimental/textbox.feature
@@ -160,3 +160,22 @@ Feature: Experimental Textbox component
       | small  | 28px   | 1043px |
       | medium | 36px   | 1037px |
       | large  | 44px   | 1033px |
+
+  @positive
+  Scenario: Check icon inside of Textbox is visible
+    When I select inputIcon to "add"
+    Then icon on preview is "add" and is visible
+
+  @positive
+  Scenario: Check iconOnClick event
+    Given I select inputIcon to "add"
+      And clear all actions in Actions Tab
+    When I click on icon inside of Textbox
+    Then iconOnClick action was called in Actions Tab
+
+  @positive
+  Scenario: Check onClick event
+    Given clear all actions in Actions Tab
+    When I click on Textbox
+    Then onClick action was called in Actions Tab
+      And Textbox input has golden border on focus

--- a/cypress/locators/textbox/index.js
+++ b/cypress/locators/textbox/index.js
@@ -4,3 +4,5 @@ import { TEXTBOX, TEXTBOX_DATA_COMPONENT } from './locators';
 export const textbox = () => cy.iFrame(TEXTBOX);
 export const textboxByPosition = position => cy.iFrame(TEXTBOX).eq(position);
 export const textboxDataComponent = () => cy.iFrame(TEXTBOX_DATA_COMPONENT);
+export const textboxIcon = () => cy.iFrame(TEXTBOX).find('span').eq(0).children();
+export const textboxInput = () => cy.iFrame(TEXTBOX).children();

--- a/cypress/support/step-definitions/textbox-steps.js
+++ b/cypress/support/step-definitions/textbox-steps.js
@@ -1,4 +1,6 @@
-import { textbox, textboxByPosition, textboxDataComponent } from '../../locators/textbox';
+import {
+  textbox, textboxByPosition, textboxDataComponent, textboxIcon, textboxInput,
+} from '../../locators/textbox';
 import {
   label, labelByPosition, commonDataElementInputPreview, commonInputPreview,
   fieldHelpPreviewByPosition, tooltipPreviewByPosition,
@@ -228,4 +230,21 @@ Then('Multiple Textbox width is {string}', (width) => {
 Then('Multiple label Align on preview is {string}', (direction) => {
   labelByPosition(FIRST_ELEMENT).should($element => expect($element).to.have.css(TEXT_ALIGN, `${direction}`));
   labelByPosition(SECOND_ELEMENT).should($element => expect($element).to.have.css(TEXT_ALIGN, `${direction}`));
+});
+
+Then('I click on icon inside of Textbox', () => {
+  textboxIcon().click();
+});
+
+Then('icon on preview is {string} and is visible', (iconName) => {
+  textboxIcon().should('have.attr', 'data-element', iconName)
+    .and('be.visible');
+});
+
+When('I click on Textbox', () => {
+  textboxInput().click();
+});
+
+Then('Textbox input has golden border on focus', () => {
+  textbox().should('have.css', 'outline', 'rgb(255, 181, 0) solid 3px');
 });

--- a/src/__experimental__/components/textbox/docgenInfo.json
+++ b/src/__experimental__/components/textbox/docgenInfo.json
@@ -25,7 +25,14 @@
             ]
           },
           "required": false,
-          "description": "The formatted value of the field"
+          "description": "The value of the Textbox"
+        },
+        "rawValue": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "The unformatted value"
         },
         "disabled": {
           "type": {
@@ -131,14 +138,14 @@
             "name": "string"
           },
           "required": false,
-          "description": "Icon associated with this component"
+          "description": "Icon to display inside of the Textbox"
         },
         "leftChildren": {
           "type": {
             "name": "node"
           },
           "required": false,
-          "description": "Adds additional child elements before the input"
+          "description": "Additional child elements to display before the input"
         },
         "validations": {
           "type": {
@@ -218,8 +225,34 @@
           },
           "required": false,
           "description": "Placeholder string to be displayed in input"
+        },
+        "iconOnClick": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "Optional handler for click event on Textbox icon"
+        },
+        "onClick": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "Handler for onClick events"
         }
       }
+    }
+  ],
+  "src/__experimental__/components/textbox/textbox.stories.js": [
+    {
+      "description": "",
+      "displayName": "defaultTextbox",
+      "methods": []
+    },
+    {
+      "description": "",
+      "displayName": "autoFocusTextbox",
+      "methods": []
     }
   ]
 }

--- a/src/__experimental__/components/textbox/textbox.component.js
+++ b/src/__experimental__/components/textbox/textbox.component.js
@@ -19,6 +19,7 @@ const Textbox = ({
   value,
   childOfForm,
   isOptional,
+  iconOnClick,
   ...props
 }) => {
   return (
@@ -37,7 +38,13 @@ const Textbox = ({
           value={ visibleValue(value, formattedValue) }
         />
         { children }
-        { inputIcon && <InputIconToggle { ...removeParentProps(props) } inputIcon={ inputIcon } /> }
+        { inputIcon && (
+          <InputIconToggle
+            { ...removeParentProps(props) }
+            onClick={ iconOnClick || props.onClick }
+            inputIcon={ inputIcon }
+          />
+        ) }
       </InputPresentation>
     </FormField>
   );
@@ -117,7 +124,11 @@ Textbox.propTypes = {
   /** Size of an input */
   size: PropTypes.oneOf(OptionsHelper.sizesRestricted),
   /** Placeholder string to be displayed in input */
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
+  /** Optional handler for click event on Textbox icon */
+  iconOnClick: PropTypes.func,
+  /** Handler for onClick events */
+  onClick: PropTypes.func
 };
 
 Textbox.defaultProps = {

--- a/src/__experimental__/components/textbox/textbox.spec.js
+++ b/src/__experimental__/components/textbox/textbox.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Textbox from '.';
+import InputIconToggle from '../input-icon-toggle';
 
 jest.mock('../../../utils/helpers/guid', () => () => 'mocked-guid');
 
@@ -12,5 +13,25 @@ describe('Textbox', () => {
       </Textbox>
     ).dive().dive().dive();
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('supports a separate onClick handler passing for the icon', () => {
+    const onClick = jest.fn();
+    const iconOnClick = jest.fn();
+
+    const wrapper = mount(
+      <Textbox
+        value='foobar'
+        inputIcon='search'
+        onClick={ onClick }
+        iconOnClick={ iconOnClick }
+      >
+        normal children
+      </Textbox>
+    );
+    const icon = wrapper.find(InputIconToggle);
+    icon.simulate('click');
+    expect(iconOnClick).toHaveBeenCalled();
+    expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/src/__experimental__/components/textbox/textbox.stories.js
+++ b/src/__experimental__/components/textbox/textbox.stories.js
@@ -7,6 +7,7 @@ import {
   number
 } from '@storybook/addon-knobs';
 import { Store, State } from '@sambego/storybook-state';
+import { action } from '@storybook/addon-actions';
 import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/theme-selectors';
 import { notes, info, infoValidations } from './documentation';
 import Textbox, { OriginalTextbox } from '.';
@@ -157,6 +158,9 @@ export function getCommonTextboxProps(config = defaultStoryPropsConfig) {
   const labelAlign = labelInline ? select('labelAlign', OptionsHelper.alignBinary) : undefined;
   const size = select('size', OptionsHelper.sizesRestricted, 'medium');
   const key = AutoFocus.getKey(autoFocus, previous);
+  const onClick = action('onClick');
+  const iconOnClick = action('iconOnClick');
+  const inputIcon = select('inputIcon', ['', ...OptionsHelper.icons]);
 
   return {
     key,
@@ -170,7 +174,10 @@ export function getCommonTextboxProps(config = defaultStoryPropsConfig) {
     labelInline,
     labelWidth,
     labelAlign,
-    size
+    size,
+    onClick,
+    iconOnClick,
+    inputIcon
   };
 }
 


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
A new iconOnClick prop has been added to allow for onClick events on the Icon to be handled separately from the onClick on the input.

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Currently Textbox only supports a single onClick handler, which is consumed by the Input and Icon. 

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests 
<del>- [ ] Storybook added or updated </del>
<del>- [ ] Theme support </del>
<del>- [ ] Typescript `d.ts` file added or updated </del>

### Additional context
<!-- Add any other context or links about the pull request here. -->
This work is needed to unblock development of new search component

### Testing instructions
<!-- How can a reviewer test this PR? -->
Test that current behaviour of select component on master branch still remains.
