### PR TITLE
feat(accordion): add tertiary button heading styling option

### DIFF
--- a/src/__experimental__/components/date/__snapshots__/date-picker.spec.js.snap
+++ b/src/__experimental__/components/date/__snapshots__/date-picker.spec.js.snap
@@ -478,7 +478,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
             role="heading"
           >
             <div>
-              octobre 2020
+              avril 2019
             </div>
           </div>
           <div
@@ -577,46 +577,10 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               role="row"
             >
               <div
-                aria-disabled={true}
-                aria-label="lun. 28 sept. 2020"
-                aria-selected={false}
-                className="DayPicker-Day DayPicker-Day--outside"
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                role="gridcell"
-                tabIndex={-1}
-              >
-                28
-              </div>
-              <div
-                aria-disabled={true}
-                aria-label="mar. 29 sept. 2020"
-                aria-selected={false}
-                className="DayPicker-Day DayPicker-Day--outside"
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                role="gridcell"
-                tabIndex={-1}
-              >
-                29
-              </div>
-              <div
-                aria-disabled={true}
-                aria-label="mer. 30 sept. 2020"
-                aria-selected={false}
-                className="DayPicker-Day DayPicker-Day--outside"
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                role="gridcell"
-                tabIndex={-1}
-              >
-                30
-              </div>
-              <div
                 aria-disabled={false}
-                aria-label="jeu. 1 oct. 2020"
-                aria-selected={false}
-                className="DayPicker-Day"
+                aria-label="lun. 1 avr. 2019"
+                aria-selected={true}
+                className="DayPicker-Day DayPicker-Day--selected"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="gridcell"
@@ -626,7 +590,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="ven. 2 oct. 2020"
+                aria-label="mar. 2 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -638,9 +602,9 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="sam. 3 oct. 2020"
+                aria-label="mer. 3 avr. 2019"
                 aria-selected={false}
-                className="DayPicker-Day"
+                className="DayPicker-Day DayPicker-Day--today"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="gridcell"
@@ -650,7 +614,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="dim. 4 oct. 2020"
+                aria-label="jeu. 4 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -660,14 +624,9 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               >
                 4
               </div>
-            </div>
-            <div
-              className="DayPicker-Week"
-              role="row"
-            >
               <div
                 aria-disabled={false}
-                aria-label="lun. 5 oct. 2020"
+                aria-label="ven. 5 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -679,7 +638,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="mar. 6 oct. 2020"
+                aria-label="sam. 6 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -691,7 +650,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="mer. 7 oct. 2020"
+                aria-label="dim. 7 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -701,9 +660,14 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               >
                 7
               </div>
+            </div>
+            <div
+              className="DayPicker-Week"
+              role="row"
+            >
               <div
                 aria-disabled={false}
-                aria-label="jeu. 8 oct. 2020"
+                aria-label="lun. 8 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -715,7 +679,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="ven. 9 oct. 2020"
+                aria-label="mar. 9 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -727,7 +691,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="sam. 10 oct. 2020"
+                aria-label="mer. 10 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -739,7 +703,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="dim. 11 oct. 2020"
+                aria-label="jeu. 11 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -749,14 +713,9 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               >
                 11
               </div>
-            </div>
-            <div
-              className="DayPicker-Week"
-              role="row"
-            >
               <div
                 aria-disabled={false}
-                aria-label="lun. 12 oct. 2020"
+                aria-label="ven. 12 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -768,7 +727,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="mar. 13 oct. 2020"
+                aria-label="sam. 13 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -780,7 +739,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="mer. 14 oct. 2020"
+                aria-label="dim. 14 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -790,9 +749,14 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               >
                 14
               </div>
+            </div>
+            <div
+              className="DayPicker-Week"
+              role="row"
+            >
               <div
                 aria-disabled={false}
-                aria-label="jeu. 15 oct. 2020"
+                aria-label="lun. 15 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -804,7 +768,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="ven. 16 oct. 2020"
+                aria-label="mar. 16 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -816,7 +780,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="sam. 17 oct. 2020"
+                aria-label="mer. 17 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -828,7 +792,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="dim. 18 oct. 2020"
+                aria-label="jeu. 18 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -838,14 +802,9 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               >
                 18
               </div>
