### PR TITLE
docs: remove cypress badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Carbon [![npm](https://img.shields.io/npm/v/carbon-react.svg)](https://www.npmjs.com/package/carbon-react) ![Cypress tests](https://github.com/Sage/carbon/workflows/Cypress%20tests/badge.svg)
-<img src="https://raw.githubusercontent.com/Sage/carbon/master/logo/carbon-logo.png" width="50">
+# Carbon [![npm](https://img.shields.io/npm/v/carbon-react.svg)](https://www.npmjs.com/package/carbon-react)
 
 Carbon is a [React](https://facebook.github.io/react/) component library developed by Sage.
 


### PR DESCRIPTION
### Proposed behaviour
Remove the cypress badge from the README.md

### Current behaviour
There is a badge but it says the build is failing. This is because the badge reports the status of the master branch, we don't run the cypress tests on the master branch.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR
<del>- [ ] Carbon implementation and Design System documentation are congruent
<del>- [ ] All themes are supported
- [x] Commits follow our style guide

<del>- [ ] Unit tests added or updated
<del>- [ ] Cypress automation tests added or updated
<del>- [ ] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
