### PR TITLE
feat(menu-item): add prop to hide dropdown arrow for items with submenu FE-3233

### DIFF
--- a/src/components/menu/menu-item/menu-item.component.js
+++ b/src/components/menu/menu-item/menu-item.component.js
@@ -36,6 +36,7 @@ const MenuItem = React.forwardRef(
       setOpenByArrowLeftOrRight,
       setFocusToElement,
       variant = "default",
+      showDropdownArrow = true,
     },
     ref
   ) => {
@@ -444,6 +445,7 @@ const MenuItem = React.forwardRef(
         isOpen={isOpen}
         variant={variant}
         role="menuitem"
+        showDropdownArrow={showDropdownArrow}
       >
         {content()}
       </StyledMenuItemWrapper>
@@ -476,6 +478,8 @@ MenuItem.propTypes = {
   onKeyDown: PropTypes.func,
   /** The target to use for the menu item. */
   target: PropTypes.string,
+  /** Flag to display the dropdown arrow when an item has a submenu */
+  showDropdownArrow: PropTypes.bool,
   /**
    * menu color scheme provided by <Menu />
    * @private

--- a/src/components/menu/menu-item/menu-item.d.ts
+++ b/src/components/menu/menu-item/menu-item.d.ts
@@ -15,6 +15,7 @@ export interface MenuItemProps {
   onKeyDown?: (event: React.KeyboardEvent<HTMLElement>) => void;
   target?: string;
   variant?: 'default' | 'alternate';
+  showDropdownArrow?: boolean;
 }
 
 declare const MenuItem: React.ComponentType<MenuItemProps>;

--- a/src/components/menu/menu-item/menu-item.spec.js
+++ b/src/components/menu/menu-item/menu-item.spec.js
@@ -257,5 +257,76 @@ describe("MenuItem", () => {
         );
       });
     });
+
+    describe("showDropdownArrow", () => {
+      it("shows the arrow by default when there is a submenu", () => {
+        wrapper = mount(
+          <MenuItem submenu="submenu">
+            <MenuItem>Item one</MenuItem>
+          </MenuItem>
+        );
+
+        assertStyleMatch(
+          {
+            paddingRight: "32px",
+          },
+          wrapper,
+          { modifier: `${StyledSubmenuTitle} ${StyledMenuItemWrapper}` }
+        );
+
+        assertStyleMatch(
+          {
+            display: "block",
+            marginTop: "-2px",
+            pointerEvents: "none",
+            position: "absolute",
+            right: "16px",
+            top: "50%",
+            zIndex: "2",
+            content: `""`,
+            width: "0",
+            height: "0",
+            borderTop: `5px solid ${baseTheme.colors.slate}`,
+            borderRight: "4px solid transparent",
+            borderBottom: "4px solid transparent",
+            borderLeft: "4px solid transparent",
+          },
+          wrapper,
+          { modifier: `${StyledSubmenuTitle} ${StyledMenuItemWrapper}::before` }
+        );
+      });
+
+      it("does not show the arrow when prop is false and there is a submenu", () => {
+        wrapper = mount(
+          <MenuItem submenu="submenu" showDropdownArrow={false}>
+            <MenuItem>Item one</MenuItem>
+          </MenuItem>
+        );
+
+        expect(wrapper).not.toHaveStyleRule("padding-right", "32px", {
+          modifier: `${StyledSubmenuTitle} ${StyledMenuItemWrapper}`,
+        });
+        expect(wrapper).not.toHaveStyleRule(
+          "border-top",
+          `5px solid ${baseTheme.colors.slate}`,
+          { modifier: `${StyledSubmenuTitle} ${StyledMenuItemWrapper}::before` }
+        );
+        expect(wrapper).not.toHaveStyleRule(
+          "border-right",
+          "4px solid transparent",
+          { modifier: `${StyledSubmenuTitle} ${StyledMenuItemWrapper}::before` }
+        );
+        expect(wrapper).not.toHaveStyleRule(
+          "border-bottom",
+          "4px solid transparent",
+          { modifier: `${StyledSubmenuTitle} ${StyledMenuItemWrapper}::before` }
+        );
+        expect(wrapper).not.toHaveStyleRule(
+          "border-left",
+          "4px solid transparent",
+          { modifier: `${StyledSubmenuTitle} ${StyledMenuItemWrapper}::before` }
+        );
+      });
+    });
   });
 });

--- a/src/components/menu/menu-item/menu-item.style.js
+++ b/src/components/menu/menu-item/menu-item.style.js
@@ -9,7 +9,15 @@ import StyledIcon from "../../icon/icon.style";
 import LinkStyle from "../../link/link.style";
 
 const StyledMenuItemWrapper = styled.a`
-  ${({ menuType, theme, selected, hasSubmenu, isOpen, variant }) => css`
+  ${({
+    menuType,
+    theme,
+    selected,
+    hasSubmenu,
+    isOpen,
+    variant,
+    showDropdownArrow,
+  }) => css`
     display: inline-block;
     font-size: 14px;
     font-weight: 700;
@@ -86,6 +94,7 @@ const StyledMenuItemWrapper = styled.a`
     }
 
     ${hasSubmenu &&
+    menuType === "light" &&
     css`
       :hover &,
       :hover {
@@ -93,7 +102,7 @@ const StyledMenuItemWrapper = styled.a`
         color: ${theme.colors.black};
 
         a,
-        button,
+        button:not(:hover),
         [data-component="icon"] {
           color: ${theme.colors.black};
         }
@@ -203,33 +212,36 @@ const StyledMenuItemWrapper = styled.a`
     css`
       padding: 0;
 
-      ${StyledSubmenuTitle} {
-        ${StyledMenuItemWrapper} {
-          padding-right: 32px;
+      ${showDropdownArrow &&
+      css`
+        ${StyledSubmenuTitle} {
+          ${StyledMenuItemWrapper} {
+            padding-right: 32px;
 
-          &::before {
-            display: block;
-            margin-top: -2px;
-            pointer-events: none;
-            position: absolute;
-            right: 16px;
-            top: 50%;
-            z-index: 2;
-            content: "";
-            width: 0;
-            height: 0;
-            border-top: 5px solid
-              ${menuType !== "dark" ? theme.colors.slate : theme.colors.white};
-            border-right: 4px solid transparent;
-            border-bottom: 4px solid transparent;
-            border-left: 4px solid transparent;
-          }
+            &::before {
+              display: block;
+              margin-top: -2px;
+              pointer-events: none;
+              position: absolute;
+              right: 16px;
+              top: 50%;
+              z-index: 2;
+              content: "";
+              width: 0;
+              height: 0;
+              border-top: 5px solid
+                ${menuType !== "dark" ? theme.colors.slate : theme.colors.white};
+              border-right: 4px solid transparent;
+              border-bottom: 4px solid transparent;
+              border-left: 4px solid transparent;
+            }
 
-          &:focus::before {
-            border-top-color: ${theme.colors.white};
+            &:focus::before {
+              border-top-color: ${theme.colors.white};
+            }
           }
         }
-      }
+      `}
 
       &:hover {
         ${StyledSubmenu} {

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -57,7 +57,8 @@ import {Menu, MenuItem, SubmenuBlock, MenuDivider} from "carbon-react/lib/compon
 </Preview>
 
 ## Default selected
-
+The example below has set the `showDropdownArrow` to false for the MenuItem with a submenu which means no dropdown arrow 
+is rendered.
 <Preview>
   <Story name="default selected">
     <div style={{minHeight: '150px'}}>
@@ -68,7 +69,7 @@ import {Menu, MenuItem, SubmenuBlock, MenuDivider} from "carbon-react/lib/compon
         <MenuItem href="#">
           Menu Item Two
         </MenuItem>
-        <MenuItem submenu="Menu Item Three">
+        <MenuItem showDropdownArrow={false} submenu="Menu Item Three">
           <MenuItem href="#">
             Item Submenu One
           </MenuItem>


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds `showDropdownArrow` prop to allow hiding of the drop down arrow for items with submenus, prop
defaults to true. Also adds small fix to correct hover styling for submenu items that have `onClick`
prop passed in light `menuType`.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
There is no option to prevent the dropdown arrow from displaying when an item has a submenu. The hover state for a submenu item with onClick is incorrect (see default story in master)

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/99557361-8069b800-29ba-11eb-9f9c-89290b09affa.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
http://localhost:9001/?path=/story/design-system-menu--default-selected has been updated