### PR TITLE
ci: add codesandbox configuration

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,0 +1,4 @@
+{
+  "sandboxes": ["carbon-quickstart-xi5jc"],
+  "buildCommand": "precompile"
+}


### PR DESCRIPTION
### Proposed behaviour
Add a configuration for CodeSandbox CI in preparation for enabling https://codesandbox.io/docs/ci

### Current behaviour
CodeSandbox CI is not enabled.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>- [ ] Unit tests
<del>- [ ] Cypress automation tests
<del>- [ ] Storybook added or updated
<del>- [ ] Theme support
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
There is no way to test this configuration yet. However, I have tested it on a clone of carbon and it worked successfully.
