### PR TITLE
fix(card-footer): update the footer non interactive text colour to black

### DIFF
--- a/src/components/card/__snapshots__/card.spec.js.snap
+++ b/src/components/card/__snapshots__/card.spec.js.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Card CardFooter styling should match the expected styling when it has interactive styling 1`] = `
+.c0 {
+  background-color: #F2F4F5;
+  border-top: #E5EAEC;
+  border-top-width: 1px;
+  border-top-style: solid;
+  font-size: 14px;
+  font-weight: 700;
+  margin: 0 -32px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c0 .c1 {
+  margin: 0;
+  padding: 18px 32px;
+}
+
+<div
+  className="c0"
+  data-element="card-footer"
+  spacing="medium"
+>
+  <div
+    id="non-interactive"
+  >
+    View Stripe Dashboard
+  </div>
+</div>
+`;
+
+exports[`Card CardFooter styling should match the expected styling when it has non-interactive content 1`] = `
+.c3 {
+  display: inline-block;
+  position: relative;
+  color: #26A826;
+  background-color: transparent;
+}
+
+.c3:hover {
+  color: #1E861E;
+  background-color: transparent;
+}
+
+.c3::before {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-family: CarbonIcons;
+  content: "\\e92d";
+  font-size: 16px;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 16px;
+  vertical-align: middle;
+  display: block;
+}
+
+.c0 {
+  background-color: #F2F4F5;
+  border-top: #E5EAEC;
+  border-top-width: 1px;
+  border-top-style: solid;
+  font-size: 14px;
+  font-weight: 700;
+  margin: 0 -32px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c0 .c4 {
+  margin: 0;
+  padding: 18px 32px;
+}
+
+.c1 {
+  display: inline-block;
+}
+
+.c1 a,
+.c1 button {
+  font-size: 14px;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #26A826;
+  display: inline-block;
+}
+
+.c1 a .c2,
+.c1 button .c2 {
+  margin-right: 5px;
+  position: relative;
+  vertical-align: middle;
+}
+
+.c1 a:hover,
+.c1 button:hover {
+  cursor: pointer;
+  color: #006300;
+}
+
+.c1 a:focus,
+.c1 button:focus {
+  color: rgba(0,0,0,0.9);
+  background-color: #FFDA7F;
+  outline: none;
+}
+
+.c1 button {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+}
+
+<div
+  className="c0"
+  data-element="card-footer"
+  spacing="medium"
+>
+  <div
+    className="c1"
+    data-component="link"
+    disabled={false}
+  >
+    <a
+      href="https://carbon.sage.com/"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      tabIndex="0"
+    >
+      <span
+        className="c2 c3"
+        data-component="icon"
+        data-element="link"
+        disabled={false}
+        fontSize="small"
+        type="link"
+      />
+      <span
+        className="carbon-link__content"
+      >
+        View Stripe Dashboard
+      </span>
+    </a>
+  </div>
+</div>
+`;

--- a/src/components/card/card-footer/card-footer.style.js
+++ b/src/components/card/card-footer/card-footer.style.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import OptionsHelper from '../../../utils/helpers/options-helper/options-helper';
 import BaseTheme from '../../../style/themes/base';
 import StyledCardColumn from '../card-column/card-column.style';
-import StyledIcon from '../../icon/icon.style';
-import LinkStyleAnchor from '../../link/link.style';
 
 const { sizesRestricted } = OptionsHelper;
 
@@ -27,20 +25,13 @@ const StyledCardFooter = styled.div`
     border-top-width: 1px;
     border-top-style: solid;
     font-size: 14px;
-    font-weight: 600;
+    font-weight: 700;
     margin: ${marginSizes[spacing]};
     display: flex;
 
     ${StyledCardColumn} {
       margin: 0;
-      color: ${theme.card.footerText};
       padding: ${paddingSizes[spacing]};
-    }
-
-    ${LinkStyleAnchor},
-    ${StyledIcon},
-    ${StyledIcon}:before {
-      color: ${theme.card.footerText};
     }
   `}
 `;

--- a/src/components/card/card.spec.js
+++ b/src/components/card/card.spec.js
@@ -2,8 +2,10 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import TestRenderer from 'react-test-renderer';
 import Card from './card.component';
+import CardFooter from './card-footer/card-footer.component';
 import { assertStyleMatch } from '../../__spec_helper__/test-utils';
 import Icon from '../icon';
+import Link from '../link';
 import OptionsHelper from '../../utils/helpers/options-helper/options-helper';
 import { rootTagTest } from '../../utils/helpers/tags/tags-specs';
 
@@ -44,6 +46,28 @@ describe('Card', () => {
 
       expect(wrapper.find(Icon).exists()).toBe(true);
       expect(wrapper.find(Icon).props().type).toBe('drag');
+    });
+  });
+
+  describe('CardFooter styling', () => {
+    it('should match the expected styling when it has non-interactive content', () => {
+      const cardFooter = TestRenderer.create(
+        <CardFooter>
+          <Link icon='link' href='https://carbon.sage.com/'>View Stripe Dashboard</Link>
+        </CardFooter>
+      );
+
+      expect(cardFooter).toMatchSnapshot();
+    });
+
+    it('should match the expected styling when it has interactive styling', () => {
+      const cardFooter = TestRenderer.create(
+        <CardFooter>
+          <div id='non-interactive'>View Stripe Dashboard</div>
+        </CardFooter>
+      );
+
+      expect(cardFooter).toMatchSnapshot();
     });
   });
 

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -70,8 +70,7 @@ export default (palette) => {
 
     card: {
       footerBackground: palette.slateTint(95),
-      footerBorder: palette.slateTint(90),
-      footerText: palette.productGreenShade(21)
+      footerBorder: palette.slateTint(90)
     },
 
     carousel: {


### PR DESCRIPTION
Fixes #2900

### Proposed behaviour
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Only content that is interactive should be green in the card footer

### Current behaviour
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
All text content in the footer is green

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
<del>- [ ] Cypress automation tests<del>
<del>- [ ] Storybook added or updated<del>
<del>- [ ] Theme support<del>
<del>- [ ] Typescript `d.ts` file added or updated<del>

### Additional context
<!-- Add any other context or links about the pull request here. -->
Proposed Change:
![image](https://user-images.githubusercontent.com/44157880/80586927-9fe4c780-8a0d-11ea-9012-18d80806f426.png)

Current:
![image](https://user-images.githubusercontent.com/44157880/80586897-952a3280-8a0d-11ea-92f1-fd2dafdb22f7.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->