### PR TITLE
chore(button): remove destructive button type

### DIFF
--- a/cypress/features/regression/button.feature
+++ b/cypress/features/regression/button.feature
@@ -42,13 +42,6 @@ Feature: Button component
       | darkBackground | rgb(0, 128, 93)    | rgb(255, 255, 255) |
 
   @positive
-  Scenario: Set Button Type do destructive
-    Given I select buttonType to "primary"
-    When I check destructive checkbox
-    Then Button font color is "rgb(255, 255, 255)"
-      And Button background color is "rgb(199, 56, 79)"
-
-  @positive
   Scenario Outline: Set Button component label to <label>
     When I set children to "<label>"
     Then Button label on preview is "<label>"

--- a/cypress/features/regression/buttonAsSibling.feature
+++ b/cypress/features/regression/buttonAsSibling.feature
@@ -43,13 +43,6 @@ Feature: Button as a sibling component
       | darkBackground | rgb(0, 128, 93)    | rgb(255, 255, 255) |
 
   @positive
-  Scenario: Set Button as a sibling Type as destructive
-    When I select buttonType to "primary"
-    When I check destructive checkbox
-    Then Button font color is "rgb(255, 255, 255)"
-      And Button as a sibling background color is "rgb(199, 56, 79)"
-
-  @positive
   Scenario Outline: Set Button as a sibling component label to <label>
     When I set children to "<label>"
     Then Button as a sibling label on preview is "<label>"

--- a/src/components/button/button.component.js
+++ b/src/components/button/button.component.js
@@ -5,7 +5,6 @@ import Icon from '../icon';
 import StyledButton, { StyledButtonSubtext } from './button.style';
 import tagComponent from '../../utils/helpers/tags';
 import OptionsHelper from '../../utils/helpers/options-helper';
-import Logger from '../../utils/logger';
 
 const Button = (props) => {
   const {
@@ -14,18 +13,9 @@ const Button = (props) => {
 
   const { as, buttonType, ...rest } = props;
 
-  const IS_USING_DEPRECATED_TYPE_DESTRUCTIVE = buttonType === 'destructive';
-
-  if (IS_USING_DEPRECATED_TYPE_DESTRUCTIVE) {
-    Logger.deprecate(
-      'buttonType="destructive" has been deprecated. See https://github.com/Sage/carbon/releases for details.'
-    );
-  }
-
   const propsWithoutAs = {
     ...rest,
-    buttonType: buttonType || as,
-    ...(IS_USING_DEPRECATED_TYPE_DESTRUCTIVE && { buttonType: 'primary', destructive: true })
+    buttonType: buttonType || as
   };
 
   if (subtext.length > 0 && size !== 'large') {
@@ -84,7 +74,6 @@ function renderChildren({
     primary: 'on-dark-background',
     secondary: 'business-color',
     tertiary: 'business-color',
-    destructive: 'on-dark-background',
     darkBackground: 'business-color'
   };
 

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -18,7 +18,7 @@ const render = (props, renderer = shallow) => {
   );
 };
 
-const variants = ['primary', 'secondary', 'tertiary', 'destructive', 'darkBackground'];
+const variants = ['primary', 'secondary', 'tertiary', 'darkBackground'];
 const sizes = { small: [32, 16], medium: [40, 24], large: [48, 32] };
 
 describe('Button', () => {


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
`<Button buttonType="primary" destructive />` will display destructive button.
`<Button buttonType="destructive"/>` will fail prop type validation.
```
BREAKING CHANGE: `<Button buttonType="destructive"/>` has been
removed in favour of `<Button buttonType="primary" destructive />`.

There is a codemod available to assist with this upgrade `npx
carbon-codemod button-destructive <target>`.

See https://github.com/Sage/carbon-codemod for more information.
```



### Current behaviour
These changes have already been made to support the new interface. Currently both
`<Button buttonType="destructive"/>` and `<Button buttonType="primary" destructive />` will display a destructive button.
![image](https://user-images.githubusercontent.com/2328042/77639531-d16efc80-6f50-11ea-8ac7-ad8298b6f6ae.png)


### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
<del>- [ ] Cypress automation tests
<del>- [ ] Storybook added or updated
<del>- [ ] Theme support
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

- https://github.com/Sage/carbon/releases/tag/v13.12.0
- #2713

### Testing instructions
<!-- How can a reviewer test this PR? -->
- Edit `src/components/button/button.stories.mdx`

```diff
 <Preview>
   <Story name="primary/destructive" parameters={{ info: { disable: true }}} >
     <>
       <Button buttonType="primary" destructive size="small">Small</Button>
-      <Button buttonType="primary" destructive >Medium</Button>
+      <Button buttonType="destructive">Medium</Button>
       <Button buttonType="primary" destructive size="large">Large</Button>
     </>
   </Story>
 </Preview>
```

- `npm start`
- Go to http://localhost:9001/?path=/story/design-system-button--primary-destructive
- A prop type validation error will be displayed in the console and the button will not have the destructive styling.


![image](https://user-images.githubusercontent.com/2328042/77641691-5c052b00-6f54-11ea-92be-1b092e741249.png)


There are unit tests for this change, there is no need for a cypress test.

