### PR TITLE
test(preview/profile/row): apply new url approach

### DIFF
--- a/cypress/features/regression/preview.feature
+++ b/cypress/features/regression/preview.feature
@@ -7,7 +7,7 @@ Feature: Preview default component
     Then Preview component is loading
 
   @positive
-  Scenario: Enable and disable loading checkbox for a Preview component
+  Scenario: Disable loading checkbox for a Preview component
     When I open default "Preview" component in noIFrame with "preview" json from "commonComponents" using "loadingFalse" object name
     Then Preview component is not loading
 

--- a/cypress/features/regression/preview.feature
+++ b/cypress/features/regression/preview.feature
@@ -1,93 +1,86 @@
 Feature: Preview default component
   I want to test Preview component
 
-  Background: Open Preview component default page
-    Given I open "Preview" component page
-
   @positive
   Scenario: Enable loading checkbox for a Preview component
-    Given I uncheck loading checkbox
-    When I check loading checkbox
+    When I open default "Preview" component in noIFrame with "preview" json from "commonComponents" using "loading" object name
     Then Preview component is loading
 
   @positive
   Scenario: Enable and disable loading checkbox for a Preview component
-    When I uncheck loading checkbox
+    When I open default "Preview" component in noIFrame with "preview" json from "commonComponents" using "loadingFalse" object name
     Then Preview component is not loading
 
   @positive
   Scenario Outline: Change Preview children to <children>
-    Given I set children to <children> word
-    When I uncheck loading checkbox
+    When I open default "Preview" component in noIFrame with "preview" json from "commonComponents" using "<nameOfObject>" object name
     Then Preview children is set to <children>
     Examples:
-      | children                |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-      # @ignore because of FE-2782
-# | &"'<>|
+      | children                | nameOfObject             |
+      | mp150ú¿¡üßä             | childrenOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | childrenSpecialCharacter |
+  # @ignore because of FE-2782
+  # | &"'<>|
 
   @positive
   Scenario Outline: Set width to <width>
-    When I set width to "<width>"
-      And I check loading checkbox
+    When I open default "Preview" component in noIFrame with "preview" json from "commonComponents" using "<nameOfObject>" object name
     Then Preview width is set to "<width>"
     Examples:
-      | width |
-      | 0px   |
-      | 1px   |
-      | 100px |
+      | width | nameOfObject |
+      | 0px   | width0       |
+      | 1px   | width1       |
+      | 100px | width100     |
 
   @positive
   Scenario Outline: Set height to <height>
-    When I set height to "<height>"
-      And I check loading checkbox
+    When I open default "Preview" component in noIFrame with "preview" json from "commonComponents" using "<nameOfObject>" object name
     Then Preview height is set to "<height>"
     Examples:
-      | height |
-      | 0px    |
-      | 1px    |
-      | 100px  |
+      | height | nameOfObject |
+      | 0px    | height0      |
+      | 1px    | height1      |
+      | 100px  | height100    |
 
   @positive
   Scenario Outline: Set lines to <lines>
-    When I set lines to "<lines>"
-    Then Preview has "<lines>" lines
+    When I open default "Preview" component in noIFrame with "preview" json from "commonComponents" using "<nameOfObject>" object name
+    Then Preview has <lines> lines
     Examples:
-      | lines |
-      | 0     |
-      | 1     |
-      | 100   |
+      | lines | nameOfObject |
+      | 0     | lines0       |
+      | 1     | lines1       |
+      | 100   | lines100     |
 
   @positive
   Scenario Outline: Set width to out of scope to <width>
-    When I set width to <width> word
+    When I open default "Preview" component in noIFrame with "preview" json from "commonComponents" using "<nameOfObject>" object name
     Then Preview width is not set to <width>
     Examples:
-      | width                   |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-      # @ignore because of FE-2782
-# | &"'<>|
+      | width                   | nameOfObject          |
+      | mp150ú¿¡üßä             | widthOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | widthSpecialCharacter |
+  # @ignore because of FE-2782
+  # | &"'<>|
 
   @positive
   Scenario Outline: Set height to out of scope to <height>
-    When I set height to <height> word
+    When I open default "Preview" component in noIFrame with "preview" json from "commonComponents" using "<nameOfObject>" object name
     Then Preview height is not set to <height>
     Examples:
-      | height                  |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
-      # @ignore because of FE-2782
-# | &"'<>|
+      | height                  | nameOfObject           |
+      | mp150ú¿¡üßä             | heightOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | heightSpecialCharacter |
+  # @ignore because of FE-2782
+  # | &"'<>|
 
   @positive
   Scenario Outline: Set lines to out of scope to <lines>
-    When I set lines to <lines> word
+    When I open default "Preview" component in noIFrame with "preview" json from "commonComponents" using "<nameOfObject>" object name
     Then Preview lines is not set to <lines>
     Examples:
-      | lines                   |
-      | mpú¿¡üßä                |
-      | !@#$%^*()_+-=~[];:.,?{} |
-      # @ignore because of FE-2782
+      | lines                   | nameOfObject          |
+      | mp150ú¿¡üßä             | linesOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | linesSpecialCharacter |
+# @ignore because of FE-2782
 # | &"'<>|

--- a/cypress/features/regression/profile.feature
+++ b/cypress/features/regression/profile.feature
@@ -1,21 +1,18 @@
 Feature: Profile default component
-  I want to change default Profile component properties
-
-  Background: Open Profile default component page
-    Given I open "Profile" component page
+  I want to test default Profile component properties
 
   @positive
   Scenario Outline: Set email to <email>
-    When I set email to <email> word
+    When I open default "Profile" component in noIFrame with "profile" json from "commonComponents" using "<nameOfObject>" object name
     Then email is set to <email>
     Examples:
-      | email              |
-      | example@email.com  |
-      | johnsmith@sage.com |
+      | email              | nameOfObject |
+      | example@email.com  | email1       |
+      | johnsmith@sage.com | email2       |
 
   @positive
   Scenario Outline: Get avatar via email
-    When I set email to <email> word
+    When I open default "Profile" component in noIFrame with "profile" json from "commonComponents" using "emailGravatar" object name
     Then email is set to <email>
       And avatar is taken from "<avatar>"
     Examples:
@@ -24,55 +21,54 @@ Feature: Profile default component
 
   @negative
   Scenario Outline: Set email out of scope to <email>
-    When I set email to <email> word
+    When I open default "Profile" component in noIFrame with "profile" json from "commonComponents" using "<nameOfObject>" object name
     Then email is set to <email>
     Examples:
-      | email                        |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | email                        | nameOfObject          |
+      | mp150ú¿¡üßä                  | emailOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | emailSpecialCharacter |
 
   # value which is rendering as src doesn't work properly for CI
   # ignored regression
   @ignore
   Scenario Outline: Set initials to <initials>
-    When I set initials to "<initials>"
+    When I open default "Profile" component in noIFrame with "profile" json from "commonComponents" using "<nameOfObject>" object name
     Then initials is set to "<initials>"
     Examples:
-      | initials |
-      | OW       |
-      | TJH      |
+      | initials | nameOfObject |
+      | OW       | initialsOW   |
+      | TJH      | initialsTJH  |
 
   # value which is rendering as src doesn't work properly for CI
   # ignored regression
   @ignore
   Scenario Outline: Get initials from name <name>
-    When I set name to <name> word
-      And I set initials to empty
+    When I open default "Profile" component in noIFrame with "profile" json from "commonComponents" using "<nameOfObject>" object name
     Then initials is set to <result>
     Examples:
-      | name                 | result |
-      | Oscar Wilde          | OW     |
-      | Thomas Jeffrey Hanks | TJH    |
+      | name                 | result | nameOfObject           |
+      | Oscar Wilde          | OW     | nameOscarWilde         |
+      | Thomas Jeffrey Hanks | TJH    | nameThomasJeffreyHanks |
 
   @positive
   Scenario Outline: Set Profile size to <size>
-    When I select size to "<size>"
-    Then Profile size has "<sizeInPx>"
+    When I open default "Profile" component in noIFrame with "profile" json from "commonComponents" using "<nameOfObject>" object name
+    Then Profile size has <sizeInPx>
     Examples:
