### PR TITLE
fix(switch): fix misaligned validation icon on large switch - FE-2863

### DIFF
--- a/src/__experimental__/components/switch/__snapshots__/switch-slider.spec.js.snap
+++ b/src/__experimental__/components/switch/__snapshots__/switch-slider.spec.js.snap
@@ -55,6 +55,7 @@ exports[`SwitchSlider base theme renders as expected 1`] = `
 .c0 .c7 {
   position: absolute;
   right: -30px;
+  height: 100%;
 }
 
 .c3 .c1 {

--- a/src/__experimental__/components/switch/__snapshots__/switch.spec.js.snap
+++ b/src/__experimental__/components/switch/__snapshots__/switch.spec.js.snap
@@ -130,6 +130,7 @@ exports[`Switch base theme renders as expected 1`] = `
 .c11 .c32 {
   position: absolute;
   right: -30px;
+  height: 100%;
 }
 
 .c15 .c4 {

--- a/src/__experimental__/components/switch/switch-slider.style.js
+++ b/src/__experimental__/components/switch/switch-slider.style.js
@@ -78,6 +78,7 @@ const StyledSwitchSlider = styled.span`
     ${StyledValidationIcon} {
       position: absolute;
       right: -30px;
+      height: 100%;
     }
   `}
 `;


### PR DESCRIPTION
### Proposed behaviour
![Zrzut ekranu 2020-07-7 o 16 29 26](https://user-images.githubusercontent.com/20651022/86796595-0bcb5800-c06f-11ea-9a26-be89e3a4683e.png)

### Current behaviour
![Zrzut ekranu 2020-07-7 o 16 33 18](https://user-images.githubusercontent.com/20651022/86797119-9613bc00-c06f-11ea-9d74-1648db6a7084.png)


### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Screenshots are included in the PR
- [x] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
- [x] Unit tests added or updated
<del>- [ ] Cypress automation tests added or updated</del>
<del>- [ ] Storybook added or updated</del>
<del>- [ ] Typescript `d.ts` file added or updated</del>

### Testing instructions
Storybook -> Switch -> Validations -> change `error size` knob to `large` 
