### PR TITLE
test(helper): function to pass parameters via url

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -52,5 +52,6 @@
   "readOnly": "--readonly",
   "transparent": "--transparent",
   "disabled": "--disabled",
-  "with_footer": "--with-footer"
+  "with_footer": "--with-footer",
+  "test_basic": "-test--basic"
 }

--- a/cypress/features/regression/alert.feature
+++ b/cypress/features/regression/alert.feature
@@ -11,27 +11,27 @@ Feature: Alert component
     Given I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "<nameOfObject>" object name
     Then component title on preview is <title> in NoIFrame
     Examples:
-      | title                 | nameOfObject              |
-      | mp150ú¿¡üßä           | openTitleOtherLanguage    |
-      | !@$^*()_+-=~[];:.,?{} | openTitleSpecialCharacter |
+      | title                   | nameOfObject              |
+      | mp150ú¿¡üßä             | openTitleOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | openTitleSpecialCharacter |
 
   @positive
   Scenario Outline: Change Alert component subtitle to <subtitle>
     Given I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "<nameOfObject>" object name
     Then component subtitle on preview is <subtitle> in NoIFrame
     Examples:
-      | subtitle              | nameOfObject                 |
-      | mp150ú¿¡üßä           | openSubtitleOtherLanguage    |
-      | !@$^*()_+-=~[];:.,?{} | openSubtitleSpecialCharacter |
+      | subtitle                | nameOfObject                 |
+      | mp150ú¿¡üßä             | openSubtitleOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | openSubtitleSpecialCharacter |
 
   @positive
   Scenario Outline: Change Alert component children to <children>
     Given I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "<nameOfObject>" object name
     Then Alert children on preview is "<children>"
     Examples:
-      | children              | nameOfObject                 |
-      | mp150ú¿¡üßä           | openChildrenOtherLanguage    |
-      | !@$^*()_+-=~[];:.,?{} | openChildrenSpecialCharacter |
+      | children                | nameOfObject                 |
+      | mp150ú¿¡üßä             | openChildrenOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | openChildrenSpecialCharacter |
 
   @positive
   Scenario: Enable background UI
@@ -47,7 +47,7 @@ Feature: Alert component
   Scenario: Disable escape key
     When I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "openDisableEscKey" object name
       And I press ESC onto focused element
-    Then Alert is visible
+    Then Alert is visible in NoIFrame
 
   @positive
   Scenario Outline: Set height for Alert dialog to <height>

--- a/cypress/features/regression/alert.feature
+++ b/cypress/features/regression/alert.feature
@@ -1,130 +1,83 @@
 Feature: Alert component
   I want to change Alert component properties
 
-  Background: Open Alert component page
-    Given I open "Alert" component page with button
-
   @positive
   Scenario: CloseIcon has the border outline
-    When I open component preview
-    Then closeIcon has the border outline color "rgb(255, 181, 0)" and width "3px"
+    When I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "open" object name
+    Then closeIcon has the border outline color "rgb(255, 181, 0)" and width "3px" in NoIFrame
 
   @positive
   Scenario Outline: Change Alert component title to <title>
-    When I set title to <title> word
-      And I open component preview
-    Then component title on preview is <title>
+    Given I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "<nameOfObject>" object name
+    Then component title on preview is <title> in NoIFrame
     Examples:
-      | title                   |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-  # @ignore because of FE-2782
-  # | &"'<>|
+      | title                 | nameOfObject              |
+      | mp150ú¿¡üßä           | openTitleOtherLanguage    |
+      | !@$^*()_+-=~[];:.,?{} | openTitleSpecialCharacter |
 
   @positive
-  Scenario Outline: Change Alert subtitle to <subtitle>
-    When I set subtitle to <subtitle> word
-      And I open component preview
-    Then component subtitle on preview is <subtitle>
+  Scenario Outline: Change Alert component subtitle to <subtitle>
+    Given I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "<nameOfObject>" object name
+    Then component subtitle on preview is <subtitle> in NoIFrame
     Examples:
-      | subtitle                |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-  # @ignore because of FE-2782
-  # | &"'<>|                     |
+      | subtitle              | nameOfObject                 |
+      | mp150ú¿¡üßä           | openSubtitleOtherLanguage    |
+      | !@$^*()_+-=~[];:.,?{} | openSubtitleSpecialCharacter |
 
   @positive
