### PR TITLE
feat(button): add dashed button FE-2655

### DIFF
--- a/cypress/features/regression/button.feature
+++ b/cypress/features/regression/button.feature
@@ -35,6 +35,7 @@ Feature: Button component
       | secondary      | rgb(0, 128, 93)    | rgba(0, 0, 0, 0)   |
       | tertiary       | rgb(0, 128, 93)    | rgba(0, 0, 0, 0)   |
       | darkBackground | rgb(0, 128, 93)    | rgb(255, 255, 255) |
+      | dashed         | rgba(0, 0, 0, 0.9) | rgba(0, 0, 0, 0)   |
 
   @positive
   Scenario Outline: Set Button component label to <label>
@@ -78,3 +79,8 @@ Feature: Button component
     Given I check has icon checkbox
     When I select iconType to "arrow_left_small"
     Then Button icon is set to "arrow_left_small"
+
+  @positive
+  Scenario: Verify dashed outline
+    When I select buttonType to "dashed"
+    Then Button background style is "dashed"

--- a/cypress/support/step-definitions/button-steps.js
+++ b/cypress/support/step-definitions/button-steps.js
@@ -67,6 +67,10 @@ Then('Button background color is {string}', (color) => {
   buttonDataComponent().should('have.css', 'background-color', color);
 });
 
+Then('Button background style is {string}', (style) => {
+  buttonDataComponent().should('have.css', 'border-style', style);
+});
+
 Then('Button as a sibling background color is {string}', (color) => {
   buttonDataComponent().eq(positionOfElement('first')).should('have.css', 'background-color', color);
   buttonDataComponent().eq(positionOfElement('second')).should('have.css', 'background-color', color);

--- a/src/components/button/button-types.style.js
+++ b/src/components/button/button-types.style.js
@@ -100,6 +100,31 @@ export default ({ colors, disabled }, isDisabled, destructive) => ({
       }
     ` : ''}
   `,
+  dashed: `
+    background: transparent;
+    border: 2px solid ${colors.dashedBorder}
+    border-style: dashed;
+    color: ${colors.dashedButtonText};
+    &:hover {
+      background-color: ${colors.dashedHoverBackground}
+    }
+
+    ${destructive ? `
+      ${makeColors(colors.error)}
+      &:hover {
+        ${makeColors(colors.destructive.hover)}
+      }
+      ` : ''}
+
+    ${isDisabled ? `
+      border-color: ${disabled.button};
+      color: ${disabled.text};
+      &:hover {
+        background-color: transparent;
+        ${makeColors(disabled.text)}
+      }
+    ` : ''}
+  `,
   darkBackground: `
     background: ${colors.white};
     border-color: transparent;

--- a/src/components/button/button.d.ts
+++ b/src/components/button/button.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 export interface ButtonProps {
-  as?: 'primary' | 'secondary' | 'tertiary' | 'destructive' | 'darkBackground';
+  as?: 'primary' | 'secondary' | 'tertiary' | 'dashed' | 'destructive' | 'darkBackground';
   disabled?: boolean;
   size?: 'small' | 'medium' | 'large';
   subtext?: string;

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -22,7 +22,7 @@ const render = (props, renderer = shallow) => {
   );
 };
 
-const variants = ['primary', 'secondary', 'tertiary', 'darkBackground'];
+const variants = ['primary', 'secondary', 'tertiary', 'dashed', 'darkBackground'];
 const sizes = { small: [32, 16], medium: [40, 24], large: [48, 32] };
 
 describe('Button', () => {
@@ -97,8 +97,12 @@ describe('Button', () => {
         }, TestRenderer.create).toJSON();
         assertStyleMatch({
           background:
-          (variant === 'secondary' || variant === 'tertiary' ? 'transparent' : BaseTheme.disabled.button),
-          borderColor: (variant === 'secondary' ? BaseTheme.disabled.button : 'transparent'),
+          (
+            (variant === 'secondary'
+              || variant === 'tertiary'
+               || variant === 'dashed') ? 'transparent' : BaseTheme.disabled.button
+          ),
+          borderColor: (variant === 'secondary' || variant === 'dashed' ? BaseTheme.disabled.button : 'transparent'),
           color: BaseTheme.disabled.text
         }, wrapper);
       });
@@ -205,8 +209,14 @@ describe('Button', () => {
 
               assertStyleMatch({
                 background:
-                (variant === 'secondary' || variant === 'tertiary' ? 'transparent' : BaseTheme.disabled.button),
-                borderColor: (variant === 'secondary' ? BaseTheme.disabled.button : 'transparent'),
+                (
+                  (variant === 'secondary'
+                    || variant === 'tertiary'
+                     || variant === 'dashed') ? 'transparent' : BaseTheme.disabled.button
+                ),
+                borderColor: (
+                  variant === 'secondary' || variant === 'dashed' ? BaseTheme.disabled.button : 'transparent'
+                ),
                 color: BaseTheme.disabled.text,
                 fontSize: (size === 'large' ? '16px' : '14px'),
                 height: `${sizes[size][0].toString()}px`,
@@ -221,9 +231,14 @@ describe('Button', () => {
               }, TestRenderer.create).toJSON();
 
               assertStyleMatch({
-                background:
-                (variant === 'secondary' || variant === 'tertiary' ? 'transparent' : BaseTheme.disabled.button),
-                borderColor: (variant === 'secondary' ? BaseTheme.disabled.button : 'transparent'),
+                background: (
+                  (variant === 'secondary'
+                    || variant === 'tertiary'
+                     || variant === 'dashed') ? 'transparent' : BaseTheme.disabled.button
+                ),
+                borderColor: (
+                  variant === 'secondary' || variant === 'dashed' ? BaseTheme.disabled.button : 'transparent'
+                ),
                 color: BaseTheme.disabled.text,
                 fontSize: (size === 'large' ? '16px' : '14px'),
                 height: `${sizes[size][0].toString()}px`,

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -148,6 +148,42 @@ Tertiary buttons can have an icon positioned before or after the text.
   </Story>
 </Preview>
 
+## Dashed Buttons
+Dashed buttons are used for adding new content that replaces empty states.
+
+<Preview>
+  <Story name="dashed" parameters={{ info: { disable: true }}} >
+    <>
+      <Button buttonType="dashed" size="small">Small</Button>
+      <Button buttonType="dashed">Medium</Button>
+      <Button buttonType="dashed" size="large">Large</Button>
+    </>
+  </Story>
+</Preview>
+
+Dashed buttons can be disabled.
+<Preview>
+  <Story name="dashed/disabled" parameters={{ info: { disable: true }}} >
+    <>
+      <Button buttonType="dashed" disabled size="small">Small</Button>
+      <Button buttonType="dashed" disabled>Medium</Button>
+      <Button buttonType="dashed" disabled size="large">Large</Button>
+    </>
+  </Story>
+</Preview>
+
+Dashed buttons can have an icon positioned before or after the text.
+<Preview>
+  <Story name="dashed/icon" parameters={{ info: { disable: true }}} >
+  <>
+    <Button buttonType="dashed" iconType="add" size="small">Small</Button>
+    <Button buttonType="dashed" iconType="add" iconPosition="after">Medium</Button>
+    <Button buttonType="dashed" disabled iconType="add" size="small">Small</Button>
+    <Button buttonType="dashed" disabled iconType="add" iconPosition="after">Medium</Button>
+    </>
+  </Story>
+</Preview>
+
 ## With overriden styles
 It is possible to override the default styles of a Button by passing in a styleOverride object as a prop. 
 See the prop types for how this object should be formatted.

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -27,6 +27,9 @@ export default (palette) => {
 
       // element
       border: palette.slateTint(40),
+      dashedBorder: '#99ADB6',
+      dashedButtonText: 'rgba(0, 0, 0, 0.9)',
+      dashedHoverBackground: '#CCD6DB',
       focusedIcon: palette.slateTint(20),
       focusedLinkBackground: palette.goldTint(50),
       previewBackground: palette.slateTint(75),

--- a/src/utils/helpers/options-helper/__spec__.js
+++ b/src/utils/helpers/options-helper/__spec__.js
@@ -251,6 +251,7 @@ describe('OptionsHelper', () => {
       'primary',
       'secondary',
       'tertiary',
+      'dashed',
       'darkBackground'
     ]);
   });

--- a/src/utils/helpers/options-helper/options-helper.js
+++ b/src/utils/helpers/options-helper/options-helper.js
@@ -350,6 +350,7 @@ const OptionsHelper = {
     'primary',
     'secondary',
     'tertiary',
+    'dashed',
     'darkBackground'
   ],
 


### PR DESCRIPTION
### Proposed behaviour
Adds dashed button style to the choice of Buttons. 
<img width="1297" alt="Screenshot 2020-04-14 at 14 40 31" src="https://user-images.githubusercontent.com/56251247/79231566-2e7a1600-7e5e-11ea-954b-94fbd491a8c4.png">

### Current behaviour
Currently dashed button does not exist as an option in the Button component

### Checklist

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests
- [x] Storybook added or updated
<del>- [ ] Theme support
- [x] Typescript `d.ts` file added or updated

### Additional context
N/A

### Testing instructions
 - Open storybook.
 - Navigate to Button component.
 - Select Knobs version of Button (URL should appear similar to `http://localhost:9001/?path=/story/button--knobs` depending on which port you are using.).
 - Go to Knobs tab and click the buttonType dropdown menu.
 - Select 'dashed' from the choice of buttonType props.
