### PR TITLE
fix(flat-table): update hover color for flat table row and cell

### DIFF
--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -68,14 +68,14 @@ describe('FlatTableRow', () => {
 
     it('then all Cells of the Row should have proper hover color', () => {
       assertStyleMatch({
-        backgroundColor: baseTheme.table.hover
+        backgroundColor: baseTheme.flatTable.default.hover
       },
       wrapper, { modifier: `:hover ${StyledFlatTableCell}` });
     });
 
     it('then the Row Header of the Row should have proper hover color', () => {
       assertStyleMatch({
-        backgroundColor: baseTheme.table.hover
+        backgroundColor: baseTheme.flatTable.default.hover
       },
       wrapper, { modifier: `:hover ${StyledFlatTableRowHeader}` });
     });

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.js
@@ -40,9 +40,11 @@ const StyledFlatTableRow = styled.tr`
       }
     }
 
-    :hover ${StyledFlatTableCell},
-    :hover ${StyledFlatTableRowHeader} {
-      background-color: ${theme.table.hover};
+    :hover {
+      ${StyledFlatTableCell},
+      ${StyledFlatTableRowHeader} {
+        background-color: ${theme.flatTable.default.hover};
+      }
     }
   `}
 `;

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -79,6 +79,13 @@ export default (palette) => {
       inactiveSelectorBackground: palette.slateTint(80)
     },
 
+
+    flatTable: {
+      default: {
+        hover: palette.slateTint(95)
+      }
+    },
+
     help: {
       color: blackWithOpacity(0.65),
       hover: blackWithOpacity(0.9)


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Updates hover colour to be aligned with DLS, added `flatTable` object and a `default` `hover` property to theme

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Colour is not what is described in DLS

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
<del>- [ ] Cypress automation tests<del>
<del>- [ ] Storybook added or updated<del>
<del>- [ ] Theme support<del>
<del>- [ ] Typescript `d.ts` file added or updated<del>

### Additional context
<!-- Add any other context or links about the pull request here. -->

![image](https://user-images.githubusercontent.com/44157880/79844237-53690e80-83b3-11ea-960e-da2301a81712.png)


### Testing instructions
<!-- How can a reviewer test this PR? -->
