### PR TITLE
feat: Added translation support for "show" in pager component FE-2544

### DIFF
--- a/src/components/pager/__snapshots__/pager.spec.js.snap
+++ b/src/components/pager/__snapshots__/pager.spec.js.snap
@@ -218,6 +218,7 @@ exports[`Pager renders the Pager correctly with the Classic Theme 1`] = `
       className="c2"
     >
       Show 
+       
       <div
         className="carbon-dropdown common-input--with-icon common-input"
         data-component="dropdown"
@@ -639,6 +640,7 @@ exports[`Pager renders the Pager correctly with the Mint Theme 1`] = `
       className="c2"
     >
       Show 
+       
       <div
         className="carbon-dropdown common-input--with-icon common-input"
         data-component="dropdown"

--- a/src/components/pager/pager.component.js
+++ b/src/components/pager/pager.component.js
@@ -43,7 +43,9 @@ const Pager = (props) => {
 
   function pageSizeOptions() {
     const elem = (
-      <PagerSizeOptionsInnerStyles>Show {sizeSelector()} {descriptor}</PagerSizeOptionsInnerStyles>
+      <PagerSizeOptionsInnerStyles>
+        { I18n.t('pager.show', { defaultValue: 'Show ' }) } { sizeSelector() } { descriptor }
+      </PagerSizeOptionsInnerStyles>
     );
 
     return props.showPageSizeSelection ? elem : null;
@@ -58,7 +60,7 @@ const Pager = (props) => {
         setCurrentPage={ setCurrentPage }
         setCurrentThemeName={ setCurrentTheme }
       />
-      <PagerSummaryStyles>{props.totalRecords} {descriptor}</PagerSummaryStyles>
+      <PagerSummaryStyles>{ props.totalRecords } { descriptor }</PagerSummaryStyles>
     </PagerContainerStyles>
   );
 };


### PR DESCRIPTION
### Proposed behaviour
Adds translation feature to the pager component

### Current behaviour
Word "Show" is not translateable

### Checklist
- [X] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>- [ ] Unit tests</del>
<del>- [ ] Cypress automation tests</del>
<del>- [ ] Storybook added or updated</del>
<del>- [ ] Theme support</del>
<del>- [ ] Typescript `d.ts` file added or updated</del>

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
Add a translation file and change the translation
