### PR TITLE
chore(storybook): change viewport to align to dls FE-3427

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -22,6 +22,44 @@ configureActions({
   limit: 20,
 });
 
+const customViewports = {
+  extraSmall: {
+    name: 'Smart Phones',
+    styles: {
+      width: '320px',
+      height: '599px',
+    },
+  },
+  small: {
+    name: 'Portrait Tablets',
+    styles: {
+      width: '600px',
+      height: '959px',
+    },
+  },
+  medium: {
+    name: 'Landscape Tablets & Low-Res Laptops',
+    styles: {
+      width: '960px',
+      height: '1259px',
+    },
+  },
+  large: {
+    name: 'High-Res Laptops & Monitors',
+    styles: {
+      width: '1260px',
+      height: '1920px',
+    },
+  },
+  extraLarge: {
+    name: 'Ultra High-Res Monitors',
+    styles: {
+      width: '1921px',
+      height: '2500px',
+    },
+  },
+};
+
 addParameters({
   options: {
     isFullscreen: false,
@@ -47,6 +85,7 @@ addParameters({
     }
   },
   chromatic: { disable: false },
+  viewport: { viewports: customViewports },
 });
 
 setupI18n();


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
changes to the viewport to add config to support storybook having responsive styles and the testing of responsive components. You can now changes the viewport to the sizes recommended in the DLS https://brand.sage.com/d/NdbrveWvNheA/foundations#/grid/grid-system

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Default viewports only that do not align to the DLS
### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
- Visit storybook using the chromatic build
- Change the viewport
- Confirm behaviour is as expected