### PR TITLE
ci: run workflows on pr where possible

### DIFF
--- a/.github/workflows/chromatic-pr.yml
+++ b/.github/workflows/chromatic-pr.yml
@@ -1,9 +1,13 @@
-name: Chromatic
+name: Chromatic PR
 
-on: push # We need chromatic to upload from every branch
+# Running on pull_request allows developers to push to a branch without triggering chromatic
+# Opening/re-opening/synchronising a PR, will run chromatic, even if the PR is a draft.
+on: pull_request
 
 jobs:
   chromatic:
+    # if not a fork
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} 
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/chromatic-push.yml
+++ b/.github/workflows/chromatic-push.yml
@@ -1,0 +1,28 @@
+name: Chromatic Push
+
+on:
+  push:
+    # We need these branches to update their baselines when they are merged into
+    branches:    
+      - master
+      - '[0-9]+.x'
+      - '[0-9]+.x.x'
+      - '[0-9]+.[0-9]+.x'
+      - trigger-integration # This branch is used to update checks on PR's from forks
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+    - run: npm ci
+    - uses: chromaui/action@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        exitOnceUploaded: true # We don't want it to fail CI, we'll be using the GitHub Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,6 @@
 name: CI
 
-on:
-  push:
-    # There is no need to run CI again because we use  "Require branches to be up to date before merging"
-    branches-ignore:    
-      - master
-      - '[0-9]+.x'
-      - '[0-9]+.x.x'
-      - '[0-9]+.[0-9]+.x'
+on: pull_request
 
 jobs:
   lint:

--- a/.github/workflows/cypress-pr.yml
+++ b/.github/workflows/cypress-pr.yml
@@ -1,17 +1,11 @@
-name: Cypress tests
+name: Cypress PR
 
-on:
-  push:
-    # There is no need to run CI again because we use  "Require branches to be up to date before merging"
-    branches-ignore:    
-      - master
-      - '[0-9]+.x'
-      - '[0-9]+.x.x'
-      - '[0-9]+.[0-9]+.x'
+on: pull_request
 
 jobs:
-  test:
-    name: Cypress regression
+  cypress:
+     # if not a fork
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-18.04
     strategy:
       # when one test fails, DO NOT cancel the other

--- a/.github/workflows/cypress-push.yml
+++ b/.github/workflows/cypress-push.yml
@@ -1,0 +1,76 @@
+name: Cypress Push
+
+on:
+  push:
+    branches:    
+      - trigger-integration # This is the branch that we use to test PR's from forks
+
+jobs:
+  cypress:
+    runs-on: ubuntu-18.04
+    strategy:
+      # when one test fails, DO NOT cancel the other
+      # containers, because this will kill Cypress processes
+      # leaving the Dashboard hanging ...
+      # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
+      matrix:
+        # run 20 copies of the current job in parallel
+        containers: [
+            1, 2, 3, 4, 5, 
+            6, 7, 8, 9, 10, 
+            11, 12, 13, 14, 15, 
+            16, 17, 18, 19, 20
+            ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.2.0
+      # Restore the previous NPM modules and Cypress binary archives.
+      # Any updated archives will be saved automatically after the entire
+      # workflow successfully finishes.
+      # See https://github.com/actions/cache
+      - name: Cache central NPM modules
+        uses: actions/cache@v2.0.0
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Cache Cypress binary
+        uses: actions/cache@v2.0.0
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            cypress-${{ runner.os }}-cypress-
+      - name: install dependencies and verify Cypress
+        env:
+          # make sure every Cypress install prints minimal information
+          CI: 1
+        run: |
+          npm ci
+          npx cypress cache path
+          npx cypress cache list
+          npx cypress verify
+          npx cypress info
+      # because of "record" and "parallel" parameters
+      # these containers will load balance all found tests among themselves
+      - name: Cypress run
+        uses: cypress-io/github-action@v1.24.3
+        with:
+          install: false
+          start: npm start
+          # quote the url to be safe against YML parsing surprises
+          wait-on: 'http://localhost:9001'
+          wait-on-timeout: 250
+          record: true
+          parallel: true
+          group: ubuntu-regression
+          spec: './cypress/features/regression/**/*.feature'
+        env:
+          # pass the Dashboard record key as an environment variable
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CI: 'true'
+          # Recommended: pass the GitHub token lets this action correctly
+          # determine the unique run id necessary to re-run the checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,11 @@ Your branch should meet the following criteria:
 
 **To be merged, the pull request must be approved by at least two project maintainers**
 
+#### GitHub Checks
+Our GitHub checks don't run on a forked PR because the Chromatic and Cypress Dashboard require credentials. When you submit a PR a project maintainer will review your code.
+If there are no changes that could expose our credentials they will use [`git-push-fork-to-upstream-branch`](https://github.com/jklukas/git-push-fork-to-upstream-branch) to
+copy your branch into our repo. Doing this will trigger a `push` build and your PR checks will be updated. This is documented on the [Circle CI blog](https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/).
+
 ## Styleguides
 ### Git commit messages
 We use the [`conventional-commits`](https://www.conventionalcommits.org/en/v1.0.0/) commit message format. This specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with [SemVer](https://semver.org/), by describing the features, fixes, and breaking changes made in commit messages.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Read our [contributing guide](CONTRIBUTING.md) to learn about our development pr
 
 ## Thanks
 <a href="https://www.chromatic.com/"><img src="https://user-images.githubusercontent.com/321738/84662277-e3db4f80-af1b-11ea-88f5-91d67a5e59f6.png" width="153" height="30" alt="Chromatic" /></a>
+
 Thanks to [Chromatic](https://www.chromatic.com/) for providing the visual testing platform that helps us review UI changes and catch visual regressions.
 
 ## Licence


### PR DESCRIPTION
### Proposed behaviour

Update `CONTRIBUTING.md` to explain how we run CI on forked PR's.

#### Cypress

- run on `pull_request`, skip if it is a pr from a fork
- run on `push` to `test-integration`, used to update pr's from forks

#### Chromatic

- run on `pull_request`, skip if it is a pr from a fork
- run on `push` to `test-integration`, used to update pr's from forks

#### CI
- run on `pull_request`, including forks

### Current behaviour

- Forked PR's not documented
- We run CI on push to any branch, so its not possible for developers to save their interim work on the remote without triggering CI.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR
<del>- [ ] Carbon implementation and Design System documentation are congruent
<del>- [ ] All themes are supported
- [x] Commits follow our style guide

<del>- [ ] Unit tests added or updated
<del>- [ ] Cypress automation tests added or updated
<del>- [ ] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
N/A

### Testing instructions
Check all github checks are passing.
