### PR TITLE
test(radiobuttongroup,groupedcharacter, numberinput): update tests

### DIFF
--- a/cypress/features/regression/configurableItems.feature
+++ b/cypress/features/regression/configurableItems.feature
@@ -1,8 +1,8 @@
 Feature: Configurable Items component
   I want to change Configurable Items component
 
-  Background: Open Configurable Items component in iframe
-    Given I open "Configurable Items" component in iframe
+  Background: Open Configurable Items component in noIframe
+    Given I open "Configurable Items" component in noiFrame
 
   @positive
   Scenario Outline: Drag record inside Configurable Items element <record> to <destinationId> element position

--- a/cypress/features/regression/draggableContext.feature
+++ b/cypress/features/regression/draggableContext.feature
@@ -1,8 +1,8 @@
 Feature: Draggable Context component
   I want to change Draggable Context component
 
-  Background: Open Draggable Context component in iframe
-    Given I open "DraggableContext" component in iframe
+  Background: Open Draggable Context component in noIframe
+    Given I open "DraggableContext" component in noiFrame
 
   @positive
   Scenario Outline: Drag record <record> inside Draggable Context to <destinationId> element position

--- a/cypress/features/regression/experimental/decimalInput.feature
+++ b/cypress/features/regression/experimental/decimalInput.feature
@@ -32,7 +32,7 @@ Feature: Decimal component
   Scenario Outline: Change Decimal component label help to <label>
     Given I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
     When I hover mouse onto "question" icon in no iFrame
-    Then tooltipPreview on preview into iFrame is set to <label>
+    Then tooltipPreview on preview in noIframe is set to <label>
     Examples:
       | label                        | nameOfObject              |
       | mp150ú¿¡üßä                  | labelHelpOtherLanguage    |

--- a/cypress/features/regression/experimental/groupedCharacter.feature
+++ b/cypress/features/regression/experimental/groupedCharacter.feature
@@ -1,11 +1,9 @@
 Feature: Experimental GroupedCharacter component
-  I want to change Experimental Grouped character component properties
-
-  Background: Open Experimental GroupedCharacter component page
-    Given I open "Experimental GroupedCharacter" component page
+  I want to check Experimental Grouped character component properties
 
   @positive
   Scenario Outline: Set groups to <groups> and verify input
+    Given I open "Experimental GroupedCharacter" component page
     When I input json to "groups" input field the "<groups>"
       And I put "<example>" example grouped character
     Then Input component value is set to "<result>"
@@ -17,126 +15,119 @@ Feature: Experimental GroupedCharacter component
 
   @positive
   Scenario Outline: Set separator to <separator>
-    When I set separator to "<separator>"
-      And I put "<text>" example grouped character
+    When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "<nameOfObject>" object name
+      And I put "<text>" example grouped character in no Iframe
     Then example grouped character is "<result>"
     Examples:
-      | separator | text   | result   |
-      | -         | 123456 | 12-34-56 |
-      | ?         | sage   | sa?ge    |
-      | #         | tests  | te#st#s  |
-      | @         | a      | a        |
-      | $         | ab     | ab       |
-      | %         | abc    | ab%c     |
-      | ^         | abcde  | ab^cd^e  |
-      | !         | abcdef | ab!cd!ef |
-      | *         | 123456 | 12*34*56 |
+      | separator | text   | result   | nameOfObject |
+      | -         | 123456 | 12-34-56 | separator-   |
+      | ?         | sage   | sa?ge    | separator?   |
+      | #         | tests  | te#st#s  | separator#   |
+      | @         | a      | a        | separator@   |
+      | $         | ab     | ab       | separator$   |
+      | %         | abc    | ab%c     | separator%   |
+      | ^         | abcde  | ab^cd^e  | separator^   |
+      | !         | abcdef | ab!cd!ef | separator!   |
+      | *         | 123456 | 12*34*56 | separator*   |
 
   @positive
   Scenario: Disable and enable GroupedCharacter component
-    Given I check disabled checkbox
-    When I uncheck disabled checkbox
+    When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "disabledFalse" object name
     Then GroupedCharacter input component is not disabled
 
   @positive
   Scenario: Disable GroupedCharacter component
-    When I check disabled checkbox
+    When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "disabled" object name
     Then GroupedCharacter input component is disabled
 
   @positive
   Scenario: Disable and enable readOnly property for GroupedCharacter component
-    Given I check readOnly checkbox
-    When I uncheck readOnly checkbox
+    When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "readOnlyFalse" object name
     Then GroupedCharacter input component is not readonly
 
   @positive
   Scenario: Disable readOnly property for GroupedCharacter component
-    When I check readOnly checkbox
+    When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "readOnly" object name
     Then GroupedCharacter input component is readonly
 
   @positive
   Scenario Outline: Change fieldHelp text to <fieldHelp>
-    When I set fieldHelp to <fieldHelp> word
-    Then fieldHelp on preview is set to <fieldHelp>
+    When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "<nameOfObject>" object name
+    Then fieldHelp on preview is set to <fieldHelp> in NoIFrame
     Examples:
-      | fieldHelp                    |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | fieldHelp                    | nameOfObject              |
+      | mp150ú¿¡üßä                  | fieldHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | fieldHelpSpecialCharacter |
 
   @positive
   Scenario Outline: Set label to <label>
-    When I set label to <label> word
-    Then label on preview is <label>
+    When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "<nameOfObject>" object name
+    Then label on preview is <label> in NoIFrame
     Examples:
-      | label                        |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | label                        | nameOfObject          |
+      | mp150ú¿¡üßä                  | labelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | labelSpecialCharacter |
 
   @positive
   Scenario Outline: Set size to <size>
-    When I select size to "<size>"
+    When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "<nameOfObject>" object name
     Then GroupedCharacter input component size is set to "<size>" and has min-height set to <minHeight> and paddings set to <px>
     Examples:
-      | size   | minHeight | px |
-      | small  | 32        | 8  |
-      | medium | 40        | 11 |
-      | large  | 48        | 13 |
+      | size   | minHeight | px | nameOfObject |
+      | small  | 32        | 8  | sizeSmall    |
+      | medium | 40        | 11 | sizeMedium   |
+      | large  | 48        | 13 | sizeLarge    |
 
   @positive
   Scenario Outline: Change labelHelp text to <labelHelp>
-    Given I set label to "label"
-      And I set labelHelp to <labelHelp> word
-    When I hover mouse onto help icon
-    Then tooltipPreview on preview is set to <labelHelp>
+    Given I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "<nameOfObject>" object name
+    When I hover mouse onto help icon in noIFrame
+    Then tooltipPreview on preview in noIframe is set to <labelHelp>
     Examples:
-      | labelHelp                    |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | labelHelp                    | nameOfObject              |
+      | mp150ú¿¡üßä                  | labelHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | labelHelpSpecialCharacter |
 
   @positive
   Scenario: Enable label inline
-    Given I set label to "label"
-    When I check labelInline checkbox
-    Then Grouped character component label Inline is enabled
+    When I open default "Experimental Number Input" component in noIFrame with "groupedCharacter" json from "experimental" using "labelInline" object name
+    Then label is inline
 
   @positive
   Scenario: Disable label inline
