### PR TITLE
test: remove cypress tests covered by chromatic - FE-3204

### DIFF
--- a/cypress/features/regression/experimental/checkbox.feature
+++ b/cypress/features/regression/experimental/checkbox.feature
@@ -11,16 +11,6 @@ Feature: Experimental Checkbox component
       | !@#$%^*()_+-=~[];:.,?{}&"'<> | labelSpecialCharacter |
 
   @positive
-  Scenario: Disable and enable checkbox
-    When I open Default "Experimental Checkbox Test" component in noIFrame with "checkbox" json from "experimental" using "disabledFalse" object name
-    Then Checkbox is enabled
-
-  @positive
-  Scenario: Disable checkbox
-    When I open Default "Experimental Checkbox Test" component in noIFrame with "checkbox" json from "experimental" using "disabled" object name
-    Then Checkbox is disabled
-
-  @positive
   Scenario Outline: Change Checkbox component field help to <fieldHelp>
     When I open Default "Experimental Checkbox Test" component in noIFrame with "checkbox" json from "experimental" using "<nameOfObject>" object name
     Then fieldHelp on preview is set to <fieldHelp> in NoIFrame
@@ -28,26 +18,6 @@ Feature: Experimental Checkbox component
       | fieldHelp                    | nameOfObject              |
       | mp150ú¿¡üßä                  | fieldHelpOtherLanguage    |
       | !@#$%^*()_+-=~[];:.,?{}&"'<> | fieldHelpSpecialCharacter |
-
-  @positive
-  Scenario: Enable fieldHelpInline
-    When I open default "Experimental Checkbox Test" component in noIFrame with "checkbox" json from "experimental" using "fieldHelpInline" object name
-    Then Checkbox field help is inline
-
-  @positive
-  Scenario: Enable and disable fieldHelpInline
-    When I open default "Experimental Checkbox Test" component in noIFrame with "checkbox" json from "experimental" using "fieldHelpInlineDisabled" object name
-    Then Checkbox field help is not inline
-
-  @positive
-  Scenario: Enable reverse checkbox
-    When I open Default "Experimental Checkbox Test" component in noIFrame with "checkbox" json from "experimental" using "reverse" object name
-    Then Checkbox is set to reverse and has width "16px"
-
-  @positive
-  Scenario: Enable and disable reverse checkbox
-    When I open Default "Experimental Checkbox Test" component in noIFrame with "checkbox" json from "experimental" using "reverseFalse" object name
-    Then Checkbox is not set to reverse and has width "16px"
 
   @positive
   Scenario Outline: Change Checkbox component label help to <labelHelp>
@@ -58,15 +28,6 @@ Feature: Experimental Checkbox component
       | labelHelp                    | nameOfObject              |
       | mp150ú¿¡üßä                  | labelHelpOtherLanguage    |
       | !@#$%^*()_+-=~[];:.,?{}&"'<> | labelHelpSpecialCharacter |
-
-  @positive
-  Scenario Outline: Change Checkbox size to <size>
-    When I open Default "Experimental Checkbox Test" component in noIFrame with "checkbox" json from "experimental" using "<nameOfObject>" object name
-    Then Checkbox size on preview is set to "<size>"
-    Examples:
-      | size  | nameOfObject |
-      | small | smallSize    |
-      | large | largeSize    |
 
   @positive
   Scenario: Change Checkbox tick color

--- a/cypress/features/regression/experimental/switch.feature
+++ b/cypress/features/regression/experimental/switch.feature
@@ -11,16 +11,6 @@ Feature: Switch component
       | !@#$%^*()_+-=~[];:.,?{}&"'<> | fieldHelpSpecialCharacter |
 
   @positive
-  Scenario: Enable fieldHelpInline
-    When I open Default "Experimental Switch Test" component in noIFrame with "switch" json from "experimental" using "fieldHelpInline" object name
-    Then Switch is set to fieldHelpInline and has marginLeft set to "0px"
-
-  @positive
-  Scenario: Disable fieldHelpInline
-    When I open Default "Experimental Switch Test" component in noIFrame with "switch" json from "experimental" using "fieldHelpInlineFalse" object name
-    Then Switch is not set to fieldHelpInline and has marginTop set to "8px"
-
-  @positive
   Scenario Outline: Change Switch component label to <label>
     When I open Default "Experimental Switch Test" component in noIFrame with "switch" json from "experimental" using "<nameOfObject>" object name
     Then label on preview is <label> in NoIFrame
@@ -28,16 +18,6 @@ Feature: Switch component
       | label                        | nameOfObject          |
       | mp150ú¿¡üßä                  | labelOtherLanguage    |
       | !@#$%^*()_+-=~[];:.,?{}&"'<> | labelSpecialCharacter |
-
-  @positive
-  Scenario: Enable labelInline property
-    When I open Default "Experimental Switch Test" component in noIFrame with "switch" json from "experimental" using "labelInline" object name
-    Then label is inline
-
-  @positive
-  Scenario: Disabled labelInline property
-    When I open Default "Experimental Switch Test" component in noIFrame with "switch" json from "experimental" using "labelInlineFalse" object name
-    Then label is not inline
 
   @positive
   Scenario: Enable loading property
@@ -48,32 +28,3 @@ Feature: Switch component
   Scenario: Disable loading property
     When I open Default "Experimental Switch Test" component in noIFrame with "switch" json from "experimental" using "loadingFalse" object name
     Then Switch component is not loading
-
-  @positive
-  Scenario: Disable Switch
-    When I open Default "Experimental Switch Test" component in noIFrame with "switch" json from "experimental" using "disabled" object name
-    Then Switch is disabled
-
-  @positive
-  Scenario: Enable Switch
-    When I open Default "Experimental Switch Test" component in noIFrame with "switch" json from "experimental" using "disabledFalse" object name
-    Then Switch is enabled
-
-  @positive
-  Scenario Outline: Change Switch size to <size>
-    When I open Default "Experimental Switch Test" component in noIFrame with "switch" json from "experimental" using "<nameOfObject>" object name
-    Then Switch is set to "<size>"
-    Examples:
-      | size  | nameOfObject |
-      | small | sizeSmall    |
-      | large | sizeLarge    |
-
-  @positive
-  Scenario: Enable reverse property
-    When I open Default "Experimental Switch Test" component in noIFrame with "switch" json from "experimental" using "reverse" object name
-    Then Switch component is reversed
-
-  @positive
-  Scenario: Disable reverse property
-    When I open Default "Experimental Switch Test" component in noIFrame with "switch" json from "experimental" using "reverseFalse" object name
-    Then Switch component is not reversed

--- a/cypress/features/regression/test/pager.feature
+++ b/cypress/features/regression/test/pager.feature
@@ -72,15 +72,6 @@ Feature: Pager component
     Then pageSize is not visible
 
   @positive
-  Scenario Outline: Pagination <button> button is disabled
-    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "default" object name
-    Then pagination "<button>" button is disabled
-    Examples:
-      | button   |
-      | first    |
-      | previous |
-
-  @positive
   Scenario Outline: Pagination <button> button is disabled after clicking on last button
     Given I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "default" object name
     When I click "last" pagination button
@@ -121,11 +112,6 @@ Feature: Pager component
       | button |
       | next   |
       | last   |
-
-  @positive
-  Scenario: Pagination buttons are disabled
-    When I open Test test_basic "Pager" component in noIFrame with "pager" json from "test" using "disabled" object name
-    Then pagination buttons are disabled
 
   @positive
   Scenario: Pagination input has golden border

--- a/cypress/features/regression/test/tabs.feature
+++ b/cypress/features/regression/test/tabs.feature
@@ -2,25 +2,8 @@ Feature: Tabs component
   I want to check Tabs component properties
 
   @positive
-  Scenario Outline: I align Tabs to <nameOfObject>
-    When I open Test test_basic "Tabs" component in noIFrame with "tabs" json from "test" using "<nameOfObject>" object name
-    Then Tabs component is align to "<value>"
-    Examples:
-      | nameOfObject | value |
-      | alignRignt   | right |
-      | alignLeft    | start |
-
-  @positive
-  Scenario Outline: I set Tabs position to <positionLeft>
-    When I open Test test_basic "Tabs" component in noIFrame with "tabs" json from "test" using "<nameOfObject>" object name
-    Then Tabs component position is set to "<value>"
-    Examples:
-      | nameOfObject | value  |
-      | positionLeft | column |
-      | positionTop  | row    |
-
-  @positive
   Scenario Outline: Tab <id> content is set and visible
+    Given I open Test test_basic "Tabs" component in noIFrame with "tabs" json from "test" using "default" object name
     When I open Tab <id>
     Then Tab <id> content is visible
     Examples:

--- a/cypress/fixtures/experimental/checkbox.json
+++ b/cypress/fixtures/experimental/checkbox.json
@@ -5,46 +5,16 @@
   "labelSpecialCharacter": {
     "label": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
   },
-  "disabledFalse": {
-    "disabled": false
-  },
-  "disabled": {
-    "disabled": true
-  },
   "fieldHelpOtherLanguage": {
     "fieldHelp": "mp150ú¿¡üßä"
   },
   "fieldHelpSpecialCharacter": {
     "fieldHelp": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
   },
-  "fieldHelpInline": {
-    "fieldHelpInline": true
-  },
-  "fieldHelpInlineDisabled": {
-    "fieldHelpInline": false
-  },
-  "reverse": {
-    "reverse": true
-  },
-  "reverseFalse": {
-    "reverse": false
-  },
   "labelHelpOtherLanguage": {
     "labelHelp": "mp150ú¿¡üßä"
   },
   "labelHelpSpecialCharacter": {
     "labelHelp": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
-  },
-  "smallSize": {
-    "size": "small"
-  },
-  "largeSize": {
-    "size": "large"
-  },
-  "labelAlignLeft": {
-    "labelAlign": "left"
-  },
-  "labelAlignRight": {
-    "labelAlign": "right"
   }
 }

--- a/cypress/fixtures/experimental/switch.json
+++ b/cypress/fixtures/experimental/switch.json
@@ -5,58 +5,16 @@
   "fieldHelpSpecialCharacter": {
     "fieldHelp": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
   },
-  "fieldHelpInline": {
-    "fieldHelpInline": true
-  },
-  "fieldHelpInlineFalse": {
-    "fieldHelpInline": false
-  },
   "labelOtherLanguage": {
     "label": "mp150ú¿¡üßä"
   },
   "labelSpecialCharacter": {
     "label": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
   },
-  "inputWidth1": {
-    "labelInline": true,
-    "inputWidth": 1
-  },
-  "inputWidth10": {
-    "labelInline": true,
-    "inputWidth": 10
-  },
-  "inputWidth150": {
-    "labelInline": true,
-    "inputWidth": 150
-  },
-  "labelInline": {
-    "labelInline": true
-  },
-  "labelInlineFalse": {
-    "labelInline": false
-  },
   "loading": {
     "loading": true
   },
   "loadingFalse": {
     "loading": false
-  },
-  "disabled": {
-    "disabled": true
-  },
-  "disabledFalse": {
-    "disabled": false
-  },
-  "sizeSmall": {
-    "size": "small"
-  },
-  "sizeLarge": {
-    "size": "large"
-  },
-  "reverse": {
-    "reverse": true
-  },
-  "reverseFalse": {
-    "reverse": false
   }
 }

--- a/cypress/fixtures/test/pager.json
+++ b/cypress/fixtures/test/pager.json
@@ -63,9 +63,5 @@
   },
   "default": {
 
-  },
-  "disabled": {
-    "totalRecors": 1,
-    "pageSize": 10
   }
 }

--- a/cypress/fixtures/test/tabs.json
+++ b/cypress/fixtures/test/tabs.json
@@ -1,14 +1,5 @@
 { 
-  "alignRignt": {
-    "align": "right"
-  },
-  "alignLeft": {
-    "align": "left"
-  },
-  "positionTop": {
-    "position": "top"
-  },
-  "positionLeft": {
-    "position": "left"
+  "default": {
+
   }
 } 

--- a/cypress/locators/checkbox/index.js
+++ b/cypress/locators/checkbox/index.js
@@ -1,10 +1,7 @@
 import {
-  CHECKBOX, CHECKBOX_DATA_COMPONENT,
+  CHECKBOX,
 } from './locators';
 
 // component preview locators
-
 export const checkboxRole = () => cy.iFrame(CHECKBOX);
 export const checkbox = position => cy.get(CHECKBOX).eq(position);
-export const checkboxRoleNoIFrame = () => cy.get(CHECKBOX);
-export const checkboxDataComponentNoIframe = () => cy.get(CHECKBOX_DATA_COMPONENT);

--- a/cypress/locators/checkbox/locators.js
+++ b/cypress/locators/checkbox/locators.js
@@ -1,3 +1,2 @@
 // component preview locators
 export const CHECKBOX = '[role="checkbox"]';
-export const CHECKBOX_DATA_COMPONENT = '[data-component="checkbox"]';

--- a/cypress/locators/switch/index.js
+++ b/cypress/locators/switch/index.js
@@ -4,5 +4,3 @@ import { SWITCH_DATA_COMPONENT } from './locators';
 export const switchDataComponent = () => cy.get(SWITCH_DATA_COMPONENT);
 export const switchInput = () => switchDataComponent().find('input')
 export const switchLoading = () => switchDataComponent().find('div > div > div > div > span > div').children();
-export const switchInputByPosition = position => switchDataComponent().find('div div div').children().eq(position)
-  .find('input');

--- a/cypress/locators/tabs/index.js
+++ b/cypress/locators/tabs/index.js
@@ -1,6 +1,3 @@
-import { TABS } from './locators';
-
 // component preview locators
-export const tabs = () => cy.get(TABS);
 export const tabById = id => cy.get(`[data-tabid="tab-${id}"]`);
 export const tabContentById = id => cy.get(`[aria-labelledby="tab-${id}-tab"]`);

--- a/cypress/locators/tabs/locators.js
+++ b/cypress/locators/tabs/locators.js
@@ -1,2 +1,0 @@
-// component preview locators
-export const TABS = '[data-component="tabs"] > ul';

--- a/cypress/support/step-definitions/checkbox-steps.js
+++ b/cypress/support/step-definitions/checkbox-steps.js
@@ -1,47 +1,9 @@
 import {
   checkbox,
   checkboxRole,
-  checkboxDataComponentNoIframe,
-  checkboxRoleNoIFrame,
 } from '../../locators/checkbox';
-import { labelNoIFrame, fieldHelpPreviewNoIFrame } from '../../locators';
+import { labelNoIFrame } from '../../locators';
 import { positionOfElement } from '../helper';
-
-Then('Checkbox is set to reverse and has width {string}', (width) => {
-  checkboxDataComponentNoIframe().children().children().children()
-    .find(`div:nth-child(${positionOfElement('third')}) > input`)
-    .should('have.css', 'box-sizing', 'border-box')
-    .and('have.css', 'width', width);
-});
-
-Then('Checkbox is not set to reverse and has width {string}', (width) => {
-  checkboxDataComponentNoIframe().children().children().children()
-    .find(`div:nth-child(${positionOfElement('second')})`)
-    .should('have.css', 'box-sizing', 'border-box')
-    .and('have.css', 'width', width);
-});
-
-Then('Checkbox size on preview is set to {string}', (size) => {
-  if (size === 'small') {
-    checkboxRoleNoIFrame().should('have.css', 'width', '16px')
-      .and('have.css', 'height', '16px');
-  } else {
-    checkboxRoleNoIFrame().should('have.css', 'width', '24px')
-      .and('have.css', 'height', '24px');
-  }
-});
-
-Then('Checkbox field help is inline', () => {
-  fieldHelpPreviewNoIFrame().should('have.css', 'margin-left', '0px')
-    .and('have.css', 'margin-top', '0px')
-    .and('have.css', 'padding-left', '8px');
-});
-
-Then('Checkbox field help is not inline', () => {
-  fieldHelpPreviewNoIFrame().should('have.css', 'margin-left', '16px')
-    .and('have.css', 'margin-top', '0px')
-    .and('have.css', 'padding-left', '8px');
-});
 
 Given('I check {string} checkbox', (position) => {
   checkbox(positionOfElement(position)).click();
@@ -49,21 +11,6 @@ Given('I check {string} checkbox', (position) => {
 
 Then('checkbox label on preview is {word}', (text) => {
   labelNoIFrame().should('have.text', `${text} (default)`);
-});
-
-Then('Checkbox is enabled', () => {
-  checkboxDataComponentNoIframe().should('not.be.disabled')
-    .and('not.have.attr', 'disabled');
-  checkboxDataComponentNoIframe().children().should('not.be.disabled')
-    .and('not.have.attr', 'disabled');
-  checkboxRoleNoIFrame().should('not.be.disabled')
-    .and('not.have.attr', 'disabled');
-});
-
-Then('Checkbox is disabled', () => {
-  checkboxDataComponentNoIframe().should('have.attr', 'disabled');
-  checkboxDataComponentNoIframe().children().should('have.attr', 'disabled');
-  checkboxRoleNoIFrame().should('have.attr', 'disabled');
 });
 
 When('I mark checkbox on preview', () => {

--- a/cypress/support/step-definitions/switch-steps.js
+++ b/cypress/support/step-definitions/switch-steps.js
@@ -1,33 +1,6 @@
 import {
-  switchLoading, switchInput, switchInputByPosition,
+  switchLoading, switchInput,
 } from '../../locators/switch';
-import { getDataElementByValue } from '../../locators';
-import { positionOfElement } from '../helper';
-
-Then('Switch is disabled', () => {
-  getDataElementByValue('label').should('have.attr', 'disabled');
-  switchInput().should('be.disabled')
-    .and('have.attr', 'disabled');
-});
-
-Then('Switch is enabled', () => {
-  getDataElementByValue('label').should('not.be.disabled')
-    .and('not.have.attr', 'disabled');
-  switchInput().should('not.be.disabled')
-    .and('not.have.attr', 'disabled');
-});
-
-Then('Switch is set to {string}', (size) => {
-  if (size === 'small') {
-    switchInput().should('have.css', 'width', '60px')
-      .and('have.css', 'height', '24px');
-  } else if (size === 'large') {
-    switchInput().should('have.css', 'width', '78px')
-      .and('have.css', 'height', '40px');
-  } else {
-    throw new Error('Only small or large size can be applied');
-  }
-});
 
 Then('Switch component is loading', () => {
   switchInput().should('have.attr', 'disabled');
@@ -37,12 +10,4 @@ Then('Switch component is loading', () => {
 Then('Switch component is not loading', () => {
   switchInput().should('not.have.attr', 'disabled');
   switchLoading().should('not.have.attr', 'data-component', 'loader');
-});
-
-Then('Switch component is reversed', () => {
-  switchInputByPosition(positionOfElement('second')).should('have.attr', 'name', 'switch-default');
-});
-
-Then('Switch component is not reversed', () => {
-  switchInputByPosition(positionOfElement('first')).should('have.attr', 'name', 'switch-default');
 });

--- a/cypress/support/step-definitions/tabs-steps.js
+++ b/cypress/support/step-definitions/tabs-steps.js
@@ -1,14 +1,6 @@
-import { tabs, tabById, tabContentById } from '../../locators/tabs';
+import { tabById, tabContentById } from '../../locators/tabs';
 
 const TAB_CONTENT = 'Content for tab ';
-
-Then('Tabs component is align to {string}', (value) => {
-  tabs().should('have.css', 'text-align', value);
-});
-
-Then('Tabs component position is set to {string}', (value) => {
-  tabs().should('have.css', 'flex-direction', value);
-});
 
 Then('I open Tab {int}', (id) => {
   tabById(id).click();


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Tests that were duplicated, now are covered only by chromatic

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
We have tests that are duplicated by cypress tests and chromatic stories in our project. In that situation, we need only one of these to be sure that components are fine.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
