### PR TITLE
fix(menu): add routerLink prop as no longer provided by link component

### DIFF
--- a/src/components/link/link.component.js
+++ b/src/components/link/link.component.js
@@ -153,7 +153,7 @@ Link.propTypes = {
   /** Aligns the tooltip. */
   tooltipAlign: PropTypes.oneOf(OptionsHelper.alignAroundEdges),
   /** A routing component to render when the to prop is set */
-  routerLink: PropTypes.func
+  routerLink: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
 };
 
 Link.defaultProps = {

--- a/src/components/menu/docgenInfo.json
+++ b/src/components/menu/docgenInfo.json
@@ -118,6 +118,21 @@
           "required": false,
           "description": "The to link to use for the menu item."
         },
+        "routerLink": {
+          "type": {
+            "name": "union",
+            "value": [
+              {
+                "name": "object"
+              },
+              {
+                "name": "func"
+              }
+            ]
+          },
+          "required": false,
+          "description": "The router link to be used with the to prop."
+        },
         "target": {
           "type": {
             "name": "string"

--- a/src/components/menu/menu-item/__definition__.js
+++ b/src/components/menu/menu-item/__definition__.js
@@ -14,7 +14,8 @@ let definition = new Definition('menu-item', MenuItem, {
     submenu: "String",
     submenuDirection: "String",
     target: "String",
-    to: "String"
+    to: "String",
+    routerLink: "Object | Function"
   },
   propDescriptions: {
     children: "This component supports children.",
@@ -26,7 +27,8 @@ let definition = new Definition('menu-item', MenuItem, {
     submenu: "Text for the menu item if the children are a submenu.",
     submenuDirection: "Direction for the submenu to align.",
     target: "Target for the link (eg. _blank)",
-    to: "A React Router link for the menu item."
+    to: "A React Router link for the menu item.",
+    routerLink: "The router link to be used with the to prop."
   }
 });
 

--- a/src/components/menu/menu-item/__spec__.js
+++ b/src/components/menu/menu-item/__spec__.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import {Link as RouterLink} from 'react-router';
 import { shallow } from 'enzyme';
-import { elementsTagTest, rootTagTest } from '../../../utils/helpers/tags/tags-specs';
+import { elementsTagTest, rootTagTest } from '../../../utils/helpers/tags/tags-specs/tags-specs';
 import MenuItem from './menu-item';
-import Link from './../../link';
+import Link from '../../link';
 
 describe('MenuItem', () => {
   let wrapper;
@@ -62,4 +63,16 @@ describe('MenuItem', () => {
       rootTagTest(wrapper, 'menu-item', 'bar', 'baz');
     });
   });
+
+  describe('with link', () => {
+    it('renders a link with the routerLink element', () => {
+      const menuItemWrapper = shallow(
+        <MenuItem data-element='bar' data-role='baz' to='/test' routerLink={RouterLink}>
+          Test
+        </MenuItem>
+      );
+      expect(menuItemWrapper.find(Link).props().routerLink).toEqual(RouterLink);
+      expect(menuItemWrapper.find(Link).props().to).toEqual('/test');
+    });
+  })
 });

--- a/src/components/menu/menu-item/docgenInfo.json
+++ b/src/components/menu/menu-item/docgenInfo.json
@@ -118,6 +118,21 @@
           "required": false,
           "description": "The to link to use for the menu item."
         },
+        "routerLink": {
+          "type": {
+            "name": "union",
+            "value": [
+              {
+                "name": "object"
+              },
+              {
+                "name": "func"
+              }
+            ]
+          },
+          "required": false,
+          "description": "The router link to be used with the to prop."
+        },
         "target": {
           "type": {
             "name": "string"

--- a/src/components/menu/menu-item/menu-item.js
+++ b/src/components/menu/menu-item/menu-item.js
@@ -142,11 +142,14 @@ class MenuItem extends React.Component {
       className: this.classes,
       href: this.props.href,
       to: this.props.to,
-      routerLink: this.props.routerLink,
       target: this.props.target,
       onClick: this.props.onClick,
       icon: this.props.icon
     };
+
+    if (component !== 'div') {
+      props.routerLink = this.props.routerLink;
+    }
 
     props = assign({}, props, tagComponent('menu-item', this.props));
 

--- a/src/components/menu/menu-item/menu-item.js
+++ b/src/components/menu/menu-item/menu-item.js
@@ -65,6 +65,11 @@ class MenuItem extends React.Component {
     to: PropTypes.string,
 
     /**
+     * The link element to use when providing the to value
+     */
+
+    routerLink: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    /**
      * The target to use for the menu item.
      */
     target: PropTypes.string
@@ -137,6 +142,7 @@ class MenuItem extends React.Component {
       className: this.classes,
       href: this.props.href,
       to: this.props.to,
+      routerLink: this.props.routerLink,
       target: this.props.target,
       onClick: this.props.onClick,
       icon: this.props.icon


### PR DESCRIPTION
### Proposed behaviour

When the Link component had React Router removed in version 17 of Carbon, the Menu component was not updated to handle the new prop expectation of routerLink.

This now passes the routerLink element prop to the Link component.

The prop type expectation has been updated to allow direct passing of Link from React Router without needing to wrap in a function.

### Current behaviour

The Menu Item does not pass the routerLink prop to the rendered Link component.
A warning appears in the stating the React Router Link element is not a function.

Example codesandbox can be found here: https://github.com/Sage/carbon/issues/2924

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Carbon implementation and Design System documentation are congruent<del>
- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
<del>- [ ] Cypress automation tests<del>
- [x] Storybook added or updated
<del>- [ ] Theme support<del>
<del>- [ ] Typescript `d.ts` file added or updated<del>

### Additional context

Happy to discuss approach being taken in regards to handling Typescript files without full usage of Typescript.

### Testing instructions

Unsure as to how this is normally tested within Carbon.

I've done the following locally and then launched my application using a function to load the Link and directly passing the Link.
```
$ rm -rf my-app/node_modules/carbon-react/lib
$ cd carbon
$ rm -rf lib
$ npm run precompile
$ cp lib/ ../my-app/node_modules/carbon-react/lib
```