### PR TITLE
test(configurable items, draggable context, confirm): fix and add new tests

### DIFF
--- a/cypress/features/regression/configurableItems.feature
+++ b/cypress/features/regression/configurableItems.feature
@@ -5,9 +5,7 @@ Feature: Configurable Items component
     Given I open "Configurable Items" component in iframe
 
   @positive
-  @ignore
-  @FE-1915
-  Scenario Outline: Drag record inside Configurable Items to <destinationId> position
+  Scenario Outline: Drag record inside Configurable Items element <record> to <destinationId> element position
     When I drag Configurable Items "<record>" to <destinationId>
     Then Configurable Items "<record>" is dragged to <destinationId>
     Examples:

--- a/cypress/features/regression/configurableItemsEvents.feature
+++ b/cypress/features/regression/configurableItemsEvents.feature
@@ -1,0 +1,11 @@
+Feature: Configurable Items component
+  I want to change Configurable Items component events
+
+  Background: Open Configurable Items component page
+    Given I open "Configurable Items" component page
+      And clear all actions in Actions Tab
+
+  @positive
+  Scenario: Verify the drag function for Configurable Items component
+    When I drag Configurable Items with iFrame "test 1" to 3
+    Then dragged action was called in Actions Tab

--- a/cypress/features/regression/confirm.feature
+++ b/cypress/features/regression/confirm.feature
@@ -147,3 +147,23 @@ Feature: Confirm component
     When I open component preview
       And I click on a confirmButton
     Then Confirm dialog is not visible
+
+  @positive
+  Scenario: Verify the open action for Confirm dialog
+    Given clear all actions in Actions Tab
+    When I open component preview
+    Then open action was called in Actions Tab
+
+  @positive
+  Scenario: Verify the confirm action for Confirm dialog
+    Given clear all actions in Actions Tab
+      And I open component preview
+    When I click on a confirmButton
+    Then confirm action was called in Actions Tab
+
+  @positive
+  Scenario: Verify the cancel action for Confirm dialog
+    Given clear all actions in Actions Tab
+      And I open component preview
+    When I click on a cancelButton
+    Then cancel action was called in Actions Tab

--- a/cypress/features/regression/draggableContext.feature
+++ b/cypress/features/regression/draggableContext.feature
@@ -4,10 +4,8 @@ Feature: Draggable Context component
   Background: Open Draggable Context component in iframe
     Given I open "DraggableContext" component in iframe
 
-  # @positive
-  @ignore
-  # ignored untill task will be implemented FE-1327
-  Scenario Outline: Drag record inside Draggable Context
+  @positive
+  Scenario Outline: Drag record <record> inside Draggable Context to <destinationId> element position
     When I drag Draggable Context "<record>" to <destinationId>
     Then Draggable Context "<record>" is dragged to <destinationId>
     Examples:

--- a/cypress/locators/configurable-items/index.js
+++ b/cypress/locators/configurable-items/index.js
@@ -1,11 +1,24 @@
-import { ITEMS_WRAPPER } from './locators';
+import { ITEMS_WRAPPER, ITEMS_ICON } from './locators';
 import { LABEL } from '../locators';
 
 // component preview locators
 export const draggableItemByText = text => cy.get(LABEL)
   .contains(text).parent().parent()
-  .find('.icon-drag_vertical');
+  .parent()
+  .parent()
+  .parent()
+  .find(ITEMS_ICON);
+export const draggableItemByTextNoIframe = text => cy.iFrame(LABEL)
+  .contains(text).parent().parent()
+  .parent()
+  .parent()
+  .parent()
+  .find(ITEMS_ICON);
 export const draggableItemByPosition = position => cy.get(ITEMS_WRAPPER)
+  .find(`div:nth-child(${position})`)
+  .find('li[data-element="configurable-item-row"] > div[data-element="configurable-item-row-content-wrapper"]')
+  .find('label');
+export const draggableItemByPositionNoIframe = position => cy.iFrame(ITEMS_WRAPPER)
   .find(`div:nth-child(${position})`)
   .find('li[data-element="configurable-item-row"] > div[data-element="configurable-item-row-content-wrapper"]')
   .find('label');

--- a/cypress/locators/configurable-items/locators.js
+++ b/cypress/locators/configurable-items/locators.js
@@ -1,2 +1,3 @@
 // component preview locators
 export const ITEMS_WRAPPER = '[data-element="configurable-items-wrapper"]';
+export const ITEMS_ICON = '[data-element="drag_vertical"]';

--- a/cypress/locators/draggable-context/index.js
+++ b/cypress/locators/draggable-context/index.js
@@ -1,5 +1,8 @@
 import { CELL, CELL_ICON, TBODY } from './locators';
 
 // component preview locators
