### PR TITLE
chore(note): add createdDate to ts def and make status text required

### DIFF
--- a/src/components/note/__internal__/note.component.js
+++ b/src/components/note/__internal__/note.component.js
@@ -102,7 +102,7 @@ Note.propTypes = {
   /** Adds a created on date to the Note footer */
   createdDate: PropTypes.string,
   /** Adds a status and tooltip to the Note footer */
-  status: PropTypes.shape({ text: PropTypes.string, timeStamp: PropTypes.string })
+  status: PropTypes.shape({ text: PropTypes.string.isRequired, timeStamp: PropTypes.string })
 };
 
 export default Note;

--- a/src/components/note/__internal__/note.d.ts
+++ b/src/components/note/__internal__/note.d.ts
@@ -6,8 +6,9 @@ export interface NoteProps {
    inlineControl?: React.ReactNode;
    title?: string;
    name?: string;
+   createdDate?: string;
    status?: {
-    text?: string;
+    text: string;
     timeStamp?: string;
   };
 }

--- a/src/components/note/__internal__/note.style.js
+++ b/src/components/note/__internal__/note.style.js
@@ -120,6 +120,10 @@ StyledFooter.defaultProps = {
   theme: baseTheme
 };
 
+StyledFooterContent.defaultProps = {
+  theme: baseTheme
+};
+
 export {
   StyledNote, StyledNoteContent, StyledInlineControl, StyledTitle, StyledFooter, StyledFooterContent
 };


### PR DESCRIPTION
BREAKING CHANGE: `status` now has `text` property as `isRequired`

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds missing `createdDate` type definition to `note.d.ts`, makes `status.text` a required prop and adds default theme to `StyledFooterContent`
### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Definitions are incomplete

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR<del>
<del>- [ ] Carbon implementation and Design System documentation are congruent<del>
<del>- [ ] All themes are supported<del>
<del>- [ ] Commits follow our style guide<del>
<del>- [ ] Unit tests added or updated<del>
<del>- [ ] Cypress automation tests added or updated<del>
<del>- [ ] Storybook added or updated<del>
- [x] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
