### PR TITLE
test(i18n/inline-inputs): apply new url approach

### DIFF
--- a/cypress/features/regression/designSystem/inlineInputs.feature
+++ b/cypress/features/regression/designSystem/inlineInputs.feature
@@ -1,29 +1,28 @@
 Feature: InlineInputs component
-  I want to change InlineInputs component properties
-
-  Background: Open InlineInputs component default page
-    Given I open design systems default_story "Inline-Inputs" component page
+  I want to test InlineInputs component properties
 
   @positive
   Scenario Outline: Change InlineInputs label to <label>
-    When I set label to <label> word
+    When I open Test default_story "Inline-Inputs" component in noIFrame with "inlineInputs" json from "designSystem" using "<nameOfObject>" object name
     Then label is set to <label>
+    Examples:
+      | label                        | nameOfObject          |
+      | mp150ú¿¡üßä                  | labelOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | labelSpecialCharacter |
+
+  @positive
+  Scenario Outline: Change first inline input to <label>
+    Given I open "Design System Inline Inputs" component page "default-story" in no iframe
+    When I set 1st inline input to <label>
+    Then 1st inline input on preview is <label>
     Examples:
       | label                        |
       | mp150ú¿¡üßä                  |
       | !@#$%^*()_+-=~[];:.,?{}&"'<> |
 
   @positive
-  Scenario Outline: Change first inline input to <label>
-    When I set 1st inline input to <label>
-    Then 1st inline input on preview is <label>
-    Examples:
-      | label                   |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
-
-  @positive
   Scenario Outline: Change second inline input to <input>
+    Given I open "Design System Inline Inputs" component page "default-story" in no iframe
     When I set 2nd inline input to <input>
     Then 2nd inline input on preview is <input>
     Examples:
@@ -33,6 +32,7 @@ Feature: InlineInputs component
 
   @positive
   Scenario Outline: Change third inline input element select to <select>
+    Given I open "Design System Inline Inputs" component page "default-story" in no iframe
     When I set 3rd inline input to <select>
     Then 3rd inline input on preview is <select>
     Examples:

--- a/cypress/features/regression/i18nComponent.feature
+++ b/cypress/features/regression/i18nComponent.feature
@@ -1,38 +1,33 @@
 Feature: I18n component
-  I want to change I18n component properties
-
-  Background: Open I18n component page
-    Given I open "I18nComponent" component page
+  I want to test I18n component properties
 
   @positive
   Scenario: Disable markdown
-    When I uncheck markdown checkbox
+    When I open default "I18nComponent" component in noIFrame with "i18n" json from "commonComponents" using "markdownFalse" object name
     Then preview text is "# My __example__ translation."
 
   @positive
-  Scenario: Disable and enable markdown
-    When I uncheck markdown checkbox
-      And I check markdown checkbox
+  Scenario: Enable markdown
+    When I open default "I18nComponent" component in noIFrame with "i18n" json from "commonComponents" using "markdown" object name
     Then preview text is "# My example translation."
 
   @positive
   Scenario:  Disable inline
-    When I uncheck inline checkbox
+    When I open default "I18nComponent" component in noIFrame with "i18n" json from "commonComponents" using "inlineFalse" object name
     Then preview text is "My example translation." with "h1" tag and "my-example-translation" id
 
   @positive
   Scenario: Disable and enable inline
-    When I uncheck inline checkbox
-      And I check inline checkbox
+    When I open default "I18nComponent" component in noIFrame with "i18n" json from "commonComponents" using "inline" object name
     Then preview text is "# My example translation."
 
   @negative
   Scenario Outline: Set scope text that is missing
-    When I set scope to "<text>"
+    When I open default "I18nComponent" component in noIFrame with "i18n" json from "commonComponents" using "<nameOfObject>" object name
     # used single quotes to pass double quotes inside
     Then preview text is '[missing "en.<text>" translation]'
     Examples:
-      | text        |
-      | Sample text |
-      | 1234567890  |
+      | text        | nameOfObject    |
+      | Sample text | scopeSampleText |
+      | 1234567890  | scopeNumbers    |
 # no special characters required for this case

--- a/cypress/fixtures/commonComponents/i18n.json
+++ b/cypress/fixtures/commonComponents/i18n.json
@@ -1,0 +1,20 @@
+{ 
+  "markdownFalse": {
+    "markdown": false
+  },
+  "markdown": {
+    "markdown": true
+  },
+  "inlineFalse": {
+    "inline": false
+  },
+  "inline": {
+    "inline": true
+  },
+  "scopeSampleText": {
+    "scope": "Sample text"
+  },
+  "scopeNumbers": {
+    "scope": "1234567890"
+  }
+}

--- a/cypress/fixtures/designSystem/inlineInputs.json
+++ b/cypress/fixtures/designSystem/inlineInputs.json
@@ -1,0 +1,8 @@
+{ 
+  "labelOtherLanguage": {
+    "label": "mp150ú¿¡üßä"
+  },
+  "labelSpecialCharacter": {
+    "label": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  }
+}

--- a/cypress/locators/i18n/index.js
+++ b/cypress/locators/i18n/index.js
@@ -1,4 +1,4 @@
 import { I18N_PREVIEW } from './locators';
 
 // component preview locators
-export const i18nPreview = () => cy.iFrame(I18N_PREVIEW);
+export const i18nPreview = () => cy.get(I18N_PREVIEW);

--- a/cypress/locators/inline-inputs/index.js
+++ b/cypress/locators/inline-inputs/index.js
@@ -1,7 +1,6 @@
 import { INLINE_INPUT } from './locators';
 
 // component preview locators
-export const inlineInput = index => cy.iFrame(INLINE_INPUT)
+export const inlineInput = index => cy.get(INLINE_INPUT)
   .find(`div:nth-child(${index})`)
-  .find('div > div')
   .find('input');

--- a/cypress/locators/inline-inputs/locators.js
+++ b/cypress/locators/inline-inputs/locators.js
@@ -1,2 +1,2 @@
 // component preview locators
-export const INLINE_INPUT = 'div[data-component="row"]';
+export const INLINE_INPUT = '[data-component="row"]';

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -213,7 +213,7 @@ Then('label on preview is {word} in NoIFrame', (text) => {
 });
 
 Then('label is set to {word}', (text) => {
-  label().should('have.text', text);
+  getDataElementByValue('label').should('have.text', text);
 });
 
 When('I hover mouse onto help icon in IFrame', () => {

--- a/cypress/support/step-definitions/i18n-steps.js
+++ b/cypress/support/step-definitions/i18n-steps.js
@@ -1,12 +1,9 @@
 import { i18nPreview } from '../../locators/i18n';
-import { DEBUG_FLAG } from '..';
 
 Then('preview text is {string}', (text) => {
-  cy.wait(500, { log: DEBUG_FLAG }); // required because component not always refreshed on time
   i18nPreview().should('contain', text);
 });
 
 Then('preview text is {string} with {string} tag and {string} id', (text, tag, id) => {
-  cy.wait(500, { log: DEBUG_FLAG }); // required because component not always refreshed on time
   i18nPreview().children(`${tag}[id=${id}]`).should('have.text', text);
 });

--- a/cypress/support/step-definitions/inline-inputs-steps.js
+++ b/cypress/support/step-definitions/inline-inputs-steps.js
@@ -1,5 +1,4 @@
 import { inlineInput } from '../../locators/inline-inputs';
-import { pressTABKey } from '../helper';
 
 Then('{int}{word} inline input on preview is {word}', (number, word, text) => {
   inlineInput(number).then(($el) => {
@@ -11,5 +10,4 @@ When('I set {int}{word} inline input to {word}', (number, word, text) => {
   inlineInput(number).then(($el) => {
     $el[0].setAttribute('value', text);
   });
-  pressTABKey(1);
 });


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Apply new `url` approach in tests for:
`i18n` (timing: was `00:32` -> `00:08`),
`inline inputs` (timing: was  `00:49` -> `00:14`)

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are passing all parameters via `knobs`.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent