### PR TITLE
test(chromatic): make the date static in dialog stories

### DIFF
--- a/src/components/dialog/dialog.stories.js
+++ b/src/components/dialog/dialog.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { text, select, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
@@ -41,7 +41,8 @@ const handleClick = (evt) => {
 };
 
 function makeStory(name, themeSelector, disableChromatic = false) {
-  const component = () => {
+  const Component = () => {
+    const [date, setDate] = useState('2020-06-01');
     const height = text('height', '400');
     const title = text('title', 'Example Dialog');
     const subtitle = text('subtitle', 'Example Subtitle');
@@ -77,7 +78,11 @@ function makeStory(name, themeSelector, disableChromatic = false) {
               <Textbox label='Birth Place' />
               <Textbox label='Favourite Colour' />
               <Textbox label='Address' />
-              <DateInput name='date' label='Birthday' />
+              <DateInput
+                name='date' label='Birthday'
+                value={ date }
+                onChange={ e => setDate(e.target.value) }
+              />
               <Dropdown
                 name='foo' options={ fromJS([{
                   id: '1', name: 'Orange'
@@ -105,7 +110,11 @@ function makeStory(name, themeSelector, disableChromatic = false) {
                 value='1'
               />
               <Textbox label='Pet Name' />
-              <DateInput name='date' label="Pet's birthday" />
+              <DateInput
+                name='date' label="Pet's birthday"
+                value={ date }
+                onChange={ e => setDate(e.target.value) }
+              />
               <Checkbox name='checkbox' label='Do you like my Dog' />
               <div>This is an example of a dialog with a Form as content</div>
             </Form>
@@ -136,7 +145,7 @@ function makeStory(name, themeSelector, disableChromatic = false) {
     }
   };
 
-  return [name, component, metadata];
+  return [name, Component, metadata];
 }
 
 storiesOf('Dialog', module)


### PR DESCRIPTION
### Proposed behaviour

Make the date in dialog stories static to prevent false positives.

![image](https://user-images.githubusercontent.com/2328042/85727453-eb0a1680-b6ee-11ea-93d8-815f072853a9.png)


### Current behaviour
The date component in Dialog stories always uses todays date, so the first build of each day will change the baseline.


### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Screenshots are included in the PR
<del>- [ ] Carbon implementation and Design System documentation are congruent
<del>- [ ] All themes are supported

- [x] Commits follow our style guide
<del>- [ ] Unit tests added or updated
<del>- [ ] Cypress automation tests added or updated

- [x] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->
https://www.chromatic.com/snapshot?appId=5ecf782fe724630022d27d7d&id=5ef489a19df5b8002256699d

### Testing instructions

Check pr's made after this change is merged don't show a diff for Dialog. You can't test until this is merged.
