### PR TITLE
ci(travis): only build on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js: node
 
+# We build PR's and branches, this tells travis to only build on the master branch or PR's that target the master branch
+branches:
+  only:
+  - master
+
 addons:
    apt:
      packages:


### PR DESCRIPTION
### Proposed behaviour
We build PR's and branches, this tells Travis to only build on the master branch or PR's that target the master branch.

### Current behaviour
We build all PR's and branches. Having a double build is causing a worker contention. There is no need to build the pull request branch and the result of the merge. We can just build the result of the merge because that is what we care about in almost if not all cases.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>- [ ] Unit tests
<del>- [ ] Cypress automation tests
<del>- [ ] Storybook added or updated
<del>- [ ] Theme support
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests

### Testing instructions
This PR should only have one Travis job.
