### PR TITLE
fix(icon-button): stop handling esc key - FE-2599 

### DIFF
--- a/cypress/features/regression/dialog.feature
+++ b/cypress/features/regression/dialog.feature
@@ -6,6 +6,24 @@ Feature: Dialog component
       And I open component preview
 
   @positive
+  Scenario: Esc key pressed on Close Icon does not close Dialog with disableEscKey
+    Given I check disableEscKey checkbox
+    When I click ESC key on close icon
+    Then Dialog is visible
+
+  @positive
+  Scenario: Space key pressed on Close closes Dialog with disableEscKey
+    Given I check disableEscKey checkbox
+    When I press space key on iconButton close icon
+    Then Dialog is not visible
+
+  @positive
+  Scenario: Close Icon does not close Dialog when escape key is pressed
+    Given I check disableEscKey checkbox
+    When I click ESC key on close icon
+    Then Dialog is visible
+
+  @positive
   Scenario Outline: Set height for Dialog to <height>
     When I set height to "<height>"
     Then Dialog height is set to "<height>"

--- a/cypress/support/step-definitions/dialog-steps.js
+++ b/cypress/support/step-definitions/dialog-steps.js
@@ -5,6 +5,14 @@ import { DEBUG_FLAG } from '..';
 const FIRST_ELEMENT = 0;
 const SECOND_ELEMENT = 1;
 
+When('I press space key on iconButton close icon', () => {
+  closeIconButton().trigger('keydown', { keyCode: 32, which: 32 });
+});
+
+When('I click ESC key on close icon', () => {
+  closeIconButton().trigger('keydown', { keyCode: 27, which: 27 });
+});
+
 When('I click close icon', () => {
   closeIconButton().click();
 });

--- a/src/components/icon-button/icon-button.component.js
+++ b/src/components/icon-button/icon-button.component.js
@@ -6,7 +6,7 @@ import Icon from '../icon';
 
 const IconButton = ({ onAction, children, ...rest }) => {
   const onKeyDown = (e) => {
-    if (Events.isEnterKey(e) || Events.isSpaceKey(e) || Events.isEscKey(e)) {
+    if (Events.isEnterKey(e) || Events.isSpaceKey(e)) {
       e.preventDefault();
       onAction(e);
     } else {


### PR DESCRIPTION
### Proposed behaviour
Only Enter and Space key should trigger onAction callback.

### Current behaviour
Esc key triggers onAction callback.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>- [ ] Unit tests
<del>- [ ] Cypress automation tests
<del>- [ ] Storybook added or updated
<del>- [ ] Theme support
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
Opening dialog:
http://localhost:9001/?path=/story/dialog--default

When "X" (close icon) is focused, ESC key press should not close Dialog when dialog prop/knob "disableEscKey" is set to true.
