### PR TITLE
fix(date): fix date crashing when allowEmptyValue is set - FE-3471

### DIFF
--- a/src/__experimental__/components/date/date-picker.component.js
+++ b/src/__experimental__/components/date/date-picker.component.js
@@ -4,6 +4,7 @@ import I18n from "i18n-js";
 import "react-day-picker/lib/style.css";
 import LocaleUtils from "react-day-picker/moment";
 import DayPicker from "react-day-picker";
+
 import Browser from "../../../utils/helpers/browser/browser";
 import DateHelper from "../../../utils/helpers/date/date";
 import StyledPortal from "../../../components/portal/portal.style";
@@ -11,42 +12,57 @@ import Navbar from "./navbar";
 import Weekday from "./weekday";
 import StyledDayPicker from "./day-picker.style";
 
-const DatePicker = (props) => {
+const DatePicker = ({
+  inputElement,
+  inputDate,
+  handleDateSelect,
+  minDate,
+  maxDate,
+  selectedDate,
+  disablePortal,
+}) => {
   const window = Browser.getWindow();
   const [containerPosition, setContainerPosition] = useState(() =>
-    getContainerPosition(window, props.inputElement)
+    getContainerPosition(window, inputElement)
   );
-  const [currentInputDate, setCurrentInputDate] = useState(
-    isoFormattedValueString(props.inputDate)
+
+  const [lastValidDate, setLastValidDate] = useState(
+    DateHelper.formatDateString(new Date().toString())
   );
+
   const datepicker = useRef(null);
 
   useEffect(() => {
-    const formattedDate = isoFormattedValueString(props.inputDate);
-    const hasUpdated = currentInputDate !== formattedDate;
-    if (hasUpdated) {
-      datepicker.current.showMonth(DateHelper.stringToDate(formattedDate));
-      setCurrentInputDate(formattedDate);
-    }
-  }, [props.inputDate, currentInputDate]);
+    let monthDate;
+    const isoFormattedInputDate = isoFormattedValueString(inputDate);
 
-  const handleDayClick = (selectedDate, modifiers) => {
+    if (isDateValid(isoFormattedInputDate)) {
+      monthDate = new Date(isoFormattedInputDate);
+      setLastValidDate(isoFormattedInputDate);
+    } else {
+      monthDate = new Date(lastValidDate);
+    }
+
+    datepicker.current.showMonth(monthDate);
+  }, [inputDate, lastValidDate]);
+
+  const handleDayClick = (date, modifiers) => {
     if (!modifiers.disabled) {
-      props.handleDateSelect(selectedDate);
+      handleDateSelect(date);
     }
   };
 
   const datePickerProps = {
-    disabledDays: getDisabledDays(props.minDate, props.maxDate),
+    disabledDays: getDisabledDays(minDate, maxDate),
     enableOutsideDays: true,
     fixedWeeks: true,
-    initialMonth: props.selectedDate || undefined,
+    initialMonth: selectedDate || undefined,
     inline: true,
     locale: I18n.locale,
     localeUtils: LocaleUtils,
     navbarElement: <Navbar />,
     onDayClick: handleDayClick,
-    selectedDays: props.selectedDate || undefined,
+    selectedDays: selectedDate || undefined,
     weekdayElement: (weekdayElementProps) => {
       const { className, weekday, localeUtils } = weekdayElementProps;
       const weekdayLong = localeUtils.formatWeekdayLong(weekday, I18n.locale);
@@ -64,20 +80,20 @@ const DatePicker = (props) => {
     <StyledDayPicker>
       <DayPicker
         {...datePickerProps}
-        containerProps={{ style: props.disablePortal ? {} : containerPosition }}
+        containerProps={{ style: disablePortal ? {} : containerPosition }}
         ref={datepicker}
       />
     </StyledDayPicker>
   );
 
-  if (props.disablePortal) {
+  if (disablePortal) {
     return picker;
   }
 
   return (
     <StyledPortal
       onReposition={() =>
-        setContainerPosition(getContainerPosition(window, props.inputElement))
+        setContainerPosition(getContainerPosition(window, inputElement))
       }
     >
       {picker}
@@ -101,6 +117,14 @@ DatePicker.propTypes = {
   /** Callback to set selected date */
   handleDateSelect: PropTypes.func,
 };
+
+/**
+ * Checks if date can be transformed to native js Date object
+ */
+function isDateValid(string) {
+  const date = new Date(string);
+  return date.toString() !== "Invalid Date";
+}
 
 function isoFormattedValueString(valueToFormat) {
   return DateHelper.formatValue(valueToFormat);

--- a/src/__experimental__/components/date/date-picker.spec.js
+++ b/src/__experimental__/components/date/date-picker.spec.js
@@ -192,21 +192,40 @@ describe("DatePicker", () => {
   describe('when the "inputDate" prop have been changed to a different date', () => {
     beforeEach(() => {
       wrapper = render({ inputElement, inputDate: firstDate }, mount);
+      jest.resetAllMocks();
+    });
+    describe("and provided date is valid", () => {
+      it('then "showMonth" method on the "DayPicker" should have been called with the same date', () => {
+        const dayPicker = wrapper.find(DayPicker).instance();
+        const showMonthSpy = spyOn(dayPicker, "showMonth");
+        act(() => {
+          wrapper.setProps({ inputDate: secondDate });
+          global.innerWidth = 100;
+          global.innerHeight = 100;
+
+          // Trigger the window resize event.
+          global.dispatchEvent(new Event("resize"));
+        });
+
+        expect(showMonthSpy).toHaveBeenCalledWith(new Date(secondDate));
+      });
     });
 
-    it('then "showMonth" method on the "DayPicker" should have been called with the same date', () => {
-      const dayPicker = wrapper.find(DayPicker).instance();
-      const showMonthSpy = spyOn(dayPicker, "showMonth");
-      act(() => {
-        wrapper.setProps({ inputDate: secondDate });
-        global.innerWidth = 100;
-        global.innerHeight = 100;
+    describe("and provided date is invalid", () => {
+      it('then "showMonth" method on the "DayPicker" should have been called with previous valid date', () => {
+        const dayPicker = wrapper.find(DayPicker).instance();
+        const showMonthSpy = spyOn(dayPicker, "showMonth");
+        act(() => {
+          wrapper.setProps({ inputDate: "12/42/3213" });
+          global.innerWidth = 100;
+          global.innerHeight = 100;
 
-        // Trigger the window resize event.
-        global.dispatchEvent(new Event("resize"));
+          // Trigger the window resize event.
+          global.dispatchEvent(new Event("resize"));
+        });
+
+        expect(showMonthSpy).toHaveBeenCalledWith(new Date(firstDate));
       });
-
-      expect(showMonthSpy).toHaveBeenCalledWith(moment(secondDate).toDate());
     });
   });
 });

--- a/src/__experimental__/components/date/date.component.js
+++ b/src/__experimental__/components/date/date.component.js
@@ -338,17 +338,15 @@ class BaseDateInput extends React.Component {
   renderDatePicker = (dateRangeProps) => {
     if (!this.state.isDatePickerOpen) return null;
 
-    const { visibleValue, lastValidEventValues } = this.state;
-    const inputDate = DateHelper.isValidDate(visibleValue)
-      ? visibleValue
-      : lastValidEventValues.formattedValue;
+    const { visibleValue } = this.state;
+
     return (
       <div onClick={this.markCurrentDatepicker} role="presentation">
         <DatePicker
           inputElement={this.input && this.input.parentElement}
           selectedDate={this.state.selectedDate}
           handleDateSelect={this.handleDateSelect}
-          inputDate={inputDate}
+          inputDate={visibleValue}
           disablePortal={this.props.disablePortal}
           {...dateRangeProps}
         />

--- a/src/__experimental__/components/date/date.spec.js
+++ b/src/__experimental__/components/date/date.spec.js
@@ -290,14 +290,6 @@ describe("Date", () => {
           expect(wrapper.find(DatePicker).exists()).toBe(true);
           expect(onBlurFn).not.toHaveBeenCalled();
         });
-
-        it("when the visibleValue is invalid it passes the previously valid value to picker", () => {
-          simulateFocusOnInput(wrapper);
-          wrapper.find(BaseDateInput).setState({ visibleValue: "foo" });
-          const picker = wrapper.find(DatePicker);
-          expect(picker.exists()).toBe(true);
-          expect(picker.props().inputDate).toEqual(firstDate);
-        });
       });
 
       describe("and the rawValue is invalid", () => {


### PR DESCRIPTION
### Proposed behaviour
This PR fixes following two issues:
Fixes #3460
Fixes #3560

### Current behaviour
Currently Date input crashes when `allowEmptyValue` is set to `true` and user manually either clears the Textbox or tries to manually type new date in Textbox

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
Storybook -> Experimental -> Date -> Test -> `allowEmptyValue` knob
