### PR TITLE
feat(simple-color-picker): keyboard accessbility, up and down navigation - FE-2578

### DIFF
--- a/cypress/features/regression/actionPopoverIFrame.feature
+++ b/cypress/features/regression/actionPopoverIFrame.feature
@@ -34,7 +34,7 @@ Feature: Action Popover component
 
   @positive
   Scenario: Open Action Popover using downarrow keyboard key
-    When I press downarrow on focused element
+    When I press downarrow on actionPopoverButton element
     Then focused element inner content is set to "Email Invoice"
       And Action Popover element has golden border on focus
 

--- a/cypress/features/regression/experimental/simpleColorPicker.feature
+++ b/cypress/features/regression/experimental/simpleColorPicker.feature
@@ -1,0 +1,58 @@
+Feature: Simple Color Picker component
+  I want to test Simple Color Picker component
+
+  Background: Open Simple Color Picker component default page
+    Given I open "Experimental Simple Color Picker" component page
+
+  @positive
+  Scenario: When avaiableColors prop is provided changes rendnered colors
+    Given It renders with all colors
+    When I input new color json into "availableColors" input field
+    Then It renders with all new colors
+
+  @positive
+  Scenario: Color Picker renders all the provided colors and their respective labels
+    # commented because of BDD default scenario Given - When - Then
+    # When I open "Experimental Simple Color Picker" component page
+    Then It renders with all colors
+
+  @positive
+  Scenario: When on last color, going forward selects first color
+    When I press ArrowRight on the 10 color
+    Then Experimental Simple Color Picker 1 element was picked up
+
+  @positive
+  Scenario: When on first color, going backward selects last color
+    When I press ArrowLeft on the 1 color
+    Then Experimental Simple Color Picker 10 element was picked up
+
+  @positive
+  Scenario: Left arrow moves selection left
+    When I press ArrowLeft on the 3 color
+    Then Experimental Simple Color Picker 2 element was picked up
+
+  @positive
+  Scenario: Right arrow moves selection right
+    When I press ArrowRight on the 3 color
+    Then Experimental Simple Color Picker 4 element was picked up
+
+  @positive
+  Scenario: Up arrow moves selection up
+    Given I select 6 color
+    When I press ArrowUp on the 6 color
+    Then Experimental Simple Color Picker 1 element was picked up
+
+  @positive
+  Scenario: Down arrow moves selection down
+    When I press ArrowDown on the 3 color
+    Then Experimental Simple Color Picker 8 element was picked up
+
+  @positive
+  Scenario Outline: Check the Simple Color Picker <position> element was selected
+    When I pick simple <position> color
+    Then Experimental Simple Color Picker <position> element was picked up
+    Examples:
+      | position |
+      | 1        |
+      | 2        |
+      | 3        |

--- a/cypress/fixtures/simpleColorPicker.json
+++ b/cypress/fixtures/simpleColorPicker.json
@@ -1,0 +1,42 @@
+[
+  {
+    "color": "#00A376",
+    "label": "green"
+  },
+  {
+    "color": "#0073C1",
+    "label": "blue"
+  },
+  {
+    "color": "#582C83",
+    "label": "purple"
+  },
+  {
+    "color": "#E96400",
+    "label": "orange"
+  },
+  {
+    "color": "#99ADB6",
+    "label": "gray"
+  },
+  {
+    "color": "#C7384F",
+    "label": "flush mahogany"
+  },
+  {
+    "color": "#004500",
+    "label": "dark green"
+  },
+  {
+    "color": "#FFB500",
+    "label": "yellow"
+  },
+  {
+    "color": "#335C6D",
+    "label": "dark blue"
+  },
+  {
+    "color": "#00DC00",
+    "label": "light blue"
+  }
+]

--- a/cypress/fixtures/simpleColorPickerNew.json
+++ b/cypress/fixtures/simpleColorPickerNew.json
@@ -1,0 +1,42 @@
+[
+  {
+    "color": "#CCA376",
+    "label": "color a"
+  },
+  {
+    "color": "#CC73C1",
+    "label": "color b"
+  },
+  {
+    "color": "#CC2C83",
+    "label": "color c"
+  },
+  {
+    "color": "#CC6400",
+    "label": "color d"
+  },
+  {
+    "color": "#CCADB6",
+    "label": "color e"
+  },
+  {
+    "color": "#CC384F",
+    "label": "color f"
+  },
+  {
+    "color": "#CC4500",
+    "label": "color g"
+  },
+  {
+    "color": "#CCB500",
+    "label": "color h"
+  },
+  {
+    "color": "#CC5C6D",
+    "label": "color i"
+  },
+  {
+    "color": "#CCDC00",
+    "label": "color j"
+  }
+]

