### PR TITLE
fix(tabs): prevent padding override for large tabs with siblings

### DIFF
--- a/src/components/tabs/__internal__/tab-title/tab-title.spec.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.spec.js
@@ -334,7 +334,7 @@ describe("TabTitle", () => {
       );
     });
 
-    it("adjusts padding when isTabSelected is true", () => {
+    it('adjusts padding when isTabSelected is true and position is "top"', () => {
       wrapper = render(
         {
           title: "Tab 1",
@@ -353,6 +353,30 @@ describe("TabTitle", () => {
       ).toEqual("Tab 1");
       assertStyleMatch(
         { paddingBottom: "6px" },
+        wrapper.find(StyledTitleContent)
+      );
+    });
+
+    it('does not adjust padding when isTabSelected is true and position is "left"', () => {
+      wrapper = render(
+        {
+          title: "Tab 1",
+          siblings: [<span>foo</span>, <span>bar</span>],
+          titlePosition: "before",
+          isTabSelected: true,
+          position: "left",
+        },
+        mount
+      );
+
+      expect(wrapper.find(StyledTitleContent).props().hasSiblings).toEqual(
+        true
+      );
+      expect(
+        wrapper.find(StyledTitleContent).props().children[0][0].props.children
+      ).toEqual("Tab 1");
+      assertStyleMatch(
+        { padding: "10px 16px" },
         wrapper.find(StyledTitleContent)
       );
     });
@@ -400,6 +424,29 @@ describe("TabTitle", () => {
       ).toEqual("Tab 1");
       assertStyleMatch(
         { paddingBottom: "5px" },
+        wrapper.find(StyledTitleContent)
+      );
+    });
+
+    it('renders as expected when size is "large" and position is "left"', () => {
+      wrapper = render(
+        {
+          title: "Tab 1",
+          siblings: [<span>foo</span>, <span>bar</span>],
+          titlePosition: "before",
+          size: "large",
+          position: "left",
+        },
+        mount
+      );
+
+      expect(
+        wrapper.find(StyledTitleContent).props().children[0][0].props.children
+      ).toEqual("Tab 1");
+      assertStyleMatch(
+        {
+          padding: "22px 24px",
+        },
         wrapper.find(StyledTitleContent)
       );
     });

--- a/src/components/tabs/__internal__/tab-title/tab-title.style.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.style.js
@@ -182,9 +182,11 @@ const StyledTitleContent = styled.div`
     info,
     size,
     isTabSelected,
+    position,
   }) =>
     hasSiblings &&
     !hasCustomLayout &&
+    position === "top" &&
     css`
       ${size === "default" &&
       css`


### PR DESCRIPTION
Fixes  #3537

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Fixes "large" `size` `Tabs` that have `siblings` and `position` "left" overriding the padding incorrectly

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`padding-top` and `padding-bottom` overrides are applied when `Tabs` are `position` "left" and size "large" with `siblings`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/103665951-eced4600-4f6b-11eb-8d12-148082f7c377.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
Can be tested in this sandbox
https://codesandbox.io/s/carbon-quickstart-forked-mbr0c
