### PR TITLE
fix(accordion): lack of accordion resize when content size changes

### DIFF
--- a/src/components/accordion/accordion.component.js
+++ b/src/components/accordion/accordion.component.js
@@ -41,7 +41,7 @@ const Accordion = React.forwardRef(({
 
   useEffect(() => {
     setContentHeight(!isExpanded ? 0 : accordionContent.current.scrollHeight);
-  }, [isExpanded]);
+  }, [isExpanded, children]);
 
   const toggleAccordion = useCallback((ev) => {
     if (!isControlled) setIsExpandedInternal(!isExpanded);

--- a/src/components/accordion/accordion.spec.js
+++ b/src/components/accordion/accordion.spec.js
@@ -83,6 +83,22 @@ describe('Accordion', () => {
       wrapper.find(StyledAccordionTitleContainer).prop('onKeyDown')(ev);
       expect(onChange).toHaveBeenCalledWith(ev, true);
     });
+
+    it('adjusts accordions height when the content changes', () => {
+      act(() => render({ expanded: true }));
+      wrapper.update();
+      isExpanded(wrapper);
+
+      const newContentHeight = 400;
+      jest.spyOn(
+        wrapper.find(StyledAccordionContent).getDOMNode(), 'scrollHeight', 'get'
+      ).mockImplementation(() => newContentHeight);
+      wrapper.setProps({ children: <div /> });
+      wrapper.update();
+      assertStyleMatch({
+        maxHeight: `${newContentHeight}px`
+      }, wrapper.find(StyledAccordionContentContainer));
+    });
   });
 
   describe('uncontrolled behaviour', () => {

--- a/src/components/accordion/accordion.spec.js
+++ b/src/components/accordion/accordion.spec.js
@@ -25,7 +25,8 @@ const isExpanded = (wrapper) => {
   }, wrapper.find(StyledAccordionIcon));
   assertStyleMatch({
     visibility: undefined,
-    maxHeight: `${contentHeight}px`
+    maxHeight: `${contentHeight}px`,
+    height: `${contentHeight}px`
   }, wrapper.find(StyledAccordionContentContainer));
 };
 
@@ -35,7 +36,8 @@ const isCollapsed = (wrapper) => {
   }, wrapper.find(StyledAccordionIcon));
   assertStyleMatch({
     visibility: 'hidden',
-    maxHeight: '0px'
+    maxHeight: '0px',
+    height: '0px'
   }, wrapper.find(StyledAccordionContentContainer));
 };
 

--- a/src/components/accordion/accordion.stories.mdx
+++ b/src/components/accordion/accordion.stories.mdx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
 import { AccordionGroup, Accordion } from '.';
 import Textbox from '../../__experimental__/components/textbox';
+import Button from '../button';
 
 <Meta
   title="Design System/Accordion"
@@ -99,6 +101,25 @@ import { Accordion, AccordionGroup } from "carbon-react/lib/components/accordion
 
 <Preview>
   <Story id="test-accordion--grouped" name="grouped">
+  </Story>
+</Preview>
+
+### With dynamic content
+Accordion adjust it's height properly when it's content is being dynamically changed
+
+<Preview>
+  <Story name="With dynamic content">
+    {() => {
+      const [contentCount, setContentCount] = useState(3);
+      return (
+        <>
+          <Button onClick={ () => setContentCount(contentCount + 1) }>Add content</Button>
+          <Accordion title="Title">
+            {Array.from({ length: contentCount }).map((_, index) => <div key={ index }>Content</div>)}
+          </Accordion>
+        </>
+      )
+    }}
   </Story>
 </Preview>
 

--- a/src/components/accordion/accordion.stories.mdx
+++ b/src/components/accordion/accordion.stories.mdx
@@ -111,9 +111,18 @@ Accordion adjust it's height properly when it's content is being dynamically cha
   <Story name="With dynamic content">
     {() => {
       const [contentCount, setContentCount] = useState(3);
+      const modifyContentCount = modifier => {
+        if(modifier === 1) {
+          setContentCount(contentCount + 1)
+        }
+        if (modifier === -1 && contentCount > 0) {
+          setContentCount(contentCount - 1)
+        }
+      }
       return (
         <>
-          <Button onClick={ () => setContentCount(contentCount + 1) }>Add content</Button>
+          <Button onClick={ () => modifyContentCount(1) }>Add content</Button>
+          <Button onClick={ () => modifyContentCount(-1) }>Remove content</Button>
           <Accordion title="Title">
             {Array.from({ length: contentCount }).map((_, index) => <div key={ index }>Content</div>)}
           </Accordion>

--- a/src/components/accordion/accordion.style.js
+++ b/src/components/accordion/accordion.style.js
@@ -74,6 +74,7 @@ const StyledAccordionContentContainer = styled.div`
   overflow: hidden;
   transition: all 0.3s;
   max-height: ${({ maxHeight }) => maxHeight}px;
+  height: ${({ maxHeight }) => maxHeight}px;
   ${({ isExpanded }) => !isExpanded && 'visibility: hidden'};
 `;
 


### PR DESCRIPTION
### Proposed behaviour
After adding, removing or modifying Accordions content it should adjust its height properly

### Current behaviour
Currently, accordion resize content only on constructor or when you expend the accordion.

### Checklist

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [ ] Cypress automation tests
- [x] Storybook added or updated
- [ ] Theme support
- [ ] Typescript `d.ts` file added or updated

### Additional context
Closes #2848

### Testing instructions
Storybook -> Design System -> Accordion -> With dynamic content