-    Given I set label to "label"
-      And I check labelInline checkbox
-    When I uncheck labelInline checkbox
+    When I open default "Experimental Number Input" component in noIFrame with "groupedCharacter" json from "experimental" using "labelInlineFalse" object name
     Then GroupedCharacter component labelInline is disabled
 
   @positive
   Scenario Outline: Set label width to <labelWidth>
-    Given I set label to "label"
-      And I check labelInline checkbox
-    When I set label width slider to <labelWidth>
-    Then GroupedCharacter Input component labelWidth is set to "<labelWidth>"
+    When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "<nameOfObject>" object name
+    Then label width on preview is <labelWidth>
     Examples:
-      | labelWidth |
-      | 1          |
-      | 10         |
-      | 100        |
+      | labelWidth | nameOfObject  |
+      | 1          | labelWidth1   |
+      | 10         | labelWidth10  |
+      | 100        | labelWidth100 |
 
   @positive
   Scenario Outline: Set input width to <inputWidth>
-    Given I set label to "label"
-      And I check labelInline checkbox
-    When I set inputWidth slider to <inputWidth>
-    Then GroupedCharacter Input component inputWidth is set to <inputWidth>
+    When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "<nameOfObject>" object name
+    Then inputWidth on preview is <inputWidth>
     Examples:
-      | inputWidth |
-      | 1          |
-      | 10         |
-      | 100        |
+      | inputWidth | nameOfObject  |
+      | 1          | inputWidth1   |
+      | 10         | inputWidth10  |
+      | 100        | inputWidth100 |
 
   @positive
   Scenario Outline: Set label align to <labelAlign>
-    Given I set label to "label"
-      And I check labelInline checkbox
-    When I select labelAlign to "<labelAlign>"
-    Then label Align on preview is "<labelAlign>"
+    When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "<nameOfObject>" object name
+    Then label Align on preview is "<labelAlign>" in NoIFrame
     Examples:
-      | labelAlign |
-      | right      |
-      | left       |
+      | labelAlign | nameOfObject    |
+      | right      | labelAlignRight |
+      | left       | labelAlignLeft  |
+
+  @positive
+  Scenario: Check icon inside of input is visible
+    When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "inputIconAdd" object name
+    Then icon name in noIframe on preview is "add"

--- a/cypress/features/regression/experimental/numberInput.feature
+++ b/cypress/features/regression/experimental/numberInput.feature
@@ -1,162 +1,110 @@
 Feature: Experimental Number Input component
-  I want to change Experimental Number Input component properties
-
-  Background: Open Experimental Number Input component page
-    Given I open "Experimental Number Input" component page
+  I want to check Experimental Number Input component properties
 
   @positive
-  Scenario: Enable onChangeDeferred action
-    Given I check Enable onChangeDeferred Action property
-      And clear all actions in Actions Tab
-    When I input 1 into NumberInput component
-      And I wait 1000
-    Then onChangeDeferred action was called in Actions Tab
-
-  @positive
-  Scenario: Disable onChangeDeferred action
-    Given clear all actions in Actions Tab
-    When I input 1 into NumberInput component
-    Then onChange action was called in Actions Tab
-
-  @positive
-  Scenario Outline: Enable onKeyDown action uses <key>
-    Given I check Enable onKeyDown Action property
-      And clear all actions in Actions Tab
-    When I press keyboard "<key>" keys into NumberInput input component
-    Then onKeyDown action was called in Actions Tab
+  Scenario Outline: Change field help text to <fieldHelp>
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "<nameOfObject>" object name
+    Then fieldHelp on preview is set to <fieldHelp> in NoIFrame
     Examples:
-      | key        |
-      | downarrow  |
-      | leftarrow  |
-      | rightarrow |
-      | uparrow    |
+      | fieldHelp               | nameOfObject              |
+      | mp150ú¿¡üßä             | fieldHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | fieldHelpSpecialCharacter |
+  # @ignore because of FE-2782
+  # | &"'<>|
 
   @positive
   Scenario: Disable and enable Number input component
-    Given I check disabled checkbox
-    When I uncheck disabled checkbox
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "disabledFalse" object name
     Then Number input component is not disabled
 
   @positive
   Scenario: Disable Number input component
-    When I check disabled checkbox
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "disabled" object name
     Then Number input component is disabled
 
   @positive
   Scenario: Disable and enable readOnly property for Number input component
-    Given I check readOnly checkbox
-    When I uncheck readOnly checkbox
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "readOnlyFalse" object name
     Then Number input component is not readonly
 
   @positive
   Scenario: Disable readOnly property for Number input component
-    When I check readOnly checkbox
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "readOnly" object name
     Then Number input component is readonly
 
   @positive
-  Scenario Outline: Enable onChangeDeferred action and check deferTimeout set to <deferTimeout>
-    Given I check Enable onChangeDeferred Action property
-      And I set deferTimeout to "<deferTimeout>"
-      And clear all actions in Actions Tab
-    When I input 1 into NumberInput component
-      And onChange action was called in Actions Tab
-      And I wait <deferTimeout>
-    Then onChangeDeferred action was called in Actions Tab
-    Examples:
-      | deferTimeout |
-      | 1000         |
-      | 5000         |
-      | 10000        |
-
-  @positive
-  Scenario Outline: Change field help text to <fieldHelp>
-    When I set fieldHelp to <fieldHelp> word
-    Then fieldHelp on preview is set to <fieldHelp>
-    Examples:
-      | fieldHelp               |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-  # @ignore because of FE-2782
-  # | &"'<>|
-
-  @positive
   Scenario Outline: Set label to <label>
-    When I set label to <label> word
-    Then label on preview is <label>
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "<nameOfObject>" object name
+    Then label on preview is <label> in NoIFrame
     Examples:
-      | label                   |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | label                   | nameOfObject          |
+      | mp150ú¿¡üßä             | labelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | labelSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
-
-  @positive
-  Scenario Outline: Set size to <size>
-    When I select size to "<size>"
-    Then Number input component size is set to "<size>" and has min-height set to <minHeight> and paddings set to <px>
-    Examples:
-      | size   | minHeight | px |
-      | small  | 32        | 8  |
-      | medium | 40        | 11 |
-      | large  | 48        | 13 |
 
   @positive
   Scenario Outline: Change label help text to <labelHelp>
-    Given I set label to "label"
-      And I set labelHelp to <labelHelp> word
-    When I hover mouse onto help icon
-    Then tooltipPreview on preview is set to <labelHelp>
+    Given I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "<nameOfObject>" object name
+    When I hover mouse onto help icon in noIFrame
+    Then tooltipPreview on preview in noIframe is set to <labelHelp>
     Examples:
-      | labelHelp               |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | labelHelp               | nameOfObject              |
+      | mp150ú¿¡üßä             | labelHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | labelHelpSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
 
   @positive
   Scenario: Enable label inline
-    Given I set label to "label"
-    When I check labelInline checkbox
-    Then NumberInput component labelInline is enabled
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "labelInline" object name
+    Then label is inline
 
   @positive
   Scenario: Disable label inline
-    Given I set label to "label"
-      And I check labelInline checkbox
-    When I uncheck labelInline checkbox
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "labelInlineFalse" object name
     Then NumberInput component labelInline is disabled
 
   @positive
-  Scenario Outline: Set label width to <labelWidth>
-    Given I set label to "label"
-      And I check labelInline checkbox
-    When I set label width slider to <labelWidth>
-    Then Number Input component labelWidth is set to "<labelWidth>"
+  Scenario Outline: Set input width to <inputWidth>
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "<nameOfObject>" object name
+    Then inputWidth on preview is <inputWidth>
     Examples:
-      | labelWidth |
-      | 1          |
-      | 10         |
-      | 100        |
+      | inputWidth | nameOfObject  |
+      | 1          | inputWidth1   |
+      | 10         | inputWidth10  |
+      | 100        | inputWidth100 |
 
   @positive
-  Scenario Outline: Set input width to <inputWidth>
-    Given I set label to "label"
-      And I check labelInline checkbox
-    When I set inputWidth slider to <inputWidth>
-    Then Number Input component inputWidth is set to <inputWidth>
+  Scenario Outline: Set label width to <labelWidth>
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "<nameOfObject>" object name
+    Then label width on preview is <labelWidth>
     Examples:
-      | inputWidth |
-      | 1          |
-      | 10         |
-      | 100        |
+      | labelWidth | nameOfObject  |
+      | 1          | labelWidth1   |
+      | 10         | labelWidth10  |
+      | 100        | labelWidth100 |
 
   @positive
   Scenario Outline: Set label align to <labelAlign>
-    Given I set label to "label"
-      And I check labelInline checkbox
-    When I select labelAlign to "<labelAlign>"
-    Then label Align on preview is "<labelAlign>"
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "<nameOfObject>" object name
+    Then label Align on preview is "<labelAlign>" in NoIFrame
     Examples:
-      | labelAlign |
-      | right      |
-      | left       |
+      | labelAlign | nameOfObject    |
+      | right      | labelAlignRight |
+      | left       | labelAlignLeft  |
+
+  @positive
+  Scenario Outline: Set size to <size>
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "<nameOfObject>" object name
+    Then Number input component size is set to "<size>" and has min-height set to <minHeight> and paddings set to <px>
+    Examples:
+      | size   | minHeight | px | nameOfObject |
+      | small  | 32        | 8  | sizeSmall    |
+      | medium | 40        | 11 | sizeMedium   |
+      | large  | 48        | 13 | sizeLarge    |
+
+  @positive
+  Scenario: Check icon inside of input is visible
+    When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "inputIconAdd" object name
+    Then icon name in noIframe on preview is "add"

--- a/cypress/features/regression/experimental/numberInputActions.feature
+++ b/cypress/features/regression/experimental/numberInputActions.feature
@@ -1,0 +1,47 @@
+Feature: Experimental Number Input component
+  I want to check Experimental Number Input component properties
+
+  Background: Open Experimental Number Input component page
+    Given I open "Experimental Number Input" component page
+
+  @positive
+  Scenario: Enable onChangeDeferred action
+    Given I check Enable onChangeDeferred Action property
+      And clear all actions in Actions Tab
+    When I input 1 into NumberInput component
+      And I wait 1000
+    Then onChangeDeferred action was called in Actions Tab
+
+  @positive
+  Scenario: Disable onChangeDeferred action
+    Given clear all actions in Actions Tab
+    When I input 1 into NumberInput component
+    Then onChange action was called in Actions Tab
+
+  @positive
+  Scenario Outline: Enable onKeyDown action uses <key>
+    Given I check Enable onKeyDown Action property
+      And clear all actions in Actions Tab
+    When I press keyboard "<key>" keys into NumberInput input component
+    Then onKeyDown action was called in Actions Tab
+    Examples:
+      | key        |
+      | downarrow  |
+      | leftarrow  |
+      | rightarrow |
+      | uparrow    |
+
+  @positive
+  Scenario Outline: Enable onChangeDeferred action and check deferTimeout set to <deferTimeout>
+    Given I check Enable onChangeDeferred Action property
+      And I set deferTimeout to "<deferTimeout>"
+      And clear all actions in Actions Tab
+    When I input 1 into NumberInput component
+      And onChange action was called in Actions Tab
+      And I wait <deferTimeout>
+    Then onChangeDeferred action was called in Actions Tab
+    Examples:
+      | deferTimeout |
+      | 1000         |
+      | 5000         |
+      | 10000        |

--- a/cypress/features/regression/experimental/radioButtonGroup.feature
+++ b/cypress/features/regression/experimental/radioButtonGroup.feature
@@ -1,29 +1,31 @@
 Feature: Experimental RadioButtonGroup component
   I want to change Experimental RadioButtonGroup component properties
 
-  Background: Open Experimental RadioButton other component page
-    Given I open "Experimental RadioButton" component page
-      And "Other" tab in "second" tab list is visible
-      And I open Other tab
-
   @positive
   Scenario: RadioButton inline
-    When I check inline checkbox
-    Then RadioButton are inline
+    When I open default "Experimental RadioButton" component in noIFrame with "radioButtonGroup" json from "experimental" using "inline" object name
+    Then RadioButtons are inline
 
   @positive
   Scenario: RadioButton not inline
-    When I check inline checkbox
-      And I uncheck inline checkbox
-    Then RadioButton are not inline
+    When I open default "Experimental RadioButton" component in noIFrame with "radioButtonGroup" json from "experimental" using "inlineFalse" object name
+    Then RadioButtons are not inline
 
   @positive
   Scenario: LegendInline inline
-    When I check legendInline checkbox
+    When I open default "Experimental RadioButton" component in noIFrame with "radioButtonGroup" json from "experimental" using "legendInline" object name
     Then legendInline is inline with RadioButton
 
   @positive
   Scenario: legendInline not inline
-    When I check legendInline checkbox
-      And I uncheck legendInline checkbox
+    When I open default "Experimental RadioButton" component in noIFrame with "radioButtonGroup" json from "experimental" using "legendInlineFalse" object name
     Then legendInline is not inline with RadioButton
+
+  @positive
+  Scenario Outline: Set groupLabel to <groupLabel>
+    When I open default "Experimental RadioButton" component in noIFrame with "radioButtonGroup" json from "experimental" using "<nameOfObject>" object name
+    Then legend on preview is <groupLabel> in NoIFrame
+    Examples:
+      | groupLabel                   | nameOfObject               |
+      | mp150ú¿¡üßä                  | groupLabelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | groupLabelSpecialCharacter |

--- a/cypress/features/regression/experimental/textarea.feature
+++ b/cypress/features/regression/experimental/textarea.feature
@@ -19,179 +19,179 @@ Feature: Experimental Textarea component
       | text                         |
       | {enter}{enter}{enter}{enter} |
 
-@positive
-Scenario Outline: Set cols to <cols>
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-  Then cols is set to "<cols>"
-  Examples:
-    | cols | nameOfObject |
-    | 1    | cols1        |
-    | 100  | cols100      |
-    | 300  | cols300      |
+  @positive
+  Scenario Outline: Set cols to <cols>
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    Then cols is set to "<cols>"
+    Examples:
+      | cols | nameOfObject |
+      | 1    | cols1        |
+      | 100  | cols100      |
+      | 300  | cols300      |
 
-@positive
-Scenario Outline: Set rows to <rows>
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-  Then rows is set to "<rows>"
-  Examples:
-    | rows | nameOfObject |
-    | 1    | rows1        |
-    | 100  | rows100      |
-    | 300  | rows300      |
+  @positive
+  Scenario Outline: Set rows to <rows>
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    Then rows is set to "<rows>"
+    Examples:
+      | rows | nameOfObject |
+      | 1    | rows1        |
+      | 100  | rows100      |
+      | 300  | rows300      |
 
-@positive
-Scenario: Check disabled checkbox for a Textarea component
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "disabled" object name
-  Then Textarea component is disabled
+  @positive
+  Scenario: Check disabled checkbox for a Textarea component
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "disabled" object name
+    Then Textarea component is disabled
 
-@positive
-Scenario: Uncheck disabled checkbox for a Textarea component
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "disabledFalse" object name
-  Then Textarea component is not disabled
+  @positive
+  Scenario: Uncheck disabled checkbox for a Textarea component
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "disabledFalse" object name
+    Then Textarea component is not disabled
 
-@positive
-Scenario: Enable readOnly checkbox for a Textarea component
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "readOnly" object name
-  Then Textarea component is readOnly
+  @positive
+  Scenario: Enable readOnly checkbox for a Textarea component
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "readOnly" object name
+    Then Textarea component is readOnly
 
-@positive
-Scenario: Disable readOnly checkbox for a Textarea component
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "readOnlyFalse" object name
-  Then Textarea component is not readOnly
+  @positive
+  Scenario: Disable readOnly checkbox for a Textarea component
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "readOnlyFalse" object name
+    Then Textarea component is not readOnly
 
-@positive
-Scenario Outline: Set placeholder to <placeholder>
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-  Then placeholder is set to <placeholder>
-  Examples:
-    | placeholder             | nameOfObject                |
-    | mp150ú¿¡üßä             | placeholderOtherLanguage    |
-    | !@#$%^*()_+-=~[];:.,?{} | placeholderSpecialCharacter |
-# @ignore because of FE-2782
-# | &"'<>|
+  @positive
+  Scenario Outline: Set placeholder to <placeholder>
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    Then placeholder is set to <placeholder>
+    Examples:
+      | placeholder             | nameOfObject                |
+      | mp150ú¿¡üßä             | placeholderOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | placeholderSpecialCharacter |
+  # @ignore because of FE-2782
+  # | &"'<>|
 
-@positive
-Scenario Outline: Set fieldHelp to <fieldHelp>
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-  Then fieldHelp is set to <fieldHelp>
-  Examples:
-    | fieldHelp               | nameOfObject              |
-    | mp150ú¿¡üßä             | fieldHelpOtherLanguage    |
-    | !@#$%^*()_+-=~[];:.,?{} | fieldHelpSpecialCharacter |
-# @ignore because of FE-2782
-# | &"'<>|
+  @positive
+  Scenario Outline: Set fieldHelp to <fieldHelp>
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    Then fieldHelp on preview is set to <fieldHelp> in NoIFrame
+    Examples:
+      | fieldHelp               | nameOfObject              |
+      | mp150ú¿¡üßä             | fieldHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | fieldHelpSpecialCharacter |
+  # @ignore because of FE-2782
+  # | &"'<>|
 
-@positive
-Scenario Outline: Set characterLimit to <characterLimit>
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-  Then characterLimit is set to "<characterLimit>"
-    And characterLimit for default Textarea is shown as "<result>"
-  Examples:
-    | characterLimit | result  | nameOfObject         |
-    | -1000          | -1,000  | characterLimit-1000  |
-    | -1             | -1      | characterLimit-1     |
-    | 0              | 0       | characterLimit0      |
-    | 1              | 1       | characterLimit1      |
-    | 100            | 100     | characterLimit100    |
-    | 1000           | 1,000   | characterLimit1000   |
-    | 555555         | 555,555 | characterLimit555555 |
+  @positive
+  Scenario Outline: Set characterLimit to <characterLimit>
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    Then characterLimit is set to "<characterLimit>"
+      And characterLimit for default Textarea is shown as "<result>"
+    Examples:
+      | characterLimit | result  | nameOfObject         |
+      | -1000          | -1,000  | characterLimit-1000  |
+      | -1             | -1      | characterLimit-1     |
+      | 0              | 0       | characterLimit0      |
+      | 1              | 1       | characterLimit1      |
+      | 100            | 100     | characterLimit100    |
+      | 1000           | 1,000   | characterLimit1000   |
+      | 555555         | 555,555 | characterLimit555555 |
 
-@negative
-Scenario Outline: Set characterLimit out of scope to <characterLimit>
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-  Then characterLimit for default Textarea is not set to <characterLimit>
-  Examples:
-    | characterLimit          | nameOfObject                   |
-    | mp150ú¿¡üßä             | characterLimitOtherLanguage    |
-    | !@#$%^*()_+-=~[];:.,?{} | characterLimitSpecialCharacter |
-    | -0,112                  | characterLimit-0,112           |
-    | 0.1112333               | characterLimit0.1112333        |
-# @ignore because of FE-2782
-# | &"'<>|
+  @negative
+  Scenario Outline: Set characterLimit out of scope to <characterLimit>
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    Then characterLimit for default Textarea is not set to <characterLimit>
+    Examples:
+      | characterLimit          | nameOfObject                   |
+      | mp150ú¿¡üßä             | characterLimitOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | characterLimitSpecialCharacter |
+      | -0,112                  | characterLimit-0,112           |
+      | 0.1112333               | characterLimit0.1112333        |
+  # @ignore because of FE-2782
+  # | &"'<>|
 
-@positive
-Scenario Outline: Set inputWidth to <inputWidth>
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-  Then Textarea inputWidth is set to "<inputWidth>"
-  Examples:
-    | inputWidth | nameOfObject  |
-    | 0          | inputWidth0   |
-    | 50         | inputWidth50  |
-    | 100        | inputWidth100 |
+  @positive
+  Scenario Outline: Set inputWidth to <inputWidth>
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    Then Textarea inputWidth is set to "<inputWidth>"
+    Examples:
+      | inputWidth | nameOfObject  |
+      | 0          | inputWidth0   |
+      | 50         | inputWidth50  |
+      | 100        | inputWidth100 |
 
-@positive
-Scenario Outline: Set label to <label>
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-  Then label on preview is <label> in NoIFrame
-  Examples:
-    | label                   | nameOfObject          |
-    | mp150ú¿¡üßä             | labelOtherLanguage    |
-    | !@#$%^*()_+-=~[];:.,?{} | labelSpecialCharacter |
-# @ignore because of FE-2782
-# | &"'<>|
+  @positive
+  Scenario Outline: Set label to <label>
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    Then label on preview is <label> in NoIFrame
+    Examples:
+      | label                   | nameOfObject          |
+      | mp150ú¿¡üßä             | labelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | labelSpecialCharacter |
+  # @ignore because of FE-2782
+  # | &"'<>|
 
-@positive
-Scenario Outline: Set labelHelp to <labelHelp>
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-    And I hover mouse onto "question" icon in no iFrame
-  Then tooltipPreview on preview into iFrame is set to <labelHelp>
-  Examples:
-    | labelHelp               | nameOfObject              |
-    | mp150ú¿¡üßä             | labelHelpOtherLanguage    |
-    | !@#$%^*()_+-=~[];:.,?{} | labelHelpSpecialCharacter |
-# @ignore because of FE-2782
-# | &"'<>|
+  @positive
+  Scenario Outline: Set labelHelp to <labelHelp>
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+      And I hover mouse onto "question" icon in no iFrame
+    Then tooltipPreview on preview in noIframe is set to <labelHelp>
+    Examples:
+      | labelHelp               | nameOfObject              |
+      | mp150ú¿¡üßä             | labelHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | labelHelpSpecialCharacter |
+  # @ignore because of FE-2782
+  # | &"'<>|
 
-@positive
-Scenario: Enable labelInline checkbox for a Textarea component
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "labelInline" object name
-  Then Textarea component is labelInline
+  @positive
+  Scenario: Enable labelInline checkbox for a Textarea component
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "labelInline" object name
+    Then Textarea component is labelInline
 
-@positive
-Scenario: Enable and disable labelInline checkbox for a Textarea component
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "labelInlineFalse" object name
-  Then Textarea component is not labelInline
+  @positive
+  Scenario: Enable and disable labelInline checkbox for a Textarea component
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "labelInlineFalse" object name
+    Then Textarea component is not labelInline
 
-@positive
-Scenario Outline: Set labelWidth to <labelWidth>
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-  Then label width is set to "<labelWidth>" in NoIFrame
-  Examples:
-    | labelWidth | nameOfObject  |
-    | 0          | labelWidth0   |
-    | 25         | labelWidth25  |
-    | 100        | labelWidth100 |
+  @positive
+  Scenario Outline: Set labelWidth to <labelWidth>
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    Then label width on preview is <labelWidth>
+    Examples:
+      | labelWidth | nameOfObject  |
+      | 0          | labelWidth0   |
+      | 25         | labelWidth25  |
+      | 100        | labelWidth100 |
 
-@positive
-Scenario Outline: Set labelAlign to <labelAlign>
-  When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-  Then label Align on preview is "<labelAlign>" in NoIFrame
-  Examples:
-    | labelAlign | nameOfObject    |
-    | left       | labelAlignLeft  |
-    | right      | labelAlignRight |
+  @positive
+  Scenario Outline: Set labelAlign to <labelAlign>
+    When I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    Then label Align on preview is "<labelAlign>" in NoIFrame
+    Examples:
+      | labelAlign | nameOfObject    |
+      | left       | labelAlignLeft  |
+      | right      | labelAlignRight |
 
-@positive
-Scenario Outline: Enable warnOverLimit checkbox for a Textarea component and check the warning
-  Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-  When I input <text> into Textarea
-  Then Textarea component has warnOverLimit and used characters <characters> of <limit>
-  Examples:
-    | limit | text             | characters | nameOfObject                                            |
-    | 0     | 12345            | 5          | characterLimit0warnOverLimitenforceCharacterLimitFalse  |
-    | 5     | áéíóú¿¡üñ        | 9          | characterLimit5warnOverLimitenforceCharacterLimitFalse  |
-    | 10    | testTestTextTest | 16         | characterLimit10warnOverLimitenforceCharacterLimitFalse |
+  @positive
+  Scenario Outline: Enable warnOverLimit checkbox for a Textarea component and check the warning
+    Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    When I input <text> into Textarea
+    Then Textarea component has warnOverLimit and used characters <characters> of <limit>
+    Examples:
+      | limit | text             | characters | nameOfObject                                            |
+      | 0     | 12345            | 5          | characterLimit0warnOverLimitenforceCharacterLimitFalse  |
+      | 5     | áéíóú¿¡üñ        | 9          | characterLimit5warnOverLimitenforceCharacterLimitFalse  |
+      | 10    | testTestTextTest | 16         | characterLimit10warnOverLimitenforceCharacterLimitFalse |
 
-@positive
-Scenario Outline: Disable warnOverLimit checkbox for a Textarea component and allow to input more characters than allowed
-  Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
-  When I input <text> into Textarea
-  Then Textarea component has no warnOverLimit and used characters <characters> of <limit>
-  Examples:
-    | limit | text        | characters | nameOfObject                      |
-    | 0     | !!          | 2          | characterLimit0warnOverLimitFalse |
-    | 3     | 123456      | 6          | characterLimit3warnOverLimitFalse |
-    | 5     | áéíóú¿¡üñą  | 10         | characterLimit5warnOverLimitFalse |
+  @positive
+  Scenario Outline: Disable warnOverLimit checkbox for a Textarea component and allow to input more characters than allowed
+    Given I open default "Experimental-Textarea" component in noIFrame with "textarea" json from "experimental" using "<nameOfObject>" object name
+    When I input <text> into Textarea
+    Then Textarea component has no warnOverLimit and used characters <characters> of <limit>
+    Examples:
+      | limit | text        | characters | nameOfObject                      |
+      | 0     | !!          | 2          | characterLimit0warnOverLimitFalse |
+      | 3     | 123456      | 6          | characterLimit3warnOverLimitFalse |
+      | 5     | áéíóú¿¡üñą | 10         | characterLimit5warnOverLimitFalse |
 
   @positive
   Scenario Outline: Enable enforceCharacterLimit checkbox for a Textarea component and check the warning

--- a/cypress/features/regression/experimental/textbox.feature
+++ b/cypress/features/regression/experimental/textbox.feature
@@ -33,7 +33,7 @@ Feature: Experimental Textbox component
   @positive
   Scenario Outline: Set fieldHelp to <fieldHelp>
     When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
-    Then fieldHelp is set to <fieldHelp>
+    Then fieldHelp on preview is set to <fieldHelp> in NoIFrame
     Examples:
       | fieldHelp                    | nameOfObject              |
       | mp150ú¿¡üßä                  | fieldHelpOtherLanguage    |
@@ -52,7 +52,7 @@ Feature: Experimental Textbox component
   Scenario Outline: Set labelHelp to <labelHelp>
     When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
       And I hover mouse onto "question" icon in no iFrame
-    Then tooltipPreview on preview into iFrame is set to <labelHelp>
+    Then tooltipPreview on preview in noIframe is set to <labelHelp>
     Examples:
       | labelHelp                    | nameOfObject              |
       | mp150ú¿¡üßä                  | labelHelpOtherLanguage    |
@@ -71,7 +71,7 @@ Feature: Experimental Textbox component
   @positive
   Scenario Outline: Set labelWidth to <labelWidth>
     When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "<nameOfObject>" object name
-    Then label width is set to "<labelWidth>" in NoIFrame
+    Then label width on preview is <labelWidth>
     Examples:
       | labelWidth | nameOfObject  |
       | 0          | labelWidth0   |
@@ -121,4 +121,4 @@ Feature: Experimental Textbox component
   @positive
   Scenario: Check icon inside of Textbox is visible
     When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "inputIconAdd" object name
-    Then icon name into iFrame on preview is "add"
+    Then icon name in noIframe on preview is "add"

--- a/cypress/features/regression/test/badge.feature
+++ b/cypress/features/regression/test/badge.feature
@@ -34,4 +34,4 @@ Feature: Badge component
   Scenario: Hover Badge component and verify that cross icon appears
     Given I open Test test_basic "Badge" component in noIFrame with "badge" json from "test" using "counter1" object name
     When I focus onto Badge component
-    Then icon name into iFrame on preview is "cross"
+    Then icon name in noIframe on preview is "cross"

--- a/cypress/features/regression/test/draggableNoIFrame.feature
+++ b/cypress/features/regression/test/draggableNoIFrame.feature
@@ -1,7 +1,7 @@
 Feature: Draggable Component
   I want to change Draggable component
 
-  Background: Open Draggable Component in iframe
+  Background: Open Draggable Component in no iframe
     Given I open "Design System Draggable Test" component page "basic" in no iframe
 
   @positive

--- a/cypress/fixtures/experimental/groupedCharacter.json
+++ b/cypress/fixtures/experimental/groupedCharacter.json
@@ -1,0 +1,121 @@
+{
+  "separator-": {
+    "separator": "-"
+  },
+  "separator?": {
+    "separator": "?"
+  },
+  "separator#": {
+    "separator": "#"
+  },
+  "separator@": {
+    "separator": "@"
+  },
+  "separator$": {
+    "separator": "$"
+  },
+  "separator%": {
+    "separator": "%"
+  },
+  "separator^": {
+    "separator": "^"
+  },
+  "separator!": {
+    "separator": "!"
+  },
+  "separator*": {
+    "separator": "*"
+  },
+  "disabled": {
+    "disabled": true
+  },
+  "disabledFalse": {
+    "disabled": false
+  },
+  "readOnly": {
+    "readOnly": true
+  },
+  "readOnlyFalse": {
+    "readOnly": false
+  },
+  "fieldHelpOtherLanguage": {
+    "fieldHelp": "mp150ú¿¡üßä"
+  },
+  "fieldHelpSpecialCharacter": {
+    "fieldHelp": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "labelOtherLanguage": {
+    "label": "mp150ú¿¡üßä"
+  },
+  "labelSpecialCharacter": {
+    "label": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "labelHelpOtherLanguage": {
+    "label": "label",
+    "labelHelp": "mp150ú¿¡üßä"
+  },
+  "labelHelpSpecialCharacter": {
+    "label": "label",
+    "labelHelp": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "labelInline": {
+    "label": "label",
+    "labelInline": true
+  },
+  "labelInlineFalse": {
+    "label": "label",
+    "labelInline": false
+  },
+  "labelWidth1": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 1
+  },
+  "labelWidth10": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 10
+  },
+  "labelWidth100": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 100
+  },
+  "inputWidth1": {
+    "label": "label",
+    "labelInline": true,
+    "inputWidth": 1
+  },
+  "inputWidth10": {
+    "label": "label",
+    "labelInline": true,
+    "inputWidth": 10
+  },
+  "inputWidth100": {
+    "label": "label",
+    "labelInline": true,
+    "inputWidth": 100
+  },
+  "labelAlignRight": {
+    "label": "label",
+    "labelInline": true,
+    "labelAlign": "right"
+  },
+  "labelAlignLeft": {
+    "label": "label",
+    "labelInline": true,
+    "labelAlign": "left"
+  },
+  "sizeSmall": {
+    "size": "small"
+  },
+  "sizeMedium": {
+    "size": "medium"
+  },
+  "sizeLarge": {
+    "size": "large"
+  },
+  "inputIconAdd": {
+    "inputIcon": "add"
+  }
+}

--- a/cypress/fixtures/experimental/numberInput.json
+++ b/cypress/fixtures/experimental/numberInput.json
@@ -1,0 +1,94 @@
+{
+  "disabled": {
+    "disabled": true
+  },
+  "disabledFalse": {
+    "disabled": false
+  },
+  "readOnly": {
+    "readOnly": true
+  },
+  "readOnlyFalse": {
+    "readOnly": false
+  },
+  "fieldHelpOtherLanguage": {
+    "fieldHelp": "mp150ú¿¡üßä"
+  },
+  "fieldHelpSpecialCharacter": {
+    "fieldHelp": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "labelOtherLanguage": {
+    "label": "mp150ú¿¡üßä"
+  },
+  "labelSpecialCharacter": {
+    "label": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "labelHelpOtherLanguage": {
+    "label": "label",
+    "labelHelp": "mp150ú¿¡üßä"
+  },
+  "labelHelpSpecialCharacter": {
+    "label": "label",
+    "labelHelp": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "labelInline": {
+    "label": "label",
+    "labelInline": true
+  },
+  "labelInlineFalse": {
+    "label": "label",
+    "labelInline": false
+  },
+  "labelWidth1": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 1
+  },
+  "labelWidth10": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 10
+  },
+  "labelWidth100": {
+    "label": "label",
+    "labelInline": true,
+    "labelWidth": 100
+  },
+  "inputWidth1": {
+    "label": "label",
+    "labelInline": true,
+    "inputWidth": 1
+  },
+  "inputWidth10": {
+    "label": "label",
+    "labelInline": true,
+    "inputWidth": 10
+  },
+  "inputWidth100": {
+    "label": "label",
+    "labelInline": true,
+    "inputWidth": 100
+  },
+  "labelAlignRight": {
+    "label": "label",
+    "labelInline": true,
+    "labelAlign": "right"
+  },
+  "labelAlignLeft": {
+    "label": "label",
+    "labelInline": true,
+    "labelAlign": "left"
+  },
+  "sizeSmall": {
+    "size": "small"
+  },
+  "sizeMedium": {
+    "size": "medium"
+  },
+  "sizeLarge": {
+    "size": "large"
+  },
+  "inputIconAdd": {
+    "inputIcon": "add"
+  }
+}

--- a/cypress/fixtures/experimental/radioButtonGroup.json
+++ b/cypress/fixtures/experimental/radioButtonGroup.json
@@ -1,0 +1,20 @@
+{
+  "inline": {
+    "inline": true
+  },
+  "inlineFalse": {
+    "inline": false
+  },
+  "legendInline": {
+    "legendInline": true
+  },
+  "legendInlineFalse": {
+    "legendInline": false
+  },
+  "groupLabelOtherLanguage": {
+    "groupLabel": "mp150ú¿¡üßä"
+  },
+  "groupLabelSpecialCharacter": {
+    "groupLabel": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  }
+}

--- a/cypress/locators/radioButton/index.js
+++ b/cypress/locators/radioButton/index.js
@@ -8,8 +8,10 @@ import {
 // component preview locators
 export const radioButtonComponent = () => cy.iFrame(RADIO_BUTTON_COMPONENT);
 export const radioButtonByPosition = position => cy.iFrame(RADIO_BUTTON).eq(position);
-export const radioButtonComponentByPosition = position => cy.iFrame(RADIO_BUTTON_COMPONENT)
+
+// no Iframe locators
+export const radioButtonFieldset = () => cy.get(RADIO_BUTTON_FIELDSET_GROUP).children();
+export const radioButtonLegend = () => cy.get(RADIO_BUTTON_FIELDSET_GROUP).find('legend').parent();
+export const radioButtonGroupNoIframe = () => cy.get(RADIO_BUTTON_GROUP_COMPONENT);
+export const radioButtonComponentByPositionNoIframe = position => cy.get(RADIO_BUTTON_COMPONENT)
   .eq(position);
-export const radioButtonGroup = () => cy.iFrame(RADIO_BUTTON_GROUP_COMPONENT);
-export const radioButtonFieldset = () => cy.iFrame(RADIO_BUTTON_FIELDSET_GROUP).children();
-export const radioButtonLegend = () => cy.iFrame(RADIO_BUTTON_FIELDSET_GROUP).find('legend').parent();

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -20,6 +20,7 @@ import {
   commonDataElementInputPreviewNoIframe,
   helpIconNoIFrame,
   helpIconByPositionNoIFrame,
+  getElementNoIframe,
 } from '../../locators';
 import { dialogTitle, dialogTitleNoIFrame } from '../../locators/dialog';
 import { DEBUG_FLAG } from '..';
@@ -97,11 +98,6 @@ Given('I open dark theme {string} component page in noIFrame', (component) => {
   visitComponentUrl(component, 'dark_theme', true);
 });
 
-Given('I open {string} component in iframe', (component) => {
-  visitComponentUrl(component, 'default', true);
-});
-
-// the step above should be refactored and changed to in noiFrame
 Given('I open {string} component in noiFrame', (component) => {
   visitComponentUrl(component, 'default', true);
 });
@@ -261,7 +257,7 @@ Then('tooltipPreview on preview is set to {word}', (text) => {
   tooltipPreview().should('have.text', text);
 });
 
-Then('tooltipPreview on preview into iFrame is set to {word}', (text) => {
+Then('tooltipPreview on preview in noIframe is set to {word}', (text) => {
   tooltipPreviewNoIframe().should('have.text', text);
 });
 
@@ -562,4 +558,8 @@ Then('label Align on preview is {string} in NoIFrame', (direction) => {
   } else {
     getDataElementByValueNoIframe('label').parent().should($element => expect($element).to.have.css(TEXT_ALIGN, TEXT_ALIGN_END));
   }
+});
+
+Then('icon name in noIframe on preview is {string}', (iconName) => {
+  getElementNoIframe(iconName);
 });

--- a/cypress/support/step-definitions/configurable-items-steps.js
+++ b/cypress/support/step-definitions/configurable-items-steps.js
@@ -1,6 +1,5 @@
 import { draggableItemByText, draggableItemByTextNoIframe, draggableItemByPosition } from '../../locators/configurable-items';
 import { dragAndDrop } from '../helper';
-import { label } from '../../locators';
 
 When('I drag Configurable Items {string} to {int}', (record, destinationId) => {
   const startPosition = 110;
@@ -14,9 +13,4 @@ When('I drag Configurable Items with iFrame {string} to {int}', (record, destina
 
 Then('Configurable Items {string} is dragged to {int}', (record, destinationId) => {
   draggableItemByPosition(destinationId).should('have.text', record);
-});
-
-Then('Grouped character component label Inline is enabled', () => {
-  label().parent().should('have.css', 'box-sizing', 'border-box')
-    .and('have.css', 'justify-content', 'flex-start');
 });

--- a/cypress/support/step-definitions/detail-steps.js
+++ b/cypress/support/step-definitions/detail-steps.js
@@ -1,5 +1,5 @@
 import { childrenPreview, footnotePreview, iconSelect } from '../../locators/detail';
-import { icon, getElementNoIframe } from '../../locators';
+import { icon } from '../../locators';
 
 Then('detail children on preview is {word}', (children) => {
   childrenPreview().should('have.text', children);
@@ -20,8 +20,4 @@ Then('icon not exists on preview', () => {
 Then('icon on preview is {string}', (iconName) => {
   icon().should('have.attr', 'data-element', iconName)
     .and('be.visible');
-});
-
-Then('icon name into iFrame on preview is {string}', (iconName) => {
-  getElementNoIframe(iconName);
 });

--- a/cypress/support/step-definitions/grouped-character-steps.js
+++ b/cypress/support/step-definitions/grouped-character-steps.js
@@ -1,11 +1,18 @@
-import { commonDataElementInputPreview, getKnobsInput } from '../../locators';
+import { commonDataElementInputPreview, 
+  getKnobsInput, 
+  commonDataElementInputPreviewNoIframe 
+} from '../../locators';
 
 When('I put {string} example grouped character', (text) => {
   commonDataElementInputPreview().clear().type(text, { delay: 1000, force: true });
 });
 
+When('I put {string} example grouped character in no Iframe', (text) => {
+  commonDataElementInputPreviewNoIframe().clear().type(text, { delay: 1000, force: true });
+});
+
 Then('example grouped character is {string}', (text) => {
-  commonDataElementInputPreview().should('have.value', text);
+  commonDataElementInputPreviewNoIframe().should('have.value', text);
 });
 
 Then('Input component inputWidth is set to {string}', (width) => {

--- a/cypress/support/step-definitions/number-input-steps.js
+++ b/cypress/support/step-definitions/number-input-steps.js
@@ -1,6 +1,8 @@
 import { enableOnChangeDeferredAction, enableKeyDownAction } from '../../locators/number-input';
-import { commonDataElementInputPreview, label } from '../../locators';
-
+import { commonDataElementInputPreview, 
+  commonDataElementInputPreviewNoIframe, 
+  labelNoIFrame } 
+  from '../../locators';
 const TEXT_ALIGN_START = 'flex-start';
 
 When('I check Enable onChangeDeferred Action property', () => {
@@ -21,48 +23,34 @@ When('I press keyboard {string} keys into NumberInput input component', (key) =>
 
 Then('{word} input component is {word}', (componentName, parameter) => {
   if (parameter === 'disabled') {
-    commonDataElementInputPreview().should(`be.${parameter}`)
+    commonDataElementInputPreviewNoIframe().should(`be.${parameter}`)
       .and('have.attr', parameter);
-    commonDataElementInputPreview().parent().should('have.attr', parameter);
+    commonDataElementInputPreviewNoIframe().parent().should('have.attr', parameter);
   } else {
-    commonDataElementInputPreview().should('have.attr', parameter);
-    commonDataElementInputPreview().parent().should('have.attr', parameter);
+    commonDataElementInputPreviewNoIframe().should('have.attr', parameter);
+    commonDataElementInputPreviewNoIframe().parent().should('have.attr', parameter);
   }
 });
 
 Then('{word} input component is not {word}', (parameter) => {
   if (parameter === 'disabled') {
-    commonDataElementInputPreview().should(`not.be.${parameter}`)
+    commonDataElementInputPreviewNoIframe().should(`not.be.${parameter}`)
       .and('not.have.attr', parameter);
-    commonDataElementInputPreview().parent().should(`not.be.${parameter}`)
+    commonDataElementInputPreviewNoIframe().parent().should(`not.be.${parameter}`)
       .and('not.have.attr', parameter);
   } else {
-    commonDataElementInputPreview().should('not.have.attr', parameter);
-    commonDataElementInputPreview().parent().should('not.have.attr', parameter);
+    commonDataElementInputPreviewNoIframe().should('not.have.attr', parameter);
+    commonDataElementInputPreviewNoIframe().parent().should('not.have.attr', parameter);
   }
 });
 
 Then('{word} input component size is set to {string} and has min-height set to {int} and paddings set to {int}', (componentName, size, minHeight, px) => {
-  commonDataElementInputPreview().parent().should('have.css', 'min-height', `${minHeight}px`)
+  commonDataElementInputPreviewNoIframe().parent().should('have.css', 'min-height', `${minHeight}px`)
     .and('have.css', 'padding-left', `${px}px`)
     .and('have.css', 'padding-right', `${px}px`);
 });
 
-Then('NumberInput component labelInline is enabled', () => {
-  label().parent().should('have.css', 'box-sizing', 'border-box')
-    .and('have.css', 'justify-content', TEXT_ALIGN_START)
-    .and('have.css', 'padding-bottom', '0px')
-});
-
 Then('{word} component labelInline is disabled', () => {
-  label().parent().should('not.have.css', 'box-sizing', 'border-box')
+  labelNoIFrame().parent().should('not.have.css', 'box-sizing', 'border-box')
     .and('not.have.css', 'justify-content', TEXT_ALIGN_START)
-});
-
-Then('{word} Input component inputWidth is set to {int}', (componentName, width) => {
-  commonDataElementInputPreview().parent().should('have.css', 'flex', `0 0 ${width}%`);
-});
-
-Then('{word} Input component labelWidth is set to {string}', (componentName, width) => {
-  label().parent().should('have.attr', 'width', width);
 });

--- a/cypress/support/step-definitions/radio-button-steps.js
+++ b/cypress/support/step-definitions/radio-button-steps.js
@@ -1,10 +1,10 @@
 import { fieldHelpPreview, labelByPosition, labelWidthSliderByName } from '../../locators';
 import {
   radioButtonByPosition,
-  radioButtonComponentByPosition,
-  radioButtonGroup,
   radioButtonFieldset,
   radioButtonLegend,
+  radioButtonGroupNoIframe,
+  radioButtonComponentByPositionNoIframe,
 } from '../../locators/radioButton/index';
 import { setSlidebar, positionOfElement } from '../helper';
 
@@ -80,18 +80,18 @@ When('I set RadioButton {word} {word} slider to {int}', (propertyName, text, wid
   setSlidebar(labelWidthSliderByName(propertyName, text), width);
 });
 
-Then('RadioButton are inline', () => {
-  radioButtonGroup().should('have.css', 'display', 'flex');
-  radioButtonComponentByPosition(positionOfElement('first')).should('have.css', 'margin-left', '0px');
-  radioButtonComponentByPosition(positionOfElement('second')).should('have.css', 'margin-left', '32px');
-  radioButtonComponentByPosition(positionOfElement('third')).should('have.css', 'margin-left', '32px');
+Then('RadioButtons are inline', () => {
+  radioButtonGroupNoIframe().should('have.css', 'display', 'flex');
+  radioButtonComponentByPositionNoIframe(positionOfElement('first')).should('have.css', 'margin-left', '0px');
+  radioButtonComponentByPositionNoIframe(positionOfElement('second')).should('have.css', 'margin-left', '32px');
+  radioButtonComponentByPositionNoIframe(positionOfElement('third')).should('have.css', 'margin-left', '32px');
 });
 
-Then('RadioButton are not inline', () => {
-  radioButtonGroup().should('have.css', 'display', 'block');
-  radioButtonComponentByPosition(positionOfElement('first')).should('have.css', 'margin-left', '0px');
-  radioButtonComponentByPosition(positionOfElement('second')).should('have.css', 'margin-left', '0px');
-  radioButtonComponentByPosition(positionOfElement('third')).should('have.css', 'margin-left', '0px');
+Then('RadioButtons are not inline', () => {
+  radioButtonGroupNoIframe().should('have.css', 'display', 'block');
+  radioButtonComponentByPositionNoIframe(positionOfElement('first')).should('have.css', 'margin-left', '0px');
+  radioButtonComponentByPositionNoIframe(positionOfElement('second')).should('have.css', 'margin-left', '0px');
+  radioButtonComponentByPositionNoIframe(positionOfElement('third')).should('have.css', 'margin-left', '0px');
 });
 
 Then('legendInline is inline with RadioButton', () => {
@@ -102,4 +102,8 @@ Then('legendInline is inline with RadioButton', () => {
 
 Then('legendInline is not inline with RadioButton', () => {
   radioButtonFieldset().should('have.css', 'display', 'block');
+});
+
+Then('legend on preview is {word} in NoIFrame', (text) => {
+  radioButtonLegend().should('have.text', text);
 });

--- a/cypress/support/step-definitions/text-area-steps.js
+++ b/cypress/support/step-definitions/text-area-steps.js
@@ -3,9 +3,7 @@ import {
   characterLimit, characterLimitDefaultTextarea, textareaInput,
 } from '../../locators/textarea';
 import { setSlidebar } from '../helper';
-import {
-  fieldHelpPreviewNoIFrame, getDataElementByValueNoIframe,
-} from '../../locators';
+import { getDataElementByValueNoIframe } from '../../locators';
 
 Then('Textarea component is expandable', () => {
   textareaChildren().should('have.css', 'height', '89px');
@@ -53,10 +51,6 @@ Then('Textarea component is not readOnly', () => {
 
 Then('placeholder is set to {word}', (text) => {
   textareaChildren().should('have.attr', 'placeholder', text);
-});
-
-Then('fieldHelp is set to {word}', (text) => {
-  fieldHelpPreviewNoIFrame().should('have.text', text);
 });
 
 Then('characterLimit is set to {string}', (length) => {


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Apply new `url` approach in tests for:
`Experimental:`
- Group Character(`timing`: was `6:59` -> `2:29`).
- Number Input (`timing`: was `6:41` -> `1:11`).
- RadioButton Group(`timing`: was `0:54` -> `00:21`).

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are passing all parameters via `knobs`. 

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Screenshots are included in the PR
- [ ] Carbon implementation and Design System documentation are congruent
- [ ] All themes are supported
- [ ] Commits follow our style guide
- [ ] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [ ] Storybook added or updated
- [ ] Typescript `d.ts` file added or updated

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
