### PR TITLE
fix(dialog): display scrollbar in front of sticky footer

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -84,5 +84,6 @@
   "with_legend_and_labels": "--with-legend-and-labels",
   "in_overflow_hidden_container": "--in-overflow-hidden-container",
   "with_object_as_value": "--with-object-as-value",
-  "loading_state": "--loading-state"
+  "loading_state": "--loading-state",
+  "in_dialog_with_sticky_footer": "--in-dialog-with-sticky-footer"
 }

--- a/cypress/features/regression/dialog.feature
+++ b/cypress/features/regression/dialog.feature
@@ -78,3 +78,9 @@ Feature: Dialog component
   Scenario: Verify test_default story color
     When I open test_default "Dialog" component in noIFrame with "dialog" json from "commonComponents" using "stickyFooter" object name
     Then footer buttons have color "rgb(0, 129, 93)" and has 2 px border
+
+  @positive
+  Scenario: Verify that stickyFormFooter is not visible when scrolled to the bottom
+    Given I open test_default "Dialog" component in noIFrame with "dialog" json from "commonComponents" using "stickyFooter" object name
+    When I scroll to the bottom of the dialog
+    Then The footer is not sticky

--- a/cypress/features/regression/dialog.feature
+++ b/cypress/features/regression/dialog.feature
@@ -81,6 +81,7 @@ Feature: Dialog component
 
   @positive
   Scenario: Verify that stickyFormFooter is not visible when scrolled to the bottom
-    Given I open test_default "Dialog" component in noIFrame with "dialog" json from "commonComponents" using "stickyFooter" object name
+    Given I open "Design System Form" component page "In dialog with sticky footer" in no iframe
+      And I click on Open Preview button
     When I scroll to the bottom of the dialog
     Then The footer is not sticky

--- a/cypress/locators/dialog/index.js
+++ b/cypress/locators/dialog/index.js
@@ -2,6 +2,7 @@ import {
   ALERT_DIALOG,
   STICKY_FORM_FOOTER_ELEMENT,
   DIALOG_TITLE,
+  OPEN_PREVIEW,
 } from "./locators";
 
 // component preview locators
@@ -15,3 +16,4 @@ export const dialogTitle = () => cy.get(DIALOG_TITLE);
 export const dialogStickyFormFooter = () => cy.get(STICKY_FORM_FOOTER_ELEMENT);
 export const dialogStickyFormFooterButton = (index) =>
   cy.get(STICKY_FORM_FOOTER_ELEMENT).children().eq(index).children();
+export const openPreviewButton = () => cy.get(OPEN_PREVIEW);

--- a/cypress/locators/dialog/locators.js
+++ b/cypress/locators/dialog/locators.js
@@ -2,3 +2,4 @@
 export const ALERT_DIALOG = '[data-element="dialog"]';
 export const DIALOG_TITLE = "#carbon-dialog-title";
 export const STICKY_FORM_FOOTER_ELEMENT = '[data-element="form-footer"]';
+export const OPEN_PREVIEW = '[data-component="button"]';

