### PR TITLE
test(profile, portrait): add ignore tag

### DIFF
--- a/cypress/features/regression/portrait.feature
+++ b/cypress/features/regression/portrait.feature
@@ -18,12 +18,13 @@ Feature: Portrait default component
 		# @ignore because of FE-1447
 		# | <>                       |
 
-	@positive
+	# value which is rendering as src doesn't work properly for CI
+	@ignore
 	Scenario: Enable darkBackground checkbox for a Portrait component
 		When I check darkBackground checkbox
 		Then Portrait initials value is set to "DARK"
 
-	# value which is rendering doesn't work properly
+	# value which is rendering as src doesn't work properly for CI
 	@ignore
 	Scenario: Enable and disable darkBackground checkbox for a Portrait component
 		Given I check darkBackground checkbox
@@ -35,8 +36,8 @@ Feature: Portrait default component
 		When I select source to "src"
 		Then Portrait source is set to "src"
 
-	@ignore
 	# src is rendering as img
+	@ignore
 	Scenario: Set Portrait source to gravatar
 		Given I select source to "gravatar"
 		When I set gravatar to "ABC"
@@ -51,7 +52,8 @@ Feature: Portrait default component
 			| source                                                                                                                 |
 			| https://photos.smugmug.com/Portfolio/Business-Portrait-Examples/i-qFTj2wW/0/1f8956e8/M/163-FCP%20Moriah%20Thomas-M.jpg |
 
-	@positive
+	# value which is rendering as src doesn't work properly for CI
+	@ignore
 	Scenario Outline: Change Portrait initials to <initials>
 		When I set initials to "<initials>"
 		Then Portrait initials value is set to "<initials>"
@@ -61,8 +63,8 @@ Feature: Portrait default component
 			| BC       |
 			| DEF      |
 
-	@ignore
 	# src is rendering as img
+	@ignore
 	Scenario Outline: Set Portrait gravatar to <gravatar>
 		Given I select source to "gravatar"
 		When I set gravatar to "<gravatar>"

--- a/cypress/features/regression/portrait.feature
+++ b/cypress/features/regression/portrait.feature
@@ -19,12 +19,14 @@ Feature: Portrait default component
 		# | <>                       |
 
 	# value which is rendering as src doesn't work properly for CI
+	# ignore regression
 	@ignore
 	Scenario: Enable darkBackground checkbox for a Portrait component
 		When I check darkBackground checkbox
 		Then Portrait initials value is set to "DARK"
 
 	# value which is rendering as src doesn't work properly for CI
+	# ignore regression
 	@ignore
 	Scenario: Enable and disable darkBackground checkbox for a Portrait component
 		Given I check darkBackground checkbox
@@ -53,6 +55,7 @@ Feature: Portrait default component
 			| https://photos.smugmug.com/Portfolio/Business-Portrait-Examples/i-qFTj2wW/0/1f8956e8/M/163-FCP%20Moriah%20Thomas-M.jpg |
 
 	# value which is rendering as src doesn't work properly for CI
+	# ignore regression
 	@ignore
 	Scenario Outline: Change Portrait initials to <initials>
 		When I set initials to "<initials>"

--- a/cypress/features/regression/profile.feature
+++ b/cypress/features/regression/profile.feature
@@ -37,6 +37,7 @@ Feature: Profile default component
     # | <> |
 
   # value which is rendering as src doesn't work properly for CI
+  # ignore regression
   @ignore
   Scenario Outline: Set initials to <initials>
     When I set initials to "<initials>"
@@ -47,6 +48,7 @@ Feature: Profile default component
       | TJH      |
 
   # value which is rendering as src doesn't work properly for CI
+  # ignore regression
   @ignore
   Scenario Outline: Get initials from name <name>
     When I set name to "<name>"

--- a/cypress/features/regression/profile.feature
+++ b/cypress/features/regression/profile.feature
@@ -36,7 +36,8 @@ Feature: Profile default component
     # @ignore because of FE-1447
     # | <> |
 
-  @positive
+  # value which is rendering as src doesn't work properly for CI
+  @ignore
   Scenario Outline: Set initials to <initials>
     When I set initials to "<initials>"
     Then initials is set to "<initials>"
@@ -45,7 +46,8 @@ Feature: Profile default component
       | OW       |
       | TJH      |
 
-  @positive
+  # value which is rendering as src doesn't work properly for CI
+  @ignore
   Scenario Outline: Get initials from name <name>
     When I set name to "<name>"
       And I set initials to empty


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
add ignore tag for tests in profile and portrait components which doesn't work properly for CI

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
The following tests fail for CI
Portrait component:
1. Change Portrait initials
2. Enable darkBackground checkbox for a Portrait component

Profile component:
1. Get initials from name
2. Set initials to
### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [ ] Unit tests
- [x] Cypress automation tests
- [ ] Storybook added or updated
- [ ] Theme support
- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->
In the future, we'll try to fix this test cases or we'll remove 

