### PR TITLE
fix(pager): add singular/plural translation FE-2510

### DIFF
--- a/cypress/features/regression/pager.feature
+++ b/cypress/features/regression/pager.feature
@@ -12,12 +12,17 @@ Feature: Pager component
     Examples:
       | totalRecords | maxPages |
       | 0            | 1        |
-      | 1            | 1        |
       | 10           | 1        |
       | 100          | 10       |
       | 111          | 12       |
       | 1000         | 100      |
       | 99999        | 10000    |
+
+  @positive
+  Scenario: Set totalRecords to 1 and check spell of item word
+    When I set totalRecords to "1"
+    Then totalRecords is set to "1" item
+      And I am on 1st of "1" pages
 
   @negative
   Scenario Outline: Set totalRecords out of scope to <totalRecords>
@@ -44,10 +49,10 @@ Feature: Pager component
       | <>                      |
 
   @positive
-  Scenario Outline: Set pageSize to <pageSize>
-    Given I select pageSize to "<pageSize>"
-    When I check showPageSizeSelection checkbox
-    Then pageSize is set to "<pageSize>"
+  Scenario Outline: Set pageSize to <pageSize> items
+    Given I check showPageSizeSelection checkbox
+    When I select pageSize to "<pageSize>"
+    Then pageSize is set to "<pageSize>" items
       And I am on 1st of "<maxPages>" pages
     Examples:
       | pageSize | maxPages |
@@ -56,10 +61,17 @@ Feature: Pager component
       | 50       | 2        |
 
   @positive
+  Scenario: Set pageSize to 1 item
+    Given I check showPageSizeSelection checkbox
+    When I select pageSize to "one"
+    Then pageSize is set to "1" item
+      And I am on 1st of "100" pages
+
+  @positive
   Scenario: Enable showPageSizeSelection and verify default value
     When I check showPageSizeSelection checkbox
     Then pageSize is visible
-      And pageSize is set to "10"
+      And pageSize is set to "10" items
 
   @positive
   Scenario: Enable and disable showPageSizeSelection
@@ -99,7 +111,7 @@ Feature: Pager component
   @positive
   Scenario Outline: Pagination <button> button is disabled after previous paginate
     Given I type "10" to input pagination
-    When I click previous button 9 times
+    When I press previous button 9 times
     Then pagination "<button>" button is disabled
     Examples:
       | button   |
@@ -108,7 +120,7 @@ Feature: Pager component
 
   @positive
   Scenario Outline: Pagination <button> button is disabled after clicking next button
-    When I click next button 9 times
+    When I press next button 9 times
     Then pagination "<button>" button is disabled
     Examples:
       | button |

--- a/cypress/features/regression/tableClassic.feature
+++ b/cypress/features/regression/tableClassic.feature
@@ -12,12 +12,17 @@ Feature: Table classic component
     Examples:
       | totalRecords |
       | 0            |
-      | 1            |
       | 10           |
       | 100          |
       | 99999999     |
       | -1           |
       | -10          |
+
+  @positive
+  Scenario: TotalRecords is set to <totalRecords>
+    When I set totalRecords to "1"
+      And I check paginate checkbox
+    Then totalRecords is set to "1" record
 
   @positive
   Scenario Outline: TotalRecords is set out of scope to <totalRecords>

--- a/cypress/features/regression/tableWithInputs.feature
+++ b/cypress/features/regression/tableWithInputs.feature
@@ -100,19 +100,24 @@ Feature: Table With Inputs component
   # | <> |
 
   @positive
-  Scenario Outline: TotalRecords is set to <totalRecords>
+  Scenario Outline: TotalRecords is set to <totalRecords> items
     When I set totalRecords to "<totalRecords>"
       And I check paginate checkbox
     Then totalRecords is set to "<totalRecords>" items
     Examples:
       | totalRecords |
       | 0            |
-      | 1            |
       | 10           |
       | 100          |
       | 99999999     |
       | -1           |
       | -10          |
+
+  @positive
+  Scenario: TotalRecords is set to 1 item
+    When I set totalRecords to "1"
+      And I check paginate checkbox
+    Then totalRecords is set to "1" item
 
   @positive
   Scenario Outline: TotalRecords is set out of scope to <totalRecords>

--- a/cypress/locators/pager/index.js
+++ b/cypress/locators/pager/index.js
@@ -1,11 +1,12 @@
 import {
-  PAGER_SUMMARY, PAGE_SELECT, MAX_PAGES, PAGE_INPUT, PAGER_PREVIOUS_ARROW, PAGER_NEXT_ARROW,
+  PAGER_SUMMARY, PAGE_SELECT, MAX_PAGES, PAGE_INPUT, PAGE_SELECT_ITEM,
+  PAGER_NEXT_ARROW, PAGER_PREVIOUS_ARROW,
 } from './locators';
 
 // component preview locators
-export const pagerSummary = () => cy.iFrame(PAGER_SUMMARY)
-  .find('div:nth-child(3)');
+export const pagerSummary = () => cy.iFrame(PAGER_SUMMARY).children().eq(2);
 export const pageSelect = () => cy.iFrame(PAGE_SELECT);
+export const pageSelectItems = () => cy.iFrame(PAGE_SELECT_ITEM);
 export const maxPages = () => cy.iFrame(MAX_PAGES);
 export const currentPageInput = () => cy.iFrame(PAGE_INPUT).find('input');
 export const previousArrow = () => cy.iFrame(PAGER_PREVIOUS_ARROW);

--- a/cypress/locators/pager/locators.js
+++ b/cypress/locators/pager/locators.js
@@ -3,5 +3,6 @@ export const PAGER_SUMMARY = '[data-component="pager"]';
 export const PAGE_SELECT = '[data-element="page-select"] > div > [data-element="input"]';
 export const MAX_PAGES = 'div[data-component="pager"] > div:nth-child(2) > div > span:nth-child(3)';
 export const PAGE_INPUT = '[data-element="current-page"] > div';
+export const PAGE_SELECT_ITEM = '[data-component="pager"] > div > div > span:nth-child(3)';
 export const PAGER_PREVIOUS_ARROW = 'div[data-component="pager"] > div:nth-child(2) > div:nth-child(1) > span';
 export const PAGER_NEXT_ARROW = 'div[data-component="pager"] > div:nth-child(2) > div:nth-child(5) > span';

--- a/cypress/locators/table/index.js
+++ b/cypress/locators/table/index.js
@@ -13,7 +13,6 @@ export const tableHeader = () => cy.iFrame(TABLE_HEADER);
 export const sortIcon = index => tableHeader(index).find('span');
 export const pagination = () => cy.iFrame(PAGINATION_BUTTON);
 export const paginationButtonByIndex = index => pagination().find('div:nth-child(2) > button').eq(index);
-export const paginationButton = () => pagination().find('div:nth-child(2) > button');
 export const actionToolbar = index => cy.iFrame(ACTION_TOOLBAR).find('div:nth-child(2) > div').eq(index);
 export const actionToolbarButton = () => cy.iFrame(ACTION_TOOLBAR).find('div:nth-child(2)').find('[data-element="main-text"]').parent();
 export const checkboxInHeader = () => cy.iFrame(CHECKBOX_CELL);

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -537,5 +537,5 @@ When('I click on outside dialog in iFrame', () => {
 });
 
 Then('totalRecords is set to {string} {word}', (totalRecords, element) => {
-  pagerSummary().invoke('text').should('contain', `${totalRecords}  ${element}`);
+  pagerSummary().invoke('text').should('contain', `${totalRecords} ${element}`);
 });

--- a/cypress/support/step-definitions/pager-steps.js
+++ b/cypress/support/step-definitions/pager-steps.js
@@ -1,16 +1,17 @@
 import {
-  pageSelect, maxPages, previousArrow, nextArrow, currentPageInput,
+  pageSelect, maxPages, previousArrow, nextArrow, currentPageInput, pageSelectItems,
 } from '../../locators/pager';
 import { DEBUG_FLAG } from '..';
-import { paginationButton, pagination } from '../../locators/table';
+import { pagination, paginationButtonByIndex } from '../../locators/table';
 
 const ZERO = 0;
 const ONE = 1;
 const TWO = 2;
 const THREE = 3;
 
