### PR TITLE
feat(note): create component and tooltip status FE-2825

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -54,5 +54,6 @@
   "default_divider": "--default-divider",
   "readOnly": "--readonly",
   "transparent": "--transparent",
-  "disabled": "--disabled"
+  "disabled": "--disabled",
+  "with_footer": "--with-footer"
 }

--- a/cypress/features/regression/accessibility/accessibilityDesignSystem.feature
+++ b/cypress/features/regression/accessibility/accessibilityDesignSystem.feature
@@ -231,3 +231,8 @@ Feature: Accessibility tests - Design System folder
       | story    |
       | disabled |
       | readOnly |
+    
+  @accessibility
+  Scenario: Design System Note component with_footer page
+    When I open design systems with_footer "Note" component in no iframe
+    Then "Note with_footer" component has no accessibility violations

--- a/package-lock.json
+++ b/package-lock.json
@@ -17551,9 +17551,9 @@
       }
     },
     "draft-js": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.5.tgz",
-      "integrity": "sha512-RlHcoDtblwCD6Bw2ay3D0dTLA6lH8862OcdJrHGnYrY5JjlitzSzGvGQwqqumVvbGUNDSZLD3FyNpSs4z5WIUg==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.6.tgz",
+      "integrity": "sha512-H8OaophZecxm0L/C0LvOo6IZrbMb+s0txPXF7DW3E2oUjSo5ufvWvWb3B/0K2wRqBnwJrRxApqljD899i0fZMA==",
       "dev": true,
       "requires": {
         "fbjs": "^1.0.0",

--- a/src/components/note/__internal__/note.component.js
+++ b/src/components/note/__internal__/note.component.js
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Editor, EditorState } from 'draft-js';
+import {
+  StyledNote,
+  StyledNoteContent,
+  StyledInlineControl,
+  StyledTitle,
+  StyledFooter,
+  StyledFooterContent
+} from './note.style.js';
+import StatusWithTooltip from './status-with-tooltip';
+
+const Note = ({
+  noteContent = EditorState.createEmpty(),
+  width,
+  inlineControl,
+  title,
+  name,
+  createdDate,
+  status,
+  ...rest
+}) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const renderStatus = () => {
+    if (!status || !status.text || !status.text.length) {
+      return null;
+    }
+
+    const { text, timeStamp } = status;
+
+    return (
+      <StyledFooterContent data-component='note-status'>
+        <StatusWithTooltip { ...tooltipProps(timeStamp, showTooltip, setShowTooltip) }>
+          { text }
+        </StatusWithTooltip>
+      </StyledFooterContent>
+    );
+  };
+
+  return (
+    <StyledNote
+      width={ width }
+      { ...rest }
+      data-component='note'
+    >
+      { title && (
+        <StyledTitle>
+          { title }
+        </StyledTitle>
+      )}
+
+      { inlineControl && (
+        <StyledInlineControl>
+          { inlineControl }
+        </StyledInlineControl>
+      )}
+
+      <StyledNoteContent>
+        <Editor readOnly editorState={ noteContent } />
+      </StyledNoteContent>
+
+      {(name && createdDate) && (
+        <StyledNoteContent>
+          <StyledFooter>
+            <StyledFooterContent>{ name }</StyledFooterContent>
+            <StyledFooterContent>{ createdDate }</StyledFooterContent>
+            { renderStatus() }
+          </StyledFooter>
+        </StyledNoteContent>
+      )}
+    </StyledNote>
+  );
+};
+
+function tooltipProps(id, showTooltip, setShowTooltip) {
+  return {
+    tooltipMessage: id,
+    tooltipPosition: 'top',
+    tooltipAlign: 'center',
+    tooltipVisible: showTooltip,
+    onMouseOver: () => setShowTooltip(true),
+    onMouseLeave: () => setShowTooltip(false)
+  };
+}
+
+Note.propTypes = {
+  /**  The rich text content to display in the Note */
+  noteContent: PropTypes.object,
+  /**
+   * Set a percentage-based width for the whole Note component, relative to its parent.
+   * If unset or zero, this will default to 100%.
+   */
+  width: PropTypes.number,
+  /** renders a control for the Note */
+  inlineControl: PropTypes.node,
+  /** Adds a Title to the Note */
+  title: PropTypes.string,
+  /** Adds a name to the Note footer */
+  name: PropTypes.string,
+  /** Adds a created on date to the Note footer */
+  createdDate: PropTypes.string,
+  /** Adds a status and tooltip to the Note footer */
+  status: PropTypes.shape({ text: PropTypes.string, timeStamp: PropTypes.string })
+};
+
+export default Note;

