### PR TITLE
fix(date): allow to open date picker by clicking on calendar icon - FE-2680

### DIFF
--- a/cypress/features/regression/experimental/dateInput.feature
+++ b/cypress/features/regression/experimental/dateInput.feature
@@ -104,3 +104,23 @@ Feature: Experimental Date Input component
   Scenario: Check Date Input today date
     When I set dateInput to today
     Then the date is set to today
+
+  @positive
+  Scenario: Open dayPickerDay via click on input
+    When I click dateInput
+    Then dayPickerDay is visible
+
+  @positive
+  Scenario: Close dayPickerDay via click on input
+    When I click dateInput twice
+    Then dayPickerDay is not visible
+
+  @positive
+  Scenario: Open dayPickerDay via click on icon
+    When I click onto date icon
+    Then dayPickerDay is visible
+
+  @positive
+  Scenario: Close dayPickerDay via click on icon
+    When I click onto date icon twice
+    Then dayPickerDay is not visible

--- a/cypress/support/step-definitions/date-input-steps.js
+++ b/cypress/support/step-definitions/date-input-steps.js
@@ -1,6 +1,8 @@
 import {
   dateInput, dayPickerDay, minDate, maxDate, dateInputNoIframe,
   dayPickerDayNoIframe,
+  dayPickerWrapper,
+  dateIcon,
 } from '../../locators/date-input/index';
 
 const DAY_PICKER_PREFIX = 'DayPicker-Day--';
@@ -104,4 +106,28 @@ Then('the date is set to today', () => {
 
 Then('I click onto specific day {string} via DayPicker for validation component into iFrame', (specificDay) => {
   dayPickerDayNoIframe(specificDay).click();
+});
+
+Then('dayPickerDay is visible', () => {
+  dayPickerWrapper().should('be.visible');
+});
+
+Then('dayPickerDay is not visible', () => {
+  dayPickerWrapper().should('not.exist');
+});
+
+When('I click onto date icon', () => {
+  dateIcon().click({ force: true });
+});
+
+When('I click onto date icon twice', () => {
+  dateIcon().click().then(($el) => {
+    $el.click();
+  });
+});
+
+When('I click dateInput twice', () => {
+  dateInput().click().then(($el) => {
+    $el.click();
+  });
 });

--- a/src/__experimental__/components/date/date.component.js
+++ b/src/__experimental__/components/date/date.component.js
@@ -393,7 +393,8 @@ class BaseDateInput extends React.Component {
       onChange: this.handleVisibleInputChange,
       onFocus: this.handleFocus,
       onKeyDown: this.handleKeyDown,
-      onClick: this.handleIconClick
+      onClick: this.handleIconClick,
+      iconOnClick: this.handleIconClick
     };
 
     const validations = isDateRange ? concatAllValidations(inputProps) : this.state.validationsArray;


### PR DESCRIPTION
### Proposed behaviour
Clicking on calendar icon should open the Date Picker

### Current behaviour
Clicking on calendar icon opens Date Picker for a fraction of second and closes it instantly

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [ ] Unit tests
- [x] Cypress automation tests
- [ ] Storybook added or updated
- [ ] Theme support
- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
Storybook -> Experimental -> Date Input -> Default