### PR TITLE
test: disable chromatic for deprecated components

### DIFF
--- a/src/__deprecated__/components/date-range/date-range.stories.js
+++ b/src/__deprecated__/components/date-range/date-range.stories.js
@@ -25,6 +25,9 @@ storiesOf('__deprecated__/Date Range', module)
   .addParameters({
     info: {
       propTablesExclude: [State]
+    },
+    chromatic: {
+      disable: true
     }
   })
   .add('classic', () => {

--- a/src/__deprecated__/components/date/date.stories.js
+++ b/src/__deprecated__/components/date/date.stories.js
@@ -75,5 +75,8 @@ storiesOf('__deprecated__/Date Input', module)
   }, {
     info: { text: info, propTablesExclude: [State] },
     notes: { markdown: notes },
-    themeSelector: classicThemeSelector
+    themeSelector: classicThemeSelector,
+    chromatic: {
+      disable: true
+    }
   });

--- a/src/__deprecated__/components/dropdown-filter-ajax/dropdown-filter-ajax.stories.js
+++ b/src/__deprecated__/components/dropdown-filter-ajax/dropdown-filter-ajax.stories.js
@@ -70,6 +70,9 @@ storiesOf('__deprecated__/DropdownFilterAjax', module)
   .addParameters({
     info: {
       propTablesExclude: [State]
+    },
+    chromatic: {
+      disable: true
     }
   })
   .add('classic', () => {

--- a/src/__deprecated__/components/dropdown-filter/dropdown-filter.stories.js
+++ b/src/__deprecated__/components/dropdown-filter/dropdown-filter.stories.js
@@ -64,6 +64,9 @@ storiesOf('__deprecated__/Dropdown Filter', module)
   .addParameters({
     info: {
       propTablesExclude: [State]
+    },
+    chromatic: {
+      disable: true
     }
   })
   .add('classic', () => {

--- a/src/__deprecated__/components/dropdown/dropdown.stories.js
+++ b/src/__deprecated__/components/dropdown/dropdown.stories.js
@@ -34,6 +34,9 @@ storiesOf('__deprecated__/Dropdown', module)
   .addParameters({
     info: {
       propTablesExclude: [State]
+    },
+    chromatic: {
+      disable: true
     }
   })
   .add('classic', () => {

--- a/src/__deprecated__/components/fieldset/fieldset.stories.js
+++ b/src/__deprecated__/components/fieldset/fieldset.stories.js
@@ -16,6 +16,9 @@ storiesOf('__deprecated__/Fieldset', module)
   .addParameters({
     info: {
       propTablesExclude: [Textbox]
+    },
+    chromatic: {
+      disable: true
     }
   })
   .add('classic', () => {

--- a/src/__deprecated__/components/form/form.stories.js
+++ b/src/__deprecated__/components/form/form.stories.js
@@ -21,6 +21,9 @@ storiesOf('__deprecated__/Form', module)
     info: {
       text: Info,
       propTablesExclude: [Textbox]
+    },
+    chromatic: {
+      disable: true
     }
   })
   .add('classic', () => {

--- a/src/__deprecated__/components/radio-button/radio-button.stories.js
+++ b/src/__deprecated__/components/radio-button/radio-button.stories.js
@@ -12,53 +12,59 @@ RadioButton.__docgenInfo = getDocGenInfo(
   /radio-button(?!spec)/
 );
 
-storiesOf('__deprecated__/Radio Button', module).add(
-  'classic',
-  () => {
-    const fieldHelp = text('fieldHelp', 'Additional information below the input.');
-    const fieldHelpInline = boolean('fieldHelpInline', RadioButton.defaultProps.fieldHelpInline);
-    const label = text('label', 'Example RadioButton');
-    const labelInline = boolean('labelInline', false);
-    const labelWidth = labelInline ? text('labelWidth', '') : undefined;
-    const labelAlign = labelInline ? select('labelAlign', OptionsHelper.alignBinary, 'left') : undefined;
-    const labelHelp = text('labelHelp', 'Example label help text');
-    const inputWidth = text('inputWidth', '');
+storiesOf('__deprecated__/Radio Button', module)
+  .addParameters({
+    chromatic: {
+      disable: true
+    }
+  })
+  .add(
+    'classic',
+    () => {
+      const fieldHelp = text('fieldHelp', 'Additional information below the input.');
+      const fieldHelpInline = boolean('fieldHelpInline', RadioButton.defaultProps.fieldHelpInline);
+      const label = text('label', 'Example RadioButton');
+      const labelInline = boolean('labelInline', false);
+      const labelWidth = labelInline ? text('labelWidth', '') : undefined;
+      const labelAlign = labelInline ? select('labelAlign', OptionsHelper.alignBinary, 'left') : undefined;
+      const labelHelp = text('labelHelp', 'Example label help text');
+      const inputWidth = text('inputWidth', '');
 
-    return (
-      <React.Fragment>
-        <RadioButton
-          key='first-button'
-          fieldHelp={ fieldHelp }
-          fieldHelpInline={ fieldHelpInline }
-          inputWidth={ inputWidth }
-          label={ label }
-          labelAlign={ labelAlign }
-          labelHelp={ labelHelp }
-          labelInline={ labelInline }
-          labelWidth={ labelWidth }
-          name='radio-buttons-example'
-        />
-        <RadioButton
-          key='second-button'
-          fieldHelp={ fieldHelp }
-          fieldHelpInline={ fieldHelpInline }
-          inputWidth={ inputWidth }
-          label={ label }
-          labelAlign={ labelAlign }
-          labelHelp={ labelHelp }
-          labelInline={ labelInline }
-          labelWidth={ labelWidth }
-          name='radio-buttons-example'
-        />
-      </React.Fragment>
-    );
-  },
-  {
-    notes: { markdown: notes },
-    info: {
-      text: info,
-      propTablesExclude: [React.Fragment]
+      return (
+        <React.Fragment>
+          <RadioButton
+            key='first-button'
+            fieldHelp={ fieldHelp }
+            fieldHelpInline={ fieldHelpInline }
+            inputWidth={ inputWidth }
+            label={ label }
+            labelAlign={ labelAlign }
+            labelHelp={ labelHelp }
+            labelInline={ labelInline }
+            labelWidth={ labelWidth }
+            name='radio-buttons-example'
+          />
+          <RadioButton
+            key='second-button'
+            fieldHelp={ fieldHelp }
+            fieldHelpInline={ fieldHelpInline }
+            inputWidth={ inputWidth }
+            label={ label }
+            labelAlign={ labelAlign }
+            labelHelp={ labelHelp }
+            labelInline={ labelInline }
+            labelWidth={ labelWidth }
+            name='radio-buttons-example'
+          />
+        </React.Fragment>
+      );
     },
-    themeSelector: classicThemeSelector
-  }
-);
+    {
+      notes: { markdown: notes },
+      info: {
+        text: info,
+        propTablesExclude: [React.Fragment]
+      },
+      themeSelector: classicThemeSelector
+    }
+  );

--- a/src/__deprecated__/components/simple-color-picker/simple-color-picker.stories.js
+++ b/src/__deprecated__/components/simple-color-picker/simple-color-picker.stories.js
@@ -28,6 +28,9 @@ storiesOf('__deprecated__/SimpleColorPicker', module)
   .addParameters({
     info: {
       propTablesExclude: [State]
+    },
+    chromatic: {
+      disable: true
     }
   })
 

--- a/src/__deprecated__/components/textbox/textbox.stories.js
+++ b/src/__deprecated__/components/textbox/textbox.stories.js
@@ -37,6 +37,9 @@ storiesOf('__deprecated__/Textbox', module)
       propTablesExclude: [State],
       text: info
     },
+    chromatic: {
+      disable: true
+    },
     notes: { markdown: notes },
     themeSelector: classicThemeSelector
   })

--- a/src/__experimental__/components/checkbox/checkbox.stories.js
+++ b/src/__experimental__/components/checkbox/checkbox.stories.js
@@ -93,7 +93,7 @@ function defaultKnobs(type) {
   });
 }
 
-function makeStory(name, themeSelector, component, disableChromatic = true) {
+function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
     themeSelector,
     info: {
@@ -244,7 +244,7 @@ const checkboxValidations = () => (
 
 storiesOf('Experimental/Checkbox', module)
   .add(...makeStory('default', dlsThemeSelector, checkboxComponent))
-  .add(...makeStory('classic', classicThemeSelector, checkboxComponent, false))
+  .add(...makeStory('classic', classicThemeSelector, checkboxComponent, true))
   .add(...makeStory('validations', dlsThemeSelector, checkboxValidations))
-  .add(...makeStory('validations classic', classicThemeSelector, checkboxValidations, false))
+  .add(...makeStory('validations classic', classicThemeSelector, checkboxValidations, true))
   .add(...makeStory('autoFocus', dlsThemeSelector, checkboxComponentAutoFocus));

--- a/src/__experimental__/components/checkbox/checkbox.stories.js
+++ b/src/__experimental__/components/checkbox/checkbox.stories.js
@@ -93,13 +93,16 @@ function defaultKnobs(type) {
   });
 }
 
-function makeStory(name, themeSelector, component) {
+function makeStory(name, themeSelector, component, disableChromatic = true) {
   const metadata = {
     themeSelector,
     info: {
       text: info,
       propTablesExclude: [State],
       excludedPropTypes: ['children']
+    },
+    chromatic: {
+      disable: disableChromatic
     },
     notes: { markdown: notes },
     knobs: { escapeHTML: false }
@@ -241,7 +244,7 @@ const checkboxValidations = () => (
 
 storiesOf('Experimental/Checkbox', module)
   .add(...makeStory('default', dlsThemeSelector, checkboxComponent))
-  .add(...makeStory('classic', classicThemeSelector, checkboxComponent))
+  .add(...makeStory('classic', classicThemeSelector, checkboxComponent, false))
   .add(...makeStory('validations', dlsThemeSelector, checkboxValidations))
-  .add(...makeStory('validations classic', classicThemeSelector, checkboxValidations))
+  .add(...makeStory('validations classic', classicThemeSelector, checkboxValidations, false))
   .add(...makeStory('autoFocus', dlsThemeSelector, checkboxComponentAutoFocus));

--- a/src/__experimental__/components/date-range/date-range.stories.js
+++ b/src/__experimental__/components/date-range/date-range.stories.js
@@ -23,7 +23,7 @@ const handleChange = (evt) => {
   action('changed')(evt.target.value);
 };
 
-function makeStory(name, themeSelector, disableChromatic = true) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const startLabel = text('startLabel', '');
     const endLabel = text('endLabel', '');
@@ -199,4 +199,4 @@ function makeValidationStory(name, themeSelector) {
 storiesOf('Experimental/Date Range', module)
   .add(...makeStory('default', dlsThemeSelector))
   .add(...makeValidationStory('validations', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector, false));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/__experimental__/components/date-range/date-range.stories.js
+++ b/src/__experimental__/components/date-range/date-range.stories.js
@@ -23,7 +23,7 @@ const handleChange = (evt) => {
   action('changed')(evt.target.value);
 };
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = true) {
   const component = () => {
     const startLabel = text('startLabel', '');
     const endLabel = text('endLabel', '');
@@ -49,6 +49,9 @@ function makeStory(name, themeSelector) {
     info: {
       text: info,
       propTablesExclude: [State]
+    },
+    chromatic: {
+      disable: disableChromatic
     }
   };
 
@@ -196,4 +199,4 @@ function makeValidationStory(name, themeSelector) {
 storiesOf('Experimental/Date Range', module)
   .add(...makeStory('default', dlsThemeSelector))
   .add(...makeValidationStory('validations', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, false));

--- a/src/__experimental__/components/date/date.stories.js
+++ b/src/__experimental__/components/date/date.stories.js
@@ -62,7 +62,7 @@ const autoFocusDateComponent = () => {
   return dateComponent();
 };
 
-function makeStory(name, themeSelector, component, disableChromatic = true) {
+function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
     themeSelector,
     info: {
@@ -164,7 +164,7 @@ const EmptyDateComponent = () => {
 storiesOf('Experimental/Date Input', module)
   .addDecorator(StateDecorator(store))
   .add(...makeStory('default', dlsThemeSelector, dateComponent))
-  .add(...makeStory('classic', classicThemeSelector, dateComponent, false))
+  .add(...makeStory('classic', classicThemeSelector, dateComponent, true))
   .add(...makeStory('empty', dlsThemeSelector, EmptyDateComponent))
   .add(...makeStory('validations', dlsThemeSelector, ValidationDateComponent))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusDateComponent));

--- a/src/__experimental__/components/date/date.stories.js
+++ b/src/__experimental__/components/date/date.stories.js
@@ -62,7 +62,7 @@ const autoFocusDateComponent = () => {
   return dateComponent();
 };
 
-function makeStory(name, themeSelector, component) {
+function makeStory(name, themeSelector, component, disableChromatic = true) {
   const metadata = {
     themeSelector,
     info: {
@@ -70,6 +70,9 @@ function makeStory(name, themeSelector, component) {
       propTables: [OriginalTextbox, DateInput],
       propTablesExclude: [State],
       excludedPropTypes: ['children', 'leftChildren', 'inputIcon', 'placeholder', 'inputWidth']
+    },
+    chromatic: {
+      disable: disableChromatic
     },
     notes: { markdown: notes }
   };
@@ -161,7 +164,7 @@ const EmptyDateComponent = () => {
 storiesOf('Experimental/Date Input', module)
   .addDecorator(StateDecorator(store))
   .add(...makeStory('default', dlsThemeSelector, dateComponent))
-  .add(...makeStory('classic', classicThemeSelector, dateComponent))
+  .add(...makeStory('classic', classicThemeSelector, dateComponent, false))
   .add(...makeStory('empty', dlsThemeSelector, EmptyDateComponent))
   .add(...makeStory('validations', dlsThemeSelector, ValidationDateComponent))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusDateComponent));

--- a/src/__experimental__/components/decimal/decimal.stories.js
+++ b/src/__experimental__/components/decimal/decimal.stories.js
@@ -141,7 +141,7 @@ const autoFocusComponent = () => {
   return defaultComponent();
 };
 
-function makeStory(name, themeSelector, component, disableChromatic = true) {
+function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
     themeSelector,
     notes: { markdown: notes },
@@ -163,6 +163,6 @@ storiesOf('Experimental/Decimal Input', module)
     }
   })
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
-  .add(...makeStory('classic', classicThemeSelector, defaultComponent, false))
+  .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent))
   .add(...makeStory('validations', dlsThemeSelector, componentWithValidations));

--- a/src/__experimental__/components/decimal/decimal.stories.js
+++ b/src/__experimental__/components/decimal/decimal.stories.js
@@ -141,11 +141,14 @@ const autoFocusComponent = () => {
   return defaultComponent();
 };
 
-function makeStory(name, themeSelector, component) {
+function makeStory(name, themeSelector, component, disableChromatic = true) {
   const metadata = {
     themeSelector,
     notes: { markdown: notes },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -160,6 +163,6 @@ storiesOf('Experimental/Decimal Input', module)
     }
   })
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
-  .add(...makeStory('classic', classicThemeSelector, defaultComponent))
+  .add(...makeStory('classic', classicThemeSelector, defaultComponent, false))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent))
   .add(...makeStory('validations', dlsThemeSelector, componentWithValidations));

--- a/src/__experimental__/components/fieldset/fieldset.stories.js
+++ b/src/__experimental__/components/fieldset/fieldset.stories.js
@@ -15,7 +15,7 @@ Fieldset.__docgenInfo = getDocGenInfo(
   /fieldset\.component(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = true) {
   const component = () => {
     const legend = text('legend', '');
 
@@ -70,7 +70,10 @@ function makeStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -144,4 +147,4 @@ storiesOf('Experimental/Fieldset', module)
   })
   .add(...makeStory('default', dlsThemeSelector))
   .add(...makeValidationsStory('validations'))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, false));

--- a/src/__experimental__/components/fieldset/fieldset.stories.js
+++ b/src/__experimental__/components/fieldset/fieldset.stories.js
@@ -15,7 +15,7 @@ Fieldset.__docgenInfo = getDocGenInfo(
   /fieldset\.component(?!spec)/
 );
 
-function makeStory(name, themeSelector, disableChromatic = true) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const legend = text('legend', '');
 
@@ -147,4 +147,4 @@ storiesOf('Experimental/Fieldset', module)
   })
   .add(...makeStory('default', dlsThemeSelector))
   .add(...makeValidationsStory('validations'))
-  .add(...makeStory('classic', classicThemeSelector, false));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/__experimental__/components/form/form.stories.js
+++ b/src/__experimental__/components/form/form.stories.js
@@ -41,7 +41,7 @@ const additionalFormActions = (innerText) => {
   };
 };
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = true) {
   const component = () => {
     const formActionOptions = ['', ...OptionsHelper.actionOptions];
     const unsavedWarning = boolean('unsavedWarning', true);
@@ -109,13 +109,16 @@ function makeStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
 }
 
-function makeFieldsetTextboxStory(name, themeSelector) {
+function makeFieldsetTextboxStory(name, themeSelector, disableChromatic = true) {
   const component = () => {
     const stickyFooter = boolean('stickyFooter', false);
     const legend = text('legend', '');
@@ -175,7 +178,10 @@ function makeFieldsetTextboxStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -192,6 +198,6 @@ storiesOf('Experimental/Form', module)
     knobs: { escapeHTML: false }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector))
+  .add(...makeStory('classic', classicThemeSelector, false))
   .add(...makeFieldsetTextboxStory('fieldset > textbox', dlsThemeSelector))
-  .add(...makeFieldsetTextboxStory('fieldset > textbox classic', classicThemeSelector));
+  .add(...makeFieldsetTextboxStory('fieldset > textbox classic', classicThemeSelector, false));

--- a/src/__experimental__/components/form/form.stories.js
+++ b/src/__experimental__/components/form/form.stories.js
@@ -41,7 +41,7 @@ const additionalFormActions = (innerText) => {
   };
 };
 
-function makeStory(name, themeSelector, disableChromatic = true) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const formActionOptions = ['', ...OptionsHelper.actionOptions];
     const unsavedWarning = boolean('unsavedWarning', true);
@@ -118,7 +118,7 @@ function makeStory(name, themeSelector, disableChromatic = true) {
   return [name, component, metadata];
 }
 
-function makeFieldsetTextboxStory(name, themeSelector, disableChromatic = true) {
+function makeFieldsetTextboxStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const stickyFooter = boolean('stickyFooter', false);
     const legend = text('legend', '');
@@ -198,6 +198,6 @@ storiesOf('Experimental/Form', module)
     knobs: { escapeHTML: false }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector, false))
+  .add(...makeStory('classic', classicThemeSelector, true))
   .add(...makeFieldsetTextboxStory('fieldset > textbox', dlsThemeSelector))
-  .add(...makeFieldsetTextboxStory('fieldset > textbox classic', classicThemeSelector, false));
+  .add(...makeFieldsetTextboxStory('fieldset > textbox classic', classicThemeSelector, true));

--- a/src/__experimental__/components/grouped-character/grouped-character.stories.js
+++ b/src/__experimental__/components/grouped-character/grouped-character.stories.js
@@ -93,13 +93,16 @@ const validationsComponent = () => {
   );
 };
 
-function makeStory(name, themeSelector, component) {
+function makeStory(name, themeSelector, component, disableChromatic = true) {
   const metadata = {
     themeSelector,
     info: {
       text: info,
       propTables: [OriginalTextbox],
       propTablesExclude: [State]
+    },
+    chromatic: {
+      disable: disableChromatic
     },
     knobs: { escapeHTML: false }
   };
@@ -113,6 +116,6 @@ storiesOf('Experimental/GroupedCharacter', module)
     knobs: { escapeHTML: false }
   })
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
-  .add(...makeStory('classic', classicThemeSelector, defaultComponent))
+  .add(...makeStory('classic', classicThemeSelector, defaultComponent, false))
   .add(...makeStory('validations', dlsThemeSelector, validationsComponent))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent));

--- a/src/__experimental__/components/grouped-character/grouped-character.stories.js
+++ b/src/__experimental__/components/grouped-character/grouped-character.stories.js
@@ -93,7 +93,7 @@ const validationsComponent = () => {
   );
 };
 
