### PR TITLE
fix: prevent accidental form submission - FE-3336

### DIFF
--- a/src/__experimental__/components/date/navbar/__snapshots__/navbar.spec.js.snap
+++ b/src/__experimental__/components/date/navbar/__snapshots__/navbar.spec.js.snap
@@ -18,6 +18,7 @@ exports[`Navbar Navbar Button renders presentational div and context provider fo
 
 <button
   className="c0"
+  type="button"
 >
   sample children
 </button>

--- a/src/__experimental__/components/date/navbar/button.style.js
+++ b/src/__experimental__/components/date/navbar/button.style.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-const StyledButton = styled.button`
+const StyledButton = styled.button.attrs({ type: "button" })`
   align-items: center;
   display: block;
   border: none;

--- a/src/__experimental__/components/date/navbar/navbar.component.js
+++ b/src/__experimental__/components/date/navbar/navbar.component.js
@@ -7,10 +7,10 @@ import Icon from "../../../../components/icon";
 const Navbar = ({ onPreviousClick, onNextClick, ...props }) => {
   return (
     <StyledNavbar {...props}>
-      <StyledButton type="button" onClick={() => onPreviousClick()}>
+      <StyledButton onClick={() => onPreviousClick()}>
         <Icon type="chevron_left" />
       </StyledButton>
-      <StyledButton type="button" onClick={() => onNextClick()}>
+      <StyledButton onClick={() => onNextClick()}>
         <Icon type="chevron_right" />
       </StyledButton>
     </StyledNavbar>

--- a/src/components/advanced-color-picker/advanced-color-picker-cell.style.js
+++ b/src/components/advanced-color-picker/advanced-color-picker-cell.style.js
@@ -6,7 +6,7 @@ const transparentSvg =
   "45%22%3E%3Crect%20x%3D%22200%22%20width%3D%22200%22%20height%3D%22200%22%20%2" +
   "F%3E%3Crect%20y%3D%22200%22%20width%3D%22200%22%20height%3D%22200%22%20%2F%3E%3C%2Fsvg%3E";
 
-const StyledAdvancedColorPickerCell = styled.button`
+const StyledAdvancedColorPickerCell = styled.button.attrs({ type: "button" })`
   display: block;
   width: 25px;
   height: 25px;

--- a/src/components/batch-selection/__snapshots__/batch-selection.spec.js.snap
+++ b/src/components/batch-selection/__snapshots__/batch-selection.spec.js.snap
@@ -117,6 +117,7 @@ exports[`BatchSelection component should render correctly 1`] = `
     className="c2 c3"
     onClick={[Function]}
     onKeyDown={[Function]}
+    type="button"
   >
     <span
       className="c4 c5"

--- a/src/components/carousel/carousel.component.js
+++ b/src/components/carousel/carousel.component.js
@@ -224,7 +224,6 @@ class BaseCarousel extends React.Component {
           {...this.previousButtonProps()}
           data-element="previous"
           aria-label="previous"
-          type="button"
           disabled={isDisabled}
         >
           <CarouselStyledIconLeft type="chevron_down" />

--- a/src/components/carousel/carousel.style.js
+++ b/src/components/carousel/carousel.style.js
@@ -33,7 +33,7 @@ const CarouselStyledIconRight = styled(CarouselStyledIcon)`
   transform: rotate(-90deg);
 `;
 
-const CarouselButtonStyle = styled.button`
+const CarouselButtonStyle = styled.button.attrs({ type: "button" })`
   ${({ theme, disabled }) => css`
     border: none;
     width: 40px;

--- a/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
+++ b/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
@@ -351,6 +351,7 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
   <button
     class="c4"
     data-element="close"
+    type="button"
   >
     <span
       class="c5 c6"

--- a/src/components/drawer/__internal__/drawer.style.js
+++ b/src/components/drawer/__internal__/drawer.style.js
@@ -121,7 +121,7 @@ const StyledDrawerContent = styled.div`
   }
 `;
 
-const StyledButton = styled.button`
+const StyledButton = styled.button.attrs({ type: "button" })`
   position: absolute;
   top: 18px;
   right: 6px;

--- a/src/components/duelling-picklist/duelling-picklist.style.js
+++ b/src/components/duelling-picklist/duelling-picklist.style.js
@@ -132,17 +132,17 @@ const colors = {
   },
 };
 
-const StyledButton = styled.button`
+const StyledButton = styled.button.attrs({ type: "button" })`
   margin-left: auto;
   height: 40px;
   min-width: 40px;
   border: none;
   cursor: pointer;
-  background-color: ${({ type }) => colors.background[type]};
+  background-color: ${({ variant }) => colors.background[variant]};
   outline: none;
 
   &:hover {
-    background-color: ${({ type }) => colors.hoverBackground[type]};
+    background-color: ${({ variant }) => colors.hoverBackground[variant]};
   }
 
   span {

--- a/src/components/duelling-picklist/picklist-item.component.js
+++ b/src/components/duelling-picklist/picklist-item.component.js
@@ -53,7 +53,7 @@ export const PicklistItem = React.forwardRef(
           data-element="picklist-item"
         >
           {children}
-          <StyledButton tabIndex={-1} type={type} onClick={handleClick}>
+          <StyledButton tabIndex={-1} variant={type} onClick={handleClick}>
             <Icon type={type} />
           </StyledButton>
         </StyledPicklistItem>

--- a/src/components/icon-button/icon-button.style.js
+++ b/src/components/icon-button/icon-button.style.js
@@ -3,7 +3,7 @@ import StyledIcon from "../icon/icon.style";
 import classicIconButtonStyle from "./icon-button-classic.style";
 import { baseTheme } from "../../style/themes";
 
-const StyledIconButton = styled.button`
+const StyledIconButton = styled.button.attrs({ type: "button" })`
   background: transparent;
   border: none;
   padding: 0;

--- a/src/components/pager/__internal__/__snapshots__/pager.spec.js.snap
+++ b/src/components/pager/__internal__/__snapshots__/pager.spec.js.snap
@@ -527,6 +527,7 @@ exports[`Pager renders the Pager correctly with the Mint Theme 1`] = `
       data-element="pager-link-first"
       disabled={true}
       onClick={[Function]}
+      type="button"
     >
       First
     </button>
@@ -535,6 +536,7 @@ exports[`Pager renders the Pager correctly with the Mint Theme 1`] = `
       data-element="pager-link-previous"
       disabled={true}
       onClick={[Function]}
+      type="button"
     >
       Previous
     </button>
@@ -609,6 +611,7 @@ exports[`Pager renders the Pager correctly with the Mint Theme 1`] = `
       data-element="pager-link-next"
       disabled={false}
       onClick={[Function]}
+      type="button"
     >
       Next
     </button>
@@ -617,6 +620,7 @@ exports[`Pager renders the Pager correctly with the Mint Theme 1`] = `
       data-element="pager-link-last"
       disabled={false}
       onClick={[Function]}
+      type="button"
     >
       Last
     </button>
@@ -984,6 +988,7 @@ exports[`Pager renders the Pager without pageSizeSelection 1`] = `
       data-element="pager-link-first"
       disabled={true}
       onClick={[Function]}
+      type="button"
     >
       First
     </button>
@@ -992,6 +997,7 @@ exports[`Pager renders the Pager without pageSizeSelection 1`] = `
       data-element="pager-link-previous"
       disabled={true}
       onClick={[Function]}
+      type="button"
     >
       Previous
     </button>
@@ -1066,6 +1072,7 @@ exports[`Pager renders the Pager without pageSizeSelection 1`] = `
       data-element="pager-link-next"
       disabled={true}
       onClick={[Function]}
+      type="button"
     >
       Next
     </button>
@@ -1074,6 +1081,7 @@ exports[`Pager renders the Pager without pageSizeSelection 1`] = `
       data-element="pager-link-last"
       disabled={true}
       onClick={[Function]}
+      type="button"
     >
       Last
     </button>

--- a/src/components/pager/__internal__/pager.style.js
+++ b/src/components/pager/__internal__/pager.style.js
@@ -141,7 +141,7 @@ const StyledPagerNavInner = styled.div`
   padding: 0 12px;
 `;
 
-const StyledPagerLinkStyles = styled.button`
+const StyledPagerLinkStyles = styled.button.attrs({ type: "button" })`
   padding: 0 10px;
   font-size: 13px;
   border-width: 0;

--- a/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.component.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.component.js
@@ -28,7 +28,6 @@ class ToolbarButton extends React.Component {
           isActive={this.props.activated}
           aria-label={this.props.ariaLabel}
           {...(!this.props.tabbable && { tabIndex: -1 })}
-          type="button"
         >
           {this.props.children}
         </StyledToolbarButton>

--- a/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.style.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.style.js
@@ -3,7 +3,7 @@ import { isDLS } from "../../../../../utils/helpers/style-helper";
 import baseTheme from "../../../../../style/themes/base";
 import StyledIcon from "../../../../icon/icon.style";
 
-const StyledToolbarButton = styled.button`
+const StyledToolbarButton = styled.button.attrs({ type: "button" })`
   background-color: inherit;
   border: none;
   cursor: pointer;


### PR DESCRIPTION
### Proposed behaviour
Change `type` of all the buttons to be `button` instead of the default `submit` value.

### Current behaviour
Some of the buttons that we use internally does not have a `type` defined meaning that they default to `type="submit"`. If a component that uses this type of button will be placed inside of `<form>` tag this will lead to unintentional form submission.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent
