### PR TITLE
test(split-button/step-sequence/step-sequence-item): apply new url approach

### DIFF
--- a/cypress/features/regression/splitButton.feature
+++ b/cypress/features/regression/splitButton.feature
@@ -1,91 +1,84 @@
 Feature: Split Button component
-  I want to change Split Button component properties
-
-  Background: Open Split Button component default page
-    Given I open "Split Button" component page
+  I want to test Split Button component properties
 
   @positive
   Scenario Outline: I select buttonType to <buttonType>
-    When I select buttonType to "<buttonType>"
+    When I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "<nameOfObject>" object name
     Then Button background color is "<color>"
     Examples:
-      | buttonType | color            |
-      | primary    | rgb(0, 129, 93)  |
-      | secondary  | rgba(0, 0, 0, 0) |
+      | buttonType | color            | nameOfObject        |
+      | primary    | rgb(0, 129, 93)  | buttonTypePrimary   |
+      | secondary  | rgba(0, 0, 0, 0) | buttonTypeSecondary |
 
   @positive
   Scenario Outline: I select size to <size>
-    When I select size to "<size>"
+    When I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "<nameOfObject>" object name
     Then Split Button is set to "<size>" size and has <px> px height
     Examples:
-      | size   | px |
-      | small  | 32 |
-      | medium | 40 |
-      | large  | 48 |
+      | size   | px | nameOfObject |
+      | small  | 32 | sizeSmall    |
+      | medium | 40 | sizeMedium   |
+      | large  | 48 | sizeLarge    |
 
   @positive
   Scenario: I disable Split Button component
-    When I disable SplitButton component
+    When I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "disabled" object name
     Then Button is disabled
 
   @positive
   Scenario: I enable Split Button component
-    Given I disable SplitButton component
-    When I enable SplitButton component
+    When I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "disabledFalse" object name
     Then Button is enabled
 
   @positive
   Scenario Outline: I set Split Button text align to <align>
-    When I select align to "<align>"
+    When I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "<nameOfObject>" object name
     Then Split Button component additional buttons text align is set to "<align>" align
     Examples:
-      | align |
-      | left  |
-      | right |
+      | align | nameOfObject |
+      | left  | alignLeft    |
+      | right | alignRight   |
 
   @positive
   Scenario Outline: I set text to <text>
-    When I set text to <text> word
-    Then Button label on preview is <text> in IFrame
+    When I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "<nameOfObject>" object name
+    Then Button label on preview is <text>
     Examples:
-      | text                    |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | text                    | nameOfObject         |
+      | mp150ú¿¡üßä             | textOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | textSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
 
   @positive
   Scenario Outline: I set subtext to <subtext>
-    Given I select size to "large"
-    When I set subtext to <subtext> word
-    Then Button subtext on preview is <subtext> in IFrame
+    When I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "<nameOfObject>" object name
+    Then Button subtext on preview is <subtext>
     Examples:
-      | subtext                 |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | subtext                 | nameOfObject            |
+      | mp150ú¿¡üßä             | subtextOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | subtextSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
 
   @positive
   Scenario Outline: I check icon positioning to <iconPosition>
-    Given I check has icon checkbox
-    When I select iconType to "warning"
-      And I select iconPosition to "<iconPosition>"
+    When I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "<nameOfObject>" object name
     Then Split Button iconPosition is set to "<iconPosition>" and has "warning" icon
     Examples:
-      | iconPosition |
-      | after        |
-      | before       |
+      | iconPosition | nameOfObject       |
+      | after        | iconPositionAfter  |
+      | before       | iconPositionBefore |
 
   @positive
   Scenario: I expand Split Button component
-    When I hover mouse onto icon
+    Given I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "default" object name
+    When I hover mouse onto "dropdown" icon in no iFrame
     Then Split Button is expanded
 
   @positive
   Scenario Outline: Verify color palette for Split Button component without focus
-    # commented because of BDD default scenario Given - When - Then
-    # When I open "Split Button" component page
+    When I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "default" object name
     Then Split Button first element has proper background-color "<background-color>" and border "<border-color>" color and has border-width 2 px
       And Split Button second element has proper background-color "<background-color>" and border "<border-color>" color and has border-width 2 px
     Examples:
@@ -95,12 +88,14 @@ Feature: Split Button component
   @ignore
   # there is no possibility to trigger mouseover on first element
   Scenario: Verify color palette for first element of Split Button component with focus
+    Given I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "default" object name
     When I hover mouse onto split button
     Then Split Button first element has proper background-color "rgb(0, 96, 70)" and border "rgb(0, 96, 70)" color and has border-width 2 px
 
   @positive
   Scenario Outline: Verify color palette for second element of Split Button component with focus
-    When I hover mouse onto icon
+    Given I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "default" object name
+    When I hover mouse onto "dropdown" icon in no iFrame
     Then Split Button second element has proper background-color "<color>" and border "<color>" color and has border-width 2 px
       And Split Button additional buttons have proper background-color "<color>" and border "<color>" color and has border-width 1 px
     Examples:
@@ -108,17 +103,11 @@ Feature: Split Button component
       | rgb(0, 96, 70) |
 
   @positive
-  Scenario: Verify the click function for a main element of Split Button component
-    Given clear all actions in Actions Tab
-    When I click "main" element of Split Button component
-    Then click action was called in Actions Tab
-
-  @positive
-  Scenario Outline: Verify the click function for a <element> element of Split Button component
-    Given clear all actions in Actions Tab
-      And I hover mouse onto icon
+  Scenario Outline: Verify hover color and golden border for <element> element of Split Button component
+    Given I open default "Split Button" component in noIFrame with "splitButton" json from "commonComponents" using "default" object name
+      And I hover mouse onto "dropdown" icon in no iFrame
     When I click "<element>" element of Split Button component
-    Then click action was called in Actions Tab
+    Then Split Button expandable "<element>" element has golden border on focus
     Examples:
       | element |
       | first   |
@@ -126,10 +115,19 @@ Feature: Split Button component
       | third   |
 
   @positive
-  Scenario Outline: Verify hover color and golden border for <element> element of Split Button component
-    Given I hover mouse onto icon
-    When I click "<element>" element of Split Button component
-    Then Split Button expandable "<element>" element has golden border on focus
+  Scenario: Verify the click function for a main element of Split Button component
+    Given I open "Split Button" component page
+      And clear all actions in Actions Tab
+    When I click "main-button" element of Split Button component in IFrame
+    Then click action was called in Actions Tab
+
+  @positive
+  Scenario Outline: Verify the click function for a <element> element of Split Button component
+    Given I open "Split Button" component page
+      And clear all actions in Actions Tab
+      And I hover mouse onto icon
+    When I click "<element>" element of Split Button component in IFrame
+    Then click action was called in Actions Tab
     Examples:
       | element |
       | first   |

--- a/cypress/features/regression/stepSequence.feature
+++ b/cypress/features/regression/stepSequence.feature
@@ -1,14 +1,11 @@
 Feature: Step Sequence component
-  I want to change Step Sequence component properties
-
-  Background: Open Step Sequence component page
-    Given I open "Step Sequence" component page
+  I want to test Step Sequence component properties
 
   @positive
   Scenario Outline: I set orientation to <orientation>
-    When I select orientation to "<orientation>"
+    When I open default "Step Sequence" component in noIFrame with "stepSequence" json from "commonComponents" using "<nameOfObject>" object name
     Then orientation is set to "<orientation>"
     Examples:
-      | orientation |
-      | vertical    |
-      | horizontal  |
+      | orientation | nameOfObject          |
+      | vertical    | orientationVertical   |
+      | horizontal  | orientationHorizontal |

--- a/cypress/features/regression/stepSequenceItem.feature
+++ b/cypress/features/regression/stepSequenceItem.feature
@@ -1,69 +1,58 @@
 Feature: Step Sequence Item component
-  I want to change Step Sequence Item component properties
-
-  Background: Open Step Sequence Item component page
-    Given I open "Step Sequence Item" component page
+  I want to test Step Sequence Item component properties
 
   @positive
   Scenario Outline: I set indicator to <indicator>