-function makeStory(name, themeSelector, component, disableChromatic = true) {
+function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
     themeSelector,
     info: {
@@ -116,6 +116,6 @@ storiesOf('Experimental/GroupedCharacter', module)
     knobs: { escapeHTML: false }
   })
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
-  .add(...makeStory('classic', classicThemeSelector, defaultComponent, false))
+  .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
   .add(...makeStory('validations', dlsThemeSelector, validationsComponent))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent));

--- a/src/__experimental__/components/input/input.stories.js
+++ b/src/__experimental__/components/input/input.stories.js
@@ -181,13 +181,16 @@ const InputIntegration = () => {
   );
 };
 
-function makeStory(name, themeSelector, component) {
+function makeStory(name, themeSelector, component, disableChromatic = true) {
   const metadata = {
     themeSelector,
     info: {
       text: info,
       source: false,
       propTablesExclude: [State]
+    },
+    chromatic: {
+      disable: disableChromatic
     }
   };
 
@@ -196,4 +199,4 @@ function makeStory(name, themeSelector, component) {
 
 storiesOf('Experimental/Input Integration', module)
   .add(...makeStory('default', dlsThemeSelector, InputIntegration))
-  .add(...makeStory('classic', classicThemeSelector, InputIntegration));
+  .add(...makeStory('classic', classicThemeSelector, InputIntegration, false));

--- a/src/__experimental__/components/input/input.stories.js
+++ b/src/__experimental__/components/input/input.stories.js
@@ -181,7 +181,7 @@ const InputIntegration = () => {
   );
 };
 
-function makeStory(name, themeSelector, component, disableChromatic = true) {
+function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
     themeSelector,
     info: {
@@ -199,4 +199,4 @@ function makeStory(name, themeSelector, component, disableChromatic = true) {
 
 storiesOf('Experimental/Input Integration', module)
   .add(...makeStory('default', dlsThemeSelector, InputIntegration))
-  .add(...makeStory('classic', classicThemeSelector, InputIntegration, false));
+  .add(...makeStory('classic', classicThemeSelector, InputIntegration, true));

--- a/src/__experimental__/components/number/number.stories.js
+++ b/src/__experimental__/components/number/number.stories.js
@@ -85,7 +85,7 @@ const autoFocusComponent = () => {
   return defaultComponent();
 };
 
-function makeStory(name, themeSelector, component, disableChromatic = true) {
+function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
     themeSelector,
     info: {
@@ -106,6 +106,6 @@ function makeStory(name, themeSelector, component, disableChromatic = true) {
 storiesOf('Experimental/Number Input', module)
   .addDecorator(StateDecorator(store))
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
-  .add(...makeStory('classic', classicThemeSelector, defaultComponent, false))
+  .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
   .add(...makeStory('validations', dlsThemeSelector, validationsComponent))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent));

--- a/src/__experimental__/components/number/number.stories.js
+++ b/src/__experimental__/components/number/number.stories.js
@@ -85,7 +85,7 @@ const autoFocusComponent = () => {
   return defaultComponent();
 };
 
-function makeStory(name, themeSelector, component) {
+function makeStory(name, themeSelector, component, disableChromatic = true) {
   const metadata = {
     themeSelector,
     info: {
@@ -93,6 +93,9 @@ function makeStory(name, themeSelector, component) {
       propTables: [OriginalTextbox],
       propTablesExclude: [Number, State, Textbox],
       excludedPropTypes: ['children', 'leftChildren', 'inputIcon']
+    },
+    chromatic: {
+      disable: disableChromatic
     },
     notes: { markdown: notes }
   };
@@ -103,6 +106,6 @@ function makeStory(name, themeSelector, component) {
 storiesOf('Experimental/Number Input', module)
   .addDecorator(StateDecorator(store))
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
-  .add(...makeStory('classic', classicThemeSelector, defaultComponent))
+  .add(...makeStory('classic', classicThemeSelector, defaultComponent, false))
   .add(...makeStory('validations', dlsThemeSelector, validationsComponent))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent));

--- a/src/__experimental__/components/numeral-date/numeral-date.stories.js
+++ b/src/__experimental__/components/numeral-date/numeral-date.stories.js
@@ -11,7 +11,10 @@ export default {
     info: {
       disable: true
     },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disabled: true
+    }
   }
 };
 
@@ -89,4 +92,20 @@ export const Validations = () => {
 
     </>
   );
+};
+
+Basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
+};
+
+Validations.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
 };

--- a/src/__experimental__/components/radio-button/radio-button.stories.js
+++ b/src/__experimental__/components/radio-button/radio-button.stories.js
@@ -31,12 +31,15 @@ const handleGroupChangeFactory = store => (event) => {
   action('onChange')(value);
 };
 
-function makeStory(name, themeSelector, component) {
+function makeStory(name, themeSelector, component, disableChromatic = true) {
   const metadata = {
     themeSelector,
     info: {
       text: info,
       excludedPropTypes: ['children']
+    },
+    chromatic: {
+      disable: disableChromatic
     },
     notes: { markdown: notes },
     knobs: { escapeHTML: false }
@@ -214,6 +217,6 @@ storiesOf('Experimental/RadioButton', module)
     }
   })
   .add(...makeStory('default', dlsThemeSelector, radioComponent()))
-  .add(...makeStory('classic', classicThemeSelector, radioComponent('classic')))
+  .add(...makeStory('classic', classicThemeSelector, radioComponent('classic'), false))
   .add(...makeStory('validations', dlsThemeSelector, radioComponentWithValidation()))
-  .add(...makeStory('validations classic', classicThemeSelector, radioComponentWithValidation('classic')));
+  .add(...makeStory('validations classic', classicThemeSelector, radioComponentWithValidation('classic'), false));

--- a/src/__experimental__/components/radio-button/radio-button.stories.js
+++ b/src/__experimental__/components/radio-button/radio-button.stories.js
@@ -31,7 +31,7 @@ const handleGroupChangeFactory = store => (event) => {
   action('onChange')(value);
 };
 
-function makeStory(name, themeSelector, component, disableChromatic = true) {
+function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
     themeSelector,
     info: {
@@ -217,6 +217,6 @@ storiesOf('Experimental/RadioButton', module)
     }
   })
   .add(...makeStory('default', dlsThemeSelector, radioComponent()))
-  .add(...makeStory('classic', classicThemeSelector, radioComponent('classic'), false))
+  .add(...makeStory('classic', classicThemeSelector, radioComponent('classic'), true))
   .add(...makeStory('validations', dlsThemeSelector, radioComponentWithValidation()))
-  .add(...makeStory('validations classic', classicThemeSelector, radioComponentWithValidation('classic'), false));
+  .add(...makeStory('validations classic', classicThemeSelector, radioComponentWithValidation('classic'), true));

--- a/src/__experimental__/components/search/search.stories.js
+++ b/src/__experimental__/components/search/search.stories.js
@@ -17,10 +17,10 @@ export default {
     info: {
       disable: true
     },
+    knobs: { escapeHTML: false },
     chromatic: {
-      disable: true
-    },
-    knobs: { escapeHTML: false }
+      disabled: true
+    }
   }
 };
 
@@ -56,4 +56,12 @@ export const Basic = () => {
       id='search_id'
     />
   );
+};
+
+Basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
 };

--- a/src/__experimental__/components/search/search.stories.js
+++ b/src/__experimental__/components/search/search.stories.js
@@ -17,6 +17,9 @@ export default {
     info: {
       disable: true
     },
+    chromatic: {
+      disable: true
+    },
     knobs: { escapeHTML: false }
   }
 };

--- a/src/__experimental__/components/select/select.stories.js
+++ b/src/__experimental__/components/select/select.stories.js
@@ -157,7 +157,7 @@ const customFilterComponent = () => {
   );
 };
 
-function makeStory(name, themeSelector, component, disableChromatic = true) {
+function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
     themeSelector,
     chromatic: {
@@ -297,7 +297,7 @@ storiesOf('Experimental/Select', module)
     knobs: { escapeHTML: false }
   })
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
-  .add(...makeStory('classic', classicThemeSelector, defaultComponent, false))
+  .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
   .add(...makeMultipleStory('multiple', dlsThemeSelector))
   .add(...makeValidationsStory('validations', dlsThemeSelector))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent))

--- a/src/__experimental__/components/select/select.stories.js
+++ b/src/__experimental__/components/select/select.stories.js
@@ -157,9 +157,12 @@ const customFilterComponent = () => {
   );
 };
 
