### PR TITLE
test: increase chromatic delay

### DIFF
--- a/src/components/accordion/accordion.stories.mdx
+++ b/src/components/accordion/accordion.stories.mdx
@@ -229,7 +229,7 @@ The default width of 100% can be overriden.
 ### With Box component and different paddings
 
 <Preview>
-  <Story name="with Box component and different paddings" parameters={{ chromatic: { delay: 750 }}}>
+  <Story name="with Box component and different paddings" parameters={{ chromatic: { delay: 3500 }}}>
     {() => {
       const [isOpen, setOpen] = useState(true);
       return(
@@ -508,7 +508,7 @@ Accordion styles can be easily overriden by providing `styleOverride` prop with 
 
 ### With a definition list
 <Preview>
-  <Story name="with a definition list">
+  <Story name="with a definition list" parameters={{ chromatic: { delay: 3500 }}}>
     <Accordion title='Heading' expanded={true}>
       <Dl>
         <Dt>Drink</Dt>

--- a/src/components/portrait/portrait.stories.js
+++ b/src/components/portrait/portrait.stories.js
@@ -43,6 +43,6 @@ storiesOf("Portrait", module).add(
     info: { text: info, propTablesExclude: [ThemeProvider] },
     notes: { markdown: notes },
     knobs: { escapeHTML: false },
-    chromatic: { delay: 750 },
+    chromatic: { delay: 3500 },
   }
 );

--- a/src/components/profile/profile.stories.js
+++ b/src/components/profile/profile.stories.js
@@ -43,6 +43,6 @@ storiesOf("Profile", module).add(
     info: { text: info, propTablesExclude: [ThemeProvider] },
     notes: { markdown: notes },
     knobs: { escapeHTML: false },
-    chromatic: { delay: 750 },
+    chromatic: { delay: 3500 },
   }
 );


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
- increase `delay` for `chromatic` snapshots

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Few stories still not rendering correctly, we need to increase `delay` for `chromatic` snapshots

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent