### PR TITLE
chore(animated menu button): add deprecation warning

### DIFF
--- a/src/components/animated-menu-button/animated-menu-button.js
+++ b/src/components/animated-menu-button/animated-menu-button.js
@@ -7,6 +7,7 @@ import tagComponent from '../../utils/helpers/tags';
 import Devices from '../../utils/helpers/devices';
 import { validProps } from '../../utils/ether';
 import './animated-menu-button.scss';
+import Logger from '../../utils/logger';
 
 /**
  * An AnimatedMenuButton widget.
@@ -34,6 +35,7 @@ import './animated-menu-button.scss';
 class AnimatedMenuButton extends React.Component {
   constructor(...args) {
     super(...args);
+    Logger.deprecate('Animated Menu Button component is scheduled to be removed from Carbon.');
 
     this.blockBlur = false;
 


### PR DESCRIPTION
### Proposed behaviour
Adds a deprecation warning to the console.

<img width="611" alt="Screenshot 2020-07-10 at 14 42 10" src="https://user-images.githubusercontent.com/56251247/87160880-9a341980-c2bb-11ea-82e0-c38792ce127f.png">

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Screenshots are included in the PR
<del>- [ ] Carbon implementation and Design System documentation are congruent</del>
<del>- [ ] All themes are supported</del>
- [x] Commits follow our style guide
<del>- [ ] Unit tests added or updated</del>
<del>- [ ] Cypress automation tests added or updated</del>
<del>- [ ] Storybook added or updated</del>
<del>- [ ] Typescript `d.ts` file added or updated</del>

### Additional context
N/A

### Testing instructions
Pull down branch.
Open storybook.
Inspect console for deprecation warning.
