### PR TITLE
test(tile, switch): update cypress tests with a new URL approach

### DIFF
--- a/cypress/features/regression/experimental/checkbox.feature
+++ b/cypress/features/regression/experimental/checkbox.feature
@@ -1,5 +1,5 @@
 Feature: Experimental Checkbox component
-  I want to check Experimental Checkbox properties
+  I want to test Experimental Checkbox properties
 
   @positive
   Scenario Outline: Change Checkbox component label to <label>
@@ -32,12 +32,12 @@ Feature: Experimental Checkbox component
   @positive
   Scenario: Enable fieldHelpInline
     When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "fieldHelpInlineDisabled" object name
-    Then Checkbox is set to fieldHelpInline and has margin-left set to "24px"
+    Then Checkbox is set to fieldHelpInline and has marginLeft set to "24px"
 
   @positive
   Scenario: Enable and disable fieldHelpInline
     When I open default "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "fieldHelpInline" object name
-    Then Checkbox is not set to fieldHelpInline and has margin set to "0px"
+    Then Checkbox is not set to fieldHelpInline and has marginTop set to "0px"
 
   @positive
   Scenario: Enable reverse checkbox

--- a/cypress/features/regression/experimental/switch.feature
+++ b/cypress/features/regression/experimental/switch.feature
@@ -1,0 +1,83 @@
+Feature: Switch component
+  I want to test Switch properties
+
+  @positive
+  Scenario Outline: Change Switch component fieldHelp to <fieldHelp>
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "<nameOfObject>" object name
+    Then fieldHelp on preview is set to <fieldHelp> in NoIFrame
+    Examples:
+      | fieldHelp               | nameOfObject              |
+      | mp150ú¿¡üßä             | fieldHelpOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | fieldHelpSpecialCharacter |
+  # @ignore because of FE-2782
+  # | &"'<>|
+
+  @positive
+  Scenario: Enable fieldHelpInline
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "fieldHelpInline" object name
+    Then Switch is set to fieldHelpInline and has marginLeft set to "0px"
+
+  @positive
+  Scenario: Disable fieldHelpInline
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "fieldHelpInlineFalse" object name
+    Then Switch is not set to fieldHelpInline and has marginTop set to "8px"
+
+  @positive
+  Scenario Outline: Change Switch component label to <label>
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "<nameOfObject>" object name
+    Then label on preview is <label> in NoIFrame
+    Examples:
+      | label                   | nameOfObject          |
+      | mp150ú¿¡üßä             | labelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | labelSpecialCharacter |
+  # @ignore because of FE-2782
+  # | &"'<>|
+
+  @positive
+  Scenario: Enable labelInline property
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "labelInline" object name
+    Then label is inline
+
+  @positive
+  Scenario: Disabled labelInline property
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "labelInlineFalse" object name
+    Then label is not inline
+
+  @positive
+  Scenario: Enable loading property
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "loading" object name
+    Then Switch component is loading
+
+  @positive
+  Scenario: Disable loading property
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "loadingFalse" object name
+    Then Switch component is not loading
+
+  @positive
+  Scenario: Disable Switch
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "disabled" object name
+    Then Switch is disabled
+
+  @positive
+  Scenario: Enable Switch
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "disabledFalse" object name
+    Then Switch is enabled
+
+  @positive
+  Scenario Outline: Change Switch size to <size>
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "<nameOfObject>" object name
+    Then Switch is set to "<size>"
+    Examples:
+      | size  | nameOfObject |
+      | small | sizeSmall    |
+      | large | sizeLarge    |
+
+  @positive
+  Scenario: Enable reverse property
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "reverse" object name
+    Then Switch component is reversed
+
+  @positive
+  Scenario: Disable reverse property
+    When I open default "Experimental Switch" component in noIFrame with "switch" json from "experimental" using "reverseFalse" object name
+    Then Switch component is not reversed

--- a/cypress/features/regression/tile.feature
+++ b/cypress/features/regression/tile.feature
@@ -1,55 +1,52 @@
 Feature: Tile component
-  I want to change Tile component properties
-
-  Background: Open Tile component page
-    Given I open "Tile" component page
+  I want to test Tile component properties
 
   @positive
   Scenario Outline: I select Tile component as to <as>
-    When I select group Default as to "<as>"
+    When I open default "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
     Then Tile component as property is set to "<color>"
     Examples:
-      | as          | color              |
-      | tile        | rgb(255, 255, 255) |
-      | transparent | rgba(0, 0, 0, 0)   |
+      | as          | color              | nameOfObject  |
+      | tile        | rgb(255, 255, 255) | asTile        |
+      | transparent | rgba(0, 0, 0, 0)   | asTransparent |
 
   @positive
   Scenario Outline: I select Tile component orientation to <orientation>
-    When I select group Default orientation to "<orientation>"
+    When I open default "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
     Then Tile component orientation property is set to "<orientation>"
     Examples:
-      | orientation |
-      | horizontal  |
-      | vertical    |
+      | orientation | nameOfObject          |
+      | horizontal  | orientationHorizontal |
+      | vertical    | orientationVertical   |
 
   @positive
   Scenario Outline: I select Tile component padding to <padding>
-    When I select group Default padding to "<padding>"
+    When I open default "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
     Then Tile component padding property is set to "<px>"
     Examples:
-      | padding | px |
-      | XS      | 8  |
-      | S       | 16 |
-      | M       | 24 |
-      | L       | 32 |
-      | XL      | 40 |
+      | padding | px | nameOfObject |
+      | XS      | 8  | paddingXS    |
+      | S       | 16 | paddingS     |
+      | M       | 24 | paddingM     |
+      | L       | 32 | paddingL     |
+      | XL      | 40 | paddingXL    |
 
   @positive
-  Scenario Outline: Change Tile pixelWidth to <width>
-    When I set group Default pixelWidth slider to <width>
-    Then Tile pixel width is set to "<width>"
+  Scenario Outline: Change Tile pixelWidth to <pixelWidth>
+    When I open default "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
+    Then Tile pixel width is set to <pixelWidth>
     Examples:
-      | width |
-      | 1     |
-      | 100   |
-      | 1999  |
+      | pixelWidth | nameOfObject   |
+      | 1          | pixelWidth1    |
+      | 100        | pixelWidth100  |
+      | 1999       | pixelWidth1999 |
 
   @positive
   Scenario Outline: Change Tile width to <width>
-    When I set group Default width slider to <width>
-    Then Tile width is set to "<width>"
+    When I open default "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
+    Then Tile width is set to <width>
     Examples:
-      | width |
-      | 1     |
-      | 10    |
-      | 90    |
+      | width | nameOfObject |
+      | 1     | width1       |
+      | 10    | width10      |
+      | 90    | width90      |

--- a/cypress/fixtures/commonComponents/tile.json
+++ b/cypress/fixtures/commonComponents/tile.json
@@ -1,0 +1,59 @@
+{
+  "asTile": {
+    "as_Default": "tile"
+  },
+  "asTransparent": {
+    "as_Default": "transparent"
+  },
+  "orientationHorizontal": {
+    "orientation_Default": "horizontal"
+  },
+  "orientationVertical": {
+    "orientation_Default": "vertical"
+    },
+  "paddingXS": {
+    "padding_Default": "XS"
+  },
+  "paddingS": {
+    "padding_Default": "S"
+  },
+  "paddingM": {
+    "padding_Default": "M"
+  },
+  "paddingL": {
+    "padding_Default": "L"
+  },
+  "paddingXL": {
+    "padding_Default": "XL"
+  },
+  "width1": {
+    "width_Default": 1
+  },
+  "width10": {
+    "width_Default": 10
+  },
+  "width90": {
+    "width_Default": 90
+  },
+  "pixelWidth1": {
+    "pixelWidth_Default": 1
+  },
+  "pixelWidth100": {
+    "pixelWidth_Default": 100
+  },
+  "pixelWidth1999": {
+    "pixelWidth_Default": 1999
+  },  
+  "contentOneChildrenOtherLanguage": {
+    "contentOneChildren_TileContent": "mp150ú¿¡üßä"
+  },
+  "contentOneChildrenSpecialCharacter": {
+    "contentOneChildren_TileContent": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "contentOneTitleOtherLanguage": {
+    "contentOneTitle_TileContent": "mp150ú¿¡üßä"
+  },
+  "contentOneTitleSpecialCharacter": {
+    "contentOneTitle_TileContent": "!@#$%^*()_+-=~[];:.,?{}"
+  }
+}

--- a/cypress/fixtures/experimental/switch.json
+++ b/cypress/fixtures/experimental/switch.json
@@ -1,0 +1,62 @@
+{
+  "fieldHelpOtherLanguage": {
+    "fieldHelp": "mp150ú¿¡üßä"
+  },
+  "fieldHelpSpecialCharacter": {
+    "fieldHelp": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "fieldHelpInline": {
+    "fieldHelpInline": true
+  },
+  "fieldHelpInlineFalse": {
+    "fieldHelpInline": false
+  },
+  "labelOtherLanguage": {
+    "label": "mp150ú¿¡üßä"
+  },
+  "labelSpecialCharacter": {
+    "label": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "inputWidth1": {
+    "labelInline": true,
+    "inputWidth": 1
+  },
+  "inputWidth10": {
+    "labelInline": true,
+    "inputWidth": 10
+  },
+  "inputWidth150": {
+    "labelInline": true,
+    "inputWidth": 150
+  },
+  "labelInline": {
+    "labelInline": true
+  },
+  "labelInlineFalse": {
+    "labelInline": false
+  },
+  "loading": {
+    "loading": true
+  },
+  "loadingFalse": {
+    "loading": false
+  },
+  "disabled": {
+    "disabled": true
+  },
+  "disabledFalse": {
+    "disabled": false
+  },
+  "sizeSmall": {
+    "size": "small"
+  },
+  "sizeLarge": {
+    "size": "large"
+  },
+  "reverse": {
+    "reverse": true
+  },
+  "reverseFalse": {
+    "reverse": false
+  }
+}

--- a/cypress/locators/switch/index.js
+++ b/cypress/locators/switch/index.js
@@ -1,11 +1,8 @@
-import { SWITCH_PREVIEW, SWITCH_DATA_COMPONENT } from './locators';
-import { COMMMON_DATA_ELEMENT_INPUT } from '../locators';
+import { SWITCH_DATA_COMPONENT } from './locators';
 
 // component preview locators
-export const switchPreview = () => cy.iFrame(SWITCH_PREVIEW);
-export const switchProperties = () => cy.iFrame(SWITCH_PREVIEW)
-  .find('span');
-export const switchInput = () => cy.iFrame(COMMMON_DATA_ELEMENT_INPUT);
-
-// component preview locators into iFrame
-export const switchDataComponent = position => cy.get(SWITCH_DATA_COMPONENT).find('input').eq(position);
+export const switchDataComponent = () => cy.get(SWITCH_DATA_COMPONENT);
+export const switchInput = () => switchDataComponent().find('input')
+export const switchLoading = () => switchDataComponent().find('div > div > div > div > span > div').children();
+export const switchInputByPosition = position => switchDataComponent().find('div div div').children().eq(position)
+  .find('input');

--- a/cypress/locators/switch/locators.js
+++ b/cypress/locators/switch/locators.js
@@ -1,3 +1,2 @@
 // component preview locators
-export const SWITCH_PREVIEW = 'div[data-component="checkbox"]';
 export const SWITCH_DATA_COMPONENT = '[data-component="Switch"]';

--- a/cypress/locators/tile/index.js
+++ b/cypress/locators/tile/index.js
@@ -1,8 +1,4 @@
-import { TILE, PIXEL_WIDTH_SLIDER, WIDTH_SLIDER } from './locators';
-
-// component knob locators
-export const pixelWidthSlider = () => cy.get(PIXEL_WIDTH_SLIDER);
-export const widthSlider = () => cy.get(WIDTH_SLIDER);
+import { TILE } from './locators';
 
 // component preview locators
-export const tile = () => cy.iFrame(TILE);
+export const tile = () => cy.get(TILE);

--- a/cypress/locators/tile/locators.js
+++ b/cypress/locators/tile/locators.js
@@ -1,6 +1,2 @@
 // knobs locators
-export const PIXEL_WIDTH_SLIDER = 'input[name="pixelWidth"]';
-export const WIDTH_SLIDER = 'input[name="width"]';
-
-// component preview locators
-export const TILE = 'div[data-component="tile"]';
+export const TILE = '[data-component="tile"]';

--- a/cypress/support/step-definitions/checkbox-steps.js
+++ b/cypress/support/step-definitions/checkbox-steps.js
@@ -4,18 +4,8 @@ import {
   checkboxDataComponentNoIframe,
   checkboxRoleNoIFrame,
 } from '../../locators/checkbox';
-import { labelNoIFrame, fieldHelpPreviewNoIFrame } from '../../locators';
+import { labelNoIFrame } from '../../locators';
 import { positionOfElement } from '../helper';
-
-Then('Checkbox is set to fieldHelpInline and has margin-left set to {string}', (marginLeft) => {
-  fieldHelpPreviewNoIFrame().should('have.css', 'margin-left', marginLeft)
-    .and('have.css', 'margin-top', '0px')
-    .and('have.css', 'padding-left', '0px');
-});
-
-Then('Checkbox is not set to fieldHelpInline and has margin set to {string}', (margin) => {
-  fieldHelpPreviewNoIFrame().should('have.css', 'margin', margin);
-});
 
 Then('Checkbox is set to reverse and has width {string}', (width) => {
   checkboxDataComponentNoIframe().children().children().children()

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -270,6 +270,17 @@ Then('fieldHelp on preview is set to {word} in NoIFrame', (text) => {
   fieldHelpPreviewNoIFrame().should('have.text', text);
 });
 
+Then('{word} is set to fieldHelpInline and has marginLeft set to {string}', (componentName, marginLeft) => {
+  fieldHelpPreviewNoIFrame().should('have.css', 'margin-left', marginLeft)
+    .and('have.css', 'margin-top', '0px')
+    .and('have.css', 'padding-left', '0px');
+});
+
+Then('{word} is not set to fieldHelpInline and has marginTop set to {string}', (componentName, marginTop) => {
+  fieldHelpPreviewNoIFrame().should('have.css', 'margin-left', '0px')
+    .and('have.css', 'margin-top', marginTop);
+});
+
 Then('{string} fieldHelp on preview is set to {word}', (position, text) => {
   fieldHelpPreviewNoIFrame(positionOfElement(position)).should('have.text', text);
 });
@@ -538,6 +549,10 @@ Then('label align on preview is set to {string} in IFrame', (labelAlign) => {
 
 Then('label is inline', () => {
   getDataElementByValue('label').parent().should('have.css', TEXT_ALIGN, TEXT_ALIGN_START);
+});
+
+Then('label is not inline', () => {
+  getDataElementByValue('label').parent().should('not.have.css', TEXT_ALIGN, TEXT_ALIGN_START);
 });
 
 Then('label is inline in IFrame', () => {

--- a/cypress/support/step-definitions/switch-steps.js
+++ b/cypress/support/step-definitions/switch-steps.js
@@ -1,51 +1,48 @@
 import {
-  switchPreview, switchProperties, switchInput, switchDataComponent,
+  switchLoading, switchInput, switchInputByPosition,
 } from '../../locators/switch';
-import { label } from '../../locators';
+import { getDataElementByValue } from '../../locators';
 import { positionOfElement } from '../helper';
 
-const COMMON_INPUT = 'common-input';
-
-Then('Switch component is set to fieldHelpInline', () => {
-  switchProperties().should('have.class', 'carbon-checkbox__help-text--inline');
+Then('Switch is disabled', () => {
+  getDataElementByValue('label').should('have.attr', 'disabled');
+  switchInput().should('be.disabled')
+    .and('have.attr', 'disabled');
 });
 
-Then('Switch component is not set to fieldHelpInline', () => {
-  switchProperties().should('not.have.class', 'carbon-checkbox__help-text--inline');
+Then('Switch is enabled', () => {
+  getDataElementByValue('label').should('not.be.disabled')
+    .and('not.have.attr', 'disabled');
+  switchInput().should('not.be.disabled')
+    .and('not.have.attr', 'disabled');
 });
 
-Then('Switch component is set to labelInline', () => {
-  label().should('have.class', `${COMMON_INPUT}__label--inline`);
-});
-
-Then('Switch component is not set to labelInline', () => {
-  label().should('not.have.class', `${COMMON_INPUT}__label--inline`);
-});
-
-Then('Switch component is reversed', () => {
-  switchPreview().should('have.class', 'carbon-switch__reverse');
-});
-
-Then('Switch component is not reversed', () => {
-  switchPreview().should('not.have.class', 'carbon-switch__reverse');
+Then('Switch is set to {string}', (size) => {
+  if (size === 'small') {
+    switchInput().should('have.css', 'width', '60px')
+      .and('have.css', 'height', '24px');
+  } else if (size === 'large') {
+    switchInput().should('have.css', 'width', '78px')
+      .and('have.css', 'height', '40px');
+  } else {
+    throw new Error('Only small or large size can be applied');
+  }
 });
 
 Then('Switch component is loading', () => {
-  switchPreview().should('have.class', `${COMMON_INPUT}--readonly`)
-    .and('have.class', `${COMMON_INPUT}--disabled`);
-  switchInput().should('have.attr', 'disabled')
-    .and('have.attr', 'readonly');
+  switchInput().should('have.attr', 'disabled');
+  switchLoading().should('have.attr', 'data-component', 'loader');
 });
 
 Then('Switch component is not loading', () => {
-  switchPreview().should('not.have.class', `${COMMON_INPUT}--readonly`)
-    .and('not.have.class', `${COMMON_INPUT}--disabled`);
-  switchInput().should('not.have.attr', 'disabled')
-    .and('not.have.attr', 'readonly');
+  switchInput().should('not.have.attr', 'disabled');
+  switchLoading().should('not.have.attr', 'data-component', 'loader');
 });
 
-Then('I toggle {string} switch {int} times', (position, times) => {
-  for (let i = 0; i < times; i++) {
-    switchDataComponent(positionOfElement(position), times).click();
-  }
+Then('Switch component is reversed', () => {
+  switchInputByPosition(positionOfElement('second')).should('have.attr', 'name', 'switch-default');
+});
+
+Then('Switch component is not reversed', () => {
+  switchInputByPosition(positionOfElement('first')).should('have.attr', 'name', 'switch-default');
 });

--- a/cypress/support/step-definitions/tile-steps.js
+++ b/cypress/support/step-definitions/tile-steps.js
@@ -1,5 +1,4 @@
-import { tile, pixelWidthSlider, widthSlider } from '../../locators/tile';
-import { setSlidebar } from '../helper';
+import { tile } from '../../locators/tile';
 
 Then('Tile component as property is set to {string}', (value) => {
   tile().should('have.css', 'background-color', value);
@@ -13,18 +12,10 @@ Then('Tile component padding property is set to {string}', (value) => {
   tile().should('have.css', 'padding', `${value}px`);
 });
 
-Then('Tile width is set to {string}', (width) => {
+Then('Tile width is set to {int}', (width) => {
   tile().should('have.attr', 'width', width);
 });
 
-Then('Tile pixel width is set to {string}', (width) => {
+Then('Tile pixel width is set to {int}', (width) => {
   tile().should('have.css', 'width', `${width}px`);
-});
-
-When('I set pixelWidth slider to {int}', (width) => {
-  setSlidebar(pixelWidthSlider(), width);
-});
-
-When('I set width slider to {int}', (width) => {
-  setSlidebar(widthSlider(), width);
 });


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Apply new `url` approach in tests for:
`tile` (timing: was `1:00` -> `0:22` ),
`switch` (timing: `1:02` ).

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are passing all parameters via `knobs`.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent