### PR TITLE
test(chromatic): exclude propTypes from chromatic

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,6 +10,7 @@ import { addParameters } from '@storybook/react';
 import { configureActions } from '@storybook/addon-actions';
 import sageTheme from './sageTheme';
 import "../src/utils/css";
+import isChromatic from 'chromatic/isChromatic';
 
 // Temporary fix for issue mentioned in FE-2565 ticket
 // Should be solved by the storybook team in foreseeable future
@@ -51,9 +52,11 @@ addParameters({
 setupI18n();
 
 addDecorator(withKnobs);
-addDecorator(withInfo({
-  header: false,
-  inline: true,
-}));
+if (!isChromatic()) {
+  addDecorator(withInfo({
+    header: false,
+    inline: true,
+  }));
+}
 addDecorator(withA11y);
 addDecorator(withThemeSelector);


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Exclude `propTypes` from `chromatic` runs.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are not ignoring `addDecorator(withInfo)` in `chromatic` runs. And when we have changed some of the `propTypes` - we have changed the `baselines` in `chromatic`.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
To check if this change works correctly - check the `chromatic` build.