### PR TITLE
feat: add styled system to carbon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9429,6 +9429,116 @@
         }
       }
     },
+    "@styled-system/background": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/background/-/background-5.1.2.tgz",
+      "integrity": "sha512-jtwH2C/U6ssuGSvwTN3ri/IyjdHb8W9X/g8Y0JLcrH02G+BW3OS8kZdHphF1/YyRklnrKrBT2ngwGUK6aqqV3A==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/border": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@styled-system/border/-/border-5.1.5.tgz",
+      "integrity": "sha512-JvddhNrnhGigtzWRCVuAHepniyVi6hBlimxWDVAdcTuk7aRn9BYJUwfHslURtwYFsF5FoEs8Zmr1oZq2M1AP0A==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/color": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/color/-/color-5.1.2.tgz",
+      "integrity": "sha512-1kCkeKDZkt4GYkuFNKc7vJQMcOmTl3bJY3YBUs7fCNM6mMYJeT1pViQ2LwBSBJytj3AB0o4IdLBoepgSgGl5MA==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/core": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/core/-/core-5.1.2.tgz",
+      "integrity": "sha512-XclBDdNIy7OPOsN4HBsawG2eiWfCcuFt6gxKn1x4QfMIgeO6TOlA2pZZ5GWZtIhCUqEPTgIBta6JXsGyCkLBYw==",
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
+    },
+    "@styled-system/css": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.1.5.tgz",
+      "integrity": "sha512-XkORZdS5kypzcBotAMPBoeckDs9aSZVkvrAlq5K3xP8IMAUek+x2O4NtwoSgkYkWWzVBu6DGdFZLR790QWGG+A=="
+    },
+    "@styled-system/flexbox": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/flexbox/-/flexbox-5.1.2.tgz",
+      "integrity": "sha512-6hHV52+eUk654Y1J2v77B8iLeBNtc+SA3R4necsu2VVinSD7+XY5PCCEzBFaWs42dtOEDIa2lMrgL0YBC01mDQ==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/grid": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/grid/-/grid-5.1.2.tgz",
+      "integrity": "sha512-K3YiV1KyHHzgdNuNlaw8oW2ktMuGga99o1e/NAfTEi5Zsa7JXxzwEnVSDSBdJC+z6R8WYTCYRQC6bkVFcvdTeg==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/layout": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/layout/-/layout-5.1.2.tgz",
+      "integrity": "sha512-wUhkMBqSeacPFhoE9S6UF3fsMEKFv91gF4AdDWp0Aym1yeMPpqz9l9qS/6vjSsDPF7zOb5cOKC3tcKKOMuDCPw==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/position": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/position/-/position-5.1.2.tgz",
+      "integrity": "sha512-60IZfMXEOOZe3l1mCu6sj/2NAyUmES2kR9Kzp7s2D3P4qKsZWxD1Se1+wJvevb+1TP+ZMkGPEYYXRyU8M1aF5A==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/prop-types": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@styled-system/prop-types/-/prop-types-5.1.5.tgz",
+      "integrity": "sha512-D/0d0ltp8QGhwrRifivQeIdoKkQDpFIGi98DXdpRXOaJStYXLx6aBSfS/YYIijbF1nZs1hWlAgXxYvDhCxHLSA==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@styled-system/shadow": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/shadow/-/shadow-5.1.2.tgz",
+      "integrity": "sha512-wqniqYb7XuZM7K7C0d1Euxc4eGtqEe/lvM0WjuAFsQVImiq6KGT7s7is+0bNI8O4Dwg27jyu4Lfqo/oIQXNzAg==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/space": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/space/-/space-5.1.2.tgz",
+      "integrity": "sha512-+zzYpR8uvfhcAbaPXhH8QgDAV//flxqxSjHiS9cDFQQUSznXMQmxJegbhcdEF7/eNnJgHeIXv1jmny78kipgBA==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/typography": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/typography/-/typography-5.1.2.tgz",
+      "integrity": "sha512-BxbVUnN8N7hJ4aaPOd7wEsudeT7CxarR+2hns8XCX1zp0DFfbWw4xYa/olA0oQaqx7F1hzDg+eRaGzAJbF+jOg==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/variant": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@styled-system/variant/-/variant-5.1.5.tgz",
+      "integrity": "sha512-Yn8hXAFoWIro8+Q5J8YJd/mP85Teiut3fsGVR9CAxwgNfIAiqlYxsk5iHU7VHJks/0KjL4ATSjmbtCDC/4l1qw==",
+      "requires": {
+        "@styled-system/core": "^5.1.2",
+        "@styled-system/css": "^5.1.5"
+      }
+    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
@@ -39285,6 +39395,26 @@
         "stylis": "^3.5.0",
         "stylis-rule-sheet": "^0.0.10",
         "supports-color": "^5.5.0"
+      }
+    },
+    "styled-system": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-5.1.5.tgz",
+      "integrity": "sha512-7VoD0o2R3RKzOzPK0jYrVnS8iJdfkKsQJNiLRDjikOpQVqQHns/DXWaPZOH4tIKkhAT7I6wIsy9FWTWh2X3q+A==",
+      "requires": {
+        "@styled-system/background": "^5.1.2",
+        "@styled-system/border": "^5.1.5",
+        "@styled-system/color": "^5.1.2",
+        "@styled-system/core": "^5.1.2",
+        "@styled-system/flexbox": "^5.1.2",
+        "@styled-system/grid": "^5.1.2",
+        "@styled-system/layout": "^5.1.2",
+        "@styled-system/position": "^5.1.2",
+        "@styled-system/shadow": "^5.1.2",
+        "@styled-system/space": "^5.1.2",
+        "@styled-system/typography": "^5.1.2",
+        "@styled-system/variant": "^5.1.5",
+        "object-assign": "^4.1.1"
       }
     },
     "stylis": {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
   },
   "dependencies": {
     "@storybook/addon-links": "^5.3.18",
+    "@styled-system/prop-types": "^5.1.5",
     "axios": "^0.19.0",
     "bignumber.js": "^9.0.0",
     "bowser": "~1.5.0",
@@ -154,6 +155,7 @@
     "react-dnd-touch-backend": "0.2.7",
     "react-transition-group": "^4.3.0",
     "regenerator-runtime": "^0.13.2",
+    "styled-system": "^5.1.5",
     "superagent": "~3.8.2",
     "wait-on": "^3.2.0"
   },

--- a/src/__experimental__/components/checkbox/checkbox.component.js
+++ b/src/__experimental__/components/checkbox/checkbox.component.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import propTypes from '@styled-system/prop-types';
 import tagComponent from '../../../utils/helpers/tags';
 import CheckboxStyle from './checkbox.style';
 import CheckableInput from '../checkable-input/checkable-input.component';
@@ -14,6 +15,7 @@ const Checkbox = ({
   fieldHelp,
   autoFocus,
   labelHelp,
+  pt = 1,
   ...props
 }) => {
   const inputProps = {
@@ -35,6 +37,7 @@ const Checkbox = ({
     <CheckboxStyle
       { ...tagComponent('checkbox', props) }
       { ...props }
+      pt={ pt }
     >
       <CheckableInput { ...inputProps }>
         <CheckboxSvg />
@@ -44,6 +47,7 @@ const Checkbox = ({
 };
 
 Checkbox.propTypes = {
+  ...propTypes.space,
   /** Set the value of the checkbox */
   checked: PropTypes.bool,
   /** Toggles disabling of input */

--- a/src/__experimental__/components/checkbox/checkbox.style.js
+++ b/src/__experimental__/components/checkbox/checkbox.style.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { space } from 'styled-system';
 import PropTypes from 'prop-types';
 import baseTheme from '../../../style/themes/base';
 import { StyledCheckableInput } from '../checkable-input/checkable-input.style';
@@ -12,11 +13,10 @@ import StyledFormField from '../form-field/form-field.style';
 import StyledIcon from '../../../components/icon/icon.style';
 
 const CheckboxStyle = styled.div`
+  ${space}
   ${({
     disabled, error, warning, info, fieldHelpInline, inputWidth, reverse, size, theme
   }) => css`
-    padding-top: 8px;
-
     ${StyledCheckableInput} {
       padding-top: 1px;
     }

--- a/src/__experimental__/components/radio-button/radio-button.style.js
+++ b/src/__experimental__/components/radio-button/radio-button.style.js
@@ -17,6 +17,7 @@ const RadioButtonStyle = styled(CheckboxStyle)`
     theme,
     inline
   }) => css`
+    padding-top: 8px;
     margin-bottom: 12px;
 
     ${FieldHelpStyle} {

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -9,6 +9,8 @@ export default (palette) => {
 
     spacing: 8,
 
+    space: [0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80],
+
     colors: {
       // main
       base: palette.productGreen,


### PR DESCRIPTION
### Proposed behaviour
Use `styled-system` to give all components the same spacing options. This can be used in any component like this: 

```
// form.style.js
import styled from 'styled-components';
import { space } from 'styled-system';
const StyledForm = styled.div`
  ${space}
  ... other styles
`;
```

In that example `Form` would then have the following props:

![image](https://user-images.githubusercontent.com/14963680/90776190-b3d07400-e2f1-11ea-9066-91a6ea0e28ee.png)

The following spacing options (in px) have been added to the theme: 
`space: [0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80]`

All of the props above can either be a number, which is an index of the theme space array, i.e. `ml={1}` relates to `8` in the array (so effectively behaves as a multiplier of 8), or a string, which can be any valid CSS string.

### Current behaviour
Spacing is currently handled individually in components, and varies from component to component. This is both hard to maintain and prone to bugs/inconsistent components.

### Checklist

- [ ] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- <del>[ ] Unit tests added or updated if required</del>
- <del>[ ] Cypress automation tests added or updated if required</del>
- <del>[ ] Storybook added or updated if required</del>
- <del>[ ] Typescript `d.ts` file added or updated if required</del>
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
