### PR TITLE
feat(advanced-color-picker): dialog popup colour picker FE-2334

### DIFF
--- a/cypress/features/regression/test/accordionGrouped.feature
+++ b/cypress/features/regression/test/accordionGrouped.feature
@@ -19,11 +19,11 @@ Feature: Accordion grouped component
   @positive
   Scenario: Navigate to the last grouped accordion row using End key
     Given I focus first accordionRow
-    When I press End on focused element
+    When I press "End" onto focused element
     Then Accordion 2 row is focused
 
   @positive
   Scenario: Navigate to the first grouped accordion row using Home key
     Given I focus last accordionRow
-    When I press Home on focused element
+    When I press "Home" onto focused element
     Then Accordion 0 row is focused

--- a/cypress/features/regression/test/actionPopoverNoIFrame.feature
+++ b/cypress/features/regression/test/actionPopoverNoIFrame.feature
@@ -44,7 +44,7 @@ Feature: Action Popover component in noIFrame
   Scenario: verify that the first element Business is focused using Home key
     Given I click the menu button element in noiFrame
       And I press keyboard downarrow key times 2
-    When I press Home on focused element
+    When I press "Home" onto focused element
     Then focused element inner content is set to "Business"
       And Action Popover element has golden border on focus
 
@@ -53,24 +53,24 @@ Feature: Action Popover component in noIFrame
     Given I click the menu button element in noiFrame
       And I press keyboard downarrow key times 2
       And I wait 250
-      And I press leftarrow on focused element
+      And I press "leftarrow" onto focused element
       And I wait 250
       And I press keyboard downarrow key times 2
-    When I press Home on focused element
+    When I press "Home" onto focused element
     Then focused element inner content is set to "Sub Menu 1"
       And Action Popover element has golden border on focus
 
   @positive
   Scenario: verify that the last element Delete is focused using Uparrow key
     When I click the menu button element in noiFrame
-      And I press uparrow on focused element
+      And I press "uparrow" onto focused element
     Then focused element inner content is set to "Delete"
       And Action Popover element has golden border on focus
 
   @positive
   Scenario: verify that the last element Delete is focused using End key
     When I click the menu button element in noiFrame
-      And I press End on focused element
+      And I press "End" onto focused element
     Then focused element inner content is set to "Delete"
       And Action Popover element has golden border on focus
 
@@ -79,42 +79,42 @@ Feature: Action Popover component in noIFrame
     Given I click the menu button element in noiFrame
       And I press keyboard downarrow key times 2
       And I wait 250
-      And I press leftarrow on focused element
+      And I press "leftarrow" onto focused element
       And I wait 250
-    When I press End on focused element
+    When I press "End" onto focused element
     Then focused element inner content is set to "Sub Menu 3"
       And Action Popover element has golden border on focus
 
   @positive
   Scenario: Open Action Popover and close it using Tab key
     When I click the menu button element in noiFrame
-      And I press Tab on focused element
+      And I press "Tab" onto focused element
     Then Action Popover element is not visible
 
   @positive
   Scenario: Open Action Popover and close it using Shift Tab key
     When I click the menu button element in noiFrame
-      And I press ShiftTab on focused element
+      And I press "ShiftTab" onto focused element
     Then Action Popover element is not visible
 
   @positive
   Scenario: Open Action Popover and close it using ESC key
     Given I click the menu button element in noiFrame
-    When I press ESC on focused element
+    When I press "ESC" onto focused element
     Then Action Popover element is not visible
 
   @positive
   Scenario: Close ActionPopover using ESC key if it hasn't a submenu
     Given I click the menu button element in noiFrame
       And I press keyboard downarrow key times 1
-    When I press ESC on focused element
+    When I press "ESC" onto focused element
     Then Action Popover element is not visible
 
   @positive
   Scenario: Action Popover is still open after using ESC key if it has a submenu
     Given I click the menu button element in noiFrame
       And I press keyboard downarrow key times 2
-    When I press ESC on focused element
+    When I press "ESC" onto focused element
     Then Action Popover element is visible
 
   @positive
@@ -148,7 +148,7 @@ Feature: Action Popover component in noIFrame
   Scenario Outline: check submenu <innerText> as inner context
     When I click the menu button element in noiFrame
       And I press keyboard downarrow key times 2
-      And I press leftarrow on focused element
+      And I press "leftarrow" onto focused element
       And I press keyboard downarrow key times <times>
     Then focused element inner content is set to "<innerText>"
       And Action Popover element has golden border on focus
@@ -163,10 +163,10 @@ Feature: Action Popover component in noIFrame
     Given I click the menu button element in noiFrame
       And I press keyboard downarrow key times 2
       And I wait 250
-      And I press leftarrow on focused element
+      And I press "leftarrow" onto focused element
       And I wait 250
       And I press keyboard downarrow key times <times>
-    When I press Enter on focused element
+    When I press "enter" onto focused element
     Then ActionPopover submenu is not visible
     Examples:
       | times |
@@ -179,10 +179,10 @@ Feature: Action Popover component in noIFrame
     Given I click the menu button element in noiFrame
       And I press keyboard downarrow key times 2
       And I wait 250
-      And I press leftarrow on focused element
+      And I press "leftarrow" onto focused element
       And I wait 250
       And I press keyboard downarrow key times <times>
-    When I press ArrowRight on focused element
+    When I press "rightarrow" onto focused element
     Then ActionPopover submenu is not visible
     Examples:
       | times |
@@ -195,10 +195,10 @@ Feature: Action Popover component in noIFrame
     Given I click the menu button element in noiFrame
       And I press keyboard downarrow key times 2
       And I wait 250
-      And I press leftarrow on focused element
+      And I press "leftarrow" onto focused element
       And I wait 250
       And I press keyboard downarrow key times <times>
-    When I press ESC on focused element
+    When I press "ESC" onto focused element
     Then ActionPopover submenu is not visible
     Examples:
       | times |

--- a/cypress/features/regression/test/advancedColorPicker.feature
+++ b/cypress/features/regression/test/advancedColorPicker.feature
@@ -1,0 +1,63 @@
+Feature: Advanced Color Picker component
+  I want to test Advanced Color Picker component
+
+  Background: Open Advanced Color Picker component page
+    Given I open basic Test "Advanced Color Picker" component page
+      And I open Advanced Color Picker
+
+  @positive
+  Scenario: Left arrow moves selection left
+    When I press "ArrowLeft" on a 7 color in advanced colorpicker
+    Then Simple Color 6 element was picked up
+
+  @positive
+  Scenario: Right arrow moves selection right
+    When I press "ArrowRight" on a 7 color in advanced colorpicker
+    Then Simple Color 8 element was picked up
+
+  @positive
+  Scenario: Up arrow moves selection up
+    When I press "ArrowUp" on a 7 color in advanced colorpicker
+    Then Simple Color 2 element was picked up
+
+  @positive
+  Scenario: Down arrow moves selection down
+    When I press "ArrowDown" on a 7 color in advanced colorpicker
+    Then Simple Color 7 element was picked up
+
+  @positive
+  Scenario: Tab key pressed two times when color is focused regains focus on color
+    When I press Tab on 7 element
+    Then closeIcon is focused
+    Given I press Tab on 7 element
+    Then Simple Color 7 has focus
+
+  @positive
+  Scenario: Space key on checked color closes picker
+    When I press Space on 7 element
+    Then closeIcon is not visible
+
+  @positive
+  Scenario: Enter key on checked color closes picker
+    When I press Enter on 7 element
+    Then closeIcon is not visible
+
+  @positive
+  Scenario: Upon opening color picker the default dolor is pre-selected and is focused
+    Given closeIcon is visible
+    When Simple Color 7 element was picked up
+    Then Simple Color 7 has focus
+
+  @positive
+  Scenario: Clicking Advanced Color Picker Cell preview opens the color picker
+    Then closeIcon is visible
+
+  @positive
+  Scenario Outline: Check the Simple Color Picker <position> element was selected
+    When I pick simple <position> color
+    Then Simple Color <position> element was picked up
+    Examples:
+      | position |
+      | 1        |
+      | 2        |
+      | 3        |

