### PR TITLE
feat(dialog-full-screen): add prop `disableContentPadding` - FE-3281

### DIFF
--- a/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
+++ b/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
@@ -170,20 +170,20 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
   width: 100%;
 }
 
-.c3.c3.c3.c3 .c10 {
+.c3.c3.c3.c3 .c11 {
   margin-top: -22px;
   margin-top: -14px;
 }
 
-.c3.c3.c3.c3 .c10 a,
-.c3.c3.c3.c3 .c10 button {
+.c3.c3.c3.c3 .c11 a,
+.c3.c3.c3.c3 .c11 button {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-top: 8px;
 }
 
-.c3.c3.c3.c3 .c10 a:focus,
-.c3.c3.c3.c3 .c10 button:focus {
+.c3.c3.c3.c3 .c11 a:focus,
+.c3.c3.c3.c3 .c11 button:focus {
   background-color: transparent;
   outline: 3px solid #FFB500;
   width: 25px;
@@ -281,17 +281,21 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
   height: calc(100% - 0px);
 }
 
-.c9:hover .c5 {
+.c0 + .c9 {
+  height: calc(100% - 0px);
+}
+
+.c10:hover .c5 {
   color: #FFFFFF;
 }
 
-.c9 .c5 {
+.c10 .c5 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c9 .c5 svg {
+.c10 .c5 svg {
   margin-top: 0;
 }
 
@@ -512,6 +516,10 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
   height: calc(100% - 0px);
 }
 
+.c2 + .c12 {
+  height: calc(100% - 0px);
+}
+
 .c10 {
   overflow-y: auto;
   padding: 0 16px;
@@ -566,17 +574,17 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
   width: 100%;
 }
 
-.c12:hover .c7 {
+.c13:hover .c7 {
   color: #FFFFFF;
 }
 
-.c12 .c7 {
+.c13 .c7 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c12 .c7 svg {
+.c13 .c7 svg {
   margin-top: 0;
 }
 
@@ -786,6 +794,10 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
   height: calc(100% - 0px);
 }
 
+.c2 + .c12 {
+  height: calc(100% - 0px);
+}
+
 .c10 {
   overflow-y: auto;
   padding: 0 16px;
@@ -840,17 +852,17 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
   width: 100%;
 }
 
-.c12:hover .c7 {
+.c13:hover .c7 {
   color: #FFFFFF;
 }
 
-.c12 .c7 {
+.c13 .c7 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c12 .c7 svg {
+.c13 .c7 svg {
   margin-top: 0;
 }
 
@@ -5158,15 +5170,10 @@ exports[`DialogFullScreen when pagesStyling prop set applies the Pages specific 
                                         "
   overflow-y: auto;
   padding: 0 16px;
-  @media screen and (min-width: 600px) {
-    padding: 0 24px;
-  }
-  @media screen and (min-width: 960px) {
-    padding: 0 32px;
-  }
-  @media screen and (min-width: 1260px) {
-    padding: 0 40px;
-  }
+
+  ",
+                                        [Function],
+                                        "
 
   ",
                                         [Function],

--- a/src/components/dialog-full-screen/content.style.js
+++ b/src/components/dialog-full-screen/content.style.js
@@ -5,15 +5,26 @@ import contentClassicStyle from "./content-classic.style";
 const StyledContent = styled.div`
   overflow-y: auto;
   padding: 0 16px;
-  @media screen and (min-width: 600px) {
-    padding: 0 24px;
-  }
-  @media screen and (min-width: 960px) {
-    padding: 0 32px;
-  }
-  @media screen and (min-width: 1260px) {
-    padding: 0 40px;
-  }
+
+  ${({ disableContentPadding }) => css`
+    ${!disableContentPadding &&
+    css`
+      @media screen and (min-width: 600px) {
+        padding: 0 24px;
+      }
+      @media screen and (min-width: 960px) {
+        padding: 0 32px;
+      }
+      @media screen and (min-width: 1260px) {
+        padding: 0 40px;
+      }
+    `}
+
+    ${disableContentPadding &&
+    css`
+      padding: 0;
+    `}
+  `}
 
   ${({ headingHeight }) => css`
     ${FullScreenHeading} + & {

--- a/src/components/dialog-full-screen/dialog-full-screen.component.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.js
@@ -116,6 +116,7 @@ class DialogFullScreen extends Modal {
           headingHeight={this.state.headingHeight}
           data-element="content"
           ref={this.contentRef}
+          disableContentPadding={this.props.disableContentPadding}
         >
           {this.props.children}
         </StyledContent>
@@ -132,6 +133,8 @@ DialogFullScreen.defaultProps = {
 
 DialogFullScreen.propTypes = {
   ...Modal.propTypes,
+  /** remove padding from content */
+  disableContentPadding: PropTypes.bool,
   /** Child elements */
   children: PropTypes.node,
   /** Title displayed at top of dialog */

--- a/src/components/dialog-full-screen/dialog-full-screen.spec.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.spec.js
@@ -42,6 +42,27 @@ describe("DialogFullScreen", () => {
     });
   });
 
+  describe("disableContentPadding", () => {
+    wrapper = mount(
+      <DialogFullScreen
+        open
+        className="foo"
+        title="my title"
+        onCancel={onCancel}
+        disableContentPadding
+      >
+        <div>test content</div>
+      </DialogFullScreen>
+    );
+
+    assertStyleMatch(
+      {
+        padding: "0",
+      },
+      wrapper.find(StyledContent)
+    );
+  });
+
   describe("modalHTML", () => {
     beforeEach(() => {
       wrapper = mount(

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.js
@@ -33,6 +33,7 @@ export const Default = () => {
   const ariaRole = text("ariaRole", "dialog");
   const formHeight = text("form height", "2000px");
   const stickyFooter = boolean("Form component stickyFooter", false);
+  const disableContentPadding = boolean("disableContentPadding", false);
 
   const handleCancel = () => {
     setIsOpen(false);
@@ -61,6 +62,7 @@ export const Default = () => {
         ariaRole={ariaRole}
         onClick={handleClick}
         showCloseIcon={showCloseIcon}
+        disableContentPadding={disableContentPadding}
       >
         <Form
           stickyFooter={stickyFooter}

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
@@ -85,6 +85,44 @@ const MyComponent = ({ isOpen, handleClose }) => (
   </Story>
 </Preview>
 
+### With disableContentPadding
+
+<Preview>
+  <Story name="with disableContentPadding" parameters={{ chromatic: { disable: true }}}>
+    {() => {
+      const [isOpen, setIsOpen] = useState(false);
+      return (
+        <>
+          <Button onClick={ () => setIsOpen(!isOpen) }>
+            Open DialogFullScreen
+          </Button>
+          <DialogFullScreen
+            open={ isOpen }
+            onCancel={ () => setIsOpen(false) }
+            title="Title"
+            subtitle="Subtitle"
+            disableContentPadding
+          >
+            <Form
+              stickyFooter={ true }
+              leftSideButtons={ <Button onClick={ () => setIsOpen(false) }>Cancel</Button> }
+              saveButton={ <Button buttonType='primary' type='submit'>Save</Button> }
+            >
+              <div>This is an example of a full screen Dialog with a Form as content</div>
+              <Textbox label='First Name' />
+              <Textbox label='Middle Name' />
+              <Textbox label='Surname' />
+              <Textbox label='Birth Place' />
+              <Textbox label='Favourite Colour' />
+              <Textbox label='Address' />
+            </Form>
+          </DialogFullScreen>
+        </>
+      )
+    }}
+  </Story>
+</Preview>
+
 ### With header children 
 
 <Preview>


### PR DESCRIPTION
### Proposed behaviour
- add new prop `disableContentPadding` to have possibility to turn off paddings in Dialog Full Screen

### Current behaviour
Padding is set by screen size

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] <del> Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] <del> Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent