### PR TITLE
feat(action-popover): support for aligning menu to right of button

### DIFF
--- a/src/components/action-popover/__snapshots__/action-popover.spec.js.snap
+++ b/src/components/action-popover/__snapshots__/action-popover.spec.js.snap
@@ -530,7 +530,9 @@ exports[`ActionPopover submenu left aligned closes the submenu on mouseleave eve
               [Function],
               ";
   position: absolute;
-  right: 0;
+  ",
+              [Function],
+              "
   background-color: ",
               [Function],
               ";
@@ -1273,7 +1275,9 @@ exports[`ActionPopover submenu left aligned closes the submenu when right key is
               [Function],
               ";
   position: absolute;
-  right: 0;
+  ",
+              [Function],
+              "
   background-color: ",
               [Function],
               ";
@@ -1763,7 +1767,9 @@ exports[`ActionPopover submenu left aligned does not close the submenu unless ri
               [Function],
               ";
   position: absolute;
-  right: 0;
+  ",
+              [Function],
+              "
   background-color: ",
               [Function],
               ";
@@ -2595,7 +2601,9 @@ exports[`ActionPopover submenu left aligned opens the submenu on mouseenter 1`] 
               [Function],
               ";
   position: absolute;
-  right: 0;
+  ",
+              [Function],
+              "
   background-color: ",
               [Function],
               ";
@@ -3338,7 +3346,9 @@ exports[`ActionPopover submenu left aligned opens the submenu when left key is p
               [Function],
               ";
   position: absolute;
-  right: 0;
+  ",
+              [Function],
+              "
   background-color: ",
               [Function],
               ";
@@ -4081,7 +4091,9 @@ exports[`ActionPopover submenu right aligned closes the submenu when left key is
               [Function],
               ";
   position: absolute;
-  right: 0;
+  ",
+              [Function],
+              "
   background-color: ",
               [Function],
               ";
@@ -4824,7 +4836,9 @@ exports[`ActionPopover submenu right aligned opens the submenu when right key is
               [Function],
               ";
   position: absolute;
-  right: 0;
+  ",
+              [Function],
+              "
   background-color: ",
               [Function],
               ";

--- a/src/components/action-popover/action-popover.component.js
+++ b/src/components/action-popover/action-popover.component.js
@@ -13,7 +13,7 @@ import ActionPopoverItem from './action-popover-item.component';
 import ActionPopoverDivider from './action-popover-divider.component';
 
 const ActionPopover = ({
-  children, id, onOpen, onClose, ...rest
+  children, id, onOpen, onClose, rightAlignMenu, ...rest
 }) => {
   const [isOpen, setOpenState] = useState(false);
   const [focusIndex, setFocusIndex] = useState(0);
@@ -84,7 +84,8 @@ const ActionPopover = ({
     items,
     menuID,
     isOpen,
-    setOpen
+    setOpen,
+    rightAlignMenu
   };
 
   return (
@@ -121,6 +122,8 @@ ActionPopover.propTypes = {
   onOpen: PropTypes.func,
   /** Callback to be called on menu close */
   onClose: PropTypes.func,
+  /** Boolean to control whether menu should align to right */
+  rightAlignMenu: PropTypes.bool,
   /** Children for popover component */
   children (props, propName, componentName) {
     let error;

--- a/src/components/action-popover/action-popover.d.ts
+++ b/src/components/action-popover/action-popover.d.ts
@@ -4,6 +4,7 @@ export interface ActionPopoverProps {
   id?: string;
   onOpen?: () => void;
   onClose?: () => void;
+  rightAlignMenu?: boolean;
 }
 
 declare const ActionPopover: React.FunctionComponent<ActionPopoverProps>;

--- a/src/components/action-popover/action-popover.spec.js
+++ b/src/components/action-popover/action-popover.spec.js
@@ -209,6 +209,16 @@ describe('ActionPopover', () => {
     }).not.toThrow();
   });
 
+  it('opens with the menu left position assigned so it is to right of the button if the "rightAlignMenu" prop is true',
+    () => {
+      render({ rightAlignMenu: true });
+      const { menu } = getElements();
+      assertStyleMatch({
+        right: undefined,
+        left: '0'
+      }, menu);
+    });
+
   describe.each([
     ['Click handlers', 'Clicking', item => item.simulate('click')],
     ['Keypress handlers', 'Pressing Enter', item => simulate.keydown.pressEnter(item)]

--- a/src/components/action-popover/action-popover.stories.mdx
+++ b/src/components/action-popover/action-popover.stories.mdx
@@ -103,6 +103,38 @@ ActionPopoverItem&apos;s can be disabled and will not dispatch an action but can
   </Story>
 </Preview>
 
+It is possible to align the Menu to the right of the MenuButton by passing the &quot;rightAlignMenu&quot; to ActionPopover
+<Preview>
+  <Story name="with menu right aligned" parameters={{ info: { disable: true }}}>
+    <div style={{ height: '250px' }}>
+    <Table>
+      <TableRow>
+        <TableHeader>First Name</TableHeader>
+        <TableHeader>Last Name</TableHeader>
+        <TableHeader>&nbsp;</TableHeader>
+      </TableRow>
+      <TableRow>
+        <TableCell>John</TableCell>
+        <TableCell>Doe</TableCell>
+        <TableCell>
+          <ActionPopover rightAlignMenu>
+            <ActionPopoverItem
+              icon='email'
+              disabled
+              onClick={() => {}}
+            >
+              Email Invoice
+            </ActionPopoverItem>
+            <ActionPopoverDivider />
+            <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
+          </ActionPopover>
+        </TableCell>
+      </TableRow>
+    </Table>
+    </div>
+  </Story>
+</Preview>
+
 Menu items can also be displayed without icons.
 <Preview>
   <Story name="with no icons" parameters={{ info: { disable: true }}}>

--- a/src/components/action-popover/action-popover.style.js
+++ b/src/components/action-popover/action-popover.style.js
@@ -15,7 +15,7 @@ const Menu = styled.div`
   padding: ${({ theme }) => `${theme.spacing}px 0`};
   box-shadow: ${({ theme }) => theme.shadows.depth1};
   position: absolute;
-  right: 0;
+  ${({ rightAlignMenu }) => (rightAlignMenu ? 'left: 0;' : 'right: 0;')}
   background-color: ${({ theme }) => theme.colors.white};
   z-index: 1;
 


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Passing the `rightAlignMenu` prop will allow the `Menu` to align to the right of the `MenuButton`, by default the `Menu` will continue to open to the left

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Currently the Menu opens to the left of the button
### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [ ] Cypress automation tests
- [x] Storybook added or updated
<del>- [ ] Theme support<del>
- [x] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->
Further PR will allow a custom `MenuButton` to be passed into the Popover by a consumer, I thought it best to separate the work.

Default behaviour with no prop set:
![image](https://user-images.githubusercontent.com/44157880/77935821-df52b380-72a9-11ea-9299-85966e0f32ab.png)

Custom behaviour with prop set:
![image](https://user-images.githubusercontent.com/44157880/77935789-d4981e80-72a9-11ea-9b07-fb73470ad9ce.png)


### Testing instructions
<!-- How can a reviewer test this PR? -->
https://github.com/Sage/carbon/pull/2765#issuecomment-606117514