### PR TITLE
docs(fieldset): add address fieldset examples (FE-2633)

### DIFF
--- a/src/__experimental__/components/fieldset/fieldset-examples.stories.mdx
+++ b/src/__experimental__/components/fieldset/fieldset-examples.stories.mdx
@@ -1,0 +1,272 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+
+import Fieldset from './';
+import { RadioButton, RadioButtonGroup } from '../radio-button';
+import { Select, Option } from '../select';
+import Textbox from '../textbox';
+
+<Meta
+  title="Design System/Fieldset/Address Fieldset Examples"
+  parameters={{ info: { disable: true }}}
+/>
+
+### Canada
+Address Fieldset for Canada.
+<Preview>
+  <Story name="Canada">
+    <Fieldset>
+      <Textbox
+        label='Address line 1'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='Address line 2'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='Town/City'
+        labelInline
+        labelAlign='right'
+      />
+      <Select
+        label='Province'
+        labelInline
+        labelAlign='right'
+      >
+        <Option
+          key='ab'
+          text='Alberta'
+          value='ab'
+        />
+        <Option
+          key='on'
+          text='Ontario'
+          value='on'
+        />
+        <Option
+          key='qc'
+          text='Quebec'
+          value='qc'
+        />
+      </Select>
+      <Textbox
+        label='ZIP Code'
+        labelInline
+        labelAlign='right'
+        styleOverride={ { input: { width: '120px', flex: 'none' } } }
+      />
+    </Fieldset>
+  </Story>
+</Preview>
+
+### EU
+Address Fieldset for EU.
+<Preview>
+  <Story name="EU">
+    <Fieldset>
+      <Textbox
+        label='Address line 1'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='Address line 2'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='Postal Code'
+        labelInline
+        labelAlign='right'
+        styleOverride={ { input: { width: '120px', flex: 'none' } } }
+      />
+      <Textbox
+        label='Town/City'
+        labelInline
+        labelAlign='right'
+      />
+      <Select
+        label='Country'
+        labelInline
+        labelAlign='right'
+      >
+        <Option
+          key='dk'
+          text='Denmark'
+          value='dk'
+        />
+        <Option
+          key='fr'
+          text='France'
+          value='fr'
+        />
+        <Option
+          key='de'
+          text='Germany'
+          value='de'
+        />
+        <Option
+          key='es'
+          text='Spain'
+          value='es'
+        />
+      </Select>
+    </Fieldset>
+  </Story>
+</Preview>
+
+### UK and Ireland
+Address Fieldset for UK and Ireland.
+<Preview>
+  <Story name="UK and Ireland">
+    <Fieldset>
+      <Textbox
+        label='Address line 1'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='Address line 2'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='Town/City'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='County'
+        labelInline
+        labelAlign='right'
+      />
+      <Select
+        label='Country'
+        labelInline
+        labelAlign='right'
+        defaultValue='uk'
+      >
+          <Option
+            key='uk'
+            text='United Kingdom'
+            value='uk'
+          />
+          <Option
+            key='irl'
+            text='Ireland'
+            value='irl'
+          />
+      </Select>
+      <Textbox
+        label='Postcode'
+        labelInline
+        labelAlign='right'
+        styleOverride={ { input: { width: '120px', flex: 'none' } } }
+      />
+    </Fieldset>
+  </Story>
+</Preview>
+
+### United States
+Address Fieldset for United States.
+<Preview>
+  <Story name="United States">
+    <Fieldset>
+      <Textbox
+        label='Address line 1'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='Address line 2'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='Town/City'
+        labelInline
+        labelAlign='right'
+      />
+      <Select
+        label='State'
+        labelInline
+        labelAlign='right'
+      >
+        <Option
+          key='ca'
+          text='California'
+          value='ca'
+        />
+        <Option
+          key='ny'
+          text='New York'
+          value='ny'
+        />
+        <Option
+          key='tx'
+          text='Texas'
+          value='tx'
+        />
+      </Select>
+      <Textbox
+        label='ZIP Code'
+        labelInline
+        labelAlign='right'
+        styleOverride={ { input: { width: '120px', flex: 'none' } } }
+      />
+    </Fieldset>
+  </Story>
+</Preview>
+
+### Other
+Address Fieldset for other countries.
+<Preview>
+  <Story name="Other">
+    <Fieldset>
+      <Textbox
+        label='Address line 1'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='Address line 2'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='Town/City'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='Province / State'
+        labelInline
+        labelAlign='right'
+      />
+      <Textbox
+        label='Postal Code'
+        labelInline
+        labelAlign='right'
+        styleOverride={ { input: { width: '120px', flex: 'none' } } }
+      />
+      <Select
+        label='Country'
+        labelInline
+        labelAlign='right'
+      >
+        <Option
+          key='au'
+          text='Australia'
+          value='au'
+        />
+        <Option
+          key='cn'
+          text='China'
+          value='cn'
+        />
+      </Select>
+    </Fieldset>
+  </Story>
+</Preview>


### PR DESCRIPTION
### Proposed behaviour
Examples of address filedsets for various regions.

![image](https://user-images.githubusercontent.com/22885392/77653670-53225280-6f70-11ea-8ffb-1140e98cd16f.png)

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
~~- [ ] Unit tests~~
~~- [ ] Cypress automation tests~~
- [x] Storybook added or updated
~~- [ ] Theme support~~
~~- [ ] Typescript `d.ts` file added or updated~~

### Additional context
Required as part of Address Fieldset Story

### Testing instructions
* npm start
* Go to http://localhost:9001/?path=/docs/design-system-fieldset-address-fieldset-examples--canada