### PR TITLE
feat(popover-container): support to be controlled and uncontrolled 

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -1,5 +1,6 @@
 {
   "story": "?path=/story/",
+  "docs": "?path=/docs/",
   "iframe": "iframe.html?id=",
   "with_button": "--with-button",
   "default_with_inputs": "--default-with-inputs",

--- a/cypress/features/regression/designSystem/popoverContainerDS.feature
+++ b/cypress/features/regression/designSystem/popoverContainerDS.feature
@@ -1,0 +1,54 @@
+Feature: Design System Popover container component
+  I want to test Design System Popover container component properties
+
+  Background: Open Design System Popover container component page
+    Given I open basic Design System "Popover container" component docs page
+
+  @positive
+  Scenario: Popover container is opened
+    When I open popover container in basic component
+    Then Popover container is visible
+
+  @positive
+  Scenario: Popover container is closed
+    Given I open popover container in basic component
+    When I click popover close icon
+    Then Popover container is not visible
+
+  @positive
+  Scenario Outline: Open Popover container is opened using <key> key
+    When I click onto popover setting icon using "<key>" key
+    Then Popover container is visible
+    Examples:
+      | key   |
+      | Enter |
+      | Space |
+
+  @positive
+  Scenario Outline: Open Popover container is closed using <key> key
+    Given I click onto popover setting icon using "<key>" key
+    When I press onto closeIcon using "<key>" key
+    Then Popover container is not visible
+    Examples:
+      | key   |
+      | Enter |
+      | Space |
+
+  @positive
+  Scenario: Popover container component is left aligned
+    # commented because of BDD default scenario Given - When - Then
+    # When I open basic Design System "Popover container" component docs page
+    Then opening icon is on the "left" side 
+      And Popover component is opened the "left" side
+
+  @positive
+  Scenario: Popover container component is right aligned
+    # commented because of BDD default scenario Given - When - Then
+    # When I open basic Design System "Popover container" component docs page
+    Then opening icon is on the "right" side 
+      And Popover component is opened the "right" side
+
+  @positive
+  Scenario: Verify open button is hide when the PopoverContainer is open
+    When I open popover container in open component
+    Then opening icon is hide

--- a/cypress/features/regression/test/popoverContainer.feature
+++ b/cypress/features/regression/test/popoverContainer.feature
@@ -6,12 +6,6 @@ Feature: Popover container component
       And I open popover container
 
   @positive
-  Scenario: Popover container is opened
-    # commented because of BDD default scenario Given - When - Then
-    # When I open popover container
-    Then Popover container is visible
-
-  @positive
   Scenario Outline: Change Popover container component title to <title>
     When I set title to "<title>"
     Then Popover title on preview is set to "<title>"
@@ -19,41 +13,5 @@ Feature: Popover container component
       | title                   |
       | mp150ú¿¡üßä             |
       | !@#$%^*()_+-=~[];:.,?{} |
-
-  @positive
-  Scenario: Popover container component iconType to add
-    When I select iconType to "add"
-    Then icon on preview is "add"
-
-  @positive
-  Scenario Outline: Popover container component position to <position>
-    When I select position to "<position>"
-    Then Popover component opened the "<position>" side
-    Examples:
-      | position |
-      | left     |
-      | right    |
-
-  @positive
-  Scenario: Popover container is closed
-    When I click popover close icon
-    Then Popover container is not visible
-
-  @positive
-  Scenario Outline: Popover container is opened using <key> key
-    Given I click popover close icon
-    When I click onto popover setting icon using "<key>" key
-    Then Popover container is visible
-    Examples:
-      | key   |
-      | Enter |
-      | Space |
-
-  @positive
-  Scenario Outline: Popover container is closed using <key> key
-    When I press onto closeIcon using "<key>" key
-    Then Popover container is not visible
-    Examples:
-      | key   |
-      | Enter |
-      | Space |
+  # @ignore because of FE-1447
+  # | <>                       |

--- a/cypress/locators/popover-container/index.js
+++ b/cypress/locators/popover-container/index.js
@@ -3,16 +3,24 @@ import {
   POPOVER_CONTAINER_CONTENT,
   POPOVER_CONTAINER_TITLE,
   POPOVER_SETTINGS_ICON,
-  POPOVER_CLOSE_ICON,
+  POPOVER_CONTAINER_BASIC_ID,
+  POPOVER_CONTAINER_RIGHT_ALIGNED_ID,
+  POPOVER_CONTENT_COVER_BUTTON_ID,
+  POPOVER_CONTENT_CLOSE_ICON,
 } from './locators';
 
-// component preview locators
-export const popoverContainerDataComponent = () => cy.iFrame(POPOVER_CONTAINER_DATA_COMPONENT);
+// DS locators
+export const popoverSettingsIconBasic = () => cy.iFrame(POPOVER_CONTAINER_BASIC_ID)
+  .find(POPOVER_CONTAINER_DATA_COMPONENT);
+export const popoverSettingsIconRightAligned = () => cy.iFrame(POPOVER_CONTAINER_RIGHT_ALIGNED_ID)
+  .find(POPOVER_CONTAINER_DATA_COMPONENT);
+export const popoverSettingsIconCover = () => cy.iFrame(POPOVER_CONTENT_COVER_BUTTON_ID)
+  .find(POPOVER_SETTINGS_ICON);
 export const popoverContainerContent = () => cy.iFrame(POPOVER_CONTAINER_CONTENT);
+export const popoverCloseIcon = () => cy.iFrame(POPOVER_CONTENT_CLOSE_ICON);
+
+// component preview locators
 export const popoverContainerTitle = () => cy.iFrame(POPOVER_CONTAINER_TITLE);
-export const popoverContainerContentFirstInnerElement = () => popoverContainerContent().children()
-  .find('div');
 export const popoverContainerContentSecondInnerElement = () => popoverContainerContent().children()
   .find('button');
-export const popoverSettingsIcon = () => cy.iFrame(POPOVER_SETTINGS_ICON);
-export const popoverCloseIcon = () => cy.iFrame(POPOVER_CLOSE_ICON);
+export const popoverContainerDataComponent = () => cy.iFrame(POPOVER_CONTAINER_DATA_COMPONENT);

--- a/cypress/locators/popover-container/locators.js
+++ b/cypress/locators/popover-container/locators.js
@@ -3,4 +3,9 @@ export const POPOVER_CONTAINER_DATA_COMPONENT = '[data-component="popover-contai
 export const POPOVER_CONTAINER_CONTENT = '[data-element="popover-container-content"]';
 export const POPOVER_CONTAINER_TITLE = '[data-element="popover-container-title"]';
 export const POPOVER_SETTINGS_ICON = '[data-element="settings"]';
-export const POPOVER_CLOSE_ICON = '[data-element="popover-container-close-icon"]';
+
+// Docs locators
+export const POPOVER_CONTAINER_BASIC_ID = '[id="story--design-system-popover-container--basic"]';
+export const POPOVER_CONTAINER_RIGHT_ALIGNED_ID = '[id="story--design-system-popover-container--position"]';
+export const POPOVER_CONTENT_COVER_BUTTON_ID = '[id="story--design-system-popover-container--cover-button"]';
+export const POPOVER_CONTENT_CLOSE_ICON = '[data-element="popover-container-close-component"]';

--- a/cypress/support/helper.js
+++ b/cypress/support/helper.js
@@ -4,17 +4,21 @@ import {
 import { DEBUG_FLAG } from '.';
 import { getElementNoIframe } from '../locators/build';
 
-function prepareUrl(component, suffix, iFrameOnly, prefix) {
+function prepareUrl(component, suffix, iFrameOnly, prefix, env) {
   let url = Cypress.config().baseUrl;
   const iFrame = Cypress.env('iframe') + prefix;
-  const story = Cypress.env('story') + prefix;
+  const story = Cypress.env(env) + prefix;
   // eslint-disable-next-line no-unused-expressions
   iFrameOnly ? url += iFrame : url += story;
   return url + component.toLowerCase().replace(/ /g, '-') + Cypress.env(suffix);
 }
 
-export function visitComponentUrl(component, suffix = 'default', iFrameOnly = false, prefix = '') {
-  cy.visit(prepareUrl(component, suffix, iFrameOnly, prefix));
+export function visitDocsUrl(component, suffix = 'default', iFrameOnly = false, prefix = '', env = 'docs') {
+  cy.visit(prepareUrl(component, suffix, iFrameOnly, prefix, env));
+}
+
+export function visitComponentUrl(component, suffix = 'default', iFrameOnly = false, prefix = '', env = 'story') {
+  cy.visit(prepareUrl(component, suffix, iFrameOnly, prefix, env));
   if (!iFrameOnly) knobsTab().click();
 }
 

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -1,6 +1,7 @@
 import {
   visitComponentUrl, setSlidebar, pressESCKey, pressTABKey, asyncWaitForKnobs,
   visitFlatTableComponentNoiFrame, positionOfElement, keyCode,
+  visitDocsUrl,
 } from '../helper';
 import {
   commonButtonPreview, labelPreview, helpIcon, helpIconByPosition, inputWidthSlider,
@@ -131,6 +132,10 @@ Given('I open sortable Test {string} component page in Iframe', (component) => {
 
 When('I open Test {string} component basic page with prop value', (componentName) => {
   visitFlatTableComponentNoiFrame(componentName, 'basic', true, 'test-');
+});
+
+Given('I open basic Design System {string} component docs page', (component) => {
+  visitDocsUrl(component, 'basic', false, 'design-system-');
 });
 
 Given('I open grouped Test {string} component page in noIframe', (component) => {

--- a/cypress/support/step-definitions/popover-container-steps.js
+++ b/cypress/support/step-definitions/popover-container-steps.js
@@ -1,40 +1,44 @@
 import {
-  popoverContainerDataComponent,
   popoverContainerContent,
   popoverContainerTitle,
-  popoverContainerContentFirstInnerElement,
   popoverContainerContentSecondInnerElement,
-  popoverSettingsIcon,
+  popoverSettingsIconBasic,
   popoverCloseIcon,
+  popoverSettingsIconRightAligned,
+  popoverSettingsIconCover,
+  popoverContainerDataComponent,
 } from '../../locators/popover-container';
 import { keyCode } from '../helper';
+
+When('I open popover container in basic component', () => {
+  popoverSettingsIconBasic().click();
+});
 
 When('I open popover container', () => {
   popoverContainerDataComponent().click();
 });
 
+When('I open popover container in open component', () => {
+  popoverSettingsIconCover().click();
+});
+
 Then('Popover container is visible', () => {
-  popoverContainerDataComponent().should('exist');
-  popoverSettingsIcon().should('exist');
-  popoverContainerContent().children().children().should('have.length', 2);
-  popoverContainerContent().should('have.css', 'background', 'rgb(255, 255, 255) none repeat scroll 0% 0% / auto padding-box border-box')
+  popoverContainerContent().should('exist');
+  popoverSettingsIconBasic().should('exist');
+  popoverContainerContent().should('be.visible');
+  popoverContainerContent().should('have.css', 'background-color', 'rgb(255, 255, 255)')
     .and('have.css', 'box-shadow', 'rgba(0, 20, 29, 0.2) 0px 5px 5px 0px, rgba(0, 20, 29, 0.1) 0px 10px 10px 0px')
     .and('have.css', 'padding', '16px 24px')
     .and('have.css', 'min-width', '300px')
     .and('have.css', 'position', 'absolute')
-    .and('have.css', 'top', '0px')
-    .and('have.css', 'opacity', '1')
-    .and('have.css', 'transform', 'matrix(1, 0, 0, 1, 0, 0)')
-    .and('have.css', 'transition', 'all 0.3s cubic-bezier(0.25, 0.25, 0, 1.5) 0s')
-    .and('be.visible');
-  popoverContainerContentFirstInnerElement().should('have.attr', 'data-element', 'popover-container-title').and('be.visible')
-    .and('have.css', 'font-size', '16px')
-    .and('have.css', 'font-weight', '700');
-  popoverContainerContentSecondInnerElement().should('have.attr', 'data-element', 'popover-container-close-icon')
+    .and('have.css', 'left', '0px')
+    .and('have.css', 'opacity', '1');
+  popoverContainerContentSecondInnerElement().should('have.attr', 'data-element', 'popover-container-close-component')
     .and('be.visible')
     .and('have.css', 'position', 'absolute')
-    .and('have.css', 'margin-right', '0px')
-    .and('have.css', 'background', 'rgba(0, 0, 0, 0) none repeat scroll 0% 0% / auto padding-box border-box')
+    .and('have.css', 'top', '16px')
+    .and('have.css', 'right', '24px')
+    .and('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
     .and('have.css', 'border', '0px none rgba(0, 0, 0, 0.9)')
     .and('have.css', 'padding', '0px');
   popoverContainerContentSecondInnerElement().children().should('have.attr', 'data-element', 'close').and('be.visible')
@@ -46,13 +50,22 @@ Then('Popover title on preview is set to {string}', (title) => {
   popoverContainerTitle().should('have.text', title);
 });
 
-Then('Popover component opened the {string} side', (side) => {
+Then('opening icon is on the {string} side', (side) => {
   if (side === 'left') {
-    popoverContainerDataComponent().parent().should('have.attr', 'style').should('contain', 'margin-left', '400px');
-    popoverContainerContent().should('have.css', 'right', '0px');
+    popoverSettingsIconBasic().parent().should('not.have.css', 'float', 'right');
   } else {
-    popoverContainerDataComponent().parent().should('not.have.attr', 'style');
-    popoverContainerContent().should('have.css', 'left', '0px');
+    popoverSettingsIconRightAligned().parent().should('have.css', 'float', 'right');
+    popoverSettingsIconRightAligned().children().should('have.attr', 'aria-label', 'Right Aligned');
+  }
+});
+
+Then('Popover component is opened the {string} side', (side) => {
+  if (side === 'left') {
+    popoverSettingsIconBasic().click();
+    popoverSettingsIconBasic().should('have.css', 'right', '0px');
+  } else {
+    popoverSettingsIconRightAligned().click();
+    popoverSettingsIconRightAligned().should('have.css', 'right', '0px');
   }
 });
 
@@ -61,7 +74,7 @@ Then('Popover container is not visible', () => {
 });
 
 When('I click onto popover setting icon using {string} key', (key) => {
-  popoverSettingsIcon().trigger('keydown', keyCode(key));
+  popoverSettingsIconBasic().trigger('keydown', keyCode(key));
 });
 
 Then('I press onto closeIcon using {string} key', (key) => {
@@ -70,4 +83,9 @@ Then('I press onto closeIcon using {string} key', (key) => {
 
 When('I click popover close icon', () => {
   popoverCloseIcon().click();
+});
+
+Then('opening icon is hide', () => {
+  popoverSettingsIconCover().parent().should('have.attr', 'tabindex', '-1');
+  popoverContainerContent().should('be.visible');
 });

--- a/src/components/popover-container/index.js
+++ b/src/components/popover-container/index.js
@@ -1,1 +1,1 @@
-export { default } from './settings-popover.component';
+export { default } from './popover-container.component';

--- a/src/components/popover-container/popover-container.component.js
+++ b/src/components/popover-container/popover-container.component.js
@@ -1,46 +1,81 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 import {
   PopoverContainerWrapperStyle,
-  PopoverContainerIcon,
   PopoverContainerHeaderStyle,
   PopoverContainerContentStyle,
   PopoverContainerCloseIcon,
-  PopoverContainerTitle
+  PopoverContainerTitleStyle,
+  PopoverContainerOpenIcon
 } from './popover-container.style';
 import Icon from '../icon';
+import createGuid from '../../utils/helpers/guid';
 
 const PopoverContainer = ({
-  children, iconType, title, position
+  children,
+  title,
+  position,
+  open,
+  onOpen,
+  onClose,
+  renderOpenComponent,
+  renderCloseComponent,
+  shouldCoverButton,
+  ariaDescribedBy
 }) => {
-  const [isOpen, setOpen] = useState(false);
-  const iconRef = useRef();
-  const closeIconRef = useRef();
+  const isControlled = open !== undefined;
+  const [isOpenInternal, setIsOpenInternal] = useState(false);
+
+  const closeButtonRef = useRef();
+  const openButtonRef = useRef();
+  const guid = useRef(createGuid());
+  const popoverContainerId = `PopoverContainer_${guid.current}`;
+
+  const isOpen = isControlled ? open : isOpenInternal;
 
   useEffect(() => {
-    if (isOpen) closeIconRef.current.focus();
+    if (isOpen && closeButtonRef.current) closeButtonRef.current.focus();
   }, [isOpen]);
 
-  const handleOpen = () => {
-    setOpen(true);
+  const handleOpenButtonClick = (e) => {
+    if (!isControlled) setIsOpenInternal(!isOpen);
+
+    // We want the open button to close the popover if it is already open
+    if (!isOpen) {
+      if (onOpen) onOpen(e);
+    } else if (onClose) onClose(e);
   };
 
-  const handleClose = () => {
-    setOpen(false);
-    iconRef.current.focus();
+  const handleCloseButtonClick = (e) => {
+    if (!isControlled) setIsOpenInternal(!isOpen);
+    if (onClose) onClose(e);
+    if (isOpen && openButtonRef.current) openButtonRef.current.focus();
+  };
+
+  const renderOpenComponentProps = {
+    tabIndex: isOpen ? -1 : 0,
+    isOpen,
+    dataElement: 'popover-container-open-component',
+    onClick: handleOpenButtonClick,
+    ref: openButtonRef,
+    ariaLabel: title
+  };
+
+  const renderCloseComponentProps = {
+    dataElement: 'popover-container-close-component',
+    tabIndex: 0,
+    onClick: handleCloseButtonClick,
+    ref: closeButtonRef,
+    ariaLabel: 'close'
   };
 
   return (
-    <PopoverContainerWrapperStyle data-component='popover-container'>
-      <PopoverContainerIcon
-        ref={ iconRef }
-        data-element='popover-container-icon'
-        tabIndex={ isOpen ? -1 : 0 }
-        onAction={ handleOpen }
-      >
-        <Icon type={ iconType } />
-      </PopoverContainerIcon>
+    <PopoverContainerWrapperStyle
+      data-component='popover-container'
+      aria-labelledby={ popoverContainerId }
+    >
+      {renderOpenComponent(renderOpenComponentProps)}
       <Transition
         in={ isOpen }
         timeout={ { exit: 300 } }
@@ -51,22 +86,21 @@ const PopoverContainer = ({
         {state => (
           <PopoverContainerContentStyle
             data-element='popover-container-content'
+            role='dialog'
             animationState={ state }
             position={ position }
+            shouldCoverButton={ shouldCoverButton }
+            aria-labelledby={ popoverContainerId }
+            aria-describedby={ ariaDescribedBy }
           >
             <PopoverContainerHeaderStyle>
-              <PopoverContainerTitle data-element='popover-container-title'>
-                {title}
-              </PopoverContainerTitle>
-              <PopoverContainerCloseIcon
-                data-element='popover-container-close-icon'
-                type='close'
-                tabIndex='0'
-                onAction={ handleClose }
-                ref={ closeIconRef }
+              <PopoverContainerTitleStyle
+                id={ popoverContainerId }
+                data-element='popover-container-title'
               >
-                <Icon type='close' />
-              </PopoverContainerCloseIcon>
+                {title}
+              </PopoverContainerTitleStyle>
+              {renderCloseComponent(renderCloseComponentProps)}
             </PopoverContainerHeaderStyle>
             {children}
           </PopoverContainerContentStyle>
@@ -77,13 +111,70 @@ const PopoverContainer = ({
 };
 
 PopoverContainer.propTypes = {
-  /** Sets the popover container dialog header name */
-  title: PropTypes.string.isRequired,
-  /** Sets the icon that opens dialog */
-  iconType: PropTypes.string.isRequired,
-  /** Sets rendering position of dialog */
+  /** A function that will render the open component
+   *
+   * `({dataElement, tabIndex, onClick, ref, ariaLabel, isOpen}) => ()`
+   *
+  */
+  renderOpenComponent: PropTypes.func,
+  /** A function that will render the close component
+   *
+   * `({dataElement, tabIndex, onClick, ref, ariaLabel, isOpen}) => ()`
+   *
+  */
+  renderCloseComponent: PropTypes.func,
+  /** If `true` the popover-container will open */
+  open: PropTypes.bool,
+  /** Sets the popover-container title displayed in the dialog */
+  title: PropTypes.string,
+  /** If `true` the popover-container will cover open button */
+  shouldCoverButton: PropTypes.bool,
+  /** Callback fires when open component is clicked */
+  onOpen: PropTypes.func,
+  /** Callback fires when close component is clicked */
+  onClose: PropTypes.func,
+  /** Sets rendering position of the popover-container */
   position: PropTypes.oneOf(['left', 'right']),
-  children: PropTypes.node
+  /** The content of the popover-container */
+  children: PropTypes.node,
+  /** The id of the element that describes the dialog */
+  ariaDescribedBy: PropTypes.string
+};
+
+PopoverContainer.defaultProps = {
+  position: 'right',
+  shouldCoverButton: false,
+  renderOpenComponent: ({
+    // eslint-disable-next-line react/prop-types
+    tabIndex, onClick, dataElement, ref, ariaLabel
+  }) => (
+    <PopoverContainerOpenIcon
+      tabIndex={ tabIndex }
+      onAction={ onClick }
+      data-element={ dataElement }
+      ref={ ref }
+      aria-label={ ariaLabel }
+      aria-haspopup
+    >
+      <Icon
+        type='settings'
+      />
+    </PopoverContainerOpenIcon>
+  ),
+  renderCloseComponent: ({
+    // eslint-disable-next-line react/prop-types
+    dataElement, tabIndex, onClick, ref, ariaLabel
+  }) => (
+    <PopoverContainerCloseIcon
+      data-element={ dataElement }
+      tabIndex={ tabIndex }
+      onAction={ onClick }
+      ref={ ref }
+      aria-label={ ariaLabel }
+    >
+      <Icon type='close' />
+    </PopoverContainerCloseIcon>
+  )
 };
 
 export default PopoverContainer;

--- a/src/components/popover-container/popover-container.d.ts
+++ b/src/components/popover-container/popover-container.d.ts
@@ -3,13 +3,24 @@ import * as React from 'react';
 import { AlignBinaryType } from '../../utils/helpers/options-helper/options-helper';
 
 export interface PopoverContainerProps {
+  /** The element that will open popover-container */
+  renderOpenComponent?: React.ReactNode | Node;
+  /** The element that will close popover-container */
+  renderCloseComponent?: React.ReactNode | Node;
+  /** The content of the popover-container */
   children?: React.ReactNode;
   /** Sets rendering position of dialog */
   position?: AlignBinaryType;
   /** Sets the popover container dialog header name */
-  title: string;
-  /** Sets the icon that opens dialog */
-  iconType: string;
+  title?: string;
+  /** Callback fires when close icon clicked */
+  onClose?: () => void;
+  /** if `true` the popover-container is open */
+  isOpen?: boolean;
+  /** if `true` the popover-container will cover open button */
+  shouldCoverButton?: boolean;
+  /** The id of the element that describe the dialog. */
+  ariaDescribedBy?: string;
 }
 
 declare const PopoverContainer: React.FunctionComponent<PopoverContainerProps>;

--- a/src/components/popover-container/popover-container.spec.js
+++ b/src/components/popover-container/popover-container.spec.js
@@ -1,23 +1,37 @@
-import React from 'react';
+/* eslint-disable react/prop-types */
+import React, { forwardRef } from 'react';
 import { mount } from 'enzyme';
+import { css } from 'styled-components';
 import { act } from 'react-dom/test-utils';
+import { Transition } from 'react-transition-group';
 import {
-  PopoverContainerIcon,
   PopoverContainerContentStyle,
-  PopoverContainerCloseIcon
+  PopoverContainerCloseIcon,
+  PopoverContainerIcon,
+  PopoverContainerOpenIcon,
+  PopoverContainerWrapperStyle,
+  PopoverContainerTitleStyle
 } from './popover-container.style';
+import StyledIcon from '../icon/icon.style';
 import PopoverContainer from './popover-container.component';
 import { assertStyleMatch } from '../../__spec_helper__/test-utils';
+import { baseTheme } from '../../style/themes';
+import Icon from '../icon';
+import guid from '../../utils/helpers/guid';
+
+jest.mock('../../utils/helpers/guid');
+guid.mockImplementation(() => 'guid-123');
+
+const render = (props, renderMethod = mount) => {
+  return (renderMethod(<PopoverContainer title='PopoverContainerSettings' { ...props } />));
+};
 
 describe('PopoverContainer', () => {
   jest.useFakeTimers();
   let wrapper;
 
   beforeEach(() => {
-    wrapper = mount(<PopoverContainer
-      title='Popover Container Settings'
-      iconType='settings'
-    />);
+    wrapper = render();
   });
 
   afterEach(() => {
@@ -29,63 +43,375 @@ describe('PopoverContainer', () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  it('should open the popover container on click', () => {
-    act(() => {
-      wrapper = mount(<PopoverContainer
-        title='Popover Container Settings'
-        iconType='settings'
-      />);
-
-      wrapper.find(PopoverContainerIcon).props().onAction();
-    });
-
-    wrapper.update();
-    expect(wrapper.find(PopoverContainerContentStyle).exists()).toBe(true);
+  it('should render correct title', () => {
+    wrapper = render({ open: true });
+    expect(wrapper.find(PopoverContainerTitleStyle).text()).toBe('PopoverContainerSettings');
   });
 
-  it.each([
-    ['enter', 13, true],
-    ['space', 32, true]
-  ])('should open the popover container if %s clicked', (keyname, keycode, expected) => {
-    act(() => {
-      wrapper = mount(<PopoverContainer
-        title='Popover Container Settings'
-        iconType='settings'
-      />);
-
-      wrapper.find(PopoverContainerIcon).props().onAction({ which: keycode });
-    });
-
-    wrapper.update();
-    expect(wrapper.find(PopoverContainerContentStyle).exists()).toBe(expected);
+  it('should render correct `aria-describedby', () => {
+    wrapper = render({ open: true, ariaDescribedBy: 'myAriaDescribedBy' });
+    expect(wrapper.find(PopoverContainerContentStyle).prop('aria-describedby')).toBe('myAriaDescribedBy');
   });
 
-  it('should close the popover popover container if close Icon clicked', () => {
-    act(() => {
-      wrapper = mount(<PopoverContainer
-        title='Popover Container Settings'
-        iconType='settings'
-      />);
+  it('should render correct children', () => {
+    wrapper = mount(
+      <PopoverContainer open>
+        <div id='myChildren'>children</div>
+      </PopoverContainer>
+    );
 
-      wrapper.find(PopoverContainerIcon).props().onAction();
+    expect(wrapper.find('#myChildren').exists()).toBe(true);
+  });
+
+  it('should appear and mount when the component opens', () => {
+    expect(wrapper.find(Transition).props().appear).toBe(true);
+    expect(wrapper.find(Transition).props().mountOnEnter).toBe(true);
+  });
+
+  it('should unount after 300ms when the component closes', () => {
+    expect(wrapper.find(Transition).props().timeout).toEqual({ exit: 300 });
+    expect(wrapper.find(Transition).props().unmountOnExit).toBe(true);
+  });
+
+  it('should transition when the component opens and closes', () => {
+    expect(wrapper.find(Transition).props().in).toBe(false);
+
+    act(() => {
+      wrapper.find(PopoverContainerOpenIcon).props().onAction();
     });
 
     wrapper.update();
 
-    act(() => {
-      wrapper.find(PopoverContainerCloseIcon).props().onAction();
-      jest.runAllTimers();
+    expect(wrapper.find(Transition).props().in).toBe(true);
+  });
+
+  it('should render correct `id` based on `guid()`', () => {
+    wrapper = render({ open: true });
+    expect(wrapper.find(PopoverContainerTitleStyle).props().id).toBe('PopoverContainer_guid-123');
+  });
+
+  it('should render correct `data-element` related to the component', () => {
+    wrapper = render({ open: true });
+    expect(wrapper.find(PopoverContainerTitleStyle).prop('data-element')).toBe('popover-container-title');
+  });
+
+  it('should render correct `data-component` related to the component', () => {
+    expect(wrapper.find(PopoverContainerWrapperStyle).prop('data-component')).toBe('popover-container');
+  });
+
+  it('should render the same id for `aria-labelledby` and `PopoverContainerTitleStyle`', () => {
+    wrapper = render({ open: true });
+    expect(wrapper.find(PopoverContainerTitleStyle).props().id).toBe('PopoverContainer_guid-123');
+    expect(wrapper.find(PopoverContainerWrapperStyle).prop('aria-labelledby')).toBe('PopoverContainer_guid-123');
+  });
+
+  it('should let opening button to be focusable if popover is closed', () => {
+    wrapper = render({ open: false });
+
+    expect(wrapper.find('button').props().tabIndex).toBe(0);
+  });
+
+  it('`position` should be right by default', () => {
+    expect(wrapper.props().position).toBe('right');
+  });
+
+  it('`shouldCoverButton` should be false by default', () => {
+    expect(wrapper.props().shouldCoverButton).toBe(false);
+  });
+
+  describe('if is controlled', () => {
+    describe('and is opened', () => {
+      describe('and `onClose` prop do not exists', () => {
+        it('should not error when open button is clicked and no `onClose` callback is provided', () => {
+          expect(() => {
+            wrapper = render({
+              open: true
+            });
+
+            wrapper.find(PopoverContainerOpenIcon).props().onAction();
+          }).not.toThrow();
+        });
+      });
+
+      describe('and `onClose` prop is provided', () => {
+        it('should fire `onClose` callback if open button is clicked', () => {
+          const onCloseFn = jest.fn();
+          wrapper = render({
+            open: true,
+            onClose: onCloseFn
+          });
+
+          wrapper.find(PopoverContainerOpenIcon).props().onAction();
+          expect(onCloseFn).toHaveBeenCalled();
+        });
+
+        it('should fire `onClose` callback if close button is clicked', () => {
+          const onCloseFn = jest.fn();
+          wrapper = render({
+            open: true,
+            onClose: onCloseFn
+          });
+
+          wrapper.find(PopoverContainerCloseIcon).props().onAction();
+          expect(onCloseFn).toHaveBeenCalled();
+        });
+      });
     });
 
-    wrapper.update();
-    expect(wrapper.find(PopoverContainerContentStyle).exists()).toBe(false);
-    jest.clearAllTimers();
+    describe('and is closed', () => {
+      describe('and `onOpen` prop is provided', () => {
+        it('should fire `onOpen` callback if open button is clicked', () => {
+          const onOpenFn = jest.fn();
+          wrapper = render({
+            open: false,
+            onOpen: onOpenFn
+          });
+
+          wrapper.find(PopoverContainerOpenIcon).props().onAction();
+          expect(onOpenFn).toHaveBeenCalled();
+        });
+      });
+
+      describe('and `onOpen` prop is not provided', () => {
+        it('should not error when open button is clicked if no `onOpen` callback is provided', () => {
+          expect(() => {
+            wrapper = render({
+              open: false
+            });
+
+            wrapper.find(PopoverContainerOpenIcon).props().onAction();
+          }).not.toThrow();
+        });
+      });
+    });
+  });
+
+  describe('if is not controlled', () => {
+    it('should render default open button with the expected prop values', () => {
+      wrapper = render();
+      const openIcon = wrapper.find(PopoverContainerOpenIcon);
+
+      expect(openIcon.exists()).toBe(true);
+      expect(openIcon.find(Icon).props()).toEqual({
+        bgSize: 'small',
+        disabled: false,
+        fontSize: 'small',
+        type: 'settings'
+      });
+      expect(openIcon.prop('aria-haspopup')).toEqual(true);
+      expect(openIcon.prop('tabIndex')).toEqual(0);
+      expect(openIcon.prop('aria-label')).toEqual('PopoverContainerSettings');
+    });
+
+    it('should render default close button', () => {
+      wrapper = render();
+
+      act(() => {
+        wrapper.find(PopoverContainerOpenIcon).props().onAction();
+      });
+
+      wrapper.update();
+      expect(wrapper.find(PopoverContainerCloseIcon).exists()).toBe(true);
+    });
+
+    it('should open popover if open button is clicked', () => {
+      wrapper = render();
+
+      act(() => {
+        wrapper.find(PopoverContainerOpenIcon).props().onAction();
+      });
+
+      wrapper.update();
+      expect(wrapper.find(PopoverContainerOpenIcon).props().tabIndex).toBe(-1);
+      expect(wrapper.find(PopoverContainerContentStyle).exists()).toBe(true);
+    });
+
+    describe('and custom component is provided as an opening button', () => {
+      const MyOpenButton = forwardRef((props, ref) => (
+        <button
+          type='button'
+          { ...props }
+          ref={ ref }
+        />
+      ));
+
+      beforeEach(() => {
+        wrapper = render({
+          title: 'render props',
+          renderOpenComponent: ({
+            tabIndex, dataElement, ariaLabel, ref, onClick
+          }) => (
+            <MyOpenButton
+              tabIndex={ tabIndex }
+              data-element={ dataElement }
+              aria-label={ ariaLabel }
+              ref={ ref }
+              onClick={ onClick }
+            >
+              button
+            </MyOpenButton>
+          )
+        });
+      });
+
+      it('should be focused when user clicks the close icon', () => {
+        act(() => {
+          wrapper.find(MyOpenButton).props().onClick();
+        });
+
+        wrapper.update();
+
+        act(() => {
+          wrapper.find(PopoverContainerCloseIcon).props().onAction();
+        });
+
+        wrapper.update();
+
+        expect(wrapper.find(MyOpenButton)).toBeFocused();
+      });
+
+      it('should render correct props', () => {
+        expect(wrapper.find(MyOpenButton).props().tabIndex).toBe(0);
+        expect(wrapper.find(MyOpenButton).prop('data-element')).toBe('popover-container-open-component');
+        expect(wrapper.find(MyOpenButton).prop('aria-label')).toBe('render props');
+      });
+
+      it('should not be focused if `ref` is not provided', () => {
+        wrapper = render({
+          title: 'render props',
+          renderOpenComponent: ({
+            tabIndex, dataElement, ariaLabel, onClick, isOpen
+          }) => (
+            <MyOpenButton
+              tabIndex={ tabIndex }
+              data-element={ dataElement }
+              aria-label={ ariaLabel }
+              onClick={ onClick }
+            >
+              {isOpen ? 'isOpen is true' : 'isOpen is false'}
+            </MyOpenButton>
+          )
+        });
+
+        act(() => {
+          wrapper.find(MyOpenButton).props().onClick();
+        });
+
+        wrapper.update();
+
+        expect(wrapper.find(MyOpenButton).text()).toBe('isOpen is true');
+
+        act(() => {
+          wrapper.find(PopoverContainerCloseIcon).props().onAction();
+        });
+
+        wrapper.update();
+
+        expect(wrapper.find(MyOpenButton).text()).toBe('isOpen is false');
+        expect(wrapper.find(MyOpenButton)).not.toBeFocused();
+      });
+    });
+
+    describe('and custom component is provided as a closing button', () => {
+      const MyCloseButton = forwardRef((props, ref) => (
+        <button
+          type='button'
+          { ...props }
+          ref={ ref }
+        />
+      ));
+
+      beforeEach(() => {
+        wrapper = render({
+          open: true,
+          renderCloseComponent: ({
+            tabIndex, dataElement, ariaLabel, ref
+          }) => (
+            <MyCloseButton
+              type='button'
+              tabIndex={ tabIndex }
+              ref={ ref }
+              data-element={ dataElement }
+              aria-label={ ariaLabel }
+            >Close
+            </MyCloseButton>
+          )
+        });
+      });
+
+      it('should be focused if `ref` is provided', () => {
+        expect(wrapper.find(MyCloseButton)).toBeFocused();
+      });
+
+      it('should render correct props', () => {
+        expect(wrapper.find(MyCloseButton).props().tabIndex).toBe(0);
+        expect(wrapper.find(MyCloseButton).prop('data-element')).toBe('popover-container-close-component');
+        expect(wrapper.find(MyCloseButton).prop('aria-label')).toBe('close');
+      });
+    });
+  });
+
+  describe('if close button is clicked ', () => {
+    describe('and `ref` of opening button exists', () => {
+      it('should set focus to the opening button', () => {
+        wrapper = render();
+
+        act(() => {
+          wrapper.find(PopoverContainerOpenIcon).props().onAction();
+        });
+
+        wrapper.update();
+
+        act(() => {
+          wrapper.find(PopoverContainerCloseIcon).props().onAction();
+        });
+
+        wrapper.update();
+
+        expect(wrapper.find(PopoverContainerOpenIcon)).toBeFocused();
+      });
+    });
+  });
+});
+
+describe('PopoverContainerIcon', () => {
+  it('should render correct style', () => {
+    const wrapper = mount(
+      <PopoverContainerIcon onAction={ () => { } } theme={ baseTheme }>
+        <Icon type='settings' />
+      </PopoverContainerIcon>
+    );
+
+    assertStyleMatch({
+      color: baseTheme.popoverContainer.iconColor
+    }, wrapper, { modifier: css`${StyledIcon}` });
   });
 });
 
 describe('PopoverContainerContentStyle', () => {
+  it('should render correct props by default', () => {
+    const wrapper = render({ open: true });
+
+    expect(wrapper.find(PopoverContainerContentStyle).prop('data-element')).toBe('popover-container-content');
+    expect(wrapper.find(PopoverContainerContentStyle).props().role).toBe('dialog');
+    expect(wrapper.find(PopoverContainerContentStyle).props().position).toBe('right');
+    expect(wrapper.find(PopoverContainerContentStyle).props().shouldCoverButton).toBe(false);
+    expect(wrapper.find(PopoverContainerContentStyle).prop('aria-labelledby')).toContain('PopoverContainer_guid-123');
+    expect(wrapper.find(PopoverContainerContentStyle).props().ariaDescribedBy).toBe(undefined);
+    expect(wrapper.find(PopoverContainerContentStyle).props().animationState).toBe('entering');
+  });
+
+  it('should render to the right by default', () => {
+    const wrapper = mount(<PopoverContainerContentStyle />);
+
+    assertStyleMatch({
+      left: '0'
+    }, wrapper);
+  });
+
   it('should render to the left if position is set to `left`', () => {
     const wrapper = mount(<PopoverContainerContentStyle position='left' />);
+
     assertStyleMatch({
       right: '0'
     }, wrapper);
@@ -98,13 +424,33 @@ describe('PopoverContainerContentStyle', () => {
     }, wrapper);
   });
 
-  it('should render correct style of animation state', () => {
-    const wrapper = mount(<PopoverContainerContentStyle animationState='entered' />);
+  it('should render correct style if `shouldCoverButton` prop is provided', () => {
+    const wrapper = mount(<PopoverContainerContentStyle shouldCoverButton />);
 
     assertStyleMatch({
-      opacity: '1',
-      transform: 'translateY(0)',
-      transition: 'all 0.3s cubic-bezier(0.25,0.25,0,1.5)'
+      top: '0'
     }, wrapper);
+  });
+
+  describe('should render correct style of animation', () => {
+    it('if the animation has state `entered`', () => {
+      const wrapper = mount(<PopoverContainerContentStyle animationState='entered' />);
+
+      assertStyleMatch({
+        opacity: '1',
+        transform: 'translateY(0)',
+        transition: 'all 0.3s cubic-bezier(0.25,0.25,0,1.5)'
+      }, wrapper);
+    });
+
+    it('if the animation has state `exiting`', () => {
+      const wrapper = mount(<PopoverContainerContentStyle animationState='exiting' />);
+
+      assertStyleMatch({
+        opacity: '0',
+        transform: 'translateY(-8px)',
+        transition: 'all 0.3s cubic-bezier(0.25,0.25,0,1.5)'
+      }, wrapper);
+    });
   });
 });

--- a/src/components/popover-container/popover-container.stories.js
+++ b/src/components/popover-container/popover-container.stories.js
@@ -1,29 +1,23 @@
 import React from 'react';
-import { select, text } from '@storybook/addon-knobs';
-import OptionsHelper from '../../utils/helpers/options-helper/options-helper';
+import { withKnobs, text } from '@storybook/addon-knobs';
 import PopoverContainer from './popover-container.component';
 
 export default {
-  component: PopoverContainer,
   title: 'Test/Popover Container',
+  component: PopoverContainer,
+  decorators: [withKnobs],
   parameters: {
     info: { disable: true },
-    knobs: { escapeHTML: false }
+    docs: {
+      page: null
+    }
   }
 };
 
-export const basic = () => {
-  const title = text('title', 'Popover Title');
-  const iconType = select('iconType', [...OptionsHelper.icons], 'settings');
-  const position = select('position', [...OptionsHelper.alignBinary], 'right');
+export const Basic = () => {
+  const title = text('title', 'Title');
 
   return (
-    <div style={ position === 'left' ? { marginLeft: '400px' } : null }>
-      <PopoverContainer
-        title={ title }
-        position={ position }
-        iconType={ iconType }
-      />
-    </div>
+    <PopoverContainer title={ title } />
   );
 };

--- a/src/components/popover-container/popover-container.stories.mdx
+++ b/src/components/popover-container/popover-container.stories.mdx
@@ -3,101 +3,252 @@ import PopoverContainer from "./popover-container.component";
 import {DraggableContainer, DraggableItem} from '../draggable'
 import { Checkbox } from '../../__experimental__/components/checkbox';
 import ButtonToggle from '../button-toggle';
+import { useState } from 'react';
 import Button from '../button';
 import Link from '../link';
+import Pill from '../pill';
+import Badge from '../badge';
 
 <Meta title="Design System/Popover Container" />
 
-# Popover Container
-
-## Quick Start
-
-To use Popover Container, import the `Popover Container` and pass the content as children.
+# PopoverContainer
 
 ```jsx
-import PopoverContainer from "carbon-react/lib/components/PopoverContainer";
-const MyComponent = () => (
-  <PopoverContainer iconType="settings" title="Popover Container Title">
-    <p>Content as a children</p>
-  </PopoverContainer>
-);
+import PopoverContainer from "carbon-react/lib/components/popover-container";
 ```
 
-### Basic Popover Container
+### Quick Start
 
+To use `PopoverContainer`, import the `PopoverContainer` and pass the content as children.
 <Preview>
-  <Story name="basic" parameters={{ info: { disable: true }}}>
-    <PopoverContainer iconType="settings" title="Popover Container Title" />
+  <Story name="basic" parameters={{ info: { disable: true }}} >
+    <div style={{height: 100}}>
+      <PopoverContainer>
+      Contents
+      </PopoverContainer>
+      
+      </div>
   </Story>
 </Preview>
 
-### Popover Container with position left
-
+### With title
+Use the `title` prop to set a title within the `PopoverContainer`.
 <Preview>
-  <Story name="with position left" parameters={{ info: { disable: true }}}>
-    <div style={{marginLeft: '300px'}}>
-      <PopoverContainer position="left" iconType="settings" title="Popover Container Title" />
-    </div>
+  <Story name="title" parameters={{ info: { disable: true }}} >
+    <div style={{height: 100}}>
+      <PopoverContainer title="With a title">
+      Contents
+      </PopoverContainer>   
+      </div>
   </Story>
 </Preview>
 
-### Popover Container with different icon
-
+### Right Aligned/Open Left
+Use the `position` prop to open the `PopoverContainer` to the left, this is useful if your open button is to the right
+of the screen.
 <Preview>
-  <Story name="with different icon" parameters={{ info: { disable: true }}}>
-    <PopoverContainer iconType="edited" title="Popover Container Title" />
+  <Story name="position" parameters={{ info: { disable: true }}} >
+    <div style={{height: 100, float: 'right'}}>
+      <PopoverContainer title="Right Aligned" position="left">
+      Contents
+      </PopoverContainer>
+      </div>
   </Story>
 </Preview>
 
-### Popover Container with simple content
-
+### Cover Button
+Use the `shouldCoverButton` prop to hide the open button when the `PopoverContainer` is open.
 <Preview>
-  <Story name="with simple content" parameters={{ info: { disable: true }}}>
-    <div style={{minHeight: '280px'}}>
-      <PopoverContainer iconType="settings" title="Popover Container Title">
-        <p>Ut consectetur elit non proident minim.
-          Aute ut Lorem excepteur enim excepteur et fugiat pariatur esse fugiat excepteur laborum est laboris.
-          Ad ad irure mollit incididunt. Veniam occaecat minim ad nisi. Adipisicing adipisicing aliquip deserunt esse Lorem anim pariatur id in sint.
-          Eiusmod aliquip magna ex dolore mollit ullamco.
-          Qui tempor nostrud reprehenderit elit est amet sit tempor deserunt et reprehenderit occaecat.
-          </p>
-          <Button>Button</Button>
+  <Story name="cover button" parameters={{ info: { disable: true }}} >
+    <div style={{height: 100}}>
+      <PopoverContainer title="Cover Button" shouldCoverButton>
+      Contents
       </PopoverContainer>
     </div>
   </Story>
 </Preview>
 
-### Popover Container with complex content
+### Custom Open/Close Button
+Use the `renderOpenComponent` and `renderCloseComponent` to render your own open or close buttons.
 
 <Preview>
-  <Story name="with complex content" parameters={{ info: { disable: true }}}>
-    <div style={{minHeight: '330px'}}>
-      <PopoverContainer iconType="settings" title="Popover Container Title">
+  <Story name="render props" parameters={{ info: { disable: true }}} >
+    <div style={{height: 250}}>
+      <PopoverContainer
+        title='Custom Open &amp; Close Button'
+        renderOpenComponent={ ({isOpen, ...rest}) => <Button iconType={ !isOpen ? 'filter_new' : 'close' } iconPosition='after' {...rest}>Filter</Button>}
+        renderCloseComponent={ ({isOpen, ...rest}) => <Button {...rest}>Close</Button>}
+      >
+      Content
+    </PopoverContainer>
+      </div>
+  </Story>
+</Preview>
+
+### Controlled
+You can use the `open`, `onOpen` and `onClose` props to control the open state of the `PopoverContainer`.
+<Preview>
+  <Story name="controlled" parameters={{ info: { disable: true }}}>
+    {() => {
+          const [open, setOpen] = useState(false);
+          const onOpen = () => setOpen(true);
+          const onClose = () => setOpen(false);
+          return (
+            <div style={{height: 150}}>
+            <Button onClick={ onOpen }>Open Popover</Button>
+            <Button onClick={ onClose }>Close Popover</Button>
+            <br />
+            <PopoverContainer
+              title='Controlled'
+              open={ open }
+              onOpen={ onOpen }
+              onClose={ onClose }
+            >Contents</PopoverContainer>
+            </div>
+          );
+        }}
+  </Story>
+</Preview>
+
+
+### Complex content
+
+You can easly use many different components to create your own compisition.
+
+<Preview>
+  <Story name="complex" parameters={{ info: { disable: true }}}>
+    <div style={{height: 330}}>
+      <PopoverContainer title='Popover Container Title'>
         <Link>This is example link text</Link>
-        <div style={{padding: '25px 0 15px 0'}}>
-          <Button>
-            Small
-          </Button>
-          <Button>
-            Compact
-          </Button>
+        <div style={ { padding: '25px 0 15px 0' } }>
+          <Button>Small</Button>
+          <Button>Compact</Button>
         </div>
         <DraggableContainer>
           <DraggableItem key='1' id={ 1 }>
-            <Checkbox name="one" label='Draggable Label One' />
+            <Checkbox name='one' label='Draggable Label One' />
           </DraggableItem>
           <DraggableItem key='2' id={ 2 }>
-            <Checkbox name="two" label='Draggable Label Two' />
+            <Checkbox name='two' label='Draggable Label Two' />
           </DraggableItem>
           <DraggableItem key='3' id={ 3 }>
-            <Checkbox name="three" label='Draggable Label Three' />
+            <Checkbox name='three' label='Draggable Label Three' />
           </DraggableItem>
           <DraggableItem key='4' id={ 4 }>
-            <Checkbox name="four" label='Draggable Label Four' />
+            <Checkbox name='four' label='Draggable Label Four' />
           </DraggableItem>
         </DraggableContainer>
       </PopoverContainer>
     </div>
+  </Story>
+</Preview>
+
+
+### Filter component
+
+If you want to use the `PopoverContainer` to create for example `Filter` component.
+
+You can do it easly in this way:
+
+<Preview>
+  <Story name="filter" parameters={{ info: { disable: true }}}>
+    {() => {
+        const initValues = [
+          { value: 'Option 1', checked: false },
+          { value: 'Option 2', checked: false },
+          { value: 'Option 3', checked: false }
+        ];
+        const [open, setOpen] = useState(false);
+        const [options, setOptions] = useState(initValues);
+        const [filters, setFilters] = useState([]);
+        const clearAllOptions = () => {
+          const temps = options;
+          for (let i = 0; i < temps.length; i++) {
+            temps[i].checked = false;
+          }
+          setOptions([...temps]);
+        };
+        const clearFilters = () => setFilters([]);
+        const updateCheckValue = (e) => {
+          const temps = options;
+          const findCorrectIndex = temps.findIndex(item => item.value === e.target.value);
+          if (findCorrectIndex !== -1) {
+            temps[findCorrectIndex].checked = !temps[findCorrectIndex].checked;
+            setOptions([...temps]);
+          }
+        };
+        const updateFilters = () => setFilters(options.filter(filter => filter.checked === true));
+        const handleBadgeClose = () => {
+          clearAllOptions();
+          clearFilters();
+        };
+        const applyFilters = () => {
+          updateFilters();
+          setOpen(false);
+        };
+        const onOpen = () => {
+          setOpen(true);
+        };
+        const onClose = () => {
+          setOpen(false);
+        };
+        const renderCheckboxes = () => {
+          const checkboxStyle = {
+            marginBottom: '10px'
+          };
+          return options.map((option) => {
+            return (
+              <Checkbox
+                onChange={ updateCheckValue }
+                style={ checkboxStyle }
+                label={ option.value }
+                name={ option.value }
+                value={ option.value }
+                checked={ option.checked }
+                key={ option.value }
+              />
+            );
+          });
+        };
+        const renderPills = () => {
+          const pillStyle = {
+            margin: '0 8px'
+          };
+          return filters.map((filter, index) => {
+            return filter.checked ? <Pill key={ index } style={ pillStyle }>{filter.value}</Pill> : null;
+          });
+        };
+        return (
+          <div style={{height: 280}}>
+            <PopoverContainer
+              title='How to create Filter component'
+              open={ open }
+              onOpen={ onOpen }
+              onClose={ onClose }
+              renderOpenComponent={ ({ isOpen, ref, ...rest }) => (
+                <Badge counter={ filters.length } onClick={ handleBadgeClose }>
+                  <Button
+                    style={ { marginRight: 0 } }
+                    buttonType={ isOpen ? 'primary' : 'darkBackground' }
+                    iconPosition='after'
+                    iconType={ !isOpen ? 'filter_new' : 'close' }
+                    size='small'
+                    { ...rest }
+                  >
+                  {console.log(ref)}
+                    Filter
+                  </Button>
+                </Badge>
+              ) }
+              renderCloseComponent={ () => {} }
+            >
+              {renderCheckboxes()}
+              <Button onClick={ applyFilters } style={ { margin: '20px 0' } }>Apply</Button>
+            </PopoverContainer>
+            {renderPills()}
+          </div>
+        );
+      }}
   </Story>
 </Preview>
 

--- a/src/components/popover-container/popover-container.style.js
+++ b/src/components/popover-container/popover-container.style.js
@@ -5,10 +5,7 @@ import StyledIcon from '../icon/icon.style';
 
 const PopoverContainerWrapperStyle = styled.div`
   position: relative;
-  border: none;
-  padding: 0;
-  width: 40px;
-  height: 40px;
+  display: inline-block;
 `;
 
 const PopoverContainerIcon = styled(IconButton)`
@@ -30,7 +27,8 @@ const PopoverContainerContentStyle = styled.div`
   padding: 16px 24px;
   min-width: 300px;
   position: absolute;
-  top: 0;
+  
+  ${({ shouldCoverButton }) => shouldCoverButton && 'top: 0'}
 
   ${({ position }) => (position === 'left' ? 'right: 0' : 'left: 0')};
 
@@ -59,6 +57,12 @@ const PopoverContainerContentStyle = styled.div`
   }}
 `;
 
+const PopoverContainerOpenIcon = styled(IconButton)`
+  ${StyledIcon}{
+    color: ${({ theme }) => theme.popoverContainer.iconColor};
+  }
+`;
+
 const PopoverContainerCloseIcon = styled(IconButton)`
   position: absolute;
   top: 16px;
@@ -69,7 +73,7 @@ const PopoverContainerCloseIcon = styled(IconButton)`
   };
 `;
 
-const PopoverContainerTitle = styled.div`
+const PopoverContainerTitleStyle = styled.div`
   font-size: 16px;
   font-weight: bold;
 `;
@@ -86,11 +90,16 @@ PopoverContainerCloseIcon.defaultProps = {
   theme: baseTheme
 };
 
+PopoverContainerOpenIcon.defaultProps = {
+  theme: baseTheme
+};
+
 export {
   PopoverContainerWrapperStyle,
   PopoverContainerIcon,
   PopoverContainerHeaderStyle,
   PopoverContainerContentStyle,
   PopoverContainerCloseIcon,
-  PopoverContainerTitle
+  PopoverContainerTitleStyle,
+  PopoverContainerOpenIcon
 };


### PR DESCRIPTION
## BREAKING CHANGES:
iconType is no longer supported

#### Popover-container has got new props:
- isOpen
- onClose
- renderOpenComponent
- shouldCoverButton
- renderCloseComponent
- ariaDescribedBy
#### and also has removed one
- iconType

### Proposed behaviour
- It allows the user to use custom element to open popover-container
- popover-container will be only in controlled mode
![Annotation 2020-03-30 150847](https://user-images.githubusercontent.com/19231884/77916423-56cc1700-7299-11ea-96f6-95dfb5098d54.png)

### Current behaviour
- hardcoded Icon that opens component
- uncontrolled 

### Checklist

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [ ] Cypress automation tests
- [x] Storybook added or updated
- [x] Theme support
- [x] Typescript `d.ts` file added or updated

### Testing instructions
1: Open storybook
2: Go to TEST/popover-container