-export const draggableRecordByText = text => cy.get(CELL).contains(text).parent().find(CELL_ICON);
-export const draggableRecordByPosition = position => cy.get(TBODY).find(`:nth-child(${position}) > td`);
+export const draggableRecordByText = text => cy.get(CELL).contains(text)
+  .parent()
+  .find('td:nth-child(1)')
+  .find(CELL_ICON);
+export const draggableRecordByPosition = position => cy.get(TBODY).find(`tr:nth-child(${position}) > td:nth-child(2)`);

--- a/cypress/locators/draggable-context/locators.js
+++ b/cypress/locators/draggable-context/locators.js
@@ -1,4 +1,4 @@
 // component preview locators
-export const CELL = '.carbon-table-cell';
-export const CELL_ICON = '.draggable-table-cell__icon';
+export const CELL = '[data-component="table-cell"]';
+export const CELL_ICON = '[data-element="drag"]';
 export const TBODY = 'tbody';

--- a/cypress/support/helper.js
+++ b/cypress/support/helper.js
@@ -35,23 +35,29 @@ export function clickClear() {
 }
 
 export function dragAndDrop(draggableElement, destinationPosition, startFromHight) {
-  const ROW_HIGHT = 35;
-  const TEN_PIXEL_MOVE = 10;
+  const ROW_HIGHT = 45;
+  const TEN_PIXEL_MOVE = 15;
 
   draggableElement
-    .trigger('mousedown', { force: true })
+    .trigger('mousedown', { force: true, release: false })
     .wait(500) // required for correct drag&drop headless browser (500ms)
-    .trigger('mousemove', { force: true })
+    .trigger('mousemove', { force: true, release: false })
     .wait(100); // required for correct drag&drop headless browser (100ms)
-
+  console.log('Dragging item');
   // put row record on top of page, then move down every TEN_PIXEL_MOVE
   for (let i = 0; i < startFromHight + (destinationPosition * ROW_HIGHT); i += TEN_PIXEL_MOVE) {
     draggableElement
-      .trigger('mousemove', { clientY: i, force: true, log: DEBUG_FLAG })
+      .trigger('mousemove', {
+        clientY: i, force: true, log: DEBUG_FLAG, release: false,
+      })
+      .trigger('mousemove', 'topRight', { force: true, release: false })
+      .trigger('mousemove', 'topLeft', { force: true, release: false })
       .wait(100, { log: DEBUG_FLAG });
+    console.log(`Dragging item in for loop to position ${i}`);
   }
   draggableElement
-    .trigger('mouseup', { force: true });
+    .trigger('mouseup', { force: true, release: true });
+  console.log('Dropped item');
 }
 
 export function setSlidebar(selector, value) {

--- a/cypress/support/step-definitions/configurable-items-steps.js
+++ b/cypress/support/step-definitions/configurable-items-steps.js
@@ -1,10 +1,15 @@
-import { draggableItemByText, draggableItemByPosition } from '../../locators/configurable-items';
+import { draggableItemByText, draggableItemByTextNoIframe, draggableItemByPosition } from '../../locators/configurable-items';
 import { dragAndDrop } from '../helper';
 import { label } from '../../locators';
 
 When('I drag Configurable Items {string} to {int}', (record, destinationId) => {
   const startPosition = 110;
   dragAndDrop(draggableItemByText(record), destinationId, startPosition);
+});
+
+When('I drag Configurable Items with iFrame {string} to {int}', (record, destinationId) => {
+  const startPosition = 110;
+  dragAndDrop(draggableItemByTextNoIframe(record), destinationId, startPosition);
 });
 
 Then('Configurable Items {string} is dragged to {int}', (record, destinationId) => {

--- a/cypress/support/step-definitions/confirm-steps.js
+++ b/cypress/support/step-definitions/confirm-steps.js
@@ -1,4 +1,3 @@
-import { backgroundUILocator } from '../../locators';
 import {
   dialogTitle, dialogPreview, closeIconButton,
   dialogSubtitle, confirmButton, cancelButton,

--- a/cypress/support/step-definitions/draggable-context-steps.js
+++ b/cypress/support/step-definitions/draggable-context-steps.js
@@ -7,5 +7,5 @@ When('I drag Draggable Context {string} to {int}', (record, destinationId) => {
 });
 
 Then('Draggable Context {string} is dragged to {int}', (record, destinationId) => {
-  draggableRecordByPosition(destinationId).should('have.text', record);
+  draggableRecordByPosition(destinationId).invoke('text').should('contain', record);
 });


### PR DESCRIPTION
### Proposed behaviour
Allow feature files to run in Cypress for `configurableItems`, `draggableContext` and `confirm` components for both default and classic stories with tests for events.
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->

### Current behaviour
The `configurableItems` and `draggableContext` files currently fail and the `confirm` file had no tests for action events.
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>[ ] Unit tests
- [x] Cypress automation tests
<del>[ ] Storybook added or updated
<del>[ ] Theme support
<del>[ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->
FE-2347

### Testing instructions
Run the feature files in Cypress
Tests run successfully with no errors