-    When I set indicator to <indicator> word
+    When I open default "Step Sequence Item" component in noIFrame with "stepSequence" json from "commonComponents" using "<nameOfObject>" object name
     Then indicator is set to <indicator>
     Examples:
-      | indicator               |
-      | -100                    |
-      | 0                       |
-      | 999                     |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | indicator               | nameOfObject              |
+      | -100                    | indicator-100             |
+      | 0                       | indicator0                |
+      | 999                     | indicator999              |
+      | mp150ú¿¡üßä             | indicatorOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | indicatorSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
 
   @positive
   Scenario Outline: I set status to <status>
-    When I select status to "<status>"
+    When I open default "Step Sequence Item" component in noIFrame with "stepSequence" json from "commonComponents" using "<nameOfObject>" object name
     Then text "Step Label" color is set to "<color>"
     Examples:
-      | status     | color               |
-      | complete   | rgb(0, 163, 118)    |
-      | current    | rgba(0, 0, 0, 0.9)  |
-      | incomplete | rgba(0, 0, 0, 0.55) |
+      | status     | color               | nameOfObject     |
+      | complete   | rgb(0, 163, 118)    | statusComplete   |
+      | current    | rgba(0, 0, 0, 0.9)  | statusCurrent    |
+      | incomplete | rgba(0, 0, 0, 0.55) | statusIncomplete |
 
   @positive
-  Scenario Outline: I set hiddenCompleteLabel to <hiddenCompleteLabel>
-    When I set hiddenCompleteLabel to <hiddenCompleteLabel> word
-      And I select status to "complete"
-    Then hidden label is set to <hiddenCompleteLabel>
-    Examples:
-      | hiddenCompleteLabel     |
-      | mp150ú¿¡üßä             |
+  Scenario: I set hiddenCompleteLabel to mp150ú¿¡üßä
+    When I open default "Step Sequence Item" component in noIFrame with "stepSequence" json from "commonComponents" using "hiddenCompleteLabelOtherLanguage" object name
+    Then hidden label is set to mp150ú¿¡üßä
 
   @positive
-  Scenario Outline: I set hiddenCurrentLabel to <hiddenCurrentLabel>
-    When I set hiddenCurrentLabel to <hiddenCurrentLabel> word
-      And I select status to "current"
-    Then hidden label is set to <hiddenCurrentLabel>
-    Examples:
-      | hiddenCurrentLabel      |
-      | mp150ú¿¡üßä             |
+  Scenario: I set hiddenCurrentLabel to mp150ú¿¡üßä
+    When I open default "Step Sequence Item" component in noIFrame with "stepSequence" json from "commonComponents" using "hiddenCurrentLabelOtherLanguage" object name
+    Then hidden label is set to mp150ú¿¡üßä
 
   @positive
   Scenario Outline: I set ariaLabel to <ariaLabel>
-    When I set ariaLabel to <ariaLabel> word
+    When I open default "Step Sequence Item" component in noIFrame with "stepSequence" json from "commonComponents" using "<nameOfObject>" object name
     Then ariaLabel is set to <ariaLabel>
     Examples:
-      | ariaLabel               |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | ariaLabel               | nameOfObject              |
+      | mp150ú¿¡üßä             | ariaLabelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | ariaLabelSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
 
   @positive
   Scenario Outline: I set children to <children>
-    When I set children to <children> word
+    When I open default "Step Sequence Item" component in noIFrame with "stepSequence" json from "commonComponents" using "<nameOfObject>" object name
     Then children is set <children>
     Examples:
-      | children                |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | children                | nameOfObject             |
+      | mp150ú¿¡üßä             | childrenOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | childrenSpecialCharacter |
 # @ignore because of FE-2782
 # | &"'<>|

--- a/cypress/fixtures/commonComponents/splitButton.json
+++ b/cypress/fixtures/commonComponents/splitButton.json
@@ -1,0 +1,56 @@
+{ 
+  "buttonTypePrimary": {
+    "buttonType": "primary"
+  },
+  "buttonTypeSecondary": {
+    "buttonType": "secondary"
+  },
+  "sizeSmall": {
+    "size": "small"
+  },
+  "sizeMedium": {
+    "size": "medium"
+  },
+  "sizeLarge": {
+    "size": "large"
+  },
+  "disabled": {
+    "disabled": true
+  },
+  "disabledFalse": {
+    "disabled": false
+  },
+  "alignLeft": {
+    "align": "left"
+  },
+  "alignRight": {
+    "align": "right"
+  },
+  "textSpecialCharacter": {
+    "text": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "textOtherLanguage": {
+    "text": "mp150ú¿¡üßä"
+  },
+  "subtextSpecialCharacter": {
+    "size": "large",
+    "subtext": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "subtextOtherLanguage": {
+    "size": "large",
+    "subtext": "mp150ú¿¡üßä"
+  },
+  "iconPositionAfter": {
+    "has icon": true,
+    "iconType": "warning",
+    "iconPosition": "after"
+  },
+  "iconPositionBefore": {
+    "has icon": true,
+    "iconType": "warning",
+    "iconPosition": "before"
+  },
+  "default": {
+    
+  }
+}

--- a/cypress/fixtures/commonComponents/splitButton.json
+++ b/cypress/fixtures/commonComponents/splitButton.json
@@ -51,6 +51,5 @@
     "iconPosition": "before"
   },
   "default": {
-    
   }
 }

--- a/cypress/fixtures/commonComponents/stepSequence.json
+++ b/cypress/fixtures/commonComponents/stepSequence.json
@@ -1,0 +1,55 @@
+{ 
+  "orientationVertical": {
+    "orientation": "vertical"
+  },
+  "orientationHorizontal": {
+    "orientation": "horizontal"
+  },
+  "indicator-100": {
+    "indicator": -100
+  },
+  "indicator0": {
+    "indicator": 0
+  },
+  "indicator999": {
+    "indicator": 999
+  },
+  "indicatorOtherLanguage": {
+    "indicator": "mp150ú¿¡üßä"
+  },
+  "indicatorSpecialCharacter": {
+    "indicator": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "statusComplete": {
+    "status": "complete"
+  },
+  "statusCurrent": {
+    "status": "current"
+  },
+  "statusIncomplete": {
+    "status": "incomplete"
+  },
+  "hiddenCompleteLabelOtherLanguage": {
+    "status": "complete",
+    "hiddenCompleteLabel": "mp150ú¿¡üßä"
+  },
+  "hiddenCurrentLabelOtherLanguage": {
+    "status": "current",
+    "hiddenCurrentLabel": "mp150ú¿¡üßä"
+  },
+  "ariaLabelOtherLanguage": {
+    "ariaLabel": "mp150ú¿¡üßä"
+  },
+  "ariaLabelSpecialCharacter": {
+    "ariaLabel": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "childrenOtherLanguage": {
+    "children": "mp150ú¿¡üßä"
+  },
+  "childrenSpecialCharacter": {
+    "children": "!@#$%^*()_+-=~[];:.,?{}"
+  }
+  
+
+
+}

--- a/cypress/fixtures/commonComponents/stepSequence.json
+++ b/cypress/fixtures/commonComponents/stepSequence.json
@@ -49,7 +49,4 @@
   "childrenSpecialCharacter": {
     "children": "!@#$%^*()_+-=~[];:.,?{}"
   }
-  
-
-
 }

--- a/cypress/locators/split-button/index.js
+++ b/cypress/locators/split-button/index.js
@@ -1,10 +1,13 @@
 import { SPLIT_TOGGLE_BUTTON, ADDITIONAL_BUTTONS, SPLIT_MAIN_BUTTON } from './locators';
 
 // component preview locators
-export const splitToggleButton = () => cy.iFrame(SPLIT_TOGGLE_BUTTON);
-export const additionalButton = index => cy.iFrame(ADDITIONAL_BUTTONS).children().eq(index);
-export const splitMainButton = index => cy.iFrame(SPLIT_MAIN_BUTTON)
+export const splitToggleButton = () => cy.get(SPLIT_TOGGLE_BUTTON);
+export const additionalButton = index => cy.get(ADDITIONAL_BUTTONS).children().eq(index);
+export const splitMainButton = index => cy.get(SPLIT_MAIN_BUTTON)
   .find('button')
   .find(`span:nth-child(${index})`);
-export const splitMainButtonDataComponent = index => cy.iFrame(SPLIT_MAIN_BUTTON)
-  .find(`:nth-child(${index})`);
+export const splitMainButtonDataComponent = index => cy.get(SPLIT_MAIN_BUTTON).children().eq(index);
+
+// component functions in IFrame
+export const additionalButtonIFrame = index => cy.iFrame(ADDITIONAL_BUTTONS).children().eq(index);
+export const splitMainButtonDataComponentIFrame = index => cy.iFrame(SPLIT_MAIN_BUTTON).children().eq(index);

--- a/cypress/locators/step-sequence/index.js
+++ b/cypress/locators/step-sequence/index.js
@@ -3,8 +3,8 @@ import {
 } from './locators';
 
 // component preview locators
-export const stepSequence = () => cy.iFrame(STEP_SEQUENCE);
-export const stepSequenceElement = () => cy.iFrame(STEP_SEQUENCE_ELEMENT);
-export const stepSequenceItem = () => cy.iFrame(STEP_SEQUENCE_ITEM);
-export const stepSequenceItemIndicator = () => cy.iFrame(STEP_SEQUENCE_ITEM_INDICATOR);
-export const ariaLabel = label => cy.iFrame(`li[aria-label="${label}"]`);
+export const stepSequence = () => cy.get(STEP_SEQUENCE);
+export const stepSequenceElement = () => cy.get(STEP_SEQUENCE_ELEMENT);
+export const stepSequenceItem = () => cy.get(STEP_SEQUENCE_ITEM);
+export const stepSequenceItemIndicator = () => cy.get(STEP_SEQUENCE_ITEM_INDICATOR);
+export const ariaLabel = label => cy.get(`li[aria-label="${label}"]`);

--- a/cypress/support/step-definitions/button-steps.js
+++ b/cypress/support/step-definitions/button-steps.js
@@ -21,7 +21,7 @@ Then('Button as a sibling label on preview is {word}', (label) => {
 });
 
 Then('Button is disabled', () => {
-  buttonDataComponentIFrame().should('be.disabled')
+  buttonDataComponent().should('be.disabled')
     .and('have.attr', 'disabled');
 });
 
@@ -33,7 +33,7 @@ Then('Button as a sibling is disabled', () => {
 });
 
 Then('Button is enabled', () => {
-  buttonDataComponentIFrame().should('be.enabled');
+  buttonDataComponent().should('be.enabled');
 });
 
 Then('Button as a sibling is enabled', () => {
@@ -73,7 +73,7 @@ Then('Button as a sibling font color is {string}', (color) => {
 });
 
 Then('Button background color is {string}', (color) => {
-  buttonDataComponentIFrame().should('have.css', 'background-color', color);
+  buttonDataComponent().should('have.css', 'background-color', color);
 });
 
 Then('Button background style is {string}', (style) => {

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -433,7 +433,7 @@ Then('data-{word} {string} is present', (element, value) => {
 });
 
 Then('text {string} color is set to {string}', (text, color) => {
-  storyRoot().contains(text).should('have.css', 'color', color);
+  storyRootNoIframe().contains(text).should('have.css', 'color', color);
 });
 
 When('I click outside of the component', () => {

--- a/cypress/support/step-definitions/split-button-steps.js
+++ b/cypress/support/step-definitions/split-button-steps.js
@@ -1,16 +1,21 @@
-import { commonButtonPreview } from '../../locators';
+import { commonButtonPreviewNoIFrameRoot } from '../../locators';
 import {
-  splitToggleButton, additionalButton, splitMainButton, splitMainButtonDataComponent,
+  splitToggleButton,
+  additionalButton,
+  splitMainButton,
+  splitMainButtonDataComponent, 
+  additionalButtonIFrame,
+  splitMainButtonDataComponentIFrame,
 } from '../../locators/split-button';
 import { positionOfElement } from '../helper';
 
 Then('Split Button is expanded', () => {
-  commonButtonPreview().should('have.length', 5); // 3 expanded buttons, 1 icon button and 1 main button
+  commonButtonPreviewNoIFrameRoot().should('have.length', 6); // 3 expanded buttons, 1 icon button and 1 main button
   splitToggleButton().should('have.attr', 'aria-expanded', 'true');
 });
 
 Then('Split Button is set to {string} size and has {int} px height', (size, height) => {
-  commonButtonPreview().should('have.css', 'height', `${height}px`);
+  commonButtonPreviewNoIFrameRoot().should('have.css', 'height', `${height}px`);
   splitToggleButton().should('have.css', 'height', `${height}px`);
   splitToggleButton().click();
   additionalButton(positionOfElement('first')).should('have.css', 'height', `${height}px`);
@@ -38,7 +43,7 @@ Then('Split Button iconPosition is set to {string} and has {string} icon', (icon
 });
 
 Then('Split Button first element has proper background-color {string} and border {string} color and has border-width {int} px', (color, borderColor, px) => {
-  splitMainButtonDataComponent(positionOfElement('second')).should('have.css', 'background-color', color)
+  splitMainButtonDataComponent(positionOfElement('first')).should('have.css', 'background-color', color)
     .and('have.css', 'border-bottom-color', borderColor)
     .and('have.css', 'border-left-color', borderColor)
     .and('have.css', 'border-right-color', borderColor)
@@ -54,7 +59,7 @@ Then('Split Button first element has proper background-color {string} and border
 });
 
 Then('Split Button second element has proper background-color {string} and border {string} color and has border-width {int} px', (color, borderColor, px) => {
-  splitMainButtonDataComponent(positionOfElement('third')).should('have.css', 'background-color', color)
+  splitMainButtonDataComponent(positionOfElement('second')).should('have.css', 'background-color', color)
     .and('have.css', 'border-bottom-color', borderColor)
     .and('have.css', 'border-left-color', borderColor)
     .and('have.css', 'border-right-color', borderColor)
@@ -120,6 +125,14 @@ When('I click {string} element of Split Button component', (element) => {
     additionalButton(positionOfElement(element)).click();
   } else {
     splitMainButtonDataComponent(positionOfElement('second')).first().click();
+  }
+});
+
+When('I click {string} element of Split Button component in IFrame', (element) => {
+  if (element === 'first' || element === 'second' || element === 'third') {
+    additionalButtonIFrame(positionOfElement(element)).click();
+  } else {
+    splitMainButtonDataComponentIFrame(positionOfElement('first')).click();
   }
 });
 

--- a/cypress/support/step-definitions/split-button-steps.js
+++ b/cypress/support/step-definitions/split-button-steps.js
@@ -131,8 +131,10 @@ When('I click {string} element of Split Button component', (element) => {
 When('I click {string} element of Split Button component in IFrame', (element) => {
   if (element === 'first' || element === 'second' || element === 'third') {
     additionalButtonIFrame(positionOfElement(element)).click();
-  } else {
+  } else if (element === 'main-button'){
     splitMainButtonDataComponentIFrame(positionOfElement('first')).click();
+  } else {
+    throw new Error('There is no such split button element');
   }
 });
 

--- a/cypress/support/step-definitions/step-sequence-steps.js
+++ b/cypress/support/step-definitions/step-sequence-steps.js
@@ -1,7 +1,9 @@
 import {
-  stepSequence, stepSequenceElement, stepSequenceItemIndicator, ariaLabel,
+  stepSequence,
+  stepSequenceElement,
+  stepSequenceItemIndicator,
+  ariaLabel,
 } from '../../locators/step-sequence';
-import { DEBUG_FLAG } from '..';
 
 const ARIA_LABEL = 'Step 1 of 5';
 const INDICATOR = '1';
@@ -12,7 +14,6 @@ Then('orientation is set to {string}', (orientation) => {
 });
 
 Then('indicator is set to {word}', (indicator) => {
-  cy.wait(500, { log: DEBUG_FLAG }); // required because iframe content is changed
   stepSequenceItemIndicator().should('have.text', indicator);
 });
 


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Apply new `url` approach in tests for:
`splitButton` (timing: was `02:13` -> `00:49`),
`stepSequence` (timing: was  `00:12` -> `00:05`),
`stepSequenceItem` (timing  `01:25` -> `00:51`).

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are passing all parameters via `knobs`.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent