### PR TITLE
feat(grid-item): add align and justify props - FE-2764

### DIFF
--- a/cypress/features/regression/test/grid.feature
+++ b/cypress/features/regression/test/grid.feature
@@ -4,18 +4,6 @@ Feature: Grid component
   Background: Open Grid component page
     Given I open basic Test "Grid" component page in noIframe
 
-# will remove when Applitools will be implemented
-  @positive
-  Scenario Outline: Check Grid has "<title>" as title
-    # commented because of BDD default scenario Given - When - Then
-    # When I open "Grid" component page
-    Then pod <index> is "<title>"
-    Examples:
-      | index | title       |
-      | 0     | GridItem 1. |
-      | 1     | GridItem 2. |
-      | 2     | GridItem 3. |
-
   @positive
   Scenario Outline: Set viewport to default and check size of <podTitle>
     When I resize grid viewport to "default"

--- a/cypress/features/visual/grid.feature
+++ b/cypress/features/visual/grid.feature
@@ -1,0 +1,8 @@
+Feature: Grid component
+  I want to check that all examples of Grid component render correctly
+
+  @positive
+  @applitools
+  Scenario: Check that all examples of Grid component render correctly
+    When I open visual Test "Grid" component page in noIframe
+    Then Element displays correctly

--- a/cypress/support/step-definitions/grid-steps.js
+++ b/cypress/support/step-definitions/grid-steps.js
@@ -1,4 +1,8 @@
-import { pod, gridPod, gridComponent } from '../../locators/grid';
+import {
+  pod,
+  gridPod,
+  gridComponent,
+} from '../../locators/grid';
 
 Then('pod {int} is {string}', (index, title) => {
   pod(index).should('have.text', title);

--- a/src/components/grid/__snapshots__/grid.spec.js.snap
+++ b/src/components/grid/__snapshots__/grid.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Grid GridItem builds the style rules for the GridItem responsiveSettings 1`] = `
+exports[`Grid GridItem builds the style rules for the GridItem with custom align and justify 1`] = `
 .c0 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
@@ -16,11 +16,94 @@ exports[`Grid GridItem builds the style rules for the GridItem responsiveSetting
   grid-column-end: 13;
   grid-row-start: auto;
   grid-row-end: auto;
+  -webkit-align-self: start;
+  -ms-flex-item-align: start;
+  align-self: start;
+  justify-self: left;
+}
+
+.c2 {
   margin: 0;
   grid-column-start: 1;
   grid-column-end: 13;
   grid-row-start: auto;
   grid-row-end: auto;
+  -webkit-align-self: start;
+  -ms-flex-item-align: start;
+  align-self: start;
+  justify-self: center;
+}
+
+.c3 {
+  margin: 0;
+  grid-column-start: 1;
+  grid-column-end: 13;
+  grid-row-start: auto;
+  grid-row-end: auto;
+  -webkit-align-self: start;
+  -ms-flex-item-align: start;
+  align-self: start;
+  justify-self: right;
+}
+
+@media screen and (max-width:1920px) {
+  .c0 {
+    grid-gap: 24px;
+  }
+}
+
+@media screen and (max-width:1259px) {
+  .c0 {
+    margin: 32px;
+  }
+}
+
+@media screen and (max-width:959px) {
+  .c0 {
+    grid-gap: 16px;
+    margin: 24px;
+  }
+}
+
+@media screen and (max-width:599px) {
+  .c0 {
+    margin: 16px;
+  }
+}
+
+<div
+  className="c0"
+  data-component="grid"
+>
+  <div
+    className="c1"
+  >
+    1
+  </div>
+  <div
+    className="c2"
+  >
+    1
+  </div>
+  <div
+    className="c3"
+  >
+    1
+  </div>
+</div>
+`;
+
+exports[`Grid GridItem builds the style rules for the GridItem with responsiveSettings 1`] = `
+.c0 {
+  display: grid;
+  grid-template-columns: repeat(12,1fr);
+  grid-template-rows: auto;
+  width: auto;
+  margin: 40px;
+  grid-gap: 40px;
+}
+
+.c1 {
   margin: 0;
   grid-column-start: 1;
   grid-column-end: 13;
@@ -34,29 +117,9 @@ exports[`Grid GridItem builds the style rules for the GridItem responsiveSetting
   grid-column-end: 13;
   grid-row-start: auto;
   grid-row-end: auto;
-  margin: 0;
-  grid-column-start: 1;
-  grid-column-end: 13;
-  grid-row-start: auto;
-  grid-row-end: auto;
-  margin: 0;
-  grid-column-start: 1;
-  grid-column-end: 13;
-  grid-row-start: auto;
-  grid-row-end: auto;
 }
 
 .c3 {
-  margin: 0;
-  grid-column-start: 1;
-  grid-column-end: 13;
-  grid-row-start: auto;
-  grid-row-end: auto;
-  margin: 0;
-  grid-column-start: 1;
-  grid-column-end: 13;
-  grid-row-start: auto;
-  grid-row-end: auto;
   margin: 0;
   grid-column-start: 1;
   grid-column-end: 13;

--- a/src/components/grid/grid-item/grid-item.component.js
+++ b/src/components/grid/grid-item/grid-item.component.js
@@ -10,7 +10,9 @@ const GridItem = (props) => {
     gridColumnStart,
     gridColumnEnd,
     gridRowStart,
-    gridRowEnd
+    gridRowEnd,
+    alignSelf,
+    justifySelf
   } = props;
 
   return (
@@ -19,7 +21,9 @@ const GridItem = (props) => {
         gridColumnStart,
         gridColumnEnd,
         gridRowStart,
-        gridRowEnd
+        gridRowEnd,
+        alignSelf,
+        justifySelf
       } }
       responsiveSettings={ responsiveSettings }
     >
@@ -39,7 +43,10 @@ GridItem.propTypes = {
   gridRowStart: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Ending row position of the GridItem within the GridContainer by referring to the grid line where the item ends */
   gridRowEnd: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
+  /** How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch */
+  alignSelf: PropTypes.string,
+  /** How the grid item is aligned along the inline (row) axis. Values: start, end, center, stretch */
+  justifySelf: PropTypes.string,
   responsiveSettings: PropTypes.arrayOf(
     PropTypes.shape({
       /** How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch */

--- a/src/components/grid/grid-item/grid-item.style.js
+++ b/src/components/grid/grid-item/grid-item.style.js
@@ -1,31 +1,19 @@
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 
-function responsiveGridItem({
-  responsiveSettings,
-  gridColumnStart,
-  gridColumnEnd,
-  gridRowStart,
-  gridRowEnd
-}) {
-  const item = responsiveSettings.map((setting) => {
+function responsiveGridItem(responsiveSettings) {
+  return responsiveSettings.map((setting) => {
     const {
-      alignSelf,
       colStart,
       colEnd,
-      justifySelf,
       maxWidth,
       rowStart,
-      rowEnd
+      rowEnd,
+      alignSelf,
+      justifySelf
     } = setting;
 
     return css`
-      margin: 0;
-      grid-column-start: ${gridColumnStart};
-      grid-column-end: ${gridColumnEnd};
-      grid-row-start: ${gridRowStart};
-      grid-row-end: ${gridRowEnd};
-
       @media screen and (max-width: ${maxWidth}) {
         align-self: ${alignSelf || 'stretch'};
         justify-self: ${justifySelf || 'stretch'};
@@ -33,13 +21,33 @@ function responsiveGridItem({
         grid-column-end: ${colEnd};
         grid-row-start: ${rowStart};
         grid-row-end: ${rowEnd};
-      }`;
+      }
+    `;
   });
-  return item;
 }
 
 const GridItemStyle = styled.div`
-  ${responsiveGridItem}
+  margin: 0;
+
+  ${({
+    gridColumnStart,
+    gridColumnEnd,
+    gridRowStart,
+    gridRowEnd,
+    alignSelf,
+    justifySelf
+  }) => css`
+    grid-column-start: ${gridColumnStart};
+    grid-column-end: ${gridColumnEnd};
+    grid-row-start: ${gridRowStart};
+    grid-row-end: ${gridRowEnd};
+    align-self: ${alignSelf};
+    justify-self: ${justifySelf};
+  `}
+
+  ${({ responsiveSettings }) => responsiveSettings && css`
+    ${responsiveGridItem(responsiveSettings)};
+  `}
 `;
 
 GridItemStyle.propTypes = {
@@ -47,6 +55,8 @@ GridItemStyle.propTypes = {
   gridColumnEnd: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   gridRowStart: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   gridRowEnd: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  alignSelf: PropTypes.string,
+  justifySelf: PropTypes.string,
   responsiveSettings: PropTypes.arrayOf(
     PropTypes.shape({
       alignSelf: PropTypes.string,

--- a/src/components/grid/grid-item/index.d.ts
+++ b/src/components/grid/grid-item/index.d.ts
@@ -12,6 +12,8 @@ interface ResponsiveSettingsShape {
 }
 
 export interface GridItemProps {
+  alignSelf: string;
+  justifySelf: string;
   children: string;
   gridColumnStart: string | number;
   gridColumnEnd: string | number;

--- a/src/components/grid/grid.spec.js
+++ b/src/components/grid/grid.spec.js
@@ -148,13 +148,25 @@ describe('Grid', () => {
   describe('GridItem', () => {
     /* the aim here is not to test that CSS media queries work. we are simply */
     /* checking that styled components are built and applied correctly        */
-    it('builds the style rules for the GridItem responsiveSettings', () => {
+    it('builds the style rules for the GridItem with responsiveSettings', () => {
       expect(
         TestRenderer.create(
           <GridContainer id='testContainer'>
             <GridItem responsiveSettings={ [item11500, item11300, item1900] }>1</GridItem>
             <GridItem responsiveSettings={ [item21500, item21300, item2900] }>2</GridItem>
             <GridItem responsiveSettings={ [item31500, item3900, item31300] }>3</GridItem>
+          </GridContainer>
+        )
+      ).toMatchSnapshot();
+    });
+
+    it('builds the style rules for the GridItem with custom align and justify', () => {
+      expect(
+        TestRenderer.create(
+          <GridContainer id='testContainer'>
+            <GridItem alignSelf='start' justifySelf='left'>1</GridItem>
+            <GridItem alignSelf='start' justifySelf='center'>1</GridItem>
+            <GridItem alignSelf='start' justifySelf='right'>1</GridItem>
           </GridContainer>
         )
       ).toMatchSnapshot();

--- a/src/components/grid/grid.stories.js
+++ b/src/components/grid/grid.stories.js
@@ -184,6 +184,274 @@ basic.story = {
   }
 };
 
+export const Visual = () => {
+  return (
+    <div>
+      <GridContainer>
+        <GridItem
+          alignSelf='stretch'
+          justifySelf='stretch'
+        >
+          <Pod
+            alignTitle='left'
+            as='primary'
+            border
+            padding='medium'
+            podType='primary'
+          >
+            1
+          </Pod>
+        </GridItem>
+        <GridItem
+          alignSelf='stretch'
+          justifySelf='stretch'
+        >
+          <Pod
+            alignTitle='left'
+            as='primary'
+            border
+            padding='medium'
+            podType='primary'
+          >
+            2
+          </Pod>
+        </GridItem>
+        <GridItem
+          alignSelf='stretch'
+          justifySelf='stretch'
+        >
+          <Pod
+            alignTitle='left'
+            as='primary'
+            border
+            padding='medium'
+            podType='primary'
+          >
+            3
+          </Pod>
+        </GridItem>
+      </GridContainer>
+      <GridContainer>
+        <GridItem
+          alignSelf='stretch'
+          justifySelf='left'
+        >
+          <Pod
+            alignTitle='left'
+            as='primary'
+            border
+            padding='medium'
+            podType='primary'
+          >
+            1
+          </Pod>
+        </GridItem>
+        <GridItem
+          alignSelf='stretch'
+          justifySelf='center'
+        >
+          <Pod
+            alignTitle='left'
+            as='primary'
+            border
+            padding='medium'
+            podType='primary'
+          >
+            2
+          </Pod>
+        </GridItem>
+        <GridItem
+          alignSelf='stretch'
+          justifySelf='right'
+        >
+          <Pod
+            alignTitle='left'
+            as='primary'
+            border
+            padding='medium'
+            podType='primary'
+          >
+            3
+          </Pod>
+        </GridItem>
+      </GridContainer>
+      <GridContainer>
+        <GridItem
+          alignSelf='end'
+          justifySelf='left'
+          gridColumnStart='1'
+          gridColumnEnd='1'
+        >
+          <Pod
+            alignTitle='left'
+            as='primary'
+            border
+            padding='medium'
+            podType='primary'
+          >
+            1
+          </Pod>
+        </GridItem>
+        <GridItem
+          alignSelf='stretch'
+          justifySelf='center'
+          gridColumnStart='2'
+          gridColumnEnd='2'
+        >
+          <Pod
+            alignTitle='left'
+            as='primary'
+            border
+            padding='medium'
+            podType='primary'
+            style={ { height: '100px' } }
+          >
+            2
+          </Pod>
+        </GridItem>
+        <GridItem
+          alignSelf='stretch'
+          justifySelf='right'
+          gridColumnStart='1'
+          gridColumnEnd='1'
+          gridRowStart='2'
+          gridRowEnd='2'
+        >
+          <Pod
+            alignTitle='left'
+            as='primary'
+            border
+            padding='medium'
+            podType='primary'
+          >
+            3
+          </Pod>
+        </GridItem>
+      </GridContainer>
+      <GridContainer>
+        <GridItem responsiveSettings={ [
+          {
+            maxWidth: '1500px',
+            colStart: 1,
+            colEnd: 7,
+            rowStart: 1,
+            rowEnd: 1,
+            alignSelf: 'stretch',
+            justifySelf: 'stretch'
+          }, {
+            maxWidth: '1300px',
+            colStart: 1,
+            colEnd: 13,
+            rowStart: 1,
+            rowEnd: 1,
+            alignSelf: 'stretch',
+            justifySelf: 'stretch'
+          }, {
+            maxWidth: '900px',
+            colStart: 1,
+            colEnd: 9,
+            rowStart: 2,
+            rowEnd: 2,
+            alignSelf: 'stretch',
+            justifySelf: 'stretch'
+          }] }
+        >
+          <Pod
+            alignTitle='left' as='primary'
+            border padding='medium'
+            podType='primary'
+          >
+            1
+          </Pod>
+        </GridItem>
+        <GridItem responsiveSettings={ [
+          {
+            maxWidth: '1500px',
+            colStart: 7,
+            colEnd: 13,
+            rowStart: 1,
+            rowEnd: 1,
+            alignSelf: 'stretch',
+            justifySelf: 'stretch'
+          }, {
+            maxWidth: '1300px',
+            colStart: 1,
+            colEnd: 13,
+            rowStart: 2,
+            rowEnd: 2,
+            alignSelf: 'stretch',
+            justifySelf: 'stretch'
+          }, {
+            maxWidth: '900px',
+            colStart: 1,
+            colEnd: 9,
+            rowStart: 3,
+            rowEnd: 3,
+            alignSelf: 'stretch',
+            justifySelf: 'stretch'
+          }] }
+        >
+          <Pod
+            alignTitle='left'
+            as='primary'
+            border
+            padding='medium'
+            podType='primary'
+          >
+            2
+          </Pod>
+        </GridItem>
+        <GridItem
+          responsiveSettings={ [
+            {
+              maxWidth: '1500px',
+              colStart: 1,
+              colEnd: 13,
+              rowStart: 2,
+              rowEnd: 2,
+              alignSelf: 'stretch',
+              justifySelf: 'stretch'
+            }, {
+              maxWidth: '1300px',
+              colStart: 1,
+              colEnd: 13,
+              rowStart: 3,
+              rowEnd: 3,
+              alignSelf: 'stretch',
+              justifySelf: 'stretch'
+            }, {
+              maxWidth: '900px',
+              colStart: 1,
+              colEnd: 9,
+              rowStart: 1,
+              rowEnd: 1,
+              alignSelf: 'stretch',
+              justifySelf: 'stretch'
+            }] }
+        >
+          <Pod
+            alignTitle='left'
+            as='primary'
+            border
+            padding='medium'
+            podType='primary'
+          >
+            3
+          </Pod>
+        </GridItem>
+      </GridContainer>
+    </div>
+  );
+};
+
+Visual.story = {
+  name: 'visual',
+  parameters: {
+    info: { disable: true },
+    docs: { page: null }
+  }
+};
+
 export default {
   title: 'Test/Grid',
   component: GridContainer,

--- a/src/components/grid/grid.stories.mdx
+++ b/src/components/grid/grid.stories.mdx
@@ -59,7 +59,7 @@ Gutters for the `GridItem` are set automatically in the CSS, following the value
 <Props of={GridItem} />
 
 ### responsiveSettings Props
-<PropsTable 
+<PropsTable
   rows={
     [
       {
@@ -101,10 +101,149 @@ Gutters for the `GridItem` are set automatically in the CSS, following the value
   }
 />
 
-## Example
-This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation. Note how the order and position of each `GridItem`, responds according to an array of `responsiveSettings` allowing reordering and respositioning as required.
+## Basic example
+This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation.
 <Preview>
   <Story name="basic" parameters={{ info: { disable: true }}} >
+    <GridContainer>
+      <GridItem alignSelf="stretch" justifySelf="stretch">
+        <Pod
+          alignTitle='left' as='primary'
+          border padding='medium'
+          podType='primary'
+        >
+          1
+        </Pod>
+      </GridItem>
+      <GridItem alignSelf="stretch" justifySelf="stretch">
+        <Pod
+          alignTitle='left' as='primary'
+          border padding='medium'
+          podType='primary'
+        >
+          2
+        </Pod>
+      </GridItem>
+      <GridItem alignSelf="stretch" justifySelf="stretch">
+        <Pod
+          alignTitle='left' as='primary'
+          border padding='medium'
+          podType='primary'
+        >
+          3
+        </Pod>
+      </GridItem>
+    </GridContainer>
+  </Story>
+</Preview>
+
+## Justify example
+This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation.
+<Preview>
+  <Story name="justify" parameters={{ info: { disable: true }}} >
+    <div id="grid-justify">
+      <GridContainer>
+        <GridItem
+          alignSelf="stretch"
+          justifySelf="left"
+        >
+          <Pod
+            alignTitle='left' as='primary'
+            border padding='medium'
+            podType='primary'
+          >
+            1
+          </Pod>
+        </GridItem>
+        <GridItem
+          alignSelf="stretch"
+          justifySelf="center"
+        >
+          <Pod
+            alignTitle='left' as='primary'
+            border padding='medium'
+            podType='primary'
+          >
+            2
+          </Pod>
+        </GridItem>
+        <GridItem
+          alignSelf="stretch"
+          justifySelf="right"
+        >
+          <Pod
+            alignTitle='left' as='primary'
+            border padding='medium'
+            podType='primary'
+          >
+            3
+          </Pod>
+        </GridItem>
+      </GridContainer>
+    </div>
+  </Story>
+</Preview>
+
+## Align example
+This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation.
+<Preview>
+  <Story name="align" parameters={{ info: { disable: true }}} >
+    <div id="grid-align">
+      <GridContainer>
+        <GridItem
+          alignSelf="end"
+          justifySelf="left"
+          gridColumnStart="1"
+          gridColumnEnd="1"
+        >
+          <Pod
+            alignTitle='left' as='primary'
+            border padding='medium'
+            podType='primary'
+          >
+            1
+          </Pod>
+        </GridItem>
+        <GridItem
+          alignSelf="stretch"
+          justifySelf="center"
+          gridColumnStart="2"
+          gridColumnEnd="2"
+        >
+          <Pod
+            alignTitle='left' as='primary'
+            border padding='medium'
+            podType='primary'
+            style={ { height: '100px' } }
+          >
+            2
+          </Pod>
+        </GridItem>
+        <GridItem
+          alignSelf="stretch"
+          justifySelf="right"
+          gridColumnStart="1"
+          gridColumnEnd="1"
+          gridRowStart="2"
+          gridRowEnd="2"
+        >
+          <Pod
+            alignTitle='left' as='primary'
+            border padding='medium'
+            podType='primary'
+          >
+            3
+          </Pod>
+        </GridItem>
+      </GridContainer>
+    </div>
+  </Story>
+</Preview>
+
+## Responsive Settings Example
+This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation. Note how the order and position of each `GridItem`, responds according to an array of `responsiveSettings` allowing reordering and respositioning as required.
+<Preview>
+  <Story name="responsive-settings" parameters={{ info: { disable: true }}} >
     <GridContainer>
       <GridItem responsiveSettings={[
         {
@@ -122,7 +261,7 @@ This example is best viewed in the Canvas tab using full-screen mode with device
           rowStart: 1,
           rowEnd: 1,
           alignSelf: 'stretch',
-          justifySelf: 'stretch'  
+          justifySelf: 'stretch'
         },{
           maxWidth: '900px',
           colStart: 1,


### PR DESCRIPTION
### Proposed behaviour
User should be able to set alignSelf and justifySelf on Griditem level.

![Screenshot 2020-05-28 at 16 47 53](https://user-images.githubusercontent.com/47245766/83163481-ff182380-a102-11ea-93be-8f837097a82c.png)

### Current behaviour
User can only set alignSelf and justifySelf through responsiveSettings which is limiting.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Screenshots are included in the PR
- [x] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
- [x] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [x] Storybook added or updated
- [x] Typescript `d.ts` file added or updated

### Testing instructions
http://localhost:9001/?path=/docs/design-system-grid--justify
