### PR TITLE
feat(select): object option comparison tweak (FE-3421)

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -84,5 +84,6 @@
   "more_examples_of_card_footer": "--more-examples-of-card-footer",
   "with_is_loading_prop": "--with-is-loading-prop",
   "with_legend_and_labels": "--with-legend-and-labels",
-  "in_overflow_hidden_container": "--in-overflow-hidden-container"
+  "in_overflow_hidden_container": "--in-overflow-hidden-container",
+  "with_object_as_value": "--with-object-as-value"
 }

--- a/cypress/features/regression/designSystem/simpleSelect.feature
+++ b/cypress/features/regression/designSystem/simpleSelect.feature
@@ -77,3 +77,16 @@ Feature: Design System Select component
     When I scroll to the "bottom" of Select List
     Then Lazy loading is visible
       And Select list "Lazy Loaded A1" option is visible
+
+  @positive
+  Scenario: Check that using an object as a value displays the correct options
+    Given I open "Design System Select" component page "with object as value" in no iframe
+    When I click on dropdown button
+    Then visible options on Select list are "Amber", "Black", "Blue"
+
+  @positive
+  Scenario: Check that options can be selected and displayed correctly when using an object as a value
+    Given I open "Design System Select" component page "with object as value" in no iframe
+     And I click on dropdown button
+    When I click on "first" option on Select list
+    Then Select input has "Amber" value

--- a/cypress/locators/select/index.js
+++ b/cypress/locators/select/index.js
@@ -18,7 +18,6 @@ export const selectOption = index => cy.get(SELECT_OPTIONS).eq(index);
 export const dropdownButton = () => cy.get(DROPDOWN_BUTTON);
 export const simpleSelectNoIframe = () => cy.get(SELECT_BASIC);
 
-
 // component preview locators into iFrame
 export const simpleSelectIframe = () => cy.iFrame(SELECT_BASIC);
 export const dropdownButtonInIframe = () => cy.iFrame(DROPDOWN_BUTTON);

--- a/cypress/support/step-definitions/select-steps.js
+++ b/cypress/support/step-definitions/select-steps.js
@@ -19,7 +19,7 @@ import {
   selectListText,
 } from '../../locators/select';
 import { positionOfElement, keyCode } from '../helper';
-import { label } from '../../locators';
+import { label, getDataElementByValue } from '../../locators';
 import { dataComponentButtonByTextNoIFrame } from '../../locators/pages';
 import { loader } from '../../locators/loader';
 
@@ -184,4 +184,8 @@ Then('visible options on Select list are {string}, {string}, {string}', (firstTe
     .and('be.visible');
   selectOption(positionOfElement('third')).should('have.text', thirdText)
     .and('be.visible');
+});
+
+Then('Select input has {string} value', (text) => {
+  getDataElementByValue('input').should('have.attr', 'value', text);
 });

--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -7,6 +7,7 @@ import SelectTextbox, {
 import guid from "../../../utils/helpers/guid";
 import withFilter from "../utils/with-filter.hoc";
 import SelectList from "../select-list/select-list.component";
+import isExpectedOption from "../utils/is-expected-option";
 
 const FilterableSelectList = withFilter(SelectList);
 
@@ -101,8 +102,8 @@ const FilterableSelect = React.forwardRef(
 
     const setMatchingText = useCallback(
       (newValue) => {
-        const matchingOption = React.Children.toArray(children).find(
-          (option) => option.props.value === newValue
+        const matchingOption = React.Children.toArray(children).find((child) =>
+          isExpectedOption(child, newValue)
         );
 
         if (matchingOption && matchingOption.props.text !== undefined) {

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -370,6 +370,51 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
+### With object as value:
+Option values could be passed as objects, useful when custom data is associated with an option.
+When the `id` property is set, objects will be compared based on that property (could be used when the list is recreated after an API call).
+If there is no `id` prop specified on an object, then the exact objects will be compared.
+
+<Preview>
+  <Story name="with object as value" parameters={{ chromatic: { disable: true }}} >
+    {() => {
+      const [value, setValue] = useState({ id: 'Green', value: 5, text: 'Green' });
+      const optionList = useRef([
+        <Option text='Amber' key='Amber' value={ { id: 'Amber', value: 1, text: 'Amber' } } />,
+        <Option text='Black' key='Black' value={ { id: 'Black', value: 2, text: 'Black' } } />,
+        <Option text='Blue' key='Blue' value={ { id: 'Blue', value: 3, text: 'Blue' } } />,
+        <Option text='Brown' key='Brown' value={ { id: 'Brown', value: 4, text: 'Brown' } } />,
+        <Option text='Green' key='Green' value={ { id: 'Green', value: 5, text: 'Green' } } />,
+        <Option text='Orange' key='Orange' value={ { id: 'Orange', value: 6, text: 'Orange' } } />,
+        <Option text='Pink' key='Pink' value={ { id: 'Pink', value: 7, text: 'Pink' } } />,
+        <Option text='Purple' key='Purple' value={ { id: 'Purple', value: 8, text: 'Purple' } } />,
+        <Option text='Red' key='Red' value={ { id: 'Red', value: 9, text: 'Red' } } />,
+        <Option text='White' key='White' value={ { id: 'White', value: 10, text: 'White' } } />,
+        <Option text='Yellow' key='Yellow' value={ { id: 'Yellow', value: 11, text: 'Yellow' } } />
+      ]);
+      function onChangeHandler(event) {
+        setValue(event.target.value);
+      }
+      function clearValue() {
+        setValue({});
+      }
+      return (
+        <div>
+          <Button onClick={ clearValue } mb={ 2 }>clear</Button>
+          <FilterableSelect
+            id='with-object'
+            name='with-object'
+            value={ value }
+            onChange={ onChangeHandler }
+          >
+            { optionList.current }
+          </FilterableSelect>
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
 ## Props:
 
 <Props of={ FilterableSelect } />

--- a/src/components/select/multi-select/index.d.ts
+++ b/src/components/select/multi-select/index.d.ts
@@ -29,9 +29,9 @@ export interface MultiSelectProps {
   /** Placeholder string to be displayed in input */
   placeholder?: string;
   /** The selected value(s), when the component is operating in controlled mode */
-  value?: string | object;
+  value?: string[] | object[];
   /** The default selected value(s), when the component is operating in uncontrolled mode */
-  defaultValue?: string | object;
+  defaultValue?: string[] | object[];
   /** Child components (such as Option) for the SelectList */
   children: Array<typeof Option>;
   /** If true the Component opens on focus */

--- a/src/components/select/multi-select/multi-select.spec.js
+++ b/src/components/select/multi-select/multi-select.spec.js
@@ -220,7 +220,9 @@ describe("MultiSelect", () => {
           const wrapper = renderSelect({ defaultValue: ["opt2", "opt1"] });
           wrapper.find("input").simulate("change", changeEventObject);
 
-          wrapper.find(SelectList).prop("onSelect")(mockOptionObject);
+          act(() => {
+            wrapper.find(SelectList).prop("onSelect")(mockOptionObject);
+          });
           expect(wrapper.update().find(Pill)).toHaveLength(3);
           wrapper.find("input").simulate("keyDown", keyDownEventObject);
           expect(wrapper.find(Pill)).toHaveLength(2);
@@ -546,6 +548,30 @@ describe("MultiSelect", () => {
             openOnFocus: true,
             defaultValue: ["opt1"],
           });
+
+          wrapper.find("input").simulate("focus");
+          act(() => {
+            wrapper.find(Option).first().simulate("click");
+          });
+          expect(onChangeFn).not.toHaveBeenCalled();
+        });
+      });
+
+      describe("and that Option value is an object and it is already selected", () => {
+        it("then that prop should not be called", () => {
+          const onChangeFn = jest.fn();
+          const wrapper = mount(
+            <MultiSelect
+              name="testSelect"
+              id="testSelect"
+              openOnFocus
+              defaultValue={[{ id: "id1", value: "opt1" }]}
+            >
+              <Option value={{ id: "id1", value: "opt1" }} text="red" />
+              <Option value={{ id: "id2", value: "opt2" }} text="green" />
+              <Option value={{ id: "id3", value: "opt3" }} text="blue" />
+            </MultiSelect>
+          );
 
           wrapper.find("input").simulate("focus");
           act(() => {

--- a/src/components/select/multi-select/multi-select.stories.mdx
+++ b/src/components/select/multi-select/multi-select.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
+import Button from "../../button";
 import { MultiSelect, Option } from '../';
 import SelectTextbox from '../select-textbox/select-textbox.component';
 
@@ -198,6 +199,51 @@ You can use the `required` prop to indicate if the field is mandatory.
       <Option text='White' value='10' />
       <Option text='Yellow' value='11' />
     </MultiSelect>
+  </Story>
+</Preview>
+
+### With object as value:
+Option values could be passed as objects, useful when custom data is associated with an option.
+When the `id` property is set, objects will be compared based on that property (could be used when the list is recreated after an API call).
+If there is no `id` prop specified on an object, then the exact objects will be compared.
+
+<Preview>
+  <Story name="with object as value" parameters={{ chromatic: { disable: true }}} >
+    {() => {
+      const [value, setValue] = useState([{ id: 'Green', value: 5, text: 'Green' }]);
+      const optionList = useRef([
+        <Option text='Amber' key='Amber' value={ { id: 'Amber', value: 1, text: 'Amber' } } />,
+        <Option text='Black' key='Black' value={ { id: 'Black', value: 2, text: 'Black' } } />,
+        <Option text='Blue' key='Blue' value={ { id: 'Blue', value: 3, text: 'Blue' } } />,
+        <Option text='Brown' key='Brown' value={ { id: 'Brown', value: 4, text: 'Brown' } } />,
+        <Option text='Green' key='Green' value={ { id: 'Green', value: 5, text: 'Green' } } />,
+        <Option text='Orange' key='Orange' value={ { id: 'Orange', value: 6, text: 'Orange' } } />,
+        <Option text='Pink' key='Pink' value={ { id: 'Pink', value: 7, text: 'Pink' } } />,
+        <Option text='Purple' key='Purple' value={ { id: 'Purple', value: 8, text: 'Purple' } } />,
+        <Option text='Red' key='Red' value={ { id: 'Red', value: 9, text: 'Red' } } />,
+        <Option text='White' key='White' value={ { id: 'White', value: 10, text: 'White' } } />,
+        <Option text='Yellow' key='Yellow' value={ { id: 'Yellow', value: 11, text: 'Yellow' } } />
+      ]);
+      function onChangeHandler(event) {
+        setValue(event.target.value);
+      }
+      function clearValue() {
+        setValue([]);
+      }
+      return (
+        <div>
+          <Button onClick={ clearValue } mb={ 2 }>clear</Button>
+          <MultiSelect
+            id='with-object'
+            name='with-object'
+            value={ value }
+            onChange={ onChangeHandler }
+          >
+            { optionList.current }
+          </MultiSelect>
+        </div>
+      );
+    }}
   </Story>
 </Preview>
 

--- a/src/components/select/select-textbox/select-textbox.component.js
+++ b/src/components/select/select-textbox/select-textbox.component.js
@@ -126,6 +126,7 @@ SelectTextbox.propTypes = {
     PropTypes.string,
     PropTypes.object,
     PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(PropTypes.object),
   ]),
 };
 

--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -16,7 +16,7 @@ import SelectTextbox, {
 import SelectList from "../select-list/select-list.component";
 import guid from "../../../utils/helpers/guid";
 import getNextChildByText from "../utils/get-next-child-by-text";
-import Option from "../option/option.component";
+import isExpectedOption from "../utils/is-expected-option";
 
 const SimpleSelect = React.forwardRef(
   (
@@ -79,8 +79,8 @@ const SimpleSelect = React.forwardRef(
 
     const setMatchingText = useCallback(
       (newValue) => {
-        const matchingOption = childOptions.find(
-          (child) => child.type === Option && child.props.value === newValue
+        const matchingOption = childOptions.find((child) =>
+          isExpectedOption(child, newValue)
         );
         let newText = "";
 
@@ -96,9 +96,9 @@ const SimpleSelect = React.forwardRef(
     const selectValueStartingWithText = useCallback(
       (newFilterText) => {
         setSelectedValue((previousValue) => {
-          const previousIndex = childOptions.findIndex((child) => {
-            return child.props.value === previousValue;
-          });
+          const previousIndex = childOptions.findIndex((child) =>
+            isExpectedOption(child, previousValue)
+          );
           const match = getNextChildByText(
             newFilterText,
             childOptions,

--- a/src/components/select/simple-select/simple-select.stories.mdx
+++ b/src/components/select/simple-select/simple-select.stories.mdx
@@ -130,24 +130,26 @@ You can use the `required` prop to indicate if the field is mandatory.
 </Preview>
 
 ### With object as value:
-Option values could be passed as objects. Useful when custom data is associated with an option.
+Option values could be passed as objects, useful when custom data is associated with an option.
+When the `id` property is set, objects will be compared based on that property (could be used when the list is recreated after an API call).
+If there is no `id` prop specified on an object, then the exact objects will be compared.
 
 <Preview>
   <Story name="with object as value" parameters={{ chromatic: { disable: true }}} >
     {() => {
-      const [value, setValue] = useState({});
+      const [value, setValue] = useState({ id: 'Green', value: 5, text: 'Green' });
       const optionList = useRef([
-        <Option text='Amber' key='Amber' value={ { value: 1, text: 'Amber' } } />,
-        <Option text='Black' key='Black' value={ { value: 2, text: 'Black' } } />,
-        <Option text='Blue' key='Blue' value={ { value: 3, text: 'Blue' } } />,
-        <Option text='Brown' key='Brown' value={ { value: 4, text: 'Brown' } } />,
-        <Option text='Green' key='Green' value={ { value: 5, text: 'Green' } } />,
-        <Option text='Orange' key='Orange' value={ { value: 6, text: 'Orange' } } />,
-        <Option text='Pink' key='Pink' value={ { value: 7, text: 'Pink' } } />,
-        <Option text='Purple' key='Purple' value={ { value: 8, text: 'Purple' } } />,
-        <Option text='Red' key='Red' value={ { value: 9, text: 'Red' } } />,
-        <Option text='White' key='White' value={ { value: 10, text: 'White' } } />,
-        <Option text='Yellow' key='Yellow' value={ { value: 11, text: 'Yellow' } } />
+        <Option text='Amber' key='Amber' value={ { id: 'Amber', value: 1, text: 'Amber' } } />,
+        <Option text='Black' key='Black' value={ { id: 'Black', value: 2, text: 'Black' } } />,
+        <Option text='Blue' key='Blue' value={ { id: 'Blue', value: 3, text: 'Blue' } } />,
+        <Option text='Brown' key='Brown' value={ { id: 'Brown', value: 4, text: 'Brown' } } />,
+        <Option text='Green' key='Green' value={ { id: 'Green', value: 5, text: 'Green' } } />,
+        <Option text='Orange' key='Orange' value={ { id: 'Orange', value: 6, text: 'Orange' } } />,
+        <Option text='Pink' key='Pink' value={ { id: 'Pink', value: 7, text: 'Pink' } } />,
+        <Option text='Purple' key='Purple' value={ { id: 'Purple', value: 8, text: 'Purple' } } />,
+        <Option text='Red' key='Red' value={ { id: 'Red', value: 9, text: 'Red' } } />,
+        <Option text='White' key='White' value={ { id: 'White', value: 10, text: 'White' } } />,
+        <Option text='Yellow' key='Yellow' value={ { id: 'Yellow', value: 11, text: 'Yellow' } } />
       ]);
       function onChangeHandler(event) {
         setValue(event.target.value);

--- a/src/components/select/utils/is-expected-option.js
+++ b/src/components/select/utils/is-expected-option.js
@@ -1,4 +1,5 @@
 import Option from "../option/option.component";
+import isExpectedValue from "./is-expected-value";
 
 export default function isExpectedOption(element, expectedValue) {
   if (
@@ -9,13 +10,5 @@ export default function isExpectedOption(element, expectedValue) {
     return false;
   }
 
-  if (
-    typeof element.props.value === "object" &&
-    element.props.value.id !== null &&
-    element.props.value.id !== undefined
-  ) {
-    return element.props.value.id === expectedValue.id;
-  }
-
-  return element.props.value === expectedValue;
+  return isExpectedValue(element.props.value, expectedValue);
 }

--- a/src/components/select/utils/is-expected-option.js
+++ b/src/components/select/utils/is-expected-option.js
@@ -1,0 +1,21 @@
+import Option from "../option/option.component";
+
+export default function isExpectedOption(element, expectedValue) {
+  if (
+    element.type !== Option ||
+    expectedValue === null ||
+    expectedValue === undefined
+  ) {
+    return false;
+  }
+
+  if (
+    typeof element.props.value === "object" &&
+    element.props.value.id !== null &&
+    element.props.value.id !== undefined
+  ) {
+    return element.props.value.id === expectedValue.id;
+  }
+
+  return element.props.value === expectedValue;
+}

--- a/src/components/select/utils/is-expected-option.spec.js
+++ b/src/components/select/utils/is-expected-option.spec.js
@@ -1,0 +1,56 @@
+import React from "react";
+import Option from "../option/option.component";
+import isExpectedOption from "./is-expected-option";
+
+describe("isExpectedOption", () => {
+  describe("when the element is not an Option", () => {
+    it("then it should return false", () => {
+      const element = <div>mock</div>;
+      const expectedValue = "foo";
+
+      expect(isExpectedOption(element, expectedValue)).toBe(false);
+    });
+  });
+
+  describe("when the element is an Option", () => {
+    describe("and it's value prop is a string", () => {
+      describe("with the same content as the second argument", () => {
+        it("then it should return true", () => {
+          const element = <Option value="foo" text="bar" />;
+          const expectedValue = "foo";
+
+          expect(isExpectedOption(element, expectedValue)).toBe(true);
+        });
+      });
+
+      describe("with the different content than the second argument", () => {
+        it("then it should return false", () => {
+          const element = <Option value="foo" text="bar" />;
+          const expectedValue = "bar";
+
+          expect(isExpectedOption(element, expectedValue)).toBe(false);
+        });
+      });
+    });
+
+    describe("and it's value prop is an object", () => {
+      describe("with the same id prop as the second argument's id", () => {
+        it("then it should return true", () => {
+          const element = <Option value={{ id: "foo", value: "foo" }} />;
+          const expectedValue = { id: "foo", value: "foo" };
+
+          expect(isExpectedOption(element, expectedValue)).toBe(true);
+        });
+      });
+
+      describe("with different id prop than the second argument's id", () => {
+        it("then it should return false", () => {
+          const element = <Option value={{ id: "foo", value: "foo" }} />;
+          const expectedValue = { id: "bar", value: "foo" };
+
+          expect(isExpectedOption(element, expectedValue)).toBe(false);
+        });
+      });
+    });
+  });
+});

--- a/src/components/select/utils/is-expected-value.js
+++ b/src/components/select/utils/is-expected-value.js
@@ -1,0 +1,11 @@
+export default function isExpectedValue(currentValue, expectedValue) {
+  if (
+    typeof currentValue === "object" &&
+    currentValue.id !== null &&
+    currentValue.id !== undefined
+  ) {
+    return currentValue.id === expectedValue.id;
+  }
+
+  return currentValue === expectedValue;
+}

--- a/src/components/select/utils/is-expected-value.spec.js
+++ b/src/components/select/utils/is-expected-value.spec.js
@@ -1,0 +1,43 @@
+import isExpectedValue from "./is-expected-value";
+
+describe("isExpectedOption", () => {
+  describe("when the currentValue is a string", () => {
+    describe("with the same content as the second argument", () => {
+      it("then it should return true", () => {
+        const currentValue = "foo";
+        const expectedValue = "foo";
+
+        expect(isExpectedValue(currentValue, expectedValue)).toBe(true);
+      });
+    });
+
+    describe("with the different content than the second argument", () => {
+      it("then it should return false", () => {
+        const currentValue = "foo";
+        const expectedValue = "bar";
+
+        expect(isExpectedValue(currentValue, expectedValue)).toBe(false);
+      });
+    });
+  });
+
+  describe("when the currentValue is an object", () => {
+    describe("with the same id prop as the second argument's id", () => {
+      it("then it should return true", () => {
+        const currentValue = { id: "foo", value: "foo" };
+        const expectedValue = { id: "foo", value: "foo" };
+
+        expect(isExpectedValue(currentValue, expectedValue)).toBe(true);
+      });
+    });
+
+    describe("with different id prop than the second argument's id", () => {
+      it("then it should return false", () => {
+        const currentValue = { id: "foo", value: "foo" };
+        const expectedValue = { id: "bar", value: "foo" };
+
+        expect(isExpectedValue(currentValue, expectedValue)).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Proposed behaviour
When the `id` property is set on an Option object value, objects will be compared based on that property (could be used when the list is recreated after an API call). If there is no `id` prop specified on an object, then the exact objects will be compared.

### Current behaviour
When Option values are defined as objects, the exact objects are compared looking for the selected value.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
1. run `npm start`.
2. open http://localhost:9001/?path=/docs/design-system-select--with-object-as-value
3. open http://localhost:9001/?path=/docs/design-system-select-filterable--with-object-as-value
4. open http://localhost:9001/?path=/docs/design-system-select-multiselect--with-object-as-value