### PR TITLE
feat(text-editor): add new text editor component FE-2814

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -47,5 +47,8 @@
   "dashed_full_width": "--dashed-full-width",
   "dashed_icon": "--dashed-icon",
   "visual": "--visual",
-  "with_both_errors_and_warnings_summary": "--with-both-errors-and-warnings-summary"
+  "with_both_errors_and_warnings_summary": "--with-both-errors-and-warnings-summary",
+  "with_optional_character_limit": "--with-optional-character-limit",
+  "with_content": "--with-content",
+  "with_optional_buttons": "--with-optional-buttons"
 }

--- a/cypress/features/regression/accessibility/accessibilityDesignSystem.feature
+++ b/cypress/features/regression/accessibility/accessibilityDesignSystem.feature
@@ -152,9 +152,9 @@ Feature: Accessibility tests - Design System folder
     When I open visual Test "<component>" component page in noIframe
     Then "<component>" component has no accessibility violations
     Examples:
-      | component   |
-      | Drawer      |
-      | Grid        |
+      | component |
+      | Drawer    |
+      | Grid      |
 
   @accessibility
   Scenario: Design System Form component
@@ -185,6 +185,16 @@ Feature: Accessibility tests - Design System folder
       | Draggable       |
       | Flat Table      |
       | Tile Select     |
+      | Text Editor     |
+
+  @accessibility
+  Scenario Outline: Design System Text Editor component <story> page
+    When I open design systems <story> "Text Editor" component in no iframe
+    Then "Text Editor component <story> page" component has no accessibility violations
+    Examples:
+      | story                 |
+      | with_content          |
+      | with_optional_buttons |
 
   @accessibility
   Scenario Outline: Design System <component> component default story page

--- a/cypress/features/regression/designSystem/textEditor.feature
+++ b/cypress/features/regression/designSystem/textEditor.feature
@@ -1,0 +1,99 @@
+Feature: Design System Text Editor component
+  I want to test Design System Text Editor component
+
+  Background: Open Design System Text Editor component page
+    Given I open design systems basic "Text Editor" component in no iframe
+
+  @positive
+  Scenario: Verify that counter works properly
+    When I type "Testing is awesome" in Text Editor
+    Then Text Editor counter shows "2982" characters left
+
+  @positive
+  Scenario Outline: Verify <buttonType> button works correctly in Text Editor Toolbar
+    Given I click onto "<buttonType>" in Text Editor Toolbar
+    When I type "Testing is awesome" in Text Editor
+    Then text has "<buttonType>" css property
+      And button "<buttonType>" is clicked and active
+    Examples:
+      | buttonType |
+      | bold       |
+      | italic     |
+
+  @positive
+  Scenario Outline: Verify <buttonType> button works correctly in Text Editor Toolbar
+    Given I click onto "<buttonType>" in Text Editor Toolbar
+    When I type "Testing{Enter}is{Enter}awesome" in Text Editor
+    Then text is rendered in "<buttonType>" type
+      And button "<buttonType>" is clicked and active
+    Examples:
+      | buttonType  |
+      | bullet-list |
+      | number-list |
+
+  @positive
+  Scenario: Verify Tab keyboard accessibility for Text Editor
+    Given I focus the Text Editor
+    When I press "Tab" onto focused element
+    Then button "bold" is focused
+
+  @positive
+  Scenario Outline: Verify that Right Arrow keyboard key after pressing <times> times focus the <buttonType> button in Toolbar
+    Given I focus the Text Editor
+      And I press "Tab" onto focused element
+    When I press keyboard "rightarrow" key times <times>
+    Then button "<buttonType>" is focused
+    Examples:
+      | buttonType  | times |
+      | bold        | 1     |
+      | italic      | 2     |
+      | bullet-list | 3     |
+      | number-list | 4     |
+
+  @positive
+  Scenario Outline: Verify that Left Arrow keyboard key after pressing <times> times focus the <buttonType> button in Toolbar
+    Given I focus the Text Editor
+      And I press "Tab" onto focused element
+    When I press keyboard "leftarrow" key times <times>
+    Then button "<buttonType>" is focused
+    Examples:
+      | buttonType  | times |
+      | bold        | 5     |
+      | italic      | 4     |
+      | bullet-list | 3     |
+      | number-list | 2     |
+
+  @positive
+  Scenario Outline: Verify that Enter keyboard key selects proper <buttonType> button in Toolbar after pressing
+    Given I focus the Text Editor
+      And I press "Tab" onto focused element
+      And I press keyboard "rightarrow" key times <times>
+      And I wait 250
+    When I press "Enter" onto focused element
+    Then button "<buttonType>" is clicked and active
+    Examples:
+      | buttonType  | times |
+      | bold        | 1     |
+      | italic      | 2     |
+      | bullet-list | 3     |
+      | number-list | 4     |
+
+  @positive
+  Scenario Outline: Verify that Space keyboard key selects proper <buttonType> button in Toolbar after pressing
+    Given I focus the Text Editor
+      And I press "Tab" onto focused element
+      And I press keyboard "rightarrow" key times <times>
+      And I wait 250
+    When I press "Space" onto focused element
+    Then button "<buttonType>" is clicked and active
+    Examples:
+      | buttonType  | times |
+      | bold        | 1     |
+      | italic      | 2     |
+      | bullet-list | 3     |
+      | number-list | 4     |
+
+  @positive
+  Scenario: Verify when input link - it is shown as formatted link and not as text
+    When I type "https://carbon.sage.com" in Text Editor
+    Then Text Editor shows the link "https://carbon.sage.com" inside the input

--- a/cypress/features/regression/designSystem/textEditorWithOptionalCharacterLimit.feature
+++ b/cypress/features/regression/designSystem/textEditorWithOptionalCharacterLimit.feature
@@ -1,0 +1,11 @@
+Feature: Design System Text Editor component with optional character limit
+  I want to test Design System Text Editor with optional character limit component
+
+  Background: Open Design System Text Editor component page
+    Given I open design systems with_optional_character_limit "Text Editor" component in no iframe
+
+  @positive
+  Scenario: Verify that input doesn't allow to input more than character limit is set to
+    When I type "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." in Text Editor
+    Then Text Editor counter shows "0" characters left
+      And input contains "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore " value

--- a/cypress/locators/text-editor/index.js
+++ b/cypress/locators/text-editor/index.js
@@ -1,0 +1,23 @@
+import {
+  TEXT_EDITOR_COMPONENT,
+  TEXT_EDITOR_COUNTER,
+  TEXT_EDITOR_INPUT,
+  TEXT_EDITOR_TOOLBAR,
+} from './locators';
+
+// component preview locators in NoIFrame
+export const textEditorComponent = () => cy.get(TEXT_EDITOR_COMPONENT);
+export const textEditorCounter = () => cy.get(TEXT_EDITOR_COUNTER);
+export const textEditorInput = () => cy.get(TEXT_EDITOR_INPUT);
+export const textEditorToolbar = buttonType => cy.get(TEXT_EDITOR_TOOLBAR)
+  .find('div')
+  .find(`button[aria-label="${buttonType}"]`);
+export const innerText = () => textEditorInput()
+  .find('span[data-text="true"]');
+export const innerTextList = (typeOfList, index) => textEditorInput()
+  .find(`${typeOfList}`)
+  .find(`li:nth-child(${index})`)
+  .find('div');
+export const innerTextLink = () => textEditorInput()
+  .find('div[data-component="link"]')
+  .children();

--- a/cypress/locators/text-editor/locators.js
+++ b/cypress/locators/text-editor/locators.js
@@ -1,0 +1,5 @@
+// component preview locators
+export const TEXT_EDITOR_COMPONENT = '[data-component="text-editor-container"]';
+export const TEXT_EDITOR_COUNTER = '[data-component="text-editor-counter"]';
+export const TEXT_EDITOR_INPUT = '[role="textbox"]';
+export const TEXT_EDITOR_TOOLBAR = '[data-component="text-editor-toolbar"]';

--- a/cypress/support/step-definitions/text-editor-steps.js
+++ b/cypress/support/step-definitions/text-editor-steps.js
@@ -1,0 +1,67 @@
+import {
+  textEditorInput,
+  textEditorCounter,
+  textEditorToolbar,
+  innerText,
+  innerTextList,
+  innerTextLink,
+} from '../../locators/text-editor';
+import { positionOfElement } from '../helper';
+
+When('I type {string} in Text Editor', (text) => {
+  textEditorInput().clear().type(text);
+});
+
+When('I focus the Text Editor', () => {
+  textEditorInput().focus();
+});
+
+When('Text Editor is focused', () => {
+  textEditorInput().should('be.focused');
+});
+
+Then('Text Editor counter shows {string} characters left', (charactersLeft) => {
+  textEditorCounter().should('have.text', charactersLeft);
+});
+
+When('I click onto {string} in Text Editor Toolbar', (buttonType) => {
+  textEditorToolbar(buttonType).click();
+});
+
+Then('text has {string} css property', (buttonType) => {
+  if (buttonType === 'bold') {
+    innerText().should('have.css', 'font-weight', '700');
+  } else if (buttonType === 'italic') {
+    innerText().should('have.css', 'font-style', 'italic');
+  }
+});
+
+Then('text is rendered in {string} type', (buttonType) => {
+  if (buttonType === 'bullet-list') {
+    innerTextList('ul', positionOfElement('second')).should('have.text', 'Testing');
+    innerTextList('ul', positionOfElement('third')).should('have.text', 'is');
+    innerTextList('ul', positionOfElement('fourth')).should('have.text', 'awesome');
+  } else if (buttonType === 'bullet-list-numbers') {
+    innerTextList('ol', positionOfElement('second')).should('have.text', 'Testing');
+    innerTextList('ol', positionOfElement('third')).should('have.text', 'is');
+    innerTextList('ol', positionOfElement('fourth')).should('have.text', 'awesome');
+  }
+});
+
+Then('button {string} is clicked and active', (buttonType) => {
+  textEditorToolbar(buttonType).should('have.css', 'background-color', 'rgb(204, 214, 219)');
+});
+
+Then('button {string} is focused', (buttonType) => {
+  textEditorToolbar(buttonType).should('be.focused');
+});
+
+Then('Text Editor shows the link {string} inside the input', (text) => {
+  innerTextLink().should('have.attr', 'target', '_blank')
+    .and('have.attr', 'href', text);
+  innerText().should('have.text', text);
+});
+
+Then('input contains {string} value', (text) => {
+  innerText().should('have.text', text);
+});

--- a/cypress/support/step-definitions/textbox-steps.js
+++ b/cypress/support/step-definitions/textbox-steps.js
@@ -1,8 +1,8 @@
 import {
-  textbox, textboxByPosition, textboxDataComponent, textboxIcon, textboxInput,
+  textbox, textboxByPosition, textboxIcon, textboxInput,
 } from '../../locators/textbox';
 import {
-  label, labelByPosition, commonDataElementInputPreview, commonInputPreview,
+  label, labelByPosition, commonInputPreview,
   fieldHelpPreviewByPosition, tooltipPreviewByPosition, labelNoIFrame, commonDataElementInputPreviewNoIframe,
 } from '../../locators';
 import { DEBUG_FLAG } from '..';

--- a/package-lock.json
+++ b/package-lock.json
@@ -17538,6 +17538,47 @@
         "dotenv-defaults": "^1.0.2"
       }
     },
+    "draft-js": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.5.tgz",
+      "integrity": "sha512-RlHcoDtblwCD6Bw2ay3D0dTLA6lH8862OcdJrHGnYrY5JjlitzSzGvGQwqqumVvbGUNDSZLD3FyNpSs4z5WIUg==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^1.0.0",
+        "immutable": "~3.7.4",
+        "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        },
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "immutable": {
+          "version": "3.7.6",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+          "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks=",
+          "dev": true
+        }
+      }
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -19635,6 +19676,12 @@
           "dev": true
         }
       }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "dev": true
     },
     "fd-slicer": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "homepage": "https://github.com/Sage/carbon#readme",
   "peerDependencies": {
+    "draft-js": "^0.11.5",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "i18n-js": "^3.0.0",
@@ -90,6 +91,7 @@
     "cypress-cucumber-preprocessor": "2.5.0",
     "cypress-plugin-retries": "^1.5.2",
     "cz-conventional-changelog": "^3.0.2",
+    "draft-js": "^0.11.5",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.4.0",

--- a/src/components/text-editor/__internal__/decorators/index.js
+++ b/src/components/text-editor/__internal__/decorators/index.js
@@ -1,0 +1,8 @@
+import {
+  CompositeDecorator
+} from 'draft-js';
+import linkDecorator from './link-decorator';
+
+export default new CompositeDecorator([
+  linkDecorator
+]);

--- a/src/components/text-editor/__internal__/decorators/link-decorator.js
+++ b/src/components/text-editor/__internal__/decorators/link-decorator.js
@@ -1,0 +1,34 @@
+import EditorLink from '../editor-link';
+
+function findWithRegex(regex, contentBlock, callback) {
+  const text = contentBlock.getText();
+  let matchArr;
+  let start = 0;
+  let candidates = [];
+
+  text.split(' ').forEach((chars) => {
+    candidates = [...candidates, [...chars]];
+  });
+
+  candidates.forEach((candidate) => {
+    // eslint-disable-next-line no-cond-assign
+    while ((matchArr = regex.exec(candidate.join(''))) !== null) {
+      start += matchArr.index;
+      callback(start, start + candidate.length);
+    }
+    start += candidate.length + 1;
+  });
+}
+
+const linkStrategy = (contentBlock, callback) => {
+  const expr = (
+    /\s*(https:\/\/|http:\/\/|www\.)\S+(:{0,1}(\w*@)?)(\.{1}(?!\.)\S{2,})|(:[0-9]+)(\/|\/([\w#!:.?+=&%@!-/]))?\s*/g
+  );
+
+  findWithRegex(RegExp(expr), contentBlock, callback);
+};
+
+export default {
+  strategy: linkStrategy,
+  component: EditorLink
+};

--- a/src/components/text-editor/__internal__/editor-counter/editor-counter.component.js
+++ b/src/components/text-editor/__internal__/editor-counter/editor-counter.component.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import StyledCounter from './editor-counter.style';
+
+const Counter = ({ count = 0, limit = 3000 }) => (
+  <StyledCounter data-component='text-editor-counter'>
+    { `${limit - count}` }
+  </StyledCounter>
+);
+
+Counter.propTypes = {
+  /** Sets the current count value */
+  count: PropTypes.number,
+  /** Sets the current limit value */
+  limit: PropTypes.number
+};
+
+export default Counter;

--- a/src/components/text-editor/__internal__/editor-counter/editor-counter.d.ts
+++ b/src/components/text-editor/__internal__/editor-counter/editor-counter.d.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+export interface EditorCounterProps {
+  count: number;
+  limit: number;
+}
+
+declare const EditorCounter: React.FunctionComponent<EditorCounterProps>;
+
+export default EditorCounter;

--- a/src/components/text-editor/__internal__/editor-counter/editor-counter.spec.js
+++ b/src/components/text-editor/__internal__/editor-counter/editor-counter.spec.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { assertStyleMatch } from '../../../../__spec_helper__/test-utils';
+import baseTheme from '../../../../style/themes/base';
+import Counter from './editor-counter.component';
+
+const render = (props = {}, renderer = mount) => {
+  return renderer(<Counter { ...props } />);
+};
+
+describe('EditorCounter', () => {
+  it('has the expected styles', () => {
+    assertStyleMatch({
+      color: baseTheme.editor.counter,
+      marginTop: '14px',
+      marginLeft: '4px',
+      minWidth: '40px',
+      height: '21px',
+      float: 'right'
+    }, render());
+  });
+
+  it('displays the correct value for permitted characters when the default `limit` is used', () => {
+    const wrapper = render({ count: 10 });
+
+    expect(wrapper.find('div').text()).toEqual('2990');
+  });
+
+  it('displays the correct value for permitted characters when the `limit` prop is passed a value of `10`', () => {
+    const wrapper = render({ count: 10, limit: 10 });
+
+    expect(wrapper.find('div').text()).toEqual('0');
+  });
+});

--- a/src/components/text-editor/__internal__/editor-counter/editor-counter.style.js
+++ b/src/components/text-editor/__internal__/editor-counter/editor-counter.style.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+import baseTheme from '../../../../style/themes/base';
+
+const StyledCounter = styled.div`
+  ${({ theme }) => `
+    color: ${theme.editor.counter};
+    margin-top: 14px;
+    margin-left: 4px;
+    min-width: 40px;
+    height: 21px;
+    float: right;
+    font-size: 14px;
+  `}
+`;
+
+StyledCounter.defaultProps = {
+  theme: baseTheme
+};
+
+export default StyledCounter;

--- a/src/components/text-editor/__internal__/editor-counter/index.d.ts
+++ b/src/components/text-editor/__internal__/editor-counter/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './editor-counter';
+export * from './editor-counter';

--- a/src/components/text-editor/__internal__/editor-counter/index.js
+++ b/src/components/text-editor/__internal__/editor-counter/index.js
@@ -1,0 +1,1 @@
+export { default } from './editor-counter.component';

--- a/src/components/text-editor/__internal__/editor-link/editor-link.component.js
+++ b/src/components/text-editor/__internal__/editor-link/editor-link.component.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import StyledLink from './editor-link.style';
+
+const EditorLink = ({
+  children, contentState, entityKey, ...rest
+}) => {
+  const url = !!contentState && !!entityKey ? contentState.getEntity(entityKey).getData() : children[0].props.text;
+
+  const buildValidUrl = () => {
+    const candidateUrl = url.url || url;
+    const regex = /(http:\/\/|https:\/\/)+/g;
+
+    return regex.test(candidateUrl) ? candidateUrl : `https://${candidateUrl}`;
+  };
+
+  const validUrl = buildValidUrl();
+
+  return (
+    <StyledLink
+      href={ validUrl }
+      title={ validUrl }
+      aria-label={ validUrl }
+      target='_blank'
+      rel='noopener noreferrer'
+      tabbable={ false }
+      { ...rest }
+    >
+      { children }
+    </StyledLink>
+  );
+};
+
+EditorLink.propTypes = {
+  children: PropTypes.node.isRequired,
+  contentState: PropTypes.object.isRequired,
+  entityKey: PropTypes.string
+};
+
+export default EditorLink;

--- a/src/components/text-editor/__internal__/editor-link/editor-link.d.ts
+++ b/src/components/text-editor/__internal__/editor-link/editor-link.d.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export interface EditorLinkProps {
+  children: React.ReactNode;
+  contentState: object;
+  entityKey?: string;
+}
+
+declare const EditorLink: React.FunctionComponent<EditorLinkProps>;
+
+export default EditorLink;

--- a/src/components/text-editor/__internal__/editor-link/editor-link.spec.js
+++ b/src/components/text-editor/__internal__/editor-link/editor-link.spec.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import EditorLink from './editor-link.component';
+import Link from '../../../link';
+
+const render = (props = {}, renderer = mount) => {
+  return renderer(<EditorLink { ...props } />);
+};
+
+describe('EditorLink', () => {
+  it('derives the correct url when the valid `contentState` and `entityKey` are provided', () => {
+    const contentState = {
+      getEntity: entityKey => ({ getData: () => entityKey })
+    };
+
+    const wrapper = render({ contentState, entityKey: 'bar', children: [<div key='foo' text='foo'>foo</div>] });
+
+    expect(wrapper.find(Link).props().href).toEqual('https://bar');
+    expect(wrapper.find(Link).text()).toEqual('foo');
+  });
+
+  it('derives the correct url from the `children` element when no `contentState` is provided', () => {
+    const wrapper = render({ entityKey: 'bar', children: [<div key='foo' text='foo'>foo</div>] });
+
+    expect(wrapper.find(Link).props().href).toEqual('https://foo');
+    expect(wrapper.find(Link).text()).toEqual('foo');
+  });
+
+  it('derives the correct url from the `children` element when no `entityKey` is provided', () => {
+    const contentState = {
+      getEntity: entityKey => ({ getData: () => entityKey })
+    };
+
+    const wrapper = render({ contentState, children: [<div key='foo' text='foo'>foo</div>] });
+
+    expect(wrapper.find(Link).props().href).toEqual('https://foo');
+    expect(wrapper.find(Link).text()).toEqual('foo');
+  });
+
+  it('does not append `https://` to the url when it contains `http://`', () => {
+    const wrapper = render({ entityKey: 'bar', children: [<div key='foo' text='http://foo'>foo</div>] });
+
+    expect(wrapper.find(Link).props().href).toEqual('http://foo');
+    expect(wrapper.find(Link).text()).toEqual('foo');
+  });
+});

--- a/src/components/text-editor/__internal__/editor-link/editor-link.style.js
+++ b/src/components/text-editor/__internal__/editor-link/editor-link.style.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import Link from '../../../link';
+
+const StyledEditorLink = styled(Link)`
+  max-width: 100%;
+
+  a {
+    max-width: 100%
+
+    span span span {
+      font-weight: 700;
+      font-style: normal;
+    }
+  }
+`;
+
+export default StyledEditorLink;

--- a/src/components/text-editor/__internal__/editor-link/index.d.ts
+++ b/src/components/text-editor/__internal__/editor-link/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './editor-link';
+export * from './editor-link';

--- a/src/components/text-editor/__internal__/editor-link/index.js
+++ b/src/components/text-editor/__internal__/editor-link/index.js
@@ -1,0 +1,1 @@
+export { default } from './editor-link.component';

--- a/src/components/text-editor/__internal__/text-editor.component.js
+++ b/src/components/text-editor/__internal__/text-editor.component.js
@@ -1,0 +1,283 @@
+import React, {
+  useCallback, useEffect, useRef, useState
+} from 'react';
+import PropTypes from 'prop-types';
+import {
+  ContentState,
+  EditorState,
+  Editor,
+  RichUtils,
+  getDefaultKeyBinding,
+  Modifier
+} from 'draft-js';
+import {
+  computeBlockType,
+  getContent,
+  getContentInfo,
+  getDecoratedValue,
+  getSelectedLength,
+  moveSelectionToEnd,
+  resetBlockType,
+  isASCIIChar,
+  replaceText,
+  hasInlineStyle,
+  hasBlockStyle,
+  blockStyleFn
+} from './utils';
+import StyledEditorContainer from './text-editor.style';
+import Counter from './editor-counter';
+import Toolbar from './toolbar';
+import Label from '../../../__experimental__/components/label';
+import Events from '../../../utils/helpers/events/events';
+import createGuid from '../../../utils/helpers/guid';
+
+const NUMBERS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+const INLINE_STYLES = ['BOLD', 'ITALIC'];
+const BLOCK_TYPES = ['unordered-list-item', 'ordered-list-item'];
+
+const TextEditor = React.forwardRef(({
+  characterLimit = 3000,
+  labelText,
+  onChange,
+  onCancel,
+  onSave,
+  value
+}, ref) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const [inlines, setInlines] = useState([]);
+  const [activeInlines, setActiveInlines] = useState({});
+  const [focusToolbar, setFocusToolbar] = useState(false);
+  const editor = ref || useRef();
+  const contentLength = getContent(value).getPlainText('').length;
+  const moveCursor = useRef(contentLength > 0);
+  const lastKeyPressed = useRef();
+  const labelId = useRef(`text-editor-label-${createGuid()}`);
+
+  const keyBindingFn = (ev) => {
+    if (Events.isTabKey(ev) && !Events.isShiftKey(ev)) {
+      setFocusToolbar(true);
+    }
+
+    return getDefaultKeyBinding(ev);
+  };
+
+  const handleKeyCommand = (command) => {
+    // if the backspace or enter is pressed get block type and text
+    if (command.includes('backspace') || command.includes('split-block')) {
+      const { blockType, blockLength } = getContentInfo(value);
+
+      // if a block control is active and there is no text, deactivate it and reset the block
+      if (BLOCK_TYPES.includes(blockType) && !blockLength) {
+        onChange(resetBlockType(value, 'unstyled'));
+
+        return true;
+      }
+    }
+
+    const style = command.toUpperCase();
+
+    // if formatting shortcut used eg. command is "bold" or "italic"
+    if (INLINE_STYLES.includes(style)) {
+      onChange(RichUtils.handleKeyCommand(value, command));
+      setActiveInlines({ ...activeInlines, [style]: !hasInlineStyle(value, style) });
+
+      return true;
+    }
+
+    return false;
+  };
+
+  const handleBeforeInput = (str, newState) => {
+    // short circuit if exceeds character limit
+    if (contentLength >= characterLimit) {
+      return 'handled';
+    }
+
+    setActiveInlines({});
+
+    // there is a bug in how DraftJS handles the macOS double-space-period feature, this is added to catch this and
+    // prevent the editor from crashing until a fix can be added to their codebase
+    if (lastKeyPressed.current === ' ' && !isASCIIChar(str)) {
+      lastKeyPressed.current = null;
+      onChange(replaceText(newState, ' ', newState.getCurrentInlineStyle(), true));
+
+      return 'handled';
+    }
+
+    if (str === ' ') {
+      lastKeyPressed.current = str;
+
+      return false;
+    }
+
+    lastKeyPressed.current = null;
+    // short circuit if str does not match expected chars
+    if (!['.', '*'].includes(str)) {
+      return false;
+    }
+
+    const { blockType, blockLength, blockText } = getContentInfo(value);
+
+    if ((blockLength === 1 && NUMBERS.includes(blockText) && str === '.') || (blockLength === 0 && str === '*')) {
+      const newBlockType = computeBlockType(str, blockType);
+      const hasNumberList = hasBlockStyle(value, BLOCK_TYPES[0]);
+      const hasBulletList = hasBlockStyle(value, BLOCK_TYPES[1]);
+
+
+      if (BLOCK_TYPES.includes(newBlockType) && !hasNumberList && !hasBulletList) {
+        onChange(resetBlockType(value, newBlockType));
+        setActiveInlines({ BOLD: hasInlineStyle(value, 'BOLD'), ITALIC: hasInlineStyle(value, 'ITALIC') });
+
+        return true;
+      }
+    }
+    onChange(value);
+
+    return false;
+  };
+
+  const handlePastedText = (pastedText) => {
+    const selectedTextLength = getSelectedLength(value);
+    const newLength = (contentLength + pastedText.length) - selectedTextLength;
+    // if the pastedText will exceed the limit trim the excess
+    if (newLength > characterLimit) {
+      const newContentState = Modifier.insertText(
+        getContent(value),
+        value.getSelection(),
+        pastedText.substring(0, characterLimit - contentLength)
+      );
+      const newState = EditorState.push(value, newContentState, 'insert-fragment');
+
+      onChange(newState);
+
+      return 'handled';
+    }
+    setActiveInlines({});
+
+    return 'not-handled';
+  };
+
+  const getEditorState = () => {
+    let editorState = getDecoratedValue(value);
+
+    // should the cursor position be forced to the end of the content
+    if (contentLength > 0 && moveCursor.current && isFocused) {
+      editorState = moveSelectionToEnd(editorState);
+      moveCursor.current = false;
+    }
+
+    return editorState;
+  };
+
+  const editorState = getEditorState();
+
+  const activeControls = {
+    BOLD: activeInlines.BOLD !== undefined ? activeInlines.BOLD : hasInlineStyle(editorState, INLINE_STYLES[0]),
+    ITALIC: activeInlines.ITALIC !== undefined ? activeInlines.ITALIC : hasInlineStyle(editorState, INLINE_STYLES[1]),
+    'unordered-list-item': hasBlockStyle(editorState, BLOCK_TYPES[0]),
+    'ordered-list-item': hasBlockStyle(editorState, BLOCK_TYPES[1])
+  };
+
+  const handleEditorFocus = useCallback((focusValue) => {
+    moveCursor.current = true;
+    setIsFocused(focusValue);
+
+    if (!isFocused && focusValue && editor.current !== document.activeElement) {
+      editor.current.focus();
+      setFocusToolbar(false);
+    }
+  }, [editor, isFocused]);
+
+  const handleInlineStyleChange = (ev, style) => {
+    ev.preventDefault();
+    setActiveInlines({ ...activeInlines, [style]: !hasInlineStyle(value, style) });
+    handleEditorFocus(true);
+    setInlines([...inlines, style]);
+  };
+
+  const handleBlockStyleChange = (ev, blockType) => {
+    ev.preventDefault();
+    handleEditorFocus(true);
+    onChange(RichUtils.toggleBlockType(value, blockType));
+    const temp = [];
+    INLINE_STYLES.forEach((style) => {
+      if (activeInlines[style] !== undefined) {
+        temp.push(style);
+      }
+    });
+    setInlines(temp);
+  };
+
+  useEffect(() => {
+    // apply the inline styling, having it run in as an effect ensures that styles can be added
+    // even when the editor is not focused
+    INLINE_STYLES.forEach((style) => {
+      const preserveStyle = activeInlines[style] !== undefined && activeInlines[style] !== hasInlineStyle(value, style);
+
+      if ((preserveStyle && value.getSelection().isCollapsed()) || (isFocused && inlines.includes(style))) {
+        onChange(RichUtils.toggleInlineStyle(value, style));
+        setInlines(inlines.filter(inline => inline !== style));
+      }
+      if (preserveStyle && !value.getSelection().isCollapsed()) {
+        setActiveInlines({ ...activeInlines, [style]: undefined });
+      }
+    });
+  }, [activeInlines, contentLength, editorState, inlines, isFocused, onChange, value]);
+
+  return (
+    <>
+      <Label labelId={ labelId.current }>{labelText}</Label>
+      <StyledEditorContainer
+        data-component='text-editor-container'
+        isFocused={ isFocused }
+        ariaLabelledBy={ labelId.current }
+      >
+        <Counter limit={ characterLimit } count={ contentLength } />
+        <Editor
+          ref={ editor }
+          onFocus={ () => handleEditorFocus(true) }
+          onBlur={ () => handleEditorFocus(false) }
+          editorState={ editorState }
+          onChange={ onChange }
+          handleBeforeInput={ handleBeforeInput }
+          handlePastedText={ handlePastedText }
+          handleKeyCommand={ handleKeyCommand }
+          ariaLabelledBy={ labelId.current }
+          ariaDescribedBy={ labelId.current }
+          blockStyleFn={ blockStyleFn }
+          keyBindingFn={ keyBindingFn }
+        />
+        <Toolbar
+          onSave={ onSave }
+          onCancel={ onCancel }
+          setBlockStyle={ (ev, blockType) => handleBlockStyleChange(ev, blockType) }
+          setInlineStyle={ (ev, inlineStyle, keyboardUsed) => handleInlineStyleChange(ev, inlineStyle, keyboardUsed) }
+          isDisabled={ contentLength === 0 }
+          editorState={ editorState }
+          activeControls={ activeControls }
+          canFocus={ focusToolbar }
+        />
+      </StyledEditorContainer>
+    </>
+  );
+});
+
+TextEditor.propTypes = {
+  /** The maximum characters that the input will accept */
+  characterLimit: PropTypes.number,
+  /** The text for the editor's label */
+  labelText: PropTypes.string.isRequired,
+  /** onChange callback to control value updates */
+  onChange: PropTypes.func.isRequired,
+  /** Optional callback to handle event after clicking the 'Cancel" button */
+  onCancel: PropTypes.func,
+  /** Optional callback to handle event after clicking the 'Save" button, passing this will render the form buttons */
+  onSave: PropTypes.func,
+  /** The value of the input, this is an EditorState immutable object */
+  value: PropTypes.object.isRequired
+};
+
+export const TextEditorState = EditorState;
+export const TextEditorContentState = ContentState;
+
+export default TextEditor;

--- a/src/components/text-editor/__internal__/text-editor.d.ts
+++ b/src/components/text-editor/__internal__/text-editor.d.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export interface TextEditorProps {
+  characterLimit?: number;
+  labelText: string;
+  onChange: (event: object) => void;
+  onCancel?: () => void;
+  onSave?: () => void;
+  value: object;
+}
+
+declare const TextEditor: React.FunctionComponent<TextEditorProps>;
+
+export default TextEditor;

--- a/src/components/text-editor/__internal__/text-editor.spec.js
+++ b/src/components/text-editor/__internal__/text-editor.spec.js
@@ -1,0 +1,520 @@
+import React, { useState } from 'react';
+import {
+  Editor, Modifier
+} from 'draft-js';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import { ThemeProvider } from 'styled-components';
+import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
+import mintTheme from '../../../style/themes/mint';
+import TextEditor, { TextEditorContentState, TextEditorState } from './text-editor.component';
+import EditorLink from './editor-link/editor-link.component';
+import StyledEditorContainer from './text-editor.style';
+import ToolbarButton from './toolbar/toolbar-button/toolbar-button.component';
+import Counter from './editor-counter';
+import Toolbar from './toolbar';
+import guid from '../../../utils/helpers/guid';
+
+jest.mock('../../../utils/helpers/guid');
+guid.mockImplementation(() => 'guid-12345');
+
+const createContent = (text) => {
+  if (text) {
+    return TextEditorState.createWithContent(TextEditorContentState.createFromText(text));
+  }
+  return TextEditorState.createEmpty();
+};
+
+const addToEditorState = (text, { editorState }) => {
+  const contentState = editorState.getCurrentContent();
+  const selection = contentState.getSelectionAfter();
+
+  return TextEditorState.push(editorState, Modifier.insertText(contentState, selection, text), 'insert-fragment');
+};
+
+const injectContentBlock = (value, blockType) => {
+  const contentState = value.getCurrentContent();
+  const selectionState = value.getSelection();
+  const key = selectionState.getStartKey();
+  const blockMap = contentState.getBlockMap();
+  const block = blockMap.get(key);
+
+  const newBlock = block.merge({
+    text: blockType,
+    type: blockType,
+    data: {}
+  });
+
+  const newContentState = contentState.merge({
+    blockMap: blockMap.set(key, newBlock),
+    selectionAfter: selectionState.merge({
+      anchorOffset: blockType.length,
+      focusOffset: 0
+    })
+  });
+
+  return TextEditorState.push(value, newContentState, 'change-block-type');
+};
+
+
+const MockComponent = (props) => {
+  const [value, setValue] = useState(createContent());
+
+  return (
+    <ThemeProvider theme={ mintTheme }>
+      <TextEditor
+        value={ value }
+        onChange={ val => setValue(val) }
+        labelText='Text Editor Label'
+        labelId='foo'
+        { ...props }
+      />
+    </ThemeProvider>
+  );
+};
+
+const render = (props = {}, renderer = mount) => (
+  renderer(<MockComponent { ...props } />, { attachTo: document.getElementById('enzymeContainer') })
+);
+
+describe('TextEditor', () => {
+  beforeAll(() => {
+    window.scrollTo = jest.fn();
+  });
+
+  let wrapper;
+  describe('Styles', () => {
+    it('match the expected as default', () => {
+      wrapper = render();
+
+      assertStyleMatch({
+        minHeight: '220px',
+        minWidth: '320px',
+        backgroundColor: mintTheme.colors.white,
+        border: `1px solid ${mintTheme.editor.border}`
+      }, wrapper.find(StyledEditorContainer));
+
+      assertStyleMatch({
+        minHeight: 'inherit',
+        height: '100%',
+        minWidth: '290px',
+        margin: '4px'
+      }, wrapper.find(StyledEditorContainer), { modifier: 'div.DraftEditor-root' });
+
+      assertStyleMatch({
+        minHeight: 'inherit',
+        height: '100%',
+        minWidth: '290px',
+        padding: '8px'
+      }, wrapper.find(StyledEditorContainer), { modifier: 'div.public-DraftEditor-content' });
+    });
+
+    it('add gold outline when focused removes outline on blur', () => {
+      wrapper = render({ value: createContent('foo') });
+      act(() => { wrapper.find(Editor).props().onFocus(); });
+      act(() => { wrapper.update(); });
+
+      assertStyleMatch({
+        outline: `3px solid ${mintTheme.colors.focus}`
+      }, wrapper.find(StyledEditorContainer));
+
+      act(() => { wrapper.find(Editor).props().onBlur(); });
+      act(() => { wrapper.update(); });
+
+      assertStyleMatch({
+        outline: undefined
+      }, wrapper.find(StyledEditorContainer));
+    });
+  });
+
+  describe('Modifying the Editor state', () => {
+    let buttons, getEditorParent, getEditor;
+
+    const hasInlineStyle = style => wrapper.find(Editor).props().editorState.getCurrentInlineStyle().has(style);
+
+    const hasBlockStyle = (style) => {
+      const { editorState } = wrapper.find(Editor).props();
+      const selection = editorState.getSelection();
+      const content = editorState.getCurrentContent();
+      const currentBlock = content.getBlockForKey(selection.getStartKey());
+      const blockType = currentBlock.getType();
+
+      return blockType === style;
+    };
+
+    const fireMouseDown = props => props.onMouseDown({ preventDefault: jest.fn() });
+
+    const addOrderedBlockViaKeyboard = () => {
+      act(() => {
+        getEditorParent().props().onChange(addToEditorState('1', getEditor().props()));
+      });
+      act(() => { wrapper.update(); });
+      act(() => { getEditor().props().handleBeforeInput('.'); });
+    };
+
+    beforeEach(() => {
+      wrapper = render();
+      getEditorParent = () => wrapper.find(TextEditor);
+      getEditor = () => wrapper.find(Editor);
+    });
+
+    describe('Clicking the controls', () => {
+      it.each([[['BOLD'], [0]], [['ITALIC'], [1]], [['BOLD', 'ITALIC'], [0, 1]]])(
+        '%s button toggles the inline formatting', (styles, indexArray) => {
+          buttons = () => wrapper.find(ToolbarButton);
+          indexArray.forEach((i) => {
+            act(() => { fireMouseDown(buttons().at(i).props()); });
+            act(() => { wrapper.update(); });
+          });
+          styles.forEach(style => expect(hasInlineStyle(style)).toBeTruthy());
+          indexArray.forEach((i) => {
+            act(() => { fireMouseDown(buttons().at(i).props()); });
+            act(() => { wrapper.update(); });
+          });
+          styles.forEach(style => expect(hasInlineStyle(style)).toBeFalsy());
+        }
+      );
+
+      it('persists inline styles even when the editor loses focus and has selection', () => {
+        const value = createContent('foo');
+        const selection = value.getSelection().merge({ anchorOffset: '0', focusOffset: '1' });
+        act(() => {
+          wrapper.find(TextEditor).props().onChange(TextEditorState.forceSelection(value, selection));
+        });
+        act(() => { wrapper.update(); });
+
+
+        const button = wrapper.find(ToolbarButton).at(0);
+
+        act(() => { fireMouseDown(button.props()); });
+        act(() => { wrapper.update(); });
+        act(() => { wrapper.find(Editor).props().onBlur(); });
+        act(() => { wrapper.update(); });
+        act(() => { wrapper.find(Editor).props().onFocus(); });
+        expect(hasInlineStyle('BOLD')).toBeTruthy();
+      });
+
+      it('persists inline styles even when the editor loses focus and no selection', () => {
+        act(() => { wrapper.find(TextEditor).props().onChange(createContent('foo')); });
+        act(() => { wrapper.update(); });
+
+
+        const button = wrapper.find(ToolbarButton).at(0);
+
+        act(() => { fireMouseDown(button.props()); });
+        act(() => { wrapper.update(); });
+        act(() => { wrapper.find(Editor).props().onBlur(); });
+        act(() => { wrapper.update(); });
+        act(() => { wrapper.find(Editor).props().onFocus(); });
+        expect(hasInlineStyle('BOLD')).toBeTruthy();
+      });
+
+      it('persists inline styles applied straight before a block type is added', () => {
+        act(() => { wrapper.find(TextEditor).props().onChange(createContent('foo')); });
+        act(() => { wrapper.update(); });
+        act(() => { fireMouseDown(wrapper.find(ToolbarButton).at(0).props()); });
+        act(() => { wrapper.update(); });
+        act(() => { fireMouseDown(wrapper.find(ToolbarButton).at(2).props()); });
+        act(() => { wrapper.update(); });
+        expect(hasInlineStyle('BOLD')).toBeTruthy();
+      });
+
+      it.each([['unordered-list-item', 2], ['ordered-list-item', 3]])(
+        '%s button toggles the block type', (block, index) => {
+          const getButton = () => wrapper.find(ToolbarButton).at(index);
+          act(() => { fireMouseDown(getButton().props()); });
+          act(() => { wrapper.update(); });
+          expect(hasBlockStyle(block)).toBeTruthy();
+          act(() => { fireMouseDown(getButton().props()); });
+          act(() => { wrapper.update(); });
+          expect(hasBlockStyle(block)).toBeFalsy();
+          expect(hasBlockStyle('unstyled')).toBeTruthy();
+        }
+      );
+
+      it.each([['unordered-list-item', 'ordered-list-item'], ['ordered-list-item', 'unordered-list-item']])(
+        '%s button adds expected block formatting and removes %s', (first, second) => {
+          buttons = [wrapper.find(ToolbarButton).at(2), wrapper.find(ToolbarButton).at(3)];
+          const array = first === 'ordered-list-item' ? buttons.reverse() : buttons;
+          let activeStyle = 'unstyled';
+
+          array.forEach((button, i) => {
+            expect(hasBlockStyle(activeStyle)).toBeTruthy();
+            act(() => { fireMouseDown(button.props()); });
+            act(() => { wrapper.update(); });
+            const assertedStyle = i === 0 ? first : second;
+            expect(hasBlockStyle(assertedStyle)).toBeTruthy();
+            expect(hasBlockStyle(activeStyle)).toBeFalsy();
+            activeStyle = assertedStyle;
+          });
+        }
+      );
+
+      it.each([['unordered-list-item', 2], ['ordered-list-item', 3]])(
+        'BOLD, ITALIC and %s buttons add the expected formatting to the editor state', (block, index) => {
+          buttons = () => wrapper.find(ToolbarButton);
+          act(() => { fireMouseDown(buttons().at(index).props()); });
+          act(() => { fireMouseDown(buttons().at(0).props()); });
+          act(() => { fireMouseDown(buttons().at(1).props()); });
+          act(() => { wrapper.update(); });
+          ['BOLD', 'ITALIC'].forEach(style => expect(hasInlineStyle(style)).toBeTruthy());
+          expect(hasBlockStyle(block)).toBeTruthy();
+        }
+      );
+    });
+
+    describe('Adding inline styling through keyboard shortcuts', () => {
+      it.each([['BOLD', 'cmd + b'], ['ITALIC', 'cmd + i']])(
+        '%s toggles when "%s" pressed', (style) => {
+          act(() => { getEditor().props().handleKeyCommand(style.toLowerCase()); });
+          act(() => { wrapper.update(); });
+          expect(hasInlineStyle(style)).toBeTruthy();
+          act(() => { getEditor().props().handleKeyCommand(style.toLowerCase()); });
+          act(() => { wrapper.update(); });
+          expect(hasInlineStyle(style)).toBeFalsy();
+        }
+      );
+
+      it('does nothing when an invalid command received', () => {
+        act(() => { expect(getEditor().props().handleKeyCommand('foo')).toEqual(false); });
+        act(() => { wrapper.update(); });
+        expect(hasInlineStyle('BOLD')).toBeFalsy();
+        expect(hasInlineStyle('ITALIC')).toBeFalsy();
+      });
+    });
+
+    describe('Adding block styling through keyboard shortcuts', () => {
+      beforeEach(() => {
+        wrapper = render();
+        getEditorParent = () => wrapper.find(TextEditor);
+      });
+
+      it.each([['unordered-list-item', '*'], ['ordered-list-item', '1.'], ['unstyled', '@']])(
+        '%s is rendered when "%s" is inputted', (block, key) => {
+          if (block === 'ordered-list-item') {
+            addOrderedBlockViaKeyboard();
+          } else {
+            act(() => { getEditor().props().handleBeforeInput(key); });
+          }
+          act(() => { wrapper.update(); });
+          expect(hasBlockStyle(block)).toBeTruthy();
+        }
+      );
+
+      it.each([['unordered-list-item', '*'], ['ordered-list-item', '1.']])(
+        '%s is not rendered when "%s" is inputted and there is already content before', (block) => {
+          if (block === 'ordered-list-item') {
+            addOrderedBlockViaKeyboard();
+            expect(hasBlockStyle(block)).toBeFalsy();
+            expect(hasBlockStyle('unstyled')).toBeTruthy();
+          } else {
+            act(() => {
+              getEditorParent().props().onChange(addToEditorState('foo', getEditor().props()));
+            });
+            act(() => { wrapper.update(); });
+            act(() => { getEditor().props().handleBeforeInput('*'); });
+            expect(hasBlockStyle(block)).toBeFalsy();
+            expect(hasBlockStyle('unstyled')).toBeTruthy();
+          }
+        }
+      );
+
+      it.each([['unordered-list-item', '*'], ['ordered-list-item', '1.']])(
+        '%s is not rendered when "%s" is inputted consecutively', (block) => {
+          if (block === 'ordered-list-item') {
+            addOrderedBlockViaKeyboard();
+            act(() => { wrapper.update(); });
+            expect(hasBlockStyle(block)).toBeTruthy();
+            act(() => { getEditorParent().props().onChange(addToEditorState('1', getEditor().props())); });
+            act(() => { wrapper.update(); });
+            act(() => { expect(getEditor().props().handleBeforeInput('.')).toEqual(false); });
+          } else {
+            act(() => { getEditor().props().handleBeforeInput('*'); });
+            act(() => { wrapper.update(); });
+            expect(hasBlockStyle(block)).toBeTruthy();
+            act(() => { expect(getEditor().props().handleBeforeInput('*')).toEqual(false); });
+          }
+        }
+      );
+    });
+
+    describe('Double space key press', () => {
+      it('does not trigger macOS feature and render a `.` if space key pressed twice', () => {
+        wrapper = render();
+        const editor = wrapper.find(Editor);
+        const { editorState, handleBeforeInput } = editor.props();
+        act(() => {
+          handleBeforeInput(' ', editorState, 0);
+          wrapper.update();
+        });
+        act(() => { expect(handleBeforeInput(' ', editorState)).toEqual('handled'); });
+      });
+    });
+
+    describe('Pressing Tab key', () => {
+      let container;
+      beforeEach(() => {
+        container = document.createElement('div');
+        container.id = 'enzymeContainer';
+        document.body.appendChild(container);
+      });
+
+      afterEach(() => {
+        if (container && container.parentNode) {
+          container.parentNode.removeChild(container);
+        }
+
+        container = null;
+      });
+
+      it('passes focus to the Toolbar first button', () => {
+        wrapper = render();
+        const editor = wrapper.find(Editor);
+        act(() => { editor.props().keyBindingFn({ key: 'tab', which: 9 }); });
+        act(() => { wrapper.update(); });
+        expect(wrapper.find(Toolbar).props().canFocus).toEqual(true);
+        setTimeout(() => expect(wrapper.find(ToolbarButton).at(0).getDOMNode()).toBeFocused());
+      });
+    });
+
+    describe('Pressing Tab and Shift keys', () => {
+      it('does not pass focus to the Toolbar', () => {
+        wrapper = render();
+        const editor = wrapper.find(Editor);
+        act(() => { editor.props().keyBindingFn({ key: 'tab', which: 9, shiftKey: true }); });
+        act(() => { wrapper.update(); });
+        expect(wrapper.find(Toolbar).props().canFocus).toEqual(false);
+      });
+    });
+
+    describe('Deleting block styling via keyboard', () => {
+      it.each([
+        ['unordered-list-item', 'backspace'], ['ordered-list-item', 'backspace'],
+        ['unordered-list-item', 'split-block'], ['ordered-list-item', 'split-block']])(
+        '%s deleted when %s pressed', (style, command) => {
+          if (style === 'ordered-list-item') {
+            addOrderedBlockViaKeyboard();
+          } else {
+            act(() => { getEditor().props().handleBeforeInput('*'); });
+          }
+          act(() => { wrapper.update(); });
+          expect(hasBlockStyle(style)).toBeTruthy();
+          act(() => { getEditor().props().handleKeyCommand(command); });
+          act(() => { wrapper.update(); });
+          expect(hasBlockStyle(style)).toBeFalsy();
+        }
+      );
+
+      it.each([
+        ['unordered-list-item', 'backspace'], ['ordered-list-item', 'backspace'],
+        ['unordered-list-item', 'split-block'], ['ordered-list-item', 'split-block']])(
+        '%s not deleted when %s pressed and has content in block', (style, command) => {
+          act(() => {
+            getEditorParent().props().onChange(injectContentBlock(getEditorParent().props().value, style));
+          });
+          act(() => { wrapper.update(); });
+          expect(hasBlockStyle(style)).toBeTruthy();
+          act(() => { expect(getEditor().props().handleKeyCommand(command)).toEqual(false); });
+          act(() => { wrapper.update(); });
+          expect(hasBlockStyle(style)).toBeTruthy();
+        }
+      );
+
+      it.each([['unordered-list-item'], ['ordered-list-item']])(
+        'adds styling to %s control when currentBlock has a a given type', (style) => {
+          const index = style === 'unordered-list-item' ? 2 : 3;
+          act(() => {
+            getEditorParent().props().onChange(injectContentBlock(getEditorParent().props().value, style));
+          });
+          act(() => { wrapper.update(); });
+          expect(hasBlockStyle(style)).toBeTruthy();
+          assertStyleMatch({
+            backgroundColor: mintTheme.editor.button.hover
+          }, wrapper.find(ToolbarButton).at(index));
+        }
+      );
+    });
+
+    describe('Decorators', () => {
+      it.each(['http://foo.com ', 'https://bar.co.uk/ ', 'www.wiz.org '])(
+        'renders an EditorLink when the regex pattern is matched by %s', (url) => {
+          wrapper = render();
+          act(() => { getEditorParent().props().onChange(addToEditorState(url, getEditor().props())); });
+          act(() => { wrapper.update(); });
+          expect(getEditor().find(EditorLink).exists()).toBeTruthy();
+        }
+      );
+
+      it.each([['foo www.foo.com foo ', 1],
+        [' foo https://foo.com   http://foo.com ', 2],
+        ['  www.foo.com foo    https://foo.com         http://foo.com/foo#  foo ', 3]])(
+        'renders the expected number of EditorLink when %s is input', (urlString, count) => {
+          wrapper = render();
+          act(() => { getEditorParent().props().onChange(createContent(urlString)); });
+          act(() => { wrapper.update(); });
+          expect(getEditor().find(EditorLink)).toHaveLength(count);
+        }
+      );
+
+      it.each(['foo://foo.com', 'https://bar.', 'wwww..s', 'http://f..o', '.ca', ' _ '])(
+        'does not render an EditorLink when the regex pattern is not matched by %s', (url) => {
+          wrapper = render();
+          act(() => { getEditorParent().props().onChange(addToEditorState(url, getEditor().props())); });
+          act(() => { wrapper.update(); });
+          expect(getEditor().find(EditorLink).exists()).toBeFalsy();
+        }
+      );
+    });
+
+    describe('Character Limit', () => {
+      describe('Counter', () => {
+        it('displays the default text when no prop value passed', () => {
+          wrapper = render();
+          expect(wrapper.find(Counter).text()).toEqual('3000');
+        });
+
+        it('overrides the text when `characterLimit` prop passed', () => {
+          wrapper = render({ characterLimit: 200 });
+          expect(wrapper.find(Counter).text()).toEqual('200');
+        });
+
+        it('the text updates as content is added to the editor', () => {
+          wrapper = render({ characterLimit: 10 });
+          const textEditor = wrapper.find(TextEditor);
+          const editor = wrapper.find(Editor);
+          act(() => { textEditor.props().onChange(addToEditorState('foo foo', editor.props())); });
+          expect(wrapper.find(Counter).text()).toEqual('3');
+        });
+      });
+
+      it('allows pasting into input that would not exceed the limit', () => {
+        wrapper = render({ characterLimit: 2 });
+        const editor = wrapper.find(Editor);
+        act(() => { expect(editor.props().handlePastedText('ab')).toEqual('not-handled'); });
+      });
+
+      it('prevents pasting into input that would exceed the limit', () => {
+        wrapper = render({ characterLimit: 2 });
+        const editor = wrapper.find(Editor);
+        act(() => { expect(editor.props().handlePastedText('abc')).toEqual('handled'); });
+      });
+
+      it('allows input when content does not exceed limit', () => {
+        wrapper = render({ characterLimit: 1 });
+        const editor = wrapper.find(Editor);
+        act(() => { expect(editor.props().handleBeforeInput('*')).toEqual(true); });
+      });
+
+      it('prevents input when content would exceed limit', () => {
+        wrapper = render({ characterLimit: 0 });
+        const editor = wrapper.find(Editor);
+        act(() => { expect(editor.props().handleBeforeInput('*')).toEqual('handled'); });
+      });
+    });
+  });
+
+  afterAll(() => {
+    // Clear Mock
+    window.scrollTo.mockRestore();
+  });
+});

--- a/src/components/text-editor/__internal__/text-editor.stories.mdx
+++ b/src/components/text-editor/__internal__/text-editor.stories.mdx
@@ -1,0 +1,137 @@
+import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
+import { useState, useRef } from 'react';
+import EditorLink from './editor-link';
+import TextEditor, 
+{
+  TextEditorState as EditorState, 
+  TextEditorContentState as ContentState
+} from './text-editor.component';
+import Toolbar from './toolbar';
+import ToolbarButton from './toolbar/toolbar-button';
+import EditorCounter from './editor-counter';
+import IconButton from '../../icon-button';
+import Icon from '../../icon';
+
+<Meta title="Design System/Text Editor" parameters={{ info: { disable: true }}} />
+
+# Text Editor
+The `TextEditor` was created using the `draftjs` framework. It requires consuming projects to install `draftjs` as a 
+peer-dependency to enable it to work.
+
+## Quick Start
+
+To use the text editor , import the `TextEditor` and pass the content as as an immutable `EditorState` object.
+
+It can be used as a controlled component where the content of the input is controlled externally, as such both 
+`onChange` and `value` props are required. The `labelText` and `labelId` props are also required in order to ensure 
+accessibility requirements are met.
+
+```jsx
+import TextEditor, { EditorState, ContentState } from "carbon-react/lib/components/text-editor";
+```
+
+### Basic usage:
+In its basic format the `TextEditor` requires three props; `value`, `onChange` and `label` props. The initial 
+editorState can be created empty using `EditorState.createEmpty()`, as it is below. It is also possible to render links 
+in the input, this can be done by manually typing or pasting a valid url into the editor. Another feature of the 
+component is that it supports a wide range of keyboard shortcuts to apply the various styling options: `cmd/ctrl+b` 
+toggles `bold`; `cmd/ctrl+i` toggles `italic`; and inputting a `*` or `1.` on a new line will render a 
+`unordered-list` or `ordered-list` respectively.
+
+<Preview>
+  <Story name="basic">
+    {() => {
+      const [value, setValue] = useState(EditorState.createEmpty());
+      return (
+        <div style={{ padding: '4px' }}>
+          <TextEditor
+            onChange={(newValue) => {setValue(newValue)}}
+            value={ value }
+            labelText='Text Editor Label'
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With content:
+The initial editorState can also be created with content using 
+`EditorState.createWithContent(ContentState.createFromText(''))`, as it is below. Other options available for 
+populating the content that can be found https://draftjs.org/docs/api-reference-content-state#static-methods. 
+It is also possible to initialise the editor with content in other formats, such as `html` or `markdown` through use of 
+other packages; using the methods for data conversion provided by `draftjs` 
+(https://draftjs.org/docs/api-reference-data-conversion/), enables the parsing of these formats into something the 
+editor can expects.
+
+<Preview>
+  <Story name="with content">
+    {() => {
+      const [value, setValue] = useState(
+        EditorState.createWithContent(ContentState.createFromText('Some initial content'))
+      );
+      return (
+        <div style={{ padding: '4px' }}>
+          <TextEditor
+            onChange={(newValue) => {setValue(newValue)}}
+            value={ value }
+            labelText='Text Editor Label'
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With optional Save/ Cancel buttons
+By passing the `onSave` callback prop it is possible to render the form control buttons as seen below. This callback 
+will be executed when the `Save` button is clicked and there is content in the editor input, the button is disabled 
+otherwise. Any `onCancel` callback prop passed will be called when the `Cancel` button is clicked.
+
+<Preview>
+  <Story name="with optional buttons">
+    {() => {
+      const [value, setValue] = useState(EditorState.createEmpty());
+      const ref = useRef(null);
+      return (
+        <div style={{ padding: '4px' }}>
+          <TextEditor
+            onChange={(newValue) => {setValue(newValue)}}
+            value={ value } ref={ ref }
+            onSave={ () => { } }
+            onCancel={ () => { } }
+            labelText='Text Editor Label'
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With user defined character limit
+It is possible to override the default value for the character limit via the `characterLimit` prop. Setting this prop 
+will prevent any input that would cause the content length to exceed it.
+
+<Preview>
+  <Story name="with optional character limit">
+    {() => {
+      const [value, setValue] = useState(EditorState.createEmpty());
+      const [limit, setLimit] = useState(100);
+      const ref = useRef(null);
+      return (
+          <div style={{ padding: '4px' }}>
+            <TextEditor
+              onChange={(newValue) => {setValue(newValue)}}
+              value={ value } ref={ ref }
+              onSubmit={ () => {} }
+              labelText='Text Editor Label'
+              characterLimit={ limit }
+            />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+### Text Editor Props
+<Props of={TextEditor} />

--- a/src/components/text-editor/__internal__/text-editor.style.js
+++ b/src/components/text-editor/__internal__/text-editor.style.js
@@ -1,0 +1,57 @@
+import styled, { css } from 'styled-components';
+import { isDLS } from '../../../utils/helpers/style-helper';
+import baseTheme from '../../../style/themes/base';
+
+const StyledEditorContainer = styled.div`
+  ${({ theme, isFocused }) => css`
+    min-height: 220px;
+    min-width: 320px;
+    
+    div.DraftEditor-root {
+      min-height: inherit;
+      height: 100%;
+      min-width: 290px;
+      margin: 4px;
+    }
+
+    div.DraftEditor-editorContainer,
+    div.public-DraftEditor-content {
+      min-height: inherit;
+      height: 100%;
+      min-width: 290px;
+      background-color: ${theme.colors.white};
+      line-height: 21px;
+
+      .text-editor-block-ordered {
+        position: relative;
+        left: -26px;
+        top: -12px;
+        bottom: 4px;
+        padding-left: 8px;
+      }
+
+      .text-editor-block-unordered {
+        position: relative;
+        left: -22px;
+        top: -12px;
+        bottom: 4px;
+        padding-left: 8px;
+      }
+    }
+
+    div.public-DraftEditor-content {
+      padding: 8px;
+    }
+  
+  
+    background-color: ${theme.colors.white};
+    border: 1px solid ${theme.editor.border};
+    ${isDLS(theme) && isFocused && `outline: 3px solid ${theme.colors.focus};`}
+  `}
+`;
+
+StyledEditorContainer.defaultProps = {
+  theme: baseTheme
+};
+
+export default StyledEditorContainer;

--- a/src/components/text-editor/__internal__/toolbar/index.d.ts
+++ b/src/components/text-editor/__internal__/toolbar/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './toolbar';
+export * from './toolbar';

--- a/src/components/text-editor/__internal__/toolbar/index.js
+++ b/src/components/text-editor/__internal__/toolbar/index.js
@@ -1,0 +1,1 @@
+export { default } from './toolbar.component';

--- a/src/components/text-editor/__internal__/toolbar/toolbar-button/index.d.ts
+++ b/src/components/text-editor/__internal__/toolbar/toolbar-button/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './toolbar-button';
+export * from './toolbar-button';

--- a/src/components/text-editor/__internal__/toolbar/toolbar-button/index.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar-button/index.js
@@ -1,0 +1,1 @@
+export { default } from './toolbar-button.component';

--- a/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.component.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.component.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import StyledToolbarButton from './toolbar-button.style';
+import TooltipDecorator from '../../../../../utils/decorators/tooltip-decorator/tooltip-decorator';
+
+class ToolbarButton extends React.Component {
+  componentDidUpdate() {
+    // ensure tooltip is hidden when prop updates
+    if (!this.props.tooltipVisible) {
+      this.onHide();
+    }
+  }
+
+  render() {
+    return (
+      <>
+        <StyledToolbarButton
+          data-component='text-editor-toolbar-button'
+          ref={ (comp) => { this._target = comp; } }
+          onMouseOver={ this.props.onMouseOver }
+          onMouseLeave={ this.props.onMouseLeave }
+          onFocus={ this.props.onMouseOver }
+          onKeyDown={ this.props.onKeyDown }
+          onMouseDown={ this.props.onMouseDown }
+          onBlur={ this.props.onMouseLeave }
+          isActive={ this.props.activated }
+          aria-label={ this.props.ariaLabel }
+          { ...(!this.props.tabbable) && { tabIndex: -1 } }
+        >
+          { this.props.children }
+        </StyledToolbarButton>
+
+        { this.tooltipHTML }
+      </>
+    );
+  }
+}
+
+ToolbarButton.propTypes = {
+  /** Accessibility label for a button */
+  ariaLabel: PropTypes.string.isRequired,
+  /** The children for the button */
+  children: PropTypes.node.isRequired,
+  /** Used to control the button's active status */
+  activated: PropTypes.bool,
+  /** Callback to handle any keydown events on a button */
+  onKeyDown: PropTypes.func.isRequired,
+  /** Callback to handle any mouse down events on a button */
+  onMouseDown: PropTypes.func.isRequired,
+  /** Callback to handle any mouse over events on a button */
+  onMouseOver: PropTypes.func.isRequired,
+  /** Callback to handle any mouse leave events on a button */
+  onMouseLeave: PropTypes.func.isRequired,
+  /** Controls whether the button's tooltip should be shown */
+  tooltipVisible: PropTypes.bool,
+  tabbable: PropTypes.bool
+};
+
+ToolbarButton.defaultProps = {
+  tooltipVisible: false
+};
+
+export default TooltipDecorator(ToolbarButton);

--- a/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.d.ts
+++ b/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.d.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+export interface ToolbarButtonProps {
+  ariaLabel: string;
+  children: React.ReactNode;
+  activated: boolean;
+  onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
+  onMouseDown: (event: React.MouseEvent<HTMLElement>) => void;
+  onMouseOver: (event: React.MouseEvent<HTMLElement>) => void;
+  onMouseLeave: (event: React.MouseEvent<HTMLElement>) => void;
+  tooltipVisible?: boolean;
+}
+
+declare const ToolbarButton: React.FunctionComponent<ToolbarButtonProps>;
+
+export default ToolbarButton;

--- a/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.spec.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.spec.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { ThemeProvider } from 'styled-components';
+import { assertStyleMatch } from '../../../../../__spec_helper__/test-utils';
+import mintTheme from '../../../../../style/themes/mint';
+import ToolbarButton from './toolbar-button.component';
+import Tooltip from '../../../../tooltip';
+import StyledIcon from '../../../../icon/icon.style';
+
+const onKeyDown = jest.fn();
+const onMouseDown = jest.fn();
+const onMouseOver = jest.fn();
+const onMouseLeave = jest.fn();
+
+const render = (props = {}, theme = mintTheme, renderer = mount) => {
+  const defaultProps = {
+    onKeyDown,
+    onMouseDown,
+    onMouseOver,
+    onMouseLeave
+  };
+  return renderer(
+    <ThemeProvider theme={ theme }><ToolbarButton { ...defaultProps } { ...props }>foo</ToolbarButton></ThemeProvider>
+  );
+};
+
+describe('ToolbarButton', () => {
+  describe('styling', () => {
+    it('matches the expected as default', () => {
+      const wrapper = render();
+
+      assertStyleMatch({
+        backgroundColor: 'inherit',
+        border: 'none',
+        cursor: 'pointer',
+        width: '32px',
+        fontSize: '14px',
+        height: '32px'
+      }, wrapper);
+
+      assertStyleMatch({
+        backgroundColor: mintTheme.editor.button.hover
+      }, wrapper, { modifier: ':hover' });
+
+      assertStyleMatch({
+        outline: `2px solid ${mintTheme.colors.focus}`,
+        outlineOffset: '-2px'
+      }, wrapper, { modifier: ':focus' });
+
+      assertStyleMatch({
+        width: 'auto'
+      }, wrapper, { modifier: `${StyledIcon}` });
+    });
+
+    it('matches the expected `background-color` when `activated` prop is truthy', () => {
+      assertStyleMatch({
+        backgroundColor: mintTheme.editor.button.hover
+      }, render({ activated: true }));
+    });
+  });
+
+  describe('Tooltip', () => {
+    const ToolBarButtonWithToolTip = (props) => {
+      const defaultProps = {
+        onKeyDown,
+        onMouseDown,
+        onMouseOver,
+        onMouseLeave,
+        tooltipMessage: 'foo',
+        tooltipPosition: 'top',
+        tooltipAlign: 'center',
+        tooltipVisible: false
+      };
+      return (
+        <ToolbarButton { ...defaultProps } { ...props }>foo</ToolbarButton>
+      );
+    };
+
+    it('is displayed when `tooltipVisible` is true', () => {
+      const wrapper = mount(<ToolBarButtonWithToolTip tooltipVisible />);
+
+      expect(wrapper.find(Tooltip).exists()).toBeTruthy();
+    });
+
+    it('is hidden when `tooltipVisible` is false', () => {
+      const wrapper = mount(<ToolBarButtonWithToolTip />);
+
+      expect(wrapper.find(Tooltip).exists()).toBeFalsy();
+    });
+  });
+});

--- a/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.style.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.style.js
@@ -1,0 +1,40 @@
+import styled, { css } from 'styled-components';
+import { isDLS } from '../../../../../utils/helpers/style-helper';
+import baseTheme from '../../../../../style/themes/base';
+import StyledIcon from '../../../../icon/icon.style';
+
+const StyledToolbarButton = styled.button`
+  background-color: inherit;
+  border: none;
+  cursor: pointer;
+  width: 32px;
+  font-size: 14px;
+  height: 32px;
+
+  ${StyledIcon} {
+    width: auto;
+  }
+
+  ${({ theme, isActive }) => css`
+    :focus, :active {
+      ${isDLS(theme) && css`
+        outline: 2px solid ${theme.colors.focus};
+        outline-offset: -2px;
+      `}
+    }
+
+    :hover {
+      background-color: ${theme.editor.button.hover};
+    }
+
+    ${isActive && css`
+      background-color: ${theme.editor.button.hover};
+    `}
+  `}
+`;
+
+StyledToolbarButton.defaultProps = {
+  theme: baseTheme
+};
+
+export default StyledToolbarButton;

--- a/src/components/text-editor/__internal__/toolbar/toolbar.component.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.component.js
@@ -1,0 +1,178 @@
+import React, {
+  useCallback, useEffect, useRef, useState
+} from 'react';
+import PropTypes from 'prop-types';
+import { StyledToolbar, StyledEditorStyleControls, StyledEditorActionControls } from './toolbar.style';
+import ToolbarButton from './toolbar-button';
+import Button from '../../../button';
+import Events from '../../../../utils/helpers/events/events';
+import Icon from '../../../icon';
+
+const BOLD = 'BOLD';
+const ITALIC = 'ITALIC';
+const UNORDERED_LIST = 'unordered-list-item';
+const ORDERED_LIST = 'ordered-list-item';
+
+const Toolbar = ({
+  activeControls, canFocus, isDisabled, onCancel, onSave, setBlockStyle, setInlineStyle
+}) => {
+  const [showTooltip, setShowTooltip] = useState('');
+  const controlRefs = [useRef(), useRef(), useRef(), useRef()];
+  const [focusIndex, setFocusIndex] = useState(0);
+  const [tabbable, setTabbable] = useState(true);
+
+  const handleInlineStyleChange = useCallback((ev, inlineType) => {
+    setInlineStyle(ev, inlineType);
+    setShowTooltip('');
+  }, [setInlineStyle]);
+
+  const handleBlockType = useCallback((ev, blockType) => {
+    setBlockStyle(ev, blockType);
+    setShowTooltip('');
+  }, [setBlockStyle]);
+
+  const handleKeyDown = useCallback((ev, type) => {
+    if (Events.isTabKey(ev)) {
+      setFocusIndex(null);
+    } else if (Events.isSpaceKey(ev) || Events.isEnterKey(ev)) {
+      if ([BOLD, ITALIC].includes(type)) {
+        handleInlineStyleChange(ev, type);
+      } else {
+        handleBlockType(ev, type);
+      }
+      setFocusIndex(0);
+      setTabbable(true);
+    } else if (Events.isLeftKey(ev)) {
+      if (focusIndex === null || focusIndex === 0) {
+        setFocusIndex(3);
+      } else {
+        setFocusIndex(focusIndex - 1);
+      }
+      setTabbable(false);
+    } else if (Events.isRightKey(ev)) {
+      if (focusIndex === 3) {
+        setFocusIndex(0);
+      } else {
+        setFocusIndex(focusIndex + 1);
+      }
+      setTabbable(false);
+    }
+  }, [focusIndex, handleBlockType, handleInlineStyleChange]);
+
+  useEffect(() => {
+    if (focusIndex === null) {
+      setTabbable(true);
+    } else if (canFocus && focusIndex !== null) {
+      controlRefs[focusIndex].current._target.focus();
+    }
+  }, [canFocus, controlRefs, focusIndex, tabbable]);
+
+  const isTabbable = useCallback((index) => {
+    if (!controlRefs[index] || !controlRefs[index].current) {
+      return false;
+    }
+
+    return controlRefs[index].current._target === document.activeElement;
+  }, [controlRefs]);
+
+  return (
+    <StyledToolbar data-component='text-editor-toolbar'>
+      <StyledEditorStyleControls>
+        <ToolbarButton
+          ariaLabel='bold'
+          onKeyDown={ ev => handleKeyDown(ev, BOLD) }
+          onMouseDown={ ev => handleInlineStyleChange(ev, BOLD) }
+          activated={ activeControls.BOLD }
+          ref={ controlRefs[0] }
+          tabbable={ tabbable }
+          { ...tooltipProps('Bold', showTooltip, setShowTooltip) }
+        >
+          <Icon type='bold' />
+        </ToolbarButton>
+        <ToolbarButton
+          ariaLabel='italic'
+          onKeyDown={ ev => handleKeyDown(ev, ITALIC) }
+          onMouseDown={ ev => handleInlineStyleChange(ev, ITALIC) }
+          activated={ activeControls.ITALIC }
+          ref={ controlRefs[1] }
+          tabbable={ isTabbable(1) }
+          { ...tooltipProps('Italic', showTooltip, setShowTooltip) }
+        >
+          <Icon type='italic' />
+        </ToolbarButton>
+        <ToolbarButton
+          ariaLabel='bullet-list'
+          onKeyDown={ ev => handleKeyDown(ev, UNORDERED_LIST) }
+          onMouseDown={ ev => handleBlockType(ev, UNORDERED_LIST) }
+          activated={ activeControls[UNORDERED_LIST] }
+          ref={ controlRefs[2] }
+          tabbable={ isTabbable(2) }
+          { ...tooltipProps('Bulleted List', showTooltip, setShowTooltip) }
+        >
+          <Icon type='bullet_list_dotted' />
+        </ToolbarButton>
+        <ToolbarButton
+          ariaLabel='number-list'
+          onKeyDown={ ev => handleKeyDown(ev, ORDERED_LIST) }
+          onMouseDown={ ev => handleBlockType(ev, ORDERED_LIST) }
+          activated={ activeControls[ORDERED_LIST] }
+          ref={ controlRefs[3] }
+          tabbable={ isTabbable(3) }
+          { ...tooltipProps('Numbered List', showTooltip, setShowTooltip) }
+        >
+          <Icon type='bullet_list_numbers' />
+        </ToolbarButton>
+      </StyledEditorStyleControls>
+
+      { onSave && (
+        <StyledEditorActionControls>
+          <Button
+            buttonType='tertiary'
+            onClick={ onCancel ? ev => onCancel(ev) : undefined }
+          >
+            Cancel
+          </Button>
+          <Button
+            buttonType='primary'
+            onClick={ onSave }
+            disabled={ isDisabled }
+          >
+            Save
+          </Button>
+        </StyledEditorActionControls>
+      ) }
+    </StyledToolbar>
+  );
+};
+
+function tooltipProps(id, showTooltip, setShowTooltip) {
+  return {
+    tooltipMessage: id,
+    tooltipPosition: 'top',
+    tooltipAlign: 'center',
+    tooltipVisible: showTooltip === id,
+    onMouseOver: () => setShowTooltip(id),
+    onMouseLeave: () => setShowTooltip('')
+  };
+}
+
+Toolbar.propTypes = {
+  /** Used to override the active status of the inline controls */
+  activeControls: PropTypes.object.isRequired,
+  /** Flag to trigger control focusing */
+  canFocus: PropTypes.bool,
+  /** Used to allow toolbar to determine active controls */
+  editorState: PropTypes.object,
+  /** Sets the form controls ('Save', 'Cancel') to disabled */
+  isDisabled: PropTypes.bool,
+  /** Optional callback to handle event after clicking the 'Cancel" button */
+  onCancel: PropTypes.func,
+  /** Optional callback to handle event after clicking the 'Save" button */
+  onSave: PropTypes.func,
+  /** Callback to handle setting the inline styles */
+  setInlineStyle: PropTypes.func.isRequired,
+  /** Callback to handle setting the block styles */
+  setBlockStyle: PropTypes.func.isRequired
+};
+
+export default Toolbar;

--- a/src/components/text-editor/__internal__/toolbar/toolbar.d.ts
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.d.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export interface ToolbarProps {
+  activeControls: object;
+  isDisabled?: boolean;
+  onCancel?: () => void;
+  onSave: () => void;
+  setInlineStyle: (args: number) => any;
+  setBlockStyle: (args: number) => any;
+}
+
+declare const Toolbar: React.FunctionComponent<ToolbarProps>;
+
+export default Toolbar;

--- a/src/components/text-editor/__internal__/toolbar/toolbar.spec.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.spec.js
@@ -1,0 +1,366 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import { ThemeProvider } from 'styled-components';
+import { simulate, assertStyleMatch } from '../../../../__spec_helper__/test-utils';
+import baseTheme from '../../../../style/themes/base';
+import Toolbar from './toolbar.component';
+import { StyledEditorStyleControls, StyledEditorActionControls } from './toolbar.style';
+import StyledButton from '../../../button/button.style';
+import Button from '../../../button/button.component';
+import StyledToolbarButton from './toolbar-button/toolbar-button.style';
+import ToolbarButton from './toolbar-button/toolbar-button.component';
+import Tooltip from '../../../tooltip';
+
+const setInlineStyle = jest.fn();
+const setBlockStyle = jest.fn();
+
+const render = (props = {}, theme = baseTheme, renderer = mount) => {
+  const defaultProps = {
+    setInlineStyle,
+    setBlockStyle,
+    activeControls: {}
+  };
+
+  return renderer(
+    <ThemeProvider theme={ theme }><Toolbar { ...defaultProps } { ...props } /></ThemeProvider>,
+    { attachTo: document.getElementById('enzymeContainer') }
+  );
+};
+
+describe('Toolbar', () => {
+  let wrapper;
+  let container;
+  describe('styling', () => {
+    it('matches the expected for the main container', () => {
+      assertStyleMatch({
+        padding: '8px',
+        display: 'flex',
+        justifyContent: 'flex-start',
+        background: 'white',
+        flexWrap: 'wrap',
+        fontSize: '14px',
+        userSelect: 'none',
+        order: '2',
+        border: 'none',
+        backgroundColor: baseTheme.editor.toolbar.background,
+        borderTop: `1px solid ${baseTheme.editor.border}`,
+        minWidth: '290px'
+      }, render());
+    });
+
+    it('matches the expected for the format styles controls container', () => {
+      assertStyleMatch({
+        display: 'inline-block',
+        textAlign: 'left',
+        width: '50%',
+        minWidth: '60px',
+        marginLeft: '-2px'
+      }, render().find(StyledEditorStyleControls));
+    });
+
+    it('matches the expected for the action controls container', () => {
+      assertStyleMatch({
+        display: 'inline-block',
+        textAlign: 'right',
+        width: '50%',
+        minWidth: '60px'
+      }, render({ onSave: () => {} }).find(StyledEditorActionControls));
+
+      assertStyleMatch({
+        width: '62px',
+        height: '33px'
+      }, render({ onSave: () => {} }).find(StyledEditorActionControls), { modifier: `${StyledButton}` });
+
+      assertStyleMatch({
+        fontSize: '16px'
+      }, render({ onSave: () => {} }).find(StyledEditorActionControls),
+      { modifier: `${StyledButton}:first-of-type` });
+    });
+  });
+
+  describe('Tooltip', () => {
+    describe.each([[0, 'Bold'], [1, 'Italic'], [2, 'Bulleted List'], [3, 'Numbered List']])(
+      'is displayed', (index, text) => {
+        function checkOtherTooltipState(buttons) {
+          buttons.forEach((btn, i) => {
+            if (i !== index) {
+              expect(btn.find(Tooltip).exists()).toBeFalsy();
+            }
+          });
+        }
+
+        it(`with ${text} when the button at position ${index} is focused`, () => {
+          wrapper = render();
+          const button = wrapper.find(StyledToolbarButton).at(index);
+
+          act(() => {
+            button.props().onFocus();
+          });
+
+          act(() => {
+            wrapper.update();
+          });
+
+          act(() => {
+            const buttonWrapper = wrapper.find(ToolbarButton).at(index);
+            const toolTip = buttonWrapper.find(Tooltip);
+            expect(toolTip.exists()).toBeTruthy();
+            expect(toolTip.text()).toEqual(text);
+            checkOtherTooltipState(wrapper.find(ToolbarButton));
+          });
+        });
+
+        it(`with ${text} when the button at position ${index} has a 'mouseOver' event`, () => {
+          wrapper = render();
+          const getButton = () => wrapper.find(ToolbarButton).at(index);
+
+          act(() => {
+            getButton().props().onMouseOver();
+          });
+
+          act(() => {
+            wrapper.update();
+          });
+
+          act(() => {
+            const toolTip = getButton().find(Tooltip);
+            expect(toolTip.exists()).toBeTruthy();
+            expect(toolTip.text()).toEqual(text);
+            checkOtherTooltipState(wrapper.find(ToolbarButton));
+          });
+        });
+      }
+    );
+
+    describe.each([0, 1, 2, 3])(
+      'is hidden', (index) => {
+        it(`when the button at position ${index} is blurred`, () => {
+          wrapper = render();
+          const button = wrapper.find(StyledToolbarButton).at(index);
+
+          act(() => {
+            button.props().onFocus();
+          });
+
+          act(() => {
+            wrapper.update();
+          });
+
+          act(() => {
+            button.props().onBlur();
+          });
+
+          act(() => {
+            wrapper.update();
+          });
+
+          act(() => {
+            const buttonWrapper = wrapper.find(ToolbarButton).at(index);
+            const toolTip = buttonWrapper.find(Tooltip);
+            expect(toolTip.exists()).toBeFalsy();
+          });
+        });
+
+        it(`when the button at position ${index} has a 'mouseLeave' event`, () => {
+          wrapper = render();
+          const getButton = () => wrapper.find(ToolbarButton).at(index);
+
+          act(() => {
+            getButton().props().onMouseLeave();
+          });
+
+          act(() => {
+            wrapper.update();
+          });
+
+          act(() => {
+            const toolTip = getButton().find(Tooltip);
+            expect(toolTip.exists()).toBeFalsy();
+          });
+        });
+      }
+    );
+    describe('Keyboard accessibility', () => {
+      beforeEach(() => {
+        container = document.createElement('div');
+        container.id = 'enzymeContainer';
+        document.body.appendChild(container);
+      });
+
+      afterEach(() => {
+        if (container && container.parentNode) {
+          container.parentNode.removeChild(container);
+        }
+
+        container = null;
+      });
+
+      describe('Pressing the right arrow key when the controls are focused', () => {
+        wrapper = render({ canFocus: true });
+        it.each([0, 1, 2, 3])(
+          'moves focus to the next button', (index) => {
+            simulate.keydown.pressRightArrow(wrapper.find(ToolbarButton).at(index));
+            const newIndex = index < 3 ? index + 1 : 0;
+            setTimeout(() => expect(wrapper.find(ToolbarButton).at(newIndex).getDOMNode()).toBeFocused());
+          }
+        );
+      });
+
+      describe('Pressing the left arrow key when the controls are focused', () => {
+        wrapper = render({ canFocus: true });
+        it.each([0, 3, 2, 1])(
+          'moves focus to the previous button', (index) => {
+            simulate.keydown.pressLeftArrow(wrapper.find(ToolbarButton).at(index));
+            const newIndex = index === 0 ? 3 : index - 1;
+            setTimeout(() => expect(wrapper.find(ToolbarButton).at(newIndex).getDOMNode()).toBeFocused());
+          }
+        );
+      });
+
+      describe('Pressing the tab key when the controls are focused', () => {
+        wrapper = render({ canFocus: true });
+        const buttons = wrapper.find(StyledToolbarButton);
+        act(() => { simulate.keydown.pressTab(wrapper.find(Toolbar)); });
+
+        it.each([1, 2, 3])(
+          'does not move focus to next control', (index) => {
+            act(() => { wrapper.update(); });
+            simulate.keydown.pressTab(buttons.at(index));
+            expect(buttons.at(index).getDOMNode()).not.toBeFocused();
+          }
+        );
+      });
+    });
+
+    it('only displays one at a time', () => {
+      wrapper = render();
+      const getButton = index => wrapper.find(StyledToolbarButton).at(index);
+      const getButtonWrapper = index => wrapper.find(ToolbarButton).at(index);
+
+      act(() => { getButton(0).props().onFocus(); });
+
+      act(() => { wrapper.update(); });
+
+      act(() => {
+        getButton(1).props().onFocus();
+      });
+
+      act(() => { wrapper.update(); });
+
+      act(() => {
+        let toolTip = getButtonWrapper(0).find(Tooltip);
+        expect(toolTip.exists()).toBeFalsy();
+
+        toolTip = getButtonWrapper(1).find(Tooltip);
+        expect(toolTip.exists()).toBeTruthy();
+      });
+    });
+
+    describe.each([[0, 'BOLD'], [1, 'ITALIC'], [2, 'unordered-list-item'], [3, 'ordered-list-item']])(
+      'Style Formatting Buttons', (index, id) => {
+        beforeEach(() => { wrapper = render({ activeControls: { [id]: true } }); });
+
+        afterEach(() => {
+          jest.clearAllMocks();
+        });
+
+        it(`sets expected background-color when '${id.toLowerCase()}' is active`, () => {
+          assertStyleMatch({
+            backgroundColor: baseTheme.editor.button.hover
+          }, wrapper.find(ToolbarButton).at(index));
+        });
+
+        it(`calls expected callback when the '${id.toLowerCase()}' button is clicked`, () => {
+          wrapper.find(ToolbarButton).at(index).props().onMouseDown({ preventDefault: () => {} });
+          if (index < 2) {
+            expect(setInlineStyle).toHaveBeenCalledWith(expect.anything(), id);
+            expect(setBlockStyle).not.toHaveBeenCalled();
+          } else {
+            expect(setBlockStyle).toHaveBeenCalledWith(expect.anything(), id);
+            expect(setInlineStyle).not.toHaveBeenCalled();
+          }
+        });
+
+        it(`calls expected callback when 'enter' key is pressed and '${id.toLowerCase()}' button is focused`, () => {
+          act(() => {
+            wrapper.find(StyledToolbarButton).at(index).props().onFocus();
+          });
+          simulate.keydown.pressEnter(wrapper.find(ToolbarButton).at(index));
+
+          if (index < 2) {
+            expect(setInlineStyle).toHaveBeenCalledWith(expect.anything(), id);
+            expect(setBlockStyle).not.toHaveBeenCalled();
+          } else {
+            expect(setBlockStyle).toHaveBeenCalledWith(expect.anything(), id);
+            expect(setInlineStyle).not.toHaveBeenCalled();
+          }
+        });
+
+        it(`calls expected callback when 'space' key is pressed and '${id.toLowerCase()}' button is focused`, () => {
+          act(() => {
+            wrapper.find(StyledToolbarButton).at(index).props().onFocus();
+          });
+          simulate.keydown.pressSpace(wrapper.find(ToolbarButton).at(index));
+
+          if (index < 2) {
+            expect(setInlineStyle).toHaveBeenCalledWith(expect.anything(), id);
+            expect(setBlockStyle).not.toHaveBeenCalled();
+          } else {
+            expect(setBlockStyle).toHaveBeenCalledWith(expect.anything(), id);
+            expect(setInlineStyle).not.toHaveBeenCalled();
+          }
+        });
+
+        it(`does nothing when key is not 'space' or 'enter' and '${id.toLowerCase()}' button is focused`, () => {
+          act(() => {
+            wrapper.find(StyledToolbarButton).at(index).props().onFocus();
+          });
+          simulate.keydown.pressD(wrapper.find(ToolbarButton).at(index));
+
+          expect(setBlockStyle).not.toHaveBeenCalled();
+          expect(setInlineStyle).not.toHaveBeenCalled();
+        });
+      }
+    );
+
+    describe('Action Buttons', () => {
+      let saveButton, cancelButton;
+      describe('with no `onSave` prop', () => {
+        it('will not render', () => {
+          wrapper = render();
+          saveButton = wrapper.find(Button).findWhere(n => n.text() === 'Save');
+          cancelButton = wrapper.find(Button).findWhere(n => n.text() === 'Cancel');
+          expect(saveButton.exists()).toBeFalsy();
+          expect(cancelButton.exists()).toBeFalsy();
+        });
+      });
+
+      describe('with `onSave` prop', () => {
+        const onSave = jest.fn();
+        const onCancel = jest.fn();
+
+        beforeEach(() => {
+          wrapper = render({ onSave, onCancel });
+          saveButton = wrapper.find(Button).findWhere(n => n.text() === 'Save');
+          cancelButton = wrapper.find(Button).findWhere(n => n.text() === 'Cancel');
+        });
+
+        it('will render', () => {
+          expect(saveButton.exists()).toBeTruthy();
+          expect(cancelButton.exists()).toBeTruthy();
+        });
+
+        it('calls the `onSave` callback when the `Save` button is clicked', () => {
+          saveButton.hostNodes().first().props().onClick();
+          expect(onSave).toHaveBeenCalled();
+        });
+
+        it('calls the `onCancel` callback when the `Cancel` button is clicked', () => {
+          cancelButton.hostNodes().first().props().onClick();
+          expect(onCancel).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});

--- a/src/components/text-editor/__internal__/toolbar/toolbar.style.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.style.js
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+import StyledButton from '../../../button/button.style';
+import baseTheme from '../../../../style/themes/base';
+
+const StyledToolbar = styled.div`
+  padding: 8px;
+  display: flex;
+  justify-content: flex-start;
+  background: white;
+  flex-wrap: wrap;
+  font-size: 14px;
+  user-select: none;
+  order: 2;
+  border: none;
+  ${({ theme }) => `
+    background-color: ${theme.editor.toolbar.background};
+    border-top: 1px solid ${theme.editor.border};
+  `}
+  min-width: 290px;
+  z-index: 10;
+`;
+
+StyledToolbar.defaultProps = {
+  theme: baseTheme
+};
+
+const StyledEditorStyleControls = styled.div`
+  display: inline-block;
+  text-align: left;
+  width: 50%;
+  min-width: 60px;
+  margin-left: -2px;
+`;
+
+StyledEditorStyleControls.defaultProps = {
+  theme: baseTheme
+};
+
+const StyledEditorActionControls = styled.div`
+  display: inline-block;
+  text-align: right;
+  width: 50%;
+  min-width: 60px;
+
+  ${StyledButton} {
+    width: 62px;
+    height: 33px;
+  }
+  
+  ${StyledButton}:first-of-type {
+    font-size: 16px;
+  }
+`;
+
+StyledEditorActionControls.defaultProps = {
+  theme: baseTheme
+};
+
+export { StyledToolbar, StyledEditorActionControls, StyledEditorStyleControls };

--- a/src/components/text-editor/__internal__/utils/index.js
+++ b/src/components/text-editor/__internal__/utils/index.js
@@ -1,0 +1,16 @@
+export {
+  computeBlockType,
+  getContent,
+  getContentInfo,
+  getDecoratedValue,
+  getSelection,
+  getSelectionInfo,
+  getSelectedLength,
+  moveSelectionToEnd,
+  resetBlockType,
+  isASCIIChar,
+  replaceText,
+  hasBlockStyle,
+  hasInlineStyle,
+  blockStyleFn
+} from './utils';

--- a/src/components/text-editor/__internal__/utils/utils.js
+++ b/src/components/text-editor/__internal__/utils/utils.js
@@ -1,0 +1,193 @@
+import {
+  EditorState,
+  Modifier
+} from 'draft-js';
+import decorators from '../decorators';
+
+const ORDERLIST_TYPE = 'ordered-list-item';
+const UNORDERLIST_TYPE = 'unordered-list-item';
+
+export const computeBlockType = (char, type) => {
+  if (char === '.' && type !== ORDERLIST_TYPE) {
+    return ORDERLIST_TYPE;
+  }
+  if (char === '*' && type !== UNORDERLIST_TYPE) {
+    return UNORDERLIST_TYPE;
+  }
+  return 'unstyled';
+};
+
+/*
+Returns default block-level metadata for various block type. Empty object otherwise.
+*/
+const getDefaultBlockData = (blockType, initialData = {}) => {
+  switch (blockType) {
+    case ORDERLIST_TYPE:
+      return {};
+    case UNORDERLIST_TYPE:
+      return {};
+    default:
+      return initialData;
+  }
+};
+
+/*
+Changes the block type of the current block.
+*/
+export const resetBlockType = (value, newType = 'unstyled') => {
+  const contentState = value.getCurrentContent();
+  const selectionState = value.getSelection();
+  const key = selectionState.getStartKey();
+  const blockMap = contentState.getBlockMap();
+  const block = blockMap.get(key);
+
+  const newBlock = block.merge({
+    text: '',
+    type: newType,
+    data: getDefaultBlockData(newType)
+  });
+
+  const newContentState = contentState.merge({
+    blockMap: blockMap.set(key, newBlock),
+    selectionAfter: selectionState.merge({
+      anchorOffset: 0,
+      focusOffset: 0
+    })
+  });
+
+  return EditorState.push(value, newContentState, 'change-block-type');
+};
+
+export function blockStyleFn(block) {
+  switch (block.getType()) {
+    case 'unordered-list-item':
+      return 'text-editor-block-unordered';
+    case 'ordered-list-item':
+      return 'text-editor-block-ordered';
+    default:
+      return '';
+  }
+}
+
+/*
+  Return mutated editorState with decorators added
+*/
+export const getDecoratedValue = value => EditorState.set(value, { decorator: decorators });
+
+/*
+  Get the current Content State
+*/
+export const getContent = value => value.getCurrentContent();
+
+/*
+  Get the current selection State
+*/
+export const getSelection = value => value.getSelection();
+
+/*
+  Get the current Content and Block information
+*/
+export const getContentInfo = (value) => {
+  const content = getContent(value);
+  const currentBlock = content.getBlockForKey(getSelection(value).getStartKey());
+  const blockType = currentBlock.getType();
+  const blockLength = currentBlock.getLength();
+  const blockText = currentBlock.getText();
+  const blockMap = content.getBlockMap();
+
+  return {
+    content, currentBlock, blockType, blockLength, blockText, blockMap
+  };
+};
+
+/*
+  Get the current Selection information
+*/
+export const getSelectionInfo = (value) => {
+  const selection = getSelection(value);
+  const startKey = selection.getStartKey();
+  const endKey = selection.getEndKey();
+  const startOffset = selection.getStartOffset();
+  const endOffset = selection.getEndOffset();
+
+  return {
+    selection, startKey, endKey, startOffset, endOffset
+  };
+};
+
+/*
+  Move cursor to end of Content
+*/
+export const moveSelectionToEnd = value => EditorState.forceSelection(value, getContent(value).getSelectionAfter());
+
+/*
+  Returns the current Selection length
+*/
+export const getSelectedLength = (value) => {
+  const selection = getSelection(value);
+
+  let length = 0;
+
+  if (!selection.isCollapsed()) {
+    const {
+      startKey, endKey, startOffset, endOffset
+    } = getSelectionInfo(value);
+    const { content, blockLength } = getContentInfo(value);
+    const startLength = blockLength - startOffset;
+    const keyAfterEnd = content.getKeyAfter(endKey);
+
+    if (startKey === endKey) {
+      length += (endOffset - startOffset);
+    } else {
+      let currentKey = startKey;
+
+      while (currentKey && currentKey !== keyAfterEnd) {
+        if (currentKey === startKey) {
+          length += (startLength + 1);
+        } else if (currentKey === endKey) {
+          length += endOffset;
+        } else {
+          length += content.getBlockForKey(currentKey).getLength() + 1;
+        }
+
+        currentKey = content.getKeyAfter(currentKey);
+      }
+    }
+  }
+
+  return length;
+};
+
+export function hasBlockStyle(value, type) {
+  const { blockType } = getContentInfo(value);
+  return blockType === type;
+}
+
+export function hasInlineStyle(value, style) {
+  return value.getCurrentInlineStyle().has(style);
+}
+
+export function isASCIIChar(str) {
+  return /^\S+$/.test(str);
+}
+
+export function replaceText(
+  editorState,
+  text,
+  inlineStyle,
+  forceSelection,
+) {
+  const contentState = Modifier.replaceText(
+    editorState.getCurrentContent(),
+    editorState.getSelection(),
+    text,
+    inlineStyle,
+  );
+
+  return EditorState.push(
+    editorState,
+    contentState,
+    'insert-characters',
+    forceSelection,
+  );
+}

--- a/src/components/text-editor/__internal__/utils/utils.spec.js
+++ b/src/components/text-editor/__internal__/utils/utils.spec.js
@@ -1,0 +1,117 @@
+import {
+  ContentBlock, ContentState, EditorState, genKey
+} from 'draft-js';
+import { List } from 'immutable';
+import {
+  computeBlockType, resetBlockType, getSelectedLength
+} from './utils';
+
+describe('computeBlockType', () => {
+  it('returns "unstyled" as default when char is not "." or "*"', () => {
+    expect(computeBlockType('@', 'ordered-list-item')).toEqual('unstyled');
+  });
+
+  it('returns "unstyled" as default when char is "*" and type is "unordered-list-item"', () => {
+    expect(computeBlockType('*', 'unordered-list-item')).toEqual('unstyled');
+  });
+
+  it('returns "unstyled" as default when char is "." and type is "ordered-list-item"', () => {
+    expect(computeBlockType('.', 'ordered-list-item')).toEqual('unstyled');
+  });
+
+  it('returns "ordered-list-item" as default when char is "." and type is not "ordered-list-item"', () => {
+    expect(computeBlockType('.', 'unordered-list-item')).toEqual('ordered-list-item');
+  });
+
+  it('returns "unordered-list-item" as default when char is "*" and type is not "unordered-list-item"', () => {
+    expect(computeBlockType('*', 'ordered-list-item')).toEqual('unordered-list-item');
+  });
+});
+
+describe('resetBlockType', () => {
+  it.each(['ordered-list-item', 'unordered-list-item'])(
+    'returns editorState with block replaced with given %s type', (type) => {
+      const value = EditorState.createEmpty();
+      const blocks = resetBlockType(value, type).getCurrentContent().getBlocksAsArray();
+      expect(blocks.length).toEqual(1);
+      blocks.forEach(block => expect(block.getType()).toEqual(type));
+    }
+  );
+
+  it('returns editorState with default unstyled block when no type provided', () => {
+    const value = EditorState.createEmpty();
+    const blocks = resetBlockType(value).getCurrentContent().getBlocksAsArray();
+    expect(blocks.length).toEqual(1);
+    blocks.forEach(block => expect(block.getType()).toEqual('unstyled'));
+  });
+});
+
+describe('getSelectedLength', () => {
+  const makeSelection = (value, anchor, focus) => {
+    const content = value.getCurrentContent();
+
+    return value.getSelection().merge({
+      anchorKey: content.getFirstBlock().getKey(),
+      anchorOffset: anchor,
+      focusOffset: focus,
+      focusKey: content.getLastBlock().getKey()
+    });
+  };
+
+  const makeBlock = (value) => {
+    const content = value.getCurrentContent();
+
+    const newBlock = new ContentBlock({
+      key: genKey(),
+      type: 'unstyled',
+      text: 'foo',
+      characterList: List()
+    });
+
+    const newBlockMap = content.getBlockMap().set(newBlock.key, newBlock);
+
+    return EditorState.push(
+      value,
+      ContentState
+        .createFromBlockArray(newBlockMap.toArray())
+        .set('selectionBefore', content.getSelectionBefore())
+        .set('selectionAfter', content.getSelectionAfter())
+    );
+  };
+
+  it('returns 0 when there is not content', () => {
+    const editorState = EditorState.createEmpty();
+    expect(getSelectedLength(editorState)).toEqual(0);
+  });
+
+  it('returns 0 when the selection is collapsed', () => {
+    const editorState = EditorState.createWithContent(ContentState.createFromText('foo'));
+    const selection = makeSelection(editorState, 1, 1);
+    const newValue = EditorState.acceptSelection(editorState, editorState.getSelection().merge(selection));
+    expect(getSelectedLength(newValue)).toEqual(0);
+  });
+
+  it('returns the difference between the anchor and focus offsets if there is only one block of content', () => {
+    const editorState = EditorState.createWithContent(ContentState.createFromText('foo'));
+    const selection = makeSelection(editorState, 0, 1);
+    const newValue = EditorState.acceptSelection(editorState, editorState.getSelection().merge(selection));
+    expect(getSelectedLength(newValue)).toEqual(1);
+  });
+
+  it('returns the difference between the anchor and focus offsets plus any initial content', () => {
+    const editorState = makeBlock(EditorState.createWithContent(ContentState.createFromText('foo')));
+    const content = editorState.getCurrentContent();
+    const selection = makeSelection(editorState, 0, content.getLastBlock().getText().length);
+    const newValue = EditorState.acceptSelection(editorState, editorState.getSelection().merge(selection));
+    expect(getSelectedLength(newValue)).toEqual(7);
+  });
+
+  it('returns the difference between the anchor and focus offsets plus the other blocks', () => {
+    let editorState = makeBlock(EditorState.createWithContent(ContentState.createFromText('foo')));
+    editorState = makeBlock(editorState);
+    const content = editorState.getCurrentContent();
+    const selection = makeSelection(editorState, 0, content.getLastBlock().getText().length);
+    const newValue = EditorState.acceptSelection(editorState, editorState.getSelection().merge(selection));
+    expect(getSelectedLength(newValue)).toEqual(11);
+  });
+});

--- a/src/components/text-editor/index.d.ts
+++ b/src/components/text-editor/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './__internal__/text-editor';
+export * from './__internal__/text-editor';

--- a/src/components/text-editor/index.js
+++ b/src/components/text-editor/index.js
@@ -1,0 +1,3 @@
+export {
+  default, TextEditorState as EditorState, TextEditorContentState as ContentState
+} from './__internal__/text-editor.component';

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -68,6 +68,18 @@ export default (palette) => {
       lightTheme: palette.slateTint(70)
     },
 
+    editor: {
+      border: palette.slateTint(40),
+      counter: 'rgba(0,0,0,0.55)',
+      placeholder: 'rgba(0,0,0,0.30)',
+      button: {
+        hover: palette.slateTint(80)
+      },
+      toolbar: {
+        background: palette.slateTint(95)
+      }
+    },
+
     menu: {
       focus: palette.slateTint(95),
       divider: palette.slateTint(90),


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds a new text editor component, built using the `DraftJS` framework,
consumers will now need to import `DraftJS` as it has been added as a peer-dependency

The MacOS `Add period with double-space` feature has been overridden as it causes DraftJS to crash

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
There is no text editor component

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Screenshots are included in the PR
- [x] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
- [x] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [x] Storybook added or updated
- [x] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->
Default Editor:
![image](https://user-images.githubusercontent.com/44157880/86005021-01c0ae00-ba0c-11ea-8e3d-2dcab7ab5e2d.png)

With form controls/ save button disabled:
![image](https://user-images.githubusercontent.com/44157880/86005095-169d4180-ba0c-11ea-9820-b51d8ab0a566.png)

With form controls/ save button enabled:
![image](https://user-images.githubusercontent.com/44157880/86005270-506e4800-ba0c-11ea-9409-5dda44dc33e9.png)

Initialised with content:
![image](https://user-images.githubusercontent.com/44157880/86004927-e190ef00-ba0b-11ea-9f2b-3f9585e6758c.png)

With overridden character limit: 
![image](https://user-images.githubusercontent.com/44157880/86005326-6976f900-ba0c-11ea-9f08-17f79b0f46a8.png)

With Link and focused:
![image](https://user-images.githubusercontent.com/44157880/86005448-96c3a700-ba0c-11ea-8978-ad460f671f6d.png)


### Testing instructions
<!-- How can a reviewer test this PR? -->
Testable in `http://localhost:9001/?path=/docs/design-system-text-editor--...`
I will build a demo out using codesandbox to illustrate the output can be formatted and that it will accept the same format as an input
