### PR TITLE
fix(action-popover): incorrect submenu TS type

### DIFF
--- a/src/components/action-popover/action-popover-item.d.ts
+++ b/src/components/action-popover/action-popover-item.d.ts
@@ -7,7 +7,7 @@ export interface ActionPopoverItemProps {
   icon?: IconTypes;
   disabled?: boolean;
   onClick: () => void;
-  submenu?: typeof ActionPopoverMenu;
+  submenu?: React.ReactNode;
 }
 
 declare const ActionPopoverItem: React.FunctionComponent<ActionPopoverItemProps>;


### PR DESCRIPTION
### Proposed behaviour
Change submenu TS type to `React.ReactNode` so it does not throw compiler errors.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
~~- [ ] Unit tests added or updated if required~~
~~- [ ] Cypress automation tests added or updated if required~~
~~- [ ] Storybook added or updated if required~~
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent
