### PR TITLE
docs: update i18n-js peer dependency range

### DIFF
--- a/docs/getting-started.stories.mdx
+++ b/docs/getting-started.stories.mdx
@@ -28,7 +28,7 @@ npm install carbon-react
 You will need to install the following dependencies in your project, these are peer-dependencies of carbon-react and are required.
 
 ```sh
-npm install react@^16.12.0 react-dom@^16.12.0 i18n-js@^3.0.0 styled-components@^4.4.1 
+npm install react@^16.12.0 react-dom@^16.12.0 i18n-js@^3.0.1 styled-components@^4.4.1 
 ```
 
 There is a peer dependency on `draft-js` any project intending to use either the `TextEditor` or `Note` components is required to install it as well.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "draft-js": "^0.11.5",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "i18n-js": "^3.0.0",
+    "i18n-js": "^3.0.1",
     "styled-components": "^4.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Proposed behaviour

Update the minimum  i18n-js version to be 3.0.1.

### Current behaviour

We support any 3.x.x version, however 3.0.0 does not exist and has
caused some confusion.

### Checklist
<!-- Each PR should include the following -->
- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
Fixes FE-3470 Fixes #3525

### Testing instructions
Review files.
