### PR TITLE
fix(help): allow to set different icon on help component

### DIFF
--- a/src/components/help/help.component.js
+++ b/src/components/help/help.component.js
@@ -18,7 +18,8 @@ const Help = (props) => {
     as,
     tooltipPosition,
     tooltipAlign,
-    isFocused
+    isFocused,
+    type
   } = props;
 
   useEffect(() => {
@@ -67,7 +68,7 @@ const Help = (props) => {
       aria-label={ children }
     >
       <Icon
-        type='help'
+        type={ type }
         tooltipMessage={ children }
         tooltipPosition={ tooltipPosition }
         tooltipAlign={ tooltipAlign }
@@ -95,13 +96,16 @@ Help.propTypes = {
   /** A path for the anchor */
   href: PropTypes.string,
   /** A boolean recived from IconWrapper */
-  isFocused: PropTypes.bool
+  isFocused: PropTypes.bool,
+  /** Icon to display, can be received from label component */
+  type: PropTypes.oneOf(OptionsHelper.icons)
 };
 
 Help.defaultProps = {
   tooltipPosition: 'top',
   tooltipAlign: 'center',
-  tabIndex: 0
+  tabIndex: 0,
+  type: 'help'
 };
 
 export default Help;

--- a/src/components/help/help.spec.js
+++ b/src/components/help/help.spec.js
@@ -52,6 +52,20 @@ describe('Help', () => {
       expect(icon.props().tooltipAlign).toBe(mockAlignment);
     });
 
+    it('passes the type if provided', () => {
+      const mockType = 'info';
+      wrapper = renderHelp({ type: mockType });
+      icon = wrapper.find(Icon);
+      expect(icon.props().type).toBe(mockType);
+    });
+
+    it('check the default type if not provided', () => {
+      const mockType = 'help';
+      wrapper = renderHelp();
+      icon = wrapper.find(Icon);
+      expect(icon.props().type).toBe(mockType);
+    });
+
     it('renders a link when the href if provided', () => {
       const mockHref = 'href';
       wrapper = renderHelp({ href: mockHref }, mount);

--- a/src/components/help/help.stories.js
+++ b/src/components/help/help.stories.js
@@ -26,12 +26,14 @@ function makeStory(name, themeSelector) {
       Help.defaultProps.tooltipAlign
     ) : undefined;
     const href = text('href', '');
+    const type = select('type', OptionsHelper.icons, 'help');
 
     return (
       <Help
         tooltipPosition={ tooltipPosition }
         tooltipAlign={ tooltipAlign }
         href={ href }
+        type={ type }
       >
         {children}
       </Help>


### PR DESCRIPTION
### Proposed behaviour
We would like to have the ability to choose another icon for the help icon on a textbox.
So I added a "type" props in the help component.

![image](https://user-images.githubusercontent.com/16556560/73739959-87834a80-4747-11ea-9e4b-c9fccc4efc30.png)


### Current behaviour
There is a way to pass the icon we want through the labelHelpIcon props.
From the textbox through the form-field componant to the label componant :https://github.com/Sage/carbon/blob/0241195de9006711b110a500831372bae278e131/src/__experimental__/components/form-field/form-field.component.js#L56
Then from the label to the help component :https://github.com/Sage/carbon/blob/0241195de9006711b110a500831372bae278e131/src/__experimental__/components/label/label.component.js#L66
But in the help component, the icon is hard coded :https://github.com/Sage/carbon/blob/0241195de9006711b110a500831372bae278e131/src/components/help/help.component.js#L70
I just completed the chain.

### Checklist
- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [ ] Cypress automation tests
- [x] Storybook added or updated
- [ ] Theme support
- [ ] Typescript `d.ts` file added or updated

### Additional context
That modification will be usefull for Client Management : 

![image](https://user-images.githubusercontent.com/16556560/73740236-1a23e980-4748-11ea-95cb-20fd5605e2b6.png)


### Testing instructions
On an help component, we can add the props type with the value 'info'. That should display the icon for information.
It can be used on a TextBox using the "labelHelpIcon" props .
For both components, the default behavior must remain the help icon if the props are not defined to avoid side effect.