### PR TITLE
feat(radio-button): add support for inline radio buttons

### DIFF
--- a/cypress/features/regression/experimental/radioButtonGroup.feature
+++ b/cypress/features/regression/experimental/radioButtonGroup.feature
@@ -1,0 +1,29 @@
+Feature: Experimental RadioButtonGroup component
+  I want to change Experimental RadioButtonGroup component properties
+
+  Background: Open Experimental RadioButton other component page
+    Given I open "Experimental RadioButton" component page
+      And "Other" tab in "second" tab list is visible
+      And I open Other tab
+
+  @positive
+  Scenario: RadioButton inline
+    When I check inline checkbox
+    Then RadioButton are inline
+
+  @positive
+  Scenario: RadioButton not inline
+    When I check inline checkbox
+    And I uncheck inline checkbox
+    Then RadioButton are not inline
+
+  @positive
+  Scenario: Legend inline
+    When I check labelInline checkbox
+    Then legend is inline with RadioButton
+
+  @positive
+  Scenario: Legend not inline
+    When I check labelInline checkbox
+    And I uncheck labelInline checkbox
+    Then legend is not inline with RadioButton

--- a/cypress/features/regression/experimental/radioButtonGroupClassic.feature
+++ b/cypress/features/regression/experimental/radioButtonGroupClassic.feature
@@ -1,0 +1,29 @@
+Feature: Experimental RadioButtonGroup classic component
+  I want to change Experimental RadioButtonGroup classic component properties
+
+  Background: Open Experimental RadioButton other component page
+    Given I open "Experimental RadioButton" component page classic
+      And "Other" tab in "second" tab list is visible
+      And I open Other tab
+
+  @positive
+  Scenario: RadioButton inline
+    When I check inline checkbox
+    Then RadioButton are inline
+
+  @positive
+  Scenario: RadioButton not inline
+    When I check inline checkbox
+    And I uncheck inline checkbox
+    Then RadioButton are not inline
+
+  @positive
+  Scenario: Legend inline
+    When I check labelInline checkbox
+    Then legend is inline with RadioButton
+
+  @positive
+  Scenario: Legend not inline
+    When I check labelInline checkbox
+    And I uncheck labelInline checkbox
+    Then legend is not inline with RadioButton

--- a/cypress/locators/radioButton/index.js
+++ b/cypress/locators/radioButton/index.js
@@ -1,6 +1,17 @@
-import { RADIO_BUTTON, RADIO_BUTTON_COMPONENT } from './locators';
+import {
+  RADIO_BUTTON,
+  RADIO_BUTTON_COMPONENT,
+  RADIO_BUTTON_GROUP_COMPONENT,
+  RADIO_BUTTON_FIELDSET_COMPONENT,
+  RADIO_BUTTON_LEGEND_COMPONENT,
+} from './locators';
 
 // component preview locators
 export const radioButtonComponent = () => cy.iFrame(RADIO_BUTTON_COMPONENT);
 export const radioButtonByPosition = position => cy.iFrame(RADIO_BUTTON).eq(position);
+export const radioButtonComponentByPosition = position => cy.iFrame(RADIO_BUTTON_COMPONENT)
+  .eq(position);
 export const radioButtonComponentNoiFrame = () => cy.get(RADIO_BUTTON_COMPONENT);
+export const radioButtonGroup = () => cy.iFrame(RADIO_BUTTON_GROUP_COMPONENT);
+export const radioButtonFieldset = () => cy.iFrame(RADIO_BUTTON_FIELDSET_COMPONENT);
+export const radioButtonLegend = () => cy.iFrame(RADIO_BUTTON_LEGEND_COMPONENT);

--- a/cypress/locators/radioButton/locators.js
+++ b/cypress/locators/radioButton/locators.js
@@ -1,2 +1,5 @@
 export const RADIO_BUTTON = '[role="radio"]';
 export const RADIO_BUTTON_COMPONENT = '[data-component="radio-button"]';
+export const RADIO_BUTTON_GROUP_COMPONENT = '[data-component="radio-button-group"]';
+export const RADIO_BUTTON_FIELDSET_COMPONENT = '[data-component="fieldset-style"]';
+export const RADIO_BUTTON_LEGEND_COMPONENT = '[data-component="legend-style"]';

