### PR TITLE
ci: prevent credentials being stored from checkout

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        persist-credentials: false
     - uses: actions/setup-node@v1
       with:
         node-version: '12'

--- a/src/__deprecated__/components/fieldset/__definition__.js
+++ b/src/__deprecated__/components/fieldset/__definition__.js
@@ -1,0 +1,76 @@
+import Fieldset from '.';
+import OptionsHelper from '../../../utils/helpers/options-helper';
+import Definition from '../../../../demo/utils/definition';
+import textboxDefinition from '../textbox/__definition__';
+
+let definition = new Definition('fieldset', Fieldset, {
+  description: `Edits a set of closely related inputs that are grouped together.`,
+  designerNotes: `
+* You can nest any Carbon input into this component.
+* Useful for presenting a series of inputs that are closely related, within a wider Form or Pod (e.g. an address or contact details).
+* Configure Pod and Fieldset components to work together, or choose the pre-configured Show/Edit Pod component.
+* The [Show/Edit Pod](/components/show-edit-pod) component automatically presents content as a read-only Pod, until the user clicks an edit icon, which shows the same information in an editable Fieldset.
+* But, configuring Pod and Fieldset components manually will give you more customization options, like the following.
+* Top-aligned labels (Carbon default) or inline right-aligned labels are usually fastest for users.
+* Create a single path to completion with your inputs, and between your inputs and the primary action Button.
+* Indicate mandatory, or optional fields, whichever is the minority. Think carefully before collecting optional data - don’t collect information you don’t need! Try suffixing ‘(optional)’ after your field label.
+* More guidance is available for each of the individual inputs you might place inside this component.
+  `,
+  relatedComponentsNotes: `
+* Filling in a broad series of inputs? [Try Form](/components/form).
+* Viewing content that’s grouped together visually? [Try Pod](/components/pod).
+* Using Fieldset and Pod components together? [Try Show/Edit Pod](/components/show-edit-pod).
+* Creating a new entity that is usually presented in a pod? [Try Create](/components/create).
+ `,
+  propTypes: {
+    legend: "String"
+  },
+  propDescriptions: {
+    legend: "Adds a legend to the fieldset."
+  }
+});
+
+definition.addChildByDefinition(textboxDefinition, {
+  fieldHelp: null,
+  labelHelp: null,
+  labelInline: true,
+  label: "First Name",
+  labelAlign: "right",
+});
+definition.addChildByDefinition(textboxDefinition, {
+  fieldHelp: null,
+  labelHelp: null,
+  labelInline: true,
+  label: "Last Name",
+  labelAlign: "right",
+});
+definition.addChildByDefinition(textboxDefinition, {
+  fieldHelp: null,
+  labelHelp: null,
+  labelInline: true,
+  label: "Address",
+  labelAlign: "right",
+});
+definition.addChildByDefinition(textboxDefinition, {
+  fieldHelp: null,
+  labelHelp: null,
+  labelInline: true,
+  label: "City",
+  labelAlign: "right",
+});
+definition.addChildByDefinition(textboxDefinition, {
+  fieldHelp: null,
+  labelHelp: null,
+  labelInline: true,
+  label: "Country",
+  labelAlign: "right",
+});
+definition.addChildByDefinition(textboxDefinition, {
+  fieldHelp: null,
+  labelHelp: null,
+  labelInline: true,
+  label: "Telephone",
+  labelAlign: "right",
+});
+
+export default definition;

