### PR TITLE
refactor(action-popover): simplify custom theme FE-3219

### DIFF
--- a/src/components/action-popover/action-popover.stories.mdx
+++ b/src/components/action-popover/action-popover.stories.mdx
@@ -9,6 +9,7 @@ import {
   Table, TableRow, TableCell, TableHeader
 } from '../table';
 import DocsWrapper from '../../../.storybook/docs-helpers/components/iframe-wrapper';
+import LinkTo from '@storybook/addon-links/react';
 
 <Meta title="Design System/Action Popover" parameters={{ info: { disable: true }}}/>
 
@@ -29,20 +30,18 @@ left, right, or above the element that generates it.
 - Content in the popover is usually left aligned.
 
 ## Related Components
-- Data entry rather than an action? [Try Select](/components/__experimental__/select "Try Select").
-- Only a single action? [Try Button](/components/button/ "Try Button").
-- Doesn’t relate to a single table row or tile? [Try Split Button](/components/split-button "Try Split Button"), or 
-[Try Multi-Action Button](/components/multi-action-button "Try Multi-Action Button").
+- Data entry rather than an action? <LinkTo kind='Design System/Select' story='basic'>Try Select</LinkTo>.
+- Only a single action? <LinkTo kind='Design System/Button' story='primary'>Try Button</LinkTo>.
+- Doesn’t relate to a single table row or tile? <LinkTo kind='Split Button' story='default'>Try Split Button</LinkTo>, or 
+<LinkTo kind='Multi Action Button' story='default'>Multi Action Button</LinkTo>.
 
 
-<Story id="test-action-popover--default" />
+<Story id="design-system-action-popover-test--default" />
 
-<Story id="test-action-popover--classic" />
-
-## With all items interactive
+## with icons
 Each item is clickable and represents an action to be taken on a given row.
 <Preview>
-  <Story name="popover with icons" parameters={{ info: { disable: true }}}>
+  <Story name="with icons" parameters={{ info: { disable: true }}}>
     <div style={{ height: '250px' }}>
       <Table>
         <TableRow>
@@ -71,7 +70,8 @@ Each item is clickable and represents an action to be taken on a given row.
   </Story>
 </Preview>
 
-ActionPopoverItem&apos;s can be disabled and will not dispatch an action but can still be navigated.
+## with disabled item
+ActionPopoverItem&apos;s can be disabled and will not dispatch an action but can still be navigated with the keyboard.
 <Preview>
   <Story name="with disabled item" parameters={{ info: { disable: true }}}>
     <div style={{ height: '250px' }}>
@@ -103,6 +103,7 @@ ActionPopoverItem&apos;s can be disabled and will not dispatch an action but can
   </Story>
 </Preview>
 
+## with menu right aligned
 It is possible to align the Menu to the right of the MenuButton by passing the &quot;rightAlignMenu&quot; to ActionPopover
 <Preview>
   <Story name="with menu right aligned" parameters={{ info: { disable: true }}}>
@@ -135,6 +136,7 @@ It is possible to align the Menu to the right of the MenuButton by passing the &
   </Story>
 </Preview>
 
+## with no icons
 Menu items can also be displayed without icons.
 <Preview>
   <Story name="with no icons" parameters={{ info: { disable: true }}}>
@@ -164,11 +166,11 @@ Menu items can also be displayed without icons.
 </Preview>
 
 
-## With a custom Menu Button
+## with custom menu button
 It is possible to use the &quot;renderButton&quot; prop to override the default button used to trigger the opening and closing of 
 ActionPopoverMenu. See the prop tables below for the properties surfaced to any custom component being passed in.
 <Preview>
-  <Story name="popover with custom button" parameters={{ info: { disable: true }}}>
+  <Story name="with custom menu button" parameters={{ info: { disable: true }}}>
     <div style={{ height: '250px' }}>
       <Table>
         <TableRow>
@@ -211,7 +213,7 @@ ActionPopoverMenu. See the prop tables below for the properties surfaced to any 
 </Preview>
 
 
-## With a sub-menu
+## with submenu
 A menu item can be passed a sub-menu to add further sub-actions if needed. items with sub-menus will display an chevron 
 icons pointing in the direction that the sub-menu will open; by default it will open to the left.
 
@@ -259,6 +261,7 @@ leave.
   </Story>
 </Preview>
 
+## with disabled submenu
 A sub-menu will not open if the item is in a disabled state.
 <Preview>
   <Story name="with disabled submenu" parameters={{ info: { disable: true }}}>
@@ -301,6 +304,7 @@ A sub-menu will not open if the item is in a disabled state.
   </Story>
 </Preview>
 
+## with submenu aligned right
 The sub-menu will open to the right side when there is no space to render the sub-menu to the left.
 <Story name="with submenu aligned right" parameters={{ docs: { disable: true }, info: { disable: true }}}>
   <div style={{ height: '250px' }}>
@@ -342,12 +346,12 @@ The sub-menu will open to the right side when there is no space to render the su
 
 <MyPreview>
   <DocsWrapper 
-    src='iframe.html?id=design-system-actionpopover--with-submenu-aligned-right'
+    src='iframe.html?id=design-system-action-popover--with-submenu-aligned-right'
     height='250px'
   />
 </MyPreview>
 
-## Keyboard navigation 
+## keyboard navigation 
 ActionPopover and ActionPopoverItem have extensive keyboard support. It is possible to open the menu when the
 ActionPopover is focused: pressing either the "enter" or "down" key will open the menu and focus the first item; 
 pressing the "up" key when the button is focused will open the menu and focus the last element.
@@ -361,7 +365,7 @@ Pressing the "enter" key will trigger the action associated with the currently f
 or "tab" key will close the menu with no action being triggered and focus the next focusable element. Pressing 
 "shift + tab" will close the menu and focus the previously focused element.
 <Preview>
-  <Story name="keyboard access" parameters={{ info: { disable: true }}}>
+  <Story name="keyboard navigation" parameters={{ info: { disable: true }}}>
     <div style={{ height: '250px' }}>
       <Table>
         <TableRow>
@@ -403,12 +407,13 @@ or "tab" key will close the menu with no action being triggered and focus the ne
   </Story>
 </Preview>
 
+## keyboard navigation left aligned submenu
 Sub-menus can be accessed via the keyboard as well, when the sub-menu is left aligned it can be opened by navigating to 
 the parent item and pressing the "left" key. The same accessible shortcuts described above can then be used to navigate 
 the sub-menu. Pressing the "right" key will return focus back to the main menu and close the sub-menu without 
 triggering an action. 
 <Preview>
-  <Story name="keyboard access left aligned submenu" parameters={{ info: { disable: true }}}>
+  <Story name="keyboard navigation left aligned submenu" parameters={{ info: { disable: true }}}>
     <div style={{ height: '250px' }}>
       <Table>
         <TableRow>
@@ -463,6 +468,7 @@ triggering an action.
   </Story>
 </Preview>
 
+## keyboard navigation right aligned submenu
 When sub-menus aligns to the right hand side, the key shortcuts are switiched: pressingt the "right" key whilst focus 
 is on a item will open a sub-menu if it has one and pressing the "left" key will close it. 
 <Story name="keyboard access right aligned submenu" parameters={{ docs: { disable: true }, info: { disable: true }}}>
@@ -521,28 +527,26 @@ is on a item will open a sub-menu if it has one and pressing the "left" key will
 
 <MyPreview>
   <DocsWrapper
-    src='iframe.html?id=design-system-actionpopover--keyboard-access-right-aligned-submenu'
+    src='iframe.html?id=design-system-action-popover--keyboard-access-right-aligned-submenu'
     height='250px'
   />
 </MyPreview>
 
-## Services Column
+## with additional options
 
-The ActionPopover can be composed in a number of ways: below is an example of a services column popover that is 
-populated with any additional overflow options for a given row. The popover's height is dynamic to the content placed 
-within it. Beyond a reasonable number of items, content may be truncated and the foot of the popover may then contain 
-a &quot;Manage&quot; option.
+When a row has many actions you may choose to incldue the primary actions with a dedicated action to for less frequently
+used actions, in this example "manage devices".
 
 <Preview>
-  <Story name="services column">
+  <Story name="with additional options">
     <div style={ { marginTop: '40px', height: '275px', maxWidth: '800px' } }>
       <Table isZebra>
         <TableRow>
-          <TableHeader colSpan='3'>Services</TableHeader>
+          <TableHeader colSpan='3'>Devices</TableHeader>
         </TableRow>
         <TableRow>
-          <TableCell>Accounting</TableCell>
-          <TableCell>Payroll</TableCell>
+          <TableCell>Mobile Phone</TableCell>
+          <TableCell>Online</TableCell>
           <TableCell>
             <ActionPopover
               rightAlignMenu
@@ -559,40 +563,10 @@ a &quot;Manage&quot; option.
                 </ActionPopoverMenuButton>
               ) }
             >
-              <ActionPopoverItem onClick={ () => {} }>Auto Entry</ActionPopoverItem>
-              <ActionPopoverItem onClick={ () => {} }>Corporation Tax</ActionPopoverItem>
-              <ActionPopoverItem onClick={ () => {} }>Final Accounts</ActionPopoverItem>
-              <ActionPopoverItem onClick={ () => {} }>VAT Centre</ActionPopoverItem>
+              <ActionPopoverItem onClick={ () => {} }>Enroll Device</ActionPopoverItem>
+              <ActionPopoverItem onClick={ () => {} }>Assign Owner</ActionPopoverItem>
               <ActionPopoverDivider />
-              <ActionPopoverItem onClick={ () => {} }>Manage Services</ActionPopoverItem>
-            </ActionPopover>
-          </TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell>Accounting</TableCell>
-          <TableCell>Payroll</TableCell>
-          <TableCell>
-            <ActionPopover
-              rightAlignMenu
-              renderButton={ ({ tabIndex, 'data-element': dataElement }) => (
-                <ActionPopoverMenuButton
-                  buttonType='tertiary'
-                  iconType='dropdown'
-                  iconPosition='after'
-                  size='small'
-                  tabIndex={ tabIndex }
-                  data-element={ dataElement }
-                >
-                  More
-                </ActionPopoverMenuButton>
-              ) }
-            >
-              <ActionPopoverItem onClick={ () => {} }>Auto Entry</ActionPopoverItem>
-              <ActionPopoverItem onClick={ () => {} }>Corporation Tax</ActionPopoverItem>
-              <ActionPopoverItem onClick={ () => {} }>Final Accounts</ActionPopoverItem>
-              <ActionPopoverItem onClick={ () => {} }>VAT Centre</ActionPopoverItem>
-              <ActionPopoverDivider />
-              <ActionPopoverItem onClick={ () => {} }>Manage Services</ActionPopoverItem>
+              <ActionPopoverItem onClick={ () => {} }>Manage Devices</ActionPopoverItem>
             </ActionPopover>
           </TableCell>
         </TableRow>

--- a/src/components/action-popover/action-popover.style.js
+++ b/src/components/action-popover/action-popover.style.js
@@ -1,8 +1,5 @@
 import React from 'react';
-import styled, { ThemeProvider, css } from 'styled-components';
-import { mergeDeep } from '../../style/utils/merge-deep';
-import mintTheme from '../../style/themes/mint';
-import { mergeWithBase } from '../../style/themes/base';
+import styled, { ThemeProvider, css, withTheme } from 'styled-components';
 import Icon from '../icon';
 import StyledIcon from '../icon/icon.style';
 import StyledButton from '../button/button.style';
@@ -91,29 +88,24 @@ const MenuButton = styled.div`
  * theme provider wrapped around it
  * @param {*} themeFn
  */
-const iconThemeProviderFactory = themeFn => (Component) => {
-  const customTheme = (palette) => {
-    const color = themeFn(palette);
-    return (mergeDeep(
-      mintTheme,
-      {
-        icon: {
-          default: color,
-          defaultHover: color
-        }
-      }
-    ));
+const iconThemeProviderFactory = (Component, themeFn) => withTheme(({ theme, ...props }) => {
+  const color = themeFn(theme.palette);
+  const customTheme = {
+    ...theme,
+    icon: {
+      default: color,
+      defaultHover: color
+    }
   };
-  const theme = mergeWithBase(customTheme);
-  return props => <ThemeProvider { ...{ theme } }><Component { ...props } /></ThemeProvider>;
-};
+  return <ThemeProvider theme={ customTheme }><Component { ...props } /></ThemeProvider>;
+});
 
-const ButtonIcon = iconThemeProviderFactory(palette => palette.slate)(Icon);
-const MenuItemIcon = styled(iconThemeProviderFactory(() => 'inherit')(Icon))`
+const ButtonIcon = iconThemeProviderFactory(Icon, palette => palette.slate);
+const MenuItemIcon = styled(iconThemeProviderFactory(Icon, () => 'inherit'))`
   ${({ theme }) => `padding-right: ${theme.spacing}px;`}
 `;
 
-const SubMenuItemIcon = styled(iconThemeProviderFactory(() => 'inherit')(Icon))`
+const SubMenuItemIcon = styled(ButtonIcon)`
   ${({ theme, type }) => css`
     position: absolute;
     &, :hover { 


### PR DESCRIPTION
### Proposed behaviour
`mergeDeep` can't merge objects that have a Proxy which is needed to support `@styled-system/color`. I've removed the usage of `mergeDeep` because it can be easily simplified.

### Current behaviour
ActionPopover uses `mergeDeep` to create custom color icons.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
FE-3219

### Testing instructions
Check CI/Chromatic/ActionPopover stories, in particular the icon colour.
