### PR TITLE
test(popover-container/search/toast): apply new url approach

### DIFF
--- a/cypress/features/regression/test/popoverContainer.feature
+++ b/cypress/features/regression/test/popoverContainer.feature
@@ -1,17 +1,14 @@
 Feature: Popover container component
-  I want to change Popover container component properties
-
-  Background: Open Popover container component page
-    Given I open "Design System Popover container Test" component page "basic"
-      And I open popover container
+  I want to test Popover container component properties
 
   @positive
   Scenario Outline: Change Popover container component title to <title>
-    When I set title to <title> word
+    Given I open Test test_basic "Popover container" component in noIFrame with "popoverContainer" json from "test" using "<nameOfObject>" object name
+    When I open popover container in NoIFrame
     Then Popover title on preview is set to <title>
     Examples:
-      | title                   |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | title                   | nameOfObject          |
+      | mp150ú¿¡üßä             | titleOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | titleSpecialCharacter |
 # @ignore because of FE-2782
 # | &"'<>|

--- a/cypress/features/regression/test/search.feature
+++ b/cypress/features/regression/test/search.feature
@@ -1,40 +1,41 @@
 Feature: Search component
-  I want to change Search component properties
-
-  Background: Open Search component page
-    Given I open "Design System Search Test" component page "basic"
+  I want to test Search component properties
 
   @positive
   Scenario Outline: Set placeholder to <placeholder>
-    When I set placeholder to <placeholder> word
+    When I open Test test_basic "Search" component in noIFrame with "search" json from "test" using "<nameOfObject>" object name
     Then Search component placeholder is set to <placeholder>
     Examples:
-      | placeholder                  |
-      | mp150ú¿¡üßä                  |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+      | placeholder                  | nameOfObject |
+      | mp150ú¿¡üßä                  | placeholderOtherLanguage |
+      | !@#$%^*()_+-=~[];:.,?{}&"'<> | placeholderSpecialCharacter |
 
   @positive
   Scenario: Verify proper color for search icon button
-    Given Type "Sea" text into search input
+    Given I open "Design System Search Test" component page "basic"
+      And Type "Sea" text into search input
     When I click onto search icon
     Then search icon has proper inner color
 
   @positive
   Scenario: Check the change event for Search component
-    Given clear all actions in Actions Tab
+    Given I open "Design System Search Test" component page "basic"
+      And clear all actions in Actions Tab
     When Type "Search" text into search input
     Then change action was called in Actions Tab
 
   @positive
   Scenario: Check the blur event for Search component
-    Given clear all actions in Actions Tab
+    Given I open "Design System Search Test" component page "basic"
+      And clear all actions in Actions Tab
       And I click inside input
     When I click "search" icon in iFrame
     Then blur action was called in Actions Tab
 
   @positive
   Scenario: Click event for Search icon
-    Given Type "Search" text into search input
+    Given I open "Design System Search Test" component page "basic"
+      And Type "Search" text into search input
       And clear all actions in Actions Tab
     When I click onto search icon
     Then click action was called in Actions Tab

--- a/cypress/features/regression/test/search.feature
+++ b/cypress/features/regression/test/search.feature
@@ -6,8 +6,8 @@ Feature: Search component
     When I open Test test_basic "Search" component in noIFrame with "search" json from "test" using "<nameOfObject>" object name
     Then Search component placeholder is set to <placeholder>
     Examples:
-      | placeholder                  | nameOfObject |
-      | mp150ú¿¡üßä                  | placeholderOtherLanguage |
+      | placeholder                  | nameOfObject                |
+      | mp150ú¿¡üßä                  | placeholderOtherLanguage    |
       | !@#$%^*()_+-=~[];:.,?{}&"'<> | placeholderSpecialCharacter |
 
   @positive

--- a/cypress/features/regression/test/toast.feature
+++ b/cypress/features/regression/test/toast.feature
@@ -1,21 +1,18 @@
 Feature: Toast component
   I want to test Toast component properties
 
-  Background: Open Toast component default page
-    Given I open "Design System Toast Test" component page "basic"
-
   @positive
   Scenario: Verify the click action in Actions Tab
+    Given I open "Design System Toast Test" component page "basic"
     When clear all actions in Actions Tab
       And I click closeIcon in IFrame
     Then click action was called in Actions Tab
 
   @positive
   Scenario Outline: Change Toast children to <children>
-    When I set children to "<children>"
-    And I wait 500
+    When I open Test test_basic "Toast" component in noIFrame with "toast" json from "test" using "<nameOfObject>" object name
     Then Toast children is set to "<children>"
     Examples:
-      | children                |
-      | mp150ú¿¡üßä             |
-      | !@#$%^*()_+-=~[];:.,?{} |
+      | children                | nameOfObject             |
+      | mp150ú¿¡üßä             | childrenOtherLanguage    |
+      | !@#$%^*()_+-=~[];:.,?{} | childrenSpecialCharacter |

--- a/cypress/fixtures/test/popoverContainer.json
+++ b/cypress/fixtures/test/popoverContainer.json
@@ -1,0 +1,8 @@
+{ 
+  "titleOtherLanguage": {
+    "title": "mp150ú¿¡üßä"
+  },
+  "titleSpecialCharacter": {
+    "title": "!@#$%^*()_+-=~[];:.,?{}"
+  }
+}

--- a/cypress/fixtures/test/search.json
+++ b/cypress/fixtures/test/search.json
@@ -1,0 +1,8 @@
+{ 
+  "placeholderOtherLanguage": {
+    "placeholder": "mp150ú¿¡üßä"
+  },
+  "placeholderSpecialCharacter": {
+    "placeholder": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+  }
+}

--- a/cypress/fixtures/test/toast.json
+++ b/cypress/fixtures/test/toast.json
@@ -1,0 +1,8 @@
+{ 
+  "childrenOtherLanguage": {
+    "children": "mp150ú¿¡üßä"
+  },
+  "childrenSpecialCharacter": {
+    "children": "!@#$%^*()_+-=~[];:.,?{}"
+  }
+}

--- a/cypress/locators/popover-container/index.js
+++ b/cypress/locators/popover-container/index.js
@@ -20,7 +20,7 @@ export const popoverContainerContentDS = () => cy.iFrame(POPOVER_CONTAINER_CONTE
 export const popoverCloseIconDS = () => cy.iFrame(POPOVER_CONTENT_CLOSE_ICON);
 
 // component preview locators
-export const popoverContainerTitle = () => cy.iFrame(POPOVER_CONTAINER_TITLE);
+export const popoverContainerTitle = () => cy.get(POPOVER_CONTAINER_TITLE);
 export const popoverContainerContentSecondInnerElement = () => popoverContainerContentDS().children()
   .find('button');
 export const popoverContainerDataComponent = () => cy.iFrame(POPOVER_CONTAINER_DATA_COMPONENT);

--- a/cypress/locators/toast/index.js
+++ b/cypress/locators/toast/index.js
@@ -2,5 +2,7 @@ import { TOAST_PREVIEW } from './locators';
 
 // component preview locators
 export const toastPreview = () => cy.iFrame(TOAST_PREVIEW).children();
-export const toastComponent = () => cy.iFrame(TOAST_PREVIEW);
+export const toastComponentIFrame = () => cy.iFrame(TOAST_PREVIEW);
 export const toastTogglePreview = e => cy.iFrame(`#${e}`);
+
+export const toastComponent = () => cy.get(TOAST_PREVIEW);

--- a/cypress/support/step-definitions/search-steps.js
+++ b/cypress/support/step-definitions/search-steps.js
@@ -4,7 +4,7 @@ import {
 } from '../../locators/search';
 
 Then('Search component placeholder is set to {word}', (placeholder) => {
-  searchInput().should('have.attr', 'placeholder', placeholder);
+  searchInputNoiFrame().should('have.attr', 'placeholder', placeholder);
 });
 
 When('I clear default search input', () => {

--- a/cypress/support/step-definitions/toast-steps.js
+++ b/cypress/support/step-definitions/toast-steps.js
@@ -1,4 +1,9 @@
-import { toastPreview, toastComponent, toastTogglePreview } from '../../locators/toast';
+import {
+  toastPreview,
+  toastComponent,
+  toastTogglePreview,
+  toastComponentIFrame
+} from '../../locators/toast';
 import { getDataElementByValueIframe } from '../../locators';
 
 When('I click on {string} Toggle Preview', (e) => {
@@ -19,7 +24,7 @@ Then('Toast component is visible', () => {
 });
 
 Then('Toast component is not visible', () => {
-  toastComponent().should('not.exist');
+  toastComponentIFrame().should('not.exist');
 });
 
 Then('Toast component has a close icon', () => {
@@ -31,20 +36,20 @@ Then('Toast component has no close icon', () => {
 });
 
 Then('Toast has background-color {string} and border {string} color', (color) => {
-  toastComponent().children().first().should('have.css', 'background-color', color);
-  toastComponent().should('have.css', 'border-color', color);
+  toastComponentIFrame().children().first().should('have.css', 'background-color', color);
+  toastComponentIFrame().should('have.css', 'border-color', color);
 });
 
 Then('Toast is centred', () => {
-  toastComponent().should('have.css', 'margin-right', '0px');
+  toastComponentIFrame().should('have.css', 'margin-right', '0px');
 });
 
 Then('Toast is not centred', () => {
-  toastComponent().should('have.css', 'margin-right', '30px');
+  toastComponentIFrame().should('have.css', 'margin-right', '30px');
 });
 
 Then('Toast component is stacked', () => {
-  toastComponent().parent().parent().as('toastParent');
+  toastComponentIFrame().parent().parent().as('toastParent');
   cy.get('@toastParent').should('have.length', 2);
   cy.get('@toastParent').children().eq(0).find('div')
     .should('have.attr', 'data-component', 'toast');
@@ -53,12 +58,12 @@ Then('Toast component is stacked', () => {
 });
 
 Then('Toast component is stacked delayed', () => {
-  toastComponent().parent().parent().as('toastParent');
+  toastComponentIFrame().parent().parent().as('toastParent');
   cy.get('@toastParent').should('have.length', 1);
   cy.get('@toastParent').children().eq(0).find('div')
     .should('have.attr', 'data-component', 'toast');
   cy.wait(1500);
-  toastComponent().parent().parent()
+  toastComponentIFrame().parent().parent()
     .as('toastParentDelayed');
   cy.get('@toastParentDelayed').children().eq(1)
     .find('div')


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->

Apply new `url` approach in tests for:
`Popover Container` (timing: was `00:30` -> `00:05`),
`Search` (timing: was  `00:50` -> `00:40`),
`Toast` (timing  was `00:22` -> `00:10`).

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are passing all parameters via `knobs`.


### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent