### PR TITLE
test: remove unnecesary steps

### DIFF
--- a/cypress/features/regression/accessibility/accessibilityCommon.feature
+++ b/cypress/features/regression/accessibility/accessibilityCommon.feature
@@ -1,18 +1,19 @@
 Feature: Accessibility tests - Common list
   I want to check that all components have no violations
 
-  @ignore
-  # ignored because of accessibility issues after
-  # changing state of components -> FE-2894
-  Scenario Outline: Component <component> page with button
-    Given I open "<component>" component page with button in noIFrame
-    When I open component preview no iframe
+  @accessibility
+  Scenario Outline: Component <component> page auto opened
+    Given I open "<component>" component page "default" in no iframe
+      And I wait 500
     Then "<component>" component has no accessibility violations
     Examples:
-      | component |
-      | alert     |
-      | sidebar   |
-
+      | component          |
+      | alert              |
+      | confirm            |
+      | dialog             |
+      | dialog-full-screen |
+      | sidebar            |
+    
   @accessibility
   Scenario: Component button toggle
     When I open "Button-Toggle-Group" component page "basic" in no iframe
@@ -22,52 +23,49 @@ Feature: Accessibility tests - Common list
   # ignored because of accessibility issues after
   # changing state of components -> FE-2894
   Scenario Outline: Component <component> page with preview button
-    Given I open "<component>" component page in noIFrame
+    Given I open "<component>" component page "default" in no iframe
     When I open component preview no iframe
     Then "<data-component>" component has no accessibility violations
     Examples:
       | component          |
-      | dialog-full-screen |
-      | dialog             |
       | flash              |
       | pages              |
-      | confirm            |
 
-  @accessibility
-  Scenario Outline: Component <component> default story
-    When I open "<component>" component page in noIFrame
-    Then "<component>" component has no accessibility violations
-    Examples:
-      | component           |
-      | app wrapper         |
-      | button toggle       |
-      | carousel            |
-      | card                |
-      | configurable-items  |
-      | content             |
-      | detail              |
-      | draggableContext    |
-      | heading             |
-      | help                |
-      | i18ncomponent       |
-      | icon                |
-      | link                |
-      | loader              |
-      | menulist            |
-      | message             |
-      | mount-in-app        |
-      | multi-action-button |
-      | pill                |
-      | pod                 |
-      | portrait            |
-      | preview             |
-      | profile             |
-      | row                 |
-      | showeditpod         |
-      | settingsrow         |
-      | split-button        |
-      | step-sequence-item  |
-      | step-sequence       |
-      | table-ajax          |
-      | table               |
-      | tooltip             |
+@accessibility
+Scenario Outline: Component <component> default story
+  When I open "<component>" component page "default" in no iframe
+  Then "<component>" component has no accessibility violations
+  Examples:
+    | component           |
+    | app wrapper         |
+    | button toggle       |
+    | carousel            |
+    | card                |
+    | configurable-items  |
+    | content             |
+    | detail              |
+    | draggableContext    |
+    | heading             |
+    | help                |
+    | i18ncomponent       |
+    | icon                |
+    | link                |
+    | loader              |
+    | menulist            |
+    | message             |
+    | mount-in-app        |
+    | multi-action-button |
+    | pill                |
+    | pod                 |
+    | portrait            |
+    | preview             |
+    | profile             |
+    | row                 |
+    | showeditpod         |
+    | settingsrow         |
+    | split-button        |
+    | step-sequence-item  |
+    | step-sequence       |
+    | table-ajax          |
+    | table               |
+    | tooltip             |

--- a/cypress/features/regression/accessibility/accessibilityDesignSystem.feature
+++ b/cypress/features/regression/accessibility/accessibilityDesignSystem.feature
@@ -3,7 +3,7 @@ Feature: Accessibility tests - Design System folder
 
   @accessibility
   Scenario Outline: Design System Accordion component <story> page closed state
-    When I open design systems <story> "Accordion" component in no iframe
+    When I open "Design System Accordion" component page "<story>" in no iframe
     Then "Accordion <story> page" component has no accessibility violations
     Examples:
       | story                |
@@ -13,27 +13,21 @@ Feature: Accessibility tests - Design System folder
 
   @accessibility
   Scenario: Design System Accordion component primary page opened state
-    Given I open design systems default_story "Accordion" component in no iframe
+    Given I open "Design System Accordion" component page "default_story" in no iframe
     When I expand Design System accordionRow via click in NoIFrame
     Then "Accordion default page" component has no accessibility violations
-
-  @accessibility
-  Scenario: Design System Action Popover component keyboard_access page
-    Given I open design systems keyboard_access "Action Popover" component in no iframe
-    When I click the menu button element in noiFrame
-    Then "Action Popover keyboard_access page" component has no accessibility violations
 
   @ignore
   # ignored because of accessibility issues after
   # changing state of components -> FE-2894
   Scenario: Design System Advanced Color Picker component default story page
-    Given I open design systems default_story "Advanced Color Picker" component in no iframe
+    Given I open "Design System Advanced Color Picker" component page "default_story" in no iframe
     When I open Advanced Color Picker in noIFrame
     Then "Advanced Color Picker" component has no accessibility violations
 
   @accessibility
   Scenario Outline: Component <component> basic default page
-    When I open basic Test "<component>" component page in noIframe
+    When I open "Test <component>" component page "basic" in no iframe
     Then "<component>" component has no accessibility violations
     Examples:
       | component        |
@@ -52,7 +46,7 @@ Feature: Accessibility tests - Design System folder
 
   @accessibility
   Scenario Outline: Design System Button component <story> page
-    When I open design systems <story> "Button" component in no iframe
+    When I open "Design System Button" component page "<story>" in no iframe
     Then "Button <story> page" component has no accessibility violations
     Examples:
       | story                 |
@@ -92,25 +86,25 @@ Feature: Accessibility tests - Design System folder
 
   @accessibility
   Scenario: Design System Form component
-    When I open design systems with_both_errors_and_warnings_summary "Form" component in no iframe
+    When I open "Design System Form" component page "with_both_errors_and_warnings_summary" in no iframe
     Then "Form" component has no accessibility violations
 
   @accessibility
   Scenario: Design System Form component
-    When I open validations Test "Numeral Date" component page in noIframe
+    When I open "Design System Numeral Date Test" component page "validations" in no iframe
     Then "Numeral Date" component has no accessibility violations
 
   @ignore
   # ignored because of accessibility issues after
   # changing state of components -> FE-2894
   Scenario: Design System Popover Container component basic page
-    Given I open design systems basic "Popover Container" component in no iframe
+    Given I open "Design System Popover Container" component page "basic" in no iframe
     When I open popover container in NoIFrame
     Then "Popover Container" component has no accessibility violations
 
   @accessibility
   Scenario Outline: Design System <component> component basic page
-    When I open design systems basic "<component>" component in no iframe
+    When I open "Design System <component>" component page "basic" in no iframe
     Then "<component>" component has no accessibility violations
     Examples:
       | component         |
@@ -125,7 +119,7 @@ Feature: Accessibility tests - Design System folder
 
   @accessibility
   Scenario Outline: Design System Text Editor component <story> page
-    When I open design systems <story> "Text Editor" component in no iframe
+    When I open "Design System Text Editor" component page "<story>" in no iframe
     Then "Text Editor component <story> page" component has no accessibility violations
     Examples:
       | story                 |
@@ -134,7 +128,7 @@ Feature: Accessibility tests - Design System folder
 
   @accessibility
   Scenario Outline: Design System <component> component default story page
-    When I open design systems default_story "<component>" component in no iframe
+    When I open "Design System <component>" component page "default_story" in no iframe
     Then "<component>" component has no accessibility violations
     Examples:
       | component |
@@ -143,7 +137,7 @@ Feature: Accessibility tests - Design System folder
 
   @accessibility
   Scenario Outline: Design System Select component <story> page
-    When I open design systems <story> "Select" component in no iframe
+    When I open "Design System Select" component page "<story>" in no iframe
     Then "Select" component has no accessibility violations
     Examples:
       | story       |
@@ -153,13 +147,13 @@ Feature: Accessibility tests - Design System folder
 
   @accessibility
   Scenario: Design System Select component basic page
-    Given I open design systems basic "Select" component in no iframe
+    Given I open "Design System Select" component page "basic" in no iframe
     When I click on Select input in noIframe
     Then "Select" component has no accessibility violations
 
   @accessibility
   Scenario Outline: Design System Filterable Select component <story> page
-    When I open design systems <story> "Select filterable" component in no iframe
+    When I open "Design System Select filterable" component page "<story>" in no iframe
     Then "Select" component has no accessibility violations
     Examples:
       | story    |
@@ -173,12 +167,12 @@ Feature: Accessibility tests - Design System folder
 
   @accessibility
   Scenario: Component Hr
-    When I open design systems default_story "Hr" component in no iframe
+    When I open "Design System Hr" component page "default_story" in no iframe
     Then "Hr" component has no accessibility violations
 
   @accessibility
   Scenario Outline: Component Menu <story>
-    When I open design systems <story> "Menu" component in no iframe
+    When I open "Design System Menu" component page "<story>" in no iframe
     Then "Menu <story>" component has no accessibility violations
     Examples:
       | story         |
@@ -187,7 +181,7 @@ Feature: Accessibility tests - Design System folder
 
   @accessibility
   Scenario Outline: Component Navigation Bar <story>
-    When I open design systems <story> "Navigation Bar" component in no iframe
+    When I open "Design System Navigation Bar" component page "<story>" in no iframe
     Then "Navigation Bar <story>" component has no accessibility violations
     Examples:
       | story         |
@@ -196,12 +190,12 @@ Feature: Accessibility tests - Design System folder
 
   @accessibility
   Scenario: Component Tabs
-    When I open design systems basic "Tabs" component in no iframe
+    When I open "Design System Tabs" component page "basic" in no iframe
     Then "Tabs" component has no accessibility violations
 
   @accessibility
   Scenario Outline: Component Tile <story>
-    When I open design systems <story> "Tile" component in no iframe
+    When I open "Design System Tile" component page "<story>" in no iframe
     Then "Tile <story>" component has no accessibility violations
     Examples:
       | story                             |

--- a/cypress/features/regression/accessibility/accessibilityExperimental.feature
+++ b/cypress/features/regression/accessibility/accessibilityExperimental.feature
@@ -3,7 +3,7 @@ Feature: Accessibility tests - Experimental folder
 
   @accessibility
   Scenario Outline: Component <component> default story
-    When I open Experimental "<component>" component page in noIFrame
+    When I open "Experimental <component>" component page "default" in no iframe
     Then "<component>" component has no accessibility violations
     Examples:
       | component           |
@@ -23,7 +23,7 @@ Feature: Accessibility tests - Experimental folder
 
   @accessibility
   Scenario Outline: Component <component> validation story
-    When I open Experimental "<component>" component page validations in noIframe
+    When I open "Experimental <component>" component page "validations" in no iframe
     Then "<component>" component has no accessibility violations
     Examples:
       | component           |

--- a/cypress/features/regression/alertActions.feature
+++ b/cypress/features/regression/alertActions.feature
@@ -2,12 +2,12 @@ Feature: Alert component actions
   I want to check Alert component actions
 
   Background: Open Alert component page
-    Given I open "Alert Test" component page
+    Given I open "Alert Test" component page "default"
 
   @positive
   Scenario: Clicking close icon, closes Alert dialog
     # commented because of BDD default scenario Given - When - Then
-    # When I open "Alert Test" component page
+    # When I open "Alert Test" component page "default"
     Then closeIcon is visible in iframe
       And I click closeIcon in IFrame
       And Alert is not visible
@@ -18,8 +18,8 @@ Feature: Alert component actions
     When I hit ESC key
     Then Alert is visible
 
-@positive
-Scenario: Check cancel click event
-  Given clear all actions in Actions Tab
-  When I click closeIcon in IFrame
-  Then cancel action was called in Actions Tab
+  @positive
+  Scenario: Check cancel click event
+    Given clear all actions in Actions Tab
+    When I click closeIcon in IFrame
+    Then cancel action was called in Actions Tab

--- a/cypress/features/regression/buttonToggle.feature
+++ b/cypress/features/regression/buttonToggle.feature
@@ -75,7 +75,7 @@ Feature: Button Toggle component
 
   @positive
   Scenario Outline: Verify the onChange event for Button Toggle
-    Given I open "Button Toggle" component page
+    Given I open "Button Toggle" component page "default"
       And clear all actions in Actions Tab
     When I click on Button Toggle <index>
     Then onChange action was called in Actions Tab

--- a/cypress/features/regression/carousel.feature
+++ b/cypress/features/regression/carousel.feature
@@ -54,7 +54,7 @@ Feature: Carousel component
 
   @positive
   Scenario: Verify the click event for a clickable slide
-    Given I open "Carousel" component page
+    Given I open "Carousel" component page "default"
       And I select slideIndex to "1"
       And clear all actions in Actions Tab
     When I click clickable slide

--- a/cypress/features/regression/configurableItems.feature
+++ b/cypress/features/regression/configurableItems.feature
@@ -1,8 +1,8 @@
 Feature: Configurable Items component
   I want to change Configurable Items component
 
-  Background: Open Configurable Items component in noIframe
-    Given I open "Configurable Items" component in noiFrame
+  Background: Open Configurable Items component in no iframe
+    Given I open "Configurable Items" component page "default" in no iframe
 
   @positive
   Scenario Outline: Drag record inside Configurable Items element <record> to <destinationId> element position

--- a/cypress/features/regression/configurableItemsEvents.feature
+++ b/cypress/features/regression/configurableItemsEvents.feature
@@ -2,7 +2,7 @@ Feature: Configurable Items component
   I want to change Configurable Items component events
 
   Background: Open Configurable Items component page
-    Given I open "Configurable Items" component page
+    Given I open "Configurable Items" component page "default"
       And clear all actions in Actions Tab
 
   @positive

--- a/cypress/features/regression/confirmActions.feature
+++ b/cypress/features/regression/confirmActions.feature
@@ -2,7 +2,7 @@ Feature: Confirm component - in iFrame
   I want to test Confirm component in iFrame
 
   Background: Open Confirm component page
-    Given I open "Confirm Test" component page
+    Given I open "Confirm Test" component page "default"
 
   @positive
   Scenario: Disable escape key

--- a/cypress/features/regression/designSystem/accordion.feature
+++ b/cypress/features/regression/designSystem/accordion.feature
@@ -2,7 +2,7 @@ Feature: Design System Accordion component
   I want to test Design System Accordion component
 
   Background: Open Design System Accordion component page
-    Given I open design systems default_story "Accordion" component in no iframe
+    Given I open "Design System Accordion" component page "default_story" in no iframe
 
   @positive
   Scenario: I expand accordion using click

--- a/cypress/features/regression/designSystem/advancedColorPicker.feature
+++ b/cypress/features/regression/designSystem/advancedColorPicker.feature
@@ -2,7 +2,7 @@ Feature: Advanced Color Picker component
   I want to test Advanced Color Picker component
 
   Background: Open Advanced Color Picker component page
-  Given I open design systems default_story "Advanced Color Picker" component in no iframe
+  Given I open "Design System Advanced Color Picker" component page "default_story" in no iframe
     And I open Advanced Color Picker
 
   @positive

--- a/cypress/features/regression/designSystem/batchSelection.feature
+++ b/cypress/features/regression/designSystem/batchSelection.feature
@@ -3,7 +3,7 @@ Feature: Design Systems Batch selection component
 
   @positive
   Scenario Outline: I focus <buttonIndex> inner element for Batch selection component
-    Given I open design systems basic "Batch selection" component in no iframe
+    Given I open "Design System Batch selection" component page "basic" in no iframe
     When I focus Batch selection "<buttonIndex>" button
     Then Batch selection component "<buttonIndex>" button is focused
     Examples:

--- a/cypress/features/regression/designSystem/drawer.feature
+++ b/cypress/features/regression/designSystem/drawer.feature
@@ -3,7 +3,7 @@ Feature: Drawer component
 
   @positive
   Scenario Outline: Verify chevron orientation when is clicked once for <drawer> Drawer
-    Given I open design systems <drawer> "Drawer" component in no iframe
+    Given I open "Design System Drawer" component page "<drawer>" in no iframe
     When I click on <drawerID> Drawers arrow 1 time
     Then Drawers <drawerID> sidebar should have class <class>
       And toggle <drawerID> Drawers icon switched orientation to <class>
@@ -15,7 +15,7 @@ Feature: Drawer component
 
   @positive
   Scenario Outline: Verify chevron orientation when is clicked twice for <drawer> Drawer
-    Given I open design systems <drawer> "Drawer" component in no iframe
+    Given I open "Design System Drawer" component page "<drawer>" in no iframe
     When I click on <drawerID> Drawers arrow 2 times
     Then Drawers <drawerID> sidebar should have class <class>
       And toggle <drawerID> Drawers icon switched orientation to <class>
@@ -27,12 +27,12 @@ Feature: Drawer component
 
   @positive
   Scenario: Confirm that animationDuration is set to 2 second
-    Given I open design systems two_second_animation "Drawer" component in no iframe
+    Given I open "Design System Drawer" component page "two_second_animation" in no iframe
     When I click on two-second-animation-drawer Drawers arrow 1 time
     Then Drawer two-second-animation-drawer animationDuration is set to "2s"
 
   @positive
   Scenario: Confirm that animationDuration is set to 3 seconds
-    Given I open design systems three_second_animation "Drawer" component in no iframe
+    Given I open "Design System Drawer" component page "three_second_animation" in no iframe
     When I click on three-second-animation-drawer Drawers arrow 1 time
     Then Drawer three-second-animation-drawer animationDuration is set to "3s"

--- a/cypress/features/regression/designSystem/duellingPicklist.feature
+++ b/cypress/features/regression/designSystem/duellingPicklist.feature
@@ -2,7 +2,8 @@ Feature: Design System Duelling Picklist Component
   I want to test Design System Duelling Picklist component
 
   Background: Design System Duelling Picklist Component in noIframe
-    Given I open Design Systems page "duellingpicklist" component docs page
+    Given I open "Test DuellingPicklist" component page "basic" in no iframe
+
 
   @positive
   Scenario: All items are unassigned

--- a/cypress/features/regression/designSystem/filterableSelect.feature
+++ b/cypress/features/regression/designSystem/filterableSelect.feature
@@ -2,7 +2,7 @@ Feature: Design System Filterable Select component
   I want to change Design System Filterable Select component properties
 
   Background: Open Design System Filterable Select component page
-    Given I open design systems controlled "Select filterable" component in no iframe
+    Given I open "Design System Select filterable" component page "controlled" in no iframe
 
   @positive
   Scenario: Filter by typed character

--- a/cypress/features/regression/designSystem/filterableSelectEvents.feature
+++ b/cypress/features/regression/designSystem/filterableSelectEvents.feature
@@ -2,7 +2,7 @@ Feature: Design System Select filterable component
   I want to check Design System Select filterable component events
 
   Background: Open Design System Select filterable component page
-    Given I open design systems basic "Select filterable" component page
+    Given I open "Design System Select filterable" component page "basic"
 
   @positive
   Scenario: Check the onChange events after typed string into the input

--- a/cypress/features/regression/designSystem/flatTable.feature
+++ b/cypress/features/regression/designSystem/flatTable.feature
@@ -3,17 +3,17 @@ Feature: Design Systems FlatTable component
 
   @positive
   Scenario: FlatTable has sticky row
-    When I open design systems with_row_header "Flat Table" component in no iframe
+    When I open "Design System Flat Table" component page "with_row_header" in no iframe
     Then FlatTable rows are sticky
 
   @positive
   Scenario: FlatTable has sticky header
-    When I open design systems with_sticky_head "Flat Table" component in no iframe
+    When I open "Design System Flat Table" component page "with_sticky_head" in no iframe
     Then FlatTable has sticky header
 
   @positive
   Scenario: Verify outline color
-    When I open design systems with_clickable_rows "Flat Table" component in no iframe
+    When I open "Design System Flat Table" component page "with_clickable_rows" in no iframe
     Then I focus 2 row and focused row element has golden border on focus
 
   @positive

--- a/cypress/features/regression/designSystem/menuDefaultDivider.feature
+++ b/cypress/features/regression/designSystem/menuDefaultDivider.feature
@@ -2,12 +2,12 @@ Feature: Design Systems Menu component - divider story
   I want to check Design Systems Menu component default divider story properties
 
   Background: Open Design Systems Menu component default divider page
-    Given I open design systems default_divider "Menu" component in no iframe
+    Given I open "Design System Menu" component page "default_divider" in no iframe
 
   @positive
   Scenario: Check the persistence of Menu component
     # commented because of BDD default scenario Given - When - Then
-    # When I open design systems default "Menu" component in no iframe
+    # When I open "Design System Menu" component page "default_divider" in no iframe
     Then Menu elements are visible
 
   @positive

--- a/cypress/features/regression/designSystem/multiSelect.feature
+++ b/cypress/features/regression/designSystem/multiSelect.feature
@@ -3,13 +3,13 @@ Feature: Design System Multi Select component
 
   @positive
   Scenario: Multi Select list is not open when has a focus
-    Given I open design systems controlled "Select multiselect" component in no iframe
+    Given I open "Design System Select multiselect" component page "controlled" in no iframe
     When I focus select input
     Then multi Select list is closed
 
   @positive
   Scenario Outline: Multi Select list is not open using keyboard <key>
-    Given I open design systems controlled "Select multiselect" component in no iframe
+    Given I open "Design System Select multiselect" component page "controlled" in no iframe
       And I focus select input
     When I click onto controlled select using "<key>" key
     Then multi Select list is closed
@@ -20,45 +20,45 @@ Feature: Design System Multi Select component
 
   @positive
   Scenario: Multi Select list is not opened by clicking mouse in the text input