--- a/cypress/support/step-definitions/radio-button-steps.js
+++ b/cypress/support/step-definitions/radio-button-steps.js
@@ -1,5 +1,12 @@
 import { fieldHelpPreview, labelByPosition, labelWidthSliderByName } from '../../locators';
-import { radioButtonByPosition, radioButtonComponentNoiFrame } from '../../locators/radioButton/index';
+import {
+  radioButtonComponentNoiFrame,
+  radioButtonByPosition,
+  radioButtonComponentByPosition,
+  radioButtonGroup,
+  radioButtonFieldset,
+  radioButtonLegend,
+} from '../../locators/radioButton/index';
 import { setSlidebar } from '../helper';
 
 const INLINE = 'carbon-radio-button__help-text--inline';
@@ -108,4 +115,30 @@ Then('{string} RadioButton label width is set to {string}', (radioButtonName, wi
 
 When('I set RadioButton {word} {word} slider to {int}', (propertyName, text, width) => {
   setSlidebar(labelWidthSliderByName(propertyName, text), width);
+});
+
+Then('RadioButton are inline', () => {
+  radioButtonGroup().should('have.css', 'display', 'flex');
+  radioButtonComponentByPosition(FIRST_RADIOBUTTON).should('have.css', 'margin-left', '0px');
+  radioButtonComponentByPosition(SECOND_RADIOBUTTON).should('have.css', 'margin-left', '32px');
+  radioButtonComponentByPosition(THIRD_RADIOBUTTON).should('have.css', 'margin-left', '32px');
+});
+
+Then('RadioButton are not inline', () => {
+  radioButtonGroup().should('have.css', 'display', 'block');
+  radioButtonComponentByPosition(FIRST_RADIOBUTTON).should('have.css', 'margin-left', '0px');
+  radioButtonComponentByPosition(SECOND_RADIOBUTTON).should('have.css', 'margin-left', '0px');
+  radioButtonComponentByPosition(THIRD_RADIOBUTTON).should('have.css', 'margin-left', '0px');
+});
+
+Then('legend is inline with RadioButton', () => {
+  radioButtonFieldset().should('have.css', 'display', 'flex');
+  radioButtonLegend().should('have.css', 'margin-right', '32px')
+    .and('have.css', 'height', '34px');
+});
+
+Then('legend is not inline with RadioButton', () => {
+  radioButtonFieldset().should('have.css', 'display', 'block');
+  radioButtonLegend().should('have.css', 'margin-right', '0px')
+    .and('have.css', 'height', '26px');
 });

--- a/src/__experimental__/components/fieldset/__snapshots__/fieldset.spec.js.snap
+++ b/src/__experimental__/components/fieldset/__snapshots__/fieldset.spec.js.snap
@@ -4,6 +4,11 @@ exports[`Fieldset renders correctly 1`] = `
 <styled.fieldset
   data-component="fieldset"
 >
-  <Textbox />
+  <styled.div
+    data-component="fieldset-style"
+    inline={false}
+  >
+    <Textbox />
+  </styled.div>
 </styled.fieldset>
 `;

--- a/src/__experimental__/components/fieldset/docgenInfo.json
+++ b/src/__experimental__/components/fieldset/docgenInfo.json
@@ -18,6 +18,13 @@
           },
           "required": false,
           "description": "The text for the fieldsets legend element."
+        },
+        "inline": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Pass true to format the children/legend inline"
         }
       }
     }

--- a/src/__experimental__/components/fieldset/fieldset.component.js
+++ b/src/__experimental__/components/fieldset/fieldset.component.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { validProps } from '../../../utils/ether';
 import tagComponent from '../../../utils/helpers/tags';
-import { FieldsetStyle, LegendContainerStyle } from './fieldset.style';
+import { FieldsetStyle, LegendContainerStyle, FieldsetContentStyle } from './fieldset.style';
 import ValidationIcon from '../../../components/validations/validation-icon.component';
 import { getValidationType } from '../../../components/validations/with-validation.hoc';
 
@@ -27,7 +27,10 @@ const Fieldset = (props) => {
     if (!props.legend) return null;
 
     return (
-      <LegendContainerStyle>
+      <LegendContainerStyle
+        inline={ props.inline }
+        data-component='legend-style'
+      >
         <legend data-element='legend'>
           { props.legend }
         </legend>
@@ -46,8 +49,13 @@ const Fieldset = (props) => {
       { ...tagComponent('fieldset', props) }
       { ...safeProps }
     >
-      { legend() }
-      { props.children }
+      <FieldsetContentStyle
+        data-component='fieldset-style'
+        inline={ props.inline }
+      >
+        { legend() }
+        { props.children }
+      </FieldsetContentStyle>
     </FieldsetStyle>
   );
 };
@@ -64,7 +72,13 @@ Fieldset.propTypes = {
   /** Prop to indicate additional information  */
   hasInfo: PropTypes.bool,
   /** A message that the ValidationIcon component will display */
-  tooltipMessage: PropTypes.string
+  tooltipMessage: PropTypes.string,
+  /** When true, legend is placed in line with the children */
+  inline: PropTypes.bool
+};
+
+Fieldset.defaultProps = {
+  inline: false
 };
 
 export default Fieldset;

--- a/src/__experimental__/components/fieldset/fieldset.spec.js
+++ b/src/__experimental__/components/fieldset/fieldset.spec.js
@@ -4,7 +4,7 @@ import { css } from 'styled-components';
 import { shallow, mount } from 'enzyme';
 import Fieldset from './fieldset.component';
 import Textbox from '../textbox';
-import { LegendContainerStyle } from './fieldset.style';
+import { LegendContainerStyle, FieldsetContentStyle } from './fieldset.style';
 import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
 import classicTheme from '../../../style/themes/classic';
 import ValidationIcon from '../../../components/validations/validation-icon.component';
@@ -44,6 +44,33 @@ describe('Fieldset', () => {
         padding: '0 6px'
       }, mount(<LegendContainerStyle theme={ classicTheme } />),
       { modifier: css`legend` });
+    });
+
+    it('applies the correct inline styles', () => {
+      assertStyleMatch({
+        marginRight: '32px',
+        height: '34px !important'
+      }, mount(<LegendContainerStyle inline />));
+    });
+  });
+
+  describe('Fieldset FieldsetContentStyle', () => {
+    it('is rendered if supplied', () => {
+      const wrapper = render({ inline: true });
+      expect(wrapper.find(FieldsetContentStyle).get(0).props.inline).toEqual(true);
+    });
+
+    it('is not rendered if omited', () => {
+      expect(basicWrapper.find(FieldsetContentStyle).get(0).props.inline).toEqual(false);
+    });
+
+    it('applies the correct inline styles', () => {
+      assertStyleMatch(
+        {
+          display: 'flex'
+        },
+        mount(<FieldsetContentStyle inline />)
+      );
     });
   });
 

--- a/src/__experimental__/components/fieldset/fieldset.style.js
+++ b/src/__experimental__/components/fieldset/fieldset.style.js
@@ -22,6 +22,12 @@ const FieldsetStyle = styled.fieldset`
 `;
 
 const LegendContainerStyle = styled.div`
+  ${({
+    inline
+  }) => inline && `
+  margin-right: 32px;
+  height: 34px !important;
+  `}
   display: flex;
   align-items: center;
   margin-bottom: 32px;
@@ -39,7 +45,14 @@ const LegendContainerStyle = styled.div`
   }
 `;
 
+const FieldsetContentStyle = styled.div`
+  ${({
+    inline
+  }) => inline && 'display: flex;'}
+`;
+
 export {
   FieldsetStyle,
-  LegendContainerStyle
+  LegendContainerStyle,
+  FieldsetContentStyle
 };

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
@@ -217,132 +217,144 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   role="radiogroup"
 >
   <div
-    className="c2 c3"
-  >
-    <legend
-      data-element="legend"
-    >
-      Test RadioButtonGroup Legend
-    </legend>
-  </div>
-  <div
-    checked={false}
-    className="c4 c5"
-    data-component="radio-button"
-    name="test-group"
+    className=""
+    data-component="fieldset-style"
   >
     <div
-      checked={false}
-      className="c6"
-      name="test-group"
+      className="c2 c3"
+      data-component="legend-style"
+    >
+      <legend
+        data-element="legend"
+      >
+        Test RadioButtonGroup Legend
+      </legend>
+    </div>
+    <div
+      className=""
+      data-component="radio-button-group"
+      role="group"
     >
       <div
-        className="c7 c8"
+        checked={false}
+        className="c4 c5"
+        data-component="radio-button"
+        name="test-group"
       >
         <div
-          className="c9 c10"
+          checked={false}
+          className="c6"
+          name="test-group"
         >
           <div
-            className="c11 c12"
+            className="c7 c8"
           >
-            <input
-              aria-checked={false}
-              aria-describedby="rId-0-help"
-              aria-labelledby="rId-0-label"
-              checked={false}
-              className="c13 c14"
-              id="rId-0"
-              name="test-group"
-              onBlur={[Function]}
-              onChange={[Function]}
-              role="radio"
-              type="radio"
-              value="test-1"
-            />
             <div
-              className="c15 "
+              className="c9 c10"
             >
-              <svg
-                focusable="false"
-                viewBox="0 0 15 15"
+              <div
+                className="c11 c12"
               >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  stroke="none"
-                  strokeWidth="1"
+                <input
+                  aria-checked={false}
+                  aria-describedby="rId-0-help"
+                  aria-labelledby="rId-0-label"
+                  checked={false}
+                  className="c13 c14"
+                  id="rId-0"
+                  name="test-group"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  role="radio"
+                  type="radio"
+                  value="test-1"
+                />
+                <div
+                  className="c15 "
                 >
-                  <circle
-                    className="radio-button-check"
-                    cx="7.5"
-                    cy="7.5"
-                    fill="#FFFFFF"
-                    r="5"
-                  />
-                </g>
-              </svg>
+                  <svg
+                    focusable="false"
+                    viewBox="0 0 15 15"
+                  >
+                    <g
+                      fill="none"
+                      fillRule="evenodd"
+                      stroke="none"
+                      strokeWidth="1"
+                    >
+                      <circle
+                        className="radio-button-check"
+                        cx="7.5"
+                        cy="7.5"
+                        fill="#FFFFFF"
+                        r="5"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </div>
-  <div
-    checked={false}
-    className="c4 c5"
-    data-component="radio-button"
-    name="test-group"
-  >
-    <div
-      checked={false}
-      className="c6"
-      name="test-group"
-    >
       <div
-        className="c7 c8"
+        checked={false}
+        className="c4 c5"
+        data-component="radio-button"
+        name="test-group"
       >
         <div
-          className="c9 c10"
+          checked={false}
+          className="c6"
+          name="test-group"
         >
           <div
-            className="c11 c12"
+            className="c7 c8"
           >
-            <input
-              aria-checked={false}
-              aria-describedby="rId-1-help"
-              aria-labelledby="rId-1-label"
-              checked={false}
-              className="c13 c14"
-              id="rId-1"
-              name="test-group"
-              onBlur={[Function]}
-              onChange={[Function]}
-              role="radio"
-              type="radio"
-              value="test-2"
-            />
             <div
-              className="c15 "
+              className="c9 c10"
             >
-              <svg
-                focusable="false"
-                viewBox="0 0 15 15"
+              <div
+                className="c11 c12"
               >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  stroke="none"
-                  strokeWidth="1"
+                <input
+                  aria-checked={false}
+                  aria-describedby="rId-1-help"
+                  aria-labelledby="rId-1-label"
+                  checked={false}
+                  className="c13 c14"
+                  id="rId-1"
+                  name="test-group"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  role="radio"
+                  type="radio"
+                  value="test-2"
+                />
+                <div
+                  className="c15 "
                 >
-                  <circle
-                    className="radio-button-check"
-                    cx="7.5"
-                    cy="7.5"
-                    fill="#FFFFFF"
-                    r="5"
-                  />
-                </g>
-              </svg>
+                  <svg
+                    focusable="false"
+                    viewBox="0 0 15 15"
+                  >
+                    <g
+                      fill="none"
+                      fillRule="evenodd"
+                      stroke="none"
+                      strokeWidth="1"
+                    >
+                      <circle
+                        className="radio-button-check"
+                        cx="7.5"
+                        cy="7.5"
+                        fill="#FFFFFF"
+                        r="5"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -982,58 +982,69 @@ exports[`RadioButton styles base renders as expected 1`] = `
   role="radiogroup"
 >
   <div
-    checked={false}
-    className="c2 c3"
-    data-component="radio-button"
+    className=""
+    data-component="fieldset-style"
   >
     <div
