### PR TITLE
fix(switch): fix switch validation icon overlapping the label - FE-2905

### DIFF
--- a/.storybook/welcome-page/header/header.component.js
+++ b/.storybook/welcome-page/header/header.component.js
@@ -43,7 +43,7 @@ const Header = () => (
           <div data-component="link">
             <a tabIndex="0" href="https://www.npmjs.com/package/carbon-react">
               <span>
-                <img src="https://img.shields.io/npm/v/carbon-react.svg" data-chromatic="ignore" alt="npm" />
+                <img src="https://img.shields.io/npm/v/carbon-react.svg" alt="npm" />
               </span>
             </a>
           </div>

--- a/.storybook/welcome-page/welcome.stories.js
+++ b/.storybook/welcome-page/welcome.stories.js
@@ -15,6 +15,9 @@ export default {
     },
     options: {
       showPanel: false
+    },
+    chromatic: {
+      disable: true
     }
   }
 };

--- a/src/__experimental__/components/switch/__snapshots__/switch.spec.js.snap
+++ b/src/__experimental__/components/switch/__snapshots__/switch.spec.js.snap
@@ -33,24 +33,24 @@ exports[`Switch base theme renders as expected 1`] = `
   display: flex;
 }
 
-.c1 .c29 {
+.c1 .c31 {
   width: auto;
 }
 
-.c1 .c29 .c31,
-.c1 .c29 .c32 {
+.c1 .c31 .c33,
+.c1 .c31 .c34 {
   color: rgba(0,0,0,0.65);
   vertical-align: middle;
 }
 
-.c1 .c29 .c31:hover,
-.c1 .c29 .c32:hover,
-.c1 .c29 .c31:focus,
-.c1 .c29 .c32:focus {
+.c1 .c31 .c33:hover,
+.c1 .c31 .c34:hover,
+.c1 .c31 .c33:focus,
+.c1 .c31 .c34:focus {
   color: rgba(0,0,0,0.9);
 }
 
-.c1 .c28 {
+.c1 .c30 {
   -webkit-flex-basis: 100%;
   -ms-flex-preferred-size: 100%;
   flex-basis: 100%;
@@ -70,6 +70,28 @@ exports[`Switch base theme renders as expected 1`] = `
 }
 
 .c14 .c6 {
+  margin-right: 0;
+  margin-left: 8px;
+}
+
+.c14 .c6 {
+  margin-left: 0;
+}
+
+.c15 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c15 .c4 {
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.c15 .c6 {
   margin-right: 0;
   margin-left: 8px;
 }
@@ -125,37 +147,10 @@ exports[`Switch base theme renders as expected 1`] = `
   z-index: 1;
 }
 
-.c11 .c32 {
+.c11 .c34 {
   position: absolute;
   right: -30px;
   height: 100%;
-}
-
-.c15 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-}
-
-.c15 .c6,
-.c15 .c8 {
-  border: none;
-  box-sizing: border-box;
-  height: 24px;
-  width: 60px;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
-  margin-left: 0;
-}
-
-.c15 .c8:not([disabled]):focus + .c10,
-.c15 .c8:not([disabled]):hover + .c10 {
-  outline: solid 3px #FFB500;
 }
 
 .c16 .c4 {
@@ -185,24 +180,6 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c16 .c6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-}
-
-.c16 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c16 .c6 {
-  margin-left: 0;
-  margin-top: 0;
-}
-
 .c17 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -228,6 +205,24 @@ exports[`Switch base theme renders as expected 1`] = `
 .c17 .c8:not([disabled]):focus + .c10,
 .c17 .c8:not([disabled]):hover + .c10 {
   outline: solid 3px #FFB500;
+}
+
+.c17 .c6 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+}
+
+.c17 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c17 .c6 {
+  margin-left: 0;
+  margin-top: 0;
 }
 
 .c18 .c4 {
@@ -257,19 +252,6 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c18 .c6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-}
-
-.c18 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .c19 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -295,23 +277,6 @@ exports[`Switch base theme renders as expected 1`] = `
 .c19 .c8:not([disabled]):focus + .c10,
 .c19 .c8:not([disabled]):hover + .c10 {
   outline: solid 3px #FFB500;
-}
-
-.c19 .c6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-}
-
-.c19 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c19 .c6 {
-  margin-left: 10px;
 }
 
 .c20 .c4 {
@@ -341,11 +306,17 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c20 .c6,
-.c20 .c8,
-.c20 .c10 {
-  height: 40px;
-  width: 78px;
+.c20 .c6 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+}
+
+.c20 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c21 .c4 {
@@ -389,55 +360,7 @@ exports[`Switch base theme renders as expected 1`] = `
 }
 
 .c21 .c6 {
-  margin-left: 0;
-  margin-top: 0;
-}
-
-.c21 .c6,
-.c21 .c8,
-.c21 .c10 {
-  height: 40px;
-  width: 78px;
-}
-
-.c0 {
-  margin-bottom: 24px;
-}
-
-.c0 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-}
-
-.c0 .c6,
-.c0 .c8 {
-  border: none;
-  box-sizing: border-box;
-  height: 24px;
-  width: 60px;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
-  margin-left: 0;
-}
-
-.c0 .c8:not([disabled]):focus + .c10,
-.c0 .c8:not([disabled]):hover + .c10 {
-  outline: solid 3px #FFB500;
-}
-
-.c0 .c28 {
-  margin-left: 0;
-}
-
-.c0 .c29 .c32 {
-  position: relative;
-  display: inline-block;
+  margin-left: 10px;
 }
 
 .c22 .c4 {
@@ -468,28 +391,10 @@ exports[`Switch base theme renders as expected 1`] = `
 }
 
 .c22 .c6,
-.c22 .c8 {
-  border-radius: 24px;
-  height: 28px;
-  width: 55px;
-}
-
+.c22 .c8,
 .c22 .c10 {
-  -webkit-transition: box-shadow .1s linear;
-  transition: box-shadow .1s linear;
-}
-
-.c22 .c8:not([disabled]):focus + .c10 {
-  box-shadow: 0 0 6px 2px rgba(37,91,199,0.6);
-}
-
-.c22 .c8:not([disabled]):focus + .c10,
-.c22 .c8:not([disabled]):hover + .c10 {
-  outline: none;
-}
-
-.c22 .c6 .c30 {
-  top: 1px;
+  height: 40px;
+  width: 78px;
 }
 
 .c23 .c4 {
@@ -532,29 +437,56 @@ exports[`Switch base theme renders as expected 1`] = `
   display: flex;
 }
 
