### PR TITLE
fix(dialog): close button styling

### DIFF
--- a/cypress/features/regression/dialog.feature
+++ b/cypress/features/regression/dialog.feature
@@ -6,6 +6,11 @@ Feature: Dialog component
       And I open component preview
 
   @positive
+    Scenario: CloseIcon has the border outline
+    When closeIcon is focused
+    Then closeIcon has the border outline
+
+  @positive
   Scenario Outline: Set height for Dialog to <height>
     When I set height to "<height>"
     Then Dialog height is set to "<height>"

--- a/cypress/features/regression/dialogClassic.feature
+++ b/cypress/features/regression/dialogClassic.feature
@@ -3,8 +3,13 @@ Feature: Dialog component classic story
 
   Background: Open Dialog component page classic story
     Given I open "Dialog" component page classic
+      And I open component preview
+
+  @positive
+  Scenario: CloseIcon has the border outline
+    When closeIcon is focused
+    Then closeIcon has border outline for classic story
 
   @positive
   Scenario: Verify classic story color
-    When I open component preview
     Then footer buttons have color "rgb(37, 91, 199)" and has 1 px border

--- a/cypress/features/regression/message.feature
+++ b/cypress/features/regression/message.feature
@@ -7,7 +7,7 @@ Feature: Message component
   @positive
   Scenario: CloseIcon has correct border colour
     Given I click closeIcon
-    Then closeIcon has golden border on focus
+    Then closeIcon has the border outline
 
   @positive
   Scenario Outline: Change Message title to <title>

--- a/cypress/locators/confirm/locators.js
+++ b/cypress/locators/confirm/locators.js
@@ -2,7 +2,7 @@
 export const DIALOG_INNER_CONTENT = '.carbon-dialog__inner-content';
 export const DIALOG_TITLE = '#carbon-dialog-title';
 export const DIALOG = 'div[data-element="dialog"]';
-export const CLOSE_ICON_BUTTON = '.icon-close';
+export const CLOSE_ICON_BUTTON = 'button[data-element="close"]';
 export const DIALOG_SUBTITLE = '#carbon-dialog-subtitle';
 export const CONFIRM_BUTTON = 'button[data-element="confirm"]';
 export const CANCEL_BUTTON = 'button[data-element="cancel"]';

--- a/cypress/locators/locators.js
+++ b/cypress/locators/locators.js
@@ -5,7 +5,7 @@ export const PRECISION_SLIDER = 'input[name="precision"]';
 export const CHARACTER_LIMIT = 'input[name="characterLimit"]';
 export const FORM = '#storybook-panel-root';
 export const TAB_LIST = '[role="tablist"]';
-export const CLOSE_ICON_BUTTON = 'span[data-element="close"]';
+export const CLOSE_ICON_BUTTON = 'button[data-element="close"]';
 
 // component preview locators
 export const HELP_ICON_PREVIEW = '[data-component="help"]';

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -385,17 +385,16 @@ Then('closeIcon is not visible', () => {
   closeIconButton().should('not.exist');
 });
 
-// needs to be refactored when golden color will be fixed for Close icon - FE-2508
 Then('closeIcon has the border outline', () => {
-  closeIconButton().rightclick();
-  closeIconButton().should('have.css', 'outline-color', 'rgba(0, 103, 244, 0.247)')
-    .and('have.css', 'outline-width', '5px');
+  closeIconButton().should('have.css', 'outline', 'rgb(255, 181, 0) solid 3px');
 });
 
