### PR TITLE
build: remove react-highlight dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35853,22 +35853,6 @@
         "shallowequal": "^1.1.0"
       }
     },
-    "react-highlight": {
-      "version": "github:briancappello/react-highlight#ecf53ae1bb03deddb897515e7ed65b9e9f7af65b",
-      "from": "github:briancappello/react-highlight#react-v16-compiled",
-      "dev": true,
-      "requires": {
-        "highlight.js": "^9.11.0"
-      },
-      "dependencies": {
-        "highlight.js": {
-          "version": "9.18.5",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
-          "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
-          "dev": true
-        }
-      }
-    },
     "react-hotkeys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "react-dnd-test-backend": "^10.0.2",
     "react-dnd-test-utils": "^10.0.2",
     "react-dom": "^16.12.0",
-    "react-highlight": "briancappello/react-highlight#react-v16-compiled",
     "react-router-dom": "^5.2.0",
     "react-test-renderer": "^16.12.0",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
### Proposed behavior
Remove react-highlight dependency because we don't use it anymore

### Current behavior
react-highlight dependency exists

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] <del> Screenshots are included in the PR if useful
- [ ]  <del> All themes are supported if required
- [ ] <del> Unit tests added or updated if required
- [ ] <del> Cypress automation tests added or updated if required
- [ ] <del> Storybook added or updated if required
- [ ] <del> Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
Test regression needed
