### PR TITLE
fix(checkbox): restore proper checkbox behaviour in validations story - FE-2579

### DIFF
--- a/src/__experimental__/components/checkbox/checkbox.stories.js
+++ b/src/__experimental__/components/checkbox/checkbox.stories.js
@@ -196,7 +196,7 @@ const checkboxGroupComponent = () => (
       {formCheckbox.map(type => (
         <State store={ checkboxes[type].store } key={ `check-state-${type}` }>
           <Checkbox
-            id='checkbox'
+            id={ `checkbox_${type}` }
             key={ `checkbox-input-${type}` }
             validations={ testValidator }
             warnings={ testWarning }

--- a/src/__experimental__/components/checkbox/checkbox.stories.js
+++ b/src/__experimental__/components/checkbox/checkbox.stories.js
@@ -212,9 +212,9 @@ const checkboxGroupComponent = () => (
 
     <h3>In Group</h3>
     <State store={ groupStore }>
-      {state => [
+      {state => (
         <CheckboxGroup
-          key='checkbox-group'
+          id='checkbox-group'
           name='checkbox-group'
           groupName='checkbox-group'
           label={ text('label', 'What would you choose?', 'group') }
@@ -228,13 +228,13 @@ const checkboxGroupComponent = () => (
             <Checkbox
               checked={ state[id] }
               name={ `checkbox-input-${id}` }
-              key={ `checkbox-input-${id}` }
               onChange={ ev => handleGroupChange(ev, id) }
               { ...defaultKnobs(id) }
+              key={ `checkbox-input-${id}` }
             />
           ))}
         </CheckboxGroup>
-      ]}
+      )}
     </State>
   </div>
 );


### PR DESCRIPTION
### Proposed behaviour
Clicking on label of a given Checkbox should check this particular checkbox

### Current behaviour
Clicking on label in Experimental/Checkbox/validations always checks first checkbox no matter which of the checkboxes label is clicked

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>- [ ] Unit tests</del>
<del>- [ ] Cypress automation tests</del>
- [x] Storybook added or updated
<del>- [ ] Theme support</del>
<del>- [ ] Typescript `d.ts` file added or updated</del>

### Testing instructions
Storybook -> Experimental -> Checkbox -> validations