-    Given I open design systems controlled "Select multiselect" component in no iframe
+    Given I open "Design System Select multiselect" component page "controlled" in no iframe
     When I click on Select input
     Then multi Select list is closed
 
   @positive
   Scenario: Open Multi Select list by clicking mouse on the dropdown button
-    Given I open design systems controlled "Select multiselect" component in no iframe
+    Given I open "Design System Select multiselect" component page "controlled" in no iframe
     When I click on dropdown button
     Then multi Select list is opened
 
   @positive
   Scenario: Close Multi Select list by double clicking mouse on the dropdown button
-    Given I open design systems controlled "Select multiselect" component in no iframe
+    Given I open "Design System Select multiselect" component page "controlled" in no iframe
       And I click on dropdown button
     When I click on dropdown button
     Then multi Select list is closed
 
   @positive
   Scenario: Close Multi Select list by clicking out of component
-    Given I open design systems controlled "Select multiselect" component in no iframe
+    Given I open "Design System Select multiselect" component page "controlled" in no iframe
       And I click on dropdown button
     When I click onto root in Test directory in no iFrame
     Then multi Select list is closed
 
   @positive
   Scenario: Open on focus multi Select component is opened when has a focus
-    Given I open design systems open_on_focus "Select multiselect" component in no iframe
+    Given I open "Design System Select multiselect" component page "open_on_focus" in no iframe
     When I focus openOnFocus Select input
     Then multi Select list is opened
 
   @positive
   Scenario: Open on focus Multi Select list by clicking mouse on the dropdown button
-    Given I open design systems open_on_focus "Select multiselect" component in no iframe
+    Given I open "Design System Select multiselect" component page "open_on_focus" in no iframe
     When I click on dropdown button
     Then multi Select list is opened
 
   @positive
   Scenario: Choose option from the Select list via clicking an option
-    Given I open design systems controlled "Select multiselect" component in no iframe
+    Given I open "Design System Select multiselect" component page "controlled" in no iframe
       And I click on dropdown button
     When I click on "first" option on Select list
     Then Multi select input has "Amber" pill
@@ -66,7 +66,7 @@ Feature: Design System Multi Select component
 
   @positive
   Scenario: Filter by typed character
-    Given I open design systems controlled "Select multiselect" component in no iframe
+    Given I open "Design System Select multiselect" component page "controlled" in no iframe
     When I type "A" into input
     Then multi Select list is opened
       And "first" option on Select list is "Amber"
@@ -76,7 +76,7 @@ Feature: Design System Multi Select component
 
   @positive
   Scenario Outline: Open multi select list using arrow key
-    Given I open design systems controlled "Select multiselect" component in no iframe
+    Given I open "Design System Select multiselect" component page "controlled" in no iframe
       And I focus select input
       And I click onto controlled select using "<key>" key
     When I click onto controlled select using "<key>" key
@@ -89,7 +89,7 @@ Feature: Design System Multi Select component
 
   @positive
   Scenario: Verify the inner context of Select Multiple component
-    Given I open design systems controlled "Select multiselect" component in no iframe
+    Given I open "Design System Select multiselect" component page "controlled" in no iframe
     When Type "Amber" text into multi select input and select the value
       And Type "Black" text into multi select input and select the value
       And Type "Green" text into multi select input and select the value

--- a/cypress/features/regression/designSystem/multiSelectEvents.feature
+++ b/cypress/features/regression/designSystem/multiSelectEvents.feature
@@ -2,7 +2,7 @@ Feature: Design System Multi Select component
   I want to check Design System Multi Select component events
 
   Background: Open Design System Multi Select component page
-    Given I open design systems basic "Select multiselect" component page
+    Given I open "Design System Select multiselect" component page "basic"
 
   @positive
   Scenario: Check the onChange events after typed string into the input

--- a/cypress/features/regression/designSystem/numeralDate.feature
+++ b/cypress/features/regression/designSystem/numeralDate.feature
@@ -3,14 +3,14 @@ Feature: Design System Numeral Date component
 
   @positive
   Scenario: Verify that Numeral Date input doesn't allow type numeral character in inputs
-    Given I open design systems controlled "Numeral Date" component in no iframe
+    Given I open "Design System Numeral Date" component page "controlled" in no iframe
       And I click on first input
     When I type no numeral characters "date" in inputs
     Then inputs have value ""
 
   @positive
   Scenario Outline: Check that <position> inputs have a character limit
-    Given I open design systems controlled "Numeral Date" component in no iframe
+    Given I open "Design System Numeral Date" component page "controlled" in no iframe
       And I click on first input
     When I type numeral characters "<string>" in "<position>" inputs
     Then "<position>" numeral input is set to "<result>"

--- a/cypress/features/regression/designSystem/popoverContainer.feature
+++ b/cypress/features/regression/designSystem/popoverContainer.feature
@@ -3,20 +3,20 @@ Feature: Design System Popover container component
 
   @positive
   Scenario: Popover container is opened
-    Given I open design systems basic "Popover container" component in no iframe
+    Given I open "Design System Popover container" component page "basic" in no iframe
     When I open popover container
     Then Popover container is visible
 
   @positive
   Scenario: Popover container is closed
-    Given I open design systems basic "Popover container" component in no iframe
+    Given I open "Design System Popover container" component page "basic" in no iframe
       And I open popover container
     When I click popover close icon
     Then Popover container is not visible
 
   @positive
   Scenario Outline: Open Popover container is opened using <key> key
-    Given I open design systems basic "Popover container" component in no iframe
+    Given I open "Design System Popover container" component page "basic" in no iframe
     When I click onto popover setting icon using "<key>" key
     Then Popover container is visible
     Examples:
@@ -26,7 +26,7 @@ Feature: Design System Popover container component
 
   @positive
   Scenario Outline: Open Popover container is closed using <key> key
-    Given I open design systems basic "Popover container" component in no iframe
+    Given I open "Design System Popover container" component page "basic" in no iframe
       And I click onto popover setting icon using "<key>" key
     When I press onto closeIcon using "<key>" key
     Then Popover container is not visible
@@ -37,18 +37,18 @@ Feature: Design System Popover container component
 
   @positive
   Scenario: Popover container component is left aligned
-    When I open design systems basic "Popover container" component in no iframe
+    When I open "Design System Popover container" component page "basic" in no iframe
     Then opening icon is on the "left" side
       And Popover component is opened the "left" side
 
   @positive
   Scenario: Popover container component is right aligned
-    When I open design systems position "Popover container" component in no iframe
+    When I open "Design System Popover container" component page "position" in no iframe
     Then opening icon is on the "right" side
       And Popover component is opened the "right" side
 
   @positive
   Scenario: Verify open button is hide when the PopoverContainer is open
-    Given I open design systems cover_button "Popover container" component in no iframe
+    Given I open "Design System Popover container" component page "cover_button" in no iframe
     When I open popover container in open component
     Then opening icon is hide

--- a/cypress/features/regression/designSystem/search.feature
+++ b/cypress/features/regression/designSystem/search.feature
@@ -3,39 +3,39 @@ Feature: Design System Search component
 
   @positive
   Scenario: Search input is empty after click on cross icon
-    Given I open design systems default_story "Search" component in no iframe
+    Given I open "Design System Search" component page "default_story" in no iframe
       And Type "Search" text into default search input
     When I click on cross icon
     Then search input is empty
 
   @positive
   Scenario: Search icon has golden outline
-    Given I open design systems with_search_button "Search" component in no iframe
+    Given I open "Design System Search" component page "with_search_button" in no iframe
       And Type "Sea" text into search with button input
     When I click on search icon
     Then search icon has golden border
 
   @positive
   Scenario: searchButton property is enabled
-    Given I open design systems with_search_button "Search" component in no iframe
+    Given I open "Design System Search" component page "with_search_button" in no iframe
     When Type "S" text into search with button input
     Then search icon as button is visible
 
   @positive
   Scenario: searchButton property is disabled
-    Given I open design systems default_story "Search" component in no iframe
+    Given I open "Design System Search" component page "default_story" in no iframe
     When Type "S" text into default search input
     Then search icon as button is not visible
 
   @positive
   Scenario: Verify inner elements in Search component when is empty
-    Given I open design systems default_story "Search" component in no iframe
+    Given I open "Design System Search" component page "default_story" in no iframe
     When I clear default search input
     Then Search component has input and "search" as icon
 
   @positive
   Scenario: Verify inner elements in Search component when is filled
-    Given I open design systems default_story "Search" component in no iframe
+    Given I open "Design System Search" component page "default_story" in no iframe
     When Type "Search" text into default search input
     Then Search component has input and "cross" as icon
       And Search component input has golden border

--- a/cypress/features/regression/designSystem/simpleSelect.feature
+++ b/cypress/features/regression/designSystem/simpleSelect.feature
@@ -2,7 +2,7 @@ Feature: Design System Select component
   I want to change Design System Select component properties
 
   Background: Open Design System Select component page
-    Given I open design systems controlled "Select" component in no iframe
+    Given I open "Design System Search" component page "controlled" in no iframe
 
   @positive
   Scenario Outline: Open Select list using <key>

--- a/cypress/features/regression/designSystem/simpleSelect.feature
+++ b/cypress/features/regression/designSystem/simpleSelect.feature
@@ -2,7 +2,7 @@ Feature: Design System Select component
   I want to change Design System Select component properties
 
   Background: Open Design System Select component page
-    Given I open "Design System Search" component page "controlled" in no iframe
+    Given I open "Design System Select" component page "controlled" in no iframe
 
   @positive
   Scenario Outline: Open Select list using <key>

--- a/cypress/features/regression/designSystem/simpleSelectEvents.feature
+++ b/cypress/features/regression/designSystem/simpleSelectEvents.feature
@@ -2,7 +2,7 @@ Feature: Design System Simple Select component
   I want to check Design System Simple Select component events
 
   Background: Open Design System Simple Select component page
-    Given I open "Design System Search" component page "basic"
+    Given I open "Design System Select" component page "basic"
 
   @positive
   Scenario: Check the onOpen, onClick, onFocus after clicking on the input

--- a/cypress/features/regression/designSystem/simpleSelectEvents.feature
+++ b/cypress/features/regression/designSystem/simpleSelectEvents.feature
@@ -2,7 +2,7 @@ Feature: Design System Simple Select component
   I want to check Design System Simple Select component events
 
   Background: Open Design System Simple Select component page
-    Given I open design systems basic "Select" component page
+    Given I open "Design System Search" component page "basic"
 
   @positive
   Scenario: Check the onOpen, onClick, onFocus after clicking on the input

--- a/cypress/features/regression/designSystem/textEditor.feature
+++ b/cypress/features/regression/designSystem/textEditor.feature
@@ -2,7 +2,7 @@ Feature: Design System Text Editor component
   I want to test Design System Text Editor component
 
   Background: Open Design System Text Editor component page
-    Given I open design systems basic "Text Editor" component in no iframe
+    Given I open "Design System Text Editor" component page "basic" in no iframe
 
   @positive
   Scenario: Verify that counter works properly

--- a/cypress/features/regression/designSystem/textEditorWithOptionalCharacterLimit.feature
+++ b/cypress/features/regression/designSystem/textEditorWithOptionalCharacterLimit.feature
@@ -2,7 +2,7 @@ Feature: Design System Text Editor component with optional character limit
   I want to test Design System Text Editor with optional character limit component
 
   Background: Open Design System Text Editor component page
-    Given I open design systems with_optional_character_limit "Text Editor" component in no iframe
+    Given I open "Design System Text Editor" component page "with_optional_character_limit" in no iframe
 
   @positive
   Scenario: Verify that input doesn't allow to input more than character limit is set to

--- a/cypress/features/regression/designSystem/tileSelect.feature
+++ b/cypress/features/regression/designSystem/tileSelect.feature
@@ -2,7 +2,7 @@ Feature: Design System TileSelect component
   I want to test Design System TileSelect component
 
   Background: Open Design System Search component page
-    Given I open design systems single_tile "Tile Select" component in no iframe
+    Given I open "Design System Tile Select" component page "single_tile" in no iframe
 
   @positive
   Scenario: Single tile is checked

--- a/cypress/features/regression/designSystem/toast.feature
+++ b/cypress/features/regression/designSystem/toast.feature
@@ -3,26 +3,26 @@ Feature: Toast Design System component
 
   @positive
   Scenario: Verify a stacked Toast component
-    Given I open design systems stacked "Toast" component in no iframe
+    Given I open "Design System Toast" component page "stacked" in no iframe
     When I click on "button-stacked" Toggle Preview
     Then Toast component is stacked
 
   @positive
   Scenario: Verify a stacked delayed Toast component
-    Given I open design systems stacked "Toast" component in no iframe
+    Given I open "Design System Toast" component page "stacked" in no iframe
     When I click on "button-stacked" Toggle Preview
     Then Toast component is stacked
 
   @positive
   Scenario: CloseIcon has the border outline
-    Given I open design systems dismissible "Toast" component in no iframe
+    Given I open "Design System Toast" component page "dismissible" in no iframe
       And I click on "button-toast-dismissible" Toggle Preview
     When closeIcon is focused in no iframe
     Then closeIcon has the border outline color "rgb(255, 181, 0)" and width "3px"
 
   @positive
   Scenario Outline: Change Toast variant to <variant>
-    Given I open design systems variant_<variant> "Toast" component in no iframe
+    Given I open "Design System Toast" component page "variant_<variant>" in no iframe
     When I click on "button-variant-<variant>" Toggle Preview
     Then Toast icon is set to "<icon>"
     Examples:
@@ -34,7 +34,7 @@ Feature: Toast Design System component
 
   @positive
   Scenario Outline: Verify Toast <variant> color
-    Given I open design systems variant_<variant> "Toast" component in no iframe
+    Given I open "Design System Toast" component page "variant_<variant>" in no iframe
     When I click on "button-variant-<variant>" Toggle Preview
     Then Toast has background-color "<color>" and border "<color>" color
     Examples:
@@ -46,24 +46,24 @@ Feature: Toast Design System component
 
   @positive
   Scenario: Test onDismiss on a Toast component
-    Given I open design systems dismissible "Toast" component in no iframe
+    Given I open "Design System Toast" component page "dismissible" in no iframe
     When I click on "button-toast-dismissible" Toggle Preview
     Then closeIcon is focused in no iframe
 
   @positive
   Scenario: Confirm that default Toast has no close icon
-    Given I open design systems default_story "Toast" component in no iframe
+    Given I open "Design System Toast" component page "default_story" in no iframe
     When I click on "button-default" Toggle Preview
     Then Toast component has no close icon
 
   @positive
   Scenario: Confirm that isCenter property centers Toast
-    Given I open design systems centered "Toast" component in no iframe
+    Given I open "Design System Toast" component page "centered" in no iframe
     When I click on "button-variant-centered" Toggle Preview
     Then Toast is centred
 
   @positive
   Scenario: Confirm that Toast is not centered by default
-    Given I open design systems default_story "Toast" component in no iframe
+    Given I open "Design System Toast" component page "default_story" in no iframe
     When I click on "button-default" Toggle Preview
     Then Toast is not centred

--- a/cypress/features/regression/dialogActions.feature
+++ b/cypress/features/regression/dialogActions.feature
@@ -2,7 +2,7 @@ Feature: Dialog component actions in IFrame
   I want to test Dialog component - actions in IFrame
 
   Background: Open Dialog component page
-    Given I open "Dialog Test" component page
+    Given I open "Dialog Test" component page "default"
 
   @positive
   Scenario: Disable escape key

--- a/cypress/features/regression/dialogFullScreen.feature
+++ b/cypress/features/regression/dialogFullScreen.feature
@@ -8,7 +8,7 @@ Feature: Dialog Full Screen component
 
   @positive
   Scenario: Clicking close icon closes Dialog Full Screen
-    Given I open "Dialog Full Screen Test" component page
+    Given I open "Dialog Full Screen Test" component page "default"
       And I check showCloseIcon checkbox
     When I click closeIcon in IFrame
     Then Confirm dialog is not visible

--- a/cypress/features/regression/dialogFullScreen.feature
+++ b/cypress/features/regression/dialogFullScreen.feature
@@ -52,14 +52,14 @@ Feature: Dialog Full Screen component
 
   @positive
   Scenario: Disable escape key
-    Given I open "Dialog Full Screen Test" component page
+    Given I open "Dialog Full Screen Test" component page "default"
       And I check disableEscKey checkbox
     When I hit ESC key
     Then Dialog Full Screen is visible
 
   @negative
   Scenario: Enable escape key
-    Given I open "Dialog Full Screen Test" component page
+    Given I open "Dialog Full Screen Test" component page "default"
       And I check disableEscKey checkbox
       And I uncheck disableEscKey checkbox
     When I hit ESC key
@@ -72,7 +72,7 @@ Feature: Dialog Full Screen component
 
   @positive
   Scenario: Cancel event
-    Given I open "Dialog Full Screen Test" component page
+    Given I open "Dialog Full Screen Test" component page "default"
       And clear all actions in Actions Tab
     When I click closeIcon in IFrame
     Then cancel action was called in Actions Tab

--- a/cypress/features/regression/draggableContext.feature
+++ b/cypress/features/regression/draggableContext.feature
@@ -1,8 +1,8 @@
 Feature: Draggable Context component
   I want to change Draggable Context component
 
-  Background: Open Draggable Context component in noIframe
-    Given I open "DraggableContext" component in noiFrame
+  Background: Open Draggable Context component in no iframe
+    Given I open "DraggableContext" component page "default" in no iframe
 
   @positive
   Scenario Outline: Drag record <record> inside Draggable Context to <destinationId> element position

--- a/cypress/features/regression/experimental/checkbox.feature
+++ b/cypress/features/regression/experimental/checkbox.feature
@@ -70,6 +70,6 @@ Feature: Experimental Checkbox component
 
   @positive
   Scenario: Change Checkbox tick color
-    Given I open "Experimental Checkbox Test" component page
+    Given I open "Experimental Checkbox Test" component page "default"
     When I mark checkbox on preview
     Then Checkbox tick has color "rgba(0, 0, 0, 0.9)"

--- a/cypress/features/regression/experimental/dateInput.feature
+++ b/cypress/features/regression/experimental/dateInput.feature
@@ -65,7 +65,7 @@ Feature: Experimental Date Input component
 
   @positive
   Scenario: Change Date Input component minDate
-    Given I open "Experimental Date Input" component page
+    Given I open "Experimental Date Input" component page "default"
       And I set minDate to today
       And I set dateInput to today
     When I choose date yesterday via DayPicker
@@ -73,7 +73,7 @@ Feature: Experimental Date Input component
 
   @positive
   Scenario: Change Date Input component maxDate
-    Given I open "Experimental Date Input" component page
+    Given I open "Experimental Date Input" component page "default"
       And I set maxDate to today
       And I set dateInput to today
     When I choose date tomorrow via DayPicker
@@ -81,30 +81,30 @@ Feature: Experimental Date Input component
 
   @positive
   Scenario: Check Date Input today date
-    Given I open "Experimental Date Input" component page
+    Given I open "Experimental Date Input" component page "default"
     When I set dateInput to today
     Then the date is set to today
 
   @positive
   Scenario: Open dayPickerDay via click on input
-    Given I open "Experimental Date Input" component page
+    Given I open "Experimental Date Input" component page "default"
     When I click dateInput
     Then dayPickerDay is visible
 
   @positive
   Scenario: Close dayPickerDay via click on input
-    Given I open "Experimental Date Input" component page
+    Given I open "Experimental Date Input" component page "default"
     When I click dateInput twice
     Then dayPickerDay is not visible
 
   @positive
   Scenario: Open dayPickerDay via click on icon
-    Given I open "Experimental Date Input" component page
+    Given I open "Experimental Date Input" component page "default"
     When I click onto date icon
     Then dayPickerDay is visible
 
   @positive
   Scenario: Close dayPickerDay via click on icon
-    Given I open "Experimental Date Input" component page
+    Given I open "Experimental Date Input" component page "default"
     When I click onto date icon twice
     Then dayPickerDay is not visible

--- a/cypress/features/regression/experimental/decimalInput.feature
+++ b/cypress/features/regression/experimental/decimalInput.feature
@@ -3,7 +3,7 @@ Feature: Decimal input component
 
   @positive
   Scenario Outline: Change Decimal component fieldHelp to <fieldHelp>
-    When I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
+    When I open default "Experimental Decimal Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
     Then fieldHelp on preview is set to <fieldHelp> in NoIFrame
     Examples:
       | fieldHelp                    | nameOfObject              |
@@ -12,7 +12,7 @@ Feature: Decimal input component
 
   @positive
   Scenario Outline: Change Decimal component label to <label>
-    When I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
+    When I open default "Experimental Decimal Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
     Then label on preview is <label> in NoIFrame
     Examples:
       | label                        | nameOfObject          |
@@ -21,7 +21,7 @@ Feature: Decimal input component
 
   @positive
   Scenario Outline: Change Decimal input align to the <direction>
-    When I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
+    When I open default "Experimental Decimal Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
     Then input direction is "<direction>"
     Examples:
       | direction | nameOfObject    |
@@ -30,7 +30,7 @@ Feature: Decimal input component
 
   @positive
   Scenario Outline: Change Decimal component label help to <label>
-    Given I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
+    Given I open default "Experimental Decimal Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
     When I hover mouse onto "question" icon in no iFrame
     Then tooltipPreview on preview is set to <label>
     Examples:
@@ -40,12 +40,12 @@ Feature: Decimal input component
 
   @positive
   Scenario: Change Decimal component label inline
-    Given I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "labelInline" object name
+    Given I open default "Experimental Decimal Input" component in noIFrame with "decimal" json from "experimental" using "labelInline" object name
     Then label is inline
 
   @positive
   Scenario Outline: Change Decimal component label width to <width>
-    When I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
+    When I open default "Experimental Decimal Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
     Then label width on preview is <width>
     Examples:
       | width | nameOfObject  |