--- a/src/__deprecated__/components/fieldset/__spec__.js
+++ b/src/__deprecated__/components/fieldset/__spec__.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import Fieldset from './fieldset';
+import Textbox from '../textbox';
+import { shallow } from 'enzyme';
+import { elementsTagTest, rootTagTest } from '../../../utils/helpers/tags/tags-specs';
+
+describe('Fieldset', () => {
+  let instance;
+
+  beforeEach(() => {
+    instance = TestUtils.renderIntoDocument(<Fieldset><Textbox /></Fieldset>);
+  });
+
+  it('renders its children', () => {
+    let child = TestUtils.findRenderedComponentWithType(instance, Textbox);
+    expect(child).toBeDefined();
+  });
+
+  it('applies any props to the fieldset', () => {
+    instance = TestUtils.renderIntoDocument(<Fieldset id="foo"><Textbox /></Fieldset>);
+    let child = TestUtils.findRenderedDOMComponentWithTag(instance, 'fieldset');
+    expect(child.id).toEqual('foo');
+  });
+
+  describe('if a legend is supplied', () => {
+    it('renders its legend', () => {
+      instance = TestUtils.renderIntoDocument(<Fieldset legend="foo"><Textbox /></Fieldset>);
+      let child = TestUtils.findRenderedDOMComponentWithTag(instance, 'legend');
+      expect(child).toBeDefined();
+    });
+  });
+
+  describe("tags", () => {
+    describe("on component", () => {
+      let wrapper = shallow(<Fieldset data-element='bar' data-role='baz' />);
+
+      it('include correct component, element and role data tags', () => {
+        rootTagTest(wrapper, 'fieldset', 'bar', 'baz');
+      });
+    });
+
+    describe("on internal elements", () => {
+      let wrapper = shallow(<Fieldset legend='test' />);
+
+      elementsTagTest(wrapper, [
+        'legend'
+      ]);
+    });
+  });
+});

--- a/src/__deprecated__/components/fieldset/docgenInfo.json
+++ b/src/__deprecated__/components/fieldset/docgenInfo.json
@@ -1,0 +1,41 @@
+{
+  "src/components/fieldset/fieldset.js": [
+    {
+      "description": "",
+      "displayName": "Fieldset",
+      "methods": [
+        {
+          "name": "legend",
+          "docblock": "Returns the legend if on is defined.\n\n@method legend\n@return {Object} JSX",
+          "modifiers": [
+            "get"
+          ],
+          "params": [],
+          "returns": {
+            "description": "JSX",
+            "type": {
+              "name": "Object"
+            }
+          },
+          "description": "Returns the legend if on is defined."
+        }
+      ],
+      "props": {
+        "children": {
+          "type": {
+            "name": "node"
+          },
+          "required": false,
+          "description": "Children elements"
+        },
+        "legend": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "A label for the fieldset."
+        }
+      }
+    }
+  ]
+}

--- a/src/__deprecated__/components/fieldset/documentation/notes.md
+++ b/src/__deprecated__/components/fieldset/documentation/notes.md
@@ -1,0 +1,16 @@
+# Designer Notes
+- You can nest any Carbon input into this component.
+- Useful for presenting a series of inputs that are closely related, within a wider Form or Pod (e.g. an address or contact details).
+- Configure Pod and Fieldset components to work together, or choose the pre-configured Show/Edit Pod component.
+ -The Show/Edit Pod component automatically presents content as a read-only Pod, until the user clicks an edit icon, which shows the same information in an editable Fieldset.
+- But, configuring Pod and Fieldset components manually will give you more customization options, like the following.
+- Top-aligned labels (Carbon default) or inline right-aligned labels are usually fastest for users.
+- Create a single path to completion with your inputs, and between your inputs and the primary action Button.
+- Indicate mandatory, or optional fields, whichever is the minority. Think carefully before collecting optional data - don’t collect information you don’t need! Try suffixing ‘(optional)’ after your field label.
+- More guidance is available for each of the individual inputs you might place inside this component.
+
+# Related Components
+- Filling in a broad series of inputs? [Try Form](/components/form "Form").
+- Viewing content that’s grouped together visually? [Try Pod](/components/pod "Pod").
+- Using Fieldset and Pod components together? [Try Show/Edit Pod](/components/show-edit-pod "Show/Edit Pod").
+- Creating a new entity that is usually presented in a pod? [Try Create](/components/create, "Create").

--- a/src/__deprecated__/components/fieldset/fieldset.js
+++ b/src/__deprecated__/components/fieldset/fieldset.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { validProps } from '../../../utils/ether';
+import tagComponent from '../../../utils/helpers/tags';
+import './fieldset.scss';
+
+class Fieldset extends React.Component {
+  static propTypes = {
+    /**
+     * Children elements
+     */
+    children: PropTypes.node,
+
+    /**
+     * A label for the fieldset.
+     */
+    legend: PropTypes.string
+  };
+
+
+  /**
+   * Returns the legend if on is defined.
+   *
+   * @method legend
+   * @return {Object} JSX
+   */
+  get legend() {
+    if (!this.props.legend) { return null; }
+
+    return (
+      <legend className='carbon-fieldset__legend common-input__label' data-element='legend'>
+        { this.props.legend }
+      </legend>
+    );
+  }
+
+  /**
+   * @method render
+   */
+  render() {
+    const {
+      className, labelAlign, childOfForm, ...props
+    } = validProps(this);
+    const classes = classNames('carbon-fieldset', className);
+
+    return (
+      <fieldset
+        className={ classes } { ...props }
+        { ...tagComponent('fieldset', this.props) }
+      >
+        { this.legend }
+        { this.props.children }
+      </fieldset>
+    );
+  }
+}
+
+export default Fieldset;

--- a/src/__deprecated__/components/fieldset/fieldset.scss
+++ b/src/__deprecated__/components/fieldset/fieldset.scss
@@ -1,0 +1,63 @@
+@import "./../../../style-config/input-field";
+
+.carbon-fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+
+  [data-component='icon'].carbon-input-icon,
+  .common-input__icon {
+    z-index: 2;
+    [data-element='error'] {
+      top: 5px;
+    }
+  }
+
+  .common-input__input--error {
+    position: relative;
+    z-index: 1;
+  }
+
+  .common-input__icon--warning {
+    right: 5px;
+    top: 6px;
+    z-index: 2;
+  }
+
+  .common-input__input:focus,
+  .common-input__input:hover {
+    position: relative;
+    z-index: 2;
+  }
+
+  .common-input + .common-input {
+    margin-top: -1px;
+
+    .common-input__input {
+      border-radius: 0;
+    }
+  }
+
+  .common-input:first-child {
+    .common-input__input {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+
+  .common-input:last-child {
+    .common-input__input {
+      border-radius: 0 0 $input-border-radius $input-border-radius;
+    }
+  }
+
+  .common-input--readonly {
+    .common-input__input {
+      border: $input-common-border;
+    }
+
+    .common-input__input:hover {
+      border: $input-common-border;
+    }
+  }
+}

--- a/src/__deprecated__/components/fieldset/fieldset.stories.js
+++ b/src/__deprecated__/components/fieldset/fieldset.stories.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { text } from '@storybook/addon-knobs';
+import { classicThemeSelector } from '../../../../.storybook/theme-selectors';
+import notes from './documentation/notes.md';
+import Fieldset from './fieldset';
+import Textbox from '../textbox';
+import getDocGenInfo from '../../../utils/helpers/docgen-info';
+
+Fieldset.__docgenInfo = getDocGenInfo(
+  require('./docgenInfo.json'),
+  /fieldset(?!spec)/
+);
+
+storiesOf('__deprecated__/Fieldset', module)
+  .addParameters({
+    info: {
+      propTablesExclude: [Textbox]
+    },
+    chromatic: {
+      disable: true
+    }
+  })
+  .add('classic', () => {
+    const legend = text('legend', '');
+
+    return (
+      <Fieldset
+        legend={ legend }
+      >
+        <Textbox
+          label='First Name'
+          labelInline
+          labelAlign='right'
+        />
+        <Textbox
+          label='Last Name'
+          labelInline
+          labelAlign='right'
+        />
+        <Textbox
+          label='Address'
+          labelInline
+          labelAlign='right'
+        />
+        <Textbox
+          label='City'
+          labelInline
+          labelAlign='right'
+        />
+        <Textbox
+          label='Country'
+          labelInline
+          labelAlign='right'
+        />
+        <Textbox
+          label='Telephone'
+          labelInline
+          labelAlign='right'
+        />
+      </Fieldset>
+    );
+  }, {
+    notes: { markdown: notes },
+    knobs: { escapeHTML: false },
+    themeSelector: classicThemeSelector
+  });

--- a/src/__deprecated__/components/fieldset/package.json
+++ b/src/__deprecated__/components/fieldset/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./fieldset.js",
+  "name": "Fieldset"
+}

--- a/src/__deprecated__/components/radio-button/__definition__.js
+++ b/src/__deprecated__/components/radio-button/__definition__.js
@@ -1,0 +1,33 @@
+import RadioButton from './';
+import Definition from '../../../../demo/utils/definition';
+
+let definition = new Definition('radio-button', RadioButton, {
+  description: `Selects one option from a longer list.`,
+  designerNotes: `
+* Consider ‘smart default’ selections, based on what your user is likely to choose. But, users may well leave the defaults in place, so make sure any consequences are easy to undo, and not harmful.
+* Useful to show less than about 10 options.
+* Disabled or read-only radio buttons might be difficult for a user to distinguish visually, so try to avoid this.
+  `,
+  relatedComponentsNotes: `
+* Choosing one option from a very long list? [Try Dropdown](/components/dropdown).
+* Choosing more than one option? [Try Checkbox](/components/checkbox).
+* Choosing one option from a highly visible small range? [Try Button Toggle](/components/button-toggle).
+ `,
+  type: 'form',
+  numberOfExamples: 2,
+  propTypes: {
+    className: "String",
+    reverse: 'Boolean'
+  },
+  propValues: {
+    name: "example"
+  },
+  propDescriptions: {
+    className: "Classes to apply to the component.",
+    reverse: 'Flips the input and label render order'
+  }
+});
+
+definition.isAnInput();
+
+export default definition;

--- a/src/__deprecated__/components/radio-button/__spec__.js
+++ b/src/__deprecated__/components/radio-button/__spec__.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import RadioButton from './radio-button';
+import { shallow } from 'enzyme';
+import { rootTagTest } from '../../../utils/helpers/tags/tags-specs';
+
+describe('RadioButton', () => {
+  let instance;
+
+  beforeEach(() => {
+    instance = TestUtils.renderIntoDocument(
+      <RadioButton
+        name='radiobutton'
+        label='radiobutton'
+      />
+    )
+  });
+
+  describe('render', () => {
+    it('renders a parent div with a pod CSS class', () => {
+      let radioButtonNode = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'div')[0];
+      expect(radioButtonNode.classList[0]).toEqual('carbon-radio-button');
+    });
+
+    it('renders an input with type radiobutton and a checked value of false', () => {
+      let radiobutton = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'input')[0];
+      expect(radiobutton.type).toEqual('radio');
+      expect(radiobutton.checked).toBeFalsy();
+    });
+
+   it('renders a radiobuttonSprite to be used as the visible input', () => {
+      let div = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'div')[2];
+      let sprite = div.firstChild;
+      let radio = sprite.getElementsByTagName('path')[0]
+
+      expect(sprite.getAttribute('viewBox')).toEqual('0 0 15 15');
+      expect(radio.classList).toContain('radio-button-outline');
+    });
+  });
+
+  describe('mainClasses', () => {
+    it('returns carbon-radio-button and additional decorated classes', () => {
+      expect(instance.mainClasses).toEqual('carbon-radio-button common-input');
+    });
+  });
+
+  describe('inputClasses', () => {
+    it('returns carbon-radio-button__input and additional decorated classes', () => {
+      expect(instance.inputClasses).toEqual('carbon-radio-button__input common-input__input');
+    });
+  });
+
+  describe('fieldHelpClasses', () => {
+    it('returns carbon-radio-button__help-text', () => {
+      expect(instance.fieldHelpClasses).toEqual('carbon-radio-button__help-text common-input__help-text');
+    });
+  });
+
+  describe("tags on component", () => {
+    let wrapper = shallow(<RadioButton data-element='bar' data-role='baz' />);
+
+    it('include correct component, element and role data tags', () => {
+      rootTagTest(wrapper, 'radio-button', 'bar', 'baz');
+    });
+  });
+});

--- a/src/__deprecated__/components/radio-button/docgenInfo.json
+++ b/src/__deprecated__/components/radio-button/docgenInfo.json
@@ -1,0 +1,132 @@
+{
+  "src/components/radio-button/radio-button.js": [
+    {
+      "description": "",
+      "displayName": "RadioButton",
+      "methods": [],
+      "props": {
+        "className": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Classes to apply to the component."
+        },
+        "fieldHelpInline": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Displays fieldHelp inline with the checkbox/radio button."
+        },
+        "deferTimeout": {
+          "type": {
+            "name": "number"
+          },
+          "required": false,
+          "description": "Integer to determine timeout for defered callback. Default: 750"
+        },
+        "onChangeDeferred": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "Defered callback called after onChange event"
+        },
+        "label": {
+          "type": {
+            "name": "node"
+          },
+          "required": false,
+          "description": "Either a string or false to turn the label off"
+        },
+        "labelInline": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Pass true to format the input/label inline"
+        },
+        "labelWidth": {
+          "type": {
+            "name": "union",
+            "value": [
+              {
+                "name": "string"
+              },
+              {
+                "name": "number"
+              }
+            ]
+          },
+          "required": false,
+          "description": "Pass a percentage to define the width of the label when it\n is displayed inline."
+        },
+        "labelAlign": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Aligns label content to the right if set"
+        },
+        "labelHelp": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Text applied to tooptip of help icon"
+        },
+        "inputWidth": {
+          "type": {
+            "name": "union",
+            "value": [
+              {
+                "name": "string"
+              },
+              {
+                "name": "number"
+              }
+            ]
+          },
+          "required": false,
+          "description": "Pass a percentage to define the width of the label when it\n is displayed inline"
+        },
+        "fieldHelp": {
+          "type": {
+            "name": "node"
+          },
+          "required": false,
+          "description": "A string representing a help message"
+        },
+        "validations": {
+          "type": {
+            "name": "array"
+          },
+          "required": false,
+          "description": "Array of validations to apply to this input"
+        },
+        "warnings": {
+          "type": {
+            "name": "array"
+          },
+          "required": false,
+          "description": "Array of warnings to apply to this input"
+        },
+        "info": {
+          "type": {
+            "name": "array"
+          },
+          "required": false,
+          "description": "Array of info to apply to this input"
+        },
+        "timeToDisappear": {
+          "type": {
+            "name": "number"
+          },
+          "required": false,
+          "description": "Number which sets timing of when the message will disappear\nExpected time is set in miliseconds"
+        }
+      }
+    }
+  ]
+}

--- a/src/__deprecated__/components/radio-button/documentation/index.js
+++ b/src/__deprecated__/components/radio-button/documentation/index.js
@@ -1,0 +1,2 @@
+export { default as notes } from './notes.md';
+export { default as info } from './info';

--- a/src/__deprecated__/components/radio-button/documentation/info.js
+++ b/src/__deprecated__/components/radio-button/documentation/info.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { StoryHeader, StoryCode, StoryCodeBlock } from '../../../../../.storybook/style/storybook-info.styles';
+
+const info = (
+  <div>
+    <p>Radio Button Component</p>
+    <p>A radio button widget. Selects one option from a longer list.</p>
+    <StoryHeader>Implementation</StoryHeader>
+
+    <p>Import the component:</p>
+    <StoryCode padded>import Radio Button from &quot;carbon-react/lib/components/radio-button&quot;</StoryCode>
+
+    <p>To render the radiobutton:</p>
+    <StoryCodeBlock>
+      {'<RadioButton name="frequency" value="weekly" label="Weekly"/>'}
+      {'<RadioButton name="frequency" value="2weekly" label="2 Weekly"/>'}
+      {'<RadioButton name="frequency" value="4weekly" label="4 Weekly"/>'}
+      {'<RadioButton name="frequency" value="monthly" label="Monthly"/>'}
+    </StoryCodeBlock>
+
+    <p>For additional properties specific to this component, see propTypes.</p>
+  </div>
+);
+
+export default info;

--- a/src/__deprecated__/components/radio-button/documentation/notes.md
+++ b/src/__deprecated__/components/radio-button/documentation/notes.md
@@ -1,0 +1,9 @@
+# Designer Notes
+- Consider ‘smart default’ selections, based on what your user is likely to choose. But, users may well leave the defaults in place, so make sure any consequences are easy to undo, and not harmful.
+- Useful to show less than about 10 options.
+- Disabled or read-only radio buttons might be difficult for a user to distinguish visually, so try to avoid this.
+
+# Related Components
+- Choosing one option from a very long list? [Try Dropdown](/components/dropdown "Try Dropdown").
+- Choosing more than one option? [Try Checkbox](/components/checkbox "Try Checkbox").
+- Choosing one option from a highly visible small range? [Try Button Toggle](/components/button-toggle "Try Button Toggle").

