### PR TITLE
feat(flat-table): add colspan and rowspan props (FE-2744)

### DIFF
--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -66,7 +66,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
   word-break: break-all;
 }
 
-.c9 {
+.c10 {
   background-color: #fff;
   border-width: 0;
   border-bottom: 1px solid #CCD6DB;
@@ -78,12 +78,36 @@ exports[`FlatTable when rendered with proper table data should have expected str
   white-space: nowrap;
 }
 
-.c9:first-of-type {
+.c10:first-of-type {
   border-left: 1px solid #CCD6DB;
 }
 
-.c9:last-of-type {
+.c10:last-of-type {
   border-right: 1px solid #CCD6DB;
+}
+
+.c11 {
+  background-color: #fff;
+  border-width: 0;
+  border-bottom: 1px solid #CCD6DB;
+  overflow: visible;
+  padding: 10px 24px;
+  text-overflow: ellipsis;
+  text-align: left;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.c11:first-of-type {
+  border-left: 1px solid #CCD6DB;
+}
+
+.c11:last-of-type {
+  border-right: 1px solid #CCD6DB;
+}
+
+.c11:first-of-type + .c9 {
+  border-left: 1px solid #CCD6DB;
 }
 
 .c4 {
@@ -128,6 +152,12 @@ exports[`FlatTable when rendered with proper table data should have expected str
         >
           header2
         </th>
+        <th
+          className="c7 c8"
+          data-element="flat-table-header"
+        >
+          header3
+        </th>
       </tr>
     </thead>
     <tbody>
@@ -142,16 +172,41 @@ exports[`FlatTable when rendered with proper table data should have expected str
           row header
         </th>
         <td
-          className="c9"
+          className="c9 c10"
           data-element="flat-table-cell"
         >
           cell1
         </td>
         <td
-          className="c9"
+          className="c9 c10"
           data-element="flat-table-cell"
         >
           cell2
+        </td>
+        <td
+          className="c9 c11"
+          data-element="flat-table-cell"
+          rowSpan="2"
+        >
+          cell3
+        </td>
+      </tr>
+      <tr
+        className="c4"
+        data-element="flat-table-row"
+      >
+        <th
+          className="c5 c6"
+          data-element="flat-table-row-header"
+        >
+          row header
+        </th>
+        <td
+          className="c9 c10"
+          colSpan="2"
+          data-element="flat-table-cell"
+        >
+          cell1
         </td>
       </tr>
     </tbody>

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.component.d.ts
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.component.d.ts
@@ -3,7 +3,11 @@ import * as React from 'react';
 export interface FlatTableCellProps {
   /** Content alignment */
   align: string;
-  children: React.ReactNode | string;
+  children?: React.ReactNode | string;
+  /** Number of columns that a cell should span */
+  colspan?: number | string;
+  /** Number of rows that a cell should span */
+  rowspan?: number | string;
 }
 
 declare const FlatTableCell: React.FunctionComponent<FlatTableCellProps>;

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
@@ -2,9 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import StyledFlatTableCell from './flat-table-cell.style';
 
-const FlatTableCell = ({ align, children }) => {
+const FlatTableCell = ({
+  align,
+  children,
+  colspan,
+  rowspan
+}) => {
   return (
-    <StyledFlatTableCell align={ align } data-element='flat-table-cell'>
+    <StyledFlatTableCell
+      align={ align }
+      data-element='flat-table-cell'
+      colSpan={ colspan }
+      rowSpan={ rowspan }
+    >
       { children }
     </StyledFlatTableCell>
   );
@@ -13,7 +23,11 @@ const FlatTableCell = ({ align, children }) => {
 FlatTableCell.propTypes = {
   /** Content alignment */
   align: PropTypes.oneOf(['center', 'left', 'right']),
-  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  /** Number of columns that a cell should span */
+  colspan: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /** Number of rows that a cell should span */
+  rowspan: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 };
 
 FlatTableCell.defaultProps = {

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components';
 import baseTheme from '../../../style/themes/base';
 
 const StyledFlatTableCell = styled.td`
-  ${({ align, theme }) => css`
+  ${({ align, theme, rowSpan }) => css`
     background-color: #fff;
     border-width: 0;
     border-bottom: 1px solid ${theme.table.secondary};
@@ -20,6 +20,12 @@ const StyledFlatTableCell = styled.td`
     &:last-of-type {
       border-right: 1px solid ${theme.table.secondary};
     }
+
+    ${rowSpan && css`
+      &:first-of-type + & {
+        border-left: 1px solid ${theme.table.secondary};
+      }
+    `}
   `}
 `;
 

--- a/src/components/flat-table/flat-table-header/flat-table-header.component.d.ts
+++ b/src/components/flat-table/flat-table-header/flat-table-header.component.d.ts
@@ -4,6 +4,10 @@ export interface FlatTableHeaderProps {
   /** Content alignment */
   align: string;
   children: React.ReactNode | string;
+  /** Number of columns that a header cell should span */
+  colspan?: number | string;
+  /** Number of rows that a header cell should span */
+  rowspan?: number | string;
 }
 
 declare const FlatTableHeader: React.FunctionComponent<FlatTableHeaderProps>;

--- a/src/components/flat-table/flat-table-header/flat-table-header.component.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.component.js
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types';
 import StyledFlatTableHeader from './flat-table-header.style';
 
 const FlatTableHeader = ({
-  align, children
+  align, children, colspan, rowspan
 }) => {
   return (
     <StyledFlatTableHeader
       align={ align }
       data-element='flat-table-header'
+      colSpan={ colspan }
+      rowSpan={ rowspan }
     >
       { children }
     </StyledFlatTableHeader>
@@ -18,7 +20,11 @@ const FlatTableHeader = ({
 FlatTableHeader.propTypes = {
   /** Content alignment */
   align: PropTypes.oneOf(['center', 'left', 'right']),
-  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  /** Number of columns that a header cell should span */
+  colspan: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /** Number of rows that a header cell should span */
+  rowspan: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 };
 
 FlatTableHeader.defaultProps = {

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -100,6 +100,7 @@ function renderFlatTable(props = {}, renderer = TestRenderer.create) {
           <FlatTableRowHeader>row header</FlatTableRowHeader>
           <FlatTableHeader>header1</FlatTableHeader>
           <FlatTableHeader>header2</FlatTableHeader>
+          <FlatTableHeader>header3</FlatTableHeader>
         </FlatTableRow>
       </FlatTableHead>
       <FlatTableBody>
@@ -107,6 +108,11 @@ function renderFlatTable(props = {}, renderer = TestRenderer.create) {
           <FlatTableRowHeader>row header</FlatTableRowHeader>
           <FlatTableCell>cell1</FlatTableCell>
           <FlatTableCell>cell2</FlatTableCell>
+          <FlatTableCell rowspan='2'>cell3</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableRowHeader>row header</FlatTableRowHeader>
+          <FlatTableCell colspan='2'>cell1</FlatTableCell>
         </FlatTableRow>
       </FlatTableBody>
     </FlatTable>

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -332,6 +332,63 @@ to match the same color as the background
   <Story id="test-flat-table--sortable" name="with sorting headers" />
 </Preview>
 
+### With a cell spanning the whole row 
+
+<Preview>
+  <Story name="with colspan" parameters={{ info: { disable: true }}} >
+      <FlatTable>
+        <FlatTableHead>
+          <FlatTableRow>
+            <FlatTableHeader>Client</FlatTableHeader>
+            <FlatTableHeader>Client Type</FlatTableHeader>
+            <FlatTableHeader>Categories</FlatTableHeader>
+            <FlatTableHeader>Services</FlatTableHeader>
+          </FlatTableRow>
+        </FlatTableHead>
+        <FlatTableBody>
+          <FlatTableRow>
+            <FlatTableCell colspan='4' align='center'>No results</FlatTableCell>
+          </FlatTableRow>
+        </FlatTableBody>
+      </FlatTable>
+  </Story>
+</Preview>
+
+### With a cell spanning the whole column 
+
+<Preview>
+  <Story name="with rowspan" parameters={{ info: { disable: true }}} >
+      <FlatTable>
+        <FlatTableHead>
+          <FlatTableRow>
+            <FlatTableHeader>Client</FlatTableHeader>
+            <FlatTableHeader>Client Type</FlatTableHeader>
+            <FlatTableHeader>Categories</FlatTableHeader>
+            <FlatTableHeader>Services</FlatTableHeader>
+          </FlatTableRow>
+        </FlatTableHead>
+        <FlatTableBody>
+          <FlatTableRow>
+            <FlatTableCell rowspan='3'>John Smith</FlatTableCell>
+            <FlatTableCell>Business</FlatTableCell>
+            <FlatTableCell>Group1, Group3</FlatTableCell>
+            <FlatTableCell>Accounting</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableCell>Charity</FlatTableCell>
+            <FlatTableCell>Group3</FlatTableCell>
+            <FlatTableCell>Payroll</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableCell>Partnership</FlatTableCell>
+            <FlatTableCell>Group3</FlatTableCell>
+            <FlatTableCell>Final Tax</FlatTableCell>
+          </FlatTableRow>
+        </FlatTableBody>
+      </FlatTable>
+  </Story>
+</Preview>
+
 ## Props:
 
 ### FlatTable


### PR DESCRIPTION
### Proposed behaviour
![Screenshot 2020-05-07 at 12 11 48](https://user-images.githubusercontent.com/22885392/81282807-f8dedc00-905b-11ea-9dba-e7191b3d23bd.png)
![Screenshot 2020-05-07 at 12 11 57](https://user-images.githubusercontent.com/22885392/81282813-fbd9cc80-905b-11ea-8e7a-aaf16d859e36.png)

The colspan and rowspan props have been added to the FlatTableCell and FlatTableHeader components to allow to specify a cell that spans multiple rows/cells like in the HTML Table element.

### Current behaviour
There is no possibility to pass colspan and rowspan to rendered HTML th and td elements.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Carbon implementation and Design System documentation are congruent
- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [ ] Cypress automation tests
- [x] Storybook added or updated
~~- [ ] Theme support~~
- [x] Typescript `d.ts` file added or updated

### Testing instructions
1. run npm start locally.
2. open http://localhost:9001/?path=/docs/design-system-flat-table--with-colspan
3. open http://localhost:9001/?path=/docs/design-system-flat-table--with-rowspan