### PR TITLE
test(message, multiactionbutton, pages): update test with new approach

### DIFF
--- a/cypress/features/regression/message.feature
+++ b/cypress/features/regression/message.feature
@@ -1,78 +1,64 @@
 Feature: Message component
-  I want to change Message component default properties
-
-  Background: Open Message component default page
-    Given I open "Message" component page
+  I want to test Message component default properties
 
   @positive
   Scenario: CloseIcon has correct border colour
-    Given I click closeIcon in IFrame
-    Then closeIcon has the border outline color "rgb(255, 181, 0)" and width "3px" in IFrame
+    Given I open default "Message" component in noIFrame with "message" json from "commonComponents" using "default" object name
+    When I click closeIcon
+    Then closeIcon has the border outline color "rgb(255, 181, 0)" and width "3px"
 
   @positive
   Scenario Outline: Change Message title to <title>
-    When I set title to <title> word
+    When I open default "Message" component in noIFrame with "message" json from "commonComponents" using "<nameOfObject>" object name
     Then Message title on preview is set to <title>
     Examples:
-      | title                        |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | title                        | nameOfObject          |
+      | mp150ú¿¡üßä                  | titleOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | titleSpecialCharacter |
 
   @positive
   Scenario Outline: Change type of Message component to <type>
-    When I select type to "<type>"
+    When I open default "Message" component in noIFrame with "message" json from "commonComponents" using "<nameOfObject>" object name
     Then Message type on preview is "<typeResult>"
     Examples:
-      | type    | typeResult |
-      | error   | error      |
-      | info    | info       |
-      | success | tick       |
-      | warning | warning    |
-
-  @positive
-  Scenario: Enable open state of Message component
-    # Commented because of BDD default scenario Given - When - Then
-    # When I check open checkbox
-    Then Message component is visible
+      | type    | typeResult | nameOfObject |
+      | error   | error      | typeError    |
+      | info    | info       | typeInfo     |
+      | success | tick       | typeSuccess  |
+      | warning | warning    | typeWarning  |
 
   @positive
   Scenario: Disable open state of Message component
-    When I uncheck open checkbox
+    When I open default "Message" component in noIFrame with "message" json from "commonComponents" using "openFalse" object name
     Then Message component is not visible
 
   @positive
   Scenario: Enable transparent state for a Message component
-    When I check transparent checkbox
+    When I open default "Message" component in noIFrame with "message" json from "commonComponents" using "transparent" object name
     Then Message component is transparent
 
   @positive
   Scenario: Disable transparent state for a Message component
-    Given I check transparent checkbox
-    When I uncheck transparent checkbox
+    When I open default "Message" component in noIFrame with "message" json from "commonComponents" using "transparentFalse" object name
     Then Message component is not transparent
 
   @positive
   Scenario Outline: Change Message children to <children>
-    When I set children to <children> word
+    When I open default "Message" component in noIFrame with "message" json from "commonComponents" using "<nameOfObject>" object name
     Then Message children on preview is set to <children>
     Examples:
-      | children                     |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
-
-  @positive
-  Scenario: Enable on close state for a Message component
-    # Commented because of BDD default scenario Given - When - Then
-    # When I check onDismiss checkbox
-    Then Message has cross icon
-
-  @positive
-  Scenario: Verify the click function for a Message component
-    Given clear all actions in Actions Tab
-    When I click closeIcon in IFrame
-    Then click action was called in Actions Tab
+      | children                     | nameOfObject             |
+      | mp150ú¿¡üßä                  | childrenOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | childrenSpecialCharacter |
 
   @positive
   Scenario: Disable showCloseIcon for a Message component
-    When I uncheck showCloseIcon checkbox
+    When I open default "Message" component in noIFrame with "message" json from "commonComponents" using "showCloseIconFalse" object name
     Then Message has no cross icon
+
+  @positive
+  Scenario: Verify the click function for a Message component
+    Given I open "Message" component page
+      And clear all actions in Actions Tab
+    When I click closeIcon in IFrame
+    Then click action was called in Actions Tab

--- a/cypress/features/regression/multiActionButton.feature
+++ b/cypress/features/regression/multiActionButton.feature
@@ -1,90 +1,89 @@
 Feature: Multi Action Button default component
   I want to test Multi Action Button default component properties
 
-  Background: Open Multi Action Button default component page
-    Given I open "Multi Action Button" component page
-
   @positive
   Scenario Outline: Change Multi Action Button text to <text>
-    When I set text to <text> word
+    When I open default "Multi Action Button" component in noIFrame with "multiActionButton" json from "commonComponents" using "<nameOfObject>" object name
     Then Multi Action Button text on preview is set to <text>
     Examples:
-      | text                    |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | text                    | nameOfObject         |
+      | mp150ú¿¡üßä             | textOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | textSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
 
   @positive
   Scenario Outline: Change buttonType property of Multi Action Button component to <buttonType>
-    When I select buttonType to "<buttonType>"
+    When I open default "Multi Action Button" component in noIFrame with "multiActionButton" json from "commonComponents" using "<nameOfObject>" object name
     Then Multi Action Button has "<background-color>" background-color
       And Multi Action Button border color is "<border-color>" border-color
     Examples:
-      | buttonType | background-color | border-color     |
-      | primary    | rgb(0, 129, 93)  | rgba(0, 0, 0, 0) |
-      | secondary  | rgba(0, 0, 0, 0) | rgb(0, 129, 93)  |
+      | buttonType | background-color | border-color     | nameOfObject        |
+      | primary    | rgb(0, 129, 93)  | rgba(0, 0, 0, 0) | buttonTypePrimary   |
+      | secondary  | rgba(0, 0, 0, 0) | rgb(0, 129, 93)  | buttonTypeSecondary |
 
   @positive
   Scenario Outline: Set Multi Action Button size to <size>
-    When I select size to "<size>"
-    Then Multi Action Button height is "<height>"
+    When I open default "Multi Action Button" component in noIFrame with "multiActionButton" json from "commonComponents" using "<nameOfObject>" object name
+    Then Multi Action Button height is <height>
     Examples:
-      | size   | height |
-      | small  | 32     |
-      | medium | 40     |
-      | large  | 48     |
+      | size   | height | nameOfObject |
+      | small  | 32     | sizeSmall    |
+      | medium | 40     | sizeMedium   |
+      | large  | 48     | sizeLarge    |
 
   @positive
   Scenario Outline: Check <align> property of Multi Action Button component
-    When I select align to "<align>"
+    When I open default "Multi Action Button" component in noIFrame with "multiActionButton" json from "commonComponents" using "<nameOfObject>" object name
       And I hover on Multi Action Button
     Then Multi Action Button align on preview is "<align>"
     Examples:
-      | align |
-      | left  |
-      | right |
+      | align | nameOfObject |
+      | left  | alignLeft    |
+      | right | alignRight   |
 
   @positive
   Scenario: Disabled Multi Action Button component
-    When I disable MultiActionButton component
+    When I open default "Multi Action Button" component in noIFrame with "multiActionButton" json from "commonComponents" using "disabled" object name
     Then Multi Action Button state is disabled
 
   @positive
-  Scenario: Disabled and enabled Multi Action Button component
-    Given  I disable MultiActionButton component
-    When I enable MultiActionButton component
+  Scenario: Enabled Multi Action Button component
+    When I open default "Multi Action Button" component in noIFrame with "multiActionButton" json from "commonComponents" using "disabledFalse" object name
     Then Multi Action Button state is not disabled
 
   @positive
   Scenario Outline: Set Multi Action Button subtext to <subtext>
-    Given I select size to "large"
-    When I set subtext to <subtext> word
+    When I open default "Multi Action Button" component in noIFrame with "multiActionButton" json from "commonComponents" using "<nameOfObject>" object name
     Then Multi Action Button subtext on preview is <subtext>
     Examples:
-      | subtext                 |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | subtext                 | nameOfObject            |
+      | mp150ú¿¡üßä             | subtextOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | subtextSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
 
   @positive
   Scenario: Invoking Multi Action Button component
+    Given I open default "Multi Action Button" component in noIFrame with "multiActionButton" json from "commonComponents" using "default" object name
     When I hover on Multi Action Button
     Then Multi Action Button is expanded and contains three items
 
   @positive
-  Scenario: Check click event
-    Given clear all actions in Actions Tab
-    When I click on "button"
-    Then click action was called in Actions Tab
-
-  @positive
   Scenario Outline: Verify that the Multi Action Button has golden border
+    Given I open default "Multi Action Button" component in noIFrame with "multiActionButton" json from "commonComponents" using "default" object name
     When I hit Tab key 1 times
     Then Multi Action Button has golden border color
 
   @positive
   Scenario: Verify background-color after hovering
+    Given I open default "Multi Action Button" component in noIFrame with "multiActionButton" json from "commonComponents" using "default" object name
     When I hover on Multi Action Button
     Then Multi Action Button has "rgb(0, 96, 70)" background-color
+
+  @positive
+  Scenario: Check click event
+    Given I open "Multi Action Button" component page
+      And clear all actions in Actions Tab
+    When I click on "button"
+    Then click action was called in Actions Tab

--- a/cypress/features/regression/pages.feature
+++ b/cypress/features/regression/pages.feature
@@ -1,78 +1,25 @@
 Feature: Pages component
   I want to test Pages component
 
-  Background: Open Pages component default page
-    Given I open "Pages" component page
-
   @positive
   Scenario Outline: Change Pages component pageIndex to <pageIndex>
-    When I select pageIndex to "<pageIndex>"
-      And I open component preview
-      # wait because of animation
-      And I wait 2500
+    Given I open default "Pages" component in noIFrame with "pages" json from "commonComponents" using "<nameOfObject>" object name
+    When I open Pages component preview
     Then My <page> Page is visible
     Examples:
-      | pageIndex | page   |
-      | 0         | First  |
-      | 1         | Second |
-      | 2         | Third  |
+      | pageIndex | page   | nameOfObject |
+      | 0         | First  | pageIndex0   |
+      | 1         | Second | pageIndex1   |
+      | 2         | Third  | pageIndex2   |
 
   @positive
   Scenario Outline: Open and close page by index <pageIndex>
-    Given I select pageIndex to "<pageIndex>"
-    When I open component preview
+    Given I open default "Pages" component in noIFrame with "pages" json from "commonComponents" using "<nameOfObject>" object name
+    When I open Pages component preview
       And I close page
     Then page is closed
     Examples:
-      | pageIndex |
-      | 0         |
-      | 1         |
-      | 2         |
-
-  @positive
-  Scenario: Go to second page
-    Given I open component preview
-    When I go to second page
-    Then My Second Page is visible
-      And other pages except Second Page are not visible
-
-  @positive
-  Scenario: Go to third page
-    When I open component preview
-      And I go to second page
-      And I go to third page
-    Then My Third Page is visible
-      And other pages except Third Page are not visible
-
-  @positive
-  Scenario: Go back from second page to first page
-    Given I select pageIndex to "1"
-      And I open component preview
-      # wait because of animation
-      And I wait 1000
-    When I go back
-    Then My First Page is visible
-      And other pages except First Page are not visible
-
-  @positive
-  Scenario: Go back from third page to first page
-    Given I select pageIndex to "2"
-      And I open component preview
-      # wait because of animation
-      And I wait 1000
-    When I go back
-    Then My First Page is visible
-      And other pages except First Page are not visible
-
- @positive
-  Scenario: Open event
-    Given clear all actions in Actions Tab
-    When I open component preview
-    Then open action was called in Actions Tab
-
-   @positive
-  Scenario: Cancel event
-    Given I open component preview
-      And clear all actions in Actions Tab
-    When I close page
-    Then cancel action was called in Actions Tab
+      | pageIndex | nameOfObject |
+      | 0         | pageIndex0   |
+      | 1         | pageIndex1   |
+      | 2         | pageIndex2   |

--- a/cypress/features/regression/pagesActions.feature
+++ b/cypress/features/regression/pagesActions.feature
@@ -1,0 +1,53 @@
+Feature: Pages component in IFrame
+  I want to test Pages component
+
+  Background: Open Pages component default page
+    Given I open "Pages" component page
+
+ @positive
+  Scenario: Go to second page
+    Given I open Pages component preview in Iframe
+    When I go to second page
+    Then My Second Page is visible in Iframe
+      And other pages except Second Page are not visible
+
+  @positive
+  Scenario: Go to third page
+    When I open Pages component preview in Iframe
+      And I go to second page
+      And I go to third page
+    Then My Third Page is visible in Iframe
+      And other pages except Third Page are not visible
+
+  @positive
+  Scenario: Go back from second page to first page
+    Given I select pageIndex to "1"
+      And I open Pages component preview in Iframe
+      # wait because of animation
+      And I wait 1000
+    When I go back
+    Then My First Page is visible in Iframe
+      And other pages except First Page are not visible
+
+  @positive
+  Scenario: Go back from third page to first page
+    Given I select pageIndex to "2"
+      And I open Pages component preview in Iframe
+      # wait because of animation
+      And I wait 1000
+    When I go back
+    Then My First Page is visible in Iframe
+      And other pages except First Page are not visible
+
+ @positive
+  Scenario: Open event
+    Given clear all actions in Actions Tab
+    When I open Pages component preview in Iframe
+    Then open action was called in Actions Tab
+
+   @positive
+  Scenario: Cancel event
+    Given I open Pages component preview in Iframe
+      And clear all actions in Actions Tab
+    When I close page in IFrame
+    Then cancel action was called in Actions Tab

--- a/cypress/fixtures/commonComponents/message.json
+++ b/cypress/fixtures/commonComponents/message.json
@@ -1,0 +1,40 @@
+{
+  "default": {
+  },
+  "titleOtherLanguage": {
+    "title": "mp150ú¿¡üßä"
+  },
+  "titleSpecialCharacter": {
+    "title": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "typeError": {
+    "type": "error"
+  },
+  "typeInfo": {
+    "type": "info"
+  },
+  "typeSuccess": {
+    "type": "tick"
+  },
+  "typeWarning": {
+    "type": "warning"
+  },
+  "openFalse": {
+    "open": false
+  },
+  "transparent": {
+    "transparent": true
+  },
+  "transparentFalse": {
+    "transparent": false
+  },
+  "childrenOtherLanguage": {
+    "children": "mp150ú¿¡üßä"
+  },
+  "childrenSpecialCharacter": {
+    "children": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "showCloseIconFalse": {
+    "showCloseIcon": false
+  }
+}

--- a/cypress/fixtures/commonComponents/multiActionButton.json
+++ b/cypress/fixtures/commonComponents/multiActionButton.json
@@ -1,0 +1,45 @@
+{
+  "textOtherLanguage": {
+    "text": "mp150ú¿¡üßä"
+  },
+  "textSpecialCharacter": {
+    "text": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "buttonTypePrimary": {
+    "buttonType": "primary"
+  },
+  "buttonTypeSecondary": {
+    "buttonType": "secondary"
+  },
+  "sizeSmall": {
+    "size": "small"
+  },
+  "sizeMedium": {
+    "size": "medium"
+  },
+  "sizeLarge": {
+    "size": "large"
+  },
+  "alignLeft": {
+    "align": "left"
+  },
+  "alignRight": {
+    "align": "right"
+  },
+  "disabledFalse": {
+    "disabled": false
+  },
+  "disabled": {
+    "disabled": true
+  },
+  "subtextOtherLanguage": {
+    "size": "large",
+    "subtext": "mp150ú¿¡üßä"
+  },
+  "subtextSpecialCharacter": {
+    "size": "large",
+    "subtext": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "default": {
+  }
+}

--- a/cypress/fixtures/commonComponents/pages.json
+++ b/cypress/fixtures/commonComponents/pages.json
@@ -1,0 +1,11 @@
+{
+  "pageIndex0": {
+    "pageIndex": 0
+  },
+  "pageIndex1": {
+    "pageIndex": 1
+  },
+  "pageIndex2": {
+    "pageIndex": 2
+  }
+}

--- a/cypress/locators/button/index.js
+++ b/cypress/locators/button/index.js
@@ -1,7 +1,6 @@
 import { BUTTON_SUBTEXT_PREVIEW, BUTTON_DATA_COMPONENT_PREVIEW } from './locators';
 
 // component preview locators
-export const buttonSubtextPreviewIframe = () => cy.iFrame(BUTTON_SUBTEXT_PREVIEW);
 export const buttonDataComponentIFrame = () => cy.iFrame(BUTTON_DATA_COMPONENT_PREVIEW);
 
 // component preview locators in no IFrame

--- a/cypress/locators/index.js
+++ b/cypress/locators/index.js
@@ -47,6 +47,7 @@ export const inputWidthPreview = () => cy.iFrame(INPUT_WIDTH_PREVIEW);
 export const commonDataElementInputPreview = () => cy.iFrame(COMMMON_DATA_ELEMENT_INPUT);
 export const getDataElementByValueIframe = element => cy.iFrame(`[data-element="${element}"]`);
 export const getDataElementByNameAndValue = (name, value) => cy.iFrame(`[data-${name}="${value}"]`);
+export const getComponentIFrame = component => cy.iFrame(`[data-component="${component}"]`);
 
 // component preview locators into iFrame
 export const storyRootNoIframe = () => cy.get(STORY_ROOT);

--- a/cypress/locators/message/index.js
+++ b/cypress/locators/message/index.js
@@ -4,7 +4,7 @@ import {
 } from './locators';
 
 // component preview locators
-export const messagePreview = () => cy.iFrame(MESSAGE_PREVIEW);
-export const messageType = () => cy.iFrame(MESSAGE_TYPE);
-export const messageChildren = () => cy.iFrame(MESSAGE_CHILDREN);
-export const messageDismissIcon = () => cy.iFrame(MESSAGE_DISMISS_ICON);
+export const messagePreview = () => cy.get(MESSAGE_PREVIEW);
+export const messageType = () => cy.get(MESSAGE_TYPE);
+export const messageChildren = () => cy.get(MESSAGE_CHILDREN);
+export const messageDismissIcon = () => cy.get(MESSAGE_DISMISS_ICON);

--- a/cypress/locators/multi-action-button/index.js
+++ b/cypress/locators/multi-action-button/index.js
@@ -1,10 +1,9 @@
-import { MULTI_ACTION_BUTTON_LIST, MULTI_ACTION_BUTTON_SUBTEXT, MULTI_ACTION_BUTTON_TEXT, MULTI_ACTION_BUTTON_COMPONENT } from './locators';
-import { BUTTON_SUBTEXT_PREVIEW } from '../button/locators';
+import { MULTI_ACTION_BUTTON_LIST, MULTI_ACTION_BUTTON_COMPONENT } from './locators';
 import { BUTTON_DATA_COMPONENT } from '../pages/locators';
 
 // component preview locators
-export const multiActionButtonComponent = () => cy.iFrame(MULTI_ACTION_BUTTON_COMPONENT);
-export const multiActionButtonList = () => cy.iFrame(MULTI_ACTION_BUTTON_LIST).children();
+export const multiActionButtonComponent = () => cy.get(MULTI_ACTION_BUTTON_COMPONENT);
+export const multiActionButtonList = () => cy.get(MULTI_ACTION_BUTTON_LIST).children();
 export const multiActionButtonText = () => multiActionButtonComponent()
   .find(BUTTON_DATA_COMPONENT);
 export const multiActionButton = () => multiActionButtonComponent()

--- a/cypress/locators/pages/index.js
+++ b/cypress/locators/pages/index.js
@@ -2,7 +2,9 @@ import {
   BUTTON_DATA_COMPONENT, CLOSE_DATA_ELEMENT, BACK_ARROW,
 } from './locators';
 
-// iFrame locators
+// component preview locators
 export const dataComponentButtonByText = text => cy.iFrame(BUTTON_DATA_COMPONENT).contains(text);
-export const closeDataElement = () => cy.iFrame(CLOSE_DATA_ELEMENT);
+export const closeDataElement = () => cy.get(CLOSE_DATA_ELEMENT);
 export const backArrow = () => cy.iFrame(BACK_ARROW);
+
+export const closeDataElementIFrame = () => cy.iFrame(CLOSE_DATA_ELEMENT);

--- a/cypress/support/step-definitions/button-steps.js
+++ b/cypress/support/step-definitions/button-steps.js
@@ -1,8 +1,7 @@
 import {
   buttonSubtextPreview,
   buttonDataComponent,
-  buttonDataComponentIFrame, 
-  buttonSubtextPreviewIframe,
+  buttonDataComponentIFrame,
 } from '../../locators/button';
 import { iconIFrame, icon } from '../../locators';
 import { positionOfElement } from '../helper';
@@ -55,7 +54,7 @@ Then('Button subtext on preview is {word}', (subtext) => {
 });
 
 Then('Button subtext on preview is {word} in IFrame', (subtext) => {
-  buttonSubtextPreviewIframe().should('have.text', subtext);
+  buttonSubtextPreview().should('have.text', subtext);
 });
 
 Then('Button as a sibling subtext on preview is {word}', (subtext) => {

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -3,6 +3,8 @@ import {
   visitFlatTableComponentNoiFrame, positionOfElement, keyCode,
   visitDocsUrl,
   visitComponentUrlWithParameters,
+  clickActionsTab,
+  clickClear,
 } from '../helper';
 import {
   commonButtonPreview, labelPreview, helpIconByPosition, inputWidthSlider,
@@ -562,4 +564,9 @@ Then('icon name in noIframe on preview is {string}', (iconName) => {
 
 When('I click {string} icon in iFrame', (iconName) => {
   getDataElementByValueIframe(iconName).click();
+});
+
+When('clear all actions in Actions Tab', () => {
+  clickActionsTab();
+  clickClear();
 });

--- a/cypress/support/step-definitions/message-steps.js
+++ b/cypress/support/step-definitions/message-steps.js
@@ -1,28 +1,18 @@
 import {
   messageType, messagePreview, messageChildren, messageDismissIcon,
 } from '../../locators/message';
-import { clickActionsTab, clickClear } from '../helper';
-import { getDataElementByValueIframe } from '../../locators';
+import { getDataElementByValue } from '../../locators';
 
 Then('Message title on preview is set to {word}', (text) => {
-  getDataElementByValueIframe('title').should('have.text', text);
+  getDataElementByValue('title').should('have.text', text);
 });
 
 Then('Message type on preview is {string}', (type) => {
   messageType().should('have.attr', 'data-element', type);
 });
 
-Then('Message component is visible', () => {
-  messagePreview().should('be.visible');
-});
-
 Then('Message component is not visible', () => {
   messagePreview().should('not.exist');
-});
-
-When('clear all actions in Actions Tab', () => {
-  clickActionsTab();
-  clickClear();
 });
 
 Then('Message component is transparent', () => {
@@ -37,14 +27,6 @@ Then('Message children on preview is set to {word}', (text) => {
   messageChildren().should('have.text', text);
 });
 
-Then('Message has cross icon', () => {
-  messageDismissIcon().should('be.visible');
-});
-
 Then('Message has no cross icon', () => {
   messageDismissIcon().should('not.exist');
-});
-
-Then('I click dismiss icon', () => {
-  messageDismissIcon().click();
 });

--- a/cypress/support/step-definitions/multi-action-button-steps.js
+++ b/cypress/support/step-definitions/multi-action-button-steps.js
@@ -2,7 +2,7 @@ import {
   multiActionButtonList, multiActionButtonText, multiActionButton,
   multiActionButtonComponent,
 } from '../../locators/multi-action-button';
-import { buttonSubtextPreviewIframe } from '../../locators/button';
+import { buttonSubtextPreview } from '../../locators/button';
 
 const MULTI_ACTION_BUTTON_INNER_TEXT = 'Example ButtonExample Button with long textShort';
 const TEXT_ALIGN = 'text-align';
@@ -30,7 +30,7 @@ Then('Multi Action Button border color is {string} border-color', (borderColor) 
     .and('have.css', 'border-left-color', borderColor);
 });
 
-Then('Multi Action Button height is {string}', (height) => {
+Then('Multi Action Button height is {int}', (height) => {
   multiActionButton().should('have.css', 'height', `${height}px`);
 });
 
@@ -40,7 +40,7 @@ Then('Multi Action Button align on preview is {string}', (align) => {
 });
 
 Then('Multi Action Button subtext on preview is {word}', (subtext) => {
-  buttonSubtextPreviewIframe().should('have.text', subtext);
+  buttonSubtextPreview().should('have.text', subtext);
 });
 
 Then('Multi Action Button has golden border color', () => {
@@ -49,10 +49,6 @@ Then('Multi Action Button has golden border color', () => {
 
 When('I hover on Multi Action Button', () => {
   multiActionButtonComponent().trigger('mouseover');
-});
-
-When('I click the Multi Action Button', () => {
-  multiActionButtonComponent().click();
 });
 
 Then('Multi Action Button is expanded and contains three items', () => {

--- a/cypress/support/step-definitions/pages-steps.js
+++ b/cypress/support/step-definitions/pages-steps.js
@@ -1,26 +1,35 @@
 import {
-  dataComponentButtonByText, closeDataElement, backArrow,
+  dataComponentButtonByText, closeDataElement, backArrow, closeDataElementIFrame,
 } from '../../locators/pages';
 import { DEBUG_FLAG } from '..';
-import { getDataElementByValueIframe } from '../../locators';
+import { getDataElementByValue, getComponentNoIframe, getComponentIFrame, getDataElementByValueIframe } from '../../locators';
 
 Then('My {word} Page is visible', (word) => {
+  getDataElementByValue('title').should('have.text', `My ${word} Page`);
+});
+
+Then('My {word} Page is visible in Iframe', (word) => {
   getDataElementByValueIframe('title').should('have.text', `My ${word} Page`);
 });
 
 When('I go to {word} page', (word) => {
   dataComponentButtonByText(`Go to ${word} page`).click();
-  cy.wait(500, { log: DEBUG_FLAG }); // wait was added due to changing animation
+  cy.wait(1000, { log: DEBUG_FLAG }); // wait was added due to changing animation
 });
 
 When('I close page', () => {
   closeDataElement().click({ multiple: true });
+});
+
+When('I close page in IFrame', () => {
+  closeDataElementIFrame().click({ multiple: true });
   cy.wait(500, { log: DEBUG_FLAG }); // wait was added due to changing animation
 });
 
 Then('I go back', () => {
   backArrow().click();
   cy.wait(1000, { log: DEBUG_FLAG }); // wait was added due to changing animation
+  cy.focused().click();
 });
 
 Then('other pages except {word} Page are not visible', (word) => {
@@ -42,5 +51,13 @@ Then('other pages except {word} Page are not visible', (word) => {
 });
 
 Then('page is closed', () => {
-  getDataElementByValueIframe('title').should('not.exist');
+  getDataElementByValue('title').should('not.exist');
+});
+
+Then('I open Pages component preview', () => {
+  getComponentNoIframe('button').click();
+});
+
+Then('I open Pages component preview in Iframe', () => {
+  getComponentIFrame('button').click();
 });


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Apply new `url` approach in tests for:
`message` (timing: was `01:19` -> `0:26` ),
`multiactionbutton` (timing: was  `01:33` -> `0:29` ),
`pages` (timing  `01:27` -> `0:14` ),
`pagesActions` (timing `0:32`)

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are passing all parameters via `knobs`.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent