### PR TITLE
feat(textbox): add space props - FE-3306

### DIFF
--- a/src/__experimental__/components/form-field/form-field.component.js
+++ b/src/__experimental__/components/form-field/form-field.component.js
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect } from "react";
 import PropTypes from "prop-types";
+import propTypes from "@styled-system/prop-types";
 import FormFieldStyle, { FieldLineStyle } from "./form-field.style";
 import Label from "../label";
 import FieldHelp from "../field-help";
@@ -38,7 +39,6 @@ const FormField = ({
   isOptional,
   readOnly,
   useValidationIcon,
-  mb,
   adaptiveLabelBreakpoint,
   styleOverride = {},
   isRequired,
@@ -67,11 +67,62 @@ const FormField = ({
     }
   }, [id, context, error, warning, info]);
 
+  // Conditionally add the spacing props, we can't spread ...rest because some of the parent components
+  // incorrectly pass props that are consumed in other components.
+  //
+  // The styled-system/space props need to be conditional, a undefined value is still considered a value and affects the
+  // the behaviour
+  //
+  // FIXME FE-3370
+  const spacingProps = [
+    "m",
+    "margin",
+    "ml",
+    "marginLeft",
+    "mr",
+    "marginRight",
+    "mt",
+    "marginTop",
+    "mb",
+    "marginBottom",
+    "mx",
+    "marginLeft",
+    "mx",
+    "marginRight",
+    "my",
+    "marginTop",
+    "my",
+    "marginBottom",
+    "p",
+    "padding",
+    "pl",
+    "paddingLeft",
+    "pr",
+    "paddingRight",
+    "pt",
+    "paddingTop",
+    "pb",
+    "paddingBottom",
+    "px",
+    "paddingLeft",
+    "px",
+    "paddingRight",
+    "py",
+    "paddingTop",
+    "py",
+    "paddingBottom",
+  ].reduce((prev, curr) => {
+    if (Object.prototype.hasOwnProperty.call(props, curr)) {
+      prev[curr] = props[curr];
+    }
+    return prev;
+  }, {});
+
   return (
     <FormFieldStyle
       {...tagComponent(props["data-component"], props)}
       styleOverride={styleOverride.root}
-      mb={mb}
+      {...spacingProps}
     >
       <FieldLineStyle inline={inlineLabel}>
         {reverse && children}
@@ -141,6 +192,8 @@ const errorPropType = (props, propName, componentName, ...rest) => {
 };
 
 FormField.propTypes = {
+  /** Styled system spacing props */
+  ...propTypes.space,
   children: PropTypes.node,
   childOfForm: PropTypes.bool,
   disabled: PropTypes.bool,
@@ -169,8 +222,6 @@ FormField.propTypes = {
   reverse: PropTypes.bool,
   size: PropTypes.oneOf(OptionsHelper.sizesRestricted),
   useValidationIcon: PropTypes.bool,
-  /** Override form spacing (margin bottom) */
-  mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint: PropTypes.number,
   /** Flag to configure component as mandatory */

--- a/src/__experimental__/components/form-field/form-field.style.js
+++ b/src/__experimental__/components/form-field/form-field.style.js
@@ -1,4 +1,5 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
+import { space } from "styled-system";
 import BaseTheme from "../../../style/themes/base";
 import { isClassic } from "../../../utils/helpers/style-helper";
 
@@ -8,11 +9,7 @@ const FormFieldStyle = styled.div`
   }
 
   &&& {
-    ${({ mb, theme }) =>
-      (mb || mb === 0) &&
-      css`
-        margin-bottom: ${mb ? `${mb * theme.spacing}px` : 0};
-      `};
+    ${space}
   }
 
   ${({ styleOverride }) => styleOverride};

--- a/src/__experimental__/components/form-field/form-field.style.js
+++ b/src/__experimental__/components/form-field/form-field.style.js
@@ -11,7 +11,7 @@ const FormFieldStyle = styled.div`
     ${({ mb, theme }) =>
       (mb || mb === 0) &&
       css`
-        margin-bottom: ${mb * theme.spacing}px;
+        margin-bottom: ${mb ? `${mb * theme.spacing}px` : 0};
       `};
   }
 

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
@@ -14,7 +14,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
 }
 
 .c14.c14.c14 {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 .c7 {

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -6,7 +6,7 @@ exports[`RadioButton base renders as expected 1`] = `
 }
 
 .c4.c4.c4 {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 .c6 {

--- a/src/__experimental__/components/textbox/docgenInfo.json
+++ b/src/__experimental__/components/textbox/docgenInfo.json
@@ -242,7 +242,7 @@
           "required": false,
           "description": "Size of an input",
           "defaultValue": {
-            "value": "'medium'",
+            "value": "\"medium\"",
             "computed": false
           }
         },
@@ -252,6 +252,13 @@
           },
           "required": false,
           "description": "Placeholder string to be displayed in input"
+        },
+        "positionedChildren": {
+          "type": {
+            "name": "node"
+          },
+          "required": false,
+          "description": "Container for DatePicker or SelectList components\n@private\n@ignore"
         },
         "iconOnClick": {
           "type": {
@@ -374,7 +381,10 @@
             "computed": false
           }
         }
-      }
+      },
+      "composes": [
+        "@styled-system/prop-types"
+      ]
     }
   ],
   "src/__experimental__/components/textbox/textbox.stories.js": [

--- a/src/__experimental__/components/textbox/textbox.component.js
+++ b/src/__experimental__/components/textbox/textbox.component.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import propTypes from "@styled-system/prop-types";
 import { Input, InputPresentation } from "../input";
 import InputIconToggle from "../input-icon-toggle";
 import FormField from "../form-field";
@@ -95,6 +96,8 @@ function visibleValue(value, formattedValue) {
 }
 
 Textbox.propTypes = {
+  /** Styled system spacing props */
+  ...propTypes.space,
   /**
    * An optional alternative for props.value, this is useful if the
    * real value is an ID but you want to show a human-readable version.

--- a/src/__experimental__/components/textbox/textbox.d.ts
+++ b/src/__experimental__/components/textbox/textbox.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-export interface TextboxProps {
+import { SpacingProps } from '../../../utils/helpers/options-helper';
+export interface TextboxProps extends SpacingProps {
   /**
    * An optional alternative for props.value, this is useful if the
    * real value is an ID but you want to show a human-readable version.

--- a/src/__experimental__/components/textbox/textbox.spec.js
+++ b/src/__experimental__/components/textbox/textbox.spec.js
@@ -2,7 +2,10 @@ import React from "react";
 import { shallow, mount } from "enzyme";
 import Textbox from ".";
 import InputIconToggle from "../input-icon-toggle";
-import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemSpacing,
+} from "../../../__spec_helper__/test-utils";
 import FormField from "../form-field";
 import InputPresentation from "../input/input-presentation.component";
 import InputPresentationStyle from "../input/input-presentation.style";
@@ -10,6 +13,7 @@ import { StyledLabelContainer } from "../label/label.style";
 import StyledValidationIcon from "../../../components/validations/validation-icon.style";
 import StyledPrefix from "./__internal__/prefix.style";
 import Label from "../label";
+import FormFieldStyle from "../form-field/form-field.style";
 
 jest.mock("../../../utils/helpers/guid", () => () => "mocked-guid");
 
@@ -158,4 +162,11 @@ describe("Textbox", () => {
       ).toEqual(<Component />);
     });
   });
+
+  testStyledSystemSpacing(
+    (props) => <Textbox {...props} />,
+    undefined,
+    (wrapper) => wrapper.find(FormFieldStyle),
+    { modifier: "&&&" }
+  );
 });

--- a/src/components/flat-table/flat-table-checkbox/__snapshots__/flat-table-checkbox.spec.js.snap
+++ b/src/components/flat-table/flat-table-checkbox/__snapshots__/flat-table-checkbox.spec.js.snap
@@ -6,7 +6,7 @@ exports[`FlatTableCheckbox "th" is passed in via the "as" prop renders to match 
 }
 
 .c5.c5.c5 {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 .c7 {
@@ -219,7 +219,7 @@ exports[`FlatTableCheckbox the "as" prop is not passed in renders to match the e
 }
 
 .c5.c5.c5 {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 .c7 {


### PR DESCRIPTION
### Proposed behaviour

Add all `styled-system/space` props to `Textbox`.

![image](https://user-images.githubusercontent.com/2328042/99990773-27c85f80-2dac-11eb-99a8-40b56f054f3c.png)


### Current behaviour

`Textbox` supports `mb` prop.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
I created FE-3370 to address the complexity caused by components passing the same props to multiple child components.

### Testing instructions
See sandbox in comments below

https://codesandbox.io/s/fe-3306-e0d9r