### PR TITLE
test(textarea): update with new approach

### DIFF
--- a/cypress/features/regression/experimental/textarea.feature
+++ b/cypress/features/regression/experimental/textarea.feature
@@ -1,243 +1,225 @@
 Feature: Experimental Textarea component
-  I want to change Experimental Textarea component properties
-
-  Background: Open Experimental Textarea component page
-    Given I open "Experimental Textarea" component page
+  I want to check Experimental Textarea component properties
 
   @positive
-  Scenario: Enable expandable checkbox for a Textarea component
-    When I check expandable checkbox
+  Scenario Outline: Enable expandable checkbox for a Textarea component
+    Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "expandableEnabled" object name
+    When I input <text> into Textarea
     Then Textarea component is expandable
+    Examples:
+      | text                         |
+      | {enter}{enter}{enter}{enter} |
 
   @positive
-  Scenario: Enable and disable expandable checkbox for a Textarea component
-    Given I check expandable checkbox
-    When I uncheck expandable checkbox
+  Scenario Outline: Enable and disable expandable checkbox for a Textarea component
+    Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "expandableDisabled" object name
+    When I input <text> into Textarea
     Then Textarea component is not expandable
-
-  @positive
-  Scenario Outline: Set cols to <cols>
-    When I set cols slider to <cols>
-    Then cols is set to "<cols>"
     Examples:
-      | cols |
-      | 1    |
-      | 100  |
-      | 300  |
+      | text                         |
+      | {enter}{enter}{enter}{enter} |
 
-  @positive
-  Scenario Outline: Set rows to <rows>
-    When I set rows slider to <rows>
-    Then rows is set to "<rows>"
-    Examples:
-      | rows |
-      | 1    |
-      | 100  |
-      | 300  |
+@positive
+Scenario Outline: Set cols to <cols>
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+  Then cols is set to "<cols>"
+  Examples:
+    | cols | nameOfObject |
+    | 1    | cols1        |
+    | 100  | cols100      |
+    | 300  | cols300      |
 
-  @positive
-  Scenario: Check disabled checkbox for a Textarea component
-    When I check disabled checkbox
-    Then Textarea component is disabled
+@positive
+Scenario Outline: Set rows to <rows>
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+  Then rows is set to "<rows>"
+  Examples:
+    | rows | nameOfObject |
+    | 1    | rows1        |
+    | 100  | rows100      |
+    | 300  | rows300      |
 
-  @positive
-  Scenario: Uncheck disabled checkbox for a Textarea component
-    Given I check disabled checkbox
-    When I uncheck disabled checkbox
-    Then Textarea component is not disabled
+@positive
+Scenario: Check disabled checkbox for a Textarea component
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "disabled" object name
+  Then Textarea component is disabled
 
-  @positive
-  Scenario: Enable readOnly checkbox for a Textarea component
-    When I check readOnly checkbox
-    Then Textarea component is readOnly
+@positive
+Scenario: Uncheck disabled checkbox for a Textarea component
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "disabledFalse" object name
+  Then Textarea component is not disabled
 
-  @positive
-  Scenario: Disable readOnly checkbox for a Textarea component
-    Given I check readOnly checkbox
-    When I uncheck readOnly checkbox
-    Then Textarea component is not readOnly
+@positive
+Scenario: Enable readOnly checkbox for a Textarea component
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "readOnly" object name
+  Then Textarea component is readOnly
 
-  @positive
-  Scenario Outline: Set placeholder to <placeholder>
-    When I set placeholder to <placeholder> word
-    Then placeholder is set to <placeholder>
-    Examples:
-      | placeholder             |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-  # @ignore because of FE-2782
-  # | &"'<>|
+@positive
+Scenario: Disable readOnly checkbox for a Textarea component
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "readOnlyFalse" object name
+  Then Textarea component is not readOnly
 
-  @positive
-  Scenario Outline: Set fieldHelp to <fieldHelp>
-    When I set fieldHelp to <fieldHelp> word
-    Then fieldHelp is set to <fieldHelp>
-    Examples:
-      | fieldHelp               |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-  # @ignore because of FE-2782
-  # | &"'<>|
+@positive
+Scenario Outline: Set placeholder to <placeholder>
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+  Then placeholder is set to <placeholder>
+  Examples:
+    | placeholder             | nameOfObject                |
+    | mp150ú¿¡üßä             | placeholderOtherLanguage    |
+    | !@#$%^*()_+-=~[];:.,?{} | placeholderSpecialCharacter |
+# @ignore because of FE-2782
+# | &"'<>|
 
-  @positive
-  Scenario Outline: Set characterLimit to <characterLimit>
-    When I set characterLimit to "<characterLimit>"
-    Then characterLimit is set to "<characterLimit>"
-      And characterLimit for default Textarea is shown as "<result>"
-    Examples:
-      | characterLimit | result  |
-      | -1000          | -1,000  |
-      | -1             | -1      |
-      | 0              | 0       |
-      | 1              | 1       |
-      | 100            | 100     |
-      | 1000           | 1,000   |
-      | 555555         | 555,555 |
+@positive
+Scenario Outline: Set fieldHelp to <fieldHelp>
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+  Then fieldHelp is set to <fieldHelp>
+  Examples:
+    | fieldHelp               | nameOfObject              |
+    | mp150ú¿¡üßä             | fieldHelpOtherLanguage    |
+    | !@#$%^*()_+-=~[];:.,?{} | fieldHelpSpecialCharacter |
+# @ignore because of FE-2782
+# | &"'<>|
 
-  @negative
-  Scenario Outline: Set characterLimit out of scope to <characterLimit>
-    When I set characterLimit to <characterLimit> word
-    Then characterLimit for default Textarea is not set to <characterLimit>
-    Examples:
-      | characterLimit          |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-      | -0,112                  |
-      | 0.1112333               |
-  # @ignore because of FE-2782
-  # | &"'<>|
+@positive
+Scenario Outline: Set characterLimit to <characterLimit>
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+  Then characterLimit is set to "<characterLimit>"
+    And characterLimit for default Textarea is shown as "<result>"
+  Examples:
+    | characterLimit | result  | nameOfObject         |
+    | -1000          | -1,000  | characterLimit-1000  |
+    | -1             | -1      | characterLimit-1     |
+    | 0              | 0       | characterLimit0      |
+    | 1              | 1       | characterLimit1      |
+    | 100            | 100     | characterLimit100    |
+    | 1000           | 1,000   | characterLimit1000   |
+    | 555555         | 555,555 | characterLimit555555 |
 
-  @positive
-  Scenario Outline: Set inputWidth to <inputWidth>
-    When I set inputWidth slider to <inputWidth>
-    Then Textarea inputWidth is set to "<inputWidth>"
-    Examples:
-      | inputWidth |
-      | 0          |
-      | 50         |
-      | 100        |
+@negative
+Scenario Outline: Set characterLimit out of scope to <characterLimit>
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+  Then characterLimit for default Textarea is not set to <characterLimit>
+  Examples:
+    | characterLimit          | nameOfObject                   |
+    | mp150ú¿¡üßä             | characterLimitOtherLanguage    |
+    | !@#$%^*()_+-=~[];:.,?{} | characterLimitSpecialCharacter |
+    | -0,112                  | characterLimit-0,112           |
+    | 0.1112333               | characterLimit0.1112333        |
+# @ignore because of FE-2782
+# | &"'<>|
 
-  @positive
-  Scenario Outline: Set label to <label>
-    When I set label to <label> word
-    Then label is set to <label>
-    Examples:
-      | label                   |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-  # @ignore because of FE-2782
-  # | &"'<>|
+@positive
+Scenario Outline: Set inputWidth to <inputWidth>
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+  Then Textarea inputWidth is set to "<inputWidth>"
+  Examples:
+    | inputWidth | nameOfObject  |
+    | 0          | inputWidth0   |
+    | 50         | inputWidth50  |
+    | 100        | inputWidth100 |
 
