### PR TITLE
feat(tabs, tab): add style-system - FE-3152

### DIFF
--- a/src/components/tabs/__internal__/tab-title/tab-title.component.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.component.js
@@ -104,6 +104,7 @@ const TabTitle = React.forwardRef(({
         isTabSelected={ isTabSelected }
         hasCustomLayout={ !!customLayout }
         alternateStyling={ alternateStyling || hasCustomTarget }
+        { ...tabTitleProps }
       >
         { renderContent() }
 

--- a/src/components/tabs/__internal__/tab-title/tab-title.style.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.style.js
@@ -1,12 +1,13 @@
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
+import { space } from 'styled-system';
 import BaseTheme from '../../../../style/themes/base';
 import StyledIcon from '../../../icon/icon.style';
 import StyledValidationIcon from '../../../validations/validation-icon.style';
 
 const StyledTitleContent = styled.div`
   outline: none;
-
+  
   ${({
     theme,
     size,
@@ -54,6 +55,8 @@ const StyledTitleContent = styled.div`
       padding: 10px 16px;
       ${isTabSelected && !(error || warning || info) && position === 'top' && css`padding-bottom: 8px;`}
     `}
+    
+    ${space};
   `}
 
   ${({

--- a/src/components/tabs/__internal__/tab/tab.component.js
+++ b/src/components/tabs/__internal__/tab/tab.component.js
@@ -4,6 +4,7 @@ import React, {
   useState
 } from 'react';
 import PropTypes from 'prop-types';
+import propTypes from '@styled-system/prop-types';
 import StyledTab from './tab.style';
 import tagComponent from '../../../../utils/helpers/tags/tags';
 
@@ -88,6 +89,7 @@ const Tab = ({
 };
 
 Tab.propTypes = {
+  ...propTypes.space,
   title: PropTypes.string,
   /** A unique ID to identify this specific tab. */
   tabId: PropTypes.string.isRequired,

--- a/src/components/tabs/__internal__/tab/tab.d.ts
+++ b/src/components/tabs/__internal__/tab/tab.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { SpacingProps } from 'utils/helpers/options-helper/options-helper';
 
-export interface TabProps {
+export interface TabProps extends SpacingProps {
   title?: string;
   tabId: string;
   className?: string;

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.component.js
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.component.js
@@ -10,7 +10,8 @@ const TabsHeader = ({
   extendedLine,
   alternateStyling,
   noRightBorder = false,
-  hasCustomTarget = false
+  hasCustomTarget = false,
+  ...rest
 }) => {
   return (
     <StyledTabsHeader
@@ -21,6 +22,7 @@ const TabsHeader = ({
       alternateStyling={ alternateStyling }
       noRightBorder={ noRightBorder }
       hasCustomTarget={ hasCustomTarget }
+      { ...rest }
     >
       {children}
     </StyledTabsHeader>

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.style.js
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.style.js
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
+import { space } from 'styled-system';
 import OptionsHelper from '../../../../utils/helpers/options-helper/options-helper';
 import baseTheme from '../../../../style/themes/base';
 
@@ -18,6 +19,7 @@ const StyledTabHeaders = styled.ul`
   list-style: none;
   margin: 0 0 10px;
   padding: 0;
+  ${space};
 
   ${({ align }) => align === 'right' && css`
     justify-content: flex-end;
@@ -37,6 +39,7 @@ const StyledTabHeaders = styled.ul`
     ${!hasCustomTarget && css`
       width: 20%;
       margin: 0 10px 0;
+      ${space}
     `}
 
     ${hasCustomTarget && css`

--- a/src/components/tabs/__internal__/tabs.component.js
+++ b/src/components/tabs/__internal__/tabs.component.js
@@ -201,6 +201,7 @@ const Tabs = ({
         infoMessage,
         customLayout
       } = child.props;
+
       const refId = `${tabId}-tab`;
 
       const errors = tabsErrors[tabId] ? Object.entries(tabsErrors[tabId]).filter(tab => tab[1] === true).length : 0;
@@ -247,6 +248,7 @@ const Tabs = ({
           noRightBorder={ ['no right side', 'no sides'].includes(borders) }
           customLayout={ customLayout }
           hasCustomTarget={ hasCustomTarget.current }
+          { ...child.props }
         />
       );
 
@@ -262,6 +264,7 @@ const Tabs = ({
         alternateStyling={ variant === 'alternate' || hasCustomTarget.current }
         noRightBorder={ ['no right side', 'no sides'].includes(borders) }
         hasCustomTarget={ hasCustomTarget.current }
+        { ...rest }
       >
         { tabTitles }
       </TabsHeader>

--- a/src/components/tabs/__internal__/tabs.d.ts
+++ b/src/components/tabs/__internal__/tabs.d.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { SpacingProps } from 'utils/helpers/options-helper/options-helper';
 import Tab from './tab';
 
-export interface TabsProps {
+export interface TabsProps extends SpacingProps {
   className?: string;
   renderHiddenTabs: boolean;
   selectedTabId: string;

--- a/src/components/tabs/__internal__/tabs.stories.mdx
+++ b/src/components/tabs/__internal__/tabs.stories.mdx
@@ -6,6 +6,7 @@ import Icon from '../../icon';
 import Pill from '../../pill';
 import { Row, Column } from '../../row';
 import { ActionPopover, ActionPopoverItem } from '../../action-popover';
+import StyledSystemProps from '../../../../.storybook/utils/styled-system-props';
 
 <Meta title="Design System/Tabs" parameters={{ info: { disable: true } }} />
 
@@ -1460,8 +1461,16 @@ By setting the `variant` prop to "alternate" it is possible to apply some additi
   </Story>
 </Preview>
 
-### Tabs Props
-<Props of={Tabs} />
+### Tab
 
-### Tab Props
-<Props of={Tab} />
+<StyledSystemProps
+  of={Tab}
+  spacing
+/>
+
+### Tabs
+
+<StyledSystemProps
+  of={Tabs}
+  spacing
+/>


### PR DESCRIPTION
### Proposed behaviour
Add possibility to manage paddings and margins on Tab and Tabs components.
It won't cover whole github (Dialog Full Screen, Drawer) components that was listed in the issue but it fixes things that will allow to create correct design (Tab, Tabs)

### Current behaviour
There is no possibility to manage margins and paddings

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] <del> Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [ ] <del> Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Additional context
Github issue: https://github.com/Sage/carbon/issues/3225