### PR TITLE
fix: increase width on validation labels

### DIFF
--- a/src/__experimental__/components/date-range/date-range.component.js
+++ b/src/__experimental__/components/date-range/date-range.component.js
@@ -18,6 +18,8 @@ class DateRange extends React.Component {
 
   isBlurBlocked = true;
 
+  inlineLabelWidth = 40;
+
   state = {
     startDateValue: {
       formattedValue: DateHelper.formatDateToCurrentLocale(this.startDate),
@@ -170,12 +172,14 @@ class DateRange extends React.Component {
           onFocus={ this.focusStart }
           data-element='start-date'
           ref={ this.startDateInputRef }
+          labelWidth={ this.inlineLabelWidth } // Textbox only applies this when labelsInLine prop is true
         />
         <DateInput
           { ...this.dateProps('end') }
           onFocus={ this.focusEnd }
           data-element='end-date'
           ref={ this.endDateInputRef }
+          labelWidth={ this.inlineLabelWidth } // Textbox only applies this when labelsInLine prop is true
         />
       </StyledDateRange>
     );

--- a/src/__experimental__/components/date-range/date-range.stories.js
+++ b/src/__experimental__/components/date-range/date-range.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import { storiesOf } from '@storybook/react';
 import { text, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
@@ -8,6 +9,11 @@ import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/t
 import DateRange from './date-range.component';
 
 import getDocGenInfo from '../../../utils/helpers/docgen-info';
+
+const ColumnsWrapper = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+`;
 
 DateRange.__docgenInfo = getDocGenInfo(
   require('./docgenInfo.json'),
@@ -59,13 +65,13 @@ function makeStory(name, themeSelector, disableChromatic = false) {
 }
 
 function makeValidationStory(name, themeSelector) {
-  const component = () => {
+  const component = (labelsInline) => {
     const startLabel = text('startLabel', 'From');
     const endLabel = text('endLabel', 'To');
-    const labelsInline = (startLabel || endLabel) ? boolean('labelsInline', false) : undefined;
 
     return (
-      <>
+      <div>
+        <h3>labelsInline prop {labelsInline.toString()}</h3>
         <h4>Validation as string</h4>
         <h6>On components</h6>
         {[
@@ -180,7 +186,16 @@ function makeValidationStory(name, themeSelector) {
             />
           </State>
         ))}
-      </>
+      </div>
+    );
+  };
+
+  const columns = () => {
+    return (
+      <ColumnsWrapper>
+        {component(false)}
+        {component(true)}
+      </ColumnsWrapper>
     );
   };
 
@@ -189,11 +204,11 @@ function makeValidationStory(name, themeSelector) {
     notes: { markdown: notes },
     info: {
       text: info,
-      propTablesExclude: [State]
+      propTables: [DateRange]
     }
   };
 
-  return [name, component, metadata];
+  return [name, columns, metadata];
 }
 
 storiesOf('Experimental/Date Range', module)


### PR DESCRIPTION
### Proposed behaviour

When the labelsInline prop is true on the DateRange component the validation icons should be displayed on the same line as the label text like this: 
![image](https://user-images.githubusercontent.com/14963680/85413827-3abbd700-b563-11ea-88a1-b22895793697.png)


### Current behaviour

The validation icons are being displayed on a second line underneath the label: 
![image](https://user-images.githubusercontent.com/14963680/85413511-ce40d800-b562-11ea-9a9a-101968429f44.png)
![image](https://user-images.githubusercontent.com/14963680/85413568-def14e00-b562-11ea-813a-58d1cc3661f6.png)


### Checklist

- [x] Screenshots are included in the PR
- [x] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
- <del>[ ] Unit tests added or updated</del>
- <del>[ ] Cypress automation tests added or updated</del>
- <del>[ ] Storybook added or updated</del>
- <del>[ ] Typescript `d.ts` file added or updated</del>

### Additional context

### Testing instructions