--- a/cypress/features/regression/test/advancedColorPicker.feature
+++ b/cypress/features/regression/test/advancedColorPicker.feature
@@ -6,30 +6,10 @@ Feature: Advanced Color Picker component
       And I open Advanced Color Picker
 
   @positive
-  Scenario: Left arrow moves selection left
-    When I press "ArrowLeft" on a 7 color in advanced colorpicker
-    Then Simple Color 6 element was picked up
-
-  @positive
-  Scenario: Right arrow moves selection right
-    When I press "ArrowRight" on a 7 color in advanced colorpicker
-    Then Simple Color 8 element was picked up
-
-  @positive
-  Scenario: Up arrow moves selection up
-    When I press "ArrowUp" on a 7 color in advanced colorpicker
-    Then Simple Color 2 element was picked up
-
-  @positive
-  Scenario: Down arrow moves selection down
-    When I press "ArrowDown" on a 7 color in advanced colorpicker
-    Then Simple Color 7 element was picked up
-
-  @positive
   Scenario: Tab key pressed two times when color is focused regains focus on color
-    When I press Tab on 7 element
-    Then closeIcon is focused
     Given I press Tab on 7 element
+      And closeIcon is focused
+    When I press Tab on 7 element
     Then Simple Color 7 has focus
 
   @positive
@@ -49,8 +29,10 @@ Feature: Advanced Color Picker component
     Then Simple Color 7 has focus
 
   @positive
-  Scenario: Clicking Advanced Color Picker Cell preview opens the color picker
-    Then closeIcon is visible
+  Scenario: Advanced Simple Color is visible
+    # commented because of BDD default scenario Given - When - Then
+    # When I open Advanced Color Picker
+    Then Advanced Simple Color is visible
 
   @positive
   Scenario Outline: Check the Simple Color Picker <position> element was selected

--- a/cypress/features/regression/test/advancedColorPickerNoIFrame.feature
+++ b/cypress/features/regression/test/advancedColorPickerNoIFrame.feature
@@ -1,0 +1,23 @@
+Feature: Advanced Color Picker component
+  I want to test Advanced Color Picker component
+
+  Background: Open Advanced Color Picker component page
+    Given I open basic Test "Advanced Color Picker" component page in noIframe
+      And I open Advanced Color Picker in noIFrame
+
+
+  @positive
+  Scenario Outline: <key> moves selection
+    When I press "<key>" onto focused element
+    Then Simple Color <index> element was picked up in noIframe
+    Examples:
+      | key        | index |
+      | leftarrow  | 6     |
+      | rightarrow | 8     |
+      | uparrow    | 2     |
+
+  @positive
+  Scenario: Down arrow moves selection down
+    Given I press "uparrow" onto focused element
+    When I press "downarrow" onto focused element
+    Then Simple Color 7 element was picked up in noIframe

--- a/cypress/locators/advanced-color-picker/index.js
+++ b/cypress/locators/advanced-color-picker/index.js
@@ -7,3 +7,7 @@ export const experimentalSimpleColorPickerInput = index => cy.iFrame(
   SIMPLE_COLOR,
 ).find('input').eq(index);
 export const advancedColorPickerCell = () => cy.iFrame(ADVANCED_COLOR_PICKER_CELL);
+export const experimentalSimpleColorPickerInputNoIframe = index => cy.get(
+  SIMPLE_COLOR,
+).find('input').eq(index);
+export const advancedColorPickerCellNoIframe = () => cy.get(ADVANCED_COLOR_PICKER_CELL);

--- a/cypress/locators/advanced-color-picker/index.js
+++ b/cypress/locators/advanced-color-picker/index.js
@@ -1,0 +1,9 @@
+import {
+  ADVANCED_COLOR_PICKER_CELL,
+  SIMPLE_COLOR,
+} from './locators';
+
+export const experimentalSimpleColorPickerInput = index => cy.iFrame(
+  SIMPLE_COLOR,
+).find('input').eq(index);
+export const advancedColorPickerCell = () => cy.iFrame(ADVANCED_COLOR_PICKER_CELL);

--- a/cypress/locators/advanced-color-picker/locators.js
+++ b/cypress/locators/advanced-color-picker/locators.js
@@ -1,0 +1,3 @@
+// component preview locators
+export const ADVANCED_COLOR_PICKER_CELL = '[data-element="color-picker-cell"]';
+export const SIMPLE_COLOR = '[data-component="simple-color"]';

--- a/cypress/support/step-definitions/advanced-color-picker-steps.js
+++ b/cypress/support/step-definitions/advanced-color-picker-steps.js
@@ -1,0 +1,59 @@
+import {
+  experimentalSimpleColorPickerInput,
+  advancedColorPickerCell,
+} from '../../locators/advanced-color-picker';
+
+const FIRST_ELEMENT = 1;
+const SECOND_ELEMENT = 2;
+
+When('I open Advanced Color Picker', () => {
+  advancedColorPickerCell().first().click();
+});
+
+When('I pick simple {int} color', (index) => {
+  if (index === 1) {
+    experimentalSimpleColorPickerInput(SECOND_ELEMENT).click();
+    experimentalSimpleColorPickerInput(FIRST_ELEMENT).click();
+  }
+  for (let i = 0; i < index; ++i) {
+    experimentalSimpleColorPickerInput(i + 1).click();
+  }
+});
+
+Then('Simple Color {int} has focus', (index) => {
+  experimentalSimpleColorPickerInput(index).should('have.focus');
+});
+
+Then('Simple Color {int} element was picked up', (index) => {
+  experimentalSimpleColorPickerInput(index).should('have.attr', 'aria-checked', 'true');
+});
+
+When('I press {string} on a {int} color in advanced colorpicker', (arrow, index) => {
+  switch (arrow) {
+    case 'ArrowDown':
+      experimentalSimpleColorPickerInput(index).trigger('keydown', { key: arrow, keyCode: 40, which: 40 });
+      break;
+    case 'ArrowUp':
+      experimentalSimpleColorPickerInput(index).trigger('keydown', { key: arrow, keyCode: 38, which: 38 });
+      break;
+    case 'ArrowRight':
+      experimentalSimpleColorPickerInput(index).trigger('keydown', { key: arrow, keyCode: 39, which: 39 });
+      break;
+    case 'ArrowLeft':
+      experimentalSimpleColorPickerInput(index).trigger('keydown', { key: arrow, keyCode: 37, which: 37 });
+      break;
+    default: throw new Error('Could not press that arrow key');
+  }
+});
+
+When('I press Enter on {int} element', (index) => {
+  experimentalSimpleColorPickerInput(index).trigger('keydown', { key: 'Enter', keyCode: 13, which: 13 });
+});
+
+When('I press Space on {int} element', (index) => {
+  experimentalSimpleColorPickerInput(index).trigger('keydown', { key: 'Space', keyCode: 32, which: 32 });
+});
+
+When('I press Tab on {int} element', (index) => {
+  experimentalSimpleColorPickerInput(index).trigger('keydown', { key: 'Tab', keyCode: 9, which: 9 });
+});

--- a/cypress/support/step-definitions/advanced-color-picker-steps.js
+++ b/cypress/support/step-definitions/advanced-color-picker-steps.js
@@ -1,6 +1,8 @@
 import {
   experimentalSimpleColorPickerInput,
   advancedColorPickerCell,
+  experimentalSimpleColorPickerInputNoIframe,
+  advancedColorPickerCellNoIframe,
 } from '../../locators/advanced-color-picker';
 
 const FIRST_ELEMENT = 1;
