### PR TITLE
feat(button): add destructive prop FE-2615

### DIFF
--- a/.storybook/welcome-page/components-demo/demo/demo.component.js
+++ b/.storybook/welcome-page/components-demo/demo/demo.component.js
@@ -36,7 +36,7 @@ const Demo = () => {
                 <Button buttonType='tertiary'>Tertiary</Button>
               </StyledComponentWrapper>
               <StyledComponentWrapper styling={{ padding: '1%' }}>
-                <Button buttonType='destructive'>Destructive</Button>
+                <Button buttonType='primary' destructive>Destructive</Button>
               </StyledComponentWrapper>
             </StyledDemoRow>
             <StyledDemoRow styling={{ display: 'flex' }}>

--- a/src/components/button/button-types.style.js
+++ b/src/components/button/button-types.style.js
@@ -9,7 +9,7 @@ export function makeColors(color) {
   `;
 }
 
-export default ({ colors, disabled }, isDisabled) => ({
+export default ({ colors, disabled }, isDisabled, destructive) => ({
   primary: `
     background: ${colors.primary};
     border-color: transparent;
@@ -19,14 +19,30 @@ export default ({ colors, disabled }, isDisabled) => ({
     }
 
     ${isDisabled ? `
+    background: ${disabled.button};
+    color: ${disabled.text};
+    &:hover {
+      background: ${disabled.button};
+      border-color: ${disabled.button};
+      color: ${disabled.text};
+    }
+  ` : ''}
+
+    ${destructive ? `background: ${colors.error};
+    border-color: transparent;
+    color: ${colors.white};
+    &:hover {
+      background: ${colors.destructive.hover};
+    }
+
+    ${isDisabled ? `
       background: ${disabled.button};
       color: ${disabled.text};
       &:hover {
         background: ${disabled.button};
-        border-color: ${disabled.button};
         color: ${disabled.text};
       }
-    ` : ''}
+    ` : ''}` : ''}
   `,
   secondary: `
       background: transparent;
@@ -60,23 +76,6 @@ export default ({ colors, disabled }, isDisabled) => ({
       color: ${disabled.text};
       &:hover {
         ${makeColors(disabled.text)}
-      }
-    ` : ''}
-  `,
-  destructive: `
-    background: ${colors.error};
-    border-color: transparent;
-    color: ${colors.white};
-    &:hover {
-      background: ${colors.destructive.hover};
-    }
-
-    ${isDisabled ? `
-      background: ${disabled.button};
-      color: ${disabled.text};
-      &:hover {
-        background: ${disabled.button};
-        color: ${disabled.text};
       }
     ` : ''}
   `,

--- a/src/components/button/button.component.js
+++ b/src/components/button/button.component.js
@@ -5,6 +5,7 @@ import Icon from '../icon';
 import StyledButton, { StyledButtonSubtext } from './button.style';
 import tagComponent from '../../utils/helpers/tags';
 import OptionsHelper from '../../utils/helpers/options-helper';
+import Logger from '../../utils/logger';
 
 const Button = (props) => {
   const {
@@ -13,9 +14,18 @@ const Button = (props) => {
 
   const { as, buttonType, ...rest } = props;
 
+  const IS_USING_DEPRECATED_TYPE_DESTRUCTIVE = buttonType === 'destructive';
+
+  if (IS_USING_DEPRECATED_TYPE_DESTRUCTIVE) {
+    Logger.deprecate(
+      'buttonType="destructive" has been deprecated. See https://github.com/Sage/carbon/releases for details.'
+    );
+  }
+
   const propsWithoutAs = {
     ...rest,
-    buttonType: buttonType || as
+    buttonType: buttonType || as,
+    ...(IS_USING_DEPRECATED_TYPE_DESTRUCTIVE && { buttonType: 'primary', destructive: true })
   };
 
   if (subtext.length > 0 && size !== 'large') {
@@ -104,12 +114,14 @@ function renderChildren({
 }
 
 Button.propTypes = {
-  /** Color variants for new business themes: "primary" | "secondary" | "tertiary" | "destructive" | "darkBackground" */
+  /** Color variants for new business themes: "primary" | "secondary" | "tertiary" | "darkBackground" */
   buttonType: PropTypes.oneOf(OptionsHelper.buttonTypes),
   /** The text the button displays */
   children: PropTypes.node.isRequired,
   /** Apply disabled state to the button */
   disabled: PropTypes.bool,
+  /** Apply destructive style to the button */
+  destructive: PropTypes.bool,
   /** Defines an Icon position within the button: "before" | "after" */
   iconPosition: PropTypes.oneOf([...OptionsHelper.buttonIconPositions]),
   /** Defines an Icon type within the button (see Icon for options) */
@@ -136,6 +148,7 @@ Button.defaultProps = {
   as: 'secondary',
   size: 'medium',
   disabled: false,
+  destructive: false,
   iconPosition: 'before',
   theme: 'blue',
   subtext: ''

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -104,6 +104,20 @@ describe('Button', () => {
     }
   );
 
+  describe('when the destructive prop is passed', () => {
+    it('matches the expected destructive style', () => {
+      const wrapper = render({
+        children: 'foo', destructive: true, buttonType: 'primary'
+      }, TestRenderer.create).toJSON();
+
+      assertStyleMatch({
+        background: BaseTheme.colors.error,
+        borderColor: 'transparent',
+        color: BaseTheme.colors.white
+      }, wrapper);
+    });
+  });
+
   describe('when the "disabled" prop is passed', () => {
     it('matches the style for the default Button when no "as" and "size" props are passed', () => {
       const wrapper = render({ children: 'foo', disabled: true }, TestRenderer.create).toJSON();
@@ -127,6 +141,23 @@ describe('Button', () => {
             it('matches the expected style', () => {
               const wrapper = render({
                 children: 'foo', disabled: true, buttonType: variant, size
+              }, TestRenderer.create).toJSON();
+
+              assertStyleMatch({
+                background:
+                (variant === 'secondary' || variant === 'tertiary' ? 'transparent' : BaseTheme.disabled.button),
+                borderColor: (variant === 'secondary' ? BaseTheme.disabled.button : 'transparent'),
+                color: BaseTheme.disabled.text,
+                fontSize: (size === 'large' ? '16px' : '14px'),
+                height: `${sizes[size][0].toString()}px`,
+                paddingLeft: `${sizes[size][1].toString()}px`,
+                paddingRight: `${sizes[size][1].toString()}px`
+              }, wrapper);
+            });
+
+            it('matches the expected destructive style', () => {
+              const wrapper = render({
+                children: 'foo', destructive: true, disabled: true, buttonType: variant, size
               }, TestRenderer.create).toJSON();
 
               assertStyleMatch({

--- a/src/components/button/button.stories.js
+++ b/src/components/button/button.stories.js
@@ -25,7 +25,7 @@ const getIconKnobs = () => {
 
 const getKnobs = (isClassic) => {
   const size = select('size', OptionsHelper.sizesRestricted, Button.defaultProps.size);
-  let classicProps = {}, buttonType;
+  let classicProps = {}, buttonType, destructive;
 
   if (isClassic) {
     classicProps = {
@@ -36,11 +36,13 @@ const getKnobs = (isClassic) => {
     };
   } else {
     buttonType = select('buttonType', OptionsHelper.buttonTypes, Button.defaultProps.as);
+    destructive = boolean('destructive', false);
   }
 
   return {
     buttonType,
     children: text('children', 'Example Button'),
+    destructive,
     disabled: boolean('disabled', Button.defaultProps.disabled),
     onClick: ev => action('click')(ev),
     size,

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -21,9 +21,9 @@ Primary buttons can be destructive.
 <Preview>
   <Story name="primary/destructive" parameters={{ info: { disable: true }}} >
     <>
-      <Button buttonType="destructive" size="small">Small</Button>
-      <Button buttonType="destructive">Medium</Button>
-      <Button buttonType="destructive" size="large">Large</Button>
+      <Button buttonType="primary" destructive size="small">Small</Button>
+      <Button buttonType="primary" destructive >Medium</Button>
+      <Button buttonType="primary" destructive size="large">Large</Button>
     </>
   </Story>
 </Preview>
@@ -44,7 +44,7 @@ Primary buttons can have an icon positioned before or after the text.
   <Story name="primary/icon" parameters={{ info: { disable: true }}} >
   <>
     <Button buttonType="primary" iconType="print">Medium</Button>
-    <Button buttonType="destructive" iconType="delete" iconPosition="after">Medium</Button>
+    <Button buttonType="primary" destructive iconType="delete" iconPosition="after">Medium</Button>
     <Button buttonType="primary" disabled iconType="print" iconPosition="after">Medium</Button>
     </>
   </Story>

--- a/src/components/button/button.style.js
+++ b/src/components/button/button.style.js
@@ -56,7 +56,8 @@ function stylingForType({
   disabled,
   buttonType,
   theme,
-  size
+  size,
+  destructive
 }) {
   return css`
     border: 2px solid transparent;
@@ -71,7 +72,7 @@ function stylingForType({
     
     margin-right: 16px;
 
-    ${buttonTypes(theme, disabled)[buttonType]};
+    ${buttonTypes(theme, disabled, destructive)[buttonType]};
     ${buttonSizes(theme)[size]}
   `;
 }

--- a/src/components/button/documentation/info.js
+++ b/src/components/button/documentation/info.js
@@ -8,7 +8,7 @@ const Info = (
     <StoryHeader>How to use the Button component:</StoryHeader>
 
     <p>
-      {'Button is rendered as one of "primary", "secondary", "tertiary", "destructive", "darkBacground"'}
+      {'Button is rendered as one of "primary", "secondary", "tertiary", "darkBacground"'}
     </p>
 
     <p>In your file</p>

--- a/src/utils/helpers/options-helper/__spec__.js
+++ b/src/utils/helpers/options-helper/__spec__.js
@@ -226,7 +226,6 @@ describe('OptionsHelper', () => {
       'primary',
       'secondary',
       'tertiary',
-      'destructive',
       'darkBackground'
     ]);
   });

--- a/src/utils/helpers/options-helper/options-helper.js
+++ b/src/utils/helpers/options-helper/options-helper.js
@@ -318,7 +318,6 @@ const OptionsHelper = {
     'primary',
     'secondary',
     'tertiary',
-    'destructive',
     'darkBackground'
   ],
 


### PR DESCRIPTION
### Proposed behaviour
`<Button buttonType="destructive"/>` has been deprecated in favour of `<Button buttonType="primary" destructive />`.

There is a codemod available to assist with this upgrade `npx carbon-codemod button-destructive <target>`.
See https://github.com/Sage/carbon-codemod for more information.
<img width="805" alt="Screenshot 2020-03-10 at 21 16 50" src="https://user-images.githubusercontent.com/2328042/76360411-db6beb00-6314-11ea-96b9-1dbff88252fb.png">


### Current behaviour
`<Button buttonType="destructive"/>` displays a primary destructive button. The DLS states that we need secondary and tertiary destructive buttons. These are controlled by the same prop.
`<Button buttonType="secondary"/>`, `<Button buttonType="tertiary"/>`. Adding more `buttonTypes` would introduce further complexity.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
<del>- [ ] Cypress automation tests
- [x] Storybook added or updated
<del>- [ ] Theme support
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->
https://github.com/Sage/carbon-codemod/tree/master/transforms/button-destructive

### Testing instructions
I've updated storybook you can use the `destructive` knob. If the `buttonType` is primary it will display in the same way that `buttonType=destructive` used to.

* `npm start`
* Go to http://localhost:9001/?path=/story/button--default

![image](https://user-images.githubusercontent.com/2328042/76360885-c479c880-6315-11ea-8f09-afd14a282b6f.png)