-Then('pageSize is set to {string}', (pageSize) => {
+Then('pageSize is set to {string} {word}', (pageSize, item) => {
   pageSelect().should('have.attr', 'value', pageSize);
+  pageSelectItems().invoke('text').should('contain', item);
 });
 
 Then('pageSize is visible', () => {
@@ -28,16 +29,20 @@ Then('I am on 1st of {string} pages', (count) => {
 Then('pagination {string} button is disabled', (button) => {
   switch (button) {
     case 'next':
-      paginationButton(TWO).should('have.attr', 'disabled');
+      paginationButtonByIndex(TWO).should('be.disabled')
+        .and('have.attr', 'disabled');
       break;
     case 'last':
-      paginationButton(THREE).should('have.attr', 'disabled');
+      paginationButtonByIndex(THREE).should('be.disabled')
+        .and('have.attr', 'disabled');
       break;
     case 'previous':
-      paginationButton(ONE).should('have.attr', 'disabled');
+      paginationButtonByIndex(ONE).should('be.disabled')
+        .and('have.attr', 'disabled');
       break;
     case 'first':
-      paginationButton(ZERO).should('have.attr', 'disabled');
+      paginationButtonByIndex(ZERO).should('be.disabled')
+        .and('have.attr', 'disabled');
       break;
     default: throw new Error('There are only four pagination buttons');
   }
@@ -46,16 +51,16 @@ Then('pagination {string} button is disabled', (button) => {
 Then('I click {string} pagination button', (button) => {
   switch (button) {
     case 'next':
-      paginationButton(TWO).click();
+      paginationButtonByIndex(TWO).click();
       break;
     case 'last':
-      paginationButton(THREE).click();
+      paginationButtonByIndex(THREE).click();
       break;
     case 'previous':
-      paginationButton(ONE).click();
+      paginationButtonByIndex(ONE).click();
       break;
     case 'first':
-      paginationButton(ZERO).click();
+      paginationButtonByIndex(ZERO).click();
       break;
     default: throw new Error('There are only four pagination buttons');
   }
@@ -77,7 +82,7 @@ Then('I click {string} pagination arrow', (arrow) => {
 Then('pagination buttons are disabled', () => {
   const buttonsAmount = 4;
   for (let i = 0; i < buttonsAmount; i++) {
-    paginationButton(i).should('have.attr', 'disabled');
+    paginationButtonByIndex(i).should('have.attr', 'disabled');
   }
 });
 
@@ -106,17 +111,17 @@ Then('I click {word} {int} times', (direction, count) => {
   }
 });
 
-Then('I click {word} button {int} times', (direction, count) => {
+Then('I press {word} button {int} times', (direction, count) => {
   for (let i = 0; i < count; i++) {
     // click force true because element is overlapping
     switch (direction) {
       case 'next':
         cy.wait(100, { log: DEBUG_FLAG }); // wait added due to refreshing element
-        paginationButton(TWO).click({ force: true });
+        paginationButtonByIndex(TWO).click({ force: true });
         break;
       case 'previous':
         cy.wait(100, { log: DEBUG_FLAG }); // wait added due to refreshing element
-        paginationButton(ONE).click({ force: true });
+        paginationButtonByIndex(ONE).click({ force: true });
         break;
       default: throw new Error('Direction can be only next or previous');
     }

--- a/src/components/pager/__snapshots__/pager.spec.js.snap
+++ b/src/components/pager/__snapshots__/pager.spec.js.snap
@@ -217,8 +217,9 @@ exports[`Pager renders the Pager correctly with the Classic Theme 1`] = `
     <div
       className="c2"
     >
-      Show 
-       
+      <span>
+        Show
+      </span>
       <div
         className="carbon-dropdown common-input--with-icon common-input"
         data-component="dropdown"
@@ -262,8 +263,9 @@ exports[`Pager renders the Pager correctly with the Classic Theme 1`] = `
           value="10"
         />
       </div>
-       
-       records
+      <span>
+        records
+      </span>
     </div>
   </div>
   <div
@@ -340,7 +342,7 @@ exports[`Pager renders the Pager correctly with the Classic Theme 1`] = `
   >
     100
      
-     records
+    records
   </div>
 </div>
 `;
@@ -639,8 +641,9 @@ exports[`Pager renders the Pager correctly with the Mint Theme 1`] = `
     <div
       className="c2"
     >
-      Show 
-       
+      <span>
+        Show
+      </span>
       <div
         className="carbon-dropdown common-input--with-icon common-input"
         data-component="dropdown"
@@ -684,8 +687,9 @@ exports[`Pager renders the Pager correctly with the Mint Theme 1`] = `
           value="10"
         />
       </div>
-       
-       items
+      <span>
+        items
+      </span>
     </div>
   </div>
   <div
@@ -774,7 +778,7 @@ exports[`Pager renders the Pager correctly with the Mint Theme 1`] = `
   >
     100
      
-     items
+    items
   </div>
 </div>
 `;

--- a/src/components/pager/pager.component.js
+++ b/src/components/pager/pager.component.js
@@ -22,10 +22,10 @@ const Pager = (props) => {
   }, [props.currentPage]);
 
   /** Term used to describe table data */
-  const descriptor = I18n.t(
+  const records = count => I18n.t(
     'pager.records',
     {
-      count: Number(props.totalRecords),
+      count: Number(count),
       defaultValue: isClassic(currentTheme) ? {
         one: 'record',
         zero: 'records',
@@ -50,9 +50,10 @@ const Pager = (props) => {
   }
 
   function pageSizeOptions() {
+    const show = I18n.t('pager.show', { defaultValue: 'Show' });
     const elem = (
       <PagerSizeOptionsInnerStyles>
-        <span>{ I18n.t('pager.show', { defaultValue: 'Show' }) }</span>{ sizeSelector() }<span>{ descriptor }</span>
+        <span>{ show }</span>{ sizeSelector() }<span>{ records(props.pageSize) }</span>
       </PagerSizeOptionsInnerStyles>
     );
 
@@ -68,7 +69,7 @@ const Pager = (props) => {
         setCurrentPage={ setCurrentPage }
         setCurrentThemeName={ setCurrentTheme }
       />
-      <PagerSummaryStyles>{ props.totalRecords } { descriptor }</PagerSummaryStyles>
+      <PagerSummaryStyles>{ props.totalRecords } { records(props.totalRecords) }</PagerSummaryStyles>
     </PagerContainerStyles>
   );
 };

--- a/src/components/pager/pager.component.js
+++ b/src/components/pager/pager.component.js
@@ -28,11 +28,9 @@ const Pager = (props) => {
       count: Number(count),
       defaultValue: isClassic(currentTheme) ? {
         one: 'record',
-        zero: 'records',
         other: 'records'
       } : {
         one: 'item',
-        zero: 'items',
         other: 'items'
       }
     }

--- a/src/components/pager/pager.component.js
+++ b/src/components/pager/pager.component.js
@@ -26,7 +26,15 @@ const Pager = (props) => {
     'pager.records',
     {
       count: Number(props.totalRecords),
-      defaultValue: isClassic(currentTheme) ? 'records' : 'items'
+      defaultValue: isClassic(currentTheme) ? {
+        one: 'record',
+        zero: 'records',
+        other: 'records'
+      } : {
+        one: 'item',
+        zero: 'items',
+        other: 'items'
+      }
     }
   );
 

--- a/src/components/pager/pager.component.js
+++ b/src/components/pager/pager.component.js
@@ -26,7 +26,7 @@ const Pager = (props) => {
     'pager.records',
     {
       count: Number(props.totalRecords),
-      defaultValue: isClassic(currentTheme) ? ' records' : ' items'
+      defaultValue: isClassic(currentTheme) ? 'records' : 'items'
     }
   );
 
@@ -44,7 +44,7 @@ const Pager = (props) => {
   function pageSizeOptions() {
     const elem = (
       <PagerSizeOptionsInnerStyles>
-        { I18n.t('pager.show', { defaultValue: 'Show ' }) } { sizeSelector() } { descriptor }
+        <span>{ I18n.t('pager.show', { defaultValue: 'Show' }) }</span>{ sizeSelector() }<span>{ descriptor }</span>
       </PagerSizeOptionsInnerStyles>
     );
 

--- a/src/components/pager/pager.spec.js
+++ b/src/components/pager/pager.spec.js
@@ -93,12 +93,12 @@ describe('Pager', () => {
       });
 
       it('records', () => {
-        expect(getRecords(render({ ...props, theme: mintTheme, totalRecords: 100 }))).toBe('items');
-        expect(getRecords(render({ ...props, theme: mintTheme, totalRecords: 1 }))).toBe('item');
-        expect(getRecords(render({ ...props, theme: mintTheme, totalRecords: 0 }))).toBe('items');
-        expect(getRecords(render({ ...props, theme: classicTheme, totalRecords: 100 }))).toBe('records');
-        expect(getRecords(render({ ...props, theme: classicTheme, totalRecords: 1 }))).toBe('record');
-        expect(getRecords(render({ ...props, theme: classicTheme, totalRecords: 0 }))).toBe('records');
+        expect(getRecords(render({ ...props, theme: mintTheme, pageSize: '100' }))).toBe('items');
+        expect(getRecords(render({ ...props, theme: mintTheme, pageSize: '1' }))).toBe('item');
+        expect(getRecords(render({ ...props, theme: mintTheme, pageSize: '0' }))).toBe('items');
+        expect(getRecords(render({ ...props, theme: classicTheme, pageSize: '100' }))).toBe('records');
+        expect(getRecords(render({ ...props, theme: classicTheme, pageSize: '1' }))).toBe('record');
+        expect(getRecords(render({ ...props, theme: classicTheme, pageSize: '0' }))).toBe('records');
       });
 
       it('total records', () => {
@@ -122,9 +122,9 @@ describe('Pager', () => {
       });
 
       it('records', () => {
-        expect(getRecords(render({ ...props, theme: mintTheme, totalRecords: 100 }))).toBe('articles');
-        expect(getRecords(render({ ...props, theme: mintTheme, totalRecords: 1 }))).toBe('article');
-        expect(getRecords(render({ ...props, theme: mintTheme, totalRecords: 0 }))).toBe('articles');
+        expect(getRecords(render({ ...props, theme: mintTheme, pageSize: '100' }))).toBe('articles');
+        expect(getRecords(render({ ...props, theme: mintTheme, pageSize: '1' }))).toBe('article');
+        expect(getRecords(render({ ...props, theme: mintTheme, pageSize: '0' }))).toBe('articles');
       });
 
       it('total records', () => {

--- a/src/components/pager/pager.spec.js
+++ b/src/components/pager/pager.spec.js
@@ -93,16 +93,20 @@ describe('Pager', () => {
       });
 
       it('records', () => {
-        const wrapper = render({ ...props, theme: mintTheme });
-        expect(getRecords(wrapper)).toBe('items');
+        expect(getRecords(render({ ...props, theme: mintTheme, totalRecords: 100 }))).toBe('items');
+        expect(getRecords(render({ ...props, theme: mintTheme, totalRecords: 1 }))).toBe('item');
+        expect(getRecords(render({ ...props, theme: mintTheme, totalRecords: 0 }))).toBe('items');
+        expect(getRecords(render({ ...props, theme: classicTheme, totalRecords: 100 }))).toBe('records');
+        expect(getRecords(render({ ...props, theme: classicTheme, totalRecords: 1 }))).toBe('record');
+        expect(getRecords(render({ ...props, theme: classicTheme, totalRecords: 0 }))).toBe('records');
       });
 
       it('total records', () => {
         expect(getTotalRecords(render({ ...props, theme: mintTheme, totalRecords: 100 }))).toBe('100 items');
-        expect(getTotalRecords(render({ ...props, theme: mintTheme, totalRecords: 1 }))).toBe('1 items');
+        expect(getTotalRecords(render({ ...props, theme: mintTheme, totalRecords: 1 }))).toBe('1 item');
         expect(getTotalRecords(render({ ...props, theme: mintTheme, totalRecords: 0 }))).toBe('0 items');
         expect(getTotalRecords(render({ ...props, theme: classicTheme, totalRecords: 100 }))).toBe('100 records');
-        expect(getTotalRecords(render({ ...props, theme: classicTheme, totalRecords: 1 }))).toBe('1 records');
+        expect(getTotalRecords(render({ ...props, theme: classicTheme, totalRecords: 1 }))).toBe('1 record');
         expect(getTotalRecords(render({ ...props, theme: classicTheme, totalRecords: 0 }))).toBe('0 records');
       });
     });
@@ -118,8 +122,9 @@ describe('Pager', () => {
       });
 
       it('records', () => {
-        const wrapper = render({ ...props, theme: mintTheme });
-        expect(getRecords(wrapper)).toBe('articles');
+        expect(getRecords(render({ ...props, theme: mintTheme, totalRecords: 100 }))).toBe('articles');
+        expect(getRecords(render({ ...props, theme: mintTheme, totalRecords: 1 }))).toBe('article');
+        expect(getRecords(render({ ...props, theme: mintTheme, totalRecords: 0 }))).toBe('articles');
       });
 
       it('total records', () => {

--- a/src/components/pager/pager.stories.js
+++ b/src/components/pager/pager.stories.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { number, boolean, select } from '@storybook/addon-knobs';
 import { State, Store } from '@sambego/storybook-state';
+import Immutable from 'immutable';
 import { dlsThemeSelector, classicThemeSelector } from '../../../.storybook/theme-selectors';
 import Pager from './pager.component';
 import { Info, notes } from './documentation';
-import OptionsHelper from '../../utils/helpers/options-helper/options-helper';
 import getDocGenInfo from '../../utils/helpers/docgen-info';
 
 Pager.__docgenInfo = getDocGenInfo(
@@ -80,7 +80,12 @@ TableComponent.propTypes = {
 function makeStory(name, themeSelector) {
   const component = () => {
     const totalRecords = number('totalRecords', 100);
-    const pageSize = select('pageSize', OptionsHelper.pageSizes, Pager.defaultProps.pageSize);
+    const pageSize = select('pageSize', {
+      one: 1,
+      10: 10,
+      25: 25,
+      50: 50
+    }, Pager.defaultProps.pageSize);
     const showPageSizeSelection = boolean(
       'showPageSizeSelection',
       Pager.defaultProps.showPageSizeSelection
@@ -96,6 +101,14 @@ function makeStory(name, themeSelector) {
           showPageSizeSelection={ showPageSizeSelection }
           totalRecords={ totalRecords }
           onPagination={ handlePagination }
+          pageSizeSelectionOptions={
+            Immutable.fromJS([
+              { id: '1', name: 1 },
+              { id: '10', name: 10 },
+              { id: '25', name: 25 },
+              { id: '50', name: 50 }
+            ])
+          }
         />
       </State>
     );


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
1. Add tests for existing I18n translations in `Pager`.
1. Add singular/plural translations fo records, the default translation will now display `0 items`, `1 item`, `10 items`.
1. Use the page size value for the translation of page size instead of total records.

![image](https://user-images.githubusercontent.com/2328042/74842544-80049980-5322-11ea-8cdd-1d4418a5c9f3.png)
![image](https://user-images.githubusercontent.com/2328042/74842463-5e0b1700-5322-11ea-82e3-aaaba6439b51.png)
![image](https://user-images.githubusercontent.com/2328042/74864890-2a42e800-5348-11ea-9e63-08e3efb98cbf.png)



### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
1. There are no tests for translations.
1. If they are using the default translations and `totalRecords=1` it will say `1 items`.
1.  If
    1. `totalRecords=1 pageSize=10` it will say `Show 10 item`.
    1. `totalRecords=100 pageSize=1` it will say `Show 1 items`.

![image](https://user-images.githubusercontent.com/2328042/74842135-cad1e180-5321-11ea-97dc-32309b49ae0f.png)
![image](https://user-images.githubusercontent.com/2328042/74842018-96f6bc00-5321-11ea-8697-24ebb051d1c2.png)

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
<del>- [ ] Cypress automation tests
- [x] Storybook added or updated
<del>- [ ] Theme support
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

The singular/plural translations currently work if the user defines their own translation. However, the page size and total records both use the `totalRecords` prop to work out how may to display. This means you can end up with `Show 10 item` and `Showing 1 item` instead of `Showing 10 items` and `Showing 1 item`.

### Testing instructions
* Go to http://localhost:9001/?path=/story/pager--default
* Check `showPageSizeSelection`
* Use `pageSize` and `totalRecords` knobs.
* Compare to https://carbon.sage.com/storybook/?path=/story/pager--default
<!-- How can a reviewer test this PR? -->
![image](https://user-images.githubusercontent.com/2328042/74862749-96bbe800-5344-11ea-943d-1a120e2d66ac.png)

