### PR TITLE
chore: prevent chromatic false positives

### DIFF
--- a/src/__experimental__/components/date/date.stories.js
+++ b/src/__experimental__/components/date/date.stories.js
@@ -167,4 +167,4 @@ storiesOf('Experimental/Date Input', module)
   .add(...makeStory('classic', classicThemeSelector, dateComponent, true))
   .add(...makeStory('empty', dlsThemeSelector, EmptyDateComponent))
   .add(...makeStory('validations', dlsThemeSelector, ValidationDateComponent))
-  .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusDateComponent));
+  .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusDateComponent, true));

--- a/src/__experimental__/components/select/select.stories.js
+++ b/src/__experimental__/components/select/select.stories.js
@@ -293,5 +293,5 @@ storiesOf('Experimental/Select', module)
   .add(...makeStory('classic', classicThemeSelector, defaultComponent(), true))
   .add(...makeMultipleStory('multiple', dlsThemeSelector))
   .add(...makeValidationsStory('validations', dlsThemeSelector))
-  .add(...makeStory('autoFocus', dlsThemeSelector, defaultComponent(true)))
+  .add(...makeStory('autoFocus', dlsThemeSelector, defaultComponent(true), true))
   .add(...makeStory('customFilter', dlsThemeSelector, customFilterComponent));

--- a/src/components/portrait/portrait.stories.js
+++ b/src/components/portrait/portrait.stories.js
@@ -44,5 +44,8 @@ storiesOf('Portrait', module)
     themeSelector: dlsThemeSelector,
     info: { text: info, propTablesExclude: [ThemeProvider] },
     notes: { markdown: notes },
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: true
+    }
   });

--- a/src/components/rainbow/rainbow.stories.js
+++ b/src/components/rainbow/rainbow.stories.js
@@ -59,5 +59,5 @@ function makeStory(name, themeSelector, disableChromatic = false) {
 }
 
 storiesOf('Rainbow ', module)
-  .add(...makeStory('default', dlsThemeSelector))
+  .add(...makeStory('default', dlsThemeSelector, true))
   .add(...makeStory('classic', classicThemeSelector, true));

--- a/src/components/table-ajax/table-ajax.stories.js
+++ b/src/components/table-ajax/table-ajax.stories.js
@@ -99,7 +99,8 @@ function makeStory(name, themeSelector, disableChromatic = false) {
   const metadata = {
     themeSelector,
     chromatic: {
-      disable: disableChromatic
+      disable: disableChromatic,
+      delay: 500
     }
   };
 


### PR DESCRIPTION
### Proposed behaviour

Prevent screenshots on these components

- Rainbow (soon to be deprecated)
- Select (being re-written)
- Date (possible re-write coming soon, false positive possible related to portal or font-loading)
- Portrait (we need to fix this)

I've delayed the `TableAjax` story to allow for data to load.

### Current behaviour
Chromatic detects a 1px change in the `Portal` and the font moves in `Rainbow`.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR
<del>- [ ] Carbon implementation and Design System documentation are congruent
<del>- [ ] All themes are supported
- [x] Commits follow our style guide

<del>- [ ] Unit tests added or updated
<del>- [ ] Cypress automation tests added or updated
<del>- [ ] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
N/A

### Testing instructions
Review chromatic dashboard and ensure the components listed above have been removed.