### PR TITLE
feat(select): add max height prop to select to control height of list FE-2700

### DIFF
--- a/src/__experimental__/components/select/__snapshots__/select.spec.js.snap
+++ b/src/__experimental__/components/select/__snapshots__/select.spec.js.snap
@@ -120,6 +120,7 @@ Object {
   "filterValue": undefined,
   "id": "listbox-2",
   "isLoopable": undefined,
+  "maxHeight": undefined,
   "onLazyLoad": undefined,
   "onSelect": [Function],
   "open": true,

--- a/src/__experimental__/components/select/select-list.component.js
+++ b/src/__experimental__/components/select/select-list.component.js
@@ -95,7 +95,8 @@ class SelectList extends React.Component {
       onMouseDown,
       onMouseEnter,
       onMouseLeave,
-      onSelect
+      onSelect,
+      maxHeight
     } = this.props;
 
     const filter = this.filter(filterValue, customFilter);
@@ -115,6 +116,7 @@ class SelectList extends React.Component {
             alwaysHighlight={ alwaysHighlight }
             isLoopable={ isLoopable }
             keyNavigation
+            maxHeight={ maxHeight }
           >
             {
               filter(children, (child) => {
@@ -169,7 +171,9 @@ SelectList.propTypes = {
   /** A callback for when a child is selected */
   onSelect: PropTypes.func,
   /** Target DOM element to position the dropdown menu list relative to */
-  target: PropTypes.object
+  target: PropTypes.object,
+  /** Sets the max height of the scrollable list */
+  maxHeight: PropTypes.string
 };
 
 export default SelectList;

--- a/src/__experimental__/components/select/select.component.js
+++ b/src/__experimental__/components/select/select.component.js
@@ -422,6 +422,7 @@ class Select extends React.Component {
       typeAhead,
       filterable,
       transparent,
+      maxHeight,
       ...props
     } = this.props;
 
@@ -461,6 +462,7 @@ class Select extends React.Component {
               target={ this.input.current && this.input.current.parentElement }
               role='listbox'
               id={ this.listboxId }
+              maxHeight={ maxHeight }
             >
               { children }
             </SelectList>
@@ -488,7 +490,7 @@ Select.propTypes = {
   disabled: PropTypes.bool,
   /** Label text for the <Textbox> */
   label: PropTypes.string,
-  /** Flag to indicite whether select list is loopable while traversing using up and down keys */
+  /** Flag to indicate whether select list is loopable while traversing using up and down keys */
   isLoopable: PropTypes.bool,
   /** A custom callback for the <Textbox>'s Blur event */
   onBlur: PropTypes.func,
@@ -530,7 +532,9 @@ Select.propTypes = {
   /** Add additional child elements before the input */
   leftChildren: PropTypes.node,
   /** If true the component input has no border and is transparent */
-  transparent: PropTypes.bool
+  transparent: PropTypes.bool,
+  /** Sets the max height of the scrollable list */
+  maxHeight: PropTypes.string
 };
 
 Select.defaultProps = {

--- a/src/__experimental__/components/select/select.spec.js
+++ b/src/__experimental__/components/select/select.spec.js
@@ -14,6 +14,7 @@ import { Input } from '../input';
 import InputPresentationStyle from '../input/input-presentation.style';
 import StyledInput from '../input/input.style';
 import InputIconToggleStyle from '../input-icon-toggle/input-icon-toggle.style';
+import { ScrollableList } from '../../../components/scrollable-list';
 
 jest.mock('../../../utils/helpers/guid');
 guid.mockImplementation(() => 'guid-12345');
@@ -81,6 +82,14 @@ describe('Select', () => {
     list = listOf(openList(wrapper));
     expect(list.exists()).toBe(true);
     expect(list.props()).toMatchSnapshot();
+  });
+
+  it('sets the max height of the ScrollableList when the prop is set', () => {
+    const wrapper = renderWrapper({ props: { maxHeight: '150px' } });
+
+    let list = listOf(wrapper);
+    list = listOf(openList(wrapper));
+    expect(list.find(ScrollableList).props().maxHeight).toEqual('150px');
   });
 
   it('applies custom data-* attributes at the right level', () => {

--- a/src/__experimental__/components/select/select.stories.js
+++ b/src/__experimental__/components/select/select.stories.js
@@ -43,6 +43,7 @@ const commonKnobs = (store, enableMultiSelect = false) => {
   const isLoopable = boolean('isLoopable', false);
   const preventFocusAutoOpen = boolean('preventFocusAutoOpen', false);
   const key = AutoFocus.getKey(autoFocus, previous);
+  const maxHeight = text('maxHeight', '');
 
   const knobs = {
     key,
@@ -67,7 +68,8 @@ const commonKnobs = (store, enableMultiSelect = false) => {
     autoFocus,
     label,
     isLoopable,
-    preventFocusAutoOpen
+    preventFocusAutoOpen,
+    maxHeight
   };
 
   if (label.length) {


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Adds `maxHeight` prop which can be passed into the list to control the height of the options

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
There is no way of controlling the max height of the list

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
<del>- [ ] Cypress automation tests<del>
- [x] Storybook added or updated
<del>- [ ] Theme support<del>
<del>- [] Typescript `d.ts` file added or updated<del>

### Additional context
<!-- Add any other context or links about the pull request here. -->

![image](https://user-images.githubusercontent.com/44157880/79584458-54a1ef00-80c6-11ea-9a00-16fe0291bd56.png)

![image](https://user-images.githubusercontent.com/44157880/79584466-59ff3980-80c6-11ea-8ebb-754c4fc9c447.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
