### PR TITLE
docs(storybook): load lato from cdn and remove url loader

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -18,11 +18,7 @@ module.exports = {
         test: /\.scss$/, use: ['style-loader', 'css-loader', 'sass-loader']
       }
     );
-    config.module.rules.push(
-      {
-        test: /\.(woff|woff2|eot|ttf|otf)$/, use: ['url-loader']
-      }
-    );
+  
     config.resolve = {
       alias: {
         helpers: path.resolve(__dirname, '__helpers__/')

--- a/.storybook/style/story-root.scss
+++ b/.storybook/style/story-root.scss
@@ -8,6 +8,8 @@
   font-style: normal;
 }
 
+@import url('https://fonts.googleapis.com/css?family=Lato:400,700,900');
+
 body {
   font-family: 'Lato', sans-serif;
 }


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Fix broken Icons in storybook demos, load Lato from cdn
### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Icons are not loading and lato font is not found
### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>- [ ] Unit tests<del>
<del>- [ ] Cypress automation tests<del>
<del>- [x] Storybook added or updated<del>
<del>- [ ] Theme support<del>
<del>- [ ] Typescript `d.ts` file added or updated<del>

### Additional context
<!-- Add any other context or links about the pull request here. -->
This a temporary fix whilst an investigation is undertaken to work out why the original one has failed
### Testing instructions
<!-- How can a reviewer test this PR? -->
