### PR TITLE
fix(tooltip): update style to break long lines of text

### DIFF
--- a/src/components/tooltip/__snapshots__/tooltip.spec.js.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.spec.js.snap
@@ -16,7 +16,7 @@ exports[`Tooltip visible and has children matches snapshot 1`] = `
   padding: 12px 16px;
   text-align: center;
   max-width: 300px;
-  word-break: normal;
+  word-break: break-all;
   white-space: pre-wrap;
 }
 

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -85,7 +85,7 @@ describe('Tooltip', () => {
               padding: '12px 16px',
               textAlign: 'center',
               maxWidth: '300px',
-              wordBreak: 'normal',
+              wordBreak: 'break-all',
               whiteSpace: 'pre-wrap'
             },
             renderInner()

--- a/src/components/tooltip/tooltip.style.js
+++ b/src/components/tooltip/tooltip.style.js
@@ -13,7 +13,7 @@ const StyledTooltipInner = styled.div`
     padding: 12px 16px;
     text-align: center;
     max-width: 300px;
-    word-break: normal;
+    word-break: break-all;
     white-space: pre-wrap;
 
     ${type === 'error' && css`


### PR DESCRIPTION
### Proposed behaviour
Text exceeding fixed width of 300px will break to a new line.

### Current behaviour
Text exceeding fixed width of 300px currently does not break to a new line.

### Checklist
- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests

### Additional context
https://github.com/Sage/carbon/issues/2171
https://jira.sage.com/browse/FE-2427

### Testing instructions
To reproduce this issue in Storybook;
 Boot carbon on the master branch
 Run Storybook with npm run storybook
 Navigate to the default story of the Tooltip component
 In the children knob enter a string longer than 45 chars. The tooltip wraps the word toa new line now
