### PR TITLE
feat(flat-table): add new component <Sort /> - FE-2482

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -20,5 +20,6 @@
   "style_override": "--styles-overriden",
   "customFilter": "--customFilter",
   "knobs": "--knobs",
+  "sortable": "--sortable",
   "max_violation_value": 2
 }

--- a/cypress/features/regression/test/flatTableSortable.feature
+++ b/cypress/features/regression/test/flatTableSortable.feature
@@ -1,0 +1,79 @@
+Feature: FlatTable sortable component
+  I want to check FlatTable sortable component properties
+
+  Background: Open FlatTable sortable component page
+    Given I open sortable Test "Flat Table" component page in Iframe
+
+  @positive
+  Scenario Outline: Sort <headerName> flat table column descending
+    When I click on "<position>" header 1 times
+    Then "<position>" column is sorted in "desc" order
+    Examples:
+      | position | headerName |
+      | first    | Client     |
+      | second   | total      |
+
+  @positive
+  Scenario Outline: Sort <headerName> flat table column ascending
+    When I click on "<position>" header 2 times
+    Then "<position>" column is sorted in "asc" order
+    Examples:
+      | position | headerName |
+      | first    | Client     |
+      | second   | total      |
+
+  @positive
+  Scenario Outline: Flat table header has <colorTheme> color
+    When I select colorTheme to "<colorTheme>"
+    Then Flat table header has "<color>" color
+    Examples:
+      | colorTheme        | color              |
+      | dark              | rgb(51, 91, 109)   |
+      | transparent-base  | rgb(242, 244, 245) |
+      | light             | rgb(204, 214, 218) |
+      | transparent-white | rgb(255, 255, 255) |
+
+  @positive
+  Scenario Outline: <headerName> flat table header has focus
+    When I focus "<position>" header cell
+    Then "<position>" header has focus
+    Examples:
+      | headerName | position |
+      | Client     | first    |
+      | total      | second   |
+
+  @positive
+  Scenario Outline: <headerName> can be sorted descending after press Enter 1 time
+    When I press "Enter" on "<position>" header 1 time
+    Then "<position>" column is sorted in "desc" order
+    Examples:
+      | headerName | position |
+      | Client     | first    |
+      | total      | second   |
+
+  @positive
+  Scenario Outline: <headerName> can be sorted descending after press Space 1 time
+    When I press "Space" on "<position>" header 1 time
+    Then "<position>" column is sorted in "desc" order
+    Examples:
+      | headerName | position |
+      | Client     | first    |
+      | total      | second   |
+
+  @positive
+  Scenario Outline: <headerName> can be sorted ascending after press Enter 2 time
+    When I press "Enter" on "<position>" header 2 time
+    Then "<position>" column is sorted in "asc" order
+    Examples:
+      | headerName | position |
+      | Client     | first    |
+      | total      | second   |
+
+  @positive
+  Scenario Outline: <headerName> can be sorted ascending after press Space 2 time
+    When I press "Space" on "<position>" header 2 time
+    Then "<position>" column is sorted in "asc" order
+    Examples:
+      | headerName | position |
+      | Client     | first    |
+      | total      | second   |

--- a/cypress/locators/flat-table/index.js
+++ b/cypress/locators/flat-table/index.js
@@ -1,5 +1,5 @@
 import {
-  FLAT_TABLE_ROW, FLAT_TABLE_COMPONENT,
+  FLAT_TABLE_ROW, FLAT_TABLE_COMPONENT, FLAT_TABLE_CELL,
 } from './locators';
 
 // component preview locators
@@ -11,6 +11,7 @@ export const flatTableHeaderCells = () => flatTableHeader().find('th');
 export const flatTableBodyRowByPosition = index => flatTableBodyRows().eq(index);
 export const flatTableStickyRow = index => flatTableBodyRowByPosition(index).find('th');
 export const flatTableBodyCellByPosition = (rowIndex, cellIndex) => flatTableBodyRowByPosition(rowIndex).find('td').eq(cellIndex);
+export const flatTableCell = index => cy.iFrame(FLAT_TABLE_CELL).eq(index);
 
 export const flatTableNoiFrame = () => cy.get(FLAT_TABLE_COMPONENT);
 export const flatTableRowsNoiFrame = () => cy.get(FLAT_TABLE_ROW);

--- a/cypress/locators/flat-table/locators.js
+++ b/cypress/locators/flat-table/locators.js
@@ -2,3 +2,4 @@
 export const FLAT_TABLE_COMPONENT = '[data-component="flat-table"]';
 export const FLAT_TABLE_ROW = '[data-element="flat-table-row"]';
 export const FLAT_TABLE_STICKY_ROW = '[data-element="flat-table-row-header"]';
+export const FLAT_TABLE_CELL = '[data-element="flat-table-cell"]';

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -121,6 +121,10 @@ Given('I open style override Test {string} component page in noIframe', (compone
   visitComponentUrl(component, 'style_override', true, 'test-');
 });
 
+Given('I open sortable Test {string} component page in Iframe', (component) => {
+  visitComponentUrl(component, 'sortable', false, 'test-');
+});
+
 When('I open Test {string} component basic page with prop value', (componentName) => {
   visitFlatTableComponentNoiFrame(componentName, 'basic', true, 'test-');
 });

--- a/cypress/support/step-definitions/flat-table-steps.js
+++ b/cypress/support/step-definitions/flat-table-steps.js
@@ -1,9 +1,12 @@
 import {
   flatTableHeaderCells, flatTableHeader, flatTableBodyRows, flatTableNoiFrame,
-  flatTableHeaderCellsNoiFrame, flatTableBodyRowByPositionNoiFrame, flatTableBodyCellByPosition, flatTableBodyRowByPosition,
+  flatTableHeaderCellsNoiFrame, flatTableBodyRowByPositionNoiFrame, flatTableBodyCellByPosition,
+  flatTableBodyRowByPosition,
+  flatTableCell,
 } from '../../locators/flat-table';
 import { DEBUG_FLAG } from '..';
 import { positionOfElement } from '../helper';
+import { icon } from '../../locators';
 
 Then('FlatTable rows are sticky', () => {
   cy.wait(500);
@@ -97,4 +100,92 @@ Then('I focus {int} row and focused row element has golden border on focus', (in
 
 Then('press Enter key on the row element', () => {
   flatTableBodyRowByPosition(2).focus().trigger('keydown', { keyCode: 13, which: 13, force: true });
+});
+
+Then('I click on {string} header {int} times', (position, times) => {
+  for (let i = 0; i < times; i++) {
+    flatTableHeaderCells().find('div').eq(positionOfElement(position)).click();
+  }
+});
+
+When('{string} column is sorted in {string} order', (position, sortOrder) => {
+  const valueOne = 'Tyler Webb';
+  const valueTwo = 'Monty Parker';
+  const valueThree = 'Jason Atkinson';
+  const valueFour = 'Blake Sutton';
+  const totalOne = '3840';
+  const totalTwo = '1349';
+  const totalThree = '849';
+  const totalFour = '280';
+  if (position === 'first' && sortOrder === 'desc') {
+    icon().should('have.attr', 'data-element', 'sort_down')
+      .and('be.visible');
+    flatTableCell(positionOfElement('first')).should('have.text', valueOne)
+      .and('be.visible');
+    flatTableCell(positionOfElement('third')).should('have.text', valueTwo)
+      .and('be.visible');
+    flatTableCell(positionOfElement('fifth')).should('have.text', valueThree)
+      .and('be.visible');
+    flatTableCell(positionOfElement('seventh')).should('have.text', valueFour)
+      .and('be.visible');
+  } else if (position === 'first' && sortOrder === 'asc') {
+    icon().should('have.attr', 'data-element', 'sort_up')
+      .and('be.visible');
+    flatTableCell(positionOfElement('first')).should('have.text', valueFour)
+      .and('be.visible');
+    flatTableCell(positionOfElement('third')).should('have.text', valueThree)
+      .and('be.visible');
+    flatTableCell(positionOfElement('fifth')).should('have.text', valueTwo)
+      .and('be.visible');
+    flatTableCell(positionOfElement('seventh')).should('have.text', valueOne)
+      .and('be.visible');
+  } else if (position === 'second' && sortOrder === 'desc') {
+    icon().should('have.attr', 'data-element', 'sort_down')
+      .and('be.visible');
+    flatTableCell(positionOfElement('second')).should('have.text', totalOne)
+      .and('be.visible');
+    flatTableCell(positionOfElement('fourth')).should('have.text', totalTwo)
+      .and('be.visible');
+    flatTableCell(positionOfElement('sixth')).should('have.text', totalThree)
+      .and('be.visible');
+    flatTableCell(positionOfElement('eighth')).should('have.text', totalFour)
+      .and('be.visible');
+  } else {
+    icon().should('have.attr', 'data-element', 'sort_up')
+      .and('be.visible');
+    flatTableCell(positionOfElement('second')).should('have.text', totalFour)
+      .and('be.visible');
+    flatTableCell(positionOfElement('fourth')).should('have.text', totalThree)
+      .and('be.visible');
+    flatTableCell(positionOfElement('sixth')).should('have.text', totalTwo)
+      .and('be.visible');
+    flatTableCell(positionOfElement('eighth')).should('have.text', totalOne)
+      .and('be.visible');
+  }
+});
+
+Then('Flat table header has {string} color', (colorTheme) => {
+  flatTableHeaderCells().each(($el) => {
+    cy.wrap($el).should('have.css', 'background-color', colorTheme);
+  });
+});
+
+Then('{string} header has focus', (position) => {
+  flatTableHeaderCells().find('div').eq(positionOfElement(position)).should('have.css', 'outline-color', 'rgb(255, 181, 0)');
+});
+
+Then('I focus {string} header cell', (position) => {
+  flatTableHeaderCells().find('div').eq(positionOfElement(position)).focus();
+});
+
+Then('I press {string} on {string} header {int} time(s)', (key, position, count) => {
+  for (let i = 0; i < count; i++) {
+    if (key === 'Enter') {
+      flatTableHeaderCells().find('div').eq(positionOfElement(position)).focus()
+        .trigger('keydown', { keyCode: 13, which: 13, force: true });
+    } else {
+      flatTableHeaderCells().find('div').eq(positionOfElement(position)).focus()
+        .trigger('keydown', { keyCode: 32, which: 32, force: true });
+    }
+  }
 });

--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FlatTable when rendered with proper table data should have expected structure and styles 1`] = `
-.c6 {
+.c8 {
   background-color: transparent;
   border-width: 0;
   border-bottom: 1px solid #CCD6DA;
@@ -19,7 +19,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
   white-space: nowrap;
 }
 
-.c5 {
+.c6 {
   background-color: #fff;
   border: 1px solid #CCD6DA;
   border-top: none;
@@ -35,7 +35,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
   white-space: nowrap;
 }
 
-.c2 .c4 {
+.c3 .c5 {
   border-left: none;
   border-right: none;
   font-weight: 700;
@@ -49,6 +49,13 @@ exports[`FlatTable when rendered with proper table data should have expected str
   height: 100%;
 }
 
+.c0 .c7,
+.c0 .c2 .c5 {
+  background-color: #335B6D;
+  border-right: 1px solid #668491;
+  color: #FFFFFF;
+}
+
 .c1 {
   border-collapse: separate;
   border-radius: 0px;
@@ -59,7 +66,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
   word-break: break-all;
 }
 
-.c7 {
+.c9 {
   background-color: #fff;
   border-width: 0;
   border-bottom: 1px solid #CCD6DA;
@@ -71,15 +78,15 @@ exports[`FlatTable when rendered with proper table data should have expected str
   white-space: nowrap;
 }
 
-.c7:first-of-type {
+.c9:first-of-type {
   border-left: 1px solid #CCD6DA;
 }
 
-.c7:last-of-type {
+.c9:last-of-type {
   border-right: 1px solid #CCD6DA;
 }
 
-.c3 {
+.c4 {
   border-collapse: separate;
   border-radius: 0px;
   border-spacing: 0;
@@ -97,26 +104,26 @@ exports[`FlatTable when rendered with proper table data should have expected str
     data-component="flat-table"
   >
     <thead
-      className="c2"
+      className="c2 c3"
     >
       <tr
-        className="c3"
+        className="c4"
         data-element="flat-table-row"
       >
         <th
-          className="c4 c5"
+          className="c5 c6"
           data-element="flat-table-row-header"
         >
           row header
         </th>
         <th
-          className="c6"
+          className="c7 c8"
           data-element="flat-table-header"
         >
           header1
         </th>
         <th
-          className="c6"
+          className="c7 c8"
           data-element="flat-table-header"
         >
           header2
@@ -125,23 +132,23 @@ exports[`FlatTable when rendered with proper table data should have expected str
     </thead>
     <tbody>
       <tr
-        className="c3"
+        className="c4"
         data-element="flat-table-row"
       >
         <th
-          className="c4 c5"
+          className="c5 c6"
           data-element="flat-table-row-header"
         >
           row header
         </th>
         <td
-          className="c7"
+          className="c9"
           data-element="flat-table-cell"
         >
           cell1
         </td>
         <td
-          className="c7"
+          className="c9"
           data-element="flat-table-cell"
         >
           cell2

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import OptionsHelper from '../../../utils/helpers/options-helper';
 import StyledFlatTableCell from './flat-table-cell.style';
 
 const FlatTableCell = ({ align, children }) => {
@@ -13,7 +12,7 @@ const FlatTableCell = ({ align, children }) => {
 
 FlatTableCell.propTypes = {
   /** Content alignment */
-  align: PropTypes.oneOf(OptionsHelper.alignFull),
+  align: PropTypes.oneOf(['center', 'left', 'right']),
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
 };
 

--- a/src/components/flat-table/flat-table-header/flat-table-header.component.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.component.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import OptionsHelper from '../../../utils/helpers/options-helper';
 import StyledFlatTableHeader from './flat-table-header.style';
 
-const FlatTableHeader = ({ align, children }) => {
+const FlatTableHeader = ({
+  align, children
+}) => {
   return (
-    <StyledFlatTableHeader align={ align } data-element='flat-table-header'>
+    <StyledFlatTableHeader
+      align={ align }
+      data-element='flat-table-header'
+    >
       { children }
     </StyledFlatTableHeader>
   );
@@ -13,7 +17,7 @@ const FlatTableHeader = ({ align, children }) => {
 
 FlatTableHeader.propTypes = {
   /** Content alignment */
-  align: PropTypes.oneOf(OptionsHelper.alignFull),
+  align: PropTypes.oneOf(['center', 'left', 'right']),
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
 };
 

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import OptionsHelper from '../../../utils/helpers/options-helper';
 import StyledFlatTableRowHeader from './flat-table-row-header.style';
 
 const FlatTableRowHeader = ({ align, children }) => {
@@ -13,7 +12,7 @@ const FlatTableRowHeader = ({ align, children }) => {
 
 FlatTableRowHeader.propTypes = {
   /** Content alignment */
-  align: PropTypes.oneOf(OptionsHelper.alignFull),
+  align: PropTypes.oneOf(['center', 'left', 'right']),
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
 };
 

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -68,14 +68,14 @@ describe('FlatTableRow', () => {
 
     it('then all Cells of the Row should have proper hover color', () => {
       assertStyleMatch({
-        backgroundColor: baseTheme.flatTable.default.hover
+        backgroundColor: baseTheme.flatTable.hover
       },
       wrapper, { modifier: `:hover ${StyledFlatTableCell}` });
     });
 
     it('then the Row Header of the Row should have proper hover color', () => {
       assertStyleMatch({
-        backgroundColor: baseTheme.flatTable.default.hover
+        backgroundColor: baseTheme.flatTable.hover
       },
       wrapper, { modifier: `:hover ${StyledFlatTableRowHeader}` });
     });

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.js
@@ -43,7 +43,7 @@ const StyledFlatTableRow = styled.tr`
     :hover {
       ${StyledFlatTableCell},
       ${StyledFlatTableRowHeader} {
-        background-color: ${theme.flatTable.default.hover};
+        background-color: ${theme.flatTable.hover};
       }
     }
   `}

--- a/src/components/flat-table/flat-table.component.js
+++ b/src/components/flat-table/flat-table.component.js
@@ -4,11 +4,13 @@ import { StyledFlatTableWrapper, StyledFlatTable } from './flat-table.style';
 
 const FlatTable = ({
   children,
-  hasStickyHead
+  hasStickyHead,
+  colorTheme
 }) => {
   return (
     <StyledFlatTableWrapper
       hasStickyHead={ hasStickyHead }
+      colorTheme={ colorTheme }
     >
       <StyledFlatTable data-component='flat-table'>
         { children }
@@ -21,7 +23,13 @@ FlatTable.propTypes = {
   /** FlatTableHead and FlatTableBody */
   children: PropTypes.node.isRequired,
   /** If true, the header does not scroll with the content */
-  hasStickyHead: PropTypes.bool
+  hasStickyHead: PropTypes.bool,
+  /** `FlatTable` color theme */
+  colorTheme: PropTypes.oneOf(['light', 'transparent-base', 'transparent-white', 'dark'])
+};
+
+FlatTable.defaultProps = {
+  colorTheme: 'dark'
 };
 
 export default FlatTable;

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -13,6 +13,7 @@ import { assertStyleMatch } from '../../__spec_helper__/test-utils';
 import StyledFlatTableHeader from './flat-table-header/flat-table-header.style';
 import StyledFlatTableHead from './flat-table-head/flat-table-head.style';
 import StyledFlatTableRowHeader from './flat-table-row-header/flat-table-row-header.style';
+import { baseTheme } from '../../style/themes';
 
 describe('FlatTable', () => {
   describe('when rendered with proper table data', () => {
@@ -38,12 +39,48 @@ describe('FlatTable', () => {
       expect(wrapper).toHaveStyleRule('overflow-y', 'auto');
     });
 
-    it('then all Headers should have proper styling', () => {
+    it('then all Headers should have proper styling if `colorTheme="dark"`', () => {
+      wrapper = renderFlatTable({ colorTheme: 'dark' }, mount);
+
       assertStyleMatch({
-        backgroundColor: '#fff',
-        position: 'sticky',
-        zIndex: '1'
+        backgroundColor: baseTheme.flatTable.dark.headerBackground,
+        borderRight: `1px solid ${baseTheme.flatTable.dark.border}`,
+        color: baseTheme.colors.white
       },
+
+      wrapper, { modifier: `${StyledFlatTableHeader}` });
+    });
+
+    it('then all Headers should have proper styling if `colorTheme="light"`', () => {
+      wrapper = renderFlatTable({ colorTheme: 'light' }, mount);
+
+      assertStyleMatch({
+        backgroundColor: baseTheme.flatTable.light.headerBackground,
+        borderRight: `1px solid ${baseTheme.flatTable.light.border}`
+      },
+
+      wrapper, { modifier: `${StyledFlatTableHeader}` });
+    });
+
+    it('then all Headers should have proper styling if `colorTheme="transparent-base"`', () => {
+      wrapper = renderFlatTable({ colorTheme: 'transparent-base' }, mount);
+
+      assertStyleMatch({
+        backgroundColor: baseTheme.flatTable.transparentBase.headerBackground,
+        borderRight: `1px solid ${baseTheme.flatTable.transparentBase.border}`
+      },
+
+      wrapper, { modifier: `${StyledFlatTableHeader}` });
+    });
+
+    it('then all Headers should have proper styling if `colorTheme="transparent-white"`', () => {
+      wrapper = renderFlatTable({ colorTheme: 'transparent-white' }, mount);
+
+      assertStyleMatch({
+        backgroundColor: baseTheme.flatTable.transparentWhite.headerBackground,
+        borderRight: `1px solid ${baseTheme.flatTable.transparentWhite.border}`
+      },
+
       wrapper, { modifier: `${StyledFlatTableHeader}` });
     });
 

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -1,10 +1,18 @@
 import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
-import { FlatTable, FlatTableHead, FlatTableBody, FlatTableRow, FlatTableHeader, FlatTableRowHeader, FlatTableCell } from '.';
+import { 
+  FlatTable, 
+  FlatTableHead, 
+  FlatTableBody, 
+  FlatTableRow, 
+  FlatTableHeader,
+  FlatTableRowHeader,
+  FlatTableCell,
+  Sort
+} from '.';
 
 <Meta title="Design System/Flat Table" />
 
 # Flat Table
-
 
 ### Basic usage:
 
@@ -181,8 +189,150 @@ import { FlatTable, FlatTableHead, FlatTableBody, FlatTableRow, FlatTableHeader,
   </Story>
 </Preview>
 
-## Props:
 
+### With transparent-white theme
+To create a transparent effect for the header, override the header background styling
+to match the same color as the background
+
+<Preview>
+  <Story name="transparent-white theme" parameters={{ info: { disable: true }}} >
+    <div>
+      <FlatTable colorTheme="transparent-white">
+        <FlatTableHead>
+          <FlatTableRow>
+            <FlatTableHeader>Client</FlatTableHeader>
+            <FlatTableHeader>Client Type</FlatTableHeader>
+            <FlatTableHeader>Categories</FlatTableHeader>
+            <FlatTableHeader>Services</FlatTableHeader>
+          </FlatTableRow>
+        </FlatTableHead>
+        <FlatTableBody>
+          <FlatTableRow onClick={ () => {} }>
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableCell>Business</FlatTableCell>
+            <FlatTableCell>Group1, Group2</FlatTableCell>
+            <FlatTableCell>Accounting</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow onClick={ () => {} }>
+            <FlatTableCell>Jane Doe</FlatTableCell>
+            <FlatTableCell>Business</FlatTableCell>
+            <FlatTableCell>Group1, Group3</FlatTableCell>
+            <FlatTableCell>Accounting</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow onClick={ () => {} }>
+            <FlatTableCell>John Smith</FlatTableCell>
+            <FlatTableCell>Charity</FlatTableCell>
+            <FlatTableCell>Group3</FlatTableCell>
+            <FlatTableCell>Payroll</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow onClick={ () => {} }>
+            <FlatTableCell>Jane Smith</FlatTableCell>
+            <FlatTableCell>Partnership</FlatTableCell>
+            <FlatTableCell>Group3</FlatTableCell>
+            <FlatTableCell>Final Tax</FlatTableCell>
+          </FlatTableRow>
+        </FlatTableBody>
+      </FlatTable>
+    </div>
+  </Story>
+</Preview>
+
+
+### With transparent-base theme
+To create a transparent effect for the header, override the header background styling
+to match the same color as the background
+
+<Preview>
+  <Story name="transparent-base theme" parameters={{ info: { disable: true }}} >
+    <FlatTable colorTheme="transparent-base">
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader>Client</FlatTableHeader>
+          <FlatTableHeader>Client Type</FlatTableHeader>
+          <FlatTableHeader>Categories</FlatTableHeader>
+          <FlatTableHeader>Services</FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+      <FlatTableBody>
+        <FlatTableRow onClick={ () => {} }>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableCell>Business</FlatTableCell>
+          <FlatTableCell>Group1, Group2</FlatTableCell>
+          <FlatTableCell>Accounting</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow onClick={ () => {} }>
+          <FlatTableCell>Jane Doe</FlatTableCell>
+          <FlatTableCell>Business</FlatTableCell>
+          <FlatTableCell>Group1, Group3</FlatTableCell>
+          <FlatTableCell>Accounting</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow onClick={ () => {} }>
+          <FlatTableCell>John Smith</FlatTableCell>
+          <FlatTableCell>Charity</FlatTableCell>
+          <FlatTableCell>Group3</FlatTableCell>
+          <FlatTableCell>Payroll</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow onClick={ () => {} }>
+          <FlatTableCell>Jane Smith</FlatTableCell>
+          <FlatTableCell>Partnership</FlatTableCell>
+          <FlatTableCell>Group3</FlatTableCell>
+          <FlatTableCell>Final Tax</FlatTableCell>
+        </FlatTableRow>
+      </FlatTableBody>
+    </FlatTable>
+  </Story>
+</Preview>
+
+### With light theme 
+
+<Preview>
+  <Story name="light theme" parameters={{ info: { disable: true }}} >
+      <FlatTable colorTheme="light">
+        <FlatTableHead>
+          <FlatTableRow>
+            <FlatTableHeader>Client</FlatTableHeader>
+            <FlatTableHeader>Client Type</FlatTableHeader>
+            <FlatTableHeader>Categories</FlatTableHeader>
+            <FlatTableHeader>Services</FlatTableHeader>
+          </FlatTableRow>
+        </FlatTableHead>
+        <FlatTableBody>
+          <FlatTableRow onClick={ () => {} }>
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableCell>Business</FlatTableCell>
+            <FlatTableCell>Group1, Group2</FlatTableCell>
+            <FlatTableCell>Accounting</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow onClick={ () => {} }>
+            <FlatTableCell>Jane Doe</FlatTableCell>
+            <FlatTableCell>Business</FlatTableCell>
+            <FlatTableCell>Group1, Group3</FlatTableCell>
+            <FlatTableCell>Accounting</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow onClick={ () => {} }>
+            <FlatTableCell>John Smith</FlatTableCell>
+            <FlatTableCell>Charity</FlatTableCell>
+            <FlatTableCell>Group3</FlatTableCell>
+            <FlatTableCell>Payroll</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow onClick={ () => {} }>
+            <FlatTableCell>Jane Smith</FlatTableCell>
+            <FlatTableCell>Partnership</FlatTableCell>
+            <FlatTableCell>Group3</FlatTableCell>
+            <FlatTableCell>Final Tax</FlatTableCell>
+          </FlatTableRow>
+        </FlatTableBody>
+      </FlatTable>
+  </Story>
+</Preview>
+
+### With sorting headers
+
+<Preview>
+  <Story id="test-flat-table--sortable" name="with sorting headers" />
+</Preview>
+
+## Props:
 
 ### FlatTable
 
@@ -203,6 +353,10 @@ import { FlatTable, FlatTableHead, FlatTableBody, FlatTableRow, FlatTableHeader,
 ### FlatTableHeader
 
 <Props of={FlatTableHeader} />
+
+### Sort
+
+<Props of={Sort} />
 
 ### FlatTableCell
 

--- a/src/components/flat-table/flat-table.style.js
+++ b/src/components/flat-table/flat-table.style.js
@@ -2,14 +2,50 @@ import styled, { css } from 'styled-components';
 import StyledFlatTableHeader from './flat-table-header/flat-table-header.style';
 import StyledFlatTableRowHeader from './flat-table-row-header/flat-table-row-header.style';
 import StyledFlatTableHead from './flat-table-head/flat-table-head.style';
+import { baseTheme } from '../../style/themes';
 
 const StyledFlatTableWrapper = styled.div`
   height: 100%;
+
+  ${({
+    colorTheme, theme
+  }) => {
+    switch (colorTheme) {
+      case 'light':
+        return css`
+        ${StyledFlatTableHeader}, ${StyledFlatTableHead} ${StyledFlatTableRowHeader} {
+          background-color: ${theme.flatTable.light.headerBackground};  
+          border-right: 1px solid ${theme.flatTable.light.border};
+        }`;
+
+      case 'transparent-base':
+        return css`
+        ${StyledFlatTableHeader}, ${StyledFlatTableHead} ${StyledFlatTableRowHeader} {
+          background-color: ${theme.flatTable.transparentBase.headerBackground};
+          border-right: 1px solid ${theme.flatTable.transparentBase.border};
+        }`;
+
+      case 'transparent-white':
+        return css`
+          ${StyledFlatTableHeader}, ${StyledFlatTableHead} ${StyledFlatTableRowHeader} {
+            background-color: ${theme.flatTable.transparentWhite.headerBackground};
+            border-right: 1px solid ${theme.flatTable.transparentWhite.border};
+          }`;
+      // default theme is "dark"
+      default:
+        return css`
+        ${StyledFlatTableHeader}, ${StyledFlatTableHead} ${StyledFlatTableRowHeader} {
+          background-color: ${theme.flatTable.dark.headerBackground};
+          border-right: 1px solid ${theme.flatTable.dark.border};
+          color: ${theme.colors.white};
+        }`;
+    }
+  }}
+
   ${({ hasStickyHead }) => hasStickyHead && css`
     overflow-y: auto;
 
     ${StyledFlatTableHeader} {
-      background-color: #fff;
       position: sticky;
       z-index: 1;
     }
@@ -29,5 +65,9 @@ const StyledFlatTable = styled.table`
   width: auto;
   word-break: break-all;
 `;
+
+StyledFlatTableWrapper.defaultProps = {
+  theme: baseTheme
+};
 
 export { StyledFlatTableWrapper, StyledFlatTable };

--- a/src/components/flat-table/index.js
+++ b/src/components/flat-table/index.js
@@ -5,3 +5,4 @@ export { default as FlatTableBody } from './flat-table-body/flat-table-body.comp
 export { default as FlatTableRow } from './flat-table-row/flat-table-row.component';
 export { default as FlatTableRowHeader } from './flat-table-row-header/flat-table-row-header.component';
 export { default as FlatTableCell } from './flat-table-cell/flat-table-cell.component';
+export { default as Sort } from './sort/sort.component';

--- a/src/components/flat-table/sort/index.js
+++ b/src/components/flat-table/sort/index.js
@@ -1,0 +1,1 @@
+export { default } from './sort.component';

--- a/src/components/flat-table/sort/sort.component.js
+++ b/src/components/flat-table/sort/sort.component.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Event from '../../../utils/helpers/events/events';
+import Icon from '../../icon';
+import { StyledSort, StyledSpaceHolder } from './sort.style';
+
+const Sort = ({ children, onClick, sortType }) => {
+  const onKeyDown = (e) => {
+    if (Event.isEnterOrSpaceKey(e)) {
+      e.preventDefault();
+      return onClick();
+    }
+
+    return null;
+  };
+
+  return (
+    <>
+      <StyledSort
+        type='button'
+        onKeyDown={ onKeyDown }
+        tabIndex={ 0 }
+        onClick={ onClick }
+        sortType={ sortType }
+      >
+        {children}
+        {sortType && <Icon type={ sortType === 'asc' ? 'sort_up' : 'sort_down' } />}
+      </StyledSort>
+      {!sortType && <StyledSpaceHolder /> }
+    </>
+
+  );
+};
+
+Sort.propTypes = {
+  /** if `asc` it will show `sort_up` icon, if `desc` it will show `sort_down` */
+  sortType: PropTypes.oneOf(['asc', 'desc', false]),
+  /** Callback fired when the `FlatTableSortHeader` is clicked */
+  onClick: PropTypes.func,
+  /** The content of `FlatTableSortHeader` */
+  children: PropTypes.node
+};
+
+export default Sort;

--- a/src/components/flat-table/sort/sort.d.ts
+++ b/src/components/flat-table/sort/sort.d.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export interface SortProps {
+   /** if `asc` it will show `sort_up` icon, if `desc` it will show `sort_down` */
+  sortType?: 'asc' | 'desc' | false ;
+  /** Callback fired when the `FlatTableSortHeader` is clicked */
+  onClick?: () => void;
+  /** Sets the content of `FlatTableSortHeader` */
+  children?: React.ReactNode | string;
+}
+
+declare const Sort: React.FunctionComponent<SortProps>;
+
+export default Sort;

--- a/src/components/flat-table/sort/sort.spec.js
+++ b/src/components/flat-table/sort/sort.spec.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Sort from './sort.component';
+import Icon from '../../icon';
+import { StyledSort, StyledSpaceHolder } from './sort.style';
+
+describe('Sort', () => {
+  let wrapper, onClickFn, onKeyDownFn;
+
+  const ENTER_KEY = { keyCode: 13, which: 13 };
+  const SPACE_KEY = { keyCode: 32, which: 32 };
+  const RANDOM_KEY = { keyCode: 82, which: 82 };
+
+  beforeEach(() => {
+    onClickFn = jest.fn();
+    onKeyDownFn = jest.fn();
+    wrapper = renderSort({ onClick: onClickFn, onKeyDown: onKeyDownFn });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render correctly', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('should not render Icon if sortType does not exist', () => {
+    wrapper = renderSort();
+
+    expect(wrapper.find(Icon).exists()).toBe(false);
+  });
+
+  it('should render Icon `sort_up` if sortType="asc"', () => {
+    wrapper = renderSort({ sortType: 'asc' });
+
+    expect(wrapper.find(Icon).props().type).toBe('sort_up');
+  });
+
+  it('should render Icon `sort_down` if sortType="desc"', () => {
+    wrapper = renderSort({ sortType: 'desc' });
+
+    expect(wrapper.find(Icon).props().type).toBe('sort_down');
+  });
+
+  it('should fire callback if clicked', () => {
+    wrapper.props().onClick();
+
+    expect(onClickFn).toHaveBeenCalled();
+  });
+
+  it('should fire callback if enter key is pressed', () => {
+    wrapper.find(StyledSort).simulate('keyDown', ENTER_KEY);
+
+    expect(onClickFn).toHaveBeenCalled();
+  });
+
+  it('should fire callback if space key is pressed', () => {
+    wrapper.find(StyledSort).simulate('keyDown', SPACE_KEY);
+
+    expect(onClickFn).toHaveBeenCalled();
+  });
+
+  it('should not fire callback if either enter key or space key is pressed', () => {
+    wrapper.find(StyledSort).simulate('keyDown', RANDOM_KEY);
+
+    expect(onKeyDownFn).not.toHaveBeenCalled();
+  });
+
+  it('should render `<StyledSpaceHolder />` if `sortType` prop is not provided', () => {
+    expect(wrapper.find(StyledSpaceHolder).exists()).toBe(true);
+  });
+
+  it('should not render `StyledSpaceHoldcer` if `sortTyp`e prop is provided', () => {
+    wrapper = renderSort({ sortType: 'asc' });
+
+    expect(wrapper.find(StyledSpaceHolder).exists()).toBe(false);
+  });
+});
+
+function renderSort(props, renderer = mount) {
+  return renderer(<Sort { ...props }>Name</Sort>);
+}

--- a/src/components/flat-table/sort/sort.style.js
+++ b/src/components/flat-table/sort/sort.style.js
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+import StyledIcon from '../../icon/icon.style';
+import { baseTheme } from '../../../style/themes';
+
+const StyledSort = styled.div`
+  display: inline-flex;
+  align-items: center;
+  padding-left: 2px;
+  padding-right: 2px;
+  border-bottom: 1px solid transparent;
+  position: relative;
+
+  ${StyledIcon}{
+    width: 16px;
+    height: 16px;
+    padding-left: 6px;
+    color: ${({ theme }) => theme.flatTable.headerIconColor};
+  }
+
+  :hover{
+    border-bottom: 1px solid;
+    cursor: pointer;
+  }
+
+  :focus{
+    outline: 1px solid ${({ theme }) => theme.colors.focus};
+  }
+`;
+
+const StyledSpaceHolder = styled.div`
+  display: inline-block;
+  width: 22px;
+`;
+
+StyledSort.defaultProps = {
+  theme: baseTheme
+};
+
+export { StyledSort, StyledSpaceHolder };

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -79,11 +79,28 @@ export default (palette) => {
       inactiveSelectorBackground: palette.slateTint(80)
     },
 
-
     flatTable: {
-      default: {
-        hover: palette.slateTint(95)
-      }
+      light: {
+        headerBackground: palette.slateTint(80),
+        border: palette.slateTint(70)
+      },
+
+      dark: {
+        headerBackground: palette.slateTint(20),
+        border: palette.slateTint(40)
+      },
+
+      transparentWhite: {
+        headerBackground: '#fff',
+        border: '#fff'
+      },
+
+      transparentBase: {
+        headerBackground: palette.slateTint(95),
+        border: palette.slateTint(95)
+      },
+      hover: palette.slateTint(95),
+      headerIconColor: palette.slateTint(60)
     },
 
     help: {

--- a/src/utils/helpers/options-helper/options-helper.js
+++ b/src/utils/helpers/options-helper/options-helper.js
@@ -90,10 +90,10 @@ const OptionsHelper = {
   ],
 
   flatTableThemes: [
-    'dark',
     'light',
-    'white',
-    'transparent'
+    'dark',
+    'transparent-base',
+    'transparent-white'
   ],
 
   iconBackgrounds: [


### PR DESCRIPTION
### Proposed behaviour
- Add new component <Sort/> to create possibility of sorting in the Flat Table
- Added support for themes: 'dark' and 'light'

![image](https://user-images.githubusercontent.com/19231884/78875601-6e9c5b80-7a4e-11ea-9862-289632201a95.png)

### Current behaviour
![image](https://user-images.githubusercontent.com/19231884/78875549-59273180-7a4e-11ea-80f9-6f8878b93565.png)


### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests
- [x] Storybook added or updated
- [x] Theme support
- [x] Typescript `d.ts` file added or updated

### Testing instructions
- open storybook
- go to test/flat-table/sortable
