### PR TITLE
feat(navigation-bar): add support for custom spacing props

### DIFF
--- a/src/components/navigation-bar/navigation-bar.component.js
+++ b/src/components/navigation-bar/navigation-bar.component.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import propTypes from "@styled-system/prop-types";
 import AppWrapper from "../app-wrapper/app-wrapper";
 import StyledNavigationBar from "./navigation-bar.style";
 
@@ -8,6 +9,7 @@ const NavigationBar = ({
   isLoading = false,
   children,
   ariaLabel,
+  ...props
 }) => {
   return (
     <StyledNavigationBar
@@ -15,6 +17,7 @@ const NavigationBar = ({
       aria-label={ariaLabel}
       navigationType={navigationType}
       data-component="navigation-bar"
+      {...props}
     >
       <AppWrapper className="carbon-navigation-bar__content">
         {!isLoading && children}
@@ -24,6 +27,8 @@ const NavigationBar = ({
 };
 
 NavigationBar.propTypes = {
+  /** Styled system spacing props */
+  ...propTypes.space,
   children: PropTypes.node,
   ariaLabel: PropTypes.string,
   /** color scheme of navigation component */

--- a/src/components/navigation-bar/navigation-bar.d.ts
+++ b/src/components/navigation-bar/navigation-bar.d.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import NavigationBar from './navigation-bar.component';
+import { SpacingProps } from '../../utils/helpers/options-helper';
 
-export interface NavigationBarProp {
+export interface NavigationBarProp extends SpacingProps {
   children?: React.ReactNode;
   ariaLabel?: string;
   navigationType?: 'light' | 'dark';

--- a/src/components/navigation-bar/navigation-bar.spec.js
+++ b/src/components/navigation-bar/navigation-bar.spec.js
@@ -1,12 +1,21 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
 import NavigationBar from "./navigation-bar.component";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemSpacing,
+} from "../../__spec_helper__/test-utils";
 import { baseTheme } from "../../style/themes";
 import StyledNavigationBar from "./navigation-bar.style";
 
 describe("NavigationBar", () => {
   let wrapper;
+
+  describe("style overrides", () => {
+    testStyledSystemSpacing((props) => (
+      <NavigationBar {...props}>test content</NavigationBar>
+    ));
+  });
 
   it("should render child correctly", () => {
     wrapper = shallow(

--- a/src/components/navigation-bar/navigation-bar.stories.mdx
+++ b/src/components/navigation-bar/navigation-bar.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import NavigationBar from './navigation-bar.component';
 import {Menu, MenuItem} from '../menu';
+import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
 
 <Meta title="Design System/Navigation Bar" />
 
@@ -50,4 +51,21 @@ If `isLoading={true}` the children will not be visible
   </Story> 
 </Preview>
 
-<Props of={NavigationBar} />
+### With custom spacing
+The spacing props (see prop table below) accept either a number between 1 and 8 that is then multiplied by `8px` or any 
+valid CSS string.
+<Preview>
+  <Story name="with custom spacing" parameters={{ info: { disable: true }}}>
+    <NavigationBar m={2} p={2}>
+      <Menu>
+        <MenuItem>menu item one</MenuItem>
+        <MenuItem>menu item two</MenuItem>
+      </Menu>
+    </NavigationBar> 
+  </Story> 
+</Preview>
+
+<StyledSystemProps
+  of={NavigationBar}
+  spacing
+/>

--- a/src/components/navigation-bar/navigation-bar.style.js
+++ b/src/components/navigation-bar/navigation-bar.style.js
@@ -1,7 +1,9 @@
 import styled, { css } from "styled-components";
+import { space } from "styled-system";
 import { baseTheme } from "../../style/themes";
 
 const StyledNavigationBar = styled.div`
+  ${space}
   ${({ navigationType, theme }) => css`
     min-height: 40px;
     background-color: ${theme.navigationBar.light.background};


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds support for the `styled-system` spacing props to be used to apply custom paddings and margins
to the `NavigationBar`.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No support for custom spacing in `NavigationBar`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
A basic example has been added here http://localhost:9001/?path=/story/design-system-navigation-bar--with-custom-spacing

Codesandbox:
https://codesandbox.io/s/carbon-quickstart-forked-rlez8?file=/src/index.js
