### PR TITLE
fix(menu-divider): add default cursor to passive submenu elements

### DIFF
--- a/src/components/menu/menu-divider/menu-divider.spec.js
+++ b/src/components/menu/menu-divider/menu-divider.spec.js
@@ -34,6 +34,7 @@ describe("Divider", () => {
     assertStyleMatch(
       {
         background: baseTheme.menu.light.divider,
+        cursor: "default",
       },
       wrapper
     );

--- a/src/components/menu/menu-divider/menu-divider.style.js
+++ b/src/components/menu/menu-divider/menu-divider.style.js
@@ -2,6 +2,7 @@ import styled, { css } from "styled-components";
 import { baseTheme } from "../../../style/themes";
 
 const StyledDivider = styled.div`
+  cursor: default;
   ${({ menuType, theme, size }) => css`
     margin: 0px ${size === "large" ? "" : "16px"};
     height: ${size === "large" ? "4px" : "1px"};

--- a/src/components/menu/menu-segment-title/menu-segment-title.spec.js
+++ b/src/components/menu/menu-segment-title/menu-segment-title.spec.js
@@ -50,6 +50,7 @@ describe("Title", () => {
         fontWeight: "700",
         textTransform: "uppercase",
         lineHeight: "12px",
+        cursor: "default",
       },
       wrapper
     );

--- a/src/components/menu/menu-segment-title/menu-segment-title.style.js
+++ b/src/components/menu/menu-segment-title/menu-segment-title.style.js
@@ -8,6 +8,7 @@ const StyledTitle = styled.div`
     font-weight: 700;
     text-transform: uppercase;
     line-height: 12px;
+    cursor: default;
 
     ${menuType === "light" &&
     css`


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
adds default cursor for `menu-segment-title` and `menu-divider`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
both components have `cursor: pointer`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
Can be tested http://localhost:9001/?path=/story/design-system-menu--dark-theme-alternate-colour