### PR TITLE
test: convert intermittently failing cypress test to be a chromatic test

### DIFF
--- a/cypress/features/regression/tableWithInputs.feature
+++ b/cypress/features/regression/tableWithInputs.feature
@@ -5,19 +5,6 @@ Feature: Table With Inputs component
     Given I open "Table" component page with inputs
 
   @positive
-  Scenario: I enable showPageSizeSelection
-    Given I check paginate checkbox
-    When I check showPageSizeSelection checkbox
-    Then pageSize is visible
-
-  @positive
-  Scenario: I disable showPageSizeSelection
-    Given I check paginate checkbox
-      And I check showPageSizeSelection checkbox
-    When I uncheck showPageSizeSelection checkbox
-    Then pageSize is not visible
-
-  @positive
   Scenario: I enable selectable
     When I check selectable checkbox
     Then rows are selectable

--- a/src/components/table/table.stories.js
+++ b/src/components/table/table.stories.js
@@ -19,9 +19,14 @@ TableWrapper.__docgenInfo = getDocGenInfo(
   /table\.component(?!spec)/
 );
 
-const commonKnobs = () => {
-  const paginate = boolean('paginate', false);
-  const showPageSizeSelection = paginate && boolean('showPageSizeSelection', false);
+const commonKnobs = (
+  {
+    paginate: defaultPaginate = false,
+    showPageSizeSelection: defaultShowPageSizeSelection = false
+  } = {}
+) => {
+  const paginate = boolean('paginate', defaultPaginate);
+  const showPageSizeSelection = paginate && boolean('showPageSizeSelection', defaultShowPageSizeSelection);
   const selectable = boolean('selectable', false);
   const highlightable = boolean('highlightable', false);
 
@@ -146,6 +151,40 @@ storiesOf('Table', module)
     () => {
       const tableProps = {
         ...commonKnobs(),
+        ...dlsKnobs(),
+        ...inputKnobs()
+      };
+
+      return (
+        <TableWrapper { ...tableProps } />
+      );
+    },
+    {
+      themeSelector: dlsThemeSelector
+    },
+  )
+  .add(
+    'default with inputs and paginate',
+    () => {
+      const tableProps = {
+        ...commonKnobs({ paginate: true }),
+        ...dlsKnobs(),
+        ...inputKnobs()
+      };
+
+      return (
+        <TableWrapper { ...tableProps } />
+      );
+    },
+    {
+      themeSelector: dlsThemeSelector
+    },
+  )
+  .add(
+    'default with inputs and paginate and page size',
+    () => {
+      const tableProps = {
+        ...commonKnobs({ paginate: true, showPageSizeSelection: true }),
         ...dlsKnobs(),
         ...inputKnobs()
       };


### PR DESCRIPTION
### Proposed behaviour
Add two new stories that show the configuration that the cypress test was setting with knobs. These will be screenshotted and added to chromatic where we will check for visual regressions.

### Current behaviour
The cypress tests fails intermittently, this is wasting a lot of CI minutes.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Commits follow our style guide
- [x] Cypress automation tests added or updated
- [x] Storybook added or updated

### Additional context
https://github.com/cypress-io/cypress/issues/7918
Fixes FE-2934

### Testing instructions
Ensure two new screenshots are added to chromatic.