-      | size | sizeInPx |
-      | XS   | 24       |
-      | S    | 32       |
-      | M    | 40       |
-      | ML   | 56       |
-      | L    | 72       |
-      | XL   | 104      |
-      | XXL  | 128      |
+      | size | sizeInPx | nameOfObject |
+      | XS   | 24       | sizeXS       |
+      | S    | 32       | sizeS        |
+      | M    | 40       | sizeM        |
+      | ML   | 56       | sizeML       |
+      | L    | 72       | sizeL        |
+      | XL   | 104      | sizeXL       |
+      | XXL  | 128      | sizeXXL      |
 
   @positive
   Scenario Outline: Set name to <name>
-    When I set name to <name> word
+    When I open default "Profile" component in noIFrame with "profile" json from "commonComponents" using "<nameOfObject>" object name
     Then name is set to <name>
     Examples:
-      | name                         |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | name                         | nameOfObject         |
+      | mp150ú¿¡üßä                  | nameOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | nameSpecialCharacter |

--- a/cypress/features/regression/row.feature
+++ b/cypress/features/regression/row.feature
@@ -1,97 +1,93 @@
 Feature: Row component
   I want to change Row component properties
 
-  Background: Open Row component page
-    Given I open "Row" component page
-
   @positive
   Scenario: Enable columnDivide
-    When I uncheck columnDivide checkbox
-      And I check columnDivide checkbox
+    When I open default "Row" component in noIFrame with "row" json from "commonComponents" using "columnDivide" object name
     Then columnDivide is set
 
   @positive
   Scenario: Disable columnDivide
-    When I uncheck columnDivide checkbox
+    When I open default "Row" component in noIFrame with "row" json from "commonComponents" using "columnDivideFalse" object name
     Then columnDivide is not set
 
   @positive
   Scenario Outline: Set columnAlign to <gutter>
-    When I select gutter to "<gutter>"
+    When I open default "Row" component in noIFrame with "row" json from "commonComponents" using "<nameOfObject>" object name
     Then gutter on preview is "<gutter>"
     Examples:
-      | gutter       |
-      | extra-small  |
-      | small        |
-      | medium-small |
-      | medium       |
-      | medium-large |
-      | large        |
-      | extra-large  |
+      | gutter       | nameOfObject          |
+      | extra-small  | gutterExtraSmall      |
+      | small        | gutterSizeSmall       |
+      | medium-small | gutterSizeMediumSmall |
+      | medium       | gutterSizeMedium      |
+      | medium-large | gutterSizeMediumLarge |
+      | large        | gutterSizeLarge       |
+      | extra-large  | gutterSizeExtraLarge  |
 
   @positive
   Scenario Outline: Set columnAlign to <direction>
-    When I select columnAlign to "<direction>"
+    When I open default "Row" component in noIFrame with "row" json from "commonComponents" using "<nameOfObject>" object name
     Then columnAlign on preview is "<direction>"
     Examples:
-      | direction |
-      | left      |
-      | right     |
+      | direction | nameOfObject     |
+      | left      | columnAlignLeft  |
+      | right     | columnAlignRight |
 
   @positive
   Scenario Outline: Set columnOffset to <columnOffset>
-    When I set columnOffset to <columnOffset> word
+    When I open default "Row" component in noIFrame with "row" json from "commonComponents" using "<nameOfObject>" object name
     Then columnOffset on preview is <columnOffset>
     Examples:
-      | columnOffset |
-      | -100         |
-      | -1           |
-      | 0            |
-      | 1            |
-      | 100          |
+      | columnOffset | nameOfObject     |
+      | -100         | columnOffset-100 |
+      | -1           | columnOffset-1   |
+      | 0            | columnOffset0    |
+      | 1            | columnOffset1    |
+      | 100          | columnOffset100  |
 
   @negative
   Scenario Outline: Set columnOffset out of scope to <columnOffset>
-    When I set columnOffset to <columnOffset> word
+    When I open default "Row" component in noIFrame with "row" json from "commonComponents" using "<nameOfObject>" object name
     Then columnOffset on preview is <columnOffset>
     Examples:
