### PR TITLE
docs: add documentation on webfontloader

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,13 +28,18 @@ npm install react@^16.12.0 react-dom@^16.12.0 i18n-js@^3.0.0 styled-components@^
 
 #### Fonts
 ##### CDN
-As a consumer you will be required to handle the importing of the `Lato` font. Typically, you can do this by including an `@import` in your main `css` file to get the font via a CDN.
-```js
-@import url('https://fonts.googleapis.com/css?family=Lato:400,700,900');
-``` 
+`carbon-react` requires the `Lato` and `CarbonIcons` fonts to display correctly.
 
-##### Local
-If using a CDN is an issue, you should include the font locally and configure the `@font-face` (see below) in your main `css` file. It is then possible to use `webpack` and either [file-loader](https://webpack.js.org/loaders/file-loader/) or [url-loader](https://webpack.js.org/loaders/url-loader/) to bundle them with your application. `url-loader` will allow any assets under a given limit to be embedded as a dataURL in `base64` and reduce requests; a fallback loader is used for any asset over the limit, `file-loader` is used if none is provided.
+To embed the `Lato` font, copy the code below into the `<head>` of your HTML.
+```
+<link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900" rel="stylesheet">
+``` 
+The `CarbonIcons` font is not available on a CDN.
+
+##### Self Hosted
+Please be aware that the Google Fonts CDN provides the optimal stylesheet based on the browser `user-agent` string to limit "flash of unstyled text". It's important that you fully understand the [technical considerations](https://developers.google.com/fonts/docs/technical_considerations) before hosting any font yourself.
+
+The `Lato` font can be downloaded from [Google Fonts](https://fonts.google.com/specimen/Lato).
 
 ```css
   @font-face {
@@ -47,16 +52,20 @@ If using a CDN is an issue, you should include the font locally and configure th
     font-style: normal;
   }
 ```
-You may also have to include the `CarbonIcons` font (see below) in order for the full range of `Icon`s on offer to be displayed in your project, this can be done in the same way as the `Lato` font.
+_Note: You'll need to define a `@font-face` for each font-weight._
 
+The path to the `CarbonIcons` font is `carbon-react/lib/style/fonts/carbon-icons-webfont.woff`.
 ```css
-  @font-face {
-    font-family: 'CarbonIcons';
-    src: url('./node_modules/carbon-react/lib/style/fonts/carbon-icons-webfont.woff') format("woff");
-    font-weight: normal;
-    font-style: normal;
-  }
+@font-face {
+  font-family: 'CarbonIcons';
+  src: url('./node_modules/carbon-react/lib/style/fonts/carbon-icons-webfont.woff') format("woff");
+  font-weight: normal;
+  font-style: normal;
+}
 ```
+
+If you are using `webpack`, you can use [file-loader](https://webpack.js.org/loaders/file-loader/) or [url-loader](https://webpack.js.org/loaders/url-loader/) to bundle the fonts with your application.
+`url-loader` will allow any assets under a given limit to be embedded as a dataURL in `base64` and reduce network requests; `file-loader` can be used for any asset over the limit.
 
 Example of `webpack.config.js`
 ```js
@@ -90,6 +99,29 @@ module.exports = {
   ...
 };
 ```
+
+If you are not using webpack, you will need to ensure that the font files are available in your build and that the `@font-face` use the correct URL's.
+
+You can move it to your build folder as part of your build.
+```sh
+mkdir -p dist/fonts
+cp ./node_modules/carbon-react/lib/style/fonts/carbon-icons-webfont.woff ./dist/fonts/
+```
+Or publish it to a CDN such as Amazon S3.
+```sh
+aws s3 sync ./node_modules/carbon-react/lib/style/fonts/carbon-icons-webfont.woff s3://example.com/fonts/
+```
+
+While not required, we also recommend using [`webfontloader`](https://github.com/typekit/webfontloader#custom) to control the loading behaviour and avoid a "flash of unstyled text". `webfontloader` adds CSS classes to the `<body>` giving you finer control over the blocking behaviour.
+
+```js
+WebFont.load({
+  custom: {
+    families: ['CarbonIcons', 'Lato']
+  }
+});
+```
+
 #### React and React DOM
 React and React DOM are imported from the [React library](https://reactjs.org/), which forms the basis for Carbon's components.
 ```js


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->

We want to discourage custom CSS (at the request of Sage). The aim is for `carbon-react` to provide all the styling required. This PR will change the documentation to favour other methods over having a custom CSS file.

- Change the CSS `@import` to be an external stylesheet.
- Document `webfontloader` to deal with FOUT.
- Document alternative approaches instead of webpack.
- Make it clear the you need to load the `CarbonIcons` font and it is not available on a CDN (yet).

### Current behaviour
We state to add `@import` to your CSS.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR
<del>- [ ] Carbon implementation and Design System documentation are congruent
<del>- [ ] All themes are supported
- [x] Commits follow our style guide
<del>- [ ] Unit tests added or updated
<del>- [ ] Cypress automation tests added or updated
<del>- [ ] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