@@ -8,6 +10,10 @@ const SECOND_ELEMENT = 2;
 
 When('I open Advanced Color Picker', () => {
   advancedColorPickerCell().first().click();
+});
+
+When('I open Advanced Color Picker in noIFrame', () => {
+  advancedColorPickerCellNoIframe().first().click();
 });
 
 When('I pick simple {int} color', (index) => {
@@ -28,22 +34,8 @@ Then('Simple Color {int} element was picked up', (index) => {
   experimentalSimpleColorPickerInput(index).should('have.attr', 'aria-checked', 'true');
 });
 
-When('I press {string} on a {int} color in advanced colorpicker', (arrow, index) => {
-  switch (arrow) {
-    case 'ArrowDown':
-      experimentalSimpleColorPickerInput(index).trigger('keydown', { key: arrow, keyCode: 40, which: 40 });
-      break;
-    case 'ArrowUp':
-      experimentalSimpleColorPickerInput(index).trigger('keydown', { key: arrow, keyCode: 38, which: 38 });
-      break;
-    case 'ArrowRight':
-      experimentalSimpleColorPickerInput(index).trigger('keydown', { key: arrow, keyCode: 39, which: 39 });
-      break;
-    case 'ArrowLeft':
-      experimentalSimpleColorPickerInput(index).trigger('keydown', { key: arrow, keyCode: 37, which: 37 });
-      break;
-    default: throw new Error('Could not press that arrow key');
-  }
+Then('Simple Color {int} element was picked up in noIframe', (index) => {
+  experimentalSimpleColorPickerInputNoIframe(index).should('have.attr', 'aria-checked', 'true');
 });
 
 When('I press Enter on {int} element', (index) => {
@@ -56,4 +48,8 @@ When('I press Space on {int} element', (index) => {
 
 When('I press Tab on {int} element', (index) => {
   experimentalSimpleColorPickerInput(index).trigger('keydown', { key: 'Tab', keyCode: 9, which: 9 });
+});
+
+Then('Advanced Simple Color is visible', () => {
+  advancedColorPickerCell().should('be.visible');
 });

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -476,43 +476,10 @@ Then('{string} tab in {string} tab list is visible', (knobsName, position) => {
   }
 });
 
-When('I press ESC on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 16, which: 16, release: false });
-  cy.focused().trigger('keydown', { keyCode: 27, which: 27 });
-});
-
-When('I press Tab on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 9, which: 9 });
-});
-
-When('I press Home on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 36, which: 36 });
-});
-
-When('I press uparrow on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 38, which: 38 });
-});
-
-When('I press leftarrow on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 37, which: 37 });
-});
-
 When('I press keyboard downarrow key times {int}', (times) => {
   for (let i = 0; i < times; i++) {
     cy.focused().trigger('keydown', { keyCode: 40, which: 40 });
   }
-});
-
-When('I press End on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 35, which: 35 });
-});
-
-When('I press Enter on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 13, which: 13 });
-});
-
-When('I press ArrowRight on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 39, which: 39 });
 });
 
 When('I press {string} onto focused element', (arrow) => {
@@ -523,19 +490,37 @@ When('I press {string} onto focused element', (arrow) => {
     case 'uparrow':
       cy.focused().trigger('keydown', { keyCode: 38, which: 38 });
       break;
+    case 'leftarrow':
+      cy.focused().trigger('keydown', { keyCode: 37, which: 37 });
+      break;
+    case 'rightarrow':
+      cy.focused().trigger('keydown', { keyCode: 39, which: 39 });
+      break;
     case 'enter':
       cy.focused().trigger('keydown', { keyCode: 13, which: 13 });
       break;
     case 'space':
       cy.focused().trigger('keydown', { keyCode: 32, which: 32 });
       break;
-    default: throw new Error(`This key ${arrow} is not one of the arrow ones`);
+    case 'ESC':
+      cy.focused().trigger('keydown', { keyCode: 16, which: 16, release: false });
+      cy.focused().trigger('keydown', { keyCode: 27, which: 27 });
+      break;
+    case 'Tab':
+      cy.focused().trigger('keydown', { keyCode: 9, which: 9 });
+      break;
+    case 'ShiftTab':
+      cy.focused().trigger('keydown', { keyCode: 16, which: 16, release: false });
+      cy.focused().trigger('keydown', { keyCode: 9, which: 9 });
+      break;
+    case 'Home':
+      cy.focused().trigger('keydown', { keyCode: 36, which: 36 });
+      break;
+    case 'End':
+      cy.focused().trigger('keydown', { keyCode: 35, which: 35 });
+      break;
+    default: throw new Error(`This key ${arrow} is not one of the allowed`);
   }
-});
-
-When('I press ShiftTab on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 16, which: 16, release: false });
-  cy.focused().trigger('keydown', { keyCode: 9, which: 9 });
 });
 
 Then('focused element inner content is set to {string}', (text) => {

--- a/jest.conf.json
+++ b/jest.conf.json
@@ -31,10 +31,11 @@
   "moduleFileExtensions": [
     "ts",
     "tsx",
-    "js", 
+    "js",
     "jsx"
   ],
   "transform": {
-    "^.+\\.(js|jsx|ts|tsx)$": "babel-jest"
+    "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
+    "^.+\\.svg$": "<rootDir>/svgTransform.js"
   }
 }

--- a/src/__experimental__/components/simple-color-picker/color-sample-box/checker-board.svg
+++ b/src/__experimental__/components/simple-color-picker/color-sample-box/checker-board.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" fill-opacity=".45"><rect x="200" width="200" height="200" /><rect y="200" width="200" height="200" /></svg>

--- a/src/__experimental__/components/simple-color-picker/color-sample-box/color-sample-box.spec.js
+++ b/src/__experimental__/components/simple-color-picker/color-sample-box/color-sample-box.spec.js
@@ -33,9 +33,10 @@ describe('ColorSampleBox', () => {
     wrapper = renderStyles({ color: 'transparent' });
     assertStyleMatch(
       {
-        backgroundColor: 'transparent',
-        // eslint-disable-next-line max-len
-        background: 'conic-gradient(#fff 0deg ,#fff 90deg, grey 90deg,grey 180deg, #fff 180deg,#fff 270deg, grey 270deg,grey 360deg) 0 0/25% 25%'
+        backgroundColor: '#EEEEEE',
+        backgroundImage: 'url()',
+        backgroundSize: '14px 14px',
+        backgroundPosition: '-2px -2px'
       },
       wrapper.toJSON()
     );

--- a/src/__experimental__/components/simple-color-picker/color-sample-box/color-sample-box.style.js
+++ b/src/__experimental__/components/simple-color-picker/color-sample-box/color-sample-box.style.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 import colorSampleBoxClassicStyle from './color-sample-box-classic.style';
+import checkerBoardSvg from './checker-board.svg';
 
 const StyledColorSampleBox = styled.div`
   height: 100%;
@@ -10,14 +11,16 @@ const StyledColorSampleBox = styled.div`
   align-items: center;
   justify-content: center;
   border: 2px solid transparent;
-  background-color: ${({ color }) => color};
+
+  ${({ color }) => color !== 'transparent' && css`
+    background-color: ${color};
+  `}
 
   ${({ color }) => color === 'transparent' && css`
-    background: conic-gradient(#fff 0deg ,#fff 90deg,
-                grey 90deg,grey 180deg,
-                #fff 180deg,#fff 270deg,
-                grey 270deg,grey 360deg)
-                0 0/25% 25%;
+    background-color: #EEEEEE;
+    background-image: url(${checkerBoardSvg});
+    background-size: 14px 14px;
+    background-position: -2px -2px;
   `}
 
   ${colorSampleBoxClassicStyle}

--- a/src/components/advanced-color-picker/__snapshots__/advanced-color-picker.spec.js.snap
+++ b/src/components/advanced-color-picker/__snapshots__/advanced-color-picker.spec.js.snap
@@ -1,0 +1,471 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AdvancedColorPicker when uncontrolled should match uncontrolled snapshot 1`] = `
+.c1 {
+  display: block;
+  width: 25px;
+  height: 25px;
+  border: 1px solid #516562;
+  background-color: #EBAEDE;
+}
+
+.c1:hover {
+  cursor: pointer;
+}
+
+.c1:focus {
+  outline: solid 3px #FFB500;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+}
+
+.c3 .modal-enter,
+.c3 .modal-appear {
+  opacity: 0;
+  margin-top: 50px;
+}
+
+.c3 .modal-enter.modal-enter-active,
+.c3 .modal-appear.modal-appear-active {
+  opacity: 1;
+  margin-top: 0;
+  -webkit-transition: all 300ms 100ms ease-out;
+  transition: all 300ms 100ms ease-out;
+}
+
+.c3 .modal-exit {
+  opacity: 1;
+  margin-top: 0;
+}
+
+.c3 .modal-exit.modal-exit-active {
+  opacity: 0;
+  margin-top: 50px;
+  -webkit-transition: all 300ms ease-out;
+  transition: all 300ms ease-out;
+}
+
+.c0 {
+  display: inline-block;
+  margin: 15px auto auto 15px;
+}
+
+.c2 .c7 {
+  padding: 18px 18px 18px 17px;
+}
+
+.c2 .c8 {
+  padding: 0;
+}
+
+.c2 .c4 {
+  max-width: 285px;
+}
+
+.c2 .c4 .c5 {
+  border: 1px solid #3C514E;
+  margin-right: -1px;
+  margin-bottom: -1px;
+  -webkit-transition: all .2s ease;
+  transition: all .2s ease;
+}
+
+.c2 .c4 .c5:hover {
+  -webkit-transform: scale(1.1);
+  -ms-transform: scale(1.1);
+  transform: scale(1.1);
+}
+
+.c2 .c6 {
+  top: 20px;
+  right: 13px;
+}
+
+<AdvancedColorPicker
+  availableColors={
+    Array [
+      Object {
+        "label": "white",
+        "value": "#FFFFFF",
+      },
+      Object {
+        "label": "transparent",
+        "value": "transparent",
+      },
+      Object {
+        "label": "black",
+        "value": "#000000",
+      },
+      Object {
+        "label": "blue",
+        "value": "#A3CAF0",
+      },
+      Object {
+        "label": "pink",
+        "value": "#FD9BA3",
+      },
+      Object {
+        "label": "purple",
+        "value": "#B4AEEA",
+      },
+      Object {
+        "label": "goldenrod",
+        "value": "#ECE6AF",
+      },
+      Object {
+        "label": "orchid",
+        "value": "#EBAEDE",
+      },
+      Object {
+        "label": "desert",
+        "value": "#EBC7AE",
+      },
+      Object {
+        "label": "turquoise",
+        "value": "#AEECEB",
+      },
+      Object {
+        "label": "mint",
+        "value": "#AEECD6",
+      },
+    ]
+  }
+  defaultColor="#EBAEDE"
+  name="advancedPicker"
+>
+  <styled.div>
+    <StyledComponent
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "sc-hzDkRC",
+            "isStatic": true,
+            "lastClassName": "c0",
+            "rules": Array [
+              "
+  display: inline-block;
+  margin: 15px auto auto 15px;
+",
+            ],
+          },
+          "displayName": "styled.div",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "sc-hzDkRC",
+          "target": "div",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+    >
+      <div
+        className="c0"
+      >
+        <styled.button
+          color="#EBAEDE"
+          data-element="color-picker-cell"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          tabIndex="0"
+        >
+          <StyledComponent
+            color="#EBAEDE"
+            data-element="color-picker-cell"
+            forwardedComponent={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "sc-bdVaJa",
+                  "isStatic": false,
+                  "lastClassName": "c1",
+                  "rules": Array [
+                    "
+  display: block;
+  width: 25px;
+  height: 25px;
+  border: 1px solid #516562;
+  ",
+                    [Function],
+                    "
+
+  ",
+                    [Function],
+                    "
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &:focus {
+    outline: solid 3px #FFB500;
+  }
+
+  &::-moz-focus-inner {
+    border: none;
+  }
+",
+                  ],
+                },
+                "displayName": "styled.button",
+                "foldedComponentIds": Array [],
+                "render": [Function],
+                "styledComponentId": "sc-bdVaJa",
+                "target": "button",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              }
+            }
+            forwardedRef={null}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            tabIndex="0"
+          >
+            <button
+              className="c1"
+              color="#EBAEDE"
+              data-element="color-picker-cell"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex="0"
+            />
+          </StyledComponent>
+        </styled.button>
+        <Styled(Dialog)
+          focusFirstElement={[Function]}
+          onCancel={[Function]}
+          open={false}
+          size="auto"
+        >
+          <StyledComponent
+            focusFirstElement={[Function]}
+            forwardedComponent={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "sc-fBuWsC",
+                  "isStatic": true,
+                  "lastClassName": "c2",
+                  "rules": Array [
+                    "
+  ",
+                    ".c7",
+                    " {
+    padding: 18px 18px 18px 17px;
+  }
+
+  ",
+                    ".c8",
+                    " {
+    padding: 0;
+  }
+
+  ",
+                    ".c4",
+                    " {
+    max-width: 285px;
+    ",
+                    ".c5",
+                    " {
+      border: 1px solid #3C514E;
+      margin-right: -1px;
+      margin-bottom: -1px;
+      transition: all .2s ease;
+
+      &:hover {
+        transform: scale(1.1);
+      }
+    }
+  }
+
+  ",
+                    ".c6",
+                    " {
+    top: 20px;
+    right: 13px;
+  }
+",
+                  ],
+                },
+                "displayName": "Styled(Dialog)",
+                "foldedComponentIds": Array [],
+                "render": [Function],
+                "styledComponentId": "sc-fBuWsC",
+                "target": [Function],
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              }
+            }
+            forwardedRef={null}
+            onCancel={[Function]}
+            open={false}
+            size="auto"
+          >
+            <Dialog
+              ariaRole="dialog"
+              className="c2"
+              focusFirstElement={[Function]}
+              onCancel={[Function]}
+              open={false}
+              showCloseIcon={true}
+              size="auto"
+            >
+              <Portal
+                key="1"
+              >
+                <span
+                  data-portal-entrance="guid-12345"
+                >
+                  <Portal
+                    containerInfo={
+                      .c1 .modal-enter,
+.c1 .modal-appear {
+  opacity: 0;
+  margin-top: 50px;
+}
+
+.c1 .modal-enter.modal-enter-active,
+.c1 .modal-appear.modal-appear-active {
+  opacity: 1;
+  margin-top: 0;
+  -webkit-transition: all 300ms 100ms ease-out;
+  transition: all 300ms 100ms ease-out;
+}
+
+.c1 .modal-exit {
+  opacity: 1;
+  margin-top: 0;
+}
+
+.c1 .modal-exit.modal-exit-active {
+  opacity: 0;
+  margin-top: 50px;
+  -webkit-transition: all 300ms ease-out;
+  transition: all 300ms ease-out;
+}
+
+.c0 .c5 {
+  padding: 18px 18px 18px 17px;
+}
+
+.c0 .c6 {
+  padding: 0;
+}
+
+.c0 .c2 {
+  max-width: 285px;
+}
+
+.c0 .c2 .c3 {
+  border: 1px solid #3C514E;
+  margin-right: -1px;
+  margin-bottom: -1px;
+  -webkit-transition: all .2s ease;
+  transition: all .2s ease;
+}
+
+.c0 .c2 .c3:hover {
+  -webkit-transform: scale(1.1);
+  -ms-transform: scale(1.1);
+  transform: scale(1.1);
+}
+
+.c0 .c4 {
+  top: 20px;
+  right: 13px;
+}
+
+<div
+                        class="carbon-portal"
+                        data-portal-exit="guid-12345"
+                      >
+                        <div
+                          class="carbon-dialog c0 c1"
+                          data-component="dialog"
+                          data-state="closed"
+                        >
+                          <div />
+                          <div />
+                        </div>
+                      </div>
+                    }
+                  >
+                    <styled.div
+                      className="carbon-dialog c2"
+                      data-component="dialog"
+                      data-state="closed"
+                      transitionName="modal"
+                    >
+                      <StyledComponent
+                        className="carbon-dialog c2"
+                        data-component="dialog"
+                        data-state="closed"
+                        forwardedComponent={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "sc-gipzik",
+                              "isStatic": false,
+                              "lastClassName": "c3",
+                              "rules": Array [
+                                "
+  ",
+                                [Function],
+                                "
+",
+                              ],
+                            },
+                            "displayName": "styled.div",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "sc-gipzik",
+                            "target": "div",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          }
+                        }
+                        forwardedRef={null}
+                        transitionName="modal"
+                      >
+                        <div
+                          className="carbon-dialog c2 c3"
+                          data-component="dialog"
+                          data-state="closed"
+                        >
+                          <TransitionGroup
+                            childFactory={[Function]}
+                            component="div"
+                          >
+                            <div />
+                          </TransitionGroup>
+                          <TransitionGroup
+                            childFactory={[Function]}
+                            component="div"
+                          >
+                            <div />
+                          </TransitionGroup>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </Portal>
+                </span>
+              </Portal>
+            </Dialog>
+          </StyledComponent>
+        </Styled(Dialog)>
+      </div>
+    </StyledComponent>
+  </styled.div>
+</AdvancedColorPicker>
+`;

--- a/src/components/advanced-color-picker/advanced-color-picker-cell.style.js
+++ b/src/components/advanced-color-picker/advanced-color-picker-cell.style.js
@@ -1,0 +1,35 @@
+import styled, { css } from 'styled-components';
+
+const transparentSvg = '%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%'
+    + '2Fsvg%22%20width%3D%22400%22%20height%3D%22400%22%20fill-opacity%3D%22.'
+    + '45%22%3E%3Crect%20x%3D%22200%22%20width%3D%22200%22%20height%3D%22200%22%20%2'
+    + 'F%3E%3Crect%20y%3D%22200%22%20width%3D%22200%22%20height%3D%22200%22%20%2F%3E%3C%2Fsvg%3E';
+
+const StyledAdvancedColorPickerCell = styled.button`
+  display: block;
+  width: 25px;
+  height: 25px;
+  border: 1px solid #516562;
+  ${({ color }) => color && css`
+    background-color: ${color};
+  `}
+
+  ${({ color }) => color === 'transparent' && css`
+    background: #eee url('data:image/svg+xml,${transparentSvg}');
+    background-size: 10px 10px;
+  `}
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &:focus {
+    outline: solid 3px #FFB500;
+  }
+
+  &::-moz-focus-inner {
+    border: none;
+  }
+`;
+
+export default StyledAdvancedColorPickerCell;

--- a/src/components/advanced-color-picker/advanced-color-picker.component.js
+++ b/src/components/advanced-color-picker/advanced-color-picker.component.js
@@ -1,0 +1,165 @@
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useRef
+} from 'react';
+import PropTypes from 'prop-types';
+import {
+  StyledAdvancedColorPickerWrapper,
+  StyledAdvancedColorPickerCell,
+  StyledAdvancedColorPickerPreview,
+  DialogStyle
+} from './advanced-color-picker.style';
+import { SimpleColorPicker, SimpleColor } from '../../__experimental__/components/simple-color-picker';
+import Events from '../../utils/helpers/events';
+
+const AdvancedColorPicker = ({
+  name,
+  open,
+  onOpen,
+  onClose,
+  onChange,
+  onBlur,
+  availableColors,
+  defaultColor,
+  selectedColor
+}) => {
+  const isOpen = open || false;
+  const [dialogOpen, setDialogOpen] = useState();
+  const currentColor = selectedColor || defaultColor;
+  const selectedColorRef = useRef();
+
+  const gridItemRefs = useRef(Array.from({
+    length: availableColors.length
+  }, () => React.createRef()));
+
+  const colors = availableColors.map(({ value, label }, index) => {
+    return {
+      value,
+      label,
+      ref: gridItemRefs.current[index]
+    };
+  });
+
+  useEffect(() => {
+    if (dialogOpen || isOpen) {
+      const selected = colors.find(c => currentColor === c.value);
+      selectedColorRef.current = selected.ref.current;
+      selected.ref.current.input.current.focus();
+    }
+  }, [colors, currentColor, dialogOpen, isOpen]);
+
+  const handleFocus = useCallback(() => {
+    selectedColorRef.current.input.current.focus();
+  }, [selectedColorRef]);
+
+  const handleOnOpen = useCallback((e) => {
+    setDialogOpen(true);
+
+    if (onOpen) {
+      onOpen(e);
+    }
+  }, [onOpen]);
+
+  const handleOnClose = useCallback((e) => {
+    setDialogOpen(false);
+
+    if (onClose) {
+      onClose(e);
+    }
+  }, [onClose]);
+
+  const handleOnChange = useCallback((e) => {
+    const selected = colors.find(c => e.target.value === c.value);
+    selectedColorRef.current = selected.ref.current;
+
+    if (onChange) {
+      onChange(e);
+    }
+  }, [onChange, colors, selectedColorRef]);
+
+  const handleOnKeyDown = useCallback((e) => {
+    if (Events.isEnterKey(e) || Events.isSpaceKey(e)) {
+      e.preventDefault();
+      handleOnOpen(e);
+    }
+  }, [handleOnOpen]);
+
+  const handleColorOnKeyDown = useCallback((e) => {
+    if (Events.isEnterKey(e) || Events.isSpaceKey(e)) {
+      e.preventDefault();
+      handleOnClose(e);
+    }
+  }, [handleOnClose]);
+
+  const handleOnBlur = useCallback((e) => {
+    if (onBlur) {
+      onBlur(e);
+    }
+  }, [onBlur]);
+
+  return (
+    <StyledAdvancedColorPickerWrapper>
+      <StyledAdvancedColorPickerCell
+        data-element='color-picker-cell'
+        onClick={ handleOnOpen }
+        onKeyDown={ handleOnKeyDown }
+        color={ currentColor }
+        tabIndex='0'
+      />
+      <DialogStyle
+        open={ dialogOpen || isOpen }
+        size='auto'
+        onCancel={ handleOnClose }
+        focusFirstElement={ handleFocus }
+      >
+        <StyledAdvancedColorPickerPreview
+          data-element='color-picker-preview'
+          color={ currentColor }
+        />
+        <SimpleColorPicker
+          name={ name }
+          legend=''
+          onChange={ handleOnChange }
+          onBlur={ handleOnBlur }
+          onKeyDown={ handleColorOnKeyDown }
+        >
+          {colors.map(({ value, label, ref }) => (
+            <SimpleColor
+              value={ value }
+              key={ value }
+              aria-label={ label }
+              id={ value }
+              defaultChecked={ value === currentColor }
+              ref={ ref }
+            />
+          ))}
+        </SimpleColorPicker>
+      </DialogStyle>
+    </StyledAdvancedColorPickerWrapper>
+  );
+};
+
+AdvancedColorPicker.propTypes = {
+  /** Specifies the name prop to be applied to each color in the group */
+  name: PropTypes.string.isRequired,
+  /** Prop for `availableColors` containing array of objects of colors */
+  availableColors: PropTypes.array.isRequired,
+  /** Prop for `defaultColor` containing the default color for `uncontrolled` use */
+  defaultColor: PropTypes.string.isRequired,
+  /** Prop for `selectedColor` containing pre-selected color for `controlled` use */
+  selectedColor: PropTypes.string,
+  /** Prop for `onChange` event */
+  onChange: PropTypes.func,
+  /** Prop for `onOpen` event */
+  onOpen: PropTypes.func,
+  /** Prop for `onClose` event */
+  onClose: PropTypes.func,
+  /** Prop for `open` status */
+  open: PropTypes.bool,
+  /** Prop for `onBlur` event */
+  onBlur: PropTypes.func
+};
+
+export default AdvancedColorPicker;

--- a/src/components/advanced-color-picker/advanced-color-picker.d.ts
+++ b/src/components/advanced-color-picker/advanced-color-picker.d.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+export interface AdvancedColorPickerPropTypes {
+  name?: string;
+  open?: boolean;
+  availableColors?: [];
+  selectedColor?: string;
+  defaultColor?: string;
+  onChange?: () => void;
+  onOpen?: (ev: React.ChangeEvent<HTMLElement>) => void;
+  onClose?: (ev: React.ChangeEvent<HTMLElement>) => void;
+  onBlur?: (ev: React.ChangeEvent<HTMLElement>) => void;
+}
+
+declare const AdvancedColorPicker: React.FunctionComponent<AdvancedColorPickerPropTypes>;
+
+export default AdvancedColorPicker;

--- a/src/components/advanced-color-picker/advanced-color-picker.spec.js
+++ b/src/components/advanced-color-picker/advanced-color-picker.spec.js
@@ -1,0 +1,383 @@
+import React from 'react';
+import { mount as enzymeMount } from 'enzyme';
+import { act } from 'react-test-renderer';
+import AdvancedColorPicker from './advanced-color-picker.component';
+import Dialog from '../dialog/dialog.component';
+import { SimpleColor } from '../../__experimental__/components/simple-color-picker';
+import guid from '../../utils/helpers/guid';
+import { assertStyleMatch } from '../../__spec_helper__/test-utils';
+
+jest.mock('../../utils/helpers/guid');
+guid.mockImplementation(() => 'guid-12345');
+
+describe('AdvancedColorPicker', () => {
+  const defaultColor = '#EBAEDE';
+  const demoColors = [
+    { value: '#FFFFFF', label: 'white' },
+    { value: 'transparent', label: 'transparent' },
+    { value: '#000000', label: 'black' },
+    { value: '#A3CAF0', label: 'blue' },
+    { value: '#FD9BA3', label: 'pink' },
+    { value: '#B4AEEA', label: 'purple' },
+    { value: '#ECE6AF', label: 'goldenrod' },
+    { value: '#EBAEDE', label: 'orchid' },
+    { value: '#EBC7AE', label: 'desert' },
+    { value: '#AEECEB', label: 'turquoise' },
+    { value: '#AEECD6', label: 'mint' }
+  ];
+
+  const requiredProps = {
+    name: 'advancedPicker',
+    availableColors: demoColors,
+    defaultColor
+  };
+
+  const container = { current: null };
+  const wrapper = { current: null };
+
+  const mount = (jsx) => {
+    wrapper.current = enzymeMount(jsx, { attachTo: container.current });
+  };
+
+  function render(props = {}, renderer = mount) {
+    return renderer(
+      <AdvancedColorPicker { ...props } />
+    );
+  }
+
+  function getElements() {
+    const closeIcon = document.querySelector('[data-element="close"]');
+    const defaultSimpleColor = document.querySelector(`input[value="${defaultColor}"]`);
+    const simpleColors = document.querySelectorAll('[data-component="simple-color"] > input');
+
+    return { closeIcon, defaultSimpleColor, simpleColors };
+  }
+
+  beforeEach(() => {
+    container.current = document.createElement('div');
+    document.body.appendChild(container.current);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container.current);
+    container.current = null;
+    if (wrapper.current) {
+      wrapper.current.unmount();
+      wrapper.current = null;
+    }
+  });
+
+  const aKey = new KeyboardEvent('keydown', { which: 65, keyCode: 65, key: 'a' });
+  const spaceKey = new KeyboardEvent('keydown', { which: 32, keyCode: 32, key: 'Space' });
+  const enterKey = new KeyboardEvent('keydown', { which: 13, keyCode: 13, key: 'Enter' });
+  const tabKey = new KeyboardEvent('keydown', { which: 9, keyCode: 9, key: 'Tab' });
+
+
+  describe('when uncontrolled', () => {
+    it('should match uncontrolled snapshot', () => {
+      render(requiredProps);
+      expect(wrapper.current).toMatchSnapshot();
+    });
+  });
+
+  describe('when controlled', () => {
+    describe('on tabKey changes focus', () => {
+      it('triggers focusTrap', () => {
+        const additionalProps = {
+          ...requiredProps,
+          open: true
+        };
+
+        render(additionalProps);
+
+        const { closeIcon, defaultSimpleColor } = getElements();
+
+        expect(document.activeElement).toBe(defaultSimpleColor);
+        closeIcon.focus();
+        expect(document.activeElement).toBe(closeIcon);
+        document.dispatchEvent(tabKey);
+        expect(document.activeElement).toBe(defaultSimpleColor);
+      });
+    });
+
+    describe('when dialog is open', () => {
+      describe('for focus event', () => {
+        describe('when activeElement is not selectedColor', () => {
+          it('on Tab key focuses selectedColor', () => {
+            render({ ...requiredProps, open: true });
+
+            const closeButton = wrapper.current.find('[data-element="close"]').first();
+            closeButton.getDOMNode().focus();
+
+            expect(document.activeElement).toBe(closeButton.getDOMNode());
+
+            document.dispatchEvent(tabKey);
+
+            const { defaultSimpleColor } = getElements();
+
+            expect(
+              document.activeElement.getAttribute('value')
+            ).toBe(defaultSimpleColor.getAttribute('value'));
+          });
+
+          it('renders transparent color', () => {
+            const extraProps = {
+              name: 'advancedPicker',
+              availableColors: [
+                { value: 'transparent', label: 'transparent' }
+              ],
+              defaultColor: 'transparent',
+              open: true
+            };
+
+            render(extraProps);
+
+            const { simpleColors } = getElements();
+
+            expect(document.activeElement).toBe(simpleColors[0]);
+
+            const simpleColor = wrapper.current.find(SimpleColor).at(0);
+            const colorPreviewCell = simpleColor.find('ColorSampleBox').first().find('div').first();
+            expect(
+              document.activeElement.getAttribute('value')
+            ).toBe(wrapper.current.find(SimpleColor).at(0).prop('value'));
+            assertStyleMatch(
+              {
+                backgroundColor: '#EEEEEE',
+                backgroundImage: 'url()',
+                backgroundSize: '14px 14px'
+              },
+              colorPreviewCell
+            );
+          });
+        });
+      });
+    });
+
+    describe('onChange event', () => {
+      describe('onClick event', () => {
+        describe('when onChange is provided', () => {
+          it('changes selection and triggers onChange callback', () => {
+            const onChange = jest.fn();
+            const extraProps = {
+              ...requiredProps,
+              open: true,
+              onChange
+            };
+
+            render(extraProps);
+
+            const { simpleColors } = getElements();
+
+            expect(document.activeElement).toBe(simpleColors[7]);
+
+            const color = wrapper.current.find(SimpleColor).at(8);
+            color.find('input').first().getDOMNode().click();
+
+            expect(onChange).toHaveBeenCalled();
+            expect(
+              document.activeElement.getAttribute('value')
+            ).toBe(wrapper.current.find(SimpleColor).at(8).prop('value'));
+          });
+        });
+
+        describe('when onChange is not provided', () => {
+          it('changes selection, does not trigger onChange callback', () => {
+            const onChange = jest.fn();
+            const extraProps = {
+              ...requiredProps,
+              open: true
+            };
+
+            render(extraProps);
+
+            const { simpleColors } = getElements();
+
+            expect(document.activeElement).toBe(simpleColors[7]);
+            const color = wrapper.current.find(SimpleColor).at(8);
+
+            color.find('input').first().getDOMNode().click();
+
+            expect(onChange).not.toHaveBeenCalled();
+            expect(
+              document.activeElement.getAttribute('value')
+            ).toBe(wrapper.current.find(SimpleColor).at(8).prop('value'));
+          });
+        });
+
+        it('changes selection and triggers onChange callback', () => {
+          const onBlur = jest.fn();
+          const extraProps = {
+            ...requiredProps,
+            open: true,
+            onBlur
+          };
+
+          render(extraProps);
+
+          const { simpleColors } = getElements();
+
+          expect(document.activeElement).toBe(simpleColors[7]);
+
+          const color = wrapper.current.find(SimpleColor).at(8);
+          color.find('input').first().getDOMNode().click();
+
+          expect(onBlur).toHaveBeenCalled();
+          expect(
+            document.activeElement.getAttribute('value')
+          ).toBe(wrapper.current.find(SimpleColor).at(8).prop('value'));
+        });
+      });
+    });
+
+    describe('SimpleColor onKeyDown event triggers', () => {
+      const keyDownEvents = [
+        ['Enter', true, true, enterKey],
+        ['Space', true, true, spaceKey],
+        ['a', false, false, aKey]
+      ];
+
+      const extraProps = {
+        ...requiredProps,
+        open: true
+      };
+
+      test.each(keyDownEvents)(
+        'on %p key dialog`s isOpen is: %p',
+        (name, result, expectedResult, key) => {
+          render(extraProps);
+          act(() => {
+            wrapper.current.find(SimpleColor).at(8).find('input').first()
+              .simulate('keydown', { which: key.keyCode });
+          });
+          expect(result).toEqual(expectedResult);
+        }
+      );
+    });
+
+    describe('dialog', () => {
+      const props = [[undefined, false], [false, false], [true, true]];
+
+      test.each(props)(
+        'when `open` prop is: %p, dialog`s isOpen is: %p',
+        (result, expectedResult) => {
+          render({
+            ...requiredProps,
+            open: result
+          });
+          expect(wrapper.current.find(Dialog).first().prop('open')).toEqual(expectedResult);
+        }
+      );
+
+      describe('when dialog is closed', () => {
+        it('uses defaultColor when selectedColor is not provided', () => {
+          render({ ...requiredProps });
+          expect(wrapper.current.find(AdvancedColorPicker).first().prop('defaultColor')).toBe(defaultColor);
+        });
+
+        it('uses selectedColor when provided', () => {
+          const selectedColor = '#AEECD6';
+          render({ ...requiredProps, selectedColor });
+          expect(wrapper.current.find(AdvancedColorPicker).first().prop('selectedColor')).toBe(selectedColor);
+        });
+
+        describe('when focused on picker cell', () => {
+          let colorPickerCell;
+
+          beforeEach(() => {
+            render({ ...requiredProps });
+            colorPickerCell = wrapper.current.find('[data-element="color-picker-cell"]').first();
+            colorPickerCell.getDOMNode().focus();
+          });
+
+          it('color picker cell is focused', () => {
+            expect(document.activeElement).toBe(colorPickerCell.getDOMNode());
+          });
+
+          const keyDownEvents = [
+            ['Enter', true, true, enterKey],
+            ['Space', true, true, spaceKey],
+            ['a', false, false, aKey]
+          ];
+
+          test.each(keyDownEvents)(
+            'on %p key dialog`s isOpen is: %p',
+            (name, result, expectedResult, key) => {
+              act(() => {
+                colorPickerCell.simulate('keydown', { which: key.keyCode });
+              });
+              expect(result).toEqual(expectedResult);
+            }
+          );
+
+          describe('onOpen callback function is proivided', () => {
+            describe('when open prop is uncontrolled', () => {
+              it('opens color picker and calls onOpen callback function', () => {
+                const onOpen = jest.fn();
+                wrapper.current.setProps({ onOpen });
+                wrapper.current.update();
+                colorPickerCell = wrapper.current.find('[data-element="color-picker-cell"]').first();
+                colorPickerCell.getDOMNode().focus();
+
+                act(() => {
+                  colorPickerCell.simulate('click');
+                });
+
+                const dialog = wrapper.current.find(Dialog).first();
+                expect(dialog.prop('open')).toBeTruthy();
+                expect(onOpen).toBeCalledTimes(1);
+              });
+            });
+          });
+
+          describe('when onClose event', () => {
+            it('closes color picker and calls onClose callback function', () => {
+              const onClose = jest.fn();
+
+              wrapper.current.setProps({ onClose });
+              wrapper.current.update();
+
+              act(() => {
+                colorPickerCell.simulate('click');
+              });
+
+              expect(wrapper.current.find(Dialog).first().prop('open')).toBeTruthy();
+
+              const closeButton = wrapper.current.find('[data-element="close"]').first();
+
+              act(() => {
+                closeButton.simulate('click');
+              });
+
+              wrapper.current.update();
+
+              expect(onClose).toBeCalledTimes(1);
+              expect(wrapper.current.find(Dialog).first().prop('open')).toBeFalsy();
+            });
+
+            it('when callback function is not proivided', () => {
+              const onClose = jest.fn();
+
+              act(() => {
+                colorPickerCell.simulate('click');
+              });
+
+              expect(wrapper.current.find(Dialog).first().prop('open')).toBeTruthy();
+
+              const closeButton = wrapper.current.find('[data-element="close"]').first();
+
+              act(() => {
+                closeButton.simulate('click');
+              });
+
+              wrapper.current.update();
+
+              expect(onClose).toBeCalledTimes(0);
+              expect(wrapper.current.find(Dialog).first().prop('open')).toBeFalsy();
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/components/advanced-color-picker/advanced-color-picker.stories.js
+++ b/src/components/advanced-color-picker/advanced-color-picker.stories.js
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import {
+  text,
+  object,
+  withKnobs
+} from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+import AdvancedColorPicker from '.';
+
+export default {
+  title: 'Test/Advanced Color Picker',
+  component: AdvancedColorPicker,
+  decorators: [withKnobs],
+  parameters: {
+    info: {
+      disable: true
+    },
+    knobs: { escapeHTML: false }
+  }
+};
+
+export const Basic = () => {
+  const [state, setState] = useState({
+    open: false,
+    selectedColor: null
+  });
+
+  const onOpen = (e) => {
+    setState({
+      open: true,
+      selectedColor: state.selectedColor
+    });
+
+    action('Open')(e);
+  };
+
+  const onClose = (e) => {
+    setState({
+      open: false,
+      selectedColor: state.selectedColor
+    });
+
+    action('Close')(e);
+  };
+
+  const onChange = (e) => {
+    const { value } = e.target;
+
+    setState({
+      selectedColor: value
+    });
+
+    action(`Selected - ${value}`)(e);
+  };
+
+  const onBlur = (e) => {
+    action('Blur')(e);
+  };
+
+  const demoColors = [
+    { value: '#FFFFFF', label: 'white' },
+    { value: 'transparent', label: 'transparent' },
+    { value: '#000000', label: 'black' },
+    { value: '#A3CAF0', label: 'blue' },
+    { value: '#FD9BA3', label: 'pink' },
+    { value: '#B4AEEA', label: 'purple' },
+    { value: '#ECE6AF', label: 'goldenrod' },
+    { value: '#EBAEDE', label: 'orchid' },
+    { value: '#EBC7AE', label: 'desert' },
+    { value: '#AEECEB', label: 'turquoise' },
+    { value: '#AEECD6', label: 'mint' }
+  ];
+  const name = text('name', 'advancedPicker');
+  const availableColors = object('availableColors', demoColors);
+
+  return (
+    <AdvancedColorPicker
+      name={ name }
+      onOpen={ onOpen }
+      onClose={ onClose }
+      onChange={ onChange }
+      onBlur={ onBlur }
+      availableColors={ availableColors }
+      selectedColor={ state.selectedColor }
+      defaultColor='#EBAEDE'
+      open={ state.open }
+    />
+  );
+};

--- a/src/components/advanced-color-picker/advanced-color-picker.stories.mdx
+++ b/src/components/advanced-color-picker/advanced-color-picker.stories.mdx
@@ -1,0 +1,53 @@
+import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
+import AdvancedColorPicker from '.';
+import { useState } from 'react';
+
+<Meta title="Design System/Advanced Color Picker" />
+
+# Advanced Color Picker
+
+### Basic usage:
+
+<Preview>
+  <Story name="default" parameters={{ info: { disable: true }}} >
+  {() => {
+    const [open, setOpen] = useState(false);
+    const [color, setColor] = useState();
+    const onChange = (e) => {
+      const { value } = e.target;
+      setColor(value);
+    };
+    return (
+      <AdvancedColorPicker
+        name='advancedPicker'
+        availableColors={ [
+          { value: '#FFFFFF', label: 'white' },
+          { value: 'transparent', label: 'transparent' },
+          { value: '#000000', label: 'black' },
+          { value: '#A3CAF0', label: 'blue' },
+          { value: '#FD9BA3', label: 'pink' },
+          { value: '#B4AEEA', label: 'purple' },
+          { value: '#ECE6AF', label: 'goldenrod' },
+          { value: '#EBAEDE', label: 'orchid' },
+          { value: '#EBC7AE', label: 'desert' },
+          { value: '#AEECEB', label: 'turquoise' },
+          { value: '#AEECD6', label: 'mint' }
+        ] }
+        defaultColor='#EBAEDE'
+        selectedColor={ color }
+        onChange={ onChange }
+        onOpen={ () => { setOpen(!open) } }
+        onClose={ () => { setOpen(false) } }
+        onBlur={ () => {} }
+        open={ open }
+      />
+    )
+  }}
+  </Story>
+</Preview>
+
+## Props:
+
+### AdvancedColorPicker
+
+<Props of={AdvancedColorPicker} />

--- a/src/components/advanced-color-picker/advanced-color-picker.style.js
+++ b/src/components/advanced-color-picker/advanced-color-picker.style.js
@@ -1,0 +1,70 @@
+import styled, { css } from 'styled-components';
+import StyledAdvancedColorPickerCell from './advanced-color-picker-cell.style';
+import { SimpleColorFieldset } from '../../__experimental__/components/simple-color-picker/simple-color-picker.style';
+import StyledSimpleColor from '../../__experimental__/components/simple-color-picker/simple-color/simple-color.style';
+import { DialogContentStyle, DialogInnerContentStyle } from '../dialog/dialog.style';
+import Dialog from '../dialog/dialog.component';
+import StyledIconButton from '../icon-button/icon-button.style';
+import checkerBoardSvg from '../../__experimental__/components/simple-color-picker/color-sample-box/checker-board.svg';
+
+const StyledAdvancedColorPickerWrapper = styled.div`
+  display: inline-block;
+  margin: 15px auto auto 15px;
+`;
+
+const StyledAdvancedColorPickerPreview = styled.div`
+  width: 25px;
+  height: 25px;
+  margin-bottom: 15px;
+  border: 1px solid #516562;
+
+  ${({ color }) => color !== 'transparent' && css`
+    background-color: ${color};
+  `}
+
+  ${({ color }) => color === 'transparent' && css`
+    background-color: #EEEEEE;
+    background-image: url(${checkerBoardSvg});
+    background-size: 10px 10px;
+  `}
+
+  &:hover {
+    cursor: initial;
+  }
+`;
+
+const DialogStyle = styled(Dialog)`
+  ${DialogContentStyle} {
+    padding: 18px 18px 18px 17px;
+  }
+
+  ${DialogInnerContentStyle} {
+    padding: 0;
+  }
+
+  ${SimpleColorFieldset} {
+    max-width: 285px;
+    ${StyledSimpleColor} {
+      border: 1px solid #3C514E;
+      margin-right: -1px;
+      margin-bottom: -1px;
+      transition: all .2s ease;
+
+      &:hover {
+        transform: scale(1.1);
+      }
+    }
+  }
+
+  ${StyledIconButton} {
+    top: 20px;
+    right: 13px;
+  }
+`;
+
+export {
+  StyledAdvancedColorPickerWrapper,
+  StyledAdvancedColorPickerCell,
+  StyledAdvancedColorPickerPreview,
+  DialogStyle
+};

--- a/src/components/advanced-color-picker/index.js
+++ b/src/components/advanced-color-picker/index.js
@@ -1,0 +1,1 @@
+export { default } from './advanced-color-picker.component';

--- a/src/components/dialog/dialog.component.js
+++ b/src/components/dialog/dialog.component.js
@@ -41,7 +41,7 @@ class Dialog extends Modal {
     this.centerDialog(true);
     ElementResize.addListener(this._innerContent, this.applyFixedBottom);
     this.window.addEventListener('resize', this.centerDialog);
-    this.removeFocusTrap = focusTrap(this._dialog);
+    this.removeFocusTrap = focusTrap(this._dialog, this.props.focusFirstElement);
   }
 
   handleClose() {

--- a/src/components/dialog/dialog.style.js
+++ b/src/components/dialog/dialog.style.js
@@ -4,6 +4,7 @@ import { StyledFormFooter } from '../../__deprecated__/components/form/form.styl
 import StyledIconButton from '../icon-button/icon-button.style';
 
 const dialogSizes = {
+  auto: 'auto',
   'extra-small': '300px',
   small: '380px',
   'medium-small': '540px',

--- a/src/components/modal/modal.component.js
+++ b/src/components/modal/modal.component.js
@@ -74,7 +74,7 @@ class Modal extends React.Component {
 
   closeModal = (ev) => {
     if (this.props.open && this.props.onCancel && !this.props.disableEscKey && Events.isEscKey(ev)) {
-      this.props.onCancel();
+      this.props.onCancel(ev);
     }
   }
 

--- a/src/utils/helpers/focus-trap/focus-trap.js
+++ b/src/utils/helpers/focus-trap/focus-trap.js
@@ -8,12 +8,23 @@ function blockTabbing(ev) {
 function trap(firstFocusableElement, lastFocusableElement, ev) {
   if (ev.key === 'Tab' || ev.keyCode === 9) {
     if (ev.shiftKey) /* shift + tab */ {
-      if (document.activeElement === firstFocusableElement) {
+      if (typeof firstFocusableElement === 'function') {
+        ev.preventDefault();
+        if (document.activeElement !== lastFocusableElement) {
+          lastFocusableElement.focus();
+        } else {
+          firstFocusableElement();
+        }
+      } else if (document.activeElement === firstFocusableElement) {
         lastFocusableElement.focus();
         ev.preventDefault();
       }
     } else if (document.activeElement === lastFocusableElement) {
-      firstFocusableElement.focus();
+      if (typeof firstFocusableElement === 'function') {
+        firstFocusableElement();
+      } else {
+        firstFocusableElement.focus();
+      }
       ev.preventDefault();
     }
   }
@@ -21,10 +32,14 @@ function trap(firstFocusableElement, lastFocusableElement, ev) {
 // eslint-disable-next-line max-len
 const defaultFocusableSelectors = 'button, [href], input:not([type="hidden"]), select, textarea, [tabindex]:not([tabindex="-1"])';
 
-const focusTrap = (element, fs = defaultFocusableSelectors) => {
-  const focusableElements = element.querySelectorAll(fs);
-  const firstFocusableElement = focusableElements[0];
+const focusTrap = (element, focusFirstElement) => {
+  const focusableElements = element.querySelectorAll(defaultFocusableSelectors);
+  let firstFocusableElement = focusableElements[0];
   const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+  if (focusFirstElement) {
+    firstFocusableElement = focusFirstElement;
+  }
 
   if (focusableElements.length <= 0) {
     document.addEventListener('keydown', blockTabbing);

--- a/svgTransform.js
+++ b/svgTransform.js
@@ -1,0 +1,8 @@
+module.exports = {
+  process() {
+    return 'module.exports = {};';
+  },
+  getCacheKey() {
+    return 'svgTransform';
+  }
+};


### PR DESCRIPTION
### Requirements
#2746

### Proposed behaviour
New component, color selection through dialog popup with preview ability.
Supports keyboard navigation.
![acp](https://user-images.githubusercontent.com/47245766/76874661-68f49100-6867-11ea-8f19-9f5b2dc2bf17.gif)


### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests
- [x] Storybook added or updated
<del>- [ ] Theme support
- [x] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
