### PR TITLE
fix(submenu): stop submenu width from flexing with parent

### DIFF
--- a/src/components/menu/__internal__/submenu/submenu.style.js
+++ b/src/components/menu/__internal__/submenu/submenu.style.js
@@ -7,6 +7,7 @@ import StyledIcon from "../../../icon/icon.style";
 
 const StyledSubmenuWrapper = styled.div`
   position: relative;
+  width: fit-content;
 `;
 
 const StyledSubmenu = styled.ul`

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -7,6 +7,10 @@ import { SageIcon } from "../../../.storybook/welcome-page/footer/footer.style.j
 
 <Meta title="Design System/Menu" parameters={{ info: { disable: true } }} />
 
+# Menu
+
+Provides navigation for an app, which can be used via mouse or keyboard.
+
 ## Quick Start
 
 ```jsx
@@ -325,8 +329,14 @@ is rendered.
               <VerticalDivider displayInline pr={0} />
             </Box>
             <Menu display="flex" flex="1">
-              <MenuItem flex="1" onClick={() => {}}>
-                Menu Item One
+              <MenuItem flex="1" onClick={() => {}} submenu="Menu Item One">
+                <MenuItem href="#">Item Submenu One</MenuItem>
+                <MenuItem href="#">Item Submenu Two</MenuItem>
+                <MenuDivider />
+                <MenuItem icon="settings" href="#">
+                  Item Submenu Three
+                </MenuItem>
+                <MenuItem href="#">Item Submenu Four</MenuItem>
               </MenuItem>
               <MenuItem flex="0 0 auto" href="#">
                 Menu Item Two


### PR DESCRIPTION
### Proposed behaviour
The width of a `MenuItem` should not affect the width of it's underlying submenu

![image](https://user-images.githubusercontent.com/14963680/102609177-f466bf80-4122-11eb-868e-2da88d1448de.png)

Also add a title to the Menu MDX file.

### Current behaviour
If a `MenuItem` containing a submenu flexes above it's original width, the submenu's width also grows.

![image](https://user-images.githubusercontent.com/14963680/102609224-08aabc80-4123-11eb-9c87-77fd4b08e5fd.png)


### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
http://localhost:9001/?path=/story/design-system-menu--full-navbar-alignment-example

https://codesandbox.io/s/upbeat-leavitt-pl01n?file=/src/index.js - see the codesandboxbot comment below for the version of this sandbox with the Carbon changes in