### PR TITLE
docs(link): update onclick story to remove incorrect prop usage

### DIFF
--- a/src/components/link/link.stories.mdx
+++ b/src/components/link/link.stories.mdx
@@ -121,11 +121,11 @@ The alignment of the tooltip can be controlled using the `tooltipAlign` prop.
 </Preview>
 
 ### OnClick
-By passing the `hasOnClick` prop to the Link component, a custom `onClick` function can be passed to the Link component
+A custom `onClick` function can be passed to the Link component to render it as a button instead of an anchor.
 
 <Preview>
-  <Story name="with OnClick" parameters={{ chromatic: { disable: true }}}>
-    <Link hasOnClick onClick={ ()=> {} }>
+  <Story name="with onClick" parameters={{ chromatic: { disable: true }}}>
+    <Link onClick={ ()=> {} }>
       This is a link
     </Link>
   </Story>


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Docs no longer have superfluous `hasOnClick` prop in `onClick` story 
### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Docs have superfluous `hasOnClick` prop in `onClick` story 

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
