### PR TITLE
build: updated browserslist depedency of babel/preset-env - FE-2509

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1343,6 +1343,46 @@
         "semver": "^5.5.0"
       },
       "dependencies": {
+        "browserslist": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.5.tgz",
+          "integrity": "sha512-4LMHuicxkabIB+n9874jZX/az1IaZ5a+EUuvD7KFOu9x/Bd5YHyO0DIz2ls/Kl8g0ItS4X/ilEgf4T1Br0lgSg==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001022",
+            "electron-to-chromium": "^1.3.338",
+            "node-releases": "^1.1.46"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001023",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
+          "integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.340",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.340.tgz",
+          "integrity": "sha512-hRFBAglhcj5iVYH+o8QU0+XId1WGoc0VGowJB1cuJAt3exHGrivZvWeAO5BRgBZqwZtwxjm8a5MQeGoT/Su3ww==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.47",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.47.tgz",
+          "integrity": "sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",


### PR DESCRIPTION
### Proposed behaviour
npm run storybook will no longer display warning for Browserslist depedency caniuse being out of date.

### Current behaviour
npm run storybook displays console warning "Browserslist: caniuse-lite is outdated. Please run next command `npm update`"

### Checklist

- [ ] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>- [ ] Unit tests
<del>- [ ] Cypress automation tests
<del>- [ ] Storybook added or updated
<del>- [ ] Theme support
<del>- [ ] Typescript `d.ts` file added or updated
