### PR TITLE
feat(flat-table): add possibility to set column width and cell paddings

### DIFF
--- a/cypress/features/regression/designSystem/flatTable.feature
+++ b/cypress/features/regression/designSystem/flatTable.feature
@@ -34,7 +34,7 @@ Feature: Design Systems FlatTable component
     Examples:
       | position | headerName |
       | first    | Client     |
-      | second   | total      |
+      | second   | total      | 
 
   @positive
   Scenario Outline: <headerName> flat table header has focus

--- a/cypress/locators/flat-table/index.js
+++ b/cypress/locators/flat-table/index.js
@@ -1,5 +1,5 @@
 import {
-  FLAT_TABLE_COMPONENT, FLAT_TABLE_CELL
+  FLAT_TABLE_COMPONENT, FLAT_TABLE_CELL,
 } from './locators';
 
 // component preview locators
@@ -13,5 +13,5 @@ export const flatTableHeaderCells = () => flatTableHeader().find('th');
 export const flatTableBodyRowByPosition = index => flatTable().find('tbody tr').eq(index);
 
 export const flatTableClickableRow = index => cy.get(FLAT_TABLE_COMPONENT).find('tbody tr').eq(index);
-export const flatTableSortable = () => cy.get(FLAT_TABLE_COMPONENT).find('thead tr th div:nth-child(1)');
+export const flatTableSortable = () => cy.get(FLAT_TABLE_COMPONENT).find('thead tr th > div > div:nth-child(1)');
 export const flatTableCell = index => cy.get(FLAT_TABLE_CELL).eq(index);

--- a/src/__spec_helper__/test-utils.js
+++ b/src/__spec_helper__/test-utils.js
@@ -128,7 +128,7 @@ const getDefaultValue = (value) => {
   return value;
 };
 
-const testStyledSystemSpacing = (component, defaults, styleContainer) => {
+const testStyledSystemSpacing = (component, defaults, styleContainer, assertOpts) => {
   describe('default props', () => {
     const wrapper = mount(component());
     const StyleElement = styleContainer ? styleContainer(wrapper) : wrapper;
@@ -155,7 +155,8 @@ const testStyledSystemSpacing = (component, defaults, styleContainer) => {
             marginTop,
             marginBottom
           },
-          StyleElement
+          StyleElement,
+          assertOpts
         ));
       } else {
         expect(StyleElement).not.toHaveStyleRule('marginLeft');
@@ -188,7 +189,8 @@ const testStyledSystemSpacing = (component, defaults, styleContainer) => {
             paddingTop,
             paddingBottom
           },
-          StyleElement
+          StyleElement,
+          assertOpts
         ));
       } else {
         expect(StyleElement).not.toHaveStyleRule('paddingLeft');
@@ -210,7 +212,8 @@ const testStyledSystemSpacing = (component, defaults, styleContainer) => {
 
         expect(assertStyleMatch(
           { [propName]: '16px' },
-          styleContainer ? styleContainer(wrapper) : wrapper
+          styleContainer ? styleContainer(wrapper) : wrapper,
+          assertOpts
         ));
       });
     });

--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -8,7 +8,6 @@ exports[`FlatTable when rendered with proper table data should have expected str
   box-sizing: border-box;
   font-weight: 700;
   left: auto;
-  padding: 8px 24px;
   text-align: left;
   top: 0;
   -webkit-user-select: none;
@@ -17,6 +16,16 @@ exports[`FlatTable when rendered with proper table data should have expected str
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
+  word-break: keep-all;
+  padding: 0;
+}
+
+.c8 > div {
+  box-sizing: border-box;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 24px;
+  padding-right: 24px;
 }
 
 .c6 {
@@ -26,13 +35,21 @@ exports[`FlatTable when rendered with proper table data should have expected str
   box-sizing: border-box;
   left: 0;
   font-weight: normal;
-  padding: 10px 24px;
   position: -webkit-sticky;
   position: sticky;
   text-align: left;
   top: auto;
   vertical-align: middle;
   white-space: nowrap;
+  padding: 0;
+}
+
+.c6 > div {
+  box-sizing: border-box;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-left: 24px;
+  padding-right: 24px;
 }
 
 .c3 .c5,
@@ -41,9 +58,12 @@ exports[`FlatTable when rendered with proper table data should have expected str
   border-right: none;
   font-weight: 700;
   left: 0;
-  padding: 8px 24px;
   top: 0;
   z-index: 1000;
+}
+
+.c3 .c5 > div {
+  padding: 8px 24px;
 }
 
 .c1 {
@@ -51,9 +71,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
   border-radius: 0px;
   border-spacing: 0;
   min-width: 100%;
-  table-layout: fixed;
-  width: auto;
-  word-break: break-all;
+  width: 100%;
 }
 
 .c0 {
@@ -72,12 +90,19 @@ exports[`FlatTable when rendered with proper table data should have expected str
   background-color: #fff;
   border-width: 0;
   border-bottom: 1px solid #CCD6DB;
-  overflow: visible;
-  padding: 10px 24px;
   text-overflow: ellipsis;
   text-align: left;
   vertical-align: middle;
   white-space: nowrap;
+  padding: 0;
+}
+
+.c10 > div {
+  box-sizing: border-box;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-left: 24px;
+  padding-right: 24px;
 }
 
 .c10:first-of-type {
@@ -92,12 +117,19 @@ exports[`FlatTable when rendered with proper table data should have expected str
   background-color: #fff;
   border-width: 0;
   border-bottom: 1px solid #CCD6DB;
-  overflow: visible;
-  padding: 10px 24px;
   text-overflow: ellipsis;
   text-align: left;
   vertical-align: middle;
   white-space: nowrap;
+  padding: 0;
+}
+
+.c11 > div {
+  box-sizing: border-box;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-left: 24px;
+  padding-right: 24px;
 }
 
 .c11:first-of-type {
@@ -119,7 +151,6 @@ exports[`FlatTable when rendered with proper table data should have expected str
   min-width: 100%;
   table-layout: fixed;
   width: auto;
-  word-break: break-all;
 }
 
 <div
@@ -140,25 +171,33 @@ exports[`FlatTable when rendered with proper table data should have expected str
           className="c5 c6"
           data-element="flat-table-row-header"
         >
-          row header
+          <div>
+            row header
+          </div>
         </th>
         <th
           className="c7 c8"
           data-element="flat-table-header"
         >
-          header1
+          <div>
+            header1
+          </div>
         </th>
         <th
           className="c7 c8"
           data-element="flat-table-header"
         >
-          header2
+          <div>
+            header2
+          </div>
         </th>
         <th
           className="c7 c8"
           data-element="flat-table-header"
         >
-          header3
+          <div>
+            header3
+          </div>
         </th>
       </tr>
     </thead>
@@ -171,26 +210,34 @@ exports[`FlatTable when rendered with proper table data should have expected str
           className="c5 c6"
           data-element="flat-table-row-header"
         >
-          row header
+          <div>
+            row header
+          </div>
         </th>
         <td
           className="c9 c10"
           data-element="flat-table-cell"
         >
-          cell1
+          <div>
+            cell1
+          </div>
         </td>
         <td
           className="c9 c10"
           data-element="flat-table-cell"
         >
-          cell2
+          <div>
+            cell2
+          </div>
         </td>
         <td
           className="c9 c11"
           data-element="flat-table-cell"
           rowSpan="2"
         >
-          cell3
+          <div>
+            cell3
+          </div>
         </td>
       </tr>
       <tr
@@ -201,14 +248,18 @@ exports[`FlatTable when rendered with proper table data should have expected str
           className="c5 c6"
           data-element="flat-table-row-header"
         >
-          row header
+          <div>
+            row header
+          </div>
         </th>
         <td
           className="c9 c10"
           colSpan="2"
           data-element="flat-table-cell"
         >
-          cell1
+          <div>
+            cell1
+          </div>
         </td>
       </tr>
     </tbody>

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { space } from '@styled-system/prop-types';
+
 import StyledFlatTableCell from './flat-table-cell.style';
 
 const FlatTableCell = ({
   align,
   children,
   colspan,
-  rowspan
+  rowspan,
+  py,
+  px,
+  ...rest
 }) => {
   return (
     <StyledFlatTableCell
@@ -14,13 +19,20 @@ const FlatTableCell = ({
       data-element='flat-table-cell'
       colSpan={ colspan }
       rowSpan={ rowspan }
+      py={ py || '10px' }
+      px={ px || 3 }
+      { ...rest }
     >
-      { children }
+      <div>
+        { children }
+      </div>
     </StyledFlatTableCell>
   );
 };
 
 FlatTableCell.propTypes = {
+  /** Styled system spacing props */
+  ...space,
   /** Content alignment */
   align: PropTypes.oneOf(['center', 'left', 'right']),
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.d.ts
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.d.ts
@@ -3,7 +3,7 @@ import { SpacingProps } from '../../../utils/helpers/options-helper';
 
 export interface FlatTableCellProps extends SpacingProps {
   /** Content alignment */
-  align: string;
+  align?: string;
   children?: React.ReactNode | string;
   /** Number of columns that a cell should span */
   colspan?: number | string;

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.d.ts
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { SpacingProps } from '../../../utils/helpers/options-helper';
 
-export interface FlatTableCellProps {
+export interface FlatTableCellProps extends SpacingProps {
   /** Content alignment */
   align: string;
   children?: React.ReactNode | string;

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.spec.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.spec.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import FlatTableCell from './flat-table-cell.component';
+import { testStyledSystemSpacing } from '../../../__spec_helper__/test-utils';
+
+describe('FlatTableCell', () => {
+  testStyledSystemSpacing(props => <FlatTableCell { ...props } />, { py: '10px', px: 3 }, null, { modifier: ' > div' });
+});

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
@@ -1,4 +1,6 @@
 import styled, { css } from 'styled-components';
+import { space } from 'styled-system';
+
 import baseTheme from '../../../style/themes/base';
 
 const StyledFlatTableCell = styled.td`
@@ -6,12 +8,16 @@ const StyledFlatTableCell = styled.td`
     background-color: #fff;
     border-width: 0;
     border-bottom: 1px solid ${theme.table.secondary};
-    overflow: visible;
-    padding: 10px 24px;
     text-overflow: ellipsis;
     text-align: ${align};
     vertical-align: middle;
     white-space: nowrap;
+    padding: 0;
+    
+    > div {
+      box-sizing: border-box;
+      ${space};
+    }
 
     &:first-of-type {
       border-left: 1px solid ${theme.table.secondary};

--- a/src/components/flat-table/flat-table-head/flat-table-head.style.js
+++ b/src/components/flat-table/flat-table-head/flat-table-head.style.js
@@ -9,9 +9,12 @@ const StyledFlatTableHead = styled.thead`
     border-right: none;
     font-weight: 700;
     left: 0;
-    padding: 8px 24px;
     top: 0;
     z-index: ${({ theme }) => theme.zIndex.overlay};
+  }
+
+  ${StyledFlatTableRowHeader} > div {
+    padding: 8px 24px;
   }
 `;
 

--- a/src/components/flat-table/flat-table-header/flat-table-header.component.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.component.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import propTypes from '@styled-system/prop-types';
+
 import StyledFlatTableHeader from './flat-table-header.style';
 
 const FlatTableHeader = ({
-  align, children, colspan, rowspan
+  align, children, colspan, rowspan, width, py, px, ...rest
 }) => {
   return (
     <StyledFlatTableHeader
@@ -11,20 +13,30 @@ const FlatTableHeader = ({
       data-element='flat-table-header'
       colSpan={ colspan }
       rowSpan={ rowspan }
+      colWidth={ width }
+      py={ py || 1 }
+      px={ px || 3 }
+      { ...rest }
     >
-      { children }
+      <div>
+        { children }
+      </div>
     </StyledFlatTableHeader>
   );
 };
 
 FlatTableHeader.propTypes = {
+  /** Styled system spacing props */
+  ...propTypes.space,
   /** Content alignment */
   align: PropTypes.oneOf(['center', 'left', 'right']),
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   /** Number of columns that a header cell should span */
   colspan: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /** Number of rows that a header cell should span */
-  rowspan: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  rowspan: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /** Column width, pass a number to set a fixed width in pixels */
+  width: PropTypes.number
 };
 
 FlatTableHeader.defaultProps = {

--- a/src/components/flat-table/flat-table-header/flat-table-header.d.ts
+++ b/src/components/flat-table/flat-table-header/flat-table-header.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { SpacingProps } from '../../../utils/helpers/options-helper';
 
-export interface FlatTableHeaderProps {
+export interface FlatTableHeaderProps extends SpacingProps {
   /** Content alignment */
   align: string;
   children: React.ReactNode | string;
@@ -8,6 +9,8 @@ export interface FlatTableHeaderProps {
   colspan?: number | string;
   /** Number of rows that a header cell should span */
   rowspan?: number | string;
+  /** Column width, pass a number to set a fixed width in pixels */
+  width?: number;
 }
 
 declare const FlatTableHeader: React.FunctionComponent<FlatTableHeaderProps>;

--- a/src/components/flat-table/flat-table-header/flat-table-header.d.ts
+++ b/src/components/flat-table/flat-table-header/flat-table-header.d.ts
@@ -3,8 +3,8 @@ import { SpacingProps } from '../../../utils/helpers/options-helper';
 
 export interface FlatTableHeaderProps extends SpacingProps {
   /** Content alignment */
-  align: string;
-  children: React.ReactNode | string;
+  align?: string;
+  children?: React.ReactNode | string;
   /** Number of columns that a header cell should span */
   colspan?: number | string;
   /** Number of rows that a header cell should span */

--- a/src/components/flat-table/flat-table-header/flat-table-header.spec.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.spec.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import FlatTableHeader from './flat-table-header.component';
+import StyledFlatTableHeader from './flat-table-header.style';
+import {
+  assertStyleMatch,
+  testStyledSystemSpacing
+} from '../../../__spec_helper__/test-utils';
+
+describe('FlatTableHeader', () => {
+  testStyledSystemSpacing(props => <FlatTableHeader { ...props } />, { py: 1, px: 3 }, null, { modifier: ' > div' });
+
+  it('renders with proper width style rule when width prop is passed', () => {
+    const wrapper = mount(<FlatTableHeader width={ 40 } />);
+    assertStyleMatch(
+      {
+        width: '40px'
+      },
+      wrapper.find(StyledFlatTableHeader)
+    );
+
+    assertStyleMatch(
+      {
+        width: '40px'
+      },
+      wrapper.find(StyledFlatTableHeader),
+      { modifier: ' > div' }
+    );
+  });
+});

--- a/src/components/flat-table/flat-table-header/flat-table-header.style.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.style.js
@@ -1,20 +1,31 @@
 import styled, { css } from 'styled-components';
+import { space } from 'styled-system';
+
 import baseTheme from '../../../style/themes/base';
 
 const StyledFlatTableHeader = styled.th`
-  ${({ align, theme }) => css`
+  ${({ align, theme, colWidth }) => css`
     background-color: transparent;
     border-width: 0;
     border-bottom: 1px solid ${theme.table.secondary};
     box-sizing: border-box;
     font-weight: 700;
     left: auto;
-    padding: 8px 24px;
     text-align: ${align};
     top: 0;
     user-select: none;
     vertical-align: middle;
     white-space: nowrap;
+    word-break: keep-all;
+    padding: 0;
+    ${colWidth && css`width: ${colWidth}px`};
+
+    > div {
+      box-sizing: border-box;
+      ${space};
+      ${colWidth && css`width: ${colWidth}px`};
+    }
+
   `}
 `;
 

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
@@ -1,19 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { space } from '@styled-system/prop-types';
+
 import StyledFlatTableRowHeader from './flat-table-row-header.style';
 
-const FlatTableRowHeader = ({ align, children }) => {
+const FlatTableRowHeader = ({
+  align,
+  children,
+  width,
+  py,
+  px,
+  ...rest
+}) => {
   return (
-    <StyledFlatTableRowHeader align={ align } data-element='flat-table-row-header'>
-      { children }
+    <StyledFlatTableRowHeader
+      align={ align }
+      data-element='flat-table-row-header'
+      colWidth={ width }
+      py={ py || '10px' }
+      px={ px || 3 }
+      { ...rest }
+    >
+      <div>
+        { children }
+      </div>
     </StyledFlatTableRowHeader>
   );
 };
 
 FlatTableRowHeader.propTypes = {
+  /** Styled system spacing props */
+  ...space,
   /** Content alignment */
   align: PropTypes.oneOf(['center', 'left', 'right']),
-  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  /** Column width, pass a number to set a fixed width in pixels */
+  width: PropTypes.number
 };
 
 FlatTableRowHeader.defaultProps = {

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.d.ts
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.d.ts
@@ -3,8 +3,8 @@ import { SpacingProps } from '../../../utils/helpers/options-helper';
 
 export interface FlatTableRowHeaderProps extends SpacingProps {
   /** Content alignment */
-  align: string;
-  children: React.ReactNode | string;
+  align?: string;
+  children?: React.ReactNode | string;
   /** Column width, pass a number to set a fixed width in pixels */
   width?: number;
 }

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.d.ts
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.d.ts
@@ -1,9 +1,12 @@
 import * as React from 'react';
+import { SpacingProps } from '../../../utils/helpers/options-helper';
 
-export interface FlatTableRowHeaderProps {
+export interface FlatTableRowHeaderProps extends SpacingProps {
   /** Content alignment */
   align: string;
   children: React.ReactNode | string;
+  /** Column width, pass a number to set a fixed width in pixels */
+  width?: number;
 }
 
 declare const FlatTableRowHeader: React.FunctionComponent<FlatTableRowHeaderProps>;

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.spec.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import StyledFlatTableRowHeader from './flat-table-row-header.style';
+import FlatTableRowHeader from './flat-table-row-header.component';
+import { assertStyleMatch, testStyledSystemSpacing } from '../../../__spec_helper__/test-utils';
+
+describe('FlatTableRowHeader', () => {
+  testStyledSystemSpacing(
+    props => <FlatTableRowHeader { ...props } />,
+    { py: '10px', px: 3 },
+    null,
+    { modifier: ' > div' }
+  );
+
+  it('renders with proper width style rule when width prop is passed', () => {
+    const wrapper = mount(<FlatTableRowHeader width={ 40 } />);
+    assertStyleMatch(
+      {
+        width: '40px'
+      },
+      wrapper.find(StyledFlatTableRowHeader)
+    );
+
+    assertStyleMatch(
+      {
+        width: '40px'
+      },
+      wrapper.find(StyledFlatTableRowHeader),
+      { modifier: ' > div' }
+    );
+  });
+});

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.js
@@ -1,20 +1,29 @@
 import styled, { css } from 'styled-components';
+import { space } from 'styled-system';
+
 import baseTheme from '../../../style/themes/base';
 
 const StyledFlatTableRowHeader = styled.th`
-  ${({ align, theme }) => css`
+  ${({ align, theme, colWidth }) => css`
     background-color: #fff;
     border: 1px solid ${theme.table.secondary};
     border-top: none;
     box-sizing: border-box;
     left: 0;
     font-weight: normal;
-    padding: 10px 24px;
     position: sticky;
     text-align: ${align};
     top: auto;
     vertical-align: middle;
     white-space: nowrap;
+    padding: 0;
+    ${colWidth && css`width: ${colWidth}px`};
+
+    > div {
+      box-sizing: border-box;
+      ${colWidth && css`width: ${colWidth}px`};
+      ${space};
+    }
   `}
 `;
 

--- a/src/components/flat-table/flat-table-row/__snapshots__/flat-table-row.spec.js.snap
+++ b/src/components/flat-table/flat-table-row/__snapshots__/flat-table-row.spec.js.snap
@@ -5,12 +5,19 @@ exports[`FlatTableRow should have expected styles 1`] = `
   background-color: #fff;
   border-width: 0;
   border-bottom: 1px solid #CCD6DB;
-  overflow: visible;
-  padding: 10px 24px;
   text-overflow: ellipsis;
   text-align: left;
   vertical-align: middle;
   white-space: nowrap;
+  padding: 0;
+}
+
+.c1 > div {
+  box-sizing: border-box;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-left: 24px;
+  padding-right: 24px;
 }
 
 .c1:first-of-type {
@@ -28,7 +35,6 @@ exports[`FlatTableRow should have expected styles 1`] = `
   min-width: 100%;
   table-layout: fixed;
   width: auto;
-  word-break: break-all;
 }
 
 <table>
@@ -41,13 +47,17 @@ exports[`FlatTableRow should have expected styles 1`] = `
         className="c1"
         data-element="flat-table-cell"
       >
-        cell1
+        <div>
+          cell1
+        </div>
       </td>
       <td
         className="c1"
         data-element="flat-table-cell"
       >
-        cell2
+        <div>
+          cell2
+        </div>
       </td>
     </tr>
   </tbody>

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.js
@@ -12,7 +12,6 @@ const StyledFlatTableRow = styled.tr`
   min-width: 100%;
   table-layout: fixed;
   width: auto;
-  word-break: break-all;
 
   ${({ isRowInteractive, theme }) => isRowInteractive && css`
     cursor: pointer;

--- a/src/components/flat-table/flat-table.stories.js
+++ b/src/components/flat-table/flat-table.stories.js
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
-import { boolean, withKnobs, select } from '@storybook/addon-knobs';
+import {
+  boolean, withKnobs, select, number
+} from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import OptionsHelper from '../../utils/helpers/options-helper/options-helper';
 import {
@@ -30,6 +32,8 @@ export const basic = () => {
   const hasHeaderRow = boolean('hasHeaderRow', false);
   const hasClickableRows = boolean('hasClickableRows', false);
   const colorTheme = select('colorTheme', [...OptionsHelper.flatTableThemes], 'dark');
+  const firstColumnWidth = number('first column width', 150);
+  const secondColumnWidth = number('second column width', 120);
   const processed = getTableData();
   // used to show how the table behaves constrained or on lower resolutions
   const tableSizeConstraints = {
@@ -70,7 +74,11 @@ export const basic = () => {
                 }
 
                 return (
-                  <Component key={ cellData.id }>
+                  <Component
+                    key={ cellData.id }
+                    { ...(index === 0 && { width: firstColumnWidth }) }
+                    { ...(index === 1 && { width: secondColumnWidth }) }
+                  >
                     { cellData.content }
                   </Component>
                 );
@@ -276,7 +284,7 @@ const headRowData = {
 };
 
 const rowData = {
-  client: (<div><h5 style={ { margin: 0 } }>Soylent Corp</h5>John Doe</div>),
+  client: (<><h5 style={ { margin: 0 } }>Soylent Corp</h5>John Doe</>),
   clientType: 'business',
   categories: 'Group1, Group2, Group3',
   products: 'Accounting',

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
 import { useState, useRef } from 'react';
+import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
 import { 
   FlatTable, 
   FlatTableHead, 
@@ -14,17 +15,19 @@ import {
 import BatchSelection from '../batch-selection';
 import IconButton from '../icon-button';
 import Icon from '../icon';
+import Textbox from '../../__experimental__/components/textbox';
 import Pager from '../pager'
+import { ActionPopover, ActionPopoverItem } from '../action-popover';
 import { SidebarContext } from '../drawer';
 
-<Meta title="Design System/Flat Table" />
+<Meta title="Design System/Flat Table" parameters={{ info: { disable: true }}} />
 
 # Flat Table
 
 ### Basic usage:
 
 <Preview>
-  <Story name="basic" parameters={{ info: { disable: true }}} >
+  <Story name="basic">
     <FlatTable>
       <FlatTableHead>
         <FlatTableRow>
@@ -66,9 +69,9 @@ import { SidebarContext } from '../drawer';
 
 ### With row headers
 <Preview>
-  <Story name="with row header" parameters={{ info: { disable: true }}} >
+  <Story name="with row header">
     <div style={ { width: '380px', overflowX: 'auto' } }>
-      <FlatTable hasRowHeader>
+      <FlatTable>
         <FlatTableHead>
           <FlatTableRow>
             <FlatTableRowHeader>Name</FlatTableRowHeader>
@@ -108,9 +111,73 @@ import { SidebarContext } from '../drawer';
   </Story>
 </Preview>
 
+### With custom cell paddings
+
+Padding can be set on each cell individually by using the usual spacing props syntax.
+<Preview>
+  <Story name="with custom cell paddings">
+    <FlatTable>
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader px={5} py={2}>Name</FlatTableHeader>
+          <FlatTableHeader py={2}>Location</FlatTableHeader>
+          <FlatTableHeader py={2}>Relationship Status</FlatTableHeader>
+          <FlatTableHeader py={2}>Dependents</FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+      <FlatTableBody>
+        {[1,2,3,4].map((key) => 
+          <FlatTableRow key={key}>
+            <FlatTableCell px={5}>John Doe</FlatTableCell>
+            <FlatTableCell>London</FlatTableCell>
+            <FlatTableCell>Single</FlatTableCell>
+            <FlatTableCell>5</FlatTableCell>
+          </FlatTableRow>
+        )}
+      </FlatTableBody>
+    </FlatTable>
+  </Story>
+</Preview>
+
+### With custom column width
+
+Column width can be set by passing number as a `width` prop to the column header component.
+**Column width can't be smaller than the sum of horizontal cell padding and content width.**
+<Preview>
+  <Story name="with custom column width">
+    <FlatTable>
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader>Name</FlatTableHeader>
+          <FlatTableHeader>Location</FlatTableHeader>
+          <FlatTableHeader width={200}>Notes</FlatTableHeader>
+          <FlatTableHeader width={40} px={1}>
+            <Icon iconColor="on-dark-background" type="settings"/>
+          </FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+      <FlatTableBody>
+        {[1,2,3,4].map((key) => 
+          <FlatTableRow key={key}>
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableCell>London</FlatTableCell>
+            <FlatTableCell><Textbox size="small"/></FlatTableCell>
+            <FlatTableCell px={1}>
+              <ActionPopover>
+                <ActionPopoverItem onClick={() => {}} icon='graph'>Business</ActionPopoverItem>
+                <ActionPopoverItem onClick={() => {}} icon='email'>Email Invoice</ActionPopoverItem>
+              </ActionPopover>
+            </FlatTableCell>
+          </FlatTableRow>
+        )}
+      </FlatTableBody>
+    </FlatTable>
+  </Story>
+</Preview>
+
 ### With stickyHead prop set to true
 <Preview>
-  <Story name="with sticky head" parameters={{ info: { disable: true }}} >
+  <Story name="with sticky head">
     <div style={ { height: '150px' } }>
       <FlatTable hasStickyHead>
         <FlatTableHead>
@@ -154,7 +221,7 @@ import { SidebarContext } from '../drawer';
 
 ### With clickable rows
 <Preview>
-  <Story name="with clickable rows" parameters={{ info: { disable: true }}} >
+  <Story name="with clickable rows">
     <FlatTable>
       <FlatTableHead>
         <FlatTableRow>
@@ -199,7 +266,7 @@ import { SidebarContext } from '../drawer';
 To create a transparent effect for the header, the background-color is set to match a white background
 
 <Preview>
-  <Story name="transparent-white theme" parameters={{ info: { disable: true }}} >
+  <Story name="transparent-white theme">
     <div>
       <FlatTable colorTheme="transparent-white">
         <FlatTableHead>
@@ -246,7 +313,7 @@ To create a transparent effect for the header, the background-color is set to ma
 To create a transparent effect for the header, the background-color is set to match the base app background
 
 <Preview>
-  <Story name="transparent-base theme" parameters={{ info: { disable: true }}} >
+  <Story name="transparent-base theme">
     <FlatTable colorTheme="transparent-base">
      <FlatTableHead>
         <FlatTableRow>
@@ -288,7 +355,7 @@ To create a transparent effect for the header, the background-color is set to ma
 
 ### With light theme 
 <Preview>
-  <Story name="light theme" parameters={{ info: { disable: true }}} >
+  <Story name="light theme">
     <FlatTable colorTheme="light">
       <FlatTableHead>
         <FlatTableRow>
@@ -335,7 +402,7 @@ To create a transparent effect for the header, the background-color is set to ma
 
 ### With a cell spanning the whole row 
 <Preview>
-  <Story name="with colspan" parameters={{ info: { disable: true }}} >
+  <Story name="with colspan">
       <FlatTable>
         <FlatTableHead>
           <FlatTableRow>
@@ -356,7 +423,7 @@ To create a transparent effect for the header, the background-color is set to ma
 
 ### With a cell spanning the whole column 
 <Preview>
-  <Story name="with rowspan" parameters={{ info: { disable: true }}} >
+  <Story name="with rowspan">
       <FlatTable>
         <FlatTableHead>
           <FlatTableRow>
@@ -395,7 +462,7 @@ If a given action is available for some, but not all, selected rows, then the ac
 
 Where icons are used for batch actions, they have text labels too, or tooltips to make their function clear. There are always confirmation dialogs for destructive actions, or those difficult to undo.
 <Preview>
-  <Story name="selectable rows" parameters={{ info: { disable: true } }} >
+  <Story name="selectable rows">
     {() => {
       const [selectAll, setSelectAll] = useState(false);
       const [selectedRows, setSelectedRows] = useState({ one: false, two: false, three: false, four: false });
@@ -473,7 +540,7 @@ Where icons are used for batch actions, they have text labels too, or tooltips t
 ### With Highlightable Rows
 It is possible to utilise the selected and onClick props on the FlatTableRow to highlight single rows of data.
 <Preview>
-  <Story name="highlightable rows" parameters={{ info: { disable: true } }} >
+  <Story name="highlightable rows">
     {() => {
       const [highlightedRow, setHighlightedRow] = useState('');
       const handleHighlightRow = (id) => {
@@ -528,7 +595,7 @@ It is possible to utilise the selected and onClick props on the FlatTableRow to 
 ### With Selectable and Highlightable Rows
 It is also possible to integrate selection of multiple rows and the highlighting of single rows.
 <Preview>
-  <Story name="selectable and highlightable rows" parameters={{ info: { disable: true } }} >
+  <Story name="selectable and highlightable rows">
     {() => {
       const [selectAll, setSelectAll] = useState(false);
       const [selectedRows, setSelectedRows] = useState({ one: false, two: false, three: false, four: false });
@@ -616,7 +683,7 @@ If pagination is needed, this can be shown at the bottom of the table.
 
 Balance performance concerns with the convenience of the user being able to see more data - we suggest giving the user the option of showing 25, 50, and 100 table rows before pagination, with a default of 50. Whatever the user selects, make this sticky per user, per table, and between sessions.
 <Preview>
-  <Story name="paginated" parameters={{ info: { disable: true }}} >
+  <Story name="paginated">
     {() => {
       const rows = [
         <FlatTableRow key='0'>
@@ -707,7 +774,7 @@ Balance performance concerns with the convenience of the user being able to see 
 
 ### When a child of Sidebar
 <Preview>
-  <Story name="when a child of sidebar" parameters={{ info: { disable: true }}} >
+  <Story name="when a child of sidebar">
     {() => {
       const [selectAll, setSelectAll] = useState(false);
       const [selectedRows, setSelectedRows] = useState({ one: false, two: false, three: false, four: false });
@@ -812,7 +879,12 @@ Balance performance concerns with the convenience of the user being able to see 
 
 ### FlatTableHeader
 
-<Props of={FlatTableHeader} />
+<StyledSystemProps
+  of={ FlatTableHeader }
+  spacing
+  defaults={{ py: 1, px: 3 }}
+  noHeader
+/>
 
 ### Sort
 
@@ -820,11 +892,21 @@ Balance performance concerns with the convenience of the user being able to see 
 
 ### FlatTableCell
 
-<Props of={FlatTableCell} />
+<StyledSystemProps
+  of={ FlatTableCell }
+  spacing
+  defaults={{ py: '10px', px: 3 }}
+  noHeader
+/>
 
 ### FlatTableRowHeader
 
-<Props of={FlatTableRowHeader} />
+<StyledSystemProps
+  of={ FlatTableRowHeader }
+  spacing
+  defaults={{ py: "10px", px: 3 }}
+  noHeader
+/>
 
 ### FlatTableCheckbox
 

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -113,7 +113,7 @@ import { SidebarContext } from '../drawer';
 
 ### With custom cell paddings
 
-Padding can be set on each cell individually by using the usual spacing props syntax.
+Padding can be set on each cell individually by using the spacing props syntax. Check prop tables at the bottom of this document for more information.
 <Preview>
   <Story name="with custom cell paddings">
     <FlatTable>

--- a/src/components/flat-table/flat-table.style.js
+++ b/src/components/flat-table/flat-table.style.js
@@ -10,9 +10,7 @@ const StyledFlatTable = styled.table`
   border-radius: 0px;
   border-spacing: 0;
   min-width: 100%;
-  table-layout: fixed;
-  width: auto;
-  word-break: break-all;
+  width: 100%;
 `;
 
 const StyledFlatTableWrapper = styled.div`


### PR DESCRIPTION
### Proposed behaviour
Set custom column width by passing number as a `width` to the column headers components.
Set custom cell padding on each cell individually by using the usual spacing props syntax.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
Storybook -> Design System -> Flat Table -> with custom cell paddings
Storybook -> Design System -> Flat Table -> with custom column width
Storybook -> Design System -> Flat Table -> Test -> knobs
