### PR TITLE
chore(button): remove sibling styling for button - FE-3330

### DIFF
--- a/.storybook/welcome-page/get-started/get-started.component.js
+++ b/.storybook/welcome-page/get-started/get-started.component.js
@@ -21,6 +21,7 @@ const GetStarted = () => (
         href="https://github.com/Sage/carbon/blob/master/docs/getting-started.stories.mdx"
         size='large'
         target='_blank'
+        ml={2}
       >
         { I18n.t('navigation.github.download') }
       </Button>

--- a/.storybook/welcome-page/header/header.component.js
+++ b/.storybook/welcome-page/header/header.component.js
@@ -35,6 +35,7 @@ const Header = () => (
             href="https://github.com/Sage/carbon/blob/master/docs/getting-started.stories.mdx"
             size='large'
             target='_blank'
+            ml={2}
           >
             { I18n.t('navigation.github.download') }
           </Button>

--- a/src/__experimental__/components/date/date.stories.mdx
+++ b/src/__experimental__/components/date/date.stories.mdx
@@ -99,7 +99,7 @@ import DateInput from "carbon-react/lib/__experimental__/components/date";
         <>
           <Box mb={2}>
             <Button onClick={() => setDate("")}>Set empty date</Button>
-            <Button onClick={() => setDate("2019-04-01")}>
+            <Button onClick={() => setDate("2019-04-01")} ml={2}>
               Set 2019-04-01
             </Button>
           </Box>

--- a/src/__experimental__/components/search/search.stories.mdx
+++ b/src/__experimental__/components/search/search.stories.mdx
@@ -33,7 +33,7 @@ import Search from 'carbon-react/lib/__experimental__/components/search';
       return (
       <div>
         <Button onClick={() => setValue('')}>Clear value</Button>
-        <Button onClick={() => setValue('test value')}>Set value</Button>
+        <Button onClick={() => setValue('test value')} ml={2}>Set value</Button>
         <Search id="test" name="test" placeholder="Search..." 
         onChange={(e)=> setValue(e.target.value)}
         value={value}

--- a/src/components/accordion/accordion.stories.mdx
+++ b/src/components/accordion/accordion.stories.mdx
@@ -467,7 +467,7 @@ Accordion adjust it's height properly when it's content is being dynamically cha
       return (
         <>
           <Button onClick={ () => modifyContentCount(1) }>Add content</Button>
-          <Button onClick={ () => modifyContentCount(-1) }>Remove content</Button>
+          <Button onClick={ () => modifyContentCount(-1) } ml={2}>Remove content</Button>
           <Accordion title="Title">
             {Array.from({ length: contentCount }).map((_, index) => <div key={ index }>Content</div>)}
           </Accordion>

--- a/src/components/button/__snapshots__/button.spec.js.snap
+++ b/src/components/button/__snapshots__/button.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button when only the "iconPosition" and "iconType" props are passed into the component renders the default props and children to match the snapshot with the Icon after children 1`] = `
-.c3 {
+.c2 {
   display: inline-block;
   position: relative;
   color: #008200;
@@ -9,12 +9,12 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   vertical-align: middle;
 }
 
-.c3:hover {
+.c2:hover {
   color: #006800;
   background-color: transparent;
 }
 
-.c3::before {
+.c2::before {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-family: CarbonIcons;
@@ -27,763 +27,595 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   display: block;
 }
 
-.c4 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c4:hover .c2 {
+.c3:hover .c1 {
   color: #FFFFFF;
 }
 
-.c4 .c2 {
+.c3 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c4 .c2 svg {
+.c3 .c1 svg {
   margin-top: 0;
 }
 
-.c5 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c5:hover .c2 {
+.c4:hover .c1 {
   color: #FFFFFF;
 }
 
-.c5 .c2 {
+.c4 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c5 .c2 svg {
+.c4 .c1 svg {
   margin-top: 0;
 }
 
-.c6 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c6:hover .c2 {
+.c5:hover .c1 {
   color: #FFFFFF;
 }
 
-.c6 .c2 {
+.c5 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c6 .c2 svg {
+.c5 .c1 svg {
   margin-top: 0;
 }
 
-.c7 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c7:hover .c2 {
+.c6:hover .c1 {
   color: #FFFFFF;
 }
 
-.c7 .c2 {
+.c6 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c7 .c2 svg {
+.c6 .c1 svg {
   margin-top: 0;
 }
 
-.c8 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c8:hover .c2 {
+.c7:hover .c1 {
   color: #FFFFFF;
 }
 
-.c8 .c2 {
+.c7 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c8 .c2 svg {
+.c7 .c1 svg {
   margin-top: 0;
 }
 
-.c9 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c9:hover .c2 {
+.c8:hover .c1 {
   color: #FFFFFF;
 }
 
-.c9 .c2 {
+.c8 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c9 .c2 svg {
+.c8 .c1 svg {
   margin-top: 0;
 }
 
-.c10 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c10:hover .c2 {
+.c9:hover .c1 {
   color: #FFFFFF;
 }
 
-.c10 .c2 {
+.c9 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c10 .c2 svg {
+.c9 .c1 svg {
   margin-top: 0;
 }
 
-.c11 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c11:hover .c2 {
+.c10:hover .c1 {
   color: #FFFFFF;
 }
 
-.c11 .c2 {
+.c10 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c11 .c2 svg {
+.c10 .c1 svg {
   margin-top: 0;
 }
 
-.c12 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c12:hover .c2 {
+.c11:hover .c1 {
   color: #FFFFFF;
 }
 
-.c12 .c2 {
+.c11 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c12 .c2 svg {
+.c11 .c1 svg {
   margin-top: 0;
 }
 
-.c13 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c13:hover .c2 {
+.c12:hover .c1 {
   color: #FFFFFF;
 }
 
-.c13 .c2 {
+.c12 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c13 .c2 svg {
+.c12 .c1 svg {
   margin-top: 0;
 }
 
-.c14 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c14:hover .c2 {
+.c13:hover .c1 {
   color: #FFFFFF;
 }
 
-.c14 .c2 {
+.c13 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c14 .c2 svg {
+.c13 .c1 svg {
   margin-top: 0;
 }
 
-.c15 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c15:hover .c2 {
+.c14:hover .c1 {
   color: #FFFFFF;
 }
 
-.c15 .c2 {
+.c14 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c15 .c2 svg {
+.c14 .c1 svg {
   margin-top: 0;
 }
 
-.c16 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c16:hover .c2 {
+.c15:hover .c1 {
   color: #FFFFFF;
 }
 
-.c16 .c2 {
+.c15 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c16 .c2 svg {
+.c15 .c1 svg {
   margin-top: 0;
 }
 
-.c17 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c17:hover .c2 {
+.c16:hover .c1 {
   color: #FFFFFF;
 }
 
-.c17 .c2 {
+.c16 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c17 .c2 svg {
+.c16 .c1 svg {
   margin-top: 0;
 }
 
-.c18 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c18:hover .c2 {
+.c17:hover .c1 {
   color: #FFFFFF;
 }
 
-.c18 .c2 {
+.c17 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c18 .c2 svg {
+.c17 .c1 svg {
   margin-top: 0;
 }
 
-.c19 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c19:hover .c2 {
+.c18:hover .c1 {
   color: #FFFFFF;
 }
 
-.c19 .c2 {
+.c18 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c19 .c2 svg {
+.c18 .c1 svg {
   margin-top: 0;
 }
 
-.c20 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c20:hover .c2 {
+.c19:hover .c1 {
   color: #FFFFFF;
 }
 
-.c20 .c2 {
+.c19 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c20 .c2 svg {
+.c19 .c1 svg {
   margin-top: 0;
 }
 
-.c21 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c21:hover .c2 {
+.c20:hover .c1 {
   color: #FFFFFF;
 }
 
-.c21 .c2 {
+.c20 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c21 .c2 svg {
+.c20 .c1 svg {
   margin-top: 0;
 }
 
-.c22 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c22:hover .c2 {
+.c21:hover .c1 {
   color: #FFFFFF;
 }
 
-.c22 .c2 {
+.c21 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c22 .c2 svg {
+.c21 .c1 svg {
   margin-top: 0;
 }
 
-.c23 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c23:hover .c2 {
+.c22:hover .c1 {
   color: #FFFFFF;
 }
 
-.c23 .c2 {
+.c22 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c23 .c2 svg {
+.c22 .c1 svg {
   margin-top: 0;
 }
 
-.c24 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c24:hover .c2 {
+.c23:hover .c1 {
   color: #FFFFFF;
 }
 
-.c24 .c2 {
+.c23 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c24 .c2 svg {
+.c23 .c1 svg {
   margin-top: 0;
 }
 
-.c25 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c25:hover .c2 {
+.c24:hover .c1 {
   color: #FFFFFF;
 }
 
-.c25 .c2 {
+.c24 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c25 .c2 svg {
+.c24 .c1 svg {
   margin-top: 0;
 }
 
-.c26 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c26:hover .c2 {
+.c25:hover .c1 {
   color: #FFFFFF;
 }
 
-.c26 .c2 {
+.c25 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c26 .c2 svg {
+.c25 .c1 svg {
   margin-top: 0;
 }
 
-.c27 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c27:hover .c2 {
+.c26:hover .c1 {
   color: #FFFFFF;
 }
 
-.c27 .c2 {
+.c26 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c27 .c2 svg {
+.c26 .c1 svg {
   margin-top: 0;
 }
 
-.c28 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c28:hover .c2 {
+.c27:hover .c1 {
   color: #FFFFFF;
 }
 
-.c28 .c2 {
+.c27 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c28 .c2 svg {
+.c27 .c1 svg {
   margin-top: 0;
 }
 
-.c29 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c29:hover .c2 {
+.c28:hover .c1 {
   color: #FFFFFF;
 }
 
-.c29 .c2 {
+.c28 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c29 .c2 svg {
+.c28 .c1 svg {
   margin-top: 0;
 }
 
-.c30 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c30:hover .c2 {
+.c29:hover .c1 {
   color: #FFFFFF;
 }
 
-.c30 .c2 {
+.c29 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c30 .c2 svg {
+.c29 .c1 svg {
   margin-top: 0;
 }
 
-.c31 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c31:hover .c2 {
+.c30:hover .c1 {
   color: #FFFFFF;
 }
 
-.c31 .c2 {
+.c30 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c31 .c2 svg {
+.c30 .c1 svg {
   margin-top: 0;
 }
 
-.c32 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c32:hover .c2 {
+.c31:hover .c1 {
   color: #FFFFFF;
 }
 
-.c32 .c2 {
+.c31 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c32 .c2 svg {
+.c31 .c1 svg {
   margin-top: 0;
 }
 
-.c33 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c33:hover .c2 {
+.c32:hover .c1 {
   color: #FFFFFF;
 }
 
-.c33 .c2 {
+.c32 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c33 .c2 svg {
+.c32 .c1 svg {
   margin-top: 0;
 }
 
-.c34 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c34:hover .c2 {
+.c33:hover .c1 {
   color: #FFFFFF;
 }
 
-.c34 .c2 {
+.c33 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c34 .c2 svg {
+.c33 .c1 svg {
   margin-top: 0;
 }
 
-.c35 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c35:hover .c2 {
+.c34:hover .c1 {
   color: #FFFFFF;
 }
 
-.c35 .c2 {
+.c34 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c35 .c2 svg {
+.c34 .c1 svg {
   margin-top: 0;
 }
 
-.c36 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c36:hover .c2 {
+.c35:hover .c1 {
   color: #FFFFFF;
 }
 
-.c36 .c2 {
+.c35 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c36 .c2 svg {
+.c35 .c1 svg {
   margin-top: 0;
 }
 
-.c37 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c37:hover .c2 {
+.c36:hover .c1 {
   color: #FFFFFF;
 }
 
-.c37 .c2 {
+.c36 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c37 .c2 svg {
+.c36 .c1 svg {
   margin-top: 0;
 }
 
-.c38 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c38:hover .c2 {
+.c37:hover .c1 {
   color: #FFFFFF;
 }
 
-.c38 .c2 {
+.c37 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c38 .c2 svg {
+.c37 .c1 svg {
   margin-top: 0;
 }
 
-.c39 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c39:hover .c2 {
+.c38:hover .c1 {
   color: #FFFFFF;
 }
 
-.c39 .c2 {
+.c38 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c39 .c2 svg {
+.c38 .c1 svg {
   margin-top: 0;
 }
 
-.c40 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c40:hover .c2 {
+.c39:hover .c1 {
   color: #FFFFFF;
 }
 
-.c40 .c2 {
+.c39 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c40 .c2 svg {
+.c39 .c1 svg {
   margin-top: 0;
 }
 
-.c41 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c41:hover .c2 {
+.c40:hover .c1 {
   color: #FFFFFF;
 }
 
-.c41 .c2 {
+.c40 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c41 .c2 svg {
+.c40 .c1 svg {
   margin-top: 0;
 }
 
-.c42 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c42:hover .c2 {
+.c41:hover .c1 {
   color: #FFFFFF;
 }
 
-.c42 .c2 {
+.c41 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c42 .c2 svg {
+.c41 .c1 svg {
   margin-top: 0;
 }
 
-.c43 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c43:hover .c2 {
+.c42:hover .c1 {
   color: #FFFFFF;
 }
 
-.c43 .c2 {
+.c42 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c43 .c2 svg {
+.c42 .c1 svg {
   margin-top: 0;
 }
 
-.c44 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c44:hover .c2 {
+.c43:hover .c1 {
   color: #FFFFFF;
 }
 
-.c44 .c2 {
+.c43 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c44 .c2 svg {
+.c43 .c1 svg {
   margin-top: 0;
 }
 
-.c45 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c45:hover .c2 {
+.c44:hover .c1 {
   color: #FFFFFF;
 }
 
-.c45 .c2 {
+.c44 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c45 .c2 svg {
+.c44 .c1 svg {
   margin-top: 0;
 }
 
-.c1 {
+.c0 {
   padding-left: 24px;
   padding-right: 24px;
   -webkit-align-items: center;
@@ -818,36 +650,32 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   min-height: 40px;
 }
 
-.c1:focus {
+.c0:focus {
   outline: solid 3px #FFB500;
 }
 
-.c1 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c1:hover {
+.c0:hover {
   background: #006300;
   border-color: #006300;
   color: #FFFFFF;
 }
 
-.c1:hover .c2 {
+.c0:hover .c1 {
   color: #FFFFFF;
 }
 
-.c1 .c2 {
+.c0 .c1 {
   margin-left: 8px;
   margin-right: 0px;
   height: 16px;
 }
 
-.c1 .c2 svg {
+.c0 .c1 svg {
   margin-top: 0;
 }
 
 <button
-  className="c0 c1"
+  className="c0"
   data-component="button"
   disabled={false}
   role="button"
@@ -862,7 +690,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
     </span>
   </span>
   <span
-    className="c2 c3"
+    className="c1 c2"
     data-component="icon"
     data-element="filter"
     disabled={false}
@@ -873,7 +701,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 `;
 
 exports[`Button when only the "iconPosition" and "iconType" props are passed into the component renders the default props and children to match the snapshot with the Icon before children 1`] = `
-.c3 {
+.c2 {
   display: inline-block;
   position: relative;
   color: #008200;
@@ -881,12 +709,12 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   vertical-align: middle;
 }
 
-.c3:hover {
+.c2:hover {
   color: #006800;
   background-color: transparent;
 }
 
-.c3::before {
+.c2::before {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-family: CarbonIcons;
@@ -899,7 +727,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   display: block;
 }
 
-.c1 {
+.c0 {
   padding-left: 24px;
   padding-right: 24px;
   -webkit-align-items: center;
@@ -934,774 +762,606 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   min-height: 40px;
 }
 
-.c1:focus {
+.c0:focus {
   outline: solid 3px #FFB500;
 }
 
-.c1 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c1:hover {
+.c0:hover {
   background: #006300;
   border-color: #006300;
   color: #FFFFFF;
 }
 
-.c1:hover .c2 {
+.c0:hover .c1 {
   color: #FFFFFF;
 }
 
-.c1 .c2 {
+.c0 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c1 .c2 svg {
+.c0 .c1 svg {
   margin-top: 0;
 }
 
-.c4 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c4:hover .c2 {
+.c3:hover .c1 {
   color: #FFFFFF;
 }
 
-.c4 .c2 {
+.c3 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c4 .c2 svg {
+.c3 .c1 svg {
   margin-top: 0;
 }
 
-.c5 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c5:hover .c2 {
+.c4:hover .c1 {
   color: #FFFFFF;
 }
 
-.c5 .c2 {
+.c4 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c5 .c2 svg {
+.c4 .c1 svg {
   margin-top: 0;
 }
 
-.c6 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c6:hover .c2 {
+.c5:hover .c1 {
   color: #FFFFFF;
 }
 
-.c6 .c2 {
+.c5 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c6 .c2 svg {
+.c5 .c1 svg {
   margin-top: 0;
 }
 
-.c7 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c7:hover .c2 {
+.c6:hover .c1 {
   color: #FFFFFF;
 }
 
-.c7 .c2 {
+.c6 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c7 .c2 svg {
+.c6 .c1 svg {
   margin-top: 0;
 }
 
-.c8 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c8:hover .c2 {
+.c7:hover .c1 {
   color: #FFFFFF;
 }
 
-.c8 .c2 {
+.c7 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c8 .c2 svg {
+.c7 .c1 svg {
   margin-top: 0;
 }
 
-.c9 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c9:hover .c2 {
+.c8:hover .c1 {
   color: #FFFFFF;
 }
 
-.c9 .c2 {
+.c8 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c9 .c2 svg {
+.c8 .c1 svg {
   margin-top: 0;
 }
 
-.c10 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c10:hover .c2 {
+.c9:hover .c1 {
   color: #FFFFFF;
 }
 
-.c10 .c2 {
+.c9 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c10 .c2 svg {
+.c9 .c1 svg {
   margin-top: 0;
 }
 
-.c11 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c11:hover .c2 {
+.c10:hover .c1 {
   color: #FFFFFF;
 }
 
-.c11 .c2 {
+.c10 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c11 .c2 svg {
+.c10 .c1 svg {
   margin-top: 0;
 }
 
-.c12 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c12:hover .c2 {
+.c11:hover .c1 {
   color: #FFFFFF;
 }
 
-.c12 .c2 {
+.c11 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c12 .c2 svg {
+.c11 .c1 svg {
   margin-top: 0;
 }
 
-.c13 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c13:hover .c2 {
+.c12:hover .c1 {
   color: #FFFFFF;
 }
 
-.c13 .c2 {
+.c12 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c13 .c2 svg {
+.c12 .c1 svg {
   margin-top: 0;
 }
 
-.c14 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c14:hover .c2 {
+.c13:hover .c1 {
   color: #FFFFFF;
 }
 
-.c14 .c2 {
+.c13 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c14 .c2 svg {
+.c13 .c1 svg {
   margin-top: 0;
 }
 
-.c15 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c15:hover .c2 {
+.c14:hover .c1 {
   color: #FFFFFF;
 }
 
-.c15 .c2 {
+.c14 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c15 .c2 svg {
+.c14 .c1 svg {
   margin-top: 0;
 }
 
-.c16 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c16:hover .c2 {
+.c15:hover .c1 {
   color: #FFFFFF;
 }
 
-.c16 .c2 {
+.c15 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c16 .c2 svg {
+.c15 .c1 svg {
   margin-top: 0;
 }
 
-.c17 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c17:hover .c2 {
+.c16:hover .c1 {
   color: #FFFFFF;
 }
 
-.c17 .c2 {
+.c16 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c17 .c2 svg {
+.c16 .c1 svg {
   margin-top: 0;
 }
 
-.c18 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c18:hover .c2 {
+.c17:hover .c1 {
   color: #FFFFFF;
 }
 
-.c18 .c2 {
+.c17 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c18 .c2 svg {
+.c17 .c1 svg {
   margin-top: 0;
 }
 
-.c19 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c19:hover .c2 {
+.c18:hover .c1 {
   color: #FFFFFF;
 }
 
-.c19 .c2 {
+.c18 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c19 .c2 svg {
+.c18 .c1 svg {
   margin-top: 0;
 }
 
-.c20 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c20:hover .c2 {
+.c19:hover .c1 {
   color: #FFFFFF;
 }
 
-.c20 .c2 {
+.c19 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c20 .c2 svg {
+.c19 .c1 svg {
   margin-top: 0;
 }
 
-.c21 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c21:hover .c2 {
+.c20:hover .c1 {
   color: #FFFFFF;
 }
 
-.c21 .c2 {
+.c20 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c21 .c2 svg {
+.c20 .c1 svg {
   margin-top: 0;
 }
 
-.c22 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c22:hover .c2 {
+.c21:hover .c1 {
   color: #FFFFFF;
 }
 
-.c22 .c2 {
+.c21 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c22 .c2 svg {
+.c21 .c1 svg {
   margin-top: 0;
 }
 
-.c23 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c23:hover .c2 {
+.c22:hover .c1 {
   color: #FFFFFF;
 }
 
-.c23 .c2 {
+.c22 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c23 .c2 svg {
+.c22 .c1 svg {
   margin-top: 0;
 }
 
-.c24 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c24:hover .c2 {
+.c23:hover .c1 {
   color: #FFFFFF;
 }
 
-.c24 .c2 {
+.c23 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c24 .c2 svg {
+.c23 .c1 svg {
   margin-top: 0;
 }
 
-.c25 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c25:hover .c2 {
+.c24:hover .c1 {
   color: #FFFFFF;
 }
 
-.c25 .c2 {
+.c24 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c25 .c2 svg {
+.c24 .c1 svg {
   margin-top: 0;
 }
 
-.c26 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c26:hover .c2 {
+.c25:hover .c1 {
   color: #FFFFFF;
 }
 
-.c26 .c2 {
+.c25 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c26 .c2 svg {
+.c25 .c1 svg {
   margin-top: 0;
 }
 
-.c27 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c27:hover .c2 {
+.c26:hover .c1 {
   color: #FFFFFF;
 }
 
-.c27 .c2 {
+.c26 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c27 .c2 svg {
+.c26 .c1 svg {
   margin-top: 0;
 }
 
-.c28 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c28:hover .c2 {
+.c27:hover .c1 {
   color: #FFFFFF;
 }
 
-.c28 .c2 {
+.c27 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c28 .c2 svg {
+.c27 .c1 svg {
   margin-top: 0;
 }
 
-.c29 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c29:hover .c2 {
+.c28:hover .c1 {
   color: #FFFFFF;
 }
 
-.c29 .c2 {
+.c28 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c29 .c2 svg {
+.c28 .c1 svg {
   margin-top: 0;
 }
 
-.c30 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c30:hover .c2 {
+.c29:hover .c1 {
   color: #FFFFFF;
 }
 
-.c30 .c2 {
+.c29 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c30 .c2 svg {
+.c29 .c1 svg {
   margin-top: 0;
 }
 
-.c31 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c31:hover .c2 {
+.c30:hover .c1 {
   color: #FFFFFF;
 }
 
-.c31 .c2 {
+.c30 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c31 .c2 svg {
+.c30 .c1 svg {
   margin-top: 0;
 }
 
-.c32 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c32:hover .c2 {
+.c31:hover .c1 {
   color: #FFFFFF;
 }
 
-.c32 .c2 {
+.c31 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c32 .c2 svg {
+.c31 .c1 svg {
   margin-top: 0;
 }
 
-.c33 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c33:hover .c2 {
+.c32:hover .c1 {
   color: #FFFFFF;
 }
 
-.c33 .c2 {
+.c32 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c33 .c2 svg {
+.c32 .c1 svg {
   margin-top: 0;
 }
 
-.c34 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c34:hover .c2 {
+.c33:hover .c1 {
   color: #FFFFFF;
 }
 
-.c34 .c2 {
+.c33 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c34 .c2 svg {
+.c33 .c1 svg {
   margin-top: 0;
 }
 
-.c35 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c35:hover .c2 {
+.c34:hover .c1 {
   color: #FFFFFF;
 }
 
-.c35 .c2 {
+.c34 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c35 .c2 svg {
+.c34 .c1 svg {
   margin-top: 0;
 }
 
-.c36 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c36:hover .c2 {
+.c35:hover .c1 {
   color: #FFFFFF;
 }
 
-.c36 .c2 {
+.c35 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c36 .c2 svg {
+.c35 .c1 svg {
   margin-top: 0;
 }
 
-.c37 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c37:hover .c2 {
+.c36:hover .c1 {
   color: #FFFFFF;
 }
 
-.c37 .c2 {
+.c36 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c37 .c2 svg {
+.c36 .c1 svg {
   margin-top: 0;
 }
 
-.c38 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c38:hover .c2 {
+.c37:hover .c1 {
   color: #FFFFFF;
 }
 
-.c38 .c2 {
+.c37 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c38 .c2 svg {
+.c37 .c1 svg {
   margin-top: 0;
 }
 
-.c39 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c39:hover .c2 {
+.c38:hover .c1 {
   color: #FFFFFF;
 }
 
-.c39 .c2 {
+.c38 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c39 .c2 svg {
+.c38 .c1 svg {
   margin-top: 0;
 }
 
-.c40 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c40:hover .c2 {
+.c39:hover .c1 {
   color: #FFFFFF;
 }
 
-.c40 .c2 {
+.c39 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c40 .c2 svg {
+.c39 .c1 svg {
   margin-top: 0;
 }
 
-.c41 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c41:hover .c2 {
+.c40:hover .c1 {
   color: #FFFFFF;
 }
 
-.c41 .c2 {
+.c40 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c41 .c2 svg {
+.c40 .c1 svg {
   margin-top: 0;
 }
 
-.c42 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c42:hover .c2 {
+.c41:hover .c1 {
   color: #FFFFFF;
 }
 
-.c42 .c2 {
+.c41 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c42 .c2 svg {
+.c41 .c1 svg {
   margin-top: 0;
 }
 
-.c43 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c43:hover .c2 {
+.c42:hover .c1 {
   color: #FFFFFF;
 }
 
-.c43 .c2 {
+.c42 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c43 .c2 svg {
+.c42 .c1 svg {
   margin-top: 0;
 }
 
-.c44 ~ .c0 {
-  margin-left: 16px;
-}
-
-.c44:hover .c2 {
+.c43:hover .c1 {
   color: #FFFFFF;
 }
 
-.c44 .c2 {
+.c43 .c1 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c44 .c2 svg {
+.c43 .c1 svg {
   margin-top: 0;
 }
 
 <button
-  className="c0 c1"
+  className="c0"
   data-component="button"
   disabled={false}
   role="button"
@@ -1709,7 +1369,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   type="button"
 >
   <span
-    className="c2 c3"
+    className="c1 c2"
     data-component="icon"
     data-element="filter"
     disabled={false}

--- a/src/components/button/button.stories.js
+++ b/src/components/button/button.stories.js
@@ -83,6 +83,7 @@ export const asASibling = () => {
           renderRouterLink={(routerProps) => (
             <RouterLink {...routerProps} style={{ textDecoration: "none" }} />
           )}
+          ml={2}
         >
           {children}
         </Button>
@@ -101,7 +102,7 @@ const generateButtons = (buttonType, iconPosition) => () => {
               <React.Fragment
                 key={`${buttonType}-${iconPosition}-${iconType}-${size}`}
               >
-                <Button key="basic" size={size} {...props}>
+                <Button key="basic" size={size} {...props} ml={2}>
                   {size}
                 </Button>
                 {size === "large" && (
@@ -110,6 +111,7 @@ const generateButtons = (buttonType, iconPosition) => () => {
                     size={size}
                     subtext="line two"
                     {...props}
+                    ml={2}
                   >
                     {size}
                   </Button>
@@ -120,7 +122,7 @@ const generateButtons = (buttonType, iconPosition) => () => {
               <React.Fragment
                 key={`${buttonType}-${iconPosition}-${iconType}-${size}-destructive`}
               >
-                <Button key="basic" size={size} destructive {...props}>
+                <Button key="basic" size={size} destructive {...props} ml={2}>
                   {size}
                 </Button>
                 {size === "large" && (
@@ -130,6 +132,7 @@ const generateButtons = (buttonType, iconPosition) => () => {
                     destructive
                     subtext="line two"
                     {...props}
+                    ml={2}
                   >
                     {size}
                   </Button>
@@ -140,7 +143,7 @@ const generateButtons = (buttonType, iconPosition) => () => {
               <React.Fragment
                 key={`${buttonType}-${iconPosition}-${iconType}-${size}-disabled`}
               >
-                <Button key="basic" size={size} disabled {...props}>
+                <Button key="basic" size={size} disabled {...props} ml={2}>
                   {size}
                 </Button>
                 {size === "large" && (
@@ -150,6 +153,7 @@ const generateButtons = (buttonType, iconPosition) => () => {
                     disabled
                     subtext="line two"
                     {...props}
+                    ml={2}
                   >
                     {size}
                   </Button>
@@ -191,7 +195,7 @@ export const fullWidthButtons = () => {
           <React.Fragment key={`${buttonType}-${buttonType}`}>
             {OptionsHelper.sizesRestricted.map((size) => (
               <React.Fragment key={`${buttonType}-${buttonType}-${size}`}>
-                <Button key="basic" size={size} {...props}>
+                <Button key="basic" size={size} {...props} ml={2}>
                   {size}
                 </Button>
                 <Button key="basic-icon" size={size} {...props} iconType="bin">
@@ -203,6 +207,7 @@ export const fullWidthButtons = () => {
                   {...props}
                   iconType="bin"
                   iconPosition="after"
+                  ml={2}
                 >
                   {size}
                 </Button>
@@ -213,6 +218,7 @@ export const fullWidthButtons = () => {
                       size={size}
                       subtext="line two"
                       {...props}
+                      ml={2}
                     >
                       {size}
                     </Button>
@@ -222,6 +228,7 @@ export const fullWidthButtons = () => {
                       subtext="line two"
                       iconType="bin"
                       {...props}
+                      ml={2}
                     >
                       {size}
                     </Button>
@@ -232,6 +239,7 @@ export const fullWidthButtons = () => {
                       iconType="bin"
                       iconPosition="after"
                       {...props}
+                      ml={2}
                     >
                       {size}
                     </Button>
@@ -243,7 +251,7 @@ export const fullWidthButtons = () => {
               <React.Fragment
                 key={`${buttonType}-${buttonType}-${size}-destructive`}
               >
-                <Button key="basic" size={size} destructive {...props}>
+                <Button key="basic" size={size} destructive {...props} ml={2}>
                   {size}
                 </Button>
                 <Button
@@ -252,6 +260,7 @@ export const fullWidthButtons = () => {
                   destructive
                   iconType="bin"
                   {...props}
+                  ml={2}
                 >
                   {size}
                 </Button>
@@ -273,6 +282,7 @@ export const fullWidthButtons = () => {
                       destructive
                       subtext="line two"
                       {...props}
+                      ml={2}
                     >
                       {size}
                     </Button>
@@ -283,6 +293,7 @@ export const fullWidthButtons = () => {
                       subtext="line two"
                       iconType="bin"
                       {...props}
+                      ml={2}
                     >
                       {size}
                     </Button>
@@ -294,6 +305,7 @@ export const fullWidthButtons = () => {
                       iconType="bin"
                       iconPosition="after"
                       {...props}
+                      ml={2}
                     >
                       {size}
                     </Button>
@@ -305,7 +317,7 @@ export const fullWidthButtons = () => {
               <React.Fragment
                 key={`${buttonType}-${buttonType}-${size}-disabled`}
               >
-                <Button key="basic" size={size} disabled {...props}>
+                <Button key="basic" size={size} disabled {...props} ml={2}>
                   {size}
                 </Button>
                 <Button
@@ -324,6 +336,7 @@ export const fullWidthButtons = () => {
                   iconType="bin"
                   iconPosition="after"
                   {...props}
+                  ml={2}
                 >
                   {size}
                 </Button>
@@ -335,6 +348,7 @@ export const fullWidthButtons = () => {
                       disabled
                       subtext="line two"
                       {...props}
+                      ml={2}
                     >
                       {size}
                     </Button>
@@ -345,6 +359,7 @@ export const fullWidthButtons = () => {
                       subtext="line two"
                       iconType="bin"
                       {...props}
+                      ml={2}
                     >
                       {size}
                     </Button>
@@ -356,6 +371,7 @@ export const fullWidthButtons = () => {
                       iconType="bin"
                       iconPosition="after"
                       {...props}
+                      ml={2}
                     >
                       {size}
                     </Button>

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -16,8 +16,8 @@ For the single most prominent call to action on the page (e.g. Save, Submit, Con
   <Story name="primary" parameters={{ info: { disable: true }}} >
     <>
       <Button buttonType="primary" size="small">Small</Button>
-      <Button buttonType="primary">Medium</Button>
-      <Button buttonType="primary" size="large">Large</Button>
+      <Button buttonType="primary" ml={2}>Medium</Button>
+      <Button buttonType="primary" size="large" ml={2}>Large</Button>
     </>
   </Story>
 </Preview>
@@ -27,8 +27,8 @@ Primary buttons can be destructive.
   <Story name="primary/destructive" parameters={{ info: { disable: true }}} >
     <>
       <Button buttonType="primary" destructive size="small">Small</Button>
-      <Button buttonType="primary" destructive >Medium</Button>
-      <Button buttonType="primary" destructive size="large">Large</Button>
+      <Button buttonType="primary" destructive ml={2}>Medium</Button>
+      <Button buttonType="primary" destructive size="large" ml={2}>Large</Button>
     </>
   </Story>
 </Preview>
@@ -38,8 +38,8 @@ Primary buttons can be disabled.
   <Story name="primary/disabled" parameters={{ info: { disable: true }}} >
     <>
       <Button buttonType="primary" disabled size="small">Small</Button>
-      <Button buttonType="primary" disabled>Medium</Button>
-      <Button buttonType="primary" disabled size="large">Large</Button>
+      <Button buttonType="primary" disabled ml={2}>Medium</Button>
+      <Button buttonType="primary" disabled size="large" ml={2}>Large</Button>
     </>
   </Story>
 </Preview>
@@ -49,8 +49,8 @@ Primary buttons can have an icon positioned before or after the text.
   <Story name="primary/icon" parameters={{ info: { disable: true }}} >
   <>
     <Button buttonType="primary" iconType="print">Medium</Button>
-    <Button buttonType="primary" destructive iconType="delete" iconPosition="after">Medium</Button>
-    <Button buttonType="primary" disabled iconType="print" iconPosition="after">Medium</Button>
+    <Button buttonType="primary" destructive iconType="delete" iconPosition="after" ml={2}>Medium</Button>
+    <Button buttonType="primary" disabled iconType="print" iconPosition="after" ml={2}>Medium</Button>
     </>
   </Story>
 </Preview>
@@ -72,8 +72,8 @@ Secondary buttons are transparent, rather than white.
   <Story name="secondary" parameters={{ info: { disable: true }}} >
     <>
       <Button size="small" >Small</Button>
-      <Button>Medium</Button>
-      <Button size="large">Large</Button>
+      <Button ml={2}>Medium</Button>
+      <Button size="large" ml={2}>Large</Button>
     </>
   </Story>
 </Preview>
@@ -83,8 +83,8 @@ Secondary buttons can be destructive.
   <Story name="secondary/destructive" parameters={{ info: { disable: true }}} >
     <>
       <Button destructive size="small">Small</Button>
-      <Button destructive >Medium</Button>
-      <Button destructive size="large">Large</Button>
+      <Button destructive ml={2}>Medium</Button>
+      <Button destructive size="large" ml={2}>Large</Button>
     </>
   </Story>
 </Preview>
@@ -94,8 +94,8 @@ Secondary buttons can be disabled.
   <Story name="secondary/disabled" parameters={{ info: { disable: true }}} >
     <>
       <Button size="small" disabled>Small</Button>
-      <Button disabled>Medium</Button>
-      <Button size="large" disabled>Large</Button>
+      <Button disabled ml={2}>Medium</Button>
+      <Button size="large" disabled ml={2}>Large</Button>
     </>
   </Story>
 </Preview>
@@ -105,8 +105,8 @@ Secondary buttons can have an icon positioned before or after the text.
   <Story name="secondary/icon" parameters={{ info: { disable: true }}} >
   <>
     <Button iconType="print">Medium</Button>
-    <Button destructive iconType="delete" iconPosition="after">Medium</Button>
-    <Button disabled iconType="print" iconPosition="after">Medium</Button>
+    <Button destructive iconType="delete" iconPosition="after" ml={2}>Medium</Button>
+    <Button disabled iconType="print" iconPosition="after" ml={2}>Medium</Button>
     </>
   </Story>
 </Preview>
@@ -128,8 +128,8 @@ Tertiary or ‘ghost’ buttons are used for reversing actions, like ‘Cancel�
   <Story name="tertiary" parameters={{ info: { disable: true }}} >
     <>
       <Button buttonType="tertiary" size="small">Small</Button>
-      <Button buttonType="tertiary">Medium</Button>
-      <Button buttonType="tertiary" size="large">Large</Button>
+      <Button buttonType="tertiary" ml={2}>Medium</Button>
+      <Button buttonType="tertiary" size="large" ml={2}>Large</Button>
     </>
   </Story>
 </Preview>
@@ -139,8 +139,8 @@ Tertiary buttons can be destructive.
   <Story name="tertiary/destructive" parameters={{ info: { disable: true }}} >
     <>
       <Button buttonType="tertiary" destructive size="small">Small</Button>
-      <Button buttonType="tertiary" destructive >Medium</Button>
-      <Button buttonType="tertiary" destructive size="large">Large</Button>
+      <Button buttonType="tertiary" destructive ml={2}>Medium</Button>
+      <Button buttonType="tertiary" destructive size="large" ml={2}>Large</Button>
     </>
   </Story>
 </Preview>
@@ -150,8 +150,8 @@ Tertiary buttons can be disabled.
   <Story name="tertiary/disabled" parameters={{ info: { disable: true }}} >
     <>
       <Button buttonType="tertiary" disabled size="small">Small</Button>
-      <Button buttonType="tertiary" disabled>Medium</Button>
-      <Button buttonType="tertiary" disabled size="large">Large</Button>
+      <Button buttonType="tertiary" disabled ml={2}>Medium</Button>
+      <Button buttonType="tertiary" disabled size="large" ml={2}>Large</Button>
     </>
   </Story>
 </Preview>
@@ -161,8 +161,8 @@ Tertiary buttons can have an icon positioned before or after the text.
   <Story name="tertiary/icon" parameters={{ info: { disable: true }}} >
   <>
     <Button buttonType="tertiary" iconType="print">Medium</Button>
-    <Button buttonType="tertiary" destructive iconType="delete" iconPosition="after">Medium</Button>
-    <Button buttonType="tertiary" disabled iconType="print" iconPosition="after">Medium</Button>
+    <Button buttonType="tertiary" destructive iconType="delete" iconPosition="after" ml={2}>Medium</Button>
+    <Button buttonType="tertiary" disabled iconType="print" iconPosition="after" ml={2}>Medium</Button>
     </>
   </Story>
 </Preview>
@@ -183,8 +183,8 @@ Dashed buttons are used for adding new content that replaces empty states.
   <Story name="dashed" parameters={{ info: { disable: true }}} >
     <>
       <Button buttonType="dashed" size="small">Small</Button>
-      <Button buttonType="dashed">Medium</Button>
-      <Button buttonType="dashed" size="large">Large</Button>
+      <Button buttonType="dashed" ml={2}>Medium</Button>
+      <Button buttonType="dashed" size="large" ml={2}>Large</Button>
     </>
   </Story>
 </Preview>
@@ -194,8 +194,8 @@ Dashed buttons can be disabled.
   <Story name="dashed/disabled" parameters={{ info: { disable: true }}} >
     <>
       <Button buttonType="dashed" disabled size="small">Small</Button>
-      <Button buttonType="dashed" disabled>Medium</Button>
-      <Button buttonType="dashed" disabled size="large">Large</Button>
+      <Button buttonType="dashed" disabled ml={2}>Medium</Button>
+      <Button buttonType="dashed" disabled size="large" ml={2}>Large</Button>
     </>
   </Story>
 </Preview>
@@ -205,9 +205,9 @@ Dashed buttons can have an icon positioned before or after the text.
   <Story name="dashed/icon" parameters={{ info: { disable: true }}} >
   <>
     <Button buttonType="dashed" iconType="add" size="small">Small</Button>
-    <Button buttonType="dashed" iconType="add" iconPosition="after">Medium</Button>
-    <Button buttonType="dashed" disabled iconType="add" size="small">Small</Button>
-    <Button buttonType="dashed" disabled iconType="add" iconPosition="after">Medium</Button>
+    <Button buttonType="dashed" iconType="add" iconPosition="after" ml={2}>Medium</Button>
+    <Button buttonType="dashed" disabled iconType="add" size="small" ml={2}>Small</Button>
+    <Button buttonType="dashed" disabled iconType="add" iconPosition="after" ml={2}>Medium</Button>
     </>
   </Story>
 </Preview>

--- a/src/components/button/button.style.js
+++ b/src/components/button/button.style.js
@@ -56,14 +56,7 @@ function additionalIconStyle({ iconType }) {
   return "16px;";
 }
 
-function stylingForType({
-  disabled,
-  buttonType,
-  theme,
-  size,
-  destructive,
-  fullWidth,
-}) {
+function stylingForType({ disabled, buttonType, theme, size, destructive }) {
   return css`
     border: 2px solid transparent;
     box-sizing: border-box;
@@ -72,13 +65,6 @@ function stylingForType({
     &:focus {
       outline: solid 3px ${theme.colors.focus};
     }
-
-    ${!fullWidth &&
-    css`
-      & ~ & {
-        margin-left: 16px;
-      }
-    `}
 
     ${buttonTypes(theme, disabled, destructive)[buttonType]};
 

--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -322,7 +322,7 @@ Click on the card to see the effect
               </Box>
               <Box>
                 <Button buttonType="tertiary"> Button </Button>
-                <Button buttonType="primary"> Button </Button>
+                <Button buttonType="primary" ml={2}> Button </Button>
               </Box>
             </Box>
           </CardFooter>
@@ -334,11 +334,11 @@ Click on the card to see the effect
                 Edit Button
               </Button>
               <VerticalDivider tint={80} py={0} px={2} h={30} /> 
-              <Button p={0} iconPosition="after" iconType="edit" buttonType="tertiary">
+              <Button p={0} iconPosition="after" iconType="edit" buttonType="tertiary" ml={2}>
                 Edit Button
               </Button>
               <VerticalDivider tint={80} py={0} px={2} h={30} />
-              <Button p={0} iconPosition="after" iconType="edit" buttonType="tertiary">
+              <Button p={0} iconPosition="after" iconType="edit" buttonType="tertiary" ml={2}>
                 Edit Button
               </Button> 
               </Box>
@@ -351,11 +351,11 @@ Click on the card to see the effect
                 Edit Button
               </Button>
               <VerticalDivider tint={80} py={0} px={2} h={30} /> 
-              <Button p={0} iconPosition="after" iconType="edit" buttonType="tertiary">
+              <Button p={0} iconPosition="after" iconType="edit" buttonType="tertiary" ml={2}>
                 Edit Button
               </Button>
               <VerticalDivider tint={80} py={0} px={2} h={30} />
-              <Button p={0} iconPosition="after" iconType="edit" buttonType="tertiary">
+              <Button p={0} iconPosition="after" iconType="edit" buttonType="tertiary" ml={2}>
                 Edit Button
               </Button> 
               </Box>

--- a/src/components/confirm/confirm.component.js
+++ b/src/components/confirm/confirm.component.js
@@ -30,6 +30,7 @@ class Confirm extends Dialog {
           data-element="confirm"
           buttonType="primary"
           destructive={this.props.destructive}
+          ml={2}
         >
           {this.props.confirmLabel ||
             I18n.t("confirm.yes", { defaultValue: "Yes" })}

--- a/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
+++ b/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
@@ -6,11 +6,11 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
   padding: 0 16px;
 }
 
-.c4 + .c0 {
+.c3 + .c0 {
   height: calc(100% - 0px);
 }
 
-.c2 {
+.c1 {
   padding-left: 24px;
   padding-right: 24px;
   -webkit-align-items: center;
@@ -45,31 +45,27 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
   min-height: 40px;
 }
 
-.c2:focus {
+.c1:focus {
   outline: solid 3px #FFB500;
 }
 
-.c2 ~ .c1 {
-  margin-left: 16px;
-}
-
-.c2:hover {
+.c1:hover {
   background: #006300;
   border-color: #006300;
   color: #FFFFFF;
 }
 
-.c2:hover .c3 {
+.c1:hover .c2 {
   color: #FFFFFF;
 }
 
-.c2 .c3 {
+.c1 .c2 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c2 .c3 svg {
+.c1 .c2 svg {
   margin-top: 0;
 }
 
@@ -96,7 +92,7 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
   data-element="content"
 >
   <button
-    class="c1 c2"
+    class="c1"
     data-component="button"
     role="button"
     type="button"
@@ -110,7 +106,7 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
     </span>
   </button>
   <button
-    class="c1 c2"
+    class="c1"
     data-component="button"
     role="button"
     type="button"

--- a/src/components/form/form.stories.mdx
+++ b/src/components/form/form.stories.mdx
@@ -163,14 +163,14 @@ Additional buttons can be passed using `leftSideButtons` and `rightSideButtons` 
       leftSideButtons={ 
         <>
           <Button onClick={ () => console.log('cancel') }>Other</Button>
-          <Button onClick={ () => console.log('cancel') }>Cancel</Button>
+          <Button onClick={ () => console.log('cancel') } ml={2}>Cancel</Button>
         </> 
       }
       saveButton={ <Button buttonType='primary' type="submit">Save</Button> }
       rightSideButtons={ 
         <>
           <Button onClick={ () => console.log('cancel') }>Reset</Button>
-          <Button onClick={ () => console.log('cancel') }>Other</Button>
+          <Button onClick={ () => console.log('cancel') } ml={2}>Other</Button>
         </> 
       }
     >
@@ -188,14 +188,14 @@ When `buttonAlignment` prop is set as `left`, buttons are aligned to the left si
        leftSideButtons={ 
         <>
           <Button onClick={ () => console.log('cancel') }>Other</Button>
-          <Button onClick={ () => console.log('cancel') }>Cancel</Button>
+          <Button onClick={ () => console.log('cancel') } ml={2}>Cancel</Button>
         </> 
       }
       saveButton={ <Button buttonType='primary' type="submit">Save</Button> }
       rightSideButtons={ 
         <>
           <Button onClick={ () => console.log('cancel') }>Reset</Button>
-          <Button onClick={ () => console.log('cancel') }>Other</Button>
+          <Button onClick={ () => console.log('cancel') } ml={2}>Other</Button>
         </> 
       }
       buttonAlignment='left'

--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.js.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.js.snap
@@ -66,10 +66,6 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c3 ~ .c2 {
-  margin-left: 16px;
-}
-
 .c3:hover {
   background: #006300;
   border-color: #006300;

--- a/src/components/popover-container/popover-container.stories.mdx
+++ b/src/components/popover-container/popover-container.stories.mdx
@@ -96,7 +96,7 @@ You can use the `open`, `onOpen` and `onClose` props to control the open state o
           return (
             <div style={{height: 150}}>
             <Button onClick={ onOpen }>Open Popover</Button>
-            <Button onClick={ onClose }>Close Popover</Button>
+            <Button onClick={ onClose } ml={2}>Close Popover</Button>
             <br />
             <PopoverContainer
               title='Controlled'
@@ -122,7 +122,7 @@ You can easly use many different components to create your own compisition.
         <Link>This is example link text</Link>
         <div style={ { padding: '25px 0 15px 0' } }>
           <Button>Small</Button>
-          <Button>Compact</Button>
+          <Button ml={2}>Compact</Button>
         </div>
         <DraggableContainer>
           <DraggableItem key='1' id={ 1 }>

--- a/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
+++ b/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
@@ -66,10 +66,6 @@ exports[`Option renders properly 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c2 ~ .c1 {
-  margin-left: 16px;
-}
-
 .c2:hover {
   background: #006300;
   border-color: #006300;

--- a/src/components/sidebar/sidebar.stories.js
+++ b/src/components/sidebar/sidebar.stories.js
@@ -56,7 +56,9 @@ export const Default = () => {
         <SidebarHeader>Header Content</SidebarHeader>
         <div>
           <Button as="primary">Test</Button>
-          <Button as="secondary">Last</Button>
+          <Button as="secondary" ml={2}>
+            Last
+          </Button>
         </div>
         Main Content
       </Sidebar>

--- a/src/components/sidebar/sidebar.stories.mdx
+++ b/src/components/sidebar/sidebar.stories.mdx
@@ -66,7 +66,7 @@ const MyComponent = ({ isOpen, handleClose }) => (
             <SidebarHeader>Header Content</SidebarHeader>
             <div>
               <Button as='primary'>Test</Button>
-              <Button as='secondary'>Last</Button>
+              <Button as='secondary' ml={2}>Last</Button>
             </div>
             Main Content
           </Sidebar>

--- a/src/components/split-button/__snapshots__/split-button.spec.js.snap
+++ b/src/components/split-button/__snapshots__/split-button.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SplitButton for business themes renders styles correctly 1`] = `
-.c6 {
+.c5 {
   display: inline-block;
   position: relative;
   color: #008200;
@@ -9,12 +9,12 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   vertical-align: middle;
 }
 
-.c6:hover {
+.c5:hover {
   color: #006800;
   background-color: transparent;
 }
 
-.c6::before {
+.c5::before {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-family: CarbonIcons;
@@ -66,45 +66,37 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   outline: solid 3px #FFB500;
 }
 
-.c2 ~ .c1 {
-  margin-left: 16px;
-}
-
 .c2:hover {
   background: #006300;
   border-color: #006300;
   color: #FFFFFF;
 }
 
-.c2:hover .c5 {
+.c2:hover .c4 {
   color: #FFFFFF;
 }
 
-.c2 .c5 {
+.c2 .c4 {
   margin-left: 0px;
   margin-right: 8px;
   height: 16px;
 }
 
-.c2 .c5 svg {
+.c2 .c4 svg {
   margin-top: 0;
 }
 
-.c7 ~ .c1 {
-  margin-left: 16px;
-}
-
-.c7:hover .c5 {
+.c6:hover .c4 {
   color: #FFFFFF;
 }
 
-.c7 .c5 {
+.c6 .c4 {
   margin-left: 8px;
   margin-right: 0px;
   height: 16px;
 }
 
-.c7 .c5 svg {
+.c6 .c4 svg {
   margin-top: 0;
 }
 
@@ -123,7 +115,7 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   margin: -1px;
 }
 
-.c4 {
+.c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -158,82 +150,74 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   padding: 0 10px;
 }
 
-.c4:focus {
+.c3:focus {
   outline: solid 3px #FFB500;
 }
 
-.c4 ~ .c3 {
-  margin-left: 16px;
-}
-
-.c4:hover {
+.c3:hover {
   background: #006300;
   border-color: #006300;
   color: #FFFFFF;
 }
 
-.c4:hover .c5 {
+.c3:hover .c4 {
   color: #FFFFFF;
 }
 
-.c4 .c5 {
+.c3 .c4 {
   margin-left: 8px;
   margin-right: 0px;
   height: 16px;
 }
 
-.c4 .c5 svg {
+.c3 .c4 svg {
   margin-top: 0;
 }
 
-.c1 + .c4 {
+.c1 + .c3 {
   margin-left: 0;
 }
 
-.c1 + .c4:focus {
+.c1 + .c3:focus {
   margin-left: -3px;
 }
 
-.c1 + .c4 .c5 {
+.c1 + .c3 .c4 {
   margin-left: 0;
 }
 
-.c8 ~ .c3 {
-  margin-left: 16px;
-}
-
-.c8:hover .c5 {
+.c7:hover .c4 {
   color: #FFFFFF;
 }
 
-.c8 .c5 {
+.c7 .c4 {
   margin-left: 8px;
   margin-right: 0px;
   height: 16px;
 }
 
-.c8 .c5 svg {
+.c7 .c4 svg {
   margin-top: 0;
 }
 
-.c8,
-.c8 .c5 {
+.c7,
+.c7 .c4 {
   color: #FFFFFF;
 }
 
-.c1 + .c8 {
+.c1 + .c7 {
   margin-left: 0;
 }
 
-.c1 + .c8:focus {
+.c1 + .c7:focus {
   margin-left: -3px;
 }
 
-.c1 + .c8 .c5 {
+.c1 + .c7 .c4 {
   margin-left: 0;
 }
 
-.c9 .c1 {
+.c8 .c1 {
   background-color: #006300;
   border: 1px solid #006300;
   color: #FFFFFF;
@@ -246,16 +230,16 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   z-index: 1000;
 }
 
-.c9 .c1:focus,
-.c9 .c1:hover {
+.c8 .c1:focus,
+.c8 .c1:hover {
   background-color: #004500;
 }
 
-.c9 .c1 + .c12 .c1 {
+.c8 .c1 + .c11 .c1 {
   margin-top: 3px;
 }
 
-.c10 .c1 {
+.c9 .c1 {
   background-color: #006046;
   border: 1px solid #006046;
   color: #FFFFFF;
@@ -267,16 +251,16 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   z-index: 1000;
 }
 
-.c10 .c1:focus,
-.c10 .c1:hover {
+.c9 .c1:focus,
+.c9 .c1:hover {
   background-color: #00402E;
 }
 
-.c10 .c1 + .c12 .c1 {
+.c9 .c1 + .c11 .c1 {
   margin-top: 3px;
 }
 
-.c11 .c1 {
+.c10 .c1 {
   background-color: #005C9A;
   border: 1px solid #005C9A;
   color: #FFFFFF;
@@ -288,12 +272,12 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   z-index: 1000;
 }
 
-.c11 .c1:focus,
-.c11 .c1:hover {
+.c10 .c1:focus,
+.c10 .c1:hover {
   background-color: #004472;
 }
 
-.c11 .c1 + .c12 .c1 {
+.c10 .c1 + .c11 .c1 {
   margin-top: 3px;
 }
 
@@ -330,7 +314,7 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
     aria-expanded={false}
     aria-haspopup="true"
     aria-label="Show more"
-    className="c1 c3 c4"
+    className="c1 c3"
     data-element="toggle-button"
     disabled={false}
     onBlur={[Function]}
@@ -341,7 +325,7 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
     size="medium"
   >
     <span
-      className="c5 c6"
+      className="c4 c5"
       data-component="icon"
       data-element="dropdown"
       disabled={false}

--- a/src/components/text-editor/__internal__/text-editor.stories.mdx
+++ b/src/components/text-editor/__internal__/text-editor.stories.mdx
@@ -121,7 +121,7 @@ otherwise. Any `onCancel` callback prop passed will be called when the `Cancel` 
             ref={ref}
             toolbarElements={[
               <Button buttonType="tertiary" onClick={ () => console.log('cancel') }>Cancel</Button>,
-              <Button buttonType='primary' type="button" onClick={ () => console.log('save') }>Save</Button>
+              <Button buttonType='primary' type="button" onClick={ () => console.log('save') } ml={2}>Save</Button>
             ]}
             labelText="Text Editor Label"
           />

--- a/src/components/tile/tile.stories.mdx
+++ b/src/components/tile/tile.stories.mdx
@@ -134,6 +134,7 @@ The Tile component can be also have a vertical layout.
                 iconPosition="after"
                 iconType="edit"
                 buttonType="tertiary"
+                ml={2}
               >
                 Edit Button
               </Button>
@@ -143,6 +144,7 @@ The Tile component can be also have a vertical layout.
                 iconPosition="after"
                 iconType="edit"
                 buttonType="tertiary"
+                ml={2}
               >
                 Edit Button
               </Button>


### PR DESCRIPTION
removes the margin-left 16px styling automatically applied to sibling buttons.

BREAKING CHANGE: The margin left 16px styling applied to the sibling buttons has been removed. An
add-prop codemod has been created to help facilitate the adding of the margin left spacing prop and
the value to the buttons in your project.

fixes #3392

### Proposed behaviour

Removal of the sibling styling from the Button component.

### Current behaviour

Button automatically applies `margin-left: 16px` to all sibling buttons.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
`add-prop` Codemod has been created and the link for that PR is https://github.com/Sage/carbon-codemod/pull/41 
This PR cannot be merged until the codemod PR has been merged with the codemod repo. The codemod PR will require QA'ing at the same time as this PR.

### Testing instructions
- All unit tests should pass.
- Cypress tests should pass.
- No styling regressions.
