### PR TITLE
feat(filterable-select): add list action button (FE-3034)

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -76,6 +76,6 @@
   "test_default": "-test--default",
   "tile_with_definition_list_default": "--tile-with-definition-list-default",
   "inline_controls": "--inline-controls",
-  "validation_icon": "--validation-icon",
-  "required": "--required"
+  "required": "--required",
+  "validation_icon": "--validation-icon"
 }

--- a/cypress.env.json
+++ b/cypress.env.json
@@ -77,5 +77,6 @@
   "tile_with_definition_list_default": "--tile-with-definition-list-default",
   "inline_controls": "--inline-controls",
   "required": "--required",
+  "with_action_button":"--with-action-button",
   "validation_icon": "--validation-icon"
 }

--- a/cypress/features/regression/designSystem/filterableSelect.feature
+++ b/cypress/features/regression/designSystem/filterableSelect.feature
@@ -55,3 +55,11 @@ Feature: Design System Filterable Select component
     When I click on "first" option on Select list
     Then Design system Select input has "Amber" value
       And "filterable" Select list is closed
+
+  @positive
+  Scenario: Selecting the action button opens up a dialog box
+    Given I open "Design System Select filterable" component page "with_action_button" in no iframe
+    When I click on dropdown button
+      And I click onto "Add a New Element" button
+    Then Dialog is visible
+    

--- a/cypress/locators/pages/index.js
+++ b/cypress/locators/pages/index.js
@@ -8,3 +8,6 @@ export const closeDataElement = () => cy.get(CLOSE_DATA_ELEMENT);
 export const backArrow = () => cy.iFrame(BACK_ARROW);
 
 export const closeDataElementIFrame = () => cy.iFrame(CLOSE_DATA_ELEMENT);
+
+export const dataComponentButtonByTextNoIFrame = text => cy.get(BUTTON_DATA_COMPONENT)
+  .contains(text);

--- a/cypress/support/step-definitions/dialog-steps.js
+++ b/cypress/support/step-definitions/dialog-steps.js
@@ -57,3 +57,7 @@ Then('footer buttons have color {string} and has {int} px border', (color, px) =
   dialogStickyFormFooterButton(positionOfElement('second')).should('have.css', 'background-color')
     .and('contain', color);
 });
+
+Then('Dialog is visible', () => {
+  dialogPreview().should('be.visible');
+});

--- a/cypress/support/step-definitions/select-steps.js
+++ b/cypress/support/step-definitions/select-steps.js
@@ -24,6 +24,7 @@ import {
 } from '../../locators/select';
 import { positionOfElement, keyCode } from '../helper';
 import { label } from '../../locators';
+import { dataComponentButtonByTextNoIFrame } from '../../locators/pages';
 
 const transparentBorderColor = 'rgba(0, 0, 0, 0.85)';
 const notTransparentBorderColor = 'rgb(102, 133, 146)';
@@ -248,4 +249,8 @@ When('I click on {string} option on Select list in iframe', (position) => {
 
 When('I click on Select label', () => {
   label().click();
+});
+
+When('I click onto {string} button', (buttonName) => {
+  dataComponentButtonByTextNoIFrame(buttonName).click();
 });

--- a/src/components/button/button.component.js
+++ b/src/components/button/button.component.js
@@ -155,7 +155,7 @@ Button.propTypes = {
   /** Second text child, renders under main text, only when size is "large" */
   subtext: PropTypes.string,
   /** Ref to be forwarded */
-  forwardRef: PropTypes.func,
+  forwardRef: PropTypes.object,
   /** Button types for legacy theme: "primary" | "secondary" */
   as: PropTypes.oneOf(OptionsHelper.themesBinary),
   /** Legacy - used to transform button into anchor */

--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -24,6 +24,8 @@ const FilterableSelect = React.forwardRef(({
   onClick,
   onKeyDown,
   noResultsMessage,
+  listActionButton,
+  onListAction,
   ...textboxProps
 }, inputRef) => {
   const selectListId = useRef(guid());
@@ -164,6 +166,13 @@ const FilterableSelect = React.forwardRef(({
   }, [value, defaultValue, onChange]);
 
   useEffect(() => {
+    const hasListActionButton = listActionButton !== undefined;
+    const onListActionMissingMessage = 'onListAction prop required when using listActionButton prop';
+
+    invariant(!hasListActionButton || (hasListActionButton && onListAction), onListActionMissingMessage);
+  }, [listActionButton, onListAction]);
+
+  useEffect(() => {
     setMatchingText(value || defaultValue);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -213,6 +222,13 @@ const FilterableSelect = React.forwardRef(({
   const onSelectOption = useCallback((optionData) => {
     const { text, value: newValue, selectionType } = optionData;
 
+    if (selectionType === 'tab') {
+      setOpenState(false);
+      textboxRef.focus();
+
+      return;
+    }
+
     if (!isControlled.current) {
       setSelectedValue(newValue);
     }
@@ -244,6 +260,11 @@ const FilterableSelect = React.forwardRef(({
 
       return text && text.toLowerCase().indexOf(textToMatch.toLowerCase()) !== -1;
     });
+  }
+
+  function handleOnListAction() {
+    setOpenState(false);
+    onListAction();
   }
 
   function assignInput(input) {
@@ -298,6 +319,8 @@ const FilterableSelect = React.forwardRef(({
           filterText={ filterText }
           highlightedValue={ highlightedValue }
           noResultsMessage={ noResultsMessage }
+          listActionButton={ listActionButton }
+          onListAction={ handleOnListAction }
         >
           { children }
         </FilterableSelectList>
@@ -323,7 +346,11 @@ FilterableSelect.propTypes = {
   /** A custom callback for when the dropdown menu opens */
   onOpen: PropTypes.func,
   /** A custom message to be displayed when any option does not match the filter text */
-  noResultsMessage: PropTypes.string
+  noResultsMessage: PropTypes.string,
+  /** True for default text button or a Button Component to be rendered */
+  listActionButton: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
+  /** A callback for when the Action Button is triggered */
+  onListAction: PropTypes.func
 };
 
 export default FilterableSelect;

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -5,6 +5,7 @@ import FilterableSelect from './filterable-select.component';
 import Textbox from '../../../__experimental__/components/textbox';
 import Option from '../option/option.component';
 import SelectList from '../select-list/select-list.component';
+import Button from '../../button';
 import Label from '../../../__experimental__/components/label';
 
 describe('FilterableSelect', () => {
@@ -385,6 +386,72 @@ describe('FilterableSelect', () => {
       expect(onKeyDownFn).toHaveBeenCalledWith(expect.objectContaining({
         ...expectedEventObject
       }));
+    });
+  });
+
+  describe('when the listActionButton prop is provided', () => {
+    let wrapper;
+    const testWrapper = document.createElement('div');
+    const onListActionFn = jest.fn();
+    const mockButton = <Button>mock button</Button>;
+
+    document.body.appendChild(testWrapper);
+
+    beforeEach(() => {
+      wrapper = mount(
+        getSelect({ listActionButton: mockButton, onListAction: onListActionFn }),
+        { attachTo: testWrapper }
+      );
+      wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+    });
+
+    afterEach(() => {
+      wrapper.detach();
+    });
+
+    it('then that prop should be passed down to the SelectList component', () => {
+      expect(wrapper.find(SelectList).props().listActionButton).toEqual(mockButton);
+      wrapper.unmount();
+    });
+
+    describe('and onListAction has been called in the SelectList', () => {
+      it('then the onlistAction prop should have been called', () => {
+        onListActionFn.mockClear();
+        act(() => {
+          wrapper.find(SelectList).props().onListAction();
+        });
+        expect(onListActionFn).toHaveBeenCalled();
+        wrapper.unmount();
+      });
+    });
+
+    describe('and the Tab key has been pressed', () => {
+      const tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true });
+
+      it('then the rendered button should be focused', () => {
+        act(() => {
+          document.body.dispatchEvent(tabKeyDownEvent);
+        });
+        expect(wrapper.update().find(SelectList).exists()).toBe(true);
+        expect(wrapper.find(SelectList).find('button').getDOMNode()).toBe(document.activeElement);
+      });
+
+      describe('with the rendered button already focused', () => {
+        beforeEach(() => {
+          act(() => {
+            wrapper.find('button').getDOMNode().focus();
+            document.body.dispatchEvent(tabKeyDownEvent);
+          });
+        });
+
+        it('then the SelectList should be closed', () => {
+          expect(wrapper.update().find(SelectList).exists()).toBe(false);
+        });
+
+        it('then the select input should be focused', () => {
+          expect(wrapper.find('input').getDOMNode()).toBe(document.activeElement);
+        });
+      });
     });
   });
 

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -1,11 +1,12 @@
 import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
-import { useState } from 'react';
-import { FilterableSelect, Option } from '../';
+import { useState, useRef } from 'react';
 import Button from '../../button';
+import Dialog from '../../dialog';
+import { FilterableSelect, Option } from '../';
 import SelectTextbox from '../select-textbox/select-textbox.component';
 
-<Meta title="Design System/Select/Filterable" />
+<Meta title="Design System/Select/Filterable" parameters={{ info: { disable: true }}} />
 
 # Filterable Select
 
@@ -29,7 +30,7 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
 ### Basic usage:
 
 <Preview>
-  <Story name="basic" parameters={{ info: { disable: true }}} >
+  <Story name="basic">
     <FilterableSelect
       name='simple'
       id='simple'
@@ -60,7 +61,7 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
 ### Controlled Usage:
 
 <Preview>
-  <Story name="controlled" parameters={{ info: { disable: true }}} >
+  <Story name="controlled" parameters={{ chromatic: { disable: true }}}>
     {() => {
       const [value, setValue] = useState('');
       function onChangeHandler(event) {
@@ -100,7 +101,7 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
 ### Disabled:
 
 <Preview>
-  <Story name="disabled" parameters={{ info: { disable: true }}} >
+  <Story name="disabled">
     <FilterableSelect name='disabled' id='disabled' defaultValue='3' disabled>
       <Option text='Amber' value='1' />
       <Option text='Black' value='2' />
@@ -120,7 +121,7 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
 ### Read Only:
 
 <Preview>
-  <Story name="readonly" parameters={{ info: { disable: true }}} >
+  <Story name="readonly">
     <FilterableSelect name='readonly' id='readonly' defaultValue='4' readOnly>
       <Option text='Amber' value='1' />
       <Option text='Black' value='2' />
@@ -137,12 +138,64 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
+### With Action Button:
+Default Action Button will be rendered when the `listActionButton` prop is set to `true` on the Component.
+
+A custom `Button` Component could be passed as the `listActionButton` value. 
+
+<Preview>
+  <Story name="with action button" parameters={{ chromatic: { disable: true }}} > 
+    {() => {
+      const [value, setValue] = useState('');
+      const [isOpen, setIsOpen] = useState(false);
+      const [optionList, setOptionList] = useState([
+        <Option text='Amber' value='amber' key='Amber' />,
+        <Option text='Black' value='black' key='Black' />,
+        <Option text='Blue' value='blue' key='Blue' />,
+        <Option text='Brown' value='brown' key='Brown' />,
+        <Option text='Green' value='green' key='Green' />,
+      ]);
+      function addNew() {
+        const counter = optionList.length.toString();
+        setOptionList((optionList) => [
+          ...optionList,
+          <Option text={ `New${counter}` } value={ `val${counter}` } key={ `New${counter}` }/>
+        ]);
+        setIsOpen(false);
+        setValue(`val${counter}`);
+      }
+      return (
+        <>
+          <FilterableSelect
+            name='action'
+            id='action'
+            label='label'
+            value={ value }
+            onChange={ (event) => setValue(event.target.value) }
+            listActionButton={<Button iconType='add' iconPosition='after'>Add a New Element</Button>}
+            onListAction={ () => setIsOpen(true) }
+          >
+            { optionList }
+          </FilterableSelect>
+          <Dialog
+            open={ isOpen }
+            onCancel={ () => setIsOpen(false) }
+            title='Dialog component triggered on action'
+          >
+            <Button onClick={ addNew }>Add new</Button>
+          </Dialog>
+        </>
+      );
+    }}
+  </Story>
+</Preview>
+
 ### Required
 
 You can use the `required` prop to indicate if the field is mandatory.
 
 <Preview>
-  <Story name="required" parameters={{ info: { disable: true }}} >
+  <Story name="required">
     <FilterableSelect
       name='required-select'
       id='required-select'

--- a/src/components/select/filterable-select/index.d.ts
+++ b/src/components/select/filterable-select/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Button from '../../button';
 import Option from '../option';
 
 export interface FilterableSelectProps {
@@ -48,6 +49,10 @@ export interface FilterableSelectProps {
   onBlur?: () => void;
   /** Callback function for when the key is pressed when focused on Select Textbox. */
   onKeyDown?: () => void;
+  /** True for default text button or a Button Component to be rendered */
+  listActionButton?: boolean | typeof Button;
+  /** A callback for when the Action Button is triggered */
+  onListAction?: () => void;
   /** Flag to configure component as mandatory */
   required?: boolean;
 }

--- a/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
+++ b/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Option renders properly 1`] = `
+.c4 {
+  display: inline-block;
+  position: relative;
+  color: #26A826;
+  background-color: transparent;
+}
+
+.c4:hover {
+  color: #1E861E;
+  background-color: transparent;
+}
+
+.c4::before {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-family: CarbonIcons;
+  content: "\\e940";
+  font-size: 16px;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 16px;
+  vertical-align: middle;
+  display: block;
+}
+
+.c2 {
+  padding-left: 24px;
+  padding-right: 24px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-flow: wrap;
+  -ms-flex-flow: wrap;
+  flex-flow: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border: 2px solid transparent;
+  box-sizing: border-box;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background: transparent;
+  border-color: #26A826;
+  color: #26A826;
+  font-size: 14px;
+  min-height: 40px;
+}
+
+.c2:focus {
+  outline: solid 3px #FFB500;
+}
+
+.c2 ~ .c1 {
+  margin-left: 16px;
+}
+
+.c2:hover {
+  background: #006300;
+  border-color: #006300;
+  color: #FFFFFF;
+}
+
+.c2:hover .c3 {
+  color: #FFFFFF;
+}
+
+.c2 .c3 {
+  margin-left: 8px;
+  margin-right: 0px;
+  height: 16px;
+}
+
+.c2 .c3 svg {
+  margin-top: 0;
+}
+
+.c0 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  border-top: 1px solid #CCD6DB;
+  box-shadow: 0 0px 0 0 rgba(0,0,0,0),0 -8px 8px 0 rgba(0,0,0,0.03);
+}
+
+.c0 .c3 {
+  color: rgba(0,0,0,0.9);
+}
+
+.c0 .c1 {
+  background: transparent;
+  border: none;
+  color: rgba(0,0,0,0.9);
+  -webkit-box-pack: left;
+  -webkit-justify-content: left;
+  -ms-flex-pack: left;
+  justify-content: left;
+  padding-left: 16px;
+  padding-right: 16px;
+  width: 100%;
+}
+
+.c0 .c1:hover {
+  background-color: #F2F5F6;
+}
+
+.c0 .c1:hover .c3 {
+  color: rgba(0,0,0,0.9);
+}
+
+<div
+  className="c0"
+>
+  <button
+    className="c1 c2"
+    data-component="button"
+    disabled={false}
+    onClick={[Function]}
+    role="button"
+    size="medium"
+    type="button"
+  >
+    <span>
+      <span
+        data-element="main-text"
+      >
+        Add New Item
+      </span>
+    </span>
+    <span
+      className="c3 c4"
+      data-component="icon"
+      data-element="add"
+      disabled={false}
+      fontSize="small"
+      type="add"
+    />
+  </button>
+</div>
+`;

--- a/src/components/select/list-action-button/list-action-button.component.js
+++ b/src/components/select/list-action-button/list-action-button.component.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import I18n from 'i18n-js';
+import StyledListActionButtonWrapper from './list-action-button.style';
+import Button from '../../button';
+
+const ListActionButton = React.forwardRef(({ listActionButton, onListAction }, ref) => {
+  const listActionButtonDefaultText = I18n.t(
+    'select.action_button_text',
+    {
+      defaultValue: 'Add New Item'
+    }
+  );
+
+  function renderListActionButton() {
+    if (!listActionButton || listActionButton === true) {
+      return (
+        <Button
+          forwardRef={ ref }
+          onClick={ onListAction }
+          iconType='add'
+          iconPosition='after'
+        >{ listActionButtonDefaultText }
+        </Button>
+      );
+    }
+
+    return React.cloneElement(listActionButton, {
+      forwardRef: ref,
+      onClick: onListAction
+    });
+  }
+
+  return (
+    <StyledListActionButtonWrapper>
+      { renderListActionButton() }
+    </StyledListActionButtonWrapper>
+  );
+});
+
+ListActionButton.propTypes = {
+  /** True for default text button or a Button Component to be rendered */
+  listActionButton: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
+  /** A callback for when the Action Button is triggered */
+  onListAction: PropTypes.func.isRequired
+};
+
+export default ListActionButton;

--- a/src/components/select/list-action-button/list-action-button.spec.js
+++ b/src/components/select/list-action-button/list-action-button.spec.js
@@ -1,0 +1,72 @@
+import React, { useRef } from 'react';
+import TestRenderer from 'react-test-renderer';
+import { shallow, mount } from 'enzyme';
+import ListActionButton from './list-action-button.component';
+import Button from '../../button';
+
+describe('Option', () => {
+  it('renders properly', () => {
+    expect(renderListActionButton({}, TestRenderer.create)).toMatchSnapshot();
+  });
+
+  it('the button ref should be forwarded', () => {
+    let mockRef;
+    const defaultAction = () => {};
+
+    const WrapperComponent = () => {
+      mockRef = useRef();
+
+      return (
+        <ListActionButton
+          listActionButton
+          onListAction={ defaultAction }
+          ref={ mockRef }
+        />
+      );
+    };
+
+    const wrapper = mount(<WrapperComponent />);
+
+    expect(mockRef.current).toBe(wrapper.find('button').getDOMNode());
+  });
+
+  describe('when a custom button is provided in the listActionButton prop', () => {
+    let wrapper;
+    const onListActionFn = jest.fn();
+
+    beforeEach(() => {
+      wrapper = renderListActionButton({
+        listActionButton: <Button data-element='test-button'>Test Button</Button>,
+        onListAction: onListActionFn
+      });
+    });
+
+    it('then that button should be rendered', () => {
+      expect(wrapper.find('[data-element="test-button"]').exists()).toBe(true);
+    });
+
+    describe('and that button has been clicked', () => {
+      it('then the onListAction prop should have been called', () => {
+        onListActionFn.mockClear();
+        wrapper.find('[data-element="test-button"]').simulate('click');
+        expect(onListActionFn).toHaveBeenCalled();
+      });
+    });
+  });
+});
+
+function renderListActionButton(props, renderer = shallow) {
+  let { onListAction } = props;
+  const defaultAction = () => {};
+
+  if (!onListAction) {
+    onListAction = defaultAction;
+  }
+
+  return renderer(
+    <ListActionButton
+      onListAction={ onListAction }
+      { ...props }
+    />
+  );
+}

--- a/src/components/select/list-action-button/list-action-button.style.js
+++ b/src/components/select/list-action-button/list-action-button.style.js
@@ -1,0 +1,41 @@
+import styled, { css } from 'styled-components';
+import { baseTheme } from '../../../style/themes';
+import StyledButton from '../../button/button.style';
+import StyledIcon from '../../icon/icon.style';
+
+const StyledListActionButtonWrapper = styled.div`
+  ${({ theme }) => css`
+    padding-top: ${theme.space[1]}px;
+    padding-bottom: ${theme.space[1]}px;
+    border-top: 1px solid ${theme.disabled.border};
+    box-shadow: 0 0px 0 0 rgba(0,0,0,0), 0 -8px 8px 0 rgba(0,0,0,0.03);
+
+    ${StyledIcon} {
+      color: ${theme.text.color};
+    }
+
+    ${StyledButton} {
+      background: transparent;
+      border: none;
+      color: ${theme.text.color};
+      justify-content: left;
+      padding-left: ${theme.space[2]}px;
+      padding-right: ${theme.space[2]}px;
+      width: 100%;
+
+      :hover {
+        background-color: ${theme.select.selected};
+
+        ${StyledIcon} {
+          color: ${theme.text.color};
+        }
+      }
+    }
+  `}
+`;
+
+StyledListActionButtonWrapper.defaultProps = {
+  theme: baseTheme
+};
+
+export default StyledListActionButtonWrapper;

--- a/src/components/select/select-list/select-list-container.style.js
+++ b/src/components/select/select-list/select-list-container.style.js
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+import { baseTheme } from '../../../style/themes';
+
+const StyledSelectListContainer = styled.div`
+  background-color: white;
+  box-shadow: ${({ theme }) => `${theme.shadows.depth1}`};
+  position: absolute;
+  width: 100%;
+`;
+
+StyledSelectListContainer.defaultProps = {
+  maxHeight: '180px',
+  theme: baseTheme
+};
+
+export default StyledSelectListContainer;

--- a/src/components/select/select-list/select-list.spec.js
+++ b/src/components/select/select-list/select-list.spec.js
@@ -4,6 +4,15 @@ import { mount } from 'enzyme';
 import SelectList from './select-list.component';
 import { baseTheme } from '../../../style/themes';
 import Option from '../option/option.component';
+import ListActionButton from '../list-action-button/list-action-button.component';
+
+const escapeKeyDownEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+const tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true });
+const enterKeyDownEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+const downKeyDownEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+const upKeyDownEvent = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+const homeKeyDownEvent = new KeyboardEvent('keydown', { key: 'Home', bubbles: true });
+const endKeyDownEvent = new KeyboardEvent('keydown', { key: 'End', bubbles: true });
 
 describe('SelectList', () => {
   it('should have select-list element rendered inside of a Portal', () => {
@@ -14,13 +23,6 @@ describe('SelectList', () => {
 
   describe('when a key is pressed', () => {
     let wrapper;
-    const escapeKeyDownEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
-    const tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true });
-    const enterKeyDownEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
-    const downKeyDownEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
-    const upKeyDownEvent = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
-    const homeKeyDownEvent = new KeyboardEvent('keydown', { key: 'Home', bubbles: true });
-    const endKeyDownEvent = new KeyboardEvent('keydown', { key: 'End', bubbles: true });
     let domNode;
     let onSelectListClose;
     let onSelect;
@@ -194,17 +196,22 @@ describe('SelectList', () => {
   });
 
   describe('when the anchor element is provided', () => {
-    let wrapper, domNode;
-    const mockAnchorElement = {
-      getBoundingClientRect: () => {
-        return {
-          top: 100,
-          left: 100,
-          width: 200,
-          height: 50
-        };
-      }
+    let wrapper;
+    let domNode;
+    const onFocusFn = jest.fn();
+    const mockAnchorElement = document.createElement('div');
+    const mockInput = document.createElement('input');
+    mockAnchorElement.appendChild(mockInput);
+    const getBoundingClientRectMock = () => {
+      return {
+        top: 100,
+        left: 100,
+        width: 200,
+        height: 50
+      };
     };
+    mockAnchorElement.getBoundingClientRect = getBoundingClientRectMock;
+    mockInput.focus = onFocusFn;
 
     beforeEach(() => {
       wrapper = mount(getSelectList({ anchorElement: mockAnchorElement }));
@@ -212,10 +219,81 @@ describe('SelectList', () => {
       document.body.appendChild(domNode);
     });
 
-    it('then the list should have expected "top", "left" and "width" values', () => {
-      expect(wrapper.find('Portal').find('ul[data-element="select-list"]').getDOMNode().style.top).toBe('150px');
-      expect(wrapper.find('Portal').find('ul[data-element="select-list"]').getDOMNode().style.left).toBe('96px');
-      expect(wrapper.find('Portal').find('ul[data-element="select-list"]').getDOMNode().style.width).toBe('208px');
+    afterEach(() => {
+      document.body.removeChild(domNode);
+    });
+
+    it('then the list wrapper should have expected "top", "left" and "width" values', () => {
+      const listWrapperSelector = 'div[data-element="select-list-wrapper"]';
+      expect(wrapper.find('Portal').find(listWrapperSelector).getDOMNode().style.top).toBe('150px');
+      expect(wrapper.find('Portal').find(listWrapperSelector).getDOMNode().style.left).toBe('96px');
+      expect(wrapper.find('Portal').find(listWrapperSelector).getDOMNode().style.width).toBe('208px');
+    });
+
+    describe.each([
+      ['Up', upKeyDownEvent],
+      ['Down', downKeyDownEvent],
+      ['Home', homeKeyDownEvent],
+      ['End', endKeyDownEvent]
+    ])('and then the %s key is pressed', (key, keyEvent) => {
+      it('then the focus function should have been called on the anchor element', () => {
+        onFocusFn.mockClear();
+        act(() => {
+          domNode.dispatchEvent(keyEvent);
+        });
+        expect(onFocusFn).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when the listActionButton prop is provided', () => {
+    it('then the ListActionButton should be rendered', () => {
+      const wrapper = renderSelectList({ listActionButton: true, onListAction: () => {} });
+      expect(wrapper.find(ListActionButton).exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    describe('when the anchor element is provided', () => {
+      let wrapper;
+      let domNode;
+      const onFocusFn = jest.fn();
+      const onSelectFn = jest.fn();
+      const expectedSelectValue = { selectionType: 'tab' };
+
+      beforeEach(() => {
+        wrapper = renderSelectList({
+          listActionButton: true,
+          onListAction: () => {},
+          onSelect: onSelectFn
+        });
+        domNode = wrapper.getDOMNode();
+        document.body.appendChild(domNode);
+      });
+
+      afterEach(() => {
+        document.body.removeChild(domNode);
+      });
+
+      it('then the focus function should have been called on the ListActionButton', () => {
+        onFocusFn.mockClear();
+        wrapper.find(ListActionButton).find('button').getDOMNode().focus = onFocusFn;
+        act(() => {
+          domNode.dispatchEvent(tabKeyDownEvent);
+        });
+        expect(onFocusFn).toHaveBeenCalled();
+      });
+
+      describe('with the ListActionButton already focused', () => {
+        it('then the onSelect function prop should have been called with expected value', () => {
+          onSelectFn.mockClear();
+          wrapper.find(ListActionButton).find('button').getDOMNode().focus();
+
+          act(() => {
+            domNode.dispatchEvent(tabKeyDownEvent);
+          });
+          expect(onSelectFn).toHaveBeenCalledWith(expectedSelectValue);
+        });
+      });
     });
   });
 });

--- a/src/components/select/select-list/select-list.style.js
+++ b/src/components/select/select-list/select-list.style.js
@@ -1,10 +1,7 @@
 import styled from 'styled-components';
-import { baseTheme } from '../../../style/themes';
 
 const StyledSelectList = styled.ul`
-  background-color: white;
   box-sizing: border-box;
-  box-shadow: ${({ theme }) => `${theme.shadows.depth1}`};
   list-style-type: none;
   max-height: ${props => `${props.maxHeight}`};
   margin: 0;
@@ -12,13 +9,10 @@ const StyledSelectList = styled.ul`
   overflow-x: hidden;
   overflow-y: scroll;
   padding: 0;
-  position: absolute;
-  width: 100%;
 `;
 
 StyledSelectList.defaultProps = {
-  maxHeight: '180px',
-  theme: baseTheme
+  maxHeight: '180px'
 };
 
 export default StyledSelectList;

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -20,7 +20,7 @@ describe('SimpleSelect', () => {
     expect(wrapper.find(Textbox).prop('type')).toBe('select');
   });
 
-  testStyledSystemSpacing(props => <SimpleSelect { ...props } />);
+  testStyledSystemSpacing(props => getSelect(props));
 
   it('the input ref should be forwarded', () => {
     let mockRef;

--- a/src/components/select/simple-select/simple-select.stories.mdx
+++ b/src/components/select/simple-select/simple-select.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { Select, Option } from '../';
 import Button from '../../button';
 import SelectTextbox from '../select-textbox/select-textbox.component';
@@ -39,11 +39,11 @@ import { Select, Option } from "carbon-react/lib/components/select";
       label='label'
       labelInline
       onOpen={ action('onOpen') }
-      onChange={ action('onChange') }
-      onClick={ action('onClick') }
-      onFocus={ action('onFocus') }
-      onBlur={ action('onBlur') }
-      onKeyDown={ action('onKeyDown') }
+      onChange={ action('onChange', { depth: 2 }) }
+      onClick={ action('onClick', { depth: 2 }) }
+      onFocus={ action('onFocus', { depth: 2 }) }
+      onBlur={ action('onBlur', { depth: 2 }) }
+      onKeyDown={ action('onKeyDown', { depth: 2 }) }
     >
       <Option text='Amber' value='1' />
       <Option text='Black' value='2' />
@@ -213,8 +213,8 @@ The inline label can change to be top aligned at a breakpoint. Enable this by pa
 <Preview>
   <Story name="enabling adaptive behaviour" parameters={{ chromatic: { disable: true }, info: { disable: true }}}>
     <Select
-      name='transparent'
-      id='transparent'
+      name='adaptive'
+      id='adaptive'
       label='label'
       defaultValue='4'
       adaptiveLabelBreakpoint={960}
@@ -238,6 +238,10 @@ The inline label can change to be top aligned at a breakpoint. Enable this by pa
   of={ Select }
   spacing
 />
+
+## Props:
+
+<Props of={ Select } />
 
 ### Props derived from the Textbox Component
 


### PR DESCRIPTION
### Proposed behaviour
A new customizable button in Select List that triggers a user defined action.

![Screenshot 2020-10-09 at 10 51 28](https://user-images.githubusercontent.com/22885392/95563228-6e8d1080-0a1d-11eb-8aac-dbaf02efb950.png)


### Current behaviour


### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
1. npm start
2. open http://localhost:9001/?path=/docs/design-system-select-filterable--with-action-button