### PR TITLE
refactor(text-editor): allow user to render toolbar action controls (FE-3412)

### DIFF
--- a/src/components/text-editor/__internal__/text-editor.component.js
+++ b/src/components/text-editor/__internal__/text-editor.component.js
@@ -43,13 +43,12 @@ const TextEditor = React.forwardRef(
       characterLimit = 3000,
       labelText,
       onChange,
-      onCancel,
-      onSave,
       value,
       required,
       error,
       warning,
       info,
+      toolbarElements,
     },
     ref
   ) => {
@@ -321,18 +320,16 @@ const TextEditor = React.forwardRef(
               keyBindingFn={keyBindingFn}
             />
             <Toolbar
-              onSave={onSave}
-              onCancel={onCancel}
               setBlockStyle={(ev, blockType) =>
                 handleBlockStyleChange(ev, blockType)
               }
               setInlineStyle={(ev, inlineStyle, keyboardUsed) =>
                 handleInlineStyleChange(ev, inlineStyle, keyboardUsed)
               }
-              isDisabled={contentLength === 0}
               editorState={editorState}
               activeControls={activeControls}
               canFocus={focusToolbar}
+              toolbarElements={toolbarElements}
             />
           </StyledEditorContainer>
         </StyledEditorOutline>
@@ -348,10 +345,6 @@ TextEditor.propTypes = {
   labelText: PropTypes.string.isRequired,
   /** onChange callback to control value updates */
   onChange: PropTypes.func.isRequired,
-  /** Optional callback to handle event after clicking the 'Cancel" button */
-  onCancel: PropTypes.func,
-  /** Optional callback to handle event after clicking the 'Save" button, passing this will render the form buttons */
-  onSave: PropTypes.func,
   /** The value of the input, this is an EditorState immutable object */
   value: PropTypes.object.isRequired,
   /** Flag to configure component as mandatory */
@@ -362,6 +355,8 @@ TextEditor.propTypes = {
   warning: PropTypes.string,
   /** Message to be displayed when there is an info */
   info: PropTypes.string,
+  /** Additional elements to be rendered in the Editor Toolbar, e.g. Save and Cancel Button */
+  toolbarElements: PropTypes.node,
 };
 
 export const TextEditorState = EditorState;

--- a/src/components/text-editor/__internal__/text-editor.d.ts
+++ b/src/components/text-editor/__internal__/text-editor.d.ts
@@ -4,8 +4,8 @@ export interface TextEditorProps {
   characterLimit?: number;
   labelText: string;
   onChange: (event: object) => void;
-  onCancel?: () => void;
-  onSave?: () => void;
+  /** Additional elements to be rendered in the Editor Toolbar, e.g. Save and Cancel Button */
+  toolbarElements?: React.ReactNode;
   value: object;
   /** Flag to configure component as mandatory */
   required?: boolean;

--- a/src/components/text-editor/__internal__/text-editor.stories.mdx
+++ b/src/components/text-editor/__internal__/text-editor.stories.mdx
@@ -10,6 +10,7 @@ import ToolbarButton from "./toolbar/toolbar-button";
 import EditorCounter from "./editor-counter";
 import IconButton from "../../icon-button";
 import Icon from "../../icon";
+import Button from "../../button";
 
 <Meta
   title="Design System/Text Editor"
@@ -118,8 +119,10 @@ otherwise. Any `onCancel` callback prop passed will be called when the `Cancel` 
             }}
             value={value}
             ref={ref}
-            onSave={() => {}}
-            onCancel={() => {}}
+            toolbarElements={[
+              <Button buttonType="tertiary" onClick={ () => console.log('cancel') }>Cancel</Button>,
+              <Button buttonType='primary' type="button" onClick={ () => console.log('save') }>Save</Button>
+            ]}
             labelText="Text Editor Label"
           />
         </div>

--- a/src/components/text-editor/__internal__/toolbar/toolbar.component.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.component.js
@@ -6,7 +6,6 @@ import {
   StyledEditorActionControls,
 } from "./toolbar.style";
 import ToolbarButton from "./toolbar-button";
-import Button from "../../../button";
 import Events from "../../../../utils/helpers/events/events";
 import Icon from "../../../icon";
 
@@ -18,9 +17,7 @@ const ORDERED_LIST = "ordered-list-item";
 const Toolbar = ({
   activeControls,
   canFocus,
-  isDisabled,
-  onCancel,
-  onSave,
+  toolbarElements,
   setBlockStyle,
   setInlineStyle,
 }) => {
@@ -144,17 +141,9 @@ const Toolbar = ({
         </ToolbarButton>
       </StyledEditorStyleControls>
 
-      {onSave && (
+      {toolbarElements && (
         <StyledEditorActionControls>
-          <Button
-            buttonType="tertiary"
-            onClick={onCancel ? (ev) => onCancel(ev) : undefined}
-          >
-            Cancel
-          </Button>
-          <Button buttonType="primary" onClick={onSave} disabled={isDisabled}>
-            Save
-          </Button>
+          {toolbarElements}
         </StyledEditorActionControls>
       )}
     </StyledToolbar>
@@ -181,14 +170,12 @@ Toolbar.propTypes = {
   editorState: PropTypes.object,
   /** Sets the form controls ('Save', 'Cancel') to disabled */
   isDisabled: PropTypes.bool,
-  /** Optional callback to handle event after clicking the 'Cancel" button */
-  onCancel: PropTypes.func,
-  /** Optional callback to handle event after clicking the 'Save" button */
-  onSave: PropTypes.func,
   /** Callback to handle setting the inline styles */
   setInlineStyle: PropTypes.func.isRequired,
   /** Callback to handle setting the block styles */
   setBlockStyle: PropTypes.func.isRequired,
+  /** Additional elements to be rendered in the Toolbar, e.g. Save and Cancel Button */
+  toolbarElements: PropTypes.node,
 };
 
 export default Toolbar;

--- a/src/components/text-editor/__internal__/toolbar/toolbar.d.ts
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.d.ts
@@ -2,9 +2,8 @@ import * as React from 'react';
 
 export interface ToolbarProps {
   activeControls: object;
-  isDisabled?: boolean;
-  onCancel?: () => void;
-  onSave: () => void;
+  /** Additional elements to be rendered, e.g. Save and Cancel Button */
+  toolbarElements?: React.ReactNode;
   setInlineStyle: (args: number) => any;
   setBlockStyle: (args: number) => any;
 }

--- a/src/components/text-editor/__internal__/toolbar/toolbar.spec.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.spec.js
@@ -81,7 +81,9 @@ describe("Toolbar", () => {
           width: "50%",
           minWidth: "60px",
         },
-        render({ onSave: () => {} }).find(StyledEditorActionControls)
+        render({ toolbarElements: <Button>foo</Button> }).find(
+          StyledEditorActionControls
+        )
       );
 
       assertStyleMatch(
@@ -89,16 +91,10 @@ describe("Toolbar", () => {
           width: "62px",
           minHeight: "33px",
         },
-        render({ onSave: () => {} }).find(StyledEditorActionControls),
+        render({ toolbarElements: <Button>foo</Button> }).find(
+          StyledEditorActionControls
+        ),
         { modifier: `${StyledButton}` }
-      );
-
-      assertStyleMatch(
-        {
-          fontSize: "16px",
-        },
-        render({ onSave: () => {} }).find(StyledEditorActionControls),
-        { modifier: `${StyledButton}:first-of-type` }
       );
     });
   });
@@ -377,50 +373,15 @@ describe("Toolbar", () => {
       });
     });
 
-    describe("Action Buttons", () => {
-      let saveButton, cancelButton;
-      describe("with no `onSave` prop", () => {
-        it("will not render", () => {
-          wrapper = render();
-          saveButton = wrapper
-            .find(Button)
-            .findWhere((n) => n.text() === "Save");
-          cancelButton = wrapper
-            .find(Button)
-            .findWhere((n) => n.text() === "Cancel");
-          expect(saveButton.exists()).toBeFalsy();
-          expect(cancelButton.exists()).toBeFalsy();
-        });
-      });
+    describe("when an element has been passed in the toolbarElements prop", () => {
+      const exampleButton = <Button data-element="toolbar-button">foo</Button>;
 
-      describe("with `onSave` prop", () => {
-        const onSave = jest.fn();
-        const onCancel = jest.fn();
+      it("then that element should be rendered", () => {
+        wrapper = render({ toolbarElements: exampleButton });
 
-        beforeEach(() => {
-          wrapper = render({ onSave, onCancel });
-          saveButton = wrapper
-            .find(Button)
-            .findWhere((n) => n.text() === "Save");
-          cancelButton = wrapper
-            .find(Button)
-            .findWhere((n) => n.text() === "Cancel");
-        });
-
-        it("will render", () => {
-          expect(saveButton.exists()).toBeTruthy();
-          expect(cancelButton.exists()).toBeTruthy();
-        });
-
-        it("calls the `onSave` callback when the `Save` button is clicked", () => {
-          saveButton.hostNodes().first().props().onClick();
-          expect(onSave).toHaveBeenCalled();
-        });
-
-        it("calls the `onCancel` callback when the `Cancel` button is clicked", () => {
-          cancelButton.hostNodes().first().props().onClick();
-          expect(onCancel).toHaveBeenCalled();
-        });
+        expect(wrapper.find("[data-element='toolbar-button']").exists()).toBe(
+          true
+        );
       });
     });
   });

--- a/src/components/text-editor/__internal__/toolbar/toolbar.style.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.style.js
@@ -46,10 +46,6 @@ const StyledEditorActionControls = styled.div`
     width: 62px;
     min-height: 33px;
   }
-
-  ${StyledButton}:first-of-type {
-    font-size: 16px;
-  }
 `;
 
 StyledEditorActionControls.defaultProps = {


### PR DESCRIPTION
BREAKING CHANGE: remove cancel and save buttons from the toolbar,
use toolbarElements prop to render custom elements such as these buttons

### Proposed behaviour
Carbon user should be allowed to add TextEditor Action Controls to have more control over these elements by passing them through the `toolbarElements` prop.

### Current behaviour
Action Controls such as Cancel and Save Button are rendered in the TextEditor Toolbar, Carbon User have no control over them

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
~~- [ ] Cypress automation tests added or updated if required~~
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent
