### PR TITLE
fix(button-toggle): add id prop support

### DIFF
--- a/fixtures/src/components/controlled/button-toggle.js
+++ b/fixtures/src/components/controlled/button-toggle.js
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import ButtonToggleGroup from 'carbon-react/lib/components/button-toggle-group';
+import ButtonToggle from 'carbon-react/lib/components/button-toggle';
+import { LogConsumer } from '../log';
+
+const ControlledButtonToggle = () => {
+  const [checkedValue, setCheckedValue] = useState();
+  const [checkedValueExampleTwo, setCheckedValueExampleTwo] = useState('two');
+  return (
+    <LogConsumer>
+      {(log) => {
+        const onChange = setter => (e) => {
+          log(e, { method: 'onChange' });
+          setter(e.target.value);
+        };
+        const onBlur = e => log(e, { method: 'onBlur' });
+
+        return (
+          <React.Fragment>
+            <div id='controlled_button_toggle'>
+              <h1>Controlled Button Toggle</h1>
+              <h2>Unchecked</h2>
+              <ul>
+                <li>onChange handler should update the log when each toggle is checked</li>
+                <li>onBlur handler should update the log when each toggle is blurred</li>
+                <li>each toggle button has props value, name, id which should be reflected in both events</li>
+                <li>the onChange handler sets the checked value, then each toggle checks this value to see if
+                  the checked
+                  prop should be truthy
+                </li>
+              </ul>
+              <ButtonToggleGroup
+                id='controlled_button_toggle'
+                name='controlled_button_toggle'
+                onChange={ onChange(setCheckedValue) }
+                onBlur={ onBlur }
+                value={ checkedValue }
+              >
+                <ButtonToggle
+                  id='controlled_button_toggle_one' value='one'
+                  label='one'
+                >
+                  One
+                </ButtonToggle>
+                <ButtonToggle
+                  id='controlled_button_toggle_two' value='two'
+                  label='two'
+                >
+                  Two
+                </ButtonToggle>
+                <ButtonToggle
+                  id='controlled_button_toggle_three' value='three'
+                  label='three'
+                >
+                  Three
+                </ButtonToggle>
+              </ButtonToggleGroup>
+            </div>
+            <div id='controlled_button_toggle_checked'>
+              <h2>Default Checked</h2>
+              <ul>
+                <li>value two is checked by default</li>
+              </ul>
+              <ButtonToggleGroup
+                id='controlled_button_toggle_checked'
+                name='controlled_button_toggle_checked'
+                onChange={ onChange(setCheckedValueExampleTwo) }
+                onBlur={ onBlur }
+                value={ checkedValueExampleTwo }
+              >
+                <ButtonToggle
+                  id='controlled_button_toggle_checked_one' value='one'
+                  label='one'
+                >
+                  One
+                </ButtonToggle>
+                <ButtonToggle
+                  id='controlled_button_toggle_checked_two' value='two'
+                  label='two'
+                >
+                  Two
+                </ButtonToggle>
+                <ButtonToggle
+                  id='controlled_button_toggle_checked_three' value='three'
+                  label='three'
+                >
+                  Three
+                </ButtonToggle>
+              </ButtonToggleGroup>
+            </div>
+
+          </React.Fragment>
+        );
+      }}
+    </LogConsumer>
+  );
+};
+
+export default ControlledButtonToggle;

--- a/fixtures/src/components/uncontrolled/button-toggle.js
+++ b/fixtures/src/components/uncontrolled/button-toggle.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import ButtonToggleGroup from 'carbon-react/lib/components/button-toggle-group';
+import ButtonToggle from 'carbon-react/lib/components/button-toggle';
+import { LogConsumer } from '../log';
+
+const UncontrolledButtonToggle = () => {
+  return (
+    <LogConsumer>
+      {(log) => {
+        const onChange = e => log(e, { method: 'onChange' });
+        const onBlur = e => log(e, { method: 'onBlur' });
+
+        return (
+          <React.Fragment>
+            <div id='uncontrolled_button_toggle'>
+              <h1>Uncontrolled Button Toggle</h1>
+              <h2>Unchecked</h2>
+              <ul>
+                <li>onChange handler should update the log when each toggle is checked</li>
+                <li>onBlur handler should update the log when each toggle is blurred</li>
+                <li>each toggle button has props value, name, id which should be reflected in both events</li>
+                <li>the onChange handler sets the checked value, then each toggle checks this value to see if
+                    the checked
+                    prop should be truthy
+                </li>
+              </ul>
+              <ButtonToggleGroup
+                id='uncontrolled_button_toggle'
+                name='uncontrolled_button_toggle'
+                onChange={ onChange }
+                onBlur={ onBlur }
+              >
+                <ButtonToggle
+                  id='uncontrolled_button_toggle_one' value='one'
+                  label='one'
+                >
+                      One
+                </ButtonToggle>
+                <ButtonToggle
+                  id='uncontrolled_button_toggle_two' value='two'
+                  label='two'
+                >
+                      Two
+                </ButtonToggle>
+                <ButtonToggle
+                  id='uncontrolled_button_toggle_three' value='three'
+                  label='three'
+                >
+                      Three
+                </ButtonToggle>
+              </ButtonToggleGroup>
+            </div>
+            <div id='uncontrolled_button_toggle_checked'>
+              <h2>Default Checked</h2>
+              <ul>
+                <li>value two is checked by default</li>
+              </ul>
+              <ButtonToggleGroup
+                id='uncontrolled_button_toggle_checked'
+                name='uncontrolled_button_toggle_checked'
+                onChange={ onChange }
+                onBlur={ onBlur }
+              >
+                <ButtonToggle
+                  id='uncontrolled_button_toggle_checked_one' value='one'
+                  label='one'
+                >
+                      One
+                </ButtonToggle>
+                <ButtonToggle
+                  id='uncontrolled_button_toggle_checked_two' value='two'
+                  label='two' defaultChecked
+                >
+                      Two
+                </ButtonToggle>
+                <ButtonToggle
+                  id='uncontrolled_button_toggle_checked_three' value='three'
+                  label='three'
+                >
+                      Three
+                </ButtonToggle>
+              </ButtonToggleGroup>
+            </div>
+
+          </React.Fragment>
+        );
+      }}
+    </LogConsumer>
+  );
+};
+
+export default UncontrolledButtonToggle;

--- a/fixtures/src/main.js
+++ b/fixtures/src/main.js
@@ -1,13 +1,10 @@
 import React from 'react';
 import { Route } from 'react-router';
 import { startRouter } from 'carbon-react/lib/utils/router';
-
 // Loads base css from carbon:
 import 'carbon-react/lib/utils/css';
-
 import Index from './components';
 import Chrome from './components/chrome';
-
 import UncontrolledRadioButton from './components/uncontrolled/radio-button';
 import UncontrolledSwitch from './components/uncontrolled/switch';
 import ControlledRadioButton from './components/controlled/radio-button';
@@ -38,8 +35,15 @@ import UncontrolledCheckbox from './components/uncontrolled/checkbox';
 import ControlledCheckbox from './components/controlled/checkbox';
 import UncontrolledSearch from './components/uncontrolled/search';
 import ControlledSearch from './components/controlled/search';
+import ControlledButtonToggle from './components/controlled/button-toggle';
+import UncontrolledButtonToggle from './components/uncontrolled/button-toggle';
 
 const routes = {
+  'button-toggle': {
+    description: 'Button Toggle',
+    controlled: ControlledButtonToggle,
+    uncontrolled: UncontrolledButtonToggle
+  },
   'radio-button': {
     description: 'Radio Button',
     controlled: ControlledRadioButton,

--- a/src/components/button-toggle-group/__snapshots__/button-toggle-group.spec.js.snap
+++ b/src/components/button-toggle-group/__snapshots__/button-toggle-group.spec.js.snap
@@ -124,14 +124,14 @@ input:focus ~ .c6 {
         <input
           checked={false}
           className="c5"
-          id="guid-12345"
+          id="foo"
           onChange={[Function]}
           type="radio"
           value="foo"
         />
         <label
           className="c6"
-          htmlFor="guid-12345"
+          htmlFor="foo"
           size="large"
         >
           <div
@@ -148,14 +148,14 @@ input:focus ~ .c6 {
         <input
           checked={false}
           className="c5"
-          id="guid-12345"
+          id="bar"
           onChange={[Function]}
           type="radio"
           value="bar"
         />
         <label
           className="c6"
-          htmlFor="guid-12345"
+          htmlFor="bar"
           size="large"
         >
           <div
@@ -270,14 +270,14 @@ input:focus ~ .c6 {
         <input
           checked={false}
           className="c5"
-          id="guid-12345"
+          id="foo"
           onChange={[Function]}
           type="radio"
           value="foo"
         />
         <label
           className="c6"
-          htmlFor="guid-12345"
+          htmlFor="foo"
           size="large"
         >
           <div
@@ -294,14 +294,14 @@ input:focus ~ .c6 {
         <input
           checked={false}
           className="c5"
-          id="guid-12345"
+          id="bar"
           onChange={[Function]}
           type="radio"
           value="bar"
         />
         <label
           className="c6"
-          htmlFor="guid-12345"
+          htmlFor="bar"
           size="large"
         >
           <div
@@ -420,14 +420,14 @@ input:focus ~ .c7 {
         <input
           checked={false}
           className="c5"
-          id="guid-12345"
+          id="foo"
           onChange={[Function]}
           type="radio"
           value="foo"
         />
         <label
           className="c6 c7"
-          htmlFor="guid-12345"
+          htmlFor="foo"
           size="large"
         >
           <div
@@ -444,14 +444,14 @@ input:focus ~ .c7 {
         <input
           checked={false}
           className="c5"
-          id="guid-12345"
+          id="bar"
           onChange={[Function]}
           type="radio"
           value="bar"
         />
         <label
           className="c6 c7"
-          htmlFor="guid-12345"
+          htmlFor="bar"
           size="large"
         >
           <div

--- a/src/components/button-toggle/button-toggle.component.js
+++ b/src/components/button-toggle/button-toggle.component.js
@@ -12,6 +12,7 @@ import OptionsHelper from '../../utils/helpers/options-helper';
 
 const ButtonToggle = (props) => {
   const {
+    id,
     name,
     checked,
     grouped,
@@ -44,7 +45,7 @@ const ButtonToggle = (props) => {
         name={ name }
         checked={ checked }
         disabled={ disabled }
-        guid={ inputGuid }
+        guid={ id || inputGuid }
         value={ value }
         onChange={ onChange }
       />
@@ -52,7 +53,7 @@ const ButtonToggle = (props) => {
         buttonIcon={ buttonIcon }
         buttonIconSize={ buttonIconSize }
         disabled={ disabled }
-        htmlFor={ inputGuid }
+        htmlFor={ id || inputGuid }
         size={ size }
       >
         <StyledButtonToggleContentWrapper>
@@ -65,6 +66,8 @@ const ButtonToggle = (props) => {
 };
 
 ButtonToggle.propTypes = {
+  /** Id used to identify the component. */
+  id: PropTypes.string,
   /** Set the checked value of the radio button */
   checked: PropTypes.bool,
   /** Name used on the hidden radio button. */


### PR DESCRIPTION
### Proposed behaviour
The id prop passed to ButtonToggleGroup should be in the DOM.
The id prop passed to ButtonToggle should be exposed in the onChange/onBlur event it should also be in the DOM.
The checked prop of the ButtonToggle radio button is available to be set.

### Current behaviour
The id prop is not available in the DOM
Within a ButtonToggleGroup, you can't set the checked property of the ButtonToggle radio button.

### Checklist
- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [ ] Unit tests
- [ ] Storybook added or updated
- [ ] Theme support
- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
