### PR TITLE
fix(theme): update base/none theme primary color FE-1634

### DIFF
--- a/cypress/fixtures/themes/themes.json
+++ b/cypress/fixtures/themes/themes.json
@@ -7,7 +7,7 @@
     "common": {
         "mint": "rgb(0, 129, 93)",
         "aegean": "rgb(0, 115, 194)",
-        "none": "rgb(38, 168, 38)"
+        "none": "rgb(0, 130, 0)"
     },
     "step-sequence-item": {
         "mint": "rgb(0, 163, 118)",

--- a/src/__experimental__/components/date/__snapshots__/date-picker.spec.js.snap
+++ b/src/__experimental__/components/date/__snapshots__/date-picker.spec.js.snap
@@ -399,13 +399,13 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
 }
 
 .c0 .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-  background-color: #26A826;
+  background-color: #008200;
   color: #FFFFFF;
   font-weight: 800;
 }
 
 .c0 .DayPicker-Day--selected.DayPicker-Day--disabled:not(.DayPicker-Day--outside) {
-  background-color: #26A826;
+  background-color: #008200;
   color: #FFFFFF;
 }
 
@@ -1208,13 +1208,13 @@ exports[`StyledDayPicker renders presentational div and context provider for its
 }
 
 .c0 .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-  background-color: #26A826;
+  background-color: #008200;
   color: #FFFFFF;
   font-weight: 800;
 }
 
 .c0 .DayPicker-Day--selected.DayPicker-Day--disabled:not(.DayPicker-Day--outside) {
-  background-color: #26A826;
+  background-color: #008200;
   color: #FFFFFF;
 }
 

--- a/src/components/button/__snapshots__/button.spec.js.snap
+++ b/src/components/button/__snapshots__/button.spec.js.snap
@@ -4,12 +4,12 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c3 {
   display: inline-block;
   position: relative;
-  color: #26A826;
+  color: #008200;
   background-color: transparent;
 }
 
 .c3:hover {
-  color: #1E861E;
+  color: #006800;
   background-color: transparent;
 }
 
@@ -811,8 +811,8 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   -webkit-text-decoration: none;
   text-decoration: none;
   background: transparent;
-  border-color: #26A826;
-  color: #26A826;
+  border-color: #008200;
+  color: #008200;
   font-size: 14px;
   min-height: 40px;
 }
@@ -875,12 +875,12 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c3 {
   display: inline-block;
   position: relative;
-  color: #26A826;
+  color: #008200;
   background-color: transparent;
 }
 
 .c3:hover {
-  color: #1E861E;
+  color: #006800;
   background-color: transparent;
 }
 
@@ -926,8 +926,8 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   -webkit-text-decoration: none;
   text-decoration: none;
   background: transparent;
-  border-color: #26A826;
-  color: #26A826;
+  border-color: #008200;
+  color: #008200;
   font-size: 14px;
   min-height: 40px;
 }

--- a/src/components/card/__snapshots__/card.spec.js.snap
+++ b/src/components/card/__snapshots__/card.spec.js.snap
@@ -37,12 +37,12 @@ exports[`Card CardFooter styling should match the expected styling when it has n
 .c3 {
   display: inline-block;
   position: relative;
-  color: #26A826;
+  color: #008200;
   background-color: transparent;
 }
 
 .c3:hover {
-  color: #1E861E;
+  color: #006800;
   background-color: transparent;
 }
 
@@ -87,7 +87,7 @@ exports[`Card CardFooter styling should match the expected styling when it has n
   font-size: 14px;
   -webkit-text-decoration: underline;
   text-decoration: underline;
-  color: #26A826;
+  color: #008200;
   display: inline-block;
 }
 

--- a/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
+++ b/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
@@ -39,8 +39,8 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
   -webkit-text-decoration: none;
   text-decoration: none;
   background: transparent;
-  border-color: #26A826;
-  color: #26A826;
+  border-color: #008200;
+  color: #008200;
   font-size: 14px;
   min-height: 40px;
 }
@@ -1111,7 +1111,7 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                               "hoveredTabKeyline": "#4DB84D",
                               "info": "#0073C2",
                               "previewBackground": "#BFCCD2",
-                              "primary": "#26A826",
+                              "primary": "#008200",
                               "secondary": "#006300",
                               "slate": "#003349",
                               "success": "#00B000",
@@ -1427,7 +1427,7 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                                     "hoveredTabKeyline": "#4DB84D",
                                     "info": "#0073C2",
                                     "previewBackground": "#BFCCD2",
-                                    "primary": "#26A826",
+                                    "primary": "#008200",
                                     "secondary": "#006300",
                                     "slate": "#003349",
                                     "success": "#00B000",
@@ -1782,7 +1782,7 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                                 "hoveredTabKeyline": "#4DB84D",
                                 "info": "#0073C2",
                                 "previewBackground": "#BFCCD2",
-                                "primary": "#26A826",
+                                "primary": "#008200",
                                 "secondary": "#006300",
                                 "slate": "#003349",
                                 "success": "#00B000",
@@ -2103,7 +2103,7 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                                       "hoveredTabKeyline": "#4DB84D",
                                       "info": "#0073C2",
                                       "previewBackground": "#BFCCD2",
-                                      "primary": "#26A826",
+                                      "primary": "#008200",
                                       "secondary": "#006300",
                                       "slate": "#003349",
                                       "success": "#00B000",
@@ -2419,7 +2419,7 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                                             "hoveredTabKeyline": "#4DB84D",
                                             "info": "#0073C2",
                                             "previewBackground": "#BFCCD2",
-                                            "primary": "#26A826",
+                                            "primary": "#008200",
                                             "secondary": "#006300",
                                             "slate": "#003349",
                                             "success": "#00B000",
@@ -2815,7 +2815,7 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                                         "hoveredTabKeyline": "#4DB84D",
                                         "info": "#0073C2",
                                         "previewBackground": "#BFCCD2",
-                                        "primary": "#26A826",
+                                        "primary": "#008200",
                                         "secondary": "#006300",
                                         "slate": "#003349",
                                         "success": "#00B000",
@@ -3172,7 +3172,7 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                                               "hoveredTabKeyline": "#4DB84D",
                                               "info": "#0073C2",
                                               "previewBackground": "#BFCCD2",
-                                              "primary": "#26A826",
+                                              "primary": "#008200",
                                               "secondary": "#006300",
                                               "slate": "#003349",
                                               "success": "#00B000",
@@ -3488,7 +3488,7 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                                                     "hoveredTabKeyline": "#4DB84D",
                                                     "info": "#0073C2",
                                                     "previewBackground": "#BFCCD2",
-                                                    "primary": "#26A826",
+                                                    "primary": "#008200",
                                                     "secondary": "#006300",
                                                     "slate": "#003349",
                                                     "success": "#00B000",
@@ -3850,7 +3850,7 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                                                 "hoveredTabKeyline": "#4DB84D",
                                                 "info": "#0073C2",
                                                 "previewBackground": "#BFCCD2",
-                                                "primary": "#26A826",
+                                                "primary": "#008200",
                                                 "secondary": "#006300",
                                                 "slate": "#003349",
                                                 "success": "#00B000",
@@ -4181,7 +4181,7 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                                                       "hoveredTabKeyline": "#4DB84D",
                                                       "info": "#0073C2",
                                                       "previewBackground": "#BFCCD2",
-                                                      "primary": "#26A826",
+                                                      "primary": "#008200",
                                                       "secondary": "#006300",
                                                       "slate": "#003349",
                                                       "success": "#00B000",
@@ -4503,7 +4503,7 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                                                             "hoveredTabKeyline": "#4DB84D",
                                                             "info": "#0073C2",
                                                             "previewBackground": "#BFCCD2",
-                                                            "primary": "#26A826",
+                                                            "primary": "#008200",
                                                             "secondary": "#006300",
                                                             "slate": "#003349",
                                                             "success": "#00B000",
@@ -4849,7 +4849,7 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                                                         "hoveredTabKeyline": "#4DB84D",
                                                         "info": "#0073C2",
                                                         "previewBackground": "#BFCCD2",
-                                                        "primary": "#26A826",
+                                                        "primary": "#008200",
                                                         "secondary": "#006300",
                                                         "slate": "#003349",
                                                         "success": "#00B000",

--- a/src/components/dismiss-button/__snapshots__/dismiss-button.spec.js.snap
+++ b/src/components/dismiss-button/__snapshots__/dismiss-button.spec.js.snap
@@ -98,7 +98,7 @@ exports[`LinkStyle applies peoper styling when focused 1`] = `
   font-size: 14px;
   -webkit-text-decoration: underline;
   text-decoration: underline;
-  color: #26A826;
+  color: #008200;
   display: inline-block;
 }
 

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -212,7 +212,7 @@ describe('Icon component', () => {
 
         assertStyleMatch(
           {
-            color: '#1E861E'
+            color: '#006800'
           },
           wrapper.toJSON(),
           { modifier: ':hover' }
@@ -314,7 +314,7 @@ describe('Icon component', () => {
 
         assertStyleMatch(
           {
-            backgroundColor: '#1E861E'
+            backgroundColor: '#006800'
           },
           wrapper.toJSON(),
           { modifier: ':hover' }

--- a/src/components/link/__snapshots__/link.spec.js.snap
+++ b/src/components/link/__snapshots__/link.spec.js.snap
@@ -10,7 +10,7 @@ exports[`Link renders as expected 1`] = `
   font-size: 14px;
   -webkit-text-decoration: underline;
   text-decoration: underline;
-  color: #26A826;
+  color: #008200;
   display: inline-block;
 }
 

--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.js.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.js.snap
@@ -4,12 +4,12 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
 .c5 {
   display: inline-block;
   position: relative;
-  color: #26A826;
+  color: #008200;
   background-color: transparent;
 }
 
 .c5:hover {
-  color: #1E861E;
+  color: #006800;
   background-color: transparent;
 }
 
@@ -55,8 +55,8 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   background: transparent;
-  border-color: #26A826;
-  color: #26A826;
+  border-color: #008200;
+  color: #008200;
   font-size: 14px;
   min-height: 40px;
 }

--- a/src/components/pod/__snapshots__/pod.spec.js.snap
+++ b/src/components/pod/__snapshots__/pod.spec.js.snap
@@ -22,7 +22,7 @@ exports[`StyledEditAction when isHovered prop is set should match expected style
   font-size: 14px;
   -webkit-text-decoration: underline;
   text-decoration: underline;
-  color: #26A826;
+  color: #008200;
   display: inline-block;
 }
 
@@ -56,7 +56,7 @@ exports[`StyledEditAction when isHovered prop is set should match expected style
   cursor: pointer;
   border: 1px solid #CCD6DB;
   margin-left: 8px;
-  background-color: #26A826;
+  background-color: #008200;
   color: #FFFFFF;
 }
 

--- a/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
+++ b/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
@@ -4,12 +4,12 @@ exports[`Option renders properly 1`] = `
 .c4 {
   display: inline-block;
   position: relative;
-  color: #26A826;
+  color: #008200;
   background-color: transparent;
 }
 
 .c4:hover {
-  color: #1E861E;
+  color: #006800;
   background-color: transparent;
 }
 
@@ -55,8 +55,8 @@ exports[`Option renders properly 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   background: transparent;
-  border-color: #26A826;
-  color: #26A826;
+  border-color: #008200;
+  color: #008200;
   font-size: 14px;
   min-height: 40px;
 }

--- a/src/components/split-button/__snapshots__/split-button.spec.js.snap
+++ b/src/components/split-button/__snapshots__/split-button.spec.js.snap
@@ -4,12 +4,12 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
 .c6 {
   display: inline-block;
   position: relative;
-  color: #26A826;
+  color: #008200;
   background-color: transparent;
 }
 
 .c6:hover {
-  color: #1E861E;
+  color: #006800;
   background-color: transparent;
 }
 
@@ -73,8 +73,8 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   background: transparent;
-  border-color: #26A826;
-  color: #26A826;
+  border-color: #008200;
+  color: #008200;
   font-size: 14px;
   min-height: 40px;
 }
@@ -149,8 +149,8 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   background: transparent;
-  border-color: #26A826;
-  color: #26A826;
+  border-color: #008200;
+  color: #008200;
   font-size: 14px;
   min-height: 40px;
   border-left-width: 0;

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -15,7 +15,7 @@ export default (palette) => {
     colors: {
       // main
       base: palette.productGreen,
-      primary: palette.genericGreenTint(15),
+      primary: palette.genericGreenShade(15),
       secondary: palette.genericGreenShade(35),
       tertiary: palette.genericGreenShade(55),
       brand: palette.brilliantGreen,

--- a/src/style/utils/color.spec.js
+++ b/src/style/utils/color.spec.js
@@ -30,7 +30,7 @@ describe.each([
     assert({
       [prop]: 'primary'
     }, {
-      [css]: '#26A826'
+      [css]: '#008200'
     });
   });
 


### PR DESCRIPTION
### Proposed behaviour
I've updated the `theme.colors.primary` too be genericGreenShade(15) as suggested by @sianford.

The original ticket was raised for split button but it will affect every component that uses the primary color.
![image](https://user-images.githubusercontent.com/2328042/97178271-2b59ce00-178f-11eb-853b-d13e20e2ec18.png)

### Current behaviour
@sianford raised an issue with the Split Button having an incorrect color when using the base theme. 

The new DLS says the button using the "shared services" theme (aka none/base) should be

Normal: #008200 (genericGreenShade15)
Hover: #006300 (genericGreenShade35)
![image](https://user-images.githubusercontent.com/2328042/97178346-3e6c9e00-178f-11eb-91a5-0dabd82a9e27.png)

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
FE-1634

### Testing instructions

Check components using the `none` theme in the theme selector.