-  Scenario Outline: Change Alert children to <children>
-    When I set children to "<children>"
-      And I open component preview
+  Scenario Outline: Change Alert component children to <children>
+    Given I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "<nameOfObject>" object name
     Then Alert children on preview is "<children>"
     Examples:
-      | children                |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-  # @ignore because of FE-2782
-  # | &"'<>|                   |
+      | children              | nameOfObject                 |
+      | mp150ú¿¡üßä           | openChildrenOtherLanguage    |
+      | !@$^*()_+-=~[];:.,?{} | openChildrenSpecialCharacter |
 
   @positive
   Scenario: Enable background UI
-    When I check enableBackgroundUI checkbox
-      And I open component preview
-    Then Background UI is enabled
+    When I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "openEnableBackgroundUI" object name
+    Then Background UI is enabled in NoIFrame
 
   @negative
   Scenario: Disable background UI
-    When I check enableBackgroundUI checkbox
-      And I uncheck enableBackgroundUI checkbox
-      And I open component preview
-    Then Background UI is disabled
+    When I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "openEnableBackgroundUIFalse" object name
+    Then Background UI is disabled in NoIFrame
 
   @positive
   Scenario: Disable escape key
-    When I check disableEscKey checkbox
-      And I open component preview
-      And I hit ESC key
+    When I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "openDisableEscKey" object name
+      And I press ESC onto focused element
     Then Alert is visible
-
-  @negative
-  Scenario: Enable escape key
-    When I check disableEscKey checkbox
-      And I uncheck disableEscKey checkbox
-      And I open component preview
-      And I hit ESC key
-    Then Alert is not visible
 
   @positive
   Scenario Outline: Set height for Alert dialog to <height>
-    When I set height to "<height>"
-      And I open component preview
+    When I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "<nameOfObject>" object name
     Then Alert height is set to "<height>"
     Examples:
-      | height |
-      | 0      |
-      | 1      |
-      | 100    |
+      | height | nameOfObject  |
+      | 0      | openHeight0   |
+      | 1      | openHeight1   |
+      | 100    | openHeight100 |
 
   @negative
   Scenario Outline: Set out of scope characters to height for Alert dialog
-    When I set height to "<height>"
-      And I open component preview
+    When I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "<nameOfObject>" object name
     Then Alert height is set to "<height>"
     Examples:
-      | height                  |
-      | -1                      |
-      | -10                     |
-
-  @positive
-  Scenario: Clicking close icon, closes Alert dialog
-    When I open component preview
-    Then closeIcon is visible
-      And I click closeIcon
-      And Alert is not visible
+      | height | nameOfObject  |
+      | -1     | openHeight-1  |
+      | -10    | openHeight-10 |
 
   @positive
   Scenario Outline: Set Alert size to <sizeName>
-    When I select size to "<sizeName>"
-      And I open component preview
+    When I open default "Alert" component in noIFrame with "alert" json from "commonComponents" using "<nameOfObject>" object name
     Then Alert size property on preview is "<sizePropertyInPx>"
     Examples:
-      | sizeName     | sizePropertyInPx |
-      | extra-small  | 300              |
-      | small        | 380              |
-      | medium-small | 540              |
-      | medium       | 750              |
-      | medium-large | 850              |
-      | large        | 960              |
-      | extra-large  | 1080             |
-
-  @positive
-  Scenario: Check open click event
-    When clear all actions in Actions Tab
-      And I open component preview
-    Then open action was called in Actions Tab
-
-  @positive
-  Scenario: Check cancel click event
-    Given clear all actions in Actions Tab
-      And I open component preview
-    When I click closeIcon
-    Then cancel action was called in Actions Tab
+      | sizeName     | sizePropertyInPx | nameOfObject        |
+      | extra-small  | 300              | openSizeExtraSmall  |
+      | small        | 380              | openSizeSmall       |
+      | medium-small | 540              | openSizeMediumSmall |
+      | medium       | 750              | openSizeMedium      |
+      | medium-large | 850              | openSizeMediumLarge |
+      | large        | 960              | openSizeLarge       |
+      | extra-large  | 1080             | openSizeExtraLarge  |