-      checked={false}
-      className="c4"
+      className=""
+      data-component="radio-button-group"
+      role="group"
     >
       <div
-        className="c5 c6"
+        checked={false}
+        className="c2 c3"
+        data-component="radio-button"
       >
         <div
-          className="c7 c8"
+          checked={false}
+          className="c4"
         >
           <div
-            className="c9 c10"
+            className="c5 c6"
           >
-            <input
-              aria-checked={false}
-              aria-describedby="guid-12345-help"
-              aria-labelledby="guid-12345-label"
-              checked={false}
-              className="c11 c12"
-              id="guid-12345"
-              onBlur={[Function]}
-              onChange={[Function]}
-              role="radio"
-              type="radio"
-              value="test"
-            />
             <div
-              className="c13 "
+              className="c7 c8"
             >
-              <svg
-                focusable="false"
-                viewBox="0 0 15 15"
+              <div
+                className="c9 c10"
               >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  stroke="none"
-                  strokeWidth="1"
+                <input
+                  aria-checked={false}
+                  aria-describedby="guid-12345-help"
+                  aria-labelledby="guid-12345-label"
+                  checked={false}
+                  className="c11 c12"
+                  id="guid-12345"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  role="radio"
+                  type="radio"
+                  value="test"
+                />
+                <div
+                  className="c13 "
                 >
-                  <circle
-                    className="radio-button-check"
-                    cx="7.5"
-                    cy="7.5"
-                    fill="#FFFFFF"
-                    r="5"
-                  />
-                </g>
-              </svg>
+                  <svg
+                    focusable="false"
+                    viewBox="0 0 15 15"
+                  >
+                    <g
+                      fill="none"
+                      fillRule="evenodd"
+                      stroke="none"
+                      strokeWidth="1"
+                    >
+                      <circle
+                        className="radio-button-check"
+                        cx="7.5"
+                        cy="7.5"
+                        fill="#FFFFFF"
+                        r="5"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/__experimental__/components/radio-button/docgenInfo.json
+++ b/src/__experimental__/components/radio-button/docgenInfo.json
@@ -33,6 +33,20 @@
           "required": false,
           "description": "Help text"
         },
+        "labelInline": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Pass true to format the radiobutton/legend inline"
+        },
+        "inline": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Pass true to format the radiobutton inline"
+        },
         "hasError": {
           "type": {
             "name": "bool"

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -3,15 +3,21 @@ import PropTypes from 'prop-types';
 
 import tagComponent from '../../../utils/helpers/tags';
 import RadioButtonFieldsetStyle from './radio-button-fieldset.style';
+import RadioButtonGroupStyle from './radio-button-group.style';
 import RadioButtonMapper from './radio-button-mapper.component';
 import withValidation from '../../../components/validations/with-validation.hoc';
 
 const RadioButtonGroup = (props) => {
   const {
-    children, name, legend, hasError, hasWarning, hasInfo, onBlur, onChange, value, tooltipMessage
+    children, name, legend, hasError, hasWarning, hasInfo, onBlur,
+    onChange, value, tooltipMessage, inline, labelInline
   } = props;
 
   const groupLabelId = `${name}-label`;
+
+  const renderChildren = () => {
+    return React.Children.map(children, child => React.cloneElement(child, { inline }));
+  };
 
   return (
     <RadioButtonFieldsetStyle
@@ -22,16 +28,23 @@ const RadioButtonGroup = (props) => {
       hasWarning={ hasWarning }
       hasInfo={ hasInfo }
       tooltipMessage={ tooltipMessage }
+      inline={ labelInline }
       { ...tagComponent('radiogroup', props) }
     >
-      <RadioButtonMapper
-        name={ name }
-        onBlur={ onBlur }
-        onChange={ onChange }
-        value={ value }
+      <RadioButtonGroupStyle
+        data-component='radio-button-group'
+        role='group'
+        inline={ inline }
       >
-        {children}
-      </RadioButtonMapper>
+        <RadioButtonMapper
+          name={ name }
+          onBlur={ onBlur }
+          onChange={ onChange }
+          value={ value }
+        >
+          {renderChildren()}
+        </RadioButtonMapper>
+      </RadioButtonGroupStyle>
     </RadioButtonFieldsetStyle>
   );
 };
@@ -58,13 +71,19 @@ RadioButtonGroup.propTypes = {
   /** value of the selected RadioButton */
   value: PropTypes.string,
   /** Message to be displayed in a Tooltip when the user hovers over the help icon */
-  tooltipMessage: PropTypes.string
+  tooltipMessage: PropTypes.string,
+  /** When true, radiobutton is placed in line */
+  inline: PropTypes.bool,
+  /** When true, legend is placed in line with an radiobutton */
+  labelInline: PropTypes.bool
 };
 
 RadioButtonGroup.defaultProps = {
   hasError: false,
   hasWarning: false,
-  hasInfo: false
+  hasInfo: false,
+  inline: false,
+  labelInline: false
 };
 
 export default withValidation(RadioButtonGroup, { unblockValidation: true });

--- a/src/__experimental__/components/radio-button/radio-button-group.spec.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.spec.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { css } from 'styled-components';
+import { mount } from 'enzyme';
 import { RadioButton, RadioButtonGroup } from '.';
 import { LegendContainerStyle } from '../fieldset/fieldset.style';
 import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
+import RadioButtonGroupStyle from './radio-button-group.style';
 
 const buttonValues = ['test-1', 'test-2'];
 const name = 'test-group';
@@ -54,6 +56,15 @@ describe('RadioButtonGroup', () => {
         },
         render().toJSON(),
         { modifier: css`${LegendContainerStyle} legend` }
+      );
+    });
+
+    it('applies the correct Legend Container styles', () => {
+      assertStyleMatch(
+        {
+          display: 'flex'
+        },
+        mount(<RadioButtonGroupStyle inline />)
       );
     });
   });

