### PR TITLE
build(deps): [security] bump prismjs up to 1.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33804,9 +33804,9 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.19.0.tgz",
-      "integrity": "sha512-IVFtbW9mCWm9eOIaEkNyo2Vl4NnEifis2GQ7/MLRG5TQe6t+4Sj9J5QWI9i3v+SS43uZBlCAOn+zYTVYQcPXJw==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+      "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
       "dev": true,
       "requires": {
         "clipboard": "^2.0.0"


### PR DESCRIPTION
### Proposed behaviour
Update prismjs as per dependabots security alert. It was unable to do it automatically, I think because prismjs wasn't explicitly in our package.json as a dep.

### Current behaviour

### Checklist

- <del>[ ] Screenshots are included in the PR</del>
- <del>[ ] Carbon implementation and Design System documentation are congruent</del>
- <del>[ ] All themes are supported</del>
- [x] Commits follow our style guide
- <del>[ ] Unit tests added or updated</del>
- <del>[ ] Cypress automation tests added or updated</del>
- <del>[ ] Storybook added or updated</del>
- <del>[ ] Typescript `d.ts` file added or updated</del>

### Additional context

### Testing instructions
