### PR TITLE
test(numeraldate,checkbox,dateinput,daterange): update tests with a new approach

### DIFF
--- a/cypress/features/regression/designSystem/numeralDate.feature
+++ b/cypress/features/regression/designSystem/numeralDate.feature
@@ -1,18 +1,17 @@
 Feature: Design System Numeral Date component
   I want to test Design System Numeral Date component
 
-  Background: Open Design System Numeral Date component page
-    Given I open Design Systems default_story "Numeral Date" component docs page
-
   @positive
   Scenario: Verify that Numeral Date input doesn't allow type numeral character in inputs
-    Given I click on first input
+    Given I open design systems default_story "Numeral Date" component in no iframe
+      And I click on first input
     When I type no numeral characters "date" in inputs
     Then inputs have value ""
 
   @positive
   Scenario Outline: Check that <position> inputs have a character limit
-    Given I click on first input
+    Given I open design systems default_story "Numeral Date" component in no iframe
+      And I click on first input
     When I type numeral characters "<string>" in "<position>" inputs
     Then "<position>" numeral input is set to "<result>"
     Examples:
@@ -20,3 +19,10 @@ Feature: Design System Numeral Date component
       | first    | 123    | 12     |
       | second   | 123    | 12     |
       | third    | 12345  | 1234   |
+
+  @positive
+  Scenario: Set Numeral Date component date format to <dateFormat>
+    When I open Test test_basic "Numeral Date" component in noIFrame with "numeralDate" json from "test" using "dateFormat" object name
+    Then Date format in "first" input is set to 13
+      And Date format in "second" input is set to 02
+      And Date format in "third" input is set to 1990

--- a/cypress/features/regression/experimental/checkbox.feature
+++ b/cypress/features/regression/experimental/checkbox.feature
@@ -1,88 +1,84 @@
 Feature: Experimental Checkbox component
-  I want to change Experimental Checkbox properties
-
-  Background: Open Experimental Checkbox component page
-    Given I open "Experimental Checkbox" component page
+  I want to check Experimental Checkbox properties
 
   @positive
   Scenario Outline: Change Checkbox component label to <label>
-    When I set label to <label> word
+    When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "<nameOfObject>" object name
     Then checkbox label on preview is <label>
     Examples:
-      | label                        |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | label                        | nameOfObject          |
+      | mp150ú¿¡üßä                  | labelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | labelSpecialCharacter |
 
   @positive
   Scenario: Disable and enable checkbox
-    Given I check disabled checkbox
-    When I uncheck disabled checkbox
+    When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "disabledFalse" object name
     Then Checkbox is enabled
 
   @positive
   Scenario: Disable checkbox
-    When I check disabled checkbox
+    When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "disabled" object name
     Then Checkbox is disabled
 
   @positive
   Scenario Outline: Change Checkbox component field help to <fieldHelp>
-    When I set fieldHelp to <fieldHelp> word
-    Then fieldHelp on preview is set to <fieldHelp>
+    When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "<nameOfObject>" object name
+    Then fieldHelp on preview is set to <fieldHelp> in NoIFrame
     Examples:
-      | fieldHelp                    |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | fieldHelp                    | nameOfObject              |
+      | mp150ú¿¡üßä                  | fieldHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | fieldHelpSpecialCharacter |
 
   @positive
   Scenario: Enable fieldHelpInline
-    When I check fieldHelpInline checkbox
+    When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "fieldHelpInlineDisabled" object name
     Then Checkbox is set to fieldHelpInline and has margin-left set to "16px"
 
   @positive
   Scenario: Enable and disable fieldHelpInline
-    Given I check fieldHelpInline checkbox
-    When I uncheck fieldHelpInline checkbox
-    Then Checkbox is not set to fieldHelpInline and has margin set to "0px 0px 0px 16px"
+    When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "fieldHelpInline" object name
+    Then Checkbox is not set to fieldHelpInline and has margin set to "0px"
 
   @positive
   Scenario: Enable reverse checkbox
-    When I check reverse checkbox
+    When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "reverse" object name
     Then Checkbox is set to reverse and has width "16px"
 
   @positive
   Scenario: Enable and disable reverse checkbox
-    # Given I open "Experimental Checkbox" component page
+    When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "reverseFalse" object name
     Then Checkbox is not set to reverse and has width "16px"
 
   @positive
   Scenario Outline: Change Checkbox component label help to <labelHelp>
-    When I set labelHelp to <labelHelp> word
-      And I hover mouse onto help icon
-    Then tooltipPreview on preview is set to <labelHelp>
+    When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "<nameOfObject>" object name
+      And I hover mouse onto help icon in noIFrame
+    Then tooltipPreview on preview is set to <labelHelp> in NoIFrame
     Examples:
-      | labelHelp                    |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | labelHelp                    | nameOfObject              |
+      | mp150ú¿¡üßä                  | labelHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | labelHelpSpecialCharacter |
 
   @positive
   Scenario Outline: Change Checkbox label align to <direction>
-    When I select labelAlign to "<direction>"
+    When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "<nameOfObject>" object name
     Then Checkbox labelAlign on preview is set to "<direction>"
     Examples:
-      | direction |
-      | left      |
-      | right     |
+      | direction | nameOfObject    |
+      | left      | labelAlignLeft  |
+      | right     | labelAlignRight |
 
   @positive
   Scenario Outline: Change Checkbox size to <size>
-    When I select size to "<size>"
+    When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "<nameOfObject>" object name
     Then Checkbox size on preview is set to "<size>"
     Examples:
-      | size  |
-      | small |
-      | large |
+      | size  | nameOfObject |
+      | small | smallSize    |
+      | large | largeSize    |
 
   @positive
   Scenario: Change Checkbox tick color
+    Given I open "Experimental Checkbox" component page
     When I mark checkbox on preview
     Then Checkbox tick has color "rgba(0, 0, 0, 0.9)"

--- a/cypress/features/regression/experimental/dateInput.feature
+++ b/cypress/features/regression/experimental/dateInput.feature
@@ -1,130 +1,110 @@
 Feature: Experimental Date Input component
-  I want to change Experimental Date Input component properties
-
-  Background: Open Experimental Date Input component page
-    Given I open "Experimental Date Input" component page
+  I want to check Experimental Date Input component properties
 
   @positive
   Scenario: Disable Date Input
-    When I disable DateInput component
+    When I open default "Experimental Date Input" component in noIFrame with "dateInput" json from "experimental" using "disabled" object name
     Then Date input is disabled
 
   @negative
   Scenario: Disable and enable Date Input
-    When I disable DateInput component
-      And I enable DateInput component
+    When I open default "Experimental Date Input" component in noIFrame with "dateInput" json from "experimental" using "disabledFalse" object name
     Then Date input is enabled
 
   @positive
   Scenario: Date Input component is readOnly
-    When I check readOnly checkbox
+    When I open default "Experimental Date Input" component in noIFrame with "dateInput" json from "experimental" using "readOnly" object name
     Then Date input component is readOnly
 
   @negative
   Scenario: Date Input component is not readOnly
-    When I check readOnly checkbox
-      And I uncheck readOnly checkbox
+    When I open default "Experimental Date Input" component in noIFrame with "dateInput" json from "experimental" using "readOnlyFalse" object name
     Then Date input component is not readOnly
 
   @positive
   Scenario Outline: Change DateInput component field help to <fieldHelp>
-    When I set fieldHelp to <fieldHelp> word
-    Then fieldHelp on preview is set to <fieldHelp>
+    When I open default "Experimental Date Input" component in noIFrame with "dateInput" json from "experimental" using "<nameOfObject>" object name
+    Then fieldHelp on preview is set to <fieldHelp> in NoIFrame
     Examples:
-      | fieldHelp               |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-  # @ignore because of FE-2782
-  # | &"'<>|
+      | fieldHelp               | nameOfObject              |
+      | mp150ú¿¡üßä             | fieldHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | fieldHelpSpecialCharacter |
 
   @positive
   Scenario Outline: Change DateInput label to <label>
-    When I set label to <label> word
-    Then label on preview is <label>
+    When I open default "Experimental Date Input" component in noIFrame with "dateInput" json from "experimental" using "<nameOfObject>" object name
+    Then label on preview is <label> in NoIFrame
     Examples:
-      | label                   |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-  # @ignore because of FE-2782
-  # | &"'<>|
+      | label                   | nameOfObject          |
+      | mp150ú¿¡üßä             | labelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | labelSpecialCharacter |
 
   @positive
   Scenario: Enable label inline checkbox for Date Input component
-    When I set label to "labelSample"
-      And I check labelInline checkbox
-    Then label is inline in IFrame
+    When I open default "Experimental Date Input" component in noIFrame with "dateInput" json from "experimental" using "labelInline" object name
+    Then label is inline
 
   @positive
   Scenario Outline: Change Date Input component label align to <labelAlign>
-    When I set label to "label"
-      And I set labelHelp to "label"
-      And I check labelInline checkbox
-      And I select labelAlign to "<labelAlign>"
-    Then label align on preview is set to "<labelAlign>" in IFrame
+    When I open default "Experimental Date Input" component in noIFrame with "dateInput" json from "experimental" using "<nameOfObject>" object name
+    Then label align on preview is set to "<labelAlign>"
     Examples:
