### PR TITLE
fix(link): add target prop - FE-2793

### DIFF
--- a/cypress/features/regression/link.feature
+++ b/cypress/features/regression/link.feature
@@ -5,6 +5,16 @@ Feature: Link component
     Given I open "Link" component page
 
   @positive
+  Scenario Outline: Change Link target to <target>
+    When I set target to <target> word
+    Then Link on preview target is set to <target>
+    Examples:
+      | target |
+      | _blank |
+      | _self  |
+      | _top   |
+
+  @positive
   Scenario Outline: Change Link children to <children>
     When I set children to <children> word
     Then children on preview is <children>

--- a/cypress/support/step-definitions/link-steps.js
+++ b/cypress/support/step-definitions/link-steps.js
@@ -12,6 +12,10 @@ Then('Link is enabled', () => {
   linkPreview().should('not.have.attr', 'disabled');
 });
 
+Then('Link on preview target is set to {word}', (target) => {
+  linkPreview().children().should('have.attr', 'target', `${target}`);
+});
+
 Then('Link on preview href is set to {word}', (href) => {
   linkPreview().children().should('have.attr', 'href', `${href}`);
 });

--- a/src/components/link/docgenInfo.json
+++ b/src/components/link/docgenInfo.json
@@ -56,7 +56,19 @@
           "returns": null
         },
         {
-          "name": "renderLinkContent",
+          "name": "handleClick",
+          "docblock": null,
+          "modifiers": [],
+          "params": [
+            {
+              "name": "ev",
+              "type": null
+            }
+          ],
+          "returns": null
+        },
+        {
+          "name": "linkContent",
           "docblock": "className `@carbon-link__content` is related to `ShowEditPod` component",
           "modifiers": [],
           "params": [],
@@ -64,7 +76,7 @@
           "description": "className `@carbon-link__content` is related to `ShowEditPod` component"
         },
         {
-          "name": "renderLink",
+          "name": "createLinkBasedOnType",
           "docblock": null,
           "modifiers": [],
           "params": [],
@@ -132,6 +144,13 @@
           "required": false,
           "description": "Function called when a key is pressed."
         },
+        "onMouseDown": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "Function called when a mouse down event triggers."
+        },
         "tabbable": {
           "type": {
             "name": "bool"
@@ -148,7 +167,7 @@
             "name": "string"
           },
           "required": false,
-          "description": "Using `to` instead of `href` will create a React Router link rather than a web href."
+          "description": "Using `to` an passing in a component to the `routerLink` prop will render a routing link instead of a web href."
         },
         "tooltipMessage": {
           "type": {
@@ -159,19 +178,52 @@
         },
         "tooltipPosition": {
           "type": {
-            "name": "string"
+            "name": "enum",
+            "computed": true,
+            "value": "OptionsHelper.positions"
           },
           "required": false,
           "description": "Positions the tooltip with the link."
         },
         "tooltipAlign": {
           "type": {
-            "name": "string"
+            "name": "enum",
+            "computed": true,
+            "value": "OptionsHelper.alignAroundEdges"
           },
           "required": false,
           "description": "Aligns the tooltip."
+        },
+        "routerLink": {
+          "type": {
+            "name": "union",
+            "value": [
+              {
+                "name": "func"
+              },
+              {
+                "name": "object"
+              }
+            ]
+          },
+          "required": false,
+          "description": "A routing component to render when the to prop is set"
+        },
+        "target": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Target property in which link should open ie: _blank, _self, _parent, _top"
         }
       }
+    }
+  ],
+  "src/components/link/link.spec.js": [
+    {
+      "description": "",
+      "displayName": "RouterLink",
+      "methods": []
     }
   ]
 }

--- a/src/components/link/link.component.js
+++ b/src/components/link/link.component.js
@@ -55,7 +55,8 @@ class Link extends React.Component {
       onMouseDown: this.props.onMouseDown,
       disabled: this.props.disabled,
       onClick: this.handleClick,
-      tabIndex: this.tabIndex
+      tabIndex: this.tabIndex,
+      target: this.props.target
     };
 
     if (this.props.to) {
@@ -153,7 +154,9 @@ Link.propTypes = {
   /** Aligns the tooltip. */
   tooltipAlign: PropTypes.oneOf(OptionsHelper.alignAroundEdges),
   /** A routing component to render when the to prop is set */
-  routerLink: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+  routerLink: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  /** Target property in which link should open ie: _blank, _self, _parent, _top */
+  target: PropTypes.string
 };
 
 Link.defaultProps = {

--- a/src/components/link/link.d.ts
+++ b/src/components/link/link.d.ts
@@ -16,6 +16,7 @@ export interface LinkProps {
   tooltipAlign?: 'bottom' | 'center' | 'left' | 'right' | 'top';
   children?: React.ReactNode;
   routerLink?: React.ReactNode;
+  target?: string;
 }
 
 declare const Link: React.ComponentType<LinkProps & React.HTMLProps<HTMLLinkElement>>;

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -80,6 +80,15 @@ describe('Link', () => {
     });
   });
 
+  describe('when component received a `target` prop', () => {
+    it('should render an `<a>`  element with target attribute', () => {
+      const target = '_blank';
+      wrapper.setProps({ target });
+
+      expect(wrapper.find('a').prop('target')).toBe(target);
+    });
+  });
+
   describe('when component received a `href` prop', () => {
     it('should render an `<a>` element', () => {
       wrapper.setProps({ href: '#' });

--- a/src/components/link/link.stories.js
+++ b/src/components/link/link.stories.js
@@ -40,6 +40,7 @@ function makeStory(name, themeSelector) {
     ) : undefined;
     const hasOnClick = boolean('onClick', false);
     const onClick = hasOnClick ? action('click') : undefined;
+    const target = text('target', '_blank');
 
     return (
       <Link
@@ -54,6 +55,7 @@ function makeStory(name, themeSelector) {
         tooltipAlign={ tooltipAlign }
         onClick={ onClick }
         routerLink={ to ? RouterLink : undefined }
+        target={ target }
       >
         {children}
       </Link>


### PR DESCRIPTION
### Proposed behaviour
Link component should render with target property if it is provided.

Fixes #2921

### Current behaviour
When target property is provided Link does not render that property. Because of that user is not able to specify that link should open in new tab for example.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR
<del>- [ ] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
- [x] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [x] Storybook added or updated
- [x] Typescript `d.ts` file added or updated

### Additional context
This codesandbox demo that shows that `target` prop is not working.
https://codesandbox.io/s/link-target-issue-jjgwl?file=/src/index.js

### Testing instructions
http://localhost:9001/?path=/docs/link--default