### PR TITLE
fix(select): value cannot be cleared (FE-3188)

### DIFF
--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -157,6 +157,10 @@ const FilterableSelect = React.forwardRef(({
 
     setSelectedValue(newValue);
     setHighlightedValue(newValue);
+
+    if (isControlled.current && !newValue) {
+      setTextValue('');
+    }
   }, [value, defaultValue, onChange]);
 
   useEffect(() => {

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -370,77 +370,85 @@ describe('FilterableSelect', () => {
       document.body.removeChild(domNode);
     });
   });
-});
 
+  describe('when the onKeyDown prop is passed', () => {
+    const expectedEventObject = {
+      key: 'ArrowDown'
+    };
 
-describe('when the onKeyDown prop is passed', () => {
-  const expectedEventObject = {
-    key: 'ArrowDown'
-  };
+    it('then when a key is pressed, that prop should be called with expected values', () => {
+      const onKeyDownFn = jest.fn();
+      const wrapper = renderSelect({ onKeyDown: onKeyDownFn });
 
-  it('then when a key is pressed, that prop should be called with expected values', () => {
-    const onKeyDownFn = jest.fn();
-    const wrapper = renderSelect({ onKeyDown: onKeyDownFn });
+      wrapper.find('input').simulate('keyDown', expectedEventObject);
 
-    wrapper.find('input').simulate('keyDown', expectedEventObject);
-
-    expect(onKeyDownFn).toHaveBeenCalledWith(expect.objectContaining({
-      ...expectedEventObject
-    }));
-  });
-});
-
-describe('when the component is controlled', () => {
-  const expectedObject = {
-    target: {
-      id: 'testSelect',
-      name: 'testSelect',
-      value: 'opt3'
-    }
-  };
-
-  const clickOptionObject = {
-    value: 'opt3',
-    text: 'black',
-    selectionType: 'click'
-  };
-
-  describe('and an option is selected', () => {
-    it('then the onChange prop should be called with expected value', () => {
-      const onChangeFn = jest.fn();
-      const wrapper = renderSelect({ onChange: onChangeFn, value: 'opt1' });
-
-      wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
-      expect(wrapper.find(SelectList).exists()).toBe(true);
-      act(() => {
-        wrapper.find(SelectList).prop('onSelect')(clickOptionObject);
-      });
-      expect(onChangeFn).toHaveBeenCalledWith(expectedObject);
+      expect(onKeyDownFn).toHaveBeenCalledWith(expect.objectContaining({
+        ...expectedEventObject
+      }));
     });
   });
 
-  describe('when a printable character has been typed in the Textbox', () => {
-    let onChangeFn;
+  describe('when the component is controlled', () => {
+    const onChangeFn = jest.fn();
     let wrapper;
+    const expectedObject = {
+      target: {
+        id: 'testSelect',
+        name: 'testSelect',
+        value: 'opt3'
+      }
+    };
+
+    const clickOptionObject = {
+      value: 'opt3',
+      text: 'black',
+      selectionType: 'click'
+    };
 
     beforeEach(() => {
-      onChangeFn = jest.fn();
+      onChangeFn.mockClear();
       wrapper = renderSelect({ onChange: onChangeFn, value: 'opt1' });
-      wrapper.find('input').simulate('change', { target: { value: 'b' } });
-      wrapper.update();
     });
 
-    it('then the onChange function should have been called with with the expected value', () => {
-      expect(onChangeFn).toHaveBeenCalledWith(expectedObject);
+    describe('and an option is selected', () => {
+      it('then the onChange prop should be called with expected value', () => {
+        wrapper.find(Textbox).find('[type="dropdown"]').first().simulate('click');
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+        act(() => {
+          wrapper.find(SelectList).prop('onSelect')(clickOptionObject);
+        });
+        expect(onChangeFn).toHaveBeenCalledWith(expectedObject);
+      });
+    });
+
+    describe('when a printable character has been typed in the Textbox', () => {
+      beforeEach(() => {
+        wrapper.find('input').simulate('change', { target: { value: 'b' } });
+        wrapper.update();
+      });
+
+      it('then the onChange function should have been called with with the expected value', () => {
+        expect(onChangeFn).toHaveBeenCalledWith(expectedObject);
+      });
+
+      describe('and an an empty value has been passed', () => {
+        it('then the textbox displayed value should be cleared', () => {
+          expect(wrapper.find(Textbox).props().formattedValue).toBe('blue');
+          wrapper.setProps({ value: '' });
+          expect(wrapper.update().find(Textbox).props().formattedValue).toBe('');
+        });
+
+        it('then the textbox value should be cleared', () => {
+          expect(wrapper.find(Textbox).props().value).toBe('opt1');
+          wrapper.setProps({ value: '' });
+          expect(wrapper.update().find(Textbox).props().value).toBe(undefined);
+        });
+      });
     });
   });
 
   describe('required', () => {
-    let wrapper;
-
-    beforeAll(() => {
-      wrapper = renderSelect({ label: 'required', required: true });
-    });
+    const wrapper = renderSelect({ label: 'required', required: true });
 
     it('the required prop is passed to the input', () => {
       const input = wrapper.find('input');
@@ -453,6 +461,7 @@ describe('when the component is controlled', () => {
     });
   });
 });
+
 
 function renderSelect(props = {}, renderer = mount) {
   return renderer(getSelect(props));

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
 import { useState } from 'react';
 import { FilterableSelect, Option } from '../';
+import Button from '../../button';
 import SelectTextbox from '../select-textbox/select-textbox.component';
 
 <Meta title="Design System/Select/Filterable" />
@@ -66,25 +67,31 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
         setValue(event.target.value);
         action('value set');
       };
+      function clearValue() {
+        setValue('');
+      }
       return (
-        <FilterableSelect
-          id='controlled'
-          name='controlled'
-          value={ value }
-          onChange={ onChangeHandler }
-        >
-          <Option text='Amber' value='1' />
-          <Option text='Black' value='2' />
-          <Option text='Blue' value='3' />
-          <Option text='Brown' value='4' />
-          <Option text='Green' value='5' />
-          <Option text='Orange' value='6' />
-          <Option text='Pink' value='7' />
-          <Option text='Purple' value='8' />
-          <Option text='Red' value='9' />
-          <Option text='White' value='10' />
-          <Option text='Yellow' value='11' />
-        </FilterableSelect>
+        <div>
+          <Button onClick={ clearValue } mb={ 2 }>clear</Button>
+          <FilterableSelect
+            id='controlled'
+            name='controlled'
+            value={ value }
+            onChange={ onChangeHandler }
+          >
+            <Option text='Amber' value='1' />
+            <Option text='Black' value='2' />
+            <Option text='Blue' value='3' />
+            <Option text='Brown' value='4' />
+            <Option text='Green' value='5' />
+            <Option text='Orange' value='6' />
+            <Option text='Pink' value='7' />
+            <Option text='Purple' value='8' />
+            <Option text='Red' value='9' />
+            <Option text='White' value='10' />
+            <Option text='Yellow' value='11' />
+          </FilterableSelect>
+        </div>
       );
     }}
   </Story>

--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -62,10 +62,13 @@ const SimpleSelect = React.forwardRef(({
 
   const setMatchingText = useCallback((newValue) => {
     const matchingOption = React.Children.toArray(children).find(option => (option.props.value === newValue));
+    let newText = '';
 
     if (matchingOption) {
-      setTextValue(matchingOption.props.text);
+      newText = matchingOption.props.text;
     }
+
+    setTextValue(newText);
   }, [children]);
 
   const selectValueStartingWithText = useCallback((newFilterText) => {

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -599,6 +599,8 @@ describe('SimpleSelect', () => {
   });
 
   describe('when the component is controlled', () => {
+    const onChangeFn = jest.fn();
+    let wrapper;
     const expectedObject = {
       target: {
         id: 'testSelect',
@@ -613,11 +615,13 @@ describe('SimpleSelect', () => {
       selectionType: 'click'
     };
 
+    beforeEach(() => {
+      onChangeFn.mockClear();
+      wrapper = renderSelect({ onChange: onChangeFn, value: 'opt1' });
+    });
+
     describe('and an option is selected', () => {
       it('then the onChange prop should be called with expected value', () => {
-        const onChangeFn = jest.fn();
-        const wrapper = renderSelect({ onChange: onChangeFn, value: 'opt1' });
-
         wrapper.find('input').simulate('click');
         expect(wrapper.find(SelectList).exists()).toBe(true);
         act(() => {
@@ -628,12 +632,7 @@ describe('SimpleSelect', () => {
     });
 
     describe('when a printable character has been typed in the Textbox', () => {
-      let onChangeFn;
-      let wrapper;
-
       beforeEach(() => {
-        onChangeFn = jest.fn();
-        wrapper = renderSelect({ onChange: onChangeFn, value: 'opt1' });
         wrapper.find('input').simulate('change', { target: { value: 'b' } });
         wrapper.update();
       });
@@ -644,6 +643,20 @@ describe('SimpleSelect', () => {
 
       it('then the onChange function should have been called with with the expected value', () => {
         expect(onChangeFn).toHaveBeenCalledWith(expectedObject);
+      });
+    });
+
+    describe('and an an empty value has been passed', () => {
+      it('then the textbox displayed value should be cleared', () => {
+        expect(wrapper.find(Textbox).props().formattedValue).toBe('red');
+        wrapper.setProps({ value: '' });
+        expect(wrapper.update().find(Textbox).props().formattedValue).toBe('');
+      });
+
+      it('then the textbox value should be cleared', () => {
+        expect(wrapper.find(Textbox).props().value).toBe('opt1');
+        wrapper.setProps({ value: '' });
+        expect(wrapper.update().find(Textbox).props().value).toBe(undefined);
       });
     });
   });

--- a/src/components/select/simple-select/simple-select.stories.mdx
+++ b/src/components/select/simple-select/simple-select.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
 import { useState } from 'react';
 import { Select, Option } from '../';
+import Button from '../../button';
 import SelectTextbox from '../select-textbox/select-textbox.component';
 import StyledSystemProps from '../../../../.storybook/utils/styled-system-props';
 
@@ -96,25 +97,31 @@ You can use the `required` prop to indicate if the field is mandatory.
         setValue(event.target.value);
         action('value set');
       };
+      function clearValue() {
+        setValue('');
+      }
       return (
-        <Select
-          id='controlled'
-          name='controlled'
-          value={ value }
-          onChange={ onChangeHandler }
-        >
-          <Option text='Amber' value='1' />
-          <Option text='Black' value='2' />
-          <Option text='Blue' value='3' />
-          <Option text='Brown' value='4' />
-          <Option text='Green' value='5' />
-          <Option text='Orange' value='6' />
-          <Option text='Pink' value='7' />
-          <Option text='Purple' value='8' />
-          <Option text='Red' value='9' />
-          <Option text='White' value='10' />
-          <Option text='Yellow' value='11' />
-        </Select>
+        <div>
+          <Button onClick={ clearValue } mb={ 2 }>clear</Button>
+          <Select
+            id='controlled'
+            name='controlled'
+            value={ value }
+            onChange={ onChangeHandler }
+          >
+            <Option text='Amber' value='1' />
+            <Option text='Black' value='2' />
+            <Option text='Blue' value='3' />
+            <Option text='Brown' value='4' />
+            <Option text='Green' value='5' />
+            <Option text='Orange' value='6' />
+            <Option text='Pink' value='7' />
+            <Option text='Purple' value='8' />
+            <Option text='Red' value='9' />
+            <Option text='White' value='10' />
+            <Option text='Yellow' value='11' />
+          </Select>
+        </div>
       );
     }}
   </Story>


### PR DESCRIPTION
### Proposed behaviour
Allow SimpleSelect and FilterableSelect to be cleared when controlled

### Current behaviour
SimpleSelect and FilterableSelect cannot be cleared when controlled

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
~~- [ ] Cypress automation tests added or updated if required~~
- [x] Storybook added or updated if required
~~- [ ] Typescript `d.ts` file added or updated if required~~
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
1. run npm start
2. open http://localhost:9001/?path=/docs/design-system-select--controlled
3. select a value
4. click on clear button
5. open http://localhost:9001/?path=/docs/design-system-select-filterable--controlled
6. select a value
7. click on clear button