### PR TITLE
feat(action-popover): add support for custom menu button override FE-2329

### DIFF
--- a/cypress/features/regression/test/actionPopoverStyleOverrideNoIFrame.feature
+++ b/cypress/features/regression/test/actionPopoverStyleOverrideNoIFrame.feature
@@ -1,0 +1,15 @@
+Feature: Style overriden Action Popover component
+  I want to verify overriden styles for Action Popover component
+
+  Background: Style overriden Action Popover component
+    Given I open style override Test "Action Popover" component page in noIframe
+
+  @positive
+  Scenario: Open style overriden Action Popover component page and verify overriden styles are rendered properly
+    # When I open style override Test "Action Popover" component page in noIframe
+    Then Action Popover overriden styles rendered properly
+
+  @positive
+  Scenario: Overriden button opens Action Popover
+    When I click the menu button element in noiFrame
+    Then Action Popover element is visible

--- a/cypress/locators/button/index.js
+++ b/cypress/locators/button/index.js
@@ -3,3 +3,6 @@ import { BUTTON_SUBTEXT_PREVIEW, BUTTON_DATA_COMPONENT_PREVIEW } from './locator
 // component preview locators
 export const buttonSubtextPreview = () => cy.iFrame(BUTTON_SUBTEXT_PREVIEW);
 export const buttonDataComponent = () => cy.iFrame(BUTTON_DATA_COMPONENT_PREVIEW);
+
+// component preview locators in no IFrame
+export const buttonDataComponentNoIFrame = () => cy.get(BUTTON_DATA_COMPONENT_PREVIEW);

--- a/cypress/support/step-definitions/action-popover-steps.js
+++ b/cypress/support/step-definitions/action-popover-steps.js
@@ -5,7 +5,8 @@ import {
   actionPopoverSubmenuNoIFrame,
   actionPopoverSubmenuInnerElementNoIFrame,
 } from '../../locators/action-popover';
-import { eventInAction } from '../../locators';
+import { eventInAction, iconNoIframe } from '../../locators';
+import { buttonDataComponentNoIFrame } from '../../locators/button';
 
 Then('Action Popover element is visible', () => {
   actionPopover().should('be.visible');
@@ -76,4 +77,28 @@ Then('{string} action was called in Actions Tab for actionPopover', (event) => {
 Then('ActionPopover submenu is not visible', () => {
   actionPopoverSubmenuNoIFrame()
     .should('not.be.visible');
+});
+
+Then('Action Popover overriden styles rendered properly', () => {
+  actionPopoverButton().should('have.css', 'display', 'table');
+  actionPopoverButton().children().should('have.css', 'padding-left', '8px')
+    .and('have.css', 'padding-right', '8px')
+    .and('have.css', 'width', '78px');
+  buttonDataComponentNoIFrame().should('have.css', 'border', '2px solid rgba(0, 0, 0, 0)')
+    .and('have.css', 'box-sizing', 'border-box')
+    .and('have.css', 'padding-top', '1px')
+    .and('have.css', 'padding-bottom', '1px');
+  iconNoIframe().should('have.attr', 'data-element', 'dropdown')
+    .and('have.css', 'margin-left', '8px')
+    .and('have.css', 'margin-right', '0px')
+    .and('have.css', 'height', '16px');
+  actionPopover().eq(1).should('be.hidden')
+    .and('have.css', 'visibility', 'hidden')
+    .and('have.css', 'margin', '0px')
+    .and('have.css', 'padding', '8px 0px')
+    .and('have.css', 'box-shadow', 'rgba(0, 20, 29, 0.2) 0px 5px 5px 0px, rgba(0, 20, 29, 0.1) 0px 10px 10px 0px')
+    .and('have.css', 'position', 'absolute')
+    .and('have.css', 'left', '0px')
+    .and('have.css', 'background-color', 'rgb(255, 255, 255)')
+    .and('have.css', 'z-index', '1');
 });

--- a/src/components/action-popover/__snapshots__/action-popover.spec.js.snap
+++ b/src/components/action-popover/__snapshots__/action-popover.spec.js.snap
@@ -76,7 +76,7 @@ exports[`ActionPopover styles renders correctly for the "classic" theme 2`] = `
 exports[`ActionPopover styles renders correctly for the "classic" theme 3`] = `
 .c0 {
   position: relative;
-  width: 24px;
+  display: table;
   margin: auto;
 }
 

--- a/src/components/action-popover/action-popover-item.d.ts
+++ b/src/components/action-popover/action-popover-item.d.ts
@@ -4,7 +4,7 @@ import ActionPopoverMenu from './action-popover-menu';
 
 export interface ActionPopoverItemProps {
   children: string;
-  icon: IconTypes;
+  icon?: IconTypes;
   disabled?: boolean;
   onClick: () => void;
   submenu?: typeof ActionPopoverMenu;

--- a/src/components/action-popover/action-popover-menu.component.js
+++ b/src/components/action-popover/action-popover-menu.component.js
@@ -26,7 +26,9 @@ const ActionPopoverMenu = React.forwardRef(({
               clearTimeout(timer.current);
               timer.current = setTimeout(() => {
                 setOpen(false);
-                item.ref.current.focus();
+                if (item.ref && item.ref.current) {
+                  item.ref.current.focus();
+                }
               }, 0);
             } else {
               setFocusIndex(index);

--- a/src/components/action-popover/action-popover.component.js
+++ b/src/components/action-popover/action-popover.component.js
@@ -13,7 +13,7 @@ import ActionPopoverItem from './action-popover-item.component';
 import ActionPopoverDivider from './action-popover-divider.component';
 
 const ActionPopover = ({
-  children, id, onOpen, onClose, rightAlignMenu, ...rest
+  children, id, onOpen, onClose, rightAlignMenu, renderButton, ...rest
 }) => {
   const [isOpen, setOpenState] = useState(false);
   const [focusIndex, setFocusIndex] = useState(0);
@@ -73,6 +73,25 @@ const ActionPopover = ({
     };
   }, [setOpen]);
 
+  const menuButton = () => {
+    if (renderButton) {
+      return renderButton({
+        tabIndex: -1,
+        'data-element': 'action-popover-menu-button',
+        styleOverride: {
+          root: {
+            '&:focus': { outlineWidth: '2px' },
+            paddingLeft: '8px',
+            paddingRight: '8px',
+            width: '100%'
+          }
+        }
+      });
+    }
+
+    return <ButtonIcon type='ellipsis_vertical' />;
+  };
+
   const parentID = id || `ActionPopoverButton_${guid}`;
   const menuID = `ActionPopoverMenu_${guid}`;
   const menuProps = {
@@ -102,7 +121,7 @@ const ActionPopover = ({
       ref={ button }
       { ...rest }
     >
-      <ButtonIcon type='ellipsis_vertical' />
+      { menuButton() }
       <ActionPopoverMenu
         data-component='action-popover'
         role='menu'
@@ -138,7 +157,9 @@ ActionPopover.propTypes = {
     });
 
     return error;
-  }
+  },
+  /** Render a custom menu button to override default ellipsis icon */
+  renderButton: PropTypes.func
 };
 
 ActionPopover.defaultProps = {

--- a/src/components/action-popover/action-popover.d.ts
+++ b/src/components/action-popover/action-popover.d.ts
@@ -5,6 +5,7 @@ export interface ActionPopoverProps {
   onOpen?: () => void;
   onClose?: () => void;
   rightAlignMenu?: boolean;
+  renderButton?: (args: object) => React.ReactNode;
 }
 
 declare const ActionPopover: React.FunctionComponent<ActionPopoverProps>;

--- a/src/components/action-popover/action-popover.spec.js
+++ b/src/components/action-popover/action-popover.spec.js
@@ -45,16 +45,32 @@ describe('ActionPopover', () => {
     const defaultProps = {
       children: [
         <ActionPopoverItem
+          key='item-1'
           icon='pdf'
           { ...{ onClick: onClickWrapper('pdf') } }
           disabled
         >
           Download PDF
         </ActionPopoverItem>,
-        <ActionPopoverItem icon='email' { ...{ onClick: onClickWrapper('email') } }>Email Invoice</ActionPopoverItem>,
-        <ActionPopoverItem icon='print' { ...{ onClick: onClickWrapper('print') } }>Print Invoice</ActionPopoverItem>,
-        <ActionPopoverDivider />,
-        <ActionPopoverItem icon='csv' { ...{ onClick: onClickWrapper('csv') } }>Download CSV</ActionPopoverItem>,
+        <ActionPopoverItem
+          key='item-2'
+          icon='email' { ...{ onClick: onClickWrapper('email') } }
+        >
+          Email Invoice
+        </ActionPopoverItem>,
+        <ActionPopoverItem
+          key='item-3'
+          icon='print' { ...{ onClick: onClickWrapper('print') } }
+        >
+          Print Invoice
+        </ActionPopoverItem>,
+        <ActionPopoverDivider key='divider' />,
+        <ActionPopoverItem
+          key='item-4'
+          icon='csv' { ...{ onClick: onClickWrapper('csv') } }
+        >
+          Download CSV
+        </ActionPopoverItem>,
         null,
         undefined
       ],
@@ -96,6 +112,7 @@ describe('ActionPopover', () => {
     const defaultProps = {
       children: [
         <ActionPopoverItem
+          key='item-1'
           disabled
           icon='pdf'
           { ...{ onClick: onClickWrapper('pdf') } }
@@ -103,18 +120,26 @@ describe('ActionPopover', () => {
           Download PDF
         </ActionPopoverItem>,
         <ActionPopoverItem
+          key='item-2'
           icon='email'
           submenu={ submenu }
           { ...{ onClick: onClickWrapper('email') } }
         >
           Email Invoice
         </ActionPopoverItem>,
-        <ActionPopoverItem icon='print' { ...{ onClick: onClickWrapper('print') } }>Print Invoice</ActionPopoverItem>,
-        <ActionPopoverDivider />,
         <ActionPopoverItem
+          key='item-3'
+          icon='print' { ...{ onClick: onClickWrapper('print') } }
+        >
+          Print Invoice
+        </ActionPopoverItem>,
+        <ActionPopoverDivider key='divider' />,
+        <ActionPopoverItem
+          key='item-4'
           icon='csv'
           { ...{ onClick: onClickWrapper('csv') } }
-        >Download CSV
+        >
+          Download CSV
         </ActionPopoverItem>,
         null,
         undefined
@@ -782,6 +807,16 @@ describe('ActionPopover', () => {
         });
 
         expect(onClose).toHaveBeenCalledTimes(0);
+      });
+
+      it('removes focus from an item when clicked if it has no submenu', () => {
+        const { items } = getElements();
+        const item = items.at(2).getDOMNode();
+
+        act(() => {
+          item.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+          expect(item).not.toBeFocused();
+        });
       });
 
       it('returns focus back to parent item when submenu item clicked', () => {

--- a/src/components/action-popover/action-popover.spec.js
+++ b/src/components/action-popover/action-popover.spec.js
@@ -17,6 +17,7 @@ import {
 } from './action-popover.style';
 import { rootTagTest } from '../../utils/helpers/tags/tags-specs';
 import Icon from '../icon';
+import Button from '../button';
 import guid from '../../utils/helpers/guid';
 
 jest.mock('../../utils/helpers/guid');
@@ -886,6 +887,35 @@ describe('ActionPopover', () => {
       expect(console.error).toHaveBeenCalledWith('Warning: Failed prop type: `WithTheme(ActionPopoverItem)` only'
       + ' accepts submenu of type `ActionPopoverMenu`\n    in WithTheme(ActionPopoverItem)');
       global.console.error.mockReset();
+    });
+  });
+
+  describe('Custom Menu Button', () => {
+    it('supports being passed an override component to act as the menu button', () => {
+      const popover = enzymeMount(
+        <ThemeProvider theme={ mintTheme }>
+          <ActionPopover renderButton={ props => <Button { ...props }>Foo</Button> }>
+            <ActionPopoverItem onClick={ jest.fn() }>foo</ActionPopoverItem>
+          </ActionPopover>
+        </ThemeProvider>
+      ).find(ActionPopover);
+
+      const button = popover.find(Button);
+
+      expect(popover.find(Icon).first().exists()).toBeFalsy();
+      expect(button.exists()).toBeTruthy();
+      expect(button.props().tabIndex).toEqual(-1);
+      expect(button.props()['data-element']).toEqual('action-popover-menu-button');
+
+      assertStyleMatch({
+        paddingLeft: '8px',
+        paddingRight: '8px',
+        width: '100%'
+      }, button);
+
+      assertStyleMatch({
+        outlineWidth: '2px'
+      }, button, { modifier: '&:focus' });
     });
   });
 });

--- a/src/components/action-popover/action-popover.stories.js
+++ b/src/components/action-popover/action-popover.stories.js
@@ -202,66 +202,77 @@ Classic.story = {
   }
 };
 
-const generateTableCells = (options, cols) => {
-  const cells = options.slice(0, cols - 1).map((cell, index) => <TableCell key={ String(index) }>{cell}</TableCell>);
-
-  if (cells.length === options.length) {
-    return cells;
-  }
-
-  const overflow = (
-    <TableCell>
-      <ActionPopover
-        rightAlignMenu
-        renderButton={ ({ styleOverride, tabIndex, ...rest }) => (
-          <Button
-            buttonType='tertiary'
-            iconType='dropdown'
-            iconPosition='after'
-            size='small'
-            tabIndex={ tabIndex }
-            styleOverride={ styleOverride }
-            date-element={ rest['data-element'] }
-          >
-              More
-          </Button>
-        )
-        }
-      >
-        {options.slice(cols - 1, options.length).map((opt, index) => {
-          return <ActionPopoverItem key={ String(index) } onClick={ action(opt) }>{opt}</ActionPopoverItem>;
-        })}
-        <ActionPopoverDivider />
-        <ActionPopoverItem onClick={ action('manage services') }>Manage Services</ActionPopoverItem>
-      </ActionPopover>
-    </TableCell>
-  );
-  return [
-    ...cells,
-    overflow
-  ];
-};
-
-const options = ['Accounting', 'Payroll', 'Auto Entry', 'Corporation Tax', 'Final Accounts', 'VAT Centre'];
-
-export const ServicesColumn = () => (
-  <div style={ { marginTop: '40px', height: '275px', maxWidth: '400px' } }>
+export const StylesOverriden = () => (
+  <div style={ { marginTop: '40px', height: '275px', maxWidth: '800px' } }>
     <Table isZebra>
       <TableRow>
         <TableHeader colSpan='3'>Services</TableHeader>
       </TableRow>
       <TableRow>
-        {generateTableCells(options, 3)}
+        <TableCell>Accounting</TableCell>
+        <TableCell>Payroll</TableCell>
+        <TableCell>
+          <ActionPopover
+            rightAlignMenu
+            renderButton={ ({ styleOverride, tabIndex, ...rest }) => (
+              <Button
+                buttonType='tertiary'
+                iconType='dropdown'
+                iconPosition='after'
+                size='small'
+                tabIndex={ tabIndex }
+                styleOverride={ styleOverride }
+                date-element={ rest['data-element'] }
+              >
+                  More
+              </Button>
+            ) }
+          >
+            <ActionPopoverItem onClick={ action('auto entry') }>Auto Entry</ActionPopoverItem>
+            <ActionPopoverItem onClick={ action('corporation tax') }>Corporation Tax</ActionPopoverItem>
+            <ActionPopoverItem onClick={ action('final accounts') }>Final Accounts</ActionPopoverItem>
+            <ActionPopoverItem onClick={ action('vat centre') }>VAT Centre</ActionPopoverItem>
+            <ActionPopoverDivider />
+            <ActionPopoverItem onClick={ action('manage services') }>Manage Services</ActionPopoverItem>
+          </ActionPopover>
+        </TableCell>
       </TableRow>
       <TableRow>
-        {generateTableCells(options, 3)}
+        <TableCell>Accounting</TableCell>
+        <TableCell>Payroll</TableCell>
+        <TableCell>
+          <ActionPopover
+            rightAlignMenu
+            renderButton={ ({ styleOverride, tabIndex, ...rest }) => (
+              <Button
+                buttonType='tertiary'
+                iconType='dropdown'
+                iconPosition='after'
+                size='small'
+                tabIndex={ tabIndex }
+                styleOverride={ styleOverride }
+                date-element={ rest['data-element'] }
+              >
+                  More
+              </Button>
+            ) }
+          >
+            <ActionPopoverItem onClick={ action('auto entry') }>Auto Entry</ActionPopoverItem>
+            <ActionPopoverItem onClick={ action('corporation tax') }>Corporation Tax</ActionPopoverItem>
+            <ActionPopoverItem onClick={ action('final accounts') }>Final Accounts</ActionPopoverItem>
+            <ActionPopoverItem onClick={ action('vat centre') }>VAT Centre</ActionPopoverItem>
+            <ActionPopoverDivider />
+            <ActionPopoverItem onClick={ action('manage services') }>Manage Services</ActionPopoverItem>
+          </ActionPopover>
+        </TableCell>
       </TableRow>
     </Table>
   </div>
 );
 
-ServicesColumn.story = {
-  name: 'services column',
+
+StylesOverriden.story = {
+  name: 'styles overriden',
   parameters: {
     themeSelector: dlsThemeSelector
   }

--- a/src/components/action-popover/action-popover.stories.js
+++ b/src/components/action-popover/action-popover.stories.js
@@ -7,6 +7,7 @@ import { dlsThemeSelector, classicThemeSelector } from '../../../.storybook/them
 import {
   Table, TableRow, TableCell, TableHeader
 } from '../table';
+import Button from '../button';
 
 const submenu = (
   <ActionPopoverMenu>
@@ -141,7 +142,7 @@ export const Classic = () => (
               disabled
               icon='graph'
               submenu={ submenu }
-              onClick={ action('email') }
+              onClick={ action('business') }
             >
               Business
             </ActionPopoverItem>
@@ -198,5 +199,70 @@ Classic.story = {
   name: 'classic',
   parameters: {
     themeSelector: classicThemeSelector
+  }
+};
+
+const generateTableCells = (options, cols) => {
+  const cells = options.slice(0, cols - 1).map((cell, index) => <TableCell key={ String(index) }>{cell}</TableCell>);
+
+  if (cells.length === options.length) {
+    return cells;
+  }
+
+  const overflow = (
+    <TableCell>
+      <ActionPopover
+        rightAlignMenu
+        renderButton={ ({ styleOverride, tabIndex, ...rest }) => (
+          <Button
+            buttonType='tertiary'
+            iconType='dropdown'
+            iconPosition='after'
+            size='small'
+            tabIndex={ tabIndex }
+            styleOverride={ styleOverride }
+            date-element={ rest['data-element'] }
+          >
+              More
+          </Button>
+        )
+        }
+      >
+        {options.slice(cols - 1, options.length).map((opt, index) => {
+          return <ActionPopoverItem key={ String(index) } onClick={ action(opt) }>{opt}</ActionPopoverItem>;
+        })}
+        <ActionPopoverDivider />
+        <ActionPopoverItem onClick={ action('manage services') }>Manage Services</ActionPopoverItem>
+      </ActionPopover>
+    </TableCell>
+  );
+  return [
+    ...cells,
+    overflow
+  ];
+};
+
+const options = ['Accounting', 'Payroll', 'Auto Entry', 'Corporation Tax', 'Final Accounts', 'VAT Centre'];
+
+export const ServicesColumn = () => (
+  <div style={ { marginTop: '40px', height: '275px', maxWidth: '400px' } }>
+    <Table isZebra>
+      <TableRow>
+        <TableHeader colSpan='3'>Services</TableHeader>
+      </TableRow>
+      <TableRow>
+        {generateTableCells(options, 3)}
+      </TableRow>
+      <TableRow>
+        {generateTableCells(options, 3)}
+      </TableRow>
+    </Table>
+  </div>
+);
+
+ServicesColumn.story = {
+  name: 'services column',
+  parameters: {
+    themeSelector: dlsThemeSelector
   }
 };

--- a/src/components/action-popover/action-popover.stories.mdx
+++ b/src/components/action-popover/action-popover.stories.mdx
@@ -8,6 +8,7 @@ import { MenuItem } from './action-popover-item.component';
 import {
   Table, TableRow, TableCell, TableHeader
 } from '../table';
+import Button from '../button';
 import DocsWrapper from '../../../.storybook/docs-helpers/components/iframe-wrapper';
 
 <Meta title="Design System/ActionPopover" parameters={{ info: { disable: true }}}/>
@@ -75,30 +76,30 @@ ActionPopoverItem&apos;s can be disabled and will not dispatch an action but can
 <Preview>
   <Story name="with disabled item" parameters={{ info: { disable: true }}}>
     <div style={{ height: '250px' }}>
-    <Table>
-      <TableRow>
-        <TableHeader>First Name</TableHeader>
-        <TableHeader>Last Name</TableHeader>
-        <TableHeader>&nbsp;</TableHeader>
-      </TableRow>
-      <TableRow>
-        <TableCell>John</TableCell>
-        <TableCell>Doe</TableCell>
-        <TableCell>
-          <ActionPopover>
-            <ActionPopoverItem
-              icon='email'
-              disabled
-              onClick={() => {}}
-            >
-              Email Invoice
-            </ActionPopoverItem>
-            <ActionPopoverDivider />
-            <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
-          </ActionPopover>
-        </TableCell>
-      </TableRow>
-    </Table>
+      <Table>
+        <TableRow>
+          <TableHeader>First Name</TableHeader>
+          <TableHeader>Last Name</TableHeader>
+          <TableHeader>&nbsp;</TableHeader>
+        </TableRow>
+        <TableRow>
+          <TableCell>John</TableCell>
+          <TableCell>Doe</TableCell>
+          <TableCell>
+            <ActionPopover>
+              <ActionPopoverItem
+                icon='email'
+                disabled
+                onClick={() => {}}
+              >
+                Email Invoice
+              </ActionPopoverItem>
+              <ActionPopoverDivider />
+              <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
+            </ActionPopover>
+          </TableCell>
+        </TableRow>
+      </Table>
     </div>
   </Story>
 </Preview>
@@ -107,30 +108,30 @@ It is possible to align the Menu to the right of the MenuButton by passing the &
 <Preview>
   <Story name="with menu right aligned" parameters={{ info: { disable: true }}}>
     <div style={{ height: '250px' }}>
-    <Table>
-      <TableRow>
-        <TableHeader>First Name</TableHeader>
-        <TableHeader>Last Name</TableHeader>
-        <TableHeader>&nbsp;</TableHeader>
-      </TableRow>
-      <TableRow>
-        <TableCell>John</TableCell>
-        <TableCell>Doe</TableCell>
-        <TableCell>
-          <ActionPopover rightAlignMenu>
-            <ActionPopoverItem
-              icon='email'
-              disabled
-              onClick={() => {}}
-            >
-              Email Invoice
-            </ActionPopoverItem>
-            <ActionPopoverDivider />
-            <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
-          </ActionPopover>
-        </TableCell>
-      </TableRow>
-    </Table>
+      <Table>
+        <TableRow>
+          <TableHeader>First Name</TableHeader>
+          <TableHeader>Last Name</TableHeader>
+          <TableHeader>&nbsp;</TableHeader>
+        </TableRow>
+        <TableRow>
+          <TableCell>John</TableCell>
+          <TableCell>Doe</TableCell>
+          <TableCell>
+            <ActionPopover rightAlignMenu>
+              <ActionPopoverItem
+                icon='email'
+                disabled
+                onClick={() => {}}
+              >
+                Email Invoice
+              </ActionPopoverItem>
+              <ActionPopoverDivider />
+              <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
+            </ActionPopover>
+          </TableCell>
+        </TableRow>
+      </Table>
     </div>
   </Story>
 </Preview>
@@ -139,26 +140,62 @@ Menu items can also be displayed without icons.
 <Preview>
   <Story name="with no icons" parameters={{ info: { disable: true }}}>
     <div style={{ height: '250px' }}>
-    <Table>
-      <TableRow>
-        <TableHeader>First Name</TableHeader>
-        <TableHeader>Last Name</TableHeader>
-        <TableHeader>&nbsp;</TableHeader>
-      </TableRow>
-      <TableRow>
-        <TableCell>John</TableCell>
-        <TableCell>Doe</TableCell>
-        <TableCell>
-          <ActionPopover>
-            <ActionPopoverItem onClick={() => {}}>
-              Email Invoice
-            </ActionPopoverItem>
-            <ActionPopoverDivider />
-            <ActionPopoverItem onClick={() => {}}>Delete</ActionPopoverItem>
-          </ActionPopover>
-        </TableCell>
-      </TableRow>
-    </Table>
+      <Table>
+        <TableRow>
+          <TableHeader>First Name</TableHeader>
+          <TableHeader>Last Name</TableHeader>
+          <TableHeader>&nbsp;</TableHeader>
+        </TableRow>
+        <TableRow>
+          <TableCell>John</TableCell>
+          <TableCell>Doe</TableCell>
+          <TableCell>
+            <ActionPopover>
+              <ActionPopoverItem onClick={() => {}}>
+                Email Invoice
+              </ActionPopoverItem>
+              <ActionPopoverDivider />
+              <ActionPopoverItem onClick={() => {}}>Delete</ActionPopoverItem>
+            </ActionPopover>
+          </TableCell>
+        </TableRow>
+      </Table>
+    </div>
+  </Story>
+</Preview>
+
+
+## With a custom Menu Button
+It is possible to use the &quot;renderButton&quot; prop to override the default button used to trigger the opening and closing of 
+ActionPopoverMenu. See the prop tables below for the properties surfaced to any custom component being passed in.
+<Preview>
+  <Story name="popover with custom button" parameters={{ info: { disable: true }}}>
+    <div style={{ height: '250px' }}>
+      <Table>
+        <TableRow>
+          <TableHeader>First Name</TableHeader>
+          <TableHeader>Last Name</TableHeader>
+          <TableHeader>&nbsp;</TableHeader>
+        </TableRow>
+        <TableRow>
+          <TableCell>John</TableCell>
+          <TableCell>Doe</TableCell>
+          <TableCell>
+            <ActionPopover renderButton={(props) => (
+                <Button buttonType='tertiary' iconType='dropdown' iconPosition='after' { ...props }>More</Button>
+              )}>
+              <ActionPopoverItem
+                icon='email'
+                onClick={() => {}}
+              >
+                Email Invoice
+              </ActionPopoverItem>
+              <ActionPopoverDivider />
+              <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
+            </ActionPopover>
+          </TableCell>
+        </TableRow>
+      </Table>
     </div>
   </Story>
 </Preview>
@@ -175,39 +212,39 @@ leave.
 <Preview>
   <Story name="with submenu" parameters={{ info: { disable: true }}}>
     <div style={{ height: '250px' }}>
-    <Table>
-      <TableRow>
-        <TableHeader>First Name</TableHeader>
-        <TableHeader>Last Name</TableHeader>
-        <TableHeader>&nbsp;</TableHeader>
-      </TableRow>
-      <TableRow>
-        <TableCell>John</TableCell>
-        <TableCell>Doe</TableCell>
-        <TableCell>
-          <ActionPopover>
-            <ActionPopoverItem
-              icon='print'
-              onClick={() => {}}
-              submenu={ 
-                <ActionPopoverMenu>
-                  <ActionPopoverItem onClick={() => {}}>
-                    CSV
-                  </ActionPopoverItem>
-                  <ActionPopoverItem onClick={() => {}}>
-                    PDF
-                  </ActionPopoverItem>
-                </ActionPopoverMenu> 
-              }
-            >
-              Print
-            </ActionPopoverItem>
-            <ActionPopoverDivider />
-            <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
-          </ActionPopover>
-        </TableCell>
-      </TableRow>
-    </Table>
+      <Table>
+        <TableRow>
+          <TableHeader>First Name</TableHeader>
+          <TableHeader>Last Name</TableHeader>
+          <TableHeader>&nbsp;</TableHeader>
+        </TableRow>
+        <TableRow>
+          <TableCell>John</TableCell>
+          <TableCell>Doe</TableCell>
+          <TableCell>
+            <ActionPopover>
+              <ActionPopoverItem
+                icon='print'
+                onClick={() => {}}
+                submenu={ 
+                  <ActionPopoverMenu>
+                    <ActionPopoverItem onClick={() => {}}>
+                      CSV
+                    </ActionPopoverItem>
+                    <ActionPopoverItem onClick={() => {}}>
+                      PDF
+                    </ActionPopoverItem>
+                  </ActionPopoverMenu> 
+                }
+              >
+                Print
+              </ActionPopoverItem>
+              <ActionPopoverDivider />
+              <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
+            </ActionPopover>
+          </TableCell>
+        </TableRow>
+      </Table>
     </div>
   </Story>
 </Preview>
@@ -216,40 +253,40 @@ A sub-menu will not open if the item is in a disabled state.
 <Preview>
   <Story name="with disabled submenu" parameters={{ info: { disable: true }}}>
     <div style={{ height: '250px' }}>
-    <Table>
-      <TableRow>
-        <TableHeader>First Name</TableHeader>
-        <TableHeader>Last Name</TableHeader>
-        <TableHeader>&nbsp;</TableHeader>
-      </TableRow>
-      <TableRow>
-        <TableCell>John</TableCell>
-        <TableCell>Doe</TableCell>
-        <TableCell>
-          <ActionPopover>
-            <ActionPopoverItem
-              disabled
-              icon='print'
-              onClick={() => {}}
-              submenu={ 
-                <ActionPopoverMenu>
-                  <ActionPopoverItem onClick={() => {}}>
-                    CSV
-                  </ActionPopoverItem>
-                  <ActionPopoverItem onClick={() => {}}>
-                    PDF
-                  </ActionPopoverItem>
-                </ActionPopoverMenu> 
-              }
-            >
-              Print
-            </ActionPopoverItem>
-            <ActionPopoverDivider />
-            <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
-          </ActionPopover>
-        </TableCell>
-      </TableRow>
-    </Table>
+      <Table>
+        <TableRow>
+          <TableHeader>First Name</TableHeader>
+          <TableHeader>Last Name</TableHeader>
+          <TableHeader>&nbsp;</TableHeader>
+        </TableRow>
+        <TableRow>
+          <TableCell>John</TableCell>
+          <TableCell>Doe</TableCell>
+          <TableCell>
+            <ActionPopover>
+              <ActionPopoverItem
+                disabled
+                icon='print'
+                onClick={() => {}}
+                submenu={ 
+                  <ActionPopoverMenu>
+                    <ActionPopoverItem onClick={() => {}}>
+                      CSV
+                    </ActionPopoverItem>
+                    <ActionPopoverItem onClick={() => {}}>
+                      PDF
+                    </ActionPopoverItem>
+                  </ActionPopoverMenu> 
+                }
+              >
+                Print
+              </ActionPopoverItem>
+              <ActionPopoverDivider />
+              <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
+            </ActionPopover>
+          </TableCell>
+        </TableRow>
+      </Table>
     </div>
   </Story>
 </Preview>
@@ -316,42 +353,42 @@ or "tab" key will close the menu with no action being triggered and focus the ne
 <Preview>
   <Story name="keyboard access" parameters={{ info: { disable: true }}}>
     <div style={{ height: '250px' }}>
-    <Table>
-      <TableRow>
-        <TableHeader>First Name</TableHeader>
-        <TableHeader>Last Name</TableHeader>
-        <TableHeader>&nbsp;</TableHeader>
-      </TableRow>
-      <TableRow>
-        <TableCell>John</TableCell>
-        <TableCell>Doe</TableCell>
-        <TableCell>
-          <ActionPopover>
-            <ActionPopoverItem
-              icon='email'
-              onClick={() => {}}
-            >
-              Email Invoice
-            </ActionPopoverItem>
-            <ActionPopoverItem
-              disabled
-              icon='csv'
-              onClick={() => {}}
-            >
-              Download CSV
-            </ActionPopoverItem>
-            <ActionPopoverItem
-              icon='pdf'
-              onClick={() => {}}
-            >
-              Download PDF
-            </ActionPopoverItem>
-            <ActionPopoverDivider />
-            <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
-          </ActionPopover>
-        </TableCell>
-      </TableRow>
-    </Table>
+      <Table>
+        <TableRow>
+          <TableHeader>First Name</TableHeader>
+          <TableHeader>Last Name</TableHeader>
+          <TableHeader>&nbsp;</TableHeader>
+        </TableRow>
+        <TableRow>
+          <TableCell>John</TableCell>
+          <TableCell>Doe</TableCell>
+          <TableCell>
+            <ActionPopover>
+              <ActionPopoverItem
+                icon='email'
+                onClick={() => {}}
+              >
+                Email Invoice
+              </ActionPopoverItem>
+              <ActionPopoverItem
+                disabled
+                icon='csv'
+                onClick={() => {}}
+              >
+                Download CSV
+              </ActionPopoverItem>
+              <ActionPopoverItem
+                icon='pdf'
+                onClick={() => {}}
+              >
+                Download PDF
+              </ActionPopoverItem>
+              <ActionPopoverDivider />
+              <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
+            </ActionPopover>
+          </TableCell>
+        </TableRow>
+      </Table>
     </div>
   </Story>
 </Preview>
@@ -363,55 +400,55 @@ triggering an action.
 <Preview>
   <Story name="keyboard access left aligned submenu" parameters={{ info: { disable: true }}}>
     <div style={{ height: '250px' }}>
-    <Table>
-      <TableRow>
-        <TableHeader>First Name</TableHeader>
-        <TableHeader>Last Name</TableHeader>
-        <TableHeader>&nbsp;</TableHeader>
-      </TableRow>
-      <TableRow>
-        <TableCell>John</TableCell>
-        <TableCell>Doe</TableCell>
-        <TableCell>
-          <ActionPopover>
-            <ActionPopoverItem
-              icon='csv'
-              onClick={() => {}}
-              submenu={ 
-                <ActionPopoverMenu>
-                  <ActionPopoverItem icon='csv' onClick={() => {}}>
-                    CSV
-                  </ActionPopoverItem>
-                  <ActionPopoverItem icon='pdf' onClick={() => {}}>
-                    PDF
-                  </ActionPopoverItem>
-                </ActionPopoverMenu> 
-              }
-            >
-              Download
-            </ActionPopoverItem>
-            <ActionPopoverItem
-              icon='pdf'
-              onClick={() => {}}
-              submenu={ 
-                <ActionPopoverMenu>
-                  <ActionPopoverItem icon='csv' onClick={() => {}}>
-                    CSV
-                  </ActionPopoverItem>
-                  <ActionPopoverItem icon='pdf' onClick={() => {}}>
-                    PDF
-                  </ActionPopoverItem>
-                </ActionPopoverMenu> 
-              }
-            >
-              Print
-            </ActionPopoverItem>
-            <ActionPopoverDivider />
-            <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
-          </ActionPopover>
-        </TableCell>
-      </TableRow>
-    </Table>
+      <Table>
+        <TableRow>
+          <TableHeader>First Name</TableHeader>
+          <TableHeader>Last Name</TableHeader>
+          <TableHeader>&nbsp;</TableHeader>
+        </TableRow>
+        <TableRow>
+          <TableCell>John</TableCell>
+          <TableCell>Doe</TableCell>
+          <TableCell>
+            <ActionPopover>
+              <ActionPopoverItem
+                icon='csv'
+                onClick={() => {}}
+                submenu={ 
+                  <ActionPopoverMenu>
+                    <ActionPopoverItem icon='csv' onClick={() => {}}>
+                      CSV
+                    </ActionPopoverItem>
+                    <ActionPopoverItem icon='pdf' onClick={() => {}}>
+                      PDF
+                    </ActionPopoverItem>
+                  </ActionPopoverMenu> 
+                }
+              >
+                Download
+              </ActionPopoverItem>
+              <ActionPopoverItem
+                icon='pdf'
+                onClick={() => {}}
+                submenu={ 
+                  <ActionPopoverMenu>
+                    <ActionPopoverItem icon='csv' onClick={() => {}}>
+                      CSV
+                    </ActionPopoverItem>
+                    <ActionPopoverItem icon='pdf' onClick={() => {}}>
+                      PDF
+                    </ActionPopoverItem>
+                  </ActionPopoverMenu> 
+                }
+              >
+                Print
+              </ActionPopoverItem>
+              <ActionPopoverDivider />
+              <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
+            </ActionPopover>
+          </TableCell>
+        </TableRow>
+      </Table>
     </div>
   </Story>
 </Preview>
@@ -478,6 +515,83 @@ is on a item will open a sub-menu if it has one and pressing the "left" key will
     height='250px'
   />
 </MyPreview>
+
+## Services Column
+
+The ActionPopover can be composed in a number of ways: below is an example of a services column popover that is 
+populated with any additional overflow options for a given row. The popover's height is dynamic to the content placed 
+within it. Beyond a reasonable number of items, content may be truncated and the foot of the popover may then contain 
+a &quot;Manage&quot; option.
+
+<Preview>
+  <Story name="services column">
+    <div style={ { marginTop: '40px', height: '275px', maxWidth: '800px' } }>
+      <Table isZebra>
+        <TableRow>
+          <TableHeader colSpan='3'>Services</TableHeader>
+        </TableRow>
+        <TableRow>
+          <TableCell>Accounting</TableCell>
+          <TableCell>Payroll</TableCell>
+          <TableCell>
+            <ActionPopover
+              rightAlignMenu
+              renderButton={ ({ styleOverride, tabIndex, ...rest }) => (
+                <Button
+                  buttonType='tertiary'
+                  iconType='dropdown'
+                  iconPosition='after'
+                  size='small'
+                  tabIndex={ tabIndex }
+                  styleOverride={ styleOverride }
+                  date-element={ rest['data-element'] }
+                >
+                  More
+                </Button>
+              ) }
+            >
+              <ActionPopoverItem onClick={ () => {} }>Auto Entry</ActionPopoverItem>
+              <ActionPopoverItem onClick={ () => {} }>Corporation Tax</ActionPopoverItem>
+              <ActionPopoverItem onClick={ () => {} }>Final Accounts</ActionPopoverItem>
+              <ActionPopoverItem onClick={ () => {} }>VAT Centre</ActionPopoverItem>
+              <ActionPopoverDivider />
+              <ActionPopoverItem onClick={ () => {} }>Manage Services</ActionPopoverItem>
+            </ActionPopover>
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Accounting</TableCell>
+          <TableCell>Payroll</TableCell>
+          <TableCell>
+            <ActionPopover
+              rightAlignMenu
+              renderButton={ ({ styleOverride, tabIndex, ...rest }) => (
+                <Button
+                  buttonType='tertiary'
+                  iconType='dropdown'
+                  iconPosition='after'
+                  size='small'
+                  tabIndex={ tabIndex }
+                  styleOverride={ styleOverride }
+                  date-element={ rest['data-element'] }
+                >
+                  More
+                </Button>
+              ) }
+            >
+              <ActionPopoverItem onClick={ () => {} }>Auto Entry</ActionPopoverItem>
+              <ActionPopoverItem onClick={ () => {} }>Corporation Tax</ActionPopoverItem>
+              <ActionPopoverItem onClick={ () => {} }>Final Accounts</ActionPopoverItem>
+              <ActionPopoverItem onClick={ () => {} }>VAT Centre</ActionPopoverItem>
+              <ActionPopoverDivider />
+              <ActionPopoverItem onClick={ () => {} }>Manage Services</ActionPopoverItem>
+            </ActionPopover>
+          </TableCell>
+        </TableRow>
+      </Table>
+    </div>
+  </Story>
+</Preview>
 
 ### ActionPopover Props
 <Props of={ActionPopover} />

--- a/src/components/action-popover/action-popover.style.js
+++ b/src/components/action-popover/action-popover.style.js
@@ -71,7 +71,7 @@ const MenuButton = styled.div`
   && ${StyledIcon} {
     cursor: pointer;
   }
-  width: 24px;
+  display: table;
   margin: auto;
   ${({ isOpen, theme }) => (isOpen && `background-color: ${theme.colors.white}`)}
   &:hover, &:focus {
@@ -80,7 +80,7 @@ const MenuButton = styled.div`
   &:focus {
     outline: 2px solid ${({ theme }) => theme.colors.focus};
   }
-
+  
   ${MenuButtonClassic}
 `;
 

--- a/src/components/button/button.style.js
+++ b/src/components/button/button.style.js
@@ -35,6 +35,8 @@ export const StyledButtonSubtext = styled.span`
   font-size: 14px;
   font-weight: 400;
   display: block;
+
+  ${({ styleOverride }) => styleOverride}
 `;
 
 function additionalIconStyle({ iconType }) {
@@ -65,6 +67,8 @@ function stylingForType({
     }
     ${buttonTypes(theme, disabled, destructive)[buttonType]};
     ${buttonSizes(theme)[size]}
+
+    ${({ styleOverride }) => styleOverride}
   `;
 }
 

--- a/src/components/button/button.style.js
+++ b/src/components/button/button.style.js
@@ -35,8 +35,6 @@ export const StyledButtonSubtext = styled.span`
   font-size: 14px;
   font-weight: 400;
   display: block;
-
-  ${({ styleOverride }) => styleOverride}
 `;
 
 function additionalIconStyle({ iconType }) {
@@ -67,8 +65,6 @@ function stylingForType({
     }
     ${buttonTypes(theme, disabled, destructive)[buttonType]};
     ${buttonSizes(theme)[size]}
-
-    ${({ styleOverride }) => styleOverride}
   `;
 }
 


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
A new renderButton prop has been added to allow the menu button to be overriden with a custom
component passed in by the consumer.

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
The component does not support a custom button, it renders only the Icon

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests
- [x] Storybook added or updated
<del>- [ ] Theme support<del>
- [x] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->
I have built a demo of how to use the `ActionPopover` component to deliver a `ServicesColumn`

### Testing instructions
<!-- How can a reviewer test this PR? -->
The demo is available in `test-action-popover--services-column` in storybook.
I will demonstrate the custom button functionality using the codesandbox demo link create as part of the build

Services Column closed with custom button:
![image](https://user-images.githubusercontent.com/44157880/78127167-96b30b80-740b-11ea-8c2f-2013f96e6b4c.png)

Services Column open:
![image](https://user-images.githubusercontent.com/44157880/78127116-81d67800-740b-11ea-9055-b4508bdd27e0.png)
