### PR TITLE
feat(hr): add styled-system spacing props

### DIFF
--- a/.storybook/utils/styled-system-props.js
+++ b/.storybook/utils/styled-system-props.js
@@ -1,0 +1,169 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { PropsTable } from '@storybook/components';
+import { Props } from '@storybook/addon-docs/blocks';
+
+const generateStyledSystemProps = (
+  defaults
+) => {
+  return [
+    {
+      name: 'm',
+      type: { summary: 'number | string' },
+      description: 'Margin, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.m || '-'
+      }
+    },
+    {
+      name: 'mt',
+      type: { summary: 'number | string' },
+      description: 'Margin top, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.mt || '-'
+      }
+    },
+    {
+      name: 'mr',
+      type: { summary: 'number | string' },
+      description: 'Margin right, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.mr || '-'
+      }
+    },
+    {
+      name: 'mb',
+      type: { summary: 'number | string' },
+      description: 'Margin bottom, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.mb || '-'
+      }
+    },
+    {
+      name: 'ml',
+      type: { summary: 'number | string' },
+      description: 'Margin left, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.ml || '-'
+      }
+    },
+    {
+      name: 'mx',
+      type: { summary: 'number | string' },
+      // eslint-disable-next-line max-len
+      description: 'Margin left/right, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.mx || '-'
+      }
+    },
+    {
+      name: 'my',
+      type: { summary: 'number | string' },
+      // eslint-disable-next-line max-len
+      description: 'Margin top/bottom, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.my || '-'
+      }
+    },
+    {
+      name: 'p',
+      type: { summary: 'number | string' },
+      description: 'Padding, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.p || '-'
+      }
+    },
+    {
+      name: 'pt',
+      type: { summary: 'number | string' },
+      description: 'Padding top, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.pt || '-'
+      }
+    },
+    {
+      name: 'pr',
+      type: { summary: 'number | string' },
+      description: 'Padding right, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.pr || '-'
+      }
+    },
+    {
+      name: 'pb',
+      type: { summary: 'number | string' },
+      description: 'Padding bottom, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.pb || '-'
+      }
+    },
+    {
+      name: 'pl',
+      type: { summary: 'number | string' },
+      description: 'Padding left, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.pl || '-'
+      }
+    },
+    {
+      name: 'px',
+      type: { summary: 'number | string' },
+      // eslint-disable-next-line max-len
+      description: 'Padding left/right, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.px || '-'
+      }
+    },
+    {
+      name: 'py',
+      type: { summary: 'number | string' },
+      // eslint-disable-next-line max-len
+      description: 'Padding top/bottom, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
+      required: false,
+      defaultValue: {
+        summary: defaults.py || '-'
+      }
+    }
+  ];
+};
+
+const StyledSystemProps = ({
+  of,
+  spacing,
+  spacingDefaults,
+  noHeader
+}) => {
+  const rows = spacing ? generateStyledSystemProps(spacingDefaults) : null;
+
+  return (
+    <>
+      {!noHeader && <h2>Props</h2>}
+      {of && <Props of={ of } />}
+      <PropsTable
+        rows={ rows }
+      />
+    </>
+  );
+};
+
+StyledSystemProps.propTypes = {
+  of: PropTypes.node,
+  noHeader: PropTypes.bool,
+  spacing: PropTypes.bool,
+  spacingDefaults: PropTypes.object
+};
+
+export default StyledSystemProps;

--- a/docs/documentation-styleguide.md
+++ b/docs/documentation-styleguide.md
@@ -154,6 +154,21 @@ When you have three or more points you want to highlight, use a list. If the ord
 #### Tables
 If you want to lay out information where each item has more than one piece of data, use a table. A glossary, for instance, can be neatly presented in a table. One benefit of using a table rather than a description list with a heading and an explanation, especially when there are many rows, is that when viewed in GitHub the rows are zebra-striped which makes reading it easier.
 
+### Documenting component props
+In order to generate prop tables for components you should use the `StyledSystemProps` component which generates the tables for you. As shown below, you pass your component into the `of` prop and this will generate the prop table for your component. 
+
+It will also generate a second prop table containing all of the spacing props added to the component by `styled-system` if you add the `spacing` prop. To set the defaults for these spacing props, set the `spacingDefault` prop as shown below.  
+
+```
+import StyledSystemProps from '{path to}/.storybook/utils/styled-system-props';
+
+<StyledSystemProps 
+  of={MyComponent}
+  spacing
+  spacingDefault={{ ml: '10%', mt: 3 }}
+/>
+```
+
 ### Use of Links
 You can use links to third-party sites and other documents in this repository in your own document to avoid duplication of information, unless the details you wish to refer to are short. Ensure the links are correct by trying them from your branch via GitHub.
 

--- a/src/__spec_helper__/test-utils.js
+++ b/src/__spec_helper__/test-utils.js
@@ -1,3 +1,5 @@
+import { mount } from 'enzyme';
+
 import { carbonThemeList } from '../style/themes';
 import { mockMatchMedia } from './mock-match-media';
 
@@ -98,6 +100,103 @@ const assertHoverTraversal = assertCorrectTraversal(wrapper => hoverList(wrapper
 
 const carbonThemesJestTable = carbonThemeList.map(theme => [theme.name, theme]);
 
+const spacingProps = [
+  ['m', 'margin'],
+  ['ml', 'marginLeft'],
+  ['mr', 'marginRight'],
+  ['mt', 'marginTop'],
+  ['mb', 'marginBottom'],
+  ['mx', 'marginLeft'],
+  ['mx', 'marginRight'],
+  ['my', 'marginTop'],
+  ['my', 'marginBottom'],
+  ['p', 'padding'],
+  ['pl', 'paddingLeft'],
+  ['pr', 'paddingRight'],
+  ['pt', 'paddingTop'],
+  ['pb', 'paddingBottom'],
+  ['px', 'paddingLeft'],
+  ['px', 'paddingRight'],
+  ['py', 'paddingTop'],
+  ['py', 'paddingBottom']
+];
+
+const getDefaultValue = (value) => {
+  if (typeof value === 'number') {
+    return `${value * 8}px`;
+  }
+  return value;
+};
+
+const testStyledSystemSpacing = (component, defaults, styleContainer) => {
+  describe('default props', () => {
+    const wrapper = mount(component());
+
+    it('should set the correct margins', () => {
+      let marginLeft;
+      let marginRight;
+      let marginTop;
+      let marginBottom;
+
+      if (defaults) {
+        marginLeft = getDefaultValue(defaults.ml || defaults.mx || defaults.m || undefined);
+        marginRight = getDefaultValue(defaults.mr || defaults.mx || defaults.m || undefined);
+        marginTop = getDefaultValue(defaults.mt || defaults.my || defaults.m || undefined);
+        marginBottom = getDefaultValue(defaults.mb || defaults.my || defaults.m || undefined);
+      }
+
+      expect(assertStyleMatch(
+        {
+          marginLeft,
+          marginRight,
+          marginTop,
+          marginBottom
+        },
+        styleContainer ? styleContainer(wrapper) : wrapper
+      ));
+    });
+
+    it('should set the correct paddings', () => {
+      let paddingLeft;
+      let paddingRight;
+      let paddingTop;
+      let paddingBottom;
+
+      if (defaults) {
+        paddingLeft = getDefaultValue(defaults.pl || defaults.px || defaults.p || undefined);
+        paddingRight = getDefaultValue(defaults.pr || defaults.px || defaults.p || undefined);
+        paddingTop = getDefaultValue(defaults.pt || defaults.py || defaults.p || undefined);
+        paddingBottom = getDefaultValue(defaults.pb || defaults.py || defaults.p || undefined);
+      }
+
+      expect(assertStyleMatch(
+        {
+          paddingLeft,
+          paddingRight,
+          paddingTop,
+          paddingBottom
+        },
+        styleContainer ? styleContainer(wrapper) : wrapper
+      ));
+    });
+  });
+
+  describe.each(spacingProps)('when a custom spacing is specified using the "%s" styled system props',
+    (styledSystemProp, propName) => {
+      it(`then that ${propName} should have been set correctly`, () => {
+        let wrapper = mount(component());
+
+        const props = { [styledSystemProp]: 2 };
+        wrapper = mount(component({ ...props }));
+
+        expect(assertStyleMatch(
+          { [propName]: '16px' },
+          styleContainer ? styleContainer(wrapper) : wrapper
+        ));
+      });
+    });
+};
+
 export {
   assertStyleMatch,
   toCSSCase,
@@ -112,5 +211,6 @@ export {
   click,
   simulate,
   carbonThemesJestTable,
-  mockMatchMedia
+  mockMatchMedia,
+  testStyledSystemSpacing
 };

--- a/src/components/hr/hr.component.js
+++ b/src/components/hr/hr.component.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import propTypes from '@styled-system/prop-types';
 
 import StyledHr from './hr.style';
 import useIsAboveBreakpoint from '../../hooks/__internal__/useIsAboveBreakpoint';
 
 const Hr = ({
   adaptiveMxBreakpoint,
-  mt = 3,
-  mb = 3,
   ml,
-  mr
+  mr,
+  ...props
 }) => {
   const largeScreen = useIsAboveBreakpoint(adaptiveMxBreakpoint);
   let marginLeft = ml;
@@ -22,23 +22,18 @@ const Hr = ({
   return (
     <StyledHr
       data-component='hr'
-      mt={ mt }
-      mb={ mb }
       ml={ marginLeft }
       mr={ marginRight }
+      mt={ props.mt || 3 }
+      mb={ props.mb || 3 }
+      { ...props }
     />
   );
 };
 
 Hr.propTypes = {
-  /** Margin top, this value will be multiplied by the theme spacing constant (8) */
-  mt: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
-  /** Margin bottom, this value will be multiplied by the theme spacing constant (8) */
-  mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
-  /** Margin left, any valid css value */
-  ml: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /** Margin right, any valid css value */
-  mr: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Styled system spacing props */
+  ...propTypes.space,
   /** Breakpoint for adaptive left and right margins (below the breakpoint they go to 0).
    * Enables the adaptive behaviour when set */
   adaptiveMxBreakpoint: PropTypes.number

--- a/src/components/hr/hr.d.ts
+++ b/src/components/hr/hr.d.ts
@@ -1,15 +1,7 @@
 import * as React from 'react';
-import { FormFieldSpacing } from '../../utils/helpers/options-helper/options-helper';
+import { SpacingProps } from '../../utils/helpers/options-helper';
 
-export interface HrProps {
-  /** Margin top, this value will be multiplied by the theme spacing constant (8) */
-  mt?: FormFieldSpacing;
-  /** Margin bottom, this value will be multiplied by the theme spacing constant (8) */
-  mb?: FormFieldSpacing;
-  /** Margin left, any valid css value */
-  ml?: string;
-  /** Margin right, any valid css value */
-  mr?: string;
+export interface HrProps extends SpacingProps {
   /** Breakpoint for adaptive left and right margins (below the breakpoint they go to 0).
    * Enables the adaptive behaviour when set
    */

--- a/src/components/hr/hr.spec.js
+++ b/src/components/hr/hr.spec.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { assertStyleMatch, mockMatchMedia } from '../../__spec_helper__/test-utils';
+import {
+  assertStyleMatch,
+  mockMatchMedia,
+  testStyledSystemSpacing
+} from '../../__spec_helper__/test-utils';
 import Hr from './hr.component';
 import StyledHr from './hr.style';
 
@@ -18,14 +22,7 @@ describe('Hr', () => {
     wrapper = render();
   });
 
-  describe('default props', () => {
-    it('should apply the correct margins', () => {
-      assertStyleMatch({
-        marginTop: '24px',
-        marginBottom: '24px'
-      }, wrapper.find(StyledHr));
-    });
-  });
+  testStyledSystemSpacing(props => <Hr { ...props } />, { mt: '24px', mb: '24px' });
 
   describe('margin props', () => {
     it('should apply the correct top margin', () => {

--- a/src/components/hr/hr.stories.mdx
+++ b/src/components/hr/hr.stories.mdx
@@ -1,10 +1,12 @@
-import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { PropsTable } from '@storybook/components';
 import { useState } from 'react';
 
 import Hr from '.';
 import Form from '../form';
 import Textbox from '../../__experimental__/components/textbox';
 import Button from '../button';
+import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
 
 <Meta
   title="Design System/Hr"
@@ -90,3 +92,10 @@ The left and right margins can be set to 0 below a screen width breakpoint. This
     <Hr mb={7} mt={7} ml="10%" mr="40%" adaptiveMxBreakpoint={960} />
   </Story> 
 </Preview>
+
+
+<StyledSystemProps
+  of={Hr}
+  spacing
+  spacingDefaults={{ mt: '3', mb: '3' }}
+/>

--- a/src/components/hr/hr.style.js
+++ b/src/components/hr/hr.style.js
@@ -1,15 +1,13 @@
 import styled from 'styled-components';
+import { space } from 'styled-system';
 import baseTheme from '../../style/themes/base';
 
 const StyledHr = styled.hr`
+  ${space}
   width: inherit;
   border: 0;
   height: 1px;
   background: ${({ theme }) => theme.hr.background};
-  margin-top: ${({ mt, theme }) => mt * theme.spacing}px;
-  margin-bottom: ${({ mb, theme }) => mb * theme.spacing}px;
-  margin-left: ${({ ml }) => ml};
-  margin-right: ${({ mr }) => mr};
 `;
 
 StyledHr.defaultProps = {

--- a/src/utils/helpers/options-helper/options-helper.d.ts
+++ b/src/utils/helpers/options-helper/options-helper.d.ts
@@ -182,3 +182,22 @@ export type FormFieldSpacing = 0 | 1 | 2 | 3 | 4 | 5 | 7;
 export type SizesType = 'small' | 'large';
 
 export type ThemesBinary = 'primary' | 'secondary';
+
+export interface SpacingProps {
+  /** Margins */
+  m?: number | string;
+  mt?: number | string;
+  mr?: number | string;
+  mb?: number | string;
+  ml?: number | string;
+  mx?: number | string;
+  my?: number | string;
+  /** Paddings */
+  p?: number | string;
+  pt?: number | string;
+  pr?: number | string;
+  pb?: number | string;
+  pl?: number | string;
+  px?: number | string;
+  py?: number | string;
+}


### PR DESCRIPTION
### Proposed behaviour
Add `styled-system` spacing props to `Hr`.

Add storybook component to generate prop tables for a component, and the `styled-system` spacing props like the below screenshot: 

![image](https://user-images.githubusercontent.com/14963680/92764483-5f6a6280-f38c-11ea-8b25-9753fb23b05b.png)


### Current behaviour
`Hr` currently has it's own margin props and does not use `styled-system`.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
PR codesandbox generated below: https://codesandbox.io/s/divine-butterfly-wux1t