### PR TITLE
docs(alert): remove classic theme stories 

### DIFF
--- a/src/components/alert/alert.stories.js
+++ b/src/components/alert/alert.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { boolean, text, select } from '@storybook/addon-knobs';
 import { State, Store } from '@sambego/storybook-state';
 import { action } from '@storybook/addon-actions';
-import { dlsThemeSelector, classicThemeSelector } from '../../../.storybook/theme-selectors';
+import { dlsThemeSelector } from '../../../.storybook/theme-selectors';
 import OptionsHelper from '../../utils/helpers/options-helper';
 import Button from '../button';
 import Alert from '.';
@@ -28,7 +28,7 @@ const handleOpen = () => {
   action('open')();
 };
 
-function makeStory(name, themeSelector, disableChromatic = false) {
+function makeStory(name, themeSelector, disableChromatic = true) {
   const component = () => {
     const title = text('title', 'Attention');
     const subtitle = text('subtitle', '');
@@ -126,6 +126,4 @@ storiesOf('Alert', module)
     notes: { markdown: notes }
   })
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector, true))
-  .add(...makeButtonStory('with button', dlsThemeSelector))
-  .add(...makeButtonStory('with button classic', classicThemeSelector, true));
+  .add(...makeButtonStory('with button', dlsThemeSelector));


### PR DESCRIPTION
This PR replaces #3032

### Proposed behaviour
Removal of classic theme from storybook.

### Current behaviour
Currently, component has classic theme storybook examples.

### Checklist

<del>- [ ] Screenshots are included in the PR </del>
- [x] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
<del>- [ ] Unit tests added or updated </del>
- [x] Cypress automation tests added or updated
- [x] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated </del>

### Additional context
N/A

### Testing instructions
Open storybook.
Check that Alert component has no Classic Theme storybook examples.
