### PR TITLE
fix(sidebar): close button styling

### DIFF
--- a/cypress/features/regression/sidebar.feature
+++ b/cypress/features/regression/sidebar.feature
@@ -8,7 +8,7 @@ Feature: Sidebar component
   @positive
   Scenario: CloseIcon has the border outline
     When closeIcon is focused
-    Then closeIcon has the border outline
+    Then closeIcon has the border outline color "rgb(255, 181, 0)" and width "3px"
 
   @positive
   Scenario: Check the cancel click event
@@ -18,6 +18,7 @@ Feature: Sidebar component
 
   @positive
   Scenario: Enable open checkbox for a Sidebar component
+    # commented because of BDD default scenario Given - When - Then
     # When I check open checkbox
     Then Sidebar component is visible
 

--- a/cypress/features/regression/sidebar.feature
+++ b/cypress/features/regression/sidebar.feature
@@ -6,6 +6,17 @@ Feature: Sidebar component
       And I check open checkbox
 
   @positive
+  Scenario: CloseIcon has the border outline
+    When closeIcon is focused
+    Then closeIcon has the border outline
+
+  @positive
+  Scenario: Check the cancel click event
+    Given clear all actions in Actions Tab
+    When I close Sidebar
+    Then cancel action was called in Actions Tab
+
+  @positive
   Scenario: Enable open checkbox for a Sidebar component
     # When I check open checkbox
     Then Sidebar component is visible
@@ -48,9 +59,3 @@ Feature: Sidebar component
       | medium-large | 550              |
       | large        | 650              |
       | extra-large  | 750              |
-
-  @positive
-  Scenario: Check the cancel click event
-    When clear all actions in Actions Tab
-      And I close Sidebar
-    Then cancel action was called in Actions Tab

--- a/src/components/sidebar/sidebar-classic.style.js
+++ b/src/components/sidebar/sidebar-classic.style.js
@@ -4,7 +4,7 @@ import { isClassic } from '../../utils/helpers/style-helper';
 const sidebarClassicStyle = ({ theme }) => isClassic(theme) && css`
     background-color: #e6ebed;
     padding: 20px;
-    
+
     ${({ position }) => position === 'right' && css`
         border-left: 1px solid #ccd6db;
         box-shadow: -10px 0 15px rgba(0,0,0,.05);
@@ -18,13 +18,4 @@ const sidebarClassicStyle = ({ theme }) => isClassic(theme) && css`
     `}
 `;
 
-const sidebarCloseClassicStyle = ({ theme }) => isClassic(theme) && css`
-    color: rgba(0, 0, 0, 0.85);
-    top: 15px;
-    
-    &:hover {
-        color: #255BC7;
-    };
-`;
-
-export { sidebarClassicStyle, sidebarCloseClassicStyle };
+export default sidebarClassicStyle;

--- a/src/components/sidebar/sidebar-classic.style.js
+++ b/src/components/sidebar/sidebar-classic.style.js
@@ -1,5 +1,6 @@
 import { css } from 'styled-components';
 import { isClassic } from '../../utils/helpers/style-helper';
+import StyledIconButton from '../icon-button/icon-button.style';
 
 const sidebarClassicStyle = ({ theme }) => isClassic(theme) && css`
     background-color: #e6ebed;
@@ -16,6 +17,10 @@ const sidebarClassicStyle = ({ theme }) => isClassic(theme) && css`
         box-shadow: 10px 0 15px rgba(0,0,0,.05);
         left: 0;
     `}
