### PR TITLE
feat: add new SimpleSelect Component (FE-2646)

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -50,5 +50,8 @@
   "with_both_errors_and_warnings_summary": "--with-both-errors-and-warnings-summary",
   "with_optional_character_limit": "--with-optional-character-limit",
   "with_content": "--with-content",
-  "with_optional_buttons": "--with-optional-buttons"
+  "with_optional_buttons": "--with-optional-buttons",
+  "readOnly": "--readonly",
+  "transparent": "--transparent",
+  "disabled": "--disabled"
 }

--- a/cypress/features/regression/accessibility/accessibilityDesignSystem.feature
+++ b/cypress/features/regression/accessibility/accessibilityDesignSystem.feature
@@ -179,13 +179,15 @@ Feature: Accessibility tests - Design System folder
     When I open design systems basic "<component>" component in no iframe
     Then "<component>" component has no accessibility violations
     Examples:
-      | component       |
-      | Badge           |
-      | Batch Selection |
-      | Draggable       |
-      | Flat Table      |
-      | Tile Select     |
-      | Text Editor     |
+      | component         |
+      | Badge             |
+      | Batch Selection   |
+      | Draggable         |
+      | Flat Table        |
+      | Tile Select       |
+      | Select            |
+      | Select Filterable |
+      | Text Editor       |
 
   @accessibility
   Scenario Outline: Design System Text Editor component <story> page
@@ -204,3 +206,28 @@ Feature: Accessibility tests - Design System folder
       | component |
       | Pager     |
       | Search    |
+
+  @accessibility
+  Scenario Outline: Design System Select component <story> page
+    When I open design systems <story> "Select" component in no iframe
+    Then "Select" component has no accessibility violations
+    Examples:
+      | story       |
+      | disabled    |
+      | readOnly    |
+      | transparent |
+
+  @accessibility
+  Scenario: Design System Select component basic page
+    Given I open design systems basic "Select" component in no iframe
+    When I click on Select input in noIframe
+    Then "Select" component has no accessibility violations
+
+  @accessibility
+  Scenario Outline: Design System Filterable Select component <story> page
+    When I open design systems <story> "Select filterable" component in no iframe
+    Then "Select" component has no accessibility violations
+    Examples:
+      | story    |
+      | disabled |
+      | readOnly |

--- a/cypress/features/regression/designSystem/filterableSelectEvents.feature
+++ b/cypress/features/regression/designSystem/filterableSelectEvents.feature
@@ -1,0 +1,45 @@
+Feature: Design System Select filterable component
+  I want to check Design System Select filterable component events
+
+  Background: Open Design System Select filterable component page
+    Given I open design systems basic "Select filterable" component page
+
+  @positive
+  Scenario: Check the onChange events after typed string into the input
+    Given clear all actions in Actions Tab
+      And I focus basic Select input
+    When I type "A" into basic input
+    Then onChange action was called in Actions Tab
+
+  @positive
+  Scenario: Check the onClick, onFocus events after clicking on the input
+    Given clear all actions in Actions Tab
+    When I click on basic Select input
+    Then onFocus action was called in Actions Tab
+      And onClick action was called in Actions Tab
+
+  @positive
+  Scenario: Check the onOpen, onClick, onFocus after clicking on the dropdown button
+    Given clear all actions in Actions Tab
+    When I click on "first" dropdown button
+      And I wait 500
+    Then onOpen action was called in Actions Tab
+      And onFocus action was called in Actions Tab
+      And onClick action was called in Actions Tab
+
+  @positive
+  Scenario: Check the onKeyDown event after clicking arrow
+    Given clear all actions in Actions Tab
+    When I focus basic Select input
+      And I click onto basic select using "downarrow" key
+      And I wait 500
+    Then onOpen action was called in Actions Tab
+      And onFocus action was called in Actions Tab
+      And onKeyDown action was called in Actions Tab
+
+  @positive
+  Scenario: Check the onBlur event
+    Given clear all actions in Actions Tab
+      And I focus basic Select input
+    When I click on Select label
+    Then onBlur action was called in Actions Tab

--- a/cypress/features/regression/designSystem/fiterableSelect.feature
+++ b/cypress/features/regression/designSystem/fiterableSelect.feature
@@ -1,0 +1,63 @@
+Feature: Design System Filterable Select component
+  I want to change Design System Filterable Select component properties
+
+  Background: Open Design System Filterable Select component page
+    Given I open Design Systems basic "Select filterable" component docs page
+
+  @positive
+  Scenario: Filter by typed character
+    When I type "A" into input
+    Then "first" option on Select list is "Amber"
+      And "first" option on the list is highlighted
+      And  "second" option on Select list is "Black"
+      And  "third" option on Select list is "Orange"
+
+  @positive
+  Scenario Outline: Filterable Select list is not open using keyboard <key>
+    Given I focus select input
+    When I click onto controlled select using "<key>" key
+    Then "second" filterable Select list is closed
+    Examples:
+      | key   |
+      | Enter |
+      | Space |
+
+  @positive
+  Scenario: Filterable Select list is not open when has a focus
+    When I focus select input
+    Then "second" filterable Select list is closed
+
+  @positive
+  Scenario: Filterable Select list is not opened by clicking mouse on the text input
+    When I click on Select input
+    Then "second" filterable Select list is closed
+
+  @positive
+  Scenario: Open Filterable Select list by clicking mouse on the dropdown button
+    When I click on "second" dropdown button
+    Then "second" filterable Select list is opened
+
+  @positive
+  Scenario: Close Filterable Select list by clicking out of component
+    Given I click on "second" dropdown button
+    When I click out of controlled input
+    Then "second" filterable Select list is closed
+
+  @positive
+  Scenario: Close Filterable Select list by double clicking mouse on the dropdown button
+    Given I click on "second" dropdown button
+    When I click on "second" dropdown button
+    Then "second" filterable Select list is closed
+
+  @positive
+  Scenario: Close Filterable Select list using Esc keyboard
+    Given I click on "second" dropdown button
+    When I hit ESC key
+    Then "second" filterable Select list is closed
+
+  @positive
+  Scenario: Choose option from the Select list via clicking an option
+    Given I type "Amber" into input
+    When I click on "first" option on Select list
+    Then Design system Select input has "Amber" value
+      And "second" filterable Select list is closed

--- a/cypress/features/regression/designSystem/simpleSelect.feature
+++ b/cypress/features/regression/designSystem/simpleSelect.feature
@@ -1,0 +1,67 @@
+Feature: Design System Select component
+  I want to change Design System Select component properties
+
+  Background: Open Design System Select component page
+    Given I open Design Systems basic "Select" component docs page
+
+  @positive
+  Scenario Outline: Open Select list using <key>
+    Given I click onto controlled select using "<key>" key
+    Then "second" simple Select list is opened
+    Examples:
+      | key   |
+      | Enter |
+      | Space |
+
+  @positive
+  Scenario: Open Select list by mouse click on text input
+    When I click on Select input
+    Then "second" simple Select list is opened
+
+  @positive
+  Scenario: Close Select list using Tab keyboard
+    Given I focus select input
+    When I press "Tab" onto focused element
+    Then "second" simple Select list is closed
+
+  @positive
+  Scenario: Close Select list using Esc keyboard
+    Given I click on Select input
+    When I hit ESC key
+    Then "second" simple Select list is closed
+
+  @positive
+  Scenario: Close Select list by clicking out of component
+    Given I click on "second" dropdown button
+    When I click out of controlled input
+    Then "second" simple Select list is closed
+
+  @positive
+  Scenario: Choose option from Select list by mouse clicking
+    Given I click on Select input
+    When I select value "Amber"
+    Then Design system Select input has "Amber" value
+      And "second" simple Select list is closed
+
+  @positive
+  Scenario Outline: Choose <selectedValue> option from Select list by typing <selectableValue> value in input
+    Given I click on Select input
+    When I type "<selectableValue>" into input
+    Then Design system Select input has "<selectedValue>" value
+      And "<position>" option on the list is highlighted
+    Examples:
+      | selectableValue | selectedValue | position |
+      | Amb             | Amber         | first    |
+      | Bla             | Black         | second   |
+
+  @positive
+  Scenario Outline: Open select list using arrow key
+    Given I focus select input
+    When I click onto controlled select using "<key>" key
+    Then "second" simple Select list is opened
+      And "<position>" option on the list is highlighted
+      And Design system Select input has "<value>" value
+    Examples:
+      | key       | position | value  |
+      | downarrow | first    | Amber  |
+      | uparrow   | eleventh | Yellow |

--- a/cypress/features/regression/designSystem/simpleSelectEvents.feature
+++ b/cypress/features/regression/designSystem/simpleSelectEvents.feature
@@ -1,0 +1,50 @@
+Feature: Design System Simple Select component
+  I want to check Design System Simple Select component events
+
+  Background: Open Design System Simple Select component page
+    Given I open design systems basic "Select" component page
+
+  @positive
+  Scenario: Check the onOpen, onClick, onFocus after clicking on the input
+    Given clear all actions in Actions Tab
+    When I click on basic Select input
+    Then onOpen action was called in Actions Tab
+      And onFocus action was called in Actions Tab
+      And onClick action was called in Actions Tab
+
+  @positive
+  Scenario: Check the onChange event by clicking mouse on the select list option
+    Given I click on basic Select input
+      And clear all actions in Actions Tab
+    When I click on "first" option on Select list
+    Then onChange action was called in Actions Tab
+
+  @positive
+  Scenario: Check the onKeyDown event after clicking arrow
+    Given clear all actions in Actions Tab
+    When I focus basic Select input
+      And I click onto basic select using "downarrow" key
+      And I wait 500
+    Then onKeyDown action was called in Actions Tab
+      And onFocus action was called in Actions Tab
+
+  @positive
+  Scenario Outline: Check the onKeyDown event after press <key>
+    Given clear all actions in Actions Tab
+    When I focus basic Select input
+      And I click onto basic select using "<key>" key
+      And I wait 500
+    Then onOpen action was called in Actions Tab
+      And onKeyDown action was called in Actions Tab
+      And onFocus action was called in Actions Tab
+    Examples:
+      | key   |
+      | Enter |
+      | Space |
+
+  @positive
+  Scenario: Check the onBlur event
+    Given clear all actions in Actions Tab
+      And I focus basic Select input
+    When I click on Select label
+    Then onBlur action was called in Actions Tab

--- a/cypress/locators/select/index.js
+++ b/cypress/locators/select/index.js
@@ -1,4 +1,13 @@
-import { SELECT, SELECT_INPUT } from './locators';
+import {
+  SELECT,
+  SELECT_INPUT,
+  CONTROLLED_SELECT_ID,
+  SELECT_OPTIONS,
+  DROPDOWN_BUTTON,
+  CONTROLLED_LABEL,
+  SELECT_LIST,
+  SELECT_BASIC,
+} from './locators';
 import { PILL_PREVIEW } from '../pill/locators';
 
 // component preview locators
@@ -11,3 +20,14 @@ export const selectPill = index => cy.iFrame(SELECT)
 
 // component preview locators into iFrame
 export const selectInputNoIframe = () => cy.get(SELECT_INPUT);
+
+// locators into DS
+export const simpleSelectID = () => cy.iFrame(CONTROLLED_SELECT_ID);
+export const selectDataComponent = (index, component) => cy.iFrame(`[data-component="${component}-select"]`).eq(index);
+export const selectList = () => cy.iFrame(SELECT_LIST);
+export const selectOption = index => cy.iFrame(SELECT_OPTIONS).eq(index);
+export const dropdownButton = index => cy.iFrame(DROPDOWN_BUTTON).eq(index);
+export const controlledLabel = () => cy.iFrame(CONTROLLED_LABEL);
+
+export const simpleSelectNoIframe = () => cy.get(SELECT_BASIC);
+export const simpleSelectIframe = () => cy.iFrame(SELECT_BASIC);

--- a/cypress/locators/select/locators.js
+++ b/cypress/locators/select/locators.js
@@ -1,3 +1,10 @@
 // component preview locators
 export const SELECT = '[data-component="carbon-select"]';
 export const SELECT_INPUT = '[data-element="input"]';
+
+export const CONTROLLED_SELECT_ID = '[id="controlled"]';
+export const SELECT_OPTIONS = '[data-component="option"]';
+export const DROPDOWN_BUTTON = '[data-element="dropdown"]';
+export const CONTROLLED_LABEL = '[id="controlled-usage"]';
+export const SELECT_LIST = '[data-element="select-list"]';
+export const SELECT_BASIC = '[id="simple"]';

--- a/cypress/support/helper.js
+++ b/cypress/support/helper.js
@@ -118,6 +118,7 @@ export function positionOfElement(type) {
     eighth: '7',
     ninth: '8',
     tenth: '9',
+    eleventh: '10',
     nineteenth: '19',
   }[type];
 }

--- a/cypress/support/step-definitions/select-steps.js
+++ b/cypress/support/step-definitions/select-steps.js
@@ -1,6 +1,19 @@
 import {
-  select, selectInput, selectInputNoIframe, selectPill,
+  select,
+  selectInput,
+  selectInputNoIframe,
+  selectPill,
+  simpleSelectID,
+  selectOption,
+  dropdownButton,
+  controlledLabel,
+  selectList,
+  simpleSelectNoIframe,
+  selectDataComponent,
+  simpleSelectIframe,
 } from '../../locators/select';
+import { positionOfElement, keyCode } from '../helper';
+import { label } from '../../locators';
 
 const transparentBorderColor = 'rgba(0, 0, 0, 0.85)';
 const notTransparentBorderColor = 'rgb(102, 133, 146)';
