### PR TITLE
fix(anchor-navigation): incorrect scroll animation in firefox - FE-2611

### DIFF
--- a/src/components/anchor-navigation/anchor-navigation.component.js
+++ b/src/components/anchor-navigation/anchor-navigation.component.js
@@ -64,17 +64,21 @@ const AnchorNavigation = ({ children, stickyNavigation, styleOverride }) => {
   };
 
   const scrollToSection = (section) => {
-    section.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' });
     isUserScroll.current = false;
+    section.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' });
   };
 
   const handleClick = (event, index) => {
     event.preventDefault();
     const sectionToScroll = sectionRefs.current[index].current;
 
-    scrollToSection(sectionToScroll);
     focusFirstFocusableChild(sectionToScroll);
-    setSelectedIndex(index);
+
+    // workaround due to preventScroll focus method option on firefox not working consistently
+    window.setTimeout(() => {
+      scrollToSection(sectionToScroll);
+      setSelectedIndex(index);
+    }, 10);
   };
 
   const focusNavItem = (event, index) => {

--- a/src/components/anchor-navigation/anchor-navigation.spec.js
+++ b/src/components/anchor-navigation/anchor-navigation.spec.js
@@ -118,8 +118,9 @@ describe('AnchorNavigation', () => {
 
       act(() => {
         window.dispatchEvent(new Event('scroll'));
+        jest.advanceTimersByTime(150);
       });
-      jest.advanceTimersByTime(150);
+      wrapper.update();
       expectNavigationItemToBeSelected(index, wrapper);
 
       if (hasFocusableElement) {
@@ -134,6 +135,10 @@ describe('AnchorNavigation', () => {
       (index, hasFocusableElement) => {
         const preventDefault = jest.fn();
         wrapper.find(`${StyledNavigationItem} a`).at(index).simulate('keydown', { preventDefault, which: keyCode });
+        act(() => {
+          jest.advanceTimersByTime(15);
+        });
+
         if (hasFocusableElement) {
           expect(wrapper.find(Content).at(index).find('input')).toBeFocused();
         }


### PR DESCRIPTION
### Proposed behaviour
After clicking on one of the navigation menu items window should be scrolled to the proper section.

### Current behaviour
After clicking on one of the navigation menu items on Firefox section is scrolled instantly and section is only partially visible

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [ ] Cypress automation tests
- [ ] Storybook added or updated
- [ ] Theme support
- [ ] Typescript `d.ts` file added or updated

### Additional context
For more information including a video check FE-2611

### Testing instructions
Storybook -> Test -> AnchorNavigation -> Basic