-      | columnOffset            |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | columnOffset            | nameOfObject                 |
+      | mp150ú¿¡üßä             | columnOffsetOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | columnOffsetSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
 
   @positive
   Scenario Outline: Set columnSpan to <columnSpan>
-    When I set columnSpan to <columnSpan> word
+    When I open default "Row" component in noIFrame with "row" json from "commonComponents" using "<nameOfObject>" object name
     Then columnSpan on preview is <columnSpan>
     Examples:
-      | columnSpan |
-      | -100       |
-      | -1         |
-      | 0          |
-      | 1          |
-      | 100        |
+      | columnSpan | nameOfObject   |
+      | -100       | columnSpan-100 |
+      | -1         | columnSpan-1   |
+      | 0          | columnSpan0    |
+      | 1          | columnSpan1    |
+      | 100        | columnSpan100  |
 
   @positive
   Scenario Outline: Set columnSpan out of scope to <columnSpan>
-    When I set columnSpan to <columnSpan> word
+    When I open default "Row" component in noIFrame with "row" json from "commonComponents" using "<nameOfObject>" object name
     Then columnSpan on preview is <columnSpan>
     Examples:
-      | columnSpan              |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | columnSpan              | nameOfObject               |
+      | mp150ú¿¡üßä             | columnSpanOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | columnSpanSpecialCharacter |
   # @ignore because of FE-2782
   # | &"'<>|
 
 
   @positive
   Scenario Outline: Set children to <children>
-    When I set children to <children> word
+    When I open default "Row" component in noIFrame with "row" json from "commonComponents" using "<nameOfObject>" object name
     Then column text is <children>
     Examples:
-      | children                |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | children                | nameOfObject             |
+      | mp150ú¿¡üßä             | childrenOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | childrenSpecialCharacter |
 # @ignore because of FE-2782
 # | &"'<>|

--- a/cypress/features/regression/row.feature
+++ b/cypress/features/regression/row.feature
@@ -1,5 +1,5 @@
 Feature: Row component
-  I want to change Row component properties
+  I want to test Row component properties
 
   @positive
   Scenario: Enable columnDivide

--- a/cypress/fixtures/commonComponents/preview.json
+++ b/cypress/fixtures/commonComponents/preview.json
@@ -1,0 +1,67 @@
+{ 
+  "loading": {
+    "loading": true
+  },
+  "loadingFalse": {
+    "loading": false
+  },
+  "childrenOtherLanguage": {
+    "loading": false,
+    "children": "mp150ú¿¡üßä"
+  },
+  "childrenSpecialCharacter": {
+    "loading": false,
+    "children": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "width0": {
+    "loading": true,
+    "width": "0px"
+  },
+  "width1": {
+    "loading": true,
+    "width": "1px"
+  },
+  "width100": {
+    "loading": true,
+    "width": "100px"
+  },
+  "height0": {
+    "loading": true,
+    "height": "0px"
+  },
+  "height1": {
+    "loading": true,
+    "height": "1px"
+  },
+  "height100": {
+    "loading": true,
+    "height": "100px"
+  },
+  "lines0": {
+    "lines": 0
+  },
+  "lines1": {
+    "lines": 1
+  },
+  "lines100": {
+    "lines": 100
+  },
+  "widthOtherLanguage": {
+    "width": "mp150ú¿¡üßä"
+  },
+  "widthSpecialCharacter": {
+    "width": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "heightOtherLanguage": {
+    "height": "mp150ú¿¡üßä"
+  },
+  "heightSpecialCharacter": {
+    "height": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "linesOtherLanguage": {
+    "lines": "mp150ú¿¡üßä"
+  },
+  "linesSpecialCharacter": {
+    "lines": "!@#$%^*()_+-=~[];:.,?{}"
+  }
+}

--- a/cypress/fixtures/commonComponents/profile.json
+++ b/cypress/fixtures/commonComponents/profile.json
@@ -1,0 +1,58 @@
+{ 
+  "email1": {
+    "email": "example@email.com"
+  },
+  "email2": {
+    "email": "johnsmith@sage.com"
+  },
+  "emailGravatar": {
+    "email": "andrew.tait@sage.com"
+  },
+  "emailOtherLanguage": {
+    "email": "mp150ú¿¡üßä"
+  },
+  "emailSpecialCharacter": {
+    "email": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  },
+  "initialsOW": {
+    "initials": "OW"
+  },
+  "initialsTJH": {
+    "initials": "TJH"
+  },
+  "nameOscarWilde": {
+    "name": "Oscar Wilde",
+    "initials": ""
+  },
+  "nameThomasJeffreyHanks": {
+    "name": "Thomas Jeffrey Hanks",
+    "initials": ""
+  },
+  "sizeXS": {
+    "size": "XS"
+  },
+  "sizeS": {
+    "size": "S"
+  },
+  "sizeM": {
+    "size": "M"
+  },
+  "sizeML": {
+    "size": "ML"
+  },
+  "sizeL": {
+    "size": "L"
+  },
+  "sizeXL": {
+    "size": "XL"
+  },
+  "sizeXXL": {
+    "size": "XXL"
+  },
+  "nameOtherLanguage": {
+    "name": "mp150ú¿¡üßä"
+  },
+  "nameSpecialCharacter": {
+    "name": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  }
+}

--- a/cypress/fixtures/commonComponents/row.json
+++ b/cypress/fixtures/commonComponents/row.json
@@ -1,0 +1,83 @@
+{ 
+  "columnDivide": {
+    "columnDivide": true
+  },
+  "columnDivideFalse": {
+    "columnDivide": false
+  },
+  "gutterExtraSmall": {
+    "gutter": "extra-small"
+  },
+  "gutterSizeSmall": {
+    "gutter": "small"
+  },
+  "gutterSizeMediumSmall": {
+    "gutter": "medium-small"
+  },
+  "gutterSizeMedium": {
+    "gutter": "medium"
+  },
+  "gutterSizeMediumLarge": {
+    "gutter": "medium-large"
+  },
+  "gutterSizeLarge": {
+    "gutter": "large"
+  },
+  "gutterSizeExtraLarge": {
+    "gutter": "extra-large"
+  },
+  "columnAlignLeft": {
+    "columnAlign": "left"
+  },
+  "columnAlignRight": {
+    "columnAlign": "right"
+  },
+  "columnOffset-100": {
+    "columnOffset": -100
+  },
+  "columnOffset-1": {
+    "columnOffset": -1
+  },
+  "columnOffset0": {
+    "columnOffset": 0
+  },
+  "columnOffset1": {
+    "columnOffset": 1
+  },
+  "columnOffset100": {
+    "columnOffset": 100
+  },
+  "columnOffsetOtherLanguage": {
+    "columnOffset": "mp150ú¿¡üßä"
+  },
+  "columnOffsetSpecialCharacter": {
+    "columnOffset": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "columnSpan-100": {
+    "columnSpan": -100
+  },
+  "columnSpan-1": {
+    "columnSpan": -1
+  },
+  "columnSpan0": {
+    "columnSpan": 0
+  },
+  "columnSpan1": {
+    "columnSpan": 1
+  },
+  "columnSpan100": {
+    "columnSpan": 100
+  },
+  "columnSpanOtherLanguage": {
+    "columnSpan": "mp150ú¿¡üßä"
+  },
+  "columnSpanSpecialCharacter": {
+    "columnSpan": "!@#$%^*()_+-=~[];:.,?{}"
+  },
+  "childrenOtherLanguage": {
+    "children": "mp150ú¿¡üßä"
+  },
+  "childrenSpecialCharacter": {
+    "children": "!@#$%^*()_+-=~[];:.,?{}"
+  }
+}

--- a/cypress/locators/preview/index.js
+++ b/cypress/locators/preview/index.js
@@ -1,4 +1,4 @@
 import { PREVIEW } from './locators';
 
 // component preview locators
-export const preview = () => cy.iFrame(PREVIEW);
+export const preview = () => cy.get(PREVIEW);

--- a/cypress/locators/profile/index.js
+++ b/cypress/locators/profile/index.js
@@ -3,8 +3,8 @@ import {
 } from './locators';
 
 // component preview locators
-export const emailPreview = () => cy.iFrame(EMAIL);
-export const avatarPreview = () => cy.iFrame(AVATAR);
-export const initialsPreview = () => cy.iFrame(INITIALS);
-export const profile = () => cy.iFrame(PROFILE);
-export const namePreview = () => cy.iFrame(NAME);
+export const emailPreview = () => cy.get(EMAIL);
+export const avatarPreview = () => cy.get(AVATAR);
+export const initialsPreview = () => cy.get(INITIALS);
+export const profile = () => cy.get(PROFILE);
+export const namePreview = () => cy.get(NAME);

--- a/cypress/locators/row/index.js
+++ b/cypress/locators/row/index.js
@@ -1,5 +1,5 @@
 import { ROW, COLUMN } from './locators';
 
 // component preview locators
-export const row = () => cy.iFrame(ROW);
+export const row = () => cy.get(ROW);
 export const column = () => row().find(COLUMN);

--- a/cypress/support/step-definitions/preview-steps.js
+++ b/cypress/support/step-definitions/preview-steps.js
@@ -1,5 +1,5 @@
 import { preview } from '../../locators/preview';
-import { STORY_ROOT } from '../../locators/locators';
+import { storyRootNoIframe } from '../../locators';
 
 Then('Preview component is loading', () => {
   preview().should('be.visible');
@@ -10,7 +10,7 @@ Then('Preview component is not loading', () => {
 });
 
 Then('Preview children is set to {word}', (text) => {
-  cy.iFrame(STORY_ROOT).should('have.text', text);
+  storyRootNoIframe().should('have.text', text);
 });
 
 Then('Preview {word} is set to {string}', (parameter, text) => {
@@ -19,7 +19,7 @@ Then('Preview {word} is set to {string}', (parameter, text) => {
 
 Then('Preview {word} is not set to {word}', (parameter, text) => {
   if (parameter === 'lines') {
-    cy.iFrame(STORY_ROOT).children().should('have.length', 0);
+    storyRootNoIframe().children().should('have.length', 0);
     preview().should('not.exist');
   // eslint-disable-next-line no-restricted-globals
   } else if (isNaN(parameter)) {
@@ -27,12 +27,12 @@ Then('Preview {word} is not set to {word}', (parameter, text) => {
   }
 });
 
-Then('Preview has {string} lines', (value) => {
-  if (value === '0') {
-    cy.iFrame(STORY_ROOT).children().should('have.length', `${value}`);
+Then('Preview has {int} lines', (value) => {
+  if (value === 0) {
+    storyRootNoIframe().children().should('have.length', `${value}`);
     preview().should('not.exist');
   } else {
-    cy.iFrame(STORY_ROOT).children().should('have.length', `${value}`);
+    storyRootNoIframe().children().should('have.length', `${value}`);
     preview().should('be.visible');
   }
 });

--- a/cypress/support/step-definitions/profile-steps.js
+++ b/cypress/support/step-definitions/profile-steps.js
@@ -22,14 +22,13 @@ Then('name is set to {word}', (name) => {
   namePreview().should('have.text', name);
 });
 
-Then('Profile size has {string}', (property) => {
+Then('Profile size has {int}', (property) => {
   initialsPreview().should('have.css', 'height', `${property}px`);
 });
 
 Then('initials is set to {word}', (initials) => {
-  // eslint-disable-next-line no-param-reassign
   initials = initials.substring(0, 3);
-  cy.fixture(`${INITIALS_FOLDER}${initials}`, 'base64').then(($initials) => {
+  cy.fixture(`${INITIALS_FOLDER}${initials}.jpg`, 'base64').then(($initials) => {
     initialsPreview().children()
       .should('have.attr', 'src', `${DATA_IMAGE_PREFIX}${$initials}`);
   });


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Apply new `url` approach in tests for:
`row` (timing: was `02:03` -> `00:33`),
`preview` (timing: was  `01:20` -> `00:26`),
`profile` (timing  `01:25` -> `00:21`).

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are passing all parameters via `knobs`.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent