### PR TITLE
chore(styled-system): add spacing default value

### DIFF
--- a/.storybook/utils/styled-system-props.js
+++ b/.storybook/utils/styled-system-props.js
@@ -143,7 +143,7 @@ const generateStyledSystemProps = (
 const StyledSystemProps = ({
   of,
   spacing,
-  spacingDefaults,
+  spacingDefaults = {},
   noHeader
 }) => {
   const rows = spacing ? generateStyledSystemProps(spacingDefaults) : null;


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Sets `spacingDefaults` to an empty object as default if no value is passed in
### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
The `StyledSystemProps` component has no default value for the `spacingDefaults` prop meaning that
it throws an error if nothing is passed to it
### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
