### PR TITLE
feat(grid): add styled-system cusom padding and margin props (FE-3025)

### DIFF
--- a/cypress/support/step-definitions/grid-steps.js
+++ b/cypress/support/step-definitions/grid-steps.js
@@ -33,13 +33,11 @@ When('I resize grid viewport to {string}', (sizeOfViewport) => {
 });
 
 Then('pod {int} has height from row {string} to row {string}', (index, rowStart, rowEnd) => {
-  gridPod(index).should('have.css', 'grid-row-start', `${rowStart}`)
-    .and('have.css', 'grid-row-end', `${rowEnd}`);
+  gridPod(index).should('have.css', 'grid-row', `${rowStart} / ${rowEnd}`);
 });
 
 Then('pod {int} has width from column {int} to column {int}', (index, colStart, colEnd) => {
-  gridPod(index).should('have.css', 'grid-column-start', `${colStart}`)
-    .and('have.css', 'grid-column-end', `${colEnd}`);
+  gridPod(index).should('have.css', 'grid-column', `${colStart} / ${colEnd}`);
 });
 
 Then('grid has {string} set to {int}', (property, value) => {

--- a/src/components/grid/__snapshots__/grid.spec.js.snap
+++ b/src/components/grid/__snapshots__/grid.spec.js.snap
@@ -12,38 +12,32 @@ exports[`Grid GridItem builds the style rules for the GridItem with custom align
 
 .c1 {
   margin: 0;
-  grid-column-start: 1;
-  grid-column-end: 13;
-  grid-row-start: auto;
-  grid-row-end: auto;
   -webkit-align-self: start;
   -ms-flex-item-align: start;
   align-self: start;
   justify-self: left;
+  grid-column: 1 / 13;
+  grid-row: auto;
 }
 
 .c2 {
   margin: 0;
-  grid-column-start: 1;
-  grid-column-end: 13;
-  grid-row-start: auto;
-  grid-row-end: auto;
   -webkit-align-self: start;
   -ms-flex-item-align: start;
   align-self: start;
   justify-self: center;
+  grid-column: 1 / 13;
+  grid-row: auto;
 }
 
 .c3 {
   margin: 0;
-  grid-column-start: 1;
-  grid-column-end: 13;
-  grid-row-start: auto;
-  grid-row-end: auto;
   -webkit-align-self: start;
   -ms-flex-item-align: start;
   align-self: start;
   justify-self: right;
+  grid-column: 1 / 13;
+  grid-row: auto;
 }
 
 @media screen and (max-width:1920px) {
@@ -105,26 +99,20 @@ exports[`Grid GridItem builds the style rules for the GridItem with responsiveSe
 
 .c1 {
   margin: 0;
-  grid-column-start: 1;
-  grid-column-end: 13;
-  grid-row-start: auto;
-  grid-row-end: auto;
+  grid-column: 1 / 13;
+  grid-row: auto;
 }
 
 .c2 {
   margin: 0;
-  grid-column-start: 1;
-  grid-column-end: 13;
-  grid-row-start: auto;
-  grid-row-end: auto;
+  grid-column: 1 / 13;
+  grid-row: auto;
 }
 
 .c3 {
   margin: 0;
-  grid-column-start: 1;
-  grid-column-end: 13;
-  grid-row-start: auto;
-  grid-row-end: auto;
+  grid-column: 1 / 13;
+  grid-row: auto;
 }
 
 @media screen and (max-width:1920px) {
@@ -158,10 +146,8 @@ exports[`Grid GridItem builds the style rules for the GridItem with responsiveSe
     -ms-flex-item-align: stretch;
     align-self: stretch;
     justify-self: stretch;
-    grid-column-start: 1;
-    grid-column-end: 7;
-    grid-row-start: 1;
-    grid-row-end: 1;
+    grid-column: 1 / 7;
+    grid-row: 1;
   }
 }
 
@@ -171,10 +157,8 @@ exports[`Grid GridItem builds the style rules for the GridItem with responsiveSe
     -ms-flex-item-align: stretch;
     align-self: stretch;
     justify-self: stretch;
-    grid-column-start: 1;
-    grid-column-end: 13;
-    grid-row-start: 1;
-    grid-row-end: 1;
+    grid-column: 1 / 13;
+    grid-row: 1;
   }
 }
 
@@ -184,10 +168,8 @@ exports[`Grid GridItem builds the style rules for the GridItem with responsiveSe
     -ms-flex-item-align: stretch;
     align-self: stretch;
     justify-self: stretch;
-    grid-column-start: 1;
-    grid-column-end: 9;
-    grid-row-start: 2;
-    grid-row-end: 2;
+    grid-column: 1 / 9;
+    grid-row: 2;
   }
 }
 
@@ -197,10 +179,8 @@ exports[`Grid GridItem builds the style rules for the GridItem with responsiveSe
     -ms-flex-item-align: stretch;
     align-self: stretch;
     justify-self: stretch;
-    grid-column-start: 7;
-    grid-column-end: 13;
-    grid-row-start: 1;
-    grid-row-end: 1;
+    grid-column: 7 / 13;
+    grid-row: 1;
   }
 }
 
@@ -210,10 +190,8 @@ exports[`Grid GridItem builds the style rules for the GridItem with responsiveSe
     -ms-flex-item-align: stretch;
     align-self: stretch;
     justify-self: stretch;
-    grid-column-start: 1;
-    grid-column-end: 13;
-    grid-row-start: 2;
-    grid-row-end: 2;
+    grid-column: 1 / 13;
+    grid-row: 2;
   }
 }
 
@@ -223,10 +201,8 @@ exports[`Grid GridItem builds the style rules for the GridItem with responsiveSe
     -ms-flex-item-align: stretch;
     align-self: stretch;
     justify-self: stretch;
-    grid-column-start: 1;
-    grid-column-end: 9;
-    grid-row-start: 3;
-    grid-row-end: 3;
+    grid-column: 1 / 9;
+    grid-row: 3;
   }
 }
 
@@ -236,10 +212,8 @@ exports[`Grid GridItem builds the style rules for the GridItem with responsiveSe
     -ms-flex-item-align: stretch;
     align-self: stretch;
     justify-self: stretch;
-    grid-column-start: 1;
-    grid-column-end: 13;
-    grid-row-start: 2;
-    grid-row-end: 2;
+    grid-column: 1 / 13;
+    grid-row: 2;
   }
 }
 
@@ -249,10 +223,8 @@ exports[`Grid GridItem builds the style rules for the GridItem with responsiveSe
     -ms-flex-item-align: stretch;
     align-self: stretch;
     justify-self: stretch;
-    grid-column-start: 1;
-    grid-column-end: 9;
-    grid-row-start: 1;
-    grid-row-end: 1;
+    grid-column: 1 / 9;
+    grid-row: 1;
   }
 }
 
@@ -262,10 +234,8 @@ exports[`Grid GridItem builds the style rules for the GridItem with responsiveSe
     -ms-flex-item-align: stretch;
     align-self: stretch;
     justify-self: stretch;
-    grid-column-start: 1;
-    grid-column-end: 13;
-    grid-row-start: 3;
-    grid-row-end: 3;
+    grid-column: 1 / 13;
+    grid-row: 3;
   }
 }
 

--- a/src/components/grid/grid-container/grid-container.component.js
+++ b/src/components/grid/grid-container/grid-container.component.js
@@ -5,10 +5,39 @@ import GridItem from '../grid-item';
 
 const GridContainer = (props) => {
   const {
-    children
+    children,
+    m,
+    ml,
+    mr,
+    mt,
+    mb,
+    mx,
+    my,
+    gridGap
   } = props;
+
+  const styledSystemProps = {
+    m,
+    ml,
+    mr,
+    mt,
+    mb,
+    gridGap
+  };
+
+  if (mx) {
+    styledSystemProps.mx = mx;
+  }
+
+  if (my) {
+    styledSystemProps.my = my;
+  }
+
   return (
-    <GridContainerStyle data-component='grid'>
+    <GridContainerStyle
+      data-component='grid'
+      { ...styledSystemProps }
+    >
       {children}
     </GridContainerStyle>
   );
@@ -16,6 +45,22 @@ const GridContainer = (props) => {
 
 GridContainer.propTypes = {
   /** Defines the Components to be rendered within the GridContainer. Requires a GridItem */
-  children: PropTypes.oneOfType([GridItem, PropTypes.arrayOf(GridItem)]).isRequired
+  children: PropTypes.oneOfType([GridItem, PropTypes.arrayOf(GridItem)]).isRequired,
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default margin */
+  m: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default margin-left */
+  ml: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default margin-right */
+  mr: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default margin-top */
+  mt: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default margin-bottom */
+  mb: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default horizontal margins */
+  mx: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default vertical margins */
+  my: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value to override default grid-gap */
+  gridGap: PropTypes.string
 };
 export default GridContainer;

--- a/src/components/grid/grid-container/grid-container.style.js
+++ b/src/components/grid/grid-container/grid-container.style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { space, grid } from 'styled-system';
 
 const GridContainerStyle = styled.div`
   display: grid;
@@ -7,7 +8,7 @@ const GridContainerStyle = styled.div`
   width: auto;
   margin: 40px;
   grid-gap: 40px;
-  
+
   @media screen and (max-width: 1920px) {
     grid-gap: 24px;
   }
@@ -23,7 +24,12 @@ const GridContainerStyle = styled.div`
 
   @media screen and (max-width: 599px) {
     margin: 16px;
-  } 
+  }
+
+  @media screen {
+    ${space}
+    ${grid}
+  }
 `;
 
 export default GridContainerStyle;

--- a/src/components/grid/grid-container/index.d.ts
+++ b/src/components/grid/grid-container/index.d.ts
@@ -1,6 +1,22 @@
-import * as React from 'react';
-import { GridContainer } from '..';
+import GridItem from '../grid-item';
 
 export interface GridContainerProps {
-  children: string;
+  /** Defines the Components to be rendered within the GridContainer. Requires a GridItem */
+  children: typeof GridItem | Array<typeof GridItem>;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default margin */
+  m?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default margin-left */
+  ml?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default margin-right */
+  mr?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default margin-top */
+  mt?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-bottom */
+  mb?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default horizontal margins */
+  mx?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default vertical margins */
+  my?: string | number;
+  /** Any valid CSS value to override default grid-gap */
+  gridGap?: string;
 }

--- a/src/components/grid/grid-item/grid-item.component.js
+++ b/src/components/grid/grid-item/grid-item.component.js
@@ -7,25 +7,43 @@ const GridItem = (props) => {
   const {
     children,
     responsiveSettings,
-    gridColumnStart,
-    gridColumnEnd,
-    gridRowStart,
-    gridRowEnd,
+    gridColumn,
+    gridRow,
     alignSelf,
-    justifySelf
+    justifySelf,
+    p,
+    pl,
+    pr,
+    pt,
+    pb,
+    px,
+    py
   } = props;
+
+  const styledSystemProps = {
+    gridColumn,
+    gridRow,
+    alignSelf,
+    justifySelf,
+    p,
+    pl,
+    pr,
+    pt,
+    pb
+  };
+
+  if (px) {
+    styledSystemProps.px = px;
+  }
+
+  if (py) {
+    styledSystemProps.py = py;
+  }
 
   return (
     <GridItemStyle
-      { ...{
-        gridColumnStart,
-        gridColumnEnd,
-        gridRowStart,
-        gridRowEnd,
-        alignSelf,
-        justifySelf
-      } }
       responsiveSettings={ responsiveSettings }
+      { ...styledSystemProps }
     >
       {children}
     </GridItemStyle>
@@ -35,43 +53,52 @@ const GridItem = (props) => {
 GridItem.propTypes = {
   /** Defines the Component(s) to be rendered within the GridItem */
   children: PropTypes.node,
-  /** Starting column position of the GridItem within the GridContainer by referring to the grid line where the item begins */
-  gridColumnStart: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /** Ending column position of the GridItem within the GridContainer by referring to the grid line where the item ends */
-  gridColumnEnd: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /** Starting row position of the GridItem within the GridContainer by referring to the grid line where the item begins */
-  gridRowStart: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /** Ending row position of the GridItem within the GridContainer by referring to the grid line where the item ends */
-  gridRowEnd: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch */
   alignSelf: PropTypes.string,
+  /** Starting and ending column position of the GridItem within the GridContainer separated by "/" */
+  gridColumn: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Starting and ending row position of the GridItem within the GridContainer separated by "/" */
+  gridRow: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** How the grid item is aligned along the inline (row) axis. Values: start, end, center, stretch */
   justifySelf: PropTypes.string,
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding */
+  p: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-left */
+  pl: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-right */
+  pr: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-top */
+  pt: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-bottom */
+  pb: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default horizontal paddings */
+  px: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default vertical paddings */
+  py: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   responsiveSettings: PropTypes.arrayOf(
     PropTypes.shape({
       /** How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch */
       alignSelf: PropTypes.string,
-      /** Starting column position of the GridItem within the GridContainer by referring to the grid line where the item begins */
-      colStart: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-      /** Ending column position of the GridItem within the GridContainer by referring to the grid line where the item ends */
-      colEnd: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      /** Starting and ending column position of the GridItem within the GridContainer separated by "/" */
+      gridColumn: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      /** Starting and ending row position of the GridItem within the GridContainer separated by "/" */
+      gridRow: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       /** How the grid item is aligned along the inline (row) axis. Values: start, end, center, stretch */
       justifySelf: PropTypes.string,
-      /** Starting row position of the GridItem within the GridContainer by referring to the grid line where the item begins */
+      /** Maximum width of the item */
       maxWidth: PropTypes.string,
-      /** Starting row position of the GridItem within the GridContainer by referring to the grid line where the item begins */
-      rowStart: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-      /** Ending row position of the GridItem within the GridContainer by referring to the grid line where the item ends */
-      rowEnd: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+      /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding */
+      p: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-left */
+      pl: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-right */
+      pr: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-top */
+      pt: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-bottom */
+      pb: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     })
   )
-};
-
-GridItem.defaultProps = {
-  gridColumnStart: 1,
-  gridColumnEnd: 13,
-  gridRowStart: 'auto',
-  gridRowEnd: 'auto'
 };
 
 export default GridItem;

--- a/src/components/grid/grid-item/grid-item.style.js
+++ b/src/components/grid/grid-item/grid-item.style.js
@@ -1,73 +1,90 @@
 import styled, { css } from 'styled-components';
+import { space, grid, flexbox } from 'styled-system';
 import PropTypes from 'prop-types';
+import { baseTheme } from '../../../style/themes';
 
-function responsiveGridItem(responsiveSettings) {
+function responsiveGridItem(responsiveSettings, theme) {
   return responsiveSettings.map((setting) => {
     const {
-      colStart,
-      colEnd,
-      maxWidth,
-      rowStart,
-      rowEnd,
       alignSelf,
-      justifySelf
+      gridColumn,
+      gridRow,
+      maxWidth,
+      justifySelf,
+      p,
+      pl,
+      pr,
+      pt,
+      pb
     } = setting;
 
     return css`
       @media screen and (max-width: ${maxWidth}) {
         align-self: ${alignSelf || 'stretch'};
         justify-self: ${justifySelf || 'stretch'};
-        grid-column-start: ${colStart};
-        grid-column-end: ${colEnd};
-        grid-row-start: ${rowStart};
-        grid-row-end: ${rowEnd};
+        grid-column: ${gridColumn};
+        grid-row: ${gridRow};
+        padding: ${getSpacing(p, theme)};
+        padding-left: ${getSpacing(pl, theme)};
+        padding-right: ${getSpacing(pr, theme)};
+        padding-top: ${getSpacing(pt, theme)};
+        padding-bottom: ${getSpacing(pb, theme)};
       }
     `;
   });
 }
 
+function getSpacing(prop, theme) {
+  if (prop && typeof prop === 'number') {
+    return `${theme.space[prop]}px`;
+  }
+
+  return prop;
+}
+
 const GridItemStyle = styled.div`
   margin: 0;
 
-  ${({
-    gridColumnStart,
-    gridColumnEnd,
-    gridRowStart,
-    gridRowEnd,
-    alignSelf,
-    justifySelf
-  }) => css`
-    grid-column-start: ${gridColumnStart};
-    grid-column-end: ${gridColumnEnd};
-    grid-row-start: ${gridRowStart};
-    grid-row-end: ${gridRowEnd};
-    align-self: ${alignSelf};
-    justify-self: ${justifySelf};
-  `}
-
-  ${({ responsiveSettings }) => responsiveSettings && css`
-    ${responsiveGridItem(responsiveSettings)};
+  ${flexbox}
+  ${space}
+  ${grid}
+  ${({ responsiveSettings, theme }) => responsiveSettings && css`
+    ${responsiveGridItem(responsiveSettings, theme)};
   `}
 `;
 
 GridItemStyle.propTypes = {
-  gridColumnStart: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  gridColumnEnd: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  gridRowStart: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  gridRowEnd: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   alignSelf: PropTypes.string,
+  gridColumn: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  gridRow: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   justifySelf: PropTypes.string,
+  p: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  pl: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  pr: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  pt: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  pb: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  px: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  py: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   responsiveSettings: PropTypes.arrayOf(
     PropTypes.shape({
       alignSelf: PropTypes.string,
-      colStart: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-      colEnd: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      gridColumn: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      gridRow: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       justifySelf: PropTypes.string,
       maxWidth: PropTypes.string,
-      rowStart: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-      rowEnd: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+      p: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      pl: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      pr: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      pt: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      pb: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     })
   )
+};
+
+GridItemStyle.defaultProps = {
+  gridColumn: '1 / 13',
+  gridRow: 'auto',
+  theme: baseTheme
 };
 
 export default GridItemStyle;

--- a/src/components/grid/grid-item/index.d.ts
+++ b/src/components/grid/grid-item/index.d.ts
@@ -1,27 +1,65 @@
 import * as React from 'react';
-import { GridItem } from '..';
 
 interface ResponsiveSettingsShape {
-  alignSelf: string;
-  colStart: string | number;
-  colEnd: string | number;
-  justifySelf: string;
-  maxWidth: number;
-  rowStart: string | number;
-  rowEnd: string | number;
+  /** How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch */
+  alignSelf?: string;
+  /** How the grid item is aligned along the inline (row) axis. Values: start, end, center, stretch */
+  justifySelf?: string;
+  /**
+   *  Starting row position of the GridItem within the GridContainer
+   *  by referring to the grid line where the item begins
+   */
+  maxWidth?: number;
+  /** Starting and ending column position of the GridItem within the GridContainer separated by "/" */
+  gridColumn?: string | number;
+  /** Starting and ending row position of the GridItem within the GridContainer separated by "/" */
+  gridRow?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding */
+  p?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-left */
+  pl?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-right */
+  pr?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-top */
+  pt?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-bottom */
+  pb?: string | number;
+  /**
+   * Any valid CSS value or a number to be multiplied by base spacing unit (8).
+   * Overrides default horizontal paddings
+   */
+  px?: string | number;
+  /**
+   * Any valid CSS value or a number to be multiplied by base spacing unit (8).
+   * Overrides default vertical paddings
+   */
+  py?: string | number;
 }
 
 export interface GridItemProps {
-  alignSelf: string;
-  justifySelf: string;
-  children: string;
-  gridColumnStart: string | number;
-  gridColumnEnd: string | number;
-  gridRowStart: string | number;
-  gridRowEnd: string | number;
-  responsiveSettings: [ResponsiveSettingsShape];
+  /** How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch */
+  alignSelf?: string;
+  /** How the grid item is aligned along the inline (row) axis. Values: start, end, center, stretch */
+  justifySelf?: string;
+  /** Defines the Component(s) to be rendered within the GridItem */
+  children?: React.ReactNode;
+  /** Starting and ending column position of the GridItem within the GridContainer separated by "/" */
+  gridColumn?: string | number;
+  /** Starting and ending row position of the GridItem within the GridContainer separated by "/" */
+  gridRow?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding */
+  p?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-left */
+  pl?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-right */
+  pr?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-top */
+  pt?: string | number;
+  /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-bottom */
+  pb?: string | number;
+  responsiveSettings?: [ResponsiveSettingsShape];
 }
 
-declare const GridItemProps: React.FunctionComponent<GridItemProps>;
+declare const GridItem: React.FunctionComponent<GridItemProps>;
 
 export default GridItem;

--- a/src/components/grid/grid.spec.js
+++ b/src/components/grid/grid.spec.js
@@ -3,89 +3,84 @@ import { mount as enzymeMount } from 'enzyme';
 import TestRenderer from 'react-test-renderer';
 import { assertStyleMatch } from '../../__spec_helper__/test-utils';
 import { GridContainer, GridItem } from '.';
+import { baseTheme } from '../../style/themes';
+
+const marginProps = [
+  ['m', 'margin'],
+  ['ml', 'marginLeft'],
+  ['mr', 'marginRight'],
+  ['mt', 'marginTop'],
+  ['mb', 'marginBottom'],
+  ['mx', 'marginLeft'],
+  ['mx', 'marginRight'],
+  ['my', 'marginTop'],
+  ['my', 'marginBottom']
+];
 
 const item1900 = {
-  colStart: 1,
-  colEnd: 9,
-  maxWidth: '900px',
-  rowStart: 2,
-  rowEnd: 2
+  gridColumn: '1 / 9',
+  gridRow: 2,
+  maxWidth: '900px'
 };
 
 const item11300 = {
   alignSelf: 'stretch',
-  colStart: 1,
-  colEnd: 13,
+  gridColumn: '1 / 13',
+  gridRow: 1,
   justifySelf: 'stretch',
-  maxWidth: '1300px',
-  rowStart: 1,
-  rowEnd: 1
+  maxWidth: '1300px'
 };
 
 const item11500 = {
   alignSelf: 'stretch',
-  colStart: 1,
-  colEnd: 7,
+  gridColumn: '1 / 7',
+  gridRow: 1,
   justifySelf: 'stretch',
-  maxWidth: '1500px',
-  rowStart: 1,
-  rowEnd: 1
+  maxWidth: '1500px'
 };
 
 const item2900 = {
   alignSelf: 'stretch',
-  colStart: 1,
-  colEnd: 9,
+  gridColumn: '1 / 9',
+  gridRow: 3,
   justifySelf: 'stretch',
-  maxWidth: '900px',
-  rowStart: 3,
-  rowEnd: 3
+  maxWidth: '900px'
 };
 
 const item21300 = {
-  colStart: 1,
-  colEnd: 13,
-  maxWidth: '1300px',
-  rowStart: 2,
-  rowEnd: 2
+  gridColumn: '1 / 13',
+  gridRow: 2,
+  maxWidth: '1300px'
 };
 
 const item21500 = {
   alignSelf: 'stretch',
-  colStart: 7,
-  colEnd: 13,
+  gridColumn: '7 / 13',
+  gridRow: 1,
   justifySelf: 'stretch',
-  maxWidth: '1500px',
-  rowStart: 1,
-  rowEnd: 1
+  maxWidth: '1500px'
 };
 
 const item3900 = {
   alignSelf: 'stretch',
-  colStart: 1,
-  colEnd: 9,
+  gridColumn: '1 / 9',
+  gridRow: 1,
   justifySelf: 'stretch',
-  maxWidth: '900px',
-  rowStart: 1,
-  rowEnd: 1
+  maxWidth: '900px'
 };
 
 const item31300 = {
   alignSelf: 'stretch',
-  colStart: 1,
-  colEnd: 13,
+  gridColumn: '1 / 13',
+  gridRow: 3,
   justifySelf: 'stretch',
-  maxWidth: '1300px',
-  rowStart: 3,
-  rowEnd: 3
+  maxWidth: '1300px'
 };
 
 const item31500 = {
-  colStart: 1,
-  colEnd: 13,
-  maxWidth: '1500px',
-  rowStart: 2,
-  rowEnd: 2
+  gridColumn: '1 / 13',
+  gridRow: 2,
+  maxWidth: '1500px'
 };
 
 const mount = (attachTo) => {
@@ -144,7 +139,44 @@ describe('Grid', () => {
       );
       global.console.error.mockReset();
     });
+
+    describe.each(marginProps)('when a custom margin is specified using the "%s" styled system props',
+      (styledSystemProp, propName) => {
+        it(`then that ${propName} should have been set on the GridContainer`, () => {
+          const props = { [styledSystemProp]: '15px' };
+          const wrapper = enzymeMount(
+            <GridContainer id='testContainer' { ...props }>
+              <GridItem>1</GridItem>
+              <GridItem>2</GridItem>
+              <GridItem>3</GridItem>
+            </GridContainer>
+          );
+
+          expect(assertStyleMatch(
+            { [propName]: '15px' },
+            wrapper, { media: 'screen' }
+          ));
+        });
+      });
+
+    describe('when a custom grid-gap is specified using the "gridGap" styled system prop', () => {
+      it('then that grid-gap should have been set on the GridContainer', () => {
+        const wrapper = enzymeMount(
+          <GridContainer id='testContainer' gridGap='15px'>
+            <GridItem>1</GridItem>
+            <GridItem>2</GridItem>
+            <GridItem>3</GridItem>
+          </GridContainer>
+        );
+
+        expect(assertStyleMatch(
+          { gridGap: '15px' },
+          wrapper, { media: 'screen' }
+        ));
+      });
+    });
   });
+
   describe('GridItem', () => {
     /* the aim here is not to test that CSS media queries work. we are simply */
     /* checking that styled components are built and applied correctly        */
@@ -170,6 +202,98 @@ describe('Grid', () => {
           </GridContainer>
         )
       ).toMatchSnapshot();
+    });
+
+    describe('when a custom padding is specified using one of the styled system props', () => {
+      it('then that padding should have been set on the GridItem', () => {
+        const wrapper = enzymeMount(
+          <GridContainer id='testContainer'>
+            <GridItem p='15px'>1</GridItem>
+            <GridItem pl='15px'>2</GridItem>
+            <GridItem pr='15px'>3</GridItem>
+            <GridItem pt='15px'>4</GridItem>
+            <GridItem pb='15px'>5</GridItem>
+            <GridItem px='15px'>6</GridItem>
+            <GridItem py='15px'>7</GridItem>
+          </GridContainer>
+        );
+
+        expect(assertStyleMatch(
+          { padding: '15px' },
+          wrapper.find(GridItem).first()
+        ));
+        expect(assertStyleMatch(
+          { paddingLeft: '15px' },
+          wrapper.find(GridItem).at(1)
+        ));
+        expect(assertStyleMatch(
+          { paddingRight: '15px' },
+          wrapper.find(GridItem).at(2)
+        ));
+        expect(assertStyleMatch(
+          { paddingTop: '15px' },
+          wrapper.find(GridItem).at(3)
+        ));
+        expect(assertStyleMatch(
+          { paddingBottom: '15px' },
+          wrapper.find(GridItem).at(4)
+        ));
+        expect(assertStyleMatch(
+          {
+            paddingLeft: '15px',
+            paddingRight: '15px'
+          },
+          wrapper.find(GridItem).at(5)
+        ));
+        expect(assertStyleMatch(
+          {
+            paddingTop: '15px',
+            paddingBottom: '15px'
+          },
+          wrapper.find(GridItem).at(6)
+        ));
+      });
+    });
+
+    describe(`when a custom padding is specified as a number in responsiveSettings,
+      using one of the styled system props`, () => {
+      it('then the padding specified in a theme spacing property should have been set on the GridItem', () => {
+        const wrapper = enzymeMount(
+          <GridContainer id='testContainer'>
+            <GridItem responsiveSettings={ [{ p: 3, maxWidth: '1500px' }] }>1</GridItem>
+            <GridItem responsiveSettings={ [{ pl: 3, maxWidth: '1500px' }] }>2</GridItem>
+            <GridItem responsiveSettings={ [{ pr: 3, maxWidth: '1500px' }] }>3</GridItem>
+            <GridItem responsiveSettings={ [{ pt: 3, maxWidth: '1500px' }] }>4</GridItem>
+            <GridItem responsiveSettings={ [{ pb: 3, maxWidth: '1500px' }] }>5</GridItem>
+          </GridContainer>
+        );
+
+        expect(assertStyleMatch(
+          { padding: `${baseTheme.space[3]}px` },
+          wrapper.find(GridItem).first(),
+          { media: 'screen and (max-width:1500px)' }
+        ));
+        expect(assertStyleMatch(
+          { paddingLeft: `${baseTheme.space[3]}px` },
+          wrapper.find(GridItem).at(1),
+          { media: 'screen and (max-width:1500px)' }
+        ));
+        expect(assertStyleMatch(
+          { paddingRight: `${baseTheme.space[3]}px` },
+          wrapper.find(GridItem).at(2),
+          { media: 'screen and (max-width:1500px)' }
+        ));
+        expect(assertStyleMatch(
+          { paddingTop: `${baseTheme.space[3]}px` },
+          wrapper.find(GridItem).at(3),
+          { media: 'screen and (max-width:1500px)' }
+        ));
+        expect(assertStyleMatch(
+          { paddingBottom: `${baseTheme.space[3]}px` },
+          wrapper.find(GridItem).at(4),
+          { media: 'screen and (max-width:1500px)' }
+        ));
+      });
     });
   });
 });

--- a/src/components/grid/grid.stories.js
+++ b/src/components/grid/grid.stories.js
@@ -15,12 +15,10 @@ export const basic = () => {
     `${viewportSettings} (i)`,
     {
       alignSelf: 'stretch',
-      colStart: 1,
-      colEnd: 7,
+      gridColumn: '1 / 7',
+      gridRow: '1 / 1',
       justifySelf: 'stretch',
-      maxWidth: '1500px',
-      rowStart: 1,
-      rowEnd: 1
+      maxWidth: '1500px'
     },
     groupID1
   );
@@ -29,12 +27,10 @@ export const basic = () => {
     `${viewportSettings} (ii)`,
     {
       alignSelf: 'stretch',
-      colStart: 1,
-      colEnd: 13,
+      gridColumn: '1 / 13',
+      gridRow: '1 / 1',
       justifySelf: 'stretch',
-      maxWidth: '1300px',
-      rowStart: 1,
-      rowEnd: 1
+      maxWidth: '1300px'
     },
     groupID1
   );
@@ -43,12 +39,10 @@ export const basic = () => {
     `${viewportSettings} (iii)`,
     {
       alignSelf: 'stretch',
-      colStart: 1,
-      colEnd: 9,
+      gridColumn: '1 / 9',
+      gridRow: '2 / 2',
       justifySelf: 'stretch',
-      maxWidth: '900px',
-      rowStart: 2,
-      rowEnd: 2
+      maxWidth: '900px'
     },
     groupID1
   );
@@ -57,12 +51,10 @@ export const basic = () => {
     `${viewportSettings} (i)`,
     {
       alignSelf: 'stretch',
-      colStart: 7,
-      colEnd: 13,
+      gridColumn: '7 / 13',
+      gridRow: '1 / 1',
       justifySelf: 'stretch',
-      maxWidth: '1500px',
-      rowStart: 1,
-      rowEnd: 1
+      maxWidth: '1500px'
     },
     groupID2
   );
@@ -71,12 +63,10 @@ export const basic = () => {
     `${viewportSettings} (ii)`,
     {
       alignSelf: 'stretch',
-      colStart: 1,
-      colEnd: 13,
+      gridColumn: '1 / 13',
+      gridRow: '2 / 2',
       justifySelf: 'stretch',
-      maxWidth: '1300px',
-      rowStart: 2,
-      rowEnd: 2
+      maxWidth: '1300px'
     },
     groupID2
   );
@@ -85,12 +75,10 @@ export const basic = () => {
     `${viewportSettings} (iii)`,
     {
       alignSelf: 'stretch',
-      colStart: 1,
-      colEnd: 9,
+      gridColumn: '1 / 9',
+      gridRow: '3 / 3',
       justifySelf: 'stretch',
-      maxWidth: '900px',
-      rowStart: 3,
-      rowEnd: 3
+      maxWidth: '900px'
     },
     groupID2
   );
@@ -99,12 +87,10 @@ export const basic = () => {
     `${viewportSettings} (i)`,
     {
       alignSelf: 'stretch',
-      colStart: 1,
-      colEnd: 13,
+      gridColumn: '1 / 13',
+      gridRow: '2 / 2',
       justifySelf: 'stretch',
-      maxWidth: '1500px',
-      rowStart: 2,
-      rowEnd: 2
+      maxWidth: '1500px'
     },
     groupID3
   );
@@ -113,12 +99,10 @@ export const basic = () => {
     `${viewportSettings} (ii)`,
     {
       alignSelf: 'stretch',
-      colStart: 1,
-      colEnd: 13,
+      gridColumn: '1 / 13',
+      gridRow: '3 / 3',
       justifySelf: 'stretch',
-      maxWidth: '1300px',
-      rowStart: 3,
-      rowEnd: 3
+      maxWidth: '1300px'
     },
     groupID3
   );
@@ -127,12 +111,10 @@ export const basic = () => {
     `${viewportSettings} (iii)`,
     {
       alignSelf: 'stretch',
-      colStart: 1,
-      colEnd: 9,
+      gridColumn: '1 / 9',
+      gridRow: '1 / 1',
       justifySelf: 'stretch',
-      maxWidth: '900px',
-      rowStart: 1,
-      rowEnd: 1
+      maxWidth: '900px'
     },
     groupID3
   );
@@ -280,8 +262,7 @@ export const Visual = () => {
         <GridItem
           alignSelf='end'
           justifySelf='left'
-          gridColumnStart='1'
-          gridColumnEnd='1'
+          gridColumn='1 / 1'
         >
           <Pod
             alignTitle='left'
@@ -296,8 +277,7 @@ export const Visual = () => {
         <GridItem
           alignSelf='stretch'
           justifySelf='center'
-          gridColumnStart='2'
-          gridColumnEnd='2'
+          gridColumn='2 / 2'
         >
           <Pod
             alignTitle='left'
@@ -313,10 +293,8 @@ export const Visual = () => {
         <GridItem
           alignSelf='stretch'
           justifySelf='right'
-          gridColumnStart='1'
-          gridColumnEnd='1'
-          gridRowStart='2'
-          gridRowEnd='2'
+          gridColumn='1 / 1'
+          gridRow='2 / 2'
         >
           <Pod
             alignTitle='left'
@@ -333,26 +311,21 @@ export const Visual = () => {
         <GridItem responsiveSettings={ [
           {
             maxWidth: '1500px',
-            colStart: 1,
-            colEnd: 7,
-            rowStart: 1,
-            rowEnd: 1,
+            gridColumn: '1 / 7',
+            gridRow: '1 / 1',
             alignSelf: 'stretch',
             justifySelf: 'stretch'
           }, {
             maxWidth: '1300px',
-            colStart: 1,
-            colEnd: 13,
-            rowStart: 1,
-            rowEnd: 1,
+            gridColumn: '1 / 13',
+            gridRow: '1 / 1',
             alignSelf: 'stretch',
             justifySelf: 'stretch'
           }, {
             maxWidth: '900px',
             colStart: 1,
             colEnd: 9,
-            rowStart: 2,
-            rowEnd: 2,
+            gridRow: '2 / 2',
             alignSelf: 'stretch',
             justifySelf: 'stretch'
           }] }
@@ -368,26 +341,20 @@ export const Visual = () => {
         <GridItem responsiveSettings={ [
           {
             maxWidth: '1500px',
-            colStart: 7,
-            colEnd: 13,
-            rowStart: 1,
-            rowEnd: 1,
+            gridColumn: '7 / 13',
+            gridRow: '1 / 1',
             alignSelf: 'stretch',
             justifySelf: 'stretch'
           }, {
             maxWidth: '1300px',
-            colStart: 1,
-            colEnd: 13,
-            rowStart: 2,
-            rowEnd: 2,
+            gridColumn: '1 / 13',
+            gridRow: '2 / 2',
             alignSelf: 'stretch',
             justifySelf: 'stretch'
           }, {
             maxWidth: '900px',
-            colStart: 1,
-            colEnd: 9,
-            rowStart: 3,
-            rowEnd: 3,
+            gridColumn: '1 / 9',
+            gridRow: '3 / 3',
             alignSelf: 'stretch',
             justifySelf: 'stretch'
           }] }
@@ -406,26 +373,20 @@ export const Visual = () => {
           responsiveSettings={ [
             {
               maxWidth: '1500px',
-              colStart: 1,
-              colEnd: 13,
-              rowStart: 2,
-              rowEnd: 2,
+              gridColumn: '1 / 13',
+              gridRow: '2 / 2',
               alignSelf: 'stretch',
               justifySelf: 'stretch'
             }, {
               maxWidth: '1300px',
-              colStart: 1,
-              colEnd: 13,
-              rowStart: 3,
-              rowEnd: 3,
+              gridColumn: '1 / 13',
+              gridRow: '3 / 3',
               alignSelf: 'stretch',
               justifySelf: 'stretch'
             }, {
               maxWidth: '900px',
-              colStart: 1,
-              colEnd: 9,
-              rowStart: 1,
-              rowEnd: 1,
+              gridColumn: '1 / 9',
+              gridRow: '1 / 1',
               alignSelf: 'stretch',
               justifySelf: 'stretch'
             }] }

--- a/src/components/grid/grid.stories.mdx
+++ b/src/components/grid/grid.stories.mdx
@@ -52,55 +52,6 @@ Gutters for the `GridItem` are set automatically in the CSS, following the value
 | Large (1260 to 1920px) | High-Res Laptops & Monitors | 24px |
 | Extra Large (1921px and above) | Ultra High-Res Monitors |40px |
 
-## GridContainer Props
-<Props of={GridContainer} />
-
-## GridItem Props
-<Props of={GridItem} />
-
-### responsiveSettings Props
-<PropsTable
-  rows={
-    [
-      {
-      name: 'alignSelf',
-      type: { summary: 'string' },
-      description: 'How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch'
-      },
-      {
-        name: 'colStart',
-        type: { summary: 'number'},
-        description: 'Starting column position of the GridItem within the GridContainer by referring to the grid line where the item begins'
-      },
-      {
-        name: 'colEnd',
-        type: { summary: 'number' },
-        description: 'Ending column position of the GridItem within the GridContainer by referring to the grid line where the item ends'
-      },
-      {
-        name: 'justifySelf',
-        type: { summary: 'string' },
-        description: 'How the grid item is aligned along the inline (row) axis. Values: start, end, center, stretch'
-      },
-      {
-        name: 'maxWidth',
-        type: { summary: 'string' },
-        description: 'Starting row position of the GridItem within the GridContainer by referring to the grid line where the item begins'
-      },
-      {
-        name: 'rowStart',
-        type: { summary: 'number' },
-        description: 'Starting row position of the GridItem within the GridContainer by referring to the grid line where the item begins'
-      },
-      {
-        name: 'rowEnd',
-        type: { summary: 'number' },
-        description: 'Ending row position of the GridItem within the GridContainer by referring to the grid line where the item ends'
-      }
-    ]
-  }
-/>
-
 ## Basic example
 This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation.
 <Preview>
@@ -193,8 +144,7 @@ This example is best viewed in the Canvas tab using full-screen mode with device
         <GridItem
           alignSelf="end"
           justifySelf="left"
-          gridColumnStart="1"
-          gridColumnEnd="1"
+          gridColumn="1 / 1"
         >
           <Pod
             alignTitle='left' as='primary'
@@ -207,8 +157,7 @@ This example is best viewed in the Canvas tab using full-screen mode with device
         <GridItem
           alignSelf="stretch"
           justifySelf="center"
-          gridColumnStart="2"
-          gridColumnEnd="2"
+          gridColumn="2 / 2"
         >
           <Pod
             alignTitle='left' as='primary'
@@ -222,10 +171,8 @@ This example is best viewed in the Canvas tab using full-screen mode with device
         <GridItem
           alignSelf="stretch"
           justifySelf="right"
-          gridColumnStart="1"
-          gridColumnEnd="1"
-          gridRowStart="2"
-          gridRowEnd="2"
+          gridColumn="1 / 1"
+          gridRow="2 / 2"
         >
           <Pod
             alignTitle='left' as='primary'
@@ -240,6 +187,97 @@ This example is best viewed in the Canvas tab using full-screen mode with device
   </Story>
 </Preview>
 
+## Custom spacings
+This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation.
+<Preview>
+  <Story name="custom spacings" parameters={{ info: { disable: true }}} >
+    <GridContainer m='20px' gridGap='5px'>
+      <GridItem
+        p='20px 5px 20px 0'
+        gridColumn='1 / 10'
+        alignSelf="stretch"
+        justifySelf="stretch"
+        responsiveSettings={ [{
+          maxWidth: '800px',
+          gridColumn: '1 / 13',
+          gridRow: '1 / 1',
+          p: 0
+        }] }
+      >
+        <Pod
+          alignTitle='left' as='primary'
+          border padding='medium'
+          podType='primary'
+        >
+          1
+        </Pod>
+      </GridItem>
+      <GridItem
+        pt='20px'
+        pb='20px'
+        gridColumn='10 / 13'
+        alignSelf="stretch"
+        justifySelf="stretch"
+        responsiveSettings={ [{
+          maxWidth: '800px',
+          gridColumn: '1 / 13',
+          gridRow: '2 / 2',
+          pt: 0,
+          pb: 0
+        }] }
+      >
+        <Pod
+          alignTitle='left' as='primary'
+          border padding='medium'
+          podType='primary'
+        >
+          2
+        </Pod>
+      </GridItem>
+      <GridItem
+        pr='20px'
+        gridColumn='1 / 6'
+        alignSelf="stretch"
+        justifySelf="stretch"
+        responsiveSettings={ [{
+          maxWidth: '800px',
+          gridColumn: '1 / 13',
+          gridRow: '3 / 3',
+          pr: 0
+        }] }
+      >
+        <Pod
+          alignTitle='left' as='primary'
+          border padding='medium'
+          podType='primary'
+        >
+          3
+        </Pod>
+      </GridItem>
+      <GridItem
+        pl='20px'
+        gridColumn='6 / 13'
+        alignSelf="stretch"
+        justifySelf="stretch"
+        responsiveSettings={ [{
+          maxWidth: '800px',
+          gridColumn: '1 / 13',
+          gridRow: '4 / 4',
+          pl: 0
+        }] }
+      >
+        <Pod
+          alignTitle='left' as='primary'
+          border padding='medium'
+          podType='primary'
+        >
+          4
+        </Pod>
+      </GridItem>
+    </GridContainer>
+  </Story>
+</Preview>
+
 ## Responsive Settings Example
 This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation. Note how the order and position of each `GridItem`, responds according to an array of `responsiveSettings` allowing reordering and respositioning as required.
 <Preview>
@@ -248,26 +286,20 @@ This example is best viewed in the Canvas tab using full-screen mode with device
       <GridItem responsiveSettings={[
         {
           maxWidth: '1500px',
-          colStart: 1,
-          colEnd: 7,
-          rowStart: 1,
-          rowEnd: 1,
+          gridColumn: '1 / 7',
+          gridRow: '1 / 1',
           alignSelf: 'stretch',
           justifySelf: 'stretch'
         },{
           maxWidth: '1300px',
-          colStart: 1,
-          colEnd: 13,
-          rowStart: 1,
-          rowEnd: 1,
+          gridColumn: '1 / 13',
+          gridRow: '1 / 1',
           alignSelf: 'stretch',
           justifySelf: 'stretch'
         },{
           maxWidth: '900px',
-          colStart: 1,
-          colEnd: 9,
-          rowStart: 2,
-          rowEnd: 2,
+          gridColumn: '1 / 9',
+          gridRow: '2 / 2',
           alignSelf: 'stretch',
           justifySelf: 'stretch'
         }]}
@@ -283,26 +315,20 @@ This example is best viewed in the Canvas tab using full-screen mode with device
       <GridItem responsiveSettings={[
         {
           maxWidth: '1500px',
-          colStart: 7,
-          colEnd: 13,
-          rowStart: 1,
-          rowEnd: 1,
+          gridColumn: '7 / 13',
+          gridRow: '1 / 1',
           alignSelf: 'stretch',
           justifySelf: 'stretch'
         },{
           maxWidth: '1300px',
-          colStart: 1,
-          colEnd: 13,
-          rowStart: 2,
-          rowEnd: 2,
+          gridColumn: '1 / 13',
+          gridRow: '2 / 2',
           alignSelf: 'stretch',
           justifySelf: 'stretch'
         },{
           maxWidth: '900px',
-          colStart: 1,
-          colEnd: 9,
-          rowStart: 3,
-          rowEnd: 3,
+          gridColumn: '1 / 9',
+          gridRow: '3 / 3',
           alignSelf: 'stretch',
           justifySelf: 'stretch'
         }]}>
@@ -317,26 +343,20 @@ This example is best viewed in the Canvas tab using full-screen mode with device
       <GridItem responsiveSettings={[
         {
           maxWidth: '1500px',
-          colStart: 1,
-          colEnd: 13,
-          rowStart: 2,
-          rowEnd: 2,
+          gridColumn: '1 / 13',
+          gridRow: '2 / 2',
           alignSelf: 'stretch',
           justifySelf: 'stretch'
         },{
           maxWidth: '1300px',
-          colStart: 1,
-          colEnd: 13,
-          rowStart: 3,
-          rowEnd: 3,
+          gridColumn: '1 / 13',
+          gridRow: '3 / 3',
           alignSelf: 'stretch',
           justifySelf: 'stretch'
         },{
           maxWidth: '900px',
-          colStart: 1,
-          colEnd: 9,
-          rowStart: 1,
-          rowEnd: 1,
+          gridColumn: '1 / 9',
+          gridRow: '1 / 1',
           alignSelf: 'stretch',
           justifySelf: 'stretch'
         }]}>
@@ -351,3 +371,67 @@ This example is best viewed in the Canvas tab using full-screen mode with device
     </GridContainer>
   </Story>
 </Preview>
+
+## GridContainer Props
+<Props of={GridContainer} />
+
+## GridItem Props
+<Props of={GridItem} />
+
+### responsiveSettings Props
+<PropsTable
+  rows={
+    [
+      {
+      name: 'alignSelf',
+      type: { summary: 'string' },
+      description: 'How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch'
+      },
+      {
+        name: 'gridColumn',
+        type: { summary: 'string'},
+        description: 'Starting and ending column position of the GridItem within the GridContainer separated by "/"'
+      },
+      {
+        name: 'gridRow',
+        type: { summary: 'number' },
+        description: 'Starting and ending row position of the GridItem within the GridContainer separated by "/"'
+      },
+      {
+        name: 'justifySelf',
+        type: { summary: 'string' },
+        description: 'How the grid item is aligned along the inline (row) axis. Values: start, end, center, stretch'
+      },
+      {
+        name: 'maxWidth',
+        type: { summary: 'string' },
+        description: 'Maximum width of the screen to which these rules to be applied'
+      },
+      {
+        name: 'p',
+        type: { summary: 'string | number' },
+        description: 'Any valid CSS value to override default padding'
+      },
+      {
+        name: 'pl',
+        type: { summary: 'string | number' },
+        description: 'Any valid CSS value to override default padding-left'
+      },
+      {
+        name: 'pr',
+        type: { summary: 'string | number' },
+        description: 'Any valid CSS value to override default padding-right'
+      },
+      {
+        name: 'pt',
+        type: { summary: 'string | number' },
+        description: 'Any valid CSS value to override default padding-top'
+      },
+      {
+        name: 'pb',
+        type: { summary: 'string | number' },
+        description: 'Any valid CSS value to override default padding-bottom'
+      }
+    ]
+  }
+/>

--- a/src/components/tabs/__internal__/tabs.stories.mdx
+++ b/src/components/tabs/__internal__/tabs.stories.mdx
@@ -1316,15 +1316,15 @@ prop to the `Tab` component.
               key='tab-1'
               customLayout={ 
                 <div style={{ display: 'grid', padding: '4px 4px 22px 14px' }}>
-                  <div style={{ gridColumnStart: '10', gridColumnEnd: '11'}}>
+                  <div style={{ gridColumn: '10 / 11' }}>
                     <Icon type='settings' />
                   </div>
-                  <div style={{ gridColumnStart: '11', gridColumnEnd: '13'}}>
+                  <div style={{ gridColumn: '11 / 13' }}>
                     <ActionPopover>
                       <ActionPopoverItem onClick={() => {}}>Edit</ActionPopoverItem>
                     </ActionPopover>
                   </div>
-                  <div style={{ gridColumnStart: '1', gridColumnEnd: '6'}}>
+                  <div style={{ gridColumn: '1 / 6' }}>
                     Tab 1
                   </div>
                 </div>
@@ -1345,15 +1345,15 @@ prop to the `Tab` component.
               key='tab-2'
               customLayout={ 
                 <div style={{ display: 'grid', padding: '4px 4px 22px 14px' }}>
-                  <div style={{ gridColumnStart: '10', gridColumnEnd: '11'}}>
+                  <div style={{ gridColumn: '10 / 11' }}>
                     <Icon type='settings' />
                   </div>
-                  <div style={{ gridColumnStart: '11', gridColumnEnd: '13'}}>
+                  <div style={{ gridColumn: '11 / 13' }}>
                     <ActionPopover>
                       <ActionPopoverItem onClick={() => {}}>Edit</ActionPopoverItem>
                     </ActionPopover>
                   </div>
-                  <div style={{ gridColumnStart: '1', gridColumnEnd: '6'}}>
+                  <div style={{ gridColumn: '1 / 6' }}>
                     Tab 2
                   </div>
                 </div>
@@ -1374,15 +1374,15 @@ prop to the `Tab` component.
               key='tab-3'
               customLayout={ 
                 <div style={{ display: 'grid', padding: '4px 4px 22px 14px' }}>
-                  <div style={{ gridColumnStart: '10', gridColumnEnd: '11'}}>
+                  <div style={{ gridColumn: '10 / 11' }}>
                     <Icon type='settings' />
                   </div>
-                  <div style={{ gridColumnStart: '11', gridColumnEnd: '13'}}>
+                  <div style={{ gridColumn: '11 / 13' }}>
                     <ActionPopover>
                       <ActionPopoverItem onClick={() => {}}>Edit</ActionPopoverItem>
                     </ActionPopover>
                   </div>
-                  <div style={{ gridColumnStart: '1', gridColumnEnd: '6'}}>
+                  <div style={{ gridColumn: '1 / 6' }}>
                     Tab 3
                   </div>
                 </div>


### PR DESCRIPTION
### Proposed behaviour
grid-container should accept m, ml, mr, mt, mb and gridGap props to allow custom spacings
grid-item should accept p, pl, pr, pt, pb, gridColumn and gridRow props to allow custom spacings

replace gridColumnStart and gridColumnEnd props in the GridItem component with gridColumn styled-system compatible prop
replace gridRowStart and gridRowEnd props in the GridItem component with gridRow styled-system compatible prop

### Current behaviour
no possibility to set custom spacings
gridColumnStart, gridColumnEnd, gridRowStart and gridRowEnd props not compatible with styled-system

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
1. run npm start
2. go to http://localhost:9001/?path=/docs/design-system-grid--custom-spacings