### PR TITLE
feat: add new BatchSelection component (FE-2457)

### DIFF
--- a/cypress/features/accessibility/accessibility.feature
+++ b/cypress/features/accessibility/accessibility.feature
@@ -110,6 +110,7 @@ Feature: Accessibility tests
       | component                | data-component      |
       | Accordion                | accordion           |
       | Anchornavigation         | anchor-navigation   |
+      | Batch Selection          | batch-selection     |
       | Button Toggle Group      | button-toggle-group |
       | Draggable                | draggable           |
       | Flat Table               | flat-table          |

--- a/cypress/features/build/build.feature
+++ b/cypress/features/build/build.feature
@@ -192,6 +192,7 @@ Feature: Build tests
       | Button Toggle Group      | button-toggle-group |
       | Flat Table               | flat-table          |
       | Grid                     | grid                |
+      | Batch Selection          | batch-selection     |
       | Popover Container        | popover-container   |
       | Search                   | search              |
       

--- a/cypress/features/regression/test/batchSelection.feature
+++ b/cypress/features/regression/test/batchSelection.feature
@@ -1,0 +1,59 @@
+Feature: Batch selection component
+  I want to change Batch selection component properties
+
+  Background: Open Batch selection component page
+    Given I open basic Test "Batch selection" component page
+
+  @positive
+  Scenario Outline: Batch selection component is rendered properly
+    # commented because of BDD default scenario Given - When - Then
+    # When I open basic Test "Batch selection" component page
+    Then Batch selection component is rendered properly
+      And Batch selection <index> button is rendered properly with proper "<icon>" icon
+    Examples:
+      | index | icon |
+      | 0     | csv  |
+      | 1     | bin  |
+      | 2     | pdf  |
+
+  @positive
+  Scenario: Disable Batch selection component
+    When I check disabled checkbox
+    Then Batch selection component is disabled
+
+  @positive
+  Scenario: Hide Batch selection component
+    When I check hidden checkbox
+    Then Batch selection component is hidden
+
+  @positive
+  Scenario Outline: Set selectedCount Batch selection component to <selectedCount>
+    When I set selectedCount to "<selectedCount>"
+    Then Batch selection component selectedCount is set to "<selectedCount>"
+    Examples:
+      | selectedCount |
+      | 0             |
+      | 1             |
+      | 10            |
+      | 100           |
+
+  @positive
+  Scenario Outline: Set Batch selection colorTheme to <colorTheme>
+    When I select colorTheme to "<colorTheme>"
+    Then Batch selection component colorTheme "<colorTheme>" is set to "<color>"
+    Examples:
+      | colorTheme  | color              |
+      | dark        | rgb(0, 51, 73)     |
+      | white       | rgba(0, 0, 0, 0)   |
+      | light       | rgb(178, 193, 200) |
+      | transparent | rgba(0, 0, 0, 0)   |
+
+  @positive
+  Scenario Outline: I focus inner element for Batch selection component
+    When I focus Batch selection <buttonIndex> button
+    Then Batch selection component <buttonIndex> button is focused
+    Examples:
+      | buttonIndex |
+      | 0           |
+      | 1           |
+      | 2           |

--- a/cypress/locators/batch-selection/index.js
+++ b/cypress/locators/batch-selection/index.js
@@ -1,0 +1,8 @@
+import { BATCH_SELECTION_COMPONENT, BATCH_SELECTION_COUNTER } from './locators';
+
+// component preview locators
+export const batchSelectionComponent = () => cy.iFrame(BATCH_SELECTION_COMPONENT);
+export const batchSelectionCounter = () => batchSelectionComponent()
+  .find(BATCH_SELECTION_COUNTER);
+export const batchSelectionButtons = index => batchSelectionComponent()
+  .find('button').eq(index).children();

--- a/cypress/locators/batch-selection/locators.js
+++ b/cypress/locators/batch-selection/locators.js
@@ -1,0 +1,3 @@
+// component preview locators
+export const BATCH_SELECTION_COMPONENT = '[data-component="batch-selection"]';
+export const BATCH_SELECTION_COUNTER = '[data-element="selection-count"]';

