### PR TITLE
docs(menu): change NavBar to be NavigationBar

### DIFF
--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { Menu, MenuItem, SubmenuBlock, MenuDivider, MenuSegmentTitle } from ".";
 import Box from "../box";
-import Navbar from "../navigation-bar";
+import NavigationBar from "../navigation-bar";
 import VerticalDivider from "../vertical-divider";
 import { SageIcon } from "../../../.storybook/welcome-page/footer/footer.style.js";
 
@@ -319,7 +319,7 @@ is rendered.
     {() => {
       return (
         <div style={{ minHeight: "150px" }}>
-          <Navbar>
+          <NavigationBar>
             <SageIcon style={{ alignSelf: "center" }} />
             <Box>
               <VerticalDivider displayInline pr={0} />
@@ -345,7 +345,7 @@ is rendered.
                 <MenuItem href="#">Item Submenu Two</MenuItem>
               </MenuItem>
             </Menu>
-          </Navbar>
+          </NavigationBar>
         </div>
       );
     }}


### PR DESCRIPTION
### Proposed behaviour
Change docs to use `<NavigationBar>` instead of `<NavBar>` to be consistent with the `NavigationBar` stories.

### Current behaviour
Some users were asking what the difference between `NavBar` and `NavigationBar`.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Look at the source preview of `Full navbar alignment example` story for `Menu`.
