### PR TITLE
feat(radio-button-group): add style override

### DIFF
--- a/cypress/features/regression/test/radioButtonGroupStyleOverrideNoIFrame.feature
+++ b/cypress/features/regression/test/radioButtonGroupStyleOverrideNoIFrame.feature
@@ -1,0 +1,7 @@
+Feature: Style overriden RadioButtonGroup component
+  I want to verify overriden styles for RadioButtonGroup component
+
+  @positive
+  Scenario: Open style overriden RadioButtonGroup component page and verify overriden styles are rendered properly
+    When I open style override Test "RadioButtonGroup" component page in noIframe
+    Then RadioButtonGroup overriden styles rendered properly

--- a/cypress/locators/radioButton/index.js
+++ b/cypress/locators/radioButton/index.js
@@ -4,6 +4,7 @@ import {
   RADIO_BUTTON_GROUP_COMPONENT,
   RADIO_BUTTON_FIELDSET_COMPONENT,
   RADIO_BUTTON_LEGEND_COMPONENT,
+  RADIO_GROUP,
 } from './locators';
 
 // component preview locators
@@ -15,3 +16,8 @@ export const radioButtonComponentNoiFrame = () => cy.get(RADIO_BUTTON_COMPONENT)
 export const radioButtonGroup = () => cy.iFrame(RADIO_BUTTON_GROUP_COMPONENT);
 export const radioButtonFieldset = () => cy.iFrame(RADIO_BUTTON_FIELDSET_COMPONENT);
 export const radioButtonLegend = () => cy.iFrame(RADIO_BUTTON_LEGEND_COMPONENT);
+
+// component preview locators in no iFrame
+export const radioGroup = () => cy.get(RADIO_GROUP);
+export const radioButtonLegendInNoIFrame = () => cy.get(RADIO_BUTTON_LEGEND_COMPONENT);
+export const radioButtonGroupInNoIFrame = () => cy.get(RADIO_BUTTON_GROUP_COMPONENT);

--- a/cypress/locators/radioButton/locators.js
+++ b/cypress/locators/radioButton/locators.js
@@ -3,3 +3,4 @@ export const RADIO_BUTTON_COMPONENT = '[data-component="radio-button"]';
 export const RADIO_BUTTON_GROUP_COMPONENT = '[data-component="radio-button-group"]';
 export const RADIO_BUTTON_FIELDSET_COMPONENT = '[data-component="fieldset-style"]';
 export const RADIO_BUTTON_LEGEND_COMPONENT = '[data-component="legend-style"]';
+export const RADIO_GROUP = '[data-component="radiogroup"]';

--- a/cypress/support/step-definitions/radio-button-steps.js
+++ b/cypress/support/step-definitions/radio-button-steps.js
@@ -6,6 +6,9 @@ import {
   radioButtonGroup,
   radioButtonFieldset,
   radioButtonLegend,
+  radioGroup,
+  radioButtonLegendInNoIFrame,
+  radioButtonGroupInNoIFrame,
 } from '../../locators/radioButton/index';
 import { setSlidebar } from '../helper';
 
@@ -141,4 +144,10 @@ Then('legend is not inline with RadioButton', () => {
   radioButtonFieldset().should('have.css', 'display', 'block');
   radioButtonLegend().should('have.css', 'margin-right', '0px')
     .and('have.css', 'height', '26px');
+});
+
+Then('RadioButtonGroup overriden styles rendered properly', () => {
+  radioGroup().should('have.css', 'background', 'rgb(240, 240, 240) none repeat scroll 0% 0% / auto padding-box border-box');
+  radioButtonLegendInNoIFrame().should('have.css', 'color', 'rgb(180, 212, 85)');
+  radioButtonGroupInNoIFrame().should('have.css', 'padding', '0px 12px');
 });

--- a/src/__experimental__/components/fieldset/fieldset.component.js
+++ b/src/__experimental__/components/fieldset/fieldset.component.js
@@ -30,6 +30,7 @@ const Fieldset = (props) => {
       <LegendContainerStyle
         inline={ props.inline }
         data-component='legend-style'
+        styleOverride={ props.styleOverride.legend }
       >
         <legend data-element='legend'>
           { props.legend }
@@ -48,6 +49,7 @@ const Fieldset = (props) => {
     <FieldsetStyle
       { ...tagComponent('fieldset', props) }
       { ...safeProps }
+      styleOverride={ props.styleOverride.root }
     >
       <FieldsetContentStyle
         data-component='fieldset-style'
@@ -74,11 +76,17 @@ Fieldset.propTypes = {
   /** A message that the ValidationIcon component will display */
   tooltipMessage: PropTypes.string,
   /** When true, legend is placed in line with the children */
-  inline: PropTypes.bool
+  inline: PropTypes.bool,
+  /** Allows to override existing component styles */
+  styleOverride: PropTypes.shape({
+    root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    legend: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+  })
 };
 
 Fieldset.defaultProps = {
-  inline: false
+  inline: false,
+  styleOverride: {}
 };
 
 export default Fieldset;

--- a/src/__experimental__/components/fieldset/fieldset.style.js
+++ b/src/__experimental__/components/fieldset/fieldset.style.js
@@ -19,6 +19,8 @@ const FieldsetStyle = styled.fieldset`
     padding-top: 8px;
     padding-bottom: 8px;
   }
+
+  ${({ styleOverride }) => styleOverride};
 `;
 
 const LegendContainerStyle = styled.div`
@@ -43,6 +45,8 @@ const LegendContainerStyle = styled.div`
   ${ValidationIconStyle} ${StyledIcon}:focus {
     outline: 2px solid #FFB500;
   }
+
+  ${({ styleOverride }) => styleOverride};
 `;
 
 const FieldsetContentStyle = styled.div`

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -10,7 +10,7 @@ import withValidation from '../../../components/validations/with-validation.hoc'
 const RadioButtonGroup = (props) => {
   const {
     children, name, legend, hasError, hasWarning, hasInfo, onBlur,
-    onChange, value, tooltipMessage, inline, labelInline
+    onChange, value, tooltipMessage, inline, labelInline, styleOverride
   } = props;
 
   const groupLabelId = `${name}-label`;
@@ -29,12 +29,14 @@ const RadioButtonGroup = (props) => {
       hasInfo={ hasInfo }
       tooltipMessage={ tooltipMessage }
       inline={ labelInline }
+      styleOverride={ styleOverride }
       { ...tagComponent('radiogroup', props) }
     >
       <RadioButtonGroupStyle
         data-component='radio-button-group'
         role='group'
         inline={ inline }
+        styleOverride={ styleOverride.content }
       >
         <RadioButtonMapper
           name={ name }
@@ -75,7 +77,13 @@ RadioButtonGroup.propTypes = {
   /** When true, radiobutton is placed in line */
   inline: PropTypes.bool,
   /** When true, legend is placed in line with an radiobutton */
-  labelInline: PropTypes.bool
+  labelInline: PropTypes.bool,
+  /** Allows to override existing component styles */
+  styleOverride: PropTypes.shape({
+    root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    content: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    legend: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+  })
 };
 
 RadioButtonGroup.defaultProps = {
@@ -83,7 +91,8 @@ RadioButtonGroup.defaultProps = {
   hasWarning: false,
   hasInfo: false,
   inline: false,
-  labelInline: false
+  labelInline: false,
+  styleOverride: {}
 };
 
 export default withValidation(RadioButtonGroup, { unblockValidation: true });

--- a/src/__experimental__/components/radio-button/radio-button-group.d.ts
+++ b/src/__experimental__/components/radio-button/radio-button-group.d.ts
@@ -9,6 +9,11 @@ export interface RadioButtonGroupProps {
   hasError?: boolean;
   hasWarning?: boolean;
   hasInfo?: boolean;
+  styleOverride?: {
+    root?: object;
+    content?: object;
+    legend?: object;
+  };
 }
 
 declare const RadioButtonGroup: React.ComponentClass<WithValidationProps & RadioButtonGroupProps>;

--- a/src/__experimental__/components/radio-button/radio-button-group.spec.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.spec.js
@@ -6,6 +6,7 @@ import { RadioButton, RadioButtonGroup } from '.';
 import { LegendContainerStyle } from '../fieldset/fieldset.style';
 import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
 import RadioButtonGroupStyle from './radio-button-group.style';
+import Fieldset from '../fieldset';
 
 const buttonValues = ['test-1', 'test-2'];
 const name = 'test-group';
@@ -66,6 +67,36 @@ describe('RadioButtonGroup', () => {
         },
         mount(<RadioButtonGroupStyle inline />)
       );
+    });
+  });
+
+  describe('style overrides', () => {
+    let wrapper;
+    const customStyleObject = {
+      backgroundColor: 'red',
+      display: 'flex',
+      fontSize: '200px'
+    };
+    const styleOverride = {
+      root: customStyleObject,
+      content: customStyleObject,
+      legend: customStyleObject
+    };
+
+    beforeEach(() => {
+      wrapper = render(mount, { styleOverride });
+    });
+
+    it('renders root element with properly assigned styles', () => {
+      assertStyleMatch(customStyleObject, wrapper.find(Fieldset));
+    });
+
+    it('renders content wrapper with properly assigned styles', () => {
+      assertStyleMatch(customStyleObject, wrapper.find(RadioButtonGroupStyle));
+    });
+
+    it('renders legend element with properly assigned styles', () => {
+      assertStyleMatch(customStyleObject, wrapper.find(LegendContainerStyle));
     });
   });
 });

--- a/src/__experimental__/components/radio-button/radio-button-group.style.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.style.js
@@ -4,6 +4,8 @@ const RadioButtonGroupStyle = styled.div`
   ${({
     inline
   }) => inline && 'display: flex;'}
+
+  ${({ styleOverride }) => styleOverride};
 `;
 
 export default RadioButtonGroupStyle;

--- a/src/__experimental__/components/radio-button/radio-button.stories.mdx
+++ b/src/__experimental__/components/radio-button/radio-button.stories.mdx
@@ -1,0 +1,46 @@
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+
+import { RadioButtonGroup, RadioButton } from '.';
+
+<Meta
+  title="Test/RadioButtonGroup"
+  parameters={{ info: { disable: true }}}
+/>
+
+### With styles overriden
+With custom wrapper, label and input styles
+<Preview>
+  <Story name="styles overriden">
+    <RadioButtonGroup
+      name='frequency'
+      legend='Please select a frequency'
+      inline
+      labelInline
+      styleOverride={
+        {
+          root: { background: '#F0F0F0' },
+          content: {
+            padding: '0 12px',
+          },
+          legend: { color: '#B4D455', width: '30%' }
+        }
+      }
+    >
+      <RadioButton
+        key='weekly'
+        value='weekly'
+        label='weekly'
+      />
+      <RadioButton
+        key='monthly'
+        value='monthly'
+        label='monthly'
+      />
+      <RadioButton
+        key='yearly'
+        value='yearly'
+        label='yearly'
+      />
+    </RadioButtonGroup>
+  </Story>
+</Preview>


### PR DESCRIPTION
### Proposed behaviour
RadioButtonGroup Component should have the option to override it's legend and content styles to match other form element styles.

### Current behaviour
RadioButtonGroup styles cannot be overriden by a Carbon User.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [ ] Cypress automation tests
- [x] Storybook added or updated
~~- [ ] Theme support~~
- [x] Typescript `d.ts` file added or updated

### Testing instructions
* npm start
* Go to http://localhost:9001/?path=/story/test-radiobuttongroup--styles-overriden
