### PR TITLE
test(cypress): remove no needed test cases and comments

### DIFF
--- a/cypress/features/regression/button.feature
+++ b/cypress/features/regression/button.feature
@@ -5,16 +5,6 @@ Feature: Button component
     Given I open "Button" component page knobs
 
   @positive
-  Scenario Outline: Set Button size to <size>
-    When I select size to "<size>"
-    Then Button height is "<height>"
-    Examples:
-      | size   | height |
-      | small  | 32     |
-      | medium | 40     |
-      | large  | 48     |
-
-  @positive
   Scenario Outline: Set Button subtext to <subtext>
     Given I select size to "large"
     When I set subtext to <subtext> word
@@ -33,11 +23,7 @@ Feature: Button component
       And Button background color is "<background-color>"
     Examples:
       | buttonType     | font-color         | background-color   |
-      | primary        | rgb(255, 255, 255) | rgb(0, 129, 93)    |
-      | secondary      | rgb(0, 129, 93)    | rgba(0, 0, 0, 0)   |
-      | tertiary       | rgb(0, 129, 93)    | rgba(0, 0, 0, 0)   |
       | darkBackground | rgb(0, 129, 93)    | rgb(255, 255, 255) |
-      | dashed         | rgba(0, 0, 0, 0.9) | rgba(0, 0, 0, 0)   |
 
   @positive
   Scenario Outline: Set Button component label to <label>
@@ -49,11 +35,6 @@ Feature: Button component
       | !@#$%^*()_+-=~[];:.,?{} |
   # @ignore because of FE-2782
   # | &"'<>|
-
-  @positive
-  Scenario: Disable Button
-    When I disable Button component
-    Then Button is disabled
 
   @positive
   Scenario: Disable and enable Button
@@ -83,8 +64,3 @@ Feature: Button component
     Given I check has icon checkbox
     When I select iconType to "arrow_left_small"
     Then Button icon is set to "arrow_left_small"
-
-  @positive
-  Scenario: Verify dashed outline
-    When I select buttonType to "dashed"
-    Then Button background style is "dashed"

--- a/cypress/features/regression/button.feature
+++ b/cypress/features/regression/button.feature
@@ -17,15 +17,6 @@ Feature: Button component
   # | &"'<>|
 
   @positive
-  Scenario Outline: Set Button Type as <buttonType>
-    When I select buttonType to "<buttonType>"
-    Then Button font color is "<font-color>"
-      And Button background color is "<background-color>"
-    Examples:
-      | buttonType     | font-color         | background-color   |
-      | darkBackground | rgb(0, 129, 93)    | rgb(255, 255, 255) |
-
-  @positive
   Scenario Outline: Set Button component label to <label>
     When I set children to <label> word
     Then Button label on preview is <label>
@@ -43,24 +34,7 @@ Feature: Button component
     Then Button is enabled
 
   @positive
-  Scenario Outline: Change Button icon position to <iconPosition>
-    Given I check has icon checkbox
-      And I select iconType to "add"
-    When I select iconPosition to "<iconPosition>"
-    Then Button icon position is set to "<iconPosition>"
-    Examples:
-      | iconPosition |
-      | after        |
-      | before       |
-
-  @positive
   Scenario: Verify the click function for a Button component
     Given clear all actions in Actions Tab
     When I click on "button"
     Then click action was called in Actions Tab
-
-  @positive
-  Scenario: Set Button icon to arrow_left_small
-    Given I check has icon checkbox
-    When I select iconType to "arrow_left_small"
-    Then Button icon is set to "arrow_left_small"

--- a/cypress/features/regression/create.feature
+++ b/cypress/features/regression/create.feature
@@ -5,12 +5,6 @@ Feature: Create component
     Given I open "Create" component page
 
   @positive
-  Scenario: Verify inner content and colors of Create component
-    # commented because of BDD default scenario Given - When - Then
-    # When I open "Create" component page
-    Then Create component has proper inner color "rgb(0, 129, 93)" and background-color "rgb(242, 245, 246)" and border color "rgb(102, 133, 146)"
-
-  @positive
   Scenario: Verify inner content and colors of Create component on hover state
     Given I click outside of the component
     When I hit Tab key 1 time

--- a/cypress/features/regression/designSystem/drawer.feature
+++ b/cypress/features/regression/designSystem/drawer.feature
@@ -35,13 +35,3 @@ Feature: Drawer component
   Scenario: Confirm that animationDuration is set to 3 seconds
     When I click on three-second-animation-drawer Drawers arrow 1 time
     Then Drawer three-second-animation-drawer animationDuration is set to "3s"
-
-  @positive
-  Scenario: Set expandedWidth to 30%
-    When I click on expanded-width-30-drawer Drawers arrow 1 time
-    Then Drawer "expanded-width-30-drawer" expandedWidth is set to "287.390625px"
-
-  @positive
-  Scenario: Set expandedWidth to 62%
-    When I click on expanded-width-62-drawer Drawers arrow 1 time
-    Then Drawer "expanded-width-62-drawer" expandedWidth is set to "593.953125px"

