### PR TITLE
feat(drawer): create drawer component

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -6,6 +6,8 @@
   "default": "--default",
   "classic": "--classic",
   "basic": "--basic",
+  "controlled": "--controlled",
+  "uncontrolled": "--uncontrolled",
   "buttonToogleGroup": "--buttontogglegroup",
   "legacy_spinner": "--legacy-spinner",
   "multiple": "--multiple",

--- a/cypress/features/regression/drawer.feature
+++ b/cypress/features/regression/drawer.feature
@@ -1,0 +1,43 @@
+Feature: Drawer component
+  I want to test Drawer component
+
+  Background: Open Drawer component page
+    Given I open design systems uncontrolled Drawer component page
+
+  @positive
+  Scenario: Expanding Drawer
+    When I click on Drawer arrow 1 time
+    Then sidebar should have class open
+      And toggle icon switched orientation to open
+      And sidebar text is visible
+
+  @positive
+  Scenario: Collapsing Drawer
+    When I click on Drawer arrow 2 times
+    Then sidebar should have class closed
+      And toggle icon switched orientation to closed
+      And sidebar text is not visible
+
+  @positive
+  Scenario Outline: Set animationDuration to <animationDuration>
+    Given I set animationDuration to "<animationDuration>"
+    When I click on Drawer arrow 1 time
+    Then animationDuration is set to "<cssAnimationDuration>"
+    Examples:
+      | animationDuration | cssAnimationDuration |
+      | 500ms             | 0.5s                 |
+      | 100ms             | 0.1s                 |
+      | 0.5s              | 0.5s                 |
+      | 0.1s              | 0.1s                 |
+
+  @positive
+  Scenario Outline: Set expandedWidth to <expandedWidth>
+    Given I set expandedWidth to "<expandedWidth>"
+    When I click on Drawer arrow 1 time
+    Then expandedWidth is set to "<cssWidth>"
+    Examples:
+      | expandedWidth | cssWidth    |
+      | 10%           | 114.59375px |
+      | 50%           | 573px       |
+      | 100px         | 100px       |
+      | 500px         | 500px       |

--- a/cypress/locators/drawer/index.js
+++ b/cypress/locators/drawer/index.js
@@ -1,0 +1,9 @@
+import {
+  DRAWER,
+  DRAWER_TOGGLE,
+} from './locators';
+
+// component preview locators
+export const drawerToggle = () => cy.iFrame(DRAWER_TOGGLE);
+export const drawerSidebar = () => cy.iFrame(DRAWER).find('div:nth-child(1)');
+export const drawerSidebarContentInnerElement = index => drawerSidebar().find('div').find(`li:nth-child(${index})`);

--- a/cypress/locators/drawer/locators.js
+++ b/cypress/locators/drawer/locators.js
@@ -1,0 +1,3 @@
+// component preview locators
+export const DRAWER = '[data-element="drawer"]';
+export const DRAWER_TOGGLE = '[data-element="drawer-toggle"]';

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -20,6 +20,10 @@ import { pagerSummary } from '../../locators/pager';
 const LABEL_INPUT_INLINE_CLASS = 'common-input__label--inline';
 const TEXT_ALIGN = 'text-align';
 
+Given('I open design systems {word} {word} component page', (type, component) => {
+  visitComponentUrl(component, type, false, 'design-system-');
+});
+
 Given('I open {string} component page', (component) => {
   visitComponentUrl(component);
 });

--- a/cypress/support/step-definitions/drawer-steps.js
+++ b/cypress/support/step-definitions/drawer-steps.js
@@ -1,0 +1,50 @@
+import {
+  drawerToggle,
+  drawerSidebar,
+  drawerSidebarContentInnerElement,
+} from '../../locators/drawer';
+import { positionOfElement } from '../helper';
+
+When('I click on Drawer arrow {int} time(s)', (count) => {
+  for (let i = 0; i < count; i++) {
+    drawerToggle().first().click();
+  }
+});
+
+Then('sidebar should have class {word}', (className) => {
+  drawerSidebar().should('have.class', className);
+});
+
+Then('sidebar text is visible', () => {
+  drawerSidebarContentInnerElement(positionOfElement('second')).should('have.text', 'link a')
+    .and('be.visible');
+  drawerSidebarContentInnerElement(positionOfElement('third')).should('have.text', 'link b')
+    .and('be.visible');
+  drawerSidebarContentInnerElement(positionOfElement('fourth')).should('have.text', 'link c')
+    .and('be.visible');
+});
+
+Then('sidebar text is not visible', () => {
+  drawerSidebarContentInnerElement(positionOfElement('second')).should('have.text', 'link a')
+    .and('not.be.visible');
+  drawerSidebarContentInnerElement(positionOfElement('third')).should('have.text', 'link b')
+    .and('not.be.visible');
+  drawerSidebarContentInnerElement(positionOfElement('fourth')).should('have.text', 'link c')
+    .and('not.be.visible');
+});
+
+Then('toggle icon switched orientation to open', () => {
+  drawerToggle().should('have.css', 'transform', 'matrix(-1, 0, 0, 1, 0, 0)');
+});
+
+Then('toggle icon switched orientation to closed', () => {
+  drawerToggle().should('have.css', 'transform', 'none');
+});
+
+Then('expandedWidth is set to {string}', (width) => {
+  drawerSidebar().should('have.css', 'width', width);
+});
+
+Then('animationDuration is set to {string}', (animationDuration) => {
+  drawerSidebar().should('have.css', 'animation-duration', animationDuration);
+});

--- a/src/components/drawer/drawer.component.js
+++ b/src/components/drawer/drawer.component.js
@@ -1,0 +1,91 @@
+import React, { useState, useCallback, useRef } from 'react';
+import PropTypes from 'prop-types';
+import createGuid from '../../utils/helpers/guid';
+import Icon from '../icon';
+
+import {
+  StyledDrawerWrapper,
+  StyledDrawerContent,
+  StyledButton,
+  StyledDrawerChildren,
+  StyledDrawerSidebar
+} from './drawer.style';
+
+const Drawer = ({
+  defaultExpanded,
+  expanded,
+  onChange,
+  children,
+  expandedWidth,
+  sidebar,
+  animationDuration,
+  ...props
+}) => {
+  const isControlled = expanded !== undefined;
+  const [isExpandedInternal, setIsExpandedInternal] = useState(defaultExpanded || false);
+  const [isFirstOpen, setFirstOpen] = useState(true);
+  const isExpanded = isControlled ? expanded : isExpandedInternal;
+  const toggleDrawer = useCallback((ev) => {
+    if (!isControlled) setIsExpandedInternal(!isExpanded);
+    if (onChange) onChange(ev, !isExpanded);
+    setFirstOpen(false);
+  }, [isControlled, isExpanded, onChange]);
+
+  const closedClass = isFirstOpen ? '' : 'closed';
+  const guid = useRef(createGuid());
+  const sidebarId = `DrawerSidebar_${guid.current}`;
+
+  return (
+    <StyledDrawerWrapper
+      data-element='drawer'
+      { ...props }
+    >
+      <StyledDrawerContent
+        expandedWidth={ expandedWidth }
+        animationDuration={ animationDuration }
+        className={ isExpanded ? 'open' : closedClass }
+      >
+        <StyledButton
+          aria-label='toggle sidebar'
+          aria-expanded={ isExpanded }
+          aria-controls={ sidebarId }
+          data-element='drawer-toggle'
+          onClick={ toggleDrawer }
+          isExpanded={ isExpanded }
+          animationDuration={ animationDuration }
+        >
+          <Icon type='chevron_right' />
+        </StyledButton>
+        <StyledDrawerSidebar id={ sidebarId } role='navigation'>
+          { sidebar }
+        </StyledDrawerSidebar>
+      </StyledDrawerContent>
+      <StyledDrawerChildren>
+        {children}
+      </StyledDrawerChildren>
+    </StyledDrawerWrapper>
+  );
+};
+
+Drawer.propTypes = {
+  children: PropTypes.node.isRequired,
+  /** Set the default state of expansion of the Drawer if component is meant to be used as uncontrolled */
+  defaultExpanded: PropTypes.bool,
+  /** Sets the expansion state of the Drawer if component is meant to be used as controlled */
+  expanded: PropTypes.bool,
+  /** Callback fired when expansion state changes, onChange(event: object, isExpanded: boolean) */
+  onChange: PropTypes.func,
+  /* Sidebar object either html or react component */
+  sidebar: PropTypes.node,
+  /* The (% or px) width of the expanded sizebar  */
+  expandedWidth: PropTypes.string,
+  /** Duration of a animation */
+  animationDuration: PropTypes.string
+};
+
+Drawer.defaultProps = {
+  expandedWidth: '40%',
+  animationDuration: '400ms'
+};
+
+export default Drawer;

--- a/src/components/drawer/drawer.d.ts
+++ b/src/components/drawer/drawer.d.ts
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+export interface DrawerPropTypes {
+  children: React.FunctionComponent | React.ComponentClass;
+  defaultExpanded?: boolean;
+  expanded?: boolean;
+  onChange?: (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, isExpanded: boolean) => void;
+  sidebar?: React.ReactNode;
+  animationDuration?: string;
+  expandedWidth?: string;
+}
+
+declare const Drawer: React.FunctionComponent<DrawerPropTypes>;
+
+export default Drawer;

--- a/src/components/drawer/drawer.stories.mdx
+++ b/src/components/drawer/drawer.stories.mdx
@@ -1,0 +1,86 @@
+import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
+import Drawer from '.';
+import { useState, useCallback } from 'react';
+import { text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+
+<Meta title="Design System/Drawer" />
+
+# Drawer
+Drawer is a two column layout container.
+It is designed to have left hand side container expand and collapse to respectively reveal and hide the content of that container.
+Drawer component is designed to fill the space of the element that it is put inside.
+
+```javascript
+import Drawer from 'carbon-react/lib/components/drawer';
+```
+
+### Uncontrolled usage:
+
+<Preview>
+  <Story name="uncontrolled" parameters={{ info: { disable: true }}} >
+    return (
+      <div style={ { height: '200px' } }>
+        <Drawer
+          expandedWidth={ text('expandedWidth', '40%') }
+          animationDuration={ text('animationDuration', '0.5s') }
+          sidebar={ (
+            <ul>
+              <li>link a</li>
+              <li>link b</li>
+              <li>link c</li>
+            </ul>
+          ) }
+        >
+          content body content body content body content body content body content body content body
+        </Drawer>
+      </div>
+    )
+  </Story>
+</Preview>
+
+
+### Controlled Usage:
+
+<Preview>
+  <Story name="controlled" parameters={{ info: { disable: true }}} >
+    {() => {
+      const [isExpanded, setIsExpanded] = useState(true);
+      const onChangeHandler = useCallback(() => {
+        setIsExpanded(!isExpanded);
+        action('expansionToggled');
+      }, [isExpanded]);
+      return (
+        <div>
+          <p>
+            Note: if you experience glitchy animation on `Drawer` component,
+            please open canvas in new window (2nd icon in top right corner)
+          </p>
+          <div style={ { height: '200px' } }>
+            <Drawer
+              expandedWidth={ text('expandedWidth', '40%') }
+              animationDuration={ text('animationDuration', '0.5s') }
+              expanded={ isExpanded }
+              onChange={ onChangeHandler }
+              sidebar={ (
+                <ul>
+                  <li>link a</li>
+                  <li>link b</li>
+                  <li>link c</li>
+                </ul>
+              ) }
+            >
+              content body content body content body content body content body content body content body
+            </Drawer>
+          </div>
+        </div>
+      )
+    }}
+  </Story>
+</Preview>
+
+## Props:
+
+### Drawer
+
+<Props of={Drawer} />

--- a/src/components/drawer/drawer.style.js
+++ b/src/components/drawer/drawer.style.js
@@ -1,0 +1,117 @@
+import styled, { css, keyframes } from 'styled-components';
+
+const StyledDrawerChildren = styled.div`
+  flex: 1;
+  margin-left: 1px;
+`;
+
+const StyledDrawerSidebar = styled.div`
+  margin-top: 60px;
+  display: none;
+  opacity: 0;
+`;
+
+const sidebarVisible = () => keyframes`
+  0% {opacity: 0;}
+  50% {opacity: 0;}
+  100% {opacity: 1;}
+`;
+
+const sidebarHidden = () => keyframes`
+  0% {opacity: 1;}
+  100% {opacity: 0; display: none;}
+`;
+
+const drawerOpen = expandedWidth => keyframes`
+  0% {width: 40px;}
+  100% {width: ${expandedWidth};}
+`;
+
+const drawerClose = expandedWidth => keyframes`
+  0% {width: ${expandedWidth};}
+  100% {width: 40px;}
+`;
+
+const buttonOpen = () => keyframes`
+  0% {float: left;}
+  20% {float: right;}
+  100% {float: right;}
+`;
+
+const buttonClose = () => keyframes`
+  0% {float: right;}
+  80% {float: right;}
+  100% {float: left;}
+`;
+
+const StyledDrawerContent = styled.div`
+  min-width: 40px;
+  width: 40px;
+  min-height: 40px;
+  height: auto;
+  position: relative;
+  overflow: hidden;
+  border-right: 1px solid ${({ theme }) => theme.drawer.divider};
+
+  &.open {
+    min-width: 52px;
+    width: ${({ expandedWidth }) => expandedWidth};
+    animation: ${({ animationDuration, expandedWidth }) => css`
+      ${drawerOpen(expandedWidth)} ${animationDuration}
+    `} ease-in-out;
+
+    ${StyledDrawerSidebar} {
+      display: block;
+      opacity: 1;
+      animation: ${sidebarVisible} ${({ animationDuration }) => animationDuration} ease-in-out;
+    }
+  }
+
+  &.closed {
+    animation: ${({ animationDuration, expandedWidth }) => css`
+      ${drawerClose(expandedWidth)} ${animationDuration}
+    `} ease-in-out;
+
+    ${StyledDrawerSidebar} {
+      display: block;
+      opacity: 0;
+      animation: ${sidebarHidden} ${({ animationDuration }) => animationDuration} ease-in-out;
+    }
+  }
+`;
+
+const StyledButton = styled.button`
+  float: right;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  margin: 8px 8px auto 8px;
+  transition: margin-right ${({ animationDuration }) => animationDuration} ease-in-out;
+  background-color: transparent;
+  border: none;
+
+  &:focus {
+    outline: 3px solid ${({ theme }) => theme.colors.focus};
+  }
+  animation: ${buttonClose} ${({ animationDuration }) => animationDuration} ease-in-out;
+
+  ${({ isExpanded }) => isExpanded && css`
+    float: right;
+    transform: scaleX(-1);
+    margin-right: 20px;
+    animation: ${buttonOpen} ${({ animationDuration }) => animationDuration} ease-in-out;
+  `}
+`;
+
+const StyledDrawerWrapper = styled.div`
+  display: flex;
+  height: 100%;
+`;
+
+export {
+  StyledDrawerWrapper,
+  StyledDrawerContent,
+  StyledDrawerChildren,
+  StyledDrawerSidebar,
+  StyledButton
+};

--- a/src/components/drawer/index.js
+++ b/src/components/drawer/index.js
@@ -1,0 +1,1 @@
+export { default } from './drawer.component';

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -159,6 +159,10 @@ export default (palette) => {
       dragging: palette.slateTint(90)
     },
 
+    drawer: {
+      divider: palette.slateTint(85)
+    },
+
     pager: {
       active: 'rgba(0,0,0,0.74)',
       disabled: 'rgba(0,0,0,0.55)',


### PR DESCRIPTION
### Proposed behaviour
Drawer component, a simple two container layout that allows for left hand side container to expand and collapse as per user choice/settings white the right hand side container adjusts reflows its content based on available space.

![drawer](https://user-images.githubusercontent.com/47245766/78181163-cf7ad100-745b-11ea-8c0e-f58937d3d2b9.gif)

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>- [ ] Unit tests
- [x] Cypress automation tests
- [x] Storybook added or updated
<del>- [ ] Theme support
- [x] Typescript `d.ts` file added or updated
