### PR TITLE
fix(action-popover): add top position when menu right aligned in safari

### DIFF
--- a/src/components/action-popover/__snapshots__/action-popover.spec.js.snap
+++ b/src/components/action-popover/__snapshots__/action-popover.spec.js.snap
@@ -3873,6 +3873,7 @@ exports[`ActionPopover submenu right aligned closes the submenu when left key is
 .c7 {
   position: absolute;
   right: 0px;
+  top: 8px;
 }
 
 .c7,
@@ -4618,6 +4619,7 @@ exports[`ActionPopover submenu right aligned opens the submenu when right key is
 .c7 {
   position: absolute;
   right: 0px;
+  top: 8px;
 }
 
 .c7,

--- a/src/components/action-popover/action-popover.style.js
+++ b/src/components/action-popover/action-popover.style.js
@@ -8,6 +8,7 @@ import StyledIcon from '../icon/icon.style';
 import {
   MenuClassic, MenuItemClassic, MenuButtonClassic, SubMenuItemIconClassic
 } from './action-popover-classic.style';
+import { isSafari } from '../../utils/helpers/browser-type-check';
 
 const Menu = styled.div`
   ${({ isOpen }) => (isOpen ? 'display: block;' : 'visibility: hidden;')}
@@ -123,6 +124,7 @@ const SubMenuItemIcon = styled(iconThemeProviderFactory(() => 'inherit')(Icon))`
 
     ${type === 'chevron_right' && css`
       right: 0px;
+      ${isSafari(navigator) && css`top: ${theme.spacing}px;`}
     `}
   `}
 


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
When the submenu is positioned to the right in safari the right chevron icon is aligned to high,
this fix adds 8px to the top position to fix it

![image](https://user-images.githubusercontent.com/44157880/78888137-fdae7100-7a58-11ea-8349-f59edf34e407.png)

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
The right chevron is aligned incorrectly

![image](https://user-images.githubusercontent.com/44157880/78888117-f8e9bd00-7a58-11ea-868e-4edd03be768e.png)

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
<del>- [ ] Unit tests<del>
<del>- [ ] Cypress automation tests<del>
<del>- [ ] Storybook added or updated<del>
<del>- [ ] Theme support<del>
<del>- [ ] Typescript `d.ts` file added or updated<del>

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
Testable by visiting on safari `design-system-actionpopover--with-submenu-aligned-right`
