### PR TITLE
test: update version for cucumber preprocessor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13015,9 +13015,9 @@
       }
     },
     "cypress-cucumber-preprocessor": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cypress-cucumber-preprocessor/-/cypress-cucumber-preprocessor-2.3.0.tgz",
-      "integrity": "sha512-DX10ej3n8oon9bHQbAkH56mkbkDF8sjTSIvnX853iTuNOwnmIacBdnI25Yq9RaDjGeCQTsHu9u/9pO1aR5TtYg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/cypress-cucumber-preprocessor/-/cypress-cucumber-preprocessor-2.3.1.tgz",
+      "integrity": "sha512-cKa7/VsOthzvdSQSdFiLwSWtBrtDE2q/qAPDL6NWOF4Tqm/AWvvOv18b9l9Z1t4SpphezR7RGnG1QIU45y9PPw==",
       "dev": true,
       "requires": {
         "@cypress/browserify-preprocessor": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "babel": "cross-env NODE_ENV=production babel ./src --config-file ./babel.config.js --out-dir ./lib --ignore '**/*/__spec__.js','**/*.spec.js','**/__definition__.js' --quiet",
     "clean-lib": "rimraf ./lib",
     "copy-files": "cpx \"src/**/!(*.js|*.md|*.mdx|*.stories.*|*.snap|docgenInfo.json)\" lib",
-    "commit": "git-cz",
-    "preinstall": "npx npm-force-resolutions"
+    "commit": "git-cz"
   },
   "repository": {
     "type": "git",
@@ -96,7 +95,7 @@
     "cross-env": "^5.2.0",
     "css-loader": "1.0.0",
     "cypress": "4.4.0",
-    "cypress-cucumber-preprocessor": "2.3.0",
+    "cypress-cucumber-preprocessor": "2.3.1",
     "cypress-plugin-retries": "^1.5.2",
     "cz-conventional-changelog": "^3.0.2",
     "enzyme": "^3.3.0",


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
After cypress-cucumber-preprocessor package updates their version to 2.3.1 and fix the issue with cypress & cucumber we no more need to have this script "preinstall": "npx npm-force-resolutions"

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
While updating the dev dependency we were facing the issue:<img width="834" alt="Screenshot 2020-04-22 at 09 43 38" src="https://user-images.githubusercontent.com/34001198/79956699-c8eee080-8480-11ea-9ef9-73839505c7ec.png">

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del> - [ ] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ --> </del>
<del> - [ ] Unit tests </del>
<del> - [ ] Cypress automation tests </del>
<del> - [ ] Storybook added or updated </del>
<del> - [ ] Theme support </del>
<del> - [ ] Typescript `d.ts` file added or updated </del>

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
