### PR TITLE
feat(text-editor): add support for validation icon and error styles FE-3186

### DIFF
--- a/src/components/text-editor/__internal__/editor-counter/editor-counter.component.js
+++ b/src/components/text-editor/__internal__/editor-counter/editor-counter.component.js
@@ -1,18 +1,43 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import StyledCounter from './editor-counter.style';
+import { StyledCounterWrapper, StyledCounter } from './editor-counter.style';
+import ValidationIcon from '../../../validations';
 
-const Counter = ({ count = 0, limit = 3000 }) => (
-  <StyledCounter data-component='text-editor-counter'>
-    { `${limit - count}` }
-  </StyledCounter>
+const Counter = ({
+  count = 0,
+  limit = 3000,
+  error,
+  warning,
+  info
+}) => (
+  <StyledCounterWrapper
+    hasIcon={ !!(error || warning || info) }
+    data-component='text-editor-counter'
+  >
+    { !!(error || warning || info) && (
+      <ValidationIcon
+        error={ error }
+        warning={ warning }
+        info={ info }
+        tooltipPosition='top'
+        tabIndex={ 0 }
+      />
+    )}
+    <StyledCounter hasError={ !!error }>{ `${limit - count}` }</StyledCounter>
+  </StyledCounterWrapper>
 );
 
 Counter.propTypes = {
   /** Sets the current count value */
   count: PropTypes.number,
   /** Sets the current limit value */
-  limit: PropTypes.number
+  limit: PropTypes.number,
+  /** Message to be displayed when there is an error */
+  error: PropTypes.string,
+  /** Message to be displayed when there is a warning */
+  warning: PropTypes.string,
+  /** Message to be displayed when there is an info */
+  info: PropTypes.string
 };
 
 export default Counter;

--- a/src/components/text-editor/__internal__/editor-counter/editor-counter.d.ts
+++ b/src/components/text-editor/__internal__/editor-counter/editor-counter.d.ts
@@ -3,6 +3,9 @@ import * as React from 'react';
 export interface EditorCounterProps {
   count: number;
   limit: number;
+  error?: string;
+  warning?: string;
+  info?: string;
 }
 
 declare const EditorCounter: React.FunctionComponent<EditorCounterProps>;

--- a/src/components/text-editor/__internal__/editor-counter/editor-counter.spec.js
+++ b/src/components/text-editor/__internal__/editor-counter/editor-counter.spec.js
@@ -3,6 +3,8 @@ import { mount } from 'enzyme';
 import { assertStyleMatch } from '../../../../__spec_helper__/test-utils';
 import baseTheme from '../../../../style/themes/base';
 import Counter from './editor-counter.component';
+import { StyledCounter } from './editor-counter.style';
+import ValidationIcon from '../../../validations';
 
 const render = (props = {}, renderer = mount) => {
   return renderer(<Counter { ...props } />);
@@ -10,14 +12,20 @@ const render = (props = {}, renderer = mount) => {
 
 describe('EditorCounter', () => {
   it('has the expected styles', () => {
+    const wrapper = render();
     assertStyleMatch({
-      color: baseTheme.editor.counter,
-      marginTop: '14px',
-      marginLeft: '4px',
+      margin: '16px 16px 0px 4px',
       minWidth: '40px',
       height: '21px',
-      float: 'right'
-    }, render());
+      float: 'right',
+      textAlign: 'right',
+      alignItems: 'center'
+    }, wrapper);
+
+    assertStyleMatch({
+      color: baseTheme.editor.counter,
+      width: '100%'
+    }, wrapper.find(StyledCounter));
   });
 
   it('displays the correct value for permitted characters when the default `limit` is used', () => {
@@ -30,5 +38,25 @@ describe('EditorCounter', () => {
     const wrapper = render({ count: 10, limit: 10 });
 
     expect(wrapper.find('div').text()).toEqual('0');
+  });
+
+  describe('with validation', () => {
+    it('does not render the icon by default', () => {
+      expect(render().find(ValidationIcon).exists()).toEqual(false);
+    });
+
+    it.each([{ error: 'error' }, { warning: 'warning' }, { info: 'info' }])(
+      'renders the icon when a message is provided', (msg) => {
+        expect(render({ ...msg }).find(ValidationIcon).exists()).toEqual(true);
+      }
+    );
+
+    it('has expected styling overrides applied when there is an error', () => {
+      const wrapper = render({ error: 'error' });
+
+      assertStyleMatch({
+        color: baseTheme.colors.error
+      }, wrapper.find(StyledCounter));
+    });
   });
 });

--- a/src/components/text-editor/__internal__/editor-counter/editor-counter.style.js
+++ b/src/components/text-editor/__internal__/editor-counter/editor-counter.style.js
@@ -1,20 +1,24 @@
 import styled from 'styled-components';
 import baseTheme from '../../../../style/themes/base';
 
-const StyledCounter = styled.div`
-  ${({ theme }) => `
-    color: ${theme.editor.counter};
-    margin-top: 14px;
-    margin-left: 4px;
-    min-width: 40px;
-    height: 21px;
-    float: right;
-    font-size: 14px;
-  `}
+const StyledCounter = styled.span`
+  color: ${({ theme, hasError }) => (hasError ? `${theme.colors.error};` : `${theme.editor.counter};`)}
+  width: 100%;
+`;
+
+const StyledCounterWrapper = styled.div`
+  margin: 16px 16px 0px 4px;
+  min-width: 40px;
+  height: 21px;
+  font-size: 14px;
+  display: flex;
+  float: right;
+  text-align: right;
+  align-items: center;
 `;
 
 StyledCounter.defaultProps = {
   theme: baseTheme
 };
 
-export default StyledCounter;
+export { StyledCounter, StyledCounterWrapper };

--- a/src/components/text-editor/__internal__/text-editor.component.js
+++ b/src/components/text-editor/__internal__/text-editor.component.js
@@ -24,7 +24,7 @@ import {
   hasBlockStyle,
   blockStyleFn
 } from './utils';
-import StyledEditorContainer from './text-editor.style';
+import { StyledEditorOutline, StyledEditorContainer } from './text-editor.style';
 import Counter from './editor-counter';
 import Toolbar from './toolbar';
 import Label from '../../../__experimental__/components/label';
@@ -43,7 +43,10 @@ const TextEditor = React.forwardRef(({
   onCancel,
   onSave,
   value,
-  required
+  required,
+  error,
+  warning,
+  info
 }, ref) => {
   const [isFocused, setIsFocused] = useState(false);
   const [inlines, setInlines] = useState([]);
@@ -64,6 +67,11 @@ const TextEditor = React.forwardRef(({
   };
 
   const handleKeyCommand = (command) => {
+    // bail out if the enter is pressed and limit has been reached
+    if (command.includes('split-block') && contentLength === characterLimit) {
+      return 'handled';
+    }
+
     // if the backspace or enter is pressed get block type and text
     if (command.includes('backspace') || command.includes('split-block')) {
       const { blockType, blockLength } = getContentInfo(value);
@@ -236,37 +244,48 @@ const TextEditor = React.forwardRef(({
           {labelText}
         </Label>
       </LabelWrapper>
-      <StyledEditorContainer
-        data-component='text-editor-container'
+      <StyledEditorOutline
         isFocused={ isFocused }
-        ariaLabelledBy={ labelId.current }
+        hasError={ !!error }
       >
-        <Counter limit={ characterLimit } count={ contentLength } />
-        <Editor
-          ref={ editor }
-          onFocus={ () => handleEditorFocus(true) }
-          onBlur={ () => handleEditorFocus(false) }
-          editorState={ editorState }
-          onChange={ onChange }
-          handleBeforeInput={ handleBeforeInput }
-          handlePastedText={ handlePastedText }
-          handleKeyCommand={ handleKeyCommand }
+        <StyledEditorContainer
+          data-component='text-editor-container'
           ariaLabelledBy={ labelId.current }
-          ariaDescribedBy={ labelId.current }
-          blockStyleFn={ blockStyleFn }
-          keyBindingFn={ keyBindingFn }
-        />
-        <Toolbar
-          onSave={ onSave }
-          onCancel={ onCancel }
-          setBlockStyle={ (ev, blockType) => handleBlockStyleChange(ev, blockType) }
-          setInlineStyle={ (ev, inlineStyle, keyboardUsed) => handleInlineStyleChange(ev, inlineStyle, keyboardUsed) }
-          isDisabled={ contentLength === 0 }
-          editorState={ editorState }
-          activeControls={ activeControls }
-          canFocus={ focusToolbar }
-        />
-      </StyledEditorContainer>
+          hasError={ !!error }
+        >
+          <Counter
+            limit={ characterLimit }
+            count={ contentLength }
+            error={ error }
+            warning={ warning }
+            info={ info }
+          />
+          <Editor
+            ref={ editor }
+            onFocus={ () => handleEditorFocus(true) }
+            onBlur={ () => handleEditorFocus(false) }
+            editorState={ editorState }
+            onChange={ onChange }
+            handleBeforeInput={ handleBeforeInput }
+            handlePastedText={ handlePastedText }
+            handleKeyCommand={ handleKeyCommand }
+            ariaLabelledBy={ labelId.current }
+            ariaDescribedBy={ labelId.current }
+            blockStyleFn={ blockStyleFn }
+            keyBindingFn={ keyBindingFn }
+          />
+          <Toolbar
+            onSave={ onSave }
+            onCancel={ onCancel }
+            setBlockStyle={ (ev, blockType) => handleBlockStyleChange(ev, blockType) }
+            setInlineStyle={ (ev, inlineStyle, keyboardUsed) => handleInlineStyleChange(ev, inlineStyle, keyboardUsed) }
+            isDisabled={ contentLength === 0 }
+            editorState={ editorState }
+            activeControls={ activeControls }
+            canFocus={ focusToolbar }
+          />
+        </StyledEditorContainer>
+      </StyledEditorOutline>
     </>
   );
 });
@@ -285,7 +304,13 @@ TextEditor.propTypes = {
   /** The value of the input, this is an EditorState immutable object */
   value: PropTypes.object.isRequired,
   /** Flag to configure component as mandatory */
-  required: PropTypes.bool
+  required: PropTypes.bool,
+  /** Message to be displayed when there is an error */
+  error: PropTypes.string,
+  /** Message to be displayed when there is a warning */
+  warning: PropTypes.string,
+  /** Message to be displayed when there is an info */
+  info: PropTypes.string
 };
 
 export const TextEditorState = EditorState;

--- a/src/components/text-editor/__internal__/text-editor.d.ts
+++ b/src/components/text-editor/__internal__/text-editor.d.ts
@@ -9,6 +9,9 @@ export interface TextEditorProps {
   value: object;
   /** Flag to configure component as mandatory */
   required?: boolean;
+  error?: string;
+  warning?: string;
+  info?: string;
 }
 
 declare const TextEditor: React.FunctionComponent<TextEditorProps>;

--- a/src/components/text-editor/__internal__/text-editor.spec.js
+++ b/src/components/text-editor/__internal__/text-editor.spec.js
@@ -9,13 +9,18 @@ import { assertStyleMatch } from '../../../__spec_helper__/test-utils';
 import mintTheme from '../../../style/themes/mint';
 import TextEditor, { TextEditorContentState, TextEditorState } from './text-editor.component';
 import EditorLink from './editor-link/editor-link.component';
-import StyledEditorContainer from './text-editor.style';
+import { StyledEditorOutline, StyledEditorContainer } from './text-editor.style';
 import ToolbarButton from './toolbar/toolbar-button/toolbar-button.component';
 import Counter from './editor-counter';
 import Toolbar from './toolbar';
 import guid from '../../../utils/helpers/guid';
 import Label from '../../../__experimental__/components/label';
 import LabelWrapper from './label-wrapper';
+import ValidationIcon from '../../validations';
+import { isSafari } from '../../../utils/helpers/browser-type-check';
+
+jest.mock('../../../utils/helpers/browser-type-check');
+isSafari.mockImplementation(() => false);
 
 jest.mock('../../../utils/helpers/guid');
 guid.mockImplementation(() => 'guid-12345');
@@ -93,7 +98,7 @@ describe('TextEditor', () => {
         minHeight: '220px',
         minWidth: '320px',
         backgroundColor: mintTheme.colors.white,
-        border: `1px solid ${mintTheme.editor.border}`
+        outline: `1px solid ${mintTheme.editor.border}`
       }, wrapper.find(StyledEditorContainer));
 
       assertStyleMatch({
@@ -107,7 +112,7 @@ describe('TextEditor', () => {
         minHeight: 'inherit',
         height: '100%',
         minWidth: '290px',
-        padding: '8px'
+        padding: '14px 8px'
       }, wrapper.find(StyledEditorContainer), { modifier: 'div.public-DraftEditor-content' });
     });
 
@@ -117,15 +122,16 @@ describe('TextEditor', () => {
       act(() => { wrapper.update(); });
 
       assertStyleMatch({
-        outline: `3px solid ${mintTheme.colors.focus}`
-      }, wrapper.find(StyledEditorContainer));
+        outline: `3px solid ${mintTheme.colors.focus}`,
+        outlineOffset: '1px'
+      }, wrapper.find(StyledEditorOutline));
 
       act(() => { wrapper.find(Editor).props().onBlur(); });
       act(() => { wrapper.update(); });
 
       assertStyleMatch({
-        outline: undefined
-      }, wrapper.find(StyledEditorContainer));
+        outline: 'none'
+      }, wrapper.find(StyledEditorOutline));
     });
   });
 
@@ -518,6 +524,12 @@ describe('TextEditor', () => {
         });
       });
 
+      it('prevents enter key press when the limit has been reached', () => {
+        wrapper = render({ characterLimit: 0 });
+        const editor = wrapper.find(Editor);
+        act(() => { expect(editor.props().handleKeyCommand('split-block')).toEqual('handled'); });
+      });
+
       it('allows pasting into input that would not exceed the limit', () => {
         wrapper = render({ characterLimit: 2 });
         const editor = wrapper.find(Editor);
@@ -550,6 +562,31 @@ describe('TextEditor', () => {
 
       const label = wrapper.find(Label);
       expect(label.prop('isRequired')).toBe(true);
+    });
+  });
+
+  describe('validation', () => {
+    it.each([{ error: 'error' }, { warning: 'warning' }, { info: 'info' }])(
+      'passes the validation props to the counter and renders the icon', (msg) => {
+        expect(render({ ...msg }).find(ValidationIcon).exists()).toEqual(true);
+      }
+    );
+
+    it('applies the expected outline when an error message is passed', () => {
+      assertStyleMatch({
+        outline: `2px solid ${mintTheme.colors.error}`
+      }, render({ error: 'error' }).find(StyledEditorContainer));
+    });
+
+    it('applies the correct outline-offset when there is an error and the editor is focused', () => {
+      wrapper = render({ error: 'error' });
+      act(() => { wrapper.find(Editor).props().onFocus(); });
+      act(() => { wrapper.update(); });
+
+      assertStyleMatch({
+        outline: `3px solid ${mintTheme.colors.focus}`,
+        outlineOffset: '2px'
+      }, wrapper.find(StyledEditorOutline));
     });
   });
 

--- a/src/components/text-editor/__internal__/text-editor.stories.mdx
+++ b/src/components/text-editor/__internal__/text-editor.stories.mdx
@@ -119,17 +119,49 @@ will prevent any input that would cause the content length to exceed it.
   <Story name="with optional character limit">
     {() => {
       const [value, setValue] = useState(EditorState.createEmpty());
-      const [limit, setLimit] = useState(100);
+      const limit = 100;
       const ref = useRef(null);
       return (
-          <div style={{ padding: '4px' }}>
-            <TextEditor
-              onChange={(newValue) => {setValue(newValue)}}
-              value={ value } ref={ ref }
-              onSubmit={ () => {} }
-              labelText='Text Editor Label'
-              characterLimit={ limit }
-            />
+        <div style={{ padding: '4px' }}>
+          <TextEditor
+            onChange={(newValue) => {setValue(newValue)}}
+            value={ value } ref={ ref }
+            onSubmit={ () => {} }
+            labelText='Text Editor Label'
+            characterLimit={ limit }
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With validation
+It is possible apply validation to the `TextEditor` component by passing the desired string message to one of the `error`, 
+`warning` or `info` props. When an `error` message is provided the border styling of the editor is updated to indicate 
+this status.
+
+<Preview>
+  <Story name="with validation">
+    {() => {
+      const [value, setValue] = useState(
+        EditorState.createWithContent(ContentState.createFromText('Add content'))
+      );
+      const limit = 16;
+      const contentLength = value.getCurrentContent().getPlainText().length;
+      const ref = useRef(null);
+      return (
+        <div style={{ padding: '4px' }}>
+          <TextEditor
+            onChange={(newValue) => {setValue(newValue)}}
+            value={ value }
+            ref={ ref }
+            labelText='Text Editor Label'
+            characterLimit={ limit }
+            error={ limit - contentLength <= 5 ? 'There is an error' : undefined }
+            warning={ limit - contentLength <= 10 ? 'There is an warning' : undefined }
+            info={ limit - contentLength <= 15 ? 'There is an info' : undefined }
+          />
         </div>
       );
     }}

--- a/src/components/text-editor/__internal__/text-editor.style.js
+++ b/src/components/text-editor/__internal__/text-editor.style.js
@@ -1,9 +1,10 @@
 import styled, { css } from 'styled-components';
 import { isDLS } from '../../../utils/helpers/style-helper';
 import baseTheme from '../../../style/themes/base';
+import { isSafari } from '../../../utils/helpers/browser-type-check';
 
 const StyledEditorContainer = styled.div`
-  ${({ theme, isFocused }) => css`
+  ${({ theme, hasError }) => css`
     min-height: 220px;
     min-width: 320px;
     
@@ -22,24 +23,25 @@ const StyledEditorContainer = styled.div`
       background-color: ${theme.colors.white};
       line-height: 21px;
 
-      .text-editor-block-ordered {
-        position: relative;
-        left: -4px;
-        padding-left: 4px;
-      }
+      ${!isSafari(navigator) && css`
+        .text-editor-block-ordered {
+          position: relative;
+          left: -4px;
+          padding-left: 4px;
+        }
 
-      .text-editor-block-unordered {
-        position: relative;
-      }
+        .text-editor-block-unordered {
+          position: relative;
+        }
+      `}
     }
 
     div.public-DraftEditor-content {
-      padding: 8px;
+      padding: 14px 8px;
     }
   
     background-color: ${theme.colors.white};
-    border: 1px solid ${theme.editor.border};
-    ${isDLS(theme) && isFocused && `outline: 3px solid ${theme.colors.focus};`}
+    outline: ${hasError ? `2px solid ${theme.colors.error};` : `1px solid ${theme.editor.border};`}
   `}
 `;
 
@@ -47,4 +49,18 @@ StyledEditorContainer.defaultProps = {
   theme: baseTheme
 };
 
-export default StyledEditorContainer;
+const StyledEditorOutline = styled.div`
+  ${({ theme, isFocused, hasError }) => css`
+    outline: none;
+    ${isDLS(theme) && isFocused && `
+      outline: 3px solid ${theme.colors.focus};
+      outline-offset: ${hasError ? '2px;' : '1px;'}
+    `}
+  `}
+`;
+
+StyledEditorOutline.defaultProps = {
+  theme: baseTheme
+};
+
+export { StyledEditorContainer, StyledEditorOutline };

--- a/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.component.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.component.js
@@ -26,6 +26,7 @@ class ToolbarButton extends React.Component {
           isActive={ this.props.activated }
           aria-label={ this.props.ariaLabel }
           { ...(!this.props.tabbable) && { tabIndex: -1 } }
+          type='button'
         >
           { this.props.children }
         </StyledToolbarButton>

--- a/src/components/validations/validation-icon.component.js
+++ b/src/components/validations/validation-icon.component.js
@@ -85,9 +85,9 @@ ValidationIcon.propTypes = {
   tooltipPosition: PropTypes.string,
   /** Properties related to the theme */
   theme: PropTypes.object,
-  /** A boolean to indicate if the icon is part of an input */
-  onClick: PropTypes.func,
   /** An onClick handler */
+  onClick: PropTypes.func,
+  /** A boolean to indicate if the icon is part of an input */
   isPartOfInput: PropTypes.bool,
   /** Overrides the default tabindex of the component */
   tabIndex: PropTypes.number,


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
The `ValidationIcon` is rendered when a string value is passed to either the `error`, `warning` or
`info` prop. The component has been slightly refactored to use outlines instead of borders to
prevent the content jumping when the styling is updated based on the validation state. When the
component is in an error state, the outline and counter text colour are updated to reflect it.
### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

There is no support for rendering the `ValidationIcon` or the error state styling. The component uses borders instead of outlines.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/96477949-02858600-122f-11eb-9572-3ed864a06a6f.png)

![image](https://user-images.githubusercontent.com/44157880/96477994-10d3a200-122f-11eb-9d22-df9487b8d10c.png)

![image](https://user-images.githubusercontent.com/44157880/96478052-2052eb00-122f-11eb-9f61-6fa28496098c.png)

![image](https://user-images.githubusercontent.com/44157880/96478134-3a8cc900-122f-11eb-9846-dea197b8ff49.png)

![image](https://user-images.githubusercontent.com/44157880/96478186-49737b80-122f-11eb-9fca-d04c4b64785c.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
The changes can be tested at http://localhost:9001/?path=/story/design-system-text-editor--with-validation

https://codesandbox.io/s/carbon-quickstart-forked-80btt?file=/src/index.js
This is a basic demo of the intended validation behaviour within a form