### PR TITLE
feat(button): add support for style override object

### DIFF
--- a/src/__deprecated__/components/form/__snapshots__/form.spec.js.snap
+++ b/src/__deprecated__/components/form/__snapshots__/form.spec.js.snap
@@ -45,7 +45,6 @@ exports[`Form When child is an html element it renders the child 1`] = `
   padding-bottom: 1px;
   -webkit-text-decoration: none;
   text-decoration: none;
-  margin-right: 16px;
   background: transparent;
   border-color: #26A826;
   color: #26A826;
@@ -57,6 +56,10 @@ exports[`Form When child is an html element it renders the child 1`] = `
 
 .c5:focus {
   outline: solid 3px #FFB500;
+}
+
+.c5 ~ .c4 {
+  margin-left: 16px;
 }
 
 .c5:hover {
@@ -107,7 +110,6 @@ exports[`Form When child is an html element it renders the child 1`] = `
   padding-bottom: 1px;
   -webkit-text-decoration: none;
   text-decoration: none;
-  margin-right: 16px;
   background: #26A826;
   border-color: transparent;
   color: #FFFFFF;
@@ -119,6 +121,10 @@ exports[`Form When child is an html element it renders the child 1`] = `
 
 .c8:focus {
   outline: solid 3px #FFB500;
+}
+
+.c8 ~ .c4 {
+  margin-left: 16px;
 }
 
 .c8:hover {

--- a/src/__experimental__/components/form/__snapshots__/form.spec.js.snap
+++ b/src/__experimental__/components/form/__snapshots__/form.spec.js.snap
@@ -29,7 +29,6 @@ exports[`Form When child is an html element it renders the child 1`] = `
   padding-bottom: 1px;
   -webkit-text-decoration: none;
   text-decoration: none;
-  margin-right: 16px;
   background: transparent;
   border-color: #26A826;
   color: #26A826;
@@ -43,23 +42,27 @@ exports[`Form When child is an html element it renders the child 1`] = `
   outline: solid 3px #FFB500;
 }
 
+.c6 ~ .c5 {
+  margin-left: 16px;
+}
+
 .c6:hover {
   background: #006300;
   border-color: #006300;
   color: #FFFFFF;
 }
 
-.c6:hover .c20 {
+.c6:hover .c21 {
   color: #FFFFFF;
 }
 
-.c6 .c20 {
+.c6 .c21 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c6 .c20 svg {
+.c6 .c21 svg {
   margin-top: 0;
 }
 
@@ -91,7 +94,6 @@ exports[`Form When child is an html element it renders the child 1`] = `
   padding-bottom: 1px;
   -webkit-text-decoration: none;
   text-decoration: none;
-  margin-right: 16px;
   background: #26A826;
   border-color: transparent;
   color: #FFFFFF;
@@ -105,18 +107,26 @@ exports[`Form When child is an html element it renders the child 1`] = `
   outline: solid 3px #FFB500;
 }
 
+.c9 ~ .c5 {
+  margin-left: 16px;
+}
+
 .c9:hover {
   background: #006300;
 }
 
-.c9 .c20 {
+.c9 .c21 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c9 .c20 svg {
+.c9 .c21 svg {
   margin-top: 0;
+}
+
+.c10 ~ .c5 {
+  margin-left: 16px;
 }
 
 .c8 {
@@ -133,14 +143,6 @@ exports[`Form When child is an html element it renders the child 1`] = `
   margin: -8px;
   white-space: nowrap;
   padding: 8px;
-}
-
-.c10.c10 .c5 {
-  margin-left: 0px;
-}
-
-.c10.c10 .c5:first-child {
-  margin-left: 0;
 }
 
 .c11.c11 .c5 {
@@ -167,6 +169,14 @@ exports[`Form When child is an html element it renders the child 1`] = `
   margin-left: 0;
 }
 
+.c14.c14 .c5 {
+  margin-left: 0px;
+}
+
+.c14.c14 .c5:first-child {
+  margin-left: 0;
+}
+
 .c4 {
   margin: 20px auto 0 auto;
   max-width: inherit;
@@ -190,16 +200,8 @@ exports[`Form When child is an html element it renders the child 1`] = `
   margin-left: 16px;
 }
 
-.c4 .c21:first-of-type {
+.c4 .c22:first-of-type {
   margin-left: 0;
-}
-
-.c14 div:first-of-type .c5 {
-  margin-left: 0;
-}
-
-.c14.c14 .c7 .c5 {
-  margin-left: 16px;
 }
 
 .c15 div:first-of-type .c5 {
@@ -207,6 +209,14 @@ exports[`Form When child is an html element it renders the child 1`] = `
 }
 
 .c15.c15 .c7 .c5 {
+  margin-left: 16px;
+}
+
+.c16 div:first-of-type .c5 {
+  margin-left: 0;
+}
+
+.c16.c16 .c7 .c5 {
   margin-left: 15px;
 }
 
@@ -221,7 +231,7 @@ exports[`Form When child is an html element it renders the child 1`] = `
   justify-content: flex-end;
 }
 
-.c16 .c5 {
+.c17 .c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -245,24 +255,12 @@ exports[`Form When child is an html element it renders the child 1`] = `
   margin-left: 16px;
 }
 
-.c0.c0 .c19 {
+.c0.c0 .c20 {
   margin-bottom: 32px;
 }
 
 .c0 [data-component='icon'].common-input__icon {
   height: 19px;
-}
-
-.c17 .c5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  margin-left: 15px;
 }
 
 .c18 .c5 {
@@ -277,7 +275,19 @@ exports[`Form When child is an html element it renders the child 1`] = `
   margin-left: 15px;
 }
 
-.c18 .c1 {
+.c19 .c5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-left: 15px;
+}
+
+.c19 .c1 {
   -webkit-animation: lhSDYf 0.25s ease-out;
   animation: lhSDYf 0.25s ease-out;
   background-color: #FFFFFF;
@@ -292,7 +302,7 @@ exports[`Form When child is an html element it renders the child 1`] = `
   z-index: 1000;
 }
 
-.c18 .c1 .c3 {
+.c19 .c1 .c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/src/components/button/__snapshots__/button.spec.js.snap
+++ b/src/components/button/__snapshots__/button.spec.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button when only the "iconPosition" and "iconType" props are passed into the component renders the default props and children to match the snapshot with the Icon after children 1`] = `
-.c2 {
+.c3 {
   display: inline-block;
   position: relative;
   color: #26A826;
   background-color: transparent;
 }
 
-.c2:hover {
+.c3:hover {
   color: #1E861E;
   background-color: transparent;
 }
 
-.c2::before {
+.c3::before {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-family: CarbonIcons;
@@ -26,21 +26,25 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   display: block;
 }
 
-.c3:hover .c1 {
+.c4 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c4:hover .c2 {
   color: #FFFFFF;
 }
 
-.c3 .c1 {
+.c4 .c2 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c3 .c1 svg {
+.c4 .c2 svg {
   margin-top: 0;
 }
 
-.c0 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -68,7 +72,6 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   padding-bottom: 1px;
   -webkit-text-decoration: none;
   text-decoration: none;
-  margin-right: 16px;
   background: transparent;
   border-color: #26A826;
   color: #26A826;
@@ -78,32 +81,36 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   padding-right: 24px;
 }
 
-.c0:focus {
+.c1:focus {
   outline: solid 3px #FFB500;
 }
 
-.c0:hover {
+.c1 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c1:hover {
   background: #006300;
   border-color: #006300;
   color: #FFFFFF;
 }
 
-.c0:hover .c1 {
+.c1:hover .c2 {
   color: #FFFFFF;
 }
 
-.c0 .c1 {
+.c1 .c2 {
   margin-left: 8px;
   margin-right: 0px;
   height: 16px;
 }
 
-.c0 .c1 svg {
+.c1 .c2 svg {
   margin-top: 0;
 }
 
 <button
-  className="c0"
+  className="c0 c1"
   data-component="button"
   disabled={false}
   role="button"
@@ -118,7 +125,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
     </span>
   </span>
   <span
-    className="c1 c2"
+    className="c2 c3"
     data-component="icon"
     data-element="filter"
     disabled={false}
@@ -129,19 +136,19 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 `;
 
 exports[`Button when only the "iconPosition" and "iconType" props are passed into the component renders the default props and children to match the snapshot with the Icon before children 1`] = `
-.c2 {
+.c3 {
   display: inline-block;
   position: relative;
   color: #26A826;
   background-color: transparent;
 }
 
-.c2:hover {
+.c3:hover {
   color: #1E861E;
   background-color: transparent;
 }
 
-.c2::before {
+.c3::before {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-family: CarbonIcons;
@@ -154,7 +161,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   display: block;
 }
 
-.c0 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -182,7 +189,6 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   padding-bottom: 1px;
   -webkit-text-decoration: none;
   text-decoration: none;
-  margin-right: 16px;
   background: transparent;
   border-color: #26A826;
   color: #26A826;
@@ -192,32 +198,36 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   padding-right: 24px;
 }
 
-.c0:focus {
+.c1:focus {
   outline: solid 3px #FFB500;
 }
 
-.c0:hover {
+.c1 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c1:hover {
   background: #006300;
   border-color: #006300;
   color: #FFFFFF;
 }
 
-.c0:hover .c1 {
+.c1:hover .c2 {
   color: #FFFFFF;
 }
 
-.c0 .c1 {
+.c1 .c2 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c0 .c1 svg {
+.c1 .c2 svg {
   margin-top: 0;
 }
 
 <button
-  className="c0"
+  className="c0 c1"
   data-component="button"
   disabled={false}
   role="button"
@@ -225,7 +235,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   type="button"
 >
   <span
-    className="c1 c2"
+    className="c2 c3"
     data-component="icon"
     data-element="filter"
     disabled={false}

--- a/src/components/button/button.component.js
+++ b/src/components/button/button.component.js
@@ -42,6 +42,7 @@ function renderStyledButton(buttonProps) {
     theme,
     forwardRef,
     href,
+    styleOverride,
     ...styleProps
   } = buttonProps;
 
@@ -61,6 +62,7 @@ function renderStyledButton(buttonProps) {
       { ...tagComponent('button', buttonProps) }
       { ...styleProps }
       ref={ forwardRef }
+      styleOverride={ styleOverride }
     >
       { renderChildren(buttonProps) }
     </StyledButton>
@@ -88,7 +90,13 @@ function renderChildren({
         />) }
       <span>
         <span data-element='main-text'>{ children }</span>
-        { size === 'large' && <StyledButtonSubtext data-element='subtext'>{ subtext }</StyledButtonSubtext> }
+        { size === 'large' && (
+          <StyledButtonSubtext
+            data-element='subtext'
+          >
+            { subtext }
+          </StyledButtonSubtext>
+        )}
       </span>
       { iconType && iconPosition === 'after' && (
         <Icon
@@ -122,11 +130,15 @@ Button.propTypes = {
   forwardRef: PropTypes.func,
   /** Button types for legacy theme: "primary" | "secondary" */
   as: PropTypes.oneOf(OptionsHelper.themesBinary),
-  /** Legacy - used to transfrom button into anchor */
+  /** Legacy - used to transform button into anchor */
   href: PropTypes.string,
-  /** Legacy - used to transfrom button into anchor */
-  to: PropTypes.string
-
+  /** Legacy - used to transform button into anchor */
+  to: PropTypes.string,
+  /** Allows override of existing component styles */
+  styleOverride: PropTypes.shape({
+    root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    icon: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+  })
 };
 
 Button.defaultProps = {
@@ -135,7 +147,8 @@ Button.defaultProps = {
   disabled: false,
   destructive: false,
   iconPosition: 'before',
-  subtext: ''
+  subtext: '',
+  styleOverride: { root: {}, icon: {} }
 };
 
 const ButtonWithForwardRef = React.forwardRef((props, ref) => <Button forwardRef={ ref } { ...props } />);

--- a/src/components/button/button.d.ts
+++ b/src/components/button/button.d.ts
@@ -5,6 +5,10 @@ export interface ButtonProps {
   size?: 'small' | 'medium' | 'large';
   subtext?: string;
   children?: React.ReactNode;
+  styleOverride?: {
+    root?: () => object | object;
+    icon?: () => object | object;
+   };
 }
 declare const Button: React.ComponentType<ButtonProps & React.HTMLProps<HTMLButtonElement>>;
 export default Button;

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -393,4 +393,53 @@ describe('Button', () => {
       }, buttonWithServiceIcon.toJSON(), { modifier: `${StyledIcon}` });
     });
   });
+
+  describe('when a style override object is passed in', () => {
+    it('matches the expected styling for the button', () => {
+      const styleOverride = {
+        root: {
+          padding: '10px',
+          color: 'pink',
+          '&:focus': {
+            outlineWidth: '2px'
+          }
+        }
+      };
+      const wrapper = render(
+        { children: 'foo', styleOverride }, TestRenderer.create
+      );
+      assertStyleMatch({
+        height: '40px',
+        padding: '10px',
+        color: 'pink'
+      }, wrapper.toJSON());
+
+      assertStyleMatch({
+        outlineWidth: '2px'
+      }, wrapper.toJSON(), { modifier: ':focus' });
+    });
+
+    it('matches the expected styling for the icon', () => {
+      const styleOverride = {
+        icon: {
+          color: 'pink',
+          '&:focus': {
+            outlineWidth: '2px'
+          }
+        }
+      };
+      const wrapper = render(
+        { children: 'foo', styleOverride }, TestRenderer.create
+      );
+
+      assertStyleMatch({
+        height: '16px',
+        color: 'pink'
+      }, wrapper.toJSON(), { modifier: `${StyledIcon}` });
+
+      assertStyleMatch({
+        outlineWidth: '2px'
+      }, wrapper.toJSON(), { modifier: `${StyledIcon}:focus` });
+    });
+  });
 });

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -148,4 +148,16 @@ Tertiary buttons can have an icon positioned before or after the text.
   </Story>
 </Preview>
 
+## With overriden styles
+It is possible to override the default styles of a Button by passing in a styleOverride object as a prop. 
+See the prop types for how this object should be formatted.
+<Preview>
+  <Story name="with overriden styles" parameters={{ info: { disable: true }}} >
+  <>
+    <Button buttonType="primary" iconType="print" styleOverride={ {root: { color: 'pink' }, icon : { color: 'pink' }} }>Pink Text</Button>
+    <Button buttonType="secondary" iconType="email" iconPosition="after" styleOverride={ {root: { color: 'purple' }, icon : { color: 'purple' }} }>Purple Text</Button>
+    </>
+  </Story>
+</Preview>
+
 <Props of={Button} />

--- a/src/components/button/button.style.js
+++ b/src/components/button/button.style.js
@@ -16,16 +16,19 @@ const StyledButton = styled.button`
   vertical-align: middle;
   ${stylingForType}
 
-  ${({ iconPosition }) => css`
+  ${({ iconPosition, theme }) => css`
     ${StyledIcon} {
-      margin-left: ${iconPosition === 'before' ? '0px' : '8px'};
-      margin-right: ${iconPosition === 'before' ? '8px' : '0px'};
+      margin-left: ${iconPosition === 'before' ? '0px' : `${theme.spacing}px`};
+      margin-right: ${iconPosition === 'before' ? `${theme.spacing}px` : '0px'};
       height: ${additionalIconStyle};
       svg { 
         margin-top: 0;
       }
+      ${({ styleOverride }) => styleOverride.icon}
     }
   `}
+
+  ${({ styleOverride }) => styleOverride.root}
 `;
 
 export const StyledButtonSubtext = styled.span`
@@ -56,9 +59,10 @@ function stylingForType({
     &:focus {
       outline: solid 3px ${theme.colors.focus};
     }
-    
-    margin-right: 16px;
 
+    & ~ & {
+      margin-left: 16px;
+    }
     ${buttonTypes(theme, disabled, destructive)[buttonType]};
     ${buttonSizes(theme)[size]}
   `;
@@ -67,7 +71,8 @@ function stylingForType({
 StyledButton.defaultProps = {
   theme: BaseTheme,
   medium: true,
-  buttonType: 'secondary'
+  buttonType: 'secondary',
+  styleOverride: { root: {}, icon: {} }
 };
 
 StyledButton.propTypes = {
@@ -88,7 +93,11 @@ StyledButton.propTypes = {
   /** Second text child, renders under main text, only when size is "large" */
   subtext: PropTypes.string,
   /** Used to transform button into anchor */
-  to: PropTypes.string
+  to: PropTypes.string,
+  styleOverride: PropTypes.shape({
+    root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    icon: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+  })
 };
 
 export default StyledButton;

--- a/src/components/button/docgenInfo.json
+++ b/src/components/button/docgenInfo.json
@@ -12,7 +12,7 @@
             "value": "OptionsHelper.buttonTypes"
           },
           "required": false,
-          "description": "Color variants for new business themes: \"primary\" | \"secondary\" | \"tertiary\" | \"destructive\" | \"darkBackground\""
+          "description": "Color variants for new business themes: \"primary\" | \"secondary\" | \"tertiary\" | \"darkBackground\""
         },
         "children": {
           "type": {
@@ -27,6 +27,17 @@
           },
           "required": false,
           "description": "Apply disabled state to the button",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        },
+        "destructive": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Apply destructive style to the button",
           "defaultValue": {
             "value": "false",
             "computed": false
@@ -110,39 +121,56 @@
             "computed": false
           }
         },
-        "theme": {
-          "type": {
-            "name": "enum",
-            "computed": true,
-            "value": "OptionsHelper.buttonColors"
-          },
-          "required": false,
-          "description": "Set this prop to pass in legacy theme color variants",
-          "defaultValue": {
-            "value": "'blue'",
-            "computed": false
-          }
-        },
-        "checkTheme": {
-          "type": {
-            "name": "func"
-          },
-          "required": false,
-          "description": ""
-        },
         "href": {
           "type": {
             "name": "string"
           },
           "required": false,
-          "description": "Legacy - used to transfrom button into anchor"
+          "description": "Legacy - used to transform button into anchor"
         },
         "to": {
           "type": {
             "name": "string"
           },
           "required": false,
-          "description": "Legacy - used to transfrom button into anchor"
+          "description": "Legacy - used to transform button into anchor"
+        },
+        "styleOverride": {
+          "type": {
+            "name": "shape",
+            "value": {
+              "root": {
+                "name": "union",
+                "value": [
+                  {
+                    "name": "func"
+                  },
+                  {
+                    "name": "object"
+                  }
+                ],
+                "required": false
+              },
+              "icon": {
+                "name": "union",
+                "value": [
+                  {
+                    "name": "func"
+                  },
+                  {
+                    "name": "object"
+                  }
+                ],
+                "required": false
+              }
+            }
+          },
+          "required": false,
+          "description": "Allows override of existing component styles",
+          "defaultValue": {
+            "value": "{ root: {}, icon: {} }",
+            "computed": false
+          }
         }
       }
     },
@@ -154,6 +182,11 @@
     {
       "description": "",
       "displayName": "renderChildren",
+      "methods": []
+    },
+    {
+      "description": "",
+      "displayName": "Button",
       "methods": []
     }
   ]

--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.js.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.js.snap
@@ -54,7 +54,6 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
   padding-bottom: 1px;
   -webkit-text-decoration: none;
   text-decoration: none;
-  margin-right: 16px;
   background: transparent;
   border-color: #26A826;
   color: #26A826;
@@ -66,6 +65,10 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
 
 .c3:focus {
   outline: solid 3px #FFB500;
+}
+
+.c3 ~ .c2 {
+  margin-left: 16px;
 }
 
 .c3:hover {

--- a/src/components/split-button/__snapshots__/split-button.spec.js.snap
+++ b/src/components/split-button/__snapshots__/split-button.spec.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SplitButton for business themes renders styles correctly 1`] = `
-.c5 {
+.c6 {
   display: inline-block;
   position: relative;
   color: #26A826;
   background-color: transparent;
 }
 
-.c5:hover {
+.c6:hover {
   color: #1E861E;
   background-color: transparent;
 }
 
-.c5::before {
+.c6::before {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-family: CarbonIcons;
@@ -26,17 +26,21 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   display: block;
 }
 
-.c6:hover .c4 {
+.c7 ~ .c1 {
+  margin-left: 16px;
+}
+
+.c7:hover .c5 {
   color: #FFFFFF;
 }
 
-.c6 .c4 {
+.c7 .c5 {
   margin-left: 8px;
   margin-right: 0px;
   height: 16px;
 }
 
-.c6 .c4 svg {
+.c7 .c5 svg {
   margin-top: 0;
 }
 
@@ -68,7 +72,6 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   padding-bottom: 1px;
   -webkit-text-decoration: none;
   text-decoration: none;
-  margin-right: 16px;
   background: transparent;
   border-color: #26A826;
   color: #26A826;
@@ -82,23 +85,27 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   outline: solid 3px #FFB500;
 }
 
+.c2 ~ .c1 {
+  margin-left: 16px;
+}
+
 .c2:hover {
   background: #006300;
   border-color: #006300;
   color: #FFFFFF;
 }
 
-.c2:hover .c4 {
+.c2:hover .c5 {
   color: #FFFFFF;
 }
 
-.c2 .c4 {
+.c2 .c5 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c2 .c4 svg {
+.c2 .c5 svg {
   margin-top: 0;
 }
 
@@ -117,7 +124,7 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   margin: -1px;
 }
 
-.c3 {
+.c4 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -145,7 +152,6 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   padding-bottom: 1px;
   -webkit-text-decoration: none;
   text-decoration: none;
-  margin-right: 16px;
   background: transparent;
   border-color: #26A826;
   color: #26A826;
@@ -157,43 +163,47 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   padding: 0 10px;
 }
 
-.c3:focus {
+.c4:focus {
   outline: solid 3px #FFB500;
 }
 
-.c3:hover {
+.c4 ~ .c3 {
+  margin-left: 16px;
+}
+
+.c4:hover {
   background: #006300;
   border-color: #006300;
   color: #FFFFFF;
 }
 
-.c3:hover .c4 {
+.c4:hover .c5 {
   color: #FFFFFF;
 }
 
-.c3 .c4 {
+.c4 .c5 {
   margin-left: 8px;
   margin-right: 0px;
   height: 16px;
 }
 
-.c3 .c4 svg {
+.c4 .c5 svg {
   margin-top: 0;
 }
 
-.c1 + .c3 {
+.c1 + .c4 {
   margin-left: 0;
 }
 
-.c1 + .c3:focus {
+.c1 + .c4:focus {
   margin-left: -3px;
 }
 
-.c1 + .c3 .c4 {
+.c1 + .c4 .c5 {
   margin-left: 0;
 }
 
-.c7 .c1 {
+.c8 .c1 {
   background-color: #006045;
   border: 1px solid #006045;
   color: #FFFFFF;
@@ -205,16 +215,16 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   z-index: 10;
 }
 
-.c7 .c1:focus,
-.c7 .c1:hover {
+.c8 .c1:focus,
+.c8 .c1:hover {
   background-color: #003F2E;
 }
 
-.c7 .c1 + .c9 .c1 {
+.c8 .c1 + .c10 .c1 {
   margin-top: 3px;
 }
 
-.c8 .c1 {
+.c9 .c1 {
   background-color: #005B9A;
   border: 1px solid #005B9A;
   color: #FFFFFF;
@@ -226,12 +236,12 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   z-index: 10;
 }
 
-.c8 .c1:focus,
-.c8 .c1:hover {
+.c9 .c1:focus,
+.c9 .c1:hover {
   background-color: #004372;
 }
 
-.c8 .c1 + .c9 .c1 {
+.c9 .c1 + .c10 .c1 {
   margin-top: 3px;
 }
 
@@ -268,7 +278,7 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
     aria-expanded={false}
     aria-haspopup="true"
     aria-label="Show more"
-    className="c1 c3"
+    className="c1 c3 c4"
     data-element="toggle-button"
     disabled={false}
     onBlur={[Function]}
@@ -279,7 +289,7 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
     size="medium"
   >
     <span
-      className="c4 c5"
+      className="c5 c6"
       data-component="icon"
       data-element="dropdown"
       disabled={false}


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Add new `styleOverride` prop to allow consumers to override the default styling of Button

The way the margin is applied to a sibling button has also been updated to use `margin-left`

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Styles cannot be overriden.

All buttons have `margin-right`

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [ ] Cypress automation tests
- [x] Storybook added or updated
<del>- [ ] Theme support<del>
- [x] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
Ensure spacing is correct for buttons after `margin-right` was removed