--- a/cypress/support/step-definitions/batch-selection-steps.js
+++ b/cypress/support/step-definitions/batch-selection-steps.js
@@ -1,0 +1,48 @@
+import {
+  batchSelectionComponent,
+  batchSelectionCounter,
+  batchSelectionButtons,
+} from '../../locators/batch-selection';
+
+Then('Batch selection component is rendered properly', () => {
+  batchSelectionComponent().should('have.css', 'align-items', 'center');
+  batchSelectionComponent().children().should('have.length', 4);
+  batchSelectionCounter().invoke('text').should('contains', '0 selected');
+  batchSelectionCounter().should('have.css', 'padding', '10px 15px');
+});
+
+Then('Batch selection {int} button is rendered properly with proper {string} icon', (index, icon) => {
+  batchSelectionButtons(index).should('have.attr', 'data-element', icon)
+    .and('have.css', 'position', 'relative')
+    .parent()
+    .and('have.css', 'margin', '0px')
+    .and('have.css', 'position', 'static')
+    .and('have.css', 'padding', '10px');
+});
+
+Then('Batch selection component is {word}', (parameter) => {
+  batchSelectionComponent().should('have.attr', parameter);
+});
+
+Then('Batch selection component selectedCount is set to {string}', (value) => {
+  batchSelectionCounter().invoke('text').should('contains', `${value} selected`);
+});
+
+Then('Batch selection component colorTheme {string} is set to {string}', (color, value) => {
+  if (color === 'dark') {
+    batchSelectionComponent().should('have.css', 'background-color', value)
+      .and('have.css', 'color', 'rgb(255, 255, 255)');
+  } else if (color === 'white') {
+    batchSelectionComponent().should('have.css', 'box-shadow', 'rgba(0, 20, 29, 0.2) 0px 5px 5px 0px, rgba(0, 20, 29, 0.1) 0px 10px 10px 0px');
+  } else {
+    batchSelectionComponent().should('have.css', 'background-color', value);
+  }
+});
+
+When('I focus Batch selection {int} button', (index) => {
+  batchSelectionButtons(index).parent().focus();
+});
+
+Then('Batch selection component {int} button is focused', (index) => {
+  batchSelectionButtons(index).parent().should('have.css', 'outline', 'rgb(255, 181, 0) solid 3px');
+});

--- a/src/components/batch-selection/__snapshots__/batch-selection.spec.js.snap
+++ b/src/components/batch-selection/__snapshots__/batch-selection.spec.js.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BatchSelection component should render correctly 1`] = `
+.c5 {
+  display: inline-block;
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: transparent;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 24px;
+  width: 24px;
+}
+
+.c5:hover {
+  color: rgba(0,0,0,0.90);
+  background-color: transparent;
+}
+
+.c5::before {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-family: CarbonIcons;
+  content: "\\e93a";
+  font-size: 16px;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 16px;
+  vertical-align: middle;
+  display: block;
+}
+
+.c3 {
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.c3:focus {
+  color: rgba(0,0,0,0.9);
+  background-color: transparent;
+  outline: solid 3px #FFB500;
+}
+
+.c3:hover {
+  cursor: pointer;
+}
+
+.c3 .c4 {
+  position: relative;
+}
+
+.c3 .c4:focus {
+  border: none;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c0 .c2 {
+  margin: 0;
+  position: static;
+  padding: 10px;
+}
+
+.c0 .c2:hover {
+  background-color: #00A376;
+}
+
+.c0 .c2:hover .c4 {
+  color: #FFFFFF;
+}
+
+.c1 {
+  display: inline-block;
+  padding: 10px 15px;
+}
+
+<div
+  className="c0"
+  data-component="batch-selection"
+>
+  <span
+    className="c1"
+    data-element="selection-count"
+  >
+    <span>
+      3
+    </span>
+     
+    selected
+  </span>
+  <button
+    className="c2 c3"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+  >
+    <span
+      className="c4 c5"
+      data-component="icon"
+      data-element="edit"
+      disabled={false}
+      fontSize="small"
+      type="edit"
+    />
+  </button>
+</div>
+`;

--- a/src/components/batch-selection/__snapshots__/batch-selection.spec.js.snap
+++ b/src/components/batch-selection/__snapshots__/batch-selection.spec.js.snap
@@ -56,6 +56,10 @@ exports[`BatchSelection component should render correctly 1`] = `
   cursor: pointer;
 }
 
+.c3::-moz-focus-inner {
+  border: none;
+}
+
 .c3 .c4 {
   position: relative;
 }

--- a/src/components/batch-selection/batch-selection.component.d.ts
+++ b/src/components/batch-selection/batch-selection.component.d.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+export interface BatchSelectionProps {
+  /** Color of the background, transparent if not defined */
+  colorTheme?: 'dark' | 'light';
+  /** Content to be rendered after selected count */
+  children: React.ReactNode;
+  /** If true disables all user interaction */
+  disabled?: boolean;
+  /** Number of selected elements */
+  selectedCount: number;
+}
+
+declare const BatchSelection: React.FunctionComponent<BatchSelectionProps>;
+
+export default BatchSelection;

--- a/src/components/batch-selection/batch-selection.component.js
+++ b/src/components/batch-selection/batch-selection.component.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import I18n from 'i18n-js';
+import PropTypes from 'prop-types';
+import OptionsHelper from '../../utils/helpers/options-helper';
+import { StyledBatchSelection, StyledSelectionCount } from './batch-selection.style';
+
+const BatchSelection = ({
+  disabled,
+  children,
+  colorTheme,
+  selectedCount,
+  hidden
+}) => {
+  const getTextForCount = count => I18n.t(
+    'batch_selection.selected',
+    {
+      count: Number(count),
+      defaultValue: 'selected'
+    }
+  );
+
+  return (
+    <StyledBatchSelection
+      colorTheme={ colorTheme }
+      data-component='batch-selection'
+      disabled={ disabled }
+      hidden={ hidden }
+    >
+      <StyledSelectionCount data-element='selection-count'>
+        <span>{ selectedCount }</span> { getTextForCount(selectedCount) }
+      </StyledSelectionCount>
+      { children }
+    </StyledBatchSelection>
+  );
+};
+
+BatchSelection.propTypes = {
+  /** Content to be rendered after selected count */
+  children: PropTypes.node.isRequired,
+  /** Number of selected elements */
+  selectedCount: PropTypes.number.isRequired,
+  /** Color of the background, transparent if not defined */
+  colorTheme: PropTypes.oneOf(OptionsHelper.flatTableThemes),
+  /** If true disables all user interaction */
+  disabled: PropTypes.bool,
+  /** Hidden if true */
+  hidden: PropTypes.bool
+};
+
+BatchSelection.defaultProps = {
+  colorTheme: 'transparent'
+};
+
+export default BatchSelection;

--- a/src/components/batch-selection/batch-selection.spec.js
+++ b/src/components/batch-selection/batch-selection.spec.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import TestRenderer from 'react-test-renderer';
+import 'jest-styled-components';
+import { assertStyleMatch } from '../../__spec_helper__/test-utils';
+import BatchSelection from '.';
+import Icon from '../icon';
+import IconButton from '../icon-button';
+import StyledIcon from '../icon/icon.style';
+import StyledIconButton from '../icon-button/icon-button.style';
+import { baseTheme } from '../../style/themes';
+
+
+describe('BatchSelection component', () => {
+  let wrapper;
+
+  it('should render correctly', () => {
+    wrapper = renderBatchSelection({ selectedCount: 3 }, TestRenderer.create);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('when the colorTheme is "dark"', () => {
+    beforeEach(() => {
+      wrapper = renderBatchSelection({ selectedCount: 3, colorTheme: 'dark' });
+    });
+
+    it('should have expected styles', () => {
+      assertStyleMatch({
+        backgroundColor: baseTheme.colors.slate,
+        color: baseTheme.colors.white
+      }, wrapper);
+    });
+
+    it('should have expected Icon color', () => {
+      assertStyleMatch({
+        color: baseTheme.colors.white
+      }, wrapper, { modifier: `${StyledIcon}` });
+    });
+  });
+
+  describe('when the colorTheme is "light"', () => {
+    beforeEach(() => {
+      wrapper = renderBatchSelection({ selectedCount: 3, colorTheme: 'light' });
+    });
+
+    it('should have expected background color', () => {
+      assertStyleMatch({
+        backgroundColor: baseTheme.batchSelection.lightTheme
+      }, wrapper);
+    });
+  });
+
+  describe('when the colorTheme is "white"', () => {
+    beforeEach(() => {
+      wrapper = renderBatchSelection({ selectedCount: 3, colorTheme: 'white' });
+    });
+
+    it('should have expected background color and shadow', () => {
+      assertStyleMatch({
+        backgroundColor: baseTheme.white,
+        boxShadow: '0 5px 5px 0 rgba(0,20,29,0.2),0 10px 10px 0 rgba(0,20,29,0.1)'
+      }, wrapper);
+    });
+  });
+
+  describe('when the disabled prop is set to true', () => {
+    beforeEach(() => {
+      wrapper = renderBatchSelection({ selectedCount: 3, disabled: true });
+    });
+
+    it('should have expected styles', () => {
+      assertStyleMatch({
+        color: baseTheme.disabled.disabled,
+        cursor: 'not-allowed'
+      }, wrapper);
+    });
+
+    it('then IconButton should have expected styles', () => {
+      assertStyleMatch({
+        background: 'transparent',
+        pointerEvents: 'none'
+      }, wrapper, { modifier: `${StyledIconButton}` });
+    });
+
+    it('then IconButton should have expected Icon color', () => {
+      assertStyleMatch({
+        color: baseTheme.icon.disabled
+      }, wrapper, { modifier: `${StyledIconButton} ${StyledIcon}` });
+    });
+  });
+
+  describe('when the hidden prop is set to true', () => {
+    beforeEach(() => {
+      wrapper = renderBatchSelection({ selectedCount: 3, hidden: true });
+    });
+
+    it('should have opacity set to 0', () => {
+      assertStyleMatch({ opacity: '0' }, wrapper);
+    });
+  });
+});
+
+function renderBatchSelection(props = {}, renderer = mount) {
+  return renderer(
+    <BatchSelection { ... props }>
+      <IconButton onAction={ () => {} }>
+        <Icon type='edit' />
+      </IconButton>
+    </BatchSelection>
+  );
+}

--- a/src/components/batch-selection/batch-selection.stories.js
+++ b/src/components/batch-selection/batch-selection.stories.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import {
+  withKnobs,
+  boolean,
+  select,
+  number
+} from '@storybook/addon-knobs';
+import OptionsHelper from '../../utils/helpers/options-helper/options-helper';
+import BatchSelection from '.';
+import IconButton from '../icon-button';
+import Icon from '../icon';
+
+export default {
+  title: 'Test/Batch Selection',
+  component: BatchSelection,
+  decorators: [withKnobs]
+};
+
+export const basic = () => {
+  const props = {
+    disabled: boolean('disabled', false),
+    hidden: boolean('hidden', false),
+    selectedCount: number('selectedCount', 0),
+    colorTheme: select('colorTheme', [...OptionsHelper.flatTableThemes], 'transparent')
+  };
+
+  return (
+    <BatchSelection { ...props }>
+      <IconButton onAction={ () => {} }><Icon type='csv' /></IconButton>
+      <IconButton onAction={ () => {} }><Icon type='bin' /></IconButton>
+      <IconButton onAction={ () => {} }><Icon type='pdf' /></IconButton>
+    </BatchSelection>
+  );
+};
+
+basic.story = {
+  name: 'Basic',
+  parameters: {
+    info: { disable: true },
+    docs: {
+      page: null
+    }
+  }
+};

--- a/src/components/batch-selection/batch-selection.stories.mdx
+++ b/src/components/batch-selection/batch-selection.stories.mdx
@@ -1,0 +1,83 @@
+import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
+import BatchSelection from '.';
+import IconButton from '../icon-button';
+import Icon from '../icon';
+import Link from '../link';
+
+<Meta
+  title="Design System/Batch Selection" 
+  parameters={{ info: { disable: true }}}
+/>
+
+# Batch Selection
+
+Batch Selection Component could be used to select multiple items, and apply a common action to all the items selected.
+
+## Quick Start
+
+To use Batch Selection, import the `BatchSelection`, pass Icon Buttons with actions as children and number of selected in selectedCount prop.
+
+### Basic usage:
+
+<Preview>
+  <Story name="basic">
+    <BatchSelection selectedCount={0}>
+      <span>(<Link>Select All 38 items</Link>)</span>
+      <IconButton onAction={ () => {} }><Icon type='csv' /></IconButton>
+      <IconButton onAction={ () => {} }><Icon type='bin' /></IconButton>
+      <IconButton onAction={ () => {} }><Icon type='pdf' /></IconButton>
+    </BatchSelection>
+  </Story>
+</Preview>
+
+### On dark background:
+
+<Preview>
+  <Story name="dark">
+    <BatchSelection selectedCount={1} colorTheme='dark'>
+      <IconButton onAction={ () => {} }><Icon type='csv' /></IconButton>
+      <IconButton onAction={ () => {} }><Icon type='bin' /></IconButton>
+      <IconButton onAction={ () => {} }><Icon type='pdf' /></IconButton>
+    </BatchSelection>
+  </Story>
+</Preview>
+
+### On light background:
+
+<Preview>
+  <Story name="light">
+    <BatchSelection selectedCount={2} colorTheme='light'>
+      <IconButton onAction={ () => {} }><Icon type='csv' /></IconButton>
+      <IconButton onAction={ () => {} }><Icon type='bin' /></IconButton>
+      <IconButton onAction={ () => {} }><Icon type='pdf' /></IconButton>
+    </BatchSelection>
+  </Story>
+</Preview>
+
+### On white background:
+
+<Preview>
+  <Story name="white">
+    <BatchSelection selectedCount={3} colorTheme='white'>
+      <IconButton onAction={ () => {} }><Icon type='csv' /></IconButton>
+      <IconButton onAction={ () => {} }><Icon type='bin' /></IconButton>
+      <IconButton onAction={ () => {} }><Icon type='pdf' /></IconButton>
+    </BatchSelection>
+  </Story>
+</Preview>
+
+### Disabled:
+
+<Preview>
+  <Story name="disabled">
+    <BatchSelection selectedCount={4} disabled>
+      <IconButton onAction={ () => {} }><Icon type='csv' /></IconButton>
+      <IconButton onAction={ () => {} }><Icon type='bin' /></IconButton>
+      <IconButton onAction={ () => {} }><Icon type='pdf' /></IconButton>
+    </BatchSelection>
+  </Story>
+</Preview>
+
+## Props:
+
+<Props of={BatchSelection} />

--- a/src/components/batch-selection/batch-selection.style.js
+++ b/src/components/batch-selection/batch-selection.style.js
@@ -1,0 +1,76 @@
+import styled, { css } from 'styled-components';
+import baseTheme from '../../style/themes/base';
+import StyledIconButton from '../icon-button/icon-button.style';
+import StyledIcon from '../icon/icon.style';
+
+const StyledBatchSelection = styled.div`
+  ${({
+    disabled,
+    colorTheme,
+    theme,
+    hidden
+  }) => css`
+    align-items: center;
+    display: inline-flex;
+
+    ${hidden && 'opacity: 0;'}
+
+    ${colorTheme === 'dark' && css`
+      background-color: ${theme.colors.slate};
+      color: ${theme.colors.white};
+
+      ${StyledIcon} {
+        color: ${theme.colors.white};
+      }
+    `}
+
+    ${colorTheme === 'light' && css`
+      background-color: ${theme.batchSelection.lightTheme};
+    `}
+
+    ${colorTheme === 'white' && css`
+      background-color: ${theme.white};
+      box-shadow: ${theme.shadows.depth1};
+    `}
+
+    ${StyledIconButton} {
+      margin: 0;
+      position: static;
+      padding: 10px;
+    }
+
+    ${StyledIconButton}:hover {
+      background-color: ${theme.colors.base};
+
+      ${StyledIcon} {
+        color: ${theme.colors.white};
+      }
+    }
+
+    ${disabled && css`
+      background: transparent;
+      color: ${theme.disabled.disabled};
+      cursor: not-allowed;
+
+      ${StyledIconButton} {
+        background: transparent;
+        pointer-events: none;
+
+        ${StyledIcon} {
+          color: ${theme.icon.disabled};
+        }
+      }
+    `}
+  `}
+`;
+
+StyledBatchSelection.defaultProps = {
+  theme: baseTheme
+};
+
+const StyledSelectionCount = styled.span`
+  display: inline-block;
+  padding: 10px 15px;
+`;
+
+export { StyledBatchSelection, StyledSelectionCount };

--- a/src/components/batch-selection/index.js
+++ b/src/components/batch-selection/index.js
@@ -1,0 +1,1 @@
+export { default } from './batch-selection.component';

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -54,6 +54,10 @@ export default (palette) => {
       background: palette.slateTint(90)
     },
 
+    batchSelection: {
+      lightTheme: palette.slateTint(70)
+    },
+
     menu: {
       focus: palette.slateTint(95),
       divider: palette.slateTint(90),

--- a/src/utils/helpers/options-helper/options-helper.js
+++ b/src/utils/helpers/options-helper/options-helper.js
@@ -89,6 +89,13 @@ const OptionsHelper = {
     'warning'
   ],
 
+  flatTableThemes: [
+    'dark',
+    'light',
+    'white',
+    'transparent'
+  ],
+
   iconBackgrounds: [
     'info',
     'error',


### PR DESCRIPTION
Batch Selection component could be used to select multiple items, and apply a common action to all the items selected.

This pattern is also intended to replace the 'Selectable' configuration of the existing Table component: https://carbon.sage.com/storybook/?path=/story/table--default.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests
- [x] Storybook added or updated
- [x] Theme support
- [x] Typescript `d.ts` file added or updated