-      | labelAlign |
-      | left       |
-      | right      |
+      | labelAlign | nameOfObject    |
+      | left       | labelAlignLeft  |
+      | right      | labelAlignRight |
 
   @positive
   Scenario Outline: Change Date Input component label width to <width>
-    When I set label to "label"
-      And I check labelInline checkbox
-      And I set label width slider to <width>
-    Then label width on preview is <width> in IFrame
+    When I open default "Experimental Date Input" component in noIFrame with "dateInput" json from "experimental" using "<nameOfObject>" object name
+    Then label width on preview is <width>
     Examples:
-      | width |
-      | 0     |
-      | 10    |
-      | 100   |
+      | width | nameOfObject  |
+      | 0     | labelWidth0   |
+      | 10    | labelWidth10  |
+      | 100   | labelWidth100 |
 
   @positive
   Scenario: Change Date Input component minDate
-    Given I set minDate to today
+    Given I open "Experimental Date Input" component page
+      And I set minDate to today
       And I set dateInput to today
     When I choose date yesterday via DayPicker
     Then the date before minDate is not available
 
   @positive
   Scenario: Change Date Input component maxDate
-    Given I set maxDate to today
+    Given I open "Experimental Date Input" component page
+      And I set maxDate to today
       And I set dateInput to today
     When I choose date tomorrow via DayPicker
     Then the date after maxDate is not available
 
   @positive
-  Scenario Outline: Change Date Input component label width with slider to <width>
-    When I set label to "Sample text"
-      And I check labelInline checkbox
-      And I set label width slider to <width>
-    Then label width on preview is <width> in IFrame
-    Examples:
-      | width |
-      | 0     |
-      | 10    |
-      | 100   |
-
-  @positive
   Scenario: Check Date Input today date
+    Given I open "Experimental Date Input" component page
     When I set dateInput to today
     Then the date is set to today
 
   @positive
   Scenario: Open dayPickerDay via click on input
+    Given I open "Experimental Date Input" component page
     When I click dateInput
     Then dayPickerDay is visible
 
   @positive
   Scenario: Close dayPickerDay via click on input
+    Given I open "Experimental Date Input" component page
     When I click dateInput twice
     Then dayPickerDay is not visible
 
   @positive
   Scenario: Open dayPickerDay via click on icon
+    Given I open "Experimental Date Input" component page
     When I click onto date icon
     Then dayPickerDay is visible
 
   @positive
   Scenario: Close dayPickerDay via click on icon
+    Given I open "Experimental Date Input" component page
     When I click onto date icon twice
     Then dayPickerDay is not visible

--- a/cypress/features/regression/experimental/dateRange.feature
+++ b/cypress/features/regression/experimental/dateRange.feature
@@ -1,42 +1,30 @@
 Feature: Date Range component
-  I want to change Date Range component properties
-
-  Background: Open Date Range component page
-    Given I open "Experimental Date Range" component page
+  I want to check Date Range component properties
 
   @positive
   Scenario Outline: Change Date Range start label to <label>
-    When I set startLabel to <label> word
+    When I open default "Experimental Date Range" component in noIFrame with "dateRange" json from "experimental" using "<nameOfObject>" object name
     Then startLabel on preview is <label>
     Examples:
-      | label                   |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-  # @ignore because of FE-2782
-  # | &"'<>|
+      | label                   | nameOfObject               |
+      | mp150ú¿¡üßä             | startLabelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | startLabelSpecialCharacter |
 
   @positive
   Scenario Outline: Change Date Range end label to <label>
-    When I set endLabel to <label> word
+    When I open default "Experimental Date Range" component in noIFrame with "dateRange" json from "experimental" using "<nameOfObject>" object name
     Then endLabel on preview is <label>
     Examples:
-      | label                   |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-  # @ignore because of FE-2782
-  # | &"'<>|
+      | label                   | nameOfObject             |
+      | mp150ú¿¡üßä             | endLabelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | endLabelSpecialCharacter |
 
   @positive
   Scenario: Enable labels inline checkbox
-    When I set startLabel to "label"
-      And I set endLabel to "label"
-      And I check labelsInline checkbox
+    When I open default "Experimental Date Range" component in noIFrame with "dateRange" json from "experimental" using "labelsInline" object name
     Then labels are set to inline
 
   @positive
   Scenario: Enable and disable labels inline checkbox
-    When I set startLabel to "label"
-      And I set endLabel to "label"
-      And I check labelsInline checkbox
-      And I uncheck labelsInline checkbox
+    When I open default "Experimental Date Range" component in noIFrame with "dateRange" json from "experimental" using "labelsInlineFalse" object name
     Then labels are not set to inline

--- a/cypress/fixtures/experimental/checkbox.json
+++ b/cypress/fixtures/experimental/checkbox.json
@@ -1,0 +1,50 @@
+{
+  "labelOtherLanguage": {
+    "label": "mp150ú¿¡üßä"
+  },
+  "labelSpecialCharacter": {
+    "label": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "disabledFalse": {
+    "disabled": false
+  },
+  "disabled": {
+    "disabled": true
+  },
+  "fieldHelpOtherLanguage": {
+    "fieldHelp": "mp150ú¿¡üßä"
+  },
+  "fieldHelpSpecialCharacter": {
+    "fieldHelp": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "fieldHelpInline": {
+    "fieldHelpInline": true
+  },
+  "fieldHelpInlineDisabled": {
+    "fieldHelpInline": false
+  },
+  "reverse": {
+    "reverse": true
+  },
+  "reverseFalse": {
+    "reverse": false
+  },
+  "labelHelpOtherLanguage": {
+    "labelHelp": "mp150ú¿¡üßä"
+  },
+  "labelHelpSpecialCharacter": {
+    "labelHelp": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "smallSize": {
+    "size": "small"
+  },
+  "largeSize": {
+    "size": "large"
+  },
+  "labelAlignLeft": {
+    "labelAlign": "left"
+  },
+  "labelAlignRight": {
+    "labelAlign": "right"
+  }
+}

--- a/cypress/fixtures/experimental/dateInput.json
+++ b/cypress/fixtures/experimental/dateInput.json
@@ -1,0 +1,57 @@
+{
+  "disabled": {
+    "disabled": true
+  },
+  "disabledFalse": {
+    "disabled": false
+  },
+  "readOnly": {
+    "readOnly": true
+  },
+  "readOnlyFalse": {
+    "readOnly": false
+  },
+  "fieldHelpOtherLanguage": {
+    "fieldHelp": "mp150ú¿¡üßä"
+  },
+  "fieldHelpSpecialCharacter": {
+    "fieldHelp": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "labelOtherLanguage": {
+    "label": "mp150ú¿¡üßä"
+  },
+  "labelSpecialCharacter": {
+    "label": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "labelInline": {
+    "label": "label",
+    "labelInline": true
+  },
+  "labelAlignLeft": {
+    "labelAlign": "left",
+    "label": "label",
+    "labelHelp": "labelHelp",
+    "labelInline": true
+  },
+  "labelAlignRight": {
+    "labelAlign": "right",
+    "label": "label",
+    "labelHelp": "labelHelp",
+    "labelInline": true
+  },
+  "labelWidth0": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 0
+  },
+  "labelWidth10": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 10
+  },
+  "labelWidth100": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 100
+  }
+}

--- a/cypress/fixtures/experimental/dateRange.json
+++ b/cypress/fixtures/experimental/dateRange.json
@@ -1,0 +1,24 @@
+{
+  "startLabelOtherLanguage": {
+    "startLabel": "mp150ú¿¡üßä"
+  },
+  "startLabelSpecialCharacter": {
+    "startLabel": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "endLabelOtherLanguage": {
+    "endLabel": "mp150ú¿¡üßä"
+  },
+  "endLabelSpecialCharacter": {
+    "endLabel": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "labelsInline": {
+    "startLabel": "label",
+    "endLabel": "label",
+    "labelsInline": true
+  },
+  "labelsInlineFalse": {
+    "startLabel": "label",
+    "endLabel": "label",
+    "labelsInline": false
+  }
+}

--- a/cypress/fixtures/test/numeralDate.json
+++ b/cypress/fixtures/test/numeralDate.json
@@ -1,0 +1,5 @@
+{ 
+  "dateFormat": {
+    "dateFormat": "13,02,1990"
+  }
+}

--- a/cypress/locators/checkbox/index.js
+++ b/cypress/locators/checkbox/index.js
@@ -16,3 +16,4 @@ export const checkboxRoleNoIFrame = () => cy.get(CHECKBOX);
 export const checkboxByID = element => cy.get(`[id="checkbox_${element}-help"]`);
 export const dataComponentGroup = () => cy.get(CHECKBOX_DATA_COMPONENT_GROUP);
 export const labelForIconInCheckboxGroup = () => dataComponentGroup().find(LABEL).find('div').eq(1);
+export const checkboxDataComponentNoIframe = () => cy.get(CHECKBOX_DATA_COMPONENT);

--- a/cypress/locators/date-input/index.js
+++ b/cypress/locators/date-input/index.js
@@ -11,6 +11,7 @@ export const maxDate = () => cy.get(MAX_DATE);
 
 // component preview locators
 export const dateInput = () => cy.iFrame(DATE_INPUT);
+export const dateInputNoIFrame = () => cy.get(DATE_INPUT).parent();
 export const dateIcon = () => cy.iFrame(DATE_ICON);
 export const dayPickerWrapper = () => cy.iFrame(DAY_PICKER_WRAPPER);
 export const dayPickerLeftArrow = () => cy.iFrame(DAY_PICKER_LEFT_ARROW);

--- a/cypress/locators/date-range/index.js
+++ b/cypress/locators/date-range/index.js
@@ -1,12 +1,8 @@
 import {
-  LABEL_PREVIEW, ERROR_ICON, ERROR_MESSAGE,
+  LABEL_PREVIEW,
 } from './locators';
 import { LABEL } from '../locators';
 
 // component preview locators
-export const labelPreview = index => cy.iFrame(LABEL_PREVIEW)
+export const labelPreview = index => cy.get(LABEL_PREVIEW)
   .find(`:nth-child(${index})`).find(LABEL);
-export const dateInput = (index, label) => cy.iFrame(LABEL_PREVIEW)
-  .find(`:nth-child(${index})`).find(`input[data-element="${label}-date"]`);
-export const errorIcon = () => cy.iFrame(ERROR_ICON);
-export const errorMessage = () => cy.iFrame(ERROR_MESSAGE);

--- a/cypress/locators/date-range/locators.js
+++ b/cypress/locators/date-range/locators.js
@@ -1,4 +1,2 @@
 // component preview locators
 export const LABEL_PREVIEW = 'div[data-component="date-range"]';
-export const ERROR_ICON = 'span[tooltiptype="error"][data-component="icon"][data-element="error"]';
-export const ERROR_MESSAGE = 'div[class="carbon-tooltip__container"]';

--- a/cypress/locators/index.js
+++ b/cypress/locators/index.js
@@ -62,3 +62,4 @@ export const commonButtonPreviewNoIframe = () => cy.get(STORY_ROOT).find('button
 export const backgroundUILocatorNoIFrame = () => cy.get(BACKGROUND_UI_LOCATOR);
 export const closeIconButtonNoIFrame = () => cy.get(CLOSE_ICON_BUTTON);
 export const fieldHelpPreviewNoIFrame = () => cy.get(FIELD_HELP_PREVIEW).first();
+export const helpIconNoIFrame = () => cy.get(HELP_ICON_PREVIEW).first();

--- a/cypress/locators/numeralDate/index.js
+++ b/cypress/locators/numeralDate/index.js
@@ -1,11 +1,6 @@
-import { NUMERAL_DATE_COMPONENT, NUMERAL_DATE_DEFAULT_ID } from './locators';
+import { NUMERAL_DATE_COMPONENT } from './locators';
 import { DATE_INPUT } from '../date-input/locators';
 
-export const numeralDateComponent = () => cy.iFrame(NUMERAL_DATE_COMPONENT);
+export const numeralDateComponent = () => cy.get(NUMERAL_DATE_COMPONENT);
 export const numeralDateInput = () => numeralDateComponent().find(DATE_INPUT);
 export const numeralDateInputByPosition = index => numeralDateInput().eq(index);
-
-// DS locators
-export const numeralDateDefaultDS = () => cy.iFrame(NUMERAL_DATE_DEFAULT_ID)
-  .find(NUMERAL_DATE_COMPONENT).find(DATE_INPUT);
-export const numeralDateInputByPositionDS = index => numeralDateDefaultDS().eq(index);

--- a/cypress/locators/numeralDate/locators.js
+++ b/cypress/locators/numeralDate/locators.js
@@ -1,4 +1,1 @@
 export const NUMERAL_DATE_COMPONENT = '[data-component="numeral-date"]';
-
-// DS locators
-export const NUMERAL_DATE_DEFAULT_ID = '[id="story--design-system-numeral-date--default-story"]';

--- a/cypress/support/step-definitions/checkbox-steps.js
+++ b/cypress/support/step-definitions/checkbox-steps.js
@@ -1,61 +1,48 @@
 import {
-  checkboxCommonInputField, checkboxLabelPreview,
-  checkbox, checkboxDataComponent, checkboxRole, checkboxByID, dataComponentGroup,
-  labelForIconInCheckboxGroup,
+  checkbox,
+  checkboxRole,
+  checkboxDataComponentNoIframe,
+  checkboxRoleNoIFrame,
 } from '../../locators/checkbox';
-import { label, fieldHelpPreview, getDataElementByValueNoIframe } from '../../locators';
-import { ICON } from '../../locators/locators';
+import { labelNoIFrame, fieldHelpPreviewNoIFrame } from '../../locators';
 import { positionOfElement } from '../helper';
 
 Then('Checkbox is set to fieldHelpInline and has margin-left set to {string}', (marginLeft) => {
-  fieldHelpPreview().should('have.css', 'margin-left', marginLeft)
+  fieldHelpPreviewNoIFrame().should('have.css', 'margin-left', marginLeft)
     .and('have.css', 'margin-top', '0px')
     .and('have.css', 'padding-left', '6px');
 });
 
 Then('Checkbox is not set to fieldHelpInline and has margin set to {string}', (margin) => {
-  fieldHelpPreview().should('have.css', 'margin', margin);
+  fieldHelpPreviewNoIFrame().should('have.css', 'margin', margin);
 });
 
 Then('Checkbox is set to reverse and has width {string}', (width) => {
-  checkboxDataComponent().children().children().children()
+  checkboxDataComponentNoIframe().children().children().children()
     .find(`div:nth-child(${positionOfElement('third')})`)
     .should('have.css', 'box-sizing', 'border-box')
     .and('have.css', 'width', width);
 });
 
 Then('Checkbox is not set to reverse and has width {string}', (width) => {
-  checkboxDataComponent().children().children().children()
+  checkboxDataComponentNoIframe().children().children().children()
     .find(`div:nth-child(${positionOfElement('second')})`)
     .should('have.css', 'box-sizing', 'border-box')
     .and('have.css', 'width', width);
 });
 
-Then('checkbox inputWidth is set to {int}', (width) => {
-  checkboxCommonInputField().should('have.attr', 'style')
-    .and('contain', `width: ${width}%`);
-});
-
-Then('Checkbox inputWidth is not set', () => {
-  checkboxCommonInputField().should('not.have.attr', 'style');
-});
-
 Then('Checkbox labelAlign on preview is set to {string}', (labelAlign) => {
-  label().should('have.css', 'text-align', labelAlign);
+  labelNoIFrame().should('have.css', 'text-align', labelAlign);
 });
 
 Then('Checkbox size on preview is set to {string}', (size) => {
   if (size === 'small') {
-    checkboxRole().should('have.css', 'width', '16px')
+    checkboxRoleNoIFrame().should('have.css', 'width', '16px')
       .and('have.css', 'height', '16px');
   } else {
-    checkboxRole().should('have.css', 'width', '24px')
+    checkboxRoleNoIFrame().should('have.css', 'width', '24px')
       .and('have.css', 'height', '24px');
   }
-});
-
-Then('Checkbox label width is not set', () => {
-  checkboxLabelPreview().should('not.have.attr', 'style');
 });
 
 Given('I check {string} checkbox', (position) => {
@@ -68,45 +55,23 @@ When('I check {string} checkbox {int} times', (position, times) => {
   }
 });
 
-When('I hover mouse onto {string} icon in no iFrame for checkbox', (position) => {
-  switch (position) {
-    case 'error':
-      checkboxByID('required').trigger('mouseover');
-      break;
-    case 'warning':
-    case 'info':
-    case 'optional':
-      checkboxByID(position).trigger('mouseover');
-      break;
-    default: throw new Error('There are only three icon elements on the page');
-  }
-});
-
-When('I hover mouse onto {word} icon in no iFrame for checkbox group', (position) => {
-  dataComponentGroup().find(ICON).eq(positionOfElement(position));
-});
-
-Then('label icon for checkbox group on preview in no iFrame is set to {string}', (text) => {
-  labelForIconInCheckboxGroup().should('have.attr', 'aria-label', text);
-});
-
 Then('checkbox label on preview is {word}', (text) => {
-  label().should('have.text', `${text} (default)`);
+  labelNoIFrame().should('have.text', `${text} (default)`);
 });
 
 Then('Checkbox is enabled', () => {
-  checkboxDataComponent().should('not.be.disabled')
+  checkboxDataComponentNoIframe().should('not.be.disabled')
     .and('not.have.attr', 'disabled');
-  checkboxDataComponent().children().should('not.be.disabled')
+  checkboxDataComponentNoIframe().children().should('not.be.disabled')
     .and('not.have.attr', 'disabled');
-  checkboxRole().should('not.be.disabled')
+  checkboxRoleNoIFrame().should('not.be.disabled')
     .and('not.have.attr', 'disabled');
 });
 
 Then('Checkbox is disabled', () => {
-  checkboxDataComponent().should('have.attr', 'disabled');
-  checkboxDataComponent().children().should('have.attr', 'disabled');
-  checkboxRole().should('have.attr', 'disabled');
+  checkboxDataComponentNoIframe().should('have.attr', 'disabled');
+  checkboxDataComponentNoIframe().children().should('have.attr', 'disabled');
+  checkboxRoleNoIFrame().should('have.attr', 'disabled');
 });
 
 When('I mark checkbox on preview', () => {

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -13,11 +13,12 @@ import {
   knobsNameTab, fieldHelpPreviewByPosition, labelByPosition, dlsRoot,
   commonButtonPreviewNoIFrameRoot,
   getDataElementByValue,
-  getElementNoIframe, commonButtonPreviewNoIframe,
+  commonButtonPreviewNoIframe,
   backgroundUILocatorNoIFrame,
   closeIconButtonNoIFrame,
   fieldHelpPreviewNoIFrame,
   commonDataElementInputPreviewNoIframe,
+  helpIconNoIFrame,
 } from '../../locators';
 import { dialogTitle, dialogTitleNoIFrame } from '../../locators/dialog';
 import { DEBUG_FLAG } from '..';
@@ -228,6 +229,10 @@ Then('label is set to {word}', (text) => {
   label().should('have.text', text);
 });
 
+When('I hover mouse onto help icon in noIFrame', () => {
+  helpIconNoIFrame().trigger('mouseover');
+});
+
 When('I hover mouse onto help icon', () => {
   helpIcon().trigger('mouseover');
 });
@@ -247,6 +252,10 @@ Then('I hover mouse onto {string} icon in no iFrame', (name) => {
 
 Then('I hover mouse onto {string} icon in iFrame', (name) => {
   getDataElementByValue(name).trigger('mouseover');
+});
+
+Then('tooltipPreview on preview is set to {word} in NoIFrame', (text) => {
+  tooltipPreviewNoIframe().should('have.text', text);
 });
 
 Then('tooltipPreview on preview is set to {word}', (text) => {

--- a/cypress/support/step-definitions/date-input-steps.js
+++ b/cypress/support/step-definitions/date-input-steps.js
@@ -1,6 +1,6 @@
 import {
   dateInput, dayPickerDay, minDate, maxDate,
-  dayPickerWrapper, dateIcon,
+  dayPickerWrapper, dateIcon, dateInputNoIFrame,
 } from '../../locators/date-input/index';
 
 const DAY_PICKER_PREFIX = 'DayPicker-Day--';
@@ -11,23 +11,19 @@ const TODAY_KNOBS = Cypress.moment().format('YYYY-MM-DD');
 const TODAY_DATE_INPUT = Cypress.moment().format('DD/MM/YYYY');
 
 Then('Date input is disabled', () => {
-  dateInput().parent()
-    .should('have.attr', 'disabled');
+  dateInputNoIFrame().should('have.attr', 'disabled');
 });
 
 Then('Date input is enabled', () => {
-  dateInput().parent()
-    .should('not.have.attr', 'disabled');
+  dateInputNoIFrame().should('not.have.attr', 'disabled');
 });
 
 Then('Date input component is readOnly', () => {
-  dateInput().parent()
-    .should('have.attr', 'readonly');
+  dateInputNoIFrame().should('have.attr', 'readonly');
 });
 
 Then('Date input component is not readOnly', () => {
-  dateInput().parent()
-    .should('not.have.attr', 'readonly');
+  dateInputNoIFrame().should('not.have.attr', 'readonly');
 });
 
 When('I set dateInput to today', () => {

--- a/cypress/support/step-definitions/date-range-steps.js
+++ b/cypress/support/step-definitions/date-range-steps.js
@@ -1,10 +1,8 @@
 import {
-  labelPreview, errorIcon, dateInput,
+  labelPreview,
 } from '../../locators/date-range/index';
 
 const TEXT_ALIGN = 'text-align';
-const START_LABEL = 'start';
-const END_LABEL = 'end';
 const START_LABEL_INDEX = 1;
 const END_LABEL_INDEX = 2;
 
@@ -24,24 +22,4 @@ Then('labels are set to inline', () => {
 Then('labels are not set to inline', () => {
   labelPreview(START_LABEL_INDEX).should('not.have.css', TEXT_ALIGN, 'left');
   labelPreview(END_LABEL_INDEX).should('not.have.css', TEXT_ALIGN, 'left');
-});
-
-Then('startMessage error on preview is {string}', (errorMessage) => {
-  errorMessage().should('have.text', errorMessage);
-});
-
-Then('endMessage error on preview is {string}', (errorMessage) => {
-  errorMessage().should('have.text', errorMessage);
-});
-
-When('I hover mouse onto error icon', () => {
-  errorIcon().trigger('mouseover');
-});
-
-When('I click into startDateInput', () => {
-  dateInput(START_LABEL_INDEX, START_LABEL).click();
-});
-
-When('I click into endDateInput', () => {
-  dateInput(END_LABEL_INDEX, END_LABEL).click();
 });

--- a/cypress/support/step-definitions/numeral-date-steps.js
+++ b/cypress/support/step-definitions/numeral-date-steps.js
@@ -1,54 +1,33 @@
-import { numeralDateInputByPosition, numeralDateComponent, numeralDateInputByPositionDS } from '../../locators/numeralDate';
-import { ERROR_TOOLTIP } from '../../locators/form/locators';
+import { numeralDateInputByPosition } from '../../locators/numeralDate';
 import { positionOfElement } from '../helper';
 
-Then('Number Date component has {int} separate inputs', (index) => {
-  for (let i = 0; i < index; ++i) {
-    numeralDateInputByPosition(i).should('be.visible');
-  }
-});
-
-Then('Numeral Date inputs have {string} border color', (color) => {
-  const allNumeralDate = 3;
-  for (let i = 0; i < allNumeralDate; ++i) {
-    numeralDateInputByPosition(i).parent().should('have.css', 'background-color', 'rgb(255, 255, 255)')
-      .and('have.css', 'border-bottom-color', color)
-      .and('have.css', 'border-left-color', color)
-      .and('have.css', 'border-right-color', color)
-      .and('have.css', 'border-top-color', color);
-  }
-});
-
-Then('error message for Numeral Date input is {word}', (text) => {
-  numeralDateInputByPosition(2).parent().find(ERROR_TOOLTIP).should('have.attr', 'aria-label', text)
-    .and('be.visible');
-});
-
-Then('error icon is visible in third input', () => {
-  numeralDateComponent().find(ERROR_TOOLTIP).should('be.visible');
-});
-
 Then('I click on first input', () => {
-  numeralDateInputByPositionDS(positionOfElement('first')).click();
+  numeralDateInputByPosition(positionOfElement('first')).click();
 });
 
 Then('I type numeral characters {string} in {string} inputs', (text, position) => {
-  numeralDateInputByPositionDS(positionOfElement(position)).clear().type(text);
-  numeralDateInputByPositionDS(positionOfElement(position)).parent().should('have.css', 'outline-color', 'rgb(255, 181, 0)');
+  numeralDateInputByPosition(positionOfElement(position)).clear().type(text);
+  numeralDateInputByPosition(positionOfElement(position)).parent().should('have.css', 'outline-color', 'rgb(255, 181, 0)');
 });
 
 Then('{string} numeral input is set to {string}', (position, text) => {
-  numeralDateInputByPositionDS(positionOfElement(position)).should('have.value', text);
+  numeralDateInputByPosition(positionOfElement(position)).should('have.value', text);
 });
 
 Then('I type no numeral characters {string} in inputs', (text) => {
-  numeralDateInputByPositionDS(positionOfElement('first')).clear().type(text);
-  numeralDateInputByPositionDS(positionOfElement('second')).clear().type(text);
-  numeralDateInputByPositionDS(positionOfElement('third')).clear().type(text);
+  numeralDateInputByPosition(positionOfElement('first')).clear().type(text);
+  numeralDateInputByPosition(positionOfElement('second')).clear().type(text);
+  numeralDateInputByPosition(positionOfElement('third')).clear().type(text);
 });
 
 Then('inputs have value {string}', (text) => {
-  numeralDateInputByPositionDS(positionOfElement('first')).should('have.value', text);
-  numeralDateInputByPositionDS(positionOfElement('second')).should('have.value', text);
-  numeralDateInputByPositionDS(positionOfElement('third')).should('have.value', text);
+  numeralDateInputByPosition(positionOfElement('first')).should('have.value', text);
+  numeralDateInputByPosition(positionOfElement('second')).should('have.value', text);
+  numeralDateInputByPosition(positionOfElement('third')).should('have.value', text);
+});
+
+Then('Date format in {string} input is set to {word}', (position, text) => {
+  numeralDateInputByPosition(positionOfElement(position)).should('have.attr', 'placeholder', text);
+  numeralDateInputByPosition(positionOfElement(position)).should('have.attr', 'placeholder', text);
+  numeralDateInputByPosition(positionOfElement(position)).should('have.attr', 'placeholder', text);
 });


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Apply new `url` approach in tests for:
`Design System:`
- Numeral Date (`timing`: was `1:42` -> `00:30`).

`Experimental:`
- Checkbox (`timing`: was `3:19` -> `1:05`).
- Date Input (`timing`: was `5:26` -> `2:01`).
- Date Range (`timing`: was `1:13` -> `00:30`).

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are passing all parameters via `knobs`. 

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Screenshots are included in the PR
- [ ] Carbon implementation and Design System documentation are congruent
- [ ] All themes are supported
- [x] Commits follow our style guide
- [ ] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [ ] Storybook added or updated
- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
