### PR TITLE
test(row): add performance testing tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35399,6 +35399,11 @@
         }
       }
     },
+    "react-component-benchmark": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/react-component-benchmark/-/react-component-benchmark-0.0.4.tgz",
+      "integrity": "sha1-7uNYXiIDZF7ZaKQAIPYH2JvIL2Q="
+    },
     "react-day-picker": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-6.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "moment": "~2.20.1",
     "polished": "^4.0.3",
     "prop-types": "^15.5.8",
+    "react-component-benchmark": "0.0.4",
     "react-day-picker": "~6.1.1",
     "react-dnd": "^10.0.2",
     "react-dnd-html5-backend": "^10.0.2",

--- a/src/components/row/__spec__.js
+++ b/src/components/row/__spec__.js
@@ -1,9 +1,61 @@
+import Benchmark from "react-component-benchmark";
 import React from "react";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import { Row, Column } from "./row";
+
+const printOnCompleteResults = (resultName, results) => {
+  console.log(
+    `${resultName} ... Min: ${Math.round(
+      results.min * 1000
+    )} | Mean: ${Math.round(results.mean * 1000)} | Max: ${Math.round(
+      results.max * 1000
+    )}`
+  );
+};
 
 describe("Row", () => {
   let wrapper;
+  let props;
+  let meanTime;
+
+  beforeEach(() => {
+    meanTime = 0;
+    props = {
+      component: Row,
+      onComplete: jest.fn((results) => {
+        const mappedResults = {
+          max: results.max,
+          min: results.min,
+          median: results.median,
+          mean: results.mean,
+          stdDev: results.stdDev,
+          p70: results.p70,
+          p95: results.p95,
+          p99: results.p99,
+        };
+        meanTime = mappedResults.mean;
+      }),
+      samples: 20,
+    };
+  });
+
+  it("mounts in a reasonable amount of time", () => {
+    props.onComplete = printOnCompleteResults.bind(this, "Row)");
+    const component = mount(<Benchmark {...props} />);
+    component.instance().start();
+  });
+
+  it("updates in a reasonable amount of time", () => {
+    props.onComplete = printOnCompleteResults.bind(this, "Row");
+    const component = mount(<Benchmark {...props} type="update" />);
+    component.instance().start();
+  });
+
+  it("unmounts in a reasonable amount of time", () => {
+    props.onComplete = printOnCompleteResults.bind(this, "Row");
+    const component = mount(<Benchmark {...props} type="unmount" />);
+    component.instance().start();
+  });
 
   describe("render", () => {
     it("renders a parent div with calculated CSS classes", () => {


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
1. Add `react-component-benchmark` to the carbon 
2. data is logged into local console

<img width="321" alt="result" src="https://user-images.githubusercontent.com/30634976/99969818-4540fd80-2d9b-11eb-89e4-338d7508dd4a.PNG">

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
We need to consider of implementation for performance data for all project to track all timing for components/stories

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
To see the data in the console  first of all run 'npm start' and then `npm test ./src/components/row/__spec__.js`
### Testing instructions
<!-- How can a reviewer test this PR? -->