-function makeStory(name, themeSelector, component) {
+function makeStory(name, themeSelector, component, disableChromatic = true) {
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -294,7 +297,7 @@ storiesOf('Experimental/Select', module)
     knobs: { escapeHTML: false }
   })
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
-  .add(...makeStory('classic', classicThemeSelector, defaultComponent))
+  .add(...makeStory('classic', classicThemeSelector, defaultComponent, false))
   .add(...makeMultipleStory('multiple', dlsThemeSelector))
   .add(...makeValidationsStory('validations', dlsThemeSelector))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent))

--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.stories.js
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.stories.js
@@ -25,7 +25,7 @@ const onChange = (e) => {
   action(`Selected - ${value}`)(e);
 };
 
-function makeStory(storyName, themeSelector, disableChromatic = true) {
+function makeStory(storyName, themeSelector, disableChromatic = false) {
   const component = () => {
     const name = text('name', 'basicPicker');
     const legend = text('legend', 'Pick a colour');
@@ -188,4 +188,4 @@ storiesOf('Experimental/Simple Color Picker', module)
   })
   .add(...makeStory('default', dlsThemeSelector))
   .add(...makeValidationsStory('validations', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector, false));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.stories.js
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.stories.js
@@ -25,7 +25,7 @@ const onChange = (e) => {
   action(`Selected - ${value}`)(e);
 };
 
-function makeStory(storyName, themeSelector) {
+function makeStory(storyName, themeSelector, disableChromatic = true) {
   const component = () => {
     const name = text('name', 'basicPicker');
     const legend = text('legend', 'Pick a colour');
@@ -68,7 +68,10 @@ function makeStory(storyName, themeSelector) {
   const metadata = {
     themeSelector,
     notes: { markdown: notes },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [storyName, component, metadata];
@@ -185,4 +188,4 @@ storiesOf('Experimental/Simple Color Picker', module)
   })
   .add(...makeStory('default', dlsThemeSelector))
   .add(...makeValidationsStory('validations', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, false));

--- a/src/__experimental__/components/switch/switch.stories.js
+++ b/src/__experimental__/components/switch/switch.stories.js
@@ -52,7 +52,7 @@ validationTypes.forEach((type) => {
   };
 });
 
-function makeStory(name, themeSelector, component, disableChromatic = true) {
+function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
     themeSelector,
     knobs: { escapeHTML: false },
@@ -231,6 +231,7 @@ storiesOf('Experimental/Switch', module)
     info: { text: info, propTablesExclude: [State] }
   })
   .add(...makeStory('default', dlsThemeSelector, switchComponent))
-  .add(...makeStory('classic', classicThemeSelector, switchClassic, false))
+  .add(...makeStory('classic', classicThemeSelector, switchClassic, true))
   .add(...makeStory('validations', dlsThemeSelector, switchComponentValidation('validations')))
-  .add(...makeStory('validations classic', classicThemeSelector, switchComponentValidation('validationsclassic'), false));
+  .add(...makeStory('validations classic', classicThemeSelector,
+    switchComponentValidation('validationsclassic'), true));

--- a/src/__experimental__/components/switch/switch.stories.js
+++ b/src/__experimental__/components/switch/switch.stories.js
@@ -52,12 +52,15 @@ validationTypes.forEach((type) => {
   };
 });
 
-function makeStory(name, themeSelector, component) {
+function makeStory(name, themeSelector, component, disableChromatic = true) {
   const metadata = {
     themeSelector,
     knobs: { escapeHTML: false },
     info: {
       text: info
+    },
+    chromatic: {
+      disable: disableChromatic
     },
     notes: { markdown: notes }
   };
@@ -228,6 +231,6 @@ storiesOf('Experimental/Switch', module)
     info: { text: info, propTablesExclude: [State] }
   })
   .add(...makeStory('default', dlsThemeSelector, switchComponent))
-  .add(...makeStory('classic', classicThemeSelector, switchClassic))
+  .add(...makeStory('classic', classicThemeSelector, switchClassic, false))
   .add(...makeStory('validations', dlsThemeSelector, switchComponentValidation('validations')))
-  .add(...makeStory('validations classic', classicThemeSelector, switchComponentValidation('validationsclassic')));
+  .add(...makeStory('validations classic', classicThemeSelector, switchComponentValidation('validationsclassic'), false));

--- a/src/__experimental__/components/textarea/textarea.stories.js
+++ b/src/__experimental__/components/textarea/textarea.stories.js
@@ -100,7 +100,7 @@ const autoFocusComponent = () => {
   return defaultComponent();
 };
 
-function makeStory(name, themeSelector, component, disableChromatic = true) {
+function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
     themeSelector,
     info: { text: info, propTables: [OriginalTextarea], propTablesExclude: [Textarea] },
@@ -113,7 +113,7 @@ function makeStory(name, themeSelector, component, disableChromatic = true) {
   return [name, component, metadata];
 }
 
-function makeValidationsStory(name, themeSelector, disableChromatic = true) {
+function makeValidationsStory(name, themeSelector, disableChromatic = false) {
   const validationTypes = ['error', 'warning', 'info'];
   const component = () => {
     return (
@@ -177,7 +177,7 @@ storiesOf('Experimental/Textarea', module)
     }
   })
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
-  .add(...makeStory('classic', classicThemeSelector, defaultComponent, false))
+  .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
   .add(...makeValidationsStory('validations', dlsThemeSelector))
-  .add(...makeValidationsStory('validations classic', classicThemeSelector, false))
+  .add(...makeValidationsStory('validations classic', classicThemeSelector, true))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent));

--- a/src/__experimental__/components/textarea/textarea.stories.js
+++ b/src/__experimental__/components/textarea/textarea.stories.js
@@ -100,17 +100,20 @@ const autoFocusComponent = () => {
   return defaultComponent();
 };
 
-function makeStory(name, themeSelector, component) {
+function makeStory(name, themeSelector, component, disableChromatic = true) {
   const metadata = {
     themeSelector,
     info: { text: info, propTables: [OriginalTextarea], propTablesExclude: [Textarea] },
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
 }
 
-function makeValidationsStory(name, themeSelector) {
+function makeValidationsStory(name, themeSelector, disableChromatic = true) {
   const validationTypes = ['error', 'warning', 'info'];
   const component = () => {
     return (
@@ -158,6 +161,9 @@ function makeValidationsStory(name, themeSelector) {
       source: false,
       propTables: [OriginalTextarea],
       propTablesExclude: [Textarea]
+    },
+    chromatic: {
+      disable: disableChromatic
     }
   };
 
@@ -171,7 +177,7 @@ storiesOf('Experimental/Textarea', module)
     }
   })
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
-  .add(...makeStory('classic', classicThemeSelector, defaultComponent))
+  .add(...makeStory('classic', classicThemeSelector, defaultComponent, false))
   .add(...makeValidationsStory('validations', dlsThemeSelector))
-  .add(...makeValidationsStory('validations classic', classicThemeSelector))
+  .add(...makeValidationsStory('validations classic', classicThemeSelector, false))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent));

--- a/src/__experimental__/components/textbox/textbox.stories.js
+++ b/src/__experimental__/components/textbox/textbox.stories.js
@@ -27,7 +27,7 @@ const defaultStoryPropsConfig = {
   inputWidthEnabled: true
 };
 
-function makeStory(name, themeSelector, component) {
+function makeStory(name, themeSelector, component, disableChromatic = true) {
   const metadata = {
     themeSelector,
     info: {
@@ -36,7 +36,10 @@ function makeStory(name, themeSelector, component) {
       propTablesExclude: [Textbox]
     },
     notes: { markdown: notes },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -86,7 +89,7 @@ const multipleTextboxAutoFocus = () => {
 };
 
 
-function makeValidationsStory(name, themeSelector) {
+function makeValidationsStory(name, themeSelector, disableChromatic = true) {
   const validationTypes = ['error', 'warning', 'info'];
   const component = () => {
     return (
@@ -135,6 +138,9 @@ function makeValidationsStory(name, themeSelector) {
       source: false,
       propTables: [OriginalTextbox],
       propTablesExclude: [Textbox]
+    },
+    chromatic: {
+      disable: disableChromatic
     }
   };
 
@@ -148,10 +154,10 @@ const previous = {
 
 storiesOf('Experimental/Textbox', module)
   .add(...makeStory('default', dlsThemeSelector, defaultTextbox))
-  .add(...makeStory('classic', classicThemeSelector, defaultTextbox))
+  .add(...makeStory('classic', classicThemeSelector, defaultTextbox, false))
   .add(...makeStory('multiple', dlsThemeSelector, multipleTextbox))
   .add(...makeValidationsStory('validations', dlsThemeSelector))
-  .add(...makeValidationsStory('validations classic', classicThemeSelector))
+  .add(...makeValidationsStory('validations classic', classicThemeSelector, false))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusTextbox))
   .add(...makeStory('multiple autoFocus', dlsThemeSelector, multipleTextboxAutoFocus));
 

--- a/src/__experimental__/components/textbox/textbox.stories.js
+++ b/src/__experimental__/components/textbox/textbox.stories.js
@@ -27,7 +27,7 @@ const defaultStoryPropsConfig = {
   inputWidthEnabled: true
 };
 
-function makeStory(name, themeSelector, component, disableChromatic = true) {
+function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
     themeSelector,
     info: {
@@ -89,7 +89,7 @@ const multipleTextboxAutoFocus = () => {
 };
 
 
-function makeValidationsStory(name, themeSelector, disableChromatic = true) {
+function makeValidationsStory(name, themeSelector, disableChromatic = false) {
   const validationTypes = ['error', 'warning', 'info'];
   const component = () => {
     return (
@@ -154,10 +154,10 @@ const previous = {
 
 storiesOf('Experimental/Textbox', module)
   .add(...makeStory('default', dlsThemeSelector, defaultTextbox))
-  .add(...makeStory('classic', classicThemeSelector, defaultTextbox, false))
+  .add(...makeStory('classic', classicThemeSelector, defaultTextbox, true))
   .add(...makeStory('multiple', dlsThemeSelector, multipleTextbox))
   .add(...makeValidationsStory('validations', dlsThemeSelector))
-  .add(...makeValidationsStory('validations classic', classicThemeSelector, false))
+  .add(...makeValidationsStory('validations classic', classicThemeSelector, true))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusTextbox))
   .add(...makeStory('multiple autoFocus', dlsThemeSelector, multipleTextboxAutoFocus));
 

--- a/src/components/accordion/accordion.stories.js
+++ b/src/components/accordion/accordion.stories.js
@@ -15,7 +15,10 @@ export default {
     info: {
       disable: true
     },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disabled: true
+    }
   }
 };
 
@@ -69,3 +72,19 @@ export const Grouped = () => (
     </Accordion>
   </AccordionGroup>
 );
+
+Basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
+};
+
+Grouped.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
+};

--- a/src/components/action-popover/action-popover.stories.js
+++ b/src/components/action-popover/action-popover.stories.js
@@ -46,6 +46,9 @@ export default {
     themeSelector: dlsThemeSelector,
     info: {
       disable: true
+    },
+    chromatic: {
+      disable: true
     }
   }
 };
@@ -121,7 +124,12 @@ export const Default = () => (
 );
 
 Default.story = {
-  name: 'default'
+  name: 'default',
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
 };
 
 export const Classic = () => (
@@ -197,7 +205,10 @@ export const Classic = () => (
 Classic.story = {
   name: 'classic',
   parameters: {
-    themeSelector: classicThemeSelector
+    themeSelector: classicThemeSelector,
+    chromatic: {
+      disable: true
+    }
   }
 };
 
@@ -271,6 +282,9 @@ export const StylesOverriden = () => (
 StylesOverriden.story = {
   name: 'styles overriden',
   parameters: {
-    themeSelector: dlsThemeSelector
+    themeSelector: dlsThemeSelector,
+    chromatic: {
+      disable: false
+    }
   }
 };

--- a/src/components/advanced-color-picker/advanced-color-picker.stories.js
+++ b/src/components/advanced-color-picker/advanced-color-picker.stories.js
@@ -15,7 +15,10 @@ export default {
     info: {
       disable: true
     },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: true
+    }
   }
 };
 
@@ -86,4 +89,12 @@ export const Basic = () => {
       open={ state.open }
     />
   );
+};
+
+Basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
 };

--- a/src/components/alert/alert.stories.js
+++ b/src/components/alert/alert.stories.js
@@ -28,7 +28,7 @@ const handleOpen = () => {
   action('open')();
 };
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const title = text('title', 'Attention');
     const subtitle = text('subtitle', '');
@@ -62,13 +62,16 @@ function makeStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
 }
 
-function makeButtonStory(name, themeSelector) {
+function makeButtonStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const title = text('title', 'Attention');
     const subtitle = text('subtitle', '');
@@ -105,7 +108,10 @@ function makeButtonStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -120,6 +126,6 @@ storiesOf('Alert', module)
     notes: { markdown: notes }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector))
+  .add(...makeStory('classic', classicThemeSelector, true))
   .add(...makeButtonStory('with button', dlsThemeSelector))
-  .add(...makeButtonStory('with button classic', classicThemeSelector));
+  .add(...makeButtonStory('with button classic', classicThemeSelector, true));

--- a/src/components/anchor-navigation/anchor-navigation.stories.js
+++ b/src/components/anchor-navigation/anchor-navigation.stories.js
@@ -33,6 +33,9 @@ export default {
     themeSelector: dlsThemeSelector,
     info: {
       disable: true
+    },
+    chromatic: {
+      disabled: true
     }
   }
 };
@@ -221,4 +224,28 @@ export const WithOverridenStyles = () => {
       </div>
     </AnchorNavigation>
   );
+};
+
+Basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
+};
+
+InFullScreenDialog.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
+};
+
+WithOverridenStyles.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
 };

--- a/src/components/animated-menu-button/animated-menu-button.stories.js
+++ b/src/components/animated-menu-button/animated-menu-button.stories.js
@@ -54,7 +54,7 @@ const Wrapper = ({
 Wrapper.propTypes = { ...AnimatedMenuButton.propTypes };
 Wrapper.displayName = 'AnimatedMenuButton';
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const direction = select('direction', OptionsHelper.alignBinary, OptionsHelper.alignBinary[1]);
     const label = text('label', '');
@@ -89,7 +89,10 @@ function makeStory(name, themeSelector) {
 
   const metadata = {
     themeSelector,
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -103,4 +106,4 @@ storiesOf('Animated Menu Button', module)
     }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/app-wrapper/app-wrapper.stories.js
+++ b/src/components/app-wrapper/app-wrapper.stories.js
@@ -11,7 +11,7 @@ AppWrapper.__docgenInfo = getDocGenInfo(
   /app-wrapper(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const children = text(
       'children',
@@ -27,7 +27,10 @@ function makeStory(name, themeSelector) {
 
   const metadata = {
     themeSelector,
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -35,4 +38,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('App Wrapper', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/badge/badge.stories.js
+++ b/src/components/badge/badge.stories.js
@@ -10,6 +10,9 @@ export default {
   parameters: {
     info: {
       disable: true
+    },
+    chromatic: {
+      disable: true
     }
   }
 };
@@ -25,4 +28,12 @@ export const Basic = () => {
       <Button style={ { marginRight: 0 } } buttonType='tertiary'>Filter</Button>
     </Badge>
   );
+};
+
+Basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
 };

--- a/src/components/batch-selection/batch-selection.stories.js
+++ b/src/components/batch-selection/batch-selection.stories.js
@@ -13,7 +13,12 @@ import Icon from '../icon';
 export default {
   title: 'Test/Batch Selection',
   component: BatchSelection,
-  decorators: [withKnobs]
+  decorators: [withKnobs],
+  parameters: {
+    chromatic: {
+      disable: true
+    }
+  }
 };
 
 export const basic = () => {
@@ -39,6 +44,9 @@ basic.story = {
     info: { disable: true },
     docs: {
       page: null
+    },
+    chromatic: {
+      disable: false
     }
   }
 };

--- a/src/components/button-toggle-group/button-toggle-group.stories.js
+++ b/src/components/button-toggle-group/button-toggle-group.stories.js
@@ -23,6 +23,9 @@ export default {
     info: {
       disable: true
     },
+    chromatic: {
+      disable: true
+    },
     propTablesInclude: [ButtonToggle, ButtonToggleGroup]
   }
 };
@@ -190,6 +193,41 @@ export const Classic = () => {
 Classic.story = {
   name: 'classic',
   parameters: {
-    themeSelector: classicThemeSelector
+    themeSelector: classicThemeSelector,
+    chromatic: {
+      disable: true
+    }
+  }
+};
+
+Basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
+};
+
+BasicGrouped.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
+};
+
+ValidationsGrouped.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
+};
+
+Validations.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
   }
 };

--- a/src/components/button-toggle/button-toggle.stories.js
+++ b/src/components/button-toggle/button-toggle.stories.js
@@ -15,7 +15,7 @@ ButtonToggle.__docgenInfo = getDocGenInfo(
   /button-toggle\.component(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const children = text('children', 'Option');
     const buttonIcon = select('buttonIcon', [null, ...OptionsHelper.icons]);
@@ -83,7 +83,10 @@ function makeStory(name, themeSelector) {
 
   const metadata = {
     themeSelector,
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -91,4 +94,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Button Toggle', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/carousel/carousel.stories.js
+++ b/src/components/carousel/carousel.stories.js
@@ -36,9 +36,6 @@ storiesOf('Carousel', module)
     info: {
       propTablesExclude: [Slide, Carousel, ExampleCustomElement, ThemeProvider],
       propTables: [BaseCarousel]
-    },
-    chromatic: {
-      disable: true
     }
   })
   .add('classic', () => {
@@ -84,7 +81,10 @@ storiesOf('Carousel', module)
       </ThemeProvider>
     );
   }, {
-    themeSelector: classicThemeSelector
+    themeSelector: classicThemeSelector,
+    chromatic: {
+      disable: true
+    }
   })
   .add('default', () => {
     const indexConfig = [0, 1, 2, 3, 4];
@@ -129,5 +129,11 @@ storiesOf('Carousel', module)
     );
   }, {
     themeSelector: dlsThemeSelector,
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    // disabled because of chromatic lack of possibility to render story
+    // Your story couldn’t be captured because it exceeds our 25,000,000px limit.
+    // Its dimensions are 1,200x25,498px. Possible ways to resolve
+    chromatic: {
+      disable: true
+    }
   });

--- a/src/components/confirm/confirm.stories.js
+++ b/src/components/confirm/confirm.stories.js
@@ -31,7 +31,7 @@ const handleConfirm = () => {
   store.set({ open: false });
 };
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const children = text('children', 'This is an example of a confirm.');
     const title = text('title', 'Are you sure?');
@@ -77,7 +77,10 @@ function makeStory(name, themeSelector) {
       propTablesExclude: [State, Button],
       text: info
     },
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -85,4 +88,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Confirm', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/content/content.stories.js
+++ b/src/components/content/content.stories.js
@@ -12,7 +12,7 @@ Content.__docgenInfo = getDocGenInfo(
   /content(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const children = text('children', 'An example of some content.');
     const title = text('title', 'Content Component');
@@ -38,7 +38,10 @@ function makeStory(name, themeSelector) {
 
   const metadata = {
     themeSelector,
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -46,4 +49,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Content', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/create/create.stories.js
+++ b/src/components/create/create.stories.js
@@ -11,7 +11,7 @@ Create.__docgenInfo = getDocGenInfo(
   /create\.component(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const children = text('children', 'Resource Name');
     const className = text('className', '');
@@ -27,7 +27,10 @@ function makeStory(name, themeSelector) {
 
   const metadata = {
     themeSelector,
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -35,4 +38,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Create', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/detail/detail.stories.js
+++ b/src/components/detail/detail.stories.js
@@ -12,7 +12,7 @@ Detail.__docgenInfo = getDocGenInfo(
   /detail\.js(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const icon = select('icon', [null, ...OptionsHelper.icons], null);
     const footnote = text('footnote', 'This detail may require a footnote.');
@@ -30,7 +30,10 @@ function makeStory(name, themeSelector) {
 
   const metadata = {
     themeSelector,
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -38,4 +41,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Detail', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.js
@@ -33,7 +33,7 @@ const handleClick = (evt) => {
   action('click')(evt);
 };
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const title = text('title', 'Example Dialog');
     const subtitle = text('subtitle', 'Example Subtitle');
@@ -66,13 +66,16 @@ function makeStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
 }
 
-function makeStickyFooterStory(name, themeSelector) {
+function makeStickyFooterStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const title = text('title', 'Example Dialog');
     const subtitle = text('subtitle', 'Example Subtitle');
@@ -109,7 +112,10 @@ function makeStickyFooterStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -125,6 +131,6 @@ storiesOf('Dialog Full Screen', module)
     knobs: { escapeHTML: false }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector))
+  .add(...makeStory('classic', classicThemeSelector, true))
   .add(...makeStickyFooterStory('with sticky footer', dlsThemeSelector))
-  .add(...makeStickyFooterStory('with sticky footer classic', classicThemeSelector));
+  .add(...makeStickyFooterStory('with sticky footer classic', classicThemeSelector, true));

--- a/src/components/dialog/dialog.stories.js
+++ b/src/components/dialog/dialog.stories.js
@@ -40,7 +40,7 @@ const handleClick = (evt) => {
   action('click')(evt);
 };
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const height = text('height', '400');
     const title = text('title', 'Example Dialog');
@@ -130,7 +130,10 @@ function makeStory(name, themeSelector) {
       ]
     },
     notes: { markdown: notes },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -138,4 +141,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Dialog', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/drag-and-drop/drag-and-drop.stories.js
+++ b/src/components/drag-and-drop/drag-and-drop.stories.js
@@ -77,7 +77,7 @@ const BuildRows = props => (
   ))
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const autoScroll = boolean('autoScroll', true);
 
@@ -108,7 +108,10 @@ function makeStory(name, themeSelector) {
   const metadata = {
     themeSelector,
     info: { text: Info },
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -129,4 +132,4 @@ storiesOf('DraggableContext', module)
     }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/draggable/draggable.stories.js
+++ b/src/components/draggable/draggable.stories.js
@@ -8,7 +8,10 @@ export default {
   component: DraggableContainer,
   title: 'Test/Draggable',
   parameters: {
-    info: { disable: true }
+    info: { disable: true },
+    chromatic: {
+      disable: true
+    }
   }
 };
 
@@ -33,4 +36,12 @@ export const basic = () => {
       </DraggableItem>
     </DraggableContainer>
   );
+};
+
+basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
 };

--- a/src/components/drawer/drawer.stories.js
+++ b/src/components/drawer/drawer.stories.js
@@ -15,7 +15,10 @@ export default {
   component: Drawer,
   title: 'Test/Drawer',
   parameters: {
-    info: { disable: true }
+    info: { disable: true },
+    chromatic: {
+      disable: true
+    }
   }
 };
 
@@ -311,5 +314,10 @@ export const Visual = () => {
 };
 
 Visual.story = {
-  name: 'visual'
+  name: 'visual',
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
 };

--- a/src/components/duelling-picklist/duelling-picklist.stories.js
+++ b/src/components/duelling-picklist/duelling-picklist.stories.js
@@ -17,6 +17,9 @@ export default {
     themeSelector: dlsThemeSelector,
     info: {
       disable: true
+    },
+    chromatic: {
+      disable: true
     }
   }
 };
@@ -167,4 +170,20 @@ export const InDialog = () => {
       </Dialog>
     </>
   );
+};
+
+Basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
+};
+
+InDialog.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
 };

--- a/src/components/filter/filter.stories.js
+++ b/src/components/filter/filter.stories.js
@@ -12,7 +12,7 @@ Filter.__docgenInfo = getDocGenInfo(
   /filter(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const align = select('labelAlign', OptionsHelper.alignBinary);
 
@@ -31,7 +31,10 @@ function makeStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -44,4 +47,4 @@ storiesOf('Filter Component', module)
     }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/flash/flash.stories.js
+++ b/src/components/flash/flash.stories.js
@@ -69,6 +69,9 @@ storiesOf('Flash', module)
       text: Info,
       propTables: [FlashWithoutHOC, Button],
       propTablesExclude: [State, ThemeProvider, Button, Flash]
+    },
+    chromatic: {
+      disable: true
     }
   })
   .add('default', () => {

--- a/src/components/flat-table/flat-table.stories.js
+++ b/src/components/flat-table/flat-table.stories.js
@@ -17,7 +17,12 @@ import guid from '../../utils/helpers/guid';
 export default {
   title: 'Test/Flat Table',
   component: FlatTable,
-  decorators: [withKnobs]
+  decorators: [withKnobs],
+  parameters: {
+    chromatic: {
+      disable: true
+    }
+  }
 };
 
 export const basic = () => {
@@ -240,6 +245,9 @@ Sortable.story = {
     info: { disable: true },
     docs: {
       page: null
+    },
+    chromatic: {
+      disable: false
     }
   }
 };
@@ -250,6 +258,9 @@ basic.story = {
     info: { disable: true },
     docs: {
       page: null
+    },
+    chromatic: {
+      disable: false
     }
   }
 };

--- a/src/components/grid/grid.stories.js
+++ b/src/components/grid/grid.stories.js
@@ -181,7 +181,7 @@ basic.story = {
   parameters: {
     info: { disable: true },
     docs: { page: null },
-    chromatic: { viewports: [320, 1200] }
+    chromatic: { viewports: [1500, 1300, 900] }
   }
 };
 
@@ -449,12 +449,16 @@ Visual.story = {
   name: 'visual',
   parameters: {
     info: { disable: true },
-    docs: { page: null }
+    docs: { page: null },
+    chromatic: { viewports: [1500, 1300, 900] }
   }
 };
 
 export default {
   title: 'Test/Grid',
   component: GridContainer,
-  decorators: [withKnobs]
+  decorators: [withKnobs],
+  chromatic: {
+    disable: true
+  }
 };

--- a/src/components/heading/heading.stories.js
+++ b/src/components/heading/heading.stories.js
@@ -11,7 +11,7 @@ Heading.__docgenInfo = getDocGenInfo(
   /heading(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const title = text('title', 'This is a heading');
     const children = text('children', 'This is content beneath a heading');
@@ -40,7 +40,10 @@ function makeStory(name, themeSelector) {
   const metadata = {
     themeSelector,
     notes: { markdown: notes },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -48,4 +51,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Heading', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/help/help.stories.js
+++ b/src/components/help/help.stories.js
@@ -12,7 +12,7 @@ Help.__docgenInfo = getDocGenInfo(
   /help\.component(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const children = text('children', 'This is help text');
     const tooltipPosition = children ? select(
@@ -43,7 +43,10 @@ function makeStory(name, themeSelector) {
   const metadata = {
     themeSelector,
     notes: { markdown: notes },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -51,4 +54,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Help', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/i18n/i18n.stories.js
+++ b/src/components/i18n/i18n.stories.js
@@ -17,7 +17,7 @@ i18n.translations.en['my'] = {
   example: '# My __example__ translation.'
 };
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const markdown = boolean('markdown', true);
     const inline = markdown ? boolean('inline', I18nComponent.defaultProps.inline) : undefined;
@@ -35,7 +35,10 @@ function makeStory(name, themeSelector) {
     themeSelector,
     info: { text: Info },
     notes: { markdown: notes },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -43,4 +46,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('I18nComponent', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/icon/icon.stories.js
+++ b/src/components/icon/icon.stories.js
@@ -60,7 +60,12 @@ storiesOf('Icon', module)
       themeSelector: classicThemeSelector,
       info: { text: Info },
       notes: { markdown: notes },
-      knobs: { escapeHTML: false }
+      knobs: { escapeHTML: false },
+      parameters: {
+        chromatic: {
+          disable: true
+        }
+      }
     }
   )
   .add('default', () => {

--- a/src/components/link/link.stories.js
+++ b/src/components/link/link.stories.js
@@ -14,7 +14,7 @@ Link.__docgenInfo = getDocGenInfo(
   /link\.component(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const children = text('children', 'Link');
     const disabled = boolean('disabled', false);
@@ -66,7 +66,10 @@ function makeStory(name, themeSelector) {
     themeSelector,
     info: { text: Info },
     notes: { markdown: notes },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -74,4 +77,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Link', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/loader/loader.stories.js
+++ b/src/components/loader/loader.stories.js
@@ -24,7 +24,7 @@ const styles = {
   textAlign: 'left'
 };
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const size = select('size', OptionsHelper.sizesBinary, Loader.defaultProps.size);
     const isInsideButton = boolean('isInsideButton', false);
@@ -49,13 +49,16 @@ function makeStory(name, themeSelector) {
       text: info,
       propTablesExclude: [Button]
     },
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
 }
 
-function makeLegacySpinnerStory(name, themeSelector) {
+function makeLegacySpinnerStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const type = select('as', OptionsHelper.colors, Spinner.defaultProps.as);
     const size = select('size', OptionsHelper.sizesFull, Spinner.defaultProps.size);
@@ -66,7 +69,10 @@ function makeLegacySpinnerStory(name, themeSelector) {
   const metadata = {
     themeSelector,
     info: { text: infoSpinner },
-    notes: { markdown: notesSpinner }
+    notes: { markdown: notesSpinner },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -74,6 +80,6 @@ function makeLegacySpinnerStory(name, themeSelector) {
 
 storiesOf('Loader', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector))
+  .add(...makeStory('classic', classicThemeSelector, true))
   .add(...makeLegacySpinnerStory('legacy spinner', dlsThemeSelector))
-  .add(...makeLegacySpinnerStory('legacy spinner classic', classicThemeSelector));
+  .add(...makeLegacySpinnerStory('legacy spinner classic', classicThemeSelector, true));

--- a/src/components/menu-list/menu-list.stories.js
+++ b/src/components/menu-list/menu-list.stories.js
@@ -17,7 +17,7 @@ MenuListItem.__docgenInfo = getDocGenInfo(
   /menu-list-item\.js(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const title = text('title', '');
     const collapsible = title ? boolean('collapsible', true) : undefined;
@@ -64,7 +64,10 @@ function makeStory(name, themeSelector) {
   const metadata = {
     themeSelector,
     notes: { markdown: notes },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -72,4 +75,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('MenuList', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/menu/menu.stories.js
+++ b/src/components/menu/menu.stories.js
@@ -22,7 +22,7 @@ SubmenuBlock.__docgenInfo = getDocGenInfo(
   /submenu-block(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const as = select('as', OptionsHelper.themesBinary, Menu.defaultProps.as);
 
@@ -53,7 +53,10 @@ function makeStory(name, themeSelector) {
 
   const metadata = {
     themeSelector,
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -61,4 +64,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Menu', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/message/message.stories.js
+++ b/src/components/message/message.stories.js
@@ -13,7 +13,7 @@ Message.__docgenInfo = getDocGenInfo(
   /message\.component(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const variant = select('type', OptionsHelper.messages, Message.defaultProps.variant);
     const open = boolean('open', Message.defaultProps.open);
@@ -40,7 +40,10 @@ function makeStory(name, themeSelector) {
   const metadata = {
     themeSelector,
     notes: { markdown: notes },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -48,4 +51,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Message', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/mount-in-app/mount-in-app.stories.js
+++ b/src/components/mount-in-app/mount-in-app.stories.js
@@ -11,7 +11,7 @@ MountInApp.__docgenInfo = getDocGenInfo(
   /mount-in-app.js(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     return (
       <div>
@@ -60,7 +60,10 @@ function makeStory(name, themeSelector) {
         </div>
       )
     },
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -68,4 +71,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Mount In App', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/navigation-bar/navigation-bar.stories.js
+++ b/src/components/navigation-bar/navigation-bar.stories.js
@@ -12,7 +12,7 @@ NavigationBar.__docgenInfo = getDocGenInfo(
   /navigation-bar\.js(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const children = text('children', '');
     const as = select(
@@ -33,7 +33,10 @@ function makeStory(name, themeSelector) {
   const metadata = {
     themeSelector,
     info: { text: <p>Renders a full width application bar.</p> },
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -41,4 +44,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Navigation Bar', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/pager/pager.stories.js
+++ b/src/components/pager/pager.stories.js
@@ -16,7 +16,10 @@ export default {
     info: {
       disable: true
     },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: true
+    }
   }
 };
 
@@ -77,4 +80,12 @@ export const Basic = () => {
       }
     />
   );
+};
+
+Basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
 };

--- a/src/components/pages/pages.stories.js
+++ b/src/components/pages/pages.stories.js
@@ -102,7 +102,7 @@ const PageState = props => new CustomState(props);
 const indexConfig = [0, 1, 2];
 const pageIndex = () => select('pageIndex', indexConfig, indexConfig[0]);
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     return (
       <div>
@@ -141,6 +141,9 @@ function makeStory(name, themeSelector) {
     info: {
       text: <p>Allows to slide to different pages in a full screen dialog.</p>,
       propTablesExclude: [Button, DialogFullScreen, DialogState, PageState, DefaultPages, Page, State]
+    },
+    chromatic: {
+      disable: disableChromatic
     }
   };
 
@@ -149,4 +152,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Pages', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/pill/pill.stories.js
+++ b/src/components/pill/pill.stories.js
@@ -72,7 +72,10 @@ storiesOf('Pill', module)
       propTablesExclude: [ThemeProvider]
     },
     notes: { markdown: notes },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: true
+    }
   }).add('default', () => {
     const {
       children,

--- a/src/components/pod/pod.stories.js
+++ b/src/components/pod/pod.stories.js
@@ -14,7 +14,7 @@ Pod.__docgenInfo = getDocGenInfo(
   /pod\.js(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const border = boolean('border', Pod.defaultProps.border);
     const children = text('children', 'This is some example content for a Pod');
@@ -83,7 +83,10 @@ function makeStory(name, themeSelector) {
         </div>
       )
     },
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -94,4 +97,4 @@ storiesOf('Pod', module)
     knobs: { escapeHTML: false }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/popover-container/popover-container.stories.js
+++ b/src/components/popover-container/popover-container.stories.js
@@ -10,6 +10,9 @@ export default {
     info: { disable: true },
     docs: {
       page: null
+    },
+    chromatic: {
+      disable: true
     }
   }
 };
@@ -20,4 +23,12 @@ export const Basic = () => {
   return (
     <PopoverContainer title={ title } />
   );
+};
+
+Basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
 };

--- a/src/components/preview/preview.stories.js
+++ b/src/components/preview/preview.stories.js
@@ -11,7 +11,7 @@ Preview.__docgenInfo = getDocGenInfo(
   /preview\.component(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const children = text('children', 'Text rendered as children component.');
     const height = text('height');
@@ -33,7 +33,10 @@ function makeStory(name, themeSelector) {
 
   const metadata = {
     themeSelector,
-    info: { text: info, propTables: [Preview] }
+    info: { text: info, propTables: [Preview] },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -41,4 +44,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Preview', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/rainbow/rainbow.stories.js
+++ b/src/components/rainbow/rainbow.stories.js
@@ -38,7 +38,7 @@ const myImmutableData = Immutable.fromJS([
   }
 ]);
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const data = object('data', myImmutableData);
     const title = text('title', 'Rainbow chart');
@@ -49,7 +49,10 @@ function makeStory(name, themeSelector) {
   const metadata = {
     themeSelector,
     notes: { markdown: notes },
-    info: { text: info }
+    info: { text: info },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -57,4 +60,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Rainbow ', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/row/row.stories.js
+++ b/src/components/row/row.stories.js
@@ -17,7 +17,7 @@ Column.__docgenInfo = getDocGenInfo(
   /column\.js(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     // row
     const columnDivide = boolean('columnDivide', true);
@@ -61,7 +61,10 @@ function makeStory(name, themeSelector) {
   const metadata = {
     themeSelector,
     notes: { markdown: notes },
-    info: { text: info }
+    info: { text: info },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -69,4 +72,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Row', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/settings-row/settings-row.stories.js
+++ b/src/components/settings-row/settings-row.stories.js
@@ -11,7 +11,7 @@ SettingsRow.__docgenInfo = getDocGenInfo(
   /settings-row\.js(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const children = text('children', 'Content for settings');
     const description = text(
@@ -34,7 +34,10 @@ function makeStory(name, themeSelector) {
   const metadata = {
     themeSelector,
     notes: { markdown: notes },
-    info: { text: info }
+    info: { text: info },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -42,4 +45,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('SettingsRow', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/show-edit-pod/show-edit-pod.stories.js
+++ b/src/components/show-edit-pod/show-edit-pod.stories.js
@@ -48,7 +48,7 @@ const setField = fieldName => (e) => {
   store.set({ [fieldName]: e.target.value });
 };
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const fieldProps = [{
     key: 'edit_first_name',
     label: 'First Name'
@@ -134,7 +134,10 @@ function makeStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -150,4 +153,4 @@ storiesOf('ShowEditPod', module)
     notes: { markdown: notes }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/sidebar/sidebar.stories.js
+++ b/src/components/sidebar/sidebar.stories.js
@@ -34,7 +34,7 @@ const openSidebar = () => {
   store.set({ open: true });
 };
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const enableBackgroundUI = boolean('enableBackgroundUI', Sidebar.defaultProps.enableBackgroundUI);
     const position = select('position', OptionsHelper.alignBinary, Sidebar.defaultProps.position);
@@ -54,13 +54,16 @@ function makeStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
 }
 
-function makeButtonStory(name, themeSelector) {
+function makeButtonStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const enableBackgroundUI = boolean('enableBackgroundUI', Sidebar.defaultProps.enableBackgroundUI);
     const position = select('position', OptionsHelper.alignBinary, Sidebar.defaultProps.position);
@@ -89,7 +92,10 @@ function makeButtonStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -106,6 +112,6 @@ storiesOf('Sidebar', module)
     }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector))
+  .add(...makeStory('classic', classicThemeSelector, true))
   .add(...makeButtonStory('with button', dlsThemeSelector))
-  .add(...makeButtonStory('with button classic', classicThemeSelector));
+  .add(...makeButtonStory('with button classic', classicThemeSelector, true));

--- a/src/components/step-sequence/step-sequence.stories.js
+++ b/src/components/step-sequence/step-sequence.stories.js
@@ -17,7 +17,7 @@ StepSequenceItem.__docgenInfo = getDocGenInfo(
   /step-sequence-item\.component(?!spec)/
 );
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const orientation = select('orientation', OptionsHelper.orientation, StepSequence.defaultProps.orientation);
 
@@ -73,7 +73,10 @@ function makeStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -81,4 +84,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Step Sequence', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/table-ajax/table-ajax.stories.js
+++ b/src/components/table-ajax/table-ajax.stories.js
@@ -56,7 +56,7 @@ const handleChange = (data) => {
   }, 500);
 };
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     enableMock();
 
@@ -97,7 +97,10 @@ function makeStory(name, themeSelector) {
   };
 
   const metadata = {
-    themeSelector
+    themeSelector,
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -113,4 +116,4 @@ storiesOf('Table Ajax', module)
     knobs: { escapeHTML: false }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/table/table.stories.js
+++ b/src/components/table/table.stories.js
@@ -100,7 +100,10 @@ storiesOf('Table', module)
       <TableWrapper { ...tableProps } />
     );
   }, {
-    themeSelector: classicThemeSelector
+    themeSelector: classicThemeSelector,
+    chromatic: {
+      disable: true
+    }
   })
   .add(
     'default',
@@ -132,7 +135,10 @@ storiesOf('Table', module)
       );
     },
     {
-      themeSelector: classicThemeSelector
+      themeSelector: classicThemeSelector,
+      chromatic: {
+        disable: true
+      }
     },
   )
   .add(

--- a/src/components/tabs/tabs.stories.js
+++ b/src/components/tabs/tabs.stories.js
@@ -31,7 +31,7 @@ const checkIfSelected = (tabId) => {
   return false;
 };
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const selectOption = ['top', 'left'];
     const align = select('align', OptionsHelper.alignBinary, Tabs.defaultProps.align);
@@ -78,7 +78,10 @@ function makeStory(name, themeSelector) {
   const metadata = {
     themeSelector,
     info: { text: info },
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -91,4 +94,4 @@ storiesOf('Tabs', module)
     }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/toast/toast.stories.js
+++ b/src/components/toast/toast.stories.js
@@ -12,7 +12,10 @@ export default {
     info: {
       disable: true
     },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: true
+    }
   }
 };
 
@@ -113,6 +116,9 @@ Visual.story = {
   name: 'visual',
   parameters: {
     info: { disable: true },
-    docs: { page: null }
+    docs: { page: null },
+    chromatic: {
+      disable: false
+    }
   }
 };

--- a/src/components/tooltip/tooltip.stories.js
+++ b/src/components/tooltip/tooltip.stories.js
@@ -30,7 +30,7 @@ const props = () => {
 
 const content = () => (validTooltip(props()) ? <Tooltip { ...props() } /> : null);
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     return <div style={ { position: 'absolute' } }>{content()}</div>;
   };
@@ -38,7 +38,10 @@ function makeStory(name, themeSelector) {
   const metadata = {
     themeSelector,
     info: { text: info },
-    notes: { markdown: notes }
+    notes: { markdown: notes },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -49,4 +52,4 @@ storiesOf('Tooltip', module)
     knobs: { escapeHTML: false }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Disable `chromatic` for:
- `classic` stories;
- Test/`component` directories
Reduced amount of screenshots from 346 to 264.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are running `chromatic` runs for every story

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Screenshots are included in the PR
- [ ] Carbon implementation and Design System documentation are congruent
- [ ] All themes are supported
- [ ] Commits follow our style guide
- [ ] Unit tests added or updated
- [ ] Cypress automation tests added or updated
- [ ] Storybook added or updated
- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
