### PR TITLE
feat(definition list): create definition list component - FE-2885

### DIFF
--- a/cypress/features/regression/test/tile.feature
+++ b/cypress/features/regression/test/tile.feature
@@ -3,7 +3,7 @@ Feature: Tile component
 
   @positive
   Scenario Outline: I select Tile component as to <as>
-    When I open default "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
+    When I open Test test_basic "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
     Then Tile component as property is set to "<color>"
     Examples:
       | as          | color              | nameOfObject  |
@@ -12,7 +12,7 @@ Feature: Tile component
 
   @positive
   Scenario Outline: I select Tile component orientation to <orientation>
-    When I open default "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
+    When I open Test test_basic "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
     Then Tile component orientation property is set to "<orientation>"
     Examples:
       | orientation | nameOfObject          |
@@ -21,7 +21,7 @@ Feature: Tile component
 
   @positive
   Scenario Outline: I select Tile component padding to <padding>
-    When I open default "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
+    When I open Test test_basic "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
     Then Tile component padding property is set to "<px>"
     Examples:
       | padding | px | nameOfObject |
@@ -33,7 +33,7 @@ Feature: Tile component
 
   @positive
   Scenario Outline: Change Tile pixelWidth to <pixelWidth>
-    When I open default "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
+    When I open Test test_basic "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
     Then Tile pixel width is set to <pixelWidth>
     Examples:
       | pixelWidth | nameOfObject   |
@@ -43,7 +43,7 @@ Feature: Tile component
 
   @positive
   Scenario Outline: Change Tile width to <width>
-    When I open default "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
+    When I open Test test_basic "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
     Then Tile width is set to <width>
     Examples:
       | width | nameOfObject |

--- a/src/components/definition-list/dd.component.js
+++ b/src/components/definition-list/dd.component.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import propTypes from '@styled-system/prop-types';
+import PropTypes from 'prop-types';
+import { StyledDd } from './definition-list.style';
+
+const Dd = ({
+  mb = 2,
+  children
+}) => {
+  return (
+    <StyledDd
+      mb={ mb }
+    >
+      {children}
+    </StyledDd>
+  );
+};
+
+Dd.propTypes = {
+  ...propTypes.space,
+  /** Prop to render string or node in the `<Dd></Dd>` tags */
+  children: PropTypes.node.isRequired
+};
+
+export default Dd;

--- a/src/components/definition-list/dd.d.ts
+++ b/src/components/definition-list/dd.d.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export interface DdProps {
+    /** Prop for what will render in the `<Dd></Dd>` tags */
+    children: React.ReactNode;
+}
+
+declare const DdComponent: React.ComponentType<DdProps>;
+export default DdComponent;