--- a/cypress/features/regression/designSystem/drawer.feature
+++ b/cypress/features/regression/designSystem/drawer.feature
@@ -45,15 +45,3 @@ Feature: Drawer component
   Scenario: Set expandedWidth to 62%
     When I click on expanded-width-62-drawer Drawers arrow 1 time
     Then Drawer "expanded-width-62-drawer" expandedWidth is set to "593.953125px"
-
-  @positive
-  Scenario: Drawer backgroundColor is set to yellow
-    # commented because of BDD default scenario Given - When - Then
-    # When I open "background-color-red-drawer" Drawer
-    Then Drawer "controlled-drawer" backgroundColor is set to "rgb(255, 240, 0)"
-
-  @positive
-  Scenario: Drawer backgroundColor is set to red
-    # commented because of BDD default scenario Given - When - Then
-    # When I open "background-color-red-drawer" Drawer
-    Then Drawer "background-color-red-drawer" backgroundColor is set to "rgb(255, 0, 0)"

--- a/cypress/features/regression/designSystem/duellingPicklist.feature
+++ b/cypress/features/regression/designSystem/duellingPicklist.feature
@@ -12,12 +12,6 @@ Feature: Design System Duelling Picklist Component
       And assigned picklist is empty
 
   @positive
-  Scenario: Divider between picklists is visible
-    # commented because of BDD default scenario Given - When - Then
-    # Given I open Design Systems page "duellingpicklist" component docs page
-    Then divider is visible
-
-  @positive
   Scenario: Disable Duelling Picklist
     When I check Access to all current and new clients checkbox
     Then Duelling Picklist is disabled

--- a/cypress/features/regression/designSystem/tileSelect.feature
+++ b/cypress/features/regression/designSystem/tileSelect.feature
@@ -15,9 +15,3 @@ Feature: Design System TileSelect component
     Given I click on single tile component
     When I click deselect button
     Then Single tile is not check
-
-    @positive
-  Scenario: TileSelect is disabled
-    # commented because of BDD default scenario Given - When - Then
-    # When I open Design Systems basic "tile-select" component docs page
-    Then Tile is disabled

--- a/cypress/features/regression/help.feature
+++ b/cypress/features/regression/help.feature
@@ -49,8 +49,3 @@ Feature: Help component
       | href                         |
       | mp150ú¿¡üßä                  |
       | !@#$%^*()_+-=~[];:.,?{}&"'<> |
-
-  @positive
-  Scenario: Verify default color for help icon
-    # When I open "Help" component page
-    Then icon on preview has "rgba(0, 0, 0, 0.65)" color

--- a/cypress/features/regression/showEditPod.feature
+++ b/cypress/features/regression/showEditPod.feature
@@ -5,18 +5,6 @@ Feature: Show Edit Pod component
     Given I open "ShowEditPod" component page
 
   @positive
-  Scenario: Verify the inner content of the component
-    # commented because of BDD default scenario Given - When - Then
-    # When I open "ShowEditPod" component page
-    Then Show Edit Pod component has proper content inside itself
-
-  @positive
-  Scenario: Verify color of the edit icon
-    # commented because of BDD default scenario Given - When - Then
-    # When I open "ShowEditPod" component page
-    Then Edit icon has color "rgb(0, 129, 93)"
-
-  @positive
   Scenario: Enable border checkbox for a Show Edit Pod component
     When I check border checkbox
     Then Show Edit Pod component has border "rgb(204, 214, 219)" color

--- a/cypress/features/regression/test/accordion.feature
+++ b/cypress/features/regression/test/accordion.feature
@@ -4,7 +4,6 @@ Feature: Accordion component
   Background: Open Accordion component page
     Given I open basic Test "Accordion" component page
 
-  # will remove when Applitools will be implemented
   @positive
   Scenario Outline: Set Accordion iconType to <iconType>
     When I select iconType to "<iconType>"
@@ -14,7 +13,6 @@ Feature: Accordion component
       | chevron_down |
       | dropdown     |
 
-  # will remove when Applitools will be implemented
   @positive
   Scenario Outline: Open accordion and set Accordion iconType to <iconType>
     Given I expand accordionRow via click
@@ -25,7 +23,6 @@ Feature: Accordion component
       | chevron_down |
       | dropdown     |
 
-  # will remove when Applitools will be implemented
   @positive
   Scenario Outline: Set Accordion iconAlign to <iconAlign>
     When I select iconAlign to "<iconAlign>"
@@ -34,26 +31,6 @@ Feature: Accordion component
       | iconAlign |
       | left      |
       | right     |
