### PR TITLE
fix(input): add null check to input focus handler

### DIFF
--- a/src/__experimental__/components/input/input.component.js
+++ b/src/__experimental__/components/input/input.component.js
@@ -102,13 +102,15 @@ Input.defaultProps = {
 function selectTextOnFocus(input) {
   // setTimeout is required so the dom has a chance to place the cursor in the input
   setTimeout(() => {
-    const { length } = input.current.value;
-    const cursorStart = input.current.selectionStart;
-    const cursorEnd = input.current.selectionEnd;
-    // only select text if cursor is at the very end or the very start of the value
-    if ((cursorStart === 0 && cursorEnd === 0) || (cursorStart === length && cursorEnd === length)) {
-      if (document.activeElement === input.current) {
-        input.current.setSelectionRange(0, length);
+    if (input.current) {
+      const { length } = input.current.value;
+      const cursorStart = input.current.selectionStart;
+      const cursorEnd = input.current.selectionEnd;
+      // only select text if cursor is at the very end or the very start of the value
+      if ((cursorStart === 0 && cursorEnd === 0) || (cursorStart === length && cursorEnd === length)) {
+        if (document.activeElement === input.current) {
+          input.current.setSelectionRange(0, length);
+        }
       }
     }
   });

--- a/src/__experimental__/components/input/input.spec.js
+++ b/src/__experimental__/components/input/input.spec.js
@@ -103,6 +103,9 @@ describe('Input', () => {
   });
 
   describe('select text on focus', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
     const focusWith = (value, leftPos, rightPos) => {
       jest.useFakeTimers();
       const wrapper = renderMount({ value });
@@ -130,6 +133,14 @@ describe('Input', () => {
     it('does not select the text if focus is applied inside of the value', () => {
       const inputElement = focusWith('hello', 4, 4);
       expect(inputElement.setSelectionRange).not.toHaveBeenCalled();
+    });
+
+    it('should not break when unmounted right after receiving focus', () => {
+      jest.useFakeTimers();
+      const wrapper = renderMount();
+      wrapper.find('input').simulate('focus');
+      wrapper.unmount();
+      jest.runAllTimers();
     });
   });
 


### PR DESCRIPTION
### Proposed behaviour
The input component should not break when it receives focus and rerenders.

### Current behaviour
If the component re renders too quickly after receiving focus, it may break due to a missing null check.

### Checklist

- [X] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [X] Unit tests
<del>- [ ] Cypress automation tests</del>
<del>- [ ] Storybook added or updated</del>
<del>- [ ] Theme support</del>
<del>- [ ] Typescript `d.ts` file added or updated</del>
