### PR TITLE
docs: fixed library name in documentation

### DIFF
--- a/src/components/portrait/documentation/info.js
+++ b/src/components/portrait/documentation/info.js
@@ -8,7 +8,7 @@ const info = (
     <StoryHeader>Implementation</StoryHeader>
 
     <p>Import the component:</p>
-    <StoryCode padded>import Portrait from {'"react-carbon/lib/components/portrait"'}</StoryCode>
+    <StoryCode padded>import Portrait from {'"carbon-react/lib/components/portrait"'}</StoryCode>
 
     <p>To render a portrait:</p>
     <StoryCode>{'<Portrait src="/my-image" alt="my image">'}</StoryCode>

--- a/src/components/preview/documentation/info.js
+++ b/src/components/preview/documentation/info.js
@@ -8,7 +8,7 @@ const info = (
     <StoryHeader>Implementation</StoryHeader>
 
     <p>Import the component:</p>
-    <StoryCode padded>import Preview from {'"react-carbon/lib/components/preview"'}</StoryCode>
+    <StoryCode padded>import Preview from {'"carbon-react/lib/components/preview"'}</StoryCode>
     <p>
       You can set the custom height for the preview line by setting <StoryCode padded>height</StoryCode> prop (e.g.
       20px).

--- a/src/components/profile/documentation/info.js
+++ b/src/components/profile/documentation/info.js
@@ -9,7 +9,7 @@ const info = (
     <StoryHeader>Implementation</StoryHeader>
 
     <p>Import the component:</p>
-    <StoryCode padded>import Portrait from {'"react-carbon/lib/components/profile"'}</StoryCode>
+    <StoryCode padded>import Portrait from {'"carbon-react/lib/components/profile"'}</StoryCode>
   </div>
 );
 

--- a/src/components/split-button/documentation/info.js
+++ b/src/components/split-button/documentation/info.js
@@ -7,7 +7,7 @@ const info = (
     <StoryHeader>Implementation</StoryHeader>
 
     <p>Import the component:</p>
-    <StoryCode padded>import SplitButton from {'"react-carbon/lib/components/split-button"'}</StoryCode>
+    <StoryCode padded>import SplitButton from {'"carbon-react/lib/components/split-button"'}</StoryCode>
 
     <p>To render a SplitButton (developer can add any buttons to dropdown):</p>
     <StoryCodeBlock>


### PR DESCRIPTION
Hi, 
I noticed that the library name was incorrect in the documentation while I copy and pasted an import line, it caused good 15 minutes while I understood why I couldn't import the given component, I hope this PR will save time for someone else

### Checklist


- [X] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [N/A] Unit tests
- [N/A] Cypress automation tests
- [X] Storybook added or updated
- [ N/A] Theme support
- [N/A] Typescript `d.ts` file added or updated

