### PR TITLE
chore(dependency): revert react day picker upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28072,11 +28072,12 @@
       }
     },
     "react-day-picker": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.4.0.tgz",
-      "integrity": "sha512-dqfr96EY7mHSpbW23hJI6of2JvxClDfHLNQ7VqctxBvNsJIzEiwh3zS8hEhqNza7xuR0vC4KN517zxndgb3/fw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-6.1.1.tgz",
+      "integrity": "sha512-QZKp9QzPPGAPW1jsUV1LYhRwnE//bdUL4boq0A+VTPLOsrnJ4E5oJmla5mcYxya/lljdZdWquRn2VWo7+rimtg==",
       "requires": {
-        "prop-types": "^15.6.2"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "mocha-allure-reporter": "^1.4.0",
     "moment": "~2.20.1",
     "prop-types": "^15.5.8",
-    "react-day-picker": "~7.4.0",
+    "react-day-picker": "~6.1.1",
     "react-dnd": "^10.0.2",
     "react-dnd-html5-backend": "^10.0.2",
     "react-dnd-legacy": "npm:react-dnd@^2.6.0",


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
The previous upgrade to `react-day-picker` has caused some undesired style regressions so it is being
reverted
### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
The picker styling is out of alignment see screenshot
### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>- [ ] Unit tests<del>
<del>- [ ] Cypress automation tests<del>
<del>- [ ] Storybook added or updated<del>
<del>- [ ] Theme support<del>
<del>- [ ] Typescript `d.ts` file added or updated<del>

### Additional context
Current:
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/78874898-05641a80-7a45-11ea-98fa-d1b11a0469db.png)

After revert:
![image](https://user-images.githubusercontent.com/44157880/78875212-74417380-7a45-11ea-9f84-0502d97f7e3c.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