+
+    ${StyledIconButton} {
+      top: 15px;
+    }
 `;
 
 export default sidebarClassicStyle;

--- a/src/components/sidebar/sidebar.component.js
+++ b/src/components/sidebar/sidebar.component.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Icon from '../icon';
 import Modal from '../modal';
-import { SidebarStyle, SidebarCloseStyle } from './sidebar.style';
+import SidebarStyle from './sidebar.style';
 import './sidebar.scss';
-import Events from '../../utils/helpers/events/events';
 import focusTrap from '../../utils/helpers/focus-trap';
+import IconButton from '../icon-button';
+import Icon from '../icon';
 
 class Sidebar extends Modal {
   /** Returns classes for the component. */
@@ -17,33 +17,19 @@ class Sidebar extends Modal {
     );
   }
 
-  onButtonKeyDown = (ev) => {
-    if (Events.isEnterKey(ev) || Events.isSpaceKey(ev)) {
-      ev.preventDefault();
-      this.props.onCancel();
-    }
-
-    return null;
-  }
-
-  /** Returns the markup for the close icon. */
-  get closeButton() {
-    if (this.props.onCancel) {
-      return (
-        <SidebarCloseStyle>
-          <Icon
-            className='carbon-sidebar__close-icon'
-            data-element='close'
-            onClick={ this.props.onCancel }
-            type='close'
-            tabIndex='0'
-            role='button'
-            onKeyDown={ this.onButtonKeyDown }
-          />
-        </SidebarCloseStyle>
-      );
-    }
-    return null;
+  closeIcon() {
+    const { onCancel } = this.props;
+    if (!onCancel) return null;
+    return (
+      <IconButton
+        onAction={ onCancel }
+        data-element='close'
+      >
+        <Icon
+          type='close'
+        />
+      </IconButton>
+    );
   }
 
   handleOpen() {
@@ -75,8 +61,8 @@ class Sidebar extends Modal {
         size={ this.props.size }
         data-element='sidebar'
       >
-        {this.closeButton}
-        {this.props.children}
+        { this.closeIcon() }
+        { this.props.children }
       </SidebarStyle>
     );
   }

--- a/src/components/sidebar/sidebar.spec.js
+++ b/src/components/sidebar/sidebar.spec.js
@@ -1,18 +1,19 @@
 import React from 'react';
 import 'jest-styled-components';
+import { ThemeProvider } from 'styled-components';
 import { mount } from 'enzyme';
 import Sidebar from './sidebar.component';
 import Textbox from '../../__deprecated__/components/textbox';
-import { SidebarStyle, SidebarCloseStyle } from './sidebar.style';
+import SidebarStyle from './sidebar.style';
 import { assertStyleMatch } from '../../__spec_helper__/test-utils';
 import classicTheme from '../../style/themes/classic';
+import IconButton from '../icon-button';
 
 describe('Sidebar', () => {
-  let wrapper, spy, preventDefault;
+  let wrapper, spy;
 
   beforeEach(() => {
     spy = jasmine.createSpy();
-    preventDefault = jest.fn();
     wrapper = mount(
       <Sidebar
         open
@@ -86,39 +87,41 @@ describe('Sidebar', () => {
     });
   });
 
-  describe('Behaviour', () => {
-    describe('clicking the close icon sidebar', () => {
-      it('closes the sidebar', () => {
-        const icon = wrapper.find('.carbon-sidebar__close-icon');
-        icon.at(0).simulate('click');
-        expect(spy).toHaveBeenCalled();
-      });
+  describe('cancel icon', () => {
+    it('closes when the close icon is click', () => {
+      wrapper.find(IconButton).first().simulate('click');
+      expect(spy).toHaveBeenCalled();
     });
 
-    describe('pressing Enter key on the close icon sidebar', () => {
-      it('closes the sidebar', () => {
-        const icon = wrapper.find('.carbon-sidebar__close-icon');
-        icon.at(0).props().onKeyDown({ which: 13, preventDefault });
-        expect(spy).toHaveBeenCalled();
-      });
+    it('closes when close icon is focused and Enter key is pressed', () => {
+      const icon = wrapper.find(IconButton).first();
+      icon.simulate('keyDown', { which: 13, key: 'Enter' });
+      expect(spy).toHaveBeenCalled();
     });
 
-    describe('pressing other key than Enter or Space', () => {
-      it('does not close the sidebar', () => {
-        const icon = wrapper.find('.carbon-sidebar__close-icon');
-        icon.at(0).props().onKeyDown({ which: 16 });
-        expect(spy).not.toHaveBeenCalled();
-      });
+    it('closes when close icon is focused and ESC key is pressed', () => {
+      const icon = wrapper.find(IconButton).first();
+      icon.simulate('keyDown', { which: 27, key: 'Escape' });
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('does not close when close icon is focused any other key is pressed', () => {
+      const icon = wrapper.find(IconButton).first();
+      icon.simulate('keyDown', { which: 65, key: 'a' });
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 });
 
 describe('SidebarStyle', () => {
   describe('when prop size is passed to the component and position is set to right', () => {
-    const wrapper = mount(<SidebarStyle
-      open size='extra-small'
-      position='right'
-    />);
+    const wrapper = mount(
+      <SidebarStyle
+        open
+        size='extra-small'
+        position='right'
+      />
+    );
 
     it('should render correct style', () => {
       assertStyleMatch({
@@ -144,15 +147,18 @@ describe('SidebarStyle', () => {
   });
 
   describe('When classic style is passed to the component', () => {
-    const closeIconWrapper = mount(<SidebarCloseStyle theme={ classicTheme } />);
     let wrapper;
 
     it('should render correct style', () => {
-      wrapper = mount(<SidebarStyle
-        theme={ classicTheme }
-        open size='extra-small'
-        position='left'
-      />);
+      wrapper = mount(
+        <ThemeProvider theme={ classicTheme }>
+          <SidebarStyle
+            theme={ classicTheme }
+            open size='extra-small'
+            position='left'
+          />
+        </ThemeProvider>
+      );
 
       assertStyleMatch({
         backgroundColor: '#e6ebed',
@@ -163,18 +169,14 @@ describe('SidebarStyle', () => {
         padding: '20px',
         zIndex: '1002'
       }, wrapper);
-
-      assertStyleMatch({
-        color: 'rgba(0,0,0,0.85)',
-        position: 'absolute',
-        right: '20px',
-        top: '15px',
-        zIndex: '1'
-      }, closeIconWrapper);
     });
 
     describe('when classic style is passed to the component and position is right', () => {
-      wrapper = mount(<SidebarStyle theme={ classicTheme } position='right' />);
+      wrapper = mount(
+        <ThemeProvider theme={ classicTheme }>
+          <SidebarStyle theme={ classicTheme } position='right' />
+        </ThemeProvider>
+      );
 
       assertStyleMatch({
         borderLeft: '1px solid #ccd6db'

--- a/src/components/sidebar/sidebar.style.js
+++ b/src/components/sidebar/sidebar.style.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import baseTheme from '../../style/themes/base';
-import { sidebarClassicStyle, sidebarCloseClassicStyle } from './sidebar-classic.style';
+import sidebarClassicStyle from './sidebar-classic.style';
+import StyledIconButton from '../icon-button/icon-button.style';
 
 const sidebarSizes = {
   'extra-small': '150px',
@@ -20,7 +21,7 @@ const SidebarStyle = styled.div`
   top: 0;
   padding: 27px 32px 32px 32px;
   z-index: 1002;
-  
+
   ${({ size }) => size && css`
       width: ${sidebarSizes[size]};
   `};
@@ -30,30 +31,18 @@ const SidebarStyle = styled.div`
       ${position}: 0;
   `};
 
+  ${StyledIconButton} {
+    position: absolute;
+    z-index: 1;
+    right: 25px;
+    top: 25px;
+  }
+
   ${sidebarClassicStyle}
-`;
-
-const SidebarCloseStyle = styled.div`
-  cursor: pointer;
-  position: absolute;
-  right: 20px;
-  top: 26px;
-  z-index: 1;
-  color: ${({ theme }) => theme.colors.border};
-
-  &:hover {
-      color: ${({ theme }) => theme.colors.focusedIcon};
-  };
-
-  ${sidebarCloseClassicStyle}
 `;
 
 SidebarStyle.defaultProps = {
   theme: baseTheme
 };
 
-SidebarCloseStyle.defaultProps = {
-  theme: baseTheme
-};
-
-export { SidebarStyle, SidebarCloseStyle };
+export default SidebarStyle;


### PR DESCRIPTION
### Proposed behaviour
Update the Toast close icon, when using a modern theme the icon will have a gold outline.
![Screenshot 2020-03-04 at 12 06 24](https://user-images.githubusercontent.com/47245766/75877962-a8a38d80-5e10-11ea-9392-77cc14f1e437.png)

### Current behaviour
The icon has a blue outline.
![Screenshot 2020-03-04 at 11 53 59](https://user-images.githubusercontent.com/47245766/75877966-ab05e780-5e10-11ea-9382-2655d2263e07.png)

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests
<del>- [x] Storybook added or updated
<del>- [x] Theme support
<del>- [ ] Typescript `d.ts` file added or updated


### Additional context
There are other outstanding PR's related to close icon.
#2690 #2691 #2692 #2694 

### Testing instructions
1. `npm start`
1. Go to http://localhost:9001/?path=/story/sidebar--with-button