### PR TITLE
docs(rfc): propose i18n upgrade

### DIFF
--- a/rfcs/text/i18n.md
+++ b/rfcs/text/i18n.md
@@ -1,0 +1,305 @@
+- Start Date: 2020-07-14
+
+# Summary
+
+Introduce first class support for internationalisation and localisation within `carbon-react`.
+
+# Basic example
+
+The proposal is to introduce a new component `I18nProvider` that allows our consumers to provide a 
+[`react-i18next`](https://github.com/i18next/react-i18next) compatible<sup>[1] [2]</sup> `t` function.
+
+We will need to check each usage of our current `i18n-js` implementation to ensure the:
+* key makes sense;
+* translations are provided in each of our supported languages; and
+* interpolation/plural/formatting works correctly.
+
+`react-i18next` also uses [`Suspense`](https://reactjs.org/docs/concurrent-mode-suspense.html) to allow for async
+translation loading. We don't need to support this within `carbon-react` to adopt this approach, but we will use this in
+the future when we add `loading` states to our components.
+
+We will deprecate our `I18n` component. This component consumes `i18n-js` directly and formats any Markdown content.
+There are better alternatives for Markdown, such as [`react-markdown`](https://github.com/rexxars/react-markdown) which 
+avoids `dangerouslySetInnerHTML`. Our consumers can use `react-markdown` and `react-i18next` in tandem. Removing the
+`I18n` from carbon allows our consumers to patch any Markdown parsing vulnerabilities without requiring a new 
+`carbon-react` release.
+
+We will also deprecate all [`i18n` helpers][3]. Continuing to support these is beyond the scope of a component library
+and is better handled by a dedicated library such as [`numeral.js`](http://numeraljs.com/). Removing these will further
+reduce the complexity of this project and allow for more advanced configurations by our consumers. Where we use these
+helpers internally, we will use a dedicated library if appropriate. We will ensure that any new i18n helpers are
+considered as private methods i.e. marked as `@private` or not exported.
+
+Finally, each translation will be overridable by our consumers by providing a string prop to the component. This string 
+can also be provided by `react-i18next`.
+
+[1]: https://react.i18next.com/latest/usetranslation-hook
+[2]: https://www.i18next.com/overview/api#t
+[3]: https://github.com/Sage/carbon/blob/a59afc80fd7ac954b58da5cd9ef278239b5756c0/src/utils/helpers/i18n/i18n.js
+# Motivation
+
+We currently only publish english translations. Each time a product launches in a non-english market they have to set up
+translations, these are typically non-contextual and will be the same in each product.
+
+Having `i18n-js` as a peer-dependency means that we are encouraging the use of this, unintentionally, for content
+translations. The current recommended setup is `i18next`, so consumers will have to configure both libraries, increasing
+the bundle size and reducing performance.
+
+# Detailed design
+
+```js
+// carbon-react/lib/components/__internal__/I18nContext/index.js
+import {createContext} from "react";
+
+export default createContext(() => {throw new Error("No I18nProvider exists.")});
+```
+
+```js
+// carbon-react/lib/components/I18nProvider/index.js
+import React from "react";
+import Context from "../__internal__/I18nContext";
+export default ({t, children}) => <Context.Provider value={t}>{children}</Context.Provider>
+```
+
+```js
+// carbon-react/lib/components/Example/index.js
+import React, { Suspense, useContext } from "react";
+import Context from "../__internal__/I18nContext";
+export default ({nextLabel}) => {
+  const t = useContext(Context);
+  return <span>{nextLabel || t("example.next")}</span>;
+};
+```
+
+Below is an example of how someone could configure lazy loading of carbon translations.
+This file is accessible from `/locales/fr-FR/carbon.json`
+
+```json
+{
+  "example": {
+    "next": "Suivant",
+    "previous": "Précédent"
+  }
+}
+```
+
+This file is accessible from `/locales/fr-FR/app.json`
+```json
+{
+  "example": {
+    "next": "Dernière page"
+  }
+}
+```
+
+```js
+// App.js
+import React, { Suspense } from "react";
+import HttpApi from "i18next-http-backend";
+import i18n from "i18next";
+import { initReactI18next, useTranslation } from "react-i18next";
+import Example from "carbon-react/lib/components/Example";
+import I18nProvider from "carbon-react/lib/components/I18nProvider";
+
+i18n
+  .use(initReactI18next)
+  .use(HttpApi)
+  .init({
+    interpolation: {
+      escapeValue: false,
+    },
+    lng: "fr-FR",
+    ns: ["carbon", "app"],
+    backend: {
+      loadPath: "/locales/{{lng}}/{{ns}}.json",
+    }
+  });
+
+const Page = () => {
+  const { t } = useTranslation('carbon');
+  const { t: appT } = useTranslation('app');
+  return (
+    <I18nProvider t={t}>
+      <Example />
+      <Example nextLabel={appT('example.next')} />
+    </I18nProvider>
+  );
+};
+
+function App() {
+  return (
+    <Suspense fallback="Loading...">
+      <Page />
+    </Suspense>
+  );
+}
+
+export default App;
+
+```
+
+Consumers may also choose to bundle the translations.
+
+```js
+// App.js
+import React, { Suspense } from "react";
+import i18n from "i18next";
+import { initReactI18next, useTranslation } from "react-i18next";
+import Example from "carbon-react/lib/components/Example";
+import I18nProvider from "carbon-react/lib/components/I18nProvider";
+import frFr from "carbon-react/lib/translations/fr-FR/carbon.json";
+import AppFrFr from "carbon-react/lib/translations/fr-FR/app.json";
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      'fr-FR': {
+        carbon: frFr,
+        app: AppFrFr
+      }
+    },
+    lng: "fr-FR",
+    ns: ["carbon", "app"],
+    interpolation: {
+      escapeValue: false
+    }
+  });
+
+const Page = () => {
+  const { t } = useTranslation('carbon');
+    const { t: appT } = useTranslation('app');
+  return (
+    <I18nProvider t={t}>
+      <Example />
+      <Example nextLabel={appT('example.next')} />
+    </I18nProvider>
+  );
+};
+
+function App() {
+  return (
+    <Suspense fallback="Loading...">
+      <Page />
+    </Suspense>
+  );
+}
+
+export default App;
+
+```
+
+
+# Drawbacks
+
+1. This will be a breaking change, our consumers will have to migrate any existing translations from `i18n-js` to
+`i18next`. This is partially mitigated by the translations that we will be providing out of the box. We should ask for
+translation contributions from our consumers.
+1. We have ~78 usages of `i18n-js` that we will need to convert.
+
+# Alternatives
+
+I had previously considered creating a `I18n` component that would be responsible for configuring `i18next`. This
+solution proved to work when the translations were bundled with the app. However, as I investigated lazy loading of
+translations it became apparent that this abstraction provides us with little benefit and that I would have to expose
+the `i18next` interface regardless.
+
+Another difficultly was ensuring that `i18next` was only configured once. Components are intrinsically designed to be
+used multiple times. I tried a few ways to make this a singleton but each had a different problem. Context was the
+safest way but that would only allow us to check if a parent had configured `i18next`. This would not catch if a sibling
+re-configured it. Using a variable to check if `i18next` had been configured broke hot reloading.
+
+For consumers that are already using `i18next` it makes little sense to have two separate configurations.
+
+Below is the approach that I ruled out.
+```js
+import React, { createContext, useState, useEffect, useContext } from "react";
+import i18n from "i18next";
+import {
+  useTranslation,
+  initReactI18next,
+  withTranslation
+} from "react-i18next";
+import invariant from "invariant";
+
+const config = (lng, translation) => ({
+  resources: {
+    [lng]: {
+      translation
+    }
+  },
+  lng,
+  fallbackLng: lng
+});
+
+const enGB = config("enGB", {
+  example: {
+    next: "next",
+    previous: "previous"
+  }
+});
+
+const frFR = config("frFr", {
+  example: {
+    next: "Suivant",
+    previous: "Précédent"
+  }
+});
+
+const I18nConfiguration = createContext(false);
+
+const I18n = ({ lang, children }) => {
+  const i18nAlreadyConfigured = useContext(I18nConfiguration);
+  invariant(
+    !i18nAlreadyConfigured,
+    "You tried to use the `I18N` component but one already exists in the render tree."
+  );
+  const [isReady, setIsReady] = useState(false);
+  useEffect(() => {
+    i18n.use(initReactI18next).init({
+      ...lang,
+      interpolation: {
+        escapeValue: false
+      }
+    });
+    setIsReady(true);
+  }, [lang]);
+  return (
+    <I18nConfiguration.Provider value={true}>
+      {isReady ? children : null}
+    </I18nConfiguration.Provider>
+  );
+};
+
+const Example = () => {
+  const { t } = useTranslation();
+  return <button>{t("example.next")}</button>;
+};
+
+class ExampleCls extends React.Component {
+  render() {
+    const { t } = this.props;
+    return <button>{t("example.next")}</button>;
+  }
+}
+const LegacyExample = withTranslation()(ExampleCls);
+```
+
+```js
+import Example from "carbon-react/lib/components/Example";
+import I18n from "carbon-react/lib/components/i18n";
+import {frFr} from "carbon-react/lib/i18n";
+const MyComponent = () => (<I18n lang={frFr}><Example /></I18n>);
+```
+
+# Adoption strategy
+
+This will be a breaking change. We will need to document the upgrade process and link to it in the release notes.
+
+# How we teach this
+
+This will be added to our getting started guide and to our docs in storybook. We will share this RFC internally as well
+as the breaking change.
+
+# Unresolved questions
+
+N/A


### PR DESCRIPTION
Introduce first class support for internationalisation and localisation within `carbon-react`.

---
This PR does not follow the typical PR process. Details of the RFC process can be found [here](https://github.com/Sage/carbon/blob/master/rfcs/README.md).

Please use 👍  if you approve.
If you don't approve please comment below.