### PR TITLE
fix(card): add data role prop for automation

### DIFF
--- a/src/components/card/card.component.js
+++ b/src/components/card/card.component.js
@@ -12,7 +12,8 @@ const Card = ({
   cardWidth,
   interactive,
   draggable,
-  spacing
+  spacing,
+  dataRole
 }) => {
   const handleClick = (ev) => {
     if (!draggable && action) {
@@ -36,6 +37,7 @@ const Card = ({
       type='button'
       onClick={ onClickHandler }
       tabIndex={ 0 }
+      data-role={ dataRole }
     >
       { draggable && <Icon type='drag' />}
       { renderChildren() }
@@ -57,7 +59,8 @@ Card.propTypes = {
   /** flag to indicate if card is draggable */
   draggable: PropTypes.bool,
   /** size of card for applying padding (small | medium | large) */
-  spacing: PropTypes.oneOf(sizesRestricted)
+  spacing: PropTypes.oneOf(sizesRestricted),
+  dataRole: PropTypes.string
 };
 
 export default Card;

--- a/src/components/card/card.spec.js
+++ b/src/components/card/card.spec.js
@@ -3,9 +3,9 @@ import { shallow } from 'enzyme';
 import TestRenderer from 'react-test-renderer';
 import Card from './card.component';
 import { assertStyleMatch } from '../../__spec_helper__/test-utils';
-import 'jest-styled-components';
 import Icon from '../icon';
 import OptionsHelper from '../../utils/helpers/options-helper/options-helper';
+import { rootTagTest } from '../../utils/helpers/tags/tags-specs';
 
 describe('Card', () => {
   describe('when the content is added as children', () => {
@@ -157,6 +157,18 @@ describe('Card', () => {
         cursor: 'move'
       }, wrapper.toJSON());
     });
+  });
+
+  it('include correct component and role data tags', () => {
+    const wrapper = renderCard({ dataRole: 'foo' }, shallow);
+
+    rootTagTest(wrapper, 'card', undefined, 'foo');
+  });
+
+  it('include correct component and role tag when no prop passed', () => {
+    const wrapper = renderCard({}, shallow);
+
+    rootTagTest(wrapper, 'card', undefined, undefined);
   });
 });
 


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Allow consumer to pass data-role prop

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
data-role can not be passed to Card
### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
<del>- [ ] Cypress automation tests<del>
<del>- [ ] Storybook added or updated<del>
<del>- [ ] Theme support<del>
<del>- [ ] Typescript `d.ts` file added or updated<del>

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
