### PR TITLE
test: remove unnecesary viewport in beforeEach

### DIFF
--- a/cypress/support/step-definitions/anchor-navigation-steps.js
+++ b/cypress/support/step-definitions/anchor-navigation-steps.js
@@ -1,9 +1,5 @@
 import { anchorNavigationStickyNavigation, anchorNavigationStickyMainPage } from '../../locators/anchor-navigation';
 
-beforeEach(() => {
-  cy.viewport(1366, 500);
-});
-
 When('I click onto {string} tab', (anchorNaviIndex) => {
   anchorNavigationStickyNavigation(anchorNaviIndex).click();
 });

--- a/cypress/support/step-definitions/simple-color-picker-steps.js
+++ b/cypress/support/step-definitions/simple-color-picker-steps.js
@@ -6,10 +6,6 @@ import {
 } from '../../locators/simple-color-picker';
 import { getKnobsInput } from '../../locators';
 
-beforeEach(() => {
-  cy.viewport(1366, 1200);
-});
-
 const FIRST_ELEMENT = 1;
 const SECOND_ELEMENT = 2;
 const THIRD_ELEMENT = 3;
@@ -105,7 +101,8 @@ Then('It renders with all colors', () => {
 
 When('I input new color json into {string} input field', (inputFieldName) => {
   cy.fixture('simpleColorPickerNew.json').then(($json) => {
-    getKnobsInput(inputFieldName).clear().then($selector => $selector.val(JSON.stringify($json))).type(' ');
+    getKnobsInput(inputFieldName).clear({ force: true }).then($selector => $selector.val(JSON.stringify($json)))
+      .type(' ');
   });
 });
 


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
- `beforeEach(() => {
  cy.viewport(1366, 500);
});` should be removed from `simpleColorPicker.feature` and `anchorNavigation.feature` to make tests run without unnecessary re-rendering of viewport.
- added `{ force: true }` to make test run and pass.

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
- In Simple Color Picker and in Anchor Navigation we have beforeEach function where we are re-writting `cy.viewport`, it just loads all tests before.
- Simple Color Picker test fails because cypress doesn't see full input for `json` value insertion.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->
 
<del> - [ ] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ --> </del> 
<del> - [ ] Unit tests </del>
- [x] Cypress automation tests

<del> - [ ] Storybook added or updated</del>
<del> - [ ] Theme support</del>
<del> - [ ] Typescript `d.ts` file added or updated</del>

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
run:
`npm start` > `npm run test-cypress` and run separately `simpleColorPicker.feature` and `anchorNavigation.feature`