### PR TITLE
fix(button-toggle): onBlur not being passed on button toggle input - FE-2860

### DIFF
--- a/src/components/button-toggle/button-toggle-input.component.js
+++ b/src/components/button-toggle/button-toggle-input.component.js
@@ -13,6 +13,7 @@ function ButtonToggleInput(props) {
       disabled={ props.disabled }
       checked={ props.checked }
       onChange={ props.onChange }
+      onBlur={ props.onBlur }
       value={ props.value }
     />
   );
@@ -29,8 +30,10 @@ ButtonToggleInput.propTypes = {
   guid: PropTypes.string,
   /** Value for the input */
   value: PropTypes.string,
-  /** Change handler passed in from parent. */
-  onChange: PropTypes.func
+  /** Callback triggered by change event on the input. */
+  onChange: PropTypes.func,
+  /** Callback triggered by blur event on the input. */
+  onBlur: PropTypes.func
 };
 
 export default ButtonToggleInput;

--- a/src/components/button-toggle/button-toggle.component.js
+++ b/src/components/button-toggle/button-toggle.component.js
@@ -20,6 +20,7 @@ const ButtonToggle = (props) => {
     buttonIcon,
     buttonIconSize,
     onChange,
+    onBlur,
     value,
     size
   } = props;
@@ -48,6 +49,7 @@ const ButtonToggle = (props) => {
         guid={ inputGuid }
         value={ value }
         onChange={ onChange }
+        onBlur={ onBlur }
       />
       <StyledButtonToggleLabel
         buttonIcon={ buttonIcon }
@@ -70,8 +72,10 @@ ButtonToggle.propTypes = {
   checked: PropTypes.bool,
   /** Name used on the hidden radio button. */
   name: PropTypes.string,
-  /** Change handler passed in from parent. */
+  /** Callback triggered by change event on the input. */
   onChange: PropTypes.func,
+  /** Callback triggered by blur event on the input. */
+  onBlur: PropTypes.func,
   /** buttonIcon to render. */
   buttonIcon: PropTypes.string,
   /** Sets the size of the buttonIcon (eg. large) */

--- a/src/components/button-toggle/button-toggle.spec.js
+++ b/src/components/button-toggle/button-toggle.spec.js
@@ -2,10 +2,10 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { ThemeProvider } from 'styled-components';
 import TestRenderer from 'react-test-renderer';
-import 'jest-styled-components';
 import guid from '../../utils/helpers/guid';
-import { classicTheme } from '../../style/themes';
+import { classicTheme, baseTheme } from '../../style/themes';
 import ButtonToggle from './button-toggle.component';
+import ButtonToggleInput from './button-toggle-input.component';
 import { assertStyleMatch, carbonThemesJestTable } from '../../__spec_helper__/test-utils';
 import { StyledButtonToggleIcon } from './button-toggle.style';
 
@@ -13,6 +13,30 @@ jest.mock('../../utils/helpers/guid');
 guid.mockImplementation(() => 'guid-12345');
 
 describe('ButtonToggle', () => {
+  describe('functionality', () => {
+    it('pass onChange props to input', () => {
+      const onChangeMock = jest.fn();
+      const wrapper = renderWithTheme({
+        theme: baseTheme,
+        onChange: onChangeMock
+      });
+
+      wrapper.find(ButtonToggleInput).prop('onChange')();
+      expect(onChangeMock.mock.calls.length).toBe(1);
+    });
+
+    it('pass onBlur props to input', () => {
+      const onBlurMock = jest.fn();
+      const wrapper = renderWithTheme({
+        theme: baseTheme,
+        onBlur: onBlurMock
+      });
+
+      wrapper.find(ButtonToggleInput).prop('onBlur')();
+      expect(onBlurMock.mock.calls.length).toBe(1);
+    });
+  });
+
   describe('Classic theme', () => {
     it('renders correctly with default settings', () => {
       const wrapper = renderWithTheme({ theme: classicTheme }, TestRenderer.create);

--- a/src/components/button-toggle/button-toggle.stories.js
+++ b/src/components/button-toggle/button-toggle.stories.js
@@ -32,6 +32,10 @@ function makeStory(name, themeSelector) {
       action('onChange')(ev);
     };
 
+    const onBlur = (ev) => {
+      action('onBlur')(ev);
+    };
+
     return (
       <div>
         <ButtonToggle
@@ -42,6 +46,7 @@ function makeStory(name, themeSelector) {
           disabled={ disabled }
           grouped={ grouped }
           onChange={ onChange }
+          onBlur={ onBlur }
           key='button-toggle-1'
         >
           {children}
@@ -54,6 +59,7 @@ function makeStory(name, themeSelector) {
           disabled={ disabled }
           grouped={ grouped }
           onChange={ onChange }
+          onBlur={ onBlur }
           key='button-toggle-2'
         >
           {children}
@@ -66,6 +72,7 @@ function makeStory(name, themeSelector) {
           disabled={ disabled }
           grouped={ grouped }
           onChange={ onChange }
+          onBlur={ onBlur }
           key='button-toggle-3'
         >
           {children}

--- a/src/components/button-toggle/docgenInfo.json
+++ b/src/components/button-toggle/docgenInfo.json
@@ -11,6 +11,15 @@
           },
           "required": false,
           "description": "buttonIcon to render."
+        },
+        "buttonIconSize": {
+          "type": {
+            "name": "enum",
+            "computed": true,
+            "value": "OptionsHelper.sizesBinary"
+          },
+          "required": false,
+          "description": "Sets the size of the buttonIcon (eg. large)"
         }
       }
     }
@@ -21,6 +30,13 @@
       "displayName": "ButtonToggleInput",
       "methods": [],
       "props": {
+        "checked": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Set the checked value of the radio button"
+        },
         "name": {
           "type": {
             "name": "string"
@@ -48,6 +64,13 @@
           },
           "required": false,
           "description": "Value for the input"
+        },
+        "onChange": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "Change handler passed in from parent."
         }
       }
     }
@@ -58,6 +81,13 @@
       "displayName": "ButtonToggle",
       "methods": [],
       "props": {
+        "checked": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Set the checked value of the radio button"
+        },
         "name": {
           "type": {
             "name": "string"
@@ -70,7 +100,14 @@
             "name": "func"
           },
           "required": false,
-          "description": "Change handler passed in from parent."
+          "description": "Callback triggered by change event on the input."
+        },
+        "onBlur": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "Callback triggered by blur event on the input."
         },
         "buttonIcon": {
           "type": {
@@ -81,10 +118,16 @@
         },
         "buttonIconSize": {
           "type": {
-            "name": "string"
+            "name": "enum",
+            "computed": true,
+            "value": "OptionsHelper.sizesBinary"
           },
           "required": false,
-          "description": "Sets the size of the buttonIcon (eg. large)"
+          "description": "Sets the size of the buttonIcon (eg. large)",
+          "defaultValue": {
+            "value": "'small'",
+            "computed": false
+          }
         },
         "size": {
           "type": {
@@ -117,6 +160,13 @@
           },
           "required": true,
           "description": "A required prop. This is the button text."
+        },
+        "defaultChecked": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Set the default value of the Group if component is meant to be used as uncontrolled."
         },
         "value": {
           "type": {


### PR DESCRIPTION
### Proposed behaviour
`onBlur` prop should be passed to the underlying `input` element in ButtonToggle component
### Current behaviour
`onBlur` prop is not passed to the underlying `input` element

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR</del>
- [x] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
- [x] Unit tests added or updated
- [ ] Cypress automation tests added or updated
- [x] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated</del>

### Testing instructions
Storybook -> Button Toggle -> default 
Focus on one of the ButtonToggles -> blur it -> check `actions` tab
