### PR TITLE
feat(select): add transparent variant (FE-2630)

### DIFF
--- a/cypress/features/regression/experimental/select.feature
+++ b/cypress/features/regression/experimental/select.feature
@@ -101,3 +101,16 @@ Feature: Experimental Select component
     Given clear all actions in Actions Tab
     When Type "Black" text into input and select the value
     Then change action was called in Actions Tab
+
+  @positive
+  Scenario: Select is transparent and has placeholder right aligned
+    When I check transparent checkbox
+    Then Select is transparent
+      And Select placeholder align on preview is set to "right"
+
+  @positive
+  Scenario: Select is not transparent and has placeholder left aligned
+    Given I check transparent checkbox
+    When I uncheck transparent checkbox
+    Then Select is not transparent
+      And Select placeholder align on preview is set to "start"

--- a/cypress/support/step-definitions/select-steps.js
+++ b/cypress/support/step-definitions/select-steps.js
@@ -2,6 +2,9 @@ import {
   select, selectInput, selectInputNoIframe, selectPill,
 } from '../../locators/select';
 
+const transparentBorderColor = 'rgba(0, 0, 0, 0.85)';
+const notTransparentBorderColor = 'rgb(102, 132, 145)';
+
 Then('Select typeAhead is disabled', () => {
   select().should('have.attr', 'placeholder', 'Please Select...');
 });
@@ -91,4 +94,24 @@ When('Type {string} text into input and select the value', (text) => {
 
 When('Type {string} text into input and select the value into iFrame', (text) => {
   selectInputNoIframe().type(`${text}{downarrow}{enter}`);
+});
+
+Then('Select is transparent', () => {
+  select().parent().should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+    .and('have.css', 'border-left-color', transparentBorderColor)
+    .and('have.css', 'border-right-color', transparentBorderColor)
+    .and('have.css', 'border-top-color', transparentBorderColor);
+  select().should('have.css', 'font-weight', '900');
+});
+
+Then('Select is not transparent', () => {
+  select().parent().should('have.css', 'background-color', 'rgb(255, 255, 255)')
+    .and('have.css', 'border-left-color', notTransparentBorderColor)
+    .and('have.css', 'border-right-color', notTransparentBorderColor)
+    .and('have.css', 'border-top-color', notTransparentBorderColor);
+  select().should('have.css', 'font-weight', '400');
+});
+
+Then('Select placeholder align on preview is set to {string}', (direction) => {
+  select().should('have.css', 'text-align', direction);
 });

--- a/src/__experimental__/components/select/select.component.js
+++ b/src/__experimental__/components/select/select.component.js
@@ -418,6 +418,7 @@ class Select extends React.Component {
       onOpen,
       typeAhead,
       filterable,
+      transparent,
       ...props
     } = this.props;
 
@@ -437,6 +438,7 @@ class Select extends React.Component {
         aria-controls={ open ? this.listboxId : '' }
         aria-label={ ariaLabel }
         isAnyValueSelected={ this.isMultiSelectEnabled() && (this.getMultiSelectValues().length >= 1) }
+        transparent={ transparent }
       >
         <Textbox
           { ...props } // this needs to send all of the original props
@@ -521,7 +523,9 @@ Select.propTypes = {
   filterable: PropTypes.bool,
   isAnyValueSelected: PropTypes.bool,
   /** Add additional child elements before the input */
-  leftChildren: PropTypes.node
+  leftChildren: PropTypes.node,
+  /** If true the component input has no border and is transparent */
+  transparent: PropTypes.bool
 };
 
 Select.defaultProps = {

--- a/src/__experimental__/components/select/select.spec.js
+++ b/src/__experimental__/components/select/select.spec.js
@@ -11,6 +11,9 @@ import StyledIcon from '../../../components/icon/icon.style';
 import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
 import TextBox from '../textbox';
 import { Input } from '../input';
+import InputPresentationStyle from '../input/input-presentation.style';
+import StyledInput from '../input/input.style';
+import InputIconToggleStyle from '../input-icon-toggle/input-icon-toggle.style';
 
 jest.mock('../../../utils/helpers/guid');
 guid.mockImplementation(() => 'guid-12345');
@@ -451,6 +454,34 @@ describe('Select', () => {
       expect(listOf(wrapper).length).toEqual(0);
       textboxOf(wrapper).find('input').simulate('change', { target: { value: 'xxx' } });
       expect(listOf(wrapper).length).toEqual(1);
+    });
+  });
+
+  describe('when transparent is set to true', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = renderWrapper({ props: { transparent: true } });
+    });
+
+    it('then the input should have transparent background and no border', () => {
+      assertStyleMatch({
+        background: 'transparent',
+        border: 'none'
+      }, wrapper, { modifier: `${InputPresentationStyle}` });
+    });
+
+    it('then the input text should be right aligned with font weight set to 900', () => {
+      assertStyleMatch({
+        textAlign: 'right',
+        fontWeight: '900'
+      }, wrapper, { modifier: `${StyledInput}` });
+    });
+
+    it('then the input toggle text should have width set to auto', () => {
+      assertStyleMatch({
+        width: 'auto'
+      }, wrapper, { modifier: `${InputIconToggleStyle}` });
     });
   });
 

--- a/src/__experimental__/components/select/select.stories.js
+++ b/src/__experimental__/components/select/select.stories.js
@@ -61,6 +61,7 @@ const commonKnobs = (store, enableMultiSelect = false) => {
     placeholder: text('placeholder', ''),
     readOnly: boolean('readOnly', false),
     size: select('size', OptionsHelper.sizesRestricted, OptionsHelper.sizesRestricted[1]),
+    transparent: boolean('transparent', false),
     filterable,
     typeAhead,
     autoFocus,

--- a/src/__experimental__/components/select/select.style.js
+++ b/src/__experimental__/components/select/select.style.js
@@ -5,6 +5,8 @@ import StyledPill from '../../../components/pill/pill.style';
 import StyledInput from '../input/input.style';
 import StyledIcon from '../../../components/icon/icon.style';
 import { isClassic } from '../../../utils/helpers/style-helper';
+import InputPresentationStyle from '../input/input-presentation.style';
+import InputIconToggleStyle from '../input-icon-toggle/input-icon-toggle.style';
 
 const StyledSelect = styled.div`
   ${({ isAnyValueSelected }) => isAnyValueSelected && css`
@@ -18,6 +20,22 @@ const StyledSelect = styled.div`
       ${StyledIcon} {
         color: ${theme.colors.white};
       }
+    }
+  `}
+
+  ${({ transparent }) => transparent && css`
+    ${InputPresentationStyle} {
+      background: transparent;
+      border: none;
+    }
+
+    ${StyledInput} {
+      font-weight: 900;
+      text-align: right;
+    }
+
+    ${InputIconToggleStyle} {
+      width: auto;
     }
   `}
 `;


### PR DESCRIPTION
### Proposed behaviour
New variant of the Select Component to allow it to be displayed as transparent and right aligned.

![image](https://user-images.githubusercontent.com/22885392/77175963-b0775900-6ac3-11ea-9e73-8c65c9f3443c.png)

![image](https://user-images.githubusercontent.com/22885392/77427715-24bd3f80-6dd7-11ea-9884-905955784a5d.png)

### Current behaviour
Select Component could be rendered with standard input background and border, and it's text is left aligned in relation to the dropdown icon.

### Checklist
- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests
- [x] Storybook added or updated
~~- [ ] Theme support~~
~~- [ ] Typescript `d.ts` file added or updated~~

### Additional context
Required as part of Address Fieldset.

### Testing instructions
* npm start
* Go to http://localhost:9001/?path=/story/experimental-select--default
* Check the `transparent` knob
