### PR TITLE
fix(radio-button): align legend with first radio-button FE-3213

### DIFF
--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
@@ -9,6 +9,14 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   margin-bottom: 16px;
 }
 
+.c14 + .c4 {
+  margin-top: 16px;
+}
+
+.c14.c14.c14 {
+  margin-bottom: 0px;
+}
+
 .c7 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -36,7 +44,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   display: flex;
 }
 
-.c3 .c14 {
+.c3 .c16 {
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -45,28 +53,27 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   width: auto;
 }
 
-.c3 .c14 .c15,
-.c3 .c14 .c16 {
+.c3 .c16 .c17,
+.c3 .c16 .c18 {
   color: rgba(0,0,0,0.65);
   vertical-align: middle;
 }
 
-.c3 .c14 .c15:hover,
-.c3 .c14 .c16:hover,
-.c3 .c14 .c15:focus,
-.c3 .c14 .c16:focus {
+.c3 .c16 .c17:hover,
+.c3 .c16 .c18:hover,
+.c3 .c16 .c17:focus,
+.c3 .c16 .c18:focus {
   color: rgba(0,0,0,0.9);
 }
 
-.c3 .c13 {
+.c3 .c15 {
   -webkit-flex-basis: 100%;
   -ms-flex-preferred-size: 100%;
   flex-basis: 100%;
 }
 
 .c2 {
-  margin-top: 8px;
-  margin-top: 8px;
+  margin-top: 4px;
 }
 
 .c2 .c8 {
@@ -103,20 +110,20 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   box-shadow: 0 0 0 3px #FFB500;
 }
 
-.c2 .c14 {
+.c2 .c16 {
   width: auto;
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
 }
 
-.c2 .c13 {
+.c2 .c15 {
   margin-left: 16px;
   margin-top: 0;
   padding-left: 8px;
 }
 
-.c2 .c16 {
+.c2 .c18 {
   position: relative;
   display: inline-block;
 }
@@ -150,13 +157,104 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   r: 5;
 }
 
-.c2 .c14 {
+.c2 .c16 {
   -webkit-flex: 1 1 calc(100% - 44px);
   -ms-flex: 1 1 calc(100% - 44px);
   flex: 1 1 calc(100% - 44px);
 }
 
 .c2 .c10:checked + .c12 circle {
+  fill: rgba(0,0,0,0.9);
+}
+
+.c13 .c8 {
+  padding-top: 1px;
+}
+
+.c13 .c12 {
+  height: 16px;
+}
+
+.c13 svg {
+  background-color: #FFFFFF;
+  border: 1px solid #668592;
+}
+
+.c13 .c10,
+.c13 svg {
+  height: 16px;
+  position: absolute;
+  padding: 1px;
+}
+
+.c13 .c8,
+.c13 .c10,
+.c13 .c12,
+.c13 svg {
+  box-sizing: border-box;
+  min-width: 16px;
+  width: 16px;
+}
+
+.c13 .c10:not([disabled]):focus + .c12,
+.c13 .c10:not([disabled]):hover + .c12 {
+  box-shadow: 0 0 0 3px #FFB500;
+}
+
+.c13 .c16 {
+  width: auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+}
+
+.c13 .c15 {
+  margin-left: 16px;
+  margin-top: 0;
+  padding-left: 8px;
+}
+
+.c13 .c18 {
+  position: relative;
+  display: inline-block;
+}
+
+.c13 .c10:checked ~ .c12 svg path {
+  fill: rgba(0,0,0,0.90);
+}
+
+.c13 .c12 {
+  padding: 0;
+}
+
+.c13 .c12,
+.c13 svg {
+  border-radius: 50%;
+}
+
+.c13 .c8,
+.c13 .c10,
+.c13 .c12,
+.c13 svg {
+  height: 16px;
+  width: 16px;
+}
+
+.c13 svg {
+  padding: 1px;
+}
+
+.c13 circle {
+  r: 5;
+}
+
+.c13 .c16 {
+  -webkit-flex: 1 1 calc(100% - 44px);
+  -ms-flex: 1 1 calc(100% - 44px);
+  flex: 1 1 calc(100% - 44px);
+}
+
+.c13 .c10:checked + .c12 circle {
   fill: rgba(0,0,0,0.9);
 }
 
@@ -173,10 +271,10 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   margin-bottom: 8px;
 }
 
@@ -276,7 +374,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
       </div>
       <div
         checked={false}
-        className="c2"
+        className="c13"
         data-component="radio-button"
         name="test-group"
       >
@@ -286,7 +384,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
           name="test-group"
         >
           <div
-            className="c4 c5"
+            className="c4 c14"
           >
             <div
               className="c6 c7"

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-mapper.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-mapper.spec.js.snap
@@ -65,11 +65,6 @@ Array [
   flex-basis: 100%;
 }
 
-.c0 {
-  margin-top: 8px;
-  margin-top: 8px;
-}
-
 .c0 .c6 {
   padding-top: 1px;
 }
@@ -287,11 +282,6 @@ Array [
   -webkit-flex-basis: 100%;
   -ms-flex-preferred-size: 100%;
   flex-basis: 100%;
-}
-
-.c0 {
-  margin-top: 8px;
-  margin-top: 8px;
 }
 
 .c0 .c6 {

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -6,7 +6,7 @@ exports[`RadioButton base renders as expected 1`] = `
 }
 
 .c4.c4.c4 {
-  margin-bottom: 16px;
+  margin-bottom: 0px;
 }
 
 .c6 {
@@ -303,8 +303,7 @@ exports[`RadioButton base renders as expected 1`] = `
 }
 
 .c1 {
-  margin-top: 8px;
-  margin-top: 8px;
+  margin-top: 4px;
 }
 
 .c1 .c7 {

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -80,6 +80,7 @@ const RadioButtonGroup = (props) => {
         data-component="radio-button-group"
         role="group"
         inline={inline}
+        legendInline={legendInline}
         styleOverride={styleOverride.content}
       >
         <RadioButtonMapper
@@ -88,17 +89,22 @@ const RadioButtonGroup = (props) => {
           onChange={onChange}
           value={value}
         >
-          {React.Children.map(children, (child) =>
-            React.cloneElement(child, {
+          {React.Children.map(children, (child, i) => {
+            const length = React.Children.count(children);
+            const isLastChild = i === length - 1;
+            const isFirstChild = i === 0;
+            return React.cloneElement(child, {
               inline,
               labelSpacing,
               error: !!error,
               warning: !!warning,
               info: !!info,
               required,
+              mt: !inline && isFirstChild ? "4px" : undefined,
+              mb: isLastChild ? 0 : undefined,
               ...child.props,
-            })
-          )}
+            });
+          })}
         </RadioButtonMapper>
       </RadioButtonGroupStyle>
     </Fieldset>

--- a/src/__experimental__/components/radio-button/radio-button.component.js
+++ b/src/__experimental__/components/radio-button/radio-button.component.js
@@ -12,7 +12,7 @@ const RadioButton = ({
   onChange,
   onBlur,
   value,
-  mt = 1,
+  mt,
   mb = 2,
   ...props
 }) => {

--- a/src/__experimental__/components/radio-button/radio-button.stories.mdx
+++ b/src/__experimental__/components/radio-button/radio-button.stories.mdx
@@ -109,6 +109,7 @@ The spacing between the legend and the radio buttons can be changed with the `le
       onChange={ () => console.log('change') }
       legend="Radio group legend"
       legendInline
+      legendWidth="10"
     >
     <RadioButton 
       id="radio1" 

--- a/src/__experimental__/components/radio-button/radio-button.style.js
+++ b/src/__experimental__/components/radio-button/radio-button.style.js
@@ -8,9 +8,7 @@ import { StyledLabelContainer } from "../label/label.style";
 import baseTheme from "../../../style/themes/base";
 
 const RadioButtonStyle = styled(CheckboxStyle)`
-  ${({ disabled, fieldHelpInline, reverse, size, theme, inline, mt }) => css`
-    margin-top: ${mt * theme.spacing}px;
-
+  ${({ disabled, fieldHelpInline, reverse, size, theme, inline }) => css`
     ${StyledCheckableInputSvgWrapper} {
       padding: 0;
     }

--- a/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
+++ b/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
@@ -14,10 +14,10 @@ exports[`SimpleColorPicker renders as expected 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   margin-bottom: 8px;
 }
 

--- a/src/__internal__/fieldset/fieldset.style.js
+++ b/src/__internal__/fieldset/fieldset.style.js
@@ -26,7 +26,7 @@ const StyledFieldsetContent = styled.div`
 
 const StyledLegendContainer = styled.div`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 8px;
   ${({ inline, width, align, rightPadding, theme }) =>
     inline &&
@@ -50,6 +50,7 @@ const StyledLegendContainer = styled.div`
     css`
       ::after {
         content: "*";
+        line-height: 24px;
         color: ${theme.colors.asterisk};
         font-weight: 700;
         margin-left: ${theme.spacing}px;


### PR DESCRIPTION
### Proposed behaviour
Align the legend with the first radio button.

![image](https://user-images.githubusercontent.com/2328042/98017983-eb7e9080-1df7-11eb-9265-71fc69366ed0.png)

---

Align the red asterisk with the line-height of the legend. This results in a tiny visual change ~ 1px but is required to facilitate the other changes in this PR.

![image](https://user-images.githubusercontent.com/2328042/98017159-c63d5280-1df6-11eb-8922-359985747a9f.png)

---
Remove excess margin between legend and radios when `inline`
![image](https://user-images.githubusercontent.com/2328042/98017507-4499f480-1df7-11eb-8b62-e1ff9786d96b.png)

---
Remove excess margin below the radio group (below Radio Option 3)
![image](https://user-images.githubusercontent.com/2328042/98017824-b4a87a80-1df7-11eb-8169-fa46603607cd.png)

---
### Current behaviour
The legend is centre aligned.
![image](https://user-images.githubusercontent.com/2328042/97895860-3b902100-1d2c-11eb-93da-656d8f6abc9b.png)

---
The red asterisk is centre aligned.
![image](https://user-images.githubusercontent.com/2328042/98017227-df460380-1df6-11eb-95d1-7d811f0bf986.png)

---
Excess margin between legend and radios when `inline`
![image](https://user-images.githubusercontent.com/2328042/98017481-3c41b980-1df7-11eb-9778-5c52105719a0.png)

---
Excess margin below the radio group (below Radio Option 3)
![image](https://user-images.githubusercontent.com/2328042/98017738-9478bb80-1df7-11eb-8d29-c98d3792f89c.png)

---
### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
Fixes FE-3212, Fixes #3269

### Testing instructions
See the "radio button" and "form-alignment" stories.
https://carbon.sage.com/?path=/story/design-system-form--form-alignment-example
https://carbon.sage.com/?path=/docs/experimental-radiobutton--with-legend-and-labels