--- a/src/components/note/__internal__/note.d.ts
+++ b/src/components/note/__internal__/note.d.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+export interface NoteProps {
+   noteContent: object;
+   width?: number;
+   inlineControl?: React.ReactNode;
+   title?: string;
+   name?: string;
+   status?: {
+    text?: string;
+    timeStamp?: string;
+  };
+}
+
+declare const Note: React.ComponentType<NoteProps>;
+export default Note;

--- a/src/components/note/__internal__/note.spec.js
+++ b/src/components/note/__internal__/note.spec.js
@@ -1,0 +1,152 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import { mount } from 'enzyme';
+import Note from './note.component';
+import baseTheme from '../../../style/themes/base';
+import {
+  StyledNoteContent,
+  StyledInlineControl,
+  StyledTitle,
+  StyledFooter,
+  StyledFooterContent
+} from './note.style';
+import StatusWithTooltip from './status-with-tooltip';
+import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
+import Tooltip from '../../tooltip';
+
+function render(props = {}) {
+  return mount(
+    <ThemeProvider theme={ baseTheme }>
+      <Note { ...props } />
+    </ThemeProvider>
+  );
+}
+
+describe('Note', () => {
+  describe('Styling', () => {
+    it('matches the expected', () => {
+      const wrapper = render();
+
+      assertStyleMatch({
+        backgroundColor: `${baseTheme.colors.white}`,
+        border: `1px solid ${baseTheme.tile.border}`,
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '24px',
+        position: 'relative',
+        width: '100%',
+        minWidth: '314px'
+
+      }, wrapper);
+
+      const content = wrapper.find(StyledNoteContent);
+
+      assertStyleMatch({
+        position: 'relative',
+        width: '100%'
+      }, content);
+
+      assertStyleMatch({
+        paddingBottom: '24px'
+      }, content, { modifier: ':not(:last-of-type)' });
+
+      assertStyleMatch({
+        borderTop: `solid 1px ${baseTheme.tile.separator}`
+      }, content, { modifier: `+ ${StyledNoteContent}` });
+    });
+
+    it('supports dynamic sizing by setting the "width" prop', () => {
+      assertStyleMatch({
+        width: '75%'
+      }, render({ width: 75 }));
+    });
+  });
+
+  describe('StyledTitle', () => {
+    const title = 'title';
+
+    it('does not render the "title" when prop is undefined', () => {
+      expect(render().find(StyledTitle).exists()).toBeFalsy();
+    });
+
+    it('renders the "title" with expected styling when prop has value', () => {
+      const wrapper = render({ title });
+
+      assertStyleMatch({
+        fontWeight: '900',
+        fontSize: '16px',
+        lineHeight: '21px',
+        paddingBottom: '16px'
+      }, wrapper.find(StyledTitle));
+
+      expect(wrapper.find(StyledTitle).exists()).toBeTruthy();
+    });
+  });
+
+  describe('StyledInlineControl', () => {
+    const inlineControl = <div>inlineControl</div>;
+
+    it('does not render the "inlineControl" when prop is undefined', () => {
+      expect(render().find(StyledInlineControl).exists()).toBeFalsy();
+    });
+
+    it('renders the "inlineControl" with expected styling when prop has value', () => {
+      const wrapper = render({ inlineControl });
+
+      assertStyleMatch({
+        position: 'absolute',
+        top: '24px',
+        right: '16px',
+        zIndex: '100'
+      }, wrapper.find(StyledInlineControl));
+
+      expect(wrapper.find(StyledInlineControl).exists()).toBeTruthy();
+    });
+  });
+
+  describe('Footer Props', () => {
+    const name = 'foo';
+    const createdDate = '25/12/20';
+
+    it('does not render the "name" and "createdDate" when either prop is undefined', () => {
+      expect(render().find(StyledNoteContent)).toHaveLength(1);
+      expect(render({ name }).find(StyledNoteContent)).toHaveLength(1);
+      expect(render({ createdDate }).find(StyledNoteContent)).toHaveLength(1);
+    });
+
+    it('renders the "name" and "createdDate" when props have value', () => {
+      const wrapper = render({ name, createdDate });
+      const footerContent = wrapper.find(StyledFooterContent);
+      expect(wrapper.find(StyledNoteContent)).toHaveLength(2);
+      expect(wrapper.find(StyledFooter).exists()).toBeTruthy();
+      expect(footerContent).toHaveLength(2);
+      expect(footerContent.at(0).text()).toEqual('foo');
+      expect(footerContent.at(1).text()).toEqual('25/12/20');
+    });
+
+    it('does not render the "status" when no "text" has no value', () => {
+      const wrapper = render({ name, createdDate, status: { timeStamp: '123' } });
+      expect(wrapper.find(StyledFooterContent)).toHaveLength(2);
+    });
+
+    it('renders the "status" with tooltip when "text" and "timeStamp" have values', () => {
+      const wrapper = render({ name, createdDate, status: { text: 'foo', timeStamp: '123' } });
+      const status = () => wrapper.find(StatusWithTooltip);
+      expect(wrapper.find(StyledFooterContent)).toHaveLength(3);
+      expect(status().exists()).toBeTruthy();
+      expect(status().text()).toEqual('foo');
+      status().simulate('mouseover');
+      expect(status().find(Tooltip).exists()).toBeTruthy();
+    });
+
+    it('renders the "status" with no tooltip when "text" has value but "timeStamp" has no value', () => {
+      const wrapper = render({ name, createdDate, status: { text: 'foo' } });
+      const status = () => wrapper.find(StatusWithTooltip);
+
+      status().simulate('mouseover');
+      expect(status().find(Tooltip).exists()).toBeFalsy();
+      // coverage
+      status().simulate('mouseleave');
+    });
+  });
+});