-  @positive
-  Scenario Outline: Set labelHelp to <labelHelp>
-    When I set label to "label"
-      And I set labelHelp to <labelHelp> word
-      And I hover mouse onto help icon
-    Then tooltipPreview on preview is set to <labelHelp>
-    Examples:
-      | labelHelp               |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-  # @ignore because of FE-2782
-  # | &"'<>|
+@positive
+Scenario Outline: Set label to <label>
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+  Then label on preview is <label> in NoIFrame
+  Examples:
+    | label                   | nameOfObject          |
+    | mp150ú¿¡üßä             | labelOtherLanguage    |
+    | !@#$%^*()_+-=~[];:.,?{} | labelSpecialCharacter |
+# @ignore because of FE-2782
+# | &"'<>|
 
-  @positive
-  Scenario: Enable labelInline checkbox for a Textarea component
-    Given I set label to "label"
-    When I check labelInline checkbox
-    Then Textarea component is labelInline
+@positive
+Scenario Outline: Set labelHelp to <labelHelp>
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    And I hover mouse onto "question" icon in no iFrame
+  Then tooltipPreview on preview into iFrame is set to <labelHelp>
+  Examples:
+    | labelHelp               | nameOfObject              |
+    | mp150ú¿¡üßä             | labelHelpOtherLanguage    |
+    | !@#$%^*()_+-=~[];:.,?{} | labelHelpSpecialCharacter |
+# @ignore because of FE-2782
+# | &"'<>|
 
-  @positive
-  Scenario: Enable and disable labelInline checkbox for a Textarea component
-    When I set label to "label"
-      And I check labelInline checkbox
-      And I uncheck labelInline checkbox
-    Then Textarea component is not labelInline
+@positive
+Scenario: Enable labelInline checkbox for a Textarea component
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "labelInline" object name
+  Then Textarea component is labelInline
 
-  @positive
-  Scenario Outline: Set labelWidth to <labelWidth>
-    When I set label to "label"
-      And I check labelInline checkbox
-      And I set label width slider to <labelWidth>
-    Then label width is set to "<labelWidth>"
-    Examples:
-      | labelWidth |
-      | 0          |
-      | 25         |
-      | 100        |
+@positive
+Scenario: Enable and disable labelInline checkbox for a Textarea component
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "labelInlineFalse" object name
+  Then Textarea component is not labelInline
 
-  @positive
-  Scenario Outline: Set labelAlign to <labelAlign>
-    Given I set label to "label"
-      And I check labelInline checkbox
-    When I select labelAlign to "<labelAlign>"
-    Then label Align on preview is "<labelAlign>"
-    Examples:
-      | labelAlign |
-      | left       |
-      | right      |
+@positive
+Scenario Outline: Set labelWidth to <labelWidth>
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+  Then label width is set to "<labelWidth>" in NoIFrame
+  Examples:
+    | labelWidth | nameOfObject  |
+    | 0          | labelWidth0   |
+    | 25         | labelWidth25  |
+    | 100        | labelWidth100 |
 
-  #double checking / unchecking warnOverLimit/enforceCharacterLimit should be fixed in FE-1778 and should be deleted
-  @positive
-  Scenario Outline: Enable warnOverLimit checkbox for a Textarea component and check the warning
-    When I set characterLimit to "<limit>"
-      And I check warnOverLimit checkbox
-      And I check enforceCharacterLimit checkbox
-      And I uncheck enforceCharacterLimit checkbox
-      And I input <text> into Textarea
-    Then Textarea component has warnOverLimit and used characters <characters> of <limit>
-    Examples:
-      | limit | text             | characters |
-      | 0     | 12345            | 5          |
-      | 5     | áéíóú¿¡üñ        | 9          |
-      | 10    | testTestTextTest | 16         |
+@positive
+Scenario Outline: Set labelAlign to <labelAlign>
+  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+  Then label Align on preview is "<labelAlign>" in NoIFrame
+  Examples:
+    | labelAlign | nameOfObject    |
+    | left       | labelAlignLeft  |
+    | right      | labelAlignRight |
 
-  #double checking / unchecking warnOverLimit/enforceCharacterLimit should be fixed in FE-1778 and should be deleted
-  @positive
-  Scenario Outline: Disable warnOverLimit checkbox for a Textarea component and allow to input more characters than allowed
-    When I set characterLimit to "<limit>"
-      And I check warnOverLimit checkbox
-      And I uncheck warnOverLimit checkbox
-      And I check enforceCharacterLimit checkbox
-      And I uncheck enforceCharacterLimit checkbox
-      And I input <text> into Textarea
-    Then Textarea component has no warnOverLimit and used characters <characters> of <limit>
-    Examples:
-      | limit | text        | characters |
-      | 0     | !!          | 2          |
-      | 3     | 123456      | 6          |
-      | 5     | áéíóú¿¡üñą | 10         |
+@positive
+Scenario Outline: Enable warnOverLimit checkbox for a Textarea component and check the warning
+  Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+  When I input <text> into Textarea
+  Then Textarea component has warnOverLimit and used characters <characters> of <limit>
+  Examples:
+    | limit | text             | characters | nameOfObject                                            |
+    | 0     | 12345            | 5          | characterLimit0warnOverLimitenforceCharacterLimitFalse  |
+    | 5     | áéíóú¿¡üñ        | 9          | characterLimit5warnOverLimitenforceCharacterLimitFalse  |
+    | 10    | testTestTextTest | 16         | characterLimit10warnOverLimitenforceCharacterLimitFalse |
+
+@positive
+Scenario Outline: Disable warnOverLimit checkbox for a Textarea component and allow to input more characters than allowed
+  Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+  When I input <text> into Textarea
+  Then Textarea component has no warnOverLimit and used characters <characters> of <limit>
+  Examples:
+    | limit | text        | characters | nameOfObject                      |
+    | 0     | !!          | 2          | characterLimit0warnOverLimitFalse |
+    | 3     | 123456      | 6          | characterLimit3warnOverLimitFalse |
+    | 5     | áéíóú¿¡üñą  | 10         | characterLimit5warnOverLimitFalse |
 
   @positive
   Scenario Outline: Enable enforceCharacterLimit checkbox for a Textarea component and check the warning
-    Given I set characterLimit to "<limit>"
+    Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
     When I input <text> into Textarea
     Then Textarea component has enforceCharacterLimit enabled and used characters <characters> are equal to limit <limit>
     Examples:
-      | limit | text      | characters |
-      | -1    | ?         | 1          |
-      | 2     | !!!       | 2          |
-      | 5     | testText  | 5          |
-      | 7     | áéíóú¿¡üñ | 7          |
+      | limit | text      | characters | nameOfObject                          |
+      | -1    | ?         | 1          | characterLimit-1enforceCharacterLimit |
+      | 2     | !!!       | 2          | characterLimit2enforceCharacterLimit  |
+      | 5     | testText  | 5          | characterLimit5enforceCharacterLimit  |
+      | 7     | áéíóú¿¡üñ | 7          | characterLimit7enforceCharacterLimit  |
 
-
-  #double checking / unchecking warnOverLimit/enforceCharacterLimit should be fixed in FE-1778 and should be deleted
   @positive
   Scenario Outline: Disable enforceCharacterLimit checkbox for a Textarea component and allow to input more characters than allowed
-    When I set characterLimit to "<limit>"
-      And I check enforceCharacterLimit checkbox
-      And I uncheck enforceCharacterLimit checkbox
-      And I input <text> into Textarea
+    Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    When I input <text> into Textarea
     Then Textarea component has enforceCharacterLimit disabled and used characters <characters> are more than limit <limit>
     Examples:
-      | limit | text      | characters |
-      | -1    | testText  | 8          |
-      | 0     | !         | 1          |
-      | 3     | 12345     | 5          |
-      | 5     | áéíóú¿¡üñ | 9          |
+      | limit | text      | characters | nameOfObject                               |
+      | -1    | testText  | 8          | characterLimit-1enforceCharacterLimitFalse |
+      | 0     | !         | 1          | characterLimit0enforceCharacterLimitFalse  |
+      | 3     | 12345     | 5          | characterLimit3enforceCharacterLimitFalse  |
+      | 5     | áéíóú¿¡üñ | 9          | characterLimit5enforceCharacterLimitFalse  |
 
   @positive
   Scenario Outline: Verify input of Textarea component
+    Given I open "Experimental Textarea" component page in noIFrame
     When I input <input> into Textarea
     Then Textarea input on preview is set to <input>
     Examples:

--- a/cypress/features/regression/experimental/textarea.feature
+++ b/cypress/features/regression/experimental/textarea.feature
@@ -3,7 +3,7 @@ Feature: Experimental Textarea component
 
   @positive
   Scenario Outline: Enable expandable checkbox for a Textarea component
-    Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "expandableEnabled" object name
+    Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "expandable" object name
     When I input <text> into Textarea
     Then Textarea component is expandable
     Examples:
@@ -12,7 +12,7 @@ Feature: Experimental Textarea component
 
   @positive
   Scenario Outline: Enable and disable expandable checkbox for a Textarea component
-    Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "expandableDisabled" object name
+    Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "expandableFalse" object name
     When I input <text> into Textarea
     Then Textarea component is not expandable
     Examples:

--- a/cypress/features/regression/experimental/textbox.feature
+++ b/cypress/features/regression/experimental/textbox.feature
@@ -1,119 +1,105 @@
 Feature: Experimental Textbox component
-  I want to change Experimental Textbox component properties
-
-  Background: Open Experimental Textbox component page
-    Given I open "Experimental Textbox" component page
+  I want to check Experimental Textbox component properties
 
   @positive
   Scenario Outline: Set placeholder to <placeholder>
-    When I set placeholder to <placeholder> word
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
     Then Textbox placeholder is set to <placeholder>
     Examples:
-      | placeholder                  |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | placeholder                  | nameOfObject                |
+      | mp150ú¿¡üßä                  | placeholderOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | placeholderSpecialCharacter |
 
   @positive
   Scenario: Check disabled checkbox for a Textbox component
-    When I check disabled checkbox
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "disabled" object name
     Then Textbox component is disabled
 
   @positive
   Scenario: Uncheck disabled checkbox for a Textbox component
-    When I check disabled checkbox
-      And I uncheck disabled checkbox
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "disabledFalse" object name
     Then Textbox component is not disabled
 
   @positive
   Scenario: Enable readOnly checkbox for a Textbox component
-    When I check readOnly checkbox
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "readOnly" object name
     Then Textbox component is readOnly
 
   @positive
   Scenario: Disable readOnly checkbox for a Textbox component
-    When I check readOnly checkbox
-      And I uncheck readOnly checkbox
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "readOnlyFalse" object name
     Then Textbox component is not readOnly
 
   @positive
   Scenario Outline: Set fieldHelp to <fieldHelp>
-    When I set fieldHelp to <fieldHelp> word
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
     Then fieldHelp is set to <fieldHelp>
     Examples:
-      | fieldHelp                    |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | fieldHelp                    | nameOfObject              |
+      | mp150ú¿¡üßä                  | fieldHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | fieldHelpSpecialCharacter |
 
   @positive
   Scenario Outline: Set label to <label>
-    When I set label to <label> word
-    Then label is set to <label>
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
+    Then label on preview is <label> in NoIFrame
     Examples:
-      | label                        |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | label                        | nameOfObject          |
+      | mp150ú¿¡üßä                  | labelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | labelSpecialCharacter |
 
   @positive
   Scenario Outline: Set labelHelp to <labelHelp>
-    When I set label to "label"
-      And I set labelHelp to <labelHelp> word
-      And I hover mouse onto help icon
-    Then tooltipPreview on preview is set to <labelHelp>
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
+      And I hover mouse onto "question" icon in no iFrame
+    Then tooltipPreview on preview into iFrame is set to <labelHelp>
     Examples:
-      | labelHelp                    |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | labelHelp                    | nameOfObject              |
+      | mp150ú¿¡üßä                  | labelHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | labelHelpSpecialCharacter |
 
   @positive
   Scenario: Enable labelInline checkbox for a Textbox component
-    When I set label to "label"
-      And I check labelInline checkbox
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "labelInline" object name
     Then Textbox component is labelInline
 
   @positive
   Scenario: Enable and disable labelInline checkbox for a Textbox component
-    When I set label to "label"
-      And I check labelInline checkbox
-      And I uncheck labelInline checkbox
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "labelInlineFalse" object name
     Then Textbox component is not labelInline
 
   @positive
   Scenario Outline: Set labelWidth to <labelWidth>
-    When I set label to "label"
-      And I check labelInline checkbox
-      And I set label width slider to <labelWidth>
-    Then label width is set to "<labelWidth>"
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
+    Then label width is set to "<labelWidth>" in NoIFrame
     Examples:
-      | labelWidth |
-      | 0          |
-      | 25         |
-      | 100        |
+      | labelWidth | nameOfObject  |
+      | 0          | labelWidth0   |
+      | 25         | labelWidth25  |
+      | 100        | labelWidth100 |
 
   @positive
   Scenario Outline: Set inputWidth to <inputWidth>
-    When I set label to "label"
-      And I check labelInline checkbox
-      And I set inputWidth slider to <inputWidth>
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
     Then Textbox inputWidth is set to "<inputWidth>"
     Examples:
-      | inputWidth |
-      | 0          |
-      | 50         |
-      | 100        |
+      | inputWidth | nameOfObject  |
+      | 0          | inputWidth0   |
+      | 50         | inputWidth50  |
+      | 100        | inputWidth100 |
 
   @positive
   Scenario Outline: Set labelAlign to <labelAlign>
-    When I set label to "label"
-      And I check labelInline checkbox
-      And I select labelAlign to "<labelAlign>"
-    Then label Align on preview is "<labelAlign>"
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
+    Then label Align on preview is "<labelAlign>" in NoIFrame
     Examples:
-      | labelAlign |
-      | left       |
-      | right      |
+      | labelAlign | nameOfObject    |
+      | left       | labelAlignLeft  |
+      | right      | labelAlignRight |
 
   @positive
   Scenario Outline: Verify input of Textbox component
+    Given I open "Experimental Textbox" component page in noIFrame
     When I type <input> into Textbox
     Then Textbox input on preview is set to <input>
     Examples:
@@ -123,30 +109,16 @@ Feature: Experimental Textbox component
 
   @positive
   Scenario Outline: Set label size to <size>
-    When I select size to "<size>"
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
     Then Textbox height is "<height>"
       And Textbox width is "<width>"
     Examples:
-      | size   | height | width  |
-      | small  | 28px   | 1043px |
-      | medium | 36px   | 1037px |
-      | large  | 44px   | 1033px |
+      | size   | height | width  | nameOfObject |
+      | small  | 28px   | 1043px | sizeSmall    |
+      | medium | 36px   | 1037px | sizeMedium   |
+      | large  | 44px   | 1033px | sizeLarge    |
 
   @positive
   Scenario: Check icon inside of Textbox is visible
-    When I select inputIcon to "add"
-    Then icon on preview is "add" and is visible
-
-  @positive
-  Scenario: Check iconOnClick event
-    Given I select inputIcon to "add"
-      And clear all actions in Actions Tab
-    When I click on icon inside of Textbox
-    Then iconOnClick action was called in Actions Tab
-
-  @positive
-  Scenario: Check onClick event
-    Given clear all actions in Actions Tab
-    When I click on Textbox
-    Then onClick action was called in Actions Tab
-      And Textbox input has golden border on focus
+    When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "inputIconAdd" object name
+    Then icon name into iFrame on preview is "add"

--- a/cypress/features/regression/experimental/textbox.feature
+++ b/cypress/features/regression/experimental/textbox.feature
@@ -114,9 +114,9 @@ Feature: Experimental Textbox component
       And Textbox width is "<width>"
     Examples:
       | size   | height | width  | nameOfObject |
-      | small  | 28px   | 1043px | sizeSmall    |
-      | medium | 36px   | 1037px | sizeMedium   |
-      | large  | 44px   | 1033px | sizeLarge    |
+      | small  | 28px   | 1263px | sizeSmall    |
+      | medium | 36px   | 1257px | sizeMedium   |
+      | large  | 44px   | 1253px | sizeLarge    |
 
   @positive
   Scenario: Check icon inside of Textbox is visible

