### PR TITLE
feat(menu): add scrollable block component

### DIFF
--- a/cypress/features/regression/designSystem/menu.feature
+++ b/cypress/features/regression/designSystem/menu.feature
@@ -1,0 +1,15 @@
+Feature: Design Systems Menu component
+	I want to test the Design Systems Menu component
+
+	Background: Open Menu on scrollable menu story
+		Given I open "Design System Menu" component page "scrollable-submenu" in no iframe
+
+  @positive
+  Scenario Outline: Test that the scroll block within a submenu is scrollable 
+    When I open the "<position>" submenu
+      And I scroll to the bottom of the block
+    Then The last element is visible
+    Examples:
+    | position |
+    | first    |
+    | second   |

--- a/cypress/locators/menu/index.js
+++ b/cypress/locators/menu/index.js
@@ -2,6 +2,7 @@ import {
   MENU_PREVIEW,
   MENU_ITEM,
   SUBMENU,
+  SCROLL_BLOCK,
 } from './locators';
 
 // component preview locators
@@ -14,3 +15,6 @@ export const submenuBlock = () => cy.get(SUBMENU)
 export const innerMenu = index => submenuBlock()
   .find(`li:nth-child(${index})`)
   .find('div');
+export const scrollBlock = () => cy.get(SUBMENU).find(SCROLL_BLOCK);
+export const lastSubmenuElement = () => submenuBlock()
+  .find('li div').last();

--- a/cypress/locators/menu/locators.js
+++ b/cypress/locators/menu/locators.js
@@ -2,3 +2,4 @@
 export const MENU_PREVIEW = '[data-component="menu"]';
 export const MENU_ITEM = '[data-component="menu-item"]';
 export const SUBMENU = '[data-component="submenu-wrapper"]';
+export const SCROLL_BLOCK = '[data-component="submenu-scrollable-block"]';

--- a/cypress/support/step-definitions/menu-steps.js
+++ b/cypress/support/step-definitions/menu-steps.js
@@ -3,6 +3,8 @@ import {
   submenuBlock,
   innerMenu,
   submenu,
+  scrollBlock,
+  lastSubmenuElement,
 } from '../../locators/menu';
 import { positionOfElement } from '../helper';
 
@@ -20,4 +22,16 @@ Then('Menu third expandable element has inner elements', () => {
   innerMenu(positionOfElement('third')).should('have.attr', 'data-component', 'menu-divider');
   innerMenu(positionOfElement('fourth')).should('have.attr', 'data-component', 'link');
   innerMenu(positionOfElement('fifth')).should('have.attr', 'data-component', 'link');
+});
+
+When('I open the {string} submenu', (position) => {
+  submenu().eq(positionOfElement(position)).trigger('mouseover');
+});
+
+When('I scroll to the bottom of the block', () => {
+  scrollBlock().scrollTo('bottom');
+});
+
+Then('The last element is visible', () => {
+  lastSubmenuElement().should('be.visible');
 });

--- a/src/components/menu/__internal__/submenu/submenu.context.js
+++ b/src/components/menu/__internal__/submenu/submenu.context.js
@@ -1,0 +1,4 @@
+import React from "react";
+
+const SubmenuContext = React.createContext({});
+export default SubmenuContext;

--- a/src/components/menu/__internal__/submenu/submenu.spec.js
+++ b/src/components/menu/__internal__/submenu/submenu.spec.js
@@ -8,6 +8,7 @@ import StyledMenuItemWrapper from "../../menu-item/menu-item.style";
 import { StyledSubmenu } from "./submenu.style";
 import MenuDivider from "../../menu-divider/menu-divider.component";
 import Submenu from "./submenu.component";
+import ScrollableBlock from "../../scrollable-block";
 import { assertStyleMatch } from "../../../../__spec_helper__/test-utils";
 import { baseTheme } from "../../../../style/themes";
 
@@ -746,6 +747,30 @@ describe("Submenu component", () => {
         },
         wrapper.find(StyledSubmenu)
       );