--- a/src/components/definition-list/definition-list.spec.js
+++ b/src/components/definition-list/definition-list.spec.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { ThemeProvider } from 'styled-components';
+import mintTheme from '../../style/themes/mint';
+import { assertStyleMatch } from '../../__spec_helper__/test-utils';
+import { StyledDtDiv, StyledDdDiv } from './definition-list.style';
+import Dl from './dl.component';
+import Dt from './dt.component';
+import Dd from './dd.component';
+
+describe('DefinitionList', () => {
+  let wrapper;
+
+  const renderWrapper = (id, props, render = mount) => {
+    const definitionObject = {
+      Dl: (
+        <Dl { ...props }>
+          <Dt>Foo</Dt>
+          <Dd>Barr</Dd>
+        </Dl>
+      ),
+      Dt: <Dt { ...props }>Foo</Dt>,
+      Dd: <Dd { ...props }>Barr</Dd>
+    };
+
+    return (
+      render(
+        <ThemeProvider theme={ mintTheme }>
+          {definitionObject[id]}
+        </ThemeProvider>
+      )
+    );
+  };
+
+  describe('styles', () => {
+    it('matches the expected default styles of Dl', () => {
+      wrapper = renderWrapper('Dl', { });
+      assertStyleMatch({
+        display: 'inline-flex',
+        height: 'auto',
+        width: '100%',
+        backgroundColor: 'transparent',
+        overflow: 'hidden'
+      }, wrapper);
+    });
+
+    it('matches the expected default styles of Dt', () => {
+      wrapper = renderWrapper('Dt', { });
+      assertStyleMatch({
+        fontSize: '14px',
+        fontWeight: '700',
+        paddingRight: '24px',
+        color: 'rgba(0,0,0,0.9)',
+        marginBottom: '16px'
+      }, wrapper);
+    });
+
+    it('matches the expected default styles of Dd', () => {
+      wrapper = renderWrapper('Dd', { });
+      assertStyleMatch({
+        fontSize: '14px',
+        fontWeight: '700',
+        color: 'rgba(0,0,0,0.65)',
+        marginBottom: '16px',
+        marginLeft: '0px'
+      }, wrapper);
+    });
+
+    it('matches the custom styles applied to Dt', () => {
+      wrapper = renderWrapper('Dt', { mb: 1, pr: 2 });
+      assertStyleMatch({
+        fontSize: '14px',
+        fontWeight: '700',
+        paddingRight: '16px',
+        color: 'rgba(0,0,0,0.9)',
+        marginBottom: '8px'
+      }, wrapper);
+    });
+
+    it('matches the custom styles applied to Dd', () => {
+      wrapper = renderWrapper('Dd', { mb: 1 });
+      assertStyleMatch({
+        fontSize: '14px',
+        fontWeight: '700',
+        color: 'rgba(0,0,0,0.65)',
+        marginBottom: '8px',
+        marginLeft: '0px'
+      }, wrapper);
+    });
+
+    it.each(['left', 'center', 'right'])('matches the custom text alignments passed to Dl and Dd', (align) => {
+      assertStyleMatch({
+        textAlign: `${align}`
+      }, renderWrapper('Dl', { dtTextAlign: align, ddTextAlign: align }).find(StyledDtDiv, StyledDdDiv));
+    });
+  });
+
+  describe('Children of Dl', () => {
+    beforeEach(() => {
+      wrapper = renderWrapper('Dl', { });
+    });
+    it('should contain dt', () => {
+      expect(wrapper.find(StyledDtDiv).props().children.length).toEqual(1);
+    });
+
+    it('should contain dd', () => {
+      expect(wrapper.find(StyledDdDiv).props().children.length).toEqual(1);
+    });
+  });
+});

--- a/src/components/definition-list/definition-list.stories.js
+++ b/src/components/definition-list/definition-list.stories.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import Dl from './dl.component';
+import Dt from './dt.component';
+import Dd from './dd.component';
+
+export default {
+  title: 'Test/Definition List',
+  decorators: [withKnobs],
+  parameters: {
+    info: {
+      disable: true
+    },
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disabled: true
+    }
+  }
+};
+
+export const Basic = () => {
+  return (
+    <Dl
+      data-component='definition-list'
+    >
+      <Dt>
+        Name
+      </Dt>
+      <Dd>
+        Daniel Dipper
+      </Dd>
+
+      <Dt>
+        Phone
+      </Dt>
+      <Dd>
+        Yes, I have a phone
+      </Dd>
+    </Dl>
+  );
+};
+
+Basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
+};

--- a/src/components/definition-list/definition-list.style.js
+++ b/src/components/definition-list/definition-list.style.js
@@ -1,0 +1,70 @@
+import styled, { css } from 'styled-components';
+import { space } from 'styled-system';
+import { baseTheme } from '../../style/themes';
+import StyledButton from '../button/button.style';
+import LinkStyle from '../link/link.style';
+
+export const StyledDl = styled.dl`
+  ${space}
+  display: inline-flex;
+  height: auto;
+  width: 100%;
+  background-color: transparent;
+  overflow: hidden;
+`;
+
+export const StyledDtDiv = styled.div`
+  ${space}
+  ${({ w, dtTextAlign }) => css`
+    text-align: ${dtTextAlign};
+    width: ${w}%;
+    white-space: nowrap;
+  `}
+`;
+
+export const StyledDdDiv = styled.div`
+  ${({ ddTextAlign }) => css`
+    text-align: ${ddTextAlign};
+    width: auto;
+    white-space: nowrap;
+  `}
+`;
+
+export const StyledDt = styled.dt`
+  ${space}
+  ${({ theme }) => css`
+    font-size: 14px
+    font-weight: 700;
+    color: ${theme.definitionList.dtTextDark};
+  `}
+`;
+
+StyledDt.defaultProps = {
+  theme: baseTheme
+};
+
+export const StyledDd = styled.dd`
+  ${space}
+  ${({ theme }) => css`
+    font-size: 14px
+    font-weight: 700;
+    color: ${theme.definitionList.ddText};
+    margin-left: 0px;
+
+    ${StyledButton} {
+      padding: 0;
+      border: none;
+    }
+
+    ${LinkStyle} {
+      a, button {
+        font-weight: 700px;
+        text-decoration: none;
+      }
+    }
+  `}
+`;
+
+StyledDt.defaultProps = {
+  theme: baseTheme
+};

