### PR TITLE
docs(hr): move hr stories to design system folder

### DIFF
--- a/src/components/hr/hr.stories.mdx
+++ b/src/components/hr/hr.stories.mdx
@@ -7,7 +7,7 @@ import Textbox from '../../__experimental__/components/textbox';
 import Button from '../button';
 
 <Meta
-  title="Hr"
+  title="Design System/Hr"
   parameters={{ info: { disable: true }}}
 />
 


### PR DESCRIPTION
### Proposed behaviour
`Hr` component stories will be in the Design System folder on Storybook.

### Current behaviour
They're currently just in the root folder.

### Checklist

- <del>[ ] Screenshots are included in the PR</del>
- [x] Carbon implementation and Design System documentation are congruent
- <del>[ ] All themes are supported</del>
- [x] Commits follow our style guide
- <del>[ ] Unit tests added or updated</del>
- <del>[ ] Cypress automation tests added or updated</del>
- [x] Storybook added or updated
- <del>[ ] Typescript `d.ts` file added or updated</del>

### Additional context

### Testing instructions
