### PR TITLE
fix(storybook): fix alignment of theme selector FE-2832

### DIFF
--- a/.storybook/theme-selector/register.js
+++ b/.storybook/theme-selector/register.js
@@ -24,7 +24,7 @@ addons.register('sage/theme-switcher', api => {
 
 const IconButtonWithLabel = styled(IconButton)`
   display: inline-flex;
-  alignItems: center;
+  align-items: center;
   cursor: ${({disabled}) => disabled ? 'not-allowed' : 'pointer'} !important;
 `;
 


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Fixes the alignment of the theme selector dropdown
### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
The theme selector dropdown is misaligned
### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Screenshots are included in the PR
<del>- [ ] Carbon implementation and Design System documentation are congruent<del>
<del>- [ ] All themes are supported<del>
- [x] Commits follow our style guide
<del>- [ ] Unit tests added or updated<del>
<del>- [ ] Cypress automation tests added or updated<del>
<del>- [ ] Storybook added or updated<del>
<del>- [ ] Typescript `d.ts` file added or updated<del>

### Additional context
<!-- Add any other context or links about the pull request here. -->

Before:
![image](https://user-images.githubusercontent.com/44157880/84125742-e7ab3580-aa34-11ea-8936-77102bf2da59.png)

After:
![image](https://user-images.githubusercontent.com/44157880/84125757-ef6ada00-aa34-11ea-932f-9a96d6337967.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
