### PR TITLE
feat: add asterisk to required fields

### DIFF
--- a/cypress/features/regression/designSystem/simpleSelect.feature
+++ b/cypress/features/regression/designSystem/simpleSelect.feature
@@ -7,7 +7,7 @@ Feature: Design System Select component
   @positive
   Scenario Outline: Open Select list using <key>
     Given I click onto controlled select using "<key>" key
-    Then "second" "simple" Select list is opened
+    Then "fourth" "simple" Select list is opened
     Examples:
       | key   |
       | Enter |
@@ -16,32 +16,32 @@ Feature: Design System Select component
   @positive
   Scenario: Open Select list by mouse click on text input
     When I click on Select input
-    Then "second" "simple" Select list is opened
+    Then "fourth" "simple" Select list is opened
 
   @positive
   Scenario: Close Select list using Tab keyboard
     Given I focus select input
     When I press "Tab" onto focused element
-    Then "second" "simple" Select list is closed
+    Then "fourth" "simple" Select list is closed
 
   @positive
   Scenario: Close Select list using Esc keyboard
     Given I click on Select input
     When I hit ESC key
-    Then "second" "simple" Select list is closed
+    Then "fourth" "simple" Select list is closed
 
   @positive
   Scenario: Close Select list by clicking out of component
-    Given I click on "second" dropdown button
+    Given I click on "fourth" dropdown button
     When I click out of controlled input
-    Then "second" "simple" Select list is closed
+    Then "fourth" "simple" Select list is closed
 
   @positive
   Scenario: Choose option from Select list by mouse clicking
     Given I click on Select input
     When I select value "Amber"
     Then Design system Select input has "Amber" value
-      And "second" "simple" Select list is closed
+      And "fourth" "simple" Select list is closed
 
   @positive
   Scenario Outline: Choose <selectedValue> option from Select list by typing <selectableValue> value in input
@@ -58,7 +58,7 @@ Feature: Design System Select component
   Scenario Outline: Open select list using arrow key
     Given I focus select input
     When I click onto controlled select using "<key>" key
-    Then "second" "simple" Select list is opened
+    Then "fourth" "simple" Select list is opened
       And "<position>" option on the list is highlighted
       And Design system Select input has "<value>" value
     Examples:

--- a/cypress/features/regression/experimental/checkbox.feature
+++ b/cypress/features/regression/experimental/checkbox.feature
@@ -73,3 +73,8 @@ Feature: Experimental Checkbox component
     Given I open "Experimental Checkbox" component page
     When I mark checkbox on preview
     Then Checkbox tick has color "rgba(0, 0, 0, 0.9)"
+
+  @positive
+  Scenario: Check mandatory field of checkbox is visible 
+    When I open required "Experimental Checkbox" component in noIFrame with "checkbox" json from "experimental" using "required" object name
+    Then the field must have the required property

--- a/cypress/features/regression/experimental/dateInput.feature
+++ b/cypress/features/regression/experimental/dateInput.feature
@@ -108,3 +108,8 @@ Feature: Experimental Date Input component
     Given I open "Experimental Date Input" component page
     When I click onto date icon twice
     Then dayPickerDay is not visible
+
+  @positive
+  Scenario: Check mandatory field of dateInput is visible 
+    When I open required "Experimental Date Input" component in noIFrame with "dateInput" json from "experimental" using "required" object name
+    Then the field must have the required property

--- a/cypress/features/regression/experimental/decimalInput.feature
+++ b/cypress/features/regression/experimental/decimalInput.feature
@@ -101,3 +101,9 @@ Feature: Decimal input component
       | label                     |
       | mpú¿¡üßä                  |
       | !@#$%^*()_+=~[];:?{}&"'<> |
+  
+
+  @positive
+  Scenario: Check mandatory field of decimalInput is visible 
+    When I open required "Experimental Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "required" object name
+    Then the field must have the required property

--- a/cypress/features/regression/experimental/groupedCharacter.feature
+++ b/cypress/features/regression/experimental/groupedCharacter.feature
@@ -131,3 +131,8 @@ Feature: Experimental GroupedCharacter component
   Scenario: Check icon inside of input is visible
     When I open default "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "inputIconAdd" object name
     Then icon name in noIframe on preview is "add"
+
+  @positive
+  Scenario: Check mandatory field of dateInput is visible 
+    When I open required "Experimental GroupedCharacter" component in noIFrame with "groupedCharacter" json from "experimental" using "required" object name
+    Then the field must have the required property

--- a/cypress/features/regression/experimental/numberInput.feature
+++ b/cypress/features/regression/experimental/numberInput.feature
@@ -102,3 +102,8 @@ Feature: Experimental Number Input component
   Scenario: Check icon inside of input is visible
     When I open default "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "inputIconAdd" object name
     Then icon name in noIframe on preview is "add"
+
+  @positive
+  Scenario: Check mandatory field of dateInput is visible 
+    When I open required "Experimental Number Input" component in noIFrame with "numberInput" json from "experimental" using "required" object name
+    Then the field must have the required property

--- a/cypress/features/regression/experimental/textbox.feature
+++ b/cypress/features/regression/experimental/textbox.feature
@@ -130,3 +130,8 @@ Feature: Experimental Textbox component
   Scenario: Check icon inside of Textbox is visible
     When I open default "Experimental-Textbox" component in noIFrame with "textbox" json from "experimental" using "inputIconAdd" object name
     Then icon name in noIframe on preview is "add"
+
+  @positive
+  Scenario: Check mandatory field of Textbox is visible 
+    When I open required "Experimental textbox" component in noIFrame with "textbox" json from "experimental" using "required" object name
+    Then the field must have the required property

--- a/cypress/fixtures/experimental/checkbox.json
+++ b/cypress/fixtures/experimental/checkbox.json
@@ -46,5 +46,8 @@
   },
   "labelAlignRight": {
     "labelAlign": "right"
+  },
+  "required": {
+    "required": true
   }
 }

--- a/cypress/fixtures/experimental/dateInput.json
+++ b/cypress/fixtures/experimental/dateInput.json
@@ -53,5 +53,8 @@
     "label": "label",
     "labelInline": true,
     "labelWidth": 100
+  },
+  "required": {
+    "required": true
   }
 }

--- a/cypress/fixtures/experimental/decimal.json
+++ b/cypress/fixtures/experimental/decimal.json
@@ -131,5 +131,8 @@
   },
   "precision15": {
     "precision": 15
+  },
+  "required": {
+    "required": true
   }
 }

--- a/cypress/fixtures/experimental/groupedCharacter.json
+++ b/cypress/fixtures/experimental/groupedCharacter.json
@@ -117,5 +117,8 @@
   },
   "inputIconAdd": {
     "inputIcon": "add"
+  },
+  "required": {
+    "required": true
   }
 }

--- a/cypress/fixtures/experimental/numberInput.json
+++ b/cypress/fixtures/experimental/numberInput.json
@@ -90,5 +90,8 @@
   },
   "inputIconAdd": {
     "inputIcon": "add"
+  },
+  "required": {
+    "required": true
   }
 }

--- a/cypress/fixtures/experimental/radioButtonGroup.json
+++ b/cypress/fixtures/experimental/radioButtonGroup.json
@@ -70,5 +70,8 @@
   },
   "labelAlignLeft": {
     "labelAlign_weekly": "left"
+  },
+  "required": {
+    "required": true
   }
 }

--- a/cypress/fixtures/experimental/textbox.json
+++ b/cypress/fixtures/experimental/textbox.json
@@ -97,5 +97,7 @@
   },
   "prefixSpecialCharacter": {
     "prefix": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
-  }
+  },
+  "required": {
+    "required": true  }
 }

--- a/cypress/locators/index.js
+++ b/cypress/locators/index.js
@@ -2,7 +2,7 @@ import {
   HELP_ICON_PREVIEW, FIELD_HELP_PREVIEW, TOOLTIP_PREVIEW,
   FORM, STORY_ROOT, CLOSE_ICON_BUTTON, BACKGROUND_UI_LOCATOR, LINK, ICON, INPUT_WIDTH_PREVIEW,
   COMMMON_DATA_ELEMENT_INPUT, LABEL,
-  TAB_LIST, DLS_ROOT,
+  TAB_LIST, DLS_ROOT, INPUT_TAG,
 } from './locators';
 
 // actions locators
@@ -58,3 +58,4 @@ export const helpIconByPositionNoIFrame = position => cy.get(HELP_ICON_PREVIEW).
 export const tooltipPreview = () => cy.get(TOOLTIP_PREVIEW);
 export const tooltipPreviewByPositionNoIFrame = position => cy.get(TOOLTIP_PREVIEW).eq(position);
 export const link = () => cy.get(LINK);
+export const getInputTag = () => cy.get(INPUT_TAG);

--- a/cypress/locators/locators.js
+++ b/cypress/locators/locators.js
@@ -2,6 +2,7 @@
 export const FORM = '#storybook-panel-root';
 export const TAB_LIST = '[role="tablist"]';
 export const CLOSE_ICON_BUTTON = 'button[data-element="close"]';
+export const INPUT_TAG = 'input';
 
 // component preview locators
 export const HELP_ICON_PREVIEW = '[data-component="help"]';

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -24,6 +24,7 @@ import {
   getElementNoIframe,
   labelByPosition,
   helpIcon,
+  getInputTag,
 } from '../../locators';
 import { dialogTitle } from '../../locators/dialog';
 import { DEBUG_FLAG } from '..';
@@ -441,7 +442,9 @@ Then('label Align on preview is {string} in NoIFrame', (direction) => {
 Then('icon name in noIframe on preview is {string}', (iconName) => {
   getElementNoIframe(iconName);
 });
-
+Then('the field must have the required property', () => {
+  getInputTag().should('have.attr', 'required');
+});
 When('I click {string} icon in iFrame', (iconName) => {
   getDataElementByValueIframe(iconName).click();
 });

--- a/src/__experimental__/components/checkable-input/checkable-input.component.js
+++ b/src/__experimental__/components/checkable-input/checkable-input.component.js
@@ -53,11 +53,15 @@ class CheckableInput extends React.Component {
       helpId,
       id
     };
-
+    const noAsterisk = this.props.inputType === 'radio';
     return (
       <StyledCheckableInputWrapper { ...rest }>
         <InputBehaviour>
-          <FormField { ...formFieldProps }>
+          <FormField
+            noAsterisk={ noAsterisk }
+            { ...formFieldProps }
+            isRequired={ formFieldProps.required || formFieldProps['aria-required'] }
+          >
             <StyledCheckableInput>
               <HiddenCheckableInput { ...inputProps } />
               {children}

--- a/src/__experimental__/components/checkbox/checkbox.component.js
+++ b/src/__experimental__/components/checkbox/checkbox.component.js
@@ -19,6 +19,8 @@ const Checkbox = ({
   labelSpacing = 1,
   ml,
   adaptiveSpacingBreakpoint,
+  required,
+  'aria-required': ariaRequired,
   ...props
 }) => {
   const largeScreen = useIsAboveBreakpoint(adaptiveSpacingBreakpoint);
@@ -44,14 +46,17 @@ const Checkbox = ({
     labelSpacing,
     ml: marginLeft
   };
-
   return (
     <CheckboxStyle
       { ...tagComponent('checkbox', props) }
       { ...props }
       labelSpacing={ labelSpacing }
     >
-      <CheckableInput { ...inputProps }>
+      <CheckableInput
+        { ...(required && { required }) }
+        { ...(ariaRequired && { 'aria-required': ariaRequired }) }
+        { ...inputProps }
+      >
         <CheckboxSvg />
       </CheckableInput>
     </CheckboxStyle>
@@ -108,7 +113,11 @@ Checkbox.propTypes = {
   /** The content for the help tooltip, to appear next to the Label */
   labelHelp: PropTypes.node,
   /** Breakpoint for adaptive spacing (left margin changes to 0). Enables the adaptive behaviour when set */
-  adaptiveSpacingBreakpoint: PropTypes.number
+  adaptiveSpacingBreakpoint: PropTypes.number,
+  /** Flag to configure component as mandatory HTML 5 */
+  required: PropTypes.bool,
+  /** Flag to configure component as mandatory */
+  'aria-required': PropTypes.bool
 };
 
 Checkbox.defaultProps = {

--- a/src/__experimental__/components/checkbox/checkbox.d.ts
+++ b/src/__experimental__/components/checkbox/checkbox.d.ts
@@ -33,7 +33,7 @@ interface CheckboxProps {
   /** Flag to configure component as mandatory HTML 5 */
   required?: boolean;
   /** Flag to configure component as mandatory */
-  'aria-required?': boolean;
+  'aria-required'?: boolean;
 }
 
 declare const Checkbox: React.ComponentClass<CheckboxProps>;

--- a/src/__experimental__/components/checkbox/checkbox.d.ts
+++ b/src/__experimental__/components/checkbox/checkbox.d.ts
@@ -30,6 +30,10 @@ interface CheckboxProps {
   info?: boolean | string;
   /** Breakpoint for adaptive spacing (left margin changes to 0). Enables the adaptive behaviour when set */
   adaptiveSpacingBreakpoint?: number;
+  /** Flag to configure component as mandatory HTML 5 */
+  required?: boolean;
+  /** Flag to configure component as mandatory */
+  'aria-required?': boolean;
 }
 
 declare const Checkbox: React.ComponentClass<CheckboxProps>;

--- a/src/__experimental__/components/checkbox/checkbox.spec.js
+++ b/src/__experimental__/components/checkbox/checkbox.spec.js
@@ -507,4 +507,24 @@ describe('Checkbox', () => {
       });
     });
   });
+  it('the required prop is conserved', () => {
+    const wrapper = mount(
+      <Checkbox
+        name='my-checkbox'
+        value='test'
+        required
+      />
+    );
+    expect(wrapper.find(Checkbox).prop('required')).toBe(true);
+  });
+  it('the aria-required prop is conserved', () => {
+    const wrapper = mount(
+      <Checkbox
+        name='my-checkbox'
+        value='test'
+        aria-required
+      />
+    );
+    expect(wrapper.find(Checkbox).prop('aria-required')).toBe(true);
+  });
 });

--- a/src/__experimental__/components/checkbox/checkbox.stories.js
+++ b/src/__experimental__/components/checkbox/checkbox.stories.js
@@ -43,70 +43,6 @@ const groupStore = new Store({
   three: false
 });
 
-function defaultRequiredKnobs(isRequiredProp) {
-  const {
-    key,
-    disabled,
-    fieldHelp,
-    fieldHelpInline,
-    reverse,
-    autoFocus,
-    label,
-    labelHelp,
-    onBlur,
-    inputWidth,
-    labelWidth,
-    labelSpacing,
-    size,
-    value,
-    ml,
-    adaptiveSpacingBreakpoint
-  } = defaultKnobs();
-  if (isRequiredProp) {
-    return (
-      {
-        key,
-        disabled,
-        fieldHelp,
-        fieldHelpInline,
-        reverse,
-        autoFocus,
-        label,
-        labelHelp,
-        onBlur,
-        inputWidth,
-        labelWidth,
-        labelSpacing,
-        size,
-        value,
-        ml,
-        adaptiveSpacingBreakpoint,
-        required: boolean('required', true)
-      }
-    );
-  }
-  return (
-    {
-      key,
-      disabled,
-      fieldHelp,
-      fieldHelpInline,
-      reverse,
-      autoFocus,
-      label,
-      labelHelp,
-      onBlur,
-      inputWidth,
-      labelWidth,
-      labelSpacing,
-      size,
-      value,
-      ml,
-      adaptiveSpacingBreakpoint,
-      'aria-required': boolean('aria-required', true)
-    }
-  );
-}
 
 function defaultKnobs(type, autoFocusDefault = false) {
   let theType = '';
@@ -121,7 +57,6 @@ function defaultKnobs(type, autoFocusDefault = false) {
     key: 'checkbox',
     autoFocus: autoFocusDefault
   };
-
   const key = AutoFocus.getKey(autoFocus, previous);
 
   return ({
@@ -153,7 +88,6 @@ function defaultKnobs(type, autoFocusDefault = false) {
     adaptiveSpacingBreakpoint: number('adaptiveSpacingBreakpoint')
   });
 }
-
 
 function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
@@ -194,12 +128,18 @@ function handleGroupChange(ev, id) {
   });
 }
 
-const requiredCheckboxComponent = (isRequiredProp = false) => () => {
+const requiredCheckboxComponent = () => {
   return (
     <State store={ checkboxes.default.store }>
       <Checkbox
         onChange={ ev => handleChange(ev, 'default') }
-        { ...defaultRequiredKnobs(isRequiredProp) }
+        { ...defaultKnobs() }
+        required
+      />
+      <Checkbox
+        onChange={ ev => handleChange(ev, 'default') }
+        { ...defaultKnobs() }
+        aria-required
       />
     </State>
   );
@@ -316,5 +256,4 @@ storiesOf('Experimental/Checkbox', module)
   .add(...makeStory('validations', dlsThemeSelector, checkboxValidations))
   .add(...makeStory('validations classic', classicThemeSelector, checkboxValidations, true))
   .add(...makeStory('autoFocus', dlsThemeSelector, checkboxComponent(true)))
-  .add(...makeStory('required', dlsThemeSelector, requiredCheckboxComponent(true)))
-  .add(...makeStory('aria-required', dlsThemeSelector, requiredCheckboxComponent(false)));
+  .add(...makeStory('required', dlsThemeSelector, requiredCheckboxComponent));

--- a/src/__experimental__/components/checkbox/checkbox.stories.js
+++ b/src/__experimental__/components/checkbox/checkbox.stories.js
@@ -43,6 +43,70 @@ const groupStore = new Store({
   three: false
 });
 
+function defaultRequiredKnobs(isRequiredProp) {
+  const {
+    key,
+    disabled,
+    fieldHelp,
+    fieldHelpInline,
+    reverse,
+    autoFocus,
+    label,
+    labelHelp,
+    onBlur,
+    inputWidth,
+    labelWidth,
+    labelSpacing,
+    size,
+    value,
+    ml,
+    adaptiveSpacingBreakpoint
+  } = defaultKnobs();
+  if (isRequiredProp) {
+    return (
+      {
+        key,
+        disabled,
+        fieldHelp,
+        fieldHelpInline,
+        reverse,
+        autoFocus,
+        label,
+        labelHelp,
+        onBlur,
+        inputWidth,
+        labelWidth,
+        labelSpacing,
+        size,
+        value,
+        ml,
+        adaptiveSpacingBreakpoint,
+        required: boolean('required', true)
+      }
+    );
+  }
+  return (
+    {
+      key,
+      disabled,
+      fieldHelp,
+      fieldHelpInline,
+      reverse,
+      autoFocus,
+      label,
+      labelHelp,
+      onBlur,
+      inputWidth,
+      labelWidth,
+      labelSpacing,
+      size,
+      value,
+      ml,
+      adaptiveSpacingBreakpoint,
+      'aria-required': boolean('aria-required', true)
+    }
+  );
+}
 
 function defaultKnobs(type, autoFocusDefault = false) {
   let theType = '';
@@ -57,6 +121,7 @@ function defaultKnobs(type, autoFocusDefault = false) {
     key: 'checkbox',
     autoFocus: autoFocusDefault
   };
+
   const key = AutoFocus.getKey(autoFocus, previous);
 
   return ({
@@ -88,6 +153,7 @@ function defaultKnobs(type, autoFocusDefault = false) {
     adaptiveSpacingBreakpoint: number('adaptiveSpacingBreakpoint')
   });
 }
+
 
 function makeStory(name, themeSelector, component, disableChromatic = false) {
   const metadata = {
@@ -127,6 +193,17 @@ function handleGroupChange(ev, id) {
     [id]: checked
   });
 }
+
+const requiredCheckboxComponent = (isRequiredProp = false) => () => {
+  return (
+    <State store={ checkboxes.default.store }>
+      <Checkbox
+        onChange={ ev => handleChange(ev, 'default') }
+        { ...defaultRequiredKnobs(isRequiredProp) }
+      />
+    </State>
+  );
+};
 
 const checkboxComponent = (autoFocus = false) => () => {
   return (
@@ -238,4 +315,6 @@ storiesOf('Experimental/Checkbox', module)
   .add(...makeStory('classic', classicThemeSelector, checkboxComponent(), true))
   .add(...makeStory('validations', dlsThemeSelector, checkboxValidations))
   .add(...makeStory('validations classic', classicThemeSelector, checkboxValidations, true))
-  .add(...makeStory('autoFocus', dlsThemeSelector, checkboxComponent(true)));
+  .add(...makeStory('autoFocus', dlsThemeSelector, checkboxComponent(true)))
+  .add(...makeStory('required', dlsThemeSelector, requiredCheckboxComponent(true)))
+  .add(...makeStory('aria-required', dlsThemeSelector, requiredCheckboxComponent(false)));

--- a/src/__experimental__/components/date/date.stories.js
+++ b/src/__experimental__/components/date/date.stories.js
@@ -10,10 +10,7 @@ import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/t
 import DateInput from './date.component';
 import { OriginalTextbox } from '../textbox';
 import Button from '../../../components/button';
-import {
-  getCommonTextboxProps,
-  getCommonRequiredTextboxProps
-} from '../textbox/textbox.stories';
+import { getCommonTextboxProps } from '../textbox/textbox.stories';
 import { notes, info } from './documentation';
 import getDocGenInfo from '../../../utils/helpers/docgen-info';
 
@@ -133,7 +130,6 @@ const ValidationDateComponent = () => {
           onChange={ setDateValue }
           onBlur={ ev => action('onBlur')(ev) }
           allowEmptyValue={ boolean('allowEmptyValue', false) }
-          aria-required={ boolean('aria-required', false) }
         />
       ))}
       <h6>readOnly</h6>
@@ -192,34 +188,13 @@ const EmptyDateComponent = () => {
   );
 };
 
-const commonRequiredDateComponent = (required) => {
-  const minDate = text('minDate', '');
-  const maxDate = text('maxDate', '');
-  const allowEmptyValue = boolean('allowEmptyValue', false);
-  const autoFocus = boolean('autoFocus', false);
-
+const RequiredDateComponent = () => {
   return (
-    <DateInput
-      { ...getCommonRequiredTextboxProps({ inputWidthEnabled: false }, required) }
-      name='dateinput'
-      autoFocus={ autoFocus }
-      minDate={ minDate }
-      maxDate={ maxDate }
-      value={ store.get('value') }
-      onChange={ setValue }
-      onBlur={ ev => action('onBlur')(ev) }
-      onKeyDown={ ev => action('onKeyDown')(ev) }
-      allowEmptyValue={ allowEmptyValue }
-    />
+    <>
+      <DateInput label='required' required />
+      <DateInput label='aria-required' aria-required />
+    </>
   );
-};
-
-const requiredDateComponent = () => {
-  return (commonRequiredDateComponent(true));
-};
-
-const ariaRequiredDateComponent = () => {
-  return (commonRequiredDateComponent(false));
 };
 
 
@@ -230,5 +205,4 @@ storiesOf('Experimental/Date Input', module)
   .add(...makeStory('empty', dlsThemeSelector, EmptyDateComponent))
   .add(...makeStory('validations', dlsThemeSelector, ValidationDateComponent))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusDateComponent, true))
-  .add(...makeStory('required', dlsThemeSelector, requiredDateComponent))
-  .add(...makeStory('aria-required', dlsThemeSelector, ariaRequiredDateComponent));
+  .add(...makeStory('required', dlsThemeSelector, RequiredDateComponent));

--- a/src/__experimental__/components/date/date.stories.js
+++ b/src/__experimental__/components/date/date.stories.js
@@ -10,7 +10,10 @@ import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/t
 import DateInput from './date.component';
 import { OriginalTextbox } from '../textbox';
 import Button from '../../../components/button';
-import { getCommonTextboxProps } from '../textbox/textbox.stories';
+import {
+  getCommonTextboxProps,
+  getCommonRequiredTextboxProps
+} from '../textbox/textbox.stories';
 import { notes, info } from './documentation';
 import getDocGenInfo from '../../../utils/helpers/docgen-info';
 
@@ -130,6 +133,7 @@ const ValidationDateComponent = () => {
           onChange={ setDateValue }
           onBlur={ ev => action('onBlur')(ev) }
           allowEmptyValue={ boolean('allowEmptyValue', false) }
+          aria-required={ boolean('aria-required', false) }
         />
       ))}
       <h6>readOnly</h6>
@@ -188,10 +192,43 @@ const EmptyDateComponent = () => {
   );
 };
 
+const commonRequiredDateComponent = (required) => {
+  const minDate = text('minDate', '');
+  const maxDate = text('maxDate', '');
+  const allowEmptyValue = boolean('allowEmptyValue', false);
+  const autoFocus = boolean('autoFocus', false);
+
+  return (
+    <DateInput
+      { ...getCommonRequiredTextboxProps({ inputWidthEnabled: false }, required) }
+      name='dateinput'
+      autoFocus={ autoFocus }
+      minDate={ minDate }
+      maxDate={ maxDate }
+      value={ store.get('value') }
+      onChange={ setValue }
+      onBlur={ ev => action('onBlur')(ev) }
+      onKeyDown={ ev => action('onKeyDown')(ev) }
+      allowEmptyValue={ allowEmptyValue }
+    />
+  );
+};
+
+const requiredDateComponent = () => {
+  return (commonRequiredDateComponent(true));
+};
+
+const ariaRequiredDateComponent = () => {
+  return (commonRequiredDateComponent(false));
+};
+
+
 storiesOf('Experimental/Date Input', module)
   .addDecorator(StateDecorator(store))
   .add(...makeStory('default', dlsThemeSelector, dateComponent))
   .add(...makeStory('classic', classicThemeSelector, dateComponent, true))
   .add(...makeStory('empty', dlsThemeSelector, EmptyDateComponent))
   .add(...makeStory('validations', dlsThemeSelector, ValidationDateComponent))
-  .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusDateComponent, true));
+  .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusDateComponent, true))
+  .add(...makeStory('required', dlsThemeSelector, requiredDateComponent))
+  .add(...makeStory('aria-required', dlsThemeSelector, ariaRequiredDateComponent));

--- a/src/__experimental__/components/decimal/decimal.stories.js
+++ b/src/__experimental__/components/decimal/decimal.stories.js
@@ -8,7 +8,10 @@ import { State, Store } from '@sambego/storybook-state';
 import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/theme-selectors';
 import Decimal from './decimal.component';
 import { OriginalTextbox } from '../textbox';
-import { getCommonTextboxProps } from '../textbox/textbox.stories';
+import {
+  getCommonTextboxProps,
+  getCommonRequiredTextboxProps
+} from '../textbox/textbox.stories';
 import OptionsHelper from '../../../utils/helpers/options-helper';
 import { info, notes } from './documentation';
 import getDocGenInfo from '../../../utils/helpers/docgen-info';
@@ -70,6 +73,28 @@ const commonProps = () => {
     autoFocus,
     allowEmptyValue
   };
+};
+
+const defaultRequiredComponent = (isRequiredProp) => {
+  return (
+    <State store={ store }>
+      <Decimal
+        { ...commonProps() }
+        { ...getCommonRequiredTextboxProps({ inputWidthEnabled: true }, isRequiredProp) }
+        value={ store.get('value') }
+        onChange={ setValue }
+        onBlur={ action('onBlur') }
+      />
+    </State>
+  );
+};
+
+const requiredComponent = () => {
+  return defaultRequiredComponent(true);
+};
+
+const ariaRequiredComponent = () => {
+  return defaultRequiredComponent(false);
 };
 
 const defaultComponent = () => {
@@ -164,4 +189,6 @@ storiesOf('Experimental/Decimal Input', module)
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
   .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent))
-  .add(...makeStory('validations', dlsThemeSelector, componentWithValidations));
+  .add(...makeStory('validations', dlsThemeSelector, componentWithValidations))
+  .add(...makeStory('required', dlsThemeSelector, requiredComponent))
+  .add(...makeStory('aria-required', dlsThemeSelector, ariaRequiredComponent));

--- a/src/__experimental__/components/decimal/decimal.stories.js
+++ b/src/__experimental__/components/decimal/decimal.stories.js
@@ -8,10 +8,7 @@ import { State, Store } from '@sambego/storybook-state';
 import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/theme-selectors';
 import Decimal from './decimal.component';
 import { OriginalTextbox } from '../textbox';
-import {
-  getCommonTextboxProps,
-  getCommonRequiredTextboxProps
-} from '../textbox/textbox.stories';
+import { getCommonTextboxProps } from '../textbox/textbox.stories';
 import OptionsHelper from '../../../utils/helpers/options-helper';
 import { info, notes } from './documentation';
 import getDocGenInfo from '../../../utils/helpers/docgen-info';
@@ -75,28 +72,28 @@ const commonProps = () => {
   };
 };
 
