### PR TITLE
 fix(menu-item): add height when onclick passed and button renders

### DIFF
--- a/src/components/menu/menu-item/menu-item.spec.js
+++ b/src/components/menu/menu-item/menu-item.spec.js
@@ -170,6 +170,25 @@ describe("MenuItem", () => {
           wrapper
         );
       });
+
+      it("should render correct styles if an onClick is provided", () => {
+        wrapper = mount(
+          <MenuItem menuType="dark" onClick={() => {}}>
+            Item one
+          </MenuItem>
+        );
+
+        assertStyleMatch(
+          {
+            padding: "0 16px",
+            height: "40px",
+            lineHeight: "40px",
+            margin: "0px",
+          },
+          wrapper,
+          { modifier: "button" }
+        );
+      });
     });
 
     describe('`menuType="dark"`', () => {

--- a/src/components/menu/menu-item/menu-item.style.js
+++ b/src/components/menu/menu-item/menu-item.style.js
@@ -32,10 +32,17 @@ const StyledMenuItemWrapper = styled.a`
     }
 
     a,
-    button,
     ${LinkStyle} a,
+    button,
     ${LinkStyle} button {
       padding: 0 16px;
+    }
+
+    button,
+    ${LinkStyle} button {
+      line-height: 40px;
+      height: 40px;
+      margin: 0px;
     }
 
     a,
@@ -134,7 +141,6 @@ const StyledMenuItemWrapper = styled.a`
       a:focus,
       button,
       button:hover,
-      button:focus,
       [data-component="icon"],
       ${LinkStyle} [data-component="icon"] {
         font-weight: 700;
@@ -177,6 +183,10 @@ const StyledMenuItemWrapper = styled.a`
             [data-component="icon"] {
               color: ${theme.colors.white};
             }
+          }
+
+          .carbon-menu-item--has-link button {
+            color: ${theme.colors.white};
           }
         `}
       `}

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -22,7 +22,7 @@ import {Menu, MenuItem, SubmenuBlock, MenuDivider} from "carbon-react/lib/compon
   <Story name="default" parameters={{ chromatic: { disable: true }}}>
     <div style={{minHeight: '150px'}}>
       <Menu>
-        <MenuItem href="#">
+        <MenuItem onClick={() => {}}>
           Menu Item One
         </MenuItem>
         <MenuItem href="#">
@@ -44,7 +44,7 @@ import {Menu, MenuItem, SubmenuBlock, MenuDivider} from "carbon-react/lib/compon
           </MenuItem>
         </MenuItem>
         <MenuItem submenu="Menu Item Four">
-          <MenuItem href="#">
+          <MenuItem onClick={() => {}}>
             Item Submenu One
           </MenuItem>
           <MenuItem href="#">
@@ -205,14 +205,14 @@ import {Menu, MenuItem, SubmenuBlock, MenuDivider} from "carbon-react/lib/compon
   <Story name="dark theme" parameters={{ chromatic: { disable: true }}}>
     <div style={{minHeight: '150px'}}>
       <Menu menuType="dark">
-        <MenuItem href="#">
+        <MenuItem onClick={() => {}}>
           Menu Item One
         </MenuItem>
         <MenuItem href="#">
           Menu Item Two
         </MenuItem>
         <MenuItem submenu="Menu Item Three">
-          <MenuItem href="#">
+          <MenuItem onClick={() => {}}>
             Item Submenu One
           </MenuItem>
           <MenuItem href="#">


### PR DESCRIPTION
fix #3308

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds a height and line-height when item renders a button

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
There is no height applied when an onClick prop is passed and button renders

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
I have updated http://localhost:9001/?path=/docs/design-system-menu--default-story to include some items with onClick props so they render buttons