### PR TITLE
fix(inputs): show input icon if info validation is empty string

### DIFF
--- a/src/__experimental__/components/input-icon-toggle/input-icon-toggle.component.js
+++ b/src/__experimental__/components/input-icon-toggle/input-icon-toggle.component.js
@@ -6,7 +6,7 @@ import OptionsHelper from '../../../utils/helpers/options-helper';
 import ValidationIcon from '../../../components/validations/validation-icon.component';
 
 const shouldDisplayValidationIcon = ({ error, warning, info }) => {
-  const validation = error || warning || info;
+  const validation = error || warning || info || null;
   return typeof validation === 'string';
 };
 

--- a/src/__experimental__/components/input-icon-toggle/input-icon-toggle.spec.js
+++ b/src/__experimental__/components/input-icon-toggle/input-icon-toggle.spec.js
@@ -39,6 +39,27 @@ describe('InputIconToggle', () => {
   describe.each(
     ['error', 'warning', 'info']
   )(
+    'when %s validation prop is empty string and useValidationIcon is true', (validationProp) => {
+      let wrapper;
+
+      beforeAll(() => {
+        wrapper = render({ inputIcon: 'dropdown', [validationProp]: '', useValidationIcon: true }, mount);
+      });
+
+      it('it does not render a validation icon', () => {
+        const validationIcon = wrapper.find(ValidationIcon);
+        expect(validationIcon.exists()).toBe(false);
+      });
+
+      it('renders input icon', () => {
+        expect(wrapper.find(Icon).props().type).toBe('dropdown');
+      });
+    }
+  );
+
+  describe.each(
+    ['error', 'warning', 'info']
+  )(
     'when %s validation prop is string and useValidationIcon is true and readOnly is true', (validationProp) => {
       it('it renders a validation icon', () => {
         const wrapper = render({ [validationProp]: 'Message', useValidationIcon: true, readOnly: true });


### PR DESCRIPTION
### Proposed behaviour
This fixes a bug where if the a textbox component has a icon and the validation info is an empty string no icon would be displayed.

Fixes #3137

![image](https://user-images.githubusercontent.com/2328042/97167386-98b13300-177e-11eb-8907-28ac9544ba3c.png)

### Current behaviour
Here is an example of the select component, which uses the textbox component internally, when `info=""` there is no dropdown icon.
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
![image](https://user-images.githubusercontent.com/2328042/97166789-b6ca6380-177d-11eb-941b-1ead536cab6f.png)

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
FE-3037

### Testing instructions
See the generated PR from the bug report, each component should display the dropdown icon.
