### PR TITLE
feat: add new `pod-manager` component- FE-2940

### DIFF
--- a/cypress/features/regression/pod.feature
+++ b/cypress/features/regression/pod.feature
@@ -46,10 +46,17 @@ Feature: Pod component
       | mp150ú¿¡üßä                  | footerOtherLanguage    |
       | !@#$%^*()_+-=~[];:.,?{}&"'<> | footerSpecialCharacter |
 
-  @positive
+@positive
   Scenario: Check the triggerEditOnContent checkbox
     When I open Default "Pod Test" component in noIFrame with "pod" json from "commonComponents" using "triggerEditOnContent" object name
     Then Pod component has triggerEditOnContent property
+
+  @positive
+  Scenario: Edit button is visible on hover
+    Given I open "Pod" component page "with display edit button on hover" in no iframe
+    When I check that onEdit icon is not visible
+      And I hover mouse onto pod
+    Then The onEdit icon is visible
 
   @positive
   Scenario: Check the edit event

--- a/cypress/locators/pod/index.js
+++ b/cypress/locators/pod/index.js
@@ -10,5 +10,6 @@ export const podFooter = () => podComponent().find(POD_FOOTER);
 export const podContent = () => podComponent().find(POD_CONTENT);
 export const podSubTitle = () => cy.get(POD_SUBTITLE);
 export const podDescription = () => cy.get(POD_DESCRIPTION);
+export const podEdit = () => podComponent().find(POD_EDIT_ICON);
 
 export const podEditIframe = () => cy.iFrame(POD_DATA_COMPONENT).find(POD_EDIT_ICON);

--- a/cypress/support/step-definitions/pod-steps.js
+++ b/cypress/support/step-definitions/pod-steps.js
@@ -1,7 +1,9 @@
 import {
-  podPreview, podContent,
-  podSubTitle, podDescription, podFooter, 
+  podContent,
+  podSubTitle, podDescription,
   podEditIframe,
+  podEdit, podFooter,
+  podPreview,
 } from '../../locators/pod';
 import { getDataElementByValue } from '../../locators';
 
