### PR TITLE
feat(box): add new internal box component

### DIFF
--- a/src/__internal__/box/box.component.js
+++ b/src/__internal__/box/box.component.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Box = ({ children, ...rest }) => {
+  return (
+    <>
+      { React.cloneElement(children, { ...rest })}
+    </>
+  );
+};
+
+Box.propTypes = {
+  /** Box content */
+  children: PropTypes.node.isRequired,
+  /** Margin, integer mulitplied by base spacing constant (8) */
+  m: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Margin top, integer mulitplied by base spacing constant (8) */
+  mt: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Margin bottom, integer mulitplied by base spacing constant (8) */
+  mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Margin right, integer mulitplied by base spacing constant (8) */
+  mr: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Margin left, integer mulitplied by base spacing constant (8) */
+  ml: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Margin right and left, integer mulitplied by base spacing constant (8) */
+  mx: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Margin top and bottom, integer mulitplied by base spacing constant (8) */
+  my: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Padding, integer mulitplied by base spacing constant (8) */
+  p: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Padding top, integer mulitplied by base spacing constant (8) */
+  pt: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Padding bottom, integer mulitplied by base spacing constant (8) */
+  pb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Padding right, integer mulitplied by base spacing constant (8) */
+  pr: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Padding left, integer mulitplied by base spacing constant (8) */
+  pl: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Padding right and left, integer mulitplied by base spacing constant (8) */
+  px: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
+  /** Padding top and bottom, integer mulitplied by base spacing constant (8) */
+  py: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7])
+};
+
+export default Box;

--- a/src/__internal__/box/box.d.ts
+++ b/src/__internal__/box/box.d.ts
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+type SpacingOptions = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export interface BoxProps {
+  /** Box content */
+  children: React.ReactNode;
+  /** Margin, integer mulitplied by base spacing constant (8) */
+  m?: SpacingOptions;
+  /** Margin top, integer mulitplied by base spacing constant (8) */
+  mt?: SpacingOptions;
+  /** Margin bottom, integer mulitplied by base spacing constant (8) */
+  mb?: SpacingOptions;
+  /** Margin right, integer mulitplied by base spacing constant (8) */
+  mr?: SpacingOptions;
+  /** Margin left, integer mulitplied by base spacing constant (8) */
+  ml?: SpacingOptions;
+  /** Margin right and left, integer mulitplied by base spacing constant (8) */
+  mx?: SpacingOptions;
+  /** Margin top and bottom, integer mulitplied by base spacing constant (8) */
+  my?: SpacingOptions;
+  /** Padding, integer mulitplied by base spacing constant (8) */
+  p?: SpacingOptions;
+  /** Padding top, integer mulitplied by base spacing constant (8) */
+  pt?: SpacingOptions;
+  /** Padding bottom, integer mulitplied by base spacing constant (8) */
+  pb?: SpacingOptions;
+  /** Padding right, integer mulitplied by base spacing constant (8) */
+  pr?: SpacingOptions;
+  /** Padding left, integer mulitplied by base spacing constant (8) */
+  pl?: SpacingOptions;
+  /** Padding right and left, integer mulitplied by base spacing constant (8) */
+  px?: SpacingOptions;
+  /** Padding top and bottom, integer mulitplied by base spacing constant (8) */
+  py?: SpacingOptions;
+}
+
+declare const Box: React.ComponentClass<BoxProps>;
+
+export default Box;

--- a/src/__internal__/box/box.spec.js
+++ b/src/__internal__/box/box.spec.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Box from './box.component';
+
+const ChildComponent = () => <div />;
+
+const render = props => shallow(
+  <Box { ...props }>
+    <ChildComponent />
+  </Box>
+);
+
+describe('Internal Box component', () => {
+  let wrapper;
+
+  it('renders passed in children', () => {
+    wrapper = render();
+    expect(wrapper.find(ChildComponent).exists()).toBe(true);
+  });
+
+  it('passes margin props to child component', () => {
+    wrapper = render({
+      m: 2,
+      mt: 2,
+      mb: 2,
+      mr: 2,
+      ml: 2,
+      mx: 2,
+      my: 2
+    });
+    expect(wrapper.find(ChildComponent).props().m).toEqual(2);
+    expect(wrapper.find(ChildComponent).props().mt).toEqual(2);
+    expect(wrapper.find(ChildComponent).props().mb).toEqual(2);
+    expect(wrapper.find(ChildComponent).props().mr).toEqual(2);
+    expect(wrapper.find(ChildComponent).props().ml).toEqual(2);
+    expect(wrapper.find(ChildComponent).props().mx).toEqual(2);
+    expect(wrapper.find(ChildComponent).props().my).toEqual(2);
+  });
+
+  it('passes padding props to child component', () => {
+    wrapper = render({
+      p: 2,
+      pt: 2,
+      pb: 2,
+      pr: 2,
+      pl: 2,
+      px: 2,
+      py: 2
+    });
+    expect(wrapper.find(ChildComponent).props().p).toEqual(2);
+    expect(wrapper.find(ChildComponent).props().pt).toEqual(2);
+    expect(wrapper.find(ChildComponent).props().pb).toEqual(2);
+    expect(wrapper.find(ChildComponent).props().pr).toEqual(2);
+    expect(wrapper.find(ChildComponent).props().pl).toEqual(2);
+    expect(wrapper.find(ChildComponent).props().px).toEqual(2);
+    expect(wrapper.find(ChildComponent).props().py).toEqual(2);
+  });
+  
+});

--- a/src/__internal__/box/index.d.ts
+++ b/src/__internal__/box/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './box';

--- a/src/__internal__/box/index.js
+++ b/src/__internal__/box/index.js
@@ -1,0 +1,1 @@
+export { default } from './box.component';


### PR DESCRIPTION
### Proposed behaviour
Add new internal `Box` component which will be used to wrap any other component which needs margin or paddings props. This will save adding the same props onto every other component individually. 

Each prop uses an integer multiplier of the base spacing constant, which is 8px. 

### Current behaviour

### Checklist

- <del>[ ] Screenshots are included in the PR</del>
- [x] Carbon implementation and Design System documentation are congruent
- [x] All themes are supported
- [x] Commits follow our style guide
- [x] Unit tests added or updated
- <del>[ ] Cypress automation tests added or updated</del>
- <del>[ ] Storybook added or updated</del>
- [x] Typescript `d.ts` file added or update

### Additional context

### Testing instructions