--- a/src/__deprecated__/components/radio-button/notes.md
+++ b/src/__deprecated__/components/radio-button/notes.md
@@ -1,0 +1,9 @@
+# Designer Notes
+- Consider ‘smart default’ selections, based on what your user is likely to choose. But, users may well leave the defaults in place, so make sure any consequences are easy to undo, and not harmful.
+- Useful to show less than about 10 options.
+- Disabled or read-only radio buttons might be difficult for a user to distinguish visually, so try to avoid this.
+
+# Related Components
+- Choosing one option from a very long list? [Try Dropdown](/components/dropdown "Try Dropdown").
+- Choosing more than one option? [Try Checkbox](/components/checkbox "Try Checkbox").
+- Choosing one option from a highly visible small range? [Try Button Toggle](/components/button-toggle "Try Button Toggle").

--- a/src/__deprecated__/components/radio-button/package.json
+++ b/src/__deprecated__/components/radio-button/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./radio-button",
+  "name": "radio-button"
+}

--- a/src/__deprecated__/components/radio-button/radio-button.js
+++ b/src/__deprecated__/components/radio-button/radio-button.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import Input from '../../../utils/decorators/input';
+import InputLabel from '../../../utils/decorators/input-label';
+import InputValidation from '../../../utils/decorators/input-validation';
+import { validProps } from '../../../utils/ether';
+import tagComponent from '../../../utils/helpers/tags';
+import './radio-button.scss';
+
+/**
+ *
+ * @class RadioButton
+ * @constructor
+ * @decorators {Input, InputLabel, InputValidation}
+ */
+const RadioButton = Input(InputLabel(InputValidation(
+  class RadioButton extends React.Component {
+    static propTypes = {
+      /**
+       * Classes to apply to the component.
+       */
+      className: PropTypes.string,
+
+      /**
+       * Displays fieldHelp inline with the checkbox/radio button.
+       *
+       */
+      fieldHelpInline: PropTypes.bool
+    };
+
+    static defaultProps = {
+      fieldHelpInline: false
+    };
+
+    /**
+     * Uses the mainClasses method provided by the decorator to add additional classes.
+     *
+     * @method mainClasses
+     * @return {String} Main className
+     */
+    get mainClasses() {
+      return classNames(
+        'carbon-radio-button',
+        this.props.className
+      );
+    }
+
+    /**
+     * Uses the inputClasses method provided by the decorator to add additional classes.
+     *
+     * @method inputClasses
+     * @return {String} input className
+     */
+    get inputClasses() {
+      return 'carbon-radio-button__input';
+    }
+
+    /**
+   * Returns classes for field help.
+   *
+   * @method fieldHelpClasses
+   * @return {String}
+   */
+    get fieldHelpClasses() {
+      return classNames('carbon-radio-button__help-text', {
+        'carbon-radio-button__help-text--inline': this.props.fieldHelpInline
+      });
+    }
+
+    /**
+   * A getter that combines props passed down from the input decorator with
+   * radiobutton specific props.
+   *
+   * @method inputProps
+   * @return {Object} Props to be applied to the input
+   */
+    get inputProps() {
+      const { ...props } = validProps(this);
+      props.className = this.inputClasses;
+      props.type = 'radio';
+      return props;
+    }
+
+    /**
+   * Return the svg image for the radiobutton
+   * Amended the svg contsruction to account for an issue in React
+   * @return {Object} JSX svg
+   */
+    get radiobuttonSprite() {
+      let svg = '';
+
+      svg += '<svg width="15" height="15" viewBox="0 0 15 15">';
+      svg += '  <g stroke="none" strokeWidth="1" fill="none" fill-rule="evenodd">';
+      svg += '    <g transform="translate(-69.000000, -293.000000)">';
+      svg += '      <g transform="translate(69.000000, 268.000000)">';
+      svg += '        <g transform="translate(0.000000, 25.000000)">';
+      svg += '          <circle class="radio-button-fill" fill="#FFFFFF" cx="7.5" cy="7.5" r="7.5"></circle>';
+      svg += '          <path class="radio-button-outline" d="M7.5,15 C11.6421356,15 15,11.6421356 15,';
+      svg += '            7.5 C15,3.35786438 11.6421356,0 7.5,0 C3.35786438,0 0,3.35786438 0,7.5 C0,';
+      svg += '            11.6421356 3.35786438,15 7.5,15 Z M7.5,14 C11.0898509,14 14,11.0898509 14,';
+      svg += '            7.5 C14,3.91014913 11.0898509,1 7.5,1 C3.91014913,1 1,3.91014913 1,7.5 C1,';
+      svg += '            11.0898509 3.91014913,14 7.5,14 Z" fill="#AFAFAF"></path>';
+      svg += '          <circle fill="#FFFFFF" cx="7.5" cy="7.5" r="3.5" class="radio-button-check"></circle>';
+      svg += '        </g>';
+      svg += '      </g>';
+      svg += '    </g>';
+      svg += '  </g>';
+      svg += '</svg>';
+
+      return svg;
+    }
+
+    /**
+   * Extends the input content to include the radiobutton sprite
+   *
+   * @method additionalInputContent
+   * @return {Object} JSX additional content inline with input
+   */
+    get additionalInputContent() {
+      return (
+        <div
+          className='carbon-radio-button__sprite'
+          dangerouslySetInnerHTML={ { __html: this.radiobuttonSprite } } // eslint-disable-line react/no-danger
+        />
+      );
+    }
+
+    /**
+     * Renders the component with props.
+     *
+     * @method render
+     * @return {Object} JSX
+     */
+    render() {
+      return (
+        <div className={ this.mainClasses } { ...tagComponent('radio-button', this.props) }>
+          { this.inputHTML }
+          { this.labelHTML }
+          { this.fieldHelpHTML }
+          { this.validationHTML }
+        </div>
+      );
+    }
+  }
+)));
+
+export default RadioButton;

--- a/src/__deprecated__/components/radio-button/radio-button.scss
+++ b/src/__deprecated__/components/radio-button/radio-button.scss
@@ -1,0 +1,112 @@
+@import "../../../style-config/colors";
+@import "../../../style-config/input-field";
+@import "../../../style-config/mixins";
+
+.carbon-radio-button {
+  padding-top: 8px;
+
+  .common-input__field,
+  .common-input__label {
+    display: inline-block;
+    vertical-align: middle;
+    margin-top: -2px;
+  }
+
+  .common-input__label {
+    margin: 0;
+    padding-top: 1px;
+    padding-bottom: 5px;
+  }
+
+  &.common-input--has-field-help {
+    .common-input__label {
+      vertical-align: baseline;
+      padding-bottom: 0px;
+    }
+
+    .carbon-radio-button__help-text {
+      padding-bottom: 5px;
+    }
+  }
+}
+
+.carbon-radio-button__sprite {
+  height: 15px;
+  width: 15px;
+}
+
+.carbon-radio-button__input.common-input__input {
+  cursor: pointer;
+  height: 15px;
+  opacity: 0;
+  position: absolute;
+  vertical-align: middle;
+  width: 15px;
+
+  ~ .carbon-radio-button__sprite {
+    .radio-button-outline {
+      rx: 2;
+    }
+
+    .radio-button-fill {
+      ry: 1;
+    }
+  }
+
+  &:focus + .carbon-radio-button__sprite {
+    box-shadow: 0 0 6px rgba(25, 99, 246, 0.6);
+    border-radius: 100%;
+    @include transition(border linear 0.1s, box-shadow linear 0.1s);
+
+    .radio-button-outline {
+      fill: $input-active-border-color;
+    }
+  }
+
+  &:hover + .carbon-radio-button__sprite .radio-button-outline {
+    // the hover colour for the ring
+    fill: $input-active-border-color;
+  }
+
+  &:checked + .carbon-radio-button__sprite .radio-button-check {
+    // The checked colour in the middle
+    fill: $grey-dark;
+  }
+
+  &[disabled] + .carbon-radio-button__sprite {
+    .radio-button-outline {
+      fill: $grey;
+    }
+
+    .radio-button-fill {
+      fill: $grey-light;
+    }
+
+    .radio-button-check {
+      fill: $grey-light;
+    }
+  }
+
+  &[disabled]:checked + .carbon-radio-button__sprite .radio-button-check {
+    fill: $grey-dark-blue-50;
+  }
+}
+
+// extra specificity is required here
+.common-input__help-text {
+  &.carbon-radio-button__help-text {
+    display: block;
+    margin-top: 0;
+    margin-left: 21px;
+  }
+
+  &.carbon-radio-button__help-text--inline {
+    display: inline;
+    left: 21px;
+    margin-left: -21px;
+    margin-right: 5px;
+    padding-left: 0;
+    position: relative;
+    top: -2px;
+  }
+}

--- a/src/__deprecated__/components/radio-button/radio-button.stories.js
+++ b/src/__deprecated__/components/radio-button/radio-button.stories.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean, text, select } from '@storybook/addon-knobs';
+import { classicThemeSelector } from '../../../../.storybook/theme-selectors';
+import OptionsHelper from '../../../utils/helpers/options-helper';
+import RadioButton from './radio-button';
+import { notes, info } from './documentation';
+import getDocGenInfo from '../../../utils/helpers/docgen-info';
+
+RadioButton.__docgenInfo = getDocGenInfo(
+  require('./docgenInfo.json'),
+  /radio-button(?!spec)/
+);
+
+storiesOf('__deprecated__/Radio Button', module)
+  .addParameters({
+    chromatic: {
+      disable: true
+    }
+  })
+  .add(
+    'classic',
+    () => {
+      const fieldHelp = text('fieldHelp', 'Additional information below the input.');
+      const fieldHelpInline = boolean('fieldHelpInline', RadioButton.defaultProps.fieldHelpInline);
+      const label = text('label', 'Example RadioButton');
+      const labelInline = boolean('labelInline', false);
+      const labelWidth = labelInline ? text('labelWidth', '') : undefined;
+      const labelAlign = labelInline ? select('labelAlign', OptionsHelper.alignBinary, 'left') : undefined;
+      const labelHelp = text('labelHelp', 'Example label help text');
+      const inputWidth = text('inputWidth', '');
+
+      return (
+        <React.Fragment>
+          <RadioButton
+            key='first-button'
+            fieldHelp={ fieldHelp }
+            fieldHelpInline={ fieldHelpInline }
+            inputWidth={ inputWidth }
+            label={ label }
+            labelAlign={ labelAlign }
+            labelHelp={ labelHelp }
+            labelInline={ labelInline }
+            labelWidth={ labelWidth }
+            name='radio-buttons-example'
+          />
+          <RadioButton
+            key='second-button'
+            fieldHelp={ fieldHelp }
+            fieldHelpInline={ fieldHelpInline }
+            inputWidth={ inputWidth }
+            label={ label }
+            labelAlign={ labelAlign }
+            labelHelp={ labelHelp }
+            labelInline={ labelInline }
+            labelWidth={ labelWidth }
+            name='radio-buttons-example'
+          />
+        </React.Fragment>
+      );
+    },
+    {
+      notes: { markdown: notes },
+      info: {
+        text: info,
+        propTablesExclude: [React.Fragment]
+      },
+      themeSelector: classicThemeSelector
+    }
+  );


### PR DESCRIPTION
### Proposed behaviour

Revert #3013 and #3012 
Use `persist-credentials: false` so `semantic-release` uses the `GH_TOKEN` to push to the repo.
### Current behaviour
`semantic-release` is using the checkout token that does not have push access.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR
<del>- [ ] Carbon implementation and Design System documentation are congruent
<del>- [ ] All themes are supported
- [x] Commits follow our style guide

<del>- [ ] Unit tests added or updated
<del>- [ ] Cypress automation tests added or updated
<del>- [ ] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
https://github.com/semantic-release/git/issues/196

### Testing instructions
Merge to master and check the `semantic-release` job.
