### PR TITLE
chore(codeowners): assign cypress json files to be owned by qa

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,8 @@
 # the cypress directory
 *.spec.js    @Sage/carbon-qa
 /cypress/    @Sage/carbon-qa
+cypress.json @Sage/carbon-qa
+cypress.env.json @Sage/carbon-qa
 
 # Codeowners file changes must be approved by a Carbon Admin.
 .github/CODEOWNERS @Sage/carbon-admin


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Assign `cypress.json`and `cypress.env.json` to be owned by QA team
### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`cypress.json`and `cypress.env.json` are not owned by QA team

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

<del>- [ ] Screenshots are included in the PR<del>
<del>- [ ] Carbon implementation and Design System documentation are congruent<del>
<del>- [ ] All themes are supported<del>
- [x] Commits follow our style guide
<del>- [ ] Unit tests added or updated<del>
<del>- [ ] Cypress automation tests added or updated<del>
<del>- [ ] Storybook added or updated<del>
<del>- [ ] Typescript `d.ts` file added or updated<del>

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