--- a/cypress/features/regression/alertActions.feature
+++ b/cypress/features/regression/alertActions.feature
@@ -1,5 +1,5 @@
-Feature: Alert component
-  I want to change Alert component properties
+Feature: Alert component actions
+  I want to check Alert component actions
 
   Background: Open Alert component page
     Given I open "Alert" component page with button

--- a/cypress/features/regression/alertActions.feature
+++ b/cypress/features/regression/alertActions.feature
@@ -1,0 +1,32 @@
+Feature: Alert component
+  I want to change Alert component properties
+
+  Background: Open Alert component page
+    Given I open "Alert" component page with button
+
+  @positive
+  Scenario: Clicking close icon, closes Alert dialog
+    When I open component preview
+    Then closeIcon is visible
+      And I click closeIcon
+      And Alert is not visible
+
+  @positive
+  Scenario: Disable escape key
+    When I check disableEscKey checkbox
+      And I open component preview
+      And I hit ESC key
+    Then Alert is visible
+
+@positive
+Scenario: Check open click event
+  When clear all actions in Actions Tab
+    And I open component preview
+  Then open action was called in Actions Tab
+
+@positive
+Scenario: Check cancel click event
+  Given clear all actions in Actions Tab
+    And I open component preview
+  When I click closeIcon
+  Then cancel action was called in Actions Tab

--- a/cypress/features/regression/test/badge.feature
+++ b/cypress/features/regression/test/badge.feature
@@ -1,45 +1,37 @@
 Feature: Badge component
   I want to test Badge component properties
 
-  Background: Open Badge component page
-    Given I open "Design System Badge Test" component page "basic"
-
   @positive
   Scenario Outline: Set Badge component to <counter>
-    When I set counter to "<counter>"
+    When I open Test test_basic "Badge" component in noIFrame with "badge" json from "test" using "<nameOfObject>" object name
     Then Badge component counter is set to <counter>
     Examples:
-      | counter |
-      | 1       |
-      | 99      |
+      | counter | nameOfObject |
+      | 1       | counter1     |
+      | 99      | counter99    |
 
   @positive
   Scenario Outline: Set Badge component to 3 digits to <counter>
-    When I set counter to "<counter>"
+    When I open Test test_basic "Badge" component in noIFrame with "badge" json from "test" using "<nameOfObject>" object name
     Then Badge component counter is set to 99
     Examples:
-      | counter |
-      | 100     |
-      | 999     |
+      | counter | nameOfObject |
+      | 100     | counter100   |
+      | 999     | counter99    |
 
   @negative
   Scenario Outline: Set Badge component to out of scope to <counter>
-    When I set counter to <counter> word
+    When I open Test test_basic "Badge" component in noIFrame with "badge" json from "test" using "<nameOfObject>" object name
     Then Badge component counter does not exist
     Examples:
-      | counter                      |
-      | 0                            |
-      | -12                          |
-      | test                         |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | counter                      | nameOfObject            |
+      | 0                            | counter0                |
+      | -12                          | counter-12              |
+      | test                         | counterTest             |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | counterSpecialCharacter |
 
   @positive
   Scenario: Hover Badge component and verify that cross icon appears
+    Given I open Test test_basic "Badge" component in noIFrame with "badge" json from "test" using "counter1" object name
     When I focus onto Badge component
-    Then icon on preview is "cross"
-
-  @positive
-  Scenario: Click event
-    Given clear all actions in Actions Tab
-    When I click onto Badge component
-    Then click action was called in Actions Tab
+    Then icon name into iFrame on preview is "cross"

--- a/cypress/features/regression/test/badgeActions.feature
+++ b/cypress/features/regression/test/badgeActions.feature
@@ -1,0 +1,11 @@
+Feature: Badge component actions
+  I want to test Badge component actions
+
+  Background: Open Badge component page
+    Given I open "Design System Badge Test" component page "basic"
+
+  @positive
+  Scenario: Click event
+    Given clear all actions in Actions Tab
+    When I click onto Badge component
+    Then click action was called in Actions Tab

--- a/cypress/fixtures/commonComponents/alert.json
+++ b/cypress/fixtures/commonComponents/alert.json
@@ -8,7 +8,7 @@
   },
   "openTitleSpecialCharacter": {
     "open": true,
-    "title": "!@$^*()_%2B-=~[];:.,?{}"
+    "title": "!@#$%^*()_+-=~[];:.,?{}"
   },
   "openSubtitleOtherLanguage": {
     "open": true,
@@ -16,7 +16,7 @@
   },
   "openSubtitleSpecialCharacter": {
     "open": true,
-    "subtitle": "!@$^*()_%2B-=~[];:.,?{}"
+    "subtitle": "!@#$%^*()_+-=~[];:.,?{}"
   },
   "openChildrenOtherLanguage": {
     "open": true,
@@ -24,7 +24,7 @@
   },
   "openChildrenSpecialCharacter": {
     "open": true,
-    "children": "!@$^*()_%2B-=~[];:.,?{}"
+    "children": "!@#$%^*()_+-=~[];:.,?{}"
   },
   "openDisableEscKey": {
     "open": true,

--- a/cypress/fixtures/commonComponents/alert.json
+++ b/cypress/fixtures/commonComponents/alert.json
@@ -1,0 +1,93 @@
+{ 
+  "open": {
+    "open": true
+  },
+  "openTitleOtherLanguage": {
+    "open": true,
+    "title": "mp150ú¿¡üßä"
+  },
+  "openTitleSpecialCharacter": {
+    "open": true,
+    "title": "!@$^*()_%2B-=~[];:.,?{}"
+  },
+  "openSubtitleOtherLanguage": {
+    "open": true,
+    "subtitle": "mp150ú¿¡üßä"
+  },
+  "openSubtitleSpecialCharacter": {
+    "open": true,
+    "subtitle": "!@$^*()_%2B-=~[];:.,?{}"
+  },
+  "openChildrenOtherLanguage": {
+    "open": true,
+    "children": "mp150ú¿¡üßä"
+  },
+  "openChildrenSpecialCharacter": {
+    "open": true,
+    "children": "!@$^*()_%2B-=~[];:.,?{}"
+  },
+  "openDisableEscKey": {
+    "open": true,
+    "disableEscKey": true
+  },
+  "openDisableEscKeyFalse": {
+    "open": true,
+    "disableEscKey": false
+  },
+  "openEnableBackgroundUI":{
+    "open": true,
+    "enableBackgroundUI": true
+  },
+  "openEnableBackgroundUIFalse":{
+    "open": true,
+    "enableBackgroundUI": false
+  },
+  "openHeight0": {
+    "open": true,
+    "height": 0
+  },
+  "openHeight1": {
+    "open": true,
+    "height": 1
+  },
+  "openHeight100": {
+    "open": true,
+    "height": 100
+  },
+  "openHeight-1": {
+    "open": true,
+    "height": -1
+  },
+  "openHeight-10": {
+    "open": true,
+    "height": -10
+  },
+  "openSizeExtraSmall": {
+    "open": true,
+    "size": "extra-small"
+  },
+  "openSizeSmall": {
+    "open": true,
+    "size": "small"
+  },
+  "openSizeMediumSmall": {
+    "open": true,
+    "size": "medium-small"
+  },
+  "openSizeMedium": {
+    "open": true,
+    "size": "medium"
+  },
+  "openSizeMediumLarge": {
+    "open": true,
+    "size": "medium-large"
+  },
+  "openSizeLarge": {
+    "open": true,
+    "size": "large"
+  },
+  "openSizeExtraLarge": {
+    "open": true,
+    "size": "extra-large"
+  }
+}

--- a/cypress/fixtures/test/badge.json
+++ b/cypress/fixtures/test/badge.json
@@ -1,0 +1,26 @@
+{ 
+  "counter1": {
+    "counter": 1
+  },
+  "counter99": {
+    "counter": 99
+  },
+  "counter100": {
+    "counter": 100
+  },
+  "counter999": {
+    "counter": 999
+  },
+  "counter0": {
+    "counter": 0
+  },
+  "counter-12": {
+    "counter": -12
+  },
+  "counterTest": {
+    "counter": "test"
+  },
+  "counterSpecialCharacter": {
+    "counter": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  }
+}

--- a/cypress/locators/badge/index.js
+++ b/cypress/locators/badge/index.js
@@ -1,5 +1,8 @@
 import { BADGE, BADGE_COUNTER } from './locators';
 
+// component preview locators in NoIFrame
+export const badgeNoIFrame = () => cy.get(BADGE);
+export const badgeCounterNoIFrame = () => badgeNoIFrame().find(BADGE_COUNTER);
+
 // component preview locators
 export const badge = () => cy.iFrame(BADGE);
-export const badgeCounter = () => badge().find(BADGE_COUNTER);

--- a/cypress/locators/confirm/index.js
+++ b/cypress/locators/confirm/index.js
@@ -12,3 +12,6 @@ export const closeIconButton = () => cy.iFrame(CLOSE_ICON_BUTTON);
 export const dialogSubtitle = () => cy.iFrame(DIALOG_SUBTITLE);
 export const confirmButton = () => cy.iFrame(CONFIRM_BUTTON);
 export const cancelButton = () => cy.iFrame(CANCEL_BUTTON);
+
+// component preview locators in NoIFrame
+export const dialogSubtitleNoIFrame = () => cy.get(DIALOG_SUBTITLE);

--- a/cypress/locators/dialog/index.js
+++ b/cypress/locators/dialog/index.js
@@ -1,11 +1,26 @@
 import {
-  ALERT_DIALOG, STICKY_FORM_FOOTER_ELEMENT, DIALOG_TITLE, DIALOG_SUBTITLE,
+  ALERT_DIALOG,
+  STICKY_FORM_FOOTER_ELEMENT,
+  DIALOG_TITLE, 
+  DIALOG_SUBTITLE,
 } from './locators';
 
-// component preview locators
+// component preview locators in NoIFrame
 export const alertDialogPreview = () => cy.iFrame(ALERT_DIALOG);
+export const alertChildren = () => cy.iFrame(ALERT_DIALOG)
+  .find('div:nth-child(2)').children();
 export const dialogTitle = () => cy.iFrame(DIALOG_TITLE);
 export const dialogSubtitle = () => cy.iFrame(DIALOG_SUBTITLE);
 export const dialogStickyFormFooter = () => cy.iFrame(STICKY_FORM_FOOTER_ELEMENT);
 export const dialogStickyFormFooterButton = index => cy.iFrame(STICKY_FORM_FOOTER_ELEMENT).children()
+  .eq(index).children();
+
+// component preview locators
+export const alertDialogPreviewNoIFrame = () => cy.get(ALERT_DIALOG);
+export const alertChildrenNoIframe = () => alertDialogPreviewNoIFrame()
+  .find('div:nth-child(2)').children();
+export const dialogTitleNoIFrame = () => cy.get(DIALOG_TITLE);
+export const dialogSubtitleNoIFrame = () => cy.get(DIALOG_SUBTITLE);
+export const dialogStickyFormFooterNoIFrame = () => cy.get(STICKY_FORM_FOOTER_ELEMENT);
+export const dialogStickyFormFooterButtonNoIFrame = index => cy.get(STICKY_FORM_FOOTER_ELEMENT).children()
   .eq(index).children();

--- a/cypress/locators/dialog/index.js
+++ b/cypress/locators/dialog/index.js
@@ -5,7 +5,7 @@ import {
   DIALOG_SUBTITLE,
 } from './locators';
 
-// component preview locators in NoIFrame
+// component preview locators
 export const alertDialogPreview = () => cy.iFrame(ALERT_DIALOG);
 export const alertChildren = () => cy.iFrame(ALERT_DIALOG)
   .find('div:nth-child(2)').children();
@@ -15,7 +15,7 @@ export const dialogStickyFormFooter = () => cy.iFrame(STICKY_FORM_FOOTER_ELEMENT
 export const dialogStickyFormFooterButton = index => cy.iFrame(STICKY_FORM_FOOTER_ELEMENT).children()
   .eq(index).children();
 
-// component preview locators
+// component preview locators in NoIFrame
 export const alertDialogPreviewNoIFrame = () => cy.get(ALERT_DIALOG);
 export const alertChildrenNoIframe = () => alertDialogPreviewNoIFrame()
   .find('div:nth-child(2)').children();

--- a/cypress/locators/index.js
+++ b/cypress/locators/index.js
@@ -59,3 +59,5 @@ export const getComponentNoIframe = component => cy.get(`[data-component="${comp
 export const getElementNoIframe = element => cy.get(`[data-element="${element}"]`).first();
 export const getElementNoIframeByName = element => cy.get(`[name="${element}"]`);
 export const commonButtonPreviewNoIframe = () => cy.get(STORY_ROOT).find('button');
+export const backgroundUILocatorNoIFrame = () => cy.get(BACKGROUND_UI_LOCATOR);
+export const closeIconButtonNoIFrame = () => cy.get(CLOSE_ICON_BUTTON);

--- a/cypress/support/helper.js
+++ b/cypress/support/helper.js
@@ -32,6 +32,17 @@ export function visitComponentUrlByThemeKnobsStory(component, theme, sufix = '',
   cy.visit(`${prepareUrl(component, 'knobs', true, prefix)}&theme=${theme}${sufix}`);
 }
 
+export function visitComponentUrlOneFewParameters(component, story, sufix = '', prefix = '', json = '', path = '', nameOfObject = '') {
+  cy.fixture(`${path}/${json}`).then(($json) => {
+    const el = $json[nameOfObject];
+    let url = '';
+    for (var prop in el) {
+        url += `&knob-${prop}=${el[prop]}`;
+    }
+    cy.visit(`${prepareUrl(component, story, true, prefix)}${url}`);
+  });
+}
+
 export function visitComponentUrlByThemeByStory(component, story, theme, sufix = '', prefix = '') {
   cy.visit(`${prepareUrl(component, story, true, prefix)}&theme=${theme}${sufix}`);
 }

--- a/cypress/support/helper.js
+++ b/cypress/support/helper.js
@@ -32,12 +32,12 @@ export function visitComponentUrlByThemeKnobsStory(component, theme, sufix = '',
   cy.visit(`${prepareUrl(component, 'knobs', true, prefix)}&theme=${theme}${sufix}`);
 }
 
-export function visitComponentUrlOneFewParameters(component, story, sufix = '', prefix = '', json = '', path = '', nameOfObject = '') {
+export function visitComponentUrlWithParameters(component, story, sufix = '', prefix = '', json = '', path = '', nameOfObject = '') {
   cy.fixture(`${path}/${json}`).then(($json) => {
     const el = $json[nameOfObject];
     let url = '';
     for (var prop in el) {
-        url += `&knob-${prop}=${el[prop]}`;
+        url += `&knob-${prop}=${encodeURIComponent(el[prop])}`;
     }
     cy.visit(`${prepareUrl(component, story, true, prefix)}${url}`);
   });

--- a/cypress/support/step-definitions/alert-steps.js
+++ b/cypress/support/step-definitions/alert-steps.js
@@ -1,34 +1,46 @@
-import { alertDialogPreview } from '../../locators/dialog';
+import {
+  alertDialogPreview,
+  alertChildrenNoIframe,
+  alertDialogPreviewNoIFrame,
+} from '../../locators/dialog';
 
 Then('Alert height is set to {string}', (height) => {
-  alertDialogPreview().should('have.attr', 'height').should('contain', `${height}`);
+  alertDialogPreviewNoIFrame().should('have.attr', 'height').should('contain', `${height}`);
 });
 
 Then('Alert height is not set to {string}', (height) => {
-  alertDialogPreview().should('have.attr', 'height')
+  alertDialogPreviewNoIFrame().should('have.attr', 'height')
     .and('not.contain', `${height}`);
 });
 
 Then('Alert size property on preview is {string}', (size) => {
-  alertDialogPreview().should('have.css', 'width', `${size}px`);
+  alertDialogPreviewNoIFrame().should('have.css', 'width', `${size}px`);
 });
 
 Then('Alert children on preview is {string}', (children) => {
-  alertDialogPreview().children().eq(1).should('have.text', children);
+  alertChildrenNoIframe().should('have.text', children);
 });
 
 Then('Alert is not visible', () => {
   alertDialogPreview().should('not.exist');
 });
 
+Then('Alert is not visible in NoIFrame', () => {
+  alertDialogPreviewNoIFrame().should('not.exist');
+});
+
 Then('Alert is visible', () => {
   alertDialogPreview().should('be.visible');
+});
+
+Then('Alert is visible in NoIFrame', () => {
+  alertDialogPreviewNoIFrame().should('be.visible');
 });
 
 Then('Alert is not visible', () => {
-  alertDialogPreview().should('not.exist');
+  alertDialogPreviewNoIFrame().should('not.exist');
 });
 
 Then('Alert is visible', () => {
-  alertDialogPreview().should('be.visible');
+  alertDialogPreviewNoIFrame().should('be.visible');
 });

--- a/cypress/support/step-definitions/badge-steps.js
+++ b/cypress/support/step-definitions/badge-steps.js
@@ -1,4 +1,8 @@
-import { badge, badgeCounter } from '../../locators/badge';
+import {
+  badge,
+  badgeCounterNoIFrame, 
+  badgeNoIFrame,
+} from '../../locators/badge';
 
 Then('Badge component rendered properly', () => {
   badge().should('have.css', 'padding', '0px')
@@ -18,16 +22,16 @@ Then('Badge component rendered properly', () => {
 });
 
 Then('Badge component counter is set to {int}', (value) => {
-  badgeCounter().invoke('show').should('be.visible').invoke('text')
+  badgeCounterNoIFrame().invoke('show').should('be.visible').invoke('text')
     .and('contain', value);
 });
 
 Then('Badge component counter does not exist', () => {
-  badge().should('not.exist');
+  badgeNoIFrame().should('not.exist');
 });
 
 When('I focus onto Badge component', () => {
-  badge().focus();
+  badgeNoIFrame().focus();
 });
 
 When('I click onto Badge component', () => {

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -2,7 +2,7 @@ import {
   visitComponentUrl, setSlidebar, pressESCKey, pressTABKey, asyncWaitForKnobs,
   visitFlatTableComponentNoiFrame, positionOfElement, keyCode,
   visitDocsUrl,
-  visitComponentUrlOneFewParameters,
+  visitComponentUrlWithParameters,
 } from '../helper';
 import {
   commonButtonPreview, labelPreview, helpIcon, helpIconByPosition, inputWidthSlider,
@@ -36,11 +36,11 @@ Given('I open design systems {word} {string} component in no iframe', (type, com
 });
 
 Given('I open Test {word} {string} component in noIFrame with {string} json from {string} using {string} object name', (type, component, json, path, nameOfObject) => {
-  visitComponentUrlOneFewParameters(component, type, true, 'test-', json, path, nameOfObject);
+  visitComponentUrlWithParameters(component, type, true, 'design-system-', json, path, nameOfObject);
 });
 
 Given('I open {word} {string} component in noIFrame with {string} json from {string} using {string} object name', (type, component, json, path, nameOfObject) => {
-  visitComponentUrlOneFewParameters(component, type, true, '', json, path, nameOfObject);
+  visitComponentUrlWithParameters(component, type, true, '', json, path, nameOfObject);
 });
 
 Given('I open {string} component page', (component) => {

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -2,6 +2,7 @@ import {
   visitComponentUrl, setSlidebar, pressESCKey, pressTABKey, asyncWaitForKnobs,
   visitFlatTableComponentNoiFrame, positionOfElement, keyCode,
   visitDocsUrl,
+  visitComponentUrlOneFewParameters,
 } from '../helper';
 import {
   commonButtonPreview, labelPreview, helpIcon, helpIconByPosition, inputWidthSlider,
@@ -13,8 +14,10 @@ import {
   commonButtonPreviewNoIFrameRoot,
   getDataElementByValue,
   getElementNoIframe, commonButtonPreviewNoIframe,
+  backgroundUILocatorNoIFrame,
+  closeIconButtonNoIFrame,
 } from '../../locators';
-import { dialogTitle } from '../../locators/dialog';
+import { dialogTitle, dialogTitleNoIFrame } from '../../locators/dialog';
 import { DEBUG_FLAG } from '..';
 import { pagerSummary } from '../../locators/pager';
 
@@ -30,6 +33,14 @@ Given('I open Design Systems {word} {string} component docs page', (type, compon
 
 Given('I open design systems {word} {string} component in no iframe', (type, component) => {
   visitComponentUrl(component, type, true, 'design-system-');
+});
+
+Given('I open Test {word} {string} component in noIFrame with {string} json from {string} using {string} object name', (type, component, json, path, nameOfObject) => {
+  visitComponentUrlOneFewParameters(component, type, true, 'test-', json, path, nameOfObject);
+});
+
+Given('I open {word} {string} component in noIFrame with {string} json from {string} using {string} object name', (type, component, json, path, nameOfObject) => {
+  visitComponentUrlOneFewParameters(component, type, true, '', json, path, nameOfObject);
 });
 
 Given('I open {string} component page', (component) => {
@@ -199,6 +210,10 @@ Then('component title on preview is {word}', (title) => {
   dialogTitle().should('have.text', title);
 });
 
+Then('component title on preview is {word} in NoIFrame', (title) => {
+  dialogTitleNoIFrame().should('have.text', title);
+});
+
 Then('label on preview is {word}', (text) => {
   labelPreview().should('have.text', text);
 });
@@ -277,12 +292,28 @@ Then('Background UI is disabled', () => {
   backgroundUILocator().should('exist');
 });
 
+Then('Background UI is enabled in NoIFrame', () => {
+  backgroundUILocatorNoIFrame().should('not.exist');
+});
+
+Then('Background UI is disabled in NoIFrame', () => {
+  backgroundUILocatorNoIFrame().should('exist');
+});
+
 Then('closeIcon is visible', () => {
   closeIconButton().should('be.visible');
 });
 
+Then('closeIcon is visible in NoIFrame', () => {
+  closeIconButtonNoIFrame().should('be.visible');
+});
+
 Then('I click closeIcon', () => {
   closeIconButton().click();
+});
+
+Then('I click closeIcon in NoIFrame', () => {
+  closeIconButtonNoIFrame().click();
 });
 
 When('I click {string} button into iFrame', (text) => {
@@ -295,6 +326,11 @@ Then('closeIcon is not visible', () => {
 
 Then('closeIcon has the border outline color {string} and width {string}', (color, width) => {
   closeIconButton().should('have.css', 'outline-color', color)
+    .and('have.css', 'outline-width', width);
+});
+
+Then('closeIcon has the border outline color {string} and width {string} in NoIFrame', (color, width) => {
+  closeIconButtonNoIFrame().should('have.css', 'outline-color', color)
     .and('have.css', 'outline-width', width);
 });
 

--- a/cypress/support/step-definitions/confirm-steps.js
+++ b/cypress/support/step-definitions/confirm-steps.js
@@ -1,10 +1,19 @@
 import {
-  dialogTitle, dialogPreview, closeIconButton,
-  dialogSubtitle, confirmButton, cancelButton,
+  dialogTitle,
+  dialogPreview,
+  closeIconButton,
+  dialogSubtitle,
+  confirmButton,
+  cancelButton,
+  dialogSubtitleNoIFrame,
 } from '../../locators/confirm';
 
 Then('component subtitle on preview is {word}', (subtitle) => {
   dialogSubtitle().should('have.text', subtitle);
+});
+
+Then('component subtitle on preview is {word} in NoIFrame', (subtitle) => {
+  dialogSubtitleNoIFrame().should('have.text', subtitle);
 });
 
 When('I click on a cancelButton', () => {


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Implemented new approach for passing `parameters` via `url`. This approach allows us:
- do not load components using `iFrame`
- not typing any characters in `Knobs`
- have already prepared `component` / `element` in proper `condition` / `state`
- only make an `assertion` using `cypress`
- decrease run time for tests: 
-- `Alert` previously took approx. `02:26` and now -> `00:54`;
-- `Badge` previously took approx. `01:00` and now -> `00:23`;

It is only the `POC` for new `approach` and I didn't do a major refactor for all components. Just made changes for 2 components to compare timing and discuss.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

Currently we are passing all `parameters` using `Knobs`. Storybook takes a lot of time to be fully loaded and sometimes cypress fails to pass all `params` properly, that's why `cypress` tests often take few minutes.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Screenshots are included in the PR
- [ ] Carbon implementation and Design System documentation are congruent
- [ ] All themes are supported
- [x] Commits follow our style guide
- [ ] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [ ] Storybook added or updated
- [ ] Typescript `d.ts` file added or updated