### PR TITLE
feat(accordion): add support to rendering validation icon beside heading FE-3031 

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -76,5 +76,6 @@
   "test_default": "-test--default",
   "tile_with_definition_list_default": "--tile-with-definition-list-default",
   "inline_controls": "--inline-controls",
+  "validation_icon": "--validation-icon",
   "required": "--required"
 }

--- a/cypress/features/regression/designSystem/accordion.feature
+++ b/cypress/features/regression/designSystem/accordion.feature
@@ -1,20 +1,26 @@
 Feature: Design System Accordion component
   I want to test Design System Accordion component
 
-  Background: Open Design System Accordion component page
-    Given I open "Design System Accordion" component page "default_story" in no iframe
-
   @positive
   Scenario: I expand accordion using click
+    Given I open "Design System Accordion" component page "default_story" in no iframe
     When I expand Design System accordionRow via click in NoIFrame
     Then accordionRow is expanded
 
   @positive
   Scenario: I expand accordion using Enter key
+    Given I open "Design System Accordion" component page "default_story" in no iframe
     When I expand accordionRow using "Enter" key
     Then accordionRow is expanded
 
   @positive
   Scenario: Verify border outline color on focus
+    Given I open "Design System Accordion" component page "default_story" in no iframe
     When I focus first accordionRow
     Then accordionRow has golden border outline
+
+  @positive
+  Scenario: Open accordion by clicking on validation icon
+    Given I open "Design System Accordion" component page "validation_icon" in no iframe
+    When I click on first validation icon
+    Then accordionRow is expanded

--- a/cypress/support/step-definitions/accordion-steps.js
+++ b/cypress/support/step-definitions/accordion-steps.js
@@ -8,6 +8,7 @@ import {
   accordionDefaultTitle,
 } from '../../locators/accordion';
 import { positionOfElement, keyCode } from '../helper';
+import { icon } from '../../locators';
 
 Then('Accordion iconAlign property on preview is set to {string}', (iconAlign) => {
   accordionTitleContainerByPositionInIfame(positionOfElement('first')).first()
@@ -77,4 +78,8 @@ Then('Accordion {int} row is focused', (index) => {
 
 When('I focus {word} accordionRow', (position) => {
   accordionTitleContainer(positionOfElement(position)).first().focus({ force: true });
+});
+
+When('I click on {word} validation icon', (position) => {
+  icon().eq(positionOfElement(position)).click();
 });

--- a/src/components/accordion/accordion.component.js
+++ b/src/components/accordion/accordion.component.js
@@ -16,6 +16,7 @@ import {
   StyledAccordionContentContainer,
   StyledAccordionContent
 } from './accordion.style';
+import ValidationIcon from '../validations';
 import Logger from '../../utils/logger/logger';
 
 let deprecatedWarnTriggered = false;
@@ -38,6 +39,9 @@ const Accordion = React.forwardRef(({
   subTitle,
   title,
   width,
+  error,
+  warning,
+  info,
   ...rest
 }, ref) => {
   if (!deprecatedWarnTriggered) {
@@ -92,6 +96,7 @@ const Accordion = React.forwardRef(({
   const accordionId = id || `Accordion_${guid.current}`;
   const headerId = `AccordionHeader_${guid.current}`;
   const contentId = `AccordionContent_${guid.current}`;
+  const showValidationIcon = !!(error || warning || info);
 
   return (
     <StyledAccordionContainer
@@ -119,6 +124,7 @@ const Accordion = React.forwardRef(({
       >
         <StyledAccordionHeadingsContainer
           data-element='accordion-headings-container'
+          hasValidationIcon={ showValidationIcon }
         >
           <StyledAccordionTitle
             data-element='accordion-title'
@@ -127,6 +133,16 @@ const Accordion = React.forwardRef(({
           >
             { title }
           </StyledAccordionTitle>
+
+          { showValidationIcon && (
+            <ValidationIcon
+              error={ error }
+              warning={ warning }
+              info={ info }
+              tooltipPosition='top'
+              tabIndex={ 0 }
+            />
+          ) }
 
           {(subTitle && size === 'large') && (
             <StyledAccordionSubTitle>
@@ -196,7 +212,13 @@ Accordion.propTypes = {
   /** Sets background as white or transparent */
   scheme: PropTypes.oneOf(['white', 'transparent']),
   /** Sets accordion width */
-  width: PropTypes.string
+  width: PropTypes.string,
+  /** An error message to be displayed in the tooltip */
+  error: PropTypes.string,
+  /** A warning message to be displayed in the tooltip */
+  warning: PropTypes.string,
+  /** An info message to be displayed in the tooltip */
+  info: PropTypes.string
 };
 
 Accordion.displayName = 'Accordion';

--- a/src/components/accordion/accordion.d.ts
+++ b/src/components/accordion/accordion.d.ts
@@ -39,7 +39,13 @@ export interface AccordionProps {
   scheme: 'white' |'transparent';
   /** Sets accordion width */
   width: string;
-}
+  /** An error message to be displayed in the tooltip */
+  error: string;
+  /** A warning message to be displayed in the tooltip */
+  warning: string;
+  /** An info message to be displayed in the tooltip */
+  info: string;
+  }
 
 declare const Accordion: React.FunctionComponent<AccordionProps>;
 export default Accordion;

--- a/src/components/accordion/accordion.spec.js
+++ b/src/components/accordion/accordion.spec.js
@@ -14,9 +14,12 @@ import {
   StyledAccordionTitle,
   StyledAccordionIcon,
   StyledAccordionContent,
-  StyledAccordionContentContainer
+  StyledAccordionContentContainer,
+  StyledAccordionHeadingsContainer
 } from './accordion.style';
 import AccordionGroup from './accordion-group.component';
+import ValidationIcon from '../validations';
+import StyledValidationIcon from '../validations/validation-icon.style';
 
 const contentHeight = 200;
 
@@ -288,6 +291,39 @@ describe('Accordion', () => {
       assertStyleMatch({
         width: '500px'
       }, wrapper.find(StyledAccordionContainer));
+    });
+
+    describe('with validation icon', () => {
+      it.each([{ error: 'error' }, { warning: 'warning' }, { info: 'info' }])(
+        'renders the validation icon when a message is provided', (status) => {
+          wrapper = mount(<Accordion title='Title' { ...status } />);
+          expect(wrapper.find(ValidationIcon).exists()).toEqual(true);
+        }
+      );
+
+      it('applies expected styling when the icon is not rendered', () => {
+        wrapper = mount(<Accordion title='Title' />);
+
+        assertStyleMatch({
+          display: 'grid',
+          gridTemplateRows: 'auto auto'
+        }, wrapper.find(StyledAccordionHeadingsContainer));
+      });
+
+      it('applies expected styling when the icon is rendered', () => {
+        wrapper = mount(<Accordion title='Title' error='error' />);
+
+        assertStyleMatch({
+          display: 'grid',
+          gridTemplateColumns: 'auto auto'
+        }, wrapper.find(StyledAccordionHeadingsContainer));
+
+        assertStyleMatch({
+          height: '20px',
+          position: 'relative',
+          top: '2px'
+        }, wrapper.find(StyledAccordionHeadingsContainer), { modifier: `${StyledValidationIcon}` });
+      });
     });
   });
 

--- a/src/components/accordion/accordion.stories.mdx
+++ b/src/components/accordion/accordion.stories.mdx
@@ -5,6 +5,7 @@ import { AccordionGroup, Accordion } from '.';
 import Textbox from '../../__experimental__/components/textbox';
 import Button from '../button';
 import { Dl, Dt, Dd } from '../definition-list';
+import { Checkbox } from '../../__experimental__/components/checkbox';
 
 <Meta
   title="Design System/Accordion"
@@ -174,6 +175,111 @@ import { Accordion, AccordionGroup } from "carbon-react/lib/components/accordion
 
 <Preview>
   <Story id="design-system-accordion-test--grouped" name="grouped">
+  </Story>
+</Preview>
+
+### With validation icon
+The `ValidationIcon` can be displayed in the `Accordion` header by passing in a string via one of the `error`, 
+`warning` or `info` props. This message will be displayed as in the tooltip.
+
+<Preview>
+  <Story name="validation icon">
+    {() => {
+      const [errors, setErrors] = useState({ one: 'error', two: 'error', three: 'error' });
+      const [warnings, setWarnings] = useState({});
+      const [infos, setInfos] = useState({});
+      const [expanded, setExpanded] = useState({one: false, two: false, three: true})
+      const handleChange = (id, type, setter, msg) => {
+        const update = type[id] ? undefined : msg;
+        setter(previous => ({ ...previous, [id]: update }));
+      }
+      return (
+        <div style={{ marginTop: '16px' }}>
+          <AccordionGroup>
+            <Accordion
+              title='Heading'
+              expanded={expanded.one}
+              onChange={() => setExpanded((previousState) => ({...previousState, one: !previousState.one})) }
+              error={errors.one}
+              warning={ warnings.one }
+              info={ infos.one }>
+              <div style={{ padding: '8px'}}>
+                <Checkbox
+                  label='Add error'
+                  error={!!errors.one}
+                  onChange={ () => handleChange('one', errors, setErrors, 'error')}
+                  checked={!!errors.one}
+                />
+                <Checkbox
+                  label='Add warning'
+                  warning={!!warnings.one}
+                  onChange={ () => handleChange('one', warnings, setWarnings, 'warning')}
+                />
+                <Checkbox
+                  label='Add info'
+                  info={!!infos.one}
+                  onChange={ () => handleChange('one', infos, setInfos, 'info')}
+                />
+              </div>
+            </Accordion>
+            <Accordion
+              title='Heading'
+              expanded={expanded.two}
+              onChange={() => setExpanded((previousState) => ({...previousState, two: !previousState.two})) }
+              subTitle='Sub title'
+              error={errors.two}
+              warning={ warnings.two }
+              info={ infos.two }>
+              <div style={{ padding: '8px'}}>
+                <Checkbox
+                  label='Add error'
+                  error={!!errors.two}
+                  onChange={ () => handleChange('two', errors, setErrors, 'error')}
+                  checked={!!errors.two}
+                />
+                <Checkbox
+                  label='Add warning'
+                  warning={!!warnings.two}
+                  onChange={ () => handleChange('two', warnings, setWarnings, 'warning')}
+                />
+                <Checkbox
+                  label='Add info'
+                  info={!!infos.two}
+                  onChange={ () => handleChange('two', infos, setInfos, 'info')}
+                />
+              </div>
+            </Accordion>
+            <Accordion
+              title='Heading'
+              expanded={expanded.three}
+              onChange={() => setExpanded((previousState) => ({...previousState, three: !previousState.three})) }
+              subTitle='Sub title'
+              error={errors.three}
+              warning={ warnings.three }
+              info={ infos.three }>
+              <div style={{ padding: '8px'}}>
+                <Checkbox
+                  label='Add error'
+                  error={!!errors.three}
+                  onChange={ () => handleChange('three', errors, setErrors, 'error')}
+                  checked={!!errors.three}
+                />
+                <Checkbox
+                  label='Add warning'
+                  warning={!!warnings.three}
+                  onChange={ () => handleChange('three', warnings, setWarnings, 'warning')}
+                />
+                <Checkbox
+                  label='Add info'
+                  info={!!infos.three}
+                  onChange={ () => handleChange('three', infos, setInfos, 'info')}
+                />
+              </div>
+            </Accordion>
+          </AccordionGroup>
+        </div>
+      );
+    }}
   </Story>
 </Preview>
 

--- a/src/components/accordion/accordion.style.js
+++ b/src/components/accordion/accordion.style.js
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components';
 
 import Icon from '../icon';
 import { baseTheme } from '../../style/themes';
+import ValidationIconStyle from '../validations/validation-icon.style';
 
 const StyledAccordionContainer = styled.div`
   display: flex;
@@ -48,8 +49,16 @@ const StyledAccordionIcon = styled(Icon)`
 `;
 
 const StyledAccordionHeadingsContainer = styled.div`
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  ${({ hasValidationIcon }) => (
+    hasValidationIcon ? 'grid-template-columns: auto auto;' : 'grid-template-rows: auto auto;'
+  )}
+  
+  ${ValidationIconStyle} {
+    height: 20px;
+    position: relative;
+    top: 2px;
+  }
 `;
 
 const StyledAccordionTitleContainer = styled.div`

--- a/src/components/validations/index.js
+++ b/src/components/validations/index.js
@@ -1,0 +1,1 @@
+export { default } from './validation-icon.component';


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Add support for rendering the `ValidationIcon` next to the `Accordion` heading by passing a string value to one of the `error`, `warning` or `info` props.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

There is no support for rendering `ValidationIcon`.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/95603968-ecb5db00-0a4e-11eb-90f5-128876cfe674.png)

![image](https://user-images.githubusercontent.com/44157880/95604007-fa6b6080-0a4e-11eb-8017-568f8c32f6f1.png)

![image](https://user-images.githubusercontent.com/44157880/95604052-07884f80-0a4f-11eb-8cf2-352d84ce6587.png)

![image](https://user-images.githubusercontent.com/44157880/95604082-13741180-0a4f-11eb-9c80-68882c9418ee.png)

![image](https://user-images.githubusercontent.com/44157880/95604135-271f7800-0a4f-11eb-996e-1cc46af3fbef.png)

![image](https://user-images.githubusercontent.com/44157880/95604147-2e468600-0a4f-11eb-8ee8-7009509ece82.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
Updates can be tested locally http://localhost:9001/?path=/story/design-system-accordion--validation-icon