### PR TITLE
ci(travis): build x.x.x branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js: node
 branches:
   only:
   - master
+  - /^\d+\.x$/ # 1.x
+  - /^\d+\.x.x$/ # 1.x.x
+  - /^\d+\.\d+\.x$/ # 1.1.x
 
 addons:
    apt:


### PR DESCRIPTION
### Proposed behaviour
Build branches in the format `1.x`, `1.x.x`, `1.2.x`, all of these formats are protected branches and can only be made by a maintainer.

This will make patching older versions easier in the future.

### Current behaviour
We only build master, to build any other branches we would have to modify the Travis config on that branch.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>- [ ] Unit tests
<del>- [ ] Cypress automation tests
<del>- [ ] Storybook added or updated
<del>- [ ] Theme support
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->
This PR is an example that targeted an old version #2756.
This PR build because at the time we were building all branches.

When creating these branches they still need `GH_TOKEN` and `NPM_TOKEN` for `semantic-release` to trigger. These are added by a maintainer in the Travis UI.

### Testing instructions
No need for QA, developers the travis status check should pass as normal.
I tested the branch protection regex by creating some branches.
![image](https://user-images.githubusercontent.com/2328042/78027312-129e4c80-7355-11ea-8696-28e992e5b944.png)