--- a/src/__experimental__/components/radio-button/radio-button-group.style.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.style.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const RadioButtonGroupStyle = styled.div`
+  ${({
+    inline
+  }) => inline && 'display: flex;'}
+`;
+
+export default RadioButtonGroupStyle;

--- a/src/__experimental__/components/radio-button/radio-button.spec.js
+++ b/src/__experimental__/components/radio-button/radio-button.spec.js
@@ -15,6 +15,7 @@ import baseTheme from '../../../style/themes/base';
 import classicTheme from '../../../style/themes/classic';
 import mintTheme from '../../../style/themes/mint';
 import { getValidationType } from '../../../components/validations/with-validation.hoc';
+import RadioButtonStyle from './radio-button.style';
 
 jest.mock('../../../utils/helpers/guid');
 guid.mockImplementation(() => 'guid-12345');
@@ -249,6 +250,16 @@ describe('RadioButton', () => {
           }, wrapper, { modifier: css`${HiddenCheckableInputStyle}:checked + ${StyledCheckableInputSvgWrapper} svg` });
         });
       });
+    });
+
+    it('applies the correct Legend Container styles', () => {
+      assertStyleMatch(
+        {
+          marginLeft: '32px'
+        },
+        mount(<RadioButtonStyle inline />),
+        { modifier: '&:not(:first-of-type)' }
+      );
     });
   });
 });

