### PR TITLE
ci(semantic-release): gpg sign commits

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -22,8 +22,17 @@ jobs:
       with:
         node-version: '12'
     - run: npm ci
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v3.0.1
+      with:
+        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.GPG_PASSPHRASE }}
+        git-user-signingkey: true
+        git-commit-gpgsign: true
     - run: npx semantic-release
       env:
         # A personal access token is required to publish from protected branches
         GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        GIT_COMMITTER_NAME: Sage Carbon
+        GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }} 


### PR DESCRIPTION
### Proposed behaviour

Sign semantic-release commits, releases will be authored by @semantic-release-bot and committed by @carbonci 

### Current behaviour

Commits are not signed, releases are authored and committed by @semantic-release-bot 

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

- [Semantic release does not support signing tags](https://github.com/semantic-release/git/issues/214)
- [GitHub does not support signing pushes](https://github.community/t/push-signed/938/4)

I've pinned the version so we can verify the action before upgrading.

### Testing instructions
Check the next release is signed correctly. This PR will not trigger a release.
