### PR TITLE
fix(defition-list): change white-space to normal - FE-3155

### DIFF
--- a/src/components/definition-list/definition-list.spec.js
+++ b/src/components/definition-list/definition-list.spec.js
@@ -20,7 +20,8 @@ describe('DefinitionList', () => {
         </Dl>
       ),
       Dt: <Dt { ...props }>Foo</Dt>,
-      Dd: <Dd { ...props }>Barr</Dd>
+      Dd: <Dd { ...props }>Barr</Dd>,
+      Error: <Dl { ...props }><span>Foo</span></Dl>
     };
 
     return (
@@ -50,8 +51,7 @@ describe('DefinitionList', () => {
         fontSize: '14px',
         fontWeight: '700',
         paddingRight: '24px',
-        color: 'rgba(0,0,0,0.9)',
-        marginBottom: '16px'
+        color: 'rgba(0,0,0,0.9)'
       }, wrapper);
     });
 
@@ -61,7 +61,6 @@ describe('DefinitionList', () => {
         fontSize: '14px',
         fontWeight: '700',
         color: 'rgba(0,0,0,0.65)',
-        marginBottom: '16px',
         marginLeft: '0px'
       }, wrapper);
     });
@@ -72,8 +71,7 @@ describe('DefinitionList', () => {
         fontSize: '14px',
         fontWeight: '700',
         paddingRight: '16px',
-        color: 'rgba(0,0,0,0.9)',
-        marginBottom: '8px'
+        color: 'rgba(0,0,0,0.9)'
       }, wrapper);
     });
 
@@ -83,7 +81,6 @@ describe('DefinitionList', () => {
         fontSize: '14px',
         fontWeight: '700',
         color: 'rgba(0,0,0,0.65)',
-        marginBottom: '8px',
         marginLeft: '0px'
       }, wrapper);
     });
@@ -100,11 +97,20 @@ describe('DefinitionList', () => {
       wrapper = renderWrapper('Dl', { });
     });
     it('should contain dt', () => {
-      expect(wrapper.find(StyledDtDiv).props().children.length).toEqual(1);
+      expect(wrapper.find(StyledDtDiv).props().children).toBeDefined();
     });
 
     it('should contain dd', () => {
       expect(wrapper.find(StyledDdDiv).props().children.length).toEqual(1);
+    });
+  });
+  describe('Wrong children', () => {
+    beforeEach(() => {
+      wrapper = renderWrapper('Error', { });
+    });
+    it('should contain nothing', () => {
+      expect(wrapper.find(StyledDdDiv)).toEqual({});
+      expect(wrapper.find(StyledDtDiv)).toEqual({});
     });
   });
 });

--- a/src/components/definition-list/definition-list.style.js
+++ b/src/components/definition-list/definition-list.style.js
@@ -18,20 +18,21 @@ export const StyledDtDiv = styled.div`
   ${({ w, dtTextAlign }) => css`
     text-align: ${dtTextAlign};
     width: ${w}%;
-    white-space: nowrap;
   `}
 `;
 
 export const StyledDdDiv = styled.div`
   ${({ ddTextAlign }) => css`
     text-align: ${ddTextAlign};
-    width: auto;
-    white-space: nowrap;
+    width: inherit;
+    width: -moz-available;
+    width: -webkit-fill-available;
   `}
 `;
 
 export const StyledDt = styled.dt`
   ${space}
+  margin-bottom: 0px;
   ${({ theme }) => css`
     font-size: 14px
     font-weight: 700;
@@ -45,6 +46,7 @@ StyledDt.defaultProps = {
 
 export const StyledDd = styled.dd`
   ${space}
+  margin-bottom: 0px;
   ${({ theme }) => css`
     font-size: 14px
     font-weight: 700;

--- a/src/components/definition-list/dl.component.js
+++ b/src/components/definition-list/dl.component.js
@@ -11,22 +11,38 @@ const Dl = ({
   dtTextAlign = 'right',
   ddTextAlign = 'left'
 }) => {
-  const dtLabels = React.Children.toArray(children).filter(child => child.type === Dt);
-  const ddContent = React.Children.toArray(children).filter(child => child.type === Dd);
+  const dlComponent = [];
+  const listChildren = React.Children.toArray(children);
+  let dtLabel;
+  let ddContent = [];
 
-  return (
-    <StyledDl data-component='dl'>
+  Object.keys(listChildren).forEach((key) => {
+    if (listChildren[key].type === Dt) {
+      dtLabel = listChildren[key];
+    } else if (listChildren[key].type === Dd) {
+      ddContent.push(listChildren[key]);
+    }
+    if (dtLabel
+      && (parseInt(key, 10) === (listChildren.length - 1) || listChildren[parseInt(key, 10) + 1].type === Dt)) {
+      dlComponent.push(
+        <StyledDl data-component='dl' key={ `dl_${key}` }>
 
-      <StyledDtDiv w={ w } dtTextAlign={ dtTextAlign }>
-        {dtLabels}
-      </StyledDtDiv>
+          <StyledDtDiv w={ w } dtTextAlign={ dtTextAlign }>
+            {dtLabel}
+          </StyledDtDiv>
 
-      <StyledDdDiv w={ w } ddTextAlign={ ddTextAlign }>
-        {ddContent}
-      </StyledDdDiv>
+          <StyledDdDiv w={ w } ddTextAlign={ ddTextAlign }>
+            {ddContent}
+          </StyledDdDiv>
 
-    </StyledDl>
-  );
+        </StyledDl>
+      );
+      dtLabel = undefined;
+      ddContent = [];
+    }
+  });
+
+  return (dlComponent);
 };
 
 Dl.propTypes = {


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
The label or `<Dt>` is intruding in to the space that the content or `<Dd>` should occupy when a long string is passed to `<Dt>`.
![image](https://user-images.githubusercontent.com/17083504/93868617-fad3cf80-fcca-11ea-9b01-8e45bee9d1b6.png)

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
![image](https://user-images.githubusercontent.com/17083504/93868809-47b7a600-fccb-11ea-9b74-29166f9e7730.png)

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
1. npm start
2. http://localhost:9001/?path=/story/design-system-tile--tile-with-definition-list-with-custom-width