### PR TITLE
feat(tile-select): create tile-select component - FE-2667

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -45,5 +45,7 @@
   "with_colspan": "--with-colspan",
   "with_row_header": "--with-row-header",
   "with_rowspan": "--with-rowspan",
-  "visual": "--visual"
+  "visual": "--visual",
+  "single_select": "--single-select",
+  "single_tile": "--single-tile"
 }

--- a/cypress/features/regression/designSystem/tileSelect.feature
+++ b/cypress/features/regression/designSystem/tileSelect.feature
@@ -1,0 +1,23 @@
+Feature: Design System TileSelect component
+  I want to test Design System TileSelect component
+
+  Background: Open Design System Search component page
+    Given I open Design Systems basic "Tile Select" component docs page
+
+  @positive
+  Scenario: Single tile is checked
+    When I click on single tile component
+    Then Single tile is checked
+      And Single tile has golden focus
+
+  @positive
+  Scenario: Single tile is deselect
+    Given I click on single tile component
+    When I click deselect button
+    Then Single tile is not check
+
+    @positive
+  Scenario: TileSelect is disabled
+    # commented because of BDD default scenario Given - When - Then
+    # When I open Design Systems basic "tile-select" component docs page
+    Then Tile is disabled

--- a/cypress/features/visual/tileSelect.feature
+++ b/cypress/features/visual/tileSelect.feature
@@ -1,0 +1,21 @@
+Feature: Tile Select component
+  I want to check that all examples of Tile Select component render correctly
+
+  @positive
+  @applitools
+  Scenario Outline: Check that basic Tile Select render correctly with theme set to <theme>
+    When I open design systems basic "Tile Select" component with theme "<theme>"
+    Then Element displays correctly
+    Examples:
+      | theme |
+      | mint  |
+
+  @positive
+  @applitools
+  Scenario Outline: Check that single Tile Select render correctly with theme set to <theme>
+    When I open design systems single_select "Tile Select" component with theme "<theme>"
+    Then Element displays correctly
+    Examples:
+      | theme  |
+      | aegean |
+      | none   |

--- a/cypress/locators/tileSelect/index.js
+++ b/cypress/locators/tileSelect/index.js
@@ -1,0 +1,8 @@
+import { SINGLE_TILE_SELECT_ID, TILE_SELECT_DATA_COMPONENT, SINGLE_SELECT_TILE_SELECT_ID } from './locators';
+
+export const singleTileSelectID = () => cy.iFrame(SINGLE_TILE_SELECT_ID);
+export const tileSelectDataComponent = () => singleTileSelectID().find(TILE_SELECT_DATA_COMPONENT);
+export const singleTileSelectInput = () => singleTileSelectID().find('input');
+export const deselectButton = () => tileSelectDataComponent().find('button');
+export const disabledTileSelect = () => cy.iFrame(SINGLE_SELECT_TILE_SELECT_ID)
+  .find(TILE_SELECT_DATA_COMPONENT).eq(2).find('input');

--- a/cypress/locators/tileSelect/locators.js
+++ b/cypress/locators/tileSelect/locators.js
@@ -1,0 +1,3 @@
+export const SINGLE_TILE_SELECT_ID = '[id="story--design-system-tile-select--single-tile"]';
+export const TILE_SELECT_DATA_COMPONENT = '[data-component="tile-select"]';
+export const SINGLE_SELECT_TILE_SELECT_ID = '[id="story--design-system-tile-select--single-select"]';

--- a/cypress/support/helper.js
+++ b/cypress/support/helper.js
@@ -30,6 +30,14 @@ export function visitComponentUrlByThemeKnobsStory(component, theme, sufix = '')
   cy.visit(`${prepareUrl(component, 'knobs', true, '')}&theme=${theme}${sufix}`);
 }
 
+export function visitComponentUrlByThemeByStory(component, story, theme, sufix = '') {
+  cy.visit(`${prepareUrl(component, story, true, '')}&theme=${theme}${sufix}`);
+}
+
+export function visitDesignSystemComponentUrlByThemeByStory(component, prefix, story, theme, sufix = '') {
+  cy.visit(`${prepareUrl(component, story, true, prefix)}&theme=${theme}${sufix}`);
+}
+
 export function visitFlatTableComponentNoiFrame(component, suffix = 'default', iFrameOnly = false, prefix = '', stickyRow = true, stickyHead = true, clickableRow = true) {
   cy.visit(`${prepareUrl(component, suffix, iFrameOnly, prefix, stickyRow, stickyHead, clickableRow)}&knob-hasHeaderRow=${stickyRow}&knob-hasStickyHead=${stickyHead}&knob-hasClickableRows=${clickableRow}`);
 }
@@ -156,8 +164,4 @@ export function keyCode(type) {
     Home: { keyCode: 36, which: 36 },
     End: { keyCode: 35, which: 35 },
   }[type];
-}
-
-export function visitComponentUrlByThemeByStory(component, story, theme, sufix = '') {
-  cy.visit(`${prepareUrl(component, story, true, '')}&theme=${theme}${sufix}`);
 }

--- a/cypress/support/step-definitions/themes-steps.js
+++ b/cypress/support/step-definitions/themes-steps.js
@@ -1,5 +1,5 @@
 import {
-  visitComponentUrlByTheme, visitComponentUrlByThemeKnobsStory, visitComponentUrlByThemeByStory,
+  visitComponentUrlByTheme, visitComponentUrlByThemeKnobsStory, visitComponentUrlByThemeByStory, visitDesignSystemComponentUrlByThemeByStory,
 } from '../helper';
 import { getComponentNoIframe, getElementNoIframe } from '../../locators';
 import { buttonToggleComponent, linkComponent, loaderComponent } from '../../locators/themes';
@@ -62,4 +62,8 @@ Then('Loader component css background color is set to {string}', (themeName) => 
 
 When('I open {string} component {word} story with theme {string}', (componentName, storyName, themeName) => {
   visitComponentUrlByThemeByStory(componentName, storyName, themeName);
+});
+
+Given('I open design systems {word} {string} component with theme {string}', (storyName, componentName, themeName) => {
+  visitDesignSystemComponentUrlByThemeByStory(componentName, 'design-system-', storyName, themeName);
 });

--- a/cypress/support/step-definitions/tile-select-step.js
+++ b/cypress/support/step-definitions/tile-select-step.js
@@ -1,0 +1,27 @@
+import {
+  singleTileSelectInput, tileSelectDataComponent, deselectButton, disabledTileSelect,
+} from '../../locators/tileSelect';
+
+When('I click on single tile component', () => {
+  singleTileSelectInput().click();
+});
+
+When('I click deselect button', () => {
+  deselectButton().click();
+});
+
+Then('Single tile is checked', () => {
+  singleTileSelectInput().should('have.attr', 'aria-checked', 'true');
+});
+
+Then('Single tile is not check', () => {
+  singleTileSelectInput().should('have.attr', 'aria-checked', 'false');
+});
+
+Then('Single tile has golden focus', () => {
+  tileSelectDataComponent().find('div').should('have.css', 'outline', 'rgb(255, 181, 0) solid 3px');
+});
+
+Then('Tile is disabled', () => {
+  disabledTileSelect().should('have.attr', 'disabled');
+});

--- a/src/components/tile-select/index.js
+++ b/src/components/tile-select/index.js
@@ -1,0 +1,2 @@
+export { default as TileSelect } from './tile-select.component.js';
+export { default as TileSelectGroup } from './tile-select-group.component.js';

--- a/src/components/tile-select/tile-select-group.component.js
+++ b/src/components/tile-select/tile-select-group.component.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import tagComponent from '../../utils/helpers/tags/tags';
+import TileSelect from './tile-select.component';
+import RadioButtonMapper from '../../__experimental__/components/radio-button/radio-button-mapper.component';
+import { StyledTileSelectFieldset, StyledGroupDescription } from './tile-select.style';
+
+const TileSelectGroup = (props) => {
+  const {
+    children, name, legend, description, onChange, onBlur, value, multiSelect
+  } = props;
+
+  let tiles;
+
+  if (multiSelect) {
+    tiles = children;
+  } else {
+    tiles = (
+      <RadioButtonMapper
+        name={ name }
+        onBlur={ onBlur }
+        onChange={ onChange }
+        value={ value }
+      >
+        {React.Children.map(children, child => React.cloneElement(child, { type: 'radio' }))}
+      </RadioButtonMapper>
+    );
+  }
+
+  return (
+    <StyledTileSelectFieldset
+      legend={ legend }
+      { ...tagComponent('tile-select-group', props) }
+      multiSelect={ multiSelect }
+    >
+      <StyledGroupDescription>
+        {description}
+      </StyledGroupDescription>
+      <div>
+        {tiles}
+      </div>
+    </StyledTileSelectFieldset>
+  );
+};
+
+TileSelectGroup.propTypes = {
+  /** The TileSelect components to be rendered in the group */
+  children: (props, propName, componentName) => {
+    let error;
+    const prop = props[propName];
+
+    React.Children.forEach(prop, (child) => {
+      if (TileSelect.displayName !== child.type.displayName) {
+        error = new Error(`\`${componentName}\` only accepts children of type \`${TileSelect.displayName}\`.`);
+      }
+    });
+
+    return error;
+  },
+  /** The content for the TileSelectGroup Legend */
+  legend: PropTypes.string,
+  /** Description to be rendered below the legend */
+  description: PropTypes.string,
+  /** The currently selected value - only for single select mode. */
+  value: PropTypes.string,
+  /** The name to apply to the input - only for single select mode. */
+  name: PropTypes.string,
+  /** A callback triggered when one of tiles is selected - only for single select mode. */
+  onChange: PropTypes.func,
+  /** A callback triggered when one of tiles is blurred - only for single select mode. */
+  onBlur: PropTypes.func,
+  /** When passed as true TileSelectGroup serves only visual purpose */
+  /** It wraps TileSelects in fieldset element and renders the legend and description props content */
+  /** onChange, onBlur, value, checked and name props are meant to be passed individually on each of the TileSelects */
+  multiSelect: PropTypes.bool
+};
+
+TileSelectGroup.defaultProps = {
+  multiSelect: false
+};
+
+export default TileSelectGroup;

--- a/src/components/tile-select/tile-select-group.d.ts
+++ b/src/components/tile-select/tile-select-group.d.ts
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+export interface TileSelectGroupProps {
+  /** The TileSelect components to be rendered in the group */
+  children: React.ReactNode;
+  /** The content for the TileSelectGroup Legend */
+  legend?: string;
+  /** Description to be rendered below the legend */
+  description?: string;
+  /** The currently selected value - only for single select mode. */
+  value?: string;
+  /** The name to apply to the input - only for single select mode. */
+  name?: string;
+  /** A callback triggered when one of tiles is selected - only for single select mode. */
+  onChange?: (ev: React.ChangeEvent<HTMLElement>) => void;
+  /** A callback triggered when one of tiles is blurred - only for single select mode. */
+  onBlur?: (ev: React.SyntheticEvent<HTMLElement>) => void;
+  /** When passed as true TileSelectGroup serves only visual purpose */
+  /** It wraps TileSelects in fieldset element and renders the legend and description props content */
+  /** onChange, onBlur, value, checked and name props are meant to be passed individually on each of the TileSelects */
+  multiSelect?: boolean;
+}
+
+declare const TileSelectGroup: React.FunctionComponent<TileSelectGroupProps>;
+
+export { TileSelectGroup };

--- a/src/components/tile-select/tile-select.component.js
+++ b/src/components/tile-select/tile-select.component.js
@@ -1,0 +1,136 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import I18n from 'i18n-js';
+import tagComponent from '../../utils/helpers/tags/tags';
+
+import {
+  StyledTileSelectContainer,
+  StyledTileSelect,
+  StyledTileSelectInput,
+  StyledTitleContainer,
+  StyledTitle,
+  StyledSubtitle,
+  StyledAdornment,
+  StyledDescription,
+  StyledDeselectButton
+} from './tile-select.style';
+
+const TileSelect = (props) => {
+  const {
+    onChange,
+    onBlur,
+    value,
+    name,
+    checked,
+    className,
+    disabled,
+    title,
+    subtitle,
+    description,
+    titleAdornment,
+    type,
+    id,
+    ...rest
+  } = props;
+
+  const handleDeselect = () => onChange({
+    target: {
+      ...(name && { name }),
+      ...(id && { id }),
+      value: null,
+      checked: false
+    }
+  });
+
+  return (
+    <StyledTileSelectContainer
+      checked={ checked }
+      className={ className }
+      disabled={ disabled }
+      { ...tagComponent('tile-select', props) }
+    >
+      <StyledTileSelectInput
+        onChange={ onChange }
+        onBlur={ onBlur }
+        checked={ checked }
+        name={ name }
+        type={ type }
+        value={ value }
+        disabled={ disabled }
+        aria-checked={ checked }
+        id={ id }
+        { ...rest }
+      />
+      <StyledTileSelect disabled={ disabled } checked={ checked }>
+        <StyledTitleContainer>
+          {title && (
+            <StyledTitle>
+              {title}
+            </StyledTitle>
+          ) }
+
+          {subtitle && (
+            <StyledSubtitle>
+              {subtitle}
+            </StyledSubtitle>
+          )}
+
+          {titleAdornment && (
+            <StyledAdornment>
+              {titleAdornment}
+            </StyledAdornment>
+          ) }
+        </StyledTitleContainer>
+        <StyledDescription>
+          {description}
+        </StyledDescription>
+      </StyledTileSelect>
+      {checked && (
+        <StyledDeselectButton
+          buttonType='tertiary'
+          size='small'
+          onClick={ handleDeselect }
+        >
+          {I18n.t('tileSelect.deselect', { defaultValue: 'Deselect' })}
+        </StyledDeselectButton>
+      ) }
+    </StyledTileSelectContainer>
+  );
+};
+
+TileSelect.defaultProps = {
+  checked: false,
+  type: 'checkbox'
+};
+
+TileSelect.propTypes = {
+  /** title of the TileSelect */
+  title: PropTypes.string,
+  /** adornment to be rendered next to the title */
+  titleAdornment: PropTypes.node,
+  /** subtitle of the TileSelect */
+  subtitle: PropTypes.string,
+  /** description of the TileSelect */
+  description: PropTypes.string,
+  /** disables the TileSelect input */
+  disabled: PropTypes.bool,
+  /** the value that is represented by this TileSelect */
+  value: PropTypes.string,
+  /** input id */
+  id: PropTypes.string,
+  /** input name */
+  name: PropTypes.string,
+  /** Callback triggered when user selects or deselects this tile */
+  onChange: PropTypes.func,
+  /** Callback triggered when the user blurrs this tile */
+  onBlur: PropTypes.func,
+  /** determines if this tile is selected or unselected */
+  checked: PropTypes.bool,
+  /** Custom classname passed to the root element of TileSelect */
+  className: PropTypes.string,
+  /** Type of the TileSelect input */
+  type: PropTypes.oneOf(['radio', 'checkbox'])
+};
+
+TileSelect.displayName = 'TileSelect';
+export default TileSelect;

--- a/src/components/tile-select/tile-select.d.ts
+++ b/src/components/tile-select/tile-select.d.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+export interface TileSelectProps {
+    /** title of the TileSelect */
+    title?: string;
+    /** adornment to be rendered next to the title */
+    titleAdornment?: React.ReactNode;
+    /** subtitle of the TileSelect */
+    subtitle?: string;
+    /** description of the TileSelect */
+    description?: string;
+    /** disables the TileSelect input */
+    disabled?: boolean;
+    /** the value that is represented by this TileSelect */
+    value?: string;
+    /** input id */
+    id?: string;
+    /** input name */
+    name?: string;
+    /** Callback triggered when user selects or deselects this tile */
+    onChange?: (ev: React.ChangeEvent<HTMLElement>) => void;
+    /** Callback triggered when the user blurrs this tile */
+    onBlur?: (ev: React.SyntheticEvent<HTMLElement>) => void;
+    /** determines if this tile is selected or unselected */
+    checked?: boolean;
+    /** Custom classname passed to the root element of TileSelect */
+    className?: string;
+     /** Type of the TileSelect input */
+    type: 'radio' | 'checkbox';
+}
+
+declare const TileSelect: React.FunctionComponent<TileSelectProps>;
+
+export { TileSelect };

--- a/src/components/tile-select/tile-select.spec.js
+++ b/src/components/tile-select/tile-select.spec.js
@@ -1,0 +1,193 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import RadioButtonMapper from '../../__experimental__/components/radio-button/radio-button-mapper.component';
+import { TileSelect, TileSelectGroup } from '.';
+import { baseTheme } from '../../style/themes';
+import tint from '../../style/utils/tint';
+
+import {
+  StyledTileSelectFieldset,
+  StyledTileSelectContainer,
+  StyledTileSelect,
+  StyledTileSelectInput,
+  StyledDeselectButton,
+  StyledTitle,
+  StyledSubtitle,
+  StyledAdornment,
+  StyledDescription
+} from './tile-select.style';
+import { assertStyleMatch } from '../../__spec_helper__/test-utils';
+
+const radioValues = ['val1', 'val2', 'val3'];
+
+describe('TileSelect', () => {
+  let wrapper;
+
+  const render = (props) => {
+    wrapper = mount(
+      <TileSelect { ...props } />
+    );
+  };
+
+  beforeEach(() => {
+    render();
+  });
+
+  it('TileSelect invokes passed onChange callback', () => {
+    const onChangeMock = jest.fn();
+    render({ onChange: onChangeMock });
+    wrapper.find(StyledTileSelectInput).prop('onChange')();
+    expect(onChangeMock).toHaveBeenCalled();
+  });
+
+  it('renders deselect button when TileSelect is checked', () => {
+    render({ checked: true });
+    expect(wrapper.find(StyledDeselectButton).exists()).toBe(true);
+  });
+
+  it('clicking on the deselect button invokes passed onChange callback', () => {
+    const onChangeMock = jest.fn();
+    render({
+      onChange: onChangeMock, checked: true, id: 'id', name: 'name'
+    });
+    wrapper.find(StyledDeselectButton).prop('onClick')();
+    expect(onChangeMock).toHaveBeenCalledWith({
+      target: {
+        id: 'id',
+        name: 'name',
+        value: null,
+        checked: false
+      }
+    });
+  });
+
+  it('renders title element when title prop is passed', () => {
+    render({ title: 'Title' });
+    expect(wrapper.find(StyledTitle).prop('children')).toBe('Title');
+  });
+
+  it('renders subtitle element when subtitle prop is passed', () => {
+    render({ subtitle: 'Subtitle' });
+    expect(wrapper.find(StyledSubtitle).prop('children')).toBe('Subtitle');
+  });
+
+  it('renders title adornment element when titleAdornment prop is passed', () => {
+    const MyComp = () => <div />;
+    render({ titleAdornment: <MyComp /> });
+    expect(wrapper.find(StyledAdornment).find(MyComp).exists()).toBe(true);
+  });
+
+  describe('styles', () => {
+    it('renders proper colors when TileSelect is checked', () => {
+      render({ checked: true });
+      assertStyleMatch({
+        borderColor: baseTheme.colors.primary,
+        background: tint(baseTheme.colors.primary)(95),
+        zIndex: '10'
+      }, wrapper.find(StyledTileSelect));
+    });
+
+    it('renders component with proper background and proper text color when disabled', () => {
+      render({ disabled: true });
+      assertStyleMatch({
+        background: baseTheme.tileSelect.disabledBackground
+      }, wrapper.find(StyledTileSelect));
+
+      [StyledTitle, StyledSubtitle, StyledDescription].forEach((Component) => {
+        assertStyleMatch({
+          color: baseTheme.tileSelect.disabledText
+        }, wrapper.find(StyledTileSelect), { modifier: ` ${Component}` });
+      });
+
+      assertStyleMatch({
+        color: baseTheme.colors.black,
+        fill: baseTheme.colors.black,
+        opacity: '0.3'
+      }, wrapper.find(StyledTileSelect), { modifier: ` ${StyledAdornment} *` });
+    });
+
+    it('renders proper background when hovered', () => {
+      assertStyleMatch({
+        background: baseTheme.tileSelect.hoverBackground
+      }, wrapper.find(StyledTileSelectContainer), { modifier: `&:hover ${StyledTileSelect}` });
+    });
+
+    it('renders proper outline when focused', () => {
+      assertStyleMatch({
+        outline: `3px solid ${baseTheme.colors.focus}`,
+        zIndex: '15'
+      }, wrapper.find(StyledTileSelectInput), { modifier: `&:focus + ${StyledTileSelect}` });
+    });
+  });
+});
+
+describe('TileSelectGroup', () => {
+  let wrapper;
+
+  const render = (props) => {
+    wrapper = mount(
+      <TileSelectGroup
+        name='TileSelectGroup'
+        legend='Radio Tile Group'
+        onBlur={ jest.fn() }
+        onChange={ jest.fn() }
+        { ...props }
+      >
+        {radioValues.map((value, index) => (
+          <TileSelect
+            id={ `rId-${index}` }
+            key={ `radio-key-${value}` }
+            value={ value }
+          />
+        ))}
+      </TileSelectGroup>
+    );
+  };
+
+  beforeEach(() => {
+    render();
+  });
+
+  describe('in default single select mode', () => {
+    it('renders children wrapped by RadioButtonMapper', () => {
+      expect(wrapper.find(RadioButtonMapper).exists()).toBe(true);
+    });
+
+    it('children have prop type="radio" passed on', () => {
+      wrapper.find(TileSelect).forEach((node) => {
+        expect(node.prop('type')).toBe('radio');
+      });
+    });
+  });
+
+  describe('in multi select mode', () => {
+    it('renders children not wrapped by RadioButtonMapper', () => {
+      render({ multiSelect: true });
+      expect(wrapper.find(RadioButtonMapper).exists()).toBe(false);
+    });
+
+    it('tiles are spaced by 8px vertically', () => {
+      render({ multiSelect: true });
+      assertStyleMatch({
+        marginBottom: '8px'
+      }, wrapper.find(StyledTileSelectFieldset), { modifier: `${StyledTileSelectContainer}` });
+    });
+  });
+  describe('propTypes', () => {
+    it('validates the incorrect children prop', () => {
+      jest.spyOn(global.console, 'error').mockImplementation(() => {});
+
+      mount(
+        <TileSelectGroup legend='Legend'>
+          <p>Invalid children</p>
+          <p>Invalid children</p>
+        </TileSelectGroup>
+      );
+
+      const expected = 'Warning: Failed prop type: `TileSelectGroup` only accepts children of'
+        + ' type `TileSelect`.\n    in TileSelectGroup';
+
+      expect(console.error).toHaveBeenCalledWith(expected); // eslint-disable-line no-console
+    });
+  });
+});

--- a/src/components/tile-select/tile-select.stories.mdx
+++ b/src/components/tile-select/tile-select.stories.mdx
@@ -1,0 +1,217 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import { useState } from 'react';
+
+import { TileSelect, TileSelectGroup } from '.';
+import Pill from "../pill/"
+import Icon from '../icon';
+
+<Meta
+  title="Design System/Tile Select"
+  parameters={{ info: { disable: true }}}
+/>
+
+# TileSelect
+Tile Select is an input visualized as a single or grouped set of tiles. It behaves like a `radio` or a `checkbox` depending on the mode it operates in.
+
+## Quick Start
+
+To use this component, import the `TileSelect` and `TileSelectGroup` if you want to have `TileSelects` grouped.
+
+```jsx
+import { TileSelectGroup, TileSelect } from "carbon-react/lib/components/radio-tile"
+
+const MyComponent = () => (
+  const [value, setValue] = useState(null);
+  <TileSelectGroup
+    name="MyInputName"
+    value={value}
+    legend="Tile Select"
+    description="Pick one of the available options"
+    onChange={(e) => setValue(e.target.value)}
+  >
+    <TileSelect 
+      value="1"
+      title="Title"
+      subtitle="Subtitle"
+      description="Short and descriptive description"
+    />
+    <TileSelect 
+      value="2"
+      title="Title"
+      subtitle="Subtitle"
+      titleAdornment={<Pill>Message</Pill>}
+      description="Short and descriptive description"
+    />
+  </TileSelectGroup>
+);
+```
+
+## Examples
+
+### Single Select
+
+By default, when grouped with the `TileSelectGroup`, this component operates in single select mode and `TileSelect` inputs are of type `radio`.
+
+In this mode all input props like `onChange`, `onBlur`, `name` and currently selected `value` are meant to be passed on the `TileSelectGroup`.
+These props are then internally distributed on each of the `TileSelects` making the whole composed group act like a single form field.
+
+<Preview>
+  <Story name="Basic">
+    {() => {
+      const [value, setValue] = useState(null);
+      return (
+        <TileSelectGroup
+          name="Tile Select"
+          value={value}
+          legend="Tile Select"
+          description="Pick one of the available options"
+          onChange={(e) => setValue(e.target.value)}
+        >
+          <TileSelect 
+            value="1"
+            id="1"
+            aria-label="1"
+            title="Title"
+            subtitle="Subtitle"
+            description="Short and descriptive description"
+          />
+          <TileSelect 
+            value="2"
+            id="2"
+            aria-label="2"
+            title="Title"
+            subtitle="Subtitle"
+            titleAdornment={<Pill>Message</Pill>}
+            description="Short and descriptive description"
+          />
+          <TileSelect 
+            value="3"
+            id="3"
+            aria-label="3"
+            disabled
+            title="Title" 
+            subtitle="Subtitle"
+            titleAdornment={<Icon type='info' tooltipMessage="Short and non descriptive message" />}
+            description="Short and descriptive description"
+          />
+          <TileSelect 
+            value="4"
+            id="4"
+            aria-label="4"
+            title="Title"
+            subtitle="Subtitle"
+            titleAdornment={<Icon type='info' tooltipMessage="Short and non descriptive message" />}
+            description="Short and descriptive description"
+          />
+        </TileSelectGroup>
+      )
+    }}
+  </Story>
+</Preview>
+
+### Multi select
+To enable multi select mode on a `TileSelectGroup` `multiSelect` boolean prop has to be passed as `true`, `TileSelects` in this mode are of type `checkbox`.
+
+In multi select mode all input props like `onChange`, `onBlur`, `name`, `value` and `checked` are meant to be passed individually on each of the `TileSelects` instead of on the `TileSelectGroup`.
+
+In this mode `TileSelectGroup` serves only a visual purpose - it only renders `legend` and `description` props and applies spacing to each of the `TileSelects`
+
+<Preview>
+  <Story name="Single Select">
+    {() => {
+      const [value1, setValue1] = useState(false);
+      const [value2, setValue2] = useState(false);
+      const [value3, setValue3] = useState(false);
+      const [value4, setValue4] = useState(false);
+      return (
+        <TileSelectGroup
+          legend="Tile Select"
+          description="Pick any number of available options"
+          multiSelect
+        >
+          <TileSelect 
+            value="1"
+            name="multi-1"
+            id="multi-1"
+            aria-label="multi-1"
+            title="Title"
+            subtitle="Subtitle"
+            description="Short and descriptive description"
+            checked={value1}
+            onChange={e => setValue1(e.target.checked)}
+          />
+          <TileSelect
+            value="2"
+            name="multi-2"
+            id="multi-2"
+            aria-label="multi-2"
+            subtitle="Subtitle"
+            titleAdornment={<Pill>Message</Pill>}
+            description="Short and descriptive description"
+            checked={value2}
+            onChange={e => setValue2(e.target.checked)}
+          />
+          <TileSelect
+            value="3"
+            name="multi-3"
+            id="multi-3"
+            aria-label="multi-3"
+            disabled
+            title="Title" 
+            subtitle="Subtitle"
+            titleAdornment={<Icon type='info' tooltipMessage="Short and non descriptive message" />}
+            description="Short and descriptive description"
+            checked={value3}
+            onChange={e => setValue3(e.target.checked)}
+          />
+          <TileSelect
+            value="4"
+            name="multi-4"
+            id="multi-4"
+            aria-label="multi-4"
+            title="Title"
+            subtitle="Subtitle"
+            titleAdornment={<Icon type='info' tooltipMessage="Short and non descriptive message" />}
+            description="Short and descriptive description"
+            checked={value4}
+            onChange={e => setValue4(e.target.checked)}
+          />
+        </TileSelectGroup>
+      )
+    }}
+  </Story>
+</Preview>
+
+### Single tile
+`TileSelect` can be also used as a single component - it operates as a type `checkbox` by default.
+
+Same as in multi select example grouped by `TileSelectGroup`, `onChange`, `onBlur`, `name`, `value` and `checked` are meant to be passed directly on the `TileSelect`.
+
+<Preview>
+  <Story name="Single tile">
+    {() => {
+      const [isChecked, setIsChecked] = useState(false);
+      return (
+        <TileSelect 
+          value="1"
+          id="single-1"
+          aria-label="single-1"
+          name="single"
+          title="Title"
+          subtitle="Subtitle"
+          description="Short and descriptive description"
+          checked={isChecked}
+          onChange={e => setIsChecked(e.target.checked)}
+        />
+      )
+    }}
+  </Story>
+</Preview>
+
+## Props
+
+### TileSelect
+<Props of={TileSelect} />
+
+### TileSelectGroup
+<Props of={TileSelectGroup} />

--- a/src/components/tile-select/tile-select.style.js
+++ b/src/components/tile-select/tile-select.style.js
@@ -1,0 +1,155 @@
+import styled, { css } from 'styled-components';
+import Fieldset from '../../__experimental__/components/fieldset';
+import { Input } from '../../__experimental__/components/input';
+import Button from '../button';
+import tint from '../../style/utils/tint';
+
+import { LegendContainerStyle } from '../../__experimental__/components/fieldset/fieldset.style';
+import { baseTheme } from '../../style/themes';
+
+const StyledTitle = styled.h3`
+  font-size: 16px;
+  font-weight: 900;
+  margin: 0;
+  margin-right: 16px;
+`;
+
+const StyledSubtitle = styled.h4`
+  font-size: 14px;
+  font-weight: 700;
+  margin: 0;
+  margin-right: 16px;
+`;
+
+const StyledAdornment = styled.div`
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 500;
+`;
+
+const StyledDescription = styled.p`
+  color: ${({ theme }) => theme.tileSelect.descriptionColor};
+  font-size: 14px;
+  margin: 0;
+`;
+
+const StyledTileSelect = styled.div`
+  position: relative;
+  border: 1px solid ${({ theme }) => theme.tileSelect.border};
+  background-color: ${({ theme }) => theme.colors.white};
+  padding: 24px;
+  ${({ checked, theme }) => checked && css`
+    border-color: ${theme.colors.primary};
+    background: ${tint(theme.colors.primary)(95)};
+    z-index: 10;
+  `}
+  ${({ disabled, theme }) => disabled && css`
+    background: ${theme.tileSelect.disabledBackground};
+    ${StyledTitle}, ${StyledSubtitle}, ${StyledDescription} {
+      color: ${theme.tileSelect.disabledText};
+    }
+    ${StyledAdornment} * {
+      color: ${theme.colors.black};
+      fill: ${theme.colors.black};
+      opacity: 0.3;
+    }
+  `};
+`;
+
+const StyledTileSelectContainer = styled.div`
+  width: 100%;
+  position: relative;
+  & + & ${StyledTileSelect} {
+    margin-top: -1px;
+  }
+  ${({ checked, disabled, theme }) => !checked && !disabled && css`
+    &:hover ${StyledTileSelect} {
+      background: ${theme.tileSelect.hoverBackground};
+    }
+  `}
+`;
+
+const StyledTileSelectInput = styled(Input)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  z-index: 100;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  &:focus + ${StyledTileSelect}  {
+    outline: 3px solid ${({ theme }) => theme.colors.focus};
+    z-index: 15;
+  }
+`;
+
+const StyledTitleContainer = styled.div`
+  display: inline-flex;
+  align-items: flex-end;
+  margin-bottom: 8px;
+  position: relative;
+`;
+
+const StyledDeselectButton = styled(Button)`
+  position: absolute;
+  top: 16px;
+  right: 8px;
+  z-index: 200
+`;
+
+const StyledTileSelectFieldset = styled(Fieldset)`
+  ${LegendContainerStyle} {
+    margin-bottom: 16px;
+    legend {
+      font-size: 16px;
+      line-height: 16px;
+      margin-left: -2px;
+    } 
+  }
+  ${({ multiSelect }) => multiSelect && css`
+    ${StyledTileSelectContainer} {
+      margin-bottom: 8px;
+    }
+  `}
+`;
+
+const StyledGroupDescription = styled.p`
+  color: ${({ theme }) => theme.tileSelect.descriptionColor};
+  margin: 0;
+  margin-bottom: 16px;
+`;
+
+
+StyledTileSelect.defaultProps = {
+  theme: baseTheme
+};
+StyledTileSelectContainer.defaultProps = {
+  theme: baseTheme
+};
+StyledGroupDescription.defaultProps = {
+  theme: baseTheme
+};
+StyledTileSelectInput.defaultProps = {
+  theme: baseTheme
+};
+StyledDescription.defaultProps = {
+  theme: baseTheme
+};
+
+export {
+  StyledTileSelectFieldset,
+  StyledGroupDescription,
+  StyledTileSelectContainer,
+  StyledTileSelect,
+  StyledTileSelectInput,
+  StyledTitleContainer,
+  StyledTitle,
+  StyledSubtitle,
+  StyledAdornment,
+  StyledDescription,
+  StyledDeselectButton
+};

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -56,6 +56,14 @@ export default (palette) => {
       background: palette.slateTint(90)
     },
 
+    tileSelect: {
+      border: palette.slateTint(75),
+      disabledBackground: palette.slateTint(90),
+      hoverBackground: palette.slateTint(95),
+      descriptionColor: blackWithOpacity(0.55),
+      disabledText: blackWithOpacity(0.3)
+    },
+
     batchSelection: {
       lightTheme: palette.slateTint(70)
     },


### PR DESCRIPTION
### Proposed behaviour
This PR introduces new `TileSelect` component

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- <del>[ ] Screenshots are included in the PR</del>
- [x] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
- [x] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [x] Storybook added or updated
- [x] Typescript `d.ts` file added or updated

### Additional context

Is a copy of https://github.com/Sage/carbon/pull/2942

### Testing instructions
Storybook -> Design System -> TileSelect