@@ -110,4 +123,83 @@ Then('Select is not transparent', () => {
 
 Then('Select placeholder align on preview is set to {string}', (direction) => {
   select().should('have.css', 'text-align', direction);
+});
+
+When('I focus select input', () => {
+  simpleSelectID().focus();
+});
+
+When('I focus basic Select input', () => {
+  simpleSelectIframe().focus();
+});
+
+Then('{string} {word} Select list is opened', (index, name) => {
+  selectDataComponent(positionOfElement(index), name).should('have.attr', 'aria-expanded', 'true');
+  selectList().should('be.visible');
+});
+
+Then('{string} {word} Select list is closed', (index, name) => {
+  selectDataComponent(positionOfElement(index), name).should('have.attr', 'aria-expanded', 'false');
+  selectList().should('not.be.visible');
+});
+
+When('I click on Select input', () => {
+  simpleSelectID().click();
+});
+
+When('I click on basic Select input', () => {
+  simpleSelectIframe().click();
+});
+
+When('I click on Select input in noIframe', () => {
+  simpleSelectNoIframe().click();
+});
+
+When('{string} option on the list is highlighted', (position) => {
+  selectOption(positionOfElement(position)).should('have.attr', 'aria-selected', 'true')
+    .and('have.css', 'background-color', 'rgb(242, 245, 246)');
+});
+
+When('I click onto controlled select using {string} key', (key) => {
+  simpleSelectID().trigger('keydown', keyCode(key));
+});
+
+When('I click onto basic select using {string} key', (key) => {
+  simpleSelectIframe().trigger('keydown', keyCode(key));
+});
+
+Then('Design system Select input has {string} value', (text) => {
+  simpleSelectID().should('have.attr', 'value', text);
+});
+
+When('I click on {string} dropdown button', (position) => {
+  dropdownButton(positionOfElement(position)).click();
+});
+
+When('I click out of controlled input', () => {
+  controlledLabel().click();
+});
+
+When('I select value {string}', (text) => {
+  simpleSelectID().type(`${text}{enter}`);
+});
+
+When('I type {string} into input', (text) => {
+  simpleSelectID().type(text);
+});
+
+When('I type {string} into basic input', (text) => {
+  simpleSelectIframe().type(text);
+});
+
+When('{string} option on Select list is {string}', (position, text) => {
+  selectOption(positionOfElement(position)).should('have.text', text);
+});
+
+When('I click on {string} option on Select list', (position) => {
+  selectOption(positionOfElement(position)).click();
+});
+
+When('I click on Select label', () => {
+  label().click();
 });

--- a/src/__experimental__/components/input-icon-toggle/input-icon-toggle.component.js
+++ b/src/__experimental__/components/input-icon-toggle/input-icon-toggle.component.js
@@ -16,6 +16,7 @@ const InputIconToggle = ({
   size,
   inputIcon: type,
   onClick,
+  onMouseDown,
   error,
   warning,
   info,
@@ -42,7 +43,11 @@ const InputIconToggle = ({
 
   if (type) {
     return (
-      <InputIconToggleStyle size={ size } onClick={ onClick }>
+      <InputIconToggleStyle
+        size={ size }
+        onClick={ onClick }
+        onMouseDown={ onMouseDown }
+      >
         <Icon type={ type } />
       </InputIconToggleStyle>
     );
@@ -57,6 +62,7 @@ InputIconToggle.propTypes = {
   disabled: PropTypes.bool,
   readOnly: PropTypes.bool,
   onClick: PropTypes.func,
+  onMouseDown: PropTypes.func,
   inputIcon: PropTypes.string,
   size: PropTypes.oneOf(OptionsHelper.sizesRestricted),
   align: PropTypes.oneOf(['left', 'right']),

--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -1,0 +1,326 @@
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback
+} from 'react';
+import PropTypes from 'prop-types';
+import invariant from 'invariant';
+import SelectTextbox, { formInputPropTypes } from '../select-textbox/select-textbox.component';
+import guid from '../../../utils/helpers/guid';
+import withFilter from '../utils/with-filter.hoc';
+import SelectList from '../select-list/select-list.component';
+
+const FilterableSelectList = withFilter(SelectList);
+
+const FilterableSelect = React.forwardRef(({
+  value,
+  defaultValue,
+  id,
+  name,
+  children,
+  onOpen,
+  onChange,
+  onClick,
+  onKeyDown,
+  noResultsMessage,
+  ...textboxProps
+}, inputRef) => {
+  const selectListId = useRef(guid());
+  const labelId = useRef(guid());
+  const containerRef = useRef();
+  const listboxRef = useRef();
+  const isControlled = useRef(value !== undefined);
+  const [textboxRef, setTextboxRef] = useState();
+  const [isOpen, setOpenState] = useState(false);
+  const [textValue, setTextValue] = useState('');
+  const [selectedValue, setSelectedValue] = useState('');
+  const [highlightedValue, setHighlightedValue] = useState('');
+  const [filterText, setFilterText] = useState('');
+
+  const setOpen = useCallback((newValue) => {
+    setOpenState((isAlreadyOpen) => {
+      if (!isAlreadyOpen && newValue && onOpen) {
+        onOpen();
+      }
+
+      return newValue;
+    });
+  }, [onOpen]);
+
+  const createCustomEvent = useCallback((newValue) => {
+    const customEvent = {
+      target: {
+        ...(name && { name }),
+        ...(id && { id }),
+        value: newValue
+      }
+    };
+
+    return customEvent;
+  }, [name, id]);
+
+  const updateValues = useCallback((newFilterText, isDeleteEvent) => {
+    setFilterText(newFilterText);
+
+    setSelectedValue((previousValue) => {
+      const match = findElementWithMatchingText(newFilterText, children);
+
+      if (!match || isDeleteEvent) {
+        setTextValue(newFilterText);
+
+        return previousValue;
+      }
+
+      if (onChange) {
+        onChange(createCustomEvent(match.props.value));
+      }
+
+      if (match.props.text.toLowerCase().startsWith(newFilterText.toLowerCase())) {
+        setTextValue(match.props.text);
+      } else {
+        setTextValue(newFilterText);
+      }
+
+      if (isControlled.current) {
+        return previousValue;
+      }
+
+      setHighlightedValue(match.props.value);
+
+      return match.props.value;
+    });
+  }, [children, createCustomEvent, onChange]);
+
+  const setMatchingText = useCallback((newValue) => {
+    const matchingOption = React.Children.toArray(children).find(option => (option.props.value === newValue));
+
+    if (matchingOption) {
+      setTextValue(matchingOption.props.text);
+      setFilterText(matchingOption.props.text);
+    }
+  }, [children]);
+
+  const handleTextboxChange = useCallback((event) => {
+    const newValue = event.target.value;
+    const isDeleteEvent = event.nativeEvent.inputType === 'deleteContentBackward'
+      || event.nativeEvent.inputType === 'deleteContentForward'
+      || event.nativeEvent.inputType === 'delete';
+
+    updateValues(newValue, isDeleteEvent);
+    setOpen(true);
+  }, [setOpen, updateValues]);
+
+  const fillLastFilterCharacter = useCallback((key) => {
+    setFilterText((previousFilterText) => {
+      if (previousFilterText.length === textValue.length - 1 && key === textValue.slice(-1)) {
+        return textValue;
+      }
+
+      return previousFilterText;
+    });
+  }, [textValue]);
+
+  const handleTextboxKeydown = useCallback(((event) => {
+    const { key } = event;
+
+    if (onKeyDown) {
+      onKeyDown(event);
+    }
+
+    if (!event.defaultPrevented && isNavigationKey(key)) {
+      event.preventDefault();
+      setOpen(true);
+    }
+
+    fillLastFilterCharacter(key);
+  }), [fillLastFilterCharacter, onKeyDown, setOpen]);
+
+  const handleGlobalClick = useCallback((event) => {
+    const notInContainer = containerRef.current && !containerRef.current.contains(event.target);
+    const notInList = listboxRef.current && !listboxRef.current.contains(event.target);
+
+    if (notInContainer && notInList) {
+      setMatchingText(selectedValue);
+      setOpen(false);
+    }
+  }, [setMatchingText, setOpen, selectedValue]);
+
+  useEffect(() => {
+    const newValue = value || defaultValue;
+    const modeSwitchedMessage = 'Input elements should not switch from uncontrolled to controlled (or vice versa). '
+    + 'Decide between using a controlled or uncontrolled input element for the lifetime of the component';
+    const onChageMissingMessage = 'onChange prop required when using a controlled input element';
+
+    invariant(isControlled.current === (value !== undefined), modeSwitchedMessage);
+    invariant(!isControlled.current || (isControlled.current && onChange), onChageMissingMessage);
+
+    setSelectedValue(newValue);
+    setHighlightedValue(newValue);
+  }, [value, defaultValue, onChange]);
+
+  useEffect(() => {
+    setMatchingText(value || defaultValue);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const clickEvent = 'click';
+
+    document.addEventListener(clickEvent, handleGlobalClick);
+
+    return function cleanup() {
+      document.removeEventListener(clickEvent, handleGlobalClick);
+    };
+  }, [handleGlobalClick]);
+
+  useEffect(() => {
+    const textStartsWithFilter = textValue.toLowerCase().startsWith(filterText.toLowerCase());
+
+    if (textboxRef && textValue.length > filterText.length && textStartsWithFilter) {
+      textboxRef.selectionStart = filterText.length;
+    }
+  }, [textValue, filterText, textboxRef]);
+
+  function handleTextboxClick(event) {
+    if (onClick) {
+      onClick(event);
+    }
+  }
+
+  function handleDropdownIconClick(event) {
+    if (onClick) {
+      onClick(event);
+    }
+
+    setOpenState((isAlreadyOpen) => {
+      if (isAlreadyOpen) {
+        return false;
+      }
+
+      if (onOpen) {
+        onOpen();
+      }
+
+      return true;
+    });
+  }
+
+  const onSelectOption = useCallback((optionData) => {
+    const { text, value: newValue, selectionType } = optionData;
+
+    if (!isControlled.current) {
+      setSelectedValue(newValue);
+    }
+
+    setTextValue(text);
+
+    if (onChange) {
+      onChange(createCustomEvent(newValue));
+    }
+
+    setHighlightedValue(newValue);
+
+    if (selectionType !== 'navigationKey') {
+      setOpen(false);
+      setFilterText(text);
+      textboxRef.focus();
+      textboxRef.select();
+    }
+  }, [createCustomEvent, onChange, setOpen, textboxRef]);
+
+  const onSelectListClose = useCallback(() => {
+    setOpen(false);
+    setMatchingText(selectedValue);
+  }, [selectedValue, setMatchingText, setOpen]);
+
+  function findElementWithMatchingText(textToMatch, list) {
+    return list.find((child) => {
+      const { text } = child.props;
+
+      return text && text.toLowerCase().indexOf(textToMatch.toLowerCase()) !== -1;
+    });
+  }
+
+  function assignInput(input) {
+    setTextboxRef(input.current);
+
+    if (inputRef) {
+      inputRef.current = input.current;
+    }
+  }
+
+  function getTextboxProps() {
+    return {
+      id,
+      name,
+      inputRef: assignInput,
+      selectedValue,
+      formattedValue: textValue,
+      onClick: handleTextboxClick,
+      iconOnClick: handleDropdownIconClick,
+      onKeyDown: handleTextboxKeydown,
+      onChange: handleTextboxChange,
+      ...textboxProps
+    };
+  }
+
+  function isNavigationKey(key) {
+    return key === 'ArrowDown' || key === 'ArrowUp'
+    || key === 'Home' || key === 'End';
+  }
+
+  return (
+    <div
+      data-component='filterable-select'
+      aria-expanded={ isOpen }
+      aria-haspopup='listbox'
+      ref={ containerRef }
+    >
+      <SelectTextbox
+        aria-controls={ isOpen ? selectListId.current : '' }
+        type='text'
+        labelId={ labelId.current }
+        { ...getTextboxProps() }
+      />
+      { isOpen && (
+        <FilterableSelectList
+          ref={ listboxRef }
+          id={ selectListId.current }
+          labelId={ labelId.current }
+          role='listbox'
+          anchorElement={ textboxRef.parentElement }
+          onSelect={ onSelectOption }
+          onSelectListClose={ onSelectListClose }
+          filterText={ filterText }
+          highlightedValue={ highlightedValue }
+          noResultsMessage={ noResultsMessage }
+        >
+          { children }
+        </FilterableSelectList>
+      ) }
+    </div>
+  );
+});
+
+FilterableSelect.propTypes = {
+  ...formInputPropTypes,
+  /** The selected value(s), when the component is operating in controlled mode */
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]),
+  /** The default selected value(s), when the component is operating in uncontrolled mode */
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]),
+  /** Child components (such as Option) for the SelectList */
+  children: PropTypes.node.isRequired,
+  /** A custom callback for when the dropdown menu opens */
+  onOpen: PropTypes.func,
+  /** A custom message to be displayed when any option does not match the filter text */
+  noResultsMessage: PropTypes.string
+};
+
+export default FilterableSelect;

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -1,0 +1,463 @@
+import React, { useRef } from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import FilterableSelect from './filterable-select.component';
+import Textbox from '../../../__experimental__/components/textbox';
+import Option from '../option/option.component';
+import SelectList from '../select-list/select-list.component';
+
+describe('FilterableSelect', () => {
+  it('the Textbox should have type of "text"', () => {
+    const wrapper = renderSelect({ filterable: true });
+
+    expect(wrapper.find(Textbox).prop('type')).toBe('text');
+  });
+
+  it('the input ref should be forwarded', () => {
+    let mockRef;
+
+    const WrapperComponent = () => {
+      mockRef = useRef();
+
+      return (
+        <FilterableSelect
+          name='testSelect'
+          id='testSelect'
+          ref={ mockRef }
+        >
+          <Option value='opt1' text='red' />
+          <Option value='opt2' text='green' />
+          <Option value='opt3' text='blue' />
+          <Option value='opt4' text='black' />
+        </FilterableSelect>
+      );
+    };
+
+    const wrapper = mount(<WrapperComponent />);
+
+    expect(mockRef.current).toBe(wrapper.find('input').getDOMNode());
+  });
+
+  describe('when the value prop has been passed', () => {
+    it('then the formatted value should be set to corresponding option text', () => {
+      const wrapper = renderSelect({ value: 'opt2', onChange: jest.fn() });
+
+      expect(wrapper.find(Textbox).prop('formattedValue')).toBe('green');
+    });
+  });
+
+  describe('when the inputRef function prop is specified', () => {
+    it('then the input reference should be returned on call', () => {
+      const inputRefFn = jest.fn();
+      const wrapper = renderSelect({ inputRef: inputRefFn });
+
+      expect(inputRefFn).toHaveBeenCalledWith({ current: wrapper.find('input').getDOMNode() });
+    });
+  });
+
+  describe('when the onFocus prop has been passed and the input has been focused', () => {
+    it('then that prop should be called', () => {
+      const onFocusFn = jest.fn();
+      const wrapper = renderSelect({ onFocus: onFocusFn });
+
+      wrapper.find('input').simulate('focus');
+      expect(onFocusFn).toHaveBeenCalled();
+    });
+  });
+
+  describe('when the Textbox Input is focused', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = renderSelect();
+    });
+
+    it('the SelectList should not be rendered', () => {
+      wrapper.find('input').simulate('focus');
+      expect(wrapper.find(SelectList).exists()).toBe(false);
+    });
+
+    describe.each([
+      'ArrowDown',
+      'ArrowUp',
+      'Home',
+      'End'
+    ])('and %s key has been pressed', (key) => {
+      it('the SelectList should be rendered', () => {
+        wrapper.find('input').simulate('keydown', { key });
+        expect(wrapper.update().find(SelectList).exists()).toBe(true);
+      });
+    });
+
+    describe('and the Enter key has been pressed', () => {
+      it('the SelectList should not be rendered', () => {
+        wrapper.find('input').simulate('keydown', { key: 'Enter' });
+        expect(wrapper.find(SelectList).exists()).toBe(false);
+      });
+    });
+
+    describe('and a key that matches the last character has been pressed', () => {
+      it('the filterText prop in the SelectList should match the formattedValue in the Textbox', () => {
+        wrapper.find('input').simulate('change', { target: { value: 'blu' } });
+        wrapper.find('input').simulate('keydown', { key: 'e' });
+
+        const selectList = wrapper.find(SelectList);
+        const textbox = wrapper.find(Textbox);
+        expect(selectList.prop('filterText')).toBe(textbox.prop('formattedValue'));
+      });
+    });
+  });
+
+  describe('when the Textbox Input has been clicked', () => {
+    it('the SelectList should not be rendered', () => {
+      const wrapper = renderSelect();
+
+      wrapper.find('input').simulate('click');
+      expect(wrapper.find(SelectList).exists()).toBe(false);
+    });
+
+    describe.each(['disabled', 'readOnly'])('and the %s prop is set to true', (prop) => {
+      it('then the "onClick" prop should not be called', () => {
+        const onClickFn = jest.fn();
+        const wrapper = renderSelect({ onClick: onClickFn, [prop]: true });
+
+        wrapper.find('input').simulate('click');
+        expect(onClickFn).not.toHaveBeenCalled();
+      });
+
+      it('then the SelectList should not be rendered', () => {
+        const wrapper = renderSelect({ [prop]: true });
+
+        wrapper.find('input').simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(false);
+      });
+    });
+
+    describe('and the onClick prop is passed', () => {
+      it('then that prop should be called', () => {
+        const onClickFn = jest.fn();
+        const wrapper = renderSelect({ onClick: onClickFn });
+
+        wrapper.find('input').simulate('click');
+        expect(onClickFn).toHaveBeenCalled();
+      });
+    });
+
+    describe('when the Dropdown Icon in the Textbox has been clicked', () => {
+      it('the SelectList should be rendered', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+      });
+
+      describe('twice', () => {
+        it('the SelectList should not be rendered', () => {
+          const wrapper = renderSelect();
+          const dropdown = wrapper.find(Textbox).find('[type="dropdown"]').first();
+          dropdown.simulate('click');
+          dropdown.simulate('click');
+          expect(wrapper.find(SelectList).exists()).toBe(false);
+        });
+      });
+
+      describe('and the onOpen prop is passed', () => {
+        it('then that prop should be called', () => {
+          const onOpenFn = jest.fn();
+          const wrapper = renderSelect({ onOpen: onOpenFn });
+
+          wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+          expect(onOpenFn).toHaveBeenCalled();
+        });
+      });
+
+      describe('and the onClick prop is passed', () => {
+        it('then that prop should be called', () => {
+          const onClickFn = jest.fn();
+          const wrapper = renderSelect({ onClick: onClickFn });
+
+          wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+          expect(onClickFn).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe('when a printable character has been typed in the Textbox', () => {
+    describe('and the first filtered option starts with that character', () => {
+      it('then the visible value should be changed to that option text', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find('input').simulate('change', { target: { value: 'r' } });
+        wrapper.update();
+        expect(wrapper.find(Textbox).prop('formattedValue')).toBe('red');
+        wrapper.unmount();
+      });
+    });
+
+    describe('and the first filtered option does not start with that character', () => {
+      it('then the Textbox visible value should be changed to that character', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find('input').simulate('change', { target: { value: 'l' } });
+        wrapper.update();
+        expect(wrapper.find(Textbox).prop('formattedValue')).toBe('l');
+        wrapper.unmount();
+      });
+
+      it('then the Textbox value should be the value of the first option containing that character', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find('input').simulate('change', { target: { value: 'l' } });
+        wrapper.update();
+        expect(wrapper.find(Textbox).prop('value')).toBe('opt3');
+        wrapper.unmount();
+      });
+    });
+
+    it('the SelectList should have the filterText prop the same as the value', () => {
+      const changeEventObject = { target: { value: 'Foo' } };
+      const wrapper = renderSelect({ filterable: true });
+
+      wrapper.find('input').simulate('click');
+      wrapper.find('input').simulate('change', changeEventObject);
+      expect(wrapper.update().find(SelectList).prop('filterText')).toBe('Foo');
+    });
+
+
+    describe('with the onOpen prop passed', () => {
+      it('then that prop should be called', () => {
+        const onOpenFn = jest.fn();
+        const wrapper = renderSelect({ onOpen: onOpenFn });
+
+        wrapper.find('input').simulate('change', { target: { value: 'b' } });
+
+        expect(onOpenFn).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when the onSelect is called in the open SelectList', () => {
+    const navigationKeyOptionObject = {
+      value: 'Foo',
+      text: 'Bar',
+      selectionType: 'navigationKey'
+    };
+    const clickOptionObject = {
+      value: 'Foo',
+      text: 'Bar',
+      selectionType: 'click'
+    };
+    const textboxProps = {
+      name: 'testName',
+      id: 'testId'
+    };
+    const expectedEventObject = {
+      target: {
+        ...textboxProps,
+        value: 'Foo'
+      }
+    };
+
+    describe('with "selectionType" as "click"', () => {
+      it('the SelectList should be closed', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        act(() => {
+          wrapper.find(SelectList).prop('onSelect')(clickOptionObject);
+        });
+        expect(wrapper.update().find(SelectList).exists()).toBe(false);
+      });
+    });
+
+    describe('with "selectionType" as "navigationKey"', () => {
+      it('the SelectList should be open and the value should be selected', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        act(() => {
+          wrapper.find(SelectList).prop('onSelect')(navigationKeyOptionObject);
+        });
+        wrapper.update();
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        expect(wrapper.find(Textbox).prop('value')).toBe('Foo');
+        expect(wrapper.find(Textbox).prop('formattedValue')).toBe('Bar');
+      });
+    });
+
+    describe('and the onChange prop is passed', () => {
+      it('then that prop should be called with the same value', () => {
+        const onChangeFn = jest.fn();
+        const wrapper = renderSelect({ ...textboxProps, onChange: onChangeFn });
+
+        wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+        act(() => {
+          wrapper.find(SelectList).prop('onSelect')(clickOptionObject);
+        });
+        expect(onChangeFn).toHaveBeenCalledWith(expectedEventObject);
+      });
+    });
+  });
+
+  describe('when the onSelectListClose is called in the open SelectList', () => {
+    it('the SelectList should be closed', () => {
+      const wrapper = renderSelect();
+
+      wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+      expect(wrapper.find(SelectList).exists()).toBe(true);
+      act(() => {
+        wrapper.find(SelectList).prop('onSelectListClose')();
+      });
+      expect(wrapper.update().find(SelectList).exists()).toBe(false);
+    });
+
+    describe('and the visible text was changed', () => {
+      it('then the formattedValue prop in Textbox should be reverted to previous value', () => {
+        const selectedOptionTextValue = 'green';
+        const onChangeFn = jest.fn();
+        const wrapper = renderSelect({ onChange: onChangeFn, defaultValue: 'opt2', filterable: true });
+        const changeEventObject = { target: { value: 'Foo' } };
+
+        wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+        expect(wrapper.find(Textbox).prop('formattedValue')).toBe(selectedOptionTextValue);
+        wrapper.find('input').simulate('change', changeEventObject);
+        expect(wrapper.find(Textbox).prop('formattedValue')).toBe('Foo');
+        act(() => {
+          wrapper.find(SelectList).prop('onSelectListClose')();
+        });
+        expect(wrapper.update().find(Textbox).prop('formattedValue')).toBe(selectedOptionTextValue);
+      });
+    });
+  });
+
+  describe('when an HTML element is clicked when the SelectList is open', () => {
+    let wrapper;
+    let domNode;
+
+    beforeEach(() => {
+      wrapper = mount(getSelect());
+      domNode = wrapper.getDOMNode();
+      document.body.appendChild(domNode);
+    });
+
+    describe('and that element is the input', () => {
+      it('then the SelectList should stay open', () => {
+        wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        act(() => {
+          wrapper.find('input').getDOMNode().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+        expect(wrapper.update().find(SelectList).exists()).toBe(true);
+      });
+    });
+
+    describe('and that element is not part of the Select', () => {
+      it('then the SelectList should be closed', () => {
+        wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        act(() => {
+          document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+        expect(wrapper.update().find(SelectList).exists()).toBe(false);
+      });
+    });
+
+    afterEach(() => {
+      document.body.removeChild(domNode);
+    });
+  });
+
+  describe('when the "filterable" prop has been set to true', () => {
+    it('the Textbox should have type of "text"', () => {
+      const wrapper = renderSelect({ filterable: true });
+
+      expect(wrapper.find(Textbox).prop('type')).toBe('text');
+    });
+  });
+});
+
+
+describe('when the onKeyDown prop is passed', () => {
+  const expectedEventObject = {
+    key: 'ArrowDown'
+  };
+
+  it('then when a key is pressed, that prop should be called with expected values', () => {
+    const onKeyDownFn = jest.fn();
+    const wrapper = renderSelect({ onKeyDown: onKeyDownFn });
+
+    wrapper.find('input').simulate('keyDown', expectedEventObject);
+
+    expect(onKeyDownFn).toHaveBeenCalledWith(expect.objectContaining({
+      ...expectedEventObject
+    }));
+  });
+});
+
+describe('when the component is controlled', () => {
+  const expectedObject = {
+    target: {
+      id: 'testSelect',
+      name: 'testSelect',
+      value: 'opt3'
+    }
+  };
+
+  const clickOptionObject = {
+    value: 'opt3',
+    text: 'black',
+    selectionType: 'click'
+  };
+
+  describe('and an option is selected', () => {
+    it('then the onChange prop should be called with expected value', () => {
+      const onChangeFn = jest.fn();
+      const wrapper = renderSelect({ onChange: onChangeFn, value: 'opt1' });
+
+      wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+      expect(wrapper.find(SelectList).exists()).toBe(true);
+      act(() => {
+        wrapper.find(SelectList).prop('onSelect')(clickOptionObject);
+      });
+      expect(onChangeFn).toHaveBeenCalledWith(expectedObject);
+    });
+  });
+
+  describe('when a printable character has been typed in the Textbox', () => {
+    let onChangeFn;
+    let wrapper;
+
+    beforeEach(() => {
+      onChangeFn = jest.fn();
+      wrapper = renderSelect({ onChange: onChangeFn, value: 'opt1' });
+      wrapper.find('input').simulate('change', { target: { value: 'b' } });
+      wrapper.update();
+    });
+
+    it('then the onChange function should have been called with with the expected value', () => {
+      expect(onChangeFn).toHaveBeenCalledWith(expectedObject);
+    });
+  });
+});
+
+function renderSelect(props = {}, renderer = mount) {
+  return renderer(getSelect(props));
+}
+
+function getSelect(props) {
+  return (
+    <FilterableSelect
+      name='testSelect'
+      id='testSelect'
+      { ...props }
+    >
+      <Option value='opt1' text='red' />
+      <Option value='opt2' text='green' />
+      <Option value='opt3' text='blue' />
+      <Option value='opt4' text='black' />
+    </FilterableSelect>
+  );
+}

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -1,0 +1,143 @@
+import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
+import { action } from '@storybook/addon-actions';
+import { useState } from 'react';
+import { FilterableSelect, Option } from '../';
+import SelectTextbox from '../select-textbox/select-textbox.component';
+
+<Meta title="Design System/Select/Filterable" />
+
+# Filterable Select
+
+Select one of available options from the drop-down menu using filter
+
+## Overview 
+
+Filterable Select is a Carbon styled implementation of WAI-ARIA Combobox with Inline Autocomplete.
+
+## Guidance, hints and tips 
+
+Always insert `Option` Components inside the `FilterableSelect`, analogous to the `<select>` and `<option>` HTML Elements.
+
+If you type printable characters in the Textbox,
+you can filter through the existing options leaving only those that match the text you typed.
+
+```javascript
+import { FilterableSelect, Option } from "carbon-react/lib/components/select";
+```
+
+### Basic usage:
+
+<Preview>
+  <Story name="basic" parameters={{ info: { disable: true }}} >
+    <FilterableSelect
+      name='simple'
+      id='simple'
+      label='label'
+      labelInline
+      onOpen={ action('onOpen') }
+      onChange={ action('onChange') }
+      onClick={ action('onClick') }
+      onFocus={ action('onFocus') }
+      onBlur={ action('onBlur') }
+      onKeyDown={ action('onKeyDown') }
+    >
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </FilterableSelect>
+  </Story>
+</Preview>
+
+### Controlled Usage:
+
+<Preview>
+  <Story name="controlled" parameters={{ info: { disable: true }}} >
+    {() => {
+      const [value, setValue] = useState('');
+      function onChangeHandler(event) {
+        setValue(event.target.value);
+        action('value set');
+      };
+      return (
+        <FilterableSelect
+          id='controlled'
+          name='controlled'
+          value={ value }
+          onChange={ onChangeHandler }
+        >
+          <Option text='Amber' value='1' />
+          <Option text='Black' value='2' />
+          <Option text='Blue' value='3' />
+          <Option text='Brown' value='4' />
+          <Option text='Green' value='5' />
+          <Option text='Orange' value='6' />
+          <Option text='Pink' value='7' />
+          <Option text='Purple' value='8' />
+          <Option text='Red' value='9' />
+          <Option text='White' value='10' />
+          <Option text='Yellow' value='11' />
+        </FilterableSelect>
+      );
+    }}
+  </Story>
+</Preview>
+
+### Disabled:
+
+<Preview>
+  <Story name="disabled" parameters={{ info: { disable: true }}} >
+    <FilterableSelect name='disabled' id='disabled' defaultValue='3' disabled>
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </FilterableSelect>
+  </Story>
+</Preview>
+
+### Read Only:
+
+<Preview>
+  <Story name="readonly" parameters={{ info: { disable: true }}} >
+    <FilterableSelect name='readonly' id='readonly' defaultValue='4' readOnly>
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </FilterableSelect>
+  </Story>
+</Preview>
+
+## Props:
+
+<Props of={ FilterableSelect } />
+
+### Props derived from the Textbox Component
+
+<Props of={ SelectTextbox } />
+
+### Props of the Option Component
+
+<Props of={ Option } />

--- a/src/components/select/filterable-select/index.d.ts
+++ b/src/components/select/filterable-select/index.d.ts
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import Option from '../option';
+
+export interface FilterableSelectProps {
+  /** Id attribute of the input element */
+  id?: string;
+  /** Name attribute of the input element */
+  name?: string;
+  /** If true the Component will be read-only */
+  readOnly?: boolean;
+  /** If true the Component will be disabled? */
+  disabled?: boolean;
+  /** If true the Component will be focused when rendered */
+  autoFocus?: boolean;
+  /** Label */
+  label?: string;
+  /** Text applied to label help tooltip */
+  labelHelp?: string;
+  /** When true, label is placed in line with an input */
+  labelInline?: boolean;
+  /** Width of a label in percentage. Works only when labelInline is true */
+  labelWidth?: number;
+  /** Width of an input in percentage. Works only when labelInline is true */
+  inputWidth?: number;
+  /** Size of an input */
+  size?: 'small' | 'medium' | 'large';
+  /** Placeholder string to be displayed in input */
+  placeholder?: string;
+  /** The selected value(s), when the component is operating in controlled mode */
+  value?: string | object;
+  /** The default selected value(s), when the component is operating in uncontrolled mode */
+  defaultValue?: string | object;
+  /** Child components (such as Option) for the SelectList */
+  children: Array<typeof Option>;
+  /** If true, prevents opening the menu on focus */
+  preventFocusAutoOpen?: boolean;
+  /** If true the component input has no border and is transparent */
+  transparent?: boolean;
+  /** If true the Component has filter functionality (filtering starts when two or more characters are typed) */
+  filterable?: boolean;
+  /** A custom callback for when the dropdown menu opens */
+  onOpen?: () => void;
+  /** A custom callback for when changes occur */
+  onChange?: () => void;
+  /** Callback function for when the Select Textbox is clicked. */
+  onClick?: () => void;
+  /** Callback function for when the Select Textbox is focused. */
+  onFocus?: () => void;
+  /** Callback function for when the Select Textbox loses it's focus. */
+  onBlur?: () => void;
+}
+
+declare const FilterableSelect: React.ComponentType<FilterableSelectProps>;
+
+export default FilterableSelect;

--- a/src/components/select/index.js
+++ b/src/components/select/index.js
@@ -1,0 +1,2 @@
+export { default as Option } from './option/option.component';
+export { default as Select } from './simple-select/simple-select.component';

--- a/src/components/select/index.js
+++ b/src/components/select/index.js
@@ -1,2 +1,3 @@
 export { default as Option } from './option/option.component';
 export { default as Select } from './simple-select/simple-select.component';
+export { default as FilterableSelect } from './filterable-select/filterable-select.component';

--- a/src/components/select/option/__snapshots__/option.spec.js.snap
+++ b/src/components/select/option/__snapshots__/option.spec.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Option renders properly 1`] = `
+.c0 {
+  cursor: pointer;
+  box-sizing: content-box;
+  line-height: 16px;
+  padding: 12px 16px;
+  width: 100%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c0:hover {
+  background-color: #F2F5F6;
+}
+
+<li
+  className="c0"
+  data-component="option"
+  onClick={[Function]}
+  role="option"
+>
+  bar
+</li>
+`;
+
+exports[`Option when no children are provided renders with the text prop as children 1`] = `
+.c0 {
+  cursor: pointer;
+  box-sizing: content-box;
+  line-height: 16px;
+  padding: 12px 16px;
+  width: 100%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c0:hover {
+  background-color: #F2F5F6;
+}
+
+<li
+  className="c0"
+  data-component="option"
+  onClick={[Function]}
+  role="option"
+>
+  foo
+</li>
+`;

--- a/src/components/select/option/index.d.ts
+++ b/src/components/select/option/index.d.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export interface OptionProps {
+  /** The option's visible text, displayed within <Textbox> of <Select>, and used for filtering */
+  text: string;
+  /** Optional: alternative rendered content, displayed within <SelectList> of <Select> (eg: an icon, an image, etc) */
+  children?: React.FunctionComponent | React.ComponentClass;
+  /** The option's invisible internal value */
+  value: string | object;
+}
+
+declare const Option: React.ComponentType<OptionProps>;
+
+export default Option;

--- a/src/components/select/option/option.component.js
+++ b/src/components/select/option/option.component.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import StyledOption from './option.style';
+
+const Option = ({
+  text,
+  children,
+  onSelect,
+  value,
+  isHighlighted
+}) => {
+  function handleClick() {
+    onSelect({ text, value });
+  }
+
+  return (
+    <StyledOption
+      aria-selected={ isHighlighted }
+      data-component='option'
+      onClick={ handleClick }
+      isHighlighted={ isHighlighted }
+      role='option'
+    >
+      { children || text }
+    </StyledOption>
+  );
+};
+
+Option.propTypes = {
+  /** The option's visible text, displayed within Textbox of Select, and used for filtering */
+  text: PropTypes.string.isRequired,
+  /** Optional: alternative rendered content, displayed within SelectList of Select (eg: an icon, an image, etc) */
+  children: PropTypes.node,
+  /** The option's invisible internal value */
+  value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
+  /**
+   * @private
+   * @ignore
+   * Callback to return value when the element is selected (prop added by the SelectList component) */
+  onSelect: PropTypes.func,
+  /**
+   * @private
+   * @ignore
+   * True if the option is highlighted (prop added by the SelectList component) */
+  isHighlighted: PropTypes.bool
+};
+
+export default Option;

--- a/src/components/select/option/option.spec.js
+++ b/src/components/select/option/option.spec.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { shallow, mount } from 'enzyme';
+import Option from './option.component';
+import { baseTheme } from '../../../style/themes';
+
+describe('Option', () => {
+  it('renders properly', () => {
+    const props = { value: '1', text: 'foo', children: 'bar' };
+    expect(renderOption(props, TestRenderer.create)).toMatchSnapshot();
+  });
+
+  describe('when no children are provided', () => {
+    it('renders with the text prop as children', () => {
+      const props = { value: '1', text: 'foo' };
+      expect(renderOption(props, TestRenderer.create)).toMatchSnapshot();
+    });
+  });
+
+  describe('when isHighlighted prop is set', () => {
+    it('then it should have expected background', () => {
+      const props = { value: '1', text: 'foo', isHighlighted: true };
+      expect(renderOption(props, mount)).toHaveStyleRule('background-color', baseTheme.select.selected);
+    });
+  });
+
+  describe('when the element is hovered over', () => {
+    it('then it should have expected background', () => {
+      const props = { value: '1', text: 'foo' };
+      expect(renderOption(props, mount))
+        .toHaveStyleRule('background-color', baseTheme.select.selected, { modifier: ':hover' });
+    });
+  });
+
+  describe('when the element is clicked', () => {
+    it('then onSelect should be called with text and value', () => {
+      const onSelect = jest.fn();
+      const props = { value: '1', text: 'foo', onSelect };
+      const wrapper = renderOption(props, mount);
+      wrapper.simulate('click');
+
+      expect(onSelect).toHaveBeenCalledWith({ text: props.text, value: props.value });
+    });
+  });
+});
+
+function renderOption(props, renderer = shallow) {
+  return renderer(
+    <Option { ...props } />
+  );
+}

--- a/src/components/select/option/option.style.js
+++ b/src/components/select/option/option.style.js
@@ -1,0 +1,30 @@
+import styled, { css } from 'styled-components';
+import propTypes from 'prop-types';
+import baseTheme from '../../../style/themes/base';
+
+const StyledOption = styled.li`
+  cursor: pointer;
+  box-sizing: content-box;
+  line-height: 16px;
+  padding: 12px 16px;
+  width: 100%;
+  user-select: none;
+
+  ${({ isHighlighted, theme }) => isHighlighted && css`background-color: ${theme.select.selected};`}
+
+  :hover {
+    ${({ theme }) => css`background-color: ${theme.select.selected};`}
+  }
+`;
+
+StyledOption.propTypes = {
+  id: propTypes.any,
+  isHighlighted: propTypes.bool,
+  theme: propTypes.object
+};
+
+StyledOption.defaultProps = {
+  theme: baseTheme
+};
+
+export default StyledOption;

--- a/src/components/select/select-list/select-list.component.js
+++ b/src/components/select/select-list/select-list.component.js
@@ -1,0 +1,176 @@
+import React, {
+  useEffect,
+  useState,
+  useCallback
+} from 'react';
+import PropTypes from 'prop-types';
+import StyledSelectList from './select-list.style';
+import updateListScrollTop from './update-list-scroll';
+import getNextChildByText from '../utils/get-next-child-by-text';
+import Portal from '../../portal/portal';
+import { getNextIndexByKey } from '../utils/get-next-child-by-key';
+
+const overhang = 4;
+
+const SelectList = React.forwardRef(({
+  id,
+  labelId,
+  children,
+  onSelect,
+  onSelectListClose,
+  filterText,
+  anchorElement,
+  highlightedValue
+}, listRef) => {
+  const [currentOptionsListIndex, setCurrentOptionsListIndex] = useState(-1);
+
+  const highlightItem = useCallback((newIndex, optionList) => {
+    const { text, value } = optionList[newIndex].props;
+
+    setCurrentOptionsListIndex(newIndex);
+    updateListScrollTop(newIndex, listRef.current);
+    onSelect({ text, value, selectionType: 'navigationKey' });
+  }, [listRef, onSelect]);
+
+  const handleGlobalKeydown = useCallback((event) => {
+    const { key } = event;
+    const optionList = React.Children.toArray(children);
+    const lastIndex = optionList.length - 1;
+
+    if (key === 'Tab' || key === 'Escape') {
+      onSelectListClose();
+    } else if (key === 'Enter') {
+      const currentOption = optionList[currentOptionsListIndex];
+
+      if (!currentOption) {
+        onSelectListClose();
+
+        return;
+      }
+
+      const { text, value } = currentOption.props;
+
+      onSelect({ text, value, selectionType: 'enterKey' });
+    } else if (isNavigationKey(key)) {
+      const nextIndex = getNextIndexByKey(key, currentOptionsListIndex, lastIndex);
+
+      highlightItem(nextIndex, optionList);
+    }
+  }, [currentOptionsListIndex, children, onSelectListClose, onSelect, highlightItem]);
+
+  const repositionList = useCallback(() => {
+    if (anchorElement) {
+      const inputBoundingRect = anchorElement.getBoundingClientRect();
+      const top = `${window.pageYOffset + inputBoundingRect.top + inputBoundingRect.height}px`;
+      const width = `${inputBoundingRect.width + 2 * overhang}px`;
+      const left = `${window.pageXOffset + inputBoundingRect.left - overhang}px`;
+
+      listRef.current.setAttribute('style', `top: ${top}; width: ${width}; left: ${left}`);
+    }
+  }, [anchorElement, listRef]);
+
+  const getIndexOfMatch = useCallback((valueToMatch) => {
+    return React.Children.toArray(children).findIndex(child => child.props.value === valueToMatch);
+  }, [children]);
+
+  useEffect(() => {
+    const keyboardEvent = 'keydown';
+
+    document.addEventListener(keyboardEvent, handleGlobalKeydown);
+
+    return function cleanup() {
+      document.removeEventListener(keyboardEvent, handleGlobalKeydown);
+    };
+  }, [handleGlobalKeydown]);
+
+  useEffect(() => {
+    if (!filterText) {
+      return;
+    }
+
+    setCurrentOptionsListIndex((previousIndex) => {
+      const match = getNextChildByText(filterText, children, previousIndex);
+
+      if (!match) {
+        return previousIndex;
+      }
+
+      const indexOfMatch = getIndexOfMatch(match.props.value);
+
+      updateListScrollTop(indexOfMatch, listRef.current);
+
+      return indexOfMatch;
+    });
+  }, [children, filterText, getIndexOfMatch, listRef]);
+
+  useEffect(() => {
+    repositionList();
+  }, [repositionList]);
+
+  useEffect(() => {
+    if (!highlightedValue) {
+      return;
+    }
+
+    const indexOfMatch = getIndexOfMatch(highlightedValue);
+
+    setCurrentOptionsListIndex(indexOfMatch);
+    updateListScrollTop(indexOfMatch, listRef.current);
+  }, [getIndexOfMatch, highlightedValue, listRef]);
+
+  function getChildrenWithListProps() {
+    return React.Children.map(children, (child, index) => {
+      const newProps = {
+        onSelect: handleSelect,
+        isHighlighted: currentOptionsListIndex === index
+      };
+
+      return React.cloneElement(child, newProps);
+    });
+  }
+
+  function handleSelect(optionData) {
+    onSelect({ ...optionData, selectionType: 'click' });
+  }
+
+  function isNavigationKey(keyEvent) {
+    return keyEvent === 'ArrowDown' || keyEvent === 'ArrowUp'
+    || keyEvent === 'Home' || keyEvent === 'End';
+  }
+
+  return (
+    <Portal onReposition={ repositionList }>
+      <StyledSelectList
+        id={ id }
+        aria-labelledby={ labelId }
+        data-element='select-list'
+        role='listbox'
+        ref={ listRef }
+        tabIndex='0'
+      >
+        { getChildrenWithListProps() }
+      </StyledSelectList>
+    </Portal>
+  );
+});
+
+SelectList.propTypes = {
+  /** The ID for the parent <div> */
+  id: PropTypes.string,
+  /** The Id of the label */
+  labelId: PropTypes.string,
+  /** Child components (such as <Option>) for the <ScrollableList> */
+  children: PropTypes.node,
+  /** DOM element to position the dropdown menu list relative to */
+  anchorElement: PropTypes.object,
+  /** A callback for when a child is selected */
+  onSelect: PropTypes.func.isRequired,
+  /** A callback for when the list should be closed */
+  onSelectListClose: PropTypes.func.isRequired,
+  /** Text value to highlight an option */
+  filterText: PropTypes.string,
+  /** Value of option to be highlighted on component render */
+  highlightedValue: PropTypes.string
+};
+
+export default SelectList;

--- a/src/components/select/select-list/select-list.spec.js
+++ b/src/components/select/select-list/select-list.spec.js
@@ -1,0 +1,251 @@
+import React, { useRef } from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import SelectList from './select-list.component';
+import { baseTheme } from '../../../style/themes';
+import Option from '../option/option.component';
+
+describe('SelectList', () => {
+  it('should have select-list element rendered inside of a Portal', () => {
+    const wrapper = renderSelectList();
+    expect(wrapper.find('Portal').exists()).toEqual(true);
+    expect(wrapper.find('Portal').find('ul[data-element="select-list"]').exists()).toEqual(true);
+  });
+
+  describe('when a key is pressed', () => {
+    let wrapper;
+    const escapeKeyDownEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+    const tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true });
+    const enterKeyDownEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    const downKeyDownEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+    const upKeyDownEvent = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+    const homeKeyDownEvent = new KeyboardEvent('keydown', { key: 'Home', bubbles: true });
+    const endKeyDownEvent = new KeyboardEvent('keydown', { key: 'End', bubbles: true });
+    let domNode;
+    let onSelectListClose;
+    let onSelect;
+
+    beforeEach(() => {
+      onSelectListClose = jest.fn();
+      onSelect = jest.fn();
+      wrapper = mount(getSelectList({ onSelectListClose, onSelect, filterText: '' }));
+      domNode = wrapper.getDOMNode();
+      document.body.appendChild(domNode);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(domNode);
+    });
+
+    describe.each([
+      ['Escape', escapeKeyDownEvent],
+      ['Tab', tabKeyDownEvent],
+      ['Enter', enterKeyDownEvent]
+    ])("and it's the %s key", (keyName, keyEvent) => {
+      it('then the onSelectListClose prop should be called', () => {
+        domNode.dispatchEvent(keyEvent);
+        expect(onSelectListClose).toHaveBeenCalled();
+      });
+    });
+
+    describe("and it's the Enter key with an option highlighted", () => {
+      it('then the onSelect prop should be called with expected data', () => {
+        wrapper.setProps({ highlightedValue: 'opt3' });
+        domNode.dispatchEvent(enterKeyDownEvent);
+        expect(onSelect).toHaveBeenCalledWith({ selectionType: 'enterKey', text: 'blue', value: 'opt3' });
+      });
+    });
+
+    describe("and it's the Down key", () => {
+      describe('with no option highlighted', () => {
+        it('then the first Option should be highlighted', () => {
+          act(() => {
+            domNode.dispatchEvent(downKeyDownEvent);
+          });
+          expect(wrapper.update().find(Option).first()).toHaveStyleRule('background-color', baseTheme.select.selected);
+        });
+      });
+
+      describe('double pressed', () => {
+        it('then the second Option should be highlighted', () => {
+          act(() => {
+            domNode.dispatchEvent(downKeyDownEvent);
+          });
+          act(() => {
+            domNode.dispatchEvent(downKeyDownEvent);
+          });
+          expect(wrapper.update().find(Option).at(1)).toHaveStyleRule('background-color', baseTheme.select.selected);
+        });
+      });
+
+      describe('with the last option already highlighted', () => {
+        it('then the first Option should be highlighted', () => {
+          wrapper.setProps({ highlightedValue: 'opt3' });
+
+          act(() => {
+            domNode.dispatchEvent(downKeyDownEvent);
+          });
+
+          expect(wrapper.update().find(Option).first()).toHaveStyleRule('background-color', baseTheme.select.selected);
+        });
+      });
+    });
+
+    describe("and it's the Up key", () => {
+      describe('with no option highlighted', () => {
+        it('then the last Option should be highlighted', () => {
+          act(() => {
+            domNode.dispatchEvent(upKeyDownEvent);
+          });
+          expect(wrapper.update().find(Option).last()).toHaveStyleRule('background-color', baseTheme.select.selected);
+        });
+      });
+
+      describe('double pressed', () => {
+        it('then the second Option should be highlighted', () => {
+          act(() => {
+            domNode.dispatchEvent(upKeyDownEvent);
+          });
+          act(() => {
+            domNode.dispatchEvent(upKeyDownEvent);
+          });
+          expect(wrapper.update().find(Option).at(1)).toHaveStyleRule('background-color', baseTheme.select.selected);
+        });
+      });
+
+      describe('with the first option already highlighted', () => {
+        it('then the last Option should be highlighted', () => {
+          wrapper.setProps({ highlightedValue: 'opt1' });
+
+          act(() => {
+            domNode.dispatchEvent(upKeyDownEvent);
+          });
+
+          expect(wrapper.update().find(Option).last()).toHaveStyleRule('background-color', baseTheme.select.selected);
+        });
+      });
+    });
+
+    describe("and it's the Home key", () => {
+      it('then the first Option should be highlighted', () => {
+        act(() => {
+          domNode.dispatchEvent(homeKeyDownEvent);
+        });
+        expect(wrapper.update().find(Option).first()).toHaveStyleRule('background-color', baseTheme.select.selected);
+      });
+    });
+
+    describe("and it's the End key", () => {
+      it('then the last Option should be highlighted', () => {
+        act(() => {
+          domNode.dispatchEvent(endKeyDownEvent);
+        });
+        expect(wrapper.update().find(Option).last()).toHaveStyleRule('background-color', baseTheme.select.selected);
+      });
+    });
+
+    it('does not highlight any option if the other key is pressed', () => {
+      act(() => {
+        domNode.dispatchEvent(new KeyboardEvent('keydown', { key: 'b', bubbles: true }));
+      });
+      const options = wrapper.find(Option);
+
+      options.forEach((option) => {
+        expect(option).toHaveStyleRule('background-color', undefined);
+      });
+    });
+  });
+
+  describe('when rendered', () => {
+    it('then Options should have additional "isHighlighted" prop', () => {
+      const onSelect = jest.fn();
+      const wrapper = renderSelectList({ onSelect });
+
+      expect(wrapper.find(Option).first().prop('isHighlighted')).toBe(false);
+    });
+
+    describe('and the first option has been clicked', () => {
+      it('then the "onSelect" prop should have been called with option data and "selectionType" as "click"', () => {
+        const onSelect = jest.fn();
+        const wrapper = renderSelectList({ onSelect });
+
+        wrapper.find(Option).first().simulate('click');
+        expect(onSelect).toHaveBeenCalledWith({ selectionType: 'click', text: 'red', value: 'opt1' });
+      });
+    });
+  });
+
+  describe('when the filterText is provided', () => {
+    it('then the first element with text that is matching the filter should be highlighted', () => {
+      const wrapper = renderSelectList({ filterText: 'g' });
+
+      expect(wrapper.find(Option).at(1)).toHaveStyleRule('background-color', baseTheme.select.selected);
+    });
+
+    describe('and it does not match the text of any option', () => {
+      it('then Options should have the "isHighlighted" prop set to "false"', () => {
+        const wrapper = renderSelectList({ filterText: 'x' });
+
+        wrapper.update().find(Option).forEach((option) => {
+          expect(option.prop('isHighlighted')).toBe(false);
+        });
+      });
+    });
+  });
+
+  describe('when the anchor element is provided', () => {
+    let wrapper, domNode;
+    const mockAnchorElement = {
+      getBoundingClientRect: () => {
+        return {
+          top: 100,
+          left: 100,
+          width: 200,
+          height: 50
+        };
+      }
+    };
+
+    beforeEach(() => {
+      wrapper = mount(getSelectList({ anchorElement: mockAnchorElement }));
+      domNode = wrapper.getDOMNode();
+      document.body.appendChild(domNode);
+    });
+
+    it('then the list should have expected "top", "left" and "width" values', () => {
+      expect(wrapper.find('Portal').find('ul[data-element="select-list"]').getDOMNode().style.top).toBe('150px');
+      expect(wrapper.find('Portal').find('ul[data-element="select-list"]').getDOMNode().style.left).toBe('96px');
+      expect(wrapper.find('Portal').find('ul[data-element="select-list"]').getDOMNode().style.width).toBe('208px');
+    });
+  });
+});
+
+function renderSelectList(props = {}, renderer = mount) {
+  return renderer(getSelectList(props));
+}
+
+function getSelectList(props) {
+  const defaultProps = {
+    onSelect: () => {},
+    onSelectListClose: () => {}
+  };
+
+  const WrapperComponent = (wrapperProps) => {
+    const mockRef = useRef();
+
+    return (
+      <SelectList
+        ref={ mockRef }
+        { ...defaultProps }
+        { ...props }
+        { ...wrapperProps }
+      >
+        <Option value='opt1' text='red' />
+        <Option value='opt2' text='green' />
+        <Option value='opt3' text='blue' />
+      </SelectList>
+    );
+  };
+
+  return <WrapperComponent />;
+}

--- a/src/components/select/select-list/select-list.style.js
+++ b/src/components/select/select-list/select-list.style.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import { baseTheme } from '../../../style/themes';
+
+const StyledSelectList = styled.ul`
+  background-color: white;
+  box-sizing: border-box;
+  box-shadow: ${({ theme }) => `${theme.shadows.depth1}`};
+  list-style-type: none;
+  max-height: ${props => `${props.maxHeight}`};
+  margin: 0;
+  outline: none;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  padding: 0;
+  position: absolute;
+  width: 100%;
+`;
+
+StyledSelectList.defaultProps = {
+  maxHeight: '180px',
+  theme: baseTheme
+};
+
+export default StyledSelectList;

--- a/src/components/select/select-list/update-list-scroll.js
+++ b/src/components/select/select-list/update-list-scroll.js
@@ -1,0 +1,17 @@
+export default function updateListScrollTop(indexOfCurrent, list) {
+  if (!list || !list.children[indexOfCurrent]) {
+    list.scrollTop = 0;
+
+    return;
+  }
+
+  let newPosition = 0;
+  const { offsetHeight: listHeight, children: listChildren } = list;
+  const { offsetTop: itemTop, offsetHeight: currentItemHeight } = listChildren[indexOfCurrent];
+
+  if ((itemTop + currentItemHeight) > listHeight) {
+    newPosition = itemTop + currentItemHeight - listHeight;
+  }
+
+  list.scrollTop = newPosition;
+}

--- a/src/components/select/select-list/update-list-scroll.spec.js
+++ b/src/components/select/select-list/update-list-scroll.spec.js
@@ -1,0 +1,50 @@
+import updateListScrollTop from './update-list-scroll';
+
+describe('updateListScrollTop', () => {
+  describe('when called with a HTML list in the second argument', () => {
+    const numOfItems = 20;
+    const listHeight = 100;
+    const itemHeight = 30;
+    let list;
+
+    beforeEach(() => {
+      list = {
+        offsetHeight: listHeight,
+        children: [...Array(numOfItems).keys()].map((item, index) => {
+          return { offsetHeight: itemHeight, offsetTop: index * itemHeight };
+        }),
+        scrollTop: 0
+      };
+    });
+
+    describe('and the index is -1', () => {
+      it('should change the scrollTop property of that list to 0', () => {
+        const itemIndex = -1;
+
+        list.scrollTop = 500;
+        updateListScrollTop(itemIndex, list);
+
+        expect(list.scrollTop).toBe(0);
+      });
+    });
+
+    describe('and the combined items height is less than the list height', () => {
+      it('should change the scrollTop property of that list to 0', () => {
+        const itemIndex = 2;
+
+        updateListScrollTop(itemIndex, list);
+
+        expect(list.scrollTop).toBe(0);
+      });
+    });
+
+    describe('when called with a HTML list in the second argument', () => {
+      it('should change the scrollTop property of that list to combined height of items below passed index', () => {
+        const itemIndex = 15;
+        updateListScrollTop(itemIndex, list);
+
+        expect(list.scrollTop).toBe((itemIndex + 1) * itemHeight - listHeight);
+      });
+    });
+  });
+});

--- a/src/components/select/select-textbox/select-textbox.component.js
+++ b/src/components/select/select-textbox/select-textbox.component.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import I18n from 'i18n-js';
+import Textbox from '../../../__experimental__/components/textbox';
+import OptionsHelper from '../../../utils/helpers/options-helper/options-helper';
+import StyledSelectTextbox from './select-textbox.style';
+
+const SelectTextbox = ({
+  value,
+  disabled,
+  readOnly,
+  placeholder,
+  size,
+  onClick,
+  onFocus,
+  onBlur,
+  selectedValue,
+  ...restProps
+}) => {
+  const defaultPlaceholder = I18n.t('select.placeholder', {
+    defaultValue: 'Please Select...'
+  });
+
+  function handleTextboxClick(event) {
+    if (disabled || readOnly) {
+      return;
+    }
+
+    onClick(event);
+  }
+
+  function handleTextboxFocus(event) {
+    if (disabled || readOnly) {
+      return;
+    }
+
+    if (onFocus) {
+      onFocus(event);
+    }
+  }
+
+  function handleTextboxBlur(event) {
+    if (onBlur) {
+      onBlur(event);
+    }
+  }
+
+  function getTextboxProps() {
+    return {
+      placeholder: placeholder || defaultPlaceholder,
+      disabled,
+      readOnly,
+      onClick: handleTextboxClick,
+      onFocus: handleTextboxFocus,
+      onBlur: handleTextboxBlur,
+      ...restProps
+    };
+  }
+
+  return (
+    <StyledSelectTextbox size={ size }>
+      <Textbox
+        data-element='select-input'
+        inputIcon='dropdown'
+        autoComplete='off'
+        size={ size }
+        value={ selectedValue }
+        { ...getTextboxProps() }
+      />
+    </StyledSelectTextbox>
+  );
+};
+
+const formInputPropTypes = {
+  /** Id attribute of the input element */
+  id: PropTypes.string,
+  /** Name attribute of the input element */
+  name: PropTypes.string,
+  /** If true the Component will be read-only */
+  readOnly: PropTypes.bool,
+  /** If true the Component will be disabled */
+  disabled: PropTypes.bool,
+  /** If true the Component will be focused when rendered */
+  autoFocus: PropTypes.bool,
+  /** Label */
+  label: PropTypes.string,
+  /** Text applied to label help tooltip */
+  labelHelp: PropTypes.string,
+  /** When true, label is placed in line with an input */
+  labelInline: PropTypes.bool,
+  /** Width of a label in percentage. Works only when labelInline is true */
+  labelWidth: PropTypes.number,
+  /** Width of an input in percentage. Works only when labelInline is true */
+  inputWidth: PropTypes.number,
+  /** Size of an input */
+  size: PropTypes.oneOf(OptionsHelper.sizesRestricted),
+  /** Placeholder string to be displayed in input */
+  placeholder: PropTypes.string,
+  /** A custom callback for when changes occur */
+  onChange: PropTypes.func,
+  /** Callback function for when the Select Textbox is clicked. */
+  onClick: PropTypes.func,
+  /** Callback function for when the Select Textbox is focused. */
+  onFocus: PropTypes.func,
+  /** Callback function for when the Select Textbox loses it's focus. */
+  onBlur: PropTypes.func,
+  /** Callback function for when the key is pressed when focused on Select Textbox. */
+  onKeyDown: PropTypes.func
+};
+
+SelectTextbox.propTypes = {
+  ...formInputPropTypes,
+  /**
+   * @private
+   * @ignore
+   * Value to be displayed in the Textbox */
+  formattedValue: PropTypes.string,
+  /**
+   * @private
+   * @ignore
+   * Value of the Select Input */
+  selectedValue: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ])
+};
+
+export default SelectTextbox;
+export { formInputPropTypes };

--- a/src/components/select/select-textbox/select-textbox.spec.js
+++ b/src/components/select/select-textbox/select-textbox.spec.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import SelectTextbox from './select-textbox.component';
+import Textbox from '../../../__experimental__/components/textbox';
+import StyledInput from '../../../__experimental__/components/input/input.style';
+import InputPresentationStyle from '../../../__experimental__/components/input/input-presentation.style';
+import InputIconToggleStyle from '../../../__experimental__/components/input-icon-toggle/input-icon-toggle.style';
+import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
+
+describe('SelectTextbox', () => {
+  describe('when rendered', () => {
+    it('it should contain a Textbox with expected props', () => {
+      const wrapper = mount(<SelectTextbox />);
+
+      expect(wrapper.find(Textbox).exists()).toBe(true);
+      expect(wrapper.find(Textbox).props().placeholder).toBe('Please Select...');
+      expect(wrapper.find(Textbox).props().inputIcon).toBe('dropdown');
+      expect(wrapper.find(Textbox).props().autoComplete).toBe('off');
+    });
+
+    it('the input text should have proper paddings', () => {
+      const wrapper = mount(<SelectTextbox />);
+
+      assertStyleMatch({
+        paddingLeft: '11px'
+      }, wrapper, { modifier: `${StyledInput}` });
+    });
+
+    it('the input toggle icon should have proper left margin', () => {
+      const wrapper = mount(<SelectTextbox />);
+
+      assertStyleMatch({
+        marginRight: '0'
+      }, wrapper, { modifier: `${InputIconToggleStyle}` });
+    });
+
+    it('the input text should have proper paddings', () => {
+      const wrapper = mount(<SelectTextbox />);
+
+      assertStyleMatch({
+        paddingLeft: '0',
+        paddingRight: '0'
+      }, wrapper, { modifier: `${InputPresentationStyle}` });
+    });
+  });
+
+  describe('when the onFocus prop has been passed and the input has been focused', () => {
+    it('then that prop should be called', () => {
+      const onFocusFn = jest.fn();
+      const wrapper = mount(<SelectTextbox onFocus={ onFocusFn } />);
+
+      wrapper.find('input').simulate('focus');
+      expect(onFocusFn).toHaveBeenCalled();
+    });
+  });
+
+  describe('when the onBlur prop has been passed and the input has been unfocused', () => {
+    it('then that prop should be called', () => {
+      const onBlurFn = jest.fn();
+      const wrapper = mount(<SelectTextbox onBlur={ onBlurFn } />);
+
+      wrapper.find('input').simulate('blur');
+      expect(onBlurFn).toHaveBeenCalled();
+    });
+  });
+
+  // coverage filler for else path
+  const wrapper = mount(<SelectTextbox />);
+  wrapper.find('input').simulate('blur');
+});

--- a/src/components/select/select-textbox/select-textbox.style.js
+++ b/src/components/select/select-textbox/select-textbox.style.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import InputPresentationStyle from '../../../__experimental__/components/input/input-presentation.style';
+import InputIconToggleStyle from '../../../__experimental__/components/input-icon-toggle/input-icon-toggle.style';
+import StyledInput from '../../../__experimental__/components/input/input.style';
+import sizes from '../../../__experimental__/components/input/input-sizes.style';
+
+const StyledSelectTextbox = styled.div`
+  ${StyledInput} {
+    padding-left: ${({ size }) => sizes[size].horizontalPadding};
+  }
+
+  ${InputPresentationStyle} {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  ${InputIconToggleStyle} {
+    margin-right: 0;
+  }
+`;
+
+StyledSelectTextbox.defaultProps = {
+  size: 'medium'
+};
+
+export default StyledSelectTextbox;

--- a/src/components/select/simple-select/index.d.ts
+++ b/src/components/select/simple-select/index.d.ts
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import Option from '../option';
+
+export interface SimpleSelectProps {
+  /** Id attribute of the input element */
+  id?: string;
+  /** Name attribute of the input element */
+  name?: string;
+  /** If true the Component will be read-only */
+  readOnly?: boolean;
+  /** If true the Component will be disabled? */
+  disabled?: boolean;
+  /** If true the Component will be focused when rendered */
+  autoFocus?: boolean;
+  /** Label */
+  label?: string;
+  /** Text applied to label help tooltip */
+  labelHelp?: string;
+  /** When true, label is placed in line with an input */
+  labelInline?: boolean;
+  /** Width of a label in percentage. Works only when labelInline is true */
+  labelWidth?: number;
+  /** Width of an input in percentage. Works only when labelInline is true */
+  inputWidth?: number;
+  /** Size of an input */
+  size?: 'small' | 'medium' | 'large';
+  /** Placeholder string to be displayed in input */
+  placeholder?: string;
+  /** The selected value(s), when the component is operating in controlled mode */
+  value?: string | object;
+  /** The default selected value(s), when the component is operating in uncontrolled mode */
+  defaultValue?: string | object;
+  /** Child components (such as Option) for the SelectList */
+  children: Array<typeof Option>;
+  /** If true, prevents opening the menu on focus */
+  preventFocusAutoOpen?: boolean;
+  /** If true the component input has no border and is transparent */
+  transparent?: boolean;
+  /** A custom callback for when the dropdown menu opens */
+  onOpen?: () => void;
+  /** A custom callback for when changes occur */
+  onChange?: () => void;
+  /** Callback function for when the Select Textbox is clicked. */
+  onClick?: () => void;
+  /** Callback function for when the Select Textbox is focused. */
+  onFocus?: () => void;
+  /** Callback function for when the Select Textbox loses it's focus. */
+  onBlur?: () => void;
+}
+
+declare const SimpleSelect: React.ComponentType<SimpleSelectProps>;
+
+export default SimpleSelect;

--- a/src/components/select/simple-select/simple-select-sizes.stories.mdx
+++ b/src/components/select/simple-select/simple-select-sizes.stories.mdx
@@ -1,0 +1,72 @@
+import { Meta, Preview, Story } from '@storybook/addon-docs/blocks';
+import { Select, Option } from '../';
+
+<Meta title="Design System/Select/Sizes" />
+
+## Simple Select Sizes:
+
+### Small:
+
+<Preview>
+  <Story name="small" parameters={{ info: { disable: true }}} >
+    <div style={{ height: '250px' }}>
+      <Select name='small' id='small' defaultValue='3' size='small'>
+        <Option text='Amber' value='1' />
+        <Option text='Black' value='2' />
+        <Option text='Blue' value='3' />
+        <Option text='Brown' value='4' />
+        <Option text='Green' value='5' />
+        <Option text='Orange' value='6' />
+        <Option text='Pink' value='7' />
+        <Option text='Purple' value='8' />
+        <Option text='Red' value='9' />
+        <Option text='White' value='10' />
+        <Option text='Yellow' value='11' />
+      </Select>
+    </div>
+  </Story>
+</Preview>
+
+### Medium:
+
+<Preview>
+  <Story name="medium" parameters={{ info: { disable: true }}} >
+    <div style={{ height: '250px' }}>
+      <Select name='medium' id='medium' defaultValue='3' size='medium'>
+        <Option text='Amber' value='1' />
+        <Option text='Black' value='2' />
+        <Option text='Blue' value='3' />
+        <Option text='Brown' value='4' />
+        <Option text='Green' value='5' />
+        <Option text='Orange' value='6' />
+        <Option text='Pink' value='7' />
+        <Option text='Purple' value='8' />
+        <Option text='Red' value='9' />
+        <Option text='White' value='10' />
+        <Option text='Yellow' value='11' />
+      </Select>
+    </div>
+  </Story>
+</Preview>
+
+### Large:
+
+<Preview>
+  <Story name="large" parameters={{ info: { disable: true }}} >
+    <div style={{ height: '250px' }}>
+      <Select name='large' id='large' defaultValue='3' size='large'>
+        <Option text='Amber' value='1' />
+        <Option text='Black' value='2' />
+        <Option text='Blue' value='3' />
+        <Option text='Brown' value='4' />
+        <Option text='Green' value='5' />
+        <Option text='Orange' value='6' />
+        <Option text='Pink' value='7' />
+        <Option text='Purple' value='8' />
+        <Option text='Red' value='9' />
+        <Option text='White' value='10' />
+        <Option text='Yellow' value='11' />
+      </Select>
+    </div>
+  </Story>
+</Preview>

--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -1,0 +1,374 @@
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback
+} from 'react';
+import PropTypes from 'prop-types';
+import invariant from 'invariant';
+import StyledSimpleSelect from './simple-select.style';
+import SelectTextbox, { formInputPropTypes } from '../select-textbox/select-textbox.component';
+import SelectList from '../select-list/select-list.component';
+import guid from '../../../utils/helpers/guid';
+import getNextChildByText from '../utils/get-next-child-by-text';
+import { getNextChildByKey } from '../utils/get-next-child-by-key';
+
+const SimpleSelect = React.forwardRef(({
+  value,
+  defaultValue,
+  id,
+  name,
+  disabled,
+  readOnly,
+  children,
+  transparent,
+  openOnFocus = false,
+  onOpen,
+  onChange,
+  onClick,
+  onFocus,
+  onKeyDown,
+  ...textboxProps
+}, inputRef) => {
+  const selectListId = useRef(guid());
+  const labelId = useRef(guid());
+  const containerRef = useRef();
+  const listboxRef = useRef();
+  const filterTimer = useRef();
+  const isMouseDownReported = useRef();
+  const isControlled = useRef(value !== undefined);
+  const isTimerCounting = useRef();
+  const isClickTriggeredBySelect = useRef();
+  const filterText = useRef();
+  const [textboxRef, setTextboxRef] = useState();
+  const [isOpen, setOpenState] = useState(false);
+  const [textValue, setTextValue] = useState('');
+  const [selectedValue, setSelectedValue] = useState('');
+
+  const createCustomEvent = useCallback((newValue) => {
+    const customEvent = {
+      target: {
+        ...(name && { name }),
+        ...(id && { id }),
+        value: newValue
+      }
+    };
+
+    return customEvent;
+  }, [name, id]);
+
+  const setMatchingText = useCallback((newValue) => {
+    const matchingOption = React.Children.toArray(children).find(option => (option.props.value === newValue));
+
+    if (matchingOption) {
+      setTextValue(matchingOption.props.text);
+    }
+  }, [children]);
+
+  const selectValueStartingWithText = useCallback((newFilterText) => {
+    setSelectedValue((previousValue) => {
+      const previousIndex = React.Children.toArray(children).findIndex((child) => {
+        return child.props.value === previousValue;
+      });
+      const match = getNextChildByText(newFilterText, children, previousIndex);
+
+      if (!match) {
+        return previousValue;
+      }
+
+      if (onChange) {
+        onChange(createCustomEvent(match.props.value));
+      }
+
+      if (isControlled.current) {
+        return previousValue;
+      }
+
+      setTextValue(match.props.text);
+
+      return match.props.value;
+    });
+  }, [children, createCustomEvent, onChange]);
+
+  const handleTextboxChange = useCallback((event) => {
+    const newValue = event.target.value;
+    const newCharacter = newValue.slice(-1);
+    const isDeleteEvent = event.nativeEvent.inputType === 'deleteContentBackward'
+    || event.nativeEvent.inputType === 'deleteContentForward'
+    || event.nativeEvent.inputType === 'delete';
+
+    if (isDeleteEvent) {
+      return;
+    }
+
+    if (isTimerCounting.current) {
+      const newVal = filterText.current + newCharacter;
+
+      filterText.current = newVal;
+      selectValueStartingWithText(newVal);
+      clearTimeout(filterTimer.current);
+    } else {
+      filterText.current = newCharacter;
+      selectValueStartingWithText(newCharacter);
+    }
+
+    isTimerCounting.current = true;
+    clearTimeout(filterTimer.current);
+
+    filterTimer.current = setTimeout(() => {
+      isTimerCounting.current = false;
+      filterText.current = '';
+    }, 500);
+  }, [selectValueStartingWithText]);
+
+  const handleTextboxKeydown = useCallback(((event) => {
+    const { key } = event;
+
+    if (onKeyDown) {
+      onKeyDown(event);
+    }
+
+    if (!event.defaultPrevented && isNavigationKey(event.key)) {
+      setSelectedValue((previousSelectedValue) => {
+        const nextElement = getNextChildByKey(key, children, previousSelectedValue);
+
+        setTextValue(nextElement.props.text);
+
+        return nextElement.props.value;
+      });
+    }
+
+    if (key === 'Enter' || key === ' ' || isNavigationKey(key)) {
+      event.preventDefault();
+
+      setOpenState((isAlreadyOpen) => {
+        if (!isAlreadyOpen && onOpen) {
+          onOpen();
+        }
+
+        return true;
+      });
+    }
+  }), [children, onKeyDown, onOpen]);
+
+  const handleGlobalClick = useCallback((event) => {
+    const notInContainer = containerRef.current && !containerRef.current.contains(event.target);
+
+    if (notInContainer && !isClickTriggeredBySelect.current) {
+      setMatchingText(selectedValue);
+      setOpenState(false);
+      filterText.current = '';
+    }
+
+    isClickTriggeredBySelect.current = false;
+  }, [setMatchingText, selectedValue]);
+
+  useEffect(() => {
+    const newValue = value || defaultValue;
+    const modeSwitchedMessage = 'Input elements should not switch from uncontrolled to controlled (or vice versa). '
+    + 'Decide between using a controlled or uncontrolled input element for the lifetime of the component';
+    const onChageMissingMessage = 'onChange prop required when using a controlled input element';
+
+    invariant(isControlled.current === (value !== undefined), modeSwitchedMessage);
+    invariant(!isControlled.current || (isControlled.current && onChange), onChageMissingMessage);
+
+    setSelectedValue(newValue);
+    setMatchingText(newValue);
+  }, [value, defaultValue, setMatchingText, onChange]);
+
+  useEffect(() => {
+    const clickEvent = 'click';
+
+    document.addEventListener(clickEvent, handleGlobalClick);
+
+    return function cleanup() {
+      document.removeEventListener(clickEvent, handleGlobalClick);
+    };
+  }, [handleGlobalClick]);
+
+  useEffect(() => {
+    return function cleanup() {
+      clearTimeout(filterTimer.current);
+    };
+  }, []);
+
+  function handleDropdownIconClick(event) {
+    handleTextboxClick(event);
+  }
+
+  function handleTextboxClick(event) {
+    isMouseDownReported.current = false;
+
+    if (onClick) {
+      onClick(event);
+    }
+
+    setOpenState((isAlreadyOpen) => {
+      if (isAlreadyOpen) {
+        return false;
+      }
+
+      if (onOpen) {
+        onOpen();
+      }
+
+      return true;
+    });
+  }
+
+  function handleMouseDown() {
+    isMouseDownReported.current = true;
+  }
+
+  function handleTextboxFocus(event) {
+    if (isClickTriggeredBySelect.current) {
+      return;
+    }
+
+    if (onFocus) {
+      onFocus(event);
+    }
+
+    if (isMouseDownReported.current) {
+      isMouseDownReported.current = false;
+
+      return;
+    }
+
+    if (openOnFocus) {
+      setOpenState((isAlreadyOpen) => {
+        if (isAlreadyOpen) {
+          return true;
+        }
+
+        if (onOpen) {
+          onOpen();
+        }
+
+        return true;
+      });
+    }
+  }
+
+  function onSelectOption(optionData) {
+    const { text, value: newValue, selectionType } = optionData;
+    const isClickTriggered = selectionType === 'click';
+
+    updateValue(newValue, text);
+
+    if (selectionType !== 'navigationKey') {
+      setOpenState(false);
+      filterText.current = text;
+    }
+
+    if (isClickTriggered) {
+      isClickTriggeredBySelect.current = true;
+      textboxRef.focus();
+    }
+  }
+
+  function updateValue(newValue, text) {
+    if (!isControlled.current) {
+      setSelectedValue(newValue);
+      setTextValue(text);
+    }
+
+    if (onChange) {
+      onChange(createCustomEvent(newValue));
+    }
+  }
+
+  function onSelectListClose() {
+    setOpenState(false);
+    filterText.current = '';
+    setMatchingText(selectedValue);
+  }
+
+  function isNavigationKey(key) {
+    return key === 'ArrowDown' || key === 'ArrowUp'
+    || key === 'Home' || key === 'End';
+  }
+
+  function assignInput(input) {
+    setTextboxRef(input.current);
+
+    if (inputRef) {
+      inputRef.current = input.current;
+    }
+  }
+
+  function getTextboxProps() {
+    return {
+      id,
+      name,
+      disabled,
+      readOnly,
+      inputRef: assignInput,
+      selectedValue,
+      formattedValue: textValue,
+      onClick: handleTextboxClick,
+      iconOnClick: handleDropdownIconClick,
+      onMouseDown: handleMouseDown,
+      onFocus: handleTextboxFocus,
+      onKeyDown: handleTextboxKeydown,
+      onChange: handleTextboxChange,
+      ...textboxProps
+    };
+  }
+
+  return (
+    <StyledSimpleSelect
+      data-component='simple-select'
+      transparent={ transparent }
+      disabled={ disabled }
+      readOnly={ readOnly }
+      aria-expanded={ isOpen }
+      aria-haspopup='listbox'
+      ref={ containerRef }
+    >
+      <SelectTextbox
+        aria-controls={ isOpen ? selectListId.current : '' }
+        type='select'
+        labelId={ labelId.current }
+        { ...getTextboxProps() }
+      />
+      { isOpen && (
+        <SelectList
+          ref={ listboxRef }
+          id={ selectListId.current }
+          labelId={ labelId.current }
+          anchorElement={ textboxRef.parentElement }
+          onSelect={ onSelectOption }
+          onSelectListClose={ onSelectListClose }
+          highlightedValue={ selectedValue }
+        >
+          { children }
+        </SelectList>
+      ) }
+    </StyledSimpleSelect>
+  );
+});
+
+SimpleSelect.propTypes = {
+  ...formInputPropTypes,
+  /** The selected value(s), when the component is operating in controlled mode */
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]),
+  /** The default selected value(s), when the component is operating in uncontrolled mode */
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]),
+  /** Child components (such as Option) for the SelectList */
+  children: PropTypes.node.isRequired,
+  /** If true the Component opens on focus */
+  openOnFocus: PropTypes.bool,
+  /** If true the component input has no border and a transparent background */
+  transparent: PropTypes.bool,
+  /** A custom callback for when the dropdown menu opens */
+  onOpen: PropTypes.func
+};
+
+export default SimpleSelect;

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -1,0 +1,640 @@
+import React, { useRef } from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
+import SimpleSelect from './simple-select.component';
+import Textbox from '../../../__experimental__/components/textbox';
+import Option from '../option/option.component';
+import SelectList from '../select-list/select-list.component';
+import InputIconToggleStyle from '../../../__experimental__/components/input-icon-toggle/input-icon-toggle.style';
+import StyledInput from '../../../__experimental__/components/input/input.style';
+import InputPresentationStyle from '../../../__experimental__/components/input/input-presentation.style';
+import { baseTheme } from '../../../style/themes';
+
+describe('SimpleSelect', () => {
+  it('the Textbox should have type of "select"', () => {
+    const wrapper = renderSelect();
+
+    expect(wrapper.find(Textbox).prop('type')).toBe('select');
+  });
+
+  it('the input ref should be forwarded', () => {
+    let mockRef;
+
+    const WrapperComponent = () => {
+      mockRef = useRef();
+
+      return (
+        <SimpleSelect
+          name='testSelect'
+          id='testSelect'
+          ref={ mockRef }
+        >
+          <Option value='opt1' text='red' />
+          <Option value='opt2' text='green' />
+          <Option value='opt3' text='blue' />
+          <Option value='opt4' text='black' />
+        </SimpleSelect>
+      );
+    };
+
+    const wrapper = mount(<WrapperComponent />);
+
+    expect(mockRef.current).toBe(wrapper.find('input').getDOMNode());
+  });
+
+  it('the input text should have proper styling', () => {
+    const wrapper = renderSelect({ transparent: true });
+
+    assertStyleMatch({
+      cursor: 'pointer',
+      userSelect: 'none',
+      textShadow: `0 0 0 ${baseTheme.text.color}`
+    }, wrapper, { modifier: `${StyledInput}` });
+
+    assertStyleMatch({
+      textShadow: `0 0 0 ${baseTheme.text.placeholder}`
+    }, wrapper, { modifier: `${StyledInput}::placeholder` });
+  });
+
+  it('the input text should have proper styling when disabled', () => {
+    const wrapper = renderSelect({ disabled: true });
+
+    assertStyleMatch({
+      cursor: 'not-allowed',
+      color: baseTheme.disabled.disabled,
+      textShadow: 'none'
+    }, wrapper, { modifier: `${StyledInput}` });
+  });
+
+  it('the input text should have proper styling when readOnly', () => {
+    const wrapper = renderSelect({ readOnly: true });
+
+    assertStyleMatch({
+      cursor: 'default',
+      color: baseTheme.readOnly.textboxText,
+      textShadow: 'none'
+    }, wrapper, { modifier: `${StyledInput}` });
+  });
+
+  describe('when the transparent prop is set to true', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = renderSelect({ transparent: true });
+    });
+
+    it('then the input should have transparent background and no border', () => {
+      assertStyleMatch({
+        background: 'transparent',
+        border: 'none'
+      }, wrapper, { modifier: `${InputPresentationStyle}` });
+    });
+
+    it('then the input text should be right aligned with font weight set to 900', () => {
+      assertStyleMatch({
+        textAlign: 'right',
+        fontWeight: '900'
+      }, wrapper, { modifier: `${StyledInput}` });
+    });
+
+    it('then the input toggle text should have width set to auto', () => {
+      assertStyleMatch({
+        width: 'auto'
+      }, wrapper, { modifier: `${InputIconToggleStyle}` });
+    });
+  });
+
+  describe('when the value prop is passed', () => {
+    it('then the formatted value should be set to corresponding option text', () => {
+      const wrapper = renderSelect({ value: 'opt2', onChange: jest.fn() });
+
+      expect(wrapper.find(Textbox).prop('formattedValue')).toBe('green');
+    });
+  });
+
+  describe('when the inputRef prop is specified', () => {
+    it('then the input reference should be returned on call', () => {
+      const inputRefFn = jest.fn();
+      const wrapper = renderSelect({ inputRef: inputRefFn });
+
+      expect(inputRefFn).toHaveBeenCalledWith({ current: wrapper.find('input').getDOMNode() });
+    });
+  });
+
+  describe('when the openOnFocus prop is set', () => {
+    describe('and the Textbox Input is focused', () => {
+      it('the SelectList should be rendered', () => {
+        const wrapper = renderSelect({ openOnFocus: true });
+
+        wrapper.find('input').simulate('focus');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+      });
+
+      describe.each(['readOnly', 'disabled'])('with the %s prop passed', (prop) => {
+        it('the SelectList should not be rendered', () => {
+          const obj = { [prop]: true, openOnFocus: true };
+          const wrapper = renderSelect(obj);
+
+          wrapper.find('input').simulate('focus');
+          expect(wrapper.find(SelectList).exists()).toBe(false);
+        });
+      });
+
+      describe('with the onFocus prop passed', () => {
+        it('then that prop should be called', () => {
+          const onFocusFn = jest.fn();
+          const wrapper = renderSelect({ onFocus: onFocusFn, openOnFocus: true });
+
+          wrapper.find('input').simulate('focus');
+          expect(onFocusFn).toHaveBeenCalled();
+        });
+      });
+
+      describe('with the onOpen prop passed', () => {
+        let wrapper;
+        let onOpenFn;
+
+        beforeEach(() => {
+          onOpenFn = jest.fn();
+          wrapper = renderSelect({ onOpen: onOpenFn, openOnFocus: true });
+        });
+
+        it('then that prop should be called', () => {
+          wrapper.find('input').simulate('focus');
+
+          expect(onOpenFn).toHaveBeenCalled();
+        });
+
+        describe('and the SelectList already open', () => {
+          it('then that prop should not be called', () => {
+            wrapper.find('input').simulate('click');
+            onOpenFn.mockReset();
+            expect(wrapper.find(SelectList).exists()).toBe(true);
+            wrapper.find('input').simulate('focus');
+            expect(onOpenFn).not.toHaveBeenCalled();
+          });
+        });
+
+        describe('and the focus triggered by mouseDown', () => {
+          it('then that prop should not be called', () => {
+            wrapper.find('input').simulate('mouseDown');
+            wrapper.find('input').simulate('focus');
+            expect(onOpenFn).not.toHaveBeenCalled();
+          });
+        });
+      });
+    });
+  });
+
+  describe('when the Textbox Input is focused', () => {
+    let onOpenFn;
+    let wrapper;
+
+    beforeEach(() => {
+      onOpenFn = jest.fn();
+      wrapper = renderSelect({ onOpen: onOpenFn });
+    });
+
+    it('the SelectList should not be rendered', () => {
+      wrapper.find('input').simulate('focus');
+      expect(wrapper.find(SelectList).exists()).toBe(false);
+    });
+
+    describe.each([
+      'Enter',
+      'ArrowDown',
+      'ArrowUp',
+      'Home',
+      'End',
+      ' '// spacebar
+    ])('and the "%s" key is pressed', (key) => {
+      it('the SelectList should be rendered', () => {
+        wrapper.find('input').simulate('keydown', { key });
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+      });
+
+      it('the onOpen prop should be called', () => {
+        wrapper.find('input').simulate('keydown', { key });
+        expect(onOpenFn).toHaveBeenCalled();
+      });
+
+      describe('with the SelectList already open', () => {
+        it('the onOpen prop should not be called', () => {
+          wrapper.find('input').simulate('click');
+          onOpenFn.mockReset();
+          expect(wrapper.find(SelectList).exists()).toBe(true);
+          wrapper.find('input').simulate('keydown', { key });
+          expect(onOpenFn).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('and a key other than Enter, Up or Down is pressed', () => {
+      it('the SelectList should not be rendered', () => {
+        wrapper.find('input').simulate('keydown', { key: 'b' });
+        expect(wrapper.find(SelectList).exists()).toBe(false);
+      });
+    });
+  });
+
+  describe('when the Textbox Input is clicked', () => {
+    it('the SelectList should be rendered', () => {
+      const wrapper = renderSelect();
+
+      wrapper.find('input').simulate('click');
+      expect(wrapper.find(SelectList).exists()).toBe(true);
+    });
+
+    describe.each(['disabled', 'readOnly'])('and the %s prop is set to true', (prop) => {
+      it('then the "onClick" prop should not be called', () => {
+        const onClickFn = jest.fn();
+        const wrapper = renderSelect({ onClick: onClickFn, [prop]: true });
+
+        wrapper.find('input').simulate('click');
+        expect(onClickFn).not.toHaveBeenCalled();
+      });
+
+      it('then the SelectList should not be rendered', () => {
+        const wrapper = renderSelect({ [prop]: true });
+
+        wrapper.find('input').simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(false);
+      });
+    });
+
+    describe('and the onClick prop is passed', () => {
+      it('then that prop should be called', () => {
+        const onClickFn = jest.fn();
+        const wrapper = renderSelect({ onClick: onClickFn });
+
+        wrapper.find('input').simulate('click');
+        expect(onClickFn).toHaveBeenCalled();
+      });
+    });
+
+    describe('and the onOpen prop is passed', () => {
+      it('then that prop should be called', () => {
+        const onOpenFn = jest.fn();
+        const wrapper = renderSelect({ onOpen: onOpenFn });
+
+        wrapper.find('input').simulate('click');
+        expect(onOpenFn).toHaveBeenCalled();
+      });
+    });
+
+    describe('and the SelectList is open', () => {
+      it('then the SelectList should be closed', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find('input').simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        wrapper.find('input').simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(false);
+      });
+    });
+  });
+
+  describe('when the Dropdown Icon in the Textbox has been clicked', () => {
+    it('the SelectList should be rendered', () => {
+      const wrapper = renderSelect();
+
+      wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+      expect(wrapper.find(SelectList).exists()).toBe(true);
+    });
+
+    describe('and the SelectList is open', () => {
+      it('then the SelectList should be closed', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(false);
+      });
+    });
+  });
+
+  describe('when a printable character has been typed in the Textbox', () => {
+    it('then the first option with text starting with that character should be selected', () => {
+      const wrapper = renderSelect();
+
+      wrapper.find('input').simulate('change', { target: { value: 'b' } });
+      wrapper.update();
+      expect(wrapper.find(Textbox).prop('value')).toBe('opt3');
+      wrapper.unmount();
+    });
+
+    describe('and the same character is typed in a short amount of time', () => {
+      it('then the second option with text starting with that character should be selected', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find('input').simulate('change', { target: { value: 'b' } });
+        wrapper.find('input').simulate('change', { target: { value: 'b' } });
+        wrapper.update();
+        expect(wrapper.find(Textbox).prop('value')).toBe('opt4');
+        wrapper.unmount();
+      });
+    });
+
+    describe('and other character that does not match the text in any option has been typed', () => {
+      it('then the option starting with previous character should remain selected', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find('input').simulate('change', { target: { value: 'b' } });
+        wrapper.find('input').simulate('change', { target: { value: 'x' } });
+        wrapper.update();
+        expect(wrapper.find(Textbox).prop('value')).toBe('opt3');
+        wrapper.unmount();
+      });
+    });
+
+    describe('and another characters are typed in a short amount of time', () => {
+      it('then an option with matching text should be selected', () => {
+        const wrapper = renderSelect({ openOnFocus: true });
+
+        wrapper.find('input').simulate('focus');
+        wrapper.find('input').simulate('change', { target: { value: 'b' } });
+        wrapper.find('input').simulate('change', { target: { value: 'l' } });
+        wrapper.find('input').simulate('change', { target: { value: 'a' } });
+        wrapper.update();
+        expect(wrapper.find(Textbox).prop('value')).toBe('opt4');
+        wrapper.unmount();
+      });
+    });
+
+    describe('and another characters are typed with a long break before the last change', () => {
+      it('then the first option with text starting the last typed character should be selected', () => {
+        jest.useFakeTimers();
+        const wrapper = renderSelect();
+
+        act(() => {
+          wrapper.find('input').simulate('focus');
+          wrapper.find('input').simulate('change', { target: { value: 'b' } });
+          wrapper.find('input').simulate('change', { target: { value: 'l' } });
+          jest.runAllTimers();
+          wrapper.find('input').simulate('change', { target: { value: 'g' } });
+        });
+
+        expect(wrapper.update().find(Textbox).prop('value')).toBe('opt2');
+      });
+    });
+
+    describe('and the onChange prop is passed', () => {
+      it('then that prop should be called with the value of first matching option', () => {
+        const textboxProps = {
+          name: 'testName',
+          id: 'testId'
+        };
+        const mockEventObject = {
+          target: {
+            ...textboxProps,
+            value: 'opt3'
+          }
+        };
+        const onChangeFn = jest.fn();
+        const wrapper = renderSelect({ ...textboxProps, onChange: onChangeFn });
+
+        wrapper.find('input').simulate('focus');
+        wrapper.find('input').simulate('change', { target: { value: 'b' } });
+        expect(onChangeFn).toHaveBeenCalledWith(mockEventObject);
+      });
+    });
+
+    describe.each([
+      'deleteContentBackward',
+      'deleteContentForward',
+      'delete'
+    ])('and the "%s" change event is triggered with a value present', (deleteEventType) => {
+      const mockChangeEvent = {
+        target: { value: 'blu' },
+        nativeEvent: { inputType: deleteEventType }
+      };
+
+      it('the value should not be changed', () => {
+        const wrapper = renderSelect({ defaultValue: 'opt3' });
+
+        expect(wrapper.find(Textbox).prop('value')).toBe('opt3');
+        wrapper.find('input').simulate('focus');
+        wrapper.find('input').simulate('change', mockChangeEvent);
+        expect(wrapper.find(Textbox).prop('value')).toBe('opt3');
+      });
+    });
+  });
+
+  describe('when the onSelect is called in the SelectList', () => {
+    const navigationKeyOptionObject = {
+      value: 'Foo',
+      text: 'Bar',
+      selectionType: 'navigationKey'
+    };
+    const clickOptionObject = {
+      value: 'Foo',
+      text: 'Bar',
+      selectionType: 'click'
+    };
+    const textboxProps = {
+      name: 'testName',
+      id: 'testId'
+    };
+    const expectedEventObject = {
+      target: {
+        ...textboxProps,
+        value: 'Foo'
+      }
+    };
+
+    describe('with "selectionType" as "click"', () => {
+      it('the SelectList should be closed', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find('input').simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        act(() => {
+          wrapper.find(SelectList).prop('onSelect')(clickOptionObject);
+        });
+        expect(wrapper.update().find(SelectList).exists()).toBe(false);
+      });
+    });
+
+    describe('with "selectionType" as "navigationKey"', () => {
+      it('the SelectList should be open and the value should be selected', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find('input').simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        act(() => {
+          wrapper.find(SelectList).prop('onSelect')(navigationKeyOptionObject);
+        });
+        wrapper.update();
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        expect(wrapper.find(Textbox).prop('value')).toBe('Foo');
+        expect(wrapper.find(Textbox).prop('formattedValue')).toBe('Bar');
+      });
+    });
+
+    describe('and the onChange prop is passed', () => {
+      it('then that prop should be called with the same value', () => {
+        const onChangeFn = jest.fn();
+        const wrapper = renderSelect({ ...textboxProps, onChange: onChangeFn });
+
+        wrapper.find('input').simulate('click');
+        act(() => {
+          wrapper.find(SelectList).prop('onSelect')(clickOptionObject);
+        });
+        expect(onChangeFn).toHaveBeenCalledWith(expectedEventObject);
+      });
+    });
+
+    describe('by clicking on an Option', () => {
+      it('then the SelectList should be closed', () => {
+        const wrapper = renderSelect();
+
+        wrapper.find('input').simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        act(() => {
+          wrapper.find(Option).first().simulate('click');
+        });
+        wrapper.find('input').simulate('focus');
+        expect(wrapper.update().find(SelectList).exists()).toBe(false);
+      });
+    });
+  });
+
+  describe('when the onSelectListClose is called in the SelectList', () => {
+    it('the SelectList should be closed', () => {
+      const wrapper = renderSelect();
+
+      wrapper.find('input').simulate('click');
+      expect(wrapper.find(SelectList).exists()).toBe(true);
+      act(() => {
+        wrapper.find(SelectList).prop('onSelectListClose')();
+      });
+      expect(wrapper.update().find(SelectList).exists()).toBe(false);
+    });
+  });
+
+  describe('when an HTML element is clicked when the SelectList is open', () => {
+    let wrapper;
+    let domNode;
+
+    beforeEach(() => {
+      wrapper = mount(getSelect());
+      domNode = wrapper.getDOMNode();
+      document.body.appendChild(domNode);
+    });
+
+    describe('and that element is an Option of the Select List', () => {
+      it('then the SelectList should be closed', () => {
+        wrapper.find('input').simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        act(() => {
+          wrapper.find(Option).first().getDOMNode().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+        expect(wrapper.update().find(SelectList).exists()).toBe(false);
+      });
+    });
+
+    describe('and that element is not part of the Select', () => {
+      it('then the SelectList should be closed', () => {
+        wrapper.find('input').simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        act(() => {
+          document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+        expect(wrapper.update().find(SelectList).exists()).toBe(false);
+      });
+    });
+
+    afterEach(() => {
+      document.body.removeChild(domNode);
+    });
+  });
+
+  describe('when the onKeyDown prop is passed', () => {
+    const expectedEventObject = {
+      key: 'ArrowDown',
+      which: 40
+    };
+
+    it('then when a key is pressed, that prop should be called with expected values', () => {
+      const onKeyDownFn = jest.fn();
+      const wrapper = renderSelect({ onKeyDown: onKeyDownFn });
+
+      wrapper.find('input').simulate('keyDown', expectedEventObject);
+
+      expect(onKeyDownFn).toHaveBeenCalledWith(expect.objectContaining({
+        ...expectedEventObject
+      }));
+    });
+  });
+
+  describe('when the component is controlled', () => {
+    const expectedObject = {
+      target: {
+        id: 'testSelect',
+        name: 'testSelect',
+        value: 'opt3'
+      }
+    };
+
+    const clickOptionObject = {
+      value: 'opt3',
+      text: 'black',
+      selectionType: 'click'
+    };
+
+    describe('and an option is selected', () => {
+      it('then the onChange prop should be called with expected value', () => {
+        const onChangeFn = jest.fn();
+        const wrapper = renderSelect({ onChange: onChangeFn, value: 'opt1' });
+
+        wrapper.find('input').simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        act(() => {
+          wrapper.find(SelectList).prop('onSelect')(clickOptionObject);
+        });
+        expect(onChangeFn).toHaveBeenCalledWith(expectedObject);
+      });
+    });
+
+    describe('when a printable character has been typed in the Textbox', () => {
+      let onChangeFn;
+      let wrapper;
+
+      beforeEach(() => {
+        onChangeFn = jest.fn();
+        wrapper = renderSelect({ onChange: onChangeFn, value: 'opt1' });
+        wrapper.find('input').simulate('change', { target: { value: 'b' } });
+        wrapper.update();
+      });
+
+      it('then the value should not change', () => {
+        expect(wrapper.find(Textbox).prop('value')).toBe('opt1');
+      });
+
+      it('then the onChange function should have been called with with the expected value', () => {
+        expect(onChangeFn).toHaveBeenCalledWith(expectedObject);
+      });
+    });
+  });
+});
+
+function renderSelect(props = {}, renderer = mount) {
+  return renderer(getSelect(props));
+}
+
+function getSelect(props) {
+  return (
+    <SimpleSelect
+      name='testSelect'
+      id='testSelect'
+      { ...props }
+    >
+      <Option value='opt1' text='red' />
+      <Option value='opt2' text='green' />
+      <Option value='opt3' text='blue' />
+      <Option value='opt4' text='black' />
+    </SimpleSelect>
+  );
+}

--- a/src/components/select/simple-select/simple-select.stories.mdx
+++ b/src/components/select/simple-select/simple-select.stories.mdx
@@ -1,0 +1,185 @@
+import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
+import { action } from '@storybook/addon-actions';
+import { useState } from 'react';
+import { Select, Option } from '../';
+import SelectTextbox from '../select-textbox/select-textbox.component';
+
+<Meta title="Design System/Select" />
+
+# Simple Select
+
+Select one of available options from the drop-down menu
+
+## Overview 
+
+Simple Select is a Carbon styled equivalent of HTML Select Element.
+
+## Guidance, hints and tips 
+
+Always insert `Option` Components inside the `Select`, analogous to the original `<select>` and `<option>` HTML Elements.
+
+## Quick Start 
+
+To use the `Select` component you have to import two components: `<Select />` and `<Option />`
+from `carbon-react/lib/components/select`.
+
+```javascript
+import { Select, Option } from "carbon-react/lib/components/select";
+```
+
+### Basic usage:
+
+<Preview>
+  <Story name="basic" parameters={{ info: { disable: true }}} >
+    <Select
+      name='simple'
+      id='simple'
+      label='label'
+      labelInline
+      onOpen={ action('onOpen') }
+      onChange={ action('onChange') }
+      onClick={ action('onClick') }
+      onFocus={ action('onFocus') }
+      onBlur={ action('onBlur') }
+      onKeyDown={ action('onKeyDown') }
+    >
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </Select>
+  </Story>
+</Preview>
+
+### Controlled usage:
+
+<Preview>
+  <Story name="controlled" parameters={{ info: { disable: true }}} >
+    {() => {
+      const [value, setValue] = useState('');
+      function onChangeHandler(event) {
+        setValue(event.target.value);
+        action('value set');
+      };
+      return (
+        <Select
+          id='controlled'
+          name='controlled'
+          value={ value }
+          onChange={ onChangeHandler }
+        >
+          <Option text='Amber' value='1' />
+          <Option text='Black' value='2' />
+          <Option text='Blue' value='3' />
+          <Option text='Brown' value='4' />
+          <Option text='Green' value='5' />
+          <Option text='Orange' value='6' />
+          <Option text='Pink' value='7' />
+          <Option text='Purple' value='8' />
+          <Option text='Red' value='9' />
+          <Option text='White' value='10' />
+          <Option text='Yellow' value='11' />
+        </Select>
+      );
+    }}
+  </Story>
+</Preview>
+
+### Open on focus:
+
+<Preview>
+  <Story name="openOnFocus" parameters={{ info: { disable: true }}} >
+    <Select name='openOnFocus' id='openOnFocus' openOnFocus>
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </Select>
+  </Story>
+</Preview>
+
+### Disabled:
+
+<Preview>
+  <Story name="disabled" parameters={{ info: { disable: true }}} >
+    <Select name='disabled' id='disabled' defaultValue='3' disabled>
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </Select>
+  </Story>
+</Preview>
+
+### Read Only:
+
+<Preview>
+  <Story name="readonly" parameters={{ info: { disable: true }}} >
+    <Select name='readonly' id='readonly' defaultValue='4' readOnly>
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </Select>
+  </Story>
+</Preview>
+
+### Transparent:
+
+<Preview>
+  <Story name="transparent" parameters={{ info: { disable: true }}} >
+    <Select name='transparent' id='transparent' defaultValue='4' transparent>
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </Select>
+  </Story>
+</Preview>
+
+## Props:
+
+<Props of={ Select } />
+
+### Props derived from the Textbox Component
+
+<Props of={ SelectTextbox } />
+
+### Props of the Option Component
+
+<Props of={ Option } />

--- a/src/components/select/simple-select/simple-select.style.js
+++ b/src/components/select/simple-select/simple-select.style.js
@@ -1,0 +1,65 @@
+import styled, { css } from 'styled-components';
+import InputPresentationStyle from '../../../__experimental__/components/input/input-presentation.style';
+import StyledInput from '../../../__experimental__/components/input/input.style';
+import InputIconToggleStyle from '../../../__experimental__/components/input-icon-toggle/input-icon-toggle.style';
+import { baseTheme } from '../../../style/themes';
+
+const StyledSimpleSelect = styled.div`
+  ${StyledInput} {
+    cursor: pointer;
+    color: transparent;
+    user-select: none;
+    text-shadow: 0 0 0 ${({ theme }) => theme.text.color};
+
+    ::placeholder {
+      text-shadow: 0 0 0 ${({ theme }) => theme.text.placeholder};
+    }
+
+    ${({ disabled }) => disabled && css`
+      cursor: not-allowed;
+      color: ${({ theme }) => theme.disabled.disabled};
+      text-shadow: none;
+    `}
+
+    ${({ readOnly }) => readOnly && css`
+      cursor: default;
+      color: ${({ theme }) => theme.readOnly.textboxText};
+      text-shadow: none;
+    `}
+  }
+
+  ${InputPresentationStyle} {
+    cursor: pointer;
+
+    ${({ disabled }) => disabled && css`
+      cursor: not-allowed;
+    `}
+
+    ${({ readOnly }) => readOnly && css`
+      cursor: default;
+    `}
+  }
+
+  ${({ transparent }) => transparent && css`
+    ${InputPresentationStyle} {
+      background: transparent;
+      border: none;
+    }
+
+    ${StyledInput} {
+      font-weight: 900;
+      text-align: right;
+    }
+
+    ${InputIconToggleStyle} {
+      margin-left: 0;
+      width: auto;
+    }
+  `}
+`;
+
+StyledSimpleSelect.defaultProps = {
+  theme: baseTheme
+};
+
+export default StyledSimpleSelect;

--- a/src/components/select/utils/get-next-child-by-key.js
+++ b/src/components/select/utils/get-next-child-by-key.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+export function getNextChildByKey(key, children, previousSelectedValue) {
+  const childrenList = React.Children.toArray(children);
+  const currentSelectedIndex = childrenList.findIndex((option) => {
+    return option.props.value === previousSelectedValue;
+  });
+  const lastIndex = childrenList.length - 1;
+
+  return childrenList[getNextIndexByKey(key, currentSelectedIndex, lastIndex)];
+}
+
+export function getNextIndexByKey(key, currentIndex, lastIndex) {
+  const isNoOptionSelected = currentIndex === -1;
+  let newIndex = currentIndex;
+
+  if (key === 'Home') {
+    newIndex = 0;
+  } else if (key === 'End') {
+    newIndex = lastIndex;
+  } else if (key === 'ArrowDown') {
+    if (currentIndex === lastIndex || isNoOptionSelected) {
+      newIndex = 0;
+    } else {
+      newIndex = currentIndex + 1;
+    }
+  } else if (key === 'ArrowUp') {
+    if (currentIndex === 0 || isNoOptionSelected) {
+      newIndex = lastIndex;
+    } else {
+      newIndex = currentIndex - 1;
+    }
+  }
+
+  return newIndex;
+}

--- a/src/components/select/utils/get-next-child-by-key.spec.js
+++ b/src/components/select/utils/get-next-child-by-key.spec.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { getNextChildByKey } from './get-next-child-by-key';
+
+describe('getNextChildByKey', () => {
+  let wrapper;
+  let children;
+  let arrayOfChildren;
+  const homeKey = 'Home';
+  const endKey = 'End';
+  const upKey = 'ArrowUp';
+  const downKey = 'ArrowDown';
+
+  beforeEach(() => {
+    wrapper = renderList();
+    children = wrapper.find('li').props().children;
+    arrayOfChildren = React.Children.toArray(children);
+  });
+
+  describe('when the homeKey is passed as the first attribute', () => {
+    it('then the first child should be returned', () => {
+      expect(getNextChildByKey(homeKey, children)).toStrictEqual(arrayOfChildren[0]);
+    });
+  });
+
+  describe('when the endKey is passed as the first attribute', () => {
+    it('then the last child should be returned', () => {
+      expect(getNextChildByKey(endKey, children)).toStrictEqual(arrayOfChildren[5]);
+    });
+  });
+
+  describe('when the upKey is passed as the first attribute', () => {
+    it('then the last child should be returned', () => {
+      expect(getNextChildByKey(upKey, children)).toStrictEqual(arrayOfChildren[5]);
+    });
+
+    describe('with value of one of elements passed as third attribute', () => {
+      it('then the previous child before that element should be returned', () => {
+        expect(getNextChildByKey(upKey, children, 'white')).toStrictEqual(arrayOfChildren[1]);
+      });
+    });
+
+    describe('with value of the first element passed as third attribute', () => {
+      it('then the last child should be returned', () => {
+        expect(getNextChildByKey(upKey, children, 'amber')).toStrictEqual(arrayOfChildren[5]);
+      });
+    });
+  });
+
+  describe('when the downKey is passed as the first attribute', () => {
+    it('then the first child should be returned', () => {
+      expect(getNextChildByKey(downKey, children)).toStrictEqual(arrayOfChildren[0]);
+    });
+
+    describe('with value of one of elements passed as third attribute', () => {
+      it('then next child after the position stated by that integer should be returned', () => {
+        expect(getNextChildByKey(downKey, children, 'white')).toStrictEqual(arrayOfChildren[3]);
+      });
+    });
+
+    describe('with value of the last element passed as third attribute', () => {
+      it('then the first child should be returned', () => {
+        expect(getNextChildByKey(downKey, children, 'brown')).toStrictEqual(arrayOfChildren[0]);
+      });
+    });
+  });
+
+  describe('when a non navigation key is passed as the first attribute', () => {
+    it('then undefined should be returned', () => {
+      expect(getNextChildByKey(18, children)).toBe(undefined);
+    });
+  });
+});
+
+function renderList(renderer = mount) {
+  return renderer(
+    <li>
+      <span text='amber' value='amber' />
+      <span text='blue' value='blue' />
+      <span text='white' value='white' />
+      <span text='black' value='black' />
+      <span text='purple' value='purple' />
+      <span text='brown' value='brown' />
+    </li>
+  );
+}

--- a/src/components/select/utils/get-next-child-by-text.js
+++ b/src/components/select/utils/get-next-child-by-text.js
@@ -1,0 +1,44 @@
+import { Children } from 'react';
+
+/**
+ * Recreates HTML Select element functionality of finding first match based on typed characters
+ * */
+export default function getNextChildByText(textToMatch, children, previousIndex = -1) {
+  const arrayOfChildren = Children.toArray(children);
+  const lastCharacter = textToMatch.slice(-1);
+  const isTheSameCharacter = textToMatch.split('').every(character => character === lastCharacter);
+  let indexOfMatch = findElementStartingWithText(textToMatch, arrayOfChildren);
+  const listOfMatches = getListOfMatches(arrayOfChildren, lastCharacter);
+
+  if (isTheSameCharacter && listOfMatches.length > 1) {
+    indexOfMatch = getIndexOfNextElement(listOfMatches, previousIndex);
+  }
+
+  return arrayOfChildren[indexOfMatch];
+}
+
+function getListOfMatches(arrayOfChildren, lastCharacter) {
+  return arrayOfChildren.reduce((acc, child, index) => {
+    if (child.props.text && child.props.text.toLowerCase().startsWith(lastCharacter.toLowerCase())) {
+      acc.push(index);
+    }
+
+    return acc;
+  }, []);
+}
+
+function getIndexOfNextElement(listOfMatches, previousIndex) {
+  const isLastIndex = previousIndex === listOfMatches[listOfMatches.length - 1];
+
+  if (isLastIndex) {
+    return listOfMatches[0];
+  }
+
+  return listOfMatches[(listOfMatches.indexOf(previousIndex) + 1)];
+}
+
+function findElementStartingWithText(textToMatch, list) {
+  return list.findIndex((child) => {
+    return child.props.text && child.props.text.toLowerCase().startsWith(textToMatch.toLowerCase());
+  });
+}

--- a/src/components/select/utils/get-next-child-by-text.spec.js
+++ b/src/components/select/utils/get-next-child-by-text.spec.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import getNextChildByText from './get-next-child-by-text';
+
+describe('getNextChildByText', () => {
+  let wrapper;
+  let children;
+
+  beforeEach(() => {
+    wrapper = renderList();
+    children = wrapper.find('li').props().children;
+  });
+
+  describe('when there is only one character passed in textToMatch', () => {
+    it('then the first element that has the text prop starting with that letter should be returned', () => {
+      expect(getNextChildByText('a', children)).toStrictEqual(React.Children.toArray(children)[0]);
+      expect(getNextChildByText('b', children)).toStrictEqual(React.Children.toArray(children)[1]);
+      expect(getNextChildByText('w', children)).toStrictEqual(React.Children.toArray(children)[2]);
+    });
+
+    describe('and that character does not match the first letter in text of any element', () => {
+      it('then undefined should be returned', () => {
+        expect(getNextChildByText('x', children)).toBe(undefined);
+      });
+    });
+  });
+
+  describe('when there are multiple characters passed in textToMatch', () => {
+    describe('and the characters are the same', () => {
+      it('then the first element that has the text prop starting with that letter should be returned', () => {
+        expect(getNextChildByText('bb', children)).toStrictEqual(React.Children.toArray(children)[1]);
+      });
+
+      describe('with the previousIndex argument is set to correspond to the first match', () => {
+        it('then the second element that has the text prop starting with that letter should be returned', () => {
+          expect(getNextChildByText('bb', children, 1)).toStrictEqual(React.Children.toArray(children)[3]);
+        });
+      });
+
+      describe('with the previousIndex argument is set to correspond to the last match', () => {
+        it('then the first element that has the text prop starting with that letter should be returned', () => {
+          expect(getNextChildByText('bb', children, 5)).toStrictEqual(React.Children.toArray(children)[1]);
+        });
+      });
+    });
+
+    describe('and the characters are different', () => {
+      it('then the first element has the text prop starting with these characters should be returned', () => {
+        expect(getNextChildByText('br', children)).toStrictEqual(React.Children.toArray(children)[5]);
+        expect(getNextChildByText('bla', children)).toStrictEqual(React.Children.toArray(children)[3]);
+      });
+    });
+  });
+});
+
+function renderList(renderer = mount) {
+  return renderer(
+    <li>
+      <span text='amber' />
+      <span text='blue' />
+      <span text='white' />
+      <span text='black' />
+      <span text='purple' />
+      <span text='brown' />
+    </li>
+  );
+}

--- a/src/components/select/utils/highlight-part-of-text.js
+++ b/src/components/select/utils/highlight-part-of-text.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import MatchingText from './matching-text.style';
+
+export default function highlightPartOfText (text, partToHighlight) {
+  if (!partToHighlight || !partToHighlight.length || !text) return text;
+  const lowercaseText = text.toLowerCase();
+  const lowercasePart = partToHighlight.toLowerCase();
+  const indexOfFirstMatch = lowercaseText.indexOf(lowercasePart);
+
+  if (indexOfFirstMatch === -1) {
+    return text;
+  }
+
+  const precedingText = text.substr(0, indexOfFirstMatch);
+  const matchingText = text.substr(indexOfFirstMatch, partToHighlight.length);
+  let followingText = text.substr(indexOfFirstMatch + partToHighlight.length, text.length);
+
+  if (followingText.length >= partToHighlight.length) {
+    followingText = highlightPartOfText(followingText, partToHighlight);
+  }
+
+  const newValue = [
+    <span key='preceding'>{ precedingText }</span>,
+    <MatchingText key='match'>{ matchingText }</MatchingText>,
+    <span key='following'>{ followingText }</span>
+  ];
+
+  return newValue;
+}

--- a/src/components/select/utils/highlight-part-of-text.spec.js
+++ b/src/components/select/utils/highlight-part-of-text.spec.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import highlightPartOfText from './highlight-part-of-text';
+import MatchingText from './matching-text.style';
+
+describe('highlightPartOfText', () => {
+  describe('when the text contains no matching parts', () => {
+    it('then the returned text should not be changed', () => {
+      const text = 'abcdefghi';
+      const partToBeHighlighted = 'xyz';
+
+      expect(highlightPartOfText(text, partToBeHighlighted)).toBe(text);
+    });
+  });
+
+  describe('when the partToBeHighlighted is an empty string', () => {
+    it('then the returned text should not be changed', () => {
+      const text = 'abcdefghi';
+      const partToBeHighlighted = '';
+
+      expect(highlightPartOfText(text, partToBeHighlighted)).toBe(text);
+    });
+  });
+
+  describe('when the text contains matching part', () => {
+    it('the expected part of text should be highlighted', () => {
+      const text = 'abcdefghi';
+      const partToBeHighlighted = 'def';
+
+      const wrapper = shallow(<div>{ highlightPartOfText(text, partToBeHighlighted) }</div>);
+
+      expect(wrapper.find(MatchingText).exists()).toBe(true);
+      expect(wrapper.find(MatchingText).text()).toBe(partToBeHighlighted);
+    });
+  });
+
+  describe('when the text contains multiple matching parts', () => {
+    it('then all these parts of text should be highlighted', () => {
+      const text = 'abcdefghidefjkldef';
+      const partToBeHighlighted = 'def';
+
+      const wrapper = shallow(<div>{ highlightPartOfText(text, partToBeHighlighted) }</div>);
+
+      expect(wrapper.find(MatchingText)).toHaveLength(3);
+      expect(wrapper.find(MatchingText).at(0).text()).toBe(partToBeHighlighted);
+      expect(wrapper.find(MatchingText).at(1).text()).toBe(partToBeHighlighted);
+      expect(wrapper.find(MatchingText).at(2).text()).toBe(partToBeHighlighted);
+    });
+  });
+});

--- a/src/components/select/utils/matching-text.style.js
+++ b/src/components/select/utils/matching-text.style.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const MatchingText = styled.span`
+  font-weight: bold;
+  text-decoration: underline;
+`;
+
+export default MatchingText;

--- a/src/components/select/utils/with-filter.hoc.js
+++ b/src/components/select/utils/with-filter.hoc.js
@@ -1,0 +1,66 @@
+import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
+import I18n from 'i18n-js';
+import filterChildren from '../../../utils/filter-children';
+import StyledOption from '../option/option.style';
+import highlightPartOfText from './highlight-part-of-text';
+
+/** Filters wrapped component children based on provided filter text and highlights matching content */
+const withFilter = (WrappedComponent) => {
+  const FilteredComponent = React.forwardRef(({
+    children,
+    filterText,
+    noResultsMessage,
+    ...props
+  }, forwardedRef) => {
+    const getFilteredChildren = useCallback(() => {
+      let filteredElements = children;
+
+      if (filterText) {
+        filteredElements = filterChildren({ value: filterText })(children);
+
+        if (!filteredElements) {
+          const noResultsText = I18n.t('select.no_results_for_term', {
+            defaultValue: 'No results for "%{term}"',
+            term: filterText
+          });
+
+          return (<StyledOption>{ noResultsMessage || noResultsText }</StyledOption>);
+        }
+
+        return addHighlightedContent(filteredElements, filterText);
+      }
+
+      return children;
+    }, [children, filterText, noResultsMessage]);
+
+    return (
+      <WrappedComponent
+        filterText={ filterText }
+        { ...props }
+        ref={ forwardedRef }
+      >
+        { getFilteredChildren() }
+      </WrappedComponent>
+    );
+  });
+
+  function addHighlightedContent(filteredElements, filterText) {
+    return React.Children.map(filteredElements, (child) => {
+      const highlightedContent = highlightPartOfText(child.props.text, filterText);
+
+      return React.cloneElement(child, { children: highlightedContent });
+    });
+  }
+
+  FilteredComponent.propTypes = {
+    forwardedRef: PropTypes.object,
+    children: PropTypes.node,
+    filterText: PropTypes.string,
+    noResultsMessage: PropTypes.string
+  };
+
+  return FilteredComponent;
+};
+
+export default withFilter;

--- a/src/components/select/utils/with-filter.spec.js
+++ b/src/components/select/utils/with-filter.spec.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import withFilter from './with-filter.hoc';
+
+describe('withFilter', () => {
+  describe('when the "filterText" prop is specified', () => {
+    describe('and the "text" prop in one of the option contains the "filterText"', () => {
+      it('then only that option should be rendered', () => {
+        const wrapper = renderFilteredList({ filterText: 'gre' });
+
+        expect(wrapper.find('ul[data-element="select-list"]').children()).toHaveLength(1);
+        expect(wrapper.find('ul[data-element="select-list"]').children().text()).toBe('green');
+      });
+    });
+
+    describe('and the "text" prop in multiple options contains the "filterText"', () => {
+      it('then only these options should be rendered', () => {
+        const wrapper = renderFilteredList({ filterText: 'bl' });
+
+        expect(wrapper.find('ul[data-element="select-list"]').children()).toHaveLength(2);
+        expect(wrapper.find('ul[data-element="select-list"]').children().at(0).text()).toBe('blue');
+        expect(wrapper.find('ul[data-element="select-list"]').children().at(1).text()).toBe('black');
+      });
+    });
+
+    describe('and the "text" prop in every option does not contain the "filterText"', () => {
+      it('then the "No results" message should be displayed', () => {
+        const filterText = 'xyz';
+        const wrapper = renderFilteredList({ filterText });
+        const children = wrapper.find('ul[data-element="select-list"]').children();
+
+        expect(children).toHaveLength(1);
+        expect(children.at(0).text()).toBe(`No results for "${filterText}"`);
+      });
+
+      describe('when a custom message has been specified in noResultsMessage prop', () => {
+        it('then that message should be displayed', () => {
+          const customMessage = 'custom message';
+          const wrapper = renderFilteredList({ filterText: 'xyz', noResultsMessage: customMessage });
+          const children = wrapper.find('ul[data-element="select-list"]').children();
+
+          expect(children).toHaveLength(1);
+          expect(children.at(0).text()).toBe(customMessage);
+        });
+      });
+    });
+  });
+
+  describe('when the "filterText" prop is not specified', () => {
+    it('then all options should be rendered', () => {
+      const wrapper = renderFilteredList({ filterText: '' });
+
+      expect(wrapper.find('ul[data-element="select-list"]').children()).toHaveLength(6);
+    });
+  });
+});
+
+// eslint-disable-next-line react/prop-types
+const ListComponent = ({ children }) => {
+  return (<ul data-element='select-list'>{children}</ul>);
+};
+
+const FilteredListComponent = withFilter(ListComponent);
+
+function renderFilteredList(props, renderer = mount) {
+  return renderer(
+    <FilteredListComponent { ...props }>
+      <li text='amber' />
+      <li text='blue' />
+      <li text='green' />
+      <li text='black' />
+      <li text='purple' />
+      <li text='brown' />
+    </FilteredListComponent>
+  );
+}


### PR DESCRIPTION
### Proposed behaviour
Add new Simple Select and Filterable Select components that with other components like SelectAsync and MultiSelect will replace the Experimental Select in the future

![Screenshot 2020-05-06 at 14 24 33](https://user-images.githubusercontent.com/22885392/81176430-6f6cd280-8fa5-11ea-83e7-fb9acc9625e4.png)

FilterableSelect:

![Screenshot 2020-06-18 at 15 32 09](https://user-images.githubusercontent.com/22885392/85026489-06b66f80-b179-11ea-83b8-f223b16bda7e.png)

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Carbon implementation and Design System documentation are congruent
- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Cypress automation tests
- [x] Storybook added or updated
- [x] Theme support
- [x] Typescript `d.ts` file added or updated

### Testing instructions
1. run npm start locally.
2. open http://localhost:9001/?path=/docs/design-system-simple-select--basic
3. open http://localhost:9001/?path=/docs/design-system-select-filterable--basic

### Codesandbox
These examples will be forked, please see the comment by `codesandbox[bot]` below for the latest version.
https://codesandbox.io/s/filterable-select-review-f4nox
https://codesandbox.io/s/select-review-ofjs3