### PR TITLE
test: disable chromatic for classic theme

### DIFF
--- a/src/components/step-sequence/step-sequence-item/step-sequence-item.stories.js
+++ b/src/components/step-sequence/step-sequence-item/step-sequence-item.stories.js
@@ -5,7 +5,7 @@ import { dlsThemeSelector, classicThemeSelector } from '../../../../.storybook/t
 import StepSequenceItem from './step-sequence-item.component';
 import OptionsHelper from '../../../utils/helpers/options-helper/options-helper';
 
-function makeStory(name, themeSelector) {
+function makeStory(name, themeSelector, disableChromatic = false) {
   const component = () => {
     const indicator = text('indicator', '1');
     const status = select('status', OptionsHelper.steps, StepSequenceItem.defaultProps.status);
@@ -29,7 +29,10 @@ function makeStory(name, themeSelector) {
 
   const metadata = {
     themeSelector,
-    knobs: { escapeHTML: false }
+    knobs: { escapeHTML: false },
+    chromatic: {
+      disable: disableChromatic
+    }
   };
 
   return [name, component, metadata];
@@ -37,4 +40,4 @@ function makeStory(name, themeSelector) {
 
 storiesOf('Step Sequence Item', module)
   .add(...makeStory('default', dlsThemeSelector))
-  .add(...makeStory('classic', classicThemeSelector));
+  .add(...makeStory('classic', classicThemeSelector, true));


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Disable `chromatic` for `classic` theme for `Step Sequence Item` component

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
We need to disable `chromatic` for `classic` theme for `Step Sequence Item` component as we not supporting `classic` theme.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent