### PR TITLE
feat(textbox): add override styles functionality (FE-2631)

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -25,5 +25,6 @@
   "grouped": "--grouped",
   "with_sticky_footer": "--with-sticky-footer",
   "in_full_screen_dialog": "--in-full-screen-dialog",
+  "style_override": "--styles-overriden",
   "max_violation_value": 2
 }

--- a/cypress/features/regression/test/textboxStyleOverrideNoIFrame.feature
+++ b/cypress/features/regression/test/textboxStyleOverrideNoIFrame.feature
@@ -1,0 +1,7 @@
+Feature: Style overriden Textbox component
+  I want to verify overriden styles for Textbox component
+
+  @positive
+  Scenario: Open style overriden Textbox component page and verify overriden styles are rendered properly
+    When I open style override Test "Textbox" component page in noIframe
+    Then Textbox overriden styles rendered properly

--- a/cypress/locators/index.js
+++ b/cypress/locators/index.js
@@ -36,6 +36,7 @@ export const commonButtonPreviewNoIFrameRoot = () => cy.get(DLS_ROOT).find('butt
 export const commonInputPreview = () => storyRoot().find('input');
 export const labelPreview = () => storyRoot().find('label').first();
 export const label = () => cy.iFrame(LABEL);
+export const labelNoIFrame = () => cy.get(LABEL);
 export const labelByPosition = position => cy.iFrame(LABEL).eq(position);
 export const helpIcon = () => cy.iFrame(HELP_ICON_PREVIEW).first();
 export const helpIconByPosition = position => cy.iFrame(HELP_ICON_PREVIEW).eq(position);

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -167,6 +167,10 @@ Given('I open basic Test {string} component page in noIframe', (component) => {
   visitComponentUrl(component, 'basic', true, 'test-');
 });
 
+Given('I open style override Test {string} component page in noIframe', (component) => {
+  visitComponentUrl(component, 'style_override', true, 'test-');
+});
+
 When('I open Test {string} component basic page with prop value', (componentName) => {
   visitFlatTableComponentNoiFrame(componentName, 'basic', true, 'test-');
 });

--- a/cypress/support/step-definitions/textbox-steps.js
+++ b/cypress/support/step-definitions/textbox-steps.js
@@ -3,7 +3,7 @@ import {
 } from '../../locators/textbox';
 import {
   label, labelByPosition, commonDataElementInputPreview, commonInputPreview,
-  fieldHelpPreviewByPosition, tooltipPreviewByPosition,
+  fieldHelpPreviewByPosition, tooltipPreviewByPosition, labelNoIFrame, commonDataElementInputPreviewNoIframe,
 } from '../../locators';
 import { DEBUG_FLAG } from '..';
 
@@ -243,4 +243,22 @@ When('I click on Textbox', () => {
 
 Then('Textbox input has golden border on focus', () => {
   textbox().should('have.css', 'outline', 'rgb(255, 181, 0) solid 3px');
+});
+
+Then('Textbox overriden styles rendered properly', () => {
+  labelNoIFrame().parent().parent().should('have.css', 'background', 'rgb(240, 240, 240) none repeat scroll 0% 0% / auto padding-box border-box');
+  labelNoIFrame().parent().should('have.css', 'display', 'flex');
+  labelNoIFrame().should('have.css', 'display', 'block')
+    .and('have.css', 'font-weight', '600')
+    .and('have.css', 'box-sizing', 'border-box')
+    .and('have.css', 'padding-bottom', '0px')
+    .and('have.css', 'padding-top', '12px')
+    .and('have.css', 'padding-right', '11px')
+    .and('have.css', 'color', 'rgb(180, 212, 85)');
+  commonDataElementInputPreviewNoIframe().parent().should('have.css', 'background', 'rgb(255, 255, 255) none repeat scroll 0% 0% / auto padding-box border-box')
+    .and('have.css', 'border', '1px solid rgb(102, 132, 145)')
+    .and('have.css', 'flex', '0 0 auto');
+  commonDataElementInputPreviewNoIframe().should('have.css', 'background', 'rgba(0, 0, 0, 0) none repeat scroll 0% 0% / auto padding-box border-box')
+    .and('have.css', 'border', '0px none rgba(0, 0, 0, 0.9)')
+    .and('have.css', 'color', 'rgba(0, 0, 0, 0.9)');
 });

--- a/src/__experimental__/components/form-field/form-field.component.js
+++ b/src/__experimental__/components/form-field/form-field.component.js
@@ -33,9 +33,10 @@ const FormField = ({
   readOnly,
   tooltipMessage,
   useValidationIcon,
+  styleOverride,
   ...props
 }) => (
-  <FormFieldStyle { ...tagComponent(props['data-component'], props) }>
+  <FormFieldStyle { ...tagComponent(props['data-component'], props) } styleOverride={ styleOverride.root }>
     <FieldLineStyle inline={ labelInline }>
       {reverse && children}
 
@@ -61,6 +62,7 @@ const FormField = ({
           optional={ isOptional }
           tooltipMessage={ tooltipMessage }
           useValidationIcon={ useValidationIcon }
+          styleOverride={ styleOverride.label }
         >
           {label}
         </Label>
@@ -84,7 +86,8 @@ const FormField = ({
 );
 
 FormField.defaultProps = {
-  size: 'medium'
+  size: 'medium',
+  styleOverride: {}
 };
 
 FormField.propTypes = {
@@ -114,7 +117,12 @@ FormField.propTypes = {
   reverse: PropTypes.bool,
   size: PropTypes.oneOf(OptionsHelper.sizesRestricted),
   tooltipMessage: PropTypes.string,
-  useValidationIcon: PropTypes.bool
+  useValidationIcon: PropTypes.bool,
+  /** Allows to override existing component styles */
+  styleOverride: PropTypes.shape({
+    root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    label: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+  })
 };
 
 export default FormField;

--- a/src/__experimental__/components/form-field/form-field.style.js
+++ b/src/__experimental__/components/form-field/form-field.style.js
@@ -6,6 +6,8 @@ const FormFieldStyle = styled.div`
   & + & {
     margin-top: ${({ theme }) => (isClassic(theme) ? '10px' : '16px')};
   }
+
+  ${({ styleOverride }) => styleOverride};
 `;
 
 FormFieldStyle.defaultProps = {

--- a/src/__experimental__/components/input/input-presentation.component.js
+++ b/src/__experimental__/components/input/input-presentation.component.js
@@ -15,7 +15,9 @@ const InputPresentationContext = React.createContext();
 
 class InputPresentation extends React.Component {
   static propTypes = {
-    children: PropTypes.node
+    children: PropTypes.node,
+    /** Allows to override existing component styles */
+    styleOverride: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
   }
 
   state = {
@@ -54,7 +56,7 @@ class InputPresentation extends React.Component {
   handleMouseLeave = () => this.setState({ hasMouseOver: false });
 
   render() {
-    const { children, ...props } = this.props;
+    const { children, styleOverride, ...props } = this.props;
     const styleProps = extractProps(props, InputPresentationStyle);
 
     return (
@@ -66,6 +68,7 @@ class InputPresentation extends React.Component {
         onMouseDown={ this.handleMouseDown }
         onMouseEnter={ this.handleMouseEnter }
         onMouseLeave={ this.handleMouseLeave }
+        styleOverride={ styleOverride }
         { ...styleProps }
       >
         <InputPresentationContext.Provider value={ this.contextForInput() }>

--- a/src/__experimental__/components/input/input-presentation.style.js
+++ b/src/__experimental__/components/input/input-presentation.style.js
@@ -59,6 +59,8 @@ const InputPresentationStyle = styled.div`
   input::-webkit-contacts-auto-fill-button {
     display: none!important;
   }
+
+  ${({ styleOverride }) => styleOverride};
 `;
 
 function stylingForValidations({
@@ -111,7 +113,8 @@ InputPresentationStyle.propTypes = {
   size: PropTypes.oneOf(OptionsHelper.sizesRestricted),
   hasError: PropTypes.bool,
   hasWarning: PropTypes.bool,
-  hasInfo: PropTypes.bool
+  hasInfo: PropTypes.bool,
+  styleOverride: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
 };
 
 export default InputPresentationStyle;

--- a/src/__experimental__/components/input/input.style.js
+++ b/src/__experimental__/components/input/input.style.js
@@ -31,6 +31,8 @@ const StyledInput = styled.input`
   ${({ readOnly, theme }) => readOnly && css`
     color: ${theme.readOnly.textboxText};
   `}
+
+  ${({ styleOverride }) => styleOverride};
 `;
 
 StyledInput.defaultProps = {
@@ -38,7 +40,8 @@ StyledInput.defaultProps = {
 };
 
 StyledInput.propTypes = {
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  styleOverride: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
 };
 
 export default StyledInput;

--- a/src/__experimental__/components/label/label.component.js
+++ b/src/__experimental__/components/label/label.component.js
@@ -22,7 +22,8 @@ const Label = (props) => {
     tooltipMessage,
     useValidationIcon,
     htmlFor,
-    tabIndex
+    tabIndex,
+    styleOverride
   } = props;
   const labelProps = filterByProps(props, [
     'theme',
@@ -78,6 +79,7 @@ const Label = (props) => {
       { ...labelProps }
       id={ labelId }
       htmlFor={ htmlFor }
+      styleOverride={ styleOverride }
     >
       {children}
       {icon()}
@@ -109,12 +111,15 @@ Label.propTypes = {
   /** Set focus possibilities to an <IconWrapperStyle /> element.
    *  More information: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
   */
-  tabIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  tabIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Allows to override existing component styles */
+  styleOverride: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
 };
 
 Label.defaultProps = {
   useValidationIcon: false,
-  tabIndex: 0
+  tabIndex: 0,
+  styleOverride: {}
 };
 
 export default React.memo(Label);

--- a/src/__experimental__/components/label/label.d.ts
+++ b/src/__experimental__/components/label/label.d.ts
@@ -11,6 +11,7 @@ export interface LabelPropTypes {
   tooltipMessage?: string;
   useValidationIcon?: boolean;
   tabIndex?: [string, number];
+  styleOverride?: () => object | object;
 }
 
 declare const Label: React.FunctionComponent<LabelPropTypes>;

--- a/src/__experimental__/components/label/label.style.js
+++ b/src/__experimental__/components/label/label.style.js
@@ -73,6 +73,8 @@ const LabelStyle = styled.label`
       }
     `}
   `}
+
+  ${({ styleOverride }) => styleOverride};
 `;
 
 LabelStyle.defaultProps = {
@@ -87,7 +89,8 @@ LabelStyle.propTypes = {
   inline: PropTypes.bool,
   inputSize: PropTypes.oneOf(OptionsHelper.sizesRestricted),
   width: PropTypes.number,
-  readOnly: PropTypes.bool
+  readOnly: PropTypes.bool,
+  styleOverride: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
 };
 
 export default LabelStyle;

--- a/src/__experimental__/components/textbox/__snapshots__/textbox.spec.js.snap
+++ b/src/__experimental__/components/textbox/__snapshots__/textbox.spec.js.snap
@@ -13,6 +13,7 @@ exports[`Textbox renders with InputPresentation and Input and all props passed t
   onBlur={[Function]}
   onChange={[Function]}
   size="medium"
+  styleOverride={Object {}}
   useValidationIcon={false}
   validations={Array []}
   warnings={Array []}

--- a/src/__experimental__/components/textbox/textbox.component.js
+++ b/src/__experimental__/components/textbox/textbox.component.js
@@ -20,6 +20,7 @@ const Textbox = ({
   childOfForm,
   isOptional,
   iconOnClick,
+  styleOverride,
   ...props
 }) => {
   return (
@@ -28,8 +29,13 @@ const Textbox = ({
       isOptional={ isOptional }
       { ...props }
       useValidationIcon={ false }
+      styleOverride={ styleOverride }
     >
-      <InputPresentation type='text' { ...removeParentProps(props) }>
+      <InputPresentation
+        type='text'
+        { ...removeParentProps(props) }
+        styleOverride={ styleOverride.input }
+      >
         { leftChildren }
         <Input
           { ...removeParentProps(props) }
@@ -128,13 +134,20 @@ Textbox.propTypes = {
   /** Optional handler for click event on Textbox icon */
   iconOnClick: PropTypes.func,
   /** Handler for onClick events */
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  /** Allows to override existing component styles */
+  styleOverride: PropTypes.shape({
+    root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    input: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    label: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+  })
 };
 
 Textbox.defaultProps = {
   labelWidth: 30,
   inputWidth: 70,
-  size: 'medium'
+  size: 'medium',
+  styleOverride: {}
 };
 
 export { Textbox as OriginalTextbox };

--- a/src/__experimental__/components/textbox/textbox.spec.js
+++ b/src/__experimental__/components/textbox/textbox.spec.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+import 'jest-styled-components';
 import Textbox from '.';
 import InputIconToggle from '../input-icon-toggle';
+import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
+import FormField from '../form-field';
+import { InputPresentation } from '../input/input-presentation.component';
+import Label from '../label';
 
 jest.mock('../../../utils/helpers/guid', () => () => 'mocked-guid');
 
@@ -33,5 +38,39 @@ describe('Textbox', () => {
     icon.simulate('click');
     expect(iconOnClick).toHaveBeenCalled();
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  describe('style overrides', () => {
+    let wrapper;
+    const randomStyleObject = {
+      backgroundColor: 'red',
+      display: 'flex',
+      fontSize: '200px'
+    };
+    const styleOverride = {
+      root: randomStyleObject,
+      input: randomStyleObject,
+      label: randomStyleObject
+    };
+
+    beforeEach(() => {
+      wrapper = mount(
+        <Textbox label='test label' styleOverride={ styleOverride }>
+          normal children
+        </Textbox>
+      );
+    });
+
+    it('renders root element with properly assigned styles', () => {
+      assertStyleMatch(randomStyleObject, wrapper.find(FormField));
+    });
+
+    it('renders input element with properly assigned styles', () => {
+      assertStyleMatch(randomStyleObject, wrapper.find(InputPresentation));
+    });
+
+    it('renders label element with properly assigned styles', () => {
+      assertStyleMatch(randomStyleObject, wrapper.find(Label));
+    });
   });
 });

--- a/src/__experimental__/components/textbox/textbox.stories.mdx
+++ b/src/__experimental__/components/textbox/textbox.stories.mdx
@@ -1,0 +1,30 @@
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+
+import Textbox from '../textbox';
+
+<Meta
+  title="Test/Textbox"
+  parameters={{ info: { disable: true }}}
+/>
+
+### With styles overriden
+With custom wrapper, label and input styles
+<Preview>
+  <Story name="styles overriden">
+    <Textbox
+      label='Label 1'
+      labelInline
+      labelAlign='right'
+      styleOverride={
+        {
+          root: { background: '#F0F0F0' },
+          input: {
+            flex: 'none',
+            width: '150px',
+          },
+          label: { color: '#B4D455' }
+        }
+      }
+    />
+  </Story>
+</Preview>


### PR DESCRIPTION
### Proposed behaviour
Textbox component should have a functionality to override it's styles, e.g.: set fixed width of the input or change it's background. 

### Current behaviour
Textbox styles cannot be overriden by Carbon user.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests
- [x] Storybook added or updated
- [x] Theme support
- [x] Typescript `d.ts` file added or updated

### Additional context
Required to set fixed width of post code field in Address Fieldset

### Testing instructions
* npm start
* Go to http://localhost:9001/?path=/story/test-textbox--styles-overriden