+    });
+  });
+
+  describe("when it has a ScrollableBlock as a child", () => {
+    const renderScrollableBlock = (openSubmenu, menuType, props) => {
+      return mount(
+        <MenuContext.Provider value={menuContextValues(openSubmenu, menuType)}>
+          <Submenu title="title" tabIndex={-1} {...props}>
+            <MenuItem>Apple</MenuItem>
+            <MenuItem>Banana</MenuItem>
+            <ScrollableBlock>
+              <MenuItem>Carrot</MenuItem>
+              <MenuItem>Broccoli</MenuItem>
+            </ScrollableBlock>
+          </Submenu>
+        </MenuContext.Provider>,
+        { attachTo: container }
+      );
+    };
+
+    it("should render all of the underlying menu items", () => {
+      wrapper = renderScrollableBlock(true, "light");
+
+      expect(wrapper.find(MenuItem).length).toEqual(4);
     });
   });
 });

--- a/src/components/menu/__internal__/submenu/submenu.style.js
+++ b/src/components/menu/__internal__/submenu/submenu.style.js
@@ -4,6 +4,7 @@ import LinkStyle from "../../../link/link.style";
 import { StyledMenuItem } from "../../menu.style";
 import StyledMenuItemWrapper from "../../menu-item/menu-item.style";
 import StyledIcon from "../../../icon/icon.style";
+import StyledScrollableBlock from "../../scrollable-block/scrollable-block.style";
 
 const StyledSubmenuWrapper = styled.div`
   position: relative;
@@ -135,7 +136,7 @@ const StyledSubmenu = styled.ul`
       width: 100%;
     }
 
