### PR TITLE
fix(menu): fix to onclick menu style - FE-2816

### DIFF
--- a/cypress/features/regression/accessibility/accessibilityCommonSecondPart.feature
+++ b/cypress/features/regression/accessibility/accessibilityCommonSecondPart.feature
@@ -9,7 +9,6 @@ Feature: Accessibility tests
     Examples:
       | component                        |
       | menulist                         |
-      | menu                             |
       | message                          |
       | mount-in-app                     |
       | multi-action-button              |

--- a/cypress/features/regression/accessibility/accessibilityDesignSystem.feature
+++ b/cypress/features/regression/accessibility/accessibilityDesignSystem.feature
@@ -37,6 +37,7 @@ Feature: Accessibility tests
       | Pager                 |
       | Search                |
       | Toast                 |
+      | Menu                  |
 
   @accessibility
   Scenario Outline: Design System <component> component controlled page

--- a/cypress/features/regression/test/menu.feature
+++ b/cypress/features/regression/test/menu.feature
@@ -2,7 +2,13 @@ Feature: Menu component
   I want to change Menu component default properties
 
   Background: Open Menu component default page
-    Given I open "Menu" component page
+    Given I open basic Test "Menu" component page
+
+  @positive
+  Scenario: Verify the click function for a Menu component
+    Given clear all actions in Actions Tab
+    When I click on first item in Menu component
+    Then onClick action was called in Actions Tab
 
   @positive
   Scenario Outline: Change Menu 'as' property to <as>

--- a/cypress/features/visual/menu.feature
+++ b/cypress/features/visual/menu.feature
@@ -1,0 +1,10 @@
+Feature: Menu component
+  I want to check that all examples of Menu component render correctly
+
+  @positive
+  @applitools
+  Scenario: Check that Menu component visual story rendered correctly
+    When I open visual Test "Menu" component page in noIframe
+      And I invoke "second" expandable Menu component noIfame
+      And I invoke "fourth" expandable Menu component noIfame
+    Then Element displays correctly

--- a/cypress/locators/menu/index.js
+++ b/cypress/locators/menu/index.js
@@ -4,6 +4,13 @@ import { MENU_PREVIEW, SUBMENU_BLOCK } from './locators';
 export const menuPreview = () => cy.iFrame(MENU_PREVIEW);
 export const menuListItems = index => cy.iFrame(MENU_PREVIEW)
   .find(`ul[class="carbon-menu__items"] > li:nth-child(${index})`);
+export const menuListItemButton = index => cy.iFrame(MENU_PREVIEW).find(`
+  ul.carbon-menu__items > li:nth-child(${index}) > div.carbon-menu-item--has-link > button
+`);
 export const submenuBlock = (firstLiIndex, secondLiIndex) => cy.iFrame(SUBMENU_BLOCK)
   .find(`li:nth-child(${firstLiIndex}) > div > ul`)
   .find(`li:nth-child(${secondLiIndex}) > div`).children();
+
+// component preview no IFrame
+export const menuListItemsNoIFrame = index => cy.get(MENU_PREVIEW)
+  .find(`ul[class="carbon-menu__items"] > li:nth-child(${index}) > div > ul`);

--- a/cypress/support/step-definitions/menu-steps.js
+++ b/cypress/support/step-definitions/menu-steps.js
@@ -1,5 +1,5 @@
 import {
-  menuPreview, menuListItems, submenuBlock,
+  menuPreview, menuListItems, submenuBlock, menuListItemButton, menuListItemsNoIFrame,
 } from '../../locators/menu';
 import { positionOfElement } from '../helper';
 
@@ -13,8 +13,16 @@ Then('Menu elements are visible', () => {
   menuPreview().should('be.visible');
 });
 
+When('I click on first item in Menu component', () => {
+  menuListItemButton(positionOfElement('second')).click();
+});
+
 When('I invoke first expandable Menu component', () => {
   menuListItems(positionOfElement('second')).trigger('mouseover');
+});
+
+When('I invoke {string} expandable Menu component noIfame', (menuListItem) => {
+  menuListItemsNoIFrame(positionOfElement(menuListItem)).invoke('attr', 'style', 'display: block !important;');
 });
 
 When('I invoke second expandable Menu component', () => {

--- a/src/components/menu/menu-item/menu-item.scss
+++ b/src/components/menu/menu-item/menu-item.scss
@@ -144,6 +144,23 @@
       }
     }
   }
+
+  &.carbon-menu-item--has-link {
+    button {
+      font-weight: 700;
+      color: $slate;
+      text-decoration: none;
+      height: 100%;
+
+      &:focus {
+        background-color: transparent;
+      }
+
+      .carbon-link__content {
+        text-decoration: none;
+      }
+    }
+  }
 }
 
 .carbon-menu-item--has-submenu {

--- a/src/components/menu/menu.stories.js
+++ b/src/components/menu/menu.stories.js
@@ -1,37 +1,133 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { Link as RouterLink } from 'react-router';
+import { action } from '@storybook/addon-actions';
 import { select } from '@storybook/addon-knobs';
-import { dlsThemeSelector, classicThemeSelector } from '../../../.storybook/theme-selectors';
 import OptionsHelper from '../../utils/helpers/options-helper';
-import notes from './documentation';
 import { Menu, MenuItem, SubmenuBlock } from './menu';
-import getDocGenInfo from '../../utils/helpers/docgen-info';
 
-Menu.__docgenInfo = getDocGenInfo(
-  require('./docgenInfo.json'),
-  /menu(?!spec)/
-);
+export default {
+  component: Menu,
+  title: 'Test/Menu',
+  parameters: {
+    info: { disable: true }
+  }
+};
 
-MenuItem.__docgenInfo = getDocGenInfo(
-  require('./menu-item/docgenInfo.json'),
-  /menu-item(?!spec)/
-);
+export const Basic = () => {
+  const as = select('as', OptionsHelper.themesBinary, Menu.defaultProps.as);
+  const handleOnClick = (e) => {
+    action('onClick')(e);
+  };
 
-SubmenuBlock.__docgenInfo = getDocGenInfo(
-  require('./submenu-block/docgenInfo.json'),
-  /submenu-block(?!spec)/
-);
+  return (
+    <Menu
+      as={ as }
+    >
+      <MenuItem onClick={ handleOnClick }>
+        Item One
+      </MenuItem>
+      <MenuItem submenu='Item Two'>
+        <SubmenuBlock>
+          <MenuItem href='#'>Sub Menu Item One</MenuItem>
+          <MenuItem href='#'>Sub Menu Item Two</MenuItem>
+        </SubmenuBlock>
+      </MenuItem>
+      <MenuItem submenu='Item Two'>
+        <MenuItem href='#'>Sub Menu Item One</MenuItem>
+        <SubmenuBlock>
+          <MenuItem icon='settings' href='#'>Sub Menu Item Two</MenuItem>
+          <MenuItem href='#'>Sub Menu Item Three</MenuItem>
+          <MenuItem divide href='#'>Sub Menu Item Four</MenuItem>
+        </SubmenuBlock>
+      </MenuItem>
+    </Menu>
+  );
+};
 
-function makeStory(name, themeSelector) {
-  const component = () => {
-    const as = select('as', OptionsHelper.themesBinary, Menu.defaultProps.as);
+Basic.story = {
+  name: 'basic'
+};
 
-    return (
+export const Visual = () => {
+  const handleOnClick = (e) => {
+    action('onClick')(e);
+  };
+  return (
+    <>
       <Menu
-        as={ as }
+        as='primary'
       >
+        <MenuItem icon='settings'>
+          Item with icon settings
+        </MenuItem>
+        <MenuItem
+          to='#'
+          routerLink={ RouterLink }
+        >
+          Item with `to`
+        </MenuItem>
+        <MenuItem
+          submenuDirection='left'
+          submenu='Item submenu direction left'
+        >
+          <SubmenuBlock>
+            <MenuItem href='#'>Sub Menu Item One</MenuItem>
+            <MenuItem href='#'>Sub Menu Item Two</MenuItem>
+          </SubmenuBlock>
+        </MenuItem>
         <MenuItem>
           Item One
+        </MenuItem>
+        <MenuItem
+          submenu='Selected Submenu'
+        >
+          <SubmenuBlock>
+            <MenuItem href='#'>Sub Menu Item One</MenuItem>
+            <MenuItem divide href='#'>Sub Menu Item Two</MenuItem>
+          </SubmenuBlock>
+        </MenuItem>
+        <MenuItem
+          selected
+          submenu='Selected Submenu'
+        >
+          <SubmenuBlock>
+            <MenuItem href='#'>Sub Menu Item One</MenuItem>
+            <MenuItem href='#'>Sub Menu Item Two</MenuItem>
+          </SubmenuBlock>
+        </MenuItem>
+        <MenuItem onClick={ handleOnClick }>
+          Item with onClick callback
+        </MenuItem>
+        <MenuItem to='#'>
+          Item with `to`
+        </MenuItem>
+      </Menu>
+      <hr style={ { marginTop: '100px' } } />
+      <Menu>
+        <MenuItem submenu='Item Two'>
+          <MenuItem href='#'>Sub Menu Item One</MenuItem>
+          <SubmenuBlock>
+            <MenuItem
+              icon='settings'
+              href='#'
+            >
+              Sub Menu Item Two
+            </MenuItem>
+            <MenuItem href='#'>Sub Menu Item Three</MenuItem>
+            <MenuItem
+              divide
+              href='#'
+            >
+              Sub Menu Item Four
+            </MenuItem>
+          </SubmenuBlock>
+        </MenuItem>
+        <MenuItem
+          to='#'
+          routerLink={ RouterLink }
+          target='_blank'
+        >
+          Item with `to`
         </MenuItem>
         <MenuItem submenu='Item Two'>
           <SubmenuBlock>
@@ -39,26 +135,43 @@ function makeStory(name, themeSelector) {
             <MenuItem href='#'>Sub Menu Item Two</MenuItem>
           </SubmenuBlock>
         </MenuItem>
-        <MenuItem submenu='Item Two'>
-          <MenuItem href='#'>Sub Menu Item One</MenuItem>
+      </Menu>
+      <hr style={ { marginTop: '200px' } } />
+      <Menu
+        as='secondary'
+      >
+        <MenuItem submenu='Item One'>
           <SubmenuBlock>
-            <MenuItem icon='settings' href='#'>Sub Menu Item Two</MenuItem>
+            <MenuItem href='#'>Sub Menu Item One</MenuItem>
+            <MenuItem href='#'>Sub Menu Item Two</MenuItem>
+          </SubmenuBlock>
+        </MenuItem>
+        <MenuItem>
+          Item Two
+        </MenuItem>
+        <MenuItem submenu='Item Three'>
+          <MenuItem href='#'>Sub Menu Item Three</MenuItem>
+          <SubmenuBlock>
+            <MenuItem
+              icon='settings'
+              href='#'
+            >
+              Sub Menu Item Three
+            </MenuItem>
             <MenuItem href='#'>Sub Menu Item Three</MenuItem>
-            <MenuItem divide href='#'>Sub Menu Item Four</MenuItem>
+            <MenuItem
+              divide
+              href='#'
+            >
+              Sub Menu Item Four
+            </MenuItem>
           </SubmenuBlock>
         </MenuItem>
       </Menu>
-    );
-  };
+    </>
+  );
+};
 
-  const metadata = {
-    themeSelector,
-    notes: { markdown: notes }
-  };
-
-  return [name, component, metadata];
-}
-
-storiesOf('Menu', module)
-  .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+Visual.story = {
+  name: 'visual'
+};

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -1,0 +1,123 @@
+import {
+  Meta,
+  Props,
+  Preview,
+  Story
+} from '@storybook/addon-docs/blocks';
+import {
+  Menu,
+  MenuItem,
+  SubmenuBlock
+} from './menu';
+import { useState, useCallback } from 'react';
+import { text, object } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+
+<Meta title="Design System/Menu" />
+
+# Menu
+Menu Navigation
+
+```javascript
+import { Menu, MenuItem, SubmenuBlock } from 'carbon-react/lib/components/menu';
+```
+
+### Primary usage:
+
+<Preview>
+  <Story name="primary" parameters={{ info: { disable: true }}} >
+      {() => {
+        const handleOnClick = (e) => {
+          action('onClick')(e);
+        };
+        return (
+          <div style={ { height: '200px' } }>
+            <Menu as="primary">
+              <MenuItem onClick={ handleOnClick }>
+                Item One
+              </MenuItem>
+              <MenuItem submenu='Item Two'>
+                <SubmenuBlock>
+                  <MenuItem href='#'>Sub Menu Item One</MenuItem>
+                  <MenuItem href='#'>Sub Menu Item Two</MenuItem>
+                </SubmenuBlock>
+              </MenuItem>
+              <MenuItem submenu='Item Two'>
+                <MenuItem href='#'>Sub Menu Item One</MenuItem>
+                <SubmenuBlock>
+                  <MenuItem icon='settings' href='#'>Sub Menu Item Two</MenuItem>
+                  <MenuItem href='#'>Sub Menu Item Three</MenuItem>
+                  <MenuItem divide href='#'>Sub Menu Item Four</MenuItem>
+                </SubmenuBlock>
+              </MenuItem>
+            </Menu>
+          </div>
+        );
+      }}
+  </Story>
+</Preview>
+
+### Secondary usage:
+
+<Preview>
+  <Story name="secondary" parameters={{ info: { disable: true }}} >
+      {() => {
+        const handleOnClick = (e) => {
+          action('onClick')(e);
+        };
+        return (
+          <div style={ { height: '200px' } }>
+            <Menu as="secondary">
+              <MenuItem onClick={ handleOnClick }>
+                Item One
+              </MenuItem>
+              <MenuItem submenu='Item Two'>
+                <SubmenuBlock>
+                  <MenuItem href='#'>Sub Menu Item One</MenuItem>
+                  <MenuItem href='#'>Sub Menu Item Two</MenuItem>
+                </SubmenuBlock>
+              </MenuItem>
+              <MenuItem submenu='Item Two'>
+                <MenuItem href='#'>Sub Menu Item One</MenuItem>
+                <SubmenuBlock>
+                  <MenuItem icon='settings' href='#'>Sub Menu Item Two</MenuItem>
+                  <MenuItem href='#'>Sub Menu Item Three</MenuItem>
+                  <MenuItem divide href='#'>Sub Menu Item Four</MenuItem>
+                </SubmenuBlock>
+              </MenuItem>
+            </Menu>
+          </div>
+        );
+      }}
+  </Story>
+</Preview>
+
+### Default usage:
+
+<Preview>
+  <Story name="default" parameters={{ info: { disable: true }}} >
+      {() => {
+        const handleOnClick = (e) => {
+          action('onClick')(e);
+        };
+        return (
+          <div style={ { height: '200px' } }>
+            <Menu>
+              <MenuItem onClick={ handleOnClick }>
+                Item One
+              </MenuItem>
+              <MenuItem onClick={ handleOnClick }>
+                Item Two
+              </MenuItem>
+            </Menu>
+          </div>
+        );
+      }}
+  </Story>
+</Preview>
+
+## Props:
+
+### Menu
+
+<Props of={Menu} />


### PR DESCRIPTION
Fixes #2903
Fixes FE-2816

### Proposed behaviour
Fixes menu item styling for items with `onClick` prop

![Screenshot 2020-06-05 at 18 16 20](https://user-images.githubusercontent.com/47245766/83904930-af67d680-a758-11ea-929c-f363dd1531a2.png)

### Current behaviour
Wrong styling as per example: https://codesandbox.io/s/optimistic-pike-wpju5?file=/src/App.js

![Screenshot 2020-06-05 at 18 15 49](https://user-images.githubusercontent.com/47245766/83904892-9e1eca00-a758-11ea-839c-3efc928031b9.png)


### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Screenshots are included in the PR
- [ ] Carbon implementation and Design System documentation are congruent
<del>- [ ] All themes are supported
- [x] Commits follow our style guide
- [x] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [x] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated

### Testing instructions
http://localhost:9001/?path=/story/design-system-menu--default-story
