### PR TITLE
 feat(action-popover): add support to place menu above button  FE-2956

### DIFF
--- a/src/components/action-popover/action-popover-menu.component.js
+++ b/src/components/action-popover/action-popover-menu.component.js
@@ -19,6 +19,7 @@ const ActionPopoverMenu = React.forwardRef(
       setOpen,
       setFocusIndex,
       setItems,
+      placement = "bottom",
       ...rest
     },
     ref
@@ -148,6 +149,7 @@ const ActionPopoverMenu = React.forwardRef(
             // callback and index to update focusIndex if item hovered and has submenu
             const itemWithRef = React.cloneElement(child, {
               ref: React.createRef(),
+              placement: child.props.submenu ? placement : undefined,
             });
             itemsWithRef.push(itemWithRef);
 
@@ -160,7 +162,15 @@ const ActionPopoverMenu = React.forwardRef(
       // so we use a smaller array which makes keyboard navigation easier as we don't have to filter it on every
       // keypress
       setItems(itemsWithRef);
-    }, [children, focusIndex, isOpen, menuID, setFocusIndex, setItems]);
+    }, [
+      children,
+      placement,
+      focusIndex,
+      isOpen,
+      menuID,
+      setFocusIndex,
+      setItems,
+    ]);
 
     useEffect(() => {
       if (isOpen && focusIndex !== null) {
@@ -179,6 +189,8 @@ const ActionPopoverMenu = React.forwardRef(
         aria-labelledby={parentID}
         role="menu"
         ref={ref}
+        placement={placement}
+        buttonHeight={getButtonHeight(button)}
         {...rest}
       >
         {childrenWithRef}
@@ -186,6 +198,21 @@ const ActionPopoverMenu = React.forwardRef(
     );
   }
 );
+
+function checkRef(ref) {
+  return Boolean(ref && ref.current);
+}
+
+function getButtonHeight(buttonRef) {
+  if (!checkRef(buttonRef)) {
+    return undefined;
+  }
+
+  const buttonRect = buttonRef.current.getBoundingClientRect();
+  const { top, bottom } = buttonRect;
+
+  return bottom - top;
+}
 
 ActionPopoverMenu.propTypes = {
   /** A ref to the parent popover button */
@@ -235,6 +262,8 @@ ActionPopoverMenu.propTypes = {
   setOpen: PropTypes.func,
   /** Callback called on click event */
   onClick: PropTypes.func,
+  /** @ignore @private */
+  placement: PropTypes.oneOf(["bottom", "top"]),
 };
 
 ActionPopoverMenu.displayName = "ActionPopoverMenu";

--- a/src/components/action-popover/action-popover.component.js
+++ b/src/components/action-popover/action-popover.component.js
@@ -15,6 +15,7 @@ const ActionPopover = ({
   onClose,
   rightAlignMenu,
   renderButton,
+  placement = "bottom",
   ...rest
 }) => {
   const [isOpen, setOpenState] = useState(false);
@@ -108,6 +109,7 @@ const ActionPopover = ({
     isOpen,
     setOpen,
     rightAlignMenu,
+    placement,
   };
 
   return (
@@ -174,6 +176,8 @@ ActionPopover.propTypes = {
   },
   /** Render a custom menu button to override default ellipsis icon */
   renderButton: PropTypes.func,
+  /** Set whether the menu should open above or below the button */
+  placement: PropTypes.oneOf(["bottom", "top"]),
 };
 
 ActionPopover.defaultProps = {

--- a/src/components/action-popover/action-popover.d.ts
+++ b/src/components/action-popover/action-popover.d.ts
@@ -6,6 +6,7 @@ export interface ActionPopoverProps {
   onClose?: () => void;
   rightAlignMenu?: boolean;
   renderButton?: (args: object) => React.ReactNode;
+  placement?: "bottom" | "top";
 }
 
 declare const ActionPopover: React.FunctionComponent<ActionPopoverProps>;

--- a/src/components/action-popover/action-popover.spec.js
+++ b/src/components/action-popover/action-popover.spec.js
@@ -1215,6 +1215,62 @@ describe("ActionPopover", () => {
     });
   });
 
+  describe("placement prop set to 'top'", () => {
+    beforeEach(() => {
+      // Mock the parent boundingRect
+      spyOn(Element.prototype, "getBoundingClientRect");
+      Element.prototype.getBoundingClientRect = jest
+        .fn()
+        .mockImplementation(() => ({
+          left: "10",
+          right: "10",
+          bottom: "124",
+          top: "100",
+        }));
+
+      wrapper = enzymeMount(
+        <ThemeProvider theme={mintTheme}>
+          <ActionPopover placement="top">
+            <ActionPopoverItem
+              onClick={onClick}
+              submenu={
+                <ActionPopoverMenu onClick={onClick}>
+                  <ActionPopoverItem
+                    key="0"
+                    {...{ onClick: onClickWrapper("sub menu 1") }}
+                  >
+                    Sub Menu 1
+                  </ActionPopoverItem>
+                </ActionPopoverMenu>
+              }
+            >
+              foo
+            </ActionPopoverItem>
+          </ActionPopover>
+        </ThemeProvider>
+      );
+    });
+
+    afterEach(() => {
+      // Clear Mock from parent boundingRect
+      Element.prototype.getBoundingClientRect.mockRestore();
+    });
+
+    it("positions the menu container's bottom to the height of the menu button", () => {
+      assertStyleMatch(
+        {
+          bottom: "24px",
+        },
+        wrapper.find(ActionPopoverMenu)
+      );
+    });
+
+    it("positions the submenu container's bottom inline with the the parent item", () => {
+      const item = wrapper.find(ActionPopoverItem).at(0);
+      expect(item.find(ActionPopoverMenu).props().style.bottom).toEqual(-8);
+    });
+  });
+
   describe("Custom Menu Button", () => {
     it("supports being passed an override component to act as the menu button", () => {
       const popover = enzymeMount(

--- a/src/components/action-popover/action-popover.stories.mdx
+++ b/src/components/action-popover/action-popover.stories.mdx
@@ -378,6 +378,48 @@ The sub-menu will open to the right side when there is no space to render the su
   />
 </MyPreview>
 
+## with menu opening above
+The menu can also be rendered above the button control by setting using `placement="top"`.
+<Preview>
+  <Story name="with menu opening above" parameters={{ info: { disable: true }, chromatic: { disable: true }}}>
+    <div style={{ paddingTop: '120px', height: '250px' }}>
+      <Table>
+        <TableRow>
+          <TableHeader>First Name</TableHeader>
+          <TableHeader>Last Name</TableHeader>
+          <TableHeader>&nbsp;</TableHeader>
+        </TableRow>
+        <TableRow>
+          <TableCell>John</TableCell>
+          <TableCell>Doe</TableCell>
+          <TableCell>
+            <ActionPopover placement="top">
+              <ActionPopoverItem
+                icon='print'
+                onClick={() => {}}
+                submenu={ 
+                  <ActionPopoverMenu>
+                    <ActionPopoverItem onClick={() => {}}>
+                      CSV
+                    </ActionPopoverItem>
+                    <ActionPopoverItem onClick={() => {}}>
+                      PDF
+                    </ActionPopoverItem>
+                  </ActionPopoverMenu> 
+                }
+              >
+                Print
+              </ActionPopoverItem>
+              <ActionPopoverDivider />
+              <ActionPopoverItem onClick={() => {}} icon='delete'>Delete</ActionPopoverItem>
+            </ActionPopover>
+          </TableCell>
+        </TableRow>
+      </Table>
+    </div>
+  </Story>
+</Preview>
+
 ## keyboard navigation 
 ActionPopover and ActionPopoverItem have extensive keyboard support. It is possible to open the menu when the
 ActionPopover is focused: pressing either the "enter" or "down" key will open the menu and focus the first item; 

--- a/src/components/action-popover/action-popover.style.js
+++ b/src/components/action-popover/action-popover.style.js
@@ -20,6 +20,8 @@ const Menu = styled.div`
   ${({ rightAlignMenu }) => (rightAlignMenu ? "left: 0;" : "right: 0;")}
   background-color: ${({ theme }) => theme.colors.white};
   z-index: ${({ theme }) => `${theme.zIndex.popover}`};
+  ${({ placement, buttonHeight }) =>
+    placement === "top" && buttonHeight && `bottom: ${buttonHeight}px;`}
 
   ${MenuClassic}
 `;

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -17,7 +17,7 @@ import IconButton from '../icon-button';
 import Icon from '../icon';
 import Textbox from '../../__experimental__/components/textbox';
 import Pager from '../pager'
-import { ActionPopover, ActionPopoverItem } from '../action-popover';
+import { ActionPopover, ActionPopoverItem, ActionPopoverMenu } from '../action-popover';
 import { SidebarContext } from '../drawer';
 
 <Meta title="Design System/Flat Table" parameters={{ info: { disable: true }}} />
@@ -860,6 +860,196 @@ Balance performance concerns with the convenience of the user being able to see 
             </FlatTableBody>
           </FlatTable>
         </>
+      );
+    }} 
+  </Story>
+</Preview>
+
+### Paginated with sticky header
+When using the `Pager` and a sticky `FlatTableHead` some of the child elements may have style properties that cause the 
+overflow to exceed the height of the table. In the example below, the `ActionPopoverMenu` has absolute positioning meaning 
+it is accounted for in the overflow. To avoid this it is possible to use the `placement` prop to render the menu on `top` 
+of the button control.
+<Preview>
+  <Story name="paginated with sticky header" parameters={{ info: { disable: true }}} >
+    {() => {
+      const [placementUp, setPlacementUp] = useState(true);
+      const rows = [
+        <FlatTableRow key='0'>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>
+            <ActionPopover>
+              <ActionPopoverItem onClick={() => {}}>
+                action
+              </ActionPopoverItem>
+            </ActionPopover>
+          </FlatTableCell>
+        </FlatTableRow>,
+        <FlatTableRow key='1'>
+          <FlatTableCell>Jane Doe</FlatTableCell>
+          <FlatTableCell>York</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableCell>
+            <ActionPopover>
+              <ActionPopoverItem onClick={() => {}} submenu={
+                <ActionPopoverMenu>
+                  <ActionPopoverItem onClick={() => {}}>
+                    CSV
+                  </ActionPopoverItem>
+                  <ActionPopoverItem onClick={() => {}}>
+                    PDF
+                  </ActionPopoverItem>
+                </ActionPopoverMenu>}
+              >
+                action
+              </ActionPopoverItem>
+            </ActionPopover>
+          </FlatTableCell>
+        </FlatTableRow>,
+        <FlatTableRow key='2'>
+          <FlatTableCell>John Smith</FlatTableCell>
+          <FlatTableCell>Edinburgh</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>
+            <ActionPopover>
+              <ActionPopoverItem onClick={() => {}}>
+                action
+              </ActionPopoverItem>
+            </ActionPopover>
+          </FlatTableCell>
+        </FlatTableRow>,
+        <FlatTableRow key='3'>
+          <FlatTableCell>Jane Smith</FlatTableCell>
+          <FlatTableCell>Newcastle</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableCell>
+            <ActionPopover placement={placementUp ? "top" : "bottom"}>
+              <ActionPopoverItem onClick={() => {}}>
+                action
+              </ActionPopoverItem>
+            </ActionPopover>
+          </FlatTableCell>
+        </FlatTableRow>,
+       <FlatTableRow key='4'>
+          <FlatTableCell>Liz Anya</FlatTableCell>
+          <FlatTableCell>Stoke</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>
+            <ActionPopover placement={placementUp ? "top" : "bottom"}>
+              <ActionPopoverItem onClick={() => {}} submenu={
+                <ActionPopoverMenu>
+                  <ActionPopoverItem onClick={() => {}}>
+                    CSV
+                  </ActionPopoverItem>
+                  <ActionPopoverItem onClick={() => {}}>
+                    PDF
+                  </ActionPopoverItem>
+                </ActionPopoverMenu>
+              }
+              >
+                action
+              </ActionPopoverItem>
+              <ActionPopoverItem onClick={() => {}} submenu={
+                <ActionPopoverMenu>
+                  <ActionPopoverItem onClick={() => {}}>
+                    CSV
+                  </ActionPopoverItem>
+                  <ActionPopoverItem onClick={() => {}}>
+                    PDF
+                  </ActionPopoverItem>
+                </ActionPopoverMenu>}
+              >
+                action
+              </ActionPopoverItem>
+            </ActionPopover>
+          </FlatTableCell>
+        </FlatTableRow>,
+        <FlatTableRow key='5'>
+          <FlatTableCell>Karl Ickbred</FlatTableCell>
+          <FlatTableCell>Newcastle</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>
+            <ActionPopover>
+              <ActionPopoverItem onClick={() => {}} submenu={
+                <ActionPopoverMenu>
+                  <ActionPopoverItem onClick={() => {}}>
+                    CSV
+                  </ActionPopoverItem>
+                  <ActionPopoverItem onClick={() => {}}>
+                    PDF
+                  </ActionPopoverItem>
+                </ActionPopoverMenu>}
+              >
+                action
+              </ActionPopoverItem>
+              <ActionPopoverItem onClick={() => {}} submenu={
+                <ActionPopoverMenu>
+                  <ActionPopoverItem onClick={() => {}}>
+                    CSV
+                  </ActionPopoverItem>
+                  <ActionPopoverItem onClick={() => {}}>
+                    PDF
+                  </ActionPopoverItem>
+                </ActionPopoverMenu>
+              }
+              >
+                action
+              </ActionPopoverItem>
+            </ActionPopover>
+          </FlatTableCell>
+        </FlatTableRow>
+      ];
+      const [recordsRange, setRecordsRange] = useState({ start: 0, end: 5 });
+      const [currentPage, setCurrentPage] = useState(1);
+      const renderRows = () => {
+        const { start, end } = recordsRange;
+        if (start < 0) return rows;
+        if (end > rows.length) return rows.slice(start, rows.length);
+        return rows.slice(start, end);
+      };
+      const handlePagination = (newPage, newPageSize) => {
+        const adjustment = currentPage === newPage ? 0 : newPage - currentPage;
+        let start = adjustment > 0 ? recordsRange.start + newPageSize : recordsRange.start - newPageSize;
+        start = start < 0 || Math.abs(start - recordsRange.end) > newPageSize ? 0 : start;
+        const end = adjustment > 0 ? recordsRange.end + newPageSize : start + newPageSize;
+        setPlacementUp(newPageSize !== 1);
+        setRecordsRange({ start, end });
+        setCurrentPage(newPage);
+      };
+      return (
+        <div style={{ height: '200px' }}>
+          <FlatTable
+            hasStickyHead
+            hasStickyFooter
+            footer={
+              <Pager
+                totalRecords={ rows.length }
+                showPageSizeSelection
+                pageSize={ 5 }
+                currentPage={ currentPage }
+                onPagination={ (next, size) => handlePagination(next, size) }
+                pageSizeSelectionOptions={ 
+                  [
+                    { id: '1', name: 1 },
+                    { id: '5', name: 5 },
+                  ]}
+              />
+            }>
+            <FlatTableHead>
+              <FlatTableRow>
+                <FlatTableHeader>Name</FlatTableHeader>
+                <FlatTableHeader>Location</FlatTableHeader>
+                <FlatTableHeader>Relationship Status</FlatTableHeader>
+                <FlatTableHeader>Dependents</FlatTableHeader>
+              </FlatTableRow>
+            </FlatTableHead>
+            <FlatTableBody>
+              { renderRows() }
+            </FlatTableBody>
+          </FlatTable>
+        </div>
       );
     }} 
   </Story>


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Allow `ActionPopoverMenu` to open above the menu button when the `placement` prop is set to "top"

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
There is no prop to support opening the menu above the button
### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
fix #3072

The menu's are positioned absolutely which causes the overflow to account for the space they take up.

### Testing instructions
<!-- How can a reviewer test this PR? -->
http://localhost:9001/?path=/story/design-system-flat-table--paginated-with-sticky-header


![image](https://user-images.githubusercontent.com/44157880/99259789-71e09c80-2812-11eb-93e8-b40884af2a05.png)