-    > *:not(${StyledMenuItem}) {
+    > *:not(${StyledMenuItem}):not(${StyledScrollableBlock}) {
       padding: 8px 15px 10px;
       background-color: ${theme.colors.white};
 

--- a/src/components/menu/index.js
+++ b/src/components/menu/index.js
@@ -3,3 +3,4 @@ export { default as MenuItem } from "./menu-item/menu-item.component";
 export { default as SubmenuBlock } from "./submenu-block/submenu-block.component";
 export { default as MenuDivider } from "./menu-divider/menu-divider.component";
 export { default as MenuSegmentTitle } from "./menu-segment-title/menu-segment-title.component";
+export { default as ScrollableBlock } from "./scrollable-block/scrollable-block.component";

--- a/src/components/menu/menu-item/menu-item.component.js
+++ b/src/components/menu/menu-item/menu-item.component.js
@@ -13,9 +13,9 @@ import Link from "../../link";
 import Box from "../../box";
 import Events from "../../../utils/helpers/events";
 import { MenuContext } from "../menu.component";
-import Submenu, {
-  SubmenuContext,
-} from "../__internal__/submenu/submenu.component";
+import Submenu from "../__internal__/submenu/submenu.component";
+import SubmenuContext from "../__internal__/submenu/submenu.context";
+
 import SubmenuBlock from "../submenu-block/submenu-block.component";
 import { StyledMenuItem } from "../menu.style";
 

--- a/src/components/menu/menu-item/menu-item.spec.js
+++ b/src/components/menu/menu-item/menu-item.spec.js
@@ -7,9 +7,9 @@ import Link from "../../link";
 import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
 import { baseTheme } from "../../../style/themes";
 import StyledMenuItemWrapper from "./menu-item.style";
-import Submenu, {
-  SubmenuContext,
-} from "../__internal__/submenu/submenu.component";
+import Submenu from "../__internal__/submenu/submenu.component";
+import SubmenuContext from "../__internal__/submenu/submenu.context";
+
 import { MenuContext } from "../menu.component";
 import SubmenuBlock from "../submenu-block";
 import StyledIcon from "../../icon/icon.style";

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -1,5 +1,12 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
-import { Menu, MenuItem, SubmenuBlock, MenuDivider, MenuSegmentTitle } from ".";
+import {
+  Menu,
+  MenuItem,
+  SubmenuBlock,
+  MenuDivider,
+  MenuSegmentTitle,
+  ScrollableBlock,
+} from ".";
 import Box from "../box";
 import NavigationBar from "../navigation-bar";
 import VerticalDivider from "../vertical-divider";
@@ -186,37 +193,42 @@ import {
 
 ## Default icon
 
-Menus with icons only must have a supplied keyboard shortcut. If no shortcut is supplied the menu item text is navigable by the first letter of each item. 
+Menus with icons only must have a supplied keyboard shortcut. If no shortcut is supplied the menu item text is navigable by the first letter of each item.
 The menu must have focus for this to work
 
 <Preview>
   <Story name="default icon">
-    <div style={{minHeight: '250px'}}>
+    <div style={{ minHeight: "250px" }}>
       <Menu>
         <MenuItem icon="home" href="#" keyboardOverride="h">
           Home
-        </MenuItem> 
-        <MenuItem icon="person" href="#" keyboardOverride="a" ariaLabel="Account"/>
-        <MenuItem icon="settings" submenu="Settings" keyboardOverride="s">
-          <MenuItem href="#">
-            Item Submenu One
-          </MenuItem>
-          <MenuItem href="#">
-            Item Submenu Two
-          </MenuItem>
-          <MenuDivider />
-          <MenuItem icon="settings" href="#" ariaLabel="settings" keyboardOverride="s"/>
-          <MenuItem href="#">
-            Item Submenu Four
-          </MenuItem>
         </MenuItem>
-        <MenuItem icon="arrow_right" submenu keyboardOverride="a" ariaLabel="Actions">
-          <MenuItem href="#">
-            Item Submenu One
-          </MenuItem>
-          <MenuItem href="#">
-            Item Submenu Two
-          </MenuItem>
+        <MenuItem
+          icon="person"
+          href="#"
+          keyboardOverride="a"
+          ariaLabel="Account"
+        />
+        <MenuItem icon="settings" submenu="Settings" keyboardOverride="s">
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+          <MenuDivider />
+          <MenuItem
+            icon="settings"
+            href="#"
+            ariaLabel="settings"
+            keyboardOverride="s"
+          />
+          <MenuItem href="#">Item Submenu Four</MenuItem>
+        </MenuItem>
+        <MenuItem
+          icon="arrow_right"
+          submenu
+          keyboardOverride="a"
+          ariaLabel="Actions"
+        >
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
         </MenuItem>
       </Menu>
     </div>
@@ -374,37 +386,42 @@ is rendered.
 
 ## Dark icon
 
-Menus with icons only must have a supplied keyboard shortcut. If no shortcut is supplied the menu item text is navigable by the first letter of each item. 
+Menus with icons only must have a supplied keyboard shortcut. If no shortcut is supplied the menu item text is navigable by the first letter of each item.
 The menu must have focus for this to work
 
 <Preview>
   <Story name="dark icon">
-    <div style={{minHeight: '250px'}}>
+    <div style={{ minHeight: "250px" }}>
       <Menu menuType="dark">
         <MenuItem icon="home" href="#" keyboardOverride="h">
           Home
-        </MenuItem> 
-        <MenuItem icon="person" href="#" keyboardOverride="a" ariaLabel="Account"/>
-        <MenuItem icon="settings" submenu="Settings" keyboardOverride="s">
-          <MenuItem href="#">
-            Item Submenu One
-          </MenuItem>
-          <MenuItem href="#">
-            Item Submenu Two
-          </MenuItem>
-          <MenuDivider />
-          <MenuItem icon="settings" href="#" ariaLabel="settings" keyboardOverride="s"/>
-          <MenuItem href="#">
-            Item Submenu Four
-          </MenuItem>
         </MenuItem>
-        <MenuItem icon="arrow_right" submenu keyboardOverride="a" ariaLabel="Actions">
-          <MenuItem href="#">
-            Item Submenu One
-          </MenuItem>
-          <MenuItem href="#">
-            Item Submenu Two
-          </MenuItem>
+        <MenuItem
+          icon="person"
+          href="#"
+          keyboardOverride="a"
+          ariaLabel="Account"
+        />
+        <MenuItem icon="settings" submenu="Settings" keyboardOverride="s">
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+          <MenuDivider />
+          <MenuItem
+            icon="settings"
+            href="#"
+            ariaLabel="settings"
+            keyboardOverride="s"
+          />
+          <MenuItem href="#">Item Submenu Four</MenuItem>
+        </MenuItem>
+        <MenuItem
+          icon="arrow_right"
+          submenu
+          keyboardOverride="a"
+          ariaLabel="Actions"
+        >
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
         </MenuItem>
       </Menu>
     </div>
@@ -414,7 +431,7 @@ The menu must have focus for this to work
 ## Full navbar alignment example
 
 <Preview>
-  <Story name="Full navbar alignment example">
+  <Story name="full navbar alignment example">
     {() => {
       return (
         <div style={{ minHeight: "250px" }}>
@@ -492,20 +509,121 @@ In order to align text and icons within a submenu a `Box` component will need to
 
 <Preview>
   <Story name="button icon" parameters={{ chromatic: { disable: true } }}>
-    <div style={{minHeight: '250px'}}>
+    <div style={{ minHeight: "250px" }}>
       <Menu menuType="dark">
         <MenuItem icon="settings" submenu="Settings">
-          <MenuItem href="#" icon="settings" onClick={()=> {}}>
+          <MenuItem href="#" icon="settings" onClick={() => {}}>
             onClick and Icon
           </MenuItem>
-          <MenuItem onClick={()=>{}}>
+          <MenuItem onClick={() => {}}>
             <Box ml="21px">onClick</Box>
           </MenuItem>
           <MenuDivider />
-          <MenuItem icon="settings" href="#">href and Icon</MenuItem>
+          <MenuItem icon="settings" href="#">
+            href and Icon
+          </MenuItem>
           <MenuItem href="#">
             <Box ml="21px">href</Box>
           </MenuItem>
+        </MenuItem>
+      </Menu>
+    </div>
+  </Story>
+</Preview>
+
+## Scrollable submenu
+
+A scrollable submenu can be added using the `ScrollableBlock` component. This can be used for all of the submenu items, or just a selection, as shown in `Menu Itme Four` below.
+Note that only one `ScrollableBlock` can be used within a single submenu.
+
+<Preview>
+  <Story
+    name="scrollable submenu"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    <div style={{ minHeight: "150px" }}>
+      <Menu>
+        <MenuItem onClick={() => {}}>Menu Item One</MenuItem>
+        <MenuItem href="#">Menu Item Two</MenuItem>
+        <MenuItem submenu="Menu Item Three">
+          <ScrollableBlock height="200px">
+            <MenuItem href="#">Item Submenu One</MenuItem>
+            <MenuItem href="#">Item Submenu Two</MenuItem>
+            <MenuItem href="#">Item Submenu Three</MenuItem>
+            <MenuItem href="#">Item Submenu Four</MenuItem>
+            <MenuItem href="#">Item Submenu Five</MenuItem>
+            <MenuItem href="#">Item Submenu Six</MenuItem>
+            <MenuItem href="#">Item Submenu Seven</MenuItem>
+            <MenuItem href="#">Item Submenu Eight</MenuItem>
+            <MenuItem href="#">Item Submenu Nine</MenuItem>
+            <MenuItem href="#">Item Submenu Ten</MenuItem>
+            <MenuItem href="#">Item Submenu Eleven</MenuItem>
+            <MenuItem href="#">Item Submenu Twelve</MenuItem>
+          </ScrollableBlock>
+        </MenuItem>
+        <MenuItem submenu="Menu Item Four">
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+          <ScrollableBlock variant="alternate" height="200px">
+            <MenuItem href="#">Item Submenu Three</MenuItem>
+            <MenuItem href="#">Item Submenu Four</MenuItem>
+            <MenuItem href="#">Item Submenu Five</MenuItem>
+            <MenuItem href="#">Item Submenu Six</MenuItem>
+            <MenuItem href="#">Item Submenu Seven</MenuItem>
+            <MenuItem href="#">Item Submenu Eight</MenuItem>
+            <MenuItem href="#">Item Submenu Nine</MenuItem>
+            <MenuItem href="#">Item Submenu Ten</MenuItem>
+            <MenuItem href="#">Item Submenu Eleven</MenuItem>
+            <MenuItem href="#">Item Submenu Twelve</MenuItem>
+          </ScrollableBlock>
+        </MenuItem>
+      </Menu>
+    </div>
+  </Story>
+</Preview>
+
+## Scrollable submenu dark
+
+<Preview>
+  <Story
+    name="scrollable submenu dark"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    <div style={{ minHeight: "150px" }}>
+      <Menu menuType="dark">
+        <MenuItem onClick={() => {}}>Menu Item One</MenuItem>
+        <MenuItem href="#">Menu Item Two</MenuItem>
+        <MenuItem submenu="Menu Item Three">
+          <ScrollableBlock height="200px">
+            <MenuItem href="#">Item Submenu One</MenuItem>
+            <MenuItem href="#">Item Submenu Two</MenuItem>
+            <MenuItem href="#">Item Submenu Three</MenuItem>
+            <MenuItem href="#">Item Submenu Four</MenuItem>
+            <MenuItem href="#">Item Submenu Five</MenuItem>
+            <MenuItem href="#">Item Submenu Six</MenuItem>
+            <MenuItem href="#">Item Submenu Seven</MenuItem>
+            <MenuItem href="#">Item Submenu Eight</MenuItem>
+            <MenuItem href="#">Item Submenu Nine</MenuItem>
+            <MenuItem href="#">Item Submenu Ten</MenuItem>
+            <MenuItem href="#">Item Submenu Eleven</MenuItem>
+            <MenuItem href="#">Item Submenu Twelve</MenuItem>
+          </ScrollableBlock>
+        </MenuItem>
+        <MenuItem submenu="Menu Item Four">
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+          <ScrollableBlock variant="alternate" height="200px">
+            <MenuItem href="#">Item Submenu Three</MenuItem>
+            <MenuItem href="#">Item Submenu Four</MenuItem>
+            <MenuItem href="#">Item Submenu Five</MenuItem>
+            <MenuItem href="#">Item Submenu Six</MenuItem>
+            <MenuItem href="#">Item Submenu Seven</MenuItem>
+            <MenuItem href="#">Item Submenu Eight</MenuItem>
+            <MenuItem href="#">Item Submenu Nine</MenuItem>
+            <MenuItem href="#">Item Submenu Ten</MenuItem>
+            <MenuItem href="#">Item Submenu Eleven</MenuItem>
+            <MenuItem href="#">Item Submenu Twelve</MenuItem>
+          </ScrollableBlock>
         </MenuItem>
       </Menu>
     </div>

--- a/src/components/menu/scrollable-block/index.js
+++ b/src/components/menu/scrollable-block/index.js
@@ -1,0 +1,1 @@
+export { default } from "./scrollable-block.component";

--- a/src/components/menu/scrollable-block/scrollable-block.component.js
+++ b/src/components/menu/scrollable-block/scrollable-block.component.js
@@ -1,0 +1,53 @@
+import React, { useContext } from "react";
+import PropTypes from "prop-types";
+
+import { MenuContext } from "../menu.component";
+import SubmenuContext from "../__internal__/submenu/submenu.context";
+import StyledScrollableBlock from "./scrollable-block.style";
+
+const ScrollableBlock = ({ children, variant = "default", ...rest }) => {
+  const menuContext = useContext(MenuContext);
+  const submenuContext = useContext(SubmenuContext);
+  const { blockIndex, focusIndex, handleKeyDown } = submenuContext;
+
+  return (
+    <StyledScrollableBlock
+      data-component="submenu-scrollable-block"
+      menuType={menuContext.menuType}
+      variant={variant}
+      overflowY="scroll"
+      p={0}
+      scrollVariant={menuContext.menuType}
+      {...rest}
+    >
+      {React.Children.map(children, (child, index) => {
+        let isFocused = false;
+        const blockItemFocused = focusIndex >= blockIndex;
+
+        if (blockItemFocused) {
+          isFocused = focusIndex - blockIndex === index;
+        }
+
+        return (
+          <SubmenuContext.Provider
+            value={{
+              isFocused,
+              handleKeyDown,
+            }}
+          >
+            {child}
+          </SubmenuContext.Provider>
+        );
+      })}
+    </StyledScrollableBlock>
+  );
+};
+
+ScrollableBlock.propTypes = {
+  /** Children elements */
+  children: PropTypes.node.isRequired,
+  /** set the colour variant for a menuType */
+  variant: PropTypes.oneOf(["default", "alternate"]),
+};
+
+export default ScrollableBlock;

--- a/src/components/menu/scrollable-block/scrollable-block.spec.js
+++ b/src/components/menu/scrollable-block/scrollable-block.spec.js
@@ -1,0 +1,123 @@
+import React from "react";
+import { mount } from "enzyme";
+
+import ScrollableBlock from ".";
+import MenuItem from "../menu-item";
+import { MenuContext } from "../menu.component";
+import SubmenuContext from "../__internal__/submenu/submenu.context";
+
+import StyledMenuItemWrapper from "../menu-item/menu-item.style";
+import MenuDivider from "../menu-divider/menu-divider.component";
+import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
+import { baseTheme } from "../../../style/themes";
+
+const handleKeyDownFn = jest.fn();
+
+const submenuContextValues = (blockIndex, focusIndex) => ({
+  handleKeyDown: handleKeyDownFn,
+  blockIndex,
+  focusIndex,
+});
+
+describe("ScrollableBlock", () => {
+  let container;
+  let wrapper;
+
+  const render = (menuType, props, blockIndex, focusIndex) => {
+    return mount(
+      <MenuContext.Provider value={{ menuType }}>
+        <SubmenuContext.Provider
+          value={submenuContextValues(blockIndex, focusIndex)}
+        >
+          <ScrollableBlock {...props}>
+            <MenuItem>Apple</MenuItem>
+            <MenuItem>Banana</MenuItem>
+            <MenuDivider />
+            <MenuItem>Carrot</MenuItem>
+            <MenuItem>Broccoli</MenuItem>
+          </ScrollableBlock>
+        </SubmenuContext.Provider>
+      </MenuContext.Provider>,
+      { attachTo: container }
+    );
+  };
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    container.id = "enzymeContainer";
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = null;
+    }
+  });
+
+  describe("when MenuType is light", () => {
+    it("should add the correct styles", () => {
+      wrapper = render("light", { variant: "default" });
+
+      assertStyleMatch(
+        {
+          backgroundColor: baseTheme.colors.white,
+        },
+        wrapper,
+        { modifier: `&& ${StyledMenuItemWrapper}` }
+      );
+    });
+
+    describe("when variant prop set to alternate", () => {
+      it("should add the correct styles", () => {
+        wrapper = render("light", { variant: "alternate" });
+
+        assertStyleMatch(
+          {
+            backgroundColor: baseTheme.menu.light.background,
+          },
+          wrapper,
+          { modifier: `&& ${StyledMenuItemWrapper}` }
+        );
+      });
+    });
+  });
+
+  describe("when MenuType is dark", () => {
+    it("should add the correct styles", () => {
+      wrapper = render("dark");
+
+      assertStyleMatch(
+        {
+          backgroundColor: baseTheme.menu.dark.submenuBackground,
+        },
+        wrapper,
+        { modifier: `&& ${StyledMenuItemWrapper}` }
+      );
+    });
+
+    describe("when variant prop set to alternate", () => {
+      it("should add the correct styles", () => {
+        wrapper = render("dark", { variant: "alternate" });
+
+        assertStyleMatch(
+          {
+            backgroundColor: baseTheme.colors.slate,
+          },
+          wrapper,
+          { modifier: `&& ${StyledMenuItemWrapper}` }
+        );
+      });
+    });
+  });
+
+  describe("when a block child focused by submenu context", () => {
+    it("should focus the underlying MenuItem", () => {
+      wrapper = render("dark", {}, 1, 2);
+
+      expect(wrapper.find(StyledMenuItemWrapper).at(1).find("a")).toBeFocused();
+    });
+  });
+});

--- a/src/components/menu/scrollable-block/scrollable-block.style.js
+++ b/src/components/menu/scrollable-block/scrollable-block.style.js
@@ -1,0 +1,29 @@
+import styled, { css } from "styled-components";
+import { baseTheme } from "../../../style/themes";
+import Box from "../../box";
+import StyledMenuItemWrapper from "../menu-item/menu-item.style";
+
+const StyledScrollableBlock = styled(Box)`
+  ${({ menuType, variant, theme }) => css`
+    && ${StyledMenuItemWrapper} {
+      background-color: ${variant === "default"
+        ? theme.colors.white
+        : theme.menu.light.background};
+    }
+
+    ${menuType === "dark" &&
+    css`
+      && ${StyledMenuItemWrapper} {
+        background-color: ${variant === "default"
+          ? theme.menu.dark.submenuBackground
+          : theme.colors.slate};
+      }
+    `}
+  `}
+`;
+
+StyledScrollableBlock.defaultProps = {
+  theme: baseTheme,
+};
+
+export default StyledScrollableBlock;


### PR DESCRIPTION
### Proposed behaviour
New `ScrollableBlock` component for use in submenus. This component extends `Box` so any box prop can be used. 

![image](https://user-images.githubusercontent.com/14963680/102513436-1c064b00-4083-11eb-8a42-1a1310d66ee2.png)

![image](https://user-images.githubusercontent.com/14963680/102513463-26c0e000-4083-11eb-89bf-f9b777806204.png)

![image](https://user-images.githubusercontent.com/14963680/102513493-2f191b00-4083-11eb-9654-186d32c52ec8.png)

![image](https://user-images.githubusercontent.com/14963680/102513521-36d8bf80-4083-11eb-9cf7-6aee631b6f4b.png)



### Current behaviour
There is no way to add a scrollable block in a submenu.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
http://localhost:9001/?path=/story/design-system-menu--scrollable-submenu
http://localhost:9001/?path=/story/design-system-menu--scrollable-submenu-dark