-const defaultRequiredComponent = (isRequiredProp) => {
+const requiredComponent = () => {
   return (
     <State store={ store }>
       <Decimal
         { ...commonProps() }
-        { ...getCommonRequiredTextboxProps({ inputWidthEnabled: true }, isRequiredProp) }
+        { ...getCommonTextboxProps({ requiredKnobs: false }) }
         value={ store.get('value') }
         onChange={ setValue }
         onBlur={ action('onBlur') }
+        required
+      />
+      <Decimal
+        { ...commonProps() }
+        { ...getCommonTextboxProps({ requiredKnobs: false }) }
+        value={ store.get('value') }
+        onChange={ setValue }
+        onBlur={ action('onBlur') }
+        aria-required
       />
     </State>
   );
 };
-
-const requiredComponent = () => {
-  return defaultRequiredComponent(true);
-};
-
-const ariaRequiredComponent = () => {
-  return defaultRequiredComponent(false);
-};
-
 const defaultComponent = () => {
   return (
     <State store={ store }>
@@ -190,5 +187,4 @@ storiesOf('Experimental/Decimal Input', module)
   .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent))
   .add(...makeStory('validations', dlsThemeSelector, componentWithValidations))
-  .add(...makeStory('required', dlsThemeSelector, requiredComponent))
-  .add(...makeStory('aria-required', dlsThemeSelector, ariaRequiredComponent));
+  .add(...makeStory('required', dlsThemeSelector, requiredComponent));

--- a/src/__experimental__/components/form-field/form-field.component.js
+++ b/src/__experimental__/components/form-field/form-field.component.js
@@ -41,6 +41,8 @@ const FormField = ({
   mb,
   adaptiveLabelBreakpoint,
   styleOverride = {},
+  noAsterisk,
+  isRequired,
   ...props
 }) => {
   if (!deprecatedWarnTriggered) {
@@ -55,7 +57,6 @@ const FormField = ({
   if (adaptiveLabelBreakpoint) {
     inlineLabel = largeScreen;
   }
-
   useEffect(() => {
     if (context && context.setError && context.setWarning && context.setInfo) {
       context.setError(id, !!error);
@@ -63,7 +64,6 @@ const FormField = ({
       context.setInfo(id, !!info);
     }
   }, [id, context, error, warning, info]);
-
   return (
     <FormFieldStyle
       { ...tagComponent(props['data-component'], props) }
@@ -97,6 +97,7 @@ const FormField = ({
             pr={ !reverse ? labelSpacing : undefined }
             pl={ reverse ? labelSpacing : undefined }
             styleOverride={ styleOverride.label }
+            isRequired={ isRequired && !noAsterisk }
           >
             {label}
           </Label>
@@ -164,6 +165,8 @@ FormField.propTypes = {
   mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint: PropTypes.number,
+  noAsterisk: PropTypes.bool,
+  isRequired: PropTypes.bool,
   /** Allows to override existing component styles */
   styleOverride: PropTypes.shape({
     root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),

--- a/src/__experimental__/components/form-field/form-field.component.js
+++ b/src/__experimental__/components/form-field/form-field.component.js
@@ -57,6 +57,7 @@ const FormField = ({
   if (adaptiveLabelBreakpoint) {
     inlineLabel = largeScreen;
   }
+
   useEffect(() => {
     if (context && context.setError && context.setWarning && context.setInfo) {
       context.setError(id, !!error);
@@ -64,6 +65,7 @@ const FormField = ({
       context.setInfo(id, !!info);
     }
   }, [id, context, error, warning, info]);
+
   return (
     <FormFieldStyle
       { ...tagComponent(props['data-component'], props) }

--- a/src/__experimental__/components/grouped-character/grouped-character.stories.js
+++ b/src/__experimental__/components/grouped-character/grouped-character.stories.js
@@ -5,10 +5,7 @@ import { text, object, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/theme-selectors';
 import GroupedCharacter from './grouped-character.component';
-import {
-  getCommonTextboxProps,
-  getCommonRequiredTextboxProps
-} from '../textbox/textbox.stories';
+import { getCommonTextboxProps } from '../textbox/textbox.stories';
 import { OriginalTextbox } from '../textbox';
 import { info } from './documentation';
 import getDocGenInfo from '../../../utils/helpers/docgen-info';
@@ -27,30 +24,32 @@ const onChange = (ev) => {
   action('change')(ev);
 };
 
-const defaultRequiredComponent = (required) => {
+const requiredComponent = () => {
   const groups = object('groups', [2, 2, 4]);
   const separator = text('separator', '-');
 
   return (
     <State store={ groupedCharacterStore }>
       <GroupedCharacter
-        { ...getCommonRequiredTextboxProps({ inputWidthEnabled: false }, required) }
+        { ...getCommonTextboxProps({ requiredKnobs: false }) }
         groups={ groups }
         separator={ separator }
         value={ groupedCharacterStore.get('value') }
         onChange={ onChange }
+        required
+      />
+      <GroupedCharacter
+        { ...getCommonTextboxProps({ requiredKnobs: false }) }
+        groups={ groups }
+        separator={ separator }
+        value={ groupedCharacterStore.get('value') }
+        onChange={ onChange }
+        aria-required
       />
     </State>
   );
 };
 
-const requiredComponent = () => {
-  return defaultRequiredComponent(true);
-};
-
-const ariaRequiredComponent = () => {
-  return defaultRequiredComponent(false);
-};
 
 const defaultComponent = () => {
   const groups = object('groups', [2, 2, 4]);
@@ -146,5 +145,4 @@ storiesOf('Experimental/GroupedCharacter', module)
   .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
   .add(...makeStory('validations', dlsThemeSelector, validationsComponent))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent))
-  .add(...makeStory('aria-required', dlsThemeSelector, ariaRequiredComponent))
   .add(...makeStory('required', dlsThemeSelector, requiredComponent));

--- a/src/__experimental__/components/grouped-character/grouped-character.stories.js
+++ b/src/__experimental__/components/grouped-character/grouped-character.stories.js
@@ -5,7 +5,10 @@ import { text, object, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/theme-selectors';
 import GroupedCharacter from './grouped-character.component';
-import { getCommonTextboxProps } from '../textbox/textbox.stories';
+import {
+  getCommonTextboxProps,
+  getCommonRequiredTextboxProps
+} from '../textbox/textbox.stories';
 import { OriginalTextbox } from '../textbox';
 import { info } from './documentation';
 import getDocGenInfo from '../../../utils/helpers/docgen-info';
@@ -22,6 +25,31 @@ const groupedCharacterStore = new Store({
 const onChange = (ev) => {
   groupedCharacterStore.set({ value: ev.target.value.rawValue });
   action('change')(ev);
+};
+
+const defaultRequiredComponent = (required) => {
+  const groups = object('groups', [2, 2, 4]);
+  const separator = text('separator', '-');
+
+  return (
+    <State store={ groupedCharacterStore }>
+      <GroupedCharacter
+        { ...getCommonRequiredTextboxProps({ inputWidthEnabled: false }, required) }
+        groups={ groups }
+        separator={ separator }
+        value={ groupedCharacterStore.get('value') }
+        onChange={ onChange }
+      />
+    </State>
+  );
+};
+
+const requiredComponent = () => {
+  return defaultRequiredComponent(true);
+};
+
+const ariaRequiredComponent = () => {
+  return defaultRequiredComponent(false);
 };
 
 const defaultComponent = () => {
@@ -117,4 +145,6 @@ storiesOf('Experimental/GroupedCharacter', module)
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
   .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
   .add(...makeStory('validations', dlsThemeSelector, validationsComponent))
-  .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent));
+  .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent))
+  .add(...makeStory('aria-required', dlsThemeSelector, ariaRequiredComponent))
+  .add(...makeStory('required', dlsThemeSelector, requiredComponent));

--- a/src/__experimental__/components/label/label.component.js
+++ b/src/__experimental__/components/label/label.component.js
@@ -38,6 +38,7 @@ const Label = ({
   htmlFor,
   pr,
   pl,
+  isRequired,
   styleOverride = {}
 }) => {
   if (!deprecatedWarnTriggered) {
@@ -113,6 +114,7 @@ const Label = ({
         htmlFor={ htmlFor }
         onMouseEnter={ handleMouseEnter }
         onMouseLeave={ handleMouseLeave }
+        isRequired={ isRequired }
       >
         {children}
       </StyledLabel>
@@ -165,7 +167,9 @@ Label.propTypes = {
   /** Padding left, integer multiplied by base spacing constant (8) */
   pl: PropTypes.oneOf([1, 2]),
   /** Allows to override existing component styles */
-  styleOverride: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+  styleOverride: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  /** Flag to configure component as mandatory */
+  isRequired: PropTypes.bool
 };
 
 export default React.memo(Label);

--- a/src/__experimental__/components/label/label.spec.js
+++ b/src/__experimental__/components/label/label.spec.js
@@ -115,6 +115,23 @@ describe('Label', () => {
         paddingRight: '16px'
       }, render({ inline: true, pr: 2 }, TestRenderer.create).toJSON());
     });
+
+    it('applies styling for an inline "isRequired" label', () => {
+      const wrapper = render({
+        inline: true,
+        childOfForm: false,
+        isRequired: true,
+        theme: mintTheme
+      });
+
+      assertStyleMatch({
+        content: "'*'",
+        color: '#C7384F',
+        fontWeight: '350',
+        marginLeft: '5px'
+      }, wrapper.find(StyledLabel),
+      { modifier: '::after' });
+    });
   });
 
   describe('when left aligned', () => {

--- a/src/__experimental__/components/label/label.style.js
+++ b/src/__experimental__/components/label/label.style.js
@@ -8,6 +8,17 @@ const LabelStyle = styled.label`
   display: block;
   font-weight: 600;
 
+  ${({
+    isRequired, theme
+  }) => isRequired && css`
+    ::after {
+      content: '*';
+      color: ${theme.colors.asterisk};
+      font-weight: 350;
+      margin-left: 5px;
+    }
+  `}
+
   ${({ disabled, theme }) => disabled && css`
     color: ${theme.disabled.disabled};
   `}

--- a/src/__experimental__/components/number/number.stories.js
+++ b/src/__experimental__/components/number/number.stories.js
@@ -9,7 +9,10 @@ import {
 import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/theme-selectors';
 import Number from './number.component';
 import { OriginalTextbox } from '../textbox';
-import { getCommonTextboxProps } from '../textbox/textbox.stories';
+import {
+  getCommonTextboxProps,
+  getCommonRequiredTextboxProps
+} from '../textbox/textbox.stories';
 import notes from './documentation/notes.md';
 import info from './documentation/info';
 
@@ -22,6 +25,32 @@ const store = new Store(
 const setValue = (ev) => {
   action('onChange')(ev);
   store.set({ value: ev.target.value });
+};
+
+const defaultRequiredComponent = (required) => {
+  const onChangeDeferredEnabled = boolean('Enable "onChangeDeferred" Action', false);
+  const onKeyDownEnabled = boolean('Enable "onKeyDown" Action', false);
+  const deferTimeout = onChangeDeferredEnabled ? number('deferTimeout') : undefined;
+
+  return (
+    <Number
+      { ...getCommonRequiredTextboxProps({ inputWidthEnabled: false }, required) }
+      value={ store.get('value') }
+      onChange={ setValue }
+      onKeyDown={ onKeyDownEnabled ? action('onKeyDown') : undefined }
+      onChangeDeferred={ onChangeDeferredEnabled ? action('onChangeDeferred') : undefined }
+      deferTimeout={ deferTimeout }
+    />
+  );
+};
+
+
+const ariaRequiredComponent = () => {
+  return defaultRequiredComponent(false);
+};
+
+const requiredComponent = () => {
+  return defaultRequiredComponent(true);
 };
 
 const defaultComponent = () => {
@@ -109,4 +138,6 @@ storiesOf('Experimental/Number Input', module)
   .add(...makeStory('default', dlsThemeSelector, defaultComponent))
   .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
   .add(...makeStory('validations', dlsThemeSelector, validationsComponent))
-  .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent));
+  .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent))
+  .add(...makeStory('required', dlsThemeSelector, requiredComponent))
+  .add(...makeStory('aria-required', dlsThemeSelector, ariaRequiredComponent));

--- a/src/__experimental__/components/number/number.stories.js
+++ b/src/__experimental__/components/number/number.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { StateDecorator, Store, State } from '@sambego/storybook-state';
@@ -9,10 +9,7 @@ import {
 import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/theme-selectors';
 import Number from './number.component';
 import { OriginalTextbox } from '../textbox';
-import {
-  getCommonTextboxProps,
-  getCommonRequiredTextboxProps
-} from '../textbox/textbox.stories';
+import { getCommonTextboxProps } from '../textbox/textbox.stories';
 import notes from './documentation/notes.md';
 import info from './documentation/info';
 
@@ -27,30 +24,33 @@ const setValue = (ev) => {
   store.set({ value: ev.target.value });
 };
 
-const defaultRequiredComponent = (required) => {
-  const onChangeDeferredEnabled = boolean('Enable "onChangeDeferred" Action', false);
-  const onKeyDownEnabled = boolean('Enable "onKeyDown" Action', false);
-  const deferTimeout = onChangeDeferredEnabled ? number('deferTimeout') : undefined;
 
+const RequiredComponent = () => {
+  const [state, setState] = useState({
+    one: '',
+    two: ''
+  });
+
+  const onChange = attr => e => setState({
+    ...state,
+    [attr]: e.target.value
+  });
   return (
-    <Number
-      { ...getCommonRequiredTextboxProps({ inputWidthEnabled: false }, required) }
-      value={ store.get('value') }
-      onChange={ setValue }
-      onKeyDown={ onKeyDownEnabled ? action('onKeyDown') : undefined }
-      onChangeDeferred={ onChangeDeferredEnabled ? action('onChangeDeferred') : undefined }
-      deferTimeout={ deferTimeout }
-    />
+    <>
+
+      <Number
+        label='required'
+        required
+        onChange={ onChange('one') }
+      />
+
+      <Number
+        label='aria-required'
+        aria-required
+        onChange={ onChange('two') }
+      />
+    </>
   );
-};
-
-
-const ariaRequiredComponent = () => {
-  return defaultRequiredComponent(false);
-};
-
-const requiredComponent = () => {
-  return defaultRequiredComponent(true);
 };
 
 const defaultComponent = () => {
@@ -139,5 +139,4 @@ storiesOf('Experimental/Number Input', module)
   .add(...makeStory('classic', classicThemeSelector, defaultComponent, true))
   .add(...makeStory('validations', dlsThemeSelector, validationsComponent))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusComponent))
-  .add(...makeStory('required', dlsThemeSelector, requiredComponent))
-  .add(...makeStory('aria-required', dlsThemeSelector, ariaRequiredComponent));
+  .add(...makeStory('required', dlsThemeSelector, RequiredComponent));

--- a/src/__experimental__/components/numeral-date/numeral-date.component.js
+++ b/src/__experimental__/components/numeral-date/numeral-date.component.js
@@ -28,7 +28,9 @@ const NumeralDate = ({
   labelAlign,
   labelHelp,
   fieldHelp,
-  adaptiveLabelBreakpoint
+  adaptiveLabelBreakpoint,
+  required,
+  'aria-required': ariaRequired
 }) => {
   const { current: uniqueId } = useRef(id || guid());
   const isControlled = useRef(value !== undefined);
@@ -100,6 +102,7 @@ const NumeralDate = ({
         labelHelp={ labelHelp }
         fieldHelp={ fieldHelp }
         adaptiveLabelBreakpoint={ adaptiveLabelBreakpoint }
+        isRequired={ required || ariaRequired }
       >
         <StyledNumeralDate
           name={ name }
@@ -212,7 +215,11 @@ NumeralDate.propTypes = {
   /** Help content to be displayed under an input */
   fieldHelp: PropTypes.node,
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
-  adaptiveLabelBreakpoint: PropTypes.number
+  adaptiveLabelBreakpoint: PropTypes.number,
+  /** Flag to configure component as mandatory HTML 5 */
+  required: PropTypes.bool,
+  /** Flag to configure component as mandatory */
+  'aria-required': PropTypes.bool
 };
 
 export default NumeralDate;

--- a/src/__experimental__/components/numeral-date/numeral-date.d.ts
+++ b/src/__experimental__/components/numeral-date/numeral-date.d.ts
@@ -71,6 +71,10 @@ export interface NumeralDateProps {
   fieldHelp?: string;
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint?: number;
+  /** Flag to configure component as mandatory HTML 5 */
+  required?: boolean,
+  /** Flag to configure component as mandatory */
+  'aria-required'?: boolean
 }
 
 declare const NumeralDate: React.ComponentType<NumeralDateProps>;

--- a/src/__experimental__/components/numeral-date/numeral-date.stories.js
+++ b/src/__experimental__/components/numeral-date/numeral-date.stories.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { array, withKnobs } from '@storybook/addon-knobs';
+import { array, withKnobs, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import NumeralDate from '.';
 
@@ -40,6 +40,7 @@ export const Basic = () => {
       value={ dateValue }
       name='numeralDate_name'
       id='numeralDate_id'
+      aria-required={ boolean('aria-required', false) }
     />
   );
 };
@@ -72,6 +73,7 @@ export const Validations = () => {
           value={ dateValue }
           name='numeralDate_name'
           id={ `numeralDate_id_${validation}-string` }
+          aria-required={ boolean('aria-required', false) }
         />
       ))}
 
@@ -87,6 +89,7 @@ export const Validations = () => {
           value={ dateValue }
           name='numeralDate_name'
           id={ `numeralDate_id_${validation}-boolean` }
+          aria-required={ boolean('aria-required', false) }
         />
       ))}
 

--- a/src/__experimental__/components/numeral-date/numeral-date.stories.js
+++ b/src/__experimental__/components/numeral-date/numeral-date.stories.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { array, withKnobs, boolean } from '@storybook/addon-knobs';
+import { array, withKnobs } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import NumeralDate from '.';
 
@@ -40,7 +40,6 @@ export const Basic = () => {
       value={ dateValue }
       name='numeralDate_name'
       id='numeralDate_id'
-      aria-required={ boolean('aria-required', false) }
     />
   );
 };
@@ -73,7 +72,6 @@ export const Validations = () => {
           value={ dateValue }
           name='numeralDate_name'
           id={ `numeralDate_id_${validation}-string` }
-          aria-required={ boolean('aria-required', false) }
         />
       ))}
 
@@ -89,7 +87,6 @@ export const Validations = () => {
           value={ dateValue }
           name='numeralDate_name'
           id={ `numeralDate_id_${validation}-boolean` }
-          aria-required={ boolean('aria-required', false) }
         />
       ))}
 

--- a/src/__experimental__/components/numeral-date/numeral-date.stories.mdx
+++ b/src/__experimental__/components/numeral-date/numeral-date.stories.mdx
@@ -180,4 +180,21 @@ The inline label can change to be top aligned at a breakpoint. Enable this by pa
   </Story>
 </Preview>
 
+### Required
+
+<Preview>
+  <Story name="Required">
+    <>
+    <NumeralDate
+      label="required"
+      required
+    />
+    <NumeralDate
+      label="aria-required"
+      aria-required
+    />
+    </>
+  </Story>
+</Preview>
+
 <Props of={NumeralDate} />

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
@@ -24,6 +24,32 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   z-index: 999;
 }
 
+.c15 {
+  color: rgba(0,0,0,0.9);
+  display: block;
+  font-weight: 600;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-bottom: 8px;
+  box-sizing: border-box;
+  margin-bottom: 0;
+  padding-left: 8px;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  width: 30%;
+}
+
 .c9 {
   display: inline-block;
   position: relative;
@@ -36,7 +62,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   display: flex;
 }
 
-.c3 .c14 {
+.c3 .c13 {
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -45,20 +71,20 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   width: auto;
 }
 
-.c3 .c14 .c15,
-.c3 .c14 .c16 {
+.c3 .c13 .c17,
+.c3 .c13 .c18 {
   color: rgba(0,0,0,0.65);
   vertical-align: middle;
 }
 
-.c3 .c14 .c15:hover,
-.c3 .c14 .c16:hover,
-.c3 .c14 .c15:focus,
-.c3 .c14 .c16:focus {
+.c3 .c13 .c17:hover,
+.c3 .c13 .c18:hover,
+.c3 .c13 .c17:focus,
+.c3 .c13 .c18:focus {
   color: rgba(0,0,0,0.9);
 }
 
-.c3 .c13 {
+.c3 .c16 {
   -webkit-flex-basis: 100%;
   -ms-flex-preferred-size: 100%;
   flex-basis: 100%;
@@ -103,20 +129,20 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   box-shadow: 0 0 0 3px #FFB500;
 }
 
-.c2 .c14 {
+.c2 .c13 {
   width: auto;
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
 }
 
-.c2 .c13 {
+.c2 .c16 {
   margin-left: 16px;
   margin-top: 0;
   padding-left: 8px;
 }
 
-.c2 .c16 {
+.c2 .c18 {
   position: relative;
   display: inline-block;
 }
@@ -150,7 +176,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   r: 5;
 }
 
-.c2 .c14 {
+.c2 .c13 {
   -webkit-flex: 1 1 calc(100% - 44px);
   -ms-flex: 1 1 calc(100% - 44px);
   flex: 1 1 calc(100% - 44px);
@@ -214,11 +240,13 @@ exports[`RadioButtonGroup renders as expected 1`] = `
         className="c2"
         data-component="radio-button"
         name="test-group"
+        required={true}
       >
         <div
           checked={false}
           className="c3"
           name="test-group"
+          required={true}
         >
           <div
             className="c4 c5"
@@ -242,6 +270,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  required={true}
                   role="radio"
                   type="radio"
                   value="test-1"
@@ -270,6 +299,21 @@ exports[`RadioButtonGroup renders as expected 1`] = `
                   </svg>
                 </div>
               </div>
+              <div
+                className="c13 c14"
+                width={30}
+              >
+                <label
+                  className="c15"
+                  data-element="label"
+                  htmlFor="rId-0"
+                  id="rId-0-label"
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  test
+                </label>
+              </div>
             </div>
           </div>
         </div>
@@ -279,11 +323,13 @@ exports[`RadioButtonGroup renders as expected 1`] = `
         className="c2"
         data-component="radio-button"
         name="test-group"
+        required={true}
       >
         <div
           checked={false}
           className="c3"
           name="test-group"
+          required={true}
         >
           <div
             className="c4 c5"
@@ -307,6 +353,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  required={true}
                   role="radio"
                   type="radio"
                   value="test-2"
@@ -334,6 +381,21 @@ exports[`RadioButtonGroup renders as expected 1`] = `
                     </g>
                   </svg>
                 </div>
+              </div>
+              <div
+                className="c13 c14"
+                width={30}
+              >
+                <label
+                  className="c15"
+                  data-element="label"
+                  htmlFor="rId-1"
+                  id="rId-1-label"
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  test
+                </label>
               </div>
             </div>
           </div>

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -40,6 +40,7 @@ const RadioButtonGroup = (props) => {
     'aria-required': ariaRequired,
     styleOverride = {}
   } = props;
+
   const isAboveLegendBreakpoint = useIsAboveBreakpoint(adaptiveLegendBreakpoint);
   const isAboveSpacingBreakpoint = useIsAboveBreakpoint(adaptiveSpacingBreakpoint);
 
@@ -147,7 +148,7 @@ RadioButtonGroup.propTypes = {
     content: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     legend: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
   }),
-  /** Flag to configure component as mandatory */
+  /** Flag to configure component as mandatory HTML 5 */
   required: PropTypes.bool,
   /** Flag to configure component as mandatory */
   'aria-required': PropTypes.bool

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -36,9 +36,10 @@ const RadioButtonGroup = (props) => {
     labelSpacing = 1,
     adaptiveLegendBreakpoint,
     adaptiveSpacingBreakpoint,
+    required,
+    'aria-required': ariaRequired,
     styleOverride = {}
   } = props;
-
   const isAboveLegendBreakpoint = useIsAboveBreakpoint(adaptiveLegendBreakpoint);
   const isAboveSpacingBreakpoint = useIsAboveBreakpoint(adaptiveSpacingBreakpoint);
 
@@ -66,6 +67,7 @@ const RadioButtonGroup = (props) => {
       ml={ marginLeft }
       mb={ mb }
       styleOverride={ styleOverride }
+      isRequired={ required || ariaRequired }
       { ...tagComponent('radiogroup', props) }
     >
       <RadioButtonGroupStyle
@@ -144,7 +146,11 @@ RadioButtonGroup.propTypes = {
     root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     content: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     legend: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
-  })
+  }),
+  /** Flag to configure component as mandatory */
+  required: PropTypes.bool,
+  /** Flag to configure component as mandatory */
+  'aria-required': PropTypes.bool
 };
 
 export default RadioButtonGroup;

--- a/src/__experimental__/components/radio-button/radio-button-group.d.ts
+++ b/src/__experimental__/components/radio-button/radio-button-group.d.ts
@@ -51,6 +51,8 @@ export interface RadioButtonGroupProps {
     content?: object;
     legend?: object;
   };
+  /** Flag to configure component as mandatory */
+  required?: boolean;
 }
 
 declare const RadioButtonGroup: React.ComponentClass<RadioButtonGroupProps>;

--- a/src/__experimental__/components/radio-button/radio-button-group.d.ts
+++ b/src/__experimental__/components/radio-button/radio-button-group.d.ts
@@ -51,8 +51,10 @@ export interface RadioButtonGroupProps {
     content?: object;
     legend?: object;
   };
+  /** Flag to configure component as mandatory HTML 5 */
+  required: boolean,
   /** Flag to configure component as mandatory */
-  required?: boolean;
+  'aria-required': boolean
 }
 
 declare const RadioButtonGroup: React.ComponentClass<RadioButtonGroupProps>;

--- a/src/__experimental__/components/radio-button/radio-button-group.spec.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.spec.js
@@ -15,6 +15,8 @@ function render(props, renderer = TestRenderer.create) {
     <RadioButton
       id={ `rId-${index}` } key={ `radio-key-${value}` }
       onChange={ jest.fn() } value={ value }
+      label='test'
+      required
     />
   ));
 
@@ -162,6 +164,28 @@ describe('RadioButtonGroup', () => {
 
     it('renders legend element with properly assigned styles', () => {
       assertStyleMatch(customStyleObject, wrapper.find(StyledLegendContainer));
+    });
+    it('the required prop is conserved', () => {
+      const wrapperRequired = mount(
+        <RadioButtonGroup name='radio' required>
+          <RadioButton
+            name='my-radio'
+            value='test'
+          />
+        </RadioButtonGroup>
+      );
+      expect(wrapperRequired.find(RadioButtonGroup).prop('required')).toBe(true);
+    });
+    it('the aria-required prop is conserved', () => {
+      const wrapperRequired = mount(
+        <RadioButtonGroup name='radio' aria-required>
+          <RadioButton
+            name='my-radio'
+            value='test'
+          />
+        </RadioButtonGroup>
+      );
+      expect(wrapperRequired.find(RadioButtonGroup).prop('aria-required')).toBe(true);
     });
   });
 });

--- a/src/__experimental__/components/radio-button/radio-button.stories.mdx
+++ b/src/__experimental__/components/radio-button/radio-button.stories.mdx
@@ -61,6 +61,68 @@ A legend can be set for the group, and each radio button can have a label.
   </Story> 
 </Preview>
 
+### With required
+A legend can be set for the group, and each radio button can have a label.
+
+<Preview>
+  <Story name="Required">
+    <RadioButtonGroup
+      name="mybuttongroup"
+      onChange={ () => console.log('change') }
+      legend="Radio group legend"
+      required
+    >
+    <RadioButton 
+      id="radio1" 
+      value="radio1"
+      label="Radio Option 1"
+      required
+    />
+    <RadioButton 
+      id="radio2" 
+      value="radio2" 
+      label="Radio Option 2"
+    />
+    <RadioButton 
+      id="radio3" 
+      value="radio3" 
+      label="Radio Option 3"
+    />
+  </RadioButtonGroup>
+  </Story> 
+</Preview>
+
+### With aria-required
+A legend can be set for the group, and each radio button can have a label.
+
+<Preview>
+  <Story name="Aria-required">
+    <RadioButtonGroup
+      name="mybuttongroup"
+      onChange={ () => console.log('change') }
+      legend="Radio group legend"
+      aria-required
+    >
+    <RadioButton 
+      id="radio1" 
+      value="radio1"
+      label="Radio Option 1"
+      aria-required
+    />
+    <RadioButton 
+      id="radio2" 
+      value="radio2" 
+      label="Radio Option 2"
+    />
+    <RadioButton 
+      id="radio3" 
+      value="radio3" 
+      label="Radio Option 3"
+    />
+  </RadioButtonGroup>
+  </Story> 
+</Preview>
+
 ### With inline legend
 The legend can be made inline. Its width can be changed with the `legendWidth` prop, its text alignment with `legendAlign`. 
 

--- a/src/__experimental__/components/textbox/docgenInfo.json
+++ b/src/__experimental__/components/textbox/docgenInfo.json
@@ -181,6 +181,20 @@
           "required": false,
           "description": "Flag to configure component as optional in Form"
         },
+        "required": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Flag to configure if a component is mandatory (HTML 5). It adds a red asterix at the end of the label"
+        },
+        "aria-required": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Flag to configure if a component is mandatory. It adds a red asterix at the end of the label"
+        },
         "error": {
           "type": {
             "name": "union",

--- a/src/__experimental__/components/textbox/textbox.component.js
+++ b/src/__experimental__/components/textbox/textbox.component.js
@@ -26,6 +26,8 @@ const Textbox = ({
   inputWidth,
   prefix,
   adaptiveLabelBreakpoint,
+  required,
+  'aria-required': ariaRequired,
   ...props
 }) => {
   if (!deprecatedWarnTriggered) {
@@ -43,6 +45,7 @@ const Textbox = ({
         labelWidth={ labelWidth }
         adaptiveLabelBreakpoint={ adaptiveLabelBreakpoint }
         styleOverride={ styleOverride }
+        isRequired={ required || ariaRequired }
       >
         <InputPresentation
           type='text'
@@ -53,6 +56,8 @@ const Textbox = ({
           { leftChildren }
           { prefix ? <StyledPrefix data-element='textbox-prefix'>{ prefix }</StyledPrefix> : null }
           <Input
+            { ...(required && { required }) }
+            { ...(ariaRequired && { 'aria-required': ariaRequired }) }
             { ...removeParentProps(props) }
             placeholder={ (props.disabled || props.readOnly) ? '' : props.placeholder }
             aria-invalid={ !!props.error }
@@ -161,6 +166,10 @@ Textbox.propTypes = {
   mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint: PropTypes.number,
+  /** Flag to configure component as required HTML 5 */
+  required: PropTypes.bool,
+  /** Flag to configure component as required */
+  'aria-required': PropTypes.bool,
   /** Allows to override existing component styles */
   styleOverride: PropTypes.shape({
     root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),

--- a/src/__experimental__/components/textbox/textbox.spec.js
+++ b/src/__experimental__/components/textbox/textbox.spec.js
@@ -110,6 +110,42 @@ describe('Textbox', () => {
     });
   });
 
+  it('then a StyledPrefix should be rendered with this prop value', () => {
+    const prefixValue = 'bar';
+    const wrapper = mount(
+      <Textbox
+        value='foo'
+        prefix={ prefixValue }
+      />
+    );
+    expect(wrapper.find(StyledPrefix).exists()).toBe(true);
+    expect(wrapper.find(StyledPrefix).text()).toBe(prefixValue);
+  });
+
+  it('the required prop is conserved', () => {
+    const prefixValue = 'bar';
+    const wrapper = mount(
+      <Textbox
+        value='foo'
+        prefix={ prefixValue }
+        required
+      />
+    );
+    expect(wrapper.find(Textbox).prop('required')).toBe(true);
+  });
+
+  it('the aria-required prop is conserved', () => {
+    const prefixValue = 'bar';
+    const wrapper = mount(
+      <Textbox
+        value='foo'
+        prefix={ prefixValue }
+        aria-required
+      />
+    );
+    expect(wrapper.find(Textbox).prop('aria-required')).toBe(true);
+  });
+
   describe('Prefix', () => {
     it('should have expected styles', () => {
       assertStyleMatch({

--- a/src/__experimental__/components/textbox/textbox.spec.js
+++ b/src/__experimental__/components/textbox/textbox.spec.js
@@ -110,18 +110,6 @@ describe('Textbox', () => {
     });
   });
 
-  it('then a StyledPrefix should be rendered with this prop value', () => {
-    const prefixValue = 'bar';
-    const wrapper = mount(
-      <Textbox
-        value='foo'
-        prefix={ prefixValue }
-      />
-    );
-    expect(wrapper.find(StyledPrefix).exists()).toBe(true);
-    expect(wrapper.find(StyledPrefix).text()).toBe(prefixValue);
-  });
-
   it('the required prop is conserved', () => {
     const prefixValue = 'bar';
     const wrapper = mount(

--- a/src/__experimental__/components/textbox/textbox.stories.js
+++ b/src/__experimental__/components/textbox/textbox.stories.js
@@ -23,7 +23,8 @@ OriginalTextbox.__docgenInfo = getDocGenInfo(
 Textbox.displayName = 'Textbox';
 
 const defaultStoryPropsConfig = {
-  inputWidthEnabled: true
+  inputWidthEnabled: true,
+  requiredKnobs: true
 };
 
 function makeStory(name, themeSelector, component, disableChromatic = false) {
@@ -105,21 +106,27 @@ const multipleTextboxAutoFocus = () => {
 };
 const requiredTextbox = () => {
   return (
-    <Textbox
-      placeholder={ text('placeholder') }
-      { ...getCommonRequiredTextboxProps(defaultStoryPropsConfig, true) }
-    />
-  );
-};
-const ariaRequiredTextbox = () => {
-  return (
-    <Textbox
-      placeholder={ text('placeholder') }
-      { ...getCommonRequiredTextboxProps(defaultStoryPropsConfig, false) }
-    />
-  );
-};
+    <>
+      <Textbox
+        placeholder='required'
+        { ...getCommonTextboxProps({
+          ...defaultStoryPropsConfig,
+          requiredKnobs: false
+        }) }
+        required
+      />
 
+      <Textbox
+        placeholder='aria-required'
+        { ...getCommonTextboxProps({
+          ...defaultStoryPropsConfig,
+          requiredKnobs: false
+        }) }
+        aria-required
+      />
+    </>
+  );
+};
 
 function makeValidationsStory(name, themeSelector, disableChromatic = false) {
   const validationTypes = ['error', 'warning', 'info'];
@@ -218,73 +225,15 @@ storiesOf('Experimental/Textbox', module)
   .add(...makeValidationsStory('validations classic', classicThemeSelector, true))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusTextbox))
   .add(...makeStory('multiple autoFocus', dlsThemeSelector, multipleTextboxAutoFocus))
-  .add(...makeStory('aria-required', dlsThemeSelector, ariaRequiredTextbox))
   .add(...makeStory('required', dlsThemeSelector, requiredTextbox));
 
 // eslint-disable-next-line
-export function getCommonRequiredTextboxProps(config = defaultStoryPropsConfig, isRequired) {
-  const {
-    key,
-    disabled,
-    readOnly,
-    autoFocus,
-    inputWidth,
-    fieldHelp,
-    label,
-    labelHelp,
-    labelInline,
-    adaptiveLabelBreakpoint,
-    labelWidth,
-    labelAlign,
-    size,
-    onClick,
-    iconOnClick,
-    inputIcon
-  } = getCommonTextboxProps(config);
+export function getCommonTextboxProps(overrides = {}, autoFocusDefault = false, disabledDefault = false, readOnlyDefault = false) {
 
-  if (isRequired) {
-    return ({
-      key,
-      disabled,
-      readOnly,
-      autoFocus,
-      inputWidth,
-      fieldHelp,
-      label,
-      labelHelp,
-      labelInline,
-      adaptiveLabelBreakpoint,
-      labelWidth,
-      labelAlign,
-      size,
-      onClick,
-      iconOnClick,
-      inputIcon,
-      required: boolean('required', true)
-    });
-  }
-  return {
-    key,
-    disabled,
-    readOnly,
-    autoFocus,
-    inputWidth,
-    fieldHelp,
-    label,
-    labelHelp,
-    labelInline,
-    adaptiveLabelBreakpoint,
-    labelWidth,
-    labelAlign,
-    size,
-    onClick,
-    iconOnClick,
-    inputIcon,
-    'aria-required': boolean('aria-required', true)
+  const config = {
+    ...defaultStoryPropsConfig,
+    ...overrides
   };
-}
-// eslint-disable-next-line
-export function getCommonTextboxProps(config = defaultStoryPropsConfig, autoFocusDefault = false, disabledDefault = false, readOnlyDefault = false) {
   const previous = {
     key: 'textbox',
     autoFocus: autoFocusDefault
@@ -313,6 +262,9 @@ export function getCommonTextboxProps(config = defaultStoryPropsConfig, autoFocu
   const iconOnClick = action('iconOnClick');
   const inputIcon = select('inputIcon', ['', ...OptionsHelper.icons]);
 
+  const required = config.requiredKnobs ? boolean('required', false) : undefined;
+  const ariaRequired = config.requiredKnobs ? boolean('ariaRequired', false) : undefined;
+
   return {
     key,
     disabled,
@@ -330,6 +282,8 @@ export function getCommonTextboxProps(config = defaultStoryPropsConfig, autoFocu
     onClick,
     iconOnClick,
     inputIcon,
-    prefix
+    prefix,
+    required,
+    'aria-required': ariaRequired
   };
 }

--- a/src/__experimental__/components/textbox/textbox.stories.js
+++ b/src/__experimental__/components/textbox/textbox.stories.js
@@ -103,6 +103,22 @@ const multipleTextboxAutoFocus = () => {
   boolean('autoFocus', true);
   return multipleTextbox();
 };
+const requiredTextbox = () => {
+  return (
+    <Textbox
+      placeholder={ text('placeholder') }
+      { ...getCommonRequiredTextboxProps(defaultStoryPropsConfig, true) }
+    />
+  );
+};
+const ariaRequiredTextbox = () => {
+  return (
+    <Textbox
+      placeholder={ text('placeholder') }
+      { ...getCommonRequiredTextboxProps(defaultStoryPropsConfig, false) }
+    />
+  );
+};
 
 
 function makeValidationsStory(name, themeSelector, disableChromatic = false) {
@@ -201,8 +217,72 @@ storiesOf('Experimental/Textbox', module)
   .add(...makeValidationsStory('validations', dlsThemeSelector))
   .add(...makeValidationsStory('validations classic', classicThemeSelector, true))
   .add(...makeStory('autoFocus', dlsThemeSelector, autoFocusTextbox))
-  .add(...makeStory('multiple autoFocus', dlsThemeSelector, multipleTextboxAutoFocus));
+  .add(...makeStory('multiple autoFocus', dlsThemeSelector, multipleTextboxAutoFocus))
+  .add(...makeStory('aria-required', dlsThemeSelector, ariaRequiredTextbox))
+  .add(...makeStory('required', dlsThemeSelector, requiredTextbox));
 
+// eslint-disable-next-line
+export function getCommonRequiredTextboxProps(config = defaultStoryPropsConfig, isRequired) {
+  const {
+    key,
+    disabled,
+    readOnly,
+    autoFocus,
+    inputWidth,
+    fieldHelp,
+    label,
+    labelHelp,
+    labelInline,
+    adaptiveLabelBreakpoint,
+    labelWidth,
+    labelAlign,
+    size,
+    onClick,
+    iconOnClick,
+    inputIcon
+  } = getCommonTextboxProps(config);
+
+  if (isRequired) {
+    return ({
+      key,
+      disabled,
+      readOnly,
+      autoFocus,
+      inputWidth,
+      fieldHelp,
+      label,
+      labelHelp,
+      labelInline,
+      adaptiveLabelBreakpoint,
+      labelWidth,
+      labelAlign,
+      size,
+      onClick,
+      iconOnClick,
+      inputIcon,
+      required: boolean('required', true)
+    });
+  }
+  return {
+    key,
+    disabled,
+    readOnly,
+    autoFocus,
+    inputWidth,
+    fieldHelp,
+    label,
+    labelHelp,
+    labelInline,
+    adaptiveLabelBreakpoint,
+    labelWidth,
+    labelAlign,
+    size,
+    onClick,
+    iconOnClick,
+    inputIcon,
+    'aria-required': boolean('aria-required', true)
+  };
+}
 // eslint-disable-next-line
 export function getCommonTextboxProps(config = defaultStoryPropsConfig, autoFocusDefault = false, disabledDefault = false, readOnlyDefault = false) {
   const previous = {

--- a/src/__internal__/fieldset/fieldset.component.js
+++ b/src/__internal__/fieldset/fieldset.component.js
@@ -7,7 +7,7 @@ import { InputGroupBehaviour, InputGroupContext } from '../input-behaviour';
 
 const Fieldset = ({
   legend, children, inline, legendWidth, legendAlign = 'right', legendSpacing = 2, error,
-  warning, info, ml, mb, styleOverride, ...rest
+  warning, info, ml, mb, styleOverride, isRequired, ...rest
 }) => (
   <InputGroupBehaviour>
     <StyledFieldset
@@ -25,6 +25,7 @@ const Fieldset = ({
             width={ legendWidth }
             align={ legendAlign }
             rightPadding={ legendSpacing }
+            isRequired={ isRequired }
           >
             <InputGroupContext.Consumer>
               {({ onMouseEnter, onMouseLeave }) => (
@@ -79,7 +80,9 @@ Fieldset.propTypes = {
   styleOverride: PropTypes.shape({
     root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     legend: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
-  })
+  }),
+  /** Flag to configure component as mandatory */
+  isRequired: PropTypes.bool
 };
 
 Fieldset.defaultProps = {

--- a/src/__internal__/fieldset/fieldset.component.js
+++ b/src/__internal__/fieldset/fieldset.component.js
@@ -81,7 +81,7 @@ Fieldset.propTypes = {
     root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     legend: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
   }),
-  /** Flag to configure component as mandatory */
+  /** If true, an asterisk will be added to the label */
   isRequired: PropTypes.bool
 };
 

--- a/src/__internal__/fieldset/fieldset.d.ts
+++ b/src/__internal__/fieldset/fieldset.d.ts
@@ -34,6 +34,8 @@ export interface FieldsetProps {
     root?: object;
     legend?: object;
   };
+  /** Flag to configure component as mandatory */
+  isRequired: boolean;
 }
 
 declare const Fieldset: React.ComponentClass<FieldsetProps>;

--- a/src/__internal__/fieldset/fieldset.d.ts
+++ b/src/__internal__/fieldset/fieldset.d.ts
@@ -34,7 +34,7 @@ export interface FieldsetProps {
     root?: object;
     legend?: object;
   };
-  /** Flag to configure component as mandatory */
+  /** If true, an asterisk will be added to the label */
   isRequired: boolean;
 }
 

--- a/src/__internal__/fieldset/fieldset.spec.js
+++ b/src/__internal__/fieldset/fieldset.spec.js
@@ -126,4 +126,16 @@ describe('Fieldset', () => {
       expect(icon.props()[validationType]).toEqual('Message');
     });
   });
+  it('add an asterisk after the text when the field is mandatory', () => {
+    assertStyleMatch(
+      {
+        content: "'*'",
+        color: '#C7384F',
+        fontWeight: '350',
+        marginLeft: '5px'
+      },
+      mount(<StyledLegendContainer isRequired />),
+      { modifier: '::after' }
+    );
+  });
 });

--- a/src/__internal__/fieldset/fieldset.style.js
+++ b/src/__internal__/fieldset/fieldset.style.js
@@ -50,6 +50,17 @@ const StyledLegendContainer = styled.div`
     line-height: 24px;
   }
 
+  ${({
+    isRequired, theme
+  }) => isRequired && css`
+    ::after {
+      content: '*';
+      color: ${theme.colors.asterisk};
+      font-weight: 350;
+      margin-left: 5px;
+    }
+  `}
+
   ${({ styleOverride }) => styleOverride};
 `;
 

--- a/src/components/dialog/dialog.stories.js
+++ b/src/components/dialog/dialog.stories.js
@@ -13,7 +13,6 @@ import Button from '../button';
 import DateInput from '../../__experimental__/components/date';
 import { Checkbox } from '../../__experimental__/components/checkbox';
 import { Select, Option } from '../../__experimental__/components/select';
-import { RadioButton, RadioButtonGroup } from '../../__experimental__/components/radio-button';
 import getDocGenInfo from '../../utils/helpers/docgen-info';
 
 Dialog.__docgenInfo = getDocGenInfo(
@@ -198,8 +197,8 @@ function makeButtonStory(name, themeSelector, stickyFooter, disableChromatic = f
               leftSideButtons={ <Button onClick={ handleCancel }>Cancel</Button> }
               saveButton={ <Button buttonType='primary' type='submit'>Save</Button> }
             >
-              <Textbox label='First Name' required />
-              <Textbox label='Middle Name' aria-required />
+              <Textbox label='First Name' />
+              <Textbox label='Middle Name' />
               <Textbox label='Surname' />
               <Textbox label='Birth Place' />
               <Textbox label='Favourite Colour' />
@@ -208,9 +207,8 @@ function makeButtonStory(name, themeSelector, stickyFooter, disableChromatic = f
                 name='date' label='Birthday'
                 value={ date }
                 onChange={ e => setDate(e.target.value.rawValue) }
-                aria-required
               />
-              <Select label='Color' aria-required>
+              <Select label='Color'>
                 {selectOptions.map(option => (
                   <Option
                     key={ option.name }
@@ -225,35 +223,7 @@ function makeButtonStory(name, themeSelector, stickyFooter, disableChromatic = f
                 value={ date }
                 onChange={ e => setDate(e.target.value.rawValue) }
               />
-              <Checkbox
-                name='checkbox'
-                label='Do you like my Dog'
-                required
-              />
-              <RadioButtonGroup
-                name='mybuttongroup'
-                onChange={ () => console.log('change') }
-                legend='Do you like animals?'
-                required
-                aria-required
-              >
-                <RadioButton
-                  id='radio1'
-                  value='radio1'
-                  label='Dog'
-                  required
-                />
-                <RadioButton
-                  id='radio2'
-                  value='radio2'
-                  label='Cat'
-                />
-                <RadioButton
-                  id='radio3'
-                  value='radio3'
-                  label='Other'
-                />
-              </RadioButtonGroup>
+              <Checkbox name='checkbox' label='Do you like my Dog' />
               <div>This is an example of a dialog with a Form as content</div>
             </Form>
           </Dialog>

--- a/src/components/dialog/dialog.stories.js
+++ b/src/components/dialog/dialog.stories.js
@@ -13,6 +13,7 @@ import Button from '../button';
 import DateInput from '../../__experimental__/components/date';
 import { Checkbox } from '../../__experimental__/components/checkbox';
 import { Select, Option } from '../../__experimental__/components/select';
+import { RadioButton, RadioButtonGroup } from '../../__experimental__/components/radio-button';
 import getDocGenInfo from '../../utils/helpers/docgen-info';
 
 Dialog.__docgenInfo = getDocGenInfo(
@@ -197,8 +198,8 @@ function makeButtonStory(name, themeSelector, stickyFooter, disableChromatic = f
               leftSideButtons={ <Button onClick={ handleCancel }>Cancel</Button> }
               saveButton={ <Button buttonType='primary' type='submit'>Save</Button> }
             >
-              <Textbox label='First Name' />
-              <Textbox label='Middle Name' />
+              <Textbox label='First Name' required />
+              <Textbox label='Middle Name' aria-required />
               <Textbox label='Surname' />
               <Textbox label='Birth Place' />
               <Textbox label='Favourite Colour' />
@@ -207,8 +208,9 @@ function makeButtonStory(name, themeSelector, stickyFooter, disableChromatic = f
                 name='date' label='Birthday'
                 value={ date }
                 onChange={ e => setDate(e.target.value.rawValue) }
+                aria-required
               />
-              <Select label='Color'>
+              <Select label='Color' aria-required>
                 {selectOptions.map(option => (
                   <Option
                     key={ option.name }
@@ -223,7 +225,35 @@ function makeButtonStory(name, themeSelector, stickyFooter, disableChromatic = f
                 value={ date }
                 onChange={ e => setDate(e.target.value.rawValue) }
               />
-              <Checkbox name='checkbox' label='Do you like my Dog' />
+              <Checkbox
+                name='checkbox'
+                label='Do you like my Dog'
+                required
+              />
+              <RadioButtonGroup
+                name='mybuttongroup'
+                onChange={ () => console.log('change') }
+                legend='Do you like animals?'
+                required
+                aria-required
+              >
+                <RadioButton
+                  id='radio1'
+                  value='radio1'
+                  label='Dog'
+                  required
+                />
+                <RadioButton
+                  id='radio2'
+                  value='radio2'
+                  label='Cat'
+                />
+                <RadioButton
+                  id='radio3'
+                  value='radio3'
+                  label='Other'
+                />
+              </RadioButtonGroup>
               <div>This is an example of a dialog with a Form as content</div>
             </Form>
           </Dialog>

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -56,14 +56,15 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### Basic required usage:
+### Required
 
 <Preview>
-  <Story name="basic required" parameters={{ info: { disable: true }}} >
-    <FilterableSelect
+  <Story name="required" parameters={{ info: { disable: true }}} >
+    <>
+      <FilterableSelect
       name='simple'
       id='simple'
-      label='label'
+      label='required'
       labelInline
       required
       onOpen={ action('onOpen') }
@@ -85,17 +86,10 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
       <Option text='White' value='10' />
       <Option text='Yellow' value='11' />
     </FilterableSelect>
-  </Story>
-</Preview>
-
-### Basic required usage:
-
-<Preview>
-  <Story name="basic aria-required" parameters={{ info: { disable: true }}} >
     <FilterableSelect
       name='simple'
       id='simple'
-      label='label'
+      label='aria-required'
       labelInline
       aria-required
       onOpen={ action('onOpen') }
@@ -117,6 +111,7 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
       <Option text='White' value='10' />
       <Option text='Yellow' value='11' />
     </FilterableSelect>
+    </>
   </Story>
 </Preview>
 

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -56,6 +56,70 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
+### Basic required usage:
+
+<Preview>
+  <Story name="basic required" parameters={{ info: { disable: true }}} >
+    <FilterableSelect
+      name='simple'
+      id='simple'
+      label='label'
+      labelInline
+      required
+      onOpen={ action('onOpen') }
+      onChange={ action('onChange') }
+      onClick={ action('onClick') }
+      onFocus={ action('onFocus') }
+      onBlur={ action('onBlur') }
+      onKeyDown={ action('onKeyDown') }
+    >
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </FilterableSelect>
+  </Story>
+</Preview>
+
+### Basic required usage:
+
+<Preview>
+  <Story name="basic aria-required" parameters={{ info: { disable: true }}} >
+    <FilterableSelect
+      name='simple'
+      id='simple'
+      label='label'
+      labelInline
+      aria-required
+      onOpen={ action('onOpen') }
+      onChange={ action('onChange') }
+      onClick={ action('onClick') }
+      onFocus={ action('onFocus') }
+      onBlur={ action('onBlur') }
+      onKeyDown={ action('onKeyDown') }
+    >
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </FilterableSelect>
+  </Story>
+</Preview>
+
 ### Controlled Usage:
 
 <Preview>

--- a/src/components/select/select-textbox/select-textbox.component.js
+++ b/src/components/select/select-textbox/select-textbox.component.js
@@ -14,6 +14,8 @@ const SelectTextbox = ({
   onFocus,
   onBlur,
   selectedValue,
+  required,
+  'aria-required': ariaRequired,
   ...restProps
 }) => {
   const defaultPlaceholder = I18n.t('select.placeholder', {
@@ -49,6 +51,8 @@ const SelectTextbox = ({
       placeholder: placeholder || defaultPlaceholder,
       disabled,
       readOnly,
+      required,
+      'aria-required': ariaRequired,
       onClick: handleTextboxClick,
       onFocus: handleTextboxFocus,
       onBlur: handleTextboxBlur,
@@ -104,7 +108,11 @@ const formInputPropTypes = {
   /** Callback function for when the key is pressed when focused on Select Textbox. */
   onKeyDown: PropTypes.func,
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
-  adaptiveLabelBreakpoint: PropTypes.number
+  adaptiveLabelBreakpoint: PropTypes.number,
+  /** Flag to configure component as mandatory HTML 5 */
+  required: PropTypes.bool,
+  /** Flag to configure component as mandatory */
+  'aria-required': PropTypes.bool
 };
 
 SelectTextbox.propTypes = {

--- a/src/components/select/select-textbox/select-textbox.spec.js
+++ b/src/components/select/select-textbox/select-textbox.spec.js
@@ -35,6 +35,18 @@ describe('SelectTextbox', () => {
     });
   });
 
+  it('the required prop is conserved', () => {
+    const wrapper = mount(
+      <SelectTextbox required />
+    );
+    expect(wrapper.find(SelectTextbox).prop('required')).toBe(true);
+  });
+  it('the aria-required prop is conserved', () => {
+    const wrapper = mount(
+      <SelectTextbox aria-required />
+    );
+    expect(wrapper.find(SelectTextbox).prop('aria-required')).toBe(true);
+  });
   // coverage filler for else path
   const wrapper = mount(<SelectTextbox />);
   wrapper.find('input').simulate('blur');

--- a/src/components/select/simple-select/simple-select-sizes.stories.mdx
+++ b/src/components/select/simple-select/simple-select-sizes.stories.mdx
@@ -10,7 +10,7 @@ import { Select, Option } from '../';
 <Preview>
   <Story name="small" parameters={{ info: { disable: true }}} >
     <div style={{ height: '250px' }}>
-      <Select name='small' id='small' defaultValue='3' size='small'>
+      <Select name='small' id='small' defaultValue='3' size='small' required>
         <Option text='Amber' value='1' />
         <Option text='Black' value='2' />
         <Option text='Blue' value='3' />

--- a/src/components/select/simple-select/simple-select.stories.mdx
+++ b/src/components/select/simple-select/simple-select.stories.mdx
@@ -58,6 +58,70 @@ import { Select, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
+### Basic aria-required usage:
+
+<Preview>
+  <Story name="basic aria-required" parameters={{ info: { disable: true }}} >
+    <Select
+      name='simple'
+      id='simple'
+      label='label'
+      labelInline
+      onOpen={ action('onOpen') }
+      onChange={ action('onChange') }
+      onClick={ action('onClick') }
+      onFocus={ action('onFocus') }
+      onBlur={ action('onBlur') }
+      onKeyDown={ action('onKeyDown') }
+      aria-required
+    >
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </Select>
+  </Story>
+</Preview>
+
+### Basic aria-required usage:
+
+<Preview>
+  <Story name="basic required" parameters={{ info: { disable: true }}} >
+    <Select
+      name='simple'
+      id='simple'
+      label='label'
+      labelInline
+      onOpen={ action('onOpen') }
+      onChange={ action('onChange') }
+      onClick={ action('onClick') }
+      onFocus={ action('onFocus') }
+      onBlur={ action('onBlur') }
+      onKeyDown={ action('onKeyDown') }
+      required
+    >
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </Select>
+  </Story>
+</Preview>
+
 ### Controlled usage:
 
 <Preview>

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -47,7 +47,8 @@ export default (palette) => {
       warning: palette.carrotOrange,
       destructive: {
         hover: palette.errorRedShade(20)
-      }
+      },
+      asterisk: palette.errorRed
     },
 
     anchorNavigation: {


### PR DESCRIPTION

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Add an asterisk after the label of a mandatory field, add required or aria-required props for the 'screen reader' apps. 
![image](https://user-images.githubusercontent.com/17121053/92587039-64011f00-f297-11ea-905f-b4b23ccf611b.png)

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
