### PR TITLE
ci(cypress): decrease amount of containers

### DIFF
--- a/.github/workflows/cypress-pr.yml
+++ b/.github/workflows/cypress-pr.yml
@@ -20,7 +20,7 @@ jobs:
             1, 2, 3, 4, 5, 
             6, 7, 8, 9, 10, 
             11, 12, 13, 14, 15, 
-            16, 17, 18, 19, 20
+            16, 17, 18, 19
             ]
     container: cypress/browsers:node14.7.0-chrome84
     steps:

--- a/.github/workflows/cypress-push.yml
+++ b/.github/workflows/cypress-push.yml
@@ -21,7 +21,7 @@ jobs:
             1, 2, 3, 4, 5, 
             6, 7, 8, 9, 10, 
             11, 12, 13, 14, 15, 
-            16, 17, 18, 19, 20
+            16, 17, 18, 19
             ]
     container: cypress/browsers:node14.7.0-chrome84
     steps:


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
- decreased amount of the containers from `20` to `19` for `cypress` tests to to avoid unnecessary waste of resources.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
According to the `cypress` recommendation (shown below on screenshot) - we are using 1 more machine than necessary on CI.

<img width="824" alt="Screenshot 2020-09-28 at 07 32 22" src="https://user-images.githubusercontent.com/34001198/94394200-0e64b780-015d-11eb-8f3b-f3944ee44227.png">


### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent