### PR TITLE
fix(note): update inline control variant check constructor FE-3134

### DIFF
--- a/src/components/note/__internal__/note.component.js
+++ b/src/components/note/__internal__/note.component.js
@@ -11,6 +11,7 @@ import {
   StyledFooterContent
 } from './note.style.js';
 import StatusWithTooltip from './status-with-tooltip';
+import { ActionPopover } from '../../action-popover';
 
 const Note = ({
   noteContent,
@@ -30,7 +31,7 @@ const Note = ({
   invariant(noteContent, '<Note> noteContent is required');
   invariant(!status || status.text, '<Note> status.text is required');
   invariant(!status || status.timeStamp, '<Note> status.timeStamp is required');
-  invariant(!inlineControl || inlineControl.type.name === 'ActionPopover',
+  invariant(!inlineControl || inlineControl.type === ActionPopover,
     '<Note> inlineControl must be an instance of <ActionPopover>');
 
   const renderStatus = () => {


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Updates the invariant for the `inlineControl` prop to check if  the passed component's constructor,
rather than its string name, is `ActionPopover`. The previous implementation throws an error in production build environments when the code is minified.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Invariant checks `inlineControl.type.name` which works in development but throws in production environment.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
