### PR TITLE
ci: remove unnecessary threads

### DIFF
--- a/.github/workflows/cypress-parallel.yml
+++ b/.github/workflows/cypress-parallel.yml
@@ -24,11 +24,40 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.2.0
+      # Restore the previous NPM modules and Cypress binary archives.
+      # Any updated archives will be saved automatically after the entire
+      # workflow successfully finishes.
+      # See https://github.com/actions/cache
+      - name: Cache central NPM modules
+        uses: actions/cache@v2.0.0
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Cache Cypress binary
+        uses: actions/cache@v2.0.0
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            cypress-${{ runner.os }}-cypress-
+      - name: install dependencies and verify Cypress
+        env:
+          # make sure every Cypress install prints minimal information
+          CI: 1
+        run: |
+          npm ci
+          npx cypress cache path
+          npx cypress cache list
+          npx cypress verify
+          npx cypress info
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: Cypress run
         uses: cypress-io/github-action@v1.24.3
         with:
+          install: false
           start: npm start
           # quote the url to be safe against YML parsing surprises
           wait-on: 'http://localhost:9001'
@@ -52,9 +81,38 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.2.0
+      # Restore the previous NPM modules and Cypress binary archives.
+      # Any updated archives will be saved automatically after the entire
+      # workflow successfully finishes.
+      # See https://github.com/actions/cache
+      - name: Cache central NPM modules
+        uses: actions/cache@v2.0.0
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Cache Cypress binary
+        uses: actions/cache@v2.0.0
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            cypress-${{ runner.os }}-cypress-
+      - name: install dependencies and verify Cypress
+        env:
+          # make sure every Cypress install prints minimal information
+          CI: 1
+        run: |
+          npm ci
+          npx cypress cache path
+          npx cypress cache list
+          npx cypress verify
+          npx cypress info
       - name: Cypress run
         uses: cypress-io/github-action@v1.24.3
         with:
+          install: false
           start: npm start
           wait-on: "http://localhost:9001"
           wait-on-timeout: 250

--- a/.github/workflows/cypress-parallel.yml
+++ b/.github/workflows/cypress-parallel.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     if: ${{ github.event.pull_request.head.repo.full_name == 'Sage/carbon' }} 
     name: Cypress regression
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes
@@ -23,7 +23,7 @@ jobs:
             ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.2.0
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: Cypress run
@@ -48,10 +48,10 @@ jobs:
   fork-test:
     if: ${{ github.event.pull_request.head.repo.full_name != 'Sage/carbon' }}  
     name: Cypress regression on forked PR
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.2.0
       - name: Cypress run
         uses: cypress-io/github-action@v1.24.3
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,6 @@ jobs:
     - script:
       name: "applitools tests for storybook with cypress 3d thread"
       <<: *cypressVisual
-    - script:
-      name: "applitools tests for storybook with cypress 4th thread"
-      <<: *cypressVisual
-    - script:
-      name: "applitools tests for storybook with cypress 5th thread"
-      <<: *cypressVisual
     - stage: deploy
       name: "s3"
       script: skip

--- a/package-lock.json
+++ b/package-lock.json
@@ -12660,9 +12660,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.6.0.tgz",
-      "integrity": "sha512-vIPXAceRP+Nxvnm/O9ruY9EQaRGmVVybtk9F1sfC9mH3067YbitrdBTynaaLuHFj90p9e0U2ZCV7OkX4x4V/Wg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.7.0.tgz",
+      "integrity": "sha512-Vav6wUFhPRlImIND/2lOQlUnAWzgCC/iXyJlJjX9nJOJul5LC1vUpf/m8Oiae870PFPyT0ZLLwPHKTXZNdXmHw==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "cpx": "^1.5.0",
     "cross-env": "^5.2.0",
     "css-loader": "1.0.0",
-    "cypress": "4.6.0",
+    "cypress": "4.7.0",
     "cypress-cucumber-preprocessor": "2.3.1",
     "cypress-plugin-retries": "^1.5.2",
     "cz-conventional-changelog": "^3.0.2",


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
- removed 4th and 5th threads from cypress run to unblock `travis` runs;
- update ubuntu to the `latest` version;
- add caching stages for correct restoring `cache`;
- update `actions/checkout@v1` to `actions/checkout@v2.2.0`;
- update `cypress` to version 4.7.0.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
To unblock `travis` runs to make it faster we need to remove 4th and 5th threads from cypress run

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Screenshots are included in the PR
- [ ] Carbon implementation and Design System documentation are congruent
- [ ] All themes are supported
- [ ] Commits follow our style guide
- [ ] Unit tests added or updated
- [ ] Cypress automation tests added or updated
- [ ] Storybook added or updated
- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
