### PR TITLE
docs: remove allure reports data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,3 @@ src/style-config/assets.scss
 cypress/fixtures/example*
 cypress/screenshots
 .vscode/
-
-#Allure reports
-allure-report
-allure-results


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
remove from `.gitignore` file unnecessary:
`Allure reports`
- allure-report
- allure-results

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
As we removed `allure-reports` from `cypress` reporting. We need to clear the `.gitignore` file and remove:
`Allure reports`
- allure-report
- allure-results

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent