### PR TITLE
fix(focus-trap): filter disabled inputs in query selector FE-3382

### DIFF
--- a/src/components/dialog/dialog.stories.mdx
+++ b/src/components/dialog/dialog.stories.mdx
@@ -115,24 +115,24 @@ When mixing editable and non-editable content, you can use the <LinkTo kind='Des
             >
               <Typography variant="h3" mb="32px">Basic details</Typography>
               <RadioButtonGroup
-              legend="How do you want to create this address?"
-              legendInline
-              value="1"
-              legendWidth={40}
-            >
-              <RadioButton
+                legend="How do you want to create this address?"
+                legendInline
                 value="1"
-                label="Create a new Address"                
-                size="large"
-                disabled
-              />
-              <RadioButton
-                value="2"
-                label="Select an Existing address"                
-                size="large"
-                disabled
-              />
-            </RadioButtonGroup>
+                legendWidth={40}
+              >
+                <RadioButton
+                  value="1"
+                  label="Create a new Address"                
+                  size="large"
+                  disabled
+                />
+                <RadioButton
+                  value="2"
+                  label="Select an Existing address"                
+                  size="large"
+                  disabled
+                />
+              </RadioButtonGroup>
               <Box p="24px" bg="slateTint90" ml="88px">
                 <Textbox labelInline label='Property Name' />
                 <Fieldset>

--- a/src/utils/helpers/focus-trap/focus-trap.js
+++ b/src/utils/helpers/focus-trap/focus-trap.js
@@ -33,7 +33,7 @@ function trap(firstFocusableElement, lastFocusableElement, bespokeTrap, ev) {
 
 // eslint-disable-next-line max-len
 const defaultFocusableSelectors =
-  'button, [href], input:not([type="hidden"]), select, textarea, [tabindex]:not([tabindex="-1"])';
+  'button:not([disabled]), [href], input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 const focusTrap = (
   element,

--- a/src/utils/helpers/focus-trap/focus-trap.spec.js
+++ b/src/utils/helpers/focus-trap/focus-trap.spec.js
@@ -218,5 +218,41 @@ describe("focusTrap", () => {
         expect(document.activeElement).toMatchObject(wrapper);
       });
     });
+
+    describe("and some children elements are disabled", () => {
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = mount(
+          <TestComponent>
+            <button type="button">Test button One</button>
+            <button type="button" disabled>
+              Disabled button One
+            </button>
+            <button type="button">Test button Two</button>
+            <button type="button" disabled>
+              Disabled button two
+            </button>
+          </TestComponent>,
+          { attachTo: htmlElement }
+        );
+      });
+
+      afterEach(() => {
+        wrapper.unmount();
+      });
+
+      it("only focuses those that are not", () => {
+        document.querySelectorAll("button")[0].focus();
+        document.dispatchEvent(tabKey);
+        expect(document.activeElement).toMatchObject(
+          wrapper.find("button").at(2)
+        );
+        document.dispatchEvent(tabKey);
+        expect(document.activeElement).toMatchObject(
+          wrapper.find("button").at(0)
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Expands `querySelectorAll` string to filter out disabled inputs

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Disabled inputs are not filtered and can break tab wrapping

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://5ecf782fe724630022d27d7d-zttdnyovdg.chromatic.com/?path=/story/dialog--editable