### PR TITLE
test: remove wait from applitools tests

### DIFF
--- a/cypress/features/visual/buttonDarkbackground.feature
+++ b/cypress/features/visual/buttonDarkbackground.feature
@@ -5,6 +5,7 @@ Feature: Button component - dark background type
   @applitools
   Scenario Outline: Check that dark background buttons render correctly with theme set to <theme>
     When I open "button" component dark_background_buttons story with theme "<theme>"
+    And the button story has loaded
     Then Element displays correctly
     Examples:
       | theme  |

--- a/cypress/features/visual/buttonDarkbackground.feature
+++ b/cypress/features/visual/buttonDarkbackground.feature
@@ -5,7 +5,7 @@ Feature: Button component - dark background type
   @applitools
   Scenario Outline: Check that dark background buttons render correctly with theme set to <theme>
     When I open "button" component dark_background_buttons story with theme "<theme>"
-    And the button story has loaded
+    # And the button story has loaded
     Then Element displays correctly
     Examples:
       | theme  |

--- a/cypress/features/visual/buttonDashed.feature
+++ b/cypress/features/visual/buttonDashed.feature
@@ -5,7 +5,7 @@ Feature: Button component - dashed type
   @applitools
   Scenario Outline: Check that dashed buttons render correctly with theme set to <theme>
     When I open "button" component dashed_buttons story with theme "<theme>"
-    And the button story has loaded
+    # And the button story has loaded
     Then Element displays correctly
     Examples:
       | theme  |

--- a/cypress/features/visual/buttonDashed.feature
+++ b/cypress/features/visual/buttonDashed.feature
@@ -5,6 +5,7 @@ Feature: Button component - dashed type
   @applitools
   Scenario Outline: Check that dashed buttons render correctly with theme set to <theme>
     When I open "button" component dashed_buttons story with theme "<theme>"
+    And the button story has loaded
     Then Element displays correctly
     Examples:
       | theme  |

--- a/cypress/features/visual/buttonPrimary.feature
+++ b/cypress/features/visual/buttonPrimary.feature
@@ -5,7 +5,7 @@ Feature: Button component - primary type
   @applitools
   Scenario Outline: Check that primary buttons render correctly with theme set to <theme>
     When I open "button" component primary_buttons story with theme "<theme>"
-    And the button story has loaded
+    # And the button story has loaded
     Then Element displays correctly
     Examples:
       | theme  |

--- a/cypress/features/visual/buttonPrimary.feature
+++ b/cypress/features/visual/buttonPrimary.feature
@@ -5,6 +5,7 @@ Feature: Button component - primary type
   @applitools
   Scenario Outline: Check that primary buttons render correctly with theme set to <theme>
     When I open "button" component primary_buttons story with theme "<theme>"
+    And the button story has loaded
     Then Element displays correctly
     Examples:
       | theme  |

--- a/cypress/features/visual/buttonSecondary.feature
+++ b/cypress/features/visual/buttonSecondary.feature
@@ -4,7 +4,8 @@ Feature: Button component - secondary type
   @positive
   @applitools
   Scenario Outline: Check that secondary buttons render correctly with theme set to <theme>
-    When I open "button" component secondary_buttons story with theme "<theme>" 
+    When I open "button" component secondary_buttons story with theme "<theme>"
+    And the button story has loaded
     Then Element displays correctly
     Examples:
       | theme  |

--- a/cypress/features/visual/buttonSecondary.feature
+++ b/cypress/features/visual/buttonSecondary.feature
@@ -5,7 +5,7 @@ Feature: Button component - secondary type
   @applitools
   Scenario Outline: Check that secondary buttons render correctly with theme set to <theme>
     When I open "button" component secondary_buttons story with theme "<theme>"
-    And the button story has loaded
+    # And the button story has loaded
     Then Element displays correctly
     Examples:
       | theme  |

--- a/cypress/features/visual/buttonTertiary.feature
+++ b/cypress/features/visual/buttonTertiary.feature
@@ -5,6 +5,7 @@ Feature: Button component - tertiary type
   @applitools
   Scenario Outline: Check that tertiary buttons render correctly with theme set to <theme>
     When I open "button" component tertiary_buttons story with theme "<theme>"
+    And the button story has loaded
     Then Element displays correctly
     Examples:
       | theme  |

--- a/cypress/features/visual/buttonTertiary.feature
+++ b/cypress/features/visual/buttonTertiary.feature
@@ -5,7 +5,7 @@ Feature: Button component - tertiary type
   @applitools
   Scenario Outline: Check that tertiary buttons render correctly with theme set to <theme>
     When I open "button" component tertiary_buttons story with theme "<theme>"
-    And the button story has loaded
+    # And the button story has loaded
     Then Element displays correctly
     Examples:
       | theme  |

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,9 +1,9 @@
 import { radioButtonComponent } from '../locators/radioButton';
 
 // Configure custom commands eyes-cypress
-import '@applitools/eyes-cypress/commands';
+// import '@applitools/eyes-cypress/commands';
 
-import applitoolsSettings from '../../applitools.config';
+// import applitoolsSettings from '../../applitools.config';
 
 export const DEBUG_FLAG = false;
 require('cypress-plugin-retries');
@@ -88,20 +88,20 @@ Cypress.Commands.add('iFrame', (selector) => { getItem(selector, 50); });
 
 Cypress.Screenshot.defaults({ screenshotOnRunFailure: DEBUG_FLAG });
 
-const {
-  Before,
-  After,
-} = require('cypress-cucumber-preprocessor/steps');
+// const {
+//   Before,
+//   After,
+// } = require('cypress-cucumber-preprocessor/steps');
 
 
-if (Cypress.env('CYPRESS_APPLITOOLS')) {
-  Before({ tags: '@applitools' }, () => {
-    applitoolsSettings.testName = cy.state('ctx').test.title;
-    applitoolsSettings.batchName = cy.state('ctx').test.parent.title;
-    cy.eyesOpen(applitoolsSettings);
-  });
+// if (Cypress.env('CYPRESS_APPLITOOLS')) {
+//   Before({ tags: '@applitools' }, () => {
+//     applitoolsSettings.testName = cy.state('ctx').test.title;
+//     applitoolsSettings.batchName = cy.state('ctx').test.parent.title;
+//     cy.eyesOpen(applitoolsSettings);
+//   });
 
-  After({ tags: '@applitools' }, () => {
-    cy.eyesClose();
-  });
-}
+//   After({ tags: '@applitools' }, () => {
+//     cy.eyesClose();
+//   });
+// }

--- a/cypress/support/step-definitions/applitools-steps.js
+++ b/cypress/support/step-definitions/applitools-steps.js
@@ -1,5 +1,12 @@
+import applitoolsSettings from '../../../applitools.config';
+
 Then('Element displays correctly', () => {
-  if (Cypress.env('CYPRESS_APPLITOOLS')) {
-    cy.eyesCheckWindow();
-  }
+  applitoolsSettings.testName = cy.state('ctx').test.title;
+  applitoolsSettings.batchName = cy.state('ctx').test.parent.title;
+
+  cy.eyesOpen(applitoolsSettings).then(() => {
+    cy.eyesCheckWindow().then(() => {
+      cy.eyesClose();
+    });
+  });
 });

--- a/cypress/support/step-definitions/applitools-steps.js
+++ b/cypress/support/step-definitions/applitools-steps.js
@@ -1,6 +1,5 @@
 Then('Element displays correctly', () => {
   if (Cypress.env('CYPRESS_APPLITOOLS')) {
-    cy.wait(2500);
     cy.eyesCheckWindow();
   }
 });

--- a/cypress/support/step-definitions/button-steps.js
+++ b/cypress/support/step-definitions/button-steps.js
@@ -1,6 +1,10 @@
-import { buttonSubtextPreview, buttonDataComponent } from '../../locators/button';
+import { buttonSubtextPreview, buttonDataComponent, buttonDataComponentNoIFrame } from '../../locators/button';
 import { icon } from '../../locators';
 import { positionOfElement } from '../helper';
+
+When('the button story has loaded', () => {
+  buttonDataComponentNoIFrame();
+});
 
 Then('Button label on preview is {word}', (label) => {
   buttonDataComponent().should('have.text', label);


### PR DESCRIPTION
### Proposed behaviour
Remove the `cy.wait()` on every applitools test. 

### Current behaviour
We use `cy.wait()` in our applitools test but `cy.eyesCheckWindow()` has a built in grace period.

The `cy.wait()` adds ~20 mins to our total build time.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR
<del>- [ ] Carbon implementation and Design System documentation are congruent
<del>- [ ] All themes are supported

- [x] Commits follow our style guide

<del>- [ ] Unit tests added or updated

- [x] Cypress automation tests added or updated

<del>- [ ] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context

`cy.eyesCheckWindow` will check multiple times and mark the test as failed after the grace period
`cy.wait` delays a fixed amount of time

If we need to delay one of the screenshots 
• [we can do it per test](https://applitools.com/docs/api/eyes-sdk/classes-gen/class_eyes/method-eyes-checkwindow-selenium-javascript.html)
• [we can do it globally](https://applitools.com/docs/api/eyes-sdk/classes-gen/class_eyes/method-eyes-setmatchtimeout-selenium-javascript.html)
### Testing instructions
<!-- How can a reviewer test this PR? -->
