### PR TITLE
fix: experimental textarea rows not being applied

### DIFF
--- a/src/__experimental__/components/textarea/textarea.style.js
+++ b/src/__experimental__/components/textarea/textarea.style.js
@@ -8,6 +8,7 @@ const StyledTextarea = styled.div`
     min-height: 40px;
     margin-top: 5px;
     margin-bottom: 5px;
+    height: unset;
   }
 
   ${({ labelInline }) => labelInline && css`


### PR DESCRIPTION
### Proposed behaviour
Textarea rows property defines the height of the rendered textarea

### Current behaviour
Textarea rows property is overriden by the css height value

### Checklist

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [ ] Unit tests
- [ ] Cypress automation tests
- [ ] Storybook added or updated
- [ ] Theme support
- [ ] Typescript `d.ts` file added or updated