-Then('closeIcon has no border outline for classic story', () => {
-  closeIconButton().rightclick();
-  closeIconButton().should('not.have.css', 'outline-color', 'rgba(0, 103, 244, 0.247)')
-    .and('not.have.css', 'outline-width', '5px');
+Then('closeIcon has border outline for classic story', () => {
+  closeIconButton().should('have.css', 'outline', 'rgba(0, 103, 244, 0.247) auto 5px');
+});
+
+Then('closeIcon is focused', () => {
+  closeIconButton().focus();
 });
 
 When('I hit ESC key', () => {

--- a/src/components/dialog/__snapshots__/dialog.spec.js.snap
+++ b/src/components/dialog/__snapshots__/dialog.spec.js.snap
@@ -41,16 +41,14 @@ exports[`Dialog when fixedBottom and stickyFormFooter are passed to the DialogSt
   z-index: 1000;
 }
 
-.c0 .carbon-dialog__close {
-  color: #4d7080;
-  cursor: pointer;
+.c0 .c2 {
   position: absolute;
-  right: 35px;
-  top: 28px;
+  right: 33px;
+  top: 32px;
   z-index: 1;
 }
 
-.c0 .carbon-dialog__close:hover {
+.c0 .c2:hover {
   color: #255BC7;
 }
 

--- a/src/components/dialog/dialog.component.js
+++ b/src/components/dialog/dialog.component.js
@@ -2,7 +2,6 @@ import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import Browser from '../../utils/helpers/browser';
-import Icon from '../icon';
 import Modal from '../modal';
 import Heading from '../heading';
 import Form from '../../__deprecated__/components/form';
@@ -14,8 +13,9 @@ import {
   DialogInnerContentStyle
 } from './dialog.style';
 import tagComponent from '../../utils/helpers/tags';
-import Events from '../../utils/helpers/events/events';
 import focusTrap from '../../utils/helpers/focus-trap';
+import IconButton from '../icon-button';
+import Icon from '../icon';
 
 class Dialog extends Modal {
   constructor(args) {
@@ -51,15 +51,6 @@ class Dialog extends Modal {
     this.document.documentElement.style.overflow = '';
     this.window.removeEventListener('resize', this.centerDialog);
     return ElementResize.removeListener(this._innerContent, this.applyFixedBottom);
-  }
-
-  onButtonKeyDown = (ev) => {
-    if (Events.isEnterKey(ev) || Events.isSpaceKey(ev)) {
-      ev.preventDefault();
-      this.props.onCancel();
-    }
-
-    return null;
   }
 
   centerDialog = (animating) => {
@@ -154,20 +145,17 @@ class Dialog extends Modal {
   }
 
   get closeIcon() {
-    if (this.props.showCloseIcon) {
-      return (
-        <Icon
-          className='carbon-dialog__close'
-          data-element='close'
-          onClick={ this.props.onCancel }
-          type='close'
-          tabIndex='0'
-          role='button'
-          onKeyDown={ this.onButtonKeyDown }
-        />
-      );
-    }
-    return null;
+    const { showCloseIcon, onCancel } = this.props;
+    if (!showCloseIcon || !onCancel) return null;
+
+    return (
+      <IconButton
+        data-element='close'
+        onAction={ onCancel }
+      >
+        <Icon type='close' />
+      </IconButton>
+    );
   }
 
   componentTags(props) {
@@ -266,7 +254,9 @@ Dialog.propTypes = {
   size: PropTypes.string,
   /** Determines if the close icon is shown */
   showCloseIcon: PropTypes.bool,
-  stickyFormFooter: PropTypes.bool
+  stickyFormFooter: PropTypes.bool,
+  /** function runs when user click close button */
+  onCancel: PropTypes.func
 };
 
 Dialog.defaultProps = {

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -13,8 +13,8 @@ import Heading from '../heading/heading';
 import { Row, Column } from '../row/row';
 import ElementResize from '../../utils/helpers/element-resize/element-resize';
 import { assertStyleMatch } from '../../__spec_helper__/test-utils';
-import classicTheme from '../../style/themes/classic';
 import Form from '../../__deprecated__/components/form';
+import IconButton from '../icon-button';
 
 /* global jest */
 
@@ -136,7 +136,6 @@ describe('Dialog', () => {
         <Dialog
           onCancel={ () => { } }
           onConfirm={ () => { } }
-          showCloseIcon
           open
           subtitle='Test'
           title='Test'
@@ -155,7 +154,6 @@ describe('Dialog', () => {
         <Dialog
           onCancel={ () => { } }
           onConfirm={ () => { } }
-          showCloseIcon
           open
           subtitle='Test'
           title='Test'
@@ -174,7 +172,6 @@ describe('Dialog', () => {
         <Dialog
           onCancel={ () => { } }
           onConfirm={ () => { } }
-          showCloseIcon
           open
           subtitle='Test'
           title='Test'
@@ -379,7 +376,6 @@ describe('Dialog', () => {
         const wrapper = mount(
           <Dialog
             onCancel={ onCancel }
-            showCloseIcon
             open
           />
         );
@@ -391,10 +387,8 @@ describe('Dialog', () => {
   describe('render', () => {
     describe('when dialog is open', () => {
       let wrapper;
-      let preventDefault;
 
       beforeEach(() => {
-        preventDefault = jest.fn();
         wrapper = mount(
           <Dialog
             open
@@ -404,7 +398,6 @@ describe('Dialog', () => {
             className='foo'
             onCancel={ onCancel }
             onConfirm={ () => { } }
-            showCloseIcon
             height='500'
             ariaRole='dialog'
             data-element='bar'
@@ -424,17 +417,25 @@ describe('Dialog', () => {
       });
 
       it('closes when the exit icon is click', () => {
-        wrapper.find('.carbon-dialog__close').at(0).simulate('click');
+        wrapper.find(IconButton).first().simulate('click');
         expect(onCancel).toHaveBeenCalled();
       });
 
-      it('closes when exit icon is focused and Enter key is clicked', () => {
-        wrapper.find('.carbon-dialog__close').at(0).props().onKeyDown({ which: 13, preventDefault });
+      it('closes when exit icon is focused and Enter key is pressed', () => {
+        const icon = wrapper.find(IconButton).first();
+        icon.simulate('keyDown', { which: 13, key: 'Enter' });
         expect(onCancel).toHaveBeenCalled();
       });
 
-      it('closes when exit icon is focused and Enter key is clicked', () => {
-        wrapper.find('.carbon-dialog__close').at(0).props().onKeyDown({ which: 16 });
+      it('closes when exit icon is focused and ESC key is pressed', () => {
+        const icon = wrapper.find(IconButton).first();
+        icon.simulate('keyDown', { which: 27, key: 'Escape' });
+        expect(onCancel).toHaveBeenCalled();
+      });
+
+      it('does not close when exit icon is focused any other key is pressed', () => {
+        const icon = wrapper.find(IconButton).first();
+        icon.simulate('keyDown', { which: 65, key: 'a' });
         expect(onCancel).not.toHaveBeenCalled();
       });
     });
@@ -460,7 +461,6 @@ describe('Dialog', () => {
           onCancel={ () => { } }
           onConfirm={ () => { } }
           open
-          showCloseIcon
           subtitle='Test'
           title='Test'
           ariaRole='dialog'
@@ -477,34 +477,12 @@ describe('Dialog', () => {
             onCancel={ () => { } }
             onConfirm={ () => { } }
             open
-            showCloseIcon
             ariaRole=''
           />
         );
 
         expect(wrapper.find('[aria-describedby="carbon-dialog-subtitle"]').length).toEqual(0);
         expect(wrapper.find('[aria-labelledby="carbon-dialog-title"]').length).toEqual(0);
-      });
-    });
-    describe('focus', () => {
-      beforeEach(() => {
-        wrapper = mount(
-          <Dialog
-            onCancel={ () => { } }
-            onConfirm={ () => { } }
-            showCloseIcon
-            open
-            subtitle='Test'
-            title='Test'
-            ariaRole='dialog'
-            theme={ classicTheme }
-          />
-        );
-      });
-
-      it('returns focus to the dialog element when focus leaves the close icon', () => {
-        const dialogElement = wrapper.find('[role="dialog"]').first().getDOMNode();
-        spyOn(dialogElement, 'focus');
       });
     });
   });
@@ -555,7 +533,6 @@ describe('Dialog', () => {
   describe('when showCloseIcon prop is true', () => {
     it('DialogTitleStyle should have padding-right: 85px', () => {
       const wrapper = mount(<Dialog
-        showCloseIcon
         title='Heading'
         open
       />);

--- a/src/components/dialog/dialog.style.js
+++ b/src/components/dialog/dialog.style.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import baseTheme from '../../style/themes/base';
 import { StyledFormFooter } from '../../__deprecated__/components/form/form.style';
+import StyledIconButton from '../icon-button/icon-button.style';
 
 const dialogSizes = {
   'extra-small': '300px',
@@ -68,12 +69,10 @@ const DialogStyle = styled.div`
       }
   `}
 
-  .carbon-dialog__close {
-    color: #4d7080;
-    cursor: pointer;
+  ${StyledIconButton} {
     position: absolute;
-    right: 35px;
-    top: 28px;
+    right: 33px;
+    top: 32px;
     z-index: 1;
 
     &:hover {

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -71,7 +71,7 @@ describe('Icon component', () => {
     }
   );
 
-  describe('when the icon type is "sevices', () => {
+  describe('when the icon type is services', () => {
     beforeEach(() => {
       browserTypeCheck.mockImplementation(() => true);
       isSafari.mockImplementation(() => true);


### PR DESCRIPTION
### Proposed behaviour
Update the Dialog close icon, when using a modern theme the icon will have a gold outline.
![image](https://user-images.githubusercontent.com/2328042/75772887-b5f34600-5d44-11ea-8057-c90405930381.png)

### Current behaviour
The icon has a blue outline.
![image](https://user-images.githubusercontent.com/2328042/75772911-c0154480-5d44-11ea-9ac7-572be91df064.png)

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests
<del>- [] Storybook added or updated
<del>- [] Theme support
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
There are other outstanding PR's related to close icon.
#2691 #2692 #2693 #2694 

### Testing instructions
1. `npm start`
1. Go to http://localhost:9001/?path=/story/dialog--default