### PR TITLE
docs: remove IE11 from browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ We support and test the Carbon Library against the latest versions of the follow
 * [Firefox](https://www.mozilla.org/firefox/)
 * [Safari](https://www.apple.com/safari/)
 * [Edge](https://www.microsoft.com/windows/microsoft-edge)
-* [Internet Explorer 11](https://www.microsoft.com/en-gb/download/internet-explorer-11-for-windows-7-details.aspx)
 
 ## Licence
 


### PR DESCRIPTION
### Proposed behaviour
Remove IE 11 from the supported bowser section.

### Current behaviour
IE11 is currently in the supported browser list.

### Checklist

<del>- [ ] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ --></del>
<del>- [ ] Unit tests</del>
<del>- [ ] Cypress automation tests</del>
<del>- [ ] Storybook added or updated</del>
<del>- [ ] Theme support</del>
<del>- [ ] Typescript `d.ts` file added or updated</del>

### Additional context
N/A

### Testing instructions
N/A