--- a/src/components/definition-list/dl.component.js
+++ b/src/components/definition-list/dl.component.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import propTypes from '@styled-system/prop-types';
+import PropTypes from 'prop-types';
+import { StyledDl, StyledDtDiv, StyledDdDiv } from './definition-list.style';
+import Dt from './dt.component';
+import Dd from './dd.component';
+
+const Dl = ({
+  children,
+  w = 50,
+  dtTextAlign = 'right',
+  ddTextAlign = 'left'
+}) => {
+  const dtLabels = React.Children.toArray(children).filter(child => child.type === Dt);
+  const ddContent = React.Children.toArray(children).filter(child => child.type === Dd);
+
+  return (
+    <StyledDl data-component='dl'>
+
+      <StyledDtDiv w={ w } dtTextAlign={ dtTextAlign }>
+        {dtLabels}
+      </StyledDtDiv>
+
+      <StyledDdDiv w={ w } ddTextAlign={ ddTextAlign }>
+        {ddContent}
+      </StyledDdDiv>
+
+    </StyledDl>
+  );
+};
+
+Dl.propTypes = {
+  ...propTypes.space,
+  /** This string will specify the text align styling of the `<dt></dt>`. */
+  dtTextAlign: PropTypes.oneOf(['left', 'center', 'right']),
+  /** This string will specify the text align styling of the `<dd></dd>`. */
+  ddTextAlign: PropTypes.oneOf(['left', 'center', 'right']),
+  /** This value will specify the width of the `StyledDtDiv` as a percentage. The remaining space will be taken up
+      by the `StyledDdDiv`.
+   */
+  w: PropTypes.number,
+  /**
+   * @private
+   * @ignore
+   */
+  children: PropTypes.node.isRequired
+};
+export default Dl;

--- a/src/components/definition-list/dl.d.ts
+++ b/src/components/definition-list/dl.d.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+export interface DlProps {
+    /** This string will specify the text align styling of the `<dt></dt>`. */
+    dtTextAlign?: 'left' | 'center' | 'right';
+
+    /** This string will specify the text align styling of the `<dd></dd>`. */
+    ddTextAlign?: 'left' | 'center' | 'right';
+
+    /** This value will specify the width of the `StyledDtDiv` as a percentage. */
+    w?: number;
+
+    /** prop to render children. */
+    children: React.ReactNode;
+}
+
+declare const DlComponent: React.ComponentType<DlProps>;
+export default DlComponent;

--- a/src/components/definition-list/dt.component.js
+++ b/src/components/definition-list/dt.component.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import propTypes from '@styled-system/prop-types';
+import PropTypes from 'prop-types';
+import { StyledDt } from './definition-list.style';
+
+const Dt = ({
+  pr = 3,
+  children,
+  mb = 2
+}) => {
+  return (
+    <StyledDt
+      data-element='dt'
+      mb={ mb }
+      pr={ pr }
+    >
+      {children}
+    </StyledDt>
+  );
+};
+
+Dt.propTypes = {
+  ...propTypes.space,
+  /** prop to render string for `<Dt />` */
+  children: PropTypes.string.isRequired
+};
+
+export default Dt;

--- a/src/components/definition-list/dt.d.ts
+++ b/src/components/definition-list/dt.d.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export interface DtProps {
+    /** prop for dt text */
+    children: string;
+}
+
+declare const DtComponent: React.ComponentType<DtProps>;
+export default DtComponent;

--- a/src/components/definition-list/index.d.ts
+++ b/src/components/definition-list/index.d.ts
@@ -1,0 +1,3 @@
+export { default as Dl } from './dl';
+export { default as Dd } from './dd';
+export { default as Dt } from './dt';

--- a/src/components/definition-list/index.js
+++ b/src/components/definition-list/index.js
@@ -1,0 +1,3 @@
+export { default as Dt } from './dt.component';
+export { default as Dd } from './dd.component';
+export { default as Dl } from './dl.component';

--- a/src/components/tile/tile.stories.js
+++ b/src/components/tile/tile.stories.js
@@ -1,81 +1,76 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { text, number, select } from '@storybook/addon-knobs';
 import OptionsHelper from '../../utils/helpers/options-helper';
 import Tile from '.';
 import Content from '../content';
-import { info, notes } from './documentation';
-import getDocGenInfo from '../../utils/helpers/docgen-info';
-import { dlsThemeSelector } from '../../../.storybook/theme-selectors';
 
-Tile.__docgenInfo = getDocGenInfo(
-  require('./docgenInfo.json'),
-  /tile\.component(?!spec)/
-);
-
-function makeStory(name, themeSelector) {
-  const component = () => {
-    const percentageOpts = {
-      range: true,
-      min: 0,
-      max: 100,
-      step: 1
-    };
-
-    const tileProps = {
-      as: select('as', OptionsHelper.tileThemes, Tile.defaultProps.as, 'Default'),
-      orientation: select('orientation', OptionsHelper.orientation, Tile.defaultProps.orientation, 'Default'),
-      padding: select('padding', OptionsHelper.sizesTile, Tile.defaultProps.padding, 'Default'),
-      pixelWidth: number('pixelWidth', 0, { ...percentageOpts, max: 2000 }, 'Default'),
-      width: number('width', 0, percentageOpts, 'Default')
-    };
-
-    const contentOneProps = {
-      key: 'one',
-      children: text('contentOneChildren', 'Test Body One', 'TileContent One'),
-      title: text('contentOneTitle', 'Test Title One', 'TileContent One'),
-      width: number('contentOneWidth', 0, percentageOpts, 'TileContent One')
-    };
-
-    const contentTwoProps = {
-      key: 'two',
-      children: text('contentTwoChildren', 'Test Body Two', 'TileContent Two'),
-      title: text('contentTwoTitle', 'Test Title Two', 'TileContent Two'),
-      width: number('contentTwoWidth', 0, percentageOpts, 'TileContent Two')
-    };
-
-    const contentThreeProps = {
-      key: 'three',
-      children: text('contentThreeChildren', 'Test Body Three', 'TileContent Three'),
-      title: text('contentThreeTitle', 'Test Title Three', 'TileContent Three'),
-      width: number('contentThreeWidth', 0, percentageOpts, 'TileContent Three')
-    };
-
-    const tileContent = [
-      contentOneProps.children ? <Content { ...contentOneProps } /> : undefined,
-      contentTwoProps.children ? <Content { ...contentTwoProps } /> : undefined,
-      contentThreeProps.children ? <Content { ...contentThreeProps } /> : undefined
-    ];
-
-    return (
-      <Tile { ...tileProps }>{tileContent}</Tile>
-    );
-  };
-
-  const metadata = {
-    themeSelector
-  };
-
-  return [name, component, metadata];
-}
-
-storiesOf('Tile', module)
-  .addParameters({
+export default {
+  title: 'Design System/Tile/Test',
+  component: Tile,
+  decorators: [],
+  parameters: {
     info: {
-      propTablesExclude: [Content],
-      text: info
+      disable: true
     },
     knobs: { escapeHTML: false },
-    notes: { markdown: notes }
-  })
-  .add(...makeStory('default', dlsThemeSelector));
+    chromatic: {
+      disabled: true
+    }
+  }
+};
+
+export const Basic = () => {
+  const percentageOpts = {
+    range: true,
+    min: 0,
+    max: 100,
+    step: 1
+  };
+
+  const tileProps = {
+    as: select('as', OptionsHelper.tileThemes, Tile.defaultProps.as, 'Default'),
+    orientation: select('orientation', OptionsHelper.orientation, Tile.defaultProps.orientation, 'Default'),
+    padding: select('padding', OptionsHelper.sizesTile, Tile.defaultProps.padding, 'Default'),
+    pixelWidth: number('pixelWidth', 0, { ...percentageOpts, max: 2000 }, 'Default'),
+    width: number('width', 0, percentageOpts, 'Default')
+  };
+
+  const contentOneProps = {
+    key: 'one',
+    children: text('contentOneChildren', 'Test Body One', 'TileContent One'),
+    title: text('contentOneTitle', 'Test Title One', 'TileContent One'),
+    width: number('contentOneWidth', 0, percentageOpts, 'TileContent One')
+  };
+
+  const contentTwoProps = {
+    key: 'two',
+    children: text('contentTwoChildren', 'Test Body Two', 'TileContent Two'),
+    title: text('contentTwoTitle', 'Test Title Two', 'TileContent Two'),
+    width: number('contentTwoWidth', 0, percentageOpts, 'TileContent Two')
+  };
+
+  const contentThreeProps = {
+    key: 'three',
+    children: text('contentThreeChildren', 'Test Body Three', 'TileContent Three'),
+    title: text('contentThreeTitle', 'Test Title Three', 'TileContent Three'),
+    width: number('contentThreeWidth', 0, percentageOpts, 'TileContent Three')
+  };
+
+  const tileContent = [
+    contentOneProps.children ? <Content { ...contentOneProps } /> : undefined,
+    contentTwoProps.children ? <Content { ...contentTwoProps } /> : undefined,
+    contentThreeProps.children ? <Content { ...contentThreeProps } /> : undefined
+  ];
+
+  return (
+    <Tile { ...tileProps }>{tileContent}</Tile>
+  );
+};
+
+Basic.story = {
+  parameters: {
+    chromatic: {
+      disable: false
+    }
+  }
+};

--- a/src/components/tile/tile.stories.mdx
+++ b/src/components/tile/tile.stories.mdx
@@ -1,0 +1,280 @@
+import { Meta, Story, Preview, Props} from '@storybook/addon-docs/blocks';
+import OptionsHelper from '../../utils/helpers/options-helper';
+import Tile from '.';
+import Content from '../content';
+import { info, notes } from './documentation';
+import getDocGenInfo from '../../utils/helpers/docgen-info';
+import { dlsThemeSelector } from '../../../.storybook/theme-selectors';
+import { action } from '@storybook/addon-actions';
+import Dl from '../definition-list/dl.component';
+import Dt from '../definition-list/dt.component';
+import Dd from '../definition-list/dd.component';
+import Link from '../link/link.component';
+import Button from '../button/button.component';
+import Heading from '../heading/heading';
+
+<Meta title="Design System/Tile" parameters={{ info: { disable: true }}} />
+
+# Tile
+Tiles contain static content for visual scanning only, and don't contain controls.
+
+## Quick Start
+```jsx
+import Tile from 'carbon-react/lib/components/tile';
+```
+## Tile - Default
+By default, the Tile component will have a horizontal layout.
+
+<Preview>
+    <Story name ='Default'>
+        <Tile>
+        <Content title="Test Title One">
+            Test Body One
+        </Content>
+        <Content title="Test Title Two">
+            Test Body Two
+        </Content>
+        <Content title="Test Title Three">
+            Test Body Three
+        </Content>
+        </Tile>
+    </Story>
+</Preview>
+
+## Tile - Vertical
+The Tile component can be also have a vertical layout. 
+
+<Preview>
+    <Story name ='Vertical'>
+        <Tile  orientation='Vertical'>
+        <Content title="Test Title One">
+            Test Body One
+        </Content>
+        <Content title="Test Title Two">
+            Test Body Two
+        </Content>
+        <Content title="Test Title Three">
+            Test Body Three
+        </Content>
+        </Tile>
+    </Story>
+</Preview>
+
+## Tile with Custom Widths
+The Tile component can also have custom widths. Any child wrapped by a Tile component can be passed an optional `width` prop - this is a percent value, dictating the width of the child element within the tile. 
+Please note that it will not have any effect if the Tile orientation is set to `vertical`.
+
+<Preview>
+    <Story name ='Custom Widths'>
+        <Tile
+        as="tile"
+        orientation="horizontal"
+        padding="M"
+        pixelWidth={0}
+        width={75}
+        >
+        <Content
+            align="left"
+            as="primary"
+            bodyFullWidth={false}
+            inline={false}
+            title="Test Title One"
+            width={40}
+        >
+            Test Body One
+        </Content>
+        <Content
+            align="left"
+            as="primary"
+            bodyFullWidth={false}
+            inline={false}
+            title="Test Title Two"
+            width={80}
+        >
+            Test Body Two
+        </Content>
+        <Content
+            align="left"
+            as="primary"
+            bodyFullWidth={false}
+            inline={false}
+            title="Test Title Three"
+            width={120}
+        >
+            Test Body Three
+        </Content>
+        </Tile>
+    </Story>
+</Preview>
+
+## Tile with Inline Styling
+The Tile component can also have inline styling applied to the content.
+
+<Preview>
+    <Story name ='with Inline'>
+        <Tile
+        as="tile"
+        orientation="horizontal"
+        padding="M"
+        pixelWidth={0}
+        width={0}
+        >
+        <Content
+            align="left"
+            as="primary"
+            bodyFullWidth={false}
+            inline={true}
+            title="Test Title One"
+            width={80}
+        >
+            Test Body One
+        </Content>
+        <Content
+            align="left"
+            as="primary"
+            bodyFullWidth={false}
+            inline={true}
+            title="Test Title Two"
+            width={80}
+        >
+            Test Body Two
+        </Content>
+        <Content
+            align="left"
+            as="primary"
+            bodyFullWidth={false}
+            inline={true}
+            title="Test Title Three"
+            width={80}
+        >
+            Test Body Three
+        </Content>
+        </Tile>
+    </Story>
+</Preview>
+
+## Props of Tile
+<Props of={ Tile } />
+
+# Tile with Definition List
+The Definition List component should only be used inside of the Tile component. The purpose of the Definition List component is to mimic
+the same tags used in HTML5 but instead they are React elements. 
+
+Please note that Dl, Dd and Dt use our common spacing props, the following are all available for use and each of these can be a number (which is a multiple of the base spacing constant, 8px) or any valid CSS string. 
+### Margin props 
+m, mt, mr, mb, ml, mx, my
+
+### Padding props 
+p, pt, pr, pb, pl, px, py
+
+## Quick Start
+```jsx
+import Tile from 'carbon-react/lib/components/tile';
+import {Dl, Dt, Dd} from 'carbon-react/lib/components/definition-list';
+```
+<Preview>
+  <Story name ='Tile with Definition List - default'>
+    <Tile width={95}>
+      <Dl>
+        <Dt>Drink</Dt>
+        <Dd>Coffee</Dd>
+        <Dt>Brew Method</Dt>
+        <Dd>Stove Top Moka Pot</Dd>
+        <Dt>Brand of Coffee</Dt>
+        <Dd>Magic Coffee Beans</Dd>
+        <Dt>Website</Dt>
+        <Dd><Link href='www.sage.com'>Magic Coffee Beans' Website</Link></Dd>
+        <Dt>Email</Dt>
+        <Dd><Link href='magic@coffeebeans.com'>magic@coffeebeans.com</Link></Dd>
+        <Dt>Main and Registered Address</Dt>
+        <Dd mb='4px'>Magic Coffee Beans,</Dd>
+        <Dd mb='4px'>In The Middle of Our Street,</Dd>
+        <Dd mb='4px'>Madness,</Dd>
+        <Dd mb='4px'>CO4 3VE</Dd>
+        <Dd>
+          <Button 
+            buttonType='tertiary' 
+            iconType="link" 
+            iconPosition="after"
+            href='https://goo.gl/maps/GMReLoBpbn9mdZVZ7'>
+            View in Google Maps
+          </Button> 
+        </Dd>
+      </Dl>
+    </Tile>
+  </Story>
+</Preview>
+
+## Tile with Definition List and Custom `StyledDtDiv` Width
+
+Providing a number value to the `w` prop, sets the width of the `<Dt />` element as a percentage. The remaining percentage is then assigned to `<Dd />` to occupy the available space.
+
+<Preview>
+  <Story name ='Tile with Definition List with custom width'>
+    <Tile width={95}>
+      <Dl w={40}>
+        <Dt>Drink</Dt>
+        <Dd>Coffee</Dd>
+        <Dt>Brew Method</Dt>
+        <Dd>Stove Top Moka Pot</Dd>
+        <Dt>Brand of Coffee</Dt>
+        <Dd>Magic Coffee Beans</Dd>
+        <Dt>Website</Dt>
+        <Dd><Link href='www.sage.com'>Magic Coffee Beans' Website</Link></Dd>
+        <Dt>Email</Dt>
+        <Dd><Link href='magic@coffeebeans.com'>magic@coffeebeans.com</Link></Dd>
+        <Dt>Main and Registered Address</Dt>
+        <Dd mb='4px'>Magic Coffee Beans,</Dd>
+        <Dd mb='4px'>In The Middle of Our Street,</Dd>
+        <Dd mb='4px'>Madness,</Dd>
+        <Dd mb='4px'>CO4 3VE</Dd>
+        <Dd>
+          <Button 
+            buttonType='tertiary' 
+            iconType="link" 
+            iconPosition="after"
+            href='https://goo.gl/maps/GMReLoBpbn9mdZVZ7'>
+            View in Google Maps
+          </Button> 
+        </Dd>
+      </Dl>
+    </Tile>
+  </Story>
+</Preview>
+
+## Tile with Definition List with Custom Text Alignments
+
+In this example `dtTextAlign` has been provided the string 'left' and `ddTextAlign` has been provided the string 'right'.
+
+<Preview>
+  <Story name ='Tile with Definition with List Custom Text Alignments'>
+    <Tile width={40}>
+      <Dl w={40} dtTextAlign='left' ddTextAlign='right'>
+        <Dt>Coffee Subscription</Dt>
+        <Dd>£7.00 a month</Dd>
+        <Dt>Grind Size</Dt>
+        <Dd>Espresso</Dd>
+        <Dt>Quantity</Dt>
+        <Dd>3kg</Dd>
+        <Dd> 
+          <Button 
+            buttonType='tertiary' 
+            href='https://goo.gl/maps/GMReLoBpbn9mdZVZ7'>
+            Have a promo code?
+          </Button> 
+        </Dd>
+      </Dl>
+    </Tile>
+  </Story>
+</Preview>
+
+## Props of Definition List:
+
+### Props of Dl:
+<Props of={ Dl } />
+
+### Props of Dd:
+<Props of={ Dd } />
+
+### Props of Dt:
+<Props of={ Dt } />

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -179,6 +179,12 @@ export default (palette) => {
       textboxText: blackWithOpacity(0.74)
     },
 
+    definitionList: {
+      dtTextDark: blackWithOpacity(0.9),
+      dtTextLight: blackWithOpacity(0.65),
+      ddText: blackWithOpacity(0.65)
+    },
+
     disabled: {
       border: palette.slateTint(80),
       button: palette.slateTint(90),


### PR DESCRIPTION
### Proposed behaviour

To create a new component called "Definition List" that will be used inside of the existing "Tile" component.

<img width="1016" alt="Screenshot 2020-09-04 at 12 43 17" src="https://user-images.githubusercontent.com/56251247/92235852-49e8ca80-eeac-11ea-85f4-e7235cb4e887.png">

<img width="1013" alt="Screenshot 2020-09-04 at 12 43 24" src="https://user-images.githubusercontent.com/56251247/92235860-4ce3bb00-eeac-11ea-8f22-5f1db7e2fa97.png">

<img width="459" alt="Screenshot 2020-09-04 at 12 43 32" src="https://user-images.githubusercontent.com/56251247/92235871-4fdeab80-eeac-11ea-8753-a91386984cbe.png">

### Current behaviour

This component does not currently exist. 

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
The .stories file has been updated to the Component Story Format (CSF) and a new MDX example documentation has been created for Tile too.

### Testing instructions
- Pull down the branch `FE-2885-right_aligned_content_component`
- `npm start` to start Storybook
- Navigate to Design System -> Tile
- Navigate to the section titled `Tile with Definition List`
- Check that the examples match that specified on design spec
