### PR TITLE
fix(action-popover): close action popover when submenu item is clicked - FE-3237/FE-3343/FE-3414

### DIFF
--- a/cypress/features/regression/test/actionPopoverNoIFrame.feature
+++ b/cypress/features/regression/test/actionPopoverNoIFrame.feature
@@ -159,7 +159,7 @@ Feature: Action Popover component in noIFrame
       | Sub Menu 3 | 2     |
 
   @positive
-  Scenario Outline: Close submenu after press Enter keyboard key
+  Scenario Outline: Close Submenu and Action Popover after press Enter keyboard key
     Given I click the menu button element in noiFrame
       And I press keyboard "downarrow" key times 2
       And I wait 250
@@ -168,6 +168,7 @@ Feature: Action Popover component in noIFrame
       And I press keyboard "downarrow" key times <times>
     When I press "Enter" onto focused element
     Then ActionPopover submenu is not visible
+      And Action Popover element is not visible
     Examples:
       | times |
       | 0     |
@@ -191,7 +192,7 @@ Feature: Action Popover component in noIFrame
       | 2     |
 
   @positive
-  Scenario Outline: Close submenu after press Esc keyboard key
+  Scenario Outline:  Close Submenu and Action Popover after press Esc keyboard key
     Given I click the menu button element in noiFrame
       And I press keyboard "downarrow" key times 2
       And I wait 250
@@ -200,8 +201,25 @@ Feature: Action Popover component in noIFrame
       And I press keyboard "downarrow" key times <times>
     When I press ESC onto focused element
     Then ActionPopover submenu is not visible
+      And Action Popover element is not visible
     Examples:
       | times |
       | 0     |
       | 1     |
       | 2     |
+
+  @positive
+  Scenario Outline:  Close Submenu and Action Popover after clicking on the submenu
+    Given I click the menu button element in noiFrame
+      And I press keyboard "downarrow" key times 2
+      And I wait 250
+      And I press "leftarrow" onto focused element
+      And I wait 250
+      And I press keyboard "downarrow" key times <times>
+    When I click <times> submenu actionPopoverInnerItem in noIframe
+    Then ActionPopover submenu is not visible
+      And Action Popover element is not visible
+    Examples:
+      | times |
+      | 0     |
+      | 1     |

--- a/cypress/features/regression/test/actionPopoverNoIFrame.feature
+++ b/cypress/features/regression/test/actionPopoverNoIFrame.feature
@@ -111,11 +111,11 @@ Feature: Action Popover component in noIFrame
     Then Action Popover element is not visible
 
   @positive
-  Scenario: Action Popover is still open after using ESC key if it has a submenu
+  Scenario: Close Action Popover using ESC key if it has a submenu
     Given I click the menu button element in noiFrame
       And I press keyboard "downarrow" key times 2
     When I press ESC onto focused element
-    Then Action Popover element is visible
+    Then Action Popover element is not visible
 
   @positive
   Scenario: Open Action Popover and close it by clicking outside of the component

--- a/cypress/locators/action-popover/index.js
+++ b/cypress/locators/action-popover/index.js
@@ -13,3 +13,5 @@ export const actionPopoverInnerItem = index => cy.iFrame(ACTION_POPOVER_DATA_COM
   .children().eq(index);
 export const actionPopoverSubmenu = index => cy.iFrame(ACTION_POPOVER_SUBMENU)
   .eq(1).children().eq(index);
+export const actionPopoverSubmenuByIndex = index => cy.get(ACTION_POPOVER_SUBMENU)
+  .eq(1).children().eq(index);

--- a/cypress/support/step-definitions/action-popover-steps.js
+++ b/cypress/support/step-definitions/action-popover-steps.js
@@ -3,6 +3,7 @@ import {
   actionPopoverButtonNoIframe,
   actionPopoverSubmenu,
   actionPopoverSubmenuNoIFrame,
+  actionPopoverSubmenuByIndex,
 } from '../../locators/action-popover';
 import {
   eventInAction,
@@ -41,6 +42,10 @@ When('I click {int} actionPopoverInnerItem', (element) => {
 
 When('I click {int} submenu actionPopoverInnerItem', (element) => {
   actionPopoverSubmenu(element).click({ force: true });
+});
+
+When('I click {int} submenu actionPopoverInnerItem in noIframe', (element) => {
+  actionPopoverSubmenuByIndex(element).click({ force: true });
 });
 
 When('I press {string} onto {int} actionPopoverInnerItem', (key, element) => {

--- a/src/components/action-popover/action-popover-context.js
+++ b/src/components/action-popover/action-popover-context.js
@@ -1,0 +1,4 @@
+import React from "react";
+
+const ActionPopoverContext = React.createContext({});
+export default ActionPopoverContext;

--- a/src/components/action-popover/action-popover-menu.component.js
+++ b/src/components/action-popover/action-popover-menu.component.js
@@ -27,44 +27,6 @@ const ActionPopoverMenu = React.forwardRef(
     const [childrenWithRef, setChildrenWithRef] = useState();
     const timer = useRef();
 
-    useEffect(() => {
-      const event = "click";
-      const menu = ref.current;
-      const handler = (e) => {
-        items.forEach((item, index) => {
-          // loop and check if item clicked is in composedPath and then update focusIndex
-          if (Events.composedPath(e).includes(item.ref.current)) {
-            if (!item.props.disabled) {
-              // if no submenu close menu and focus parent button or item, else update focusIndex
-              if (!item.props.submenu) {
-                clearTimeout(timer.current);
-                timer.current = setTimeout(() => {
-                  setOpen(false);
-                  if (item.ref && item.ref.current) {
-                    item.ref.current.focus();
-                  }
-                }, 0);
-              } else {
-                setFocusIndex(index);
-                items[index].ref.current.focus();
-              }
-            } else {
-              item.ref.current.focus();
-              e.stopPropagation();
-            }
-          }
-        });
-
-        if (onClick) onClick();
-      };
-
-      menu.addEventListener(event, handler);
-
-      return function cleanup() {
-        menu.removeEventListener(event, handler);
-      };
-    }, [focusIndex, items, onClick, ref, setFocusIndex, setOpen, timer]);
-
     const onKeyDown = useCallback(
       (e) => {
         if (Events.isTabKey(e) && Events.isShiftKey(e)) {
@@ -77,16 +39,6 @@ const ActionPopoverMenu = React.forwardRef(
         } else if (Events.isTabKey(e)) {
           // TAB: close menu and allow focus to change to next focusable element
           setOpen(false);
-        } else if (Events.isEscKey(e)) {
-          // ESC: close menu and focus menu button
-          e.preventDefault();
-          setOpen(false);
-          button.current.focus();
-        } else if (Events.isEnterKey(e)) {
-          // ENTER: focus close menu and focus parent
-          setOpen(false);
-          button.current.focus();
-          e.stopPropagation();
         } else if (Events.isDownKey(e)) {
           // DOWN: focus next item or first
           e.preventDefault();
@@ -136,7 +88,7 @@ const ActionPopoverMenu = React.forwardRef(
           }
         }
       },
-      [setOpen, button, focusIndex, items, setFocusIndex]
+      [setOpen, focusIndex, items, setFocusIndex]
     );
 
     // send a global close to other items with sub whenever updateItemIndex triggered?

--- a/src/components/action-popover/action-popover.component.js
+++ b/src/components/action-popover/action-popover.component.js
@@ -81,10 +81,10 @@ const ActionPopover = ({
       }
     };
     const event = "click";
-    document.addEventListener(event, handler);
+    document.addEventListener(event, handler, { capture: true });
 
     return function cleanup() {
-      document.removeEventListener(event, handler);
+      document.removeEventListener(event, handler, { capture: true });
     };
   }, [setOpen]);
 

--- a/src/components/action-popover/action-popover.component.js
+++ b/src/components/action-popover/action-popover.component.js
@@ -7,6 +7,7 @@ import createGuid from "../../utils/helpers/guid";
 import ActionPopoverMenu from "./action-popover-menu.component";
 import ActionPopoverItem from "./action-popover-item.component";
 import ActionPopoverDivider from "./action-popover-divider.component";
+import ActionPopoverContext from "./action-popover-context";
 
 const ActionPopover = ({
   children,
@@ -68,12 +69,14 @@ const ActionPopover = ({
     [items, onButtonClick, setOpen]
   );
 
+  const focusButton = useCallback(() => button.current.focus(), []);
+
   useEffect(() => {
     const handler = (e) => {
-      // If the event came from part of this component, close the menu.
+      // If the event didn't came from part of this component, close the menu.
       // There will be multiple document click listeners but we cant prevent propagation because it will interfere with
       // other instances on the same page
-      if (!Events.composedPath(e).includes(button.current)) {
+      if (!button.current.contains(e.target)) {
         setOpen(false);
       }
     };
@@ -129,14 +132,18 @@ const ActionPopover = ({
       {...rest}
     >
       {menuButton()}
-      <ActionPopoverMenu
-        data-component="action-popover"
-        role="menu"
-        ref={menu}
-        {...menuProps}
+      <ActionPopoverContext.Provider
+        value={{ setOpenPopover: setOpen, focusButton, isOpenPopover: isOpen }}
       >
-        {children}
-      </ActionPopoverMenu>
+        <ActionPopoverMenu
+          data-component="action-popover"
+          role="menu"
+          ref={menu}
+          {...menuProps}
+        >
+          {children}
+        </ActionPopoverMenu>
+      </ActionPopoverContext.Provider>
     </MenuButton>
   );
 };

--- a/src/components/action-popover/action-popover.spec.js
+++ b/src/components/action-popover/action-popover.spec.js
@@ -990,8 +990,8 @@ describe("ActionPopover", () => {
         });
       });
 
-      it("returns focus back to parent item when submenu item clicked", () => {
-        const { items } = getElements();
+      it("returns focus back to menu button when submenu item clicked", () => {
+        const { items, menubutton } = getElements();
         const item = items.at(1);
         const submenu = item.find(ActionPopoverMenu);
         const submenuItem = submenu.find(ActionPopoverItem).at(0);
@@ -1011,7 +1011,7 @@ describe("ActionPopover", () => {
           submenuItem
             .getDOMNode()
             .dispatchEvent(new MouseEvent("click", { bubbles: true }));
-          expect(item).toBeFocused();
+          expect(menubutton).toBeFocused();
           jest.runAllTimers(); // needed to trigger coverage
         });
       });

--- a/src/components/action-popover/action-popover.stories.js
+++ b/src/components/action-popover/action-popover.stories.js
@@ -61,7 +61,10 @@ export const Default = () => (
         <TableCell>John</TableCell>
         <TableCell>Doe</TableCell>
         <TableCell>
-          <ActionPopover>
+          <ActionPopover
+            onOpen={action("popover opened")}
+            onClose={action("popover closed")}
+          >
             <ActionPopoverItem
               disabled
               icon="graph"


### PR DESCRIPTION
### Proposed behaviour
Clicking, pressing `enter` or `esc` keys on submenu items should close whole ActionPopover

This PR also fixes FE-3414, (https://github.com/Sage/carbon/issues/3476) check sandbox to test if it works properly.

https://codesandbox.io/s/carbon-quickstart-forked-cdb9j?file=/src/index.js

### Current behaviour
Clicking, pressing `enter` or `esc` keys on submenu items closes only the submenu

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent


### Testing instructions

http://localhost:9001/?path=/story/design-system-action-popover-test--default