--- a/src/components/note/__internal__/note.stories.mdx
+++ b/src/components/note/__internal__/note.stories.mdx
@@ -1,0 +1,196 @@
+import { useState } from 'react';
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import Note from './note.component';
+import Content from '../../content';
+import {
+  ActionPopover,
+  ActionPopoverDivider,
+  ActionPopoverItem
+} from '../../action-popover';
+import { EditorState, ContentState, convertFromHTML } from 'draft-js';
+import Icon from '../../icon';
+import DateHelper from '../../../utils/helpers/date';
+
+<Meta title="Design System/Note" />
+
+# Note
+The `Note` was created using the `draft-js` framework which allows rich text content to be rendered. It requires 
+consuming projects to install `draft-js` as a peer-dependency to enable it to work. 
+
+```jsx
+import Note from "carbon-react/lib/components/note";
+import { EditorState, ContentState, convertFromHTML } from 'draft-js';
+```
+
+## Quick Start
+To use `Note`, use the import path above and pass the content via the `noteContent` prop by utilising the static 
+methods provided by the `draft-js` (see the import above) framework https://draftjs.org/docs/api-reference-content-state#static-methods.
+
+### Basic Usage:
+In its basic form, the component can render plain text content by passing a value via the `noteContent` prop using 
+`EditorState.createWithContent(ContentState.createFromText(''))` to ensure the value is in the correct format.
+<Preview>
+  <Story name="basic" parameters={{ info: { disable: true }}}>
+    {() => {
+      const noteContent = EditorState.createWithContent(ContentState.createFromText('Here is some plain text content'));
+      return (
+        <div style={{ height: 200, width: '50%' }}>
+          <Note width={ 100 } noteContent={ noteContent } />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With rich text content:
+It is also possible to render rich text content: below is an example of how the component supports rendering `html`
+content but there is a range of supporting packages that will support converting 
+content to a format you prefer and back into one that `draft-js` supports, again utilising the `createWithContent` 
+static method.  
+<Preview>
+  <Story name="with rich text" parameters={{ info: { disable: true }}}>
+    {() => {
+      const html = `<p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i> Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>
+      <ul><li>unordered</li></ul>
+      <ol><li>ordered</li></ol></br>
+      <p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i></p>
+      <p>Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>`;
+      const blocksFromHTML = convertFromHTML(html);
+      const content = ContentState.createFromBlockArray(
+        blocksFromHTML.contentBlocks,
+        blocksFromHTML.entityMap
+      );
+      const noteContent = EditorState.createWithContent(content);
+      return (
+        <div style={{ height: 200, width: '50%' }}>
+          <Note
+            width={ 100 }
+            noteContent={ noteContent }
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With optional title:
+Passing a string value to the `title` prop will render it in the `Note`.
+<Preview>
+  <Story name="with optional title" parameters={{ info: { disable: true }}}>
+    {() => {
+      const html = `<p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i> Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>
+      <ul><li>unordered</li></ul>
+      <ol><li>ordered</li></ol></br>
+      <p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i></p>
+      <p>Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>`;
+      const blocksFromHTML = convertFromHTML(html);
+      const content = ContentState.createFromBlockArray(
+        blocksFromHTML.contentBlocks,
+        blocksFromHTML.entityMap
+      );
+      const noteContent = EditorState.createWithContent(content);
+      return (
+        <div style={{ height: 200, width: '50%' }}>
+          <Note
+            width={ 100 }
+            title='Here is a Title'
+            noteContent={ noteContent }
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With optional inline control:
+The component supports adding an control to perform desired actions, this can be rendered compositionally by passing in 
+the control you wish to use to the `inlineControl` prop. The example below renders an `ActionPopover` control.
+<Preview>
+  <Story name="with optional inline control" parameters={{ info: { disable: true }}}>
+    {() => {
+      const html = `<p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i> Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>
+      <ul><li>unordered</li></ul>
+      <ol><li>ordered</li></ol></br>
+      <p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i></p>
+      <p>Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>`;
+      const blocksFromHTML = convertFromHTML(html);
+      const content = ContentState.createFromBlockArray(
+        blocksFromHTML.contentBlocks,
+        blocksFromHTML.entityMap
+      );
+      const noteContent = EditorState.createWithContent(content);
+      const control = (
+        <ActionPopover>
+          <ActionPopoverItem onClick={ () => {} }>
+            Edit
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={ () => {} }>
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      );
+      return (
+        <div style={{ height: 200, width: '50%' }}>
+          <Note
+            width={ 100 }
+            title='Here is a Title'
+            inlineControl={ control }
+            noteContent={ noteContent }
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With footer:
+A `Note` footer can be rendered by passing values to the `name` and `createdDate` props. An optional `status` can also 
+be rendered, this can be seen below when you click the `Edit` button in the inline control.
+<Preview>
+  <Story name="with footer" parameters={{ info: { disable: true }}}>
+    {() => {
+      const html = `<p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i> Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>
+      <ul><li>unordered</li></ul>
+      <ol><li>ordered</li></ol></br>
+      <p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i></p>
+      <p>Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>`;
+      const blocksFromHTML = convertFromHTML(html);
+      const content = ContentState.createFromBlockArray(
+        blocksFromHTML.contentBlocks,
+        blocksFromHTML.entityMap
+      );
+      const noteContent = EditorState.createWithContent(content);
+      const [status, setStatus] = useState({ text: '', timeStamp: '' })
+      const control = (
+        <ActionPopover>
+          <ActionPopoverItem onClick={ () => {
+            const now = new Date(Date.now());
+            setStatus({ text: 'EDITED', timeStamp: DateHelper.formatDateString(now.toString(), 'DD MMM YYYY, LT') })
+          }}>
+            Edit
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={ () => {} }>
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      );
+      return (
+        <div style={{ height: 250, width: '50%' }}>
+          <Note
+            width={ 100 }
+            title='Here is a Title'
+            inlineControl={ control }
+            name='Lauren Smith'
+            createdDate={ DateHelper.formatDateString('Wed May 23 2020 12:08:00 GMT+0100 (BST)', 'DD MMM YYYY, LT') }
+            status={ status }
+            noteContent={ noteContent }
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+<Props of={Note} />

--- a/src/components/note/__internal__/note.style.js
+++ b/src/components/note/__internal__/note.style.js
@@ -1,0 +1,125 @@
+import styled, { css } from 'styled-components';
+import PropTypes from 'prop-types';
+import baseTheme from '../../../style/themes/base';
+
+const StyledNoteContent = styled.div`
+  position: relative;
+  width: 100%;
+  
+  ${({ theme }) => `
+    &:not(:last-of-type) {
+      padding-bottom: 24px;
+    }
+
+    div.DraftEditor-root {
+      min-height: inherit;
+      height: 100%;
+    }
+
+    div.DraftEditor-editorContainer,
+    div.public-DraftEditor-content {
+      min-height: inherit;
+      height: 100%;
+      background-color: ${theme.colors.white};
+      line-height: 21px;
+    }
+
+    & + & {
+      border-top: solid 1px ${theme.tile.separator};
+    }
+  `}
+`;
+
+const StyledInlineControl = styled.div`
+  position: absolute;
+  top: 24px;
+  right: 16px; 
+  z-index: 100
+`;
+
+const StyledTitle = styled.header`
+  font-weight: 900;
+  font-size: 16px;
+  line-height: 21px;
+  padding-bottom: 16px;
+`;
+
+const StyledFooterContent = styled.div`
+  position: relative;
+  line-height: 21px;
+
+  &:first-of-type {
+    font-weight: bold;
+    font-size: 14px;
+    top: 16px;
+    height: 21px;
+  }
+
+  ${({ theme }) => `
+    &:nth-of-type(2) {
+      font-weight: bold;
+      font-size: 12px;
+      color: ${theme.note.timeStamp};
+      left: 16px;
+      top: 17px;
+      height: 21px;
+    }
+
+    &:last-of-type:not(:nth-of-type(2)) {
+      font-weight: bold;
+      font-size: 12px;
+      color: ${theme.note.timeStamp};
+      cursor: pointer;
+      top: 17px;
+      height: 21px;
+      left: 40px;
+    }
+  `}
+`;
+
+const StyledFooter = styled.div`
+  display: flex;
+  top: 4px;
+  height: 32px;
+`;
+
+const StyledNote = styled.div`
+  ${({ theme, width }) => css`
+    background-color: ${theme.colors.white};
+    border: 1px solid ${theme.tile.border};
+    display: flex;
+    flex-direction: column;
+    padding: 24px;
+    position: relative;
+    width: 100%;
+    min-width: 314px;
+
+    ${(width && width !== 0) ? `width: ${width}%;` : ''}
+
+    ${StyledNoteContent} {
+      box-sizing: border-box;
+      width: auto;
+    }
+  `}
+`;
+
+StyledNoteContent.defaultProps = {
+  theme: baseTheme
+};
+
+StyledNote.propTypes = {
+  padding: PropTypes.string,
+  width: PropTypes.number
+};
+
+StyledNote.defaultProps = {
+  theme: baseTheme
+};
+
+StyledFooter.defaultProps = {
+  theme: baseTheme
+};
+
+export {
+  StyledNote, StyledNoteContent, StyledInlineControl, StyledTitle, StyledFooter, StyledFooterContent
+};

--- a/src/components/note/__internal__/status-with-tooltip/index.js
+++ b/src/components/note/__internal__/status-with-tooltip/index.js
@@ -1,0 +1,1 @@
+export { default } from './status.component';

--- a/src/components/note/__internal__/status-with-tooltip/status.component.js
+++ b/src/components/note/__internal__/status-with-tooltip/status.component.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import StyledStatusIconWrapper from './status.style';
+import TooltipDecorator from '../../../../utils/decorators/tooltip-decorator/tooltip-decorator';
+
+class StatusIcon extends React.Component {
+  render() {
+    return (
+      <>
+        <StyledStatusIconWrapper
+          data-component='status-with-tooltip'
+          ref={ (comp) => { this._target = comp; } }
+          onMouseOver={ this.props.onMouseOver }
+          onMouseLeave={ this.props.onMouseLeave }
+          onFocus={ this.props.onMouseOver }
+        >
+          { this.props.children }
+        </StyledStatusIconWrapper>
+        { this.tooltipHTML }
+      </>
+    );
+  }
+}
+
+StatusIcon.propTypes = {
+  /** The children for the button */
+  children: PropTypes.node.isRequired,
+  /** Callback to handle any mouse over events on a button */
+  onMouseOver: PropTypes.func.isRequired,
+  /** Callback to handle any mouse leave events on a button */
+  onMouseLeave: PropTypes.func.isRequired
+};
+
+export default TooltipDecorator(StatusIcon);

--- a/src/components/note/__internal__/status-with-tooltip/status.spec.js
+++ b/src/components/note/__internal__/status-with-tooltip/status.spec.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import StatusWithTooltip from './status.component';
+import Tooltip from '../../../tooltip';
+import { assertStyleMatch } from '../../../../__spec_helper__/test-utils';
+
+const onMouseOver = jest.fn();
+const onMouseLeave = jest.fn();
+
+const render = (props = {}) => {
+  const defaultProps = {
+    onMouseOver,
+    onMouseLeave,
+    tooltipMessage: 'foo',
+    tooltipPosition: 'top',
+    tooltipAlign: 'center',
+    tooltipVisible: false
+  };
+  return mount(
+    <StatusWithTooltip { ...defaultProps } { ...props }>foo</StatusWithTooltip>
+  );
+};
+
+describe('ContentWithTooltip', () => {
+  describe('Styling', () => {
+    it('matches the expected', () => {
+      const wrapper = render();
+      assertStyleMatch({
+        left: '-4px',
+        position: 'relative'
+      }, wrapper);
+
+      assertStyleMatch({
+        content: '""',
+        marginRight: '-6px'
+      }, wrapper, { modifier: ':before' });
+    });
+  });
+
+  describe('Tooltip', () => {
+    it('is displayed when `tooltipVisible` is true', () => {
+      expect(render({ tooltipVisible: true }).find(Tooltip).exists()).toBeTruthy();
+    });
+
+    it('is hidden when `tooltipVisible` is false', () => {
+      expect(render().find(Tooltip).exists()).toBeFalsy();
+    });
+  });
+});

--- a/src/components/note/__internal__/status-with-tooltip/status.style.js
+++ b/src/components/note/__internal__/status-with-tooltip/status.style.js
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+const StyledStatusIconWrapper = styled.div`
+  :before {
+    content: "";
+    margin-right: -6px;
+
+    @-moz-document url-prefix() {
+      margin-right: 1px;
+    }
+  }
+
+  list-style: disc;
+  display: list-item;
+  left: -4px;
+  position: relative;
+`;
+
+export default StyledStatusIconWrapper;

--- a/src/components/note/index.d.ts
+++ b/src/components/note/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './__internal__/note';
+export * from './__internal__/note';

--- a/src/components/note/index.js
+++ b/src/components/note/index.js
@@ -1,0 +1,1 @@
+export { default } from './__internal__/note.component';

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -287,6 +287,10 @@ export default (palette) => {
       separator: palette.slateTint(90)
     },
 
+    note: {
+      timeStamp: 'rgba(0,0,0,0.65)'
+    },
+
     zIndex: {
       overlay: 1000,
       popover: 2000,


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Component supports some features not present in `Tile`, such as a composable inline control, title and footer content including a status with tooltip. The component uses the `draftjs` editor in `readOnly` mode to support rendering of both plain and rich text content.

The meta content has intentionally been omitted as it may be possible to simply render that as part of the `draft-js` `Editor`'s content

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
This is a new component
### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Screenshots are included in the PR
- [x] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
- [x] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [x] Storybook added or updated
- [x] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->
With plain text:
![image](https://user-images.githubusercontent.com/44157880/87308854-be8a3300-c513-11ea-89b9-119e909625dd.png)

With Rich text:
![image](https://user-images.githubusercontent.com/44157880/87308876-c8ac3180-c513-11ea-8694-65b1a2b7d03d.png)

With title:
![image](https://user-images.githubusercontent.com/44157880/87308903-d3ff5d00-c513-11ea-8746-87693cffc13d.png)

With inline control:
![image](https://user-images.githubusercontent.com/44157880/87308955-df528880-c513-11ea-9c83-527e8723b7cc.png)
![image](https://user-images.githubusercontent.com/44157880/87308973-e4afd300-c513-11ea-8f50-27dd94d40dc8.png)

With footer:
![image](https://user-images.githubusercontent.com/44157880/87309056-fb562a00-c513-11ea-87c7-e2a8deca1531.png)
![image](https://user-images.githubusercontent.com/44157880/87309140-188af880-c514-11ea-8438-d6cae5ada265.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
Can be tested on storybook
`http://localhost:9001/?path=/docs/design-system-note--`...
https://codesandbox.io/s/carbon-quickstart-hwssk?file=/src/index.js