@@ -55,7 +55,7 @@ Feature: Decimal input component
 
   @positive
   Scenario Outline: Change Decimal component input width to <width>
-    When I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
+    When I open default "Experimental Decimal Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
     Then inputWidth on preview is <width>
     Examples:
       | width | nameOfObject  |
@@ -65,7 +65,7 @@ Feature: Decimal input component
 
   @positive
   Scenario Outline: Change Decimal component label align to <labelAlign>
-    When I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
+    When I open default "Experimental Decimal Input" component in noIFrame with "decimal" json from "experimental" using "<nameOfObject>" object name
     Then label Align on preview is "<labelAlign>" in NoIFrame
     Examples:
       | labelAlign | nameOfObject    |
@@ -74,27 +74,27 @@ Feature: Decimal input component
 
   @positive
   Scenario: Disable Decimal component
-    When I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "disabled" object name
+    When I open default "Experimental Decimal Input" component in noIFrame with "decimal" json from "experimental" using "disabled" object name
     Then Decimal component is disabled
 
   @positive
   Scenario: Disable and enable Decimal component
-    When I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "disabledFalse" object name
+    When I open default "Experimental Decimal Input" component in noIFrame with "decimal" json from "experimental" using "disabledFalse" object name
     Then Decimal component is enabled
 
   @positive
   Scenario: Decimal component is readOnly
-    When I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "readOnly" object name
+    When I open default "Experimental Decimal Input" component in noIFrame with "decimal" json from "experimental" using "readOnly" object name
     Then Decimal component is readOnly
 
   @positive
   Scenario: Decimal component is not readOnly
-    When I open default "Experimental-Decimal-Input" component in noIFrame with "decimal" json from "experimental" using "readOnlyFalse" object name
+    When I open default "Experimental Decimal Input" component in noIFrame with "decimal" json from "experimental" using "readOnlyFalse" object name
     Then Decimal component is not readOnly
 
   @positive
   Scenario Outline: Check Decimal component input field will not accept characters except numbers to <label>
-    Given I open "Experimental-Decimal-Input" component page "default" in no iframe
+    Given I open "Experimental Decimal Input" component page "default" in no iframe
     When I set Decimal input to <label>
     Then Decimal input is not set to <label>
     Examples:

--- a/cypress/features/regression/experimental/decimalInput.feature
+++ b/cypress/features/regression/experimental/decimalInput.feature
@@ -94,7 +94,7 @@ Feature: Decimal input component
 
   @positive
   Scenario Outline: Check Decimal component input field will not accept characters except numbers to <label>
-    Given I open "Experimental-Decimal-Input" component page in noIFrame
+    Given I open "Experimental-Decimal-Input" component page "default" in no iframe
     When I set Decimal input to <label>
     Then Decimal input is not set to <label>
     Examples:

--- a/cypress/features/regression/experimental/groupedCharacter.feature
+++ b/cypress/features/regression/experimental/groupedCharacter.feature
@@ -3,7 +3,7 @@ Feature: Experimental GroupedCharacter component
 
   @positive
   Scenario Outline: Set groups to <groups> and verify input
-    Given I open "Experimental GroupedCharacter" component page
+    Given I open "Experimental GroupedCharacter" component page "default"
     When I input json to "groups" input field the "<groups>"
       And I put "<example>" example grouped character
     Then Input component value is set to "<result>"

--- a/cypress/features/regression/experimental/numberInputActions.feature
+++ b/cypress/features/regression/experimental/numberInputActions.feature
@@ -2,7 +2,7 @@ Feature: Experimental Number Input component
   I want to check Experimental Number Input component properties
 
   Background: Open Experimental Number Input component page
-    Given I open "Experimental Number Input" component page
+    Given I open "Experimental Number Input" component page "default"
 
   @positive
   Scenario: Enable onChangeDeferred action

--- a/cypress/features/regression/experimental/select.feature
+++ b/cypress/features/regression/experimental/select.feature
@@ -85,7 +85,7 @@ Feature: Experimental Select component
 
   @positive
   Scenario Outline: Verify the inner context of Select component typing <text> and getting <result>
-    Given I open "Experimental Select" component page
+    Given I open "Experimental Select" component page "default"
     When Type "<text>" text into input and select the value in iFrame
     Then Select input has "<result>" value in iFrame
     Examples:
@@ -96,7 +96,7 @@ Feature: Experimental Select component
 
   @positive
   Scenario: Check the change function call for Select component
-    Given I open "Experimental Select" component page
+    Given I open "Experimental Select" component page "default"
     Given clear all actions in Actions Tab
     When Type "Black" text into input and select the value in iFrame
     Then change action was called in Actions Tab

--- a/cypress/features/regression/experimental/selectCustomFilter.feature
+++ b/cypress/features/regression/experimental/selectCustomFilter.feature
@@ -2,7 +2,7 @@ Feature: Experimental Select component customFilter story
   I want to test Experimental Select component properties in customFilter story
 
   Background: Open Experimental Select component page customFilter story
-    Given I open "Experimental Select" component page customFilter
+    Given I open "Experimental Select" component page "customFilter"
 
   @positive
   Scenario Outline: Verify Select component input <value> could be selected using synonyms <synonyms>

--- a/cypress/features/regression/experimental/selectMultiple.feature
+++ b/cypress/features/regression/experimental/selectMultiple.feature
@@ -63,7 +63,7 @@ Feature: Select multiple component
 
   @positive
   Scenario: Verify the inner context of Select Multiple component
-    Given I open "Experimental Select" component page multiple
+    Given I open "Experimental Select" component page "multiple"
     When Type "Amber" text into input and select the value in iFrame
       And Type "Black" text into input and select the value in iFrame
       And Type "Green" text into input and select the value in iFrame
@@ -73,7 +73,7 @@ Feature: Select multiple component
 
   @positive
   Scenario: Check the change function call for Select Multiple component
-    Given I open "Experimental Select" component page multiple
+    Given I open "Experimental Select" component page "multiple"
     Given clear all actions in Actions Tab
     When Type "Black" text into input and select the value in iFrame
     Then change action was called in Actions Tab

--- a/cypress/features/regression/experimental/simpleColorPickerAction.feature
+++ b/cypress/features/regression/experimental/simpleColorPickerAction.feature
@@ -2,7 +2,7 @@ Feature: Simple Color Picker component
   I want to test Simple Color Picker component
 
   Background: Open Simple Color Picker component default page
-    Given I open "Experimental Simple Color Picker" component page
+    Given I open "Experimental Simple Color Picker" component page "default"
 
   @positive
   Scenario: When avaiableColors prop is provided changes rendnered colors
@@ -13,7 +13,7 @@ Feature: Simple Color Picker component
   @positive
   Scenario: Color Picker renders all the provided colors and their respective labels
     # commented because of BDD default scenario Given - When - Then
-    # When I open "Experimental Simple Color Picker" component page
+    # When I open "Experimental Simple Color Picker" component page "default"
     Then It renders with all colors
 
   @positive

--- a/cypress/features/regression/experimental/textarea.feature
+++ b/cypress/features/regression/experimental/textarea.feature
@@ -209,7 +209,7 @@ Feature: Experimental Textarea component
 
   @positive
   Scenario Outline: Verify input of Textarea component
-    Given I open "Experimental Textarea" component page in noIFrame
+    Given I open "Experimental Textarea" component page "default" in no iframe
     When I input <input> into Textarea
     Then Textarea input on preview is set to <input>
     Examples:

--- a/cypress/features/regression/experimental/textbox.feature
+++ b/cypress/features/regression/experimental/textbox.feature
@@ -107,7 +107,7 @@ Feature: Experimental Textbox component
 
   @positive
   Scenario Outline: Verify input of Textbox component
-    Given I open "Experimental Textbox" component page in noIFrame
+    Given I open "Experimental Textbox" component page "default" in no iframe
     When I type <input> into Textbox
     Then Textbox input on preview is set to <input>
     Examples:

--- a/cypress/features/regression/experimental/textboxActions.feature
+++ b/cypress/features/regression/experimental/textboxActions.feature
@@ -2,7 +2,7 @@ Feature: Experimental Textbox component - actions
   I want to change Experimental Textbox component actions
 
   Background: Open Experimental Textbox component page
-    Given I open "Experimental Textbox" component page
+    Given I open "Experimental Textbox" component page "default"
 
   @positive
   Scenario: Check iconOnClick event

--- a/cypress/features/regression/experimental/textboxMultiple.feature
+++ b/cypress/features/regression/experimental/textboxMultiple.feature
@@ -108,7 +108,7 @@ Feature: Experimental Textbox multiple component
 
   @positive
   Scenario Outline: Verify input of Textbox multiple component
-    Given I open "Experimental Textbox" component page multiple in NoIFrame
+    Given I open "Experimental Textbox" component page "multiple" in no iframe
     When I type <input> into "first" Textbox
       And I type <input> into "second" Textbox
     Then Multiple textbox input on preview is set to <input>

--- a/cypress/features/regression/menuList.feature
+++ b/cypress/features/regression/menuList.feature
@@ -59,7 +59,7 @@ Feature: MenuList component
 
   @positive
   Scenario Outline: Check search field
-    Given I open "MenuList" component page
+    Given I open "MenuList" component page "default"
       And I click into menu item second element in Iframe
     When I change search parameter to "<parameter>"
     Then search result is "<result>"

--- a/cypress/features/regression/message.feature
+++ b/cypress/features/regression/message.feature
@@ -58,7 +58,7 @@ Feature: Message component
 
   @positive
   Scenario: Verify the click function for a Message component
-    Given I open "Message Test" component page
+    Given I open "Message Test" component page "default"
       And clear all actions in Actions Tab
     When I click closeIcon in IFrame
     Then click action was called in Actions Tab

--- a/cypress/features/regression/mountInApp.feature
+++ b/cypress/features/regression/mountInApp.feature
@@ -3,5 +3,5 @@ Feature: Mount in App default component
 
   @positive
   Scenario: Mount in App is visible
-    When I open "Mount in App" component page
+    When I open "Mount in App" component page "default"
     Then Mount in App component is visible

--- a/cypress/features/regression/multiActionButton.feature
+++ b/cypress/features/regression/multiActionButton.feature
@@ -79,7 +79,7 @@ Feature: Multi Action Button default component
 
   @positive
   Scenario: Check click event
-    Given I open "Multi Action Button" component page
+    Given I open "Multi Action Button" component page "default"
       And clear all actions in Actions Tab
     When I click on "button"
     Then click action was called in Actions Tab

--- a/cypress/features/regression/pagesActions.feature
+++ b/cypress/features/regression/pagesActions.feature
@@ -2,7 +2,7 @@ Feature: Pages component in IFrame
   I want to test Pages component
 
   Background: Open Pages component default page
-    Given I open "Pages" component page
+    Given I open "Pages" component page "default"
 
  @positive
   Scenario: Go to second page

--- a/cypress/features/regression/pill.feature
+++ b/cypress/features/regression/pill.feature
@@ -65,7 +65,7 @@ Feature: Pill component
 
   @positive
   Scenario: Enable onDelete checkbox and check the delete event
