### PR TITLE
feat(sort): screen reader accessibility - FE-3291

### DIFF
--- a/cypress/locators/flat-table/index.js
+++ b/cypress/locators/flat-table/index.js
@@ -13,5 +13,5 @@ export const flatTableHeaderCells = () => flatTableHeader().find('th');
 export const flatTableBodyRowByPosition = index => flatTable().find('tbody tr').eq(index);
 
 export const flatTableClickableRow = index => cy.get(FLAT_TABLE_COMPONENT).find('tbody tr').eq(index);
-export const flatTableSortable = () => cy.get(FLAT_TABLE_COMPONENT).find('thead tr th > div > div:nth-child(1)');
+export const flatTableSortable = () => cy.get(FLAT_TABLE_COMPONENT).find('thead tr th div [type=button]');
 export const flatTableCell = index => cy.get(FLAT_TABLE_CELL).eq(index);

--- a/src/components/drawer/__internal__/drawer.stories.mdx
+++ b/src/components/drawer/__internal__/drawer.stories.mdx
@@ -665,7 +665,7 @@ Note: parent container background-color is set to red for demonstration purpose.
     const [isExpanded, setIsExpanded] = useState(true);
     const [isFilterOpen, setFilterOpen] = useState(false);
     const [isDialogOpen, setIsDialogOpen] = useState(false);
-    const [sortType, setSortType] = useState('desc');
+    const [sortType, setSortType] = useState('descending');
     const [pickedUpData, setPickedUpData] = useState();
     const handleDialogOpen = () => {
       setIsDialogOpen(true);
@@ -707,7 +707,7 @@ Note: parent container background-color is set to red for demonstration purpose.
     const createBodyData = (type) => {
       const data = bodyDataItems;
       const sortedData = data.sort((a, b) => {
-        if (type === 'asc') {
+        if (type === 'ascending') {
           if (a.ColumnA.name < b.ColumnA.name) {
             return -1;
           }
@@ -716,7 +716,7 @@ Note: parent container background-color is set to red for demonstration purpose.
           }
           return 0;
         }
-        if (type === 'desc') {
+        if (type === 'descending') {
           if (a.ColumnA.name > b.ColumnA.name) {
             return -1;
           }
@@ -744,10 +744,10 @@ Note: parent container background-color is set to red for demonstration purpose.
       ));
     };
     const handleSortChange = () => {
-      if (sortType === 'asc') {
-        return setSortType('desc');
+      if (sortType === 'ascending') {
+        return setSortType('descending');
       }
-      return setSortType('asc');
+      return setSortType('ascending');
     };
     return (
       <>

--- a/src/components/flat-table/flat-table.stories.js
+++ b/src/components/flat-table/flat-table.stories.js
@@ -128,16 +128,16 @@ export const Sortable = () => {
   ];
 
   const [headData, setHeadData] = useState(headDataItems);
-  const [sortType, setSortType] = useState("asc");
+  const [sortType, setSortType] = useState("ascending");
   const [sortValue, setSortValue] = useState();
 
   const sortByNumber = (dataToSort, sortByValue, type) => {
     const sortedData = dataToSort.sort((a, b) => {
-      if (type === "asc") {
+      if (type === "ascending") {
         return a[sortByValue] - b[sortByValue];
       }
 
-      if (type === "desc") {
+      if (type === "descending") {
         return b[sortByValue] - a[sortByValue];
       }
 
@@ -152,7 +152,7 @@ export const Sortable = () => {
       const nameA = a[sortByValue].toUpperCase();
       const nameB = b[sortByValue].toUpperCase();
 
-      if (type === "asc") {
+      if (type === "ascending") {
         if (nameA < nameB) {
           return -1;
         }
@@ -162,7 +162,7 @@ export const Sortable = () => {
         }
       }
 
-      if (type === "desc") {
+      if (type === "descending") {
         if (nameA > nameB) {
           return -1;
         }
@@ -189,7 +189,7 @@ export const Sortable = () => {
     });
 
     setSortValue(value);
-    setSortType(sortType === "asc" ? "desc" : "asc");
+    setSortType(sortType === "ascending" ? "descending" : "ascending");
     setHeadData([...tempHeadData]);
   };
 

--- a/src/components/flat-table/sort/sort.component.js
+++ b/src/components/flat-table/sort/sort.component.js
@@ -19,7 +19,8 @@ const Sort = ({ children, onClick, sortType }) => {
   return (
     <>
       <span hidden id={id.current}>
-        {children}, sort type {sortType || "none"}
+        {children}
+        {sortType ? `, sort type ${sortType}` : ", sortable"}
       </span>
       <StyledSort
         type="button"
@@ -42,7 +43,7 @@ const Sort = ({ children, onClick, sortType }) => {
 
 Sort.propTypes = {
   /** if `asc` it will show `sort_up` icon, if `desc` it will show `sort_down` */
-  sortType: PropTypes.oneOf(["asc", "desc", false]),
+  sortType: PropTypes.oneOf(["ascending", "descending", false]),
   /** Callback fired when the `FlatTableSortHeader` is clicked */
   onClick: PropTypes.func,
   /** The content of `FlatTableSortHeader` */

--- a/src/components/flat-table/sort/sort.component.js
+++ b/src/components/flat-table/sort/sort.component.js
@@ -1,10 +1,12 @@
-import React from "react";
+import React, { useRef } from "react";
 import PropTypes from "prop-types";
 import Event from "../../../utils/helpers/events/events";
 import Icon from "../../icon";
 import { StyledSort, StyledSpaceHolder } from "./sort.style";
+import guid from "../../../utils/helpers/guid";
 
 const Sort = ({ children, onClick, sortType }) => {
+  const id = useRef(guid());
   const onKeyDown = (e) => {
     if (Event.isEnterOrSpaceKey(e)) {
       e.preventDefault();
@@ -16,16 +18,21 @@ const Sort = ({ children, onClick, sortType }) => {
 
   return (
     <>
+      <span hidden id={id.current}>
+        {children}, sort type {sortType || "none"}
+      </span>
       <StyledSort
         type="button"
+        role="button"
         onKeyDown={onKeyDown}
         tabIndex={0}
         onClick={onClick}
         sortType={sortType}
+        aria-labelledby={id.current}
       >
         {children}
         {sortType && (
-          <Icon type={sortType === "asc" ? "sort_up" : "sort_down"} />
+          <Icon type={sortType === "ascending" ? "sort_up" : "sort_down"} />
         )}
       </StyledSort>
       {!sortType && <StyledSpaceHolder />}

--- a/src/components/flat-table/sort/sort.d.ts
+++ b/src/components/flat-table/sort/sort.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export interface SortProps {
    /** if `asc` it will show `sort_up` icon, if `desc` it will show `sort_down` */
-  sortType?: 'asc' | 'desc' | false ;
+  sortType?: 'ascending' | 'descending' | false ;
   /** Callback fired when the `FlatTableSortHeader` is clicked */
   onClick?: () => void;
   /** Sets the content of `FlatTableSortHeader` */

--- a/src/components/flat-table/sort/sort.spec.js
+++ b/src/components/flat-table/sort/sort.spec.js
@@ -31,14 +31,14 @@ describe("Sort", () => {
     expect(wrapper.find(Icon).exists()).toBe(false);
   });
 
-  it('should render Icon `sort_up` if sortType="asc"', () => {
-    wrapper = renderSort({ sortType: "asc" });
+  it('should render Icon `sort_up` if sortType="ascending"', () => {
+    wrapper = renderSort({ sortType: "ascending" });
 
     expect(wrapper.find(Icon).props().type).toBe("sort_up");
   });
 
-  it('should render Icon `sort_down` if sortType="desc"', () => {
-    wrapper = renderSort({ sortType: "desc" });
+  it('should render Icon `sort_down` if sortType="descending"', () => {
+    wrapper = renderSort({ sortType: "descending" });
 
     expect(wrapper.find(Icon).props().type).toBe("sort_down");
   });
@@ -72,7 +72,7 @@ describe("Sort", () => {
   });
 
   it("should not render `StyledSpaceHoldcer` if `sortTyp`e prop is provided", () => {
-    wrapper = renderSort({ sortType: "asc" });
+    wrapper = renderSort({ sortType: "ascending" });
 
     expect(wrapper.find(StyledSpaceHolder).exists()).toBe(false);
   });

--- a/src/components/flat-table/sort/sort.spec.js
+++ b/src/components/flat-table/sort/sort.spec.js
@@ -71,7 +71,7 @@ describe("Sort", () => {
     expect(wrapper.find(StyledSpaceHolder).exists()).toBe(true);
   });
 
-  it("should not render `StyledSpaceHoldcer` if `sortTyp`e prop is provided", () => {
+  it("should not render `StyledSpaceHolder` if `sortType` prop is provided", () => {
     wrapper = renderSort({ sortType: "ascending" });
 
     expect(wrapper.find(StyledSpaceHolder).exists()).toBe(false);

--- a/src/components/flat-table/sort/sort.style.js
+++ b/src/components/flat-table/sort/sort.style.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import StyledIcon from "../../icon/icon.style";
 import { baseTheme } from "../../../style/themes";
 
-const StyledSort = styled.div`
+const StyledSort = styled.th`
   display: inline-flex;
   align-items: center;
   padding-left: 2px;

--- a/src/components/flat-table/sort/sort.style.js
+++ b/src/components/flat-table/sort/sort.style.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import StyledIcon from "../../icon/icon.style";
 import { baseTheme } from "../../../style/themes";
 
-const StyledSort = styled.th`
+const StyledSort = styled.div`
   display: inline-flex;
   align-items: center;
   padding-left: 2px;


### PR DESCRIPTION
### Proposed behaviour
Added possibility to allow screen reader to read sort label

### Current behaviour
screen reader doesn't read properly

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] <del> Screenshots are included in the PR if useful
- [x] <del> All themes are supported if required
- [x] Unit tests added or updated if required
- [x] <del> Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] <del> Typescript `d.ts` file added or updated if required
- [x] <del> Carbon implementation and Design System documentation are congruent

### Testing instructions
<!-- How can a reviewer test this PR? -->
storybook => design system => flat table => test => sort
Turn on Screen Reader => TAB to sort header
