### PR TITLE
ci: update chromatic baselines

### DIFF
--- a/.github/workflows/chromatic-branch.yml
+++ b/.github/workflows/chromatic-branch.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    # These branches are auto-accepted in chromatic-release/visual-regression-release
+    branches-ignore:
+      - master
+      - '[0-9]+.x'
+      - '[0-9]+.x.x'
+      - '[0-9]+.[0-9]+.x'
+
+jobs:
+  visual-regression:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+    - run: npm ci
+    - uses: chromaui/action@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic-release.yml
+++ b/.github/workflows/chromatic-release.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    # We want to auto-accept these baselines
+    branches:
+      - master
+      - '[0-9]+.x'
+      - '[0-9]+.x.x'
+      - '[0-9]+.[0-9]+.x'
+
+jobs:
+  visual-regression-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+    - run: npm ci
+    - uses: chromaui/action@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        exitOnceUploaded: true
+        autoAcceptChanges: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,3 @@ jobs:
         node-version: '12'
     - run: npm ci
     - run: npm test
-  visual-regression:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '12'
-    - run: npm ci
-    - uses: chromaui/action@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
### Proposed behaviour
We need to auto-accept chromatic baselines on upstream branches.
It's documented here, but not clear that it's mandatory
https://www.chromatic.com/docs/ci#github-squash-rebase-merge-and-the-master-branch

I've created two new CI scripts:

- chromatic-branch.yml - runs on each push to non release branches
- chromatic-release.yml - runs on each push to release branches, and auto-accepts the changes.

I contacted support and they said they might auto-accept on our behalf in the future to save us on CI usage.

### Current behaviour
Without this the dashboard will always say there are ~300 changes

![image](https://user-images.githubusercontent.com/2328042/84882311-f1f9af00-b086-11ea-8d78-b691bde09f48.png)


### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Screenshots are included in the PR
<del>- [ ] Carbon implementation and Design System documentation are congruent
<del>- [ ] All themes are supported
- [x] Commits follow our style guide
<del>- [ ] Unit tests added or updated
<del>- [ ] Cypress automation tests added or updated
<del>- [ ] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
N/A
### Testing instructions
Ensure PR checks have ran.
