### PR TITLE
fix(anchor-navigation): add missing target prop definition

### DIFF
--- a/src/components/anchor-navigation/anchor-navigation-item.component.js
+++ b/src/components/anchor-navigation/anchor-navigation-item.component.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-unused-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -33,7 +34,9 @@ AnchorNavigationItem.propTypes = {
   /** Indicates if component is selected */
   isSelected: PropTypes.bool,
   /** Allows to override existing component styles */
-  styleOverride: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+  styleOverride: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  /** Reference to the section html element meant to be shown   */
+  target: PropTypes.shape({ current: PropTypes.instanceOf(Element) })
 };
 
 AnchorNavigationItem.displayName = 'AnchorNavigationItem';

--- a/src/components/anchor-navigation/anchor-navigation-item.d.ts
+++ b/src/components/anchor-navigation/anchor-navigation-item.d.ts
@@ -3,17 +3,19 @@ import * as React from 'react';
 export interface AnchorNavigationItemProps {
   children: React.ReactNode;
   /** OnKeyDown handler */
-  onKeyDown: () => void;
+  onKeyDown?: () => void;
   /** onClick handler */
-  onClick: () => void;
+  onClick?: () => void;
   /** href to be passed to the anchor element, can be linked with id passed to the scrollable section */
   href?: string;
   /** tabIndex passed to the anchor element */
-  tabIndex: number;
+  tabIndex?: number;
   /** Indicates if component is selected */
-  isSelected: boolean;
+  isSelected?: boolean;
   /** Allows to override existing component styles */
   styleOverride?: () => object | object;
+  /** Reference to the section html element meant to be shown   */
+  target?: React.RefObject<HTMLElement>;
 }
 
 declare const AnchorNavigationItem: React.FunctionComponent<AnchorNavigationItemProps>;


### PR DESCRIPTION
### Proposed behaviour

This PR adds missing `target` prop definition both to propTypes and type declaration file.

### Current behaviour

Currently `target` prop is not defined which causes compilation errors in typescript projects

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR</del>
<del>- [ ] Carbon implementation and Design System documentation are congruent</del>
<del>- [ ] All themes are supported</del>
- [x] Commits follow our style guide
<del>- [ ] Unit tests added or updated</del>
<del>- [ ] Cypress automation tests added or updated</del>
<del>- [ ] Storybook added or updated</del>
- [x] Typescript `d.ts` file added or updated

### Additional context
Closes #3030

### Testing instructions
<!-- How can a reviewer test this PR? -->
