### PR TITLE
fix(search): close icon persists when field is empty (FE-2638)

### DIFF
--- a/cypress/features/regression/test/search.feature
+++ b/cypress/features/regression/test/search.feature
@@ -52,6 +52,13 @@ Feature: Search component
       And Search component input has golden border
 
   @positive
+  Scenario: Verify inner elements in Search component after clearing the input
+    Given I uncheck searchButton checkbox
+      And Type "Search" text into search input
+    When I click on cross icon
+    Then Search component has input and "search" as icon
+
+  @positive
   Scenario: Verify golden outline for search icon
     Given Type "Sea" text into search input
     When I click onto search icon

--- a/src/__experimental__/components/search/search.component.js
+++ b/src/__experimental__/components/search/search.component.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import invariant from 'invariant';
 import StyledSearch, { StyledSearchButton, StyledButtonIcon } from './search.style';
@@ -15,9 +15,8 @@ const Search = ({
     typeof initialValue === 'string',
     'This component has no initial value'
   );
-  let inputRef = useRef(null);
   const [searchValue, setSearchValue] = useState(initialValue);
-  const [isFocused, setIsFocused] = useState(inputRef.current === document.activeElement);
+  const [isFocused, setIsFocused] = useState(false);
   const [searchIsActive, setSearchIsActive] = useState(initialValue.length >= threshold);
 
   const iconType = useMemo(() => {
@@ -98,7 +97,6 @@ const Search = ({
         { ...rest }
         placeholder={ placeholder }
         value={ searchValue }
-        inputRef={ (el) => { inputRef = el; } }
         inputIcon={ iconType }
         iconOnClick={ handleIconClick }
       />

--- a/src/__experimental__/components/search/search.component.js
+++ b/src/__experimental__/components/search/search.component.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useLayoutEffect } from 'react';
+import React, { useState, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import invariant from 'invariant';
 import StyledSearch, { StyledSearchButton, StyledButtonIcon } from './search.style';
@@ -19,7 +19,23 @@ const Search = ({
   const [searchValue, setSearchValue] = useState(initialValue);
   const [isFocused, setIsFocused] = useState(inputRef.current === document.activeElement);
   const [searchIsActive, setSearchIsActive] = useState(initialValue.length >= threshold);
-  const [iconType, setIconType] = useState(null);
+
+  const iconType = useMemo(() => {
+    const isSearchValueEmpty = searchValue.length === 0;
+    const isFocusedOrActive = isFocused || searchIsActive;
+
+    setSearchIsActive(searchValue.length >= threshold);
+
+    if (!isSearchValueEmpty) {
+      return 'cross';
+    }
+
+    if (!isFocusedOrActive || threshold === 0 || (!searchButton && isSearchValueEmpty)) {
+      return 'search';
+    }
+
+    return '';
+  }, [isFocused, searchIsActive, searchValue, threshold, searchButton]);
 
   const handleChange = (e) => {
     if (onChange) {
@@ -63,17 +79,6 @@ const Search = ({
   const handleBlur = () => {
     setIsFocused(false);
   };
-
-  useLayoutEffect(() => {
-    setSearchIsActive(searchValue.length >= threshold);
-    if (searchValue.length > 0) {
-      setIconType('cross');
-    } else if ((searchButton && isFocused)) {
-      setIconType('');
-    } else if ((!isFocused && !searchIsActive) || threshold === 0) {
-      setIconType('search');
-    }
-  }, [isFocused, searchButton, searchIsActive, searchValue, threshold]);
 
   return (
     <StyledSearch

--- a/src/__experimental__/components/search/search.component.js
+++ b/src/__experimental__/components/search/search.component.js
@@ -17,7 +17,7 @@ const Search = ({
   );
   let inputRef = useRef(null);
   const [searchValue, setSearchValue] = useState(initialValue);
-  const [isActive, setIsActive] = useState(inputRef.current === document.activeElement);
+  const [isFocused, setIsFocused] = useState(inputRef.current === document.activeElement);
   const [searchIsActive, setSearchIsActive] = useState(initialValue.length >= threshold);
   const [iconType, setIconType] = useState(null);
 
@@ -29,7 +29,7 @@ const Search = ({
   };
 
   const handleOnFocus = () => {
-    setIsActive(true);
+    setIsFocused(true);
   };
 
   let buttonProps = {};
@@ -61,19 +61,19 @@ const Search = ({
   };
 
   const handleBlur = () => {
-    setIsActive(false);
+    setIsFocused(false);
   };
 
   useLayoutEffect(() => {
     setSearchIsActive(searchValue.length >= threshold);
     if (searchValue.length > 0) {
       setIconType('cross');
-    } else if ((searchButton && isActive)) {
+    } else if ((searchButton && isFocused)) {
       setIconType('');
-    } else if ((!isActive && !searchIsActive) || threshold === 0) {
+    } else if ((!isFocused && !searchIsActive) || threshold === 0) {
       setIconType('search');
     }
-  }, [isActive, searchButton, searchIsActive, searchValue, threshold]);
+  }, [isFocused, searchButton, searchIsActive, searchValue, threshold]);
 
   return (
     <StyledSearch
@@ -81,7 +81,7 @@ const Search = ({
       onClick={ handleOnFocus }
       onBlur={ handleBlur }
       onChange={ handleChange }
-      isActive={ isActive }
+      isFocused={ isFocused }
       searchIsActive={ searchIsActive }
       id={ id }
       data-component='search'
@@ -99,7 +99,7 @@ const Search = ({
       />
       {(searchButton && (
         <StyledSearchButton>
-          {Boolean(isActive || searchValue.length) && (
+          {Boolean(isFocused || searchValue.length) && (
             <Button
               size='small'
               { ...buttonProps }

--- a/src/__experimental__/components/search/search.style.js
+++ b/src/__experimental__/components/search/search.style.js
@@ -7,14 +7,14 @@ import StyledFormField from '../form-field/form-field.style';
 
 const StyledSearch = styled.div`
   ${({ theme }) => `border-bottom: 2px solid ${theme.search.passive};`}
-  ${({ isActive, searchHasValue }) => css`
-    ${!isActive && !searchHasValue && css`
+  ${({ isFocused, searchHasValue }) => css`
+    ${!isFocused && !searchHasValue && css`
       ${StyledInputPresentation} {
         border: 1px solid transparent;
         color: rgba(0, 0, 0, 0.65);
       }
     `}
-    ${(isActive || searchHasValue) && css`
+    ${(isFocused || searchHasValue) && css`
       border-bottom: 2px solid transparent;
       transition: border 0.2s ease, background 0.2s ease;
       color: rgba(0, 0, 0, 0.9);
@@ -24,8 +24,8 @@ const StyledSearch = styled.div`
     `}
   `}
 
-  ${({ isActive, searchIsActive }) => css`
-    ${isActive && !searchIsActive && css`
+  ${({ isFocused, searchIsActive }) => css`
+    ${isFocused && !searchIsActive && css`
       color: rgba(0, 0, 0, 0.9);
     `}
   `}
@@ -43,9 +43,9 @@ const StyledSearch = styled.div`
   ${StyledInputPresentation} {
     width: ${
   ({
-    hasSearchButton, isActive, searchIsActive, searchHasValue
+    hasSearchButton, isFocused, searchIsActive, searchHasValue
   }) => (
-    hasSearchButton && (isActive || searchIsActive || searchHasValue) ? '335px;' : '375px;'
+    hasSearchButton && (isFocused || searchIsActive || searchHasValue) ? '335px;' : '375px;'
   )};
 
     font-size: 14px;


### PR DESCRIPTION
### Proposed behaviour
Close icon should be replaced by the search icon when the text is cleared.
![image](https://user-images.githubusercontent.com/22885392/78001789-82510f00-7336-11ea-9c84-98b49fcbbab9.png)

### Current behaviour
When the text field is cleared using the close button, the close button is not replaced by the search icon.
![image](https://user-images.githubusercontent.com/22885392/78001771-7a916a80-7336-11ea-9a73-a65e775d6682.png)


### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
~~- [ ] Unit tests~~
- [x] Cypress automation tests
~~- [ ] Storybook added or updated~~
~~- [ ] Theme support~~
~~- [ ] Typescript `d.ts` file added or updated~~

### Testing instructions
1. run: npm start
2. go to: http://localhost:9001/?path=/story/test-search--basic
3. uncheck the `searchButton` knob
4. type `test` in the text field
5. click on the `close` button in the field
