### PR TITLE
fix(navbar): remove old styling to allow full width

### DIFF
--- a/src/components/navigation-bar/navigation-bar.stories.mdx
+++ b/src/components/navigation-bar/navigation-bar.stories.mdx
@@ -1,70 +1,114 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
-import NavigationBar from './navigation-bar.component';
-import {Menu, MenuItem} from '../menu';
-import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
+import NavigationBar from "./navigation-bar.component";
+import { Menu, MenuItem } from "../menu";
+import Box from "../box";
+import VerticalDivider from "../vertical-divider";
+import { SageIcon } from "../../../.storybook/welcome-page/footer/footer.style.js";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 <Meta title="Design System/Navigation Bar" />
 
 # NavigationBar
 
 ### Light Theme
+
 <Preview>
-  <Story name="default" parameters={{ info: { disable: true }}}>
-    <NavigationBar>
-      Example content
-    </NavigationBar> 
-  </Story> 
+  <Story name="default" parameters={{ info: { disable: true } }}>
+    <NavigationBar>Example content</NavigationBar>
+  </Story>
 </Preview>
 
 ### Light Theme Loading State
-If `isLoading={true}` the children will not be visible 
+
+If `isLoading={true}` the children will not be visible
+
 <Preview>
-  <Story name="isLoading" parameters={{ info: { disable: true }}}>
+  <Story name="isLoading" parameters={{ info: { disable: true } }}>
     <NavigationBar isLoading>
       <Menu>
         <MenuItem>menu item one</MenuItem>
         <MenuItem>menu item two</MenuItem>
       </Menu>
-    </NavigationBar> 
-  </Story> 
+    </NavigationBar>
+  </Story>
 </Preview>
 
 ### Dark Theme
+
 <Preview>
-  <Story name="dark theme"  parameters={{ info: { disable: true }}}>
-    <NavigationBar navigationType="dark">
-      Example content
-    </NavigationBar>  
+  <Story name="dark theme" parameters={{ info: { disable: true } }}>
+    <NavigationBar navigationType="dark">Example content</NavigationBar>
   </Story>
-</Preview> 
+</Preview>
 
 ### Dark Theme Loading State
-If `isLoading={true}` the children will not be visible 
+
+If `isLoading={true}` the children will not be visible
+
 <Preview>
-  <Story name="dark theme isLoading" parameters={{ info: { disable: true }}}>
+  <Story name="dark theme isLoading" parameters={{ info: { disable: true } }}>
     <NavigationBar navigationType="dark" isLoading>
       <Menu>
         <MenuItem>menu item one</MenuItem>
         <MenuItem>menu item two</MenuItem>
       </Menu>
-    </NavigationBar> 
-  </Story> 
+    </NavigationBar>
+  </Story>
 </Preview>
 
 ### With custom spacing
-The spacing props (see prop table below) accept either a number between 1 and 8 that is then multiplied by `8px` or any 
+
+The spacing props (see prop table below) accept either a number between 1 and 8 that is then multiplied by `8px` or any
 valid CSS string.
+
 <Preview>
-  <Story name="with custom spacing" parameters={{ info: { disable: true }}}>
+  <Story name="with custom spacing" parameters={{ info: { disable: true } }}>
     <NavigationBar m={2} py={2} px={7}>
       <Menu>
         <MenuItem>menu item one</MenuItem>
         <MenuItem>menu item two</MenuItem>
       </Menu>
-    </NavigationBar> 
-  </Story> 
+    </NavigationBar>
+  </Story>
 </Preview>
 
-<StyledSystemProps
-  spacing
-/>
+### Set content max width using Box
+
+<Preview>
+  <Story
+    name="content max width using Box"
+    parameters={{ info: { disable: true } }}
+  >
+    <NavigationBar>
+      <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
+        <SageIcon style={{ alignSelf: "center" }} />
+        <Box>
+          <VerticalDivider displayInline pr={0} />
+        </Box>
+        <Menu display="flex" flex="1">
+          <MenuItem flex="1" onClick={() => {}}>
+            Menu Item One
+          </MenuItem>
+          <MenuItem flex="0 0 auto" href="#">
+            Menu Item Two
+          </MenuItem>
+          <MenuItem flex="0 0 auto" submenu="Menu Item Three">
+            <MenuItem href="#">Item Submenu One</MenuItem>
+            <MenuItem href="#">Item Submenu Two</MenuItem>
+            <MenuDivider />
+            <MenuItem icon="settings" href="#">
+              Item Submenu Three
+            </MenuItem>
+            <MenuItem href="#">Item Submenu Four</MenuItem>
+          </MenuItem>
+          <MenuItem flex="0 0 auto" submenu="Menu Item Four">
+            <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+            <MenuItem href="#">Item Submenu Two</MenuItem>
+          </MenuItem>
+        </Menu>
+      </Box>
+    </NavigationBar>
+  </Story>
+</Preview>
+
+<StyledSystemProps spacing />

--- a/src/components/navigation-bar/navigation-bar.style.js
+++ b/src/components/navigation-bar/navigation-bar.style.js
@@ -4,14 +4,11 @@ import { baseTheme } from "../../style/themes";
 import Box from "../box";
 
 const StyledNavigationBar = styled(Box).attrs({ as: "nav" })`
-  margin: 0 auto;
   padding: 0 40px;
   display: flex;
   align-items: center;
 
   line-height: 40px;
-  max-width: 1600px;
-  min-width: 958px;
 
   & > * {
     box-sizing: border-box;
@@ -49,19 +46,6 @@ const StyledNavigationBar = styled(Box).attrs({ as: "nav" })`
       color: ${theme.colors.white};
     `}
   `}
-`;
-
-export const StyledNavigationBarContent = styled.div`
-  line-height: 40px;
-  max-width: 1600px;
-  min-width: 958px;
-
-  & > * {
-    box-sizing: border-box;
-    display: inline-block;
-    height: 40px;
-    vertical-align: middle;
-  }
 `;
 
 StyledNavigationBar.defaultProps = {


### PR DESCRIPTION
### Proposed behaviour
Remove min and max width and auto margin, leaving the nav bar to be the full width of the screen.

Add an MDX example to show users how to set a max-width on their nav bar content using `Box`: 

![image](https://user-images.githubusercontent.com/14963680/102509203-2a059d00-407e-11eb-896c-72ce67630033.png)


### Current behaviour
The nav bar has a min and max width, and margin auto for left and right which is causing problems with the max width (I.e. the nav bar not spanning the whole width of the page)

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
http://localhost:9001/?path=/story/design-system-navigation-bar--content-max-width-using-box
and test the other nav bar stories