### PR TITLE
fix(icon-button): hover background over focus outline (FE-2634)

### DIFF
--- a/src/components/batch-selection/__snapshots__/batch-selection.spec.js.snap
+++ b/src/components/batch-selection/__snapshots__/batch-selection.spec.js.snap
@@ -50,6 +50,7 @@ exports[`BatchSelection component should render correctly 1`] = `
   color: rgba(0,0,0,0.9);
   background-color: transparent;
   outline: solid 3px #FFB500;
+  z-index: 1;
 }
 
 .c3:hover {

--- a/src/components/icon-button/icon-button.style.js
+++ b/src/components/icon-button/icon-button.style.js
@@ -13,6 +13,7 @@ const StyledIconButton = styled.button`
       color: ${theme.text.color};
       background-color: transparent;
       outline: solid 3px ${theme.colors.focus};
+      z-index: 1;
     }
   `}
 


### PR DESCRIPTION
### Proposed behaviour
Change z-index of focused Icon Button to render over it's siblings.
![image](https://user-images.githubusercontent.com/22885392/77747909-be772d80-701f-11ea-93d8-12c7e42c3ab3.png)


### Current behaviour
When there is multiple icon buttons next to each other, one is focused, hovering over adjacent buttons their background will cover the focus outline.
![image](https://user-images.githubusercontent.com/22885392/77747777-82dc6380-701f-11ea-8853-3d301868e90f.png)


### Checklist
- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
~~- [ ] Unit tests~~
~~- [ ] Cypress automation tests~~
~~- [ ] Storybook added or updated~~
~~- [ ] Theme support~~
~~- [ ] Typescript `d.ts` file added or updated~~

### Testing instructions
* npm start
* Go to http://localhost:9001/?path=/docs/design-system-batch-selection--basic
* Focus on one of the Icon Buttons and hover over another
