### PR TITLE
docs: prevent guid changing in chromatic

### DIFF
--- a/src/__experimental__/components/checkbox/checkbox.stories.js
+++ b/src/__experimental__/components/checkbox/checkbox.stories.js
@@ -11,7 +11,6 @@ import { Checkbox, CheckboxGroup } from '.';
 import { info, notes } from './documentation';
 import getDocGenInfo from '../../../utils/helpers/docgen-info';
 import AutoFocus from '../../../utils/helpers/auto-focus';
-import guid from '../../../utils/helpers/guid';
 
 Checkbox.__docgenInfo = getDocGenInfo(
   require('./docgenInfo.json'),
@@ -44,12 +43,8 @@ const groupStore = new Store({
   three: false
 });
 
-const previous = {
-  key: guid(),
-  autoFocus: false
-};
 
-function defaultKnobs(type) {
+function defaultKnobs(type, autoFocusDefault = false) {
   let theType = '';
   if (type === undefined) {
     theType = 'default';
@@ -57,7 +52,11 @@ function defaultKnobs(type) {
     theType = type;
   }
   const label = `${text('label', 'Example Checkbox', type)} (${theType})`;
-  const autoFocus = boolean('autoFocus', false, type);
+  const autoFocus = boolean('autoFocus', autoFocusDefault, type);
+  const previous = {
+    key: 'checkbox',
+    autoFocus: autoFocusDefault
+  };
   const key = AutoFocus.getKey(autoFocus, previous);
 
   return ({
@@ -132,20 +131,15 @@ function handleGroupChange(ev, id) {
   });
 }
 
-const checkboxComponent = () => {
+const checkboxComponent = (autoFocus = false) => () => {
   return (
     <State store={ checkboxes.default.store }>
       <Checkbox
         onChange={ ev => handleChange(ev, 'default') }
-        { ...defaultKnobs() }
+        { ...defaultKnobs(undefined, autoFocus) }
       />
     </State>
   );
-};
-
-const checkboxComponentAutoFocus = () => {
-  boolean('autoFocus', true, 'Checkbox default');
-  return checkboxComponent();
 };
 
 const checkboxValidations = () => (
@@ -243,8 +237,8 @@ const checkboxValidations = () => (
 );
 
 storiesOf('Experimental/Checkbox', module)
-  .add(...makeStory('default', dlsThemeSelector, checkboxComponent))
-  .add(...makeStory('classic', classicThemeSelector, checkboxComponent, true))
+  .add(...makeStory('default', dlsThemeSelector, checkboxComponent()))
+  .add(...makeStory('classic', classicThemeSelector, checkboxComponent(), true))
   .add(...makeStory('validations', dlsThemeSelector, checkboxValidations))
   .add(...makeStory('validations classic', classicThemeSelector, checkboxValidations, true))
-  .add(...makeStory('autoFocus', dlsThemeSelector, checkboxComponentAutoFocus));
+  .add(...makeStory('autoFocus', dlsThemeSelector, checkboxComponent(true)));

--- a/src/__experimental__/components/select/select.stories.js
+++ b/src/__experimental__/components/select/select.stories.js
@@ -10,7 +10,6 @@ import OptionsHelper from '../../../utils/helpers/options-helper';
 import getDocGenInfo from '../../../utils/helpers/docgen-info';
 import docgenInfo from './docgenInfo.json';
 import AutoFocus from '../../../utils/helpers/auto-focus';
-import guid from '../../../utils/helpers/guid';
 
 Select.__docgenInfo = getDocGenInfo(
   docgenInfo,
@@ -30,16 +29,15 @@ const multiSelectStore = new Store({
   value: []
 });
 
-const previous = {
-  key: guid(),
-  autoFocus: false
-};
-
-const commonKnobs = (store, enableMultiSelect = false) => {
+const commonKnobs = (store, enableMultiSelect = false, autoFocusDefault = false) => {
   const filterable = boolean('filterable', Select.defaultProps.filterable);
   const typeAhead = filterable && boolean('typeAhead', Select.defaultProps.typeAhead);
   const label = text('label', 'Label');
-  const autoFocus = boolean('autoFocus', false);
+  const previous = {
+    key: 'select',
+    autoFocus: autoFocusDefault
+  };
+  const autoFocus = boolean('autoFocus', autoFocusDefault);
   const isLoopable = boolean('isLoopable', false);
   const preventFocusAutoOpen = boolean('preventFocusAutoOpen', false);
   const key = AutoFocus.getKey(autoFocus, previous);
@@ -108,19 +106,14 @@ const objectOptions = [
   }
 ];
 
-const defaultComponent = () => {
+const defaultComponent = (autoFocus = false) => () => {
   return (
     <State store={ singleSelectStore }>
-      <Select ariaLabel='singleSelect' { ...commonKnobs(singleSelectStore) }>
+      <Select ariaLabel='singleSelect' { ...commonKnobs(singleSelectStore, false, autoFocus) }>
         { selectOptions }
       </Select>
     </State>
   );
-};
-
-const autoFocusComponent = () => {
-  boolean('autoFocus', true);
-  return defaultComponent();
 };
 
 const customFilterComponent = () => {
@@ -296,9 +289,9 @@ storiesOf('Experimental/Select', module)
     },
     knobs: { escapeHTML: false }
   })
-  .add(...makeStory('default', dlsThemeSelector, defaultComponent))
-  .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
+  .add(...makeStory('default', dlsThemeSelector, defaultComponent()))
+  .add(...makeStory('classic', classicThemeSelector, defaultComponent(), true))
   .add(...makeMultipleStory('multiple', dlsThemeSelector))
   .add(...makeValidationsStory('validations', dlsThemeSelector))
-  .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent))
+  .add(...makeStory('autoFocus', dlsThemeSelector, defaultComponent(true)))
   .add(...makeStory('customFilter', dlsThemeSelector, customFilterComponent));

--- a/src/__experimental__/components/textarea/textarea.stories.js
+++ b/src/__experimental__/components/textarea/textarea.stories.js
@@ -11,7 +11,6 @@ import { notes, info } from './documentation';
 import { OriginalTextarea } from './textarea.component';
 import getDocGenInfo from '../../../utils/helpers/docgen-info';
 import AutoFocus from '../../../utils/helpers/auto-focus';
-import guid from '../../../utils/helpers/guid';
 
 OriginalTextarea.__docgenInfo = getDocGenInfo(
   require('./docgenInfo.json'),
@@ -39,17 +38,17 @@ const percentageRange = {
   step: 1
 };
 
-const previous = {
-  key: guid(),
-  autoFocus: false
-};
 
-const defaultComponent = () => {
+const defaultComponent = (autoFocusDefault = false) => () => {
+  const previous = {
+    key: 'textarea',
+    autoFocus: autoFocusDefault
+  };
   const expandable = boolean('expandable', Textarea.defaultProps.expandable);
   const cols = number('cols', 0, rangeOptions);
   const rows = number('rows', 0, rangeOptions);
   const disabled = boolean('disabled', false);
-  const autoFocus = boolean('autoFocus', false);
+  const autoFocus = boolean('autoFocus', autoFocusDefault);
   const readOnly = boolean('readOnly', false);
   const placeholder = text('placeholder', '');
   const fieldHelp = text('fieldHelp', '');
@@ -93,11 +92,6 @@ const defaultComponent = () => {
       />
     </State>
   );
-};
-
-const autoFocusComponent = () => {
-  boolean('autoFocus', true);
-  return defaultComponent();
 };
 
 function makeStory(name, themeSelector, component, disableChromatic = false) {
@@ -176,8 +170,8 @@ storiesOf('Experimental/Textarea', module)
       propTablesExclude: [State]
     }
   })
-  .add(...makeStory('default', dlsThemeSelector, defaultComponent))
-  .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
+  .add(...makeStory('default', dlsThemeSelector, defaultComponent()))
+  .add(...makeStory('classic', classicThemeSelector, defaultComponent(), true))
   .add(...makeValidationsStory('validations', dlsThemeSelector))
   .add(...makeValidationsStory('validations classic', classicThemeSelector, true))
-  .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent));
+  .add(...makeStory('autoFocus', dlsThemeSelector, defaultComponent(true)));

--- a/src/__experimental__/components/textbox/textbox.stories.js
+++ b/src/__experimental__/components/textbox/textbox.stories.js
@@ -13,7 +13,6 @@ import Textbox, { OriginalTextbox } from '.';
 import OptionsHelper from '../../../utils/helpers/options-helper';
 import getDocGenInfo from '../../../utils/helpers/docgen-info';
 import AutoFocus from '../../../utils/helpers/auto-focus';
-import guid from '../../../utils/helpers/guid';
 
 OriginalTextbox.__docgenInfo = getDocGenInfo(
   require('./docgenInfo.json'),
@@ -55,11 +54,10 @@ const defaultTextbox = () => {
 };
 
 const autoFocusTextbox = () => {
-  boolean('autoFocus', true);
   return (
     <Textbox
       placeholder={ text('placeholder') }
-      { ...getCommonTextboxProps() }
+      { ...getCommonTextboxProps(defaultStoryPropsConfig, true) }
     />
   );
 };
@@ -147,10 +145,6 @@ function makeValidationsStory(name, themeSelector, disableChromatic = false) {
   return [name, component, metadata];
 }
 
-const previous = {
-  key: guid(),
-  autoFocus: false
-};
 
 storiesOf('Experimental/Textbox', module)
   .add(...makeStory('default', dlsThemeSelector, defaultTextbox))
@@ -162,7 +156,11 @@ storiesOf('Experimental/Textbox', module)
   .add(...makeStory('multiple autoFocus', dlsThemeSelector, multipleTextboxAutoFocus));
 
 // eslint-disable-next-line
-export function getCommonTextboxProps(config = defaultStoryPropsConfig) {
+export function getCommonTextboxProps(config = defaultStoryPropsConfig, autoFocusDefault = false) {
+  const previous = {
+    key: 'textbox',
+    autoFocus: autoFocusDefault
+  };
   const percentageRange = {
     range: true,
     min: 0,
@@ -171,7 +169,7 @@ export function getCommonTextboxProps(config = defaultStoryPropsConfig) {
   };
   const disabled = boolean('disabled', false);
   const readOnly = boolean('readOnly', false);
-  const autoFocus = boolean('autoFocus', false);
+  const autoFocus = boolean('autoFocus', autoFocusDefault);
   const fieldHelp = text('fieldHelp');
   const label = text('label', 'Label');
   const labelHelp = label ? text('labelHelp') : undefined;


### PR DESCRIPTION
### Proposed behaviour

Make the initial `guid` in stories static.

### Current behaviour

The `guid` changes on every test resulting in false positives.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR
<del>- [ ] Carbon implementation and Design System documentation are congruent
<del>- [ ] All themes are supported
- [x] Commits follow our style guide

<del>- [ ] Unit tests added or updated
<del>- [ ] Cypress automation tests added or updated
<del>- [ ] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
N/A

### Testing instructions
Check chromatic, the diff should show the new baselines are a string instead of a guid.
