### PR TITLE
fix(definition-list): display as grid to enable content wrapping FE-3160

### DIFF
--- a/src/components/accordion/accordion.component.js
+++ b/src/components/accordion/accordion.component.js
@@ -1,5 +1,5 @@
 import React, {
-  useState, useRef, useEffect, useCallback
+  useState, useRef, useEffect, useLayoutEffect, useCallback
 } from 'react';
 import PropTypes from 'prop-types';
 
@@ -56,8 +56,21 @@ const Accordion = React.forwardRef(({
 
   const isExpanded = isControlled ? expanded : isExpandedInternal;
 
+  useLayoutEffect(() => {
+    const resizedContentHeight = () => {
+      setContentHeight(accordionContent.current.scrollHeight);
+    };
+
+    const event = 'resize';
+    window.addEventListener(event, resizedContentHeight);
+
+    return function cleanup() {
+      window.removeEventListener(event, resizedContentHeight);
+    };
+  }, []);
+
   useEffect(() => {
-    setContentHeight(!isExpanded ? 0 : accordionContent.current.scrollHeight);
+    setContentHeight(accordionContent.current.scrollHeight);
   }, [isExpanded, children]);
 
   const toggleAccordion = useCallback((ev) => {

--- a/src/components/accordion/accordion.d.ts
+++ b/src/components/accordion/accordion.d.ts
@@ -28,7 +28,7 @@ export interface AccordionProps {
   /** Sets accordion title */
   title: string;
   /** Sets accordion sub title */
-  subTitle: string;
+  subTitle?: string;
   /** Sets accordion size */
   size: 'large' | 'small';
   /** Adds additional top and bottom padding */

--- a/src/components/accordion/accordion.spec.js
+++ b/src/components/accordion/accordion.spec.js
@@ -140,6 +140,49 @@ describe('Accordion', () => {
       wrapper.update();
       isCollapsed(wrapper);
     });
+
+    describe('when window resizes', () => {
+      beforeEach(() => {
+        wrapper = mount(
+          <AccordionGroup>
+            <Accordion title='Title_1' defaultExpanded>
+              <div>Foo</div>
+            </Accordion>
+          </AccordionGroup>
+        );
+      });
+
+      it('recalculates the content height', () => {
+        act(() => render({ expanded: true }));
+        wrapper.update();
+        isExpanded(wrapper);
+
+        assertStyleMatch({
+          maxHeight: `${contentHeight}px`
+        }, wrapper.find(StyledAccordionContentContainer));
+
+        const newContentHeight = 400;
+
+        jest.spyOn(
+          wrapper.find(StyledAccordionContent).getDOMNode(), 'scrollHeight', 'get'
+        ).mockImplementation(() => newContentHeight);
+        act(() => {
+          global.innerWidth = 500;
+          global.innerHeight = 500;
+
+          global.dispatchEvent(new Event('resize'));
+        });
+        wrapper.update();
+
+        assertStyleMatch({
+          maxHeight: `${newContentHeight}px`
+        }, wrapper.find(StyledAccordionContentContainer));
+      });
+
+      afterEach(() => {
+        wrapper.unmount();
+      });
+    });
   });
 
   describe('layout', () => {

--- a/src/components/accordion/accordion.stories.mdx
+++ b/src/components/accordion/accordion.stories.mdx
@@ -4,6 +4,7 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 import { AccordionGroup, Accordion } from '.';
 import Textbox from '../../__experimental__/components/textbox';
 import Button from '../button';
+import { Dl, Dt, Dd } from '../definition-list';
 
 <Meta
   title="Design System/Accordion"
@@ -172,7 +173,7 @@ import { Accordion, AccordionGroup } from "carbon-react/lib/components/accordion
 ```
 
 <Preview>
-  <Story id="test-accordion--grouped" name="grouped">
+  <Story id="design-system-accordion-test--grouped" name="grouped">
   </Story>
 </Preview>
 
@@ -229,6 +230,41 @@ Accordion styles can be easily overriden by providing `styleOverride` prop with 
         labelWidth={ 15 }
         inputWidth={ 85 }
       />
+    </Accordion>
+  </Story>
+</Preview>
+
+### With a definition list
+<Preview>
+  <Story name="with a definition list">
+    <Accordion title='Heading'>
+      <Dl>
+        <Dt>Drink</Dt>
+        <Dd>Coffee</Dd>
+        <Dt>Brew Method</Dt>
+        <Dd>Stove Top Moka Pot</Dd>
+        <Dt>Brand of Coffee</Dt>
+        <Dd>Magic Coffee Beans</Dd>
+        <Dt>Website</Dt>
+        <Dd><Link href='www.sage.com'>Magic Coffee Beans' Website</Link></Dd>
+        <Dt>Email</Dt>
+        <Dd><Link href='magic@coffeebeans.com'>magic@coffeebeans.com</Link></Dd>
+        <Dt>Main and Registered Address</Dt>
+        <Dd mb='4px'>Magic Coffee Beans,</Dd>
+        <Dd mb='4px'>In The Middle of Our Street,</Dd>
+        <Dd mb='4px'>Madness,</Dd>
+        <Dd mb='4px'>CO4 3VE</Dd>
+        <Dd>
+          <Button 
+            buttonType='tertiary' 
+            iconType="link" 
+            iconPosition="after"
+            href='https://goo.gl/maps/GMReLoBpbn9mdZVZ7'
+          >
+            View in Google Maps
+          </Button> 
+        </Dd>
+      </Dl>
     </Accordion>
   </Story>
 </Preview>

--- a/src/components/accordion/accordion.style.js
+++ b/src/components/accordion/accordion.style.js
@@ -82,9 +82,14 @@ const StyledAccordionContentContainer = styled.div`
   box-sizing: border-box;
   overflow: hidden;
   transition: all 0.3s;
-  max-height: ${({ maxHeight }) => maxHeight}px;
-  height: ${({ maxHeight }) => maxHeight}px;
-  ${({ isExpanded }) => !isExpanded && 'visibility: hidden'};
+  ${({ maxHeight, isExpanded }) => css`
+    max-height: ${isExpanded ? `${maxHeight}px` : '0px'};
+    height: ${isExpanded ? `${maxHeight}px` : '0px'};
+    
+    ${!isExpanded && `
+      visibility: hidden;
+    `}
+  `}
 `;
 
 const StyledAccordionContent = styled.div`

--- a/src/components/definition-list/dd.component.js
+++ b/src/components/definition-list/dd.component.js
@@ -5,14 +5,10 @@ import { StyledDd } from './definition-list.style';
 
 const Dd = ({
   mb = 2,
-  children,
-  align = 'right'
+  children
 }) => {
   return (
-    <StyledDd
-      mb={ mb }
-      align={ align }
-    >
+    <StyledDd mb={ mb }>
       {children}
     </StyledDd>
   );

--- a/src/components/definition-list/dd.component.js
+++ b/src/components/definition-list/dd.component.js
@@ -5,11 +5,13 @@ import { StyledDd } from './definition-list.style';
 
 const Dd = ({
   mb = 2,
-  children
+  children,
+  align = 'right'
 }) => {
   return (
     <StyledDd
       mb={ mb }
+      align={ align }
     >
       {children}
     </StyledDd>

--- a/src/components/definition-list/definition-list.spec.js
+++ b/src/components/definition-list/definition-list.spec.js
@@ -36,11 +36,13 @@ describe('DefinitionList', () => {
     it('matches the expected default styles of Dl', () => {
       wrapper = renderWrapper('Dl', { });
       assertStyleMatch({
-        display: 'inline-flex',
+        display: 'grid',
         height: 'auto',
         width: '100%',
         backgroundColor: 'transparent',
-        overflow: 'hidden'
+        overflow: 'hidden',
+        gridTemplateRows: 'auto',
+        gridTemplateColumns: '50% auto'
       }, wrapper);
     });
 
@@ -63,6 +65,13 @@ describe('DefinitionList', () => {
         color: 'rgba(0,0,0,0.65)',
         marginBottom: '16px',
         marginLeft: '0px'
+      }, wrapper);
+    });
+
+    it('matches the custom styles applied to Dl', () => {
+      wrapper = renderWrapper('Dl', { w: '45' });
+      assertStyleMatch({
+        gridTemplateColumns: '45% auto'
       }, wrapper);
     });
 
@@ -100,7 +109,7 @@ describe('DefinitionList', () => {
       wrapper = renderWrapper('Dl', { });
     });
     it('should contain dt', () => {
-      expect(wrapper.find(StyledDtDiv).props().children.length).toEqual(1);
+      expect(wrapper.find(StyledDtDiv).props().children.type).toEqual(Dt);
     });
 
     it('should contain dd', () => {

--- a/src/components/definition-list/definition-list.spec.js
+++ b/src/components/definition-list/definition-list.spec.js
@@ -69,7 +69,7 @@ describe('DefinitionList', () => {
     });
 
     it('matches the custom styles applied to Dl', () => {
-      wrapper = renderWrapper('Dl', { w: '45' });
+      wrapper = renderWrapper('Dl', { w: 45 });
       assertStyleMatch({
         gridTemplateColumns: '45% auto'
       }, wrapper);

--- a/src/components/definition-list/definition-list.style.js
+++ b/src/components/definition-list/definition-list.style.js
@@ -6,27 +6,25 @@ import LinkStyle from '../link/link.style';
 
 export const StyledDl = styled.dl`
   ${space}
-  display: inline-flex;
+  display: grid;
   height: auto;
   width: 100%;
   background-color: transparent;
   overflow: hidden;
+  grid-template-rows: auto;
+  grid-template-columns: ${({ w }) => `${w}% auto;`}
 `;
 
 export const StyledDtDiv = styled.div`
   ${space}
-  ${({ w, dtTextAlign }) => css`
+  ${({ dtTextAlign }) => css`
     text-align: ${dtTextAlign};
-    width: ${w}%;
-    white-space: nowrap;
   `}
 `;
 
 export const StyledDdDiv = styled.div`
   ${({ ddTextAlign }) => css`
     text-align: ${ddTextAlign};
-    width: auto;
-    white-space: nowrap;
   `}
 `;
 
@@ -65,6 +63,6 @@ export const StyledDd = styled.dd`
   `}
 `;
 
-StyledDt.defaultProps = {
+StyledDd.defaultProps = {
   theme: baseTheme
 };

--- a/src/components/definition-list/dl.component.js
+++ b/src/components/definition-list/dl.component.js
@@ -11,20 +11,39 @@ const Dl = ({
   dtTextAlign = 'right',
   ddTextAlign = 'left'
 }) => {
-  const dtLabels = React.Children.toArray(children).filter(child => child.type === Dt);
-  const ddContent = React.Children.toArray(children).filter(child => child.type === Dd);
+  const dlComponent = [];
+  const listChildren = React.Children.toArray(children);
+  let dtLabel;
+  let ddContent = [];
+
+  listChildren.forEach((child, index) => {
+    if (child.type === Dt) {
+      dtLabel = child;
+    }
+    if (child.type === Dd) {
+      ddContent.push(child);
+    }
+
+    if (dtLabel && (index === (listChildren.length - 1) || listChildren[index + 1].type === Dt)) {
+      dlComponent.push(
+        <React.Fragment key={ `dl_row_${String(index)}` }>
+          <StyledDtDiv dtTextAlign={ dtTextAlign }>
+            {dtLabel}
+          </StyledDtDiv>
+
+          <StyledDdDiv ddTextAlign={ ddTextAlign }>
+            {ddContent}
+          </StyledDdDiv>
+        </React.Fragment>
+      );
+      dtLabel = undefined;
+      ddContent = [];
+    }
+  });
 
   return (
-    <StyledDl data-component='dl'>
-
-      <StyledDtDiv w={ w } dtTextAlign={ dtTextAlign }>
-        {dtLabels}
-      </StyledDtDiv>
-
-      <StyledDdDiv w={ w } ddTextAlign={ ddTextAlign }>
-        {ddContent}
-      </StyledDdDiv>
-
+    <StyledDl w={ w } data-component='dl'>
+      {dlComponent}
     </StyledDl>
   );
 };

--- a/src/components/definition-list/dl.component.js
+++ b/src/components/definition-list/dl.component.js
@@ -20,13 +20,16 @@ const Dl = ({
     if (child.type === Dt) {
       dtLabel = child;
     }
+
     if (child.type === Dd) {
       ddContent.push(child);
     }
+    const isLastChild = index === (listChildren.length - 1);
+    const nextItemIsDt = !isLastChild && listChildren[index + 1].type === Dt;
 
-    if (dtLabel && (index === (listChildren.length - 1) || listChildren[index + 1].type === Dt)) {
+    if (dtLabel && (nextItemIsDt || isLastChild)) {
       dlComponent.push(
-        <React.Fragment key={ `dl_row_${String(index)}` }>
+        <React.Fragment key={ child.props.key || index }>
           <StyledDtDiv dtTextAlign={ dtTextAlign }>
             {dtLabel}
           </StyledDtDiv>

--- a/src/components/grid/grid.stories.mdx
+++ b/src/components/grid/grid.stories.mdx
@@ -2,6 +2,8 @@ import { Meta, Preview, Story, Props } from '@storybook/addon-docs/blocks';
 import { PropsTable } from '@storybook/components';
 import Pod from '../pod';
 import { GridContainer, GridItem } from '.';
+import { Dl, Dt, Dd } from '../definition-list';
+import Button from '../button';
 
 <Meta title="Design System/Grid" />
 
@@ -369,6 +371,75 @@ This example is best viewed in the Canvas tab using full-screen mode with device
         </Pod>
       </GridItem>
     </GridContainer>
+  </Story>
+</Preview>
+
+## With a subgrid example
+This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation.
+<Preview>
+  <Story name="subgrid" parameters={{ info: { disable: true }}} >
+    <div id="grid-align">
+      <GridContainer>
+        <GridItem
+          justifySelf="left"
+          gridColumn="1 / 1"
+        >
+          <Pod
+            alignTitle='left' as='primary'
+            border padding='medium'
+            podType='primary'
+          >
+            1
+          </Pod>
+        </GridItem>
+        <GridItem
+          alignSelf="stretch"
+          justifySelf="center"
+          gridColumn="2 / 11"
+        >
+          <Dl>
+            <Dt>Drink</Dt>
+            <Dd>Coffee</Dd>
+            <Dt>Brew Method</Dt>
+            <Dd>Stove Top Moka Pot</Dd>
+            <Dt>Brand of Coffee</Dt>
+            <Dd>Magic Coffee Beans</Dd>
+            <Dt>Website</Dt>
+            <Dd><Link href='www.sage.com'>Magic Coffee Beans' Website</Link></Dd>
+            <Dt>Email</Dt>
+            <Dd><Link href='magic@coffeebeans.com'>magic@coffeebeans.com</Link></Dd>
+            <Dt>Main and Registered Address</Dt>
+            <Dd mb='4px'>Magic Coffee Beans,</Dd>
+            <Dd mb='4px'>In The Middle of Our Street,</Dd>
+            <Dd mb='4px'>Madness,</Dd>
+            <Dd mb='4px'>CO4 3VE</Dd>
+            <Dd>
+              <Button 
+                buttonType='tertiary' 
+                iconType="link" 
+                iconPosition="after"
+                href='https://goo.gl/maps/GMReLoBpbn9mdZVZ7'
+              >
+                View in Google Maps
+              </Button> 
+            </Dd>
+          </Dl>
+        </GridItem>
+        <GridItem
+          alignSelf="stretch"
+          justifySelf="right"
+          gridColumn="11 / 12"
+        >
+          <Pod
+            alignTitle='left' as='primary'
+            border padding='medium'
+            podType='primary'
+          >
+            3
+          </Pod>
+        </GridItem>
+      </GridContainer>
+    </div>
   </Story>
 </Preview>
 

--- a/src/components/tile/tile.stories.mdx
+++ b/src/components/tile/tile.stories.mdx
@@ -6,12 +6,10 @@ import { info, notes } from './documentation';
 import getDocGenInfo from '../../utils/helpers/docgen-info';
 import { dlsThemeSelector } from '../../../.storybook/theme-selectors';
 import { action } from '@storybook/addon-actions';
-import Dl from '../definition-list/dl.component';
-import Dt from '../definition-list/dt.component';
-import Dd from '../definition-list/dd.component';
-import Link from '../link/link.component';
-import Button from '../button/button.component';
-import Heading from '../heading/heading';
+import { Dl, Dt, Dd } from '../definition-list';
+import Link from '../link';
+import Button from '../button';
+import Heading from '../heading';
 
 <Meta title="Design System/Tile" parameters={{ info: { disable: true }}} />
 


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Updates `DefinitionList` to `display: grid` in order to support the component being both responsive whilst also maintain alignment between  associated `Dt` and `Dd` components when the content wraps.

Adds an override to ensure the `Accordion` component has dynamic height when rendering a `DefinitionList` as a child.

Adds some examples of the component used inside an `Accordion` and in a `Grid`.
### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
The original implementation used a single dimension to align the `Dt` and `Dd` children in columns
which caused issues with aligning them when some content wrapped. 

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
http://localhost:9001/?path=/story/design-system-grid--subgrid
http://localhost:9001/?path=/story/design-system-tile--tile-with-definition-list-default
http://localhost:9001/?path=/story/design-system-tile--tile-with-definition-list-with-custom-width
http://localhost:9001/?path=/story/design-system-accordion--with-a-definition-list