### PR TITLE
fix(flat-table): fix incorrect type definitions

### DIFF
--- a/src/components/flat-table/flat-table-body/flat-table-body.d.ts
+++ b/src/components/flat-table/flat-table-body/flat-table-body.d.ts
@@ -3,7 +3,7 @@ import FlatTableRow from '../flat-table-row';
 
 export interface FlatTableBodyProps {
   /** Array of FlatTableRow. */
-  children: Array<typeof FlatTableRow>;
+  children: React.ReactNode;
 }
 
 declare const FlatTableBody: React.FunctionComponent<FlatTableBodyProps>;

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.d.ts
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.d.ts
@@ -3,7 +3,7 @@ import { SpacingProps } from '../../../utils/helpers/options-helper';
 
 export interface FlatTableCellProps extends SpacingProps {
   /** Content alignment */
-  align?: string;
+  align?: "center" | "left" | "right";
   children?: React.ReactNode | string;
   /** Number of columns that a cell should span */
   colspan?: number | string;

--- a/src/components/flat-table/flat-table-header/flat-table-header.d.ts
+++ b/src/components/flat-table/flat-table-header/flat-table-header.d.ts
@@ -3,7 +3,7 @@ import { SpacingProps } from '../../../utils/helpers/options-helper';
 
 export interface FlatTableHeaderProps extends SpacingProps {
   /** Content alignment */
-  align?: string;
+  align?: "center" | "left" | "right";
   children?: React.ReactNode | string;
   /** Number of columns that a header cell should span */
   colspan?: number | string;


### PR DESCRIPTION
fixes #3369

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Update TypeScript definition files for FlatTable components

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
TypeScript definition files for FlatTable components are incorrect

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
