### PR TITLE
test(help,link,loader,menulist): update cypress with a new approach URL

### DIFF
--- a/cypress/features/regression/help.feature
+++ b/cypress/features/regression/help.feature
@@ -1,51 +1,46 @@
 Feature: Help component
-  I want to change Help component properties
-
-  Background: Open Help component page
-    Given I open "Help" component page
+  I want to test Help component properties
 
   @positive
   Scenario Outline: Change children to <children>
-    When I set children to <children> word
-      And I hover mouse onto help icon
-    Then  tooltipPreview on preview is set to <children>
+    When I open default "Help" component in noIFrame with "help" json from "commonComponents" using "<nameOfObject>" object name
+      And I hover mouse onto help icon in noIFrame
+    Then tooltipPreview on preview is set to <children> in NoIFrame
     Examples:
-      | children                     |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | children                     | nameOfObject             |
+      | mp150ú¿¡üßä                  | childrenOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | childrenSpecialCharacter |
 
   @positive
   Scenario Outline: Change tooltip position to <tooltipPosition>
-    When I select tooltipPosition to "<tooltipPosition>"
-      And I select tooltipAlign to "center"
-      And I hover mouse onto help icon
+    When I open default "Help" component in noIFrame with "help" json from "commonComponents" using "<nameOfObject>" object name
+      And I hover mouse onto help icon in noIFrame
     Then tooltipPosition is set to "<tooltipPosition>"
     Examples:
-      | tooltipPosition |
-      | left            |
-      | right           |
-      | top             |
-      | bottom          |
+      | tooltipPosition | nameOfObject          |
+      | left            | tooltipPositionLeft   |
+      | right           | tooltipPositionRight  |
+      | top             | tooltipPositionTop    |
+      | bottom          | tooltipPositionBottom |
 
   @positive
   Scenario Outline: Change tooltip align to <tooltipAlign>
-    When I select tooltipAlign to "<tooltipAlign>"
-      And I select tooltipPosition to "bottom"
-      And I hover mouse onto help icon
+    When I open default "Help" component in noIFrame with "help" json from "commonComponents" using "<nameOfObject>" object name
+      And I hover mouse onto help icon in noIFrame
     Then tooltipAlign is set to "<tooltipAlign>"
     Examples:
-      | tooltipAlign |
-      | center       |
-      | bottom       |
-      | left         |
-      | right        |
-      | top          |
+      | tooltipAlign | nameOfObject       |
+      | center       | tooltipAlignCenter |
+      | bottom       | tooltipAlignBottom |
+      | left         | tooltipAlignLeft   |
+      | right        | tooltipAlignRight  |
+      | top          | tooltipAlignTop    |
 
   @positive
   Scenario Outline: Change href to <href>
-    When I set href to <href> word
+    When I open default "Help" component in noIFrame with "help" json from "commonComponents" using "<nameOfObject>" object name
     Then Help href on preview is set to <href>
     Examples:
-      | href                         |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | href                         | nameOfObject         |
+      | mp150ú¿¡üßä                  | hrefOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | hrefSpecialCharacter |

--- a/cypress/features/regression/link.feature
+++ b/cypress/features/regression/link.feature
@@ -1,108 +1,89 @@
 Feature: Link component
-  I want to change Link component properties
-
-  Background: Open Link component default page
-    Given I open "Link" component page
+  I want to test Link component properties
 
   @positive
   Scenario Outline: Change Link target to <target>
-    When I set target to <target> word
+    When I open default "Link" component in noIFrame with "link" json from "commonComponents" using "<nameOfObject>" object name
     Then Link on preview target is set to <target>
     Examples:
-      | target |
-      | _blank |
-      | _self  |
-      | _top   |
+      | target | nameOfObject |
+      | _blank | targetBlank  |
+      | _self  | targetSelf   |
+      | _top   | targetTop    |
 
   @positive
   Scenario Outline: Change Link children to <children>
-    When I set children to <children> word
+    When I open default "Link" component in noIFrame with "link" json from "commonComponents" using "<nameOfObject>" object name
     Then children on preview is <children>
     Examples:
-      | children                     |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | children                     | nameOfObject             |
+      | mp150ú¿¡üßä                  | childrenOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | childrenSpecialCharacter |
 
   @positive
   Scenario: Disable Link component
-    When I disable Link component
+    When I open default "Link" component in noIFrame with "link" json from "commonComponents" using "disabled" object name
     Then Link is disabled
 
   @positive
-  Scenario: Disable and enable Link component
-    Given I disable Link component
-    When I enable Link component
+  Scenario: Enable Link component
+    When I open default "Link" component in noIFrame with "link" json from "commonComponents" using "disabledFalse" object name
     Then Link is enabled
 
   @positive
   Scenario Outline: Change Link href to <href>
-    When I set href to <href> word
+    When I open default "Link" component in noIFrame with "link" json from "commonComponents" using "<nameOfObject>" object name
     Then Link on preview href is set to <href>
     Examples:
-      | href                         |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | href                         | nameOfObject         |
+      | mp150ú¿¡üßä                  | hrefOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | hrefSpecialCharacter |
 
   @positive
   Scenario Outline: Change link component icon align position to <iconAlign>
-    Given I select icon to "add"
-    When I select iconAlign to "<iconAlign>"
-      And I wait 500
-    # wait because method below is based of changing DOM elements order
+    When I open default "Link" component in noIFrame with "link" json from "commonComponents" using "<nameOfObject>" object name
     Then icon align is set to "<iconAlign>"
     Examples:
-      | iconAlign |
-      | left      |
-      | right     |
+      | iconAlign | nameOfObject   |
+      | left      | iconAlignLeft  |
+      | right     | iconAlignRight |
 
   @positive
   Scenario Outline: Change tooltip align to <tooltipAlign>
-    Given I select icon to "add"
-      And I set tooltipMessage to "sample message"
-    When I select tooltipAlign to "<tooltipAlign>"
-      And I select tooltipPosition to "bottom"
-      And I hover mouse onto icon
+    When I open default "Link" component in noIFrame with "link" json from "commonComponents" using "<nameOfObject>" object name
+      And I hover mouse onto "add" icon in no iFrame
     Then tooltipAlign is set to "<tooltipAlign>"
     Examples:
-      | tooltipAlign |
-      | left         |
-      | right        |
-      | top          |
-      | bottom       |
-      | center       |
+      | tooltipAlign | nameOfObject       |
+      | left         | tooltipAlignLeft   |
+      | right        | tooltipAlignRight  |
+      | top          | tooltipAlignTop    |
+      | bottom       | tooltipAlignBottom |
+      | center       | tooltipAlignCenter |
 
   @positive
   Scenario Outline: Change tooltip tooltipPosition to <tooltipPosition>
-    Given I select icon to "add"
-      And I set tooltipMessage to "sample message"
-    When I select tooltipPosition to "<tooltipPosition>"
-      And I select tooltipAlign to "center"
-      And I hover mouse onto icon
+    When I open default "Link" component in noIFrame with "link" json from "commonComponents" using "<nameOfObject>" object name
+      And I hover mouse onto "add" icon in no iFrame
     Then tooltipPosition is set to "<tooltipPosition>"
     Examples:
-      | tooltipPosition |
-      | right           |
-      | left            |
-      | bottom          |
-      | top             |
-      | right           |
+      | tooltipPosition | nameOfObject          |
+      | right           | tooltipPositionRight  |
+      | left            | tooltipPositionLeft   |
+      | bottom          | tooltipPositionBottom |
+      | top             | tooltipPositionTop    |
 
   @positive
-  Scenario: Check tabbable and focus the link componenent
-    Given I uncheck tabbable checkbox
-    When I check tabbable checkbox
+  Scenario: Link is tabbable
+    When I open default "Link" component in noIFrame with "link" json from "commonComponents" using "tabbable" object name
     Then Link is tabbable
-      And I hit Tab key 2 times
-      And Link component is focused
 
   @positive
-  Scenario: Uncheck tabbable
-    When I uncheck tabbable checkbox
+  Scenario: Link is not tabbable
+    When I open default "Link" component in noIFrame with "link" json from "commonComponents" using "tabbableFlase" object name
     Then Link is not tabbable
-      And I hit Tab key 2 times
-      And Link component is not focused
 
   @positive
   Scenario: Change type of icon for a Link component to feedback
-    When I select icon to "feedback"
-    Then icon on link componenent preview is "feedback"
+    When I open default "Link" component in noIFrame with "link" json from "commonComponents" using "icon" object name
+    Then icon on link component preview is "feedback"

--- a/cypress/features/regression/loader.feature
+++ b/cypress/features/regression/loader.feature
@@ -1,46 +1,41 @@
 Feature: Loader default component
-  I want to change Loader component properties
-
-  Background: Open Loader default component page
-    Given I open "Loader" component page
+  I want to test Loader component properties
 
   @positive
   Scenario Outline: I set Loader component size to <size>
-    When I select size to "<size>"
-    Then Loader width is set to 1061 px and height is set to <height> px
+    When I open default "Loader" component in noIFrame with "loader" json from "commonComponents" using "<nameOfObject>" object name
+    Then Loader width is set to 1281 px and height is set to <height> px
     Examples:
-      | size  | height |
-      | small | 17     |
-      | large | 19     |
+      | size  | height | nameOfObject |
+      | small | 17     | sizeSmall    |
+      | large | 19     | sizeLarge    |
 
   @positive
   Scenario Outline: Verify size of button with loader
-    Given I check isInsideButton checkbox
-    When I select size to "<size>"
+    When I open default "Loader" component in noIFrame with "loader" json from "commonComponents" using "<nameOfObject>" object name
     Then button with loader width is set to <width> px and height is set to 40 px
     Examples:
-      | size  | width |
-      | small | 88    |
-      | large | 120   |
+      | size  | width | nameOfObject        |
+      | small | 88    | isInsideButtonSmall |
+      | large | 120   | isInsideButtonLarge |
 
   @positive
   Scenario: Loader isInsideButton
-    When I check isInsideButton checkbox
+    When I open default "Loader" component in noIFrame with "loader" json from "commonComponents" using "isInsideButton" object name
     Then Loader isInsideButton and backgroundColor is "rgb(0, 129, 93)"
 
   @positive
   Scenario: Disabled loader button
-    Given I check isInsideButton checkbox
-    When I uncheck isActive checkbox
+    When I open default "Loader" component in noIFrame with "loader" json from "commonComponents" using "isActiveFalse" object name
     Then Loader button is disabled
 
   @positive
   Scenario: Enabled loader button
-    When I check isInsideButton checkbox
+    When I open default "Loader" component in noIFrame with "loader" json from "commonComponents" using "isActive" object name
     Then Loader button is enabled
 
   @positive
   Scenario: Verify border outline color on focus
-    Given I check isInsideButton checkbox
+    Given I open default "Loader" component in noIFrame with "loader" json from "commonComponents" using "default" object name
     When I focus loader button
     Then loader button has golden border outline

--- a/cypress/features/regression/menuList.feature
+++ b/cypress/features/regression/menuList.feature
@@ -1,31 +1,66 @@
 Feature: MenuList component
-  I want to change MenuList component default properties
-
-  Background: Open MenuList component default page
-    Given I open "MenuList" component page
+  I want to test MenuList component default properties
 
   @positive
   Scenario Outline: Change MenuList title to <title>
-    When I set title to <title> word
+    When I open default "MenuList" component in noIFrame with "menuList" json from "commonComponents" using "<nameOfObject>" object name
     Then title on preview is <title>
     Examples:
-      | title                        |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | title                        | nameOfObject          |
+      | mp150ú¿¡üßä                  | titleOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | titleSpecialCharacter |
 
   @ignore
   # @positive doesn't work on Carbon Demo site
   Scenario Outline: Change MenuList filterPlaceholder to <text>
-    When I set filterPlaceholder to <text> word
-    Then filterPlaceholder on preview is <text>
+    Given I open default "MenuList" component in noIFrame with "menuList" json from "commonComponents" using "<nameOfObject>" object name
+    When I set filterPlaceholder to <filterPlaceholder> word
+    Then filterPlaceholder on preview is <filterPlaceholder>
     Examples:
-      | text                         |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | filterPlaceholder            | nameOfObject                      |
+      | mp150ú¿¡üßä                  | filterPlaceholderOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | filterPlaceholderSpecialCharacter |
+
+  @ignore
+  # @positive doesn't work on Carbon Demo site
+  Scenario: Enable initially open
+    When I open default "MenuList" component in noIFrame with "menuList" json from "commonComponents" using "initiallyOpen" object name
+    Then MenuList component is expanded
+
+  @ignore
+  # @positive doesn't work on Carbon Demo site
+  Scenario: Enable and disable innitially open
+    When I open default "MenuList" component in noIFrame with "menuList" json from "commonComponents" using "initiallyOpenFalse" object name
+    Then MenuList component is not expanded
+
+  @positive
+  Scenario: Disable filter
+    Given I open default "MenuList" component in noIFrame with "menuList" json from "commonComponents" using "filterFalse" object name
+    When I click into menu item second element
+    Then filter is disabled
+
+  @positive
+  Scenario: Enable filter
+    Given I open default "MenuList" component in noIFrame with "menuList" json from "commonComponents" using "filter" object name
+    When I click into menu item second element
+    Then filter is enabled
+
+  @positive
+  Scenario: Disable collapsible
+    Given I open default "MenuList" component in noIFrame with "menuList" json from "commonComponents" using "collapsibleFalse" object name
+    When I click into title
+    Then MenuList component is expanded
+
+  @positive
+  Scenario: Enable collapsible
+    Given I open default "MenuList" component in noIFrame with "menuList" json from "commonComponents" using "collapsible" object name
+    When I click into title
+    Then MenuList component is not expanded
 
   @positive
   Scenario Outline: Check search field
-    Given I click into menu item second element
+    Given I open "MenuList" component page
+      And I click into menu item second element in Iframe
     When I change search parameter to "<parameter>"
     Then search result is "<result>"
       And results count is <resultsCount>
@@ -36,37 +71,3 @@ Feature: MenuList component
       | Thi       | Third Sub Item                              | 1            |
       | d         | Second Sub ItemThird Sub Item               | 2            |
       | tem       | First Sub ItemSecond Sub ItemThird Sub Item | 3            |
-
-  @ignore
-  # @positive doesn't work on Carbon Demo site
-  Scenario: Enable initially open
-    When I check initiallyOpen checkbox
-    Then MenuList component is expanded
-
-  @ignore
-  # @positive doesn't work on Carbon Demo site
-  Scenario: Enable and disable innitially open
-    Given I check initiallyOpen checkbox
-    When I uncheck initiallyOpen checkbox
-    Then MenuList component is not expanded
-
-  @positive
-  Scenario: Disable filter
-    Given I click into menu item second element
-    When I uncheck filter checkbox
-    Then filter is disabled
-
-  @positive
-  Scenario: Disable and enable filter
-    Given I uncheck filter checkbox
-      And I check filter checkbox
-      And I set title to "title"
-    When I click into menu item second element
-    Then filter is enabled
-
-  @positive
-  Scenario: Disable collapsible
-    Given I set title to "title"
-      And I uncheck collapsible checkbox
-    When I click into title
-    Then MenuList component is expanded

--- a/cypress/fixtures/commonComponents/help.json
+++ b/cypress/fixtures/commonComponents/help.json
@@ -1,0 +1,46 @@
+{
+  "childrenOtherLanguage": {
+    "children": "mp150ú¿¡üßä"
+  },
+  "childrenSpecialCharacter": {
+    "children": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "tooltipPositionLeft": {
+    "tooltipPosition": "left"
+  },
+  "tooltipPositionBottom": {
+    "tooltipPosition": "bottom"
+  },
+  "tooltipPositionRight": {
+    "tooltipPosition": "right"
+  },
+  "tooltipPositionTop": {
+    "tooltipPosition": "top"
+  },
+  "tooltipAlignLeft": {
+    "tooltipAlign": "left",
+    "tooltipPosition": "bottom"
+  },
+  "tooltipAlignRight": {
+    "tooltipAlign": "right",
+    "tooltipPosition": "bottom"
+  },
+  "tooltipAlignTop": {
+    "tooltipAlign": "top",
+    "tooltipPosition": "bottom"
+  },
+  "tooltipAlignBottom": {
+    "tooltipAlign": "bottom",
+    "tooltipPosition": "bottom"
+  },
+  "tooltipAlignCenter": {
+    "tooltipAlign": "center",
+    "tooltipPosition": "bottom"
+  },
+  "hrefOtherLanguage": {
+    "href": "mp150ú¿¡üßä"
+  },
+  "hrefSpecialCharacter": {
+    "href": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  }
+}

--- a/cypress/fixtures/commonComponents/link.json
+++ b/cypress/fixtures/commonComponents/link.json
@@ -1,0 +1,91 @@
+{
+  "targetBlank": {
+    "target": "_blank"
+  },
+  "targetSelf": {
+    "target": "_self"
+  },
+  "targetTop": {
+    "target": "_top"
+  },
+  "childrenOtherLanguage": {
+    "children": "mp150ú¿¡üßä"
+  },
+  "childrenSpecialCharacter": {
+    "children": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "disabled": {
+    "disabled": true
+  },
+  "disabledFalse": {
+    "disabled": false
+  },
+  "hrefOtherLanguage": {
+    "href": "mp150ú¿¡üßä"
+  },
+  "hrefSpecialCharacter": {
+    "href": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "iconAlignRight": {
+    "icon": "add",
+    "iconAlign": "right"
+  },
+  "iconAlignLeft": {
+    "icon": "add",
+    "iconAlign": "left"
+  },
+  "tooltipAlignLeft": {
+    "icon": "add",
+    "tooltipMessage": "sample message",
+    "tooltipAlign": "left"
+  },
+  "tooltipAlignRight": {
+    "icon": "add",
+    "tooltipMessage": "sample message",
+    "tooltipAlign": "right"
+  },
+  "tooltipAlignTop": {
+    "icon": "add",
+    "tooltipMessage": "sample message",
+    "tooltipAlign": "top"
+  },
+  "tooltipAlignBottom": {
+    "icon": "add",
+    "tooltipMessage": "sample message",
+    "tooltipAlign": "bottom"
+  },
+  "tooltipAlignCenter": {
+    "icon": "add",
+    "tooltipMessage": "sample message",
+    "tooltipAlign": "center"
+  },
+  "tooltipPositionLeft": {
+    "icon": "add",
+    "tooltipMessage": "sample message",
+    "tooltipPosition": "left"
+  },
+  "tooltipPositionBottom": {
+    "icon": "add",
+    "tooltipMessage": "sample message",
+    "tooltipPosition": "bottom"
+  },
+  "tooltipPositionRight": {
+    "icon": "add",
+    "tooltipMessage": "sample message",
+    "tooltipPosition": "right"
+  },
+  "tooltipPositionTop": {
+    "icon": "add",
+    "tooltipMessage": "sample message",
+    "tooltipPosition": "top"
+  },
+  "tabbable": {
+    "tabbable": true
+  },
+  "tabbableFlase": {
+    "tabbable": false
+  },
+  "icon": {
+    "icon": "feedback"
+  }
+}

--- a/cypress/fixtures/commonComponents/loader.json
+++ b/cypress/fixtures/commonComponents/loader.json
@@ -1,0 +1,30 @@
+{
+  "sizeSmall": {
+    "size": "small"
+  },
+  "sizeLarge": {
+    "size": "large"
+  },
+  "isInsideButtonSmall": {
+    "isInsideButton": true,
+    "size": "small"
+  },
+  "isInsideButtonLarge": {
+    "isInsideButton": true,
+    "size": "large"
+  },
+  "isInsideButton": {
+    "isInsideButton": true
+  },
+  "isActiveFalse": {
+    "isInsideButton": true,
+    "isActive": false
+  },
+  "isActive": {
+    "isInsideButton": true,
+    "isActive": true
+  },
+  "default": {
+    "isInsideButton": true
+  }
+}

--- a/cypress/fixtures/commonComponents/menuList.json
+++ b/cypress/fixtures/commonComponents/menuList.json
@@ -1,0 +1,34 @@
+{
+  "titleOtherLanguage": {
+    "title": "mp150ú¿¡üßä"
+  },
+  "titleSpecialCharacter": {
+    "title": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "collapsibleFalse": {
+    "title": "title",
+    "collapsible": false
+  },
+  "collapsible": {
+    "title": "title",
+    "collapsible": true
+  },
+  "filter":{
+    "filter": true
+  },
+  "filterFalse":{
+    "filter": false
+  },
+  "initiallyOpen": {
+    "initiallyOpen": true
+  },
+  "initiallyOpenFalse": {
+    "initiallyOpen": false
+  },
+  "filterPlaceholderOtherLanguage": {
+    "filterPlaceholder": "mp150ú¿¡üßä"
+  },
+  "filterPlaceholderSpecialCharacter": {
+    "filterPlaceholder": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  }
+}

--- a/cypress/locators/confirm/index.js
+++ b/cypress/locators/confirm/index.js
@@ -1,7 +1,6 @@
 import { CLOSE_ICON_BUTTON } from '../locators';
 import {
   DIALOG_INNER_CONTENT,
-  DIALOG_TITLE,
   DIALOG,
   CANCEL_BUTTON,
   CONFIRM_BUTTON,
@@ -10,7 +9,6 @@ import {
 
 // component preview locators
 export const dialogInnerContent = () => cy.get(DIALOG_INNER_CONTENT);
-export const dialogTitle = () => cy.get(DIALOG_TITLE);
 export const dialogPreview = () => cy.get(DIALOG);
 export const closeIconButton = () => cy.get(CLOSE_ICON_BUTTON);
 export const dialogSubtitle = () => cy.get(DIALOG_SUBTITLE);

--- a/cypress/locators/confirm/locators.js
+++ b/cypress/locators/confirm/locators.js
@@ -1,6 +1,5 @@
 // component preview locators
 export const DIALOG_INNER_CONTENT = '.carbon-dialog__inner-content';
-export const DIALOG_TITLE = '[data-element="title"]';
 export const DIALOG = '[data-element="dialog"]';
 export const CLOSE_ICON_BUTTON = 'button[data-element="close"]';
 export const DIALOG_SUBTITLE = '[data-element="subtitle"]';

--- a/cypress/locators/heading/index.js
+++ b/cypress/locators/heading/index.js
@@ -1,9 +1,8 @@
 import {
-  HEADING_PREVIEW, TITLE_PREVIEW, SUBHEADER_PREVIEW, SEPARATOR_PREVIEW,
+  HEADING_PREVIEW, SUBHEADER_PREVIEW, SEPARATOR_PREVIEW,
 } from './locators';
 
 // component preview locators
 export const headingPreview = () => cy.iFrame(HEADING_PREVIEW);
-export const titlePreview = () => cy.iFrame(TITLE_PREVIEW);
 export const subheaderPreview = () => cy.iFrame(SUBHEADER_PREVIEW);
 export const separatorPreview = () => cy.iFrame(SEPARATOR_PREVIEW);

--- a/cypress/locators/heading/locators.js
+++ b/cypress/locators/heading/locators.js
@@ -2,4 +2,3 @@
 export const HEADING_PREVIEW = 'div[data-component="heading"]';
 export const SEPARATOR_PREVIEW = '.carbon-heading__separator';
 export const SUBHEADER_PREVIEW = 'div[data-element="subtitle"]';
-export const TITLE_PREVIEW = 'h1[data-element="title"]';

--- a/cypress/locators/help/index.js
+++ b/cypress/locators/help/index.js
@@ -1,6 +1,6 @@
 import { TOOLTIP_PREVIEW, TOOLTIP_POINTER, HELP_ICON_PREVIEW } from './locators';
 
 // component preview locators
-export const tooltipPreview = () => cy.iFrame(TOOLTIP_PREVIEW);
-export const tooltipPointer = () => cy.iFrame(TOOLTIP_POINTER);
-export const helpHref = () => cy.iFrame(HELP_ICON_PREVIEW);
+export const tooltipPreview = () => cy.get(TOOLTIP_PREVIEW);
+export const tooltipPointer = () => cy.get(TOOLTIP_POINTER);
+export const helpHref = () => cy.get(HELP_ICON_PREVIEW);

--- a/cypress/locators/index.js
+++ b/cypress/locators/index.js
@@ -33,7 +33,7 @@ export const labelPreview = () => storyRoot().find('label').first();
 export const label = () => cy.iFrame(LABEL);
 export const labelNoIFrame = () => cy.get(LABEL);
 export const labelByPositionInIframe = position => cy.iFrame(LABEL).eq(position);
-export const helpIcon = () => cy.iFrame(HELP_ICON_PREVIEW).first();
+export const helpIconIframe = () => cy.iFrame(HELP_ICON_PREVIEW).first();
 export const helpIconByPosition = position => cy.iFrame(HELP_ICON_PREVIEW).eq(position);
 export const tooltipPreview = () => cy.iFrame(TOOLTIP_PREVIEW);
 export const tooltipPreviewByPosition = position => cy.iFrame(TOOLTIP_PREVIEW).eq(position);
@@ -46,15 +46,15 @@ export const link = () => cy.iFrame(LINK);
 export const iconIFrame = () => cy.iFrame(ICON);
 export const inputWidthPreview = () => cy.iFrame(INPUT_WIDTH_PREVIEW);
 export const commonDataElementInputPreview = () => cy.iFrame(COMMMON_DATA_ELEMENT_INPUT);
-export const getDataElementByValue = element => cy.iFrame(`[data-element="${element}"]`);
+export const getDataElementByValueIframe = element => cy.iFrame(`[data-element="${element}"]`);
 export const getDataElementByNameAndValue = (name, value) => cy.iFrame(`[data-${name}="${value}"]`);
 
 // component preview locators into iFrame
 export const storyRootNoIframe = () => cy.get(STORY_ROOT);
 export const tooltipPreviewNoIframe = () => cy.get(TOOLTIP_PREVIEW);
 export const icon = () => cy.get(ICON);
-export const getDataElementByValueNoIframe = element => cy.get(`[data-element="${element}"]`);
-export const getDataElementByValueAndPositionNoIframe = (element, position) => cy.get(`[data-element="${element}"]`)
+export const getDataElementByValue = element => cy.get(`[data-element="${element}"]`);
+export const getDataElementByValueAndPosition = (element, position) => cy.get(`[data-element="${element}"]`)
   .eq(position);
 export const commonDataElementInputPreviewNoIframe = () => cy.get(COMMMON_DATA_ELEMENT_INPUT);
 export const commonDataElementInputPreviewByPositionNoIFrame = position => cy.get(COMMMON_DATA_ELEMENT_INPUT)
@@ -66,7 +66,7 @@ export const commonButtonPreviewNoIframe = () => cy.get(STORY_ROOT).find('button
 export const backgroundUILocatorNoIFrame = () => cy.get(BACKGROUND_UI_LOCATOR);
 export const closeIconButton = () => cy.get(CLOSE_ICON_BUTTON);
 export const fieldHelpPreviewNoIFrame = () => cy.get(FIELD_HELP_PREVIEW).first();
-export const helpIconNoIFrame = () => cy.get(HELP_ICON_PREVIEW).first();
+export const helpIcon = () => cy.get(HELP_ICON_PREVIEW);
 export const fieldHelpPreviewByPositionNoIFrame = position => cy.get(FIELD_HELP_PREVIEW).eq(position);
 export const labelByPosition = position => cy.get(LABEL).eq(position);
 export const helpIconByPositionNoIFrame = position => cy.get(HELP_ICON_PREVIEW).eq(position);

--- a/cypress/locators/link/index.js
+++ b/cypress/locators/link/index.js
@@ -1,9 +1,9 @@
 import { LINK_PREVIEW } from './locators';
 
 // component preview locators
-export const linkPreview = () => cy.iFrame(LINK_PREVIEW);
-export const linkChildren = () => cy.iFrame(LINK_PREVIEW)
+export const linkPreview = () => cy.get(LINK_PREVIEW);
+export const linkChildren = () => cy.get(LINK_PREVIEW)
   .then($element => $element.children())
   .find('span[class="carbon-link__content"]');
-export const linkIcon = () => cy.iFrame(LINK_PREVIEW).children()
+export const linkIcon = () => cy.get(LINK_PREVIEW).children()
   .find('[data-component="icon"]');

--- a/cypress/locators/loader/index.js
+++ b/cypress/locators/loader/index.js
@@ -1,5 +1,5 @@
 import { LOADER } from './locators';
 import { BUTTON_DATA_COMPONENT_PREVIEW } from '../button/locators';
 
-export const loader = () => cy.iFrame(LOADER);
-export const loaderInsideButton = () => cy.iFrame(BUTTON_DATA_COMPONENT_PREVIEW);
+export const loader = () => cy.get(LOADER);
+export const loaderInsideButton = () => cy.get(BUTTON_DATA_COMPONENT_PREVIEW);

--- a/cypress/locators/menu-list/index.js
+++ b/cypress/locators/menu-list/index.js
@@ -1,10 +1,14 @@
 import {
-  MENU_LIST_CHILDREN, MENU_TITLE, MENU_LIST_SEARCH, MENU_LIST, MENU_LIST_ITEMS,
+  MENU_LIST_CHILDREN, MENU_LIST_SEARCH, MENU_LIST, MENU_LIST_ITEMS, MENU_DATA_COMPONENT,
 } from './locators';
 
 // component preview locators
-export const menuListChildren = () => cy.iFrame(MENU_LIST_CHILDREN).children();
-export const menuTitle = () => cy.iFrame(MENU_TITLE).first();
-export const menuListSearchInput = () => cy.iFrame(MENU_LIST_SEARCH);
+export const menuListChildren = () => cy.get(MENU_LIST_CHILDREN).children();
+export const menuListSearchInput = () => cy.get(MENU_LIST_SEARCH);
+export const menuSecondOption = () => cy.get(MENU_LIST).contains('.carbon-link__content', 'Menu Item Two');
+export const menuListElements = () => cy.get(MENU_DATA_COMPONENT).find('ul');
+
+// component locators in Iframe
+export const menuSecondOptionIframe = () => cy.iFrame(MENU_LIST).contains('.carbon-link__content', 'Menu Item Two');
+export const menuListSearchInputIframe = () => cy.iFrame(MENU_LIST_SEARCH);
 export const menuList = () => cy.iFrame(MENU_LIST_ITEMS);
-export const menuSecondOption = () => cy.iFrame(MENU_LIST).contains('.carbon-link__content', 'Menu Item Two');

--- a/cypress/locators/menu-list/locators.js
+++ b/cypress/locators/menu-list/locators.js
@@ -1,6 +1,6 @@
 // component preview locators
 export const MENU_LIST_CHILDREN = 'div[data-component="menu-list"][class="carbon-menu-list"]';
-export const MENU_TITLE = '#story-root > div[data-component="menu-list"] > [data-component="link"]';
 export const MENU_LIST_SEARCH = '[data-element="input"]';
 export const MENU_LIST = 'ul[class="carbon-menu-list__list"]';
 export const MENU_LIST_ITEMS = '#story-root > div[data-component="menu-list"] > ul[class="carbon-menu-list__list"] > li:nth-child(2) > div[data-component="menu-list"] > ul[class="carbon-menu-list__list"]';
+export const MENU_DATA_COMPONENT = '[data-component="menu-list"]';

--- a/cypress/locators/message/index.js
+++ b/cypress/locators/message/index.js
@@ -1,11 +1,10 @@
 import {
-  MESSAGE_TITLE, MESSAGE_TYPE, MESSAGE_PREVIEW,
+  MESSAGE_TYPE, MESSAGE_PREVIEW,
   MESSAGE_CHILDREN, MESSAGE_DISMISS_ICON,
 } from './locators';
 
 // component preview locators
 export const messagePreview = () => cy.iFrame(MESSAGE_PREVIEW);
-export const messageTitle = () => cy.iFrame(MESSAGE_TITLE);
 export const messageType = () => cy.iFrame(MESSAGE_TYPE);
 export const messageChildren = () => cy.iFrame(MESSAGE_CHILDREN);
 export const messageDismissIcon = () => cy.iFrame(MESSAGE_DISMISS_ICON);

--- a/cypress/locators/message/locators.js
+++ b/cypress/locators/message/locators.js
@@ -3,7 +3,6 @@ export const CLICK_ACTION = ' > div:nth-child(2)';
 
 // component preview locators
 export const MESSAGE_PREVIEW = 'div[data-component="Message"]';
-export const MESSAGE_TITLE = 'div[data-element="title"]';
 export const MESSAGE_TYPE = 'div[data-component="Message"] > div > span[data-component="icon"]';
 export const MESSAGE_CHILDREN = 'div[data-element="body"]';
 export const MESSAGE_DISMISS_ICON = 'span[data-element="close"]';

--- a/cypress/locators/pages/index.js
+++ b/cypress/locators/pages/index.js
@@ -1,9 +1,8 @@
 import {
-  TITLE_DATA_ELEMENT, BUTTON_DATA_COMPONENT, CLOSE_DATA_ELEMENT, BACK_ARROW,
+  BUTTON_DATA_COMPONENT, CLOSE_DATA_ELEMENT, BACK_ARROW,
 } from './locators';
 
 // iFrame locators
-export const title = () => cy.iFrame(TITLE_DATA_ELEMENT);
 export const dataComponentButtonByText = text => cy.iFrame(BUTTON_DATA_COMPONENT).contains(text);
 export const closeDataElement = () => cy.iFrame(CLOSE_DATA_ELEMENT);
 export const backArrow = () => cy.iFrame(BACK_ARROW);

--- a/cypress/locators/pages/locators.js
+++ b/cypress/locators/pages/locators.js
@@ -1,5 +1,4 @@
 // component preview locators
-export const TITLE_DATA_ELEMENT = 'h1[data-element="title"]';
 export const BUTTON_DATA_COMPONENT = '[data-element="main-text"]';
 export const CLOSE_DATA_ELEMENT = '[data-element="close"]';
 export const BACK_ARROW = '[data-element="chevron_left"]';

--- a/cypress/locators/pod/index.js
+++ b/cypress/locators/pod/index.js
@@ -1,6 +1,6 @@
 import {
   POD_DATA_COMPONENT, POD_EDIT_ICON, POD_FOOTER, POD_CONTENT,
-  POD_TITLE, POD_SUBTITLE, POD_DESCRIPTION,
+  POD_SUBTITLE, POD_DESCRIPTION,
 } from './locators';
 
 // component preview locators
@@ -9,7 +9,6 @@ export const podPreview = () => cy.get(POD_DATA_COMPONENT).children();
 export const podFooter = () => podComponent().find(POD_FOOTER);
 export const podEdit = () => podComponent().find(POD_EDIT_ICON);
 export const podContent = () => podComponent().find(POD_CONTENT);
-export const podTitle = () => cy.get(POD_TITLE);
 export const podSubTitle = () => cy.get(POD_SUBTITLE);
 export const podDescription = () => cy.get(POD_DESCRIPTION);
 

--- a/cypress/locators/pod/locators.js
+++ b/cypress/locators/pod/locators.js
@@ -3,6 +3,5 @@ export const POD_DATA_COMPONENT = '[data-component="pod"]';
 export const POD_FOOTER = '[data-element="footer"]';
 export const POD_EDIT_ICON = '[data-element="edit"]';
 export const POD_CONTENT = '[data-element="content"]';
-export const POD_TITLE = '[data-element="title"]';
 export const POD_SUBTITLE = '[data-element="subtitle"]';
 export const POD_DESCRIPTION = '[data-element="description"]';

--- a/cypress/locators/settings-row/index.js
+++ b/cypress/locators/settings-row/index.js
@@ -1,9 +1,8 @@
 import {
-  SETTINGS_ROW_TITLE, SETTINGS_ROW_COMPONENT, SETTINGS_ROW_CHILDREN, SETTINGS_ROW_DESCRIPTION,
+  SETTINGS_ROW_COMPONENT, SETTINGS_ROW_CHILDREN, SETTINGS_ROW_DESCRIPTION,
 } from './locators';
 
 // component preview locators
-export const settingsRowTitle = () => cy.iFrame(SETTINGS_ROW_TITLE);
 export const settingsRowPreview = () => cy.iFrame(SETTINGS_ROW_COMPONENT);
 export const settingsRowChildren = () => cy.iFrame(SETTINGS_ROW_CHILDREN);
 export const settingsRowDescription = () => cy.iFrame(SETTINGS_ROW_DESCRIPTION);

--- a/cypress/locators/settings-row/locators.js
+++ b/cypress/locators/settings-row/locators.js
@@ -1,5 +1,4 @@
 // component preview locators
 export const SETTINGS_ROW_COMPONENT = 'div[data-component="settings-row"]';
-export const SETTINGS_ROW_TITLE = 'h1[data-element="title"]';
 export const SETTINGS_ROW_CHILDREN = 'div[class="carbon-settings-row__input"]';
 export const SETTINGS_ROW_DESCRIPTION = 'div[data-element="subtitle"]';

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -5,20 +5,20 @@ import {
   visitComponentUrlWithParameters,
 } from '../helper';
 import {
-  commonButtonPreview, labelPreview, helpIcon, helpIconByPosition, inputWidthSlider,
+  commonButtonPreview, labelPreview, helpIconIframe, helpIconByPosition, inputWidthSlider,
   fieldHelpPreview, labelWidthSlider, backgroundUILocator,
   closeIconButtonIFrame, tooltipPreview, getKnobsInput, getKnobsInputWithName, getKnobsInputByGroup,
   iconIFrame, inputWidthPreview, label, eventInAction, getDataElementByNameAndValue, storyRoot,
-  precisionSlider, storyRootNoIframe, tooltipPreviewNoIframe, getDataElementByValueNoIframe,
+  precisionSlider, storyRootNoIframe, tooltipPreviewNoIframe, getDataElementByValue,
   knobsNameTab, dlsRoot,
   commonButtonPreviewNoIFrameRoot,
-  getDataElementByValue,
+  getDataElementByValueIframe,
   commonButtonPreviewNoIframe,
   backgroundUILocatorNoIFrame,
   closeIconButton,
   fieldHelpPreviewNoIFrame,
   commonDataElementInputPreviewNoIframe,
-  helpIconNoIFrame,
+  helpIcon,
   helpIconByPositionNoIFrame,
   getElementNoIframe,
   labelByPosition,
@@ -210,7 +210,7 @@ Then('label on preview is {word}', (text) => {
 });
 
 Then('label on preview is {word} in NoIFrame', (text) => {
-  getDataElementByValueNoIframe('label').should('have.text', text);
+  getDataElementByValue('label').should('have.text', text);
 });
 
 Then('label is set to {word}', (text) => {
@@ -218,11 +218,11 @@ Then('label is set to {word}', (text) => {
 });
 
 When('I hover mouse onto help icon in noIFrame', () => {
-  helpIconNoIFrame().trigger('mouseover');
+  helpIcon().trigger('mouseover');
 });
 
 When('I hover mouse onto help icon', () => {
-  helpIcon().trigger('mouseover');
+  helpIconIframe().trigger('mouseover');
 });
 
 When('I hover mouse onto {string} help icon', (position) => {
@@ -239,11 +239,11 @@ When('I hover mouse onto icon', () => {
 });
 
 Then('I hover mouse onto {string} icon in no iFrame', (name) => {
-  getDataElementByValueNoIframe(name).trigger('mouseover');
+  getDataElementByValue(name).trigger('mouseover');
 });
 
 Then('I hover mouse onto {string} icon in iFrame', (name) => {
-  getDataElementByValue(name).trigger('mouseover');
+  getDataElementByValueIframe(name).trigger('mouseover');
 });
 
 Then('tooltipPreview on preview is set to {word} in NoIFrame', (text) => {
@@ -517,7 +517,7 @@ Then('input direction is {string}', (direction) => {
 });
 
 Then('label width on preview is {int}', (width) => {
-  getDataElementByValueNoIframe('label').parent().should('have.attr', 'width').should('contain', `${width}`);
+  getDataElementByValue('label').parent().should('have.attr', 'width').should('contain', `${width}`);
 });
 
 Then('label width on preview is {int} in IFrame', (width) => {
@@ -529,7 +529,7 @@ Then('inputWidth on preview is {int}', (width) => {
 });
 
 Then('label align on preview is set to {string}', (labelAlign) => {
-  getDataElementByValueNoIframe('label').should('have.css', TEXT_ALIGN, `${labelAlign}`);
+  getDataElementByValue('label').should('have.css', TEXT_ALIGN, `${labelAlign}`);
 });
 
 Then('label align on preview is set to {string} in IFrame', (labelAlign) => {
@@ -537,7 +537,7 @@ Then('label align on preview is set to {string} in IFrame', (labelAlign) => {
 });
 
 Then('label is inline', () => {
-  getDataElementByValueNoIframe('label').parent().should('have.css', TEXT_ALIGN, TEXT_ALIGN_START);
+  getDataElementByValue('label').parent().should('have.css', TEXT_ALIGN, TEXT_ALIGN_START);
 });
 
 Then('label is inline in IFrame', () => {
@@ -545,7 +545,7 @@ Then('label is inline in IFrame', () => {
 });
 
 Then('label width is set to {string} in NoIFrame', (width) => {
-  getDataElementByValueNoIframe('label').parent().should('have.attr', 'width', `${width}`);
+  getDataElementByValue('label').parent().should('have.attr', 'width', `${width}`);
 });
 
 Then('label Align on preview is {string}', (direction) => {
@@ -554,9 +554,9 @@ Then('label Align on preview is {string}', (direction) => {
 
 Then('label Align on preview is {string} in NoIFrame', (direction) => {
   if (direction === 'left') {
-    getDataElementByValueNoIframe('label').parent().should($element => expect($element).to.have.css(TEXT_ALIGN, TEXT_ALIGN_START));
+    getDataElementByValue('label').parent().should($element => expect($element).to.have.css(TEXT_ALIGN, TEXT_ALIGN_START));
   } else {
-    getDataElementByValueNoIframe('label').parent().should($element => expect($element).to.have.css(TEXT_ALIGN, TEXT_ALIGN_END));
+    getDataElementByValue('label').parent().should($element => expect($element).to.have.css(TEXT_ALIGN, TEXT_ALIGN_END));
   }
 });
 

--- a/cypress/support/step-definitions/confirm-steps.js
+++ b/cypress/support/step-definitions/confirm-steps.js
@@ -1,5 +1,4 @@
 import {
-  dialogTitle,
   dialogPreview,
   closeIconButton,
   dialogSubtitle,
@@ -10,6 +9,7 @@ import {
   dialogPreviewIFrame,
   dialogSubtitleIFrame,
 } from '../../locators/confirm';
+import { getDataElementByValue } from '../../locators';
 
 Then('component subtitle on preview is {word}', (subtitle) => {
   dialogSubtitle().should('have.text', subtitle);
@@ -36,7 +36,7 @@ Then('cancel button content on preview is {word}', (cancelButtonText) => {
 });
 
 Then('dialog title context on preview is {word}', (title) => {
-  dialogTitle().should('have.text', title);
+  getDataElementByValue('title').should('have.text', title);
 });
 
 Then('Confirm dialog is visible', () => {

--- a/cypress/support/step-definitions/flash-steps.js
+++ b/cypress/support/step-definitions/flash-steps.js
@@ -1,10 +1,10 @@
 import { flashPreview, messagePreview } from '../../locators/flash';
-import { getDataElementByValue } from '../../locators';
+import { getDataElementByValueIframe } from '../../locators';
 import { DEBUG_FLAG } from '..';
 
 Then('Flash as is set to {string} and icon is set to {string}', (as, iconValue) => {
   flashPreview().should('exist');
-  getDataElementByValue(iconValue).should('exist');
+  getDataElementByValueIframe(iconValue).should('exist');
 });
 
 Then('Flash message is set to {string}', (message) => {

--- a/cypress/support/step-definitions/heading-steps.js
+++ b/cypress/support/step-definitions/heading-steps.js
@@ -1,7 +1,7 @@
 import {
-  headingPreview, titlePreview, subheaderPreview, separatorPreview,
+  headingPreview, subheaderPreview, separatorPreview,
 } from '../../locators/heading';
-import { helpIcon, link } from '../../locators';
+import { helpIconIframe, link, getDataElementByValueIframe } from '../../locators';
 
 const DIVIDER = 'carbon-heading--has-divider';
 
@@ -10,7 +10,7 @@ Then('heading children on preview is {word}', (children) => {
 });
 
 Then('heading title is set to {word}', (title) => {
-  titlePreview().should('have.text', title);
+  getDataElementByValueIframe('title').should('have.text', title);
 });
 
 Then('subheader on preview is {word}', (subheader) => {
@@ -18,7 +18,7 @@ Then('subheader on preview is {word}', (subheader) => {
 });
 
 Then('link on preview is {word}', (helpLink) => {
-  helpIcon().should('have.attr', 'href', helpLink);
+  helpIconIframe().should('have.attr', 'href', helpLink);
 });
 
 Then('backLink on preview is {word}', (backLink) => {

--- a/cypress/support/step-definitions/help-steps.js
+++ b/cypress/support/step-definitions/help-steps.js
@@ -1,9 +1,9 @@
-import { iconIFrame } from '../../locators';
+import { icon } from '../../locators';
 import { tooltipPreview, tooltipPointer, helpHref } from '../../locators/help';
 
 Then('tooltipPosition is set to {string}', (tooltipPosition) => {
   tooltipPreview().should('be.visible');
-  iconIFrame().trigger('mouseover');
+  icon().trigger('mouseover');
   tooltipPointer().invoke('show');
   switch (tooltipPosition) {
     case 'top':
@@ -28,7 +28,7 @@ Then('tooltipPosition is set to {string}', (tooltipPosition) => {
 
 Then('tooltipAlign is set to {string}', (tooltipAlign) => {
   tooltipPreview().should('be.visible');
-  iconIFrame().trigger('mouseover');
+  icon().trigger('mouseover');
   tooltipPointer().invoke('show');
   switch (tooltipAlign) {
     case 'bottom':
@@ -60,5 +60,5 @@ Then('Help href on preview is set to {word}', (href) => {
 });
 
 Then('icon on preview has {string} color', (color) => {
-  iconIFrame().should('have.css', 'color', color);
+  icon().should('have.css', 'color', color);
 });

--- a/cypress/support/step-definitions/link-steps.js
+++ b/cypress/support/step-definitions/link-steps.js
@@ -20,7 +20,7 @@ Then('Link on preview href is set to {word}', (href) => {
   linkPreview().children().should('have.attr', 'href', `${href}`);
 });
 
-Then('icon on link componenent preview is {string}', (iconName) => {
+Then('icon on link component preview is {string}', (iconName) => {
   linkIcon().should('have.attr', 'data-element', iconName)
     .and('be.visible');
 });
@@ -40,12 +40,4 @@ Then('Link is tabbable', () => {
 
 Then('Link is not tabbable', () => {
   linkPreview().children().should('have.attr', 'tabindex', '-1');
-});
-
-Then('Link component is focused', () => {
-  cy.focused().should('have', linkPreview());
-});
-
-Then('Link component is not focused', () => {
-  cy.focused().should('not.have', linkPreview());
 });

--- a/cypress/support/step-definitions/menu-list-steps.js
+++ b/cypress/support/step-definitions/menu-list-steps.js
@@ -1,18 +1,26 @@
 import {
-  menuTitle, menuListChildren, menuListSearchInput,
-  menuSecondOption, menuList,
+  menuListChildren, menuListSearchInput,
+  menuSecondOption, menuList, menuSecondOptionIframe,
+  menuListSearchInputIframe,
+  menuListElements,
 } from '../../locators/menu-list';
+import { getDataElementByValueAndPosition } from '../../locators';
+import { positionOfElement } from '../helper';
 
 Then('title on preview is {word}', (title) => {
-  menuTitle().should('have.text', title);
+  getDataElementByValueAndPosition('title', positionOfElement('first')).should('have.text', title);
 });
 
 When('I click into title', () => {
-  menuTitle().click();
+  getDataElementByValueAndPosition('title', positionOfElement('first')).click();
 });
 
 When('I click into menu item second element', () => {
   menuSecondOption().click();
+});
+
+When('I click into menu item second element in Iframe', () => {
+  menuSecondOptionIframe().click();
 });
 
 Then('MenuList component is expanded', () => {
@@ -20,7 +28,7 @@ Then('MenuList component is expanded', () => {
 });
 
 Then('MenuList component is not expanded', () => {
-  menuListChildren().should('have.length', 0);
+  menuListElements().should('have.length', 1);
 });
 
 Then('filter is disabled', () => {
@@ -32,7 +40,7 @@ Then('filter is enabled', () => {
 });
 
 When('I change search parameter to {string}', (parameter) => {
-  menuListSearchInput().clear().type(parameter);
+  menuListSearchInputIframe().clear().type(parameter);
 });
 
 Then('search result is {string}', (text) => {

--- a/cypress/support/step-definitions/message-steps.js
+++ b/cypress/support/step-definitions/message-steps.js
@@ -1,10 +1,11 @@
 import {
-  messageTitle, messageType, messagePreview, messageChildren, messageDismissIcon,
+  messageType, messagePreview, messageChildren, messageDismissIcon,
 } from '../../locators/message';
 import { clickActionsTab, clickClear } from '../helper';
+import { getDataElementByValueIframe } from '../../locators';
 
 Then('Message title on preview is set to {word}', (text) => {
-  messageTitle().should('have.text', text);
+  getDataElementByValueIframe('title').should('have.text', text);
 });
 
 Then('Message type on preview is {string}', (type) => {

--- a/cypress/support/step-definitions/pages-steps.js
+++ b/cypress/support/step-definitions/pages-steps.js
@@ -1,10 +1,11 @@
 import {
-  dataComponentButtonByText, title, closeDataElement, backArrow,
+  dataComponentButtonByText, closeDataElement, backArrow,
 } from '../../locators/pages';
 import { DEBUG_FLAG } from '..';
+import { getDataElementByValueIframe } from '../../locators';
 
 Then('My {word} Page is visible', (word) => {
-  title().should('have.text', `My ${word} Page`);
+  getDataElementByValueIframe('title').should('have.text', `My ${word} Page`);
 });
 
 When('I go to {word} page', (word) => {
@@ -25,21 +26,21 @@ Then('I go back', () => {
 Then('other pages except {word} Page are not visible', (word) => {
   switch (word) {
     case 'First':
-      title().should('not.have.text', 'My Second Page');
-      title().should('not.have.text', 'My Third Page');
+      getDataElementByValueIframe('title').should('not.have.text', 'My Second Page');
+      getDataElementByValueIframe('title').should('not.have.text', 'My Third Page');
       break;
     case 'Second':
-      title().should('not.have.text', 'My First Page');
-      title().should('not.have.text', 'My Third Page');
+      getDataElementByValueIframe('title').should('not.have.text', 'My First Page');
+      getDataElementByValueIframe('title').should('not.have.text', 'My Third Page');
       break;
     case 'Third':
-      title().should('not.have.text', 'My First Page');
-      title().should('not.have.text', 'My Second Page');
+      getDataElementByValueIframe('title').should('not.have.text', 'My First Page');
+      getDataElementByValueIframe('title').should('not.have.text', 'My Second Page');
       break;
     default: throw new Error(`Unknown page ${word}`);
   }
 });
 
 Then('page is closed', () => {
-  title().should('not.exist');
+  getDataElementByValueIframe('title').should('not.exist');
 });

--- a/cypress/support/step-definitions/pod-steps.js
+++ b/cypress/support/step-definitions/pod-steps.js
@@ -1,9 +1,10 @@
 import {
   podComponent, podPreview, podContent,
-  podTitle, podSubTitle, podDescription, podFooter, podEdit, 
+  podSubTitle, podDescription, podFooter, podEdit, 
   podEditIframe,
 } from '../../locators/pod';
 import { DEBUG_FLAG } from '..';
+import { getDataElementByValue } from '../../locators';
 
 const POD_DIV_PROPERTY = 'carbon-pod';
 
@@ -12,7 +13,7 @@ Then('Pod children on preview is set to {word}', (text) => {
 });
 
 Then('Pod title on preview is set to {word}', (text) => {
-  podTitle().should('have.text', text);
+  getDataElementByValue('title').should('have.text', text);
 });
 
 Then('Pod subtitle on preview is set to {word}', (text) => {
@@ -56,7 +57,7 @@ Then('Pod component has no border', () => {
 Then('Pod {string} on preview is {string}', (element, alignTitle) => {
   switch (element) {
     case 'title':
-      podTitle().parent().should('have.css', 'text-align', alignTitle);
+      getDataElementByValue('title').parent().should('have.css', 'text-align', alignTitle);
       break;
     case 'subtitle':
       podSubTitle().should('have.css', 'text-align', alignTitle);
@@ -107,5 +108,5 @@ Then('Pod component has internalEditButton property', () => {
 });
 
 When('I hover mouse onto Pod content', () => {
-  podTitle().trigger('mouseover');
+  getDataElementByValue('title').trigger('mouseover');
 });

--- a/cypress/support/step-definitions/settings-row-steps.js
+++ b/cypress/support/step-definitions/settings-row-steps.js
@@ -1,12 +1,13 @@
 import {
-  settingsRowTitle, settingsRowChildren, settingsRowDescription,
+  settingsRowChildren, settingsRowDescription,
   settingsRowPreview,
 } from '../../locators/settings-row';
+import { getDataElementByValueIframe } from '../../locators';
 
 const DIVIDER_CLASS = 'carbon-settings-row--has-divider';
 
 Then('Settings Row title on preview is set to {word}', (text) => {
-  settingsRowTitle().should('have.text', `${text}`);
+  getDataElementByValueIframe('title').should('have.text', `${text}`);
 });
 
 Then('Settings Row children on preview is set to {word}', (text) => {

--- a/cypress/support/step-definitions/text-area-steps.js
+++ b/cypress/support/step-definitions/text-area-steps.js
@@ -3,7 +3,7 @@ import {
   characterLimit, characterLimitDefaultTextarea, textareaInput,
 } from '../../locators/textarea';
 import { setSlidebar } from '../helper';
-import { getDataElementByValueNoIframe } from '../../locators';
+import { getDataElementByValue } from '../../locators';
 
 Then('Textarea component is expandable', () => {
   textareaChildren().should('have.css', 'height', '89px');
@@ -84,11 +84,11 @@ Then('Textarea inputWidth is set to {string}', (width) => {
 });
 
 Then('Textarea component is labelInline', () => {
-  getDataElementByValueNoIframe('label').parent().should('have.css', 'align-items', 'flex-start');
+  getDataElementByValue('label').parent().should('have.css', 'align-items', 'flex-start');
 });
 
 Then('Textarea component is not labelInline', () => {
-  getDataElementByValueNoIframe('label').parent().should('have.css', 'align-items', 'center');
+  getDataElementByValue('label').parent().should('have.css', 'align-items', 'center');
 });
 
 When('I input {word} into Textarea', (text) => {

--- a/cypress/support/step-definitions/textbox-steps.js
+++ b/cypress/support/step-definitions/textbox-steps.js
@@ -8,12 +8,12 @@ import {
 import {
   labelNoIFrame,
   commonDataElementInputPreviewNoIframe,
-  getDataElementByValueNoIframe,
+  getDataElementByValue,
   tooltipPreviewByPositionNoIFrame,
   labelByPosition,
   fieldHelpPreviewByPositionNoIFrame,
   commonDataElementInputPreviewByPositionNoIFrame,
-  getDataElementByValueAndPositionNoIframe,
+  getDataElementByValueAndPosition,
 } from '../../locators';
 import { positionOfElement } from '../helper';
 
@@ -121,16 +121,16 @@ Then('Multiple label is set to {word}', (text) => {
 });
 
 Then('Textbox component is labelInline', () => {
-  getDataElementByValueNoIframe('label').parent().should('have.css', TEXT_ALIGN, TEXT_ALIGN_START);
+  getDataElementByValue('label').parent().should('have.css', TEXT_ALIGN, TEXT_ALIGN_START);
 });
 
 Then('Multiple Textbox component is labelInline', () => {
-  getDataElementByValueAndPositionNoIframe('label', positionOfElement('first')).parent().should('have.css', TEXT_ALIGN, TEXT_ALIGN_START);
-  getDataElementByValueAndPositionNoIframe('label', positionOfElement('second')).parent().should('have.css', TEXT_ALIGN, TEXT_ALIGN_START);
+  getDataElementByValueAndPosition('label', positionOfElement('first')).parent().should('have.css', TEXT_ALIGN, TEXT_ALIGN_START);
+  getDataElementByValueAndPosition('label', positionOfElement('second')).parent().should('have.css', TEXT_ALIGN, TEXT_ALIGN_START);
 });
 
 Then('Textbox component is not labelInline', () => {
-  getDataElementByValueNoIframe('label').parent().should('not.have.css', TEXT_ALIGN, TEXT_ALIGN_START);
+  getDataElementByValue('label').parent().should('not.have.css', TEXT_ALIGN, TEXT_ALIGN_START);
 });
 
 Then('Multiple Textbox component is not labelInline', () => {
@@ -153,8 +153,8 @@ Then('Multiple Textbox inputWidth is set to {string}', (width) => {
 });
 
 Then('Multiple label width is set to {string}', (width) => {
-  getDataElementByValueAndPositionNoIframe('label', positionOfElement('first')).parent().should('have.attr', 'width', `${width}`);
-  getDataElementByValueAndPositionNoIframe('label', positionOfElement('second')).parent().should('have.attr', 'width', `${width}`);
+  getDataElementByValueAndPosition('label', positionOfElement('first')).parent().should('have.attr', 'width', `${width}`);
+  getDataElementByValueAndPosition('label', positionOfElement('second')).parent().should('have.attr', 'width', `${width}`);
 });
 
 When('I type {word} into Textbox', (text) => {

--- a/cypress/support/step-definitions/toast-steps.js
+++ b/cypress/support/step-definitions/toast-steps.js
@@ -1,5 +1,5 @@
 import { toastPreview, toastComponent, toastTogglePreview } from '../../locators/toast';
-import { getDataElementByValue } from '../../locators';
+import { getDataElementByValueIframe } from '../../locators';
 
 When('I click on {string} Toggle Preview', (e) => {
   toastTogglePreview(e).scrollIntoView();
@@ -23,11 +23,11 @@ Then('Toast component is not visible', () => {
 });
 
 Then('Toast component has a close icon', () => {
-  getDataElementByValue('close').should('be.visible');
+  getDataElementByValueIframe('close').should('be.visible');
 });
 
 Then('Toast component has no close icon', () => {
-  getDataElementByValue('close').should('not.exist');
+  getDataElementByValueIframe('close').should('not.exist');
 });
 
 Then('Toast has background-color {string} and border {string} color', (color) => {


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots. You can paste these directly into GitHub. 

There's no need to share your internal source code with us, an example built from our codesandbox quickstart (https://codesandbox.io/s/carbon-quickstart-xi5jc) is better. You can take any screenshots from this, rather than sharing screenshots of your development product, app or site with us.

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Apply new `url` approach in tests for:
`help`  (timing  `1:17` ->  `0:22`),
`link`  (timing  `3:05` -> `0:32` ),
`loader`  (timing  `0:39` -> `0:11` ),
`menuList` (timing  `0:58` ->  `0:36` ).

### Current behaviour
<!--
A clear and concise description of the behavior before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are passing all parameters via `knobs`.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Screenshots are included in the PR
- [ ] Carbon implementation and Design System documentation are congruent
- [ ] All themes are supported
- [x] Commits follow our style guide
- [ ] Unit tests added or updated
- [x] Cypress automation tests added or updated
- [ ] Storybook added or updated
- [ ] Typescript `d.ts` file added or updated