--- a/cypress/support/step-definitions/dialog-steps.js
+++ b/cypress/support/step-definitions/dialog-steps.js
@@ -68,3 +68,11 @@ Then(
 Then("Dialog is visible", () => {
   dialogPreview().should("be.visible");
 });
+
+When("I scroll to the bottom of the dialog", () => {
+  dialogPreview().children().eq(1).scrollTo("bottom");
+});
+
+Then("The footer is not sticky", () => {
+  dialogStickyFormFooter().should("not.have.class", "sticky");
+});

--- a/cypress/support/step-definitions/dialog-steps.js
+++ b/cypress/support/step-definitions/dialog-steps.js
@@ -2,6 +2,7 @@ import {
   alertDialogPreview as dialogPreview,
   dialogStickyFormFooterButton,
   dialogStickyFormFooter,
+  openPreviewButton,
 } from "../../locators/dialog/index";
 import { backgroundUILocatorIFrame, dlsRoot } from "../../locators/index";
 import { positionOfElement } from "../helper";
@@ -75,4 +76,8 @@ When("I scroll to the bottom of the dialog", () => {
 
 Then("The footer is not sticky", () => {
   dialogStickyFormFooter().should("not.have.class", "sticky");
+});
+
+When("I click on Open Preview button", () => {
+  openPreviewButton().click();
 });

--- a/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
+++ b/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
@@ -1,15 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and the ref to content exists and contains html 1`] = `
-.c0 {
-  overflow-y: auto;
-  padding: 0 16px;
-}
-
-.c3 + .c0 {
-  height: calc(100% - 0px);
-}
-
 .c1 {
   padding-left: 24px;
   padding-right: 24px;
@@ -67,6 +58,37 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
 
 .c1 .c2 svg {
   margin-top: 0;
+}
+
+.c0 {
+  overflow-y: auto;
+  padding: 0 16px;
+}
+
+.c0 .c4.sticky {
+  padding: 16px;
+}
+
+.c3 + .c0 {
+  height: calc(100% - 0px);
+}
+
+@media screen and (min-width:600px) {
+  .c0 .c4.sticky {
+    padding: 16px 24px;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c0 .c4.sticky {
+    padding: 16px 32px;
+  }
+}
+
+@media screen and (min-width:1260px) {
+  .c0 .c4.sticky {
+    padding: 16px 40px;
+  }
 }
 
 @media screen and (min-width:600px) {
@@ -270,8 +292,18 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
   border: none;
 }
 
-.c0 + .c7 {
-  height: calc(100% - 0px);
+.c7:hover .c5 {
+  color: #FFFFFF;
+}
+
+.c7 .c5 {
+  margin-left: 0px;
+  margin-right: 8px;
+  height: 16px;
+}
+
+.c7 .c5 svg {
+  margin-top: 0;
 }
 
 .c0 + .c8 {
@@ -282,18 +314,8 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
   height: calc(100% - 0px);
 }
 
-.c10:hover .c5 {
-  color: #FFFFFF;
-}
-
-.c10 .c5 {
-  margin-left: 0px;
-  margin-right: 8px;
-  height: 16px;
-}
-
-.c10 .c5 svg {
-  margin-top: 0;
+.c0 + .c10 {
+  height: calc(100% - 0px);
 }
 
 @media screen and (min-width:600px) {

--- a/src/components/dialog-full-screen/content.style.js
+++ b/src/components/dialog-full-screen/content.style.js
@@ -1,9 +1,24 @@
 import styled, { css } from "styled-components";
 import FullScreenHeading from "../../__internal__/full-screen-heading/full-screen-heading.style";
+import { StyledFormFooter } from "../form/form.style";
 
 const StyledContent = styled.div`
   overflow-y: auto;
   padding: 0 16px;
+
+  ${StyledFormFooter}.sticky {
+    padding: 16px;
+
+    @media screen and (min-width: 600px) {
+      padding: 16px 24px;
+    }
+    @media screen and (min-width: 960px) {
+      padding: 16px 32px;
+    }
+    @media screen and (min-width: 1260px) {
+      padding: 16px 40px;
+    }
+  }
 
   ${({ disableContentPadding }) => css`
     ${!disableContentPadding &&

--- a/src/components/dialog/__snapshots__/dialog.spec.js.snap
+++ b/src/components/dialog/__snapshots__/dialog.spec.js.snap
@@ -29,6 +29,7 @@ exports[`Dialog when fixedBottom and stickyFormFooter are passed to the DialogSt
   margin-left: -35px;
   left: auto;
   position: fixed;
+  padding: 16px 35px;
 }
 
 .c0 > .c2 {

--- a/src/components/dialog/dialog.style.js
+++ b/src/components/dialog/dialog.style.js
@@ -62,6 +62,7 @@ const DialogStyle = styled.div`
       left: auto;
       width: ${dialogSizes[size]};
       position: fixed;
+      padding: 16px 35px;
     }
   `}
 

--- a/src/components/form/form.component.js
+++ b/src/components/form/form.component.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import throttle from "lodash/throttle";
 
 import ElementResize from "../../utils/helpers/element-resize";
-
 import FormSummary from "./form-summary.component";
 import {
   StyledForm,
@@ -31,26 +30,20 @@ const Form = ({
   const [isFooterSticky, setIsFooterSticky] = useState(false);
 
   const formRef = useRef();
-
   const formFooterRef = useRef();
-
   const stickyListenersAddedRef = useRef(false);
 
   const checkStickyFooter = useCallback(
     throttle(() => {
-      const footerHeight = formFooterRef.current.offsetHeight;
-      const topVisibilityOffset = 40;
-      const { top, bottom } = formRef.current.getBoundingClientRect();
+      const footerHeight = 40;
+      const { bottom } = formRef.current.getBoundingClientRect();
 
       const isBottomBelowScreen =
         bottom - footerHeight / 2 > window.innerHeight;
-      const isBottomAboveScreen =
-        bottom + footerHeight / 2 < window.innerHeight;
-      const isTopAboveScreen = top + topVisibilityOffset < window.innerHeight;
 
-      if (isBottomBelowScreen && isTopAboveScreen) {
+      if (isBottomBelowScreen) {
         setIsFooterSticky(true);
-      } else if (isBottomAboveScreen || !isTopAboveScreen) {
+      } else {
         setIsFooterSticky(false);
       }
     }, SCROLL_THROTTLE),

--- a/src/components/form/form.spec.js
+++ b/src/components/form/form.spec.js
@@ -58,7 +58,7 @@ describe("Form", () => {
       expect(wrapper.find(StyledFormFooter).hasClass("sticky")).toBe(true);
       assertStyleMatch(
         {
-          paddingBottom: "72px",
+          paddingBottom: "100px",
         },
         wrapper.find(StyledForm)
       );
@@ -73,7 +73,6 @@ describe("Form", () => {
           left: "0",
           position: "fixed",
           width: "100%",
-          zIndex: "1000",
         },
         wrapper.find(StyledFormFooter)
       );
@@ -114,7 +113,7 @@ describe("Form", () => {
       window.innerHeight = 768;
     });
 
-    it("renders footer with sticky styles if form bottom is below the window and top of form is visible", () => {
+    it("renders footer with sticky styles if form bottom is below the window", () => {
       const formNode = wrapper.find(StyledForm).getDOMNode();
       jest.spyOn(formNode, "getBoundingClientRect").mockImplementation(() => ({
         top: 100,
@@ -124,21 +123,11 @@ describe("Form", () => {
       assertThatFooterIsSticky();
     });
 
-    it("renders footer without sticky styles if form bottom is below the window but top of form is invisible", () => {
-      const formNode = wrapper.find(StyledForm).getDOMNode();
-      jest.spyOn(formNode, "getBoundingClientRect").mockImplementation(() => ({
-        top: 1000,
-        bottom: 1051,
-      }));
-
-      assertThatFooterIsNotSticky();
-    });
-
     it("renders form footer without sticky styles if form bottom is above the bottom of window", () => {
       const formNode = wrapper.find(StyledForm).getDOMNode();
       jest.spyOn(formNode, "getBoundingClientRect").mockImplementation(() => ({
         top: 100,
-        bottom: 1050,
+        bottom: 900,
       }));
 
       assertThatFooterIsNotSticky();
@@ -148,21 +137,14 @@ describe("Form", () => {
       const formNode = wrapper.find(StyledForm).getDOMNode();
       jest.spyOn(formNode, "getBoundingClientRect").mockImplementation(() => ({
         top: 100,
-        bottom: 1051,
+        bottom: 1100,
       }));
 
       assertThatFooterIsSticky();
 
       jest.spyOn(formNode, "getBoundingClientRect").mockImplementation(() => ({
         top: 100,
-        bottom: 1050,
-      }));
-
-      assertThatFooterIsSticky();
-
-      jest.spyOn(formNode, "getBoundingClientRect").mockImplementation(() => ({
-        top: 100,
-        bottom: 951,
+        bottom: 1101,
       }));
 
       assertThatFooterIsSticky();

--- a/src/components/form/form.style.js
+++ b/src/components/form/form.style.js
@@ -18,7 +18,7 @@ export const StyledForm = styled.form`
   ${({ stickyFooter }) =>
     stickyFooter &&
     css`
-      padding-bottom: 72px;
+      padding-bottom: 100px;
     `}
 `;
 
@@ -59,10 +59,10 @@ export const StyledFormFooter = styled.div`
       justify-content: flex-end;
     `}
 
-  ${({ stickyFooter, theme }) =>
-    stickyFooter &&
+  ${({ stickyFooter, theme }) => css`
+    ${stickyFooter &&
     css`
-      animation: ${FormButtonAnimation} 0.25s ease-out;
+      animation: ${FormButtonAnimation} 0.25s ease;
       background-color: ${theme.colors.white};
       box-shadow: 0 -4px 12px 0 rgba(0, 0, 0, 0.05);
       box-sizing: border-box;
@@ -73,6 +73,7 @@ export const StyledFormFooter = styled.div`
       width: 100%;
       z-index: 1000;
     `}
+  `}
 `;
 
 StyledForm.propTypes = {


### PR DESCRIPTION
Fixes: #3563

### Proposed behaviour
The sticky footer will now turn into a normal footer when you scroll to the bottom, and pop up when you scroll up

### Current behaviour
Scrollbar gets hidden behind the sticky footer:
![image](https://user-images.githubusercontent.com/14963680/104205274-1bfd2f00-5426-11eb-926c-07cdccc420dd.png)

Note this happens for both `Dialog` and `FullScreenDialog`

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
http://localhost:9001/?path=/story/design-system-form--in-dialog-with-sticky-footer
http://localhost:9001/?path=/story/design-system-form--in-dialog-full-screen-with-sticky-footer

and on the codesandbox from the Github issue, see the codesandbox bot comment below for a built version of that