### PR TITLE
ci(cypress.sh): split for run script and generate results

### DIFF
--- a/script/docker/cypress.sh
+++ b/script/docker/cypress.sh
@@ -102,7 +102,7 @@ fi
 
 if $RUN_REGRESSION; then
   echo 'Running all regression tests'
-  docker-compose exec -T cypress bash -c "wait-on http://storybook:9001 && npm run test-cypress-regression; npm run generate-cypress-allure-report"
+  docker-compose exec -T cypress bash -c "wait-on http://storybook:9001 && npm run test-cypress-regression"
 fi
 
 if $RUN_REGRESSION_COMMON; then


### PR DESCRIPTION
### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Split the for `cypress.sh --regression` tag for two separate steps in TeamCity:
- run regression
- generate report
In this case when the `regression` suite fails the next one step will generate results but should mark the build as failed

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Currently if we have failing tests our regression suite isn't marked as `failed`

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [ ] Unit tests
- [ ] Cypress automation tests
- [ ] Storybook added or updated
- [ ] Theme support
- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