-    Given I open "Pill" component page
+    Given I open "Pill" component page "default"
       And I check onDelete checkbox
       And clear all actions in Actions Tab
     When I click cross icon in Iframe

--- a/cypress/features/regression/pod.feature
+++ b/cypress/features/regression/pod.feature
@@ -125,7 +125,7 @@ Feature: Pod component
 
   @positive
   Scenario: Check the edit event
-    Given I open "Pod" component page
+    Given I open "Pod" component page "default"
       And I check onEdit checkbox
       And clear all actions in Actions Tab
     When I click onEdit icon in Iframe

--- a/cypress/features/regression/showEditPod.feature
+++ b/cypress/features/regression/showEditPod.feature
@@ -113,14 +113,14 @@ Feature: Show Edit Pod component
 
   @positive
   Scenario: Edit action was called
-    Given I open "ShowEditPod" component page
+    Given I open "ShowEditPod" component page "default"
       And clear all actions in Actions Tab
     When I click edit Show Edit Pod component in Iframe
     Then edit action was called in Actions Tab
 
   @positive
   Scenario: Delete action was called
-    Given I open "ShowEditPod" component page
+    Given I open "ShowEditPod" component page "default"
       And I click edit Show Edit Pod component in Iframe
       And clear all actions in Actions Tab
     When I click delete button
@@ -128,7 +128,7 @@ Feature: Show Edit Pod component
 
   @positive
   Scenario: Cancel action was called
-    Given I open "ShowEditPod" component page
+    Given I open "ShowEditPod" component page "default"
       And I click edit Show Edit Pod component in Iframe
       And clear all actions in Actions Tab
     When I click cancel button

--- a/cypress/features/regression/sidebar.feature
+++ b/cypress/features/regression/sidebar.feature
@@ -51,7 +51,7 @@ Feature: Sidebar component
 
   @positive
   Scenario: Check the cancel click event
-    Given I open "Sidebar Test" component page
+    Given I open "Sidebar Test" component page "default"
       And clear all actions in Actions Tab
     When I close Sidebar
     Then cancel action was called in Actions Tab

--- a/cypress/features/regression/splitButton.feature
+++ b/cypress/features/regression/splitButton.feature
@@ -112,14 +112,14 @@ Feature: Split Button component
 
   @positive
   Scenario: Verify the click function for a main element of Split Button component
-    Given I open "Split Button" component page
+    Given I open "Split Button" component page "default"
       And clear all actions in Actions Tab
     When I click "main-button" element of Split Button component in IFrame
     Then click action was called in Actions Tab
 
   @positive
   Scenario Outline: Verify the click function for a <element> element of Split Button component
-    Given I open "Split Button" component page
+    Given I open "Split Button" component page "default"
       And clear all actions in Actions Tab
       And I hover mouse onto icon
     When I click "<element>" element of Split Button component in IFrame

--- a/cypress/features/regression/tableActions.feature
+++ b/cypress/features/regression/tableActions.feature
@@ -2,7 +2,7 @@ Feature: Table component
   I want to check Table component properties
 
   Background: Open Table component default page
-    Given I open "Table" component page
+    Given I open "Table" component page "default"
 
   @positive
   Scenario Outline: Change event was called for sortColumn

--- a/cypress/features/regression/test/actionPopoverEventsInIFrame.feature
+++ b/cypress/features/regression/test/actionPopoverEventsInIFrame.feature
@@ -2,7 +2,7 @@ Feature: Action Popover component
   I want to change Action Popover component properties
 
   Background: Open Action Popover component page
-    Given I open "Design System Action Popover Test" component page
+    Given I open "Design System Action Popover Test" component page "default"
       And I click the menu button element
       And clear all actions in Actions Tab
 

--- a/cypress/features/regression/test/actionPopoverNoIFrame.feature
+++ b/cypress/features/regression/test/actionPopoverNoIFrame.feature
@@ -1,7 +1,7 @@
 Feature: Action Popover component in noIFrame
   I want to change Action Popover component properties in noIFrame
 
-  Background: Open Action Popover component page in noIFrame
+  Background: Open Action Popover component page in no iframe
     Given I open "Design System Action Popover Test" component page "default" in no iframe
 
   @positive

--- a/cypress/features/regression/test/anchorNavigationNoIFrame.feature
+++ b/cypress/features/regression/test/anchorNavigationNoIFrame.feature
@@ -2,7 +2,7 @@ Feature: Anchor Navigation component
   I want to test Anchor Navigation component properties
 
   Background: Open Anchor Navigation component page
-    Given I open in full screen Test "AnchorNavigation" component page in noIframe
+    Given I open "Test AnchorNavigation" component page "in_full_screen_dialog" in no iframe
       And I open component preview in noIFrame
 
   @positive

--- a/cypress/features/regression/test/flatTableNoiFrame.feature
+++ b/cypress/features/regression/test/flatTableNoiFrame.feature
@@ -2,7 +2,8 @@ Feature: FlatTable component
   I want to check FlatTable component properties
 
   Background: Open FlatTable component page in no iFrame
-    Given I open Design System Flat Table Test component basic page with prop value
+    Given I open Test test_basic "Flat-Table" component in noIFrame with "flatTable" json from "test" using "default" object name
+
 
   @positive
   Scenario: Header and row of FlatTabel are visible after scrolling to the right bottom

--- a/cypress/features/regression/themes/themes.feature
+++ b/cypress/features/regression/themes/themes.feature
@@ -3,113 +3,113 @@ Feature: Theming addon
 
   @positive
   Scenario Outline: I set Button component theme to <theme>
-    When I open "Design System Button Test" component with theme "<theme>" knobs story
+    When I open knobs "Design System Button Test" component in noIFrame with "themeNames" json from "themes" using "<nameOfObject>" object name
     Then "button" component css "color" is set to "<theme>" common
     Examples:
-      | theme  |
-      | mint   |
-      | aegean |
-      | none   |
+      | theme  | nameOfObject |
+      | mint   | themeMint    |
+      | aegean | themeAegean  |
+      | none   | themeNone    |
 
   @positive
   Scenario Outline: I set Button Toggle component theme to <theme>
-    When I open "button-toggle" component with theme "<theme>"
+    When I open default "Button Toggle" component in noIFrame with "themeNames" json from "themes" using "<nameOfObject>" object name
       And I click "button-toggle" component
     Then Button Toggle component css background color is set to "<theme>"
     Examples:
-      | theme  |
-      | mint   |
-      | aegean |
-      | none   |
+      | theme  | nameOfObject |
+      | mint   | themeMint    |
+      | aegean | themeAegean  |
+      | none   | themeNone    |
 
   @positive
   Scenario Outline: I set Icon component theme to <theme>
-    When I open Icon component with theme "<theme>"
+    When I open default "Icon" component in noIFrame with "themeNames" json from "themes" using "<nameOfObject>" object name
     Then "icon" component css "background-color" is set to "<theme>" common
     Examples:
-      | theme  |
-      | mint   |
-      | aegean |
-      | none   |
+      | theme  | nameOfObject     |
+      | mint   | iconThemeMint    |
+      | aegean | iconThemeAegean  |
+      | none   | iconThemeNone    |
 
   @positive
   Scenario Outline: I set Link component theme to <theme>
-    When I open "link" component with theme "<theme>"
+    When I open default "Link" component in noIFrame with "themeNames" json from "themes" using "<nameOfObject>" object name
     Then Link component css color is set to "<theme>"
     Examples:
-      | theme  |
-      | mint   |
-      | aegean |
-      | none   |
+      | theme  | nameOfObject |
+      | mint   | themeMint    |
+      | aegean | themeAegean  |
+      | none   | themeNone    |
 
   @positive
   Scenario Outline: I set Loader component theme to <theme>
-    When I open test_basic page "Loader" component with theme "<theme>"
+    When I open Test test_basic "Loader" component in noIFrame with "themeNames" json from "themes" using "<nameOfObject>" object name
     Then Loader component css background color is set to "<theme>"
     Examples:
-      | theme  |
-      | mint   |
-      | aegean |
-      | none   |
+      | theme  | nameOfObject |
+      | mint   | themeMint    |
+      | aegean | themeAegean  |
+      | none   | themeNone    |
 
   @positive
   Scenario Outline: I set Multiaction Button component theme to <theme>
-    When I open "multi-action-button" component with theme "<theme>"
+    When I open default "Multi action button" component in noIFrame with "themeNames" json from "themes" using "<nameOfObject>" object name
     Then "button" component css "color" is set to "<theme>" common
       And "button" component css "border-color" is set to "<theme>" common
     Examples:
-      | theme  |
-      | mint   |
-      | aegean |
-      | none   |
+      | theme  | nameOfObject |
+      | mint   | themeMint    |
+      | aegean | themeAegean  |
+      | none   | themeNone    |
 
   @positive
   Scenario Outline: I set Pill component theme to <theme>
-    When I open "pill" component with theme "<theme>"
+    When I open default "Pill" component in noIFrame with "themeNames" json from "themes" using "<nameOfObject>" object name
     Then "pill" component css "border-color" is set to "<theme>" common
     Examples:
-      | theme  |
-      | mint   |
-      | aegean |
-      | none   |
+      | theme  | nameOfObject |
+      | mint   | themeMint    |
+      | aegean | themeAegean  |
+      | none   | themeNone    |
 
   @positive
   Scenario Outline: I set Show Edit Pod component theme to <theme>
-    When I open "showeditpod" component with theme "<theme>"
+    When I open default "Showeditpod" component in noIFrame with "themeNames" json from "themes" using "<nameOfObject>" object name
     Then Link component css color is set to "<theme>"
     Examples:
-      | theme  |
-      | mint   |
-      | aegean |
-      | none   |
+      | theme  | nameOfObject |
+      | mint   | themeMint    |
+      | aegean | themeAegean  |
+      | none   | themeNone    |
 
   @positive
   Scenario Outline: I set Split Button component theme to <theme>
-    When I open "split-button" component with theme "<theme>"
+    When I open default "Split Button" component in noIFrame with "themeNames" json from "themes" using "<nameOfObject>" object name
     Then "button" component css "color" is set to "<theme>" common
       And "button" component css "border-color" is set to "<theme>" common
     Examples:
-      | theme  |
-      | mint   |
-      | aegean |
-      | none   |
+      | theme  | nameOfObject |
+      | mint   | themeMint    |
+      | aegean | themeAegean  |
+      | none   | themeNone    |
 
   @positive
   Scenario Outline: I set Step Sequence component theme to <theme>
-    When I open "step-sequence" component with theme "<theme>"
+    When I open default "Step Sequence" component in noIFrame with "themeNames" json from "themes" using "<nameOfObject>" object name
     Then "step-sequence-item" component css "color" is set to "<theme>"
     Examples:
-      | theme  |
-      | mint   |
-      | aegean |
-      | none   |
+      | theme  | nameOfObject |
+      | mint   | themeMint    |
+      | aegean | themeAegean  |
+      | none   | themeNone    |
 
   @positive
   Scenario Outline: I set Tabs component theme to <theme>
-    When I open test_basic page "Tabs" component with theme "<theme>"
+    When I open Test test_basic "Tabs" component in noIFrame with "themeNames" json from "themes" using "<nameOfObject>" object name
     Then "select-tab" element css "border-bottom-color" is set to "<theme>" common
     Examples:
-      | theme  |
-      | mint   |
-      | aegean |
-      | none   |
+      | theme  | nameOfObject |
+      | mint   | themeMint    |
+      | aegean | themeAegean  |
+      | none   | themeNone    |

--- a/cypress/fixtures/commonComponents/table.json
+++ b/cypress/fixtures/commonComponents/table.json
@@ -43,13 +43,13 @@
     "caption": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
   },
   "themePrimary": {
-    "theme": "primary"
+    "tableTheme": "primary"
   },
   "themeSecondary": {
-    "theme": "secondary"
+    "tableTheme": "secondary"
   },
   "themeTertiary": {
-    "theme": "tertiary"
+    "tableTheme": "tertiary"
   },
   "sizeCompact": {
     "size": "compact"

--- a/cypress/fixtures/test/flatTable.json
+++ b/cypress/fixtures/test/flatTable.json
@@ -1,0 +1,7 @@
+{ 
+  "default": {
+    "hasHeaderRow": true,
+    "hasStickyHead": true,
+    "hasClickableRows": true
+  }
+}

--- a/cypress/fixtures/themes/themeNames.json
+++ b/cypress/fixtures/themes/themeNames.json
@@ -1,0 +1,23 @@
+{
+	"themeMint": {
+		"theme": "mint"
+	},
+	"themeAegean": {
+		"theme": "aegean"
+	},
+	"themeNone": {
+		"theme": "none"
+	},
+	"iconThemeMint": {
+		"bgTheme": "business",
+		"theme": "mint"
+	},
+	"iconThemeAegean": {
+		"bgTheme": "business",
+		"theme": "aegean"
+	},
+	"iconThemeNone": {
+		"bgTheme": "business",
+		"theme": "none"
+	}
+}

--- a/cypress/locators/duelling-picklist/index.js
+++ b/cypress/locators/duelling-picklist/index.js
@@ -1,18 +1,20 @@
 import {
   DUELLING_PICKLIST_COMPONENT, PICKLIST, PICKLIST_ITEMS, PICKLIST_LEFT_LABEL,
-  PICKLIST_RIGHT_LABEL, ADD_ELEMENT, REMOVE_ELEMENT, PICKLIST_ID,
+  PICKLIST_RIGHT_LABEL, ADD_ELEMENT, REMOVE_ELEMENT,
 } from './locators';
 import { SEARCH_COMPONENT } from '../search/locators';
+import { CHECKBOX } from '../checkbox/locators';
 
 // component preview locators
-export const duellingPicklistComponent = () => cy.iFrame(DUELLING_PICKLIST_COMPONENT);
-export const picklist = () => cy.iFrame(PICKLIST_ID).find(PICKLIST);
+export const duellingPicklistComponent = () => cy.get(DUELLING_PICKLIST_COMPONENT);
+export const picklist = () => cy.get(PICKLIST);
 export const unassignedPicklist = () => picklist().eq(0);
 export const unassignedPicklistItems = () => unassignedPicklist().find(PICKLIST_ITEMS);
 export const assignedPicklist = () => picklist().eq(1);
 export const assignedPicklistItems = () => assignedPicklist().find(PICKLIST_ITEMS);
-export const picklistRightLabel = () => cy.iFrame(PICKLIST_RIGHT_LABEL);
-export const picklistLeftLabel = () => cy.iFrame(PICKLIST_LEFT_LABEL);
+export const picklistRightLabel = () => cy.get(PICKLIST_RIGHT_LABEL);
+export const picklistLeftLabel = () => cy.get(PICKLIST_LEFT_LABEL);
 export const addButton = index => unassignedPicklistItems().eq(index).find(ADD_ELEMENT);
 export const removeButton = () => assignedPicklist().find(REMOVE_ELEMENT);
-export const duellingSearchInput = () => cy.iFrame(PICKLIST_ID).find(SEARCH_COMPONENT).find('input');
+export const duellingSearchInput = () => cy.get(SEARCH_COMPONENT).find('input');
+export const checkBox = () => cy.get(CHECKBOX);

--- a/cypress/locators/duelling-picklist/locators.js
+++ b/cypress/locators/duelling-picklist/locators.js
@@ -5,4 +5,3 @@ export const PICKLIST_LEFT_LABEL = '[data-element="picklist-left-label"]';
 export const PICKLIST_RIGHT_LABEL = '[data-element="picklist-right-label"]';
 export const ADD_ELEMENT = '[data-element="add"]';
 export const REMOVE_ELEMENT = '[data-element="remove"]';
-export const PICKLIST_ID = '[id="story--test-duellingpicklist--basic"]';

--- a/cypress/support/helper.js
+++ b/cypress/support/helper.js
@@ -1,5 +1,8 @@
 import {
-  knobsTab, actionsTab, clearButton, getKnobsInputWithName,
+  knobsTab,
+  actionsTab,
+  clearButton,
+  getKnobsInputWithName,
   getElementNoIframe,
 } from '../locators';
 import { DEBUG_FLAG } from '.';
@@ -24,35 +27,19 @@ export function visitComponentUrl(component, suffix = 'default', iFrameOnly = fa
   if (!iFrameOnly) knobsTab().click();
 }
 
-export function visitComponentUrlByTheme(component, theme, sufix = '') {
-  cy.visit(`${prepareUrl(component, 'default', true, '')}&theme=${theme}${sufix}`);
-}
-
-export function visitComponentUrlByThemeKnobsStory(component, theme, sufix = '', prefix = '') {
-  cy.visit(`${prepareUrl(component, 'knobs', true, prefix)}&theme=${theme}${sufix}`);
-}
-
 export function visitComponentUrlWithParameters(component, story, sufix = '', prefix = '', json = '', path = '', nameOfObject = '') {
   cy.fixture(`${path}/${json}`).then(($json) => {
     const el = $json[nameOfObject];
     let url = '';
     for (const prop in el) {
-      url += `&knob-${prop}=${encodeURIComponent(el[prop])}`;
+      if (prop === 'theme') {
+        url += `&theme=${encodeURIComponent(el[prop])}`;
+      } else {
+        url += `&knob-${prop}=${encodeURIComponent(el[prop])}`;
+      }
     }
     cy.visit(`${prepareUrl(component, story, true, prefix)}${url}`);
   });
-}
-
-export function visitComponentUrlByThemeByStory(component, story, theme, sufix = '', prefix = '') {
-  cy.visit(`${prepareUrl(component, story, true, prefix)}&theme=${theme}${sufix}`);
-}
-
-export function visitComponentUrlByThemeByStoryDesignSystemTest(component, story, theme, sufix = '', prefix = '') {
-  cy.visit(`${prepareUrl(component, story, true, 'design-system-', prefix)}&theme=${theme}${sufix}`);
-}
-
-export function visitDesignSystemComponentUrlByThemeByStory(component, prefix, story, theme, sufix = '') {
-  cy.visit(`${prepareUrl(component, story, true, prefix)}&theme=${theme}${sufix}`);
 }
 
 export function clickActionsTab(iFrameOnly = false) {
@@ -88,15 +75,6 @@ export function dragAndDrop(draggableElement, destinationPosition, startFromHigh
   draggableElement
     .trigger('mouseup', { force: true, release: true });
   console.log('Dropped item');
-}
-
-export function setSlidebar(selector, value) {
-  const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
-  selector.then(($range) => {
-    const range = $range[0];
-    nativeInputValueSetter.call(range, value);
-    range.dispatchEvent(new Event('change', { value, bubbles: true }));
-  });
 }
 
 export function pressESCKey() {

--- a/cypress/support/helper.js
+++ b/cypress/support/helper.js
@@ -18,10 +18,6 @@ function prepareUrl(component, suffix, iFrameOnly, prefix, env) {
   return url + stringToURL(component) + (Cypress.env(suffix) || `--${stringToURL(suffix)}`);
 }
 
-export function visitDocsUrl(component, suffix = 'default', iFrameOnly = false, prefix = '', env = 'docs') {
-  cy.visit(prepareUrl(component, suffix, iFrameOnly, prefix, env));
-}
-
 export function visitComponentUrl(component, suffix = 'default', iFrameOnly = false, prefix = '', env = 'story') {
   cy.visit(prepareUrl(component, suffix, iFrameOnly, prefix, env));
   if (!iFrameOnly) knobsTab().click();

--- a/cypress/support/helper.js
+++ b/cypress/support/helper.js
@@ -55,10 +55,6 @@ export function visitDesignSystemComponentUrlByThemeByStory(component, prefix, s
   cy.visit(`${prepareUrl(component, story, true, prefix)}&theme=${theme}${sufix}`);
 }
 
-export function visitFlatTableComponentNoiFrame(component, suffix = 'default', iFrameOnly = false, prefix = '', stickyRow = true, stickyHead = true, clickableRow = true) {
-  cy.visit(`${prepareUrl(component, suffix, iFrameOnly, prefix, stickyRow, stickyHead, clickableRow)}&knob-hasHeaderRow=${stickyRow}&knob-hasStickyHead=${stickyHead}&knob-hasClickableRows=${clickableRow}`);
-}
-
 export function clickActionsTab(iFrameOnly = false) {
   if (!iFrameOnly) actionsTab().click();
 }

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -1,7 +1,6 @@
 import {
   visitComponentUrl, pressESCKey, pressTABKey, asyncWaitForKnobs,
   positionOfElement, keyCode,
-  visitDocsUrl,
   visitComponentUrlWithParameters,
   clickActionsTab,
   clickClear,
@@ -35,10 +34,6 @@ const TEXT_ALIGN = 'justify-content';
 const TEXT_ALIGN_START = 'flex-start';
 const TEXT_ALIGN_END = 'flex-end';
 
-Given('I open Design Systems {word} {string} component docs page', (type, component) => {
-  visitDocsUrl(component, type, false, 'design-system-');
-});
-
 Given('I open Test {word} {string} component in noIFrame with {string} json from {string} using {string} object name', (type, component, json, path, nameOfObject) => {
   visitComponentUrlWithParameters(component, type, true, 'design-system-', json, path, nameOfObject);
 });
@@ -47,10 +42,6 @@ Given('I open {word} {string} component in noIFrame with {string} json from {str
   visitComponentUrlWithParameters(component, type, true, '', json, path, nameOfObject);
 });
 
-// Given('I open {string} component page', (component) => {
-//   visitComponentUrl(component);
-// });
-
 Given('I open {string} component page {string}', (component, story) => {
   visitComponentUrl(component, story, false);
 });
@@ -58,10 +49,6 @@ Given('I open {string} component page {string}', (component, story) => {
 Given('I open {string} component page {string} in no iframe', (component, story) => {
   visitComponentUrl(component, story, true);
 });
-
-// Given('I open {word} Test {string} component page', (type, component) => {
-//   visitComponentUrl(component, type, false, 'test-');
-// });
 
 When('I open {word} tab', (text) => {
   cy.wait(500, { log: DEBUG_FLAG }); // required because element needs to be loaded
@@ -127,10 +114,6 @@ Then('label on preview is {word} in NoIFrame', (text) => {
 
 Then('label is set to {word}', (text) => {
   getDataElementByValue('label').should('have.text', text);
-});
-
-When('I hover mouse onto help icon in IFrame', () => {
-  helpIconIframe().trigger('mouseover');
 });
 
 When('I hover mouse onto help icon', () => {

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -47,9 +47,9 @@ Given('I open {word} {string} component in noIFrame with {string} json from {str
   visitComponentUrlWithParameters(component, type, true, '', json, path, nameOfObject);
 });
 
-Given('I open {string} component page', (component) => {
-  visitComponentUrl(component);
-});
+// Given('I open {string} component page', (component) => {
+//   visitComponentUrl(component);
+// });
 
 Given('I open {string} component page {string}', (component, story) => {
   visitComponentUrl(component, story, false);

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -1,6 +1,6 @@
 import {
   visitComponentUrl, pressESCKey, pressTABKey, asyncWaitForKnobs,
-  visitFlatTableComponentNoiFrame, positionOfElement, keyCode,
+  positionOfElement, keyCode,
   visitDocsUrl,
   visitComponentUrlWithParameters,
   clickActionsTab,
@@ -35,16 +35,8 @@ const TEXT_ALIGN = 'justify-content';
 const TEXT_ALIGN_START = 'flex-start';
 const TEXT_ALIGN_END = 'flex-end';
 
-Given('I open design systems {word} {string} component page', (type, component) => {
-  visitComponentUrl(component, type, false, 'design-system-');
-});
-
 Given('I open Design Systems {word} {string} component docs page', (type, component) => {
   visitDocsUrl(component, type, false, 'design-system-');
-});
-
-Given('I open design systems {word} {string} component in no iframe', (type, component) => {
-  visitComponentUrl(component, type, true, 'design-system-');
 });
 
 Given('I open Test {word} {string} component in noIFrame with {string} json from {string} using {string} object name', (type, component, json, path, nameOfObject) => {
@@ -67,73 +59,9 @@ Given('I open {string} component page {string} in no iframe', (component, story)
   visitComponentUrl(component, story, true);
 });
 
-Given('I open {string} component page in noIFrame', (component) => {
-  visitComponentUrl(component, 'default', true);
-});
-
-Given('I open Experimental {string} component page in noIFrame', (component) => {
-  visitComponentUrl(component, 'default', true, 'experimental-');
-});
-
-Given('I open {string} component page basic', (component) => {
-  visitComponentUrl(component, 'basic');
-});
-
-Given('I open in full screen Test {string} component page in noIframe', (component) => {
-  visitComponentUrl(component, 'in_full_screen_dialog', true, 'test-');
-});
-
-Given('I open {string} component page with button', (component) => {
-  visitComponentUrl(component, 'with_button');
-});
-
-Given('I open {string} component page with button in noIFrame', (component) => {
-  visitComponentUrl(component, 'with_button', true);
-});
-
-Given('I open dark theme {string} component page in noIFrame', (component) => {
-  visitComponentUrl(component, 'dark_theme', true);
-});
-
-Given('I open {string} component in noiFrame', (component) => {
-  visitComponentUrl(component, 'default', true);
-});
-
-Given('I open {string} component with button page in iframe', (component) => {
-  visitComponentUrl(component, 'with_button', true);
-});
-
-Given('I open {string} component page multiple', (component) => {
-  visitComponentUrl(component, 'multiple');
-});
-
-Given('I open {string} component page multiple in NoIFrame', (component) => {
-  visitComponentUrl(component, 'multiple', true);
-});
-
-Given('I open {string} component page full-width in no iframe', (component) => {
-  visitComponentUrl(component, 'full_width');
-});
-
-Given('I open Experimental {string} component page validations in noIframe', (component) => {
-  visitComponentUrl(component, 'validations', true, 'experimental-');
-});
-
-Given('I open {word} Test {string} component page', (type, component) => {
-  visitComponentUrl(component, type, false, 'test-');
-});
-
-Given('I open {word} Test {string} component page in noIframe', (type, component) => {
-  visitComponentUrl(component, type, true, 'test-');
-});
-
-When('I open Design System Flat Table Test component basic page with prop value', () => {
-  visitFlatTableComponentNoiFrame('Design System Flat Table Test', 'basic', true);
-});
-
-Given('I open {string} component page customFilter', (component) => {
-  visitComponentUrl(component, 'customFilter');
-});
+// Given('I open {word} Test {string} component page', (type, component) => {
+//   visitComponentUrl(component, type, false, 'test-');
+// });
 
 When('I open {word} tab', (text) => {
   cy.wait(500, { log: DEBUG_FLAG }); // required because element needs to be loaded

--- a/cypress/support/step-definitions/duelling-picklist-steps.js
+++ b/cypress/support/step-definitions/duelling-picklist-steps.js
@@ -1,9 +1,8 @@
 import {
   assignedPicklist, unassignedPicklistItems, duellingPicklistComponent, picklistRightLabel,
   picklistLeftLabel, assignedPicklistItems, unassignedPicklist, addButton, removeButton,
-  duellingSearchInput,
+  duellingSearchInput, checkBox,
 } from '../../locators/duelling-picklist/index';
-import { checkboxRole } from '../../locators/checkbox/index';
 import { positionOfElement, keyCode } from '../helper';
 
 Then('unassigned picklist has {int} items', (items) => {
@@ -33,11 +32,11 @@ Then('unassigned picklist is empty', () => {
 });
 
 Then('I check Access to all current and new clients checkbox', () => {
-  checkboxRole().check();
+  checkBox().check();
 });
 
 Then('I uncheck Access to all current and new clients checkbox', () => {
-  checkboxRole().uncheck();
+  checkBox().uncheck();
 });
 
 Then('Duelling Picklist is disabled', () => {

--- a/cypress/support/step-definitions/themes-steps.js
+++ b/cypress/support/step-definitions/themes-steps.js
@@ -1,32 +1,8 @@
-import {
-  visitComponentUrlByTheme,
-  visitComponentUrlByThemeKnobsStory,
-  visitComponentUrlByThemeByStory,
-  visitDesignSystemComponentUrlByThemeByStory,
-  visitComponentUrlByThemeByStoryDesignSystemTest,
-} from '../helper';
 import { getComponentNoIframe, getElementNoIframe } from '../../locators';
 import { buttonToggleComponent, linkComponent, loaderComponent } from '../../locators/themes';
 
 const COLOR = 'color';
 const BACKGROUND_COLOR = 'background-color';
-const BUSINESS_BGTHEME = '&knob-bgTheme=business';
-
-When('I open {string} component with theme {string}', (componentName, themeName) => {
-  visitComponentUrlByTheme(componentName, themeName);
-});
-
-When('I open {word} page {string} component with theme {string}', (type, componentName, themeName) => {
-  visitComponentUrlByThemeByStoryDesignSystemTest(componentName, type, themeName);
-});
-
-When('I open {string} component with theme {string} knobs story', (componentName, themeName) => {
-  visitComponentUrlByThemeKnobsStory(componentName, themeName);
-});
-
-When('I open Icon component with theme {string}', (themeName) => {
-  visitComponentUrlByTheme('icon', themeName, BUSINESS_BGTHEME);
-});
 
 Then('{string} component css {string} is set to {string} common', (componentName, css, themeName) => {
   cy.fixture('themes/themes.json').then((json) => {
@@ -66,12 +42,4 @@ Then('Loader component css background color is set to {string}', (themeName) => 
   cy.fixture('themes/themes.json').then((json) => {
     loaderComponent().should('have.css', BACKGROUND_COLOR, json.common[themeName]);
   });
-});
-
-When('I open Test {string} component {word} story with theme {string}', (componentName, storyName, themeName) => {
-  visitComponentUrlByThemeByStory(componentName, storyName, themeName, '', 'test-');
-});
-
-Given('I open design systems {word} {string} component with theme {string}', (storyName, componentName, themeName) => {
-  visitDesignSystemComponentUrlByThemeByStory(componentName, 'design-system-', storyName, themeName);
 });

--- a/docs/testing-styleguide.md
+++ b/docs/testing-styleguide.md
@@ -98,6 +98,7 @@ Where functionality is already tested in unit testing, this does not need to be 
 .
 ├── cypress
 │ ├── fixture
+│ │   ├── json files (test data)
 │ ├── features
 │ │   ├── regression
 │ │       ├── accessibility
@@ -138,12 +139,8 @@ Cypress tests are written in Gherkin syntax with Cucumber expressions. Observe t
   * Common steps (`common-steps.js`) are used for all common actions.
 
 Some common test steps:
-  * I set `<knobs field>` to `<parameter>`;
-  * I select `<knobs field>` to `<parameter>`;
-  * I check/uncheck `<knobs field>` checkbox;
-  * I open `<name>` component page;
-    * To open different stories on Storybook;
-      * I open `<name>` component page `default`/`basic`/`with button`/`iframe`/`with button page in iframe`/`multiple`/`validations`.
+  * I open `<story name>` `<component name>` component in noIFrame with `<dedicated json file>` json from `<directory to take json from>` using `<object name in json>` object name
+  * I open `<name>` component page `<story name>`;
 
 ##### Scenario tags
 Test scenarios in feature files can be tagged to enable a subset of scenarios to be run, ignored or identified in some manner. Use the following tags:

--- a/docs/testing-styleguide.md
+++ b/docs/testing-styleguide.md
@@ -141,6 +141,7 @@ Cypress tests are written in Gherkin syntax with Cucumber expressions. Observe t
 Some common test steps:
   * I open `<story name>` `<component name>` component in noIFrame with `<dedicated json file>` json from `<directory to take json from>` using `<object name in json>` object name
   * I open `<name>` component page `<story name>`;
+  * I open `<name>` component page `<story name>` in no iframe.
 
 ##### Scenario tags
 Test scenarios in feature files can be tagged to enable a subset of scenarios to be run, ignored or identified in some manner. Use the following tags:

--- a/src/components/table/table.stories.js
+++ b/src/components/table/table.stories.js
@@ -47,7 +47,7 @@ const commonKnobs = (
 const classicKnobs = () => {
   return {
     theme: select(
-      'theme',
+      'tableTheme',
       [
         OptionsHelper.tableThemes[0],
         OptionsHelper.tableThemes[1]
@@ -60,7 +60,7 @@ const classicKnobs = () => {
 const dlsKnobs = () => {
   return {
     theme: select(
-      'theme',
+      'tableTheme',
       [
         OptionsHelper.tableThemes[0],
         OptionsHelper.tableThemes[1],


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
- removed unnecessary steps were using `visitComponentUrl` function;
- unifying the `open` component steps (now we are using only 2 steps to open component);
- refactor for the `theme.feature`;
- refactor for a `theme` knob for a `table.stories.js`.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
We need to clean-up our code base to avoid confusing into using the `common-steps`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent