### PR TITLE
test: fix jsdom related console warnings (FE-2490)

### DIFF
--- a/src/__deprecated__/components/form/form.spec.js
+++ b/src/__deprecated__/components/form/form.spec.js
@@ -293,6 +293,7 @@ describe('Form', () => {
   describe('handleOnSubmit', () => {
     it('calls the validate method', () => {
       const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+      form.submit = jest.fn();
       TestUtils.Simulate.submit(form);
       expect(validate).toHaveBeenCalled();
     });
@@ -309,6 +310,7 @@ describe('Form', () => {
           </Form>
         );
         const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+        form.submit = jest.fn();
         TestUtils.Simulate.submit(form);
         expect(spy).toHaveBeenCalled();
       });
@@ -330,6 +332,7 @@ describe('Form', () => {
           done();
         });
         const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+        form.submit = jest.fn();
         TestUtils.Simulate.submit(form);
       });
     });
@@ -346,6 +349,7 @@ describe('Form', () => {
           </Form>
         );
         const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+        form.submit = jest.fn();
         TestUtils.Simulate.submit(form);
         expect(instance.state.submitted).toBe(true);
       });
@@ -372,6 +376,7 @@ describe('Form', () => {
           done();
         });
         const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+        form.submit = jest.fn();
         TestUtils.Simulate.submit(form);
       });
 
@@ -392,6 +397,7 @@ describe('Form', () => {
           expect(instance.state.submitted).toBe(false);
         });
         const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+        form.submit = jest.fn();
         TestUtils.Simulate.submit(form);
       });
     });
@@ -407,6 +413,7 @@ describe('Form', () => {
           </Form>
         );
         const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+        form.submit = jest.fn();
         TestUtils.Simulate.submit(form);
         expect(instance.state.submitted).toBe(false);
       });
@@ -429,6 +436,7 @@ describe('Form', () => {
           );
 
           const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+          form.submit = jest.fn();
           TestUtils.Simulate.submit(form);
         });
       });
@@ -445,6 +453,7 @@ describe('Form', () => {
             </Form>
           );
           const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+          form.submit = jest.fn();
           TestUtils.Simulate.submit(form);
           expect(spy).not.toHaveBeenCalled();
         });

--- a/src/__experimental__/components/form/form.spec.js
+++ b/src/__experimental__/components/form/form.spec.js
@@ -310,6 +310,8 @@ describe('Form', () => {
   describe('handleOnSubmit', () => {
     it('calls the validate method', () => {
       const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+      form.submit = jest.fn();
+
       TestUtils.Simulate.submit(form);
       expect(validate).toHaveBeenCalled();
     });
@@ -355,6 +357,7 @@ describe('Form', () => {
           done();
         });
         const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+        form.submit = jest.fn();
         TestUtils.Simulate.submit(form);
       });
     });
@@ -402,6 +405,7 @@ describe('Form', () => {
           done();
         });
         const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+        form.submit = jest.fn();
         TestUtils.Simulate.submit(form);
       });
 
@@ -423,6 +427,7 @@ describe('Form', () => {
           expect(instance.state.submitted).toBe(false);
         });
         const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+        form.submit = jest.fn();
         TestUtils.Simulate.submit(form);
       });
     });
@@ -439,6 +444,7 @@ describe('Form', () => {
           </Form>
         );
         const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+        form.submit = jest.fn();
         TestUtils.Simulate.submit(form);
         expect(instance.state.submitted).toBe(false);
       });
@@ -461,6 +467,7 @@ describe('Form', () => {
           );
 
           const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+          form.submit = jest.fn();
           TestUtils.Simulate.submit(form);
         });
 
@@ -498,6 +505,7 @@ describe('Form', () => {
             </Form>
           );
           const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+          form.submit = jest.fn();
           TestUtils.Simulate.submit(form);
           expect(spy).not.toHaveBeenCalled();
         });
@@ -513,6 +521,7 @@ describe('Form', () => {
               </Form>
             );
             const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
+            form.submit = jest.fn();
             TestUtils.Simulate.submit(form);
             expect(document.activeElement).toBe(form.getElementsByTagName('button')[1]);
           });
@@ -905,6 +914,7 @@ describe('Form', () => {
         );
         const form = TestUtils.findRenderedDOMComponentWithTag(instance, 'form');
         const spy = spyOn(instance, 'addOtherInputsToState');
+        form.submit = jest.fn();
         TestUtils.Simulate.submit(form);
         expect(spy).not.toHaveBeenCalled();
       });

--- a/src/utils/router/__spec__.js
+++ b/src/utils/router/__spec__.js
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom';
 import { startRouter } from './router';
 import { browserHistory } from 'react-router';
 
+window.scrollTo = () => {};
+
 describe('startRouter', () => {
   let render, router, routes;
 


### PR DESCRIPTION
Removes jsdom related console warnings in the Jest Test Console.

### Checklist
- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
~~- [ ] Unit tests~~
~~- [ ] Cypress automation tests~~
~~- [ ] Storybook added or updated~~
~~- [ ] Theme support~~
~~- [ ] Typescript `d.ts` file added or updated~~