--- a/src/__experimental__/components/radio-button/radio-button.stories.js
+++ b/src/__experimental__/components/radio-button/radio-button.stories.js
@@ -79,6 +79,8 @@ const groupedKnobs = (type, themeName) => {
 
 const radioComponent = themeName => () => {
   const labelHelp = text('labelHelp', 'Group label helper');
+  const inline = boolean('inline', false);
+  const labelInline = boolean('labelInline', false);
 
   return (
     <State store={ radioToggleGroupStore }>
@@ -87,6 +89,8 @@ const radioComponent = themeName => () => {
         name='frequency'
         legend={ text('groupLabel', 'Please select a frequency from the options below') }
         onChange={ handleGroupChangeFactory(radioToggleGroupStore) }
+        inline={ inline }
+        labelInline={ labelInline }
       >
         <RadioButton
           id='input-1'

--- a/src/__experimental__/components/radio-button/radio-button.style.js
+++ b/src/__experimental__/components/radio-button/radio-button.style.js
@@ -14,7 +14,8 @@ const RadioButtonStyle = styled(CheckboxStyle)`
     fieldHelpInline,
     reverse,
     size,
-    theme
+    theme,
+    inline
   }) => css`
     margin-bottom: 12px;
 
@@ -118,6 +119,12 @@ const RadioButtonStyle = styled(CheckboxStyle)`
           }
         `}
       `}
+    `}
+
+    ${inline && `
+      &:not(:first-of-type) {
+        margin-left: 32px;
+      }
     `}
 
     ${ClassicRadioButtonStyles}

--- a/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
+++ b/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
@@ -173,70 +173,76 @@ exports[`SimpleColorPicker renders as expected 1`] = `
   role="radiogroup"
 >
   <div
-    className="c2 c3"
-  >
-    <legend
-      data-element="legend"
-    >
-      SimpleColorPicker Legend
-    </legend>
-  </div>
-  <div
-    className="c4"
+    className=""
+    data-component="fieldset-style"
   >
     <div
-      checked={false}
-      className="c5"
-      color="#00A376"
-      data-component="simple-color"
+      className="c2 c3"
+      data-component="legend-style"
     >
-      <input
-        aria-checked={false}
-        checked={false}
-        className="c6 c7"
-        data-element="input"
-        id="rId-0"
-        name="test-group"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        role="radio"
-        type="radio"
-        value="#00A376"
-      />
-      <div
-        className="c8 c9"
-        color="#00A376"
-      />
+      <legend
+        data-element="legend"
+      >
+        SimpleColorPicker Legend
+      </legend>
     </div>
     <div
-      checked={false}
-      className="c5"
-      color="#0073C1"
-      data-component="simple-color"
+      className="c4"
     >
-      <input
-        aria-checked={false}
-        checked={false}
-        className="c6 c7"
-        data-element="input"
-        id="rId-1"
-        name="test-group"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        role="radio"
-        type="radio"
-        value="#0073C1"
-      />
       <div
-        className="c8 c10"
+        checked={false}
+        className="c5"
+        color="#00A376"
+        data-component="simple-color"
+      >
+        <input
+          aria-checked={false}
+          checked={false}
+          className="c6 c7"
+          data-element="input"
+          id="rId-0"
+          name="test-group"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseDown={[Function]}
+          role="radio"
+          type="radio"
+          value="#00A376"
+        />
+        <div
+          className="c8 c9"
+          color="#00A376"
+        />
+      </div>
+      <div
+        checked={false}
+        className="c5"
         color="#0073C1"
-      />
+        data-component="simple-color"
+      >
+        <input
+          aria-checked={false}
+          checked={false}
+          className="c6 c7"
+          data-element="input"
+          id="rId-1"
+          name="test-group"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseDown={[Function]}
+          role="radio"
+          type="radio"
+          value="#0073C1"
+        />
+        <div
+          className="c8 c10"
+          color="#0073C1"
+        />
+      </div>
     </div>
   </div>
 </fieldset>


### PR DESCRIPTION
### Proposed behaviour
We would like to have the ability to display the RadioButton inline. I added 2 props `inline` and `labelInline`.

`inline` is used on the radio-button component to put the radio-button in one line. 
![image](https://user-images.githubusercontent.com/2328042/76093784-7e410400-5fb9-11ea-808c-662db5a869c7.png)

`labelInline` is used in Fieldset to put the legend in the same line of the radio-button.
![image](https://user-images.githubusercontent.com/2328042/76093647-420da380-5fb9-11ea-87f6-6f716e01eab1.png)

It is possible to set both `inline` and `labelInline`
![image](https://user-images.githubusercontent.com/2328042/76093846-931d9780-5fb9-11ea-9e36-41b790ebde0b.png)

### Current behaviour
Currently the radio-button group is displayed in a column.
![image](https://user-images.githubusercontent.com/2328042/76094226-2787fa00-5fba-11ea-8c97-56eede6aa192.png)

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests
- [x] Storybook added or updated
- [ ] Theme support
- [ ] Typescript `d.ts` file added or updated

### Additional context
That modification will be useful for Client Management :
![image](https://user-images.githubusercontent.com/2328042/76094439-8cdbeb00-5fba-11ea-9a0c-df8dec847634.png)

### Testing instructions
- `npm start`
- Go to http://localhost:9001/?path=/story/experimental-radiobutton--default

- In `Addons > Knobs` check `inline` prop. That should display the radio buttons inline.

- In `Addons > Knobs` check `labelInline` prop. That should display the legend inline with the radio buttons still in a column.

- In `Addons > Knobs` check `labelInline` AND `inline`  prop. That should display the legend inline with the radio buttons inline also.