--- a/cypress/locators/simple-color-picker/index.js
+++ b/cypress/locators/simple-color-picker/index.js
@@ -1,4 +1,4 @@
-import { SIMPLE_COLOR_PICKER_PREVIEW } from './locators';
+import { SIMPLE_COLOR_PICKER_PREVIEW, EXPERIMENTAL_SIMPLE_COLOR_PICKER, EXPERIMENTAL_SIMPLE_COLOR } from './locators';
 
 // component preview locators
 export const simpleColorPickerPreview = () => cy.iFrame(SIMPLE_COLOR_PICKER_PREVIEW);
@@ -6,3 +6,6 @@ export const simpleColorPickerInput = index => cy.iFrame(SIMPLE_COLOR_PICKER_PRE
   .find(`li:nth-child(${index}) > div > input`);
 export const simpleColorPickerDiv = index => cy.iFrame(SIMPLE_COLOR_PICKER_PREVIEW)
   .find(`li:nth-child(${index}) > div > div > span`);
+export const experimentalSimpleColorPickerInput = index => cy.iFrame(
+  EXPERIMENTAL_SIMPLE_COLOR_PICKER,
+).find(`${EXPERIMENTAL_SIMPLE_COLOR}:nth-child(${index}) > input`);

--- a/cypress/locators/simple-color-picker/locators.js
+++ b/cypress/locators/simple-color-picker/locators.js
@@ -1,2 +1,4 @@
 // component preview locators
 export const SIMPLE_COLOR_PICKER_PREVIEW = 'div[data-component="simple-color-picker"] > ul';
+export const EXPERIMENTAL_SIMPLE_COLOR_PICKER = '[data-component="simple-color-picker"]';
+export const EXPERIMENTAL_SIMPLE_COLOR = '[data-component="simple-color"]';

--- a/cypress/support/step-definitions/action-popover-steps.js
+++ b/cypress/support/step-definitions/action-popover-steps.js
@@ -41,6 +41,6 @@ When('I press {string} actionPopoverInnerItem onto {int} element', (key, element
   actionPopoverInnerItem(element).type(`{${key}}`);
 });
 
-When('I press downarrow on focused element', () => {
+When('I press downarrow on actionPopoverButton element', () => {
   actionPopoverButton().first().trigger('keydown', { keyCode: 40, which: 40 });
 });

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -526,20 +526,8 @@ When('I press ESC on focused element', () => {
   cy.focused().trigger('keydown', { keyCode: 27, which: 27 });
 });
 
-When('I press Tab on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 9, which: 9 });
-});
-
-When('I press Home on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 36, which: 36 });
-});
-
-When('I press uparrow on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 38, which: 38 });
-});
-
-When('I press End on focused element', () => {
-  cy.focused().trigger('keydown', { keyCode: 35, which: 35 });
+When('I press {word} on focused element', (key) => {
+  cy.focused().trigger('keydown', { key });
 });
 
 When('I press ShiftTab on focused element', () => {

--- a/cypress/support/step-definitions/simple-color-picker-steps.js
+++ b/cypress/support/step-definitions/simple-color-picker-steps.js
@@ -1,4 +1,14 @@
-import { simpleColorPickerInput, simpleColorPickerDiv, simpleColorPickerPreview } from '../../locators/simple-color-picker';
+import {
+  simpleColorPickerInput,
+  simpleColorPickerDiv,
+  simpleColorPickerPreview,
+  experimentalSimpleColorPickerInput,
+} from '../../locators/simple-color-picker';
+import { getKnobsInput } from '../../locators';
+
+beforeEach(() => {
+  cy.viewport(1366, 1200);
+});
 
 const FIRST_ELEMENT = 1;
 const SECOND_ELEMENT = 2;
@@ -46,4 +56,64 @@ When('I pick {int} color', (index) => {
   for (let i = 0; i < index; ++i) {
     simpleColorPickerInput(i + 1).click();
   }
+});
+
+When('I pick simple {int} color', (index) => {
+  if (index === 1) {
+    experimentalSimpleColorPickerInput(SECOND_ELEMENT).click();
+    experimentalSimpleColorPickerInput(FIRST_ELEMENT).click();
+  }
+  for (let i = 0; i < index; ++i) {
+    experimentalSimpleColorPickerInput(i + 1).click();
+  }
+});
+
+Then('Experimental Simple Color Picker {int} element was picked up', (index) => {
+  experimentalSimpleColorPickerInput(index).should('have.attr', 'aria-checked', 'true');
+});
+
+When('I select {int} color', (index) => {
+  experimentalSimpleColorPickerInput(index).click();
+});
+
+When('I press {word} on the {int} color', (key, index) => {
+  switch (key) {
+    case 'ArrowDown':
+      experimentalSimpleColorPickerInput(index).trigger('keydown', { key: 'ArrowDown', keyCode: 40, which: 40 });
+      break;
+    case 'ArrowUp':
+      experimentalSimpleColorPickerInput(index).trigger('keydown', { key: 'ArrowUp', keyCode: 38, which: 38 });
+      break;
+    case 'ArrowRight':
+      experimentalSimpleColorPickerInput(index).trigger('keydown', { key: 'ArrowRight', keyCode: 39, which: 39 });
+      break;
+    case 'ArrowLeft':
+      experimentalSimpleColorPickerInput(index).trigger('keydown', { key: 'ArrowLeft', keyCode: 37, which: 37 });
+      break;
+    default: throw new Error('There are only arrow keys allowed');
+  }
+});
+
+Then('It renders with all colors', () => {
+  cy.fixture('simpleColorPicker.json').then(($json) => {
+    for (let i = 0; i < $json.length; ++i) {
+      experimentalSimpleColorPickerInput(i + 1).should('have.value', $json[i].color);
+      experimentalSimpleColorPickerInput(i + 1).should('have.attr', 'aria-label', $json[i].label);
+    }
+  });
+});
+
+When('I input new color json into {string} input field', (inputFieldName) => {
+  cy.fixture('simpleColorPickerNew.json').then(($json) => {
+    getKnobsInput(inputFieldName).clear().then($selector => $selector.val(JSON.stringify($json))).type(' ');
+  });
+});
+
+Then('It renders with all new colors', () => {
+  cy.fixture('simpleColorPickerNew.json').then(($json) => {
+    for (let i = 0; i < $json.length; ++i) {
+      experimentalSimpleColorPickerInput(i + 1).should('have.value', $json[i].color);
+      experimentalSimpleColorPickerInput(i + 1).should('have.attr', 'aria-label', $json[i].label);
+    }
+  });
 });

--- a/src/__experimental__/components/radio-button/radio-button-mapper.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-mapper.component.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 const RadioButtonMapper = ({
-  children, name, onBlur, onChange, onMouseDown, value
+  children, name, onBlur, onChange, onMouseDown, onKeyDown, value
 }) => {
   const anyChecked = useMemo(() => {
     let result = false;
@@ -46,7 +46,8 @@ const RadioButtonMapper = ({
       name,
       onBlur,
       onMouseDown,
-      onChange: onChangeProp
+      onChange: onChangeProp,
+      onKeyDown
     });
   });
 
@@ -62,6 +63,8 @@ RadioButtonMapper.propTypes = {
   onBlur: PropTypes.func,
   /** Callback fired when the user selects a RadioButton */
   onChange: PropTypes.func,
+  /** Callback fired on key down */
+  onKeyDown: PropTypes.func,
   /** Value of the selected RadioButton */
   value: PropTypes.string
 };

--- a/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
+++ b/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
@@ -52,6 +52,81 @@ exports[`SimpleColorPicker renders as expected 1`] = `
   background-color: #0073C1;
 }
 
+.c14 {
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border: 2px solid transparent;
+  background-color: #582C83;
+}
+
+.c13 {
+  display: inline-block;
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: transparent;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 24px;
+  width: 24px;
+}
+
+.c13:hover {
+  color: rgba(0,0,0,0.90);
+  background-color: transparent;
+}
+
+.c13::before {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-family: CarbonIcons;
+  content: "\\e950";
+  font-size: 16px;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 16px;
+  vertical-align: middle;
+  display: block;
+}
+
+.c11 {
+  height: 22px;
+  width: 22px;
+  pointer-events: none;
+  display: none;
+}
+
+.c11::before {
+  font-size: 22px;
+  color: #FFFFFF;
+}
+
+.c11 {
+  display: block;
+}
+
 .c7 {
   background: transparent;
   border: none;
@@ -109,12 +184,12 @@ exports[`SimpleColorPicker renders as expected 1`] = `
   padding: 0;
 }
 
-.c1.c1.c1 .c13 {
+.c1.c1.c1 .c16 {
   margin-top: 0;
   margin-bottom: -1px;
 }
 
-.c1 .c14 {
+.c1 .c17 {
   padding-top: 8px;
   padding-bottom: 8px;
 }
@@ -137,7 +212,7 @@ exports[`SimpleColorPicker renders as expected 1`] = `
   line-height: 24px;
 }
 
-.c3 .c12 .c11:focus {
+.c3 .c15 .c12:focus {
   outline: 2px solid #FFB500;
 }
 
@@ -199,13 +274,16 @@ exports[`SimpleColorPicker renders as expected 1`] = `
           aria-checked={false}
           checked={false}
           className="c6 c7"
+          data-down={false}
           data-element="input"
+          data-up={false}
           id="rId-0"
           name="test-group"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
           onMouseDown={[Function]}
           role="radio"
           type="radio"
@@ -217,22 +295,25 @@ exports[`SimpleColorPicker renders as expected 1`] = `
         />
       </div>
       <div
-        checked={false}
+        checked={true}
         className="c5"
         color="#0073C1"
         data-component="simple-color"
       >
         <input
-          aria-checked={false}
-          checked={false}
+          aria-checked={true}
+          checked={true}
           className="c6 c7"
+          data-down={false}
           data-element="input"
+          data-up={false}
           id="rId-1"
           name="test-group"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
           onMouseDown={[Function]}
           role="radio"
           type="radio"
@@ -241,6 +322,47 @@ exports[`SimpleColorPicker renders as expected 1`] = `
         <div
           className="c8 c10"
           color="#0073C1"
+        >
+          <span
+            checked={true}
+            className="c11 c12 c13"
+            color="#0073C1"
+            data-component="icon"
+            data-element="tick"
+            disabled={false}
+            fontSize="small"
+            type="tick"
+          />
+        </div>
+      </div>
+      <div
+        checked={false}
+        className="c5"
+        color="#582C83"
+        data-component="simple-color"
+      >
+        <input
+          aria-checked={false}
+          checked={false}
+          className="c6 c7"
+          data-down={false}
+          data-element="input"
+          data-up={false}
+          id="rId-2"
+          name="test-group"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          role="radio"
+          type="radio"
+          value="#582C83"
+        />
+        <div
+          className="c8 c14"
+          color="#582C83"
         />
       </div>
     </div>

--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.component.js
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.component.js
@@ -1,6 +1,11 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, {
+  useCallback,
+  useState,
+  useRef,
+  useEffect
+} from 'react';
 import PropTypes from 'prop-types';
-
+import Events from '../../../utils/helpers/events';
 import tagComponent from '../../../utils/helpers/tags/tags';
 import SimpleColor from './simple-color';
 import RadioButtonMapper from '../radio-button/radio-button-mapper.component';
@@ -8,12 +13,121 @@ import { SimpleColorFieldset, StyledColorOptions } from './simple-color-picker.s
 
 const SimpleColorPicker = (props) => {
   const {
-    children, name, legend, onChange, onBlur, value, isBlurBlocked = false
+    children,
+    name,
+    legend,
+    onChange,
+    onBlur,
+    onKeyDown,
+    value,
+    isBlurBlocked = false,
+    maxWidth = 300,
+    childWith = 58
   } = props;
 
   const myRef = useRef(null);
   const [blurBlocked, setIsBlurBlocked] = useState(isBlurBlocked);
   const [focusedElement, setFocusedElement] = useState(null);
+  const itemsPerRow = Math.floor(maxWidth / childWith);
+  const rowCount = Math.ceil(children.length / itemsPerRow);
+  let blankSlots = itemsPerRow * rowCount - children.length;
+  let currentRow = 1;
+  let loopCounter = 1;
+
+  const gridItemRefs = useRef(Array.from({
+    length: React.Children.count(children)
+  }, () => React.createRef()));
+
+  const navigationGrid = React.Children.map(children, (child, index) => {
+    const allowUp = currentRow !== 1;
+    let allowDown = false;
+
+    if ((currentRow + 1) === rowCount && (blankSlots - itemsPerRow) < 0) {
+      allowDown = true;
+      blankSlots += 1;
+    } else if ((currentRow + 1) !== rowCount && currentRow !== rowCount && rowCount > 1) {
+      allowDown = true;
+    }
+
+    if (loopCounter === itemsPerRow) {
+      loopCounter = 0;
+      currentRow += 1;
+    }
+
+    let upItem;
+
+    if (allowUp) {
+      upItem = index - itemsPerRow;
+    }
+
+    let downItem;
+
+    if (allowDown) {
+      downItem = itemsPerRow + index;
+    }
+
+    const childProps = {
+      ref: child.ref || gridItemRefs.current[index],
+      'data-up': allowUp,
+      'data-down': allowDown,
+      'data-item-up': upItem,
+      'data-item-down': downItem
+    };
+
+    loopCounter += 1;
+
+    return React.cloneElement(child, childProps);
+  });
+
+  const onKeyDownHandler = useCallback((e) => {
+    if (onKeyDown) {
+      onKeyDown(e);
+    }
+
+    const arrowKeys = [
+      Events.isLeftKey(e),
+      Events.isUpKey(e),
+      Events.isRightKey(e),
+      Events.isDownKey(e)
+    ];
+
+    if (!arrowKeys.includes(true)) return;
+
+    e.preventDefault();
+
+    let itemIndex;
+
+    if (Events.isUpKey(e)) {
+      if (e.target.getAttribute('data-up') !== 'true') return;
+      itemIndex = e.target.getAttribute('data-item-up');
+    } else if (Events.isDownKey(e)) {
+      if (e.target.getAttribute('data-down') !== 'true') return;
+      itemIndex = e.target.getAttribute('data-item-down');
+    }
+
+    if (Events.isLeftKey(e) || Events.isRightKey(e)) {
+      const position = (element) => {
+        return e.target.getAttribute('value') === element.ref.current.props.value;
+      };
+
+      if (Events.isLeftKey(e)) {
+        itemIndex = navigationGrid.findIndex(position) - 1;
+      } else {
+        itemIndex = navigationGrid.findIndex(position) + 1;
+      }
+
+      if (itemIndex < 0) {
+        itemIndex = (navigationGrid.length - 1);
+      } else if (itemIndex > (navigationGrid.length - 1)) {
+        itemIndex = 0;
+      }
+    }
+
+    const item = navigationGrid[itemIndex].ref.current;
+    const { value: colorValue } = item.props;
+    item.input.current.focus();
+    item.props.onChange({ target: { checked: true, value: colorValue } });
+  }, [onKeyDown, navigationGrid]);
 
   const handleClickOutside = (ev) => {
     if (myRef.current && ev.target && !myRef.current.contains(ev.target)) {
@@ -64,6 +178,7 @@ const SimpleColorPicker = (props) => {
       legend={ legend }
       isBlurBlocked={ blurBlocked }
       { ...tagComponent('simple-color-picker', props) }
+      maxWidth={ maxWidth }
     >
       <StyledColorOptions ref={ myRef }>
         <RadioButtonMapper
@@ -71,9 +186,10 @@ const SimpleColorPicker = (props) => {
           value={ value }
           onChange={ onChange }
           onMouseDown={ handleOnMouseDown }
+          onKeyDown={ onKeyDownHandler }
           onBlur={ handleOnBlur }
         >
-          { children }
+          { navigationGrid }
         </RadioButtonMapper>
       </StyledColorOptions>
     </SimpleColorFieldset>
@@ -105,7 +221,13 @@ SimpleColorPicker.propTypes = {
   /** A callback triggered when a color is selected. */
   onChange: PropTypes.func,
   /** A callback triggered when a color is selected. */
-  onBlur: PropTypes.func
+  onBlur: PropTypes.func,
+  /** A callback triggered on key down. */
+  onKeyDown: PropTypes.func,
+  /** prop that sets max-width in css */
+  maxWidth: PropTypes.string,
+  /** prop that represents childWith */
+  childWith: PropTypes.string
 };
 
 export default SimpleColorPicker;

--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.spec.js
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.spec.js
@@ -7,19 +7,26 @@ import { SimpleColor, SimpleColorPicker } from '.';
 import { LegendContainerStyle } from '../fieldset/fieldset.style';
 import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
 
-const colorValues = ['#00A376', '#0073C1'];
+const colorValues = [
+  { color: '#00A376' },
+  { color: '#0073C1' },
+  { color: '#582C83' }
+];
 const name = 'test-group';
 
 function render(renderer = TestRenderer.create, props, childProps) {
-  const children = colorValues.map((color, index) => (
-    <SimpleColor
-      id={ `rId-${index}` }
-      key={ `radio-key-${color}` }
-      onChange={ jest.fn() }
-      value={ color }
-      { ...childProps }
-    />
-  ));
+  const children = colorValues.map((color, index) => {
+    return (
+      <SimpleColor
+        id={ `rId-${index}` }
+        key={ `radio-key-${color.color}` }
+        onChange={ jest.fn() }
+        value={ color.color }
+        defaultChecked={ color.color === '#0073C1' }
+        { ...childProps }
+      />
+    );
+  });
 
   return renderer(
     <SimpleColorPicker
@@ -36,6 +43,163 @@ function render(renderer = TestRenderer.create, props, childProps) {
 describe('SimpleColorPicker', () => {
   it('renders as expected', () => {
     expect(render()).toMatchSnapshot();
+  });
+
+  describe('it renders childs in rows based on maxWidth and childWith', () => {
+    let wrapper, onChange, colorTwo;
+
+    beforeEach(() => {
+      onChange = jest.fn();
+      wrapper = render(mount, { maxWidth: '58', childWith: '58', onChange });
+      colorTwo = wrapper.find(SimpleColor).at(1);
+      colorTwo.getDOMNode().focus();
+    });
+
+    describe('onKeyDown', () => {
+      it('fires onKeyDown callback if provided', () => {
+        const onKeyDown = jest.fn();
+        wrapper = render(mount, {
+          maxWidth: '58',
+          childWith: '58',
+          onChange,
+          onKeyDown
+        });
+
+        const selectedColor = wrapper.find(SimpleColor).at(1).find('input');
+
+        act(() => {
+          selectedColor.find('input').first().simulate('keydown', { which: 65, key: 'a' });
+        });
+
+        expect(onKeyDown).toHaveBeenCalled();
+      });
+
+      it('confirms that 2nd color is checked by default', () => {
+        const selectedColor = wrapper.find(SimpleColor).at(1).find('input');
+        expect(selectedColor.prop('aria-checked')).toBeTruthy();
+      });
+
+      it('if unhandled key is pressed', () => {
+        act(() => {
+          colorTwo.find('input').first().simulate('keydown', { which: 17, key: 'ctrl' });
+        });
+
+        expect(onChange).not.toHaveBeenCalled();
+      });
+
+      describe('on left key', () => {
+        describe('when on first color ', () => {
+          it('does change selection to last color', () => {
+            const colorOne = wrapper.find(SimpleColor).at(0);
+            colorOne.getDOMNode().focus();
+
+            act(() => {
+              colorOne.find('input').first().simulate('keydown', { which: 37, key: 'ArrowLeft' });
+            });
+
+            expect(onChange).toHaveBeenCalled();
+
+            expect(
+              document.activeElement.getAttribute('value')
+            ).toBe(wrapper.find(SimpleColor).last().prop('value'));
+          });
+        });
+      });
+
+      describe('on up key', () => {
+        describe('when up is allowed due to multi rows', () => {
+          it('changes selection on up key', () => {
+            act(() => {
+              colorTwo.find('input').first().simulate('keydown', { which: 38, key: 'ArrowUp' });
+            });
+
+            expect(onChange).toHaveBeenCalled();
+            expect(document.activeElement.getAttribute('value')).toBe(colorValues[0].color);
+          });
+        });
+
+        describe('when up is disallowed due to top row', () => {
+          it('changes selection on up key', () => {
+            colorTwo = wrapper.find(SimpleColor).at(0);
+            colorTwo.getDOMNode().focus();
+
+            act(() => {
+              colorTwo.find('input').first().simulate('keydown', { which: 38, key: 'ArrowUp' });
+            });
+
+            expect(onChange).not.toHaveBeenCalled();
+            expect(document.activeElement.getAttribute('value')).toBe(colorValues[0].color);
+          });
+        });
+      });
+
+      describe('on right key', () => {
+        describe('when on last color ', () => {
+          it('does change selection to first color', () => {
+            const colorThree = wrapper.find(SimpleColor).at(2);
+            colorThree.getDOMNode().focus();
+
+            act(() => {
+              colorThree.find('input').first().simulate('keydown', { which: 39, key: 'ArrowRight' });
+            });
+
+            expect(onChange).toHaveBeenCalled();
+            expect(
+              document.activeElement.getAttribute('value')
+            ).toBe(wrapper.find(SimpleColor).first().prop('value'));
+          });
+        });
+
+        describe('when on 2nd color ', () => {
+          it('changes selection on right key', () => {
+            act(() => {
+              colorTwo.find('input').first().simulate('keydown', { which: 39, key: 'ArrowRight' });
+            });
+
+            expect(onChange).toHaveBeenCalled();
+            expect(document.activeElement.getAttribute('value')).toBe(colorValues[2].color);
+          });
+        });
+      });
+
+
+      describe('on down key', () => {
+        describe('when down is allowed due to multi rows', () => {
+          it('changes selection on down key', () => {
+            act(() => {
+              colorTwo.find('input').first().simulate('keydown', { which: 40, key: 'ArrowDown' });
+            });
+
+            expect(onChange).toHaveBeenCalled();
+            expect(document.activeElement.getAttribute('value')).toBe(colorValues[2].color);
+          });
+        });
+
+        describe('when up is disallowed due to top row', () => {
+          it('changes selection on down key', () => {
+            const colorThree = wrapper.find(SimpleColor).at(2);
+            colorThree.getDOMNode().focus();
+
+            act(() => {
+              colorThree.find('input').first().simulate('keydown', { which: 40, key: 'ArrowDown' });
+            });
+
+            expect(onChange).not.toHaveBeenCalled();
+            expect(document.activeElement.getAttribute('value')).toBe(colorValues[2].color);
+          });
+        });
+      });
+    });
+
+    describe('renders two rows', () => {
+      it('confirms that last color has data-down attribute false', () => {
+        wrapper = render(mount, { maxWidth: '120', childWith: '58' });
+        const colorFirst = wrapper.find(SimpleColor).first();
+        const colorLast = wrapper.find(SimpleColor).last();
+        expect(colorFirst.prop('data-down')).toBeTruthy();
+        expect(colorLast.prop('data-down')).toBeFalsy();
+      });
+    });
   });
 
   describe('events', () => {

--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.stories.js
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text, array } from '@storybook/addon-knobs';
+import { text, object } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { State, Store } from '@sambego/storybook-state';
 import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/theme-selectors';
@@ -41,7 +41,7 @@ function makeStory(storyName, themeSelector) {
       { color: '#335C6D', label: 'dark blue' },
       { color: '#00DC00', label: 'light blue' }
     ];
-    const availableColors = array('availableColors', demoColors, '/');
+    const availableColors = object('availableColors', demoColors);
 
     return (
       <State store={ store }>

--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.style.js
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.style.js
@@ -3,7 +3,7 @@ import Fieldset from '../fieldset';
 import { LegendContainerStyle } from '../fieldset/fieldset.style';
 
 const SimpleColorFieldset = styled(Fieldset)`
-  max-width: 300px;
+  max-width: ${({ maxWidth }) => maxWidth}px;
 
   ${LegendContainerStyle} {
     margin-bottom: 16px;


### PR DESCRIPTION
### Proposed behaviour
ArrowUp will move selection up if possible.
ArrowDown will move selection down if possible.
![Kapture 2020-03-12 at 15 30 35](https://user-images.githubusercontent.com/47245766/76538162-c6a76880-6476-11ea-91d8-0186bb690cea.gif)


### Current behaviour
ArrowUp behaviour is identical to ArrowLeft, moves selection to previous element.
ArrowDown behaviour is identical to ArrowRight, moves selection to next element.

![Kapture 2020-03-12 at 15 38 18](https://user-images.githubusercontent.com/47245766/76538695-9d3b0c80-6477-11ea-83b1-52b13f5b80ce.gif)


### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests
- [x] Storybook added or updated
<del>- [ ] Theme support
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