-
-  # will remove when Applitools will be implemented
-  @positive
-  Scenario Outline: Set Accordion type to <type>
-    When I select type to "<type>"
-    Then Accordion type property on preview is set to "<type>"
-    Examples:
-      | type      |
-      | primary   |
-      | secondary |
-
-  # will remove when Applitools will be implemented
-  @positive
-  Scenario Outline: Verify color pallete for <type> type Accordion
-    # When I open "Accordion" component page
-    Then Accordion has proper "<type>" type color "<color>" palette
-    Examples:
-      | type      | color              |
-      | primary   | rgb(204, 214, 219) |
-      | secondary | rgb(204, 214, 219) |
 
   @positive
   Scenario: Check expansion toggled event for the Accordion row on focus

--- a/cypress/features/regression/test/actionPopoverStyleOverrideNoIFrame.feature
+++ b/cypress/features/regression/test/actionPopoverStyleOverrideNoIFrame.feature
@@ -4,12 +4,6 @@ Feature: Style overriden Action Popover component
   Background: Style overriden Action Popover component
     Given I open style override Test "Action Popover" component page in noIframe
 
-  # will remove when Applitools will be implemented
-  @positive
-  Scenario: Open style overriden Action Popover component page and verify overriden styles are rendered properly
-    # When I open style override Test "Action Popover" component page in noIframe
-    Then Action Popover overriden styles rendered properly
-
   @positive
   Scenario: Overriden button opens Action Popover
     When I click the menu button element in noiFrame

--- a/cypress/features/regression/test/badge.feature
+++ b/cypress/features/regression/test/badge.feature
@@ -5,12 +5,6 @@ Feature: Badge component
     Given I open basic Test "Badge" component page
 
   @positive
-  Scenario: Badge component rendered properly
-    # commented because of BDD default scenario Given - When - Then
-    # When I open basic Test "Badge" component page
-    Then Badge component rendered properly
-
-  @positive
   Scenario Outline: Set Badge component to <counter>
     When I set counter to "<counter>"
     Then Badge component counter is set to <counter>

--- a/cypress/features/regression/test/batchSelection.feature
+++ b/cypress/features/regression/test/batchSelection.feature
@@ -4,32 +4,11 @@ Feature: Batch selection component
   Background: Open Batch selection component page
     Given I open basic Test "Batch selection" component page
 
-  # will remove when Applitools will be implemented
-  @positive
-  Scenario Outline: Batch selection component <icon> icon is rendered properly
-    # commented because of BDD default scenario Given - When - Then
-    # When I open basic Test "Batch selection" component page
-    Then Batch selection component is rendered properly
-      And Batch selection <index> button is rendered properly with proper "<icon>" icon
-    Examples:
-      | index | icon |
-      | 0     | csv  |
-      | 1     | bin  |
-      | 2     | pdf  |
-
-  # will remove when Applitools will be implemented
-  @positive
-  Scenario: Disable Batch selection component
-    When I check disabled checkbox
-    Then Batch selection component is disabled
-
-  # will remove when Applitools will be implemented
   @positive
   Scenario: Hide Batch selection component
     When I check hidden checkbox
     Then Batch selection component is hidden
 
-  # will remove when Applitools will be implemented
   @positive
   Scenario Outline: Set selectedCount Batch selection component to <selectedCount>
     When I set selectedCount to "<selectedCount>"
@@ -39,15 +18,3 @@ Feature: Batch selection component
       | 0             |
       | 10            |
       | 100           |
-
-  # will remove when Applitools will be implemented
-  @positive
-  Scenario Outline: Set Batch selection colorTheme to <colorTheme>
-    When I select colorTheme to "<colorTheme>"
-    Then Batch selection component colorTheme "<colorTheme>" is set to "<color>"
-    Examples:
-      | colorTheme        | color              |
-      | dark              | rgb(0, 51, 73)     |
-      | transparent-white | rgba(0, 0, 0, 0)   |
-      | light             | rgb(179, 194, 200) |
-      | transparent-base  | rgba(0, 0, 0, 0)   |

--- a/cypress/features/regression/test/search.feature
+++ b/cypress/features/regression/test/search.feature
@@ -13,7 +13,6 @@ Feature: Search component
       | mp150ú¿¡üßä                  |
       | !@#$%^*()_+-=~[];:.,?{}&"'<> |
 
-  # will remove when Applitools will be implemented
   @positive
   Scenario: Verify proper color for search icon button
     Given Type "Sea" text into search input


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Removed no needed test cases and comments
### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
We have in the code comments `will be removed when Applitools will be implemented`. We are using Chromatic now, instead of Applitools, so

- we need to remove these comments,
- remove test cases covered by Chromatic

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Screenshots are included in the PR
- [ ] Carbon implementation and Design System documentation are congruent
- [ ] All themes are supported
- [ ] Commits follow our style guide
- [ ] Unit tests added or updated
- [ ] Cypress automation tests added or updated
- [ ] Storybook added or updated
- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