--- a/cypress/features/regression/experimental/textboxActions.feature
+++ b/cypress/features/regression/experimental/textboxActions.feature
@@ -1,0 +1,19 @@
+Feature: Experimental Textbox component - actions
+  I want to change Experimental Textbox component actions
+
+  Background: Open Experimental Textbox component page
+    Given I open "Experimental Textbox" component page
+
+  @positive
+  Scenario: Check iconOnClick event
+    Given I select inputIcon to "add"
+      And clear all actions in Actions Tab
+    When I click on icon inside of Textbox
+    Then iconOnClick action was called in Actions Tab
+
+  @positive
+  Scenario: Check onClick event
+    Given clear all actions in Actions Tab
+    When I click on Textbox
+    Then onClick action was called in Actions Tab
+      And Textbox input has golden border on focus

--- a/cypress/features/regression/experimental/textboxMultiple.feature
+++ b/cypress/features/regression/experimental/textboxMultiple.feature
@@ -1,120 +1,106 @@
 Feature: Experimental Textbox multiple component
-  I want to change Experimental Textbox multiple component properties
-
-  Background: Open Experimental Textbox multiple component page
-    Given I open "Experimental Textbox" component page multiple
+  I want to check Experimental Textbox multiple component properties
 
   @positive
   Scenario Outline: Set placeholder to <placeholder>
-    When I set placeholder to <placeholder> word
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
     Then Multiple Textbox placeholder is set to <placeholder>
     Examples:
-      | placeholder                  |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | placeholder                  | nameOfObject                |
+      | mp150ú¿¡üßä                  | placeholderOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | placeholderSpecialCharacter |
 
   @positive
   Scenario: Check disabled checkbox for a Textbox multiple component
-    When I check disabled checkbox
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "disabled" object name
     Then Textbox multiple component is disabled
 
   @positive
   Scenario: Uncheck disabled checkbox for a Textbox multiple component
-    When I check disabled checkbox
-      And I uncheck disabled checkbox
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "disabledFalse" object name
     Then Textbox multiple component is not disabled
 
   @positive
   Scenario: Enable readOnly checkbox for a Textbox multiple component
-    When I check readOnly checkbox
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "readOnly" object name
     Then Textbox multiple component is readOnly
 
   @positive
   Scenario: Disable readOnly checkbox for a Textbox multiple component
-    When I check readOnly checkbox
-      And I uncheck readOnly checkbox
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "readOnlyFalse" object name
     Then Textbox multiple component is not readOnly
 
   @positive
   Scenario Outline: Set fieldHelp to <fieldHelp>
-    When I set fieldHelp to <fieldHelp> word
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
     Then Multiple fieldHelp on preview is set to <fieldHelp>
     Examples:
-      | fieldHelp                    |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | fieldHelp                    | nameOfObject              |
+      | mp150ú¿¡üßä                  | fieldHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | fieldHelpSpecialCharacter |
 
   @positive
   Scenario Outline: Set label to <label>
-    When I set label to <label> word
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
     Then Multiple label is set to <label>
     Examples:
-      | label                        |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | label                        | nameOfObject          |
+      | mp150ú¿¡üßä                  | labelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | labelSpecialCharacter |
 
   @positive
   Scenario Outline: Set labelHelp to <labelHelp>
-    Given I set label to "label"
-      And I set labelHelp to <labelHelp> word
-    When I hover mouse onto "first" help icon
-      And I hover mouse onto "second" help icon
+    Given I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
+    When I hover mouse onto "first" help icon in NoIFrame
+      And I hover mouse onto "second" help icon in NoIFrame
     Then Multiple tooltipPreview on preview is set to <labelHelp>
     Examples:
-      | labelHelp                    |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | labelHelp                    | nameOfObject              |
+      | mp150ú¿¡üßä                  | labelHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | labelHelpSpecialCharacter |
 
   @positive
   Scenario: Enable labelInline checkbox for a Textbox multiple component
-    When I set label to "label"
-      And I check labelInline checkbox
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "labelInline" object name
     Then Multiple Textbox component is labelInline
 
   @positive
-  Scenario: Enable and disable labelInline checkbox for a Textbox multiple component
-    When I set label to "label"
-      And I check labelInline checkbox
-      And I uncheck labelInline checkbox
+  Scenario: Disable labelInline checkbox for a Textbox multiple component
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "labelInlineFalse" object name
     Then Multiple Textbox component is not labelInline
 
   @positive
   Scenario Outline: Set labelWidth to <labelWidth>
-    When I set label to "label"
-      And I check labelInline checkbox
-      And I set label width slider to <labelWidth>
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
     Then Multiple label width is set to "<labelWidth>"
     Examples:
-      | labelWidth |
-      | 0          |
-      | 25         |
-      | 100        |
+      | labelWidth | nameOfObject  |
+      | 0          | labelWidth0   |
+      | 25         | labelWidth25  |
+      | 100        | labelWidth100 |
 
   @positive
   Scenario Outline: Set inputWidth to <inputWidth>
-    When I set label to "label"
-      And I check labelInline checkbox
-      And I set inputWidth slider to <inputWidth>
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
     Then Multiple Textbox inputWidth is set to "<inputWidth>"
     Examples:
-      | inputWidth |
-      | 0          |
-      | 50         |
-      | 100        |
+      | inputWidth | nameOfObject  |
+      | 0          | inputWidth0   |
+      | 50         | inputWidth50  |
+      | 100        | inputWidth100 |
 
   @positive
   Scenario Outline: Set labelAlign to <labelAlign>
-    When I set label to "label"
-      And I check labelInline checkbox
-      And I select labelAlign to "<labelAlign>"
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
     Then Multiple label Align on preview is "<labelAlign>"
     Examples:
-      | labelAlign |
-      | left       |
-      | right      |
+      | labelAlign | nameOfObject    |
+      | left       | labelAlignLeft  |
+      | right      | labelAlignRight |
 
   @positive
   Scenario Outline: Verify input of Textbox multiple component
+    Given I open "Experimental Textbox" component page multiple in NoIFrame
     When I type <input> into "first" Textbox
       And I type <input> into "second" Textbox
     Then Multiple textbox input on preview is set to <input>
@@ -125,11 +111,11 @@ Feature: Experimental Textbox multiple component
 
   @positive
   Scenario Outline: Set label size to <size>
-    When I select size to "<size>"
+    When I open multiple "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
     Then Multiple Textbox height is "<height>"
       And Multiple Textbox width is "<width>"
     Examples:
-      | size   | height | width  |
-      | small  | 28px   | 1043px |
-      | medium | 36px   | 1037px |
-      | large  | 44px   | 1033px |
+      | size   | height | width  | nameOfObject |
+      | small  | 28px   | 1263px | sizeSmall    |
+      | medium | 36px   | 1257px | sizeMedium   |
+      | large  | 44px   | 1253px | sizeLarge    |

--- a/cypress/fixtures/experimental/textarea.json
+++ b/cypress/fixtures/experimental/textarea.json
@@ -1,8 +1,8 @@
 { 
-  "expandableEnabled": {
+  "expandable": {
     "expandable": true
   },
-  "expandableDisabled": {
+  "expandableFalse": {
     "expandable": false
   },
   "cols1": {

--- a/cypress/fixtures/experimental/textarea.json
+++ b/cypress/fixtures/experimental/textarea.json
@@ -1,0 +1,201 @@
+{ 
+  "expandableEnabled": {
+    "expandable": true
+  },
+  "expandableDisabled": {
+    "expandable": false
+  },
+  "cols1": {
+    "cols": 1
+  },
+  "cols100": {
+    "cols": 100
+  },
+  "cols300": {
+    "cols": 300
+  },
+  "rows1": {
+    "rows": 1
+  },
+  "rows100": {
+    "rows": 100
+  },
+  "rows300": {
+    "rows": 300
+  },
+  "disabled": {
+    "disabled": true
+  },
+  "disabledFalse": {
+    "disabled": false
+  },
+  "readOnly": {
+    "readOnly": true
+  },
+  "readOnlyFalse": {
+    "readOnly": false
+  },
+  "placeholderOtherLanguage": {
+    "placeholder": "mp150ú¿¡üßä"
+  },
+  "placeholderSpecialCharacter": {
+    "placeholder": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "fieldHelpOtherLanguage": {
+    "fieldHelp": "mp150ú¿¡üßä"
+  },
+  "fieldHelpSpecialCharacter": {
+    "fieldHelp": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "characterLimit-1000": {
+    "characterLimit": -1000
+  },
+  "characterLimit-1": {
+    "characterLimit": -1
+  },
+  "characterLimit0": {
+    "characterLimit": 0
+  },
+  "characterLimit1": {
+    "characterLimit": 1
+  },
+  "characterLimit100": {
+    "characterLimit": 100
+  },
+  "characterLimit1000": {
+    "characterLimit": 1000
+  },
+  "characterLimit555555": {
+    "characterLimit": 555555
+  },
+  "characterLimitOtherLanguage": {
+    "characterLimit": "mp150ú¿¡üßä"
+  },
+  "characterLimitSpecialCharacter": {
+    "characterLimit": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "characterLimit-0,112": {
+    "characterLimit": "-0,112"
+  },
+  "characterLimit0.1112333": {
+    "characterLimit": 0.1112333
+  },
+  "inputWidth0": {
+    "inputWidth": 0
+  },
+  "inputWidth50": {
+    "inputWidth": 50
+  },
+  "inputWidth100": {
+    "inputWidth": 100
+  },
+  "labelOtherLanguage": {
+    "label": "mp150ú¿¡üßä"
+  },
+  "labelSpecialCharacter": {
+    "label": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "labelHelpOtherLanguage": {
+    "label": "label",
+    "labelHelp": "mp150ú¿¡üßä"
+  },
+  "labelHelpSpecialCharacter": {
+    "label": "label",
+    "labelHelp": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "labelInline": {
+    "label": "label",
+    "labelInline": true
+  },
+  "labelInlineFalse": {
+    "label": "label",
+    "labelInline": false
+  },
+  "labelAlignRight": {
+    "label": "label",
+    "labelInline": true,
+    "labelAlign": "right"
+  },
+  "labelAlignLeft": {
+    "label": "label",
+    "labelInline": true,
+    "labelAlign": "left"
+  },
+  "labelWidth0": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 0
+  },
+  "labelWidth25": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 25
+  },
+  "labelWidth100": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 100
+  },
+  "characterLimit0warnOverLimitenforceCharacterLimitFalse": {
+    "characterLimit": 0,
+    "warnOverLimit": true,
+    "enforceCharacterLimit": false
+  },
+  "characterLimit5warnOverLimitenforceCharacterLimitFalse": {
+    "characterLimit": 5,
+    "warnOverLimit": true,
+    "enforceCharacterLimit": false
+  },
+  "characterLimit10warnOverLimitenforceCharacterLimitFalse": {
+    "characterLimit": 10,
+    "warnOverLimit": true,
+    "enforceCharacterLimit": false
+  },
+  "characterLimit0warnOverLimitFalse": {
+    "characterLimit": 0,
+    "warnOverLimit": false,
+    "enforceCharacterLimit": false
+  },
+  "characterLimit3warnOverLimitFalse": {
+    "characterLimit": 3,
+    "warnOverLimit": false,
+    "enforceCharacterLimit": false
+  },
+  "characterLimit5warnOverLimitFalse": {
+    "characterLimit": 5,
+    "warnOverLimit": false,
+    "enforceCharacterLimit": false
+  },
+  "characterLimit-1enforceCharacterLimit": {
+    "characterLimit": -1,
+    "enforceCharacterLimit": true
+  },
+  "characterLimit2enforceCharacterLimit": {
+    "characterLimit": 2,
+    "enforceCharacterLimit": true
+  },
+  "characterLimit5enforceCharacterLimit": {
+    "characterLimit": 5,
+    "enforceCharacterLimit": true
+  },
+  "characterLimit7enforceCharacterLimit": {
+    "characterLimit": 7,
+    "enforceCharacterLimit": true
+  },
+  "characterLimit-1enforceCharacterLimitFalse": {
+    "characterLimit": -1,
+    "enforceCharacterLimit": false
+  },
+  "characterLimit0enforceCharacterLimitFalse": {
+    "characterLimit": 0,
+    "enforceCharacterLimit": false
+  },
+  "characterLimit3enforceCharacterLimitFalse": {
+    "characterLimit": 3,
+    "enforceCharacterLimit": false
+  },
+  "characterLimit5enforceCharacterLimitFalse": {
+    "characterLimit": 5,
+    "enforceCharacterLimit": false
+  }
+}

--- a/cypress/fixtures/experimental/textbox.json
+++ b/cypress/fixtures/experimental/textbox.json
@@ -1,0 +1,100 @@
+{
+  "placeholderOtherLanguage": {
+    "placeholder": "mp150ú¿¡üßä"
+  },
+  "placeholderSpecialCharacter": {
+    "placeholder": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "disabled": {
+    "disabled": true
+  },
+  "disabledFalse": {
+    "disabled": false
+  },
+  "readOnly": {
+    "readOnly": true
+  },
+  "readOnlyFalse": {
+    "readOnly": false
+  },
+  "fieldHelpOtherLanguage": {
+    "fieldHelp": "mp150ú¿¡üßä"
+  },
+  "fieldHelpSpecialCharacter": {
+    "fieldHelp": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "labelOtherLanguage": {
+    "label": "mp150ú¿¡üßä"
+  },
+  "labelSpecialCharacter": {
+    "label": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "labelHelpOtherLanguage": {
+    "label": "label",
+    "labelHelp": "mp150ú¿¡üßä"
+  },
+  "labelHelpSpecialCharacter": {
+    "label": "label",
+    "labelHelp": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "labelInline": {
+    "label": "label",
+    "labelInline": true
+  },
+  "labelInlineFalse": {
+    "label": "label",
+    "labelInline": false
+  },
+  "labelWidth0": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 0
+  },
+  "labelWidth25": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 25
+  },
+  "labelWidth100": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 100
+  },
+  "inputWidth0": {
+    "label": "label",
+    "labelInline": true,
+    "inputWidth": 0
+  },
+  "inputWidth50": {
+    "label": "label",
+    "labelInline": true,
+    "inputWidth": 50
+  },
+  "inputWidth100": {
+    "label": "label",
+    "labelInline": true,
+    "inputWidth": 100
+  },
+  "labelAlignRight": {
+    "label": "label",
+    "labelInline": true,
+    "labelAlign": "right"
+  },
+  "labelAlignLeft": {
+    "label": "label",
+    "labelInline": true,
+    "labelAlign": "left"
+  },
+  "sizeSmall": {
+    "size": "small"
+  },
+  "sizeMedium": {
+    "size": "medium"
+  },
+  "sizeLarge": {
+    "size": "large"
+  },
+  "inputIconAdd": {
+    "inputIcon": "add"
+  }
+}

--- a/cypress/locators/index.js
+++ b/cypress/locators/index.js
@@ -55,6 +55,8 @@ export const tooltipPreviewNoIframe = () => cy.get(TOOLTIP_PREVIEW);
 export const iconNoIframe = () => cy.get(ICON);
 export const getDataElementByValueNoIframe = element => cy.get(`[data-element="${element}"]`);
 export const commonDataElementInputPreviewNoIframe = () => cy.get(COMMMON_DATA_ELEMENT_INPUT);
+export const commonDataElementInputPreviewByPositionNoIFrame = position => cy.get(COMMMON_DATA_ELEMENT_INPUT)
+  .eq(position);
 export const getComponentNoIframe = component => cy.get(`[data-component="${component}"]`);
 export const getElementNoIframe = element => cy.get(`[data-element="${element}"]`).first();
 export const getElementNoIframeByName = element => cy.get(`[name="${element}"]`);
@@ -63,3 +65,7 @@ export const backgroundUILocatorNoIFrame = () => cy.get(BACKGROUND_UI_LOCATOR);
 export const closeIconButtonNoIFrame = () => cy.get(CLOSE_ICON_BUTTON);
 export const fieldHelpPreviewNoIFrame = () => cy.get(FIELD_HELP_PREVIEW).first();
 export const helpIconNoIFrame = () => cy.get(HELP_ICON_PREVIEW).first();
+export const fieldHelpPreviewByPositionNoIFrame = position => cy.get(FIELD_HELP_PREVIEW).eq(position);
+export const labelByPositionNoIFrame = position => cy.get(LABEL).eq(position);
+export const helpIconByPositionNoIFrame = position => cy.get(HELP_ICON_PREVIEW).eq(position);
+export const tooltipPreviewByPositionNoIFrame = position => cy.get(TOOLTIP_PREVIEW).eq(position);

--- a/cypress/locators/textarea/index.js
+++ b/cypress/locators/textarea/index.js
@@ -7,10 +7,10 @@ export const colsSlider = () => cy.get(COLS_SLIDER);
 export const rowsSlider = () => cy.get(ROWS_SLIDER);
 
 // component preview locators
-export const textarea = () => cy.iFrame(TEXTAREA);
-export const textareaChildren = () => cy.iFrame(TEXTAREA)
+export const textarea = () => cy.get(TEXTAREA);
+export const textareaChildren = () => cy.get(TEXTAREA)
   .find('textarea');
-export const characterLimit = () => cy.iFrame(CHARACTER_LIMIT)
+export const characterLimit = () => cy.get(CHARACTER_LIMIT)
   .find('span:nth-child(2)');
-export const characterLimitDefaultTextarea = () => cy.iFrame(CHARACTER_LIMIT);
-export const textareaInput = () => cy.iFrame(TEXTAREA_INPUT);
+export const characterLimitDefaultTextarea = () => cy.get(CHARACTER_LIMIT);
+export const textareaInput = () => cy.get(TEXTAREA_INPUT);

--- a/cypress/locators/textbox/index.js
+++ b/cypress/locators/textbox/index.js
@@ -1,8 +1,9 @@
 import { TEXTBOX, TEXTBOX_DATA_COMPONENT } from './locators';
 
 // component preview locators
-export const textbox = () => cy.iFrame(TEXTBOX);
-export const textboxByPosition = position => cy.iFrame(TEXTBOX).eq(position);
-export const textboxDataComponent = () => cy.iFrame(TEXTBOX_DATA_COMPONENT);
+export const textbox = () => cy.get(TEXTBOX);
+export const textboxInIFrame = () => cy.iFrame(TEXTBOX);
+export const textboxByPosition = position => cy.get(TEXTBOX).eq(position);
+export const textboxDataComponent = () => cy.get(TEXTBOX_DATA_COMPONENT);
 export const textboxIcon = () => cy.iFrame(TEXTBOX).find('span').eq(0).children();
 export const textboxInput = () => cy.iFrame(TEXTBOX).children();

--- a/cypress/support/step-definitions/button-toggle-group-steps.js
+++ b/cypress/support/step-definitions/button-toggle-group-steps.js
@@ -1,8 +1,6 @@
 import { buttonToggleGroupLabelPreview, labelPreviewWidth, labelPreviewByText } from '../../locators/button-toggle-group';
 import { label } from '../../locators';
 
-const TEXT_ALIGN = 'text-align';
-
 Then('Button Toggle Group label on preview is {string}', (text) => {
   buttonToggleGroupLabelPreview().should('have.text', text);
 });
@@ -31,10 +29,6 @@ Then('input width is set to {string}', (width) => {
 
 Then('input width is not set to {string}', (width) => {
   labelPreviewWidth().should('not.have.css', `width: ${width}%`);
-});
-
-Then('label Align on preview is {string}', (direction) => {
-  label().should($element => expect($element).to.have.css(TEXT_ALIGN, `${direction}`));
 });
 
 When('I click on Button Toggle Group {string}', (buttonName) => {

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -536,3 +536,15 @@ Then('label is inline', () => {
 Then('label is inline in IFrame', () => {
   label().should('have.css', TEXT_ALIGN, 'left');
 });
+
+Then('label width is set to {string} in NoIFrame', (width) => {
+  getDataElementByValueNoIframe('label').should('have.attr', 'width', `${width}`);
+});
+
+Then('label Align on preview is {string}', (direction) => {
+  label().should($element => expect($element).to.have.css(TEXT_ALIGN, `${direction}`));
+});
+
+Then('label Align on preview is {string} in NoIFrame', (direction) => {
+  getDataElementByValueNoIframe('label').should($element => expect($element).to.have.css(TEXT_ALIGN, `${direction}`));
+});

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -19,6 +19,7 @@ import {
   fieldHelpPreviewNoIFrame,
   commonDataElementInputPreviewNoIframe,
   helpIconNoIFrame,
+  helpIconByPositionNoIFrame,
 } from '../../locators';
 import { dialogTitle, dialogTitleNoIFrame } from '../../locators/dialog';
 import { DEBUG_FLAG } from '..';
@@ -119,7 +120,7 @@ Given('I open {string} component page multiple', (component) => {
   visitComponentUrl(component, 'multiple');
 });
 
-Given('I open {string} component page multiple in iframe', (component) => {
+Given('I open {string} component page multiple in NoIFrame', (component) => {
   visitComponentUrl(component, 'multiple', true);
 });
 
@@ -239,6 +240,10 @@ When('I hover mouse onto help icon', () => {
 
 When('I hover mouse onto {string} help icon', (position) => {
   helpIconByPosition(positionOfElement(position)).trigger('mouseover');
+});
+
+When('I hover mouse onto {string} help icon in NoIFrame', (position) => {
+  helpIconByPositionNoIFrame(positionOfElement(position)).trigger('mouseover');
 });
 
 When('I hover mouse onto icon', () => {

--- a/cypress/support/step-definitions/text-area-steps.js
+++ b/cypress/support/step-definitions/text-area-steps.js
@@ -4,30 +4,25 @@ import {
 } from '../../locators/textarea';
 import { setSlidebar } from '../helper';
 import {
-  fieldHelpPreview, label,
+  fieldHelpPreviewNoIFrame, getDataElementByValueNoIframe,
 } from '../../locators';
-import { DEBUG_FLAG } from '..';
 
 const TEXT_ALIGN = 'text-align';
 
 Then('Textarea component is expandable', () => {
-  textareaChildren()
-    .should('have.attr', 'style', 'height: 44px;');
+  textareaChildren().should('have.css', 'height', '89px');
 });
 
 Then('Textarea component is not expandable', () => {
-  textareaChildren()
-    .should('not.have.attr', 'style', 'height: 50px;');
+  textareaChildren().should('not.have.css', 'height', '89px');
 });
 
 Then('cols is set to {string}', (colsValue) => {
-  textareaChildren()
-    .should('have.attr', 'cols', colsValue);
+  textareaChildren().should('have.attr', 'cols', colsValue);
 });
 
 Then('rows is set to {string}', (colsValue) => {
-  textareaChildren()
-    .should('have.attr', 'rows', colsValue);
+  textareaChildren().should('have.attr', 'rows', colsValue);
 });
 
 When('I set cols slider to {int}', (colsValue) => {
@@ -63,7 +58,7 @@ Then('placeholder is set to {word}', (text) => {
 });
 
 Then('fieldHelp is set to {word}', (text) => {
-  fieldHelpPreview().should('have.text', text);
+  fieldHelpPreviewNoIFrame().should('have.text', text);
 });
 
 Then('characterLimit is set to {string}', (length) => {
@@ -97,11 +92,11 @@ Then('Textarea inputWidth is set to {string}', (width) => {
 });
 
 Then('Textarea component is labelInline', () => {
-  label().should('have.css', TEXT_ALIGN, 'left');
+  getDataElementByValueNoIframe('label').parent().should('have.css', 'display', 'flex');
 });
 
 Then('Textarea component is not labelInline', () => {
-  label().should('not.have.css', TEXT_ALIGN, 'left');
+  getDataElementByValueNoIframe('label').parent().should('have.css', 'display', 'block');
 });
 
 When('I input {word} into Textarea', (text) => {
@@ -113,25 +108,21 @@ When('I type {string} into Textarea input', (text) => {
 });
 
 Then('Textarea component has warnOverLimit and used characters {int} of {int}', (overCharacterLimit, limit) => {
-  cy.wait(250, { log: DEBUG_FLAG }); // delayed to ensure it to run on CI
   characterLimitDefaultTextarea().should('have.text', `${overCharacterLimit}/${limit}`)
     .and('have.css', 'color', 'rgb(199, 56, 79)');
 });
 
 Then('Textarea component has no warnOverLimit and used characters {int} of {int}', (charactersUsed, limit) => {
-  cy.wait(250, { log: DEBUG_FLAG }); // delayed to ensure it to run on CI
   characterLimitDefaultTextarea().should('have.text', `${charactersUsed}/${limit}`)
     .and('have.css', 'color', 'rgba(0, 0, 0, 0.55)');
 });
 
 Then('Textarea component has enforceCharacterLimit enabled and used characters {int} are equal to limit {int}', (charactersUsed, limit) => {
-  cy.wait(250, { log: DEBUG_FLAG }); // delayed to ensure it to run on CI
   characterLimitDefaultTextarea().should('have.text', `${charactersUsed}/${limit}`)
     .and('have.css', 'color', 'rgba(0, 0, 0, 0.55)');
 });
 
 Then('Textarea component has enforceCharacterLimit disabled and used characters {int} are more than limit {int}', (charactersUsed, limit) => {
-  cy.wait(200, { log: DEBUG_FLAG }); // delayed to ensure it to run on CI
   characterLimitDefaultTextarea().should('have.text', `${charactersUsed}/${limit}`)
     .and('have.css', 'color', 'rgba(0, 0, 0, 0.55)');
 });

--- a/cypress/support/step-definitions/textbox-steps.js
+++ b/cypress/support/step-definitions/textbox-steps.js
@@ -1,11 +1,19 @@
 import {
-  textbox, textboxByPosition, textboxIcon, textboxInput,
+  textbox,
+  textboxByPosition,
+  textboxIcon,
+  textboxInput,
+  textboxInIFrame,
 } from '../../locators/textbox';
 import {
-  label, labelByPosition, commonInputPreview,
-  fieldHelpPreviewByPosition, tooltipPreviewByPosition, labelNoIFrame, commonDataElementInputPreviewNoIframe,
+  labelByPosition,
+  commonInputPreview,
+  fieldHelpPreviewByPosition,
+  tooltipPreviewByPosition,
+  labelNoIFrame,
+  commonDataElementInputPreviewNoIframe,
+  getDataElementByValueNoIframe,
 } from '../../locators';
-import { DEBUG_FLAG } from '..';
 import { positionOfElement } from '../helper';
 
 const TEXT_ALIGN = 'text-align';
@@ -26,7 +34,6 @@ Then('Textbox component is disabled', () => {
 });
 
 Then('Textbox multiple component is disabled', () => {
-  cy.wait(100, { log: DEBUG_FLAG }); // added due to animation changing
   textbox(positionOfElement('first')).children()
     .should('have.css', 'color', 'rgba(0, 0, 0, 0.55)')
     .and('have.css', 'cursor', 'not-allowed');
@@ -36,7 +43,6 @@ Then('Textbox multiple component is disabled', () => {
 });
 
 Then('Textbox component is not disabled', () => {
-  cy.wait(100, { log: DEBUG_FLAG }); // added due to animation changing
   textbox().should('not.be.disabled');
   textbox().children()
     .should('not.have.css', 'color', 'rgba(0, 0, 0, 0.55)')
@@ -44,7 +50,6 @@ Then('Textbox component is not disabled', () => {
 });
 
 Then('Textbox multiple component is not disabled', () => {
-  cy.wait(100, { log: DEBUG_FLAG }); // added due to animation changing
   textbox(positionOfElement('first')).should('not.be.disabled');
   textbox(positionOfElement('first')).children()
     .should('not.have.css', 'color', 'rgba(0, 0, 0, 0.55)')
@@ -56,7 +61,6 @@ Then('Textbox multiple component is not disabled', () => {
 });
 
 Then('Textbox component is readOnly', () => {
-  cy.wait(100, { log: DEBUG_FLAG }); // added due to animation changing
   const borderColor = 'rgb(204, 214, 219)';
   textbox().should('have.css', 'background-color', 'rgb(250, 251, 251)')
     .and('have.css', 'border-bottom-color', borderColor)
@@ -68,7 +72,6 @@ Then('Textbox component is readOnly', () => {
 Then('Textbox multiple component is readOnly', () => {
   const borderReadonlyColor = 'rgb(204, 214, 219)';
   const backgroundColor = 'rgb(250, 251, 251)';
-  cy.wait(100, { log: DEBUG_FLAG }); // added due to animation changing
   textbox(positionOfElement('first')).should('have.css', 'background-color', backgroundColor)
     .and('have.css', 'border-bottom-color', borderReadonlyColor)
     .and('have.css', 'border-left-color', borderReadonlyColor)
@@ -82,7 +85,6 @@ Then('Textbox multiple component is readOnly', () => {
 });
 
 Then('Textbox component is not readOnly', () => {
-  cy.wait(100, { log: DEBUG_FLAG }); // added due to animation changing
   textbox().should('not.have.css', 'background', 'rgba(0, 0, 0, 0) none repeat scroll 0% 0% / auto padding-box border-box')
     .and('not.have.css', 'border-color', 'rgba(0, 0, 0, 0)')
     .and('have.css', 'background', 'rgb(255, 255, 255) none repeat scroll 0% 0% / auto padding-box border-box');
@@ -91,7 +93,6 @@ Then('Textbox component is not readOnly', () => {
 Then('Textbox multiple component is not readOnly', () => {
   const borderNoReadonlyColor = 'rgba(0, 0, 0, 0)';
   const backgroundColor = 'rgb(255, 255, 255)';
-  cy.wait(100, { log: DEBUG_FLAG }); // added due to animation changing
   textbox(positionOfElement('first')).should('not.have.css', 'background-color', borderNoReadonlyColor)
     .and('not.have.css', 'border-bottom-color', borderNoReadonlyColor)
     .and('not.have.css', 'border-left-color', borderNoReadonlyColor)
@@ -117,7 +118,7 @@ Then('Multiple label is set to {word}', (text) => {
 });
 
 Then('Textbox component is labelInline', () => {
-  label().should('have.css', TEXT_ALIGN, 'left');
+  getDataElementByValueNoIframe('label').should('have.css', TEXT_ALIGN, 'left');
 });
 
 Then('Multiple Textbox component is labelInline', () => {
@@ -126,7 +127,7 @@ Then('Multiple Textbox component is labelInline', () => {
 });
 
 Then('Textbox component is not labelInline', () => {
-  label().should('not.have.css', TEXT_ALIGN, 'left');
+  getDataElementByValueNoIframe('label').should('not.have.css', TEXT_ALIGN, 'left');
 });
 
 Then('Multiple Textbox component is not labelInline', () => {
@@ -177,16 +178,16 @@ Then('Multiple textbox input on preview is set to {word}', () => {
 });
 
 Then('Textbox height is {string}', (height) => {
-  commonInputPreview().should('have.css', 'height', height);
+  commonDataElementInputPreviewNoIframe().should('have.css', 'height', height);
 });
 
 Then('Multiple Textbox height is {string}', (height) => {
-  commonInputPreview(positionOfElement('first')).should('have.css', 'height', height);
-  commonInputPreview(positionOfElement('second')).should('have.css', 'height', height);
+  commonDataElementInputPreviewNoIframe(positionOfElement('first')).should('have.css', 'height', height);
+  commonDataElementInputPreviewNoIframe(positionOfElement('second')).should('have.css', 'height', height);
 });
 
 Then('Textbox width is {string}', (width) => {
-  commonInputPreview().should('have.css', 'width', width);
+  commonDataElementInputPreviewNoIframe().should('have.css', 'width', width);
 });
 
 Then('Multiple Textbox width is {string}', (width) => {
@@ -213,7 +214,7 @@ When('I click on Textbox', () => {
 });
 
 Then('Textbox input has golden border on focus', () => {
-  textbox().should('have.css', 'outline', 'rgb(255, 181, 0) solid 3px');
+  textboxInIFrame().should('have.css', 'outline', 'rgb(255, 181, 0) solid 3px');
 });
 
 Then('Textbox overriden styles rendered properly', () => {

--- a/cypress/support/step-definitions/textbox-steps.js
+++ b/cypress/support/step-definitions/textbox-steps.js
@@ -6,13 +6,13 @@ import {
   textboxInIFrame,
 } from '../../locators/textbox';
 import {
-  labelByPosition,
-  commonInputPreview,
-  fieldHelpPreviewByPosition,
-  tooltipPreviewByPosition,
   labelNoIFrame,
   commonDataElementInputPreviewNoIframe,
   getDataElementByValueNoIframe,
+  tooltipPreviewByPositionNoIFrame,
+  labelByPositionNoIFrame,
+  fieldHelpPreviewByPositionNoIFrame,
+  commonDataElementInputPreviewByPositionNoIFrame,
 } from '../../locators';
 import { positionOfElement } from '../helper';
 
@@ -108,13 +108,13 @@ Then('Textbox multiple component is not readOnly', () => {
 });
 
 Then('Multiple fieldHelp on preview is set to {word}', (text) => {
-  fieldHelpPreviewByPosition(positionOfElement('first')).should('have.text', text);
-  fieldHelpPreviewByPosition(positionOfElement('second')).should('have.text', text);
+  fieldHelpPreviewByPositionNoIFrame(positionOfElement('first')).should('have.text', text);
+  fieldHelpPreviewByPositionNoIFrame(positionOfElement('second')).should('have.text', text);
 });
 
 Then('Multiple label is set to {word}', (text) => {
-  labelByPosition(positionOfElement('first')).should('have.text', text);
-  labelByPosition(positionOfElement('second')).should('have.text', text);
+  labelByPositionNoIFrame(positionOfElement('first')).should('have.text', text);
+  labelByPositionNoIFrame(positionOfElement('second')).should('have.text', text);
 });
 
 Then('Textbox component is labelInline', () => {
@@ -122,8 +122,8 @@ Then('Textbox component is labelInline', () => {
 });
 
 Then('Multiple Textbox component is labelInline', () => {
-  labelByPosition(positionOfElement('first')).should('have.css', TEXT_ALIGN, 'left');
-  labelByPosition(positionOfElement('second')).should('have.css', TEXT_ALIGN, 'left');
+  labelByPositionNoIFrame(positionOfElement('first')).should('have.css', TEXT_ALIGN, 'left');
+  labelByPositionNoIFrame(positionOfElement('second')).should('have.css', TEXT_ALIGN, 'left');
 });
 
 Then('Textbox component is not labelInline', () => {
@@ -131,13 +131,13 @@ Then('Textbox component is not labelInline', () => {
 });
 
 Then('Multiple Textbox component is not labelInline', () => {
-  labelByPosition(positionOfElement('first')).should('not.have.css', TEXT_ALIGN, 'left');
-  labelByPosition(positionOfElement('second')).should('not.have.css', TEXT_ALIGN, 'left');
+  labelByPositionNoIFrame(positionOfElement('first')).should('not.have.css', TEXT_ALIGN, 'left');
+  labelByPositionNoIFrame(positionOfElement('second')).should('not.have.css', TEXT_ALIGN, 'left');
 });
 
 Then('Multiple tooltipPreview on preview is set to {word}', (text) => {
-  tooltipPreviewByPosition(positionOfElement('first')).should('have.text', text);
-  tooltipPreviewByPosition(positionOfElement('second')).should('have.text', text);
+  tooltipPreviewByPositionNoIFrame(positionOfElement('first')).wait(250).should('have.text', text);
+  tooltipPreviewByPositionNoIFrame(positionOfElement('second')).wait(250).should('have.text', text);
 });
 
 Then('Textbox inputWidth is set to {string}', (width) => {
@@ -145,13 +145,13 @@ Then('Textbox inputWidth is set to {string}', (width) => {
 });
 
 Then('Multiple Textbox inputWidth is set to {string}', (width) => {
-  textbox(positionOfElement('first')).should('have.css', 'flex', `0 0 ${width}%`);
-  textbox(positionOfElement('second')).should('have.css', 'flex', `0 0 ${width}%`);
+  textboxByPosition(positionOfElement('first')).should('have.css', 'flex', `0 0 ${width}%`);
+  textboxByPosition(positionOfElement('second')).should('have.css', 'flex', `0 0 ${width}%`);
 });
 
 Then('Multiple label width is set to {string}', (width) => {
-  labelByPosition(positionOfElement('first')).should('have.attr', 'width', `${width}`);
-  labelByPosition(positionOfElement('second')).should('have.attr', 'width', `${width}`);
+  labelByPositionNoIFrame(positionOfElement('first')).should('have.attr', 'width', `${width}`);
+  labelByPositionNoIFrame(positionOfElement('second')).should('have.attr', 'width', `${width}`);
 });
 
 When('I type {word} into Textbox', (text) => {
@@ -182,8 +182,8 @@ Then('Textbox height is {string}', (height) => {
 });
 
 Then('Multiple Textbox height is {string}', (height) => {
-  commonDataElementInputPreviewNoIframe(positionOfElement('first')).should('have.css', 'height', height);
-  commonDataElementInputPreviewNoIframe(positionOfElement('second')).should('have.css', 'height', height);
+  commonDataElementInputPreviewByPositionNoIFrame(positionOfElement('first')).should('have.css', 'height', height);
+  commonDataElementInputPreviewByPositionNoIFrame(positionOfElement('second')).should('have.css', 'height', height);
 });
 
 Then('Textbox width is {string}', (width) => {
@@ -191,13 +191,13 @@ Then('Textbox width is {string}', (width) => {
 });
 
 Then('Multiple Textbox width is {string}', (width) => {
-  commonInputPreview(positionOfElement('first')).should('have.css', 'width', width);
-  commonInputPreview(positionOfElement('second')).should('have.css', 'width', width);
+  commonDataElementInputPreviewByPositionNoIFrame(positionOfElement('first')).should('have.css', 'width', width);
+  commonDataElementInputPreviewByPositionNoIFrame(positionOfElement('second')).should('have.css', 'width', width);
 });
 
 Then('Multiple label Align on preview is {string}', (direction) => {
-  labelByPosition(positionOfElement('first')).should($element => expect($element).to.have.css(TEXT_ALIGN, `${direction}`));
-  labelByPosition(positionOfElement('second')).should($element => expect($element).to.have.css(TEXT_ALIGN, `${direction}`));
+  labelByPositionNoIFrame(positionOfElement('first')).should($element => expect($element).to.have.css(TEXT_ALIGN, `${direction}`));
+  labelByPositionNoIFrame(positionOfElement('second')).should($element => expect($element).to.have.css(TEXT_ALIGN, `${direction}`));
 });
 
 Then('I click on icon inside of Textbox', () => {


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Apply new `url` approach in  tests for:
`Experimental:`
`TextArea` (timing: was `5:00`- > `01:36`),
`TextBox` (timing: was `03:34` -> `00:45`),
`TextBox Actions` (timing: `00:14`),
`TextBox-multiple` (timing: was `03:13` -> `00:50`).

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are passing all parameters via `knobs`.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Screenshots are included in the PR
- [ ] Carbon implementation and Design System documentation are congruent
- [ ] All themes are supported
- [x] Commits follow our style guide
- [ ] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [ ] Storybook added or updated
- [ ] Typescript `d.ts` file added or updated