### PR TITLE
docs: create guide on draft js editorstate and contentstate FE-2943

### DIFF
--- a/docs/getting-started.stories.mdx
+++ b/docs/getting-started.stories.mdx
@@ -28,7 +28,13 @@ npm install carbon-react
 You will need to install the following dependencies in your project, these are peer-dependencies of carbon-react and are required.
 
 ```sh
-npm install react@^16.12.0 react-dom@^16.12.0 i18n-js@^3.0.0 styled-components@^4.4.1
+npm install react@^16.12.0 react-dom@^16.12.0 i18n-js@^3.0.0 styled-components@^4.4.1 
+```
+
+There is a peer dependency on `draft-js` any project intending to use either the `TextEditor` or `Note` components is required to install it as well.
+
+```sh
+npm install draft-js@^0.11.5
 ```
 
 #### Fonts

--- a/docs/using-draft-js.stories.mdx
+++ b/docs/using-draft-js.stories.mdx
@@ -1,0 +1,121 @@
+<Meta
+  title="Documentation/Using DraftJS"
+/>
+
+# Using Draft.js EditorState and ContentState
+
+## Contents
+[Introduction to Draft.js](#installation)
+
+* [EditorState](#editorstate)
+* [ContentState](#contentstate)
+* [Useful Links](#useful-links)
+
+## Installation
+The [TextEditor](https://carbon.sage.com/?path=/docs/design-system-text-editor--basic) and 
+[Note](https://carbon.sage.com/?path=/docs/design-system-note--basic) components utilise the `Draft.js` framework to 
+support creating and rendering rich-text content. As such, the framework has been added as a peer-dependency and 
+consuming projects are required to install it if they wish to use either component, this can be done as an 
+[npm package](https://www.npmjs.com/package/draft-js).
+
+```sh
+npm install draft-js@^0.11.5
+```
+
+### EditorState
+The `EditorState` is an Immutable Record representing the the top-level object for the entire state of the `Editor`. 
+Interacting with it will provide access to a wide range of useful information. This includes the current text
+`ContentState`, accessible via the `getCurrentContent()` method exposed as part of the API. It also provides access to 
+the current `SelectionState` (`getSelection()`), the fully decorated representation of the contents 
+(`getCurrentInlineStyle()` and `getBlockTree()`), undo/redo stacks and the most recent type of change made to the 
+contents. For more information refer to the API documentation https://draftjs.org/docs/api-reference-editor-state.
+
+#### Importing EditorState
+The `EditorState` can be imported either directly from `draft-js` or alternatively it has been exposed as part of the 
+`TextEditor` component's interface.
+
+```js
+import { EditorState } from 'draft-js';
+```
+```js
+import { TextEditorState } from 'carbon-react/lib/components/text-editor';
+```
+
+#### Useful static methods
+The framework surfaces a range of static methods for initialising the state: 
+* `EditorState.createEmpty(decorator?: DraftDecoratorType)` - will intitialise the component with a new `EditorState` 
+object with an empty `ContentState` and any `Decorators` passed to it.
+* `EditorState.createWithContent(contentState: ContentState, decorator?: DraftDecoratorType)` - is used to initialise 
+the component with some existing `ContentState` and any `Decorators` and return a new `EditorState` object.
+* `EditorState.create(config: EditorStateCreationConfig)` - offers the same as `createWithContent` but enables 
+initialising the `EditorState` from a config, affording you more fine grain control. For example, it is possible to 
+define an intitial `SelectionState` using this static method.
+
+#### Other useful methods
+* `EditorState.push(editorState: EditorState, contentState: ContentState, changeType: EditorChangeType)` - it is very
+unlikely that you will have a need to use this but if direct content changes are required they must be applied to the 
+`EditorState` using this method. It returns a new `EditorState` object with the specified `ContentState` applied as the 
+new currentContent, the `changeType` defines the operation being carried out on the state, see 
+https://draftjs.org/docs/api-reference-editor-change-type for the defined options.
+* The current `ContentState` can be accessed by calling the `getCurrentContent()` instance method.
+* The current `SelectionState` can be accessed by calling the `getSelection()` instance method.
+
+### ContentState
+`ContentState` is also an Immutable Record and represents the state of the editor's entire contents (text, block and 
+inline styles, and entity ranges) and its two selection states (before and after rendering). There are range of useful 
+methods accessible through `ContentState` that can provide information about the current content rendered in the editor, 
+for more details it is best to refer to the API reference documentation 
+https://draftjs.org/docs/api-reference-content-state.
+
+#### Importing ContentState
+The `ContentState` can be imported either directly from `draft-js` or alternatively it has been exposed as part of the 
+`TextEditor` component's interface.
+
+```js
+import { ContentState } from 'draft-js';
+```
+```js
+import { TextEditorContentState } from 'carbon-react/lib/components/text-editor';
+```
+
+#### Useful static methods
+There are two static methods that facilitate creating `ContentState`:
+* `createFromText(text: string, delimiter?: string)` - will generate state from a given string paramater, passing an 
+optional delimiter will define how the content blocks are split; if no delimiter is provided the method will default to 
+using `\n`. This method will commonly be used with the `createWithContent` method surfaced by the `EditorState` like so:
+```js
+  const Foo = (props) => {
+    const [state, setState] = useState(EditorState.createWithContent(ContentState.createFromText('text content')));
+
+    return (
+      <Editor editorState={ state } onChange={ (newState) => setState(newState)} />
+    );
+  };
+```
+* `createFromBlockArray(blocks: Array<ContentBlock>, entityMap: ?OrderedMap)` - this method will produce a 
+`ContentState` object from an array of `ContentBlock`s, an optional Immutable map of `DraftEntity` records can also be 
+provided as the second argument. A `ContentBlock` is itself an Immutable Record that maintains the following 
+information about a block: a string key, the entity type, the block's text and an Immutable characterList which 
+maintains the styling and other data for each character. Commonly this method will be used in conjunction with `Draft`'s 
+data conversion methods (https://draftjs.org/docs/api-reference-data-conversion), below is an example of using it when 
+converting html into `ContentState` using `convertFromHTML`.
+```js
+  const Foo = (props) => {
+    const html = `<p>Lorem ipsum</p>`;
+    const blocksFromHTML = convertFromHTML(html);
+    const contentState = ContentState.createFromBlockArray(
+      blocksFromHTML.contentBlocks,
+      blocksFromHTML.entityMap
+    );
+    const [state, setState] = useState(EditorState.createWithContent(contentState);
+
+    return (
+      <Editor editorState={ state } onChange={ (newState) => setState(newState)} />
+    );
+  };
+```
+
+### Useful Links
+* API reference documentaion - https://draftjs.org/docs/api-reference-editor-state.
+* A useful playground for getting to grips with `Draft.js` internal architecture and mechanisms 
+https://learn-draftjs.now.sh/.


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds a guide to inform consumers how to use the `EditorState` and `ContentState` static methods to
manipulate the `TextEditor` component's content. The `install` command has also been added to the peer-dependency section of the `getting started` guide
### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No guide exists
### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR<del>
<del>- [ ] Carbon implementation and Design System documentation are congruent<del>
<del>- [ ] All themes are supported<del>
- [x] Commits follow our style guide
<del>- [ ] Unit tests added or updated<del>
<del>- [ ] Cypress automation tests added or updated<del>
- [x] Storybook added or updated
<del>- [ ] Typescript `d.ts` file added or updated<del>

### Additional context
<!-- Add any other context or links about the pull request here. -->
The `TextEditor` and `Note` components rely on the `Draft.js` framework so this document aims to help them get to grips with formatting the content correctly

### Testing instructions
<!-- How can a reviewer test this PR? -->
No QA required