### PR TITLE
 fix(select): destructure spacing props into style wrapper

### DIFF
--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -30,6 +30,7 @@ const SimpleSelect = React.forwardRef(({
   onClick,
   onFocus,
   onKeyDown,
+  onBlur,
   ...props
 }, inputRef) => {
   const selectListId = useRef(guid());
@@ -314,6 +315,7 @@ const SimpleSelect = React.forwardRef(({
       onFocus: handleTextboxFocus,
       onKeyDown: handleTextboxKeydown,
       onChange: handleTextboxChange,
+      onBlur,
       ...props
     };
   }


### PR DESCRIPTION
Fixes: #3262, Fixes FE-3207

### Proposed behaviour
Fix https://github.com/Sage/carbon/issues/3262 where Select remains in error, even after choosing a value.

### Current behaviour
See above issue.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
Sandbox here: https://codesandbox.io/s/myformikform-2ysql 
*Look at the PR one generated below for the "after" test*
