### PR TITLE
docs(form): change radio button ids

### DIFF
--- a/src/components/form/form.stories.mdx
+++ b/src/components/form/form.stories.mdx
@@ -375,14 +375,14 @@ Please click on "Show code" below to see how to set these components up for alig
         mb={2}
       >
         <RadioButton
-          id="input-1"
-          value="input-1"
+          id="group-1-input-1"
+          value="group-1-input-1"
           label="Radio Option 1"
           labelWidth={10}
         />
         <RadioButton
-          id="input-2"
-          value="input-2"
+          id="group-1-input-2"
+          value="group-1-input-2"
           label="Radio Option 2"
           labelWidth={10}
         />
@@ -402,14 +402,14 @@ Please click on "Show code" below to see how to set these components up for alig
         mb={2}
       >
         <RadioButton
-          id="input-1"
-          value="input-1"
+          id="group-2-input-1"
+          value="group-2-input-1"
           label="Radio Option 1"
           labelWidth={10}
         />
         <RadioButton
-          id="input-2"
-          value="input-2"
+          id="group-2-input-2"
+          value="group-2-input-2"
           label="Radio Option 2"
           labelWidth={10}
         />
@@ -434,13 +434,6 @@ Please click on "Show code" below to see how to set these components up for alig
         name="checkbox2"
         onChange={() => console.log("CHECKBOX 2")}
         label="Checkbox 2"
-        ml="10%"
-      />
-      <Checkbox
-        name="checkbox3"
-        onChange={() => console.log("CHECKBOX 3")}
-        label="Checkbox 3"
-        mb={7}
         ml="10%"
       />
       <Hr ml="10%" mr="60%" mb={7} />


### PR DESCRIPTION
Fixes: #3296

### Proposed behaviour
Fix above issue, where clicking on the radio buttons in the second radio group, focuses the radio buttons in the first radio group because they have the same ids.

Also removed the third `Checkbox` from the example to unbloat it a bit

### Current behaviour
Clicking on the radio buttons in the second radio group, focuses the radio buttons in the first radio group.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
Go to story `/story/design-system-form--form-alignment-example` in the built storybook below.