### PR TITLE
test(toast): add visual story

### DIFF
--- a/cypress/features/visual/toast.feature
+++ b/cypress/features/visual/toast.feature
@@ -3,18 +3,6 @@ Feature: Toast component
 
   @positive
   @applitools
-  Scenario Outline: Check that Toast component <story> rendered correctly
-    Given I open Design Systems default_story "Toast" component docs page
-    When I click on "<story>" Toggle Preview
+  Scenario: Check that Toast component renders correctly
+    When I open visual Test "Toast" component page in noIframe
     Then Element displays correctly
-    Examples:
-      | story                    |
-      | button-variant-centered  |
-      | button-default           |
-      | button-toast-dismissible |
-      | button-stacked           |
-      | button-stacked-delayed   |
-      | button-variant-error     |
-      | button-variant-info      |
-      | button-variant-success   |
-      | button-variant-warning   |

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -14,7 +14,7 @@ import {
   getDataElementByValue,
   getElementNoIframe, commonButtonPreviewNoIframe,
 } from '../../locators';
-import { dialogTitle, dialogSubtitle } from '../../locators/dialog';
+import { dialogTitle } from '../../locators/dialog';
 import { DEBUG_FLAG } from '..';
 import { pagerSummary } from '../../locators/pager';
 

--- a/src/components/toast/toast.stories.js
+++ b/src/components/toast/toast.stories.js
@@ -34,3 +34,85 @@ export const Basic = () => {
     </Toast>
   );
 };
+
+export const Visual = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  const onDismissClick = () => {
+    setIsOpen(!isOpen);
+  };
+  const children = text('children', 'My text');
+
+  return (
+    <div>
+      <Toast
+        variant='info'
+        id='toast-quick-start'
+        open={ isOpen }
+        onDismiss={ onDismissClick }
+        targetPortalId='visual'
+      >
+        { children }
+      </Toast>
+      <Toast
+        variant='info'
+        targetPortalId='visual'
+      >
+        { children }
+      </Toast>
+      <Toast
+        variant='error'
+        targetPortalId='visual'
+        open={ isOpen }
+        onDismiss={ onDismissClick }
+      >
+        My Error
+      </Toast>
+      <Toast
+        variant='error'
+        targetPortalId='visual'
+        open={ isOpen }
+      >
+        My Error
+      </Toast>
+      <Toast
+        variant='warning'
+        targetPortalId='visual'
+        open={ isOpen }
+      >
+        My Warning
+      </Toast>
+      <Toast
+        variant='success'
+        targetPortalId='visual'
+        open={ isOpen }
+        onDismiss={ onDismissClick }
+      >
+        My Success
+      </Toast>
+      <Toast
+        variant='success'
+        targetPortalId='visual'
+        open={ isOpen }
+      >
+        My Success
+      </Toast>
+      <Toast
+        variant='warning'
+        targetPortalId='visual-center'
+        open={ isOpen }
+        onDismiss={ onDismissClick }
+        isCenter
+      >
+        My text
+      </Toast>
+    </div>
+  );
+};
+
+Visual.story = {
+  name: 'visual',
+  parameters: {
+    info: { disable: true },
+    docs: { page: null }
+  }
+};


### PR DESCRIPTION
### Proposed behaviour
Adds story for visual tests for applitool

![Screenshot 2020-06-01 at 13 20 02](https://user-images.githubusercontent.com/47245766/83408513-a1d5e800-a40a-11ea-9515-dfcb6426b7b0.png)


### Current behaviour
N/A

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Screenshots are included in the PR
- [x] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
<del>- [ ] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [x] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated
