### PR TITLE
fix(tooltip): change tooltip text-align to be always left

### DIFF
--- a/src/components/text-editor/__internal__/text-editor.stories.mdx
+++ b/src/components/text-editor/__internal__/text-editor.stories.mdx
@@ -1,55 +1,63 @@
-import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
-import { useState, useRef } from 'react';
-import EditorLink from './editor-link';
-import TextEditor, 
-{
-  TextEditorState as EditorState, 
-  TextEditorContentState as ContentState
-} from './text-editor.component';
-import Toolbar from './toolbar';
-import ToolbarButton from './toolbar/toolbar-button';
-import EditorCounter from './editor-counter';
-import IconButton from '../../icon-button';
-import Icon from '../../icon';
+import { Meta, Props, Preview, Story } from "@storybook/addon-docs/blocks";
+import { useState, useRef } from "react";
+import EditorLink from "./editor-link";
+import TextEditor, {
+  TextEditorState as EditorState,
+  TextEditorContentState as ContentState,
+} from "./text-editor.component";
+import Toolbar from "./toolbar";
+import ToolbarButton from "./toolbar/toolbar-button";
+import EditorCounter from "./editor-counter";
+import IconButton from "../../icon-button";
+import Icon from "../../icon";
 
-<Meta title="Design System/Text Editor" parameters={{ info: { disable: true }}} />
+<Meta
+  title="Design System/Text Editor"
+  parameters={{ info: { disable: true } }}
+/>
 
 # Text Editor
-The `TextEditor` was created using the `draftjs` framework. It requires consuming projects to install `draftjs` as a 
+
+The `TextEditor` was created using the `draftjs` framework. It requires consuming projects to install `draftjs` as a
 peer-dependency to enable it to work.
 
 ## Quick Start
 
 To use the text editor , import the `TextEditor` and pass the content as as an immutable `EditorState` object.
 
-It can be used as a controlled component where the content of the input is controlled externally, as such both 
-`onChange` and `value` props are required. The `labelText` and `labelId` props are also required in order to ensure 
+It can be used as a controlled component where the content of the input is controlled externally, as such both
+`onChange` and `value` props are required. The `labelText` and `labelId` props are also required in order to ensure
 accessibility requirements are met.
 
 ```jsx
-import TextEditor, { EditorState, ContentState } from "carbon-react/lib/components/text-editor";
+import TextEditor, {
+  EditorState,
+  ContentState,
+} from "carbon-react/lib/components/text-editor";
 ```
 
 ### Basic usage:
-In its basic format the `TextEditor` requires three props; `value`, `onChange` and `label` props. The initial 
-editorState can be created empty using `EditorState.createEmpty()`, as it is below. It is also possible to render links 
-in the input, this can be done by manually typing or pasting a valid url into the editor. Another feature of the 
-component is that it supports a wide range of keyboard shortcuts to apply the various styling options: `cmd/ctrl+b` 
-toggles `bold`; `cmd/ctrl+i` toggles `italic`; and inputting a `*` or `1.` on a new line will render a 
+
+In its basic format the `TextEditor` requires three props; `value`, `onChange` and `label` props. The initial
+editorState can be created empty using `EditorState.createEmpty()`, as it is below. It is also possible to render links
+in the input, this can be done by manually typing or pasting a valid url into the editor. Another feature of the
+component is that it supports a wide range of keyboard shortcuts to apply the various styling options: `cmd/ctrl+b`
+toggles `bold`; `cmd/ctrl+i` toggles `italic`; and inputting a `*` or `1.` on a new line will render a
 `unordered-list` or `ordered-list` respectively.
 You can use the `required` prop to indicate if the field is mandatory.
-
 
 <Preview>
   <Story name="basic">
     {() => {
       const [value, setValue] = useState(EditorState.createEmpty());
       return (
-        <div style={{ padding: '4px' }}>
+        <div style={{ padding: "4px" }}>
           <TextEditor
-            onChange={(newValue) => {setValue(newValue)}}
-            value={ value }
-            labelText='Text Editor Label'
+            onChange={(newValue) => {
+              setValue(newValue);
+            }}
+            value={value}
+            labelText="Text Editor Label"
           />
         </div>
       );
@@ -58,26 +66,31 @@ You can use the `required` prop to indicate if the field is mandatory.
 </Preview>
 
 ### With content:
-The initial editorState can also be created with content using 
-`EditorState.createWithContent(ContentState.createFromText(''))`, as it is below. Other options available for 
-populating the content that can be found https://draftjs.org/docs/api-reference-content-state#static-methods. 
-It is also possible to initialise the editor with content in other formats, such as `html` or `markdown` through use of 
-other packages; using the methods for data conversion provided by `draftjs` 
-(https://draftjs.org/docs/api-reference-data-conversion/), enables the parsing of these formats into something the 
+
+The initial editorState can also be created with content using
+`EditorState.createWithContent(ContentState.createFromText(''))`, as it is below. Other options available for
+populating the content that can be found https://draftjs.org/docs/api-reference-content-state#static-methods.
+It is also possible to initialise the editor with content in other formats, such as `html` or `markdown` through use of
+other packages; using the methods for data conversion provided by `draftjs`
+(https://draftjs.org/docs/api-reference-data-conversion/), enables the parsing of these formats into something the
 editor can expects.
 
 <Preview>
   <Story name="with content">
     {() => {
       const [value, setValue] = useState(
-        EditorState.createWithContent(ContentState.createFromText('Some initial content'))
+        EditorState.createWithContent(
+          ContentState.createFromText("Some initial content")
+        )
       );
       return (
-        <div style={{ padding: '4px' }}>
+        <div style={{ padding: "4px" }}>
           <TextEditor
-            onChange={(newValue) => {setValue(newValue)}}
-            value={ value }
-            labelText='Text Editor Label'
+            onChange={(newValue) => {
+              setValue(newValue);
+            }}
+            value={value}
+            labelText="Text Editor Label"
             required
           />
         </div>
@@ -87,8 +100,9 @@ editor can expects.
 </Preview>
 
 ### With optional Save/ Cancel buttons
-By passing the `onSave` callback prop it is possible to render the form control buttons as seen below. This callback 
-will be executed when the `Save` button is clicked and there is content in the editor input, the button is disabled 
+
+By passing the `onSave` callback prop it is possible to render the form control buttons as seen below. This callback
+will be executed when the `Save` button is clicked and there is content in the editor input, the button is disabled
 otherwise. Any `onCancel` callback prop passed will be called when the `Cancel` button is clicked.
 
 <Preview>
@@ -97,13 +111,16 @@ otherwise. Any `onCancel` callback prop passed will be called when the `Cancel` 
       const [value, setValue] = useState(EditorState.createEmpty());
       const ref = useRef(null);
       return (
-        <div style={{ padding: '4px' }}>
+        <div style={{ padding: "4px" }}>
           <TextEditor
-            onChange={(newValue) => {setValue(newValue)}}
-            value={ value } ref={ ref }
-            onSave={ () => { } }
-            onCancel={ () => { } }
-            labelText='Text Editor Label'
+            onChange={(newValue) => {
+              setValue(newValue);
+            }}
+            value={value}
+            ref={ref}
+            onSave={() => {}}
+            onCancel={() => {}}
+            labelText="Text Editor Label"
           />
         </div>
       );
@@ -112,23 +129,30 @@ otherwise. Any `onCancel` callback prop passed will be called when the `Cancel` 
 </Preview>
 
 ### With user defined character limit
-It is possible to override the default value for the character limit via the `characterLimit` prop. Setting this prop 
+
+It is possible to override the default value for the character limit via the `characterLimit` prop. Setting this prop
 will prevent any input that would cause the content length to exceed it.
 
 <Preview>
-  <Story name="with optional character limit" parameters={{ chromatic: { disable: true }}}>
+  <Story
+    name="with optional character limit"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
       const [value, setValue] = useState(EditorState.createEmpty());
       const limit = 100;
       const ref = useRef(null);
       return (
-        <div style={{ padding: '4px' }}>
+        <div style={{ padding: "4px" }}>
           <TextEditor
-            onChange={(newValue) => {setValue(newValue)}}
-            value={ value } ref={ ref }
-            onSubmit={ () => {} }
-            labelText='Text Editor Label'
-            characterLimit={ limit }
+            onChange={(newValue) => {
+              setValue(newValue);
+            }}
+            value={value}
+            ref={ref}
+            onSubmit={() => {}}
+            labelText="Text Editor Label"
+            characterLimit={limit}
           />
         </div>
       );
@@ -137,30 +161,74 @@ will prevent any input that would cause the content length to exceed it.
 </Preview>
 
 ### With validation
-It is possible apply validation to the `TextEditor` component by passing the desired string message to one of the `error`, 
-`warning` or `info` props. When an `error` message is provided the border styling of the editor is updated to indicate 
+
+It is possible apply validation to the `TextEditor` component by passing the desired string message to one of the `error`,
+`warning` or `info` props. When an `error` message is provided the border styling of the editor is updated to indicate
 this status.
 
 <Preview>
   <Story name="with validation">
     {() => {
       const [value, setValue] = useState(
-        EditorState.createWithContent(ContentState.createFromText('Add content'))
+        EditorState.createWithContent(
+          ContentState.createFromText("Add content")
+        )
       );
       const limit = 16;
       const contentLength = value.getCurrentContent().getPlainText().length;
       const ref = useRef(null);
       return (
-        <div style={{ padding: '4px' }}>
+        <div style={{ padding: "4px" }}>
           <TextEditor
-            onChange={(newValue) => {setValue(newValue)}}
-            value={ value }
-            ref={ ref }
-            labelText='Text Editor Label'
-            characterLimit={ limit }
-            error={ limit - contentLength <= 5 ? 'There is an error' : undefined }
-            warning={ limit - contentLength <= 10 ? 'There is an warning' : undefined }
-            info={ limit - contentLength <= 15 ? 'There is an info' : undefined }
+            onChange={(newValue) => {
+              setValue(newValue);
+            }}
+            value={value}
+            ref={ref}
+            labelText="Text Editor Label"
+            characterLimit={limit}
+            error={limit - contentLength <= 5 ? "There is an error" : undefined}
+            warning={
+              limit - contentLength <= 10 ? "There is an warning" : undefined
+            }
+            info={limit - contentLength <= 15 ? "There is an info" : undefined}
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
+With use of `template strings` it is possible to pass multiline validation messages to the component.
+
+<Preview>
+  <Story name="with multiline validation">
+    {() => {
+      const [value, setValue] = useState(
+        EditorState.createWithContent(
+          ContentState.createFromText("Add content")
+        )
+      );
+      const limit = 16;
+      const contentLength = value.getCurrentContent().getPlainText().length;
+      const ref = useRef(null);
+      const error =
+        limit - contentLength <= 5
+          ? `There is an error.
+The content is too long.
+Maybe try writing a little bit less?`
+          : undefined;
+      return (
+        <div style={{ padding: "4px" }}>
+          <TextEditor
+            onChange={(newValue) => {
+              setValue(newValue);
+            }}
+            value={value}
+            ref={ref}
+            labelText="Text Editor Label"
+            characterLimit={limit}
+            error={error}
           />
         </div>
       );
@@ -169,4 +237,5 @@ this status.
 </Preview>
 
 ### Text Editor Props
+
 <Props of={TextEditor} />

--- a/src/components/tooltip/__snapshots__/tooltip.spec.js.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.spec.js.snap
@@ -14,7 +14,7 @@ exports[`Tooltip visible and has children matches snapshot 1`] = `
   color: #FFFFFF;
   display: inline-block;
   padding: 12px 16px;
-  text-align: center;
+  text-align: left;
   max-width: 300px;
   word-break: normal;
   white-space: pre-wrap;
@@ -29,7 +29,6 @@ exports[`Tooltip visible and has children matches snapshot 1`] = `
   -webkit-animation: bcCCNc 0.2s linear;
   animation: bcCCNc 0.2s linear;
   z-index: 2000;
-  text-align: center;
 }
 
 .c2 {

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -9,7 +9,6 @@ import StyledTooltipPointer, {
   pointerSideMargin,
 } from "./tooltip-pointer.style";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
-import OptionsHelper from "../../utils/helpers/options-helper/options-helper";
 
 jest.mock("../../__experimental__/components/input/input-sizes.style", () => ({
   small: {
@@ -88,7 +87,7 @@ describe("Tooltip", () => {
               color: "#FFFFFF",
               display: "inline-block",
               padding: "12px 16px",
-              textAlign: "center",
+              textAlign: "left",
               maxWidth: "300px",
               wordBreak: "normal",
               whiteSpace: "pre-wrap",
@@ -119,25 +118,6 @@ describe("Tooltip", () => {
             },
             renderWrapper()
           );
-        });
-      });
-
-      describe.each(OptionsHelper.positions)(
-        'position === "%s"',
-        (position) => {
-          const align = ["top", "bottom"].includes(position)
-            ? "center"
-            : position;
-
-          it(`sets textAlign to "${align}"`, () => {
-            assertStyleMatch({ textAlign: align }, renderWrapper({ position }));
-          });
-        }
-      );
-
-      describe.each(OptionsHelper.alignBinary)('align === "%s"', (align) => {
-        it(`sets textAlign to "${align}"`, () => {
-          assertStyleMatch({ textAlign: align }, renderWrapper({ align }));
         });
       });
     });

--- a/src/components/tooltip/tooltip.style.js
+++ b/src/components/tooltip/tooltip.style.js
@@ -2,7 +2,6 @@ import styled, { css, keyframes } from "styled-components";
 import PropTypes from "prop-types";
 import baseTheme from "../../style/themes/base";
 import OptionsHelper from "../../utils/helpers/options-helper/options-helper";
-import { isHorizontal } from "./tooltip.utils";
 
 const fadeIn = keyframes`
   0% {
@@ -20,7 +19,7 @@ const StyledTooltipInner = styled.div`
     color: ${theme.colors.white};
     display: inline-block;
     padding: 12px 16px;
-    text-align: center;
+    text-align: left;
     max-width: 300px;
     word-break: normal;
     white-space: pre-wrap;
@@ -40,7 +39,6 @@ const StyledTooltipWrapper = styled.div`
   position: relative;
   animation: ${fadeIn} 0.2s linear;
   z-index: ${({ theme }) => theme.zIndex.popover};
-  text-align: ${({ align, position }) => getTextAlignment(position, align)};
 `;
 
 StyledTooltipInner.propTypes = {
@@ -60,19 +58,5 @@ StyledTooltipWrapper.defaultProps = {
 StyledTooltipInner.defaultProps = {
   theme: baseTheme,
 };
-
-function getTextAlignment(position, align) {
-  let textAlignment = "center";
-
-  if (isHorizontal(position)) {
-    textAlignment = position;
-  }
-
-  if (isHorizontal(align)) {
-    textAlignment = align;
-  }
-
-  return textAlignment;
-}
 
 export { StyledTooltipInner, StyledTooltipWrapper };


### PR DESCRIPTION
Fixes #3468

### Proposed behaviour
All tooltips should have `text-align: left`

### Current behaviour
Currently the `text-align` varies depending on tooltip position and alignment

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
Just check that various tooltips always have `text-align: left`