+.c23 .c6 {
+  margin-left: 0;
+  margin-top: 0;
+}
+
 .c23 .c6,
-.c23 .c8 {
-  border-radius: 24px;
-  height: 28px;
-  width: 55px;
-}
-
+.c23 .c8,
 .c23 .c10 {
-  -webkit-transition: box-shadow .1s linear;
-  transition: box-shadow .1s linear;
+  height: 40px;
+  width: 78px;
 }
 
-.c23 .c8:not([disabled]):focus + .c10 {
-  box-shadow: 0 0 6px 2px rgba(37,91,199,0.6);
+.c0 {
+  margin-bottom: 24px;
 }
 
-.c23 .c8:not([disabled]):focus + .c10,
-.c23 .c8:not([disabled]):hover + .c10 {
-  outline: none;
+.c0 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row wrap;
+  -ms-flex-flow: row wrap;
+  flex-flow: row wrap;
 }
 
-.c23 .c6 .c30 {
-  top: 1px;
+.c0 .c6,
+.c0 .c8 {
+  border: none;
+  box-sizing: border-box;
+  height: 24px;
+  width: 60px;
+  -webkit-flex-basis: 100%;
+  -ms-flex-preferred-size: 100%;
+  flex-basis: 100%;
+  margin-left: 0;
+}
+
+.c0 .c8:not([disabled]):focus + .c10,
+.c0 .c8:not([disabled]):hover + .c10 {
+  outline: solid 3px #FFB500;
+}
+
+.c0 .c30 {
+  margin-left: 0;
+}
+
+.c0 .c31 .c34 {
+  position: relative;
+  display: inline-block;
 }
 
 .c24 .c4 {
@@ -584,24 +516,6 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c24 .c6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-}
-
-.c24 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c24 .c6 {
-  margin-left: 0;
-  margin-top: 0;
-}
-
 .c24 .c6,
 .c24 .c8 {
   border-radius: 24px;
@@ -623,7 +537,7 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: none;
 }
 
-.c24 .c6 .c30 {
+.c24 .c6 .c32 {
   top: 1px;
 }
 
@@ -654,11 +568,17 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c25 .c6,
-.c25 .c8,
-.c25 .c10 {
-  height: 40px;
-  width: 78px;
+.c25 .c6 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+}
+
+.c25 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c25 .c6,
@@ -682,15 +602,8 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: none;
 }
 
-.c25 .c6 .c30 {
+.c25 .c6 .c32 {
   top: 1px;
-}
-
-.c25 .c6,
-.c25 .c8,
-.c25 .c10 {
-  height: 28px;
-  width: 55px;
 }
 
 .c26 .c4 {
@@ -720,11 +633,22 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c26 .c6,
-.c26 .c8,
-.c26 .c10 {
-  height: 40px;
-  width: 78px;
+.c26 .c6 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+}
+
+.c26 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c26 .c6 {
+  margin-left: 0;
+  margin-top: 0;
 }
 
 .c26 .c6,
@@ -748,15 +672,8 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: none;
 }
 
-.c26 .c6 .c30 {
+.c26 .c6 .c32 {
   top: 1px;
-}
-
-.c26 .c6,
-.c26 .c8,
-.c26 .c10 {
-  height: 28px;
-  width: 55px;
 }
 
 .c27 .c4 {
@@ -784,24 +701,6 @@ exports[`Switch base theme renders as expected 1`] = `
 .c27 .c8:not([disabled]):focus + .c10,
 .c27 .c8:not([disabled]):hover + .c10 {
   outline: solid 3px #FFB500;
-}
-
-.c27 .c6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-}
-
-.c27 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c27 .c6 {
-  margin-left: 0;
-  margin-top: 0;
 }
 
 .c27 .c6,
@@ -832,13 +731,163 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: none;
 }
 
-.c27 .c6 .c30 {
+.c27 .c6 .c32 {
   top: 1px;
 }
 
 .c27 .c6,
 .c27 .c8,
 .c27 .c10 {
+  height: 28px;
+  width: 55px;
+}
+
+.c28 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row wrap;
+  -ms-flex-flow: row wrap;
+  flex-flow: row wrap;
+}
+
+.c28 .c6,
+.c28 .c8 {
+  border: none;
+  box-sizing: border-box;
+  height: 24px;
+  width: 60px;
+  -webkit-flex-basis: 100%;
+  -ms-flex-preferred-size: 100%;
+  flex-basis: 100%;
+  margin-left: 0;
+}
+
+.c28 .c8:not([disabled]):focus + .c10,
+.c28 .c8:not([disabled]):hover + .c10 {
+  outline: solid 3px #FFB500;
+}
+
+.c28 .c6,
+.c28 .c8,
+.c28 .c10 {
+  height: 40px;
+  width: 78px;
+}
+
+.c28 .c6,
+.c28 .c8 {
+  border-radius: 24px;
+  height: 28px;
+  width: 55px;
+}
+
+.c28 .c10 {
+  -webkit-transition: box-shadow .1s linear;
+  transition: box-shadow .1s linear;
+}
+
+.c28 .c8:not([disabled]):focus + .c10 {
+  box-shadow: 0 0 6px 2px rgba(37,91,199,0.6);
+}
+
+.c28 .c8:not([disabled]):focus + .c10,
+.c28 .c8:not([disabled]):hover + .c10 {
+  outline: none;
+}
+
+.c28 .c6 .c32 {
+  top: 1px;
+}
+
+.c28 .c6,
+.c28 .c8,
+.c28 .c10 {
+  height: 28px;
+  width: 55px;
+}
+
+.c29 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row wrap;
+  -ms-flex-flow: row wrap;
+  flex-flow: row wrap;
+}
+
+.c29 .c6,
+.c29 .c8 {
+  border: none;
+  box-sizing: border-box;
+  height: 24px;
+  width: 60px;
+  -webkit-flex-basis: 100%;
+  -ms-flex-preferred-size: 100%;
+  flex-basis: 100%;
+  margin-left: 0;
+}
+
+.c29 .c8:not([disabled]):focus + .c10,
+.c29 .c8:not([disabled]):hover + .c10 {
+  outline: solid 3px #FFB500;
+}
+
+.c29 .c6 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+}
+
+.c29 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c29 .c6 {
+  margin-left: 0;
+  margin-top: 0;
+}
+
+.c29 .c6,
+.c29 .c8,
+.c29 .c10 {
+  height: 40px;
+  width: 78px;
+}
+
+.c29 .c6,
+.c29 .c8 {
+  border-radius: 24px;
+  height: 28px;
+  width: 55px;
+}
+
+.c29 .c10 {
+  -webkit-transition: box-shadow .1s linear;
+  transition: box-shadow .1s linear;
+}
+
+.c29 .c8:not([disabled]):focus + .c10 {
+  box-shadow: 0 0 6px 2px rgba(37,91,199,0.6);
+}
+
+.c29 .c8:not([disabled]):focus + .c10,
+.c29 .c8:not([disabled]):hover + .c10 {
+  outline: none;
+}
+
+.c29 .c6 .c32 {
+  top: 1px;
+}
+
+.c29 .c6,
+.c29 .c8,
+.c29 .c10 {
   height: 28px;
   width: 55px;
 }

--- a/src/__experimental__/components/switch/switch.component.js
+++ b/src/__experimental__/components/switch/switch.component.js
@@ -17,6 +17,7 @@ const Switch = ({
   loading,
   reverse,
   validationOnLabel,
+  labelInline,
   ...props
 }) => {
   const isControlled = checked !== undefined;
@@ -33,6 +34,7 @@ const Switch = ({
 
   const switchProps = {
     ...props,
+    labelInline,
     disabled: disabled || loading,
     checked: isControlled ? checked : checkedInternal,
     reverse: !reverse // switched to preserve backward compatibility
@@ -49,14 +51,16 @@ const Switch = ({
     reverse: !reverse // switched to preserve backward compatibility
   };
 
+  const shouldValidationBeOnLabel = labelInline && !reverse ? true : validationOnLabel;
+
   return (
     <SwitchStyle
       { ...tagComponent('Switch', props) }
       { ...switchProps }
     >
-      <CheckableInput useValidationIcon={ validationOnLabel } { ...inputProps }>
+      <CheckableInput useValidationIcon={ shouldValidationBeOnLabel } { ...inputProps }>
         <SwitchSlider
-          useValidationIcon={ !validationOnLabel }
+          useValidationIcon={ !shouldValidationBeOnLabel }
           { ...switchProps }
           loading={ loading }
         />

--- a/src/__experimental__/components/switch/switch.spec.js
+++ b/src/__experimental__/components/switch/switch.spec.js
@@ -156,6 +156,17 @@ describe('Switch', () => {
         });
       });
 
+      describe('and fieldHelpInline=true', () => {
+        const wrapper = render({ reverse: false, fieldHelpInline: true }).toJSON();
+
+        it('applies the correct FieldHelp styles', () => {
+          assertStyleMatch({
+            margin: '0',
+            marginTop: '8px'
+          }, wrapper, { modifier: css`${FieldHelpStyle}` });
+        });
+      });
+
       describe('and labelInline=true, fieldHelpInline=false', () => {
         const wrapper = render({ fieldHelpInline: false, labelInline: true, reverse: false }).toJSON();
 
@@ -197,6 +208,12 @@ describe('Switch', () => {
 
     describe('when fieldHelpInline=true and labelInline=true', () => {
       const wrapper = render({ fieldHelpInline: true, labelInline: true }).toJSON();
+
+      it('applies the correct CheckableInput styles', () => {
+        assertStyleMatch({
+          marginLeft: '10px'
+        }, wrapper, { modifier: css`${StyledCheckableInput}` });
+      });
 
       it('applies the correct Label styles', () => {
         assertStyleMatch({

--- a/src/__experimental__/components/switch/switch.spec.js
+++ b/src/__experimental__/components/switch/switch.spec.js
@@ -5,6 +5,7 @@ import 'jest-styled-components';
 import { css, ThemeProvider } from 'styled-components';
 import { mount } from 'enzyme';
 import I18n from 'i18n-js';
+
 import Switch from '.';
 import CheckableInput from '../checkable-input';
 import { StyledCheckableInput } from '../checkable-input/checkable-input.style';
@@ -274,6 +275,7 @@ describe('Switch', () => {
       wrapper.setProps(props);
     });
 
+
     describe.each(validationTypes)('when %s prop passed as string', (type) => {
       it(`displays ${type} icon by the input`, () => {
         wrapper.setProps({
@@ -321,6 +323,14 @@ describe('Switch', () => {
           boxShadow: `inset ${shadowWidth}px ${shadowWidth}px 0 ${baseTheme.colors[type]},inset -${shadowWidth}px -${shadowWidth}px 0 ${baseTheme.colors[type]}`
         }, wrapper.find(StyledSwitchSlider));
       });
+    });
+
+
+    it('forces validation icon to be displayed on label when labelInline = true and reverse = false', () => {
+      wrapper.setProps({ error: 'Error', labelInline: true, reverse: false });
+
+      expect(wrapper.find(StyledLabelContainer).find(StyledValidationIcon).exists()).toEqual(true);
+      expect(wrapper.find(StyledSwitchSlider).find(StyledValidationIcon).exists()).toEqual(false);
     });
   });
 

--- a/src/__experimental__/components/switch/switch.style.js
+++ b/src/__experimental__/components/switch/switch.style.js
@@ -63,6 +63,12 @@ const StyledSwitch = styled.div`
         ${StyledLabelContainer} {
           margin-top: 8px;
         }
+
+        ${fieldHelpInline && css`
+          ${FieldHelpStyle} {
+            margin-top: 8px;
+          }
+        `}
       `}
     `}
 
@@ -104,10 +110,12 @@ const StyledSwitch = styled.div`
         `}
       `}
 
-      ${fieldHelpInline && `
-        ${StyledCheckableInput} {
-          margin-left: 10px;
-        }
+      ${fieldHelpInline && css`
+        ${!reverse && `
+          ${StyledCheckableInput} {
+            margin-left: 10px;
+          }
+        `}
 
         ${StyledLabelContainer} {
           margin-right: 10px;


### PR DESCRIPTION
### Proposed behaviour
When `labelInline = true` and `reverse = false` validation icon is forced to be displayed on label.

<img width="313" alt="Zrzut ekranu 2020-08-21 o 12 17 51" src="https://user-images.githubusercontent.com/20651022/90880183-5814f200-e3a8-11ea-982a-7a99ae09f2a1.png">

Also ensure field help is correctly aligned with the label when fieldhelp is inline but label is not: 
![image](https://user-images.githubusercontent.com/14963680/91180944-36857480-e6e0-11ea-808d-5ba82e57baf6.png)



### Current behaviour
Described here https://github.com/Sage/carbon/issues/3022


### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
~~- [ ] Storybook added or updated if required~~
~~- [ ] Typescript `d.ts` file added or updated if required~~
- [x] Carbon implementation and Design System documentation are congruent


### Additional context
Closes #3022 

### Testing instructions
Storybook -> Switch -> Validations 
