### PR TITLE
fix(notes): update prop types

### DIFF
--- a/src/components/note/__internal__/note.component.js
+++ b/src/components/note/__internal__/note.component.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Editor, EditorState } from 'draft-js';
+import { Editor } from 'draft-js';
+import invariant from 'invariant';
 import {
   StyledNote,
   StyledNoteContent,
@@ -12,8 +13,8 @@ import {
 import StatusWithTooltip from './status-with-tooltip';
 
 const Note = ({
-  noteContent = EditorState.createEmpty(),
-  width,
+  noteContent,
+  width = 100,
   inlineControl,
   title,
   name,
@@ -23,8 +24,17 @@ const Note = ({
 }) => {
   const [showTooltip, setShowTooltip] = useState(false);
 
+  invariant(width > 0, '<Note> width must be greater than 0');
+  invariant(createdDate, '<Note> createdDate is required');
+  invariant(name, '<Note> name is required');
+  invariant(noteContent, '<Note> noteContent is required');
+  invariant(!status || status.text, '<Note> status.text is required');
+  invariant(!status || status.timeStamp, '<Note> status.timeStamp is required');
+  invariant(!inlineControl || inlineControl.type.name === 'ActionPopover',
+    '<Note> inlineControl must be an instance of <ActionPopover>');
+
   const renderStatus = () => {
-    if (!status || !status.text || !status.text.length) {
+    if (!status) {
       return null;
     }
 
@@ -87,22 +97,19 @@ function tooltipProps(id, showTooltip, setShowTooltip) {
 
 Note.propTypes = {
   /**  The rich text content to display in the Note */
-  noteContent: PropTypes.object,
-  /**
-   * Set a percentage-based width for the whole Note component, relative to its parent.
-   * If unset or zero, this will default to 100%.
-   */
+  noteContent: PropTypes.object.isRequired,
+  /** Set a percentage-based width for the whole Note component, relative to its parent. */
   width: PropTypes.number,
   /** renders a control for the Note */
   inlineControl: PropTypes.node,
   /** Adds a Title to the Note */
   title: PropTypes.string,
   /** Adds a name to the Note footer */
-  name: PropTypes.string,
+  name: PropTypes.string.isRequired,
   /** Adds a created on date to the Note footer */
-  createdDate: PropTypes.string,
+  createdDate: PropTypes.string.isRequired,
   /** Adds a status and tooltip to the Note footer */
-  status: PropTypes.shape({ text: PropTypes.string, timeStamp: PropTypes.string })
+  status: PropTypes.shape({ text: PropTypes.string.isRequired, timeStamp: PropTypes.string.isRequired })
 };
 
 export default Note;

--- a/src/components/note/__internal__/note.d.ts
+++ b/src/components/note/__internal__/note.d.ts
@@ -5,10 +5,11 @@ export interface NoteProps {
    width?: number;
    inlineControl?: React.ReactNode;
    title?: string;
-   name?: string;
+   name: string;
+   createdDate: string;
    status?: {
-    text?: string;
-    timeStamp?: string;
+    text: string;
+    timeStamp: string;
   };
 }
 

--- a/src/components/note/__internal__/note.spec.js
+++ b/src/components/note/__internal__/note.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ThemeProvider } from 'styled-components';
 import { mount } from 'enzyme';
+import { EditorState } from 'draft-js';
 import Note from './note.component';
 import baseTheme from '../../../style/themes/base';
 import {
@@ -10,14 +11,24 @@ import {
   StyledFooter,
   StyledFooterContent
 } from './note.style';
+import {
+  ActionPopover,
+  ActionPopoverItem
+} from '../../action-popover';
 import StatusWithTooltip from './status-with-tooltip';
 import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
 import Tooltip from '../../tooltip';
 
 function render(props = {}) {
+  const defaultProps = {
+    name: 'Carbon',
+    createdDate: '23 May 2020, 12:08 PM',
+    noteContent: EditorState.createEmpty(),
+    ...props
+  };
   return mount(
     <ThemeProvider theme={ baseTheme }>
-      <Note { ...props } />
+      <Note { ...defaultProps } />
     </ThemeProvider>
   );
 }
@@ -84,7 +95,11 @@ describe('Note', () => {
   });
 
   describe('StyledInlineControl', () => {
-    const inlineControl = <div>inlineControl</div>;
+    const inlineControl = (
+      <ActionPopover>
+        <ActionPopoverItem onClick={ () => {} }>Edit</ActionPopoverItem>
+      </ActionPopover>
+    );
 
     it('does not render the "inlineControl" when prop is undefined', () => {
       expect(render().find(StyledInlineControl).exists()).toBeFalsy();
@@ -108,12 +123,6 @@ describe('Note', () => {
     const name = 'foo';
     const createdDate = '25/12/20';
 
-    it('does not render the "name" and "createdDate" when either prop is undefined', () => {
-      expect(render().find(StyledNoteContent)).toHaveLength(1);
-      expect(render({ name }).find(StyledNoteContent)).toHaveLength(1);
-      expect(render({ createdDate }).find(StyledNoteContent)).toHaveLength(1);
-    });
-
     it('renders the "name" and "createdDate" when props have value', () => {
       const wrapper = render({ name, createdDate });
       const footerContent = wrapper.find(StyledFooterContent);
@@ -124,29 +133,70 @@ describe('Note', () => {
       expect(footerContent.at(1).text()).toEqual('25/12/20');
     });
 
-    it('does not render the "status" when no "text" has no value', () => {
-      const wrapper = render({ name, createdDate, status: { timeStamp: '123' } });
-      expect(wrapper.find(StyledFooterContent)).toHaveLength(2);
-    });
-
     it('renders the "status" with tooltip when "text" and "timeStamp" have values', () => {
       const wrapper = render({ name, createdDate, status: { text: 'foo', timeStamp: '123' } });
-      const status = () => wrapper.find(StatusWithTooltip);
+      const status = wrapper.find(StatusWithTooltip);
       expect(wrapper.find(StyledFooterContent)).toHaveLength(3);
-      expect(status().exists()).toBeTruthy();
-      expect(status().text()).toEqual('foo');
-      status().simulate('mouseover');
-      expect(status().find(Tooltip).exists()).toBeTruthy();
+      expect(status.exists()).toBeTruthy();
+      expect(status.text()).toEqual('foo');
+
+      status.simulate('mouseover');
+      expect(wrapper.find(StatusWithTooltip).find(Tooltip).exists()).toBeTruthy();
+
+      status.simulate('mouseleave');
+      expect(wrapper.find(StatusWithTooltip).find(Tooltip).exists()).toBeFalsy();
+    });
+  });
+
+  describe('invariant', () => {
+    beforeEach(() => {
+      jest.spyOn(global.console, 'error').mockImplementation(() => {});
     });
 
-    it('renders the "status" with no tooltip when "text" has value but "timeStamp" has no value', () => {
-      const wrapper = render({ name, createdDate, status: { text: 'foo' } });
-      const status = () => wrapper.find(StatusWithTooltip);
+    afterEach(() => {
+      global.console.error.mockReset();
+    });
 
-      status().simulate('mouseover');
-      expect(status().find(Tooltip).exists()).toBeFalsy();
-      // coverage
-      status().simulate('mouseleave');
+    it('throws if the width is < 0', () => {
+      expect(() => {
+        render({ width: 0 });
+      }).toThrow('<Note> width must be greater than 0');
+    });
+
+    it('throws if createdDate is not defined', () => {
+      expect(() => {
+        render({ createdDate: undefined });
+      }).toThrow('<Note> createdDate is required');
+    });
+
+    it('throws if name is not defined', () => {
+      expect(() => {
+        render({ name: undefined });
+      }).toThrow('<Note> name is required');
+    });
+
+    it('throws if noteContent is not defined', () => {
+      expect(() => {
+        render({ noteContent: undefined });
+      }).toThrow('<Note> noteContent is required');
+    });
+
+    it('throws if status.text is not defined', () => {
+      expect(() => {
+        render({ status: {} });
+      }).toThrow('<Note> status.text is required');
+    });
+
+    it('throws if status.timeStamp is not defined', () => {
+      expect(() => {
+        render({ status: { text: 'Edited' } });
+      }).toThrow('<Note> status.timeStamp is required');
+    });
+
+    it('throws if inlineControl is not an ActionPopover', () => {
+      expect(() => {
+        render({ inlineControl: <button type='button'>A Button</button> });
+      }).toThrow('<Note> inlineControl must be an instance of <ActionPopover>');
     });
   });
 });

--- a/src/components/note/__internal__/note.stories.mdx
+++ b/src/components/note/__internal__/note.stories.mdx
@@ -1,15 +1,12 @@
 import { useState } from 'react';
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import Note from './note.component';
-import Content from '../../content';
 import {
   ActionPopover,
   ActionPopoverDivider,
   ActionPopoverItem
 } from '../../action-popover';
 import { EditorState, ContentState, convertFromHTML } from 'draft-js';
-import Icon from '../../icon';
-import DateHelper from '../../../utils/helpers/date';
 
 <Meta title="Design System/Note" />
 
@@ -35,7 +32,7 @@ In its basic form, the component can render plain text content by passing a valu
       const noteContent = EditorState.createWithContent(ContentState.createFromText('Here is some plain text content'));
       return (
         <div style={{ height: 200, width: '50%' }}>
-          <Note width={ 100 } noteContent={ noteContent } />
+          <Note name='Lauren Smith' noteContent={ noteContent } createdDate ='23 May 2020, 12:08 PM'/>
         </div>
       );
     }}
@@ -62,129 +59,125 @@ static method.
       );
       const noteContent = EditorState.createWithContent(content);
       return (
-        <div style={{ height: 200, width: '50%' }}>
+        <div style={{ height: 300, width: '50%' }}>
           <Note
-            width={ 100 }
             noteContent={ noteContent }
-          />
-        </div>
-      );
-    }}
-  </Story>
-</Preview>
-
-### With optional title:
-Passing a string value to the `title` prop will render it in the `Note`.
-<Preview>
-  <Story name="with optional title" parameters={{ info: { disable: true }}}>
-    {() => {
-      const html = `<p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i> Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>
-      <ul><li>unordered</li></ul>
-      <ol><li>ordered</li></ol></br>
-      <p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i></p>
-      <p>Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>`;
-      const blocksFromHTML = convertFromHTML(html);
-      const content = ContentState.createFromBlockArray(
-        blocksFromHTML.contentBlocks,
-        blocksFromHTML.entityMap
-      );
-      const noteContent = EditorState.createWithContent(content);
-      return (
-        <div style={{ height: 200, width: '50%' }}>
-          <Note
-            width={ 100 }
-            title='Here is a Title'
-            noteContent={ noteContent }
-          />
-        </div>
-      );
-    }}
-  </Story>
-</Preview>
-
-### With optional inline control:
-The component supports adding an control to perform desired actions, this can be rendered compositionally by passing in 
-the control you wish to use to the `inlineControl` prop. The example below renders an `ActionPopover` control.
-<Preview>
-  <Story name="with optional inline control" parameters={{ info: { disable: true }}}>
-    {() => {
-      const html = `<p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i> Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>
-      <ul><li>unordered</li></ul>
-      <ol><li>ordered</li></ol></br>
-      <p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i></p>
-      <p>Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>`;
-      const blocksFromHTML = convertFromHTML(html);
-      const content = ContentState.createFromBlockArray(
-        blocksFromHTML.contentBlocks,
-        blocksFromHTML.entityMap
-      );
-      const noteContent = EditorState.createWithContent(content);
-      const control = (
-        <ActionPopover>
-          <ActionPopoverItem onClick={ () => {} }>
-            Edit
-          </ActionPopoverItem>
-          <ActionPopoverDivider />
-          <ActionPopoverItem onClick={ () => {} }>
-            Delete
-          </ActionPopoverItem>
-        </ActionPopover>
-      );
-      return (
-        <div style={{ height: 200, width: '50%' }}>
-          <Note
-            width={ 100 }
-            title='Here is a Title'
-            inlineControl={ control }
-            noteContent={ noteContent }
-          />
-        </div>
-      );
-    }}
-  </Story>
-</Preview>
-
-### With footer:
-A `Note` footer can be rendered by passing values to the `name` and `createdDate` props. An optional `status` can also 
-be rendered, this can be seen below when you click the `Edit` button in the inline control.
-<Preview>
-  <Story name="with footer" parameters={{ info: { disable: true }}}>
-    {() => {
-      const html = `<p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i> Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>
-      <ul><li>unordered</li></ul>
-      <ol><li>ordered</li></ol></br>
-      <p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i></p>
-      <p>Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>`;
-      const blocksFromHTML = convertFromHTML(html);
-      const content = ContentState.createFromBlockArray(
-        blocksFromHTML.contentBlocks,
-        blocksFromHTML.entityMap
-      );
-      const noteContent = EditorState.createWithContent(content);
-      const [status, setStatus] = useState({ text: '', timeStamp: '' })
-      const control = (
-        <ActionPopover>
-          <ActionPopoverItem onClick={ () => {
-            const now = new Date(Date.now());
-            setStatus({ text: 'EDITED', timeStamp: DateHelper.formatDateString(now.toString(), 'DD MMM YYYY, LT') })
-          }}>
-            Edit
-          </ActionPopoverItem>
-          <ActionPopoverDivider />
-          <ActionPopoverItem onClick={ () => {} }>
-            Delete
-          </ActionPopoverItem>
-        </ActionPopover>
-      );
-      return (
-        <div style={{ height: 250, width: '50%' }}>
-          <Note
-            width={ 100 }
-            title='Here is a Title'
-            inlineControl={ control }
             name='Lauren Smith'
-            createdDate={ DateHelper.formatDateString('Wed May 23 2020 12:08:00 GMT+0100 (BST)', 'DD MMM YYYY, LT') }
-            status={ status }
+            createdDate ='23 May 2020, 12:08 PM'
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With title
+An optional title can be provided using the `title` prop.
+<Preview>
+  <Story name="title" parameters={{ info: { disable: true }}}>
+    {() => {
+      const html = `<p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i> Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>
+      <ul><li>unordered</li></ul>
+      <ol><li>ordered</li></ol></br>
+      <p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i></p>
+      <p>Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>`;
+      const blocksFromHTML = convertFromHTML(html);
+      const content = ContentState.createFromBlockArray(
+        blocksFromHTML.contentBlocks,
+        blocksFromHTML.entityMap
+      );
+      const noteContent = EditorState.createWithContent(content);
+      return (
+        <div style={{ height: 300, width: '50%' }}>
+          <Note
+            title='Here is a Title'
+            noteContent={ noteContent }
+            name='Lauren Smith'
+            createdDate ='23 May 2020, 12:08 PM'
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With inline controls:
+Optional inline controls can be provided using the `inlineControl` prop. This should be an `ActionPopover`.
+<Preview>
+  <Story name="inline controls" parameters={{ info: { disable: true }}}>
+    {() => {
+      const html = `<p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i> Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>
+      <ul><li>unordered</li></ul>
+      <ol><li>ordered</li></ol></br>
+      <p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i></p>
+      <p>Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>`;
+      const blocksFromHTML = convertFromHTML(html);
+      const content = ContentState.createFromBlockArray(
+        blocksFromHTML.contentBlocks,
+        blocksFromHTML.entityMap
+      );
+      const noteContent = EditorState.createWithContent(content);
+      const inlineControl = (
+        <ActionPopover>
+          <ActionPopoverItem onClick={ () => {} }>
+            Edit
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={ () => {} }>
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      );
+      return (
+        <div style={{ height: 300, width: '50%' }}>
+          <Note
+            title='Here is a Title'
+            inlineControl={ inlineControl }
+            noteContent={ noteContent }
+            name='Lauren Smith'
+            createdDate ='23 May 2020, 12:08 PM'
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With status:
+An optional status can be provided using the `status` prop.
+<Preview>
+  <Story name="status" parameters={{ info: { disable: true }}}>
+    {() => {
+      const html = `<p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i> Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>
+      <ul><li>unordered</li></ul>
+      <ol><li>ordered</li></ol></br>
+      <p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i></p>
+      <p>Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>`;
+      const blocksFromHTML = convertFromHTML(html);
+      const content = ContentState.createFromBlockArray(
+        blocksFromHTML.contentBlocks,
+        blocksFromHTML.entityMap
+      );
+      const noteContent = EditorState.createWithContent(content);
+      const inlineControl = (
+        <ActionPopover>
+          <ActionPopoverItem onClick={ () => {}}>
+            Edit
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={ () => {} }>
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      );
+      return (
+        <div style={{ height: 300, width: '50%' }}>
+          <Note
+            title='Here is a Title'
+            inlineControl={ inlineControl }
+            name='Lauren Smith'
+            createdDate ='23 May 2020, 12:08 PM'
+            status={ {text: 'Edited', timeStamp: '23 May 2020, 12:08 PM' } }
             noteContent={ noteContent }
           />
         </div>

--- a/src/components/note/__internal__/note.style.js
+++ b/src/components/note/__internal__/note.style.js
@@ -120,6 +120,10 @@ StyledFooter.defaultProps = {
   theme: baseTheme
 };
 
+StyledFooterContent.defaultProps = {
+  theme: baseTheme
+};
+
 export {
   StyledNote, StyledNoteContent, StyledInlineControl, StyledTitle, StyledFooter, StyledFooterContent
 };

--- a/src/components/note/__internal__/note.style.js
+++ b/src/components/note/__internal__/note.style.js
@@ -91,10 +91,8 @@ const StyledNote = styled.div`
     flex-direction: column;
     padding: 24px;
     position: relative;
-    width: 100%;
+    width: ${width}%;
     min-width: 314px;
-
-    ${(width && width !== 0) ? `width: ${width}%;` : ''}
 
     ${StyledNoteContent} {
       box-sizing: border-box;

--- a/src/components/note/__internal__/status-with-tooltip/status.style.js
+++ b/src/components/note/__internal__/status-with-tooltip/status.style.js
@@ -14,6 +14,7 @@ const StyledStatusIconWrapper = styled.div`
   display: list-item;
   left: -4px;
   position: relative;
+  text-transform: uppercase;
 `;
 
 export default StyledStatusIconWrapper;


### PR DESCRIPTION
### Proposed behaviour

Add default theme.

The following props are now required for the Note component.
- noteContent
- name
- createdDate
- status.text if status is provided
- status.timeStamp if status is provided
- inlineControl must be an instance of ActionPopover

Ensure typescript prop types match the react prop types.

MDX examples have also been simplified.

### Current behaviour
`noteContent` defaults to an empty value, in practice this will not be used and is likely an error.

`name` and `createdDate` are optional but both are required for anything to be displayed. The DLS shows that both of these should be present.

It is possible to provide `status.timeStamp` without `status.text`, but nothing will be displayed.
It is possible to provide `status.text` without `status.timeStamp` but this is not featured in the DLS.

`inlineControl` does not validate it is an instance of `ActionPopover`.


### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR

- [x] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
- [x] Unit tests added or updated

<del>- [ ] Cypress automation tests added or updated

- [x] Storybook added or updated
- [x] Typescript `d.ts` file added or updated

### Additional context

Updated to `d.ts` required for CM.

### Testing instructions

Check storybook that there are no regressions.
There are no cypress tests at this time for Note.
Unit tests should be passing with 100% coverage.