@@ -31,4 +33,16 @@ Then('I click onEdit icon in Iframe', () => {
 
 Then('Pod component has triggerEditOnContent property', () => {
   podPreview().should('have.css', 'cursor', 'pointer');
+});
+
+When('I check that onEdit icon is not visible', () => {
+  podEdit().should('not.be.visible');
+});
+
+When('I hover mouse onto pod', () => {
+  podPreview().first().trigger('mouseover');
+});
+
+Then('The onEdit icon is visible', () => {
+  podEdit().should('be.visible');
 });

--- a/src/components/pod/index.d.ts
+++ b/src/components/pod/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './pod';
+export * from './pod';

--- a/src/components/pod/pod-context.js
+++ b/src/components/pod/pod-context.js
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+const PodContext = createContext({});
+
+export default PodContext;

--- a/src/components/pod/pod-manager.component.js
+++ b/src/components/pod/pod-manager.component.js
@@ -1,0 +1,33 @@
+import React, { useEffect, useState, useRef } from "react";
+import PropTypes from "prop-types";
+import PodContext from "./pod-context";
+
+const PodManager = ({ children }) => {
+  const podManagerRef = useRef();
+  const [heightOfTheLongestPod, setHeightOfTheLongestPod] = useState();
+
+  useEffect(() => {
+    const allHeights = [];
+    const allPodNodeList = podManagerRef.current.querySelectorAll(
+      `[data-component="pod"]`
+    );
+    const allPodsArray = Array.from(allPodNodeList);
+
+    allPodsArray.map((el) => allHeights.push(el.scrollHeight));
+
+    const tallerValue = Math.max(...allHeights);
+    setHeightOfTheLongestPod(tallerValue);
+  }, []);
+
+  return (
+    <PodContext.Provider value={{ heightOfTheLongestPod }}>
+      <div ref={podManagerRef}>{children}</div>
+    </PodContext.Provider>
+  );
+};
+
+PodManager.propTypes = {
+  children: PropTypes.node,
+};
+
+export default PodManager;

--- a/src/components/pod/pod-manager.d.ts
+++ b/src/components/pod/pod-manager.d.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export interface PodManagerProps {
+  children: React.ReactNode;
+}
+
+declare const PodManager: React.FunctionComponent<PodManagerProps>;
+
+export default PodManager;

--- a/src/components/pod/pod-manager.spec.js
+++ b/src/components/pod/pod-manager.spec.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { mount } from "enzyme";
+import PodManager from "./pod-manager.component";
+import Pod from "./pod.component";
+
+describe("MultiPodWrapper", () => {
+  let wrapper;
+
+  it("should render correctly", () => {
+    wrapper = mount(
+      <PodManager>
+        <Pod>test</Pod>
+      </PodManager>
+    );
+
+    expect(wrapper.find(Pod).exists()).toBe(true);
+  });
+});

--- a/src/components/pod/pod.component.js
+++ b/src/components/pod/pod.component.js
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 import I18n from "i18n-js";
 import Event from "../../utils/helpers/events/events";
 import tagComponent from "../../utils/helpers/tags/tags";
+import PodContext from "./pod-context";
+
 import {
   StyledBlock,
   StyledCollapsibleContent,
@@ -24,6 +26,8 @@ class Pod extends React.Component {
     isHovered: false,
     isFocused: false,
   };
+
+  static contextType = PodContext;
 
   toggleCollapse = () => {
     this.setState((prevState) => ({ isCollapsed: !prevState.isCollapsed }));
@@ -228,6 +232,7 @@ class Pod extends React.Component {
           isHovered={isHovered}
           noBorder={!border}
           variant={variant}
+          height={this.context.heightOfTheLongestPod}
           {...(this.shouldContentHaveEditEvents()
             ? { ...this.editEvents(), tabIndex: "0" }
             : {})}
@@ -262,21 +267,32 @@ Pod.propTypes = {
 
   /**
    * Determines the padding around the pod.
-   * Values: 'none', 'small', 'medium' or 'large'.
    */
-  padding: PropTypes.string,
+  padding: PropTypes.oneOf([
+    "none",
+    "extra-small",
+    "small",
+    "medium",
+    "large",
+    "extra-large",
+  ]),
 
   /**
    * Prop to apply a theme to the Pod.
-   * Value: primary, secondary, tile
    */
-  variant: PropTypes.string,
+  variant: PropTypes.oneOf([
+    "primary",
+    "secondary",
+    "tertiary",
+    "tile",
+    "transparent",
+  ]),
 
   /**
    * The collapsed state of the pod
    *
-   * undefined - Pod is not collapsible
-   * true - Pod is closed
+   * undefined - Pod is not collapsible |
+   * true - Pod is closed |
    * false - Pod is open
    */
   collapsed: PropTypes.bool,
@@ -295,7 +311,7 @@ Pod.propTypes = {
   /**
    * Aligns the title to left, right or center
    */
-  alignTitle: PropTypes.string,
+  alignTitle: PropTypes.oneOf(["left", "center", "right"]),
 
   /**
    * Description for the pod

--- a/src/components/pod/pod.d.ts
+++ b/src/components/pod/pod.d.ts
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+export interface PodProps {
+    /** Enables/disables the border around the pod. */
+  border?: boolean;
+  /** Children elements */
+  children?: React.ReactNode;
+  /** Custom className */
+  className?: string;
+  /** Determines the padding around the pod */
+  padding?: 'none' | 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large';
+  /** Prop to apply a theme to the Pod */
+  variant?: 'primary' | 'secondary' | 'tertiary'  | 'tile' | 'transparent';
+  /** The collapsed state of the pod */
+  collapsed?: boolean;
+  /** Title for the pod h4 element always shown */
+  title?: string | React.ReactNode;
+  /** Optional subtitle for the pod */
+  subtitle?: string;
+  /** Aligns the title to left, right or center */
+  alignTitle?: 'left' | 'center' | 'right';
+  /** Description for the pod */
+  description?: string;
+  /** A component to render as a Pod footer */
+  footer?: string | React.ReactNode;
+  /** Supplies an edit action to the pod */
+  onEdit?: string | {} | (() => void);
+  /** Determines if the editable pod content should be full width */
+  editContentFullWidth?: boolean;
+  /** Determines if the edit button should be hidden until the user hovers over the content */
+  displayEditButtonOnHover?: boolean;
+  /** Determines if clicking the pod content calls the onEdit action */
+  triggerEditOnContent?: boolean;
+  /** Resets edit button styles to an older version */
+  internalEditButton?: boolean;
+}
+
+declare const Pod: React.ComponentClass<PodProps>;
+
+export default Pod;

--- a/src/components/pod/pod.spec.js
+++ b/src/components/pod/pod.spec.js
@@ -25,6 +25,8 @@ import {
   rootTagTest,
 } from "../../utils/helpers/tags/tags-specs/tags-specs";
 import { baseTheme } from "../../style/themes";
+import PodManager from "./pod-manager.component";
+import PodContext from "./pod-context";
 
 describe("Pod", () => {
   let instance;
@@ -66,6 +68,23 @@ describe("Pod", () => {
       wrapper.setProps({ title: "Title" });
       expect(wrapper.find(StyledArrow).exists()).toBeFalsy();
     });
+  });
+
+  describe("PodManager", () => {
+    wrapper = mount(
+      <PodManager>
+        <PodContext.Provider value={{ heightOfTheLongestPod: "100" }}>
+          <Pod>test</Pod>
+        </PodContext.Provider>
+      </PodManager>
+    );
+
+    assertStyleMatch(
+      {
+        height: "100px",
+      },
+      wrapper.find(StyledBlock)
+    );
   });
 
   describe("collapsability", () => {

--- a/src/components/pod/pod.stories.mdx
+++ b/src/components/pod/pod.stories.mdx
@@ -2,6 +2,8 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 import Pod from './';
 import Heading from '../heading';
 import Button from '../button';
+import {Row, Column} from '../row';
+import PodManager from './pod-manager.component';
 
 <Meta
   title="Pod"
@@ -65,6 +67,43 @@ to be collapsible. If the prop is not passed the Pod will not be collapsible.
   </Story>
 </Preview>
 
+### PodManager
+If you want to have the same height of the Pods based on the heighest one, use `PodManager` to achieve it.
+The `PodManager` does not work if `Pod` uses `collapsed` prop
+
+<Preview>
+  <Story name="Even Height with PodManager">
+    {()=>{
+    return (
+      <PodManager>
+        <Row>
+          <Column>
+            <Pod>
+              <Row>
+                <Column>
+                 <Button>Button 1</Button> 
+                </Column>
+              </Row>
+              <Row>
+                <Column>
+                 <Button>Button 2</Button> 
+                </Column>
+              </Row>
+            </Pod>
+          </Column>
+          <Column>
+            <Pod>
+              <Button>Button 3</Button>
+            </Pod>
+          </Column>
+        </Row>
+        </PodManager>
+    );
+    }}
+  </Story>
+</Preview>
+
+
 ### With subtitle, description and footer
 
 <Preview>
@@ -98,7 +137,7 @@ to be collapsible. If the prop is not passed the Pod will not be collapsible.
 ### With edit button and displayEditButtonOnHover
 
 <Preview>
-  <Story name="With displayEditButtonOnHover">
+  <Story parameters={{ chromatic: { disable: true }}} name="With displayEditButtonOnHover">
     <Pod
       title="Title"
       subtitle="Subtitle"

--- a/src/components/pod/pod.style.js
+++ b/src/components/pod/pod.style.js
@@ -37,12 +37,14 @@ const StyledBlock = styled.div`
     internalEditButton,
     isHovered,
     isFocused,
+    height,
   }) => css`
     box-sizing: border-box;
     background-color: ${blockBackgrounds(variant, theme)};
     width: 100%;
+    ${height && `height: ${height}px`};
     ${variant === "tile" && "box-shadow: 0 2px 3px 0 rgba(2, 18, 36, 0.2)"};
-    ${noBorder ? "border: none" : `border: 1px solid ${theme.pod.border};`};
+    ${noBorder ? "border: none" : `border: 1px solid ${theme.pod.border}`};
     ${editable && !(fullWidth || internalEditButton) && "width: auto;"};
     ${contentTriggersEdit && "cursor: pointer"};
     ${(isHovered || isFocused) &&


### PR DESCRIPTION
fixes: #3046

### Proposed behaviour
add new `pod-manager` component that will allow users to stretch pods without any breaking change
![image](https://user-images.githubusercontent.com/19231884/104479472-c199d500-55c3-11eb-8595-be26ee60f11c.png)


### Current behaviour
There is no mechanism for setting Pods to equal heights

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent