### PR TITLE
test(radiobutton): fix for regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js: node
 
+cache:
+  npm: true
+  directories:
+    - ~/.cache
+
 addons:
    apt:
      packages:
@@ -9,27 +14,46 @@ addons:
 
 stages:
   - test
+  - regression
   - deploy
 
 jobs:
+  fast_finish: true
   include:
     - stage: test
       name: "lint"
-      script: 
-        - npm run lint
-        - npm run lint-ts
+      script: npm run lint
     - name: "unit tests"
       script: npm test
     - name: "test build"
       script: npm run test-carbon-build
       if: type = pull_request # we only need to test this in a pull, on a push to master we will be running the build in the deploy step
-    - name: "storybook smoketest"
-      script: npm run test-storybook-smoke
-    - name: "test storybook with cypress"
-      script: 
+    - name: "build cypress tests"
+      script:
         - npm run storybook-ci </dev/null &>/dev/null &
         - wait-on http://localhost:9001
         - npm run test-cypress-build
+    - &cypress-travis-regression
+      stage: regression
+      name: "cypress regression"
+      script:
+        - npm run storybook-ci </dev/null &>/dev/null &
+        - wait-on http://localhost:9001
+        - npm run cypress-travis-regression
+      if: type = cron # we only need to run regression on nightly cron builds
+      env: SUITE=accessibility/accessibility.feature
+    - <<: *cypress-travis-regression
+      env: SUITE=regression/radioButton/radioButtonMonthly.feature
+    - <<: *cypress-travis-regression
+      env: SUITE=regression/radioButton/radioButtonMonthlyClassic.feature
+    - <<: *cypress-travis-regression
+      env: SUITE=regression/radioButton/radioButtonWeekly.feature
+    - <<: *cypress-travis-regression
+      env: SUITE=regression/radioButton/radioButtonWeeklyClassic.feature
+    - <<: *cypress-travis-regression
+      env: SUITE=regression/radioButton/radioButtonYearly.feature
+    - <<: *cypress-travis-regression
+      env: SUITE=regression/radioButton/radioButtonYearlyClassic.feature
     - stage: deploy
       name: "s3"
       script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,11 @@ jobs:
   include:
     - &cypress-travis-regression
       stage: regression
-      name: "cypress regression"
+      name: "cypress ${env.SUITE}"
       script:
         - npm run storybook-ci </dev/null &>/dev/null &
         - wait-on http://localhost:9001
         - npm run cypress-travis-regression
-    - <<: *cypress-travis-regression
       env: SUITE=regression/radioButton/radioButtonMonthly.feature
     - <<: *cypress-travis-regression
       env: SUITE=regression/radioButton/radioButtonMonthlyClassic.feature

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,11 @@ addons:
        - libgconf-2-4
 
 stages:
-  - test
   - regression
-  - deploy
 
 jobs:
   fast_finish: true
   include:
-    - stage: test
-      name: "lint"
-      script: npm run lint
-    - name: "unit tests"
-      script: npm test
-    - name: "test build"
-      script: npm run test-carbon-build
-      if: type = pull_request # we only need to test this in a pull, on a push to master we will be running the build in the deploy step
-    - name: "build cypress tests"
-      script:
-        - npm run storybook-ci </dev/null &>/dev/null &
-        - wait-on http://localhost:9001
-        - npm run test-cypress-build
     - &cypress-travis-regression
       stage: regression
       name: "cypress regression"
@@ -40,8 +25,6 @@ jobs:
         - npm run storybook-ci </dev/null &>/dev/null &
         - wait-on http://localhost:9001
         - npm run cypress-travis-regression
-      if: type = cron # we only need to run regression on nightly cron builds
-      env: SUITE=accessibility/accessibility.feature
     - <<: *cypress-travis-regression
       env: SUITE=regression/radioButton/radioButtonMonthly.feature
     - <<: *cypress-travis-regression
@@ -54,28 +37,3 @@ jobs:
       env: SUITE=regression/radioButton/radioButtonYearly.feature
     - <<: *cypress-travis-regression
       env: SUITE=regression/radioButton/radioButtonYearlyClassic.feature
-    - stage: deploy
-      name: "s3"
-      script: skip
-      before_deploy: ASSETS_PREFIX=https://carbon.sage.com npm run build
-      deploy:
-          provider: s3
-          on:
-            branch: master
-          bucket: carbon.sage.com
-          skip_cleanup: true
-          local_dir: deploy
-          detect_encoding: true
-          access_key_id:
-            secure: iZx7SkuMjUMXLVQNO5LSjF6EfQeqGbgdGtPg0hfzVIEcS5s/79j5aq8aQJ7EjCXM+yPRDZMaXB+StXOZjNhEbKLYt2mZDyMki3gAII2QM2MAeI5YtltgJHlXClsMjFiomTbRPo/F9CnIerRBdAFUmQXh2BVSdz86ptsLWs9SrcSjgN/RM6bWSaFYbyckyRVQZVipHYN1vmbEw8ZNZGSQTEPyi3Pw4nXMJ+9ro/72Pt5Ioo3a/praWJL9I5hEc6uBAfFZTtsg70txARaSOycoHxQT8S/xfIzfPQXSmj3n4MTMMCOi3CyJFJfTOdHnQ2ylSllae3zLgIJv1dPQoRuPrB0A1loG2BA+1PXA7KZrwBzYty20XMM2o2tB4mlkKh8p1gOjdsAyRT415kDkEvGpw/b+jFPQ+mAg67ELCJz/HTvBvrKF8nAGsoiG0A1Bi89wxi2riMjAZ2VzbTHrTq/Lp/MlJYt4Z44CXVSKXlKBVKwlDVS7+OIp5QAC0AggtJGFb4kvS/6zUnoykM/lsRBX99lsMURlpGq/EKC5B4iU26NWvF4L+sO9UUesN7LMr8C6oSc7wVrhLHiQbJx55UZTjT4+H/Y4VOFOiEhVKKJTk0/jt/QOOxZbuyhMitLOMBTQQ9tEICv7fIFSUIfePD3bG6FR3vXvod0ct/H7/DhNM0A=
-          secret_access_key:
-            secure: qdS1pq1ZXvw6lXLrGtSaZTpx7OLREvV/7UCwPFbfQkuQBLbxLe32qlzOkkEQWd7sHwadSgvVTKvX4HKaAIx+QZ2XXFbXGx4HIOCws6ynAVVa2kV5SSHKMwiy+R6Ypttu3GD6uKEhPMUULCYuCLzIIvAOKoCaDIzzKlxzK+g/tCe94J+fKU0DS6U23FFxW51UADgTxn7opg3mkhsteaRyAtDkurAeobEzfQpTFKPNXJ3YcFjpGUf9Z5zxcXXNohKZQP4wODgYU+OZuif/cAeETChWxVThk0PMIIk9/lmwyX1UKIpWpyVTDEKXzwnO2COVWOxtVCpTB0uwfZTZ8MhVXRvFj8Dk/iw+2NN/W55fQ44xx0h6mvhMle98jKTWi6AR/F0LJMpCkZeNTVCdiDz7Ow1g23HlBIRx/seYxph2vLSLkh63kU8ygaOFWhCNdCGOOPLHi8m8X8vlLRvN9ETWY/sMWkvY/S9bXIGw8lv5Bk4lIxAmjoU05XJceq5rOlSax46d1fsicJ5gF6tcxvMau2bFGMCgeZJEpRYChqTEt284woFc8+maa4SwMVrim6J8R53Xfx8mtgCnRlgZmXymzyxu8wCVnAza24iQ4kWmx+fDw70iU5Q3nxSwjN4Q922QZiAFLGpAK0nRDFhE7NPftubYOgsisNCFOnTTTBGJghI=
-    - name: "npm & GitHub"
-      script: skip
-      deploy:
-        provider: script
-        script: npx semantic-release
-        skip_cleanup: true
-        on:
-          all_branches: true # semantic-release has a regex that allows us to publish maintenance releases
-          

--- a/cypress/features/regression/radioButton/radioButtonMonthly.feature
+++ b/cypress/features/regression/radioButton/radioButtonMonthly.feature
@@ -95,26 +95,28 @@ Feature: Experimental RadioButton monthly component
       And I uncheck group monthly fieldHelpInline checkbox
     Then "Second" field help is not set to fieldHelpInline and has margin-left set to "32px"
 
+  # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
-  Scenario Outline: Change RadioButton input width to <width>
+  Scenario Outline: Change RadioButton inputWidth to <width>
     When I set group monthly inputWidth slider to <width>
-    Then "Second" RadioButton "monthly" inputWidth is set to <px>
+    Then "Second" RadioButton "monthly" inputWidth is set to "<px>"
     Examples:
-      | width | px  |
-      | 1     | 11  |
-      | 10    | 106 |
-      | 50    | 531 |
+      | width | px         |
+      | 1     | 16         |
+      | 10    | 98.71875   |
+      | 50    | 358.234375 |
 
+  # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
   Scenario Outline: Change RadioButton label width to <width>
     When I check group monthly fieldHelpInline checkbox
       And I set group monthly labelWidth slider to <width>
-    Then "Second" RadioButton label width is set to <px>
+    Then "Second" RadioButton label width is set to "<px>"
     Examples:
-      | width | px   |
-      | 1     | 11   |
-      | 50    | 531  |
-      | 100   | 1049 |
+      | width | px        |
+      | 1     | 10.609375 |
+      | 50    | 530.5     |
+      | 100   | 847.78125 |
 
   @positive
   Scenario Outline: Change RadioButton label align to <direction>

--- a/cypress/features/regression/radioButton/radioButtonMonthlyClassic.feature
+++ b/cypress/features/regression/radioButton/radioButtonMonthlyClassic.feature
@@ -91,26 +91,28 @@ Feature: Experimental RadioButton monthly classic component
       And I uncheck group monthly fieldHelpInline checkbox
     Then "Second" field help is not set to fieldHelpInline and has margin-left set to "22px"
 
+  # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
-  Scenario Outline: Change RadioButton input width to <width>
+  Scenario Outline: Change RadioButton inputWidth to <width>
     When I set group monthly inputWidth slider to <width>
-    Then "Second" RadioButton "monthly" inputWidth is set to <px>
+    Then "Second" RadioButton "monthly" inputWidth is set to "<px>"
     Examples:
-      | width | px  |
-      | 1     | 11  |
-      | 10    | 106 |
-      | 50    | 531 |
+      | width | px         |
+      | 1     | 16         |
+      | 10    | 98.53125   |
+      | 50    | 357.546875 |
 
+  # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
   Scenario Outline: Change RadioButton label width to <width>
     When I check group monthly fieldHelpInline checkbox
       And I set group monthly labelWidth slider to <width>
-    Then "Second" RadioButton label width is set to <px>
+    Then "Second" RadioButton label width is set to "<px>"
     Examples:
-      | width | px   |
-      | 1     | 11   |
-      | 50    | 531  |
-      | 100   | 1049 |
+      | width | px         |
+      | 1     | 10.609375  |
+      | 50    | 530.5      |
+      | 100   | 831.203125 |
 
   @positive
   Scenario Outline: Change RadioButton label align to <direction>

--- a/cypress/features/regression/radioButton/radioButtonWeekly.feature
+++ b/cypress/features/regression/radioButton/radioButtonWeekly.feature
@@ -100,26 +100,28 @@ Feature: Experimental RadioButton weekly component
       And I uncheck group weekly fieldHelpInline checkbox
     Then "First" field help is not set to fieldHelpInline and has margin-left set to "32px"
 
+  # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
-  Scenario Outline: Change RadioButton input width to <width>
+  Scenario Outline: Change RadioButton inputWidth to <width>
     When I set group weekly inputWidth slider to <width>
-    Then "First" RadioButton "weekly" inputWidth is set to <px>
+    Then "First" RadioButton "weekly" inputWidth is set to "<px>"
     Examples:
-      | width | px  |
-      | 1     | 11  |
-      | 10    | 106 |
-      | 50    | 531 |
+      | width | px         |
+      | 1     | 16         |
+      | 10    | 98.71875   |
+      | 50    | 358.234375 |
 
+  # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
   Scenario Outline: Change RadioButton label width to <width>
     When I check group weekly fieldHelpInline checkbox
       And I set group weekly labelWidth slider to <width>
-    Then "First" RadioButton label width is set to <px>
+    Then "First" RadioButton label width is set to "<px>"
     Examples:
-      | width | px   |
-      | 1     | 11   |
-      | 50    | 531  |
-      | 100   | 1049 |
+      | width | px        |
+      | 1     | 10.609375 |
+      | 50    | 530.5     |
+      | 100   | 847.78125 |
 
   @positive
   Scenario Outline: Change RadioButton label align to <direction>

--- a/cypress/features/regression/radioButton/radioButtonWeeklyClassic.feature
+++ b/cypress/features/regression/radioButton/radioButtonWeeklyClassic.feature
@@ -99,8 +99,8 @@ Feature: Experimental RadioButton weekly classic component
     Examples:
       | width | px         |
       | 1     | 16         |
-      | 10    | 98.71875   |
-      | 50    | 358.234375 |
+      | 10    | 98.53125   |
+      | 50    | 357.546875 |
 
   # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
@@ -109,10 +109,10 @@ Feature: Experimental RadioButton weekly classic component
       And I set group weekly labelWidth slider to <width>
     Then "First" RadioButton label width is set to "<px>"
     Examples:
-      | width | px        |
-      | 1     | 10.609375 |
-      | 50    | 530.5     |
-      | 100   | 847.78125 |
+      | width | px         |
+      | 1     | 10.609375  |
+      | 50    | 530.5      |
+      | 100   | 831.203125 |
 
   @positive
   Scenario Outline: Change RadioButton label align to <direction>

--- a/cypress/features/regression/radioButton/radioButtonWeeklyClassic.feature
+++ b/cypress/features/regression/radioButton/radioButtonWeeklyClassic.feature
@@ -91,26 +91,28 @@ Feature: Experimental RadioButton weekly classic component
       And I uncheck group weekly fieldHelpInline checkbox
     Then "First" field help is not set to fieldHelpInline and has margin-left set to "22px"
 
+  # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
-  Scenario Outline: Change RadioButton input width to <width>
+  Scenario Outline: Change RadioButton inputWidth to <width>
     When I set group weekly inputWidth slider to <width>
-    Then "First" RadioButton "weekly" inputWidth is set to <px>
+    Then "First" RadioButton "weekly" inputWidth is set to "<px>"
     Examples:
-      | width | px  |
-      | 1     | 11  |
-      | 10    | 106 |
-      | 50    | 531 |
+      | width | px         |
+      | 1     | 16         |
+      | 10    | 98.71875   |
+      | 50    | 358.234375 |
 
+  # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
   Scenario Outline: Change RadioButton label width to <width>
     When I check group weekly fieldHelpInline checkbox
       And I set group weekly labelWidth slider to <width>
-    Then "First" RadioButton label width is set to <px>
+    Then "First" RadioButton label width is set to "<px>"
     Examples:
-      | width | px   |
-      | 1     | 11   |
-      | 50    | 531  |
-      | 100   | 1049 |
+      | width | px        |
+      | 1     | 10.609375 |
+      | 50    | 530.5     |
+      | 100   | 847.78125 |
 
   @positive
   Scenario Outline: Change RadioButton label align to <direction>

--- a/cypress/features/regression/radioButton/radioButtonYearly.feature
+++ b/cypress/features/regression/radioButton/radioButtonYearly.feature
@@ -100,26 +100,28 @@ Feature: Experimental RadioButton yearly component
       And I uncheck group yearly fieldHelpInline checkbox
     Then "Third" field help is not set to fieldHelpInline and has margin-left set to "32px"
 
+  # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
-  Scenario Outline: Change RadioButton input width to <width>
+  Scenario Outline: Change RadioButton inputWidth to <width>
     When I set group yearly inputWidth slider to <width>
-    Then "Third" RadioButton "yearly" inputWidth is set to <px>
+    Then "Third" RadioButton "yearly" inputWidth is set to "<px>"
     Examples:
-      | width | px  |
-      | 1     | 11  |
-      | 10    | 106 |
-      | 50    | 531 |
+      | width | px         |
+      | 1     | 16         |
+      | 10    | 98.71875   |
+      | 50    | 358.234375 |
 
+  # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
   Scenario Outline: Change RadioButton label width to <width>
     When I check group yearly fieldHelpInline checkbox
       And I set group yearly labelWidth slider to <width>
-    Then "Third" RadioButton label width is set to <px>
+    Then "Third" RadioButton label width is set to "<px>"
     Examples:
-      | width | px   |
-      | 1     | 11   |
-      | 50    | 531  |
-      | 100   | 1049 |
+      | width | px        |
+      | 1     | 10.609375 |
+      | 50    | 530.5     |
+      | 100   | 847.78125 |
 
   @positive
   Scenario Outline: Change RadioButton label align to <direction>

--- a/cypress/features/regression/radioButton/radioButtonYearlyClassic.feature
+++ b/cypress/features/regression/radioButton/radioButtonYearlyClassic.feature
@@ -99,8 +99,8 @@ Feature: Experimental RadioButton yearly classic component
     Examples:
       | width | px         |
       | 1     | 16         |
-      | 10    | 98.71875   |
-      | 50    | 358.234375 |
+      | 10    | 98.53125   |
+      | 50    | 357.546875 |
 
   # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive

--- a/cypress/features/regression/radioButton/radioButtonYearlyClassic.feature
+++ b/cypress/features/regression/radioButton/radioButtonYearlyClassic.feature
@@ -91,26 +91,28 @@ Feature: Experimental RadioButton yearly classic component
       And I uncheck group yearly fieldHelpInline checkbox
     Then "Third" field help is not set to fieldHelpInline and has margin-left set to "22px"
 
+  # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
-  Scenario Outline: Change RadioButton input width to <width>
+  Scenario Outline: Change RadioButton inputWidth to <width>
     When I set group yearly inputWidth slider to <width>
-    Then "Third" RadioButton "yearly" inputWidth is set to <px>
+    Then "Third" RadioButton "yearly" inputWidth is set to "<px>"
     Examples:
-      | width | px  |
-      | 1     | 11  |
-      | 10    | 106 |
-      | 50    | 531 |
+      | width | px         |
+      | 1     | 16         |
+      | 10    | 98.71875   |
+      | 50    | 358.234375 |
 
+  # pixels are adjusted for Travis CI. For normal cypress test runner test should fail
   @positive
-  Scenario Outline: Change RadioButton label width to <width>
+  Scenario Outline: Change RadioButton label  width to <width>
     When I check group yearly fieldHelpInline checkbox
       And I set group yearly labelWidth slider to <width>
-    Then "Third" RadioButton label width is set to <px>
+    Then "Third" RadioButton label width is set to "<px>"
     Examples:
-      | width | px   |
-      | 1     | 11   |
-      | 50    | 531  |
-      | 100   | 1049 |
+      | width | px        |
+      | 1     | 10.609375 |
+      | 50    | 530.5     |
+      | 100   | 847.78125 |
 
   @positive
   Scenario Outline: Change RadioButton label align to <direction>

--- a/cypress/locators/radioButton/index.js
+++ b/cypress/locators/radioButton/index.js
@@ -3,4 +3,7 @@ import { RADIO_BUTTON, RADIO_BUTTON_COMPONENT } from './locators';
 // component preview locators
 export const radioButton = () => cy.get(RADIO_BUTTON);
 export const radioButtonByPosition = position => cy.iFrame(RADIO_BUTTON).eq(position);
-export const radioButtonComponent = position => cy.iFrame(RADIO_BUTTON_COMPONENT).eq(position);
+export const radioButtonComponentByPosition = position => cy.iFrame(RADIO_BUTTON_COMPONENT)
+  .eq(position);
+export const reversedRadioButton = (position, index) => radioButtonComponentByPosition(position).find('div > div > div').children().eq(index)
+  .find('input');

--- a/cypress/support/step-definitions/radio-button-steps.js
+++ b/cypress/support/step-definitions/radio-button-steps.js
@@ -1,14 +1,17 @@
 import {
   fieldHelpPreview, labelByPosition, fieldHelpPreviewByPosition, labelWidthSliderByName,
 } from '../../locators';
-import { radioButton, radioButtonByPosition, radioButtonComponent } from '../../locators/radioButton/index';
+import {
+  radioButton, radioButtonByPosition, radioButtonComponentByPosition, reversedRadioButton,
+} from '../../locators/radioButton/index';
 import { setSlidebar } from '../helper';
 
 const INLINE = 'carbon-radio-button__help-text--inline';
 const FIRST_RADIOBUTTON = 0;
 const SECOND_RADIOBUTTON = 1;
 const THIRD_RADIOBUTTON = 2;
-const FIRST_ELEMENT = 1;
+const FIRST_ELEMENT = 0;
+const SECOND_ELEMENT = 1;
 
 Then('fieldHelpInline is enabled', () => {
   fieldHelpPreview().should('have.class', INLINE);
@@ -66,17 +69,17 @@ Then('{string} RadioButton has value {string}', (position, text) => {
 Then('{string} RadioButton component is disabled', (position) => {
   switch (position) {
     case 'First':
-      radioButtonComponent(FIRST_RADIOBUTTON).should('have.attr', 'disabled');
+      radioButtonComponentByPosition(FIRST_RADIOBUTTON).should('have.attr', 'disabled');
       radioButtonByPosition(FIRST_RADIOBUTTON).should('be.disabled')
         .and('have.attr', 'disabled');
       break;
     case 'Second':
-      radioButtonComponent(SECOND_RADIOBUTTON).should('have.attr', 'disabled');
+      radioButtonComponentByPosition(SECOND_RADIOBUTTON).should('have.attr', 'disabled');
       radioButtonByPosition(SECOND_RADIOBUTTON).should('be.disabled')
         .and('have.attr', 'disabled');
       break;
     case 'Third':
-      radioButtonComponent(THIRD_RADIOBUTTON).should('have.attr', 'disabled');
+      radioButtonComponentByPosition(THIRD_RADIOBUTTON).should('have.attr', 'disabled');
       radioButtonByPosition(THIRD_RADIOBUTTON).should('be.disabled')
         .and('have.attr', 'disabled');
       break;
@@ -87,19 +90,19 @@ Then('{string} RadioButton component is disabled', (position) => {
 Then('{string} RadioButton component is enabled', (position) => {
   switch (position) {
     case 'First':
-      radioButtonComponent(SECOND_RADIOBUTTON).should('not.have.attr', 'disabled')
+      radioButtonComponentByPosition(SECOND_RADIOBUTTON).should('not.have.attr', 'disabled')
         .and('not.be.disabled');
       radioButtonByPosition(FIRST_RADIOBUTTON).should('not.have.attr', 'disabled')
         .and('not.be.disabled');
       break;
     case 'Second':
-      radioButtonComponent(SECOND_RADIOBUTTON).should('not.have.attr', 'disabled')
+      radioButtonComponentByPosition(SECOND_RADIOBUTTON).should('not.have.attr', 'disabled')
         .and('not.be.disabled');
       radioButtonByPosition(SECOND_RADIOBUTTON).should('not.have.attr', 'disabled')
         .and('not.be.disabled');
       break;
     case 'Third':
-      radioButtonComponent(SECOND_RADIOBUTTON).should('not.have.attr', 'disabled')
+      radioButtonComponentByPosition(SECOND_RADIOBUTTON).should('not.have.attr', 'disabled')
         .and('not.be.disabled');
       radioButtonByPosition(THIRD_RADIOBUTTON).should('not.have.attr', 'disabled')
         .and('not.be.disabled');
@@ -111,19 +114,16 @@ Then('{string} RadioButton component is enabled', (position) => {
 Then('{string} RadioButton is set to reverse', (position) => {
   switch (position) {
     case 'First':
-      radioButtonComponent(FIRST_RADIOBUTTON).children().children()
-        .find(`div:nth-child(${FIRST_ELEMENT})`)
-        .should('have.css', 'box-sizing', 'border-box');
+      cy.wait(500);
+      reversedRadioButton(FIRST_RADIOBUTTON, SECOND_ELEMENT).should('have.attr', 'type', 'radio');
       break;
     case 'Second':
-      radioButtonComponent(SECOND_RADIOBUTTON).children().children()
-        .find(`div:nth-child(${FIRST_ELEMENT})`)
-        .should('have.css', 'box-sizing', 'border-box');
+      cy.wait(500);
+      reversedRadioButton(SECOND_RADIOBUTTON, SECOND_ELEMENT).should('have.attr', 'type', 'radio');
       break;
     case 'Third':
-      radioButtonComponent(FIRST_RADIOBUTTON).children().children()
-        .find(`div:nth-child(${FIRST_ELEMENT})`)
-        .should('have.css', 'box-sizing', 'border-box');
+      cy.wait(500);
+      reversedRadioButton(THIRD_RADIOBUTTON, SECOND_ELEMENT).should('have.attr', 'type', 'radio');
       break;
     default: throw new Error('There are only three radio elements on the page');
   }
@@ -132,19 +132,14 @@ Then('{string} RadioButton is set to reverse', (position) => {
 Then('{string} RadioButton is not set to reverse', (position) => {
   switch (position) {
     case 'First':
-      radioButtonComponent(FIRST_RADIOBUTTON).children().children()
-        .find(`div:nth-child(${FIRST_ELEMENT})`)
-        .should('have.css', 'box-sizing', 'border-box');
+      // cy.wait(500);
+      reversedRadioButton(FIRST_RADIOBUTTON, FIRST_ELEMENT).should('have.attr', 'type', 'radio');
       break;
     case 'Second':
-      radioButtonComponent(SECOND_RADIOBUTTON).children().children()
-        .find(`div:nth-child(${FIRST_ELEMENT})`)
-        .should('have.css', 'box-sizing', 'border-box');
+      reversedRadioButton(SECOND_RADIOBUTTON, FIRST_ELEMENT).should('have.attr', 'type', 'radio');
       break;
     case 'Third':
-      radioButtonComponent(FIRST_RADIOBUTTON).children().children()
-        .find(`div:nth-child(${FIRST_ELEMENT})`)
-        .should('have.css', 'box-sizing', 'border-box');
+      reversedRadioButton(THIRD_RADIOBUTTON, FIRST_ELEMENT).should('have.attr', 'type', 'radio');
       break;
     default: throw new Error('There are only three radio elements on the page');
   }
@@ -219,7 +214,7 @@ Then('{string} field help is not set to fieldHelpInline and has margin-left set 
   }
 });
 
-Then('{string} RadioButton {string} inputWidth is set to {int}', (position, name, width) => {
+Then('{string} RadioButton {string} inputWidth is set to {string}', (position, name, width) => {
   switch (position) {
     case 'First':
       radioButtonByPosition(FIRST_RADIOBUTTON).parent()
@@ -237,7 +232,7 @@ Then('{string} RadioButton {string} inputWidth is set to {int}', (position, name
   }
 });
 
-Then('{string} RadioButton label width is set to {int}', (position, width) => {
+Then('{string} RadioButton label width is set to {string}', (position, width) => {
   switch (position) {
     case 'First':
       labelByPosition(FIRST_RADIOBUTTON).should('have.css', 'width', `${width}px`);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "webpack": "node_modules/.bin/webpack",
     "webpack-dev-server": "node_modules/.bin/webpack-dev-server",
     "fixtures": "webpack-dev-server --config fixtures/webpack.config.js",
-    "commit": "git-cz"
+    "commit": "git-cz",
+    "cypress-travis-regression": "cross-env-shell cypress run --spec \"./cypress/features/$SUITE\" --reporter spec --browser chrome"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix set reverse and not reverse radioButton test cases, changed px for width label and input

### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [ ] Unit tests
- [ ] Cypress automation tests
- [ ] Storybook added or updated
- [ ] Theme support
- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
