### PR TITLE
test(table/tableActions/tableWithInputs/Pager): apply new url approach

### DIFF
--- a/cypress/features/regression/table.feature
+++ b/cypress/features/regression/table.feature
@@ -1,35 +1,31 @@
 Feature: Table component
-  I want to change Table component properties
-
-  Background: Open Table component default page
-    Given I open "Table" component page
+  I want to check Table component properties
 
   @positive
   Scenario: Verify the pagination is visible
-    When I check paginate checkbox
+    When I open default "Table" component in noIFrame with "table" json from "commonComponents" using "paginate" object name
     Then pagination is visible
 
   @positive
   Scenario: I enable selectable
-    When I check selectable checkbox
+    When I open default "Table" component in noIFrame with "table" json from "commonComponents" using "selectable" object name
     Then rows are selectable
 
   @positive
   Scenario: I disable selectable
-    Given I check selectable checkbox
-    When I uncheck selectable checkbox
+    When I open default "Table" component in noIFrame with "table" json from "commonComponents" using "selectableFalse" object name
     Then rows are not selectable
 
   @positive
   Scenario: Verify action toolbar elements
-    Given I check selectable checkbox
+    Given I open default "Table" component in noIFrame with "table" json from "commonComponents" using "selectable" object name
     When I check checkbox on header
     Then Action Toolbar elemens are visible and have "rgb(0, 129, 93)" color
 
   @positive
   Scenario Outline: Row <rowNumber> is highlighted
-    When I check highlightable checkbox
-      And I click row by number <rowNumber>
+    Given I open default "Table" component in noIFrame with "table" json from "commonComponents" using "highlightable" object name
+    When I click row by number <rowNumber>
     Then row number <rowNumber> is highlighted
     Examples:
       | rowNumber |
@@ -39,9 +35,8 @@ Feature: Table component
 
   @positive
   Scenario Outline: Row <rowNumber> is not highlighted
-    Given I check highlightable checkbox
-    When I uncheck highlightable checkbox
-      And I click row by number <rowNumber>
+    Given I open default "Table" component in noIFrame with "table" json from "commonComponents" using "highlightableFalse" object name
+    When I click row by number <rowNumber>
     Then row number <rowNumber> is not highlighted
     Examples:
       | rowNumber |
@@ -51,83 +46,66 @@ Feature: Table component
 
   @positive
   Scenario Outline: Sort <headerName> Column by <sortColumn>
-    When I select sortColumn to "<sortColumn>"
+    Given I open default "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then "<headerName>" Table column can be sorted
     Examples:
-      | sortColumn | headerName |
-      | name       | Country    |
-      | code       | Code       |
+      | nameOfObject   | headerName |
+      | sortColumnName | Country    |
+      | sortColumnCode | Code       |
 
   @positive
   Scenario Outline: Sort Country column in <sortOrder> order
-    Given I select sortColumn to "name"
-    When I select sortOrder to "<sortOrder>"
+    Given I open default "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then Country column is sorted in "<sortOrder>" order
     Examples:
-      | sortOrder |
-      | desc      |
-      | asc       |
+      | sortOrder | nameOfObject    |
+      | desc      | sortCountryDesc |
+      | asc       | sortCountryAsc  |
 
   @positive
   Scenario Outline: Sort Code column in <sortOrder> order
-    Given I select sortColumn to "code"
-    When I select sortOrder to "<sortOrder>"
+    Given I open default "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then Code column is sorted in "<sortOrder>" order
     Examples:
-      | sortOrder |
-      | desc      |
-      | asc       |
-
-  @ignore
-  @positive
-  #ignored because it is not working correctly during development
-  Scenario: Enable shrink property
-    When I check shrink checkbox
-    Then row is shrinked
-
-  @ignore
-  @positive
-  #ignored because it is not working correctly during development
-  Scenario: Disable shrink property
-    When I check shrink checkbox
-      And I uncheck shrink checkbox
-    Then row is not shrinked
+      | sortOrder | nameOfObject |
+      | desc      | sortCodeDesc |
+      | asc       | sortCodeAsc  |
 
   @positive
   Scenario Outline: Set caption to <caption>
-    When I set caption to <caption> word
+    When I open default "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then caption is set to <caption>
     Examples:
-      | caption                 |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | caption                 | nameOfObject            |
+      | mp150ú¿¡üßä             | captionOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | captionSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
 
   @positive
   Scenario Outline: Set theme to <theme>
-    When I select theme to "<theme>"
+    When I open default "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then theme on preview is "<theme>"
     Examples:
-      | theme     |
-      | primary   |
-      | secondary |
-      | tertiary  |
+      | theme     | nameOfObject   |
+      | primary   | themePrimary   |
+      | secondary | themeSecondary |
+      | tertiary  | themeTertiary  |
 
   @positive
   Scenario Outline: Change Table header size to <size>
-    When I select size to "<size>"
+    When I open default "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then Table header size on preview is set to "<size>"
     Examples:
-      | size    |
-      | compact |
-      | small   |
-      | medium  |
-      | large   |
+      | size    | nameOfObject |
+      | compact | sizeCompact  |
+      | small   | sizeSmall    |
+      | medium  | sizeMedium   |
+      | large   | sizeLarge    |
 
   @positive
   Scenario Outline: I enable zebra striping for <position> row in Table
-    When I check zebra striping checkbox
+    When I open default "Table" component in noIFrame with "table" json from "commonComponents" using "zebraStriping" object name
     Then <position> row has zebra striping
     Examples:
       | position |
@@ -138,60 +116,13 @@ Feature: Table component
       | 8        |
       | 9        |
 
-  @ignore
-  @negative
-  # ignored because not working correctly during development
-  Scenario Outline: Page size records is set out of scope <pageSizeRecords>
-    When I set pageSize to <pageSizeRecords> word
-    Then I see 0 records
-    Examples:
-      | pageSizeRecords              |
-      | -1                           |
-      | -10                          |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
-
   @positive
   Scenario Outline: Page size records is set to <pageSizeRecords>
-    When I set pageSize to "<pageSizeRecords>"
+    When I open default "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then I see <pageSizeRecords> records
     Examples:
-      | pageSizeRecords |
-      | 0               |
-      | 1               |
-      | 2               |
-      | 5               |
-
-  @positive
-  Scenario Outline: Change event was called for sortColumn
-    Given I select sortColumn to "<sortColumn>"
-    When clear all actions in Actions Tab
-      And I click "<headerName>" header
-    Then change action was called in Actions Tab
-    Examples:
-      | sortColumn | headerName |
-      | name       | Country    |
-      | code       | Code       |
-
-  @positive
-  Scenario Outline: Change event was called after clicking <button> button
-    Given I check paginate checkbox
-    When clear all actions in Actions Tab
-      And I click "<button>" pagination button
-    Then change action was called in Actions Tab
-    Examples:
-      | button |
-      | next   |
-      | last   |
-
-  @positive
-  Scenario Outline: Change event was called after clicking <button> button
-    Given I check paginate checkbox
-      And I click "last" pagination button
-    When clear all actions in Actions Tab
-      And I click "<button>" pagination button
-    Then change action was called in Actions Tab
-    Examples:
-      | button   |
-      | previous |
-      | first    |
+      | pageSizeRecords | nameOfObject |
+      | 0               | pageSize0    |
+      | 1               | pageSize1    |
+      | 2               | pageSize2    |
+      | 5               | pageSize5    |

--- a/cypress/features/regression/tableActions.feature
+++ b/cypress/features/regression/tableActions.feature
@@ -1,0 +1,39 @@
+Feature: Table component
+  I want to check Table component properties
+
+  Background: Open Table component default page
+    Given I open "Table" component page
+
+  @positive
+  Scenario Outline: Change event was called for sortColumn
+    Given I select sortColumn to "<sortColumn>"
+    When clear all actions in Actions Tab
+      And I click "<headerName>" header in IFrame
+    Then change action was called in Actions Tab
+    Examples:
+      | sortColumn | headerName |
+      | name       | Country    |
+      | code       | Code       |
+
+  @positive
+  Scenario Outline: Change event was called after clicking <button> button
+    Given I check paginate checkbox
+    When clear all actions in Actions Tab
+      And I click "<button>" pagination button in IFrame
+    Then change action was called in Actions Tab
+    Examples:
+      | button |
+      | next   |
+      | last   |
+
+  @positive
+  Scenario Outline: Change event was called after clicking <button> button
+    Given I check paginate checkbox
+      And I click "last" pagination button in IFrame
+    When clear all actions in Actions Tab
+      And I click "<button>" pagination button in IFrame
+    Then change action was called in Actions Tab
+    Examples:
+      | button   |
+      | previous |
+      | first    |

--- a/cypress/features/regression/tableAjax.feature
+++ b/cypress/features/regression/tableAjax.feature
@@ -1,56 +1,18 @@
 Feature: Table Ajax component
-  I want to change Table Ajax component properties
-
-  Background: Open Table Ajax component page
-    Given I open "Table Ajax" component page
+  I want to check Table Ajax component properties
 
   @positive
   Scenario Outline: Page size records is set to <pageSizeRecords>
-    When I set pageSize to "<pageSizeRecords>"
-    Then I see <pageSizeRecords> records
+    When I open default "Table Ajax" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
+    Then I see <pageSizeRecords> records for Table Ajax
     Examples:
-      | pageSizeRecords |
-      | 0               |
-      | 1               |
-      | 2               |
-      | 5               |
-
-  @ignore
-  @negative
-  # ignored because not working correctly during development
-  Scenario Outline: Page size records is set out of scope <pageSizeRecords>
-    When I set pageSize to "<pageSizeRecords>"
-    Then I see 0 records
-    Examples:
-      | pageSizeRecords              |
-      | -1                           |
-      | -10                          |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | pageSizeRecords | nameOfObject |
+      | 0               | pageSize0    |
+      | 1               | pageSize1    |
+      | 2               | pageSize2    |
+      | 5               | pageSize5    |
 
   @positive
-  @ignore
-  # ignored because it require default adjustment
-  Scenario: I enable pagination
-    When I uncheck paginate checkbox
-      And I check paginate checkbox
+  Scenario: Verify the pagination is visible
+    When I open default "Table Ajax" component in noIFrame with "table" json from "commonComponents" using "paginate" object name
     Then pagination is visible
-
-  @positive
-  @ignore
-  # ignored because it require default adjustment
-  Scenario: I enable pagination
-  Scenario: I disable pagination
-    When I uncheck paginate checkbox
-    Then pagination is not visible
-
-  @ignore
-  @positive
-  # ignored because not working correctly during development
-  Scenario Outline: Set getCustomHeaders to <getCustomHeaders>
-    When I set getCustomHeaders to "<getCustomHeaders>"
-    Then getCustomHeaders is set to "<getCustomHeaders>"
-    Examples:
-      | getCustomHeaders             |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |

--- a/cypress/features/regression/tableWithInputs.feature
+++ b/cypress/features/regression/tableWithInputs.feature
@@ -1,24 +1,20 @@
 Feature: Table With Inputs component
-  I want to change Table With Inputs component properties
-
-  Background: Open Table With Inputs component default page
-    Given I open "Table" component page with inputs
+  I want to check Table With Inputs component properties
 
   @positive
   Scenario: I enable selectable
-    When I check selectable checkbox
+    When I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "selectable" object name
     Then rows are selectable
 
   @positive
   Scenario: I disable selectable
-    Given I check selectable checkbox
-    When I uncheck selectable checkbox
+    When I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "selectableFalse" object name
     Then rows are not selectable
 
   @positive
   Scenario Outline: Row <rowNumber> is highlighted
-    When I check highlightable checkbox
-      And I click row by number <rowNumber>
+    Given I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "highlightable" object name
+    When I click row by number <rowNumber>
     Then row number <rowNumber> is highlighted
     Examples:
       | rowNumber |
@@ -28,9 +24,8 @@ Feature: Table With Inputs component
 
   @positive
   Scenario Outline: Row <rowNumber> is not highlighted
-    Given I check highlightable checkbox
-    When I uncheck highlightable checkbox
-      And I click row by number <rowNumber>
+    Given I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "highlightableFalse" object name
+    When I click row by number <rowNumber>
     Then row number <rowNumber> is not highlighted
     Examples:
       | rowNumber |
@@ -40,101 +35,82 @@ Feature: Table With Inputs component
 
   @positive
   Scenario Outline: Sort Table <headerName> Column by <sortColumn>
-    When I select sortColumn to "<sortColumn>"
+    Given I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then "<headerName>" Table column can be sorted
     Examples:
-      | sortColumn | headerName |
-      | name       | Country    |
-      | code       | Code       |
+      | nameOfObject   | headerName |
+      | sortColumnName | Country    |
+      | sortColumnCode | Code       |
 
   @positive
   Scenario Outline: Sort Code column in <sortOrder> order
-    Given I select sortColumn to "code"
-    When I select sortOrder to "<sortOrder>"
+    Given I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then Code column is sorted in "<sortOrder>" order
     Examples:
-      | sortOrder |
-      | desc      |
-      | asc       |
-
-  @ignore
-  @positive
-  #ignored because it is not working correctly during development
-  Scenario: Enable shrink property
-    When I check shrink checkbox
-    Then row is shrinked
-
-  @ignore
-  @positive
-  #ignored because it is not working correctly during development
-  Scenario: Disable shrink property
-    When I check shrink checkbox
-      And I uncheck shrink checkbox
-    Then row is not shrinked
+      | sortOrder | nameOfObject |
+      | desc      | sortCodeDesc |
+      | asc       | sortCodeAsc  |
 
   @positive
   Scenario Outline: Set caption to <caption>
-    When I set caption to <caption> word
+    When I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then caption is set to <caption>
     Examples:
-      | caption                 |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | caption                 | nameOfObject            |
+      | mp150ú¿¡üßä             | captionOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | captionSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
 
   @positive
   Scenario Outline: TotalRecords is set to <totalRecords> items
-    When I set totalRecords to "<totalRecords>"
-      And I check paginate checkbox
+    When I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then totalRecords is set to "<totalRecords>" items
     Examples:
-      | totalRecords |
-      | 0            |
-      | 100          |
-      | 99999999     |
-      | -10          |
+      | totalRecords | nameOfObject         |
+      | 0            | totalRecords0        |
+      | 100          | totalRecords100      |
+      | 99999999     | totalRecords99999999 |
+      | -10          | totalRecords-10      |
 
   @positive
   Scenario: TotalRecords is set to 1 item
-    When I set totalRecords to "1"
-      And I check paginate checkbox
+    When I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "totalRecords1" object name
     Then totalRecords is set to "1" item
 
   @positive
   Scenario Outline: TotalRecords is set out of scope to <totalRecords>
-    When I set totalRecords to <totalRecords> word
-      And I check paginate checkbox
+    When I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then totalRecords is set to "" items
     Examples:
-      | totalRecords                 |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | totalRecords                 | nameOfObject                 |
+      | mp150ú¿¡üßä                  | totalRecordsOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | totalRecordsSpecialCharacter |
 
   @positive
   Scenario Outline: Set theme to <theme>
-    When I select theme to "<theme>"
+    When I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then theme on preview is "<theme>"
     Examples:
-      | theme     |
-      | primary   |
-      | secondary |
-      | tertiary  |
+      | theme     | nameOfObject   |
+      | primary   | themePrimary   |
+      | secondary | themeSecondary |
+      | tertiary  | themeTertiary  |
 
   @positive
   Scenario Outline: Change Table header size to <size>
-    When I select size to "<size>"
+    When I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then Table header size on preview is set to "<size>"
     Examples:
-      | size    |
-      | compact |
-      | small   |
-      | medium  |
-      | large   |
+      | size    | nameOfObject |
+      | compact | sizeCompact  |
+      | small   | sizeSmall    |
+      | medium  | sizeMedium   |
+      | large   | sizeLarge    |
 
   @positive
   Scenario Outline: I enable zebra striping for <position> row in Table
-    When I check zebra striping checkbox
+    When I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "zebraStriping" object name
     Then <position> row has zebra striping
     Examples:
       | position |
@@ -147,35 +123,21 @@ Feature: Table With Inputs component
 
   @positive
   Scenario Outline: Set input type to <inputType>
-    Given I set pageSize to "1"
-    When I select input type to "<inputType>"
+    When I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then input type on preview is set to "<inputType>"
     Examples:
-      | inputType |
-      | textbox   |
-      | textarea  |
-      | date      |
-
-  @ignore
-  @negative
-  # ignored because not working correctly during development
-  Scenario Outline: Page size records is set out of scope <pageSizeRecords>
-    When I set pageSize to <pageSizeRecords> word
-    Then I see 0 records
-    Examples:
-      | pageSizeRecords              |
-      | -1                           |
-      | -10                          |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | inputType | nameOfObject      |
+      | textbox   | inputTypeTextbox  |
+      | textarea  | inputTypeTextarea |
+      | date      | inputTypeDate     |
 
   @positive
   Scenario Outline: Page size records is set to <pageSizeRecords>
-    When I set pageSize to "<pageSizeRecords>"
+    When I open default_with_inputs "Table" component in noIFrame with "table" json from "commonComponents" using "<nameOfObject>" object name
     Then I see <pageSizeRecords> records
     Examples:
-      | pageSizeRecords |
-      | 0               |
-      | 1               |
-      | 2               |
-      | 5               |
+      | pageSizeRecords | nameOfObject |
+      | 0               | pageSize0    |
+      | 1               | pageSize1    |
+      | 2               | pageSize2    |
+      | 5               | pageSize5    |

--- a/cypress/features/regression/test/pager.feature
+++ b/cypress/features/regression/test/pager.feature
@@ -1,88 +1,81 @@
 Feature: Pager component
   I want to test Pager component properties
 
-  Background: Open Pager component default page
-    Given I open design systems default_story "Pager" component page
-
   @positive
   Scenario Outline: Set totalRecords to <totalRecords>
-    When I set totalRecords to "<totalRecords>"
+    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "<nameOfObject>" object name
     Then totalRecords is set to "<totalRecords>" items
       And I am on 1st of "<maxPages>" pages
     Examples:
-      | totalRecords | maxPages |
-      | 0            | 0        |
-      | 10           | 1        |
-      | 100          | 10       |
-      | 111          | 12       |
-      | 1000         | 100      |
-      | 99999        | 10000    |
+      | totalRecords | maxPages | nameOfObject      |
+      | 0            | 0        | totalRecords0     |
+      | 10           | 1        | totalRecords10    |
+      | 100          | 10       | totalRecords100   |
+      | 111          | 12       | totalRecords111   |
+      | 1000         | 100      | totalRecords1000  |
+      | 99999        | 10000    | totalRecords99999 |
 
   @positive
   Scenario: Set totalRecords to 1 and check spell of item word
-    When I set totalRecords to "1"
+    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "totalRecords1" object name
     Then totalRecords is set to "1" item
       And I am on 1st of "1" pages
 
   @negative
   Scenario Outline: Set totalRecords out of scope to <totalRecords>
-    When I set totalRecords to "<totalRecords>"
+    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "<nameOfObject>" object name
     Then totalRecords is set to "<totalRecords>" items
       And I am on 1st of "1" pages
     Examples:
-      | totalRecords |
-      | -1           |
-      | -10          |
-      | -100         |
+      | totalRecords | nameOfObject     |
+      | -1           | totalRecords-1   |
+      | -10          | totalRecords-10  |
+      | -100         | totalRecords-100 |
 
   @negative
   Scenario Outline: Set totalRecords out of scope to <totalRecords>
-    When I set totalRecords to <totalRecords> word
+    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "<nameOfObject>" object name
     Then totalRecords is set to "" items
       And I am on 1st of "1" pages
     Examples:
-      | totalRecords            |
-      | mpú¿¡üßä                |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | totalRecords            | nameOfObject                 |
+      | mp150ú¿¡üßä             | totalRecordsOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | totalRecordsSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
 
   @positive
   Scenario Outline: Set pageSize to <pageSize> items
-    Given I check showPageSizeSelection checkbox
-    When I select pageSize to "<pageSize>"
+    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "<nameOfObject>" object name
     Then pageSize is set to "<pageSize>" items
       And I am on 1st of "<maxPages>" pages
     Examples:
-      | pageSize | maxPages |
-      | 10       | 10       |
-      | 25       | 4        |
-      | 50       | 2        |
-      | 100      | 1        |
+      | pageSize | maxPages | nameOfObject |
+      | 10       | 10       | pageSize10   |
+      | 25       | 4        | pageSize25   |
+      | 50       | 2        | pageSize50   |
+      | 100      | 1        | pageSize100  |
 
   @positive
   Scenario: Set pageSize to 1 item
-    Given I check showPageSizeSelection checkbox
-    When I select pageSize to "one"
+    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "pageSize1" object name
     Then pageSize is set to "1" item
       And I am on 1st of "100" pages
 
   @positive
   Scenario: Enable showPageSizeSelection and verify default value
-    When I check showPageSizeSelection checkbox
+    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "showPageSizeSelection" object name
     Then pageSize is visible
       And pageSize is set to "10" items
 
   @positive
-  Scenario: Enable and disable showPageSizeSelection
-    Given I check showPageSizeSelection checkbox
-    When I uncheck showPageSizeSelection checkbox
+  Scenario: Disable showPageSizeSelection
+    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "showPageSizeSelectionFalse" object name
     Then pageSize is not visible
 
   @positive
   Scenario Outline: Pagination <button> button is disabled
-    # commented because of BDD default scenario Given - When - Then
-    #  When I open "Pager" component page
+    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "default" object name
     Then pagination "<button>" button is disabled
     Examples:
       | button   |
@@ -91,6 +84,7 @@ Feature: Pager component
 
   @positive
   Scenario Outline: Pagination <button> button is disabled after clicking on last button
+    Given I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "default" object name
     When I click "last" pagination button
     Then pagination "<button>" button is disabled
     Examples:
@@ -100,7 +94,8 @@ Feature: Pager component
 
   @positive
   Scenario Outline: Pagination <button> button is disabled after clicking on first button
-    Given I click "last" pagination button
+    Given I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "default" object name
+      And I click "last" pagination button
     When I click "first" pagination button
     Then pagination "<button>" button is disabled
     Examples:
@@ -110,7 +105,8 @@ Feature: Pager component
 
   @positive
   Scenario Outline: Pagination <button> button is disabled after previous paginate
-    Given I type "10" to input pagination
+    Given I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "default" object name
+      And I type "10" to input pagination
     When I press previous button 9 times
     Then pagination "<button>" button is disabled
     Examples:
@@ -120,6 +116,7 @@ Feature: Pager component
 
   @positive
   Scenario Outline: Pagination <button> button is disabled after clicking next button
+    Given I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "default" object name
     When I press next button 9 times
     Then pagination "<button>" button is disabled
     Examples:
@@ -129,8 +126,7 @@ Feature: Pager component
 
   @positive
   Scenario: Pagination buttons are disabled
-    When I set totalRecords to "1"
-      And I select pageSize to "10"
+    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "paginationButtonsDisabled" object name
     Then pagination buttons are disabled
 
   @positive

--- a/cypress/features/regression/test/pager.feature
+++ b/cypress/features/regression/test/pager.feature
@@ -126,7 +126,7 @@ Feature: Pager component
 
   @positive
   Scenario: Pagination buttons are disabled
-    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "paginationButtonsDisabled" object name
+    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "disabled" object name
     Then pagination buttons are disabled
 
   @positive

--- a/cypress/fixtures/commonComponents/table.json
+++ b/cypress/fixtures/commonComponents/table.json
@@ -1,0 +1,121 @@
+{ 
+  "paginate": {
+    "paginate": true
+  },
+  "selectable": {
+    "selectable": true
+  },
+  "selectableFalse": {
+    "selectable": false
+  },
+  "highlightable": {
+    "highlightable": true
+  },
+  "highlightableFalse": {
+    "highlightable": false
+  },
+  "sortColumnName": {
+    "sortColumn": "name"
+  },
+  "sortColumnCode": {
+    "sortColumn": "code"
+  },
+  "sortCountryDesc": {
+    "sortColumn": "name",
+    "sortOrder": "desc"
+  },
+  "sortCountryAsc": {
+    "sortColumn": "name",
+    "sortOrder": "asc"
+  },
+  "sortCodeDesc": {
+    "sortColumn": "code",
+    "sortOrder": "desc"
+  },
+  "sortCodeAsc": {
+    "sortColumn": "code",
+    "sortOrder": "asc"
+  },
+  "captionOtherLanguage": {
+    "caption": "mp150ú¿¡üßä"
+  },
+  "captionSpecialCharacter": {
+    "caption": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "themePrimary": {
+    "theme": "primary"
+  },
+  "themeSecondary": {
+    "theme": "secondary"
+  },
+  "themeTertiary": {
+    "theme": "tertiary"
+  },
+  "sizeCompact": {
+    "size": "compact"
+  },
+  "sizeSmall": {
+    "size": "small"
+  },
+  "sizeMedium": {
+    "size": "medium"
+  },
+  "sizeLarge": {
+    "size": "large"
+  },
+  "zebraStriping": {
+    "zebra striping": true
+  },
+  "pageSize0": {
+    "pageSize": 0
+  },
+  "pageSize1": {
+    "pageSize": 1
+  },
+  "pageSize2": {
+    "pageSize": 2
+  },
+  "pageSize5": {
+    "pageSize": 5
+  },
+  "totalRecords0": {
+    "paginate": true,
+    "totalRecords": 0
+  },
+  "totalRecords100": {
+    "paginate": true,
+    "totalRecords": 100
+  },
+  "totalRecords99999999": {
+    "paginate": true,
+    "totalRecords": 99999999
+  },
+  "totalRecords-10": {
+    "paginate": true,
+    "totalRecords": -10
+  },
+  "totalRecords1": {
+    "paginate": true,
+    "totalRecords": 1
+  },
+  "totalRecordsOtherLanguage": {
+    "paginate": true,
+    "totalRecords": "mp150ú¿¡üßä"
+  },
+  "totalRecordsSpecialCharacter": {
+    "paginate": true,
+    "totalRecords": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "inputTypeTextbox": {
+    "pageSize": 1,
+    "input type": "textbox"
+  },
+  "inputTypeTextarea": {
+    "pageSize": 1,
+    "input type": "textarea"
+  },
+  "inputTypeDate": {
+    "pageSize": 1,
+    "input type": "date"
+  }
+}

--- a/cypress/fixtures/test/pager.json
+++ b/cypress/fixtures/test/pager.json
@@ -1,0 +1,71 @@
+{ 
+  "totalRecords0": {
+    "totalRecords": 0
+  },
+  "totalRecords1": {
+    "totalRecords": 1
+  },
+  "totalRecords10": {
+    "totalRecords": 10
+  },
+  "totalRecords100": {
+    "totalRecords": 100
+  },
+  "totalRecords111": {
+    "totalRecords": 111
+  },
+  "totalRecords1000": {
+    "totalRecords": 1000
+  },
+  "totalRecords99999": {
+    "totalRecords": 99999
+  },
+  "totalRecords-1": {
+    "totalRecords": -1
+  },
+  "totalRecords-10": {
+    "totalRecords": -10
+  },
+  "totalRecords-100": {
+    "totalRecords": -100
+  },
+  "totalRecordsOtherLanguage": {
+    "totalRecords": "mp150ú¿¡üßä"
+  },
+  "totalRecordsSpecialCharacter": {
+    "totalRecords": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "pageSize10": {
+    "showPageSizeSelection": true,
+    "pageSize": 10
+  },
+  "pageSize25": {
+    "showPageSizeSelection": true,
+    "pageSize": 25
+  },
+  "pageSize50": {
+    "showPageSizeSelection": true,
+    "pageSize": 50
+  },
+  "pageSize100": {
+    "showPageSizeSelection": true,
+    "pageSize": 100
+  },
+  "pageSize1": {
+    "showPageSizeSelection": true,
+    "pageSize": 1
+  },
+  "showPageSizeSelection": {
+    "showPageSizeSelection": true
+  },
+  "showPageSizeSelectionFalse": {
+    "showPageSizeSelection": false
+  },
+  "default": {
+
+  },
+  "paginationButtonsDisabled": {
+    "totalRecors": 1,
+    "pageSize": 10
+  }
+}

--- a/cypress/fixtures/test/pager.json
+++ b/cypress/fixtures/test/pager.json
@@ -64,7 +64,7 @@
   "default": {
 
   },
-  "paginationButtonsDisabled": {
+  "disabled": {
     "totalRecors": 1,
     "pageSize": 10
   }

--- a/cypress/locators/pager/index.js
+++ b/cypress/locators/pager/index.js
@@ -5,12 +5,12 @@ import {
 import { COMMMON_DATA_ELEMENT_INPUT } from '../locators';
 
 // component preview locators
-export const pagerSummary = () => cy.iFrame(PAGER_SUMMARY).children().eq(2);
-export const pageSelect = () => cy.iFrame(PAGE_SELECT)
+export const pagerSummary = () => cy.get(PAGER_SUMMARY).children().eq(2);
+export const pageSelect = () => cy.get(PAGE_SELECT)
   .find(COMMMON_DATA_ELEMENT_INPUT);
-export const pageSelectMainComponent = () => cy.iFrame(PAGE_SELECT);
-export const pageSelectItems = () => cy.iFrame(PAGE_SELECT_ITEM);
-export const maxPages = () => cy.iFrame(MAX_PAGES);
-export const currentPageInput = () => cy.iFrame(PAGE_INPUT).find('input');
-export const previousArrow = () => cy.iFrame(PAGER_PREVIOUS_ARROW);
-export const nextArrow = () => cy.iFrame(PAGER_NEXT_ARROW);
+export const pageSelectMainComponent = () => cy.get(PAGE_SELECT);
+export const pageSelectItems = () => cy.get(PAGE_SELECT_ITEM);
+export const maxPages = () => cy.get(MAX_PAGES);
+export const currentPageInput = () => cy.get(PAGE_INPUT).find('input');
+export const previousArrow = () => cy.get(PAGER_PREVIOUS_ARROW);
+export const nextArrow = () => cy.get(PAGER_NEXT_ARROW);

--- a/cypress/locators/table/index.js
+++ b/cypress/locators/table/index.js
@@ -1,19 +1,34 @@
 import {
-  ROW, CHECKBOX_CELL, TABLE, TABLE_HEADER, PAGINATION_BUTTON, ACTION_TOOLBAR,
+  ROW,
+  CHECKBOX_CELL,
+  TABLE,
+  TABLE_HEADER,
+  PAGINATION_BUTTON,
+  ACTION_TOOLBAR,
+  TABLE_AJAX,
 } from './locators';
 import { BUTTON_DATA_COMPONENT } from '../pages/locators';
 
 // component preview locators
-export const rows = () => cy.iFrame(ROW).parent();
+export const rows = () => cy.get(ROW).parent();
 export const rowByNumber = number => rows().then($rows => $rows[number]);
-export const rowNumbers = index => cy.iFrame(ROW).eq(index);
+export const rowNumbers = index => cy.get(ROW).eq(index);
 export const checkboxCell = () => rows().find(CHECKBOX_CELL);
-export const caption = () => cy.iFrame(TABLE).children().children()
+export const caption = () => cy.get(TABLE).children().children()
   .find('caption');
-export const tableHeader = () => cy.iFrame(TABLE_HEADER);
+export const tableHeader = () => cy.get(TABLE_HEADER);
 export const sortIcon = index => tableHeader(index).find('span');
-export const pagination = () => cy.iFrame(PAGINATION_BUTTON);
+export const pagination = () => cy.get(PAGINATION_BUTTON);
 export const paginationButtonByIndex = index => pagination().find('div:nth-child(2) > button').eq(index);
-export const actionToolbar = index => cy.iFrame(ACTION_TOOLBAR).find('div:nth-child(2) > div').eq(index);
-export const actionToolbarButton = () => cy.iFrame(ACTION_TOOLBAR).find('div:nth-child(2)').find(BUTTON_DATA_COMPONENT).parent();
-export const checkboxInHeader = () => cy.iFrame(CHECKBOX_CELL);
+export const actionToolbar = index => cy.get(ACTION_TOOLBAR).find('div:nth-child(2) > div').eq(index);
+export const actionToolbarButton = () => cy.get(ACTION_TOOLBAR).find('div:nth-child(2)').find(BUTTON_DATA_COMPONENT).parent();
+export const checkboxInHeader = () => cy.get(CHECKBOX_CELL);
+export const tableBody = () => cy.get(TABLE)
+  .find('table > tbody');
+export const tableAjax = () => cy.get(TABLE_AJAX)
+  .find('table > tbody');
+
+//components in IFrame
+export const tableHeaderInIFrame = () => cy.iFrame(TABLE_HEADER);
+export const paginationButtonByIndexInIFrame = index => cy.iFrame(PAGINATION_BUTTON)
+  .find('div:nth-child(2) > button').eq(index);

--- a/cypress/locators/table/locators.js
+++ b/cypress/locators/table/locators.js
@@ -5,3 +5,4 @@ export const TABLE = '[data-component="table"]';
 export const TABLE_HEADER = '[data-component="table-header"]';
 export const PAGINATION_BUTTON = '[data-component="pager"]';
 export const ACTION_TOOLBAR = '[data-component="action-toolbar"]';
+export const TABLE_AJAX = '[data-component="table-ajax"]';

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -90,10 +90,6 @@ Given('I open {string} component page with button in noIFrame', (component) => {
   visitComponentUrl(component, 'with_button', true);
 });
 
-Given('I open {string} component page with inputs', (component) => {
-  visitComponentUrl(component, 'default_with_inputs');
-});
-
 Given('I open dark theme {string} component page in noIFrame', (component) => {
   visitComponentUrl(component, 'dark_theme', true);
 });

--- a/cypress/support/step-definitions/pager-steps.js
+++ b/cypress/support/step-definitions/pager-steps.js
@@ -8,7 +8,7 @@ import {
   pageSelectMainComponent,
 } from '../../locators/pager';
 import { DEBUG_FLAG } from '..';
-import { pagination, paginationButtonByIndex } from '../../locators/table';
+import { paginationButtonByIndex, paginationButtonByIndexInIFrame } from '../../locators/table';
 import { positionOfPaginationButton } from '../helper';
 
 Then('pageSize is set to {string} {word}', (pageSize, item) => {
@@ -35,6 +35,10 @@ Then('pagination {string} button is disabled', (button) => {
 
 Then('I click {string} pagination button', (button) => {
   paginationButtonByIndex(positionOfPaginationButton(button)).click();
+});
+
+Then('I click {string} pagination button in IFrame', (button) => {
+  paginationButtonByIndexInIFrame(positionOfPaginationButton(button)).click();
 });
 
 Then('I click {string} pagination arrow', (arrow) => {
@@ -92,15 +96,6 @@ Then('I press {word} button {int} times', (direction, count) => {
 
 When('I type {string} to input pagination', (pageNumber) => {
   currentPageInput().clear().type(`${pageNumber}{enter}`);
-});
-
-Then('pagination is visible', () => {
-  pagination().should('be.visible');
-});
-
-
-Then('pagination is not visible', () => {
-  pagination().should('not.exist');
 });
 
 When('I click on pagination input', () => {

--- a/cypress/support/step-definitions/table-steps.js
+++ b/cypress/support/step-definitions/table-steps.js
@@ -1,11 +1,25 @@
 import {
   rows, checkboxCell, rowByNumber, caption, tableHeader, rowNumbers, sortIcon,
-  actionToolbar, checkboxInHeader, actionToolbarButton,
+  actionToolbar, checkboxInHeader, actionToolbarButton, pagination, tableBody,
+  tableHeaderInIFrame,
+  tableAjax,
 } from '../../locators/table';
 import { themeColor, tableHeaderSize, positionOfElement } from '../helper';
 
 Then('I see {int} records', (records) => {
-  rows().should('have.length', records);
+  if (records === 0) {
+    tableBody().should('have.length', 1);
+  } else {
+    rows().should('have.length', records);
+  }
+});
+
+Then('I see {int} records for Table Ajax', (records) => {
+  if (records === 0) {
+    tableAjax().children().should('have.length', 1);
+  } else {
+    tableAjax().children().should('have.length', records + 1);
+  }
 });
 
 Then('rows are selectable', () => {
@@ -118,6 +132,14 @@ Then('I click {string} header', (headerName) => {
   }
 });
 
+Then('I click {string} header in IFrame', (headerName) => {
+  if (headerName === 'Country') {
+    tableHeaderInIFrame().eq(positionOfElement('first')).click();
+  } else {
+    tableHeaderInIFrame().eq(positionOfElement('second')).click();
+  }
+});
+
 When('I check checkbox on header', () => {
   checkboxInHeader().eq(positionOfElement('first')).click();
 });
@@ -145,4 +167,13 @@ Then('Action Toolbar elemens are visible and have {string} color', (color) => {
     .and('have.css', 'color', color)
     .and('be.visible')
     .and('contain', 'Test Action');
+});
+
+Then('pagination is visible', () => {
+  pagination().should('be.visible');
+});
+
+
+Then('pagination is not visible', () => {
+  pagination().should('not.exist');
 });


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Apply new `url` approach in tests for:
`Table` (timing: was `3:04`- > `01:02`),
`Table Action` (timing: `00:31`),
`Table with inputs` (timing: was `02:46` -> `01:04`),
`Pager` (timing: was `02:17` -> `00:50`).

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are passing all parameters via `knobs`.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Screenshots are included in the PR
- [ ] Carbon implementation and Design System documentation are congruent
- [ ] All themes are supported
- [x] Commits follow our style guide
- [ ] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [ ] Storybook added or updated
- [ ] Typescript `d.ts` file added or updated