### PR TITLE
feat: form input components adaptive behaviour

### DIFF
--- a/src/__experimental__/components/checkbox/checkbox.component.js
+++ b/src/__experimental__/components/checkbox/checkbox.component.js
@@ -5,6 +5,7 @@ import tagComponent from '../../../utils/helpers/tags';
 import CheckboxStyle from './checkbox.style';
 import CheckableInput from '../checkable-input/checkable-input.component';
 import CheckboxSvg from './checkbox-svg.component';
+import useIsAboveBreakpoint from '../../../hooks/__internal__/useIsAboveBreakpoint';
 
 const Checkbox = ({
   id,
@@ -17,8 +18,16 @@ const Checkbox = ({
   labelHelp,
   labelSpacing = 1,
   ml,
+  adaptiveSpacingBreakpoint,
   ...props
 }) => {
+  const largeScreen = useIsAboveBreakpoint(adaptiveSpacingBreakpoint);
+
+  let marginLeft = ml;
+  if (adaptiveSpacingBreakpoint && !largeScreen) {
+    marginLeft = '0';
+  }
+
   const inputProps = {
     ...props,
     onChange,
@@ -33,7 +42,7 @@ const Checkbox = ({
     autoFocus,
     labelHelp,
     labelSpacing,
-    ml
+    ml: marginLeft
   };
 
   return (
@@ -97,7 +106,9 @@ Checkbox.propTypes = {
   /** Allows component to be focused on page load */
   autoFocus: PropTypes.bool,
   /** The content for the help tooltip, to appear next to the Label */
-  labelHelp: PropTypes.node
+  labelHelp: PropTypes.node,
+  /** Breakpoint for adaptive spacing (left margin changes to 0). Enables the adaptive behaviour when set */
+  adaptiveSpacingBreakpoint: PropTypes.number
 };
 
 Checkbox.defaultProps = {

--- a/src/__experimental__/components/checkbox/checkbox.d.ts
+++ b/src/__experimental__/components/checkbox/checkbox.d.ts
@@ -28,10 +28,8 @@ interface CheckboxProps {
   Pass string to display icon, tooltip and blue border
   Pass true boolean to only display blue border */
   info?: boolean | string;
-  /** Margin bottom, given number will be multiplied by base spacing unit (8) */
-  mb?: 0 | 1 | 2 | 3 | 4 | 5 | 7;
-  /** Margin left, any valid CSS value */
-  ml?: string;
+  /** Breakpoint for adaptive spacing (left margin changes to 0). Enables the adaptive behaviour when set */
+  adaptiveSpacingBreakpoint?: number;
 }
 
 declare const Checkbox: React.ComponentClass<CheckboxProps>;

--- a/src/__experimental__/components/checkbox/checkbox.spec.js
+++ b/src/__experimental__/components/checkbox/checkbox.spec.js
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 import 'jest-styled-components';
 import { css } from 'styled-components';
 import Checkbox from './checkbox.component';
+import CheckableInput from '../checkable-input/checkable-input.component';
 import { StyledCheckableInput } from '../checkable-input/checkable-input.style';
 import FieldHelpStyle from '../field-help/field-help.style';
 import HiddenCheckableInputStyle from '../checkable-input/hidden-checkable-input.style';
@@ -11,7 +12,11 @@ import LabelStyle from '../label/label.style';
 import StyledCheckableInputSvgWrapper from '../checkable-input/checkable-input-svg-wrapper.style';
 import StyledHelp from '../../../components/help/help.style';
 import guid from '../../../utils/helpers/guid';
-import { assertStyleMatch, carbonThemesJestTable } from '../../../__spec_helper__/test-utils';
+import {
+  assertStyleMatch,
+  carbonThemesJestTable,
+  mockMatchMedia
+} from '../../../__spec_helper__/test-utils';
 import { baseTheme, classicTheme } from '../../../style/themes';
 
 jest.mock('../../../utils/helpers/guid');
@@ -31,7 +36,7 @@ function render(props, renderer = TestRenderer.create, options = {}) {
 describe('Checkbox', () => {
   describe('base theme', () => {
     it('renders as expected', () => {
-      expect(render()).toMatchSnapshot();
+      expect(render({ })).toMatchSnapshot();
     });
 
     describe('when size=large', () => {
@@ -143,6 +148,42 @@ describe('Checkbox', () => {
 
         it('applies the appropriate svg focus styles', () => {
           assertStyleMatch(hoverFocusStyles, wrapper, { modifier: css`${`${StyledCheckableInputSvgWrapper}:focus`}` });
+        });
+      });
+    });
+
+    describe('with a left margin (ml prop)', () => {
+      describe('when adaptiveSpacingBreakpoint prop is set', () => {
+        describe('when screen bigger than breakpoint', () => {
+          beforeEach(() => {
+            mockMatchMedia(true);
+          });
+
+          it('should pass the correct margin to CheckableInput', () => {
+            const wrapper = render({
+              label: 'Label',
+              adaptiveSpacingBreakpoint: 1000,
+              ml: '10%'
+            }, mount);
+
+            expect(wrapper.find(CheckableInput).props().ml).toEqual('10%');
+          });
+        });
+
+        describe('when screen smaller than breakpoint', () => {
+          beforeEach(() => {
+            mockMatchMedia(false);
+          });
+
+          it('should pass "0" to CheckableInput', () => {
+            const wrapper = render({
+              label: 'Label',
+              adaptiveSpacingBreakpoint: 1000,
+              ml: '10%'
+            }, mount);
+
+            expect(wrapper.find(CheckableInput).props().ml).toEqual('0');
+          });
         });
       });
     });

--- a/src/__experimental__/components/checkbox/checkbox.stories.js
+++ b/src/__experimental__/components/checkbox/checkbox.stories.js
@@ -83,7 +83,9 @@ function defaultKnobs(type, autoFocusDefault = false) {
     }, type),
     labelSpacing: select('labelSpacing', [1, 2], 1),
     size: select('size', OptionsHelper.sizesBinary, 'small', type),
-    value: text('value', type, type)
+    value: text('value', type, type),
+    ml: text('ml', '0', type),
+    adaptiveSpacingBreakpoint: number('adaptiveSpacingBreakpoint')
   });
 }
 

--- a/src/__experimental__/components/checkbox/docgenInfo.json
+++ b/src/__experimental__/components/checkbox/docgenInfo.json
@@ -289,6 +289,18 @@
           },
           "required": false,
           "description": "Margin bottom, given number will be multiplied by base spacing unit (8)"
+        },
+        "ml": {
+          "type": "string",
+          "required": false,
+          "description": "Margin left, any valid CSS value"
+        },
+        "adaptiveSpacingBreakpoint": {
+          "type": {
+            "name": "number"
+          },
+          "required": false,
+          "description": "Breakpoint for adaptive spacing (left margin changes to 0). Enables the adaptive behaviour when set"
         }
       }
     }

--- a/src/__experimental__/components/date/date.component.js
+++ b/src/__experimental__/components/date/date.component.js
@@ -352,7 +352,11 @@ class BaseDateInput extends React.Component {
 
   render() {
     const {
-      minDate, maxDate, labelInline, ...inputProps
+      minDate,
+      maxDate,
+      labelInline,
+      adaptiveLabelBreakpoint,
+      ...inputProps
     } = this.props;
 
     let events = {};
@@ -382,6 +386,7 @@ class BaseDateInput extends React.Component {
           labelInline={ labelInline }
           rawValue={ isoFormattedValueString(this.state.visibleValue) }
           inputRef={ this.assignInput }
+          adaptiveLabelBreakpoint={ adaptiveLabelBreakpoint }
           { ...events }
         />
         { this.renderHiddenInput() }
@@ -439,7 +444,9 @@ BaseDateInput.propTypes = {
   /** Name of the input */
   name: PropTypes.string,
   /** The current date YYYY-MM-DD */
-  value: PropTypes.string
+  value: PropTypes.string,
+  /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLabelBreakpoint: PropTypes.number
 };
 
 export { defaultDateFormat, BaseDateInput };

--- a/src/__experimental__/components/form-field/form-field.component.js
+++ b/src/__experimental__/components/form-field/form-field.component.js
@@ -7,6 +7,7 @@ import OptionsHelper from '../../../utils/helpers/options-helper';
 import tagComponent from '../../../utils/helpers/tags';
 import Logger from '../../../utils/logger/logger';
 import { TabContext } from '../../../components/tabs/__internal__/tab';
+import useIsAboveBreakpoint from '../../../hooks/__internal__/useIsAboveBreakpoint';
 
 let deprecatedWarnTriggered = false;
 
@@ -32,13 +33,14 @@ const FormField = ({
   name,
   id,
   reverse,
-  size,
+  size = 'medium',
   childOfForm,
   isOptional,
   readOnly,
   useValidationIcon,
   mb,
-  styleOverride,
+  adaptiveLabelBreakpoint,
+  styleOverride = {},
   ...props
 }) => {
   if (!deprecatedWarnTriggered) {
@@ -48,6 +50,11 @@ const FormField = ({
   }
 
   const context = useContext(TabContext);
+  const largeScreen = useIsAboveBreakpoint(adaptiveLabelBreakpoint);
+  let inlineLabel = labelInline;
+  if (adaptiveLabelBreakpoint) {
+    inlineLabel = largeScreen;
+  }
 
   useEffect(() => {
     if (context && context.setError && context.setWarning && context.setInfo) {
@@ -63,7 +70,7 @@ const FormField = ({
       styleOverride={ styleOverride.root }
       mb={ mb }
     >
-      <FieldLineStyle inline={ labelInline }>
+      <FieldLineStyle inline={ inlineLabel }>
         {reverse && children}
 
         {label && (
@@ -81,7 +88,7 @@ const FormField = ({
             helpTabIndex={ helpTabIndex }
             htmlFor={ id }
             helpIcon={ labelHelpIcon }
-            inline={ labelInline }
+            inline={ inlineLabel }
             inputSize={ size }
             width={ labelWidth }
             childOfForm={ childOfForm }
@@ -96,7 +103,7 @@ const FormField = ({
         )}
 
         {fieldHelp && fieldHelpInline && (
-          <FieldHelp labelInline={ labelInline } labelWidth={ labelWidth }>
+          <FieldHelp labelInline={ inlineLabel } labelWidth={ labelWidth }>
             {fieldHelp}
           </FieldHelp>
         )}
@@ -105,7 +112,7 @@ const FormField = ({
       </FieldLineStyle>
 
       {fieldHelp && !fieldHelpInline && (
-        <FieldHelp labelInline={ labelInline } labelWidth={ labelWidth }>
+        <FieldHelp labelInline={ inlineLabel } labelWidth={ labelWidth }>
           {fieldHelp}
         </FieldHelp>
       )}
@@ -122,11 +129,6 @@ const errorPropType = (props, propName, componentName, ...rest) => {
   }
 
   return PropTypes.oneOfType([PropTypes.bool, PropTypes.string])(props, propName, componentName, ...rest);
-};
-
-FormField.defaultProps = {
-  size: 'medium',
-  styleOverride: {}
 };
 
 FormField.propTypes = {
@@ -160,6 +162,8 @@ FormField.propTypes = {
   useValidationIcon: PropTypes.bool,
   /** Override form spacing (margin bottom) */
   mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
+  /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLabelBreakpoint: PropTypes.number,
   /** Allows to override existing component styles */
   styleOverride: PropTypes.shape({
     root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),

--- a/src/__experimental__/components/form-field/form-field.spec.js
+++ b/src/__experimental__/components/form-field/form-field.spec.js
@@ -2,10 +2,12 @@ import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { shallow, mount } from 'enzyme';
 import FormField from '.';
-import FormFieldStyle from './form-field.style';
+import FieldHelp from '../field-help';
+import FormFieldStyle, { FieldLineStyle } from './form-field.style';
 import classicTheme from '../../../style/themes/classic';
 import Label from '../label/label.component';
 import { TabContext } from '../../../components/tabs/__internal__/tab';
+import { mockMatchMedia } from '../../../__spec_helper__/test-utils';
 
 const setError = jest.fn();
 const setWarning = jest.fn();
@@ -57,6 +59,46 @@ describe('FormField', () => {
         label: 'Name'
       });
       expect(comp.find(Label).props().htmlFor).toEqual('foo');
+    });
+
+    describe('when adaptiveLabelBreakpoint prop is set', () => {
+      describe('when screen bigger than breakpoint', () => {
+        beforeEach(() => {
+          mockMatchMedia(true);
+        });
+
+        it('should pass labelInline to its children', () => {
+          const wrapper = render({
+            label: 'Name',
+            labelInline: true,
+            fieldHelp: 'Help',
+            adaptiveLabelBreakpoint: 1000
+          }, mount);
+
+          expect(wrapper.find(FieldLineStyle).props().inline).toEqual(true);
+          expect(wrapper.find(Label).props().inline).toEqual(true);
+          expect(wrapper.find(FieldHelp).props().labelInline).toEqual(true);
+        });
+      });
+
+      describe('when screen smaller than breakpoint', () => {
+        beforeEach(() => {
+          mockMatchMedia(false);
+        });
+
+        it('should pass labelInline to its children', () => {
+          const wrapper = render({
+            label: 'Name',
+            labelInline: true,
+            fieldHelp: 'Help',
+            adaptiveLabelBreakpoint: 1000
+          }, mount);
+
+          expect(wrapper.find(FieldLineStyle).props().inline).toEqual(false);
+          expect(wrapper.find(Label).props().inline).toEqual(false);
+          expect(wrapper.find(FieldHelp).props().labelInline).toEqual(false);
+        });
+      });
     });
   });
 

--- a/src/__experimental__/components/numeral-date/numeral-date.component.js
+++ b/src/__experimental__/components/numeral-date/numeral-date.component.js
@@ -27,7 +27,8 @@ const NumeralDate = ({
   labelWidth,
   labelAlign,
   labelHelp,
-  fieldHelp
+  fieldHelp,
+  adaptiveLabelBreakpoint
 }) => {
   const { current: uniqueId } = useRef(id || guid());
   const isControlled = useRef(value !== undefined);
@@ -98,6 +99,7 @@ const NumeralDate = ({
         labelAlign={ labelAlign }
         labelHelp={ labelHelp }
         fieldHelp={ fieldHelp }
+        adaptiveLabelBreakpoint={ adaptiveLabelBreakpoint }
       >
         <StyledNumeralDate
           name={ name }
@@ -208,7 +210,9 @@ NumeralDate.propTypes = {
   /** Width of a label in percentage. Works only when labelInline is true */
   labelWidth: PropTypes.number,
   /** Help content to be displayed under an input */
-  fieldHelp: PropTypes.node
+  fieldHelp: PropTypes.node,
+  /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLabelBreakpoint: PropTypes.number
 };
 
 export default NumeralDate;

--- a/src/__experimental__/components/numeral-date/numeral-date.d.ts
+++ b/src/__experimental__/components/numeral-date/numeral-date.d.ts
@@ -69,6 +69,8 @@ export interface NumeralDateProps {
   labelWidth?: number;
   /** Help content to be displayed under an input */
   fieldHelp?: string;
+  /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLabelBreakpoint?: number;
 }
 
 declare const NumeralDate: React.ComponentType<NumeralDateProps>;

--- a/src/__experimental__/components/numeral-date/numeral-date.stories.mdx
+++ b/src/__experimental__/components/numeral-date/numeral-date.stories.mdx
@@ -13,7 +13,7 @@ For dates close to today, we advise the use of a standard datepicker. If you req
 Import `NumeralDate` into the project.
 
 ```jsx
-import { NumeralDate } from "carbon-react/lib/__experimental__/components/numeral-date"
+import NumeralDate from "carbon-react/lib/__experimental__/components/numeral-date"
 
 const MyComponent = () => (
   <NumeralDate dateFormat={['dd','mm','yyyy']} onChange={ onChange } value={{ dd: '27', mm: '04', yyyy: '1989' }} />
@@ -137,6 +137,21 @@ const MyComponent = () => (
       labelInline
       labelAlign="right"
       labelWidth={30}
+    />
+  </Story>
+</Preview>
+
+### Enabling the adaptive behaviour
+The inline label can change to be top aligned at a breakpoint. Enable this by passing in a number to the `adaptiveLabelBreakpoint` prop. This corresponds to a px screen width
+
+<Preview>
+  <Story name="enabling adaptive behaviour" parameters={{ chromatic: { disable: true }}}>
+    <NumeralDate 
+      dateFormat={['dd','mm','yyyy']} 
+      label="Inline"
+      labelAlign="right"
+      labelWidth={30}
+      adaptiveLabelBreakpoint={960}
     />
   </Story>
 </Preview>

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -6,6 +6,7 @@ import Fieldset from '../../../__internal__/fieldset';
 import RadioButtonGroupStyle from './radio-button-group.style';
 import RadioButtonMapper from './radio-button-mapper.component';
 import Logger from '../../../utils/logger/logger';
+import useIsAboveBreakpoint from '../../../hooks/__internal__/useIsAboveBreakpoint';
 
 let deprecatedWarnTriggered = false;
 
@@ -16,10 +17,40 @@ const RadioButtonGroup = (props) => {
     Logger.deprecate('`styleOverride` that is used in the `RadioButtonGroup` component is deprecated and will soon be removed.');
   }
   const {
-    children, name, legend, error, warning, info, onBlur,
-    onChange, value, inline, legendInline, legendWidth, legendAlign,
-    legendSpacing, ml, mb, labelSpacing = 1, styleOverride
+    children,
+    name,
+    legend,
+    error,
+    warning,
+    info,
+    onBlur,
+    onChange,
+    value,
+    inline = false,
+    legendInline = false,
+    legendWidth,
+    legendAlign,
+    legendSpacing,
+    ml,
+    mb,
+    labelSpacing = 1,
+    adaptiveLegendBreakpoint,
+    adaptiveSpacingBreakpoint,
+    styleOverride = {}
   } = props;
+
+  const isAboveLegendBreakpoint = useIsAboveBreakpoint(adaptiveLegendBreakpoint);
+  const isAboveSpacingBreakpoint = useIsAboveBreakpoint(adaptiveSpacingBreakpoint);
+
+  let inlineLegend = legendInline;
+  if (adaptiveLegendBreakpoint) {
+    inlineLegend = isAboveLegendBreakpoint;
+  }
+
+  let marginLeft = ml;
+  if (adaptiveSpacingBreakpoint && !isAboveSpacingBreakpoint) {
+    marginLeft = undefined;
+  }
 
   return (
     <Fieldset
@@ -28,11 +59,11 @@ const RadioButtonGroup = (props) => {
       error={ error }
       warning={ warning }
       info={ info }
-      inline={ legendInline }
+      inline={ inlineLegend }
       legendWidth={ legendWidth }
       legendAlign={ legendAlign }
       legendSpacing={ legendSpacing }
-      ml={ ml }
+      ml={ marginLeft }
       mb={ mb }
       styleOverride={ styleOverride }
       { ...tagComponent('radiogroup', props) }
@@ -104,18 +135,16 @@ RadioButtonGroup.propTypes = {
   mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
   /** Spacing between labels and radio buttons, given number will be multiplied by base spacing unit (8) */
   labelSpacing: PropTypes.oneOf([1, 2]),
+  /** Breakpoint for adaptive legend (inline labels change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLegendBreakpoint: PropTypes.number,
+  /** Breakpoint for adaptive spacing (left margin changes to 0). Enables the adaptive behaviour when set */
+  adaptiveSpacingBreakpoint: PropTypes.number,
   /** Allows to override existing component styles */
   styleOverride: PropTypes.shape({
     root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     content: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     legend: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
   })
-};
-
-RadioButtonGroup.defaultProps = {
-  inline: false,
-  legendInline: false,
-  styleOverride: {}
 };
 
 export default RadioButtonGroup;

--- a/src/__experimental__/components/radio-button/radio-button-group.d.ts
+++ b/src/__experimental__/components/radio-button/radio-button-group.d.ts
@@ -41,6 +41,10 @@ export interface RadioButtonGroupProps {
   mb?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
   /** Spacing between labels and radio buttons, given number will be multiplied by base spacing unit (8) */
   labelSpacing?: 1 | 2;
+  /** Breakpoint for adaptive legend (inline labels change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLegendBreakpoint?: number;
+  /** Breakpoint for adaptive spacing (left margin changes to 0). Enables the adaptive behaviour when set */
+  adaptiveSpacingBreakpoint?: number;
   /** Allows to override existing component styles */
   styleOverride?: {
     root?: object;

--- a/src/__experimental__/components/radio-button/radio-button-group.spec.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.spec.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { mount } from 'enzyme';
-import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
+import { assertStyleMatch, mockMatchMedia } from '../../../__spec_helper__/test-utils';
 import { RadioButton, RadioButtonGroup } from '.';
 import { StyledFieldset, StyledLegendContainer } from '../../../__internal__/fieldset/fieldset.style';
 import RadioButtonGroupStyle from './radio-button-group.style';
+import Fieldset from '../../../__internal__/fieldset';
 
 const buttonValues = ['test-1', 'test-2'];
 const name = 'test-group';
 
-function render(renderer = TestRenderer.create, props) {
+function render(props, renderer = TestRenderer.create) {
   const children = buttonValues.map((value, index) => (
     <RadioButton
       id={ `rId-${index}` } key={ `radio-key-${value}` }
@@ -32,7 +33,81 @@ function render(renderer = TestRenderer.create, props) {
 
 describe('RadioButtonGroup', () => {
   it('renders as expected', () => {
-    expect(render()).toMatchSnapshot();
+    expect(render({ })).toMatchSnapshot();
+  });
+
+  describe('with an inline legend', () => {
+    describe('when adaptiveLegendBreakpoint prop is set', () => {
+      describe('when screen bigger than breakpoint', () => {
+        beforeEach(() => {
+          mockMatchMedia(true);
+        });
+
+        it('should pass legendInline to Fieldset', () => {
+          const wrapper = render({
+            legend: 'Legend',
+            legendInline: true,
+            adaptiveLegendBreakpoint: 1000
+          }, mount);
+
+          expect(wrapper.find(Fieldset).props().inline).toEqual(true);
+        });
+      });
+
+      describe('when screen smaller than breakpoint', () => {
+        beforeEach(() => {
+          mockMatchMedia(false);
+        });
+
+        it('should pass legendInline to Fieldset', () => {
+          const wrapper = render({
+            legend: 'Legend',
+            legendInline: true,
+            adaptiveLegendBreakpoint: 1000
+          }, mount);
+
+          expect(wrapper.find(Fieldset).props().inline).toEqual(false);
+        });
+      });
+    });
+  });
+
+  describe('with a left margin (ml prop)', () => {
+    describe('when adaptiveSpacingBreakpoint prop is set', () => {
+      describe('when screen bigger than breakpoint', () => {
+        beforeEach(() => {
+          mockMatchMedia(true);
+        });
+
+        it('should pass the correct margin to Fieldset', () => {
+          const wrapper = render({
+            legend: 'Legend',
+            legendInline: true,
+            adaptiveSpacingBreakpoint: 1000,
+            ml: '10%'
+          }, mount);
+
+          expect(wrapper.find(Fieldset).props().ml).toEqual('10%');
+        });
+      });
+
+      describe('when screen smaller than breakpoint', () => {
+        beforeEach(() => {
+          mockMatchMedia(false);
+        });
+
+        it('should pass "0" to Fieldset', () => {
+          const wrapper = render({
+            legend: 'Legend',
+            legendInline: true,
+            adaptiveSpacingBreakpoint: 1000,
+            ml: '10%'
+          }, mount);
+
+          expect(wrapper.find(Fieldset).props().ml).toEqual(undefined);
+        });
+      });
+    });
   });
 
   describe('styles', () => {
@@ -55,7 +130,7 @@ describe('RadioButtonGroup', () => {
       ['info', 'string'],
       ['info', true]
     ])('when %s is passed as %s it is passed as boolean to RadioButton', (type, value) => {
-      const wrapper = render(mount, { [type]: value });
+      const wrapper = render({ [type]: value }, mount);
       wrapper.find(RadioButton).forEach(node => expect(node.props()[type]).toBe(true));
     });
   });
@@ -74,7 +149,7 @@ describe('RadioButtonGroup', () => {
     };
 
     beforeEach(() => {
-      wrapper = render(mount, { styleOverride });
+      wrapper = render({ styleOverride }, mount);
     });
 
     it('renders root element with properly assigned styles', () => {

--- a/src/__experimental__/components/radio-button/radio-button.stories.mdx
+++ b/src/__experimental__/components/radio-button/radio-button.stories.mdx
@@ -123,6 +123,38 @@ A `ml` prop can be supplied to align the `RadioButtonGroup` with above and below
   </Story> 
 </Preview>
 
+### Enable adaptive behaviour
+Passing in the `adaptiveLegendBreakpoint` and `adaptiveSpacingBreakpoint` props will enable the adaptive behaviour. 
+
+<Preview>
+  <Story name="Enable adaptive behaviour" parameters={{ chromatic: { disable: true }}}>
+    <RadioButtonGroup
+      name="mybuttongroup"
+      onChange={ () => console.log('change') }
+      legend="Radio group legend"
+      ml="20%"
+      adaptiveLegendBreakpoint={960}
+      adaptiveSpacingBreakpoint={960}
+    >
+    <RadioButton 
+      id="radio1" 
+      value="radio1"
+      label="Radio Option 1"
+    />
+    <RadioButton 
+      id="radio2" 
+      value="radio2" 
+      label="Radio Option 2"
+    />
+    <RadioButton 
+      id="radio3" 
+      value="radio3" 
+      label="Radio Option 3"
+    />
+  </RadioButtonGroup>
+  </Story> 
+</Preview>
+
 ### Different label spacing 
 The spacing between radio buttons and their labels can be changed with the `labelSpacing` prop. Similarly to the `legendSpacing` prop, this is a number which is multiplied by the base theme spacing constant. It defaults to `1` which is therefore `8px`.
 

--- a/src/__experimental__/components/switch/__snapshots__/switch.spec.js.snap
+++ b/src/__experimental__/components/switch/__snapshots__/switch.spec.js.snap
@@ -33,25 +33,25 @@ exports[`Switch base theme renders as expected 1`] = `
   display: flex;
 }
 
-.c1 .c34 {
+.c1 .c33 {
   padding-top: 0;
   width: auto;
 }
 
-.c1 .c34 .c36,
-.c1 .c34 .c37 {
+.c1 .c33 .c35,
+.c1 .c33 .c36 {
   color: rgba(0,0,0,0.65);
   vertical-align: middle;
 }
 
-.c1 .c34 .c36:hover,
-.c1 .c34 .c37:hover,
-.c1 .c34 .c36:focus,
-.c1 .c34 .c37:focus {
+.c1 .c33 .c35:hover,
+.c1 .c33 .c36:hover,
+.c1 .c33 .c35:focus,
+.c1 .c33 .c36:focus {
   color: rgba(0,0,0,0.9);
 }
 
-.c1 .c33 {
+.c1 .c32 {
   -webkit-flex-basis: 100%;
   -ms-flex-preferred-size: 100%;
   flex-basis: 100%;
@@ -111,22 +111,22 @@ exports[`Switch base theme renders as expected 1`] = `
   display: flex;
 }
 
-.c18 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c18 .c4 {
+.c17 .c4 {
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
 }
 
-.c18 .c6 {
+.c17 .c6 {
   margin-right: 0;
   margin-left: 8px;
+}
+
+.c18 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c12 {
@@ -180,7 +180,7 @@ exports[`Switch base theme renders as expected 1`] = `
   z-index: 1;
 }
 
-.c11 .c37 {
+.c11 .c36 {
   position: absolute;
   right: -30px;
   height: 100%;
@@ -352,6 +352,10 @@ exports[`Switch base theme renders as expected 1`] = `
   display: flex;
 }
 
+.c23 .c6 {
+  margin-left: 10px;
+}
+
 .c24 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -379,21 +383,11 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c24 .c6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-}
-
-.c24 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c24 .c6 {
-  margin-left: 10px;
+.c24 .c6,
+.c24 .c8,
+.c24 .c10 {
+  height: 40px;
+  width: 78px;
 }
 
 .c25 .c4 {
@@ -423,61 +417,27 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c25 .c6,
-.c25 .c8,
-.c25 .c10 {
-  height: 40px;
-  width: 78px;
-}
-
-.c26 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-}
-
-.c26 .c6,
-.c26 .c8 {
-  border: none;
-  box-sizing: border-box;
-  height: 24px;
-  width: 60px;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
-  margin-left: 0;
-}
-
-.c26 .c8:not([disabled]):focus + .c10,
-.c26 .c8:not([disabled]):hover + .c10 {
-  outline: solid 3px #FFB500;
-}
-
-.c26 .c6 {
+.c25 .c6 {
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
 }
 
-.c26 .c4 {
+.c25 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c26 .c6 {
+.c25 .c6 {
   margin-left: 0;
   margin-top: 0;
 }
 
-.c26 .c6,
-.c26 .c8,
-.c26 .c10 {
+.c25 .c6,
+.c25 .c8,
+.c25 .c10 {
   height: 40px;
   width: 78px;
 }
@@ -509,18 +469,70 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c0 .c33 {
+.c0 .c32 {
   margin-left: 0;
 }
 
-.c0 .c34 {
+.c0 .c33 {
   padding: 0;
   margin-bottom: 8px;
 }
 
-.c0 .c34 .c37 {
+.c0 .c33 .c36 {
   position: relative;
   display: inline-block;
+}
+
+.c26 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row wrap;
+  -ms-flex-flow: row wrap;
+  flex-flow: row wrap;
+}
+
+.c26 .c6,
+.c26 .c8 {
+  border: none;
+  box-sizing: border-box;
+  height: 24px;
+  width: 60px;
+  -webkit-flex-basis: 100%;
+  -ms-flex-preferred-size: 100%;
+  flex-basis: 100%;
+  margin-left: 0;
+}
+
+.c26 .c8:not([disabled]):focus + .c10,
+.c26 .c8:not([disabled]):hover + .c10 {
+  outline: solid 3px #FFB500;
+}
+
+.c26 .c6,
+.c26 .c8 {
+  border-radius: 24px;
+  height: 28px;
+  width: 55px;
+}
+
+.c26 .c10 {
+  -webkit-transition: box-shadow .1s linear;
+  transition: box-shadow .1s linear;
+}
+
+.c26 .c8:not([disabled]):focus + .c10 {
+  box-shadow: 0 0 6px 2px rgba(37,91,199,0.6);
+}
+
+.c26 .c8:not([disabled]):focus + .c10,
+.c26 .c8:not([disabled]):hover + .c10 {
+  outline: none;
+}
+
+.c26 .c6 .c34 {
+  top: 1px;
 }
 
 .c27 .c4 {
@@ -550,6 +562,19 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: solid 3px #FFB500;
 }
 
+.c27 .c6 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+}
+
+.c27 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 .c27 .c6,
 .c27 .c8 {
   border-radius: 24px;
@@ -571,7 +596,7 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: none;
 }
 
-.c27 .c6 .c35 {
+.c27 .c6 .c34 {
   top: 1px;
 }
 
@@ -615,6 +640,11 @@ exports[`Switch base theme renders as expected 1`] = `
   display: flex;
 }
 
+.c28 .c6 {
+  margin-left: 0;
+  margin-top: 0;
+}
+
 .c28 .c6,
 .c28 .c8 {
   border-radius: 24px;
@@ -636,7 +666,7 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: none;
 }
 
-.c28 .c6 .c35 {
+.c28 .c6 .c34 {
   top: 1px;
 }
 
@@ -667,22 +697,11 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c29 .c6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-}
-
-.c29 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c29 .c6 {
-  margin-left: 0;
-  margin-top: 0;
+.c29 .c6,
+.c29 .c8,
+.c29 .c10 {
+  height: 40px;
+  width: 78px;
 }
 
 .c29 .c6,
@@ -706,8 +725,15 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: none;
 }
 
-.c29 .c6 .c35 {
+.c29 .c6 .c34 {
   top: 1px;
+}
+
+.c29 .c6,
+.c29 .c8,
+.c29 .c10 {
+  height: 28px;
+  width: 55px;
 }
 
 .c30 .c4 {
@@ -765,7 +791,7 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: none;
 }
 
-.c30 .c6 .c35 {
+.c30 .c6 .c34 {
   top: 1px;
 }
 
@@ -803,6 +829,24 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: solid 3px #FFB500;
 }
 
+.c31 .c6 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+}
+
+.c31 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c31 .c6 {
+  margin-left: 0;
+  margin-top: 0;
+}
+
 .c31 .c6,
 .c31 .c8,
 .c31 .c10 {
@@ -831,97 +875,13 @@ exports[`Switch base theme renders as expected 1`] = `
   outline: none;
 }
 
-.c31 .c6 .c35 {
+.c31 .c6 .c34 {
   top: 1px;
 }
 
 .c31 .c6,
 .c31 .c8,
 .c31 .c10 {
-  height: 28px;
-  width: 55px;
-}
-
-.c32 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-}
-
-.c32 .c6,
-.c32 .c8 {
-  border: none;
-  box-sizing: border-box;
-  height: 24px;
-  width: 60px;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
-  margin-left: 0;
-}
-
-.c32 .c8:not([disabled]):focus + .c10,
-.c32 .c8:not([disabled]):hover + .c10 {
-  outline: solid 3px #FFB500;
-}
-
-.c32 .c6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-}
-
-.c32 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c32 .c6 {
-  margin-left: 0;
-  margin-top: 0;
-}
-
-.c32 .c6,
-.c32 .c8,
-.c32 .c10 {
-  height: 40px;
-  width: 78px;
-}
-
-.c32 .c6,
-.c32 .c8 {
-  border-radius: 24px;
-  height: 28px;
-  width: 55px;
-}
-
-.c32 .c10 {
-  -webkit-transition: box-shadow .1s linear;
-  transition: box-shadow .1s linear;
-}
-
-.c32 .c8:not([disabled]):focus + .c10 {
-  box-shadow: 0 0 6px 2px rgba(37,91,199,0.6);
-}
-
-.c32 .c8:not([disabled]):focus + .c10,
-.c32 .c8:not([disabled]):hover + .c10 {
-  outline: none;
-}
-
-.c32 .c6 .c35 {
-  top: 1px;
-}
-
-.c32 .c6,
-.c32 .c8,
-.c32 .c10 {
   height: 28px;
   width: 55px;
 }

--- a/src/__experimental__/components/switch/docgenInfo.json
+++ b/src/__experimental__/components/switch/docgenInfo.json
@@ -325,6 +325,13 @@
           },
           "required": true,
           "description": "the value of the checkbox, passed on form submit"
+        },
+        "adaptiveLabelBreakpoint": {
+          "type": {
+            "name": "number"
+          },
+          "required": false,
+          "description": "Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set"
         }
       }
     }

--- a/src/__experimental__/components/switch/switch.component.js
+++ b/src/__experimental__/components/switch/switch.component.js
@@ -4,6 +4,7 @@ import tagComponent from '../../../utils/helpers/tags';
 import SwitchStyle from './switch.style';
 import CheckableInput from '../checkable-input';
 import SwitchSlider from './switch-slider.component';
+import useIsAboveBreakpoint from '../../../hooks/__internal__/useIsAboveBreakpoint';
 
 const Switch = ({
   id,
@@ -18,6 +19,7 @@ const Switch = ({
   reverse,
   validationOnLabel,
   labelInline,
+  adaptiveLabelBreakpoint,
   ...props
 }) => {
   const isControlled = checked !== undefined;
@@ -32,9 +34,15 @@ const Switch = ({
     [setCheckedInternal, onChange]
   );
 
+  const largeScreen = useIsAboveBreakpoint(adaptiveLabelBreakpoint);
+  let inlineLabel = labelInline;
+  if (adaptiveLabelBreakpoint) {
+    inlineLabel = largeScreen;
+  }
+
   const switchProps = {
     ...props,
-    labelInline,
+    labelInline: inlineLabel,
     disabled: disabled || loading,
     checked: isControlled ? checked : checkedInternal,
     reverse: !reverse // switched to preserve backward compatibility
@@ -128,7 +136,9 @@ Switch.propTypes = {
   /** the value of the checkbox, passed on form submit */
   value: PropTypes.string.isRequired,
   /** Margin bottom, given number will be multiplied by base spacing unit (8) */
-  mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7])
+  mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
+  /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLabelBreakpoint: PropTypes.number
 };
 
 Switch.defaultProps = {

--- a/src/__experimental__/components/switch/switch.d.ts
+++ b/src/__experimental__/components/switch/switch.d.ts
@@ -30,6 +30,8 @@ export interface SwitchProps {
   Pass string to display icon, tooltip and blue border
   Pass true boolean to only display blue border */
   info?: boolean | string;
+  /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLabelBreakpoint?: number;
 }
 
 declare const Switch: React.ComponentClass<SwitchProps>;

--- a/src/__experimental__/components/switch/switch.spec.js
+++ b/src/__experimental__/components/switch/switch.spec.js
@@ -14,10 +14,17 @@ import HiddenCheckableInputStyle from '../checkable-input/hidden-checkable-input
 import LabelStyle, { StyledLabelContainer } from '../label/label.style';
 import StyledSwitchSlider from './switch-slider.style';
 import guid from '../../../utils/helpers/guid';
-import { assertStyleMatch, carbonThemesJestTable } from '../../../__spec_helper__/test-utils';
+import {
+  assertStyleMatch,
+  carbonThemesJestTable,
+  mockMatchMedia
+} from '../../../__spec_helper__/test-utils';
 import StyledValidationIcon from '../../../components/validations/validation-icon.style';
 import { baseTheme, classicTheme } from '../../../style/themes';
 import SwitchSliderPanel from './switch-slider-panel.style';
+import SwitchStyle from './switch.style';
+import SwitchSlider from './switch-slider.component';
+
 
 jest.mock('../../../utils/helpers/guid');
 guid.mockImplementation(() => 'guid-12345');
@@ -179,19 +186,56 @@ describe('Switch', () => {
     });
 
     describe('when labelInline=true', () => {
-      const wrapper = render({ labelInline: true }).toJSON();
-
       it('applies the correct Label styles', () => {
+        const wrapper = render({ labelInline: true }).toJSON();
         assertStyleMatch({
-          marginBottom: '0',
-          width: 'auto'
+          marginBottom: '0'
         }, wrapper, { modifier: css`${StyledLabelContainer}` });
       });
 
       it('applies the correct FieldHelp styles', () => {
+        const wrapper = render({ labelInline: true }).toJSON();
         assertStyleMatch({
           marginTop: '0'
         }, wrapper, { modifier: css`${FieldHelpStyle}` });
+      });
+
+      describe('when adaptiveLabelBreakpoint prop is set', () => {
+        describe('when screen bigger than breakpoint', () => {
+          beforeEach(() => {
+            mockMatchMedia(true);
+          });
+
+          it('should pass labelInline to its children', () => {
+            const wrapper = render({
+              label: 'Label',
+              labelInline: true,
+              adaptiveLabelBreakpoint: 1000
+            }, mount);
+
+            expect(wrapper.find(SwitchStyle).props().labelInline).toEqual(true);
+            expect(wrapper.find(CheckableInput).props().labelInline).toEqual(true);
+            expect(wrapper.find(SwitchSlider).props().labelInline).toEqual(true);
+          });
+        });
+
+        describe('when screen smaller than breakpoint', () => {
+          beforeEach(() => {
+            mockMatchMedia(false);
+          });
+
+          it('should pass labelInline as false to its children', () => {
+            const wrapper = render({
+              label: 'Label',
+              labelInline: true,
+              adaptiveLabelBreakpoint: 1000
+            }, mount);
+
+            expect(wrapper.find(SwitchStyle).props().labelInline).toEqual(false);
+            expect(wrapper.find(CheckableInput).props().labelInline).toEqual(false);
+            expect(wrapper.find(SwitchSlider).props().labelInline).toEqual(false);
+          });
+        });
       });
     });
 

--- a/src/__experimental__/components/switch/switch.style.js
+++ b/src/__experimental__/components/switch/switch.style.js
@@ -80,7 +80,6 @@ const StyledSwitch = styled.div`
 
       ${StyledLabelContainer} {
         margin-bottom: 0;
-        width: auto;
       }
 
       ${FieldHelpStyle} {

--- a/src/__experimental__/components/textarea/docgenInfo.json
+++ b/src/__experimental__/components/textarea/docgenInfo.json
@@ -387,6 +387,13 @@
           },
           "required": false,
           "description": "Margin bottom, given number will be multiplied by base spacing unit (8)"
+        },
+        "adaptiveLabelBreakpoint": {
+          "type": {
+            "name": "number"
+          },
+          "required": false,
+          "description": "Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set"
         }
       }
     }

--- a/src/__experimental__/components/textarea/textarea.component.js
+++ b/src/__experimental__/components/textarea/textarea.component.js
@@ -118,6 +118,7 @@ class Textarea extends React.Component {
       rows,
       cols,
       validationOnLabel,
+      adaptiveLabelBreakpoint,
       ...props
     } = this.props;
 
@@ -131,6 +132,7 @@ class Textarea extends React.Component {
             labelInline={ labelInline }
             { ...props }
             useValidationIcon={ validationOnLabel }
+            adaptiveLabelBreakpoint={ adaptiveLabelBreakpoint }
           >
             <InputPresentation
               type='text'
@@ -220,7 +222,9 @@ Textarea.propTypes = {
   /** Message to be displayed in a Tooltip when the user hovers over the help icon */
   tooltipMessage: PropTypes.string,
   /** Margin bottom, given number will be multiplied by base spacing unit (8) */
-  mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7])
+  mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
+  /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLabelBreakpoint: PropTypes.number
 };
 
 Textarea.defaultProps = {

--- a/src/__experimental__/components/textarea/textarea.stories.js
+++ b/src/__experimental__/components/textarea/textarea.stories.js
@@ -64,6 +64,7 @@ const defaultComponent = (autoFocusDefault = false) => () => {
   const labelInline = label ? boolean('labelInline', false) : undefined;
   const labelWidth = labelInline ? number('labelWidth', 30, percentageRange) : undefined;
   const labelAlign = labelInline ? select('labelAlign', OptionsHelper.alignBinary) : undefined;
+  const adaptiveLabelBreakpoint = labelInline ? number('adaptiveLabelBreakpoint') : undefined;
   const key = AutoFocus.getKey(autoFocus, previous);
 
   return (
@@ -89,6 +90,7 @@ const defaultComponent = (autoFocusDefault = false) => () => {
         labelWidth={ labelWidth }
         inputWidth={ inputWidth }
         labelAlign={ labelAlign }
+        adaptiveLabelBreakpoint={ adaptiveLabelBreakpoint }
       />
     </State>
   );

--- a/src/__experimental__/components/textbox/docgenInfo.json
+++ b/src/__experimental__/components/textbox/docgenInfo.json
@@ -308,6 +308,13 @@
           "required": false,
           "description": "Margin bottom, given number will be multiplied by base spacing unit (8)"
         },
+        "adaptiveLabelBreakpoint": {
+          "type": {
+            "name": "number"
+          },
+          "required": false,
+          "description": "Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set"
+        },
         "styleOverride": {
           "type": {
             "name": "shape",

--- a/src/__experimental__/components/textbox/textbox.component.js
+++ b/src/__experimental__/components/textbox/textbox.component.js
@@ -25,6 +25,7 @@ const Textbox = ({
   labelWidth,
   inputWidth,
   prefix,
+  adaptiveLabelBreakpoint,
   ...props
 }) => {
   if (!deprecatedWarnTriggered) {
@@ -40,6 +41,7 @@ const Textbox = ({
         { ...props }
         useValidationIcon={ validationOnLabel }
         labelWidth={ labelWidth }
+        adaptiveLabelBreakpoint={ adaptiveLabelBreakpoint }
         styleOverride={ styleOverride }
       >
         <InputPresentation
@@ -157,6 +159,8 @@ Textbox.propTypes = {
   prefix: PropTypes.string,
   /** Margin bottom, given number will be multiplied by base spacing unit (8) */
   mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
+  /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLabelBreakpoint: PropTypes.number,
   /** Allows to override existing component styles */
   styleOverride: PropTypes.shape({
     root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),

--- a/src/__experimental__/components/textbox/textbox.d.ts
+++ b/src/__experimental__/components/textbox/textbox.d.ts
@@ -54,6 +54,8 @@ export interface TextboxProps {
   onClick?: function;
   /** Emphasized part of the displayed text */
   prefix?: string;
+  /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLabelBreakpoint?: number;
 }
 declare const Textbox: React.ComponentType<TextboxProps>;
 export default Textbox;

--- a/src/__experimental__/components/textbox/textbox.stories.js
+++ b/src/__experimental__/components/textbox/textbox.stories.js
@@ -223,6 +223,7 @@ export function getCommonTextboxProps(config = defaultStoryPropsConfig, autoFocu
   const label = text('label', 'Label');
   const labelHelp = label ? text('labelHelp') : undefined;
   const labelInline = label ? boolean('labelInline', false) : undefined;
+  const adaptiveLabelBreakpoint = labelInline ? number('adaptiveLabelBreakpoint') : undefined;
   const labelWidth = labelInline ? number('labelWidth', 30, percentageRange) : undefined;
   const inputWidth = labelInline && config.inputWidthEnabled ? number('inputWidth', 70, percentageRange) : undefined;
   const labelAlign = labelInline ? select('labelAlign', OptionsHelper.alignBinary) : undefined;
@@ -242,6 +243,7 @@ export function getCommonTextboxProps(config = defaultStoryPropsConfig, autoFocu
     label,
     labelHelp,
     labelInline,
+    adaptiveLabelBreakpoint,
     labelWidth,
     labelAlign,
     size,

--- a/src/__spec_helper__/index.js
+++ b/src/__spec_helper__/index.js
@@ -1,4 +1,6 @@
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { setup } from './mock-match-media';
 
+setup();
 Enzyme.configure({ adapter: new Adapter() });

--- a/src/__spec_helper__/mock-match-media.js
+++ b/src/__spec_helper__/mock-match-media.js
@@ -1,0 +1,30 @@
+let mocked = false;
+let _matches = false;
+const removeListener = jest.fn();
+
+export const setup = () => {
+  if (!global.window) {
+    return;
+  }
+  const noop = () => {};
+  Object.defineProperty(global.window, 'matchMedia', {
+    writable: true,
+    value: query => ({
+      matches: _matches,
+      media: query,
+      onchange: null,
+      addListener: noop,
+      removeListener,
+      dispatchEvent: noop
+    })
+  });
+  mocked = true;
+};
+
+export const mockMatchMedia = (matches) => {
+  if (!mocked) {
+    throw new Error('window.matchMedia has not been mocked. Did you call setup()?');
+  }
+  _matches = matches;
+  return { removeListener };
+};

--- a/src/__spec_helper__/test-utils.js
+++ b/src/__spec_helper__/test-utils.js
@@ -1,4 +1,5 @@
 import { carbonThemeList } from '../style/themes';
+import { mockMatchMedia } from './mock-match-media';
 
 const isUpper = char => char.toUpperCase() === char;
 const humpToDash = (acc, char) => `${acc}${isUpper(char) ? `-${char.toLowerCase()}` : char}`;
@@ -110,5 +111,6 @@ export {
   listFrom,
   click,
   simulate,
-  carbonThemesJestTable
+  carbonThemesJestTable,
+  mockMatchMedia
 };

--- a/src/components/button/__snapshots__/button.spec.js.snap
+++ b/src/components/button/__snapshots__/button.spec.js.snap
@@ -1,5 +1,208 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Button when mb prop passed in should add the correct bottom margin 1`] = `
+.c2 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c3 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c4 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c5 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c6 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c7 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c8 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c9 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c10 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c11 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c12 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c13 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c14 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c15 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c16 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c17 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c18 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c19 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c20 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c21 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c22 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c23 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c24 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c25 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c26 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c27 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c28 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c29 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c30 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c31 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c32 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c33 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c34 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-flow: wrap;
+  -ms-flex-flow: wrap;
+  flex-flow: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border: 2px solid transparent;
+  box-sizing: border-box;
+  font-weight: 600;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background: transparent;
+  border-color: #26A826;
+  color: #26A826;
+}
+
+.c1:focus {
+  outline: solid 3px #FFB500;
+}
+
+.c1 ~ .c0 {
+  margin-left: 16px;
+}
+
+.c1:hover {
+  background: #006300;
+  border-color: #006300;
+  color: #FFFFFF;
+}
+
+.c1:hover .c35 {
+  color: #FFFFFF;
+}
+
+.c1.c1.c1 {
+  margin-bottom: 32px;
+}
+
+.c1 .c35 {
+  margin-left: 8px;
+  margin-right: 0px;
+  height: 16px;
+}
+
+.c1 .c35 svg {
+  margin-top: 0;
+}
+
+<button
+  className="c0 c1"
+/>
+`;
+
 exports[`Button when only the "iconPosition" and "iconType" props are passed into the component renders the default props and children to match the snapshot with the Icon after children 1`] = `
 .c3 {
   display: inline-block;

--- a/src/components/button/button-sizes.style.js
+++ b/src/components/button/button-sizes.style.js
@@ -1,23 +1,23 @@
-export default ({ text }, ml) => ({
+export default ({ text }, ml = 0) => ({
   small: `
     font-size: ${text.size};
     height: 32px;
     padding-left: 16px;
     padding-right: 16px;
-    margin-left: ${ml || 0};
+    margin-left: ${ml};
   `,
   medium: `
     font-size: ${text.size};
     height: 40px;
     padding-left: 24px;
     padding-right: 24px;
-    margin-left: ${ml || 0};
+    margin-left: ${ml};
   `,
   large: `
     font-size: 16px;
     height: 48px;
     padding-left: 32px;
     padding-right: 32px;
-    margin-left: ${ml || 0};
+    margin-left: ${ml};
   `
 });

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -263,10 +263,7 @@ describe('Button', () => {
 
   describe('when mb prop passed in', () => {
     it('should add the correct bottom margin', () => {
-      const wrapper = TestRenderer.create(<StyledButton mb={ 4 } />);
-      assertStyleMatch({
-        marginBottom: '32px'
-      }, wrapper.toJSON());
+      expect(TestRenderer.create(<StyledButton mb={ 4 } />)).toMatchSnapshot();
     });
   });
 

--- a/src/components/button/button.style.js
+++ b/src/components/button/button.style.js
@@ -16,9 +16,11 @@ const StyledButton = styled.button`
   vertical-align: middle;
   ${stylingForType}
 
-  ${({ mb, theme }) => mb && css`
+  &&& {
+    ${({ mb, theme }) => (mb || mb === 0) && css`
     margin-bottom: ${mb * theme.spacing}px;
   `}
+  }
 
   ${({ fullWidth }) => fullWidth && css`
     width: 100%;

--- a/src/components/form/form.stories.mdx
+++ b/src/components/form/form.stories.mdx
@@ -363,6 +363,7 @@ Please click on "Show code" below to see how to set these components up for alig
         label="Date picker"
         labelInline
         labelWidth={10}
+        value="01-09-2020"
       />
       <RadioButtonGroup
         name="nolegend"
@@ -414,7 +415,7 @@ Please click on "Show code" below to see how to set these components up for alig
         ml="10%"
       />
       <Hr ml="10%" mr="60%" mb={7} />
-      <Button buttonType="tertiary" mb={4} ml="calc(10% - 24px)">
+      <Button buttonType="tertiary" ml="calc(10% - 24px)">
         Tertiary
       </Button>
       <Textbox

--- a/src/components/form/form.style.js
+++ b/src/components/form/form.style.js
@@ -9,7 +9,7 @@ import baseTheme from '../../style/themes/base';
 import OptionsHelper from '../../utils/helpers/options-helper';
 
 export const StyledForm = styled.form`
-  & ${StyledFormField}, ${StyledFieldset} {
+  & ${StyledFormField}, ${StyledFieldset},  > ${StyledButton} {
     margin-top: 0;
     margin-bottom: ${({ fieldSpacing, theme }) => (theme.spacing * fieldSpacing)}px;
   }

--- a/src/components/hr/hr.component.js
+++ b/src/components/hr/hr.component.js
@@ -2,20 +2,30 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import StyledHr from './hr.style';
+import useIsAboveBreakpoint from '../../hooks/__internal__/useIsAboveBreakpoint';
 
 const Hr = ({
+  adaptiveMxBreakpoint,
   mt = 3,
   mb = 3,
   ml,
   mr
 }) => {
+  const largeScreen = useIsAboveBreakpoint(adaptiveMxBreakpoint);
+  let marginLeft = ml;
+  let marginRight = mr;
+  if (adaptiveMxBreakpoint && !largeScreen) {
+    marginLeft = 0;
+    marginRight = 0;
+  }
+
   return (
     <StyledHr
       data-component='hr'
       mt={ mt }
       mb={ mb }
-      ml={ ml }
-      mr={ mr }
+      ml={ marginLeft }
+      mr={ marginRight }
     />
   );
 };
@@ -26,9 +36,12 @@ Hr.propTypes = {
   /** Margin bottom, this value will be multiplied by the theme spacing constant (8) */
   mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
   /** Margin left, any valid css value */
-  ml: PropTypes.string,
+  ml: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Margin right, any valid css value */
-  mr: PropTypes.string
+  mr: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Breakpoint for adaptive left and right margins (below the breakpoint they go to 0).
+   * Enables the adaptive behaviour when set */
+  adaptiveMxBreakpoint: PropTypes.number
 };
 
 export default Hr;

--- a/src/components/hr/hr.d.ts
+++ b/src/components/hr/hr.d.ts
@@ -10,6 +10,10 @@ export interface HrProps {
   ml?: string;
   /** Margin right, any valid css value */
   mr?: string;
+  /** Breakpoint for adaptive left and right margins (below the breakpoint they go to 0).
+   * Enables the adaptive behaviour when set
+   */
+  adaptiveMxBreakpoint?: number;
 }
 
 declare const Hr: React.FunctionComponent<HrProps>;

--- a/src/components/hr/hr.spec.js
+++ b/src/components/hr/hr.spec.js
@@ -1,15 +1,21 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { assertStyleMatch } from '../../__spec_helper__/test-utils';
+import { assertStyleMatch, mockMatchMedia } from '../../__spec_helper__/test-utils';
 import Hr from './hr.component';
 import StyledHr from './hr.style';
+
+function render(props, renderer = mount) {
+  return renderer(
+    <Hr { ...props } />
+  );
+}
 
 describe('Hr', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = mount(<Hr />);
+    wrapper = render();
   });
 
   describe('default props', () => {
@@ -23,7 +29,7 @@ describe('Hr', () => {
 
   describe('margin props', () => {
     it('should apply the correct top margin', () => {
-      wrapper.setProps({ mt: 7 });
+      wrapper = render({ mt: 7 });
 
       assertStyleMatch({
         marginTop: '56px'
@@ -31,7 +37,7 @@ describe('Hr', () => {
     });
 
     it('should apply the correct bottom margin', () => {
-      wrapper.setProps({ mb: 7 });
+      wrapper = render({ mb: 7 });
 
       assertStyleMatch({
         marginBottom: '56px'
@@ -39,7 +45,7 @@ describe('Hr', () => {
     });
 
     it('should apply the correct left margin', () => {
-      wrapper.setProps({ ml: '100px' });
+      wrapper = render({ ml: '100px' });
 
       assertStyleMatch({
         marginLeft: '100px'
@@ -47,11 +53,47 @@ describe('Hr', () => {
     });
 
     it('should apply the correct right margin', () => {
-      wrapper.setProps({ mr: '100px' });
+      wrapper = render({ mr: '100px' });
 
       assertStyleMatch({
         marginRight: '100px'
       }, wrapper.find(StyledHr));
+    });
+  });
+
+  describe('when adaptiveMxBreakpoint prop is set', () => {
+    describe('when screen bigger than breakpoint', () => {
+      beforeEach(() => {
+        mockMatchMedia(true);
+      });
+
+      it('should pass the correct margins to its children', () => {
+        wrapper = render({
+          ml: '10%',
+          mr: '20%',
+          adaptiveMxBreakpoint: 1000
+        });
+
+        expect(wrapper.find(StyledHr).props().ml).toEqual('10%');
+        expect(wrapper.find(StyledHr).props().mr).toEqual('20%');
+      });
+    });
+
+    describe('when screen smaller than breakpoint', () => {
+      beforeEach(() => {
+        mockMatchMedia(false);
+      });
+
+      it('should pass labelInline to its children', () => {
+        wrapper = render({
+          ml: '10%',
+          mr: '20%',
+          adaptiveMxBreakpoint: 1000
+        });
+
+        expect(wrapper.find(StyledHr).props().ml).toEqual(0);
+        expect(wrapper.find(StyledHr).props().mr).toEqual(0);
+      });
     });
   });
 });

--- a/src/components/hr/hr.stories.mdx
+++ b/src/components/hr/hr.stories.mdx
@@ -81,3 +81,12 @@ The `mb` and `mt` props set the vertical spacing. These props are mulitipliers a
     </Form>
   </Story> 
 </Preview>
+
+### Enabling the adaptive behaviour
+The left and right margins can be set to 0 below a screen width breakpoint. This can be switched on with the `adaptiveMxBreakpoint` prop by passing in a number corresponding to a px value screen width.
+
+<Preview>
+  <Story name="Enabling adaptive behaviour" parameters={{ chromatic: { disable: true }}}>
+    <Hr mb={7} mt={7} ml="10%" mr="40%" adaptiveMxBreakpoint={960} />
+  </Story> 
+</Preview>

--- a/src/components/hr/hr.style.js
+++ b/src/components/hr/hr.style.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import PropTypes from 'prop-types';
 import baseTheme from '../../style/themes/base';
 
 const StyledHr = styled.hr`
@@ -12,13 +11,6 @@ const StyledHr = styled.hr`
   margin-left: ${({ ml }) => ml};
   margin-right: ${({ mr }) => mr};
 `;
-
-StyledHr.propTypes = {
-  mt: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
-  mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
-  ml: PropTypes.string,
-  mr: PropTypes.string
-};
 
 StyledHr.defaultProps = {
   theme: baseTheme

--- a/src/components/select/select-textbox/select-textbox.component.js
+++ b/src/components/select/select-textbox/select-textbox.component.js
@@ -102,7 +102,9 @@ const formInputPropTypes = {
   /** Callback function for when the Select Textbox loses it's focus. */
   onBlur: PropTypes.func,
   /** Callback function for when the key is pressed when focused on Select Textbox. */
-  onKeyDown: PropTypes.func
+  onKeyDown: PropTypes.func,
+  /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLabelBreakpoint: PropTypes.number
 };
 
 SelectTextbox.propTypes = {

--- a/src/components/select/simple-select/simple-select.stories.mdx
+++ b/src/components/select/simple-select/simple-select.stories.mdx
@@ -172,6 +172,33 @@ import { Select, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
+### Enabling the adaptive behaviour
+The inline label can change to be top aligned at a breakpoint. Enable this by passing in a number to the `adaptiveLabelBreakpoint` prop. This corresponds to a px screen width
+
+<Preview>
+  <Story name="enabling adaptive behaviour" parameters={{ chromatic: { disable: true }}}>
+    <Select
+      name='transparent'
+      id='transparent'
+      label='label'
+      defaultValue='4'
+      adaptiveLabelBreakpoint={960}
+    >
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </Select>
+  </Story>
+</Preview>
+
 ## Props:
 
 <Props of={ Select } />

--- a/src/hooks/__internal__/useIsAboveBreakpoint/index.d.ts
+++ b/src/hooks/__internal__/useIsAboveBreakpoint/index.d.ts
@@ -1,0 +1,3 @@
+export default function useIsAboveBreakpoint(
+  breakpoint: number,
+): boolean;

--- a/src/hooks/__internal__/useIsAboveBreakpoint/index.js
+++ b/src/hooks/__internal__/useIsAboveBreakpoint/index.js
@@ -1,0 +1,7 @@
+import useMediaQuery from '../../useMediaQuery';
+
+export default function useIsAboveBreakpoint(breakpoint) {
+  const matchesQuery = useMediaQuery(`(min-width:${breakpoint}px)`);
+  if (!breakpoint) return undefined;
+  return matchesQuery;
+}

--- a/src/hooks/__internal__/useIsAboveBreakpoint/index.spec.js
+++ b/src/hooks/__internal__/useIsAboveBreakpoint/index.spec.js
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import useIsAboveBreakpoint from '.';
+import { mockMatchMedia } from '../../../__spec_helper__/test-utils';
+
+describe('useIsAboveBreakpoint custom hook', () => {
+  describe('when query does not match', () => {
+    beforeEach(() => {
+      mockMatchMedia(false);
+    });
+
+    it('should return false', () => {
+      const TestComponent = () => {
+        const aboveBreakpoint = useIsAboveBreakpoint(1000);
+        return <span>{`${aboveBreakpoint}`}</span>;
+      };
+      const wrapper = mount(<TestComponent />);
+
+      expect(wrapper.find('span').text()).toEqual('false');
+    });
+  });
+
+  describe('when query matches', () => {
+    beforeEach(() => {
+      mockMatchMedia(true);
+    });
+
+    it('should return true', () => {
+      const TestComponent = () => {
+        const aboveBreakpoint = useIsAboveBreakpoint(1000);
+        return <span>{`${aboveBreakpoint}`}</span>;
+      };
+      const wrapper = mount(<TestComponent />);
+
+      expect(wrapper.find('span').text()).toEqual('true');
+    });
+  });
+});

--- a/src/hooks/useMediaQuery/index.d.ts
+++ b/src/hooks/useMediaQuery/index.d.ts
@@ -1,0 +1,3 @@
+export default function useMediaQuery(
+  query: string,
+): boolean;

--- a/src/hooks/useMediaQuery/index.js
+++ b/src/hooks/useMediaQuery/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function useMediaQuery(queryInput) {
+  const query = queryInput.replace(/^@media( ?)/m, '');
+
+  const [match, setMatch] = React.useState(() => false);
+
+  React.useEffect(() => {
+    const queryList = window.matchMedia(query);
+    const updateMatch = () => {
+      setMatch(queryList.matches);
+    };
+    updateMatch();
+    queryList.addListener(updateMatch);
+    return () => {
+      queryList.removeListener(updateMatch);
+    };
+  }, [query]);
+
+  return match;
+}

--- a/src/hooks/useMediaQuery/index.spec.js
+++ b/src/hooks/useMediaQuery/index.spec.js
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import useMediaQuery from '.';
+import { mockMatchMedia } from '../../__spec_helper__/test-utils';
+
+describe('useMediaQuery custom hook', () => {
+  describe('when query does not match', () => {
+    beforeEach(() => {
+      mockMatchMedia(false);
+    });
+
+    it('should return false', () => {
+      const TestComponent = () => {
+        const matchQuery = useMediaQuery('(min-width:960px)');
+        return <span>{`${matchQuery}`}</span>;
+      };
+      const wrapper = mount(<TestComponent />);
+
+      expect(wrapper.find('span').text()).toEqual('false');
+    });
+  });
+
+  describe('when query matches', () => {
+    beforeEach(() => {
+      mockMatchMedia(true);
+    });
+
+    it('should return true', () => {
+      const TestComponent = () => {
+        const matchQuery = useMediaQuery('(min-width:960px)');
+        return <span>{`${matchQuery}`}</span>;
+      };
+      const wrapper = mount(<TestComponent />);
+
+      expect(wrapper.find('span').text()).toEqual('true');
+    });
+  });
+
+  describe('on component unmount', () => {
+    let removeListenerFn;
+    beforeEach(() => {
+      const { removeListener } = mockMatchMedia(true);
+      removeListenerFn = removeListener;
+    });
+
+    it('should remove the event listener', () => {
+      const TestComponent = () => {
+        const matchQuery = useMediaQuery('(min-width:960px)');
+        return <span>{`${matchQuery}`}</span>;
+      };
+      const wrapper = mount(<TestComponent />);
+
+      expect(wrapper.find('span').text()).toEqual('true');
+      wrapper.unmount();
+      expect(removeListenerFn.mock.calls.length).toEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
### Proposed behaviour
Add adaptive behaviour to input components. When they have inline labels, these labels can now switch to top aligned below a breakpoint. This can be turned on component by component. Any of the new props will accept a number as a px value for the breakpoint. 

E.g. screen larger than breakpoint: 
![image](https://user-images.githubusercontent.com/14963680/92927286-48cc1600-f435-11ea-9e90-233e313bfca0.png)

Screen smaller than breakpoint:
![image](https://user-images.githubusercontent.com/14963680/92927339-5da8a980-f435-11ea-83c8-6cc4e77eb183.png)

This is done with a custom hook, `useMediaQuery` which has been added to utils. A Carbon user can import this to use for their own adaptive behaviour should they wish to.

### Current behaviour
No adaptive behaviour is present in these components. 

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
Codesandbox for testing here: https://codesandbox.io/s/relaxed-framework-fwkvo