### PR TITLE
test(cypress): remove flash accessibility test

### DIFF
--- a/cypress/features/regression/accessibility/accessibilityCommon.feature
+++ b/cypress/features/regression/accessibility/accessibilityCommon.feature
@@ -14,7 +14,6 @@ Feature: Accessibility tests - Common list
       | Content             |
       | Detail              |
       | Dialog              |
-      | Dialog-full-screen  |
       | Heading             |
       | Help                |
       | I18nComponent       |
@@ -22,7 +21,6 @@ Feature: Accessibility tests - Common list
       | Message             |
       | MenuList            |
       | Mount In App        |
-      # | Pages             |
       | Portrait            |
       | Preview             |
       | Profile             |
@@ -30,6 +28,16 @@ Feature: Accessibility tests - Common list
       | Sidebar             |
       | Split-button        |
       | Multi-action-button |
+
+  @accessibility
+  Scenario Outline: Component <component> default story with open preview
+    Given I open "<component>" component page "default story" in no iframe
+    When I open component preview in noIFrame
+    Then "<component>" component has no accessibility violations
+    Examples:
+      | component          |
+      | Dialog Full Screen |
+      | Pages              |
 
   @accessibility
   Scenario: Component button toggle
@@ -41,8 +49,8 @@ Feature: Accessibility tests - Common list
     When I open "<component>" component page "default" in no iframe
     Then "<component>" component has no accessibility violations
     Examples:
-      | component           |
-      | Configurable-items  |
+      | component          |
+      | Configurable-items |
 
   @accessibility
   Scenario Outline: Component <component> basic story

--- a/cypress/features/regression/accessibility/accessibilityCommon.feature
+++ b/cypress/features/regression/accessibility/accessibilityCommon.feature
@@ -36,17 +36,6 @@ Feature: Accessibility tests - Common list
     When I open "Button-Toggle-Group" component page "basic" in no iframe
     Then "Button Toggle Group" component has no accessibility violations
 
-  @ignore
-  # ignored because of accessibility issues after
-  # changing state of components -> FE-2894
-  Scenario Outline: Component <component> page with preview button
-    Given I open "<component>" component page "default" in no iframe
-    When I open component preview no iframe
-    Then "<data-component>" component has no accessibility violations
-    Examples:
-      | component |
-      | Flash     |
-
   @accessibility
   Scenario Outline: Component <component> default story
     When I open "<component>" component page "default" in no iframe


### PR DESCRIPTION
### Proposed behaviour
Re-enable some of the accessibility tests in Cypress and remove the `Flash` test case, as the `Flash` component no longer exists in Carbon

### Current behaviour
A selection of the accessibility tests are not run with an `@ignore` tag

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
The Cypress builds passing should be enough