-            </div>
-            <div
-              className="DayPicker-Week"
-              role="row"
-            >
               <div
                 aria-disabled={false}
-                aria-label="lun. 19 oct. 2020"
+                aria-label="ven. 19 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -857,7 +816,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="mar. 20 oct. 2020"
+                aria-label="sam. 20 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -869,7 +828,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="mer. 21 oct. 2020"
+                aria-label="dim. 21 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -879,9 +838,14 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               >
                 21
               </div>
+            </div>
+            <div
+              className="DayPicker-Week"
+              role="row"
+            >
               <div
                 aria-disabled={false}
-                aria-label="jeu. 22 oct. 2020"
+                aria-label="lun. 22 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -893,7 +857,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="ven. 23 oct. 2020"
+                aria-label="mar. 23 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -905,7 +869,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="sam. 24 oct. 2020"
+                aria-label="mer. 24 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -917,7 +881,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="dim. 25 oct. 2020"
+                aria-label="jeu. 25 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -927,14 +891,9 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               >
                 25
               </div>
-            </div>
-            <div
-              className="DayPicker-Week"
-              role="row"
-            >
               <div
                 aria-disabled={false}
-                aria-label="lun. 26 oct. 2020"
+                aria-label="ven. 26 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -946,7 +905,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="mar. 27 oct. 2020"
+                aria-label="sam. 27 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -958,7 +917,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="mer. 28 oct. 2020"
+                aria-label="dim. 28 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -968,9 +927,14 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               >
                 28
               </div>
+            </div>
+            <div
+              className="DayPicker-Week"
+              role="row"
+            >
               <div
                 aria-disabled={false}
-                aria-label="jeu. 29 oct. 2020"
+                aria-label="lun. 29 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -982,7 +946,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={false}
-                aria-label="ven. 30 oct. 2020"
+                aria-label="mar. 30 avr. 2019"
                 aria-selected={false}
                 className="DayPicker-Day"
                 onClick={[Function]}
@@ -993,20 +957,8 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
                 30
               </div>
               <div
-                aria-disabled={false}
-                aria-label="sam. 31 oct. 2020"
-                aria-selected={false}
-                className="DayPicker-Day"
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                role="gridcell"
-                tabIndex={-1}
-              >
-                31
-              </div>
-              <div
                 aria-disabled={true}
-                aria-label="dim. 1 nov. 2020"
+                aria-label="mer. 1 mai 2019"
                 aria-selected={false}
                 className="DayPicker-Day DayPicker-Day--outside"
                 onClick={[Function]}
@@ -1016,14 +968,9 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               >
                 1
               </div>
-            </div>
-            <div
-              className="DayPicker-Week"
-              role="row"
-            >
               <div
                 aria-disabled={true}
-                aria-label="lun. 2 nov. 2020"
+                aria-label="jeu. 2 mai 2019"
                 aria-selected={false}
                 className="DayPicker-Day DayPicker-Day--outside"
                 onClick={[Function]}
@@ -1035,7 +982,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={true}
-                aria-label="mar. 3 nov. 2020"
+                aria-label="ven. 3 mai 2019"
                 aria-selected={false}
                 className="DayPicker-Day DayPicker-Day--outside"
                 onClick={[Function]}
@@ -1047,7 +994,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={true}
-                aria-label="mer. 4 nov. 2020"
+                aria-label="sam. 4 mai 2019"
                 aria-selected={false}
                 className="DayPicker-Day DayPicker-Day--outside"
                 onClick={[Function]}
@@ -1059,7 +1006,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={true}
-                aria-label="jeu. 5 nov. 2020"
+                aria-label="dim. 5 mai 2019"
                 aria-selected={false}
                 className="DayPicker-Day DayPicker-Day--outside"
                 onClick={[Function]}
@@ -1069,9 +1016,14 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               >
                 5
               </div>
+            </div>
+            <div
+              className="DayPicker-Week"
+              role="row"
+            >
               <div
                 aria-disabled={true}
-                aria-label="ven. 6 nov. 2020"
+                aria-label="lun. 6 mai 2019"
                 aria-selected={false}
                 className="DayPicker-Day DayPicker-Day--outside"
                 onClick={[Function]}
@@ -1083,7 +1035,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={true}
-                aria-label="sam. 7 nov. 2020"
+                aria-label="mar. 7 mai 2019"
                 aria-selected={false}
                 className="DayPicker-Day DayPicker-Day--outside"
                 onClick={[Function]}
@@ -1095,7 +1047,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
               </div>
               <div
                 aria-disabled={true}
-                aria-label="dim. 8 nov. 2020"
+                aria-label="mer. 8 mai 2019"
                 aria-selected={false}
                 className="DayPicker-Day DayPicker-Day--outside"
                 onClick={[Function]}
@@ -1104,6 +1056,54 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
                 tabIndex={-1}
               >
                 8
+              </div>
+              <div
+                aria-disabled={true}
+                aria-label="jeu. 9 mai 2019"
+                aria-selected={false}
+                className="DayPicker-Day DayPicker-Day--outside"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="gridcell"
+                tabIndex={-1}
+              >
+                9
+              </div>
+              <div
+                aria-disabled={true}
+                aria-label="ven. 10 mai 2019"
+                aria-selected={false}
+                className="DayPicker-Day DayPicker-Day--outside"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="gridcell"
+                tabIndex={-1}
+              >
+                10
+              </div>
+              <div
+                aria-disabled={true}
+                aria-label="sam. 11 mai 2019"
+                aria-selected={false}
+                className="DayPicker-Day DayPicker-Day--outside"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="gridcell"
+                tabIndex={-1}
+              >
+                11
+              </div>
+              <div
+                aria-disabled={true}
+                aria-label="dim. 12 mai 2019"
+                aria-selected={false}
+                className="DayPicker-Day DayPicker-Day--outside"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="gridcell"
+                tabIndex={-1}
+              >
+                12
               </div>
             </div>
           </div>

--- a/src/__experimental__/components/date/date-picker.spec.js
+++ b/src/__experimental__/components/date/date-picker.spec.js
@@ -198,7 +198,11 @@ describe('StyledDayPicker', () => {
 
     describe('translation', () => {
       it('renders properly', () => {
-        const wrapper = render({ inputElement, inputDate: firstDate }, TestRenderer.create);
+        const wrapper = render({
+          inputElement,
+          inputDate: firstDate,
+          selectedDate: new Date('2019-04-01')
+        }, TestRenderer.create);
         expect(wrapper).toMatchSnapshot();
       });
     });

--- a/src/components/accordion/accordion.component.js
+++ b/src/components/accordion/accordion.component.js
@@ -17,6 +17,7 @@ import {
   StyledAccordionContentContainer,
   StyledAccordionContent
 } from './accordion.style';
+import Button from '../button';
 import ValidationIcon from '../validations';
 import Logger from '../../utils/logger/logger';
 
@@ -44,6 +45,9 @@ const Accordion = React.forwardRef(({
   error,
   warning,
   info,
+  buttonHeading,
+  buttonWidth = 150,
+  openTitle,
   ...rest
 }, ref) => {
   if (!deprecatedWarnTriggered) {
@@ -108,6 +112,7 @@ const Accordion = React.forwardRef(({
       borders={ borders }
       scheme={ scheme }
       styleOverride={ styleOverride.root }
+      buttonHeading={ buttonHeading }
       { ...rest }
     >
       <StyledAccordionTitleContainer
@@ -115,51 +120,70 @@ const Accordion = React.forwardRef(({
         id={ headerId }
         aria-expanded={ isExpanded }
         aria-controls={ contentId }
-        onClick={ toggleAccordion }
-        onKeyDown={ handleKeyDown }
+        onClick={ buttonHeading ? undefined : toggleAccordion }
+        onKeyDown={ buttonHeading ? undefined : handleKeyDown }
         iconAlign={ iconAlign }
         ref={ ref }
-        tabIndex='0'
+        tabIndex={ buttonHeading ? '-1' : '0' }
         size={ size }
+        isExpanded={ isExpanded }
+        buttonHeading={ buttonHeading }
+        buttonWidth={ buttonWidth }
         styleOverride={ styleOverride.headerArea }
         { ...headerSpacing }
       >
-        <StyledAccordionHeadingsContainer
-          data-element='accordion-headings-container'
-          hasValidationIcon={ showValidationIcon }
-        >
-          <StyledAccordionTitle
-            data-element='accordion-title'
-            size={ size }
-            styleOverride={ styleOverride.header }
+        {buttonHeading && (
+          <Button
+            buttonType='tertiary'
+            iconType='chevron_down'
+            iconPosition='after'
+            onClick={ toggleAccordion }
           >
-            { title }
-          </StyledAccordionTitle>
+            {isExpanded ? (openTitle || title) : title}
+          </Button>
+        )}
 
-          { showValidationIcon && (
-            <ValidationIcon
-              error={ error }
-              warning={ warning }
-              info={ info }
-              tooltipPosition='top'
-              tabIndex={ 0 }
+        {!buttonHeading && (
+          <>
+            <StyledAccordionHeadingsContainer
+              data-element='accordion-headings-container'
+              hasValidationIcon={ showValidationIcon }
+            >
+              <StyledAccordionTitle
+                data-element='accordion-title'
+                size={ size }
+                styleOverride={ styleOverride.header }
+              >
+                { title }
+              </StyledAccordionTitle>
+
+              { showValidationIcon && (
+                <ValidationIcon
+                  error={ error }
+                  warning={ warning }
+                  info={ info }
+                  tooltipPosition='top'
+                  tabIndex={ 0 }
+                />
+              ) }
+
+              {(subTitle && size === 'large') && (
+                <StyledAccordionSubTitle>
+                  { subTitle }
+                </StyledAccordionSubTitle>
+              )}
+            </StyledAccordionHeadingsContainer>
+
+            <StyledAccordionIcon
+              data-element='accordion-icon'
+              type={ iconType }
+              isExpanded={ isExpanded }
+              iconAlign={ iconAlign }
+              styleOverride={ styleOverride.icon }
             />
-          ) }
+          </>
+        )}
 
-          {(subTitle && size === 'large') && (
-            <StyledAccordionSubTitle>
-              { subTitle }
-            </StyledAccordionSubTitle>
-          )}
-        </StyledAccordionHeadingsContainer>
-
-        <StyledAccordionIcon
-          data-element='accordion-icon'
-          type={ iconType }
-          isExpanded={ isExpanded }
-          iconAlign={ iconAlign }
-          styleOverride={ styleOverride.icon }
-        />
       </StyledAccordionTitleContainer>
       <StyledAccordionContentContainer
         isExpanded={ isExpanded }
@@ -225,7 +249,13 @@ Accordion.propTypes = {
   /** A warning message to be displayed in the tooltip */
   warning: PropTypes.string,
   /** An info message to be displayed in the tooltip */
-  info: PropTypes.string
+  info: PropTypes.string,
+  /** Renders the accordion heading in the style of a tertiary button */
+  buttonHeading: PropTypes.bool,
+  /** Width of the buttonHeading when it's set, defaults to 150px */
+  buttonWidth: PropTypes.number,
+  /** When the Accordion is open the title can change to this */
+  openTitle: PropTypes.string
 };
 
 Accordion.displayName = 'Accordion';

--- a/src/components/accordion/accordion.spec.js
+++ b/src/components/accordion/accordion.spec.js
@@ -341,6 +341,52 @@ describe('Accordion', () => {
     });
   });
 
+  describe('when buttonHeading set', () => {
+    it('should render a button in the header', () => {
+      wrapper = mount(<Accordion title='Title' buttonHeading />);
+
+      expect(wrapper.find(StyledAccordionTitleContainer).find('button').exists()).toBe(true);
+    });
+
+    describe('when openTitle prop set', () => {
+      it('should display the title when closed', () => {
+        wrapper = mount(
+          <Accordion
+            title='Title'
+            buttonHeading
+            openTitle='Less info'
+          />
+        );
+        expect(wrapper.find('[data-element="main-text"]').text()).toEqual('Title');
+      });
+
+      it('should display the openTitle when open', () => {
+        wrapper = mount(
+          <Accordion
+            title='Title'
+            buttonHeading
+            openTitle='Less info'
+            expanded
+          />
+        );
+        expect(wrapper.find('[data-element="main-text"]').text()).toEqual('Less info');
+      });
+    });
+
+    describe('when openTitle prop false', () => {
+      it('should display the title when open', () => {
+        wrapper = mount(
+          <Accordion
+            title='Title'
+            buttonHeading
+            expanded
+          />
+        );
+        expect(wrapper.find('[data-element="main-text"]').text()).toEqual('Title');
+      });
+    });
+  });
+
   describe('props', () => {
     it('passes data-role attribute to the root element of component', () => {
       render({

--- a/src/components/accordion/accordion.stories.mdx
+++ b/src/components/accordion/accordion.stories.mdx
@@ -310,6 +310,26 @@ The default width of 100% can be overriden.
   </Story>
 </Preview>
 
+### Opening button
+A button can be passed in to replace the title and opening icon. 
+This is not currently designed to be used within a form using validation.
+<Preview>
+  <Story name="opening button">
+    <Accordion
+      title="More info"
+      openTitle="Less info"
+      scheme="transparent"
+      borders="none"
+      buttonHeading
+      buttonWidth={200}
+    >
+      <div>Content</div>
+      <div>Content</div>
+      <div>Content</div>
+    </Accordion>
+  </Story>
+</Preview>
+
 ### Grouped
 Accordions borders collapse when positioned next to each other making it easy to group them.
 To achieve proper keyboard accessibility as described in `W3` sources it is required to wrap neighbouring accordions in

--- a/src/components/accordion/accordion.style.js
+++ b/src/components/accordion/accordion.style.js
@@ -8,7 +8,7 @@ import ValidationIconStyle from '../validations/validation-icon.style';
 const StyledAccordionContainer = styled.div`
   ${space};
   display: flex;
-  align-items: stretch;
+  align-items: ${({ buttonHeading }) => (buttonHeading ? 'flex-start' : 'stretch')};
   justify-content: center;
   flex-direction: column;
   box-sizing: border-box;
@@ -64,29 +64,58 @@ const StyledAccordionHeadingsContainer = styled.div`
 `;
 
 const StyledAccordionTitleContainer = styled.div`
-  padding:  ${({ size, theme }) => (size === 'small' ? theme.spacing * 2 : theme.spacing * 3)}px;  
-  ${space};
-  display: flex;
-  flex-grow: 1;
-  align-items: center;
-  justify-content: space-between;
+  ${({
+    buttonHeading,
+    buttonWidth,
+    iconAlign,
+    isExpanded,
+    size,
+    styleOverride,
+    theme
+  }) => css`
+    padding: ${(size === 'small' ? theme.spacing * 2 : theme.spacing * 3)}px;  
+    ${space};
+    ${buttonHeading && 'padding: 0'}
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 
-  ${({ iconAlign }) => (iconAlign === 'left' && css`
-    justify-content: flex-end;
-    flex-direction: row-reverse;
-  `)}
+    ${(iconAlign === 'left' && css`
+      justify-content: flex-end;
+      flex-direction: row-reverse;
+    `)}
 
-  cursor: pointer;
-  z-index: 1;
+    cursor: pointer;
+    z-index: 1;
 
-  &:focus {
-    outline: 2px solid ${({ theme }) => theme.colors.focus};
-  }
+    &:focus {
+      outline: ${buttonHeading ? 'none' : `2px solid ${theme.colors.focus}`}
+    }
 
-  &:hover {
-    background-color: ${({ theme }) => theme.accordion.background};
-  }
-  ${({ styleOverride }) => styleOverride};
+    ${!buttonHeading && css`
+      &:hover {
+        background-color: ${theme.accordion.background};
+      }
+    `}
+
+    button {
+      position: relative;
+      ${buttonWidth && css`width: ${buttonWidth}px`}
+    }
+
+    button > span:first-child {
+      position: absolute;
+      margin-left: -16px;
+    }
+
+    button > span[data-component="icon"] {
+      position: absolute;
+      right: 16px;
+      transition: transform 0.3s;
+      ${!isExpanded && 'transform: rotate(90deg)'};
+    }
+    ${styleOverride};
+  `}
 `;
 
 const StyledAccordionContentContainer = styled.div`

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
@@ -2,7 +2,9 @@ import { useState } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
 import DialogFullScreen from '.';
+import { Accordion } from '../accordion';
 import AppWrapper from '../app-wrapper';
+import Box from '../box';
 import Button from '../button';
 import Form from '../form';
 import Textbox from '../../__experimental__/components/textbox';
@@ -108,6 +110,69 @@ const MyComponent = ({ isOpen, handleClose }) => (
             title="An example of a long header"
             subtitle="Subtitle"
             headerChildren={ HeaderChildren }
+          >
+            <Form
+              stickyFooter={ true }
+              leftSideButtons={ <Button onClick={ () => setIsOpen(false) }>Cancel</Button> }
+              saveButton={ <Button buttonType='primary' type='submit'>Save</Button> }
+            >
+              <div>This is an example of a full screen Dialog with a Form as content</div>
+              <Textbox label='First Name' />
+              <Textbox label='Middle Name' />
+              <Textbox label='Surname' />
+              <Textbox label='Birth Place' />
+              <Textbox label='Favourite Colour' />
+              <Textbox label='Address' />
+            </Form>
+          </DialogFullScreen>
+        </>
+      )
+    }}
+  </Story>
+</Preview>
+
+### With hidable header children 
+
+<Preview>
+  <Story name="with hidable header children" parameters={{ chromatic: { disable: true, viewports: [500, 1400] }}}>
+    {() => {
+      const [isOpen, setIsOpen] = useState(false);
+      const aboveBreakpoint = useMediaQuery('(min-width: 568px)');
+      const verticalMargin = aboveBreakpoint ? '26px' : 0;
+      const HeaderChildrenAboveBreakpoint = (
+        <div style={{ margin: `${verticalMargin} 0 26px` }}>
+          <Pill as="help" fill>A pill</Pill> 
+          <Pill as="info" fill ml={2} mr={1}>Another pill</Pill>
+        </div>
+      );
+      const HeaderChildrenBelowBreakpoint = ( 
+        <Accordion
+          title="More info"
+          openTitle="Less info"
+          scheme="transparent"
+          borders="none"
+          disableContentPadding
+          buttonHeading
+          buttonWidth={120}
+          ml="-13px"
+        >
+          <Box py="16px" pl="14px">
+            <Pill as="help" fill>A pill</Pill> 
+            <Pill as="info" fill ml={2} mr={1}>Another pill</Pill>
+          </Box>
+        </Accordion> 
+      );
+      return (
+        <>
+          <Button onClick={ () => setIsOpen(!isOpen) }>
+            Open DialogFullScreen
+          </Button>
+          <DialogFullScreen
+            open={ isOpen }
+            onCancel={ () => setIsOpen(false) }
+            title="An example of a long header"
+            subtitle="Subtitle"
+            headerChildren={ aboveBreakpoint ? HeaderChildrenAboveBreakpoint : HeaderChildrenBelowBreakpoint }
           >
             <Form
               stickyFooter={ true }


### PR DESCRIPTION
### Proposed behaviour
Add option to have the `Accordion` heading styled as a tertiary button. This includes two new `Accordion` props, `buttonHeading` and `buttonWidth`. `buttonWidth` defaults to 150px.

A third `Accordion` prop `openTitle` has been added for this as well, to allow the title to change when the `Accordion` is expanded.

![image](https://user-images.githubusercontent.com/14963680/96595749-eb54a000-12e3-11eb-8ea7-7e127520edcc.png)

![image](https://user-images.githubusercontent.com/14963680/96595797-f5769e80-12e3-11eb-85ed-26af9a7d5569.png)


### Current behaviour
The `Accordion` heading cannot currently be in the style of a tertiary button

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
Go to http://localhost:9001/?path=/docs/design-system-accordion--opening-button to view the story