### PR TITLE
fix(note): remove min width to allow note to size dynamically

### DIFF
--- a/src/components/note/__internal__/note.spec.js
+++ b/src/components/note/__internal__/note.spec.js
@@ -45,9 +45,7 @@ describe('Note', () => {
         flexDirection: 'column',
         padding: '24px',
         position: 'relative',
-        width: '100%',
-        minWidth: '314px'
-
+        width: '100%'
       }, wrapper);
 
       const content = wrapper.find(StyledNoteContent);
@@ -122,6 +120,46 @@ describe('Note', () => {
   describe('Footer Props', () => {
     const name = 'foo';
     const createdDate = '25/12/20';
+
+    it('renders the correct styling for the footer and content', () => {
+      const wrapper = render({ name, createdDate });
+
+      assertStyleMatch({
+        display: 'flex',
+        marginBottom: '-8px',
+        flexWrap: 'wrap'
+      }, wrapper.find(StyledFooter));
+
+      assertStyleMatch({
+        alignItems: 'baseline'
+      }, wrapper.find(StyledFooterContent));
+
+      assertStyleMatch({
+        fontWeight: 'bold',
+        fontSize: '14px',
+        marginTop: '16px'
+      }, wrapper.find(StyledFooterContent),
+      { modifier: ':first-of-type' });
+
+      assertStyleMatch({
+        fontWeight: 'bold',
+        fontSize: '12px',
+        marginTop: '16px',
+        color: baseTheme.note.timeStamp,
+        marginLeft: '16px'
+      }, wrapper.find(StyledFooterContent),
+      { modifier: ':nth-of-type(2)' });
+
+      assertStyleMatch({
+        fontWeight: 'bold',
+        fontSize: '12px',
+        marginTop: '16px',
+        color: baseTheme.note.timeStamp,
+        cursor: 'pointer',
+        marginLeft: '24px'
+      }, wrapper.find(StyledFooterContent),
+      { modifier: ':last-of-type:not(:nth-of-type(2))' });
+    });
 
     it('renders the "name" and "createdDate" when props have value', () => {
       const wrapper = render({ name, createdDate });

--- a/src/components/note/__internal__/note.style.js
+++ b/src/components/note/__internal__/note.style.js
@@ -45,24 +45,21 @@ const StyledTitle = styled.header`
 `;
 
 const StyledFooterContent = styled.div`
-  position: relative;
   line-height: 21px;
-
-  &:first-of-type {
-    font-weight: bold;
-    font-size: 14px;
-    top: 16px;
-    height: 21px;
-  }
-
+  align-items: baseline
   ${({ theme }) => `
+    &:first-of-type {
+      font-weight: bold;
+      font-size: 14px;
+      margin-top: ${2 * theme.spacing}px;
+    }
+
     &:nth-of-type(2) {
       font-weight: bold;
       font-size: 12px;
       color: ${theme.note.timeStamp};
-      left: 16px;
-      top: 17px;
-      height: 21px;
+      margin-left: ${2 * theme.spacing}px;
+      margin-top: ${2 * theme.spacing}px;
     }
 
     &:last-of-type:not(:nth-of-type(2)) {
@@ -70,17 +67,16 @@ const StyledFooterContent = styled.div`
       font-size: 12px;
       color: ${theme.note.timeStamp};
       cursor: pointer;
-      top: 17px;
-      height: 21px;
-      left: 40px;
+      margin-top: ${2 * theme.spacing}px;
+      margin-left: ${3 * theme.spacing}px;
     }
   `}
 `;
 
 const StyledFooter = styled.div`
   display: flex;
-  top: 4px;
-  height: 32px;
+  margin-bottom: ${({ theme }) => `${-theme.spacing}px;`}
+  flex-wrap: wrap;
 `;
 
 const StyledNote = styled.div`
@@ -92,7 +88,7 @@ const StyledNote = styled.div`
     padding: 24px;
     position: relative;
     width: ${width}%;
-    min-width: 314px;
+    box-sizing: border-box;
 
     ${StyledNoteContent} {
       box-sizing: border-box;
@@ -123,5 +119,10 @@ StyledFooterContent.defaultProps = {
 };
 
 export {
-  StyledNote, StyledNoteContent, StyledInlineControl, StyledTitle, StyledFooter, StyledFooterContent
+  StyledNote,
+  StyledNoteContent,
+  StyledInlineControl,
+  StyledTitle,
+  StyledFooter,
+  StyledFooterContent
 };


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->

The missing `box-sizing: border-box` and has
a `min-width` have been added, this means it aligns with a `fullWidth` `Button` for example. The footer has also been updated to allow the content to wrap at smaller screen sizes.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently the `Note` component overflows its parent as it is missing `box-sizing: border-box` and has
a `min-width`. The footer does not wrap as there is a min-width on the component

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Screenshots are included in the PR
- [x] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
- [x] Unit tests added or updated
<del>- [ ] Cypress automation tests added or updated<del>
<del>- [ ] Storybook added or updated<del>
<del>- [ ] Typescript `d.ts` file added or updated<del>

### Additional context
<!-- Add any other context or links about the pull request here. -->
Example of mis-align with Button:
![image](https://user-images.githubusercontent.com/44157880/89789261-46199080-db18-11ea-9b9a-4b62203ce1af.png)

Overflowing parent: 
![image](https://user-images.githubusercontent.com/44157880/89787648-bc68c380-db15-11ea-8221-e2b6885f2a8b.png)

No longer overflowing:
![image](https://user-images.githubusercontent.com/44157880/89787757-f20dac80-db15-11ea-95cf-afa4306b0247.png)

codesandbox of changes:
https://codesandbox.io/s/carbon-quickstart-5q11p?file=/src/index.js
### Testing instructions
<!-- How can a reviewer test this PR? -->
