### PR TITLE
docs(tile): update vertical story

### DIFF
--- a/src/components/tile/tile.stories.mdx
+++ b/src/components/tile/tile.stories.mdx
@@ -26,7 +26,7 @@ import Tile from 'carbon-react/lib/components/tile';
 By default, the Tile component will have a horizontal layout.
 
 <Preview>
-    <Story name ='Default'>
+    <Story name='Default'>
         <Tile>
         <Content title="Test Title One">
             Test Body One
@@ -45,8 +45,8 @@ By default, the Tile component will have a horizontal layout.
 The Tile component can be also have a vertical layout. 
 
 <Preview>
-    <Story name ='Vertical'>
-        <Tile  orientation='Vertical'>
+    <Story name='Vertical'>
+        <Tile orientation='vertical'>
         <Content title="Test Title One">
             Test Body One
         </Content>


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
No error in console relating to the value passed to the `orientation` prop

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
The orientation prop needs to be passed either `horizontal` or `vertical` but the value passed in
the story is `Vertical`. Therefore, there is an error in the console and the story does not render correctly: there is no separating lines between the content blocks

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
Check `http://localhost:9001/?path=/docs/design-system-tile--vertical` there should be no error in the console relating to the value passed to the `orientation` prop