### PR TITLE
docs(mdx): standardise mdx documents - FE-3587

### DIFF
--- a/src/__experimental__/components/checkbox/checkbox-validations.stories.mdx
+++ b/src/__experimental__/components/checkbox/checkbox-validations.stories.mdx
@@ -3,7 +3,6 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
 import { Checkbox, CheckboxGroup } from '.';
 
-
 <Meta
   title="Experimental/Checkbox/Validations"
   parameters={{ info: { disable: true }}}

--- a/src/__experimental__/components/checkbox/checkbox.stories.mdx
+++ b/src/__experimental__/components/checkbox/checkbox.stories.mdx
@@ -10,36 +10,33 @@ import { Checkbox, CheckboxGroup } from '.';
 />
 
 # Checkbox
-Checkbox provides a way to efficiently select more than one item from a list.
 
-Disabled or read-only checkboxes might be difficult for a user to distinguish visually, so try to avoid this.
+- Checkbox provides a way to efficiently select more than one item from a list.
 
-Consider ‘smart default’ selections, based on what your user is likely to choose. But, users may well leave the defaults in place, so make sure any consequences are easy to undo, and not harmful.
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
 
-Rather than a checkbox to accept legal terms, consider labelling a button ‘Accept Terms and Continue’ instead.
+## Quick Start
+
+```javascript
+import { Checkbox } from "carbon-react/lib/__experimental__/components/checkbox";
+```
+## Designer Notes
+- Disabled or read-only checkboxes might be difficult for a user to distinguish visually, so try to avoid this.
+- Consider ‘smart default’ selections, based on what your user is likely to choose. But, users may well leave the defaults in place, so make sure any consequences are easy to undo, and not harmful.
+- Rather than a checkbox to accept legal terms, consider labelling a button ‘Accept Terms and Continue’ instead.
 
 ## Related Components
 - Choosing one option from a longer list? [Try Radio Button](/?path=/docs/experimental-radiobutton--default "Radio Button").
 - Choosing one option from a very long list? [Try Select](?path=/docs/design-system-select--default-story "Select").
 - Choosing one option from a highly visible range? [Try Button Toggle](/?path=/story/button-toggle--default "Button Toggle").
 
-## Quick Start
+## Examples
 
-```jsx
-import { Checkbox } from "carbon-react/lib/__experimental__/components/checkbox"
-
-const MyComponent = () => (
-  const [isChecked, setIsChecked] = useState(false);
-  return (
-    <Checkbox
-      label="Label"
-      name="checkbox-name"
-      checked={isChecked}
-      onChange={ e => setIsChecked(e.target.checked) }
-    />
-  )
-);
-```
 ### Default
 
 <Preview>
@@ -138,7 +135,7 @@ const MyComponent = () => (
   </Story>
 </Preview>
 
-# Checkbox Group
+### Checkbox Group
 
 <Preview>
   <Story name="checkbox group">
@@ -188,7 +185,7 @@ The spacing between the legend and the checkboxes can be changed with the `legen
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Checkbox
 

--- a/src/__experimental__/components/date-range/date-range.stories.mdx
+++ b/src/__experimental__/components/date-range/date-range.stories.mdx
@@ -14,9 +14,14 @@ Captures a start and end date.
 
 Used to filter a Table of data according to a start and end date, or to set two dates which are related to each other, for example, a hotel booking.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import DateRange from "carbon-react/lib/__experimental__/components/date-range";
 ```
 
@@ -65,7 +70,7 @@ import DateRange from "carbon-react/lib/__experimental__/components/date-range";
   </Story>
 </Preview>
 
-## Validations
+### Validations
 
 Validation status can be set by passing `startError`, `startWarning`, `startInfo`, `endError`, `endWarning` and `endInfo` props to the component.
 
@@ -75,7 +80,7 @@ Passing a boolean to these props will display only a properly colored border.
 
 For more information check our [Validations](?path=/docs/documentation-validations--page "Validations") documentation page
 
-### As a string
+#### As a string
 
 <Preview>
   <Story name="validations - string - component">
@@ -97,7 +102,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a string, displayed on label
+#### As a string, displayed on label
 
 <Preview>
   <Story name="validations - string - label">
@@ -120,7 +125,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a boolean
+#### As a boolean
 
 <Preview>
   <Story name="validations - boolean">
@@ -142,7 +147,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-## Allow Empty Value
+### Allow Empty Value
 
 You can pass prop `allowEmptyValue` to start and end `DateInput` using `startDateProps` and `endDateProps`.
 
@@ -160,6 +165,8 @@ You can pass prop `allowEmptyValue` to start and end `DateInput` using `startDat
   </Story>
 </Preview>
 
-## Props:
+## Props
+
+### Date Range
 
 <Props of={DateRange} />

--- a/src/__experimental__/components/date/date.stories.mdx
+++ b/src/__experimental__/components/date/date.stories.mdx
@@ -17,11 +17,17 @@ import Box from "../../../components/box";
 - Field focus automatically opens the datepicker, but a user can key in dates too, which many users find more convenient, especially in financial applications.
 - Carbon handles a range of formats, like dd/mm/yyyy, dd/mm/yy, dd/mm, or dd. Configuration can be regional, and copes with space, slash, full stop, or colon as separators.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import DateInput from "carbon-react/lib/__experimental__/components/date";
 ```
+## Examples
 
 ### Default
 
@@ -176,7 +182,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-## Validations
+### Validations
 
 Validation status can be set by passing `error`, `warning` or `info` prop to the component
 
@@ -186,7 +192,7 @@ Passing a boolean to these props will display only a properly colored border.
 
 For more information check our [Validations](?path=/docs/documentation-validations--page "Validations") documentation page
 
-### As a string
+#### As a string
 
 <Preview>
   <Story name="validations - string - component">
@@ -212,7 +218,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a string, displayed on label
+#### As a string, displayed on label
 
 <Preview>
   <Story name="validations - string - label">
@@ -240,7 +246,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a boolean
+#### As a boolean
 
 <Preview>
   <Story name="validations - boolean">
@@ -264,7 +270,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### DateInput
 

--- a/src/__experimental__/components/decimal/decimal.stories.mdx
+++ b/src/__experimental__/components/decimal/decimal.stories.mdx
@@ -12,19 +12,29 @@ import Box from "../../../components/box";
 />
 
 # Decimal
+Captures a number with a decimal point, or a currency value.
 
-- Captures a number with a decimal point, or a currency value.
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
+
+
+## Quick Start
+
+```javascript
+import Decimal from "carbon-react/lib/__experimental__/components/decimal";
+```
+
+## Designer Notes
 - For currency values, show currency symbols outside the field rather than inserting one for the user dynamically.
 - Carbon offers a Precision configuration, so you can choose how many decimal places to show.
 - Decimals are usually right-aligned, so that the decimal places of numbers presented in rows line up for easy comparison by the user.
 - Even if the user just enters a string of numbers, consider presenting them into a format with the separators which apply in the user’s country (e.g. £12,345.67 for the UK, and €12 345,67 for France).
 - Where it’s clear a field only accepts numerals, you could disable entry of other characters - but remember to cater for a minus sign if necessary.
 
-## Quick Start
-
-```jsx
-import Decimal from "carbon-react/lib/__experimental__/components/decimal";
-```
+## Examples
 
 ### Default
 
@@ -167,7 +177,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-## Validations
+### Validations
 
 Validation status can be set by passing `error`, `warning` or `info` prop to the component
 
@@ -177,7 +187,7 @@ Passing a boolean to these props will display only a properly colored border.
 
 For more information check our [Validations](?path=/docs/documentation-validations--page "Validations") documentation page
 
-### As a string
+#### As a string
 
 <Preview>
   <Story name="validations - string - component">
@@ -203,7 +213,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a string, displayed on label
+#### As a string, displayed on label
 
 <Preview>
   <Story name="validations - string - label">
@@ -231,7 +241,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a boolean
+#### As a boolean
 
 <Preview>
   <Story name="validations - boolean">
@@ -257,7 +267,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Decimal
 

--- a/src/__experimental__/components/fieldset/fieldset.stories.mdx
+++ b/src/__experimental__/components/fieldset/fieldset.stories.mdx
@@ -14,11 +14,18 @@ import Form from '../../../components/form';
 - Useful for presenting a series of inputs that are closely related, within a wider Form or Pod (e.g. an address or contact details).
 - Configure Pod and Fieldset components to work together, or choose the pre-configured Show/Edit Pod component.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import Fieldset from "carbon-react/lib/__experimental__/components/fieldset";
 ```
+
+## Examples
 
 ### Default
 
@@ -96,9 +103,9 @@ You can manipulate the spacings beetwen `Fieldset` components by passing `fieldS
   </Story>
 </Preview>
 
-## Validations
+### Validations
 
-### As a string
+#### As a string
 
 <Preview>
   <Story name="validations - string - component">
@@ -137,7 +144,7 @@ You can manipulate the spacings beetwen `Fieldset` components by passing `fieldS
   </Story>
 </Preview>
 
-### As a string, displayed on label
+#### As a string, displayed on label
 
 <Preview>
   <Story name="validations - string - label">
@@ -178,7 +185,7 @@ You can manipulate the spacings beetwen `Fieldset` components by passing `fieldS
   </Story>
 </Preview>
 
-### As a boolean
+#### As a boolean
 
 <Preview>
   <Story name="validations - boolean">
@@ -217,6 +224,7 @@ You can manipulate the spacings beetwen `Fieldset` components by passing `fieldS
   </Story>
 </Preview>
 
-### Props
+## Props
 
+### Fieldset
 <Props of={Fieldset} />

--- a/src/__experimental__/components/grouped-character/grouped-character.stories.mdx
+++ b/src/__experimental__/components/grouped-character/grouped-character.stories.mdx
@@ -17,11 +17,17 @@ Capture data with punctuation inside the field.
 
 Fields can have punctuation within them (most commonly characters like - or /). This gives the user a clue about the format accepted.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import GroupedCharacter from "carbon-react/lib/__experimental__/components/grouped-character";
 ```
+## Examples
 
 ### Default
 
@@ -228,7 +234,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-## Validations
+### Validations
 
 Validation status can be set by passing `error`, `warning` or `info` prop to the component
 
@@ -238,7 +244,7 @@ Passing a boolean to these props will display only a properly colored border.
 
 For more information check our [Validations](?path=/docs/documentation-validations--page "Validations") documentation page
 
-### As a string
+#### As a string
 
 <Preview>
   <Story name="validations - string - component">
@@ -268,7 +274,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a string, displayed on label
+#### As a string, displayed on label
 
 <Preview>
   <Story name="validations - string - label">
@@ -300,7 +306,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a boolean
+#### As a boolean
 
 <Preview>
   <Story name="validations - boolean">
@@ -330,7 +336,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### GroupedCharacter
 

--- a/src/__experimental__/components/number/number.stories.mdx
+++ b/src/__experimental__/components/number/number.stories.mdx
@@ -14,11 +14,17 @@ import Box from "../../../components/box";
 
 Capture whole numbers - without a decimal point.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import Number from "carbon-react/lib/__experimental__/components/number";
 ```
+## Examples
 
 ### Default
 
@@ -144,7 +150,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-## Validations
+### Validations
 
 Validation status can be set by passing `error`, `warning` or `info` prop to the component
 
@@ -154,7 +160,7 @@ Passing a boolean to these props will display only a properly colored border.
 
 For more information check our [Validations](?path=/docs/documentation-validations--page "Validations") documentation page
 
-### As a string
+#### As a string
 
 <Preview>
   <Story name="validations - string - component">
@@ -180,7 +186,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a string, displayed on label
+#### As a string, displayed on label
 
 <Preview>
   <Story name="validations - string - label">
@@ -208,7 +214,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a boolean
+#### As a boolean
 
 <Preview>
   <Story name="validations - boolean">
@@ -234,7 +240,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Number
 

--- a/src/__experimental__/components/numeral-date/numeral-date.stories.mdx
+++ b/src/__experimental__/components/numeral-date/numeral-date.stories.mdx
@@ -8,15 +8,18 @@ import NumeralDate from ".";
 />
 
 # Numeral Date
-
 For dates far from today, use this Numeral Date component. It is advised to use Three inputs consisting of day, month, and year.
 For dates close to today, we advise the use of a standard datepicker. If you require this, please see the "Date Input" component.
 
-## Quick Start
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
 
+## Quick Start
 Import `NumeralDate` into the project.
 
-```jsx
+```javascript
 import NumeralDate from "carbon-react/lib/__experimental__/components/numeral-date";
 ```
 
@@ -160,14 +163,12 @@ import NumeralDate from "carbon-react/lib/__experimental__/components/numeral-da
   </Story>
 </Preview>
 
-## Internal validation
-
+### Internal validation
 `NumeralDate` has an optional internal validation mechanism implemented to check if the date partial values are correct.
 To enable `error` internal validation pass `enableInternalError` and to enable `warning` pass `enableInternalWarning`.
 To override default messages translations can be provided with following keys: `numeralDate.day`, `numeralDate.month`, `numeralDate.year`.
 
 #### As error
-
 When using the internal validations as error it is necessary to also provide an external validation to avoid situations where it is possible to submit a form while `NumeralDate` clearly indicates that the date is incorrect.
 
 <Preview>
@@ -189,7 +190,6 @@ When using the internal validations as error it is necessary to also provide an 
 </Preview>
 
 #### As warning
-
 When using the internal validations as warning the external validation is not necessary, in this case internal warnings can be treated as feedback.
 
 <Preview>
@@ -224,7 +224,6 @@ When using the internal validations as warning the external validation is not ne
 </Preview>
 
 ### Enabling the adaptive behaviour
-
 The inline label can change to be top aligned at a breakpoint. Enable this by passing in a number to the `adaptiveLabelBreakpoint` prop. This corresponds to a px screen width
 
 <Preview>
@@ -267,7 +266,6 @@ The inline label can change to be top aligned at a breakpoint. Enable this by pa
 </Preview>
 
 ### Required
-
 You can use the `required` prop to indicate if the field is mandatory.
 
 <Preview>
@@ -282,4 +280,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
+## Props 
+
+### NumeralDate
 <Props of={NumeralDate} />

--- a/src/__experimental__/components/radio-button/radio-button.stories.mdx
+++ b/src/__experimental__/components/radio-button/radio-button.stories.mdx
@@ -11,6 +11,23 @@ import Typography from '../../../components/typography';
 
 # RadioButton/RadioButtonGroup
 Used to provide a group of selectable radio buttons.
+
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start 
+
+To use these components, import both `RadioButtonGroup` and `RadioButton`, and pass the radio buttons as children of the radio group.
+
+```javascript
+import { RadioButton, RadioButtonGroup } from "carbon-react/lib/__experimental__/components/radio-button";
+```
+
+## Designer Notes
 Consider ‘smart default’ selections, based on what your user is likely to choose. But, users may well leave the defaults in place, so make sure any consequences are easy to undo, and not harmful.
 Useful to show less than about 10 options.
 Disabled or read-only radio buttons might be difficult for a user to distinguish visually, so try to avoid this.
@@ -20,27 +37,7 @@ Disabled or read-only radio buttons might be difficult for a user to distinguish
 - Choosing more than one option? [Try Checkbox](/?path=/docs/experimental-checkbox--default "Try Checkbox").
 - Choosing one option from a highly visible small range? [Try Button Toggle](/?path=/story/button-toggle--default "Try Button Toggle").
 
-## Quick Start 
-
-To use these components, import both `RadioButtonGroup` and `RadioButton`, and pass the radio buttons as children of the radio group.
-
-```jsx
-import { RadioButton, RadioButtonGroup } from "carbon-react/lib/__experimental__/components/radio-button";
-
-const MyComponent = () => (
-  <RadioButtonGroup
-    name="mybuttongroup"
-    onChange={ handleChange }
-  >
-    <RadioButton id="radio1" value="radio1" />
-    <RadioButton id="radio2" value="radio2" />
-    <RadioButton id="radio3" value="radio3" />
-
-  </RadioButtonGroup>
-)
-```
-
-## Visuals
+## Examples
 
 ### With legend and labels
 A legend can be set for the group, and each radio button can have a label.

--- a/src/__experimental__/components/search/search.stories.mdx
+++ b/src/__experimental__/components/search/search.stories.mdx
@@ -9,12 +9,19 @@ import Box from '../../../components/box';
 # Search
 This search component should be used if you require the user to conduct a search.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 Import `Search` into the project.
 
-```jsx
+```javascript
 import Search from 'carbon-react/lib/__experimental__/components/search';
 ```
+
+## Examples
 
 ### Search without Search Button and default width
 
@@ -141,4 +148,6 @@ In this example the `variant` prop is "dark" and no search button is present.
 </Preview>
 
 ## Props
+
+### Search
 <Props of={Search} />

--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.stories.mdx
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.stories.mdx
@@ -13,11 +13,18 @@ import Box from "../../../components/box";
 
 - Choose from a small palette of pre-set colours, with indication of a currently selected colour.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import SimpleColorPicker from "carbon-react/lib/__experimental__/components/simple-color-picker";
 ```
+
+## Examples
 
 ### Default
 
@@ -122,7 +129,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-## Validations
+### Validations
 
 Validation status can be set by passing `error`, `warning` or `info` prop to the component
 
@@ -132,7 +139,7 @@ Passing a boolean to these props will display only a properly colored border.
 
 For more information check our [Validations](?path=/docs/documentation-validations--page "Validations") documentation page
 
-### As a string
+#### As a string
 
 <Preview>
   <Story name="validations - string - component">
@@ -169,7 +176,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a string, displayed on legend
+#### As a string, displayed on legend
 
 <Preview>
   <Story name="validations - string - label">
@@ -207,7 +214,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a boolean
+#### As a boolean
 
 <Preview>
   <Story name="validations - boolean">
@@ -244,7 +251,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### SimpleColorPicker
 

--- a/src/__experimental__/components/switch/switch.stories.mdx
+++ b/src/__experimental__/components/switch/switch.stories.mdx
@@ -17,6 +17,18 @@ Disabled or read-only Switches might be difficult for a user to distinguish visu
 
 Consider ‘smart default’ selections, based on what your user is likely to choose. But, users may well leave the defaults in place, so make sure any consequences are easy to undo, and not harmful.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import Switch from "carbon-react/lib/__experimental__/components/switch"
+```
+
 ## Related Components
 - Choosing more than one option? [Try Checkbox](/?path=/docs/experimental-checkbox--default-story "Checkbox").
 - Choosing one option from a longer list? [Try Radio Button](/?path=/docs/experimental-radiobutton--default "Radio Button").
@@ -27,23 +39,8 @@ Consider ‘smart default’ selections, based on what your user is likely to ch
 
 The switch component uses `switch.on` and `switch.off` to retrieve the translations from I18n-js.
 
-## Quick Start
+## Examples
 
-```jsx
-import Switch from "carbon-react/lib/__experimental__/components/switch"
-
-const MyComponent = () => (
-  const [isChecked, setIsChecked] = useState(false);
-  return (
-    <Switch
-      label="Label"
-      name="switch-name"
-      checked={isChecked}
-      onChange={ e => setIsChecked(e.target.checked) }
-    />
-  )
-);
-```
 ### Default
 
 <Preview>
@@ -163,7 +160,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-## Validations
+### Validations
 
 Validation status can be set by passing `error`, `warning` or `info` prop to the component
 
@@ -173,7 +170,7 @@ Passing a boolean to these props will display only a properly colored border.
 
 For more information check our [Validations](?path=/docs/documentation-validations--page "Validations") documentation page
 
-### As a string
+#### As a string
 
 <Preview>
   <Story name="single switch - string validation">
@@ -189,7 +186,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a string with validationOnLabel
+#### As a string with validationOnLabel
 
 <Preview>
   <Story name="single switch - string validation - validationOnLabel">
@@ -206,7 +203,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a boolean
+#### As a boolean
 <Preview>
   <Story name="single switch - boolean validation">
     {() => ['error', 'warning', 'info'].map(type => (
@@ -221,7 +218,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Switch
 

--- a/src/__experimental__/components/textarea/textarea.stories.mdx
+++ b/src/__experimental__/components/textarea/textarea.stories.mdx
@@ -13,11 +13,18 @@ import Box from "../../../components/box";
 - If content in a textarea is read-only, remove the field border so it appears as static text.
 - Use placeholder text to give the user context or examples of what to write.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import Textarea from "carbon-react/lib/__experimental__/components/textarea";
 ```
+
+## Examples
 
 ### Default
 
@@ -175,7 +182,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-## Validations
+### Validations
 
 Validation status can be set by passing `error`, `warning` or `info` prop to the component
 
@@ -185,7 +192,7 @@ Passing a boolean to these props will display only a properly colored border.
 
 For more information check our [Validations](?path=/docs/documentation-validations--page "Validations") documentation page
 
-### As a string
+#### As a string
 
 <Preview>
   <Story name="validations - string - component">
@@ -209,7 +216,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a string, displayed on label
+#### As a string, displayed on label
 
 <Preview>
   <Story name="validations - string - label">
@@ -235,7 +242,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a boolean
+#### As a boolean
 
 <Preview>
   <Story name="validations - boolean">
@@ -255,7 +262,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Textarea
 

--- a/src/__experimental__/components/textbox/textbox.stories.mdx
+++ b/src/__experimental__/components/textbox/textbox.stories.mdx
@@ -9,17 +9,26 @@ import Textbox, { OriginalTextbox } from ".";
 
 Captures a single line of text.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import Textbox from "carbon-react/lib/__experimental__/components/textbox";
+```
+
+## Designer Notes
 - Use placeholder text to give the user examples of data formats (e.g. AB123456C for a UK National Insurance number).
 - Use prefixes if your data always begins with a certain sequence (e.g. a UK VAT number usually starts with ‘GB’).
 - If content in a textbox is never editable, think about removing the field border so it appears as static text.
 - You can disable a textbox, but try to avoid this. If you need to, make it clear what the user needs to do in order to activate the textbox.
 - Use wider fields for longer data (e.g. an address line), and narrower fields for shorter data (e.g. a postcode), to give the user a clue about the data expected.
 
-## Quick Start
-
-```jsx
-import Textbox from "carbon-react/lib/__experimental__/components/textbox";
-```
+## Examples
 
 ### Default
 
@@ -147,7 +156,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-## Validations
+### Validations
 
 Validation status can be set by passing `error`, `warning` or `info` prop to the component
 
@@ -157,7 +166,7 @@ Passing a boolean to these props will display only a properly colored border.
 
 For more information check our [Validations](?path=/docs/documentation-validations--page "Validations") documentation page
 
-### As a string
+#### As a string
 
 <Preview>
   <Story name="validations - string - component">
@@ -183,7 +192,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a string, displayed on label
+#### As a string, displayed on label
 
 <Preview>
   <Story name="validations - string - label">
@@ -211,7 +220,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-### As a boolean
+#### As a boolean
 
 <Preview>
   <Story name="validations - boolean">
@@ -237,7 +246,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Textbox
 

--- a/src/components/accordion/accordion.stories.mdx
+++ b/src/components/accordion/accordion.stories.mdx
@@ -15,37 +15,35 @@ import Box from '../box';
 />
 
 # Accordion
-Group, hide and show content.
-
-## Overview
 Accordions are a good progressive disclosure technique - initially showing only top-level information, but allowing the user quick access to more on request. But, they can confuse users sometimes, so use them sparingly.
 
-## Guidance, hints and tips
-
-Don’t put accordions within accordions.
-
-Don’t hide important controls within accordions - for example, primary actions should always be outside them.
-
-Accordions expand and collapse vertically. If there are lots, or content is extensive, be careful that the user doesn’t become confused, lose their place, or have problems with discoverability. Use them sparingly for these reasons.
-
-Accordions should remain open or closed until a user interacts with them. Consider whether multiple, or only one accordion section can be open at a time.
-
-An arrow icon pointing down indicates that the accordion is closed.
-
-An arrow icon pointing up indicates that the accordion is open.
-
-The icon can animate when a transition is made.
-
-The user can click the icon directly, the text label, or the text label’s background to action the accordion.
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
 
 ## Quick Start
+To use accordion, import the `Accordion` and pass the content as children. To group accordions import `AccordionGroup`. 
 
-To use accordion, import the `Accordion` and pass the content as children.
+```javascript
+import { Accordion, AccordionGroup } from "carbon-react/lib/components/accordion"
+```
+
+## Designer Notes
+- Don’t put accordions within accordions.
+- Don’t hide important controls within accordions - for example, primary actions should always be outside them.
+- Accordions expand and collapse vertically. If there are lots, or content is extensive, be careful that the user doesn’t become confused, lose their place, or have problems with discoverability. Use them sparingly for these reasons.
+- Accordions should remain open or closed until a user interacts with them. Consider whether multiple, or only one accordion section can be open at a time.
+- An arrow icon pointing down indicates that the accordion is closed.
+- An arrow icon pointing up indicates that the accordion is open.
+- The icon can animate when a transition is made.
+- The user can click the icon directly, the text label, or the text label’s background to action the accordion.
 
 It can be used as a controlled component where the expansion state is controlled externally,
 in that case both `onChange` and `expanded` props are required.
 
-```jsx
+```javascript
 import { Accordion } from "carbon-react/lib/components/accordion"
 
 const MyComponent = () => (
@@ -58,7 +56,7 @@ const MyComponent = () => (
 It can also be used as an uncontrolled component where the expansion state is controlled internally.
 It is still possible to pass `onChange` to hook a callback for state changes, however to set initial expansion state `defaultExpanded` can be passed.
 
-```jsx
+```javascript
 import { Accordion } from "carbon-react/lib/components/accordion"
 
 const MyComponent = () => (
@@ -68,10 +66,11 @@ const MyComponent = () => (
 );
 ```
 
-## Visuals
+## Examples
 
 ### Default
 Default version of accordion has white background and no side borders.
+
 <Preview>
   <Story name="default">
     <Accordion title='Heading'>
@@ -84,6 +83,7 @@ Default version of accordion has white background and no side borders.
 
 ### With disableContentPadding
 Accordion without padding inside of the content.
+
 <Preview>
   <Story parameters={{ chromatic: { disable: true }}} name="with disableContentPadding">
     <Accordion disableContentPadding title='Heading'>
@@ -96,6 +96,7 @@ Accordion without padding inside of the content.
 
 ### Transparent
 Transparent scheme has transparent background.
+
 <Preview>
   <Story name="transparent" parameters={{ chromatic: { disable: true }}}>
     <Accordion scheme="transparent" title='Heading'>
@@ -108,6 +109,7 @@ Transparent scheme has transparent background.
 
 ### Small
 Small version has a smaller heading and less padding.
+
 <Preview>
   <Story name="small">
     <Accordion size="small" title='Heading'>
@@ -120,6 +122,7 @@ Small version has a smaller heading and less padding.
 
 ### Sub title
 A sub title can be added when the size is large (default).
+
 <Preview>
   <Story name="sub title">
     <Accordion subTitle='Sub title' title='Heading'>
@@ -132,6 +135,7 @@ A sub title can be added when the size is large (default).
 
 ### Full border
 The accordion can have side borders along with the default top and bottom.
+
 <Preview>
   <Story name="full border">
     <Accordion borders='full' title='Heading'>
@@ -144,6 +148,7 @@ The accordion can have side borders along with the default top and bottom.
 
 ### Left aligned icon
 The accordion icon can be left aligned.
+
 <Preview>
   <Story name="icon left">
     <Accordion iconAlign='left' title='Heading'>
@@ -156,6 +161,7 @@ The accordion icon can be left aligned.
 
 ### Different width
 The default width of 100% can be overriden.
+
 <Preview>
   <Story name="different width">
     <Accordion width="500px" title='Heading'>
@@ -167,6 +173,7 @@ The default width of 100% can be overriden.
 </Preview>
 
 ### With different padding and margin
+Showing the different paddings and margins
 
 <Preview>
   <Story name="with different padding and margin">
@@ -197,6 +204,7 @@ The default width of 100% can be overriden.
 </Preview>
 
 ### With different padding and margin in Accordion title
+Showing the different paddings and margins within the accordion title
 
 <Preview>
   <Story name="with different padding and margin in Accordion title">
@@ -227,6 +235,7 @@ The default width of 100% can be overriden.
 </Preview>
 
 ### With Box component and different paddings
+The box component can be used inside the accordion with different paddings
 
 <Preview>
   <Story name="with Box component and different paddings" parameters={{ chromatic: { disable: true }}}>
@@ -313,6 +322,7 @@ The default width of 100% can be overriden.
 ### Opening button
 A button can be passed in to replace the title and opening icon. 
 This is not currently designed to be used within a form using validation.
+
 <Preview>
   <Story name="opening button">
     <Accordion
@@ -331,13 +341,9 @@ This is not currently designed to be used within a form using validation.
 </Preview>
 
 ### Grouped
-Accordions borders collapse when positioned next to each other making it easy to group them.
+To group accordions import `AccordionGroup`. Accordions borders collapse when positioned next to each other making it easy to group them.
 To achieve proper keyboard accessibility as described in `W3` sources it is required to wrap neighbouring accordions in
 `AccordionGroup`.
-
-```jsx
-import { Accordion, AccordionGroup } from "carbon-react/lib/components/accordion"
-```
 
 <Preview>
   <Story id="design-system-accordion-test--grouped" name="grouped">
@@ -477,7 +483,6 @@ Accordion adjust it's height properly when it's content is being dynamically cha
   </Story>
 </Preview>
 
-
 ### With overriden styles
 Accordion styles can be easily overriden by providing `styleOverride` prop with proper structure as defined in propTypes.
 
@@ -507,6 +512,8 @@ Accordion styles can be easily overriden by providing `styleOverride` prop with 
 </Preview>
 
 ### With a definition list
+Accordion with a definiton list
+
 <Preview>
   <Story name="with a definition list" parameters={{ chromatic: { disable: true }}}>
     <Accordion title='Heading' expanded={true}>
@@ -541,5 +548,8 @@ Accordion styles can be easily overriden by providing `styleOverride` prop with 
   </Story>
 </Preview>
 
-<Props of={Accordion} />
-<StyledSystemProps of={Accordion} spacing />
+## Props
+
+### Accordion
+
+<StyledSystemProps of={Accordion} noHeader spacing />

--- a/src/components/action-popover/action-popover.stories.mdx
+++ b/src/components/action-popover/action-popover.stories.mdx
@@ -25,10 +25,29 @@ import {
 <Meta title="Design System/Action Popover" parameters={{info: { disable: true }, chromatic: { disable: true }}} />
 
 # ActionPopover
-
 ActionPopovers present a handy list of actions the user can perform on a whole table, a specific row within a table, or a tile.
-
 Click the ellipsis icon to show actions the user can take on a specific table row, for example, emailing the invoice.
+
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+To use action popover, import `ActionPopover` alongside `ActionPopoverItem` and the other components that you would like to use in relation,
+to the action popover. 
+
+```javascript
+import {  
+  ActionPopover, 
+  ActionPopoverDivider, 
+  ActionPopoverItem, 
+  ActionPopoverMenu, 
+  ActionPopoverMenuButton
+} from "carbon-react/lib/components/action-popover"
+```
 
 ## Designer Notes
 - Action Popovers only perform commands - they aren’t used to collect data, or choose between data items as in a form.
@@ -46,10 +65,15 @@ left, right, or above the element that generates it.
 - Doesn’t relate to a single table row or tile? <LinkTo kind='Split Button' story='default'>Try Split Button</LinkTo>, or 
 <LinkTo kind='Multi Action Button' story='default'>Multi Action Button</LinkTo>.
 
+## Examples
 
-<Story id="design-system-action-popover-test--default" />
+### Default
+Story showing most of the functionality of the action popover and what can be achieved by using it
+<Preview>
+  <Story id="design-system-action-popover-test--default" />
+</Preview>
 
-## with icons
+### With icons
 Each item is clickable and represents an action to be taken on a given row.
 <Preview>
   <Story name="with icons">
@@ -81,7 +105,7 @@ Each item is clickable and represents an action to be taken on a given row.
   </Story>
 </Preview>
 
-## with disabled item
+### With disabled item
 ActionPopoverItem&apos;s can be disabled and will not dispatch an action but can still be navigated with the keyboard.
 <Preview>
   <Story name="with disabled item">
@@ -114,7 +138,7 @@ ActionPopoverItem&apos;s can be disabled and will not dispatch an action but can
   </Story>
 </Preview>
 
-## with menu right aligned
+### With menu right aligned
 It is possible to align the Menu to the right of the MenuButton by passing the &quot;rightAlignMenu&quot; to ActionPopover
 <Preview>
   <Story name="with menu right aligned">
@@ -147,7 +171,7 @@ It is possible to align the Menu to the right of the MenuButton by passing the &
   </Story>
 </Preview>
 
-## with no icons
+### With no icons
 Menu items can also be displayed without icons.
 <Preview>
   <Story name="with no icons">
@@ -177,7 +201,7 @@ Menu items can also be displayed without icons.
 </Preview>
 
 
-## with custom menu button
+### With custom menu button
 It is possible to use the &quot;renderButton&quot; prop to override the default button used to trigger the opening and closing of 
 ActionPopoverMenu. See the prop tables below for the properties surfaced to any custom component being passed in.
 <Preview>
@@ -250,7 +274,7 @@ ActionPopoverMenu. See the prop tables below for the properties surfaced to any 
 </Preview>
 
 
-## with submenu
+### With submenu
 A menu item can be passed a sub-menu to add further sub-actions if needed. items with sub-menus will display an chevron 
 icons pointing in the direction that the sub-menu will open; by default it will open to the left.
 
@@ -298,7 +322,7 @@ leave.
   </Story>
 </Preview>
 
-## with disabled submenu
+### With disabled submenu
 A sub-menu will not open if the item is in a disabled state.
 <Preview>
   <Story name="with disabled submenu">
@@ -341,7 +365,7 @@ A sub-menu will not open if the item is in a disabled state.
   </Story>
 </Preview>
 
-## with submenu aligned right
+### With submenu aligned right
 The sub-menu will open to the right side when there is no space to render the sub-menu to the left.
 <Story name="with submenu aligned right" parameters={{ docs: { disable: true }}}>
   <div style={{ height: '250px' }}>
@@ -388,7 +412,7 @@ The sub-menu will open to the right side when there is no space to render the su
   />
 </MyPreview>
 
-## with menu opening above
+### With menu opening above
 The menu can also be rendered above the button control by setting using `placement="top"`.
 <Preview>
   <Story name="with menu opening above">
@@ -430,7 +454,7 @@ The menu can also be rendered above the button control by setting using `placeme
   </Story>
 </Preview>
 
-## keyboard navigation 
+### Keyboard navigation 
 ActionPopover and ActionPopoverItem have extensive keyboard support. It is possible to open the menu when the
 ActionPopover is focused: pressing either the "enter" or "down" key will open the menu and focus the first item; 
 pressing the "up" key when the button is focused will open the menu and focus the last element.
@@ -486,7 +510,7 @@ or "tab" key will close the menu with no action being triggered and focus the ne
   </Story>
 </Preview>
 
-## keyboard navigation left aligned submenu
+### Keyboard navigation left aligned submenu
 Sub-menus can be accessed via the keyboard as well, when the sub-menu is left aligned it can be opened by navigating to 
 the parent item and pressing the "left" key. The same accessible shortcuts described above can then be used to navigate 
 the sub-menu. Pressing the "right" key will return focus back to the main menu and close the sub-menu without 
@@ -547,7 +571,7 @@ triggering an action.
   </Story>
 </Preview>
 
-## keyboard navigation right aligned submenu
+### Keyboard navigation right aligned submenu
 When sub-menus aligns to the right hand side, the key shortcuts are switiched: pressingt the "right" key whilst focus 
 is on a item will open a sub-menu if it has one and pressing the "left" key will close it. 
 <Story name="keyboard access right aligned submenu" parameters={{ docs: { disable: true }}}>
@@ -611,7 +635,7 @@ is on a item will open a sub-menu if it has one and pressing the "left" key will
   />
 </MyPreview>
 
-## with additional options
+### With additional options
 
 When a row has many actions you may choose to incldue the primary actions with a dedicated action to for less frequently
 used actions, in this example "manage devices".
@@ -828,6 +852,7 @@ It is possible to utilise the selected and onClick props on the FlatTableRow to 
   </Story>
 </Preview>
 
+## Props
 ### ActionPopover Props
 <Props of={ActionPopover} />
 

--- a/src/components/advanced-color-picker/advanced-color-picker.stories.mdx
+++ b/src/components/advanced-color-picker/advanced-color-picker.stories.mdx
@@ -5,8 +5,24 @@ import { useState } from 'react';
 <Meta title="Design System/Advanced Color Picker" />
 
 # Advanced Color Picker
+Selects a single colour from a defined set.
 
-### Default usage:
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+To use advanced color picker, import `AdvancedColorPicker`
+
+```javascript
+import AdvancedColorPicker from "carbon-react/lib/components/advanced-color-picker"
+```
+
+## Examples
+
+### Basic usage
+Shows how the color picker can be used to select a color from a predefined set.
 
 <Preview>
   <Story name="default" parameters={{ info: { disable: true }}} >
@@ -46,8 +62,7 @@ import { useState } from 'react';
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### AdvancedColorPicker
-
 <Props of={AdvancedColorPicker} />

--- a/src/components/alert/alert.stories.mdx
+++ b/src/components/alert/alert.stories.mdx
@@ -15,13 +15,24 @@ import Button from '../button';
 # Alert
 An important message that interrupts user activity, but can be dismissed.
 
-Useful if a message is so important you’d like to prevent any other activity until the user resolves it.
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
 
-If the message isn’t so important, or you want to avoid disrupting the user’s activity, consider showing a static Message component in the underlying screen.
+## Quick Start
 
-Include a Message component within the Alert component, use plain text, or apply a standard Carbon Error or Warning icon.
+```javascript
+import Alert from "carbon-react/lib/components/alert";
+```
 
-This component has the same options and properties as the Dialog component.
+## Designer Notes
+- Useful if a message is so important you’d like to prevent any other activity until the user resolves it.
+- If the message isn’t so important, or you want to avoid disrupting the user’s activity, consider showing a static Message component in the underlying screen.
+- Include a Message component within the Alert component, use plain text, or apply a standard Carbon Error or Warning icon.
+- This component has the same options and properties as the Dialog component.
 
 ## Related Components
 - Longer message which stays on-screen? [Try Message](/?path=/docs/message--default-story "Try Message").
@@ -29,24 +40,7 @@ This component has the same options and properties as the Dialog component.
 - Confirm or cancel an action I’ve initiated? [Try Confirm](/?path=/docs/confirm--default-story "Try Confirm").
 - Simple task in context? [Try Dialog](/?path=/docs/dialog--default-story "Try Dialog").
 
-## Quick Start
-
-Import the component and use as shown below:
-
-```jsx
-import Alert from "carbon-react/lib/components/alert";
-
-const MyComponent = ({ isOpen, handleClose }) => (
-  <Alert
-    onCancel={ handleClose }
-    title="Title"
-    subtitle="Subtitle"
-    open={ isOpen }
-  >
-    This is an example of an alert
-  </Alert>
-);
-```
+## Examples 
 
 ### Default
 
@@ -73,7 +67,7 @@ const MyComponent = ({ isOpen, handleClose }) => (
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Alert
 

--- a/src/components/anchor-navigation/anchor-navigation.stories.mdx
+++ b/src/components/anchor-navigation/anchor-navigation.stories.mdx
@@ -11,10 +11,20 @@ import Textbox from '../../__experimental__/components/textbox';
 # Anchor Navigation
 Easily navigate through long scrollable content.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
+To use `AnchorNavigation` import `AnchorNavigation`, `AnchorNavigationItem` and `AnchorSectionDivider` from Carbon.
 
-To use `AnchorNavigation` first import `AnchorNavigation`, `AnchorNavigationItem` and `AnchorSectionDivider` from Carbon.
+```javascript
+import { AnchorNavigation, AnchorNavigationItem, AnchorSectionDivider } from "carbon-react/lib/components/anchor-navigation"
+```
 
+## Designer Notes 
 Create `refs` which will be used internally in `AnchorNavigation` to measure positions of the elements.
 
 Pass proper structure of `AnchorNavigationItem`'s with assigned `refs` to `stickyNavigation` prop.
@@ -24,9 +34,7 @@ Keep in mind that to assign a `ref` to a component it either has to be a `Class`
 
 **It is necessary to mantain the same order of navigation items and children when assigning the `refs`**
 
-```jsx
-import { AnchorNavigation, AnchorNavigationItem, AnchorSectionDivider } from "carbon-react/lib/components/anchor-navigation"
-
+```javascript
 const MyComponent = () => (
   const ref1 = React.createRef();
   const ref2 = React.createRef();
@@ -62,6 +70,8 @@ const MyComponent = () => (
 );
 ```
 
+## Examples
+
 ### Default
 `AnchorNavigation` can be placed anywhere on the page to help with navigating long scrollable sections.
 
@@ -79,7 +89,7 @@ const MyComponent = () => (
 
 <Story id="test-anchornavigation--with-overriden-styles" name="WithOverridenStyles" />
 
-## Props:
+## Props
 
 ### AnchorNavigation
 

--- a/src/components/app-wrapper/app-wrapper.stories.mdx
+++ b/src/components/app-wrapper/app-wrapper.stories.mdx
@@ -8,21 +8,17 @@ import AppWrapper from '.';
 
 AppWrapper manages the width and containment of your application.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
-Import `AppWrapper` into the project.
 
-```jsx
+```javascript
 import AppWrapper from "carbon-react/lib/components/app-wrapper";
-
-const MyComponent = () => (
-  <AppWrapper>
-    <div>
-      Something in here
-    </div>
-  </AppWrapper>
-);
-
 ```
+## Examples
 
 ### Default
 <Preview>
@@ -89,4 +85,7 @@ can clearly see the component.
 </Preview>
 
 ## Props
+
+### AppWrapper
+
 <Props of={AppWrapper} />

--- a/src/components/badge/badge.stories.mdx
+++ b/src/components/badge/badge.stories.mdx
@@ -6,27 +6,22 @@ import Button from '../button'
 <Meta title="Design System/Badge" parameters={{ info: { disable: true } }} />
 
 # Badge
+Compact visual indicators that help things in common stand out.
 
-## Overview
 
-This kind of component is especialy usable for notifications
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
 
 ## Quick Start
+To use Badge component you need to import `Badge` and use another component as a child.
 
-To use `Badge` component you need to put other component as a child.
-
-```jsx
+```javascript
 import Badge from 'carbon-react/lib/components/badge';
-import Button form 'carbon-react/lib/components/button';
-
-const MyComponent = () => (
-  <Badge counter={ 10 }>
-    <Button buttonType='tertiary'>Filter</Button>
-  </Badge>
-);
 ```
 
-## Visuals
+## Examples
 
 ### Default Badge
 
@@ -39,7 +34,6 @@ const MyComponent = () => (
 </Preview>
 
 ### Badge with counter 100
-
 Badge doesn't support more than 2 digits
 
 <Preview>
@@ -51,7 +45,6 @@ Badge doesn't support more than 2 digits
 </Preview>
 
 ### Badge with counter 0
-
 If the counter is less than 1 badge will not show itself
 
 <Preview>
@@ -62,4 +55,7 @@ If the counter is less than 1 badge will not show itself
   </Story>
 </Preview>
 
+## Props
+
+### Badge
 <Props of={Badge} />

--- a/src/components/batch-selection/batch-selection.stories.mdx
+++ b/src/components/batch-selection/batch-selection.stories.mdx
@@ -10,14 +10,24 @@ import Link from '../link';
 />
 
 # Batch Selection
-
 Batch Selection Component could be used to select multiple items, and apply a common action to all the items selected.
 
-## Quick Start
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
 
+## Quick Start
 To use Batch Selection, import the `BatchSelection`, pass Icon Buttons with actions as children and number of selected in selectedCount prop.
 
-### Default usage:
+```javascript
+import BatchSelection from 'carbon-react/lib/components/batch-selection';
+import IconButton from 'carbon-react/lib/components/icon-button';
+```
+
+## Examples
+
+### Basic usage
 
 <Preview>
   <Story name="default">
@@ -30,7 +40,7 @@ To use Batch Selection, import the `BatchSelection`, pass Icon Buttons with acti
   </Story>
 </Preview>
 
-### On dark background:
+### On dark background
 
 <Preview>
   <Story name="dark">
@@ -42,7 +52,7 @@ To use Batch Selection, import the `BatchSelection`, pass Icon Buttons with acti
   </Story>
 </Preview>
 
-### On light background:
+### On light background
 
 <Preview>
   <Story name="light">
@@ -54,7 +64,7 @@ To use Batch Selection, import the `BatchSelection`, pass Icon Buttons with acti
   </Story>
 </Preview>
 
-### On white background:
+### On white background
 
 <Preview>
   <Story name="white">
@@ -66,7 +76,7 @@ To use Batch Selection, import the `BatchSelection`, pass Icon Buttons with acti
   </Story>
 </Preview>
 
-### Disabled:
+### Disabled
 
 <Preview>
   <Story name="disabled">
@@ -78,6 +88,11 @@ To use Batch Selection, import the `BatchSelection`, pass Icon Buttons with acti
   </Story>
 </Preview>
 
-## Props:
+## Props
+
+### Batch Selection
 
 <Props of={BatchSelection} />
+
+### Icon Button
+<Props of={IconButton} />

--- a/src/components/box/box.stories.mdx
+++ b/src/components/box/box.stories.mdx
@@ -9,14 +9,23 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 <Meta title="Design System/Box" />
 
 # Box
+Basic component that gives access to a number of styling options. Should be used to achieve more precise layouts when required. Gives access to Spacing, Color, Layout and FlexBox attributes.
+
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+Import the box component to start using
 
 ```javascript
 import Box from "carbon-react/lib/components/box";
 ```
 
-## Overview
+## Examples
 
-Basic component that gives access to a number of styling options. Should be used to achieve more precise layouts when required. Gives access to Spacing, Color, Layout and FlexBox attributes.
+### Spacing
 
 <Preview>
   <Story name="spacing" parameters={{ info: { disable: true } }}>
@@ -26,7 +35,7 @@ Basic component that gives access to a number of styling options. Should be used
   </Story>
 </Preview>
 
-## Color
+### Color
 
 <Preview>
   <Story name="color" parameters={{ info: { disable: true } }}>
@@ -38,7 +47,7 @@ Basic component that gives access to a number of styling options. Should be used
   </Story>
 </Preview>
 
-## Flex
+### Flex
 
 <Preview>
   <Story name="flex" parameters={{ info: { disable: true } }}>
@@ -70,7 +79,7 @@ Basic component that gives access to a number of styling options. Should be used
   </Story>
 </Preview>
 
-## Layout
+### Layout
 
 <Preview>
   <Story name="layout" parameters={{ info: { disable: true } }}>
@@ -101,7 +110,6 @@ Basic component that gives access to a number of styling options. Should be used
 </Preview>
 
 ## OverflowWrap
-
 Use the `overflowWrap` prop to apply `overflow-wrap: break-word` to the content within the `Box` wrapper.
 
 <Preview>
@@ -130,9 +138,9 @@ Use the `overflowWrap` prop to apply `overflow-wrap: break-word` to the content 
   </Story>
 </Preview>
 
-## Scroll
-
-Use the `scrollVariant` prop to indicate which theme scrollbar you would like to display. Use `light` or `dark` values to display as below. This will still require the use of the `overflow` prop and only displays in Chrome or Safari
+### Scroll
+Use the `scrollVariant` prop to indicate which theme scrollbar you would like to display. Use `light` or `dark` values to display as below. This will still require the use of the `overflow` prop and only displays in Chrome or Safari.
+If no `scrollVariant` prop is set then the scroll bar will resort to the browser default.
 
 <Preview>
   <Story
@@ -205,23 +213,32 @@ Use the `scrollVariant` prop to indicate which theme scrollbar you would like to
   </Story>
 </Preview>
 
-<StyledSystemProps spacing color flexBox layout />
-<ArgsTable
-  rows={[
-    {
-      name: "overflowWrap",
-      type: { summary: "break-word | anywhere" },
-      description:
-        'String to set Box content break strategy. Note "anywhere" is not supported in Safari and IE11',
-      required: false,
-      defaultValue: "",
-    },
-    {
-      name: "scrollVariant",
-      type: { summary: "dark | light" },
-      description: "String to denote which style variant to use for scrollbars",
-      required: false,
-      defaultValue: "",
-    },
-  ]}
+## Props 
+
+### Style System
+
+<StyledSystemProps
+  spacing
+  color
+  flexBox
+  layout
+  noHeader
 />
+
+### Scroll Variant 
+
+<ArgsTable rows={[
+  {
+    name: 'overflowWrap',
+    type: { summary: 'break-word | anywhere' },
+    description: 'String to set Box content break strategy. Note "anywhere" is not supported in Safari and IE11',
+    required: false,
+    defaultValue: ''
+  },
+  {
+    name: 'scrollVariant',
+    type: { summary: 'dark | light' },
+    description: 'String to denote which style variant to use for scrollbars',
+    required: false
+  }
+]} />

--- a/src/components/button-toggle-group/button-toggle-group.stories.mdx
+++ b/src/components/button-toggle-group/button-toggle-group.stories.mdx
@@ -8,16 +8,13 @@ import ButtonToggleGroup from './button-toggle-group.component';
 
 # Button Toggle Group
 
-Press one of the buttons to make selection
+Press one of the buttons to make selection. ButtonToggleGroup component should be used when user has to make a choice between a small number of options.
 
-## Overview 
-
-ButtonToggleGroup component should be used when user has to make a choice between a small number of options.
-
-## Guidance, hints and tips 
-
-- Always insert `ButtonToggle` Components inside the `ButtonToggleGroup`.
-- An icon could be added to make the meaning of an option clearer.
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
 
 ## Quick Start 
 
@@ -28,7 +25,12 @@ import ButtonToggle from 'carbon-react/lib/components/button-toggle';
 import ButtonToggleGroup from 'carbon-react/lib/components/button-toggle-group';
 ```
 
-## Default usage
+## Designer Notes
+- Always insert `ButtonToggle` Components inside the `ButtonToggleGroup`.
+- An icon could be added to make the meaning of an option clearer.
+
+## Examples
+### Default
 
 <Preview>
   <Story name='default' parameters={{ info: { disable: true }}} >
@@ -56,7 +58,7 @@ import ButtonToggleGroup from 'carbon-react/lib/components/button-toggle-group';
   </Story>
 </Preview>
 
-### Controlled usage:
+### Controlled
 
 <Preview>
   <Story name="controlled" parameters={{ info: { disable: true }}} >
@@ -94,7 +96,7 @@ import ButtonToggleGroup from 'carbon-react/lib/components/button-toggle-group';
   </Story>
 </Preview>
 
-## Grouped
+### Grouped
 
 <Preview>
   <Story name='grouped' parameters={{ info: { disable: true }}} >
@@ -125,7 +127,7 @@ import ButtonToggleGroup from 'carbon-react/lib/components/button-toggle-group';
   </Story>
 </Preview>
 
-## With field help inline
+### With field help inline
 
 <Preview>
   <Story name='fieldhelp inline' parameters={{ info: { disable: true }}} >
@@ -154,7 +156,7 @@ import ButtonToggleGroup from 'carbon-react/lib/components/button-toggle-group';
   </Story>
 </Preview>
 
-## With label inline
+### With label inline
 
 <Preview>
   <Story name='label inline' parameters={{ info: { disable: true }}} >
@@ -183,7 +185,7 @@ import ButtonToggleGroup from 'carbon-react/lib/components/button-toggle-group';
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Props of the ButtonToggleGroup
 

--- a/src/components/button-toggle/button-toggle.stories.mdx
+++ b/src/components/button-toggle/button-toggle.stories.mdx
@@ -10,16 +10,13 @@ import ButtonToggle from '../button-toggle';
 
 # Button Toggle
 
-Press one of the buttons to make selection
+Press one of the buttons to make selection. ButtonToggle component should be used when user has to make a choice between a small number of options.
 
-## Overview 
-
-ButtonToggle component should be used when user has to make a choice between a small number of options.
-
-## Guidance, hints and tips 
-
-- An icon could be added to make the meaning of an option clearer.
-- This component should not be used as part of the `Form`, `ButtonToggleGroup` should be used instead.
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
 
 ## Quick Start 
 
@@ -29,7 +26,13 @@ To use the `ButtonToggle` component you have to import the `<ButtonToggle />` co
 import ButtonToggle from 'carbon-react/lib/components/button-toggle';
 ```
 
-## Default usage
+## Designer Notes 
+
+- An icon could be added to make the meaning of an option clearer.
+- This component should not be used as part of the `Form`, `ButtonToggleGroup` should be used instead.
+
+## Examples
+### Default 
 
 <Preview>
   <Story name='default'>
@@ -50,7 +53,7 @@ import ButtonToggle from 'carbon-react/lib/components/button-toggle';
   </Story>
 </Preview>
 
-## Disabled
+### Disabled
 
 <Preview>
   <Story name='disabled'>
@@ -74,7 +77,7 @@ import ButtonToggle from 'carbon-react/lib/components/button-toggle';
   </Story>
 </Preview>
 
-## Grouped
+### Grouped
 
 <Preview>
   <Story name='grouped'>
@@ -98,7 +101,7 @@ import ButtonToggle from 'carbon-react/lib/components/button-toggle';
   </Story>
 </Preview>
 
-## With large icon
+### With large icon
 
 <Preview>
   <Story name='with large icon'>
@@ -125,7 +128,7 @@ import ButtonToggle from 'carbon-react/lib/components/button-toggle';
   </Story>
 </Preview>
 
-## With small icon
+### With small icon
 
 <Preview>
   <Story name='with small icon'>
@@ -149,6 +152,7 @@ import ButtonToggle from 'carbon-react/lib/components/button-toggle';
   </Story>
 </Preview>
 
-## Props:
+## Props
 
+### Button Toggle
 <Props of={ButtonToggle} />

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -4,14 +4,24 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 <Meta title="Design System/Button" parameters={{ info: { disable: true } }} />
 
-# Button
 
+# Button
+A Button triggers a single action or event.
+Use it to submit a form (Save), to advance to the next step in a process (Next), or to create a new item (New).
+
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quickstart
 ```javascript
 import Button from "carbon-react/lib/components/button";
 ```
 
-## Primary Buttons
+## Examples
 
+### Primary Buttons
 For the single most prominent call to action on the page (e.g. Save, Submit, Continue).
 
 <Preview>
@@ -118,8 +128,7 @@ Primary buttons can be set into `noWrap` mode to prevent text wrapping.
   </Story>
 </Preview>
 
-## Secondary Buttons
-
+### Secondary Buttons
 Less prominent, there can be multiple secondary buttons on a page.
 Secondary buttons are transparent, rather than white.
 
@@ -209,8 +218,7 @@ Secondary buttons can be set into `noWrap` mode to prevent text wrapping.
   </Story>
 </Preview>
 
-## Tertiary Buttons
-
+### Tertiary Buttons
 Tertiary or ‘ghost’ buttons are used for reversing actions, like ‘Cancel’ or ‘Back’.
 
 <Preview>
@@ -317,8 +325,7 @@ Tertiary buttons can be set to `noWrap` mode to prevent text wrapping.
   </Story>
 </Preview>
 
-## Dashed Buttons
-
+### Dashed Buttons
 Dashed buttons are used for adding new content that replaces empty states.
 
 <Preview>
@@ -402,8 +409,7 @@ Dashed buttons can be set to `noWrap` mode to prevent text wrapping.
   </Story>
 </Preview>
 
-## Button as a link
-
+### Button as a link
 Passing in the `href` prop will render an anchor with `role="button"` and the Button styles
 
 <Preview>
@@ -415,7 +421,6 @@ Passing in the `href` prop will render an anchor with `role="button"` and the Bu
 </Preview>
 
 ### Icon Only Button
-
 Buttons can be rendered with just an icon.
 
 <Preview>
@@ -475,13 +480,15 @@ Icon only buttons can also display a tooltip message when the icon is hovered ov
   </Story>
 </Preview>
 
-## Shared Props
-
+## Props
 Options shared between all of the above types of buttons. When setting padding we recommend using either the `p`, `py`
 or `px` props to ensure the spacing within the button is applied evenly.
+
+### Button
 
 <StyledSystemProps
   of={Button}
   spacing
   defaults={{ pt: "1px", pb: "1px", px: "24px" }}
+  noHeader
 />

--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -19,15 +19,24 @@ import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
   parameters={{ info: { disable: true }}}
 />
 
+# Card
+Organise and present content and actions about a single subject.
+
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick start
-```js
+```javascript
 import Card from "carbon-react/lib/components/card";
 import CardRow from 'carbon-react/lib/components/card/card-row';
 import CardFooter from "carbon-react/lib/components/card/card-footer";
 import CardColumn from "carbon-react/lib/components/card/card-column";
 ```
 
-## Guidance, hints and tips
+## Designer Notes
 - Cards: contain interactive content or controls. 
 Sometimes it might be possible to move them around on the page. They have shadows - 'card shadow' as a default, 
 and depth level 1 on hover.
@@ -38,7 +47,9 @@ Often cards are one large touch target to a detail screen on a subject.
 - When an array of cards or tiles are shown together, 
 they may wrap into a grid depending on the available width and height of their container.
 
-## Default - medium spacing
+## Examples
+
+### Default - medium spacing
 
 <Preview>
   <Story name="default">
@@ -72,7 +83,7 @@ they may wrap into a grid depending on the available width and height of their c
   </Story>
 </Preview>
 
-## Small spacing
+### Small spacing
 
 <Preview>
   <Story name="small spacing">
@@ -106,7 +117,7 @@ they may wrap into a grid depending on the available width and height of their c
   </Story>
 </Preview>
 
-## Large spacing
+### Large spacing
 
 <Preview>
   <Story name="large spacing">
@@ -140,7 +151,7 @@ they may wrap into a grid depending on the available width and height of their c
   </Story>
 </Preview>
 
-## With cardWidth provided
+### With cardWidth provided
 
 <Preview>
   <Story name="with cardWidth provided">
@@ -174,7 +185,7 @@ they may wrap into a grid depending on the available width and height of their c
   </Story>
 </Preview>
 
-## Interactive
+### Interactive
 Click on the card to see the effect
 
 <Preview>
@@ -217,7 +228,7 @@ Click on the card to see the effect
   </Story>
 </Preview>
 
-## Different `<CardRow />` padding
+### Different `<CardRow />` padding
 
 <Preview>
   <Story name="different CardRow padding" parameters={{ chromatic: { disable: true }}}>
@@ -260,7 +271,7 @@ Click on the card to see the effect
   </Story>
 </Preview>
 
-## Different `<CardFooter />` paddings
+### Different `<CardFooter />` padding
 
 <Preview>
   <Story name="different CardFooter padding" parameters={{ chromatic: { disable: true }}}>
@@ -341,7 +352,7 @@ Click on the card to see the effect
   </Story>
 </Preview>
 
-## More `<CardFooter />` examples
+### More `<CardFooter />` examples
 
 <Preview>
   <Story name="more examples of CardFooter">
@@ -417,18 +428,20 @@ Click on the card to see the effect
   </Story>
 </Preview>
 
-## Props for `<Card />`
+## Props
+ 
+### Card
 
 <Props of={Card} />
 
-## Props for `<CardRow />`
+### CardRow
 
-<StyledSystemProps padding of={CardRow} />
+<StyledSystemProps noHeader padding of={CardRow} />
 
-## Props for `<CardColumn />`
+### CardColumn
 
 <Props of={CardColumn} />
 
-## Props for `<CardFooter />`
+### CardFooter
 
-<StyledSystemProps spacing of={CardFooter} />
+<StyledSystemProps spacing noHeader of={CardFooter} />

--- a/src/components/carousel/carousel.stories.mdx
+++ b/src/components/carousel/carousel.stories.mdx
@@ -12,11 +12,17 @@ import BaseCarousel, { Carousel, Slide } from "./carousel.component";
 - Presents a series of images which the user can step through one-by-one, or quickly jump to a particular step.
 - Useful for showcasing a set of new features, for example.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import { Carousel, Slide } from "carbon-react/lib/components/carousel";
 ```
+## Examples
 
 ### Default
 
@@ -153,8 +159,8 @@ import { Carousel, Slide } from "carbon-react/lib/components/carousel";
   </Story>
 </Preview>
 
-## Props:
+## Props
 
-### Carousel:
+### Carousel
 
 <Props of={BaseCarousel} />

--- a/src/components/configurable-items/configurable-items.stories.mdx
+++ b/src/components/configurable-items/configurable-items.stories.mdx
@@ -12,14 +12,20 @@ import Box from "../box";
 - This component renders a list of items that can be checked/unchecked and re-ordered.
 - Designed to be used in tandem with the onConfigure prop in the table component so that columns can be enabled/disabled and re-ordered.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import {
   ConfigurableItems,
   ConfigurableItemRow,
 } from "carbon-react/lib/components/configurable-items";
 ```
+## Examples
 
 ### Default
 
@@ -98,7 +104,7 @@ import {
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Configurable Items
 

--- a/src/components/confirm/confirm.stories.mdx
+++ b/src/components/confirm/confirm.stories.mdx
@@ -12,6 +12,20 @@ import Button from '../button';
 # Confirm
 Confirms or cancels an action.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import Confirm from "carbon-react/lib/components/confirm";
+```
+
+## Designer Notes
 Shows a static message in a dialog which asks the user to confirm or cancel an action they’ve initiated.
 
 Useful to confirm actions which may be difficult to undo, or potentially harmful.
@@ -28,25 +42,7 @@ A good example could be confirming deletion of a large number of records.
 - Error or warning message that interrupts activity? [Try Alert](/?path=/docs/alert--default-story "Alert").
 - Simple task in context? [Try Dialog](/?path=/docs/dialog--default-story "Dialog").
 
-## Quick Start
-
-Import the component and use as shown below:
-
-```jsx
-import Confirm from "carbon-react/lib/components/confirm";
-
-const MyComponent = ({ isOpen, handleClose, handleConfirm }) => (
-  <Confirm
-    onCancel={ handleClose }
-    onConfirm={ handleConfirm }
-    title="Title"
-    subtitle="Subtitle"
-    open={ isOpen }
-  >
-    Are you sure?
-  </Confirm>
-);
-```
+## Examples
 
 ### Default
 
@@ -240,7 +236,7 @@ Allows to set variant which is supported in `<Button />` and it will be applied 
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Confirm
 

--- a/src/components/content/content.stories.mdx
+++ b/src/components/content/content.stories.mdx
@@ -9,12 +9,20 @@ The Content component shows a title in bold, with plain text content children. M
 contrast ratio of at least 4.5.1, to meet the [WCAG 2.0 AA standard](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html) 
 for text less than 19px in size. Webaim have a good online [Contrast Checker](http://webaim.org/resources/contrastchecker/).
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
+
 ```js 
 import Content from "carbon-react/lib/components/content";
 ```
+## Examples
 
-## Default content
+### Default content
+
 <Preview>
   <Story name="default">
     <Content title='Title' variant='primary'>
@@ -23,7 +31,8 @@ import Content from "carbon-react/lib/components/content";
   </Story>
 </Preview>
 
-## Inline content
+### Inline content
+
 <Preview>
   <Story name="inline">
     <Content title='Title' inline>
@@ -32,7 +41,8 @@ import Content from "carbon-react/lib/components/content";
   </Story>
 </Preview>
 
-## Secondary styling
+### Secondary styling
+
 <Preview>
   <Story name="secondary styling">
     <Content title='Title' variant='secondary'>
@@ -42,4 +52,6 @@ import Content from "carbon-react/lib/components/content";
 </Preview>
 
 ## Props
+
+### Content 
 <Props of={Content} />

--- a/src/components/definition-list/definition-list.stories.mdx
+++ b/src/components/definition-list/definition-list.stories.mdx
@@ -7,17 +7,25 @@ import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
 
 # Definition List
 
+## Contents
+- [Quick Start](#quick-start)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import { Dl, Dt, Dd } from "carbon-react/lib/components/definition-list";
+```
+
 ## Related Components
 Definition List most of the time is in use with other components. Look at the examples below
 
 - [Tile component with Definition List](/?path=/docs/design-system-tile--with-definition-list-default "Tile component with Definition List").
 - [Accordion component with Definition List](/?path=/docs/design-system-accordion--with-a-definition-list "Accordion component with Definition List").
 
-## Quick Start
-
-```js
-import { Dl, Dt, Dd } from "carbon-react/lib/components/definition-list";
-```
+## Examples 
 
 ### Default
 

--- a/src/components/detail/detail.stories.mdx
+++ b/src/components/detail/detail.stories.mdx
@@ -13,20 +13,17 @@ Make sure that the colour of all text has a contrast ratio of at least 4.5.1,
 to meet the [WCAG 2.0 AA standard](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html "WCAG 2.0 AA standard") 
 for text less than 19px in size. Webaim have a good online [Contrast Checker](http://webaim.org/resources/contrastchecker/ "Contrast Checker").
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
-Import `Detail` into the project.
 
-```jsx
+```javascript
 import Detail from "carbon-react/lib/components/detail";
-
-const MyComponent = () => (
-  <Detail>
-    This is where the children will live.
-  </Detail>
-);
-
 ```
-
+## Examples
 ### Default Detail
 This is an example of how the Detail component will look in its default format.
 <Preview>
@@ -59,6 +56,9 @@ Detail can also have an icon that renders to the left.
 </Preview>
 
 ### Inside of Components
+
+#### Inside of Card
+
 Detail can be nested inside of components. Inside of this example it is nested inside of the `Card` component.
 
 <Preview>
@@ -85,6 +85,8 @@ Detail can be nested inside of components. Inside of this example it is nested i
   </Story>
 </Preview>
 
+#### Inside of Tile
+
 In this example, Detail is nested inside of the `Tile` component.
 <Preview>
   <Story name="inside of tile">
@@ -110,4 +112,5 @@ In this example, Detail is nested inside of the `Tile` component.
 
 
 ## Props
+### Detail
 <Props of={Detail} />

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
@@ -28,6 +28,21 @@ import { Dl, Dt, Dd } from "../definition-list";
 
 A full-width and full-height dialog overlaid on top of any page.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import DialogFullScreen from "carbon-react/lib/components/dialog-full-screen";
+```
+
+## Designer Notes
+
 Useful to perform an action in context without navigating the user to a separate page.
 
 Whilst a standard Dialog component’s width might constrain what you can do, the full screen dialog uses the full width and height available.
@@ -39,24 +54,7 @@ A good example could be importing a large volume of data, and checking for error
 - Simple task in context? [Try Dialog](/?path=/docs/dialog--default-story "Dialog").
 - Need to refer back to the underlying page? [Try Sidebar](/?path=/docs/sidebar--default-story "Sidebar").
 
-## Quick Start
-
-Import the component and use as shown below:
-
-```jsx
-import DialogFullScreen from "carbon-react/lib/components/dialog-full-screen";
-
-const MyComponent = ({ isOpen, handleClose }) => (
-  <DialogFullScreen
-    open={isOpen}
-    onCancel={handleClose}
-    title="Title"
-    subtitle="Subtitle"
-  >
-    Dialog content
-  </DialogFullScreen>
-);
-```
+## Examples
 
 ### Default
 
@@ -797,7 +795,7 @@ to have a possibility to manage active `Tabs` group
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### DialogFullScreen
 

--- a/src/components/dialog/dialog.stories.mdx
+++ b/src/components/dialog/dialog.stories.mdx
@@ -22,6 +22,21 @@ import Loader from '../loader';
 # Dialog
 A dialog box overlaid on top of any page.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import Dialog from "carbon-react/lib/components/dialog";
+```
+
+## Designer Notes
+
 Useful to perform an action in context without navigating the user to a separate page.
 
 Several pre-set widths are available - the height of the dialog will flex to fit the content. It’s best to avoid dialogs that are taller than the user’s viewport height. Typical user viewport heights can be as little as 650 pixels.
@@ -34,24 +49,7 @@ A configuration shows a close icon at the top right of the Dialog. Sometimes use
 - Complex task that needs more space? [Try Dialog Full Screen](/?path=/docs/dialog-full-screen--default-story "Dialog Full Screen").
 - Need to refer back to the underlying page? [Try Sidebar](/?path=/docs/sidebar--default-story "Sidebar").
 
-## Quick Start
-
-Import the component and use as shown below:
-
-```jsx
-import Dialog from "carbon-react/lib/components/dialog";
-
-const MyComponent = ({ isOpen, handleClose }) => (
-  <Dialog
-    open={ isOpen }
-    onCancel={ handleClose }
-    title="Title"
-    subtitle="Subtitle"
-  >
-    Dialog content
-  </Dialog>
-);
-```
+## Examples
 
 ### Default
 
@@ -216,7 +214,7 @@ When mixing editable and non-editable content, you can use the <LinkTo kind='Des
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Dialog
 

--- a/src/components/drag-and-drop/drag-and-drop.stories.mdx
+++ b/src/components/drag-and-drop/drag-and-drop.stories.mdx
@@ -20,7 +20,7 @@ A draggable context is used to define an area in the page where drag and drop ca
 
 You also need to use WithDrop and WithDrag
 
-```jsx
+```javascript
 import {
   DraggableContext,
   WithDrop,

--- a/src/components/draggable/draggable.stories.mdx
+++ b/src/components/draggable/draggable.stories.mdx
@@ -8,46 +8,33 @@ import { Checkbox } from "../../__experimental__/components/checkbox";
 />
 
 # Draggable
-
-Pick, move and replace an order
-
-## Overview 
-
-Draggable is a great component if you need to have interactive components 
+Pick, move and replace an order. Draggable is a great component if you need to have interactive components 
 with possibility to change their order with drag and drop mechanics
 
-## Guidance, hints and tips 
-
-Always use `DraggableItem` inside of the `DraggableContainer`
-
-`DraggableItem` doesn't work without `DraggableContainer`
-
-`DraggableItem` requires an `id` to be passed to the component
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
 
 ## Quick Start 
-
 To use the Draggable component you have to import two components: `<DraggableContainer />` and `<DraggableItem />`.
 
-The first: `<DraggableContainer />` is a required container to let content inside of `<DraggableItem />` be draggable.
-
-`<DraggableItem />` Is a component that access every child to be put in. 
-
-The whole `<DraggableItem />` is draggable
-
-```jsx
-import { DraggableContainer, DraggableItem } from "carbon-react/Draggable";
-
-<DraggableContainer>
-  <DraggalbeItem key="1" id={1}>Some content goes here</DraggableItem>
-  <DraggalbeItem key="2" id={2}>Some content goes here</DraggableItem>
-  <DraggalbeItem key="3" id={3}>Some content goes here</DraggableItem>
-  <DraggalbeItem key="4" id={4}>Some content goes here</DraggableItem>
-</DraggableContainer>;
+```javascript
+import { DraggableContainer, DraggableItem } from "carbon-react/lib/components/draggable";
 ```
 
-## Visuals
+## Designer Notes 
+- Always use `DraggableItem` inside of the `DraggableContainer`
+- `DraggableItem` doesn't work without `DraggableContainer`
+- `DraggableItem` requires an `id` to be passed to the component
+- The whole `<DraggableItem />` is draggable
+- The first: `<DraggableContainer />` is a required container to let content inside of `<DraggableItem />` be draggable.
+- `<DraggableItem />` Is a component that access every child to be put in. 
 
-### simple text as a content
+## Examples
+
+### Simple text as a content
 
 <Preview>
   <Story name="default">
@@ -60,7 +47,7 @@ import { DraggableContainer, DraggableItem } from "carbon-react/Draggable";
   </Story>
 </Preview>
 
-### other components as children
+### Other components as children
 
 <Preview>
   <Story name="components as children">
@@ -81,16 +68,16 @@ import { DraggableContainer, DraggableItem } from "carbon-react/Draggable";
   </Story>  
 </Preview>
 
-### with getOrder callback
+### With getOrder callback
 
 <Preview>
   <Story name="with getOrder callback" id="design-system-draggable-test--default" />
 </Preview>
 
-## DraggableContainer Props
+## Props
 
+### DraggableContainer
 <Props of={DraggableContainer} />
 
-## DraggableItem Props
-
+### DraggableItem 
 <Props of={DraggableItem} exclude={['findItem', 'moveItem', 'getOrder']} />

--- a/src/components/drawer/__internal__/drawer.stories.mdx
+++ b/src/components/drawer/__internal__/drawer.stories.mdx
@@ -29,11 +29,20 @@ Drawer is a two column layout container.
 It is designed to have left hand side container expand and collapse to respectively reveal and hide the content of that container.
 Drawer component is designed to fill the space of the element that it is put inside.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
 ```javascript
 import Drawer from 'carbon-react/lib/components/drawer';
 ```
 
-### Uncontrolled usage:
+## Examples
+
+### Uncontrolled usage
 
 <Preview>
   <Story name="uncontrolled" parameters={{ info: { disable: true }, chromatic: { disable: true }}} >
@@ -57,7 +66,7 @@ import Drawer from 'carbon-react/lib/components/drawer';
   </Story>
 </Preview>
 
-### Uncontrolled - defaultExpanded usage:
+### Uncontrolled - defaultExpanded usage
 
 <Preview>
   <Story name="default expanded" parameters={{ info: { disable: true }, chromatic: { disable: true }}} >
@@ -82,7 +91,7 @@ import Drawer from 'carbon-react/lib/components/drawer';
   </Story>
 </Preview>
 
-### Custom Background Color (Red):
+### Custom Background Color (Red)
 
 <Preview>
   <Story name="background color red" parameters={{ info: { disable: true }, chromatic: { disable: true }}} >
@@ -108,7 +117,7 @@ import Drawer from 'carbon-react/lib/components/drawer';
   </Story>
 </Preview>
 
-### Custom Background Color (White):
+### Custom Background Color (White)
 Note: parent container background-color is set to red for demonstration purpose.
 
 <Preview>
@@ -134,7 +143,7 @@ Note: parent container background-color is set to red for demonstration purpose.
   </Story>
 </Preview>
 
-### Custom Background Color (Transparent):
+### Custom Background Color (Transparent)
 Note: parent container background-color is set to red for demonstration purpose.
 
 <Preview>
@@ -160,7 +169,7 @@ Note: parent container background-color is set to red for demonstration purpose.
   </Story>
 </Preview>
 
-### Custom Title:
+### Custom Title
 
 <Preview>
   <Story name="title" parameters={{ info: { disable: true }, chromatic: { disable: true }}} >
@@ -185,7 +194,7 @@ Note: parent container background-color is set to red for demonstration purpose.
   </Story>
 </Preview>
 
-### With Controls usage:
+### With Controls usage
 
 <Preview>
   <Story name="with controls" parameters={{ info: { disable: true }}} >
@@ -211,7 +220,7 @@ Note: parent container background-color is set to red for demonstration purpose.
   </Story>
 </Preview>
 
-### Custom Sidebar - FlatTable component as sidebar content:
+### Custom Sidebar - FlatTable component as sidebar content
 
 <Preview>
   <Story name="custom sidebar" parameters={{ info: { disable: true }, chromatic: { disable: true }}} >
@@ -291,7 +300,7 @@ Note: parent container background-color is set to red for demonstration purpose.
   </Story>
 </Preview>
 
-### Custom Content - FlatTable component as drawer content:
+### Custom Content - FlatTable component as drawer content
 
 <Preview>
   <Story name="custom content" parameters={{ info: { disable: true }, chromatic: { disable: true }}} >
@@ -400,7 +409,7 @@ Note: parent container background-color is set to red for demonstration purpose.
   </Story>
 </Preview>
 
-### Animation Speed (2 second):
+### Animation Speed (2 second)
 
 <Preview>
   <Story name="two second animation" parameters={{ info: { disable: true }, chromatic: { disable: true }}} >
@@ -444,7 +453,7 @@ Note: parent container background-color is set to red for demonstration purpose.
   </Story>
 </Preview>
 
-### Expanded width 30%:
+### Expanded width 30%
 
 <Preview>
   <Story name="expanded width 30" parameters={{ info: { disable: true }}} >
@@ -487,7 +496,7 @@ Note: parent container background-color is set to red for demonstration purpose.
   </Story>
 </Preview>
 
-### Expanded width 62%:
+### Expanded width 62%
 
 <Preview>
   <Story name="expanded width 62" parameters={{ info: { disable: true }}} >
@@ -530,7 +539,7 @@ Note: parent container background-color is set to red for demonstration purpose.
   </Story>
 </Preview>
 
-### Animation Speed (2 second):
+### Animation Speed (2 second)
 
 <Preview>
   <Story name="three second animation" parameters={{ info: { disable: true }, chromatic: { disable: true }}} >
@@ -574,7 +583,7 @@ Note: parent container background-color is set to red for demonstration purpose.
   </Story>
 </Preview>
 
-### Controlled Usage:
+### Controlled Usage
 
 <Preview>
   <Story name="controlled" parameters={{ info: { disable: true }}} >
@@ -619,7 +628,7 @@ Note: parent container background-color is set to red for demonstration purpose.
   </Story>
 </Preview>
 
-### Side View Navigation:
+### Side View Navigation
 
 <Preview>
   <Story name="side view navigation" parameters={{info: {disable: true}}}>
@@ -818,10 +827,10 @@ Note: parent container background-color is set to red for demonstration purpose.
 </Preview>
 
 ### With Tab controls
-
 You will need to override the targeting when using Tabs inside of the Drawer's sidebar. This can be done using the 
 `onTabChange` callback. If you also need to override the validation statuses, this can be done using the 
 `validationStatusOverride` prop.
+
 <Preview>
   <Story name="with tab controls" parameters={{ info: { disable: true }}} >
     {() => {
@@ -1021,6 +1030,7 @@ You will need to override the targeting when using Tabs inside of the Drawer's s
   </Story>
 </Preview>
 
-### Drawer Props
+## Props
 
+### Drawer
 <Props of={Drawer} />

--- a/src/components/duelling-picklist/duelling-picklist.stories.mdx
+++ b/src/components/duelling-picklist/duelling-picklist.stories.mdx
@@ -14,10 +14,26 @@ import DuellingPicklist from './duelling-picklist.component';
 # Duelling Picklist
 Select a subset of relatively short list.
 
-## Quick Start
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
 
+## Quick Start
 To create fully functioning `Duelling Picklist` component you can compose it yourself out of provided `Carbon` components.
 
+```javascript
+import { 
+Picklist,
+PicklistItem,
+PicklistDivider,
+PicklistPlaceholder,
+DuellingPicklist 
+} from 'carbon-react/lib/components/duelling-picklist';
+```
+
+## Designer Notes
 `DuellingPicklist` is meant to be a container composed of two `Picklist` children and a `PicklistDivider` between them.
 It also accepts `leftLabel` and `rightLabel` props of type string which will be rendered above the corresponding `PickList`s.
 Similarly to labels, `leftControls` and `rightControls` props accept a node to be rendered between the labels and the `Picklist`.
@@ -43,31 +59,25 @@ Example of composed Duelling Picklist components with order preservation and sea
 </Preview>
 
 ### In dialog
-
 Same as above but as a children of `Dialog` component.
 
 <Preview>
   <Story id="test-duellingpicklist--in-dialog" name="InDialog" />
 </Preview>
 
-## Props:
+## Props
 
 ### Picklist
-
 <Props of={Picklist} />
 
 ### PicklistItem
-
 <Props of={PicklistItem} />
 
 ### DuellingPicklist
-
 <Props of={DuellingPicklist} />
 
 ### PicklistDivider
-
 <Props of={PicklistDivider} />
 
 ### PicklistPlaceholder
-
 <Props of={PicklistPlaceholder} />

--- a/src/components/flat-table/flat-table-expandable.stories.mdx
+++ b/src/components/flat-table/flat-table-expandable.stories.mdx
@@ -26,10 +26,11 @@ import {
   parameters={{ info: { disable: true } }}
 />
 
-## Flat Table expandable options
+# Flat Table expandable options
+
+## Examples
 
 ### Default
-
 Flat table rows can be made expandable, with any number of sub rows.
 
 <Preview>
@@ -92,7 +93,6 @@ Flat table rows can be made expandable, with any number of sub rows.
 </Preview>
 
 ### Expandable by first column only
-
 Only clicking on the first column can expand the row with this option set.
 
 <Preview>
@@ -174,7 +174,6 @@ Only clicking on the first column can expand the row with this option set.
 </Preview>
 
 ### With initially expanded rows
-
 Set the rows to be open by default.
 
 <Preview>
@@ -237,7 +236,6 @@ Set the rows to be open by default.
 </Preview>
 
 ### With row headers
-
 Rows with row headers can also be made expandable.
 
 <Preview>
@@ -302,7 +300,6 @@ Rows with row headers can also be made expandable.
 </Preview>
 
 ### With pagination
-
 Tables with pagination can have expandable rows.
 
 <Preview>
@@ -408,7 +405,6 @@ Tables with pagination can have expandable rows.
 </Preview>
 
 ### With parent and children selectable
-
 By writing your own selectable logic, both parent and child rows can be made selectable.
 
 <Preview>
@@ -622,7 +618,6 @@ By writing your own selectable logic, both parent and child rows can be made sel
 </Preview>
 
 ### Parent only selectable
-
 By writing your own selectable logic, the parent rows only can be made selectable.
 
 <Preview>
@@ -791,7 +786,6 @@ By writing your own selectable logic, the parent rows only can be made selectabl
 </Preview>
 
 ### Children only selectable
-
 By writing your own selectable logic, the child rows only can be made selectable.
 
 <Preview>
@@ -975,8 +969,7 @@ By writing your own selectable logic, the child rows only can be made selectable
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### FlatTableRow
-
 <Props of={FlatTableRow} />

--- a/src/components/flat-table/flat-table-themes.stories.mdx
+++ b/src/components/flat-table/flat-table-themes.stories.mdx
@@ -10,7 +10,9 @@ import {
 
 <Meta title="Design System/Flat Table/Color Themes" parameters={{ info: { disable: true }}} />
 
-## Table Header Color Themes
+# Table Header Color Themes
+
+## Examples
 
 ### With transparent-white theme
 To create a transparent effect for the header, the background-color is set to match a white background
@@ -103,7 +105,8 @@ To create a transparent effect for the header, the background-color is set to ma
   </Story>
 </Preview>
 
-### With light theme 
+### With light theme
+
 <Preview>
   <Story name="light theme">
     <FlatTable colorTheme="light">

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -24,8 +24,33 @@ import Box from '../box';
 <Meta title="Design System/Flat Table" parameters={{ info: { disable: true }}} />
 
 # Flat Table
+Logically structure content in a grid for the user to enter, view, or work with.
 
-### Default usage:
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start 
+Import all the necessary components from the flat table folder
+
+```javascript 
+import { 
+  FlatTable, 
+  FlatTableHead, 
+  FlatTableBody, 
+  FlatTableRow, 
+  FlatTableHeader,
+  FlatTableRowHeader,
+  FlatTableCell,
+  FlatTableCheckbox,
+  Sort
+} from 'carbon-react/lib/components/flat-table';
+```
+
+## Examples 
+
+### Default
 
 <Preview>
   <Story name="default">
@@ -69,6 +94,7 @@ import Box from '../box';
 </Preview>
 
 ### With row headers
+
 <Preview>
   <Story name="with row header" parameters={{ chromatic: { disable: true }}}>
     <div style={ { width: '380px', overflowX: 'auto' } }>
@@ -113,8 +139,8 @@ import Box from '../box';
 </Preview>
 
 ### With custom cell paddings
-
 Padding can be set on each cell individually by using the spacing props syntax. Check prop tables at the bottom of this document for more information.
+
 <Preview>
   <Story name="with custom cell paddings">
     <FlatTable>
@@ -141,9 +167,9 @@ Padding can be set on each cell individually by using the spacing props syntax. 
 </Preview>
 
 ### With custom column width
-
 Column width can be set by passing number as a `width` prop to the column header component.
 **Column width can't be smaller than the sum of horizontal cell padding and content width.**
+
 <Preview>
   <Story name="with custom column width">
     <FlatTable>
@@ -177,6 +203,7 @@ Column width can be set by passing number as a `width` prop to the column header
 </Preview>
 
 ### With stickyHead prop set to true
+
 <Preview>
   <Story name="with sticky head" parameters={{ chromatic: { disable: true }}}>
     <div style={ { height: '150px' } }>
@@ -221,6 +248,7 @@ Column width can be set by passing number as a `width` prop to the column header
 </Preview>
 
 ### With stickyFooter prop set to true
+
 <Preview>
   <Story name="with sticky footer" parameters={{ chromatic: { disable: true }}}>
     {() => {
@@ -311,6 +339,7 @@ Column width can be set by passing number as a `width` prop to the column header
 </Preview>
 
 ### With clickable rows
+
 <Preview>
   <Story name="with clickable rows" parameters={{ chromatic: { disable: true }}}>
     <FlatTable>
@@ -353,6 +382,7 @@ Column width can be set by passing number as a `width` prop to the column header
 </Preview>
 
 ### With zebra stripes
+
 <Preview>
   <Story name="zebra">
     <FlatTable isZebra>
@@ -395,11 +425,13 @@ Column width can be set by passing number as a `width` prop to the column header
 </Preview>
 
 ### With sorting headers
+
 <Preview>
   <Story id="design-system-flat-table-test--sortable" name="with sorting headers" />
 </Preview>
 
 ### With a cell spanning the whole row 
+
 <Preview>
   <Story name="with colspan">
       <FlatTable>
@@ -421,6 +453,7 @@ Column width can be set by passing number as a `width` prop to the column header
 </Preview>
 
 ### With a cell spanning the whole column 
+
 <Preview>
   <Story name="with rowspan">
       <FlatTable>
@@ -460,6 +493,7 @@ If a given action isn’t available for a single selected item, the option appea
 If a given action is available for some, but not all, selected rows, then the action is performed, but the user is notified.
 
 Where icons are used for batch actions, they have text labels too, or tooltips to make their function clear. There are always confirmation dialogs for destructive actions, or those difficult to undo.
+
 <Preview>
   <Story name="selectable rows" parameters={{ chromatic: { disable: true }}}>
     {() => {
@@ -538,6 +572,7 @@ Where icons are used for batch actions, they have text labels too, or tooltips t
 
 ### With Highlightable Rows
 It is possible to utilise the selected and onClick props on the FlatTableRow to highlight single rows of data.
+
 <Preview>
   <Story name="highlightable rows" parameters={{ chromatic: { disable: true }}}>
     {() => {
@@ -593,6 +628,7 @@ It is possible to utilise the selected and onClick props on the FlatTableRow to 
 
 ### With Selectable and Highlightable Rows
 It is also possible to integrate selection of multiple rows and the highlighting of single rows.
+
 <Preview>
   <Story name="selectable and highlightable rows" parameters={{ chromatic: { disable: true }}}>
     {() => {
@@ -681,6 +717,7 @@ It is also possible to integrate selection of multiple rows and the highlighting
 If pagination is needed, this can be shown at the bottom of the table.
 
 Balance performance concerns with the convenience of the user being able to see more data - we suggest giving the user the option of showing 25, 50, and 100 table rows before pagination, with a default of 50. Whatever the user selects, make this sticky per user, per table, and between sessions.
+
 <Preview>
   <Story name="paginated">
     {() => {
@@ -775,6 +812,7 @@ When using the `Pager` and a sticky `FlatTableHead` some of the child elements m
 overflow to exceed the height of the table. In the example below, the `ActionPopoverMenu` has absolute positioning meaning 
 it is accounted for in the overflow. To avoid this it is possible to use the `placement` prop to render the menu on `top` 
 of the button control.
+
 <Preview>
   <Story name="paginated with sticky header" parameters={{ info: { disable: true }}} >
     {() => {
@@ -959,6 +997,7 @@ of the button control.
 </Preview>
 
 ### When a child of Sidebar
+
 <Preview>
   <Story name="when a child of sidebar" parameters={{ chromatic: { disable: true }}}>
     {() => {
@@ -1092,26 +1131,21 @@ of the button control.
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### FlatTable
-
 <Props of={FlatTable} />
 
 ### FlatTableHead
-
 <Props of={FlatTableHead} />
 
 ### FlatTableBody
-
 <Props of={FlatTableBody} />
 
 ### FlatTableRow
-
 <Props of={FlatTableRow} />
 
 ### FlatTableHeader
-
 <StyledSystemProps
   of={ FlatTableHeader }
   spacing
@@ -1120,11 +1154,9 @@ of the button control.
 />
 
 ### Sort
-
 <Props of={Sort} />
 
 ### FlatTableCell
-
 <StyledSystemProps
   of={ FlatTableCell }
   spacing
@@ -1133,7 +1165,6 @@ of the button control.
 />
 
 ### FlatTableRowHeader
-
 <StyledSystemProps
   of={ FlatTableRowHeader }
   spacing
@@ -1142,5 +1173,4 @@ of the button control.
 />
 
 ### FlatTableCheckbox
-
 <Props of={FlatTableCheckbox} />

--- a/src/components/form/form.stories.mdx
+++ b/src/components/form/form.stories.mdx
@@ -27,30 +27,20 @@ import AppWrapper from '../app-wrapper';
 # Form
 Represents a document section containing interactive controls for submitting information.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
-
 To use Form, import the `Form` and pass the content, usually various inputs, as children.
-
 You can provide a save button using the `saveButton` prop.
 
-
-```jsx
+```javascript
 import Form from "carbon-react/lib/components/form";
-
-const MyComponent = () => (
-  <Form
-    onSubmit={ handleSubmit }
-    leftSideButtons={ <Button onClick={ handleCancel }>Cancel</Button> }
-    saveButton={ <Button buttonType='primary' type="submit">Save</Button> }
-  >
-    <Textbox label="Label1" />
-    <Textbox label="Label2" />
-  </Form>
-);
 ```
 
-## Visuals
-
+## Examples
 ### With sticky footer
 When `stickyFooter` prop is set as true, footer becomes stickied to the bottom of the screen when necessary - this also works in `Dialog` and `DialogFullScreen`
 
@@ -234,7 +224,7 @@ It is possible to render `Form` as a content of `Dialog` component.
   </Story>
 </Preview>
 
-With sticky footer
+#### With sticky footer
 
 <Preview>
   <Story name="in Dialog with sticky footer" parameters={{ chromatic: { disable: true }}}>
@@ -319,7 +309,7 @@ It is possible to render `Form` as a content of `DialogFullScreen` component.
   </Story>
 </Preview>
 
-With sticky footer
+#### With sticky footer
 
 <Preview>
   <Story name="in DialogFullScreen with sticky footer" parameters={{ chromatic: { disable: true }}}>
@@ -527,4 +517,5 @@ Please click on "Show code" below to see how to set these components up for alig
 
 ## Props
 
+### Form
 <Props of={Form} />

--- a/src/components/grid/grid.stories.mdx
+++ b/src/components/grid/grid.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Preview, Story, Props } from "@storybook/addon-docs/blocks";
 import { ArgsTable } from "@storybook/components";
+import styled from 'styled-components';
 import Pod from "../pod";
 import { GridContainer, GridItem } from ".";
 import { Dl, Dt, Dd } from "../definition-list";
@@ -8,9 +9,7 @@ import Button from "../button";
 <Meta title="Design System/Grid" />
 
 # Grid
-
-## The Carbon responsive grid system is a layout component that provides guidance on how components should be positioned within a user interface, adapting to screen size and orientation.
-
+The Carbon responsive grid system is a layout component that provides guidance on how components should be positioned within a user interface, adapting to screen size and orientation.
 The Grid system is designed to provide:
 
 - A common language for designers and developers to use when discussing layout.
@@ -18,19 +17,28 @@ The Grid system is designed to provide:
 - No fixed breakpoints; responsive adjustments can be customised at a GridItem level.
 - Position and width calculated dynamically.
 
-## How it works
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
 
+## Quick Start
+
+```javascript
+import { GridContainer, GridItem } from "carbon-react/lib/components/grid";
+```
+
+## Designer Notes 
 - The Grid system is implemented with the `GridContainer` and `GridItem` components that provide two types of layout.
 - It uses the [CSS Grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout), which is a truly two-dimentional grid, allowing us to specify dimensions of rows and columns, and control where we position components within the grid.
 
 ### `GridContainer`
-
 - Comprised of 12 equal-width columns, including external paddings and internal gutters.
 - Allows either percentage or a fixed pixel width.
 - Respects the boundaries of any outer element, so if an outer element has a `max-width: 1280px`, `GridContainer` including it's paddings and gutters will be based on that size.
 
 ### `GridItem`
-
 The child of a `GridContainer` is a `GridItem`, which can have a set of breakpoints applied that are used to control how each `GridItem` responds at given widths.
 
 - Can be defined at any width between 1 and 12, each unit corresponding to a column of the `GridContainer`.
@@ -38,7 +46,6 @@ The child of a `GridContainer` is a `GridItem`, which can have a set of breakpoi
 - Can be re-ordered on the page by viewport dimensions.
 
 ### Paddings
-
 Paddings for the `GridContainer` are set automatically in the CSS, following the values in this table.
 
 | Breakpoints                    | Device Type                         | Paddings |
@@ -50,7 +57,6 @@ Paddings for the `GridContainer` are set automatically in the CSS, following the
 | Extra Large (1921px and above) | Ultra High-Res Monitors             | 40px     |
 
 ### Gutters
-
 Gutters for the `GridItem` are set automatically in the CSS, following the values in this table.
 
 | Breakpoints                    | Device Type                         | Gutters |
@@ -61,8 +67,9 @@ Gutters for the `GridItem` are set automatically in the CSS, following the value
 | Large (1260 to 1920px)         | High-Res Laptops & Monitors         | 24px    |
 | Extra Large (1921px and above) | Ultra High-Res Monitors             | 40px    |
 
-## Default example
+## Examples
 
+### Default
 This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation.
 
 <Preview>
@@ -87,8 +94,7 @@ This example is best viewed in the Canvas tab using full-screen mode with device
   </Story>
 </Preview>
 
-## Justify example
-
+### Justify
 This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation.
 
 <Preview>
@@ -115,8 +121,7 @@ This example is best viewed in the Canvas tab using full-screen mode with device
   </Story>
 </Preview>
 
-## Align example
-
+### Align
 This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation.
 
 <Preview>
@@ -154,8 +159,7 @@ This example is best viewed in the Canvas tab using full-screen mode with device
   </Story>
 </Preview>
 
-## Custom spacings
-
+### Custom
 This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation.
 
 <Preview>
@@ -239,8 +243,7 @@ This example is best viewed in the Canvas tab using full-screen mode with device
   </Story>
 </Preview>
 
-## Responsive Settings Example
-
+### Responsive Settings
 This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation. Note how the order and position of each `GridItem`, responds according to an array of `responsiveSettings` allowing reordering and respositioning as required.
 
 <Preview>
@@ -340,8 +343,7 @@ This example is best viewed in the Canvas tab using full-screen mode with device
   </Story>
 </Preview>
 
-## With a subgrid example
-
+### With a subgrid
 This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation.
 
 <Preview>
@@ -408,72 +410,68 @@ This example is best viewed in the Canvas tab using full-screen mode with device
   </Story>
 </Preview>
 
-## GridContainer Props
+## Props
 
+### GridContainer 
 <Props of={GridContainer} />
 
-## GridItem Props
-
+### GridItem 
 <Props of={GridItem} />
 
-### responsiveSettings Props
-
+### responsiveSettings
 <ArgsTable
-  rows={[
-    {
-      name: "alignSelf",
-      type: { summary: "string" },
-      description:
-        "How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch",
-    },
-    {
-      name: "gridColumn",
-      type: { summary: "string" },
-      description:
-        'Starting and ending column position of the GridItem within the GridContainer separated by "/"',
-    },
-    {
-      name: "gridRow",
-      type: { summary: "number" },
-      description:
-        'Starting and ending row position of the GridItem within the GridContainer separated by "/"',
-    },
-    {
-      name: "justifySelf",
-      type: { summary: "string" },
-      description:
-        "How the grid item is aligned along the inline (row) axis. Values: start, end, center, stretch",
-    },
-    {
-      name: "maxWidth",
-      type: { summary: "string" },
-      description:
-        "Maximum width of the screen to which these rules to be applied",
-    },
-    {
-      name: "p",
-      type: { summary: "string | number" },
-      description: "Any valid CSS value to override default padding",
-    },
-    {
-      name: "pl",
-      type: { summary: "string | number" },
-      description: "Any valid CSS value to override default padding-left",
-    },
-    {
-      name: "pr",
-      type: { summary: "string | number" },
-      description: "Any valid CSS value to override default padding-right",
-    },
-    {
-      name: "pt",
-      type: { summary: "string | number" },
-      description: "Any valid CSS value to override default padding-top",
-    },
-    {
-      name: "pb",
-      type: { summary: "string | number" },
-      description: "Any valid CSS value to override default padding-bottom",
-    },
-  ]}
+  rows={
+    [
+      {
+      name: 'alignSelf',
+      type: { summary: 'string' },
+      description: 'How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch'
+      },
+      {
+        name: 'gridColumn',
+        type: { summary: 'string'},
+        description: 'Starting and ending column position of the GridItem within the GridContainer separated by "/"'
+      },
+      {
+        name: 'gridRow',
+        type: { summary: 'number' },
+        description: 'Starting and ending row position of the GridItem within the GridContainer separated by "/"'
+      },
+      {
+        name: 'justifySelf',
+        type: { summary: 'string' },
+        description: 'How the grid item is aligned along the inline (row) axis. Values: start, end, center, stretch'
+      },
+      {
+        name: 'maxWidth',
+        type: { summary: 'string' },
+        description: 'Maximum width of the screen to which these rules to be applied'
+      },
+      {
+        name: 'p',
+        type: { summary: 'string | number' },
+        description: 'Any valid CSS value to override default padding'
+      },
+      {
+        name: 'pl',
+        type: { summary: 'string | number' },
+        description: 'Any valid CSS value to override default padding-left'
+      },
+      {
+        name: 'pr',
+        type: { summary: 'string | number' },
+        description: 'Any valid CSS value to override default padding-right'
+      },
+      {
+        name: 'pt',
+        type: { summary: 'string | number' },
+        description: 'Any valid CSS value to override default padding-top'
+      },
+      {
+        name: 'pb',
+        type: { summary: 'string | number' },
+        description: 'Any valid CSS value to override default padding-bottom'
+      }
+    ]
+  }
 />

--- a/src/components/heading/heading.stories.mdx
+++ b/src/components/heading/heading.stories.mdx
@@ -19,13 +19,17 @@ Make sure that the colour of all text has a contrast ratio of at least 4.5.1,
 to meet the [WCAG 2.0 AA standard](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html "WCAG 2.0 AA standard") for text less than 19px in size.
 Webaim have a good online Contrast Checker.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-Import `Heading` into the project.
-
-```jsx
+```javascript
 import Heading from "carbon-react/lib/components/heading";
 ```
+## Examples
 
 ### Default
 
@@ -221,4 +225,5 @@ In this example, the Heading component has the Tile component and the Definition
 
 ## Props
 
+### Heading 
 <Props of={Heading} />

--- a/src/components/help/help.stories.mdx
+++ b/src/components/help/help.stories.mdx
@@ -8,19 +8,18 @@ Typically triggered by the user hovering on an icon, displaying a single, short 
 Useful for explaining the difference between commands represented with icons, for example, batch table actions. 
 Bear in mind that tooltips may not work well (or at all) on mobile devices, so alternatives may be needed.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 Import `Help` into the project.
 
-```jsx
+```javascript
 import Help from "carbon-react/lib/components/help";
-
-const MyComponent = () => (
-  <Help>
-    Some helpful text goes here
-  </Help>
-);
-
 ```
+## Examples
 
 ### Default
 <Preview>
@@ -100,4 +99,6 @@ Using the `href` prop, a link can be specified.
 </Preview>
 
 ## Props
+
+### Help
 <Props of={Help} />

--- a/src/components/hr/hr.stories.mdx
+++ b/src/components/hr/hr.stories.mdx
@@ -16,19 +16,19 @@ import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
 # Hr
 Provides a horizontal dividing line to make the above and below components feel distinctly separate from one another.
 
-## Quick Start
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
 
+## Quick Start
 To use Hr, import the `Hr` and set the margins to align it with other components.
 
-```jsx
+```javascript
 import Hr from "carbon-react/lib/components/hr";
-
-const MyComponent = () => (
-  <Hr />
-);
 ```
 
-## Visuals
+## Examples
 
 ### Default
 By default the hr is 100% width and has top and bottom margins of 24px.
@@ -56,7 +56,7 @@ The `mb` and `mt` props set the vertical spacing. These props are mulitipliers a
       onSubmit={ () => console.log('submit')}
       leftSideButtons={ <Button onClick={ () => console.log('cancel') }>Cancel</Button> }
       saveButton={ <Button buttonType='primary' type="submit">Save</Button> }
-      stickyFooter
+      stickyFooter={false}
     >
       <Textbox label="Textbox" />
       <Textbox label="Textbox" />
@@ -74,7 +74,7 @@ The `mb` and `mt` props set the vertical spacing. These props are mulitipliers a
       onSubmit={ () => console.log('submit')}
       leftSideButtons={ <Button onClick={ () => console.log('cancel') }>Cancel</Button> }
       saveButton={ <Button buttonType='primary' type="submit">Save</Button> }
-      stickyFooter
+      stickyFooter={false}
     >
       <Textbox label="Textbox" labeAlign="right" labelInline labelWidth={10} inputWidth={50} />
       <Textbox label="Textbox" labeAlign="right"  labelInline labelWidth={10} inputWidth={50} />
@@ -93,9 +93,12 @@ The left and right margins can be set to 0 below a screen width breakpoint. This
   </Story> 
 </Preview>
 
+## Props
 
+### Hr
 <StyledSystemProps
   of={Hr}
   spacing
+  noHeader
   defaults={{ mt: '3', mb: '3' }}
 />

--- a/src/components/i18n/i18n.stories.mdx
+++ b/src/components/i18n/i18n.stories.mdx
@@ -21,7 +21,7 @@ You can use this component with any other component that displays text.
 ## Quick Start
 Import `I18nComponent` into the project.
 
-```jsx
+```javascript
 import I18n from "carbon-react/lib/components/i18n";
 
 const MyComponent = () => (

--- a/src/components/icon-button/icon-button.stories.mdx
+++ b/src/components/icon-button/icon-button.stories.mdx
@@ -1,0 +1,30 @@
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import IconButton from ".";
+import Icon from "../icon"
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+
+<Meta title="Design System/Icon Button" parameters={{ info: { disable: true } }} />
+
+# Icon Button 
+A component that can be used when a button with no text is needed
+
+## Quick Start
+
+```javascript
+import IconButton from "carbon-react/lib/components/icon-button";
+```
+
+## Examples 
+
+### Default 
+<Preview>
+  <Story name="default">
+    <IconButton onAction={() => {}}><Icon type='home' /></IconButton>
+  </Story>
+</Preview>
+
+## Props
+
+### Icon Button 
+
+<Props of={IconButton} />

--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -17,17 +17,17 @@ A tooltip option is available within this component.
 
 Many other components allow you to specify one of the standard Carbon icons to associate with them, for example, the Link component.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import Icon from "carbon-react/lib/components/icon";
-
-const MyComponent = () => (
-  return (
-    <Icon type="add" />
-  )
-);
 ```
+## Examples
 
 ### Default
 
@@ -155,4 +155,5 @@ See <LinkTo kind='Documentation/Colors' name="page">Colors</LinkTo> for more inf
 
 ## Props
 
+### Icon
 <Props of={Icon} />

--- a/src/components/inline-inputs/inline-inputs.stories.mdx
+++ b/src/components/inline-inputs/inline-inputs.stories.mdx
@@ -10,8 +10,21 @@ import OptionsHelper from '../../utils/helpers/options-helper';
 <Meta title="Design System/Inline Inputs" />
 
 # Inline Inputs
+Inline inputs allows the user to align multiple inputs.
 
-### Default usage:
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start 
+```javascript
+import InlineInputs from 'carbon-react/lib/components/inline-inputs';
+```
+
+## Examples 
+
+### Default
 
 <Preview>
   <Story name="default" parameters={{ info: { disable: true }, knobs: { escapeHTML: false }}} >
@@ -55,7 +68,7 @@ import OptionsHelper from '../../utils/helpers/options-helper';
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### InlineInputs
 

--- a/src/components/link/link.stories.mdx
+++ b/src/components/link/link.stories.mdx
@@ -12,6 +12,22 @@ import Typography from '../typography';
 
 Navigates the user to another location.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+Import `Link` into the project.
+
+```javascript
+import Link from "carbon-react/lib/components/link";
+```
+
+## Designer Notes
+
 To use `Link` with a routing library see our documentation on this here: <LinkTo kind='Documentation/Usage with routing'>Usage with routing</LinkTo>
 
 Avoid using links for commands (performing an action like saving a form) - use them for navigating the user to a new location.
@@ -20,15 +36,7 @@ To make the meaning of a link clearer, you can add an icon before it. Just name 
 Make your link names meaningful - for example, instead of ‘Click here’, try ‘Download Invoice 001’.
 WCAG guidelines recommend that Color is not used as the only visual means of conveying information, indicating an action. Carbon applies bold weight, but you could also use text decoration.
 
-## Quick Start
-
-Import `Link` into the project.
-
-```jsx
-import Link from "carbon-react/lib/components/link";
-
-const MyComponent = () => <Link>This is a link</Link>;
-```
+## Examples
 
 ### Default
 
@@ -172,4 +180,5 @@ Use the `target` prop to modify the behaviour when the Link component is clicked
 
 ## Props
 
+### Link
 <Props of={InternalLink} />

--- a/src/components/loader/loader.stories.mdx
+++ b/src/components/loader/loader.stories.mdx
@@ -11,25 +11,21 @@ Showing a Loader helps the user to understand that they should wait, rather than
 In general, place a Loader in the centre and middle of the page or container it relates to.
 Like many Design System elements, Loaders are made of square elements. They usually take the accent colour of the product they're in.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
 
 ## Quick Start
 Import `Loader` into the project.
 
-```jsx
-
+```javascript
 import Loader from "carbon-react/lib/components/loader";
-
-```
-If you require the `Loader` component to be nested inside of the `Button` component, you will also need to import the `Button` component.
-
-```jsx
-
-import Loader from "carbon-react/lib/components/loader";
-import Button from "carbon-react/lib/components/button";
-
 ```
 
-## Default
+## Examples
+
+### Default
 This example of the Loader component demonstrates how it will appear as default.
 
 <Preview>
@@ -57,7 +53,7 @@ This is an example of the large Loader component. The larger size is only used w
 </Preview>
 
 
-## Inside Buttons
+### Inside Buttons
 This is an example of the Loader nested inside of a Button component. When used inside a primary button the colour of the squares will be white.
 To ensure that the correct styling is applied to the `Loader` component when it is nested inside of the `Button` component,
 please remember to pass the `isInsideButton` prop to the `Loader` component.
@@ -70,4 +66,7 @@ please remember to pass the `isInsideButton` prop to the `Loader` component.
   </Story>
 </Preview>
 
+## Props
+
+### Loader
 <Props of={Loader} />

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -16,12 +16,16 @@ import Search from "../../__experimental__/components/search";
 <Meta title="Design System/Menu" parameters={{ info: { disable: true } }} />
 
 # Menu
-
 Provides navigation for an app, which can be used via mouse or keyboard.
+
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
 
 ## Quick Start
 
-```jsx
+```javascript
 import {
   Menu,
   MenuItem,
@@ -30,9 +34,9 @@ import {
 } from "carbon-react/lib/components/menu";
 ```
 
-## Visuals
+## Examples
 
-## Default
+### Default
 
 <Preview>
   <Story name="default" parameters={{ chromatic: { disable: true } }}>
@@ -58,7 +62,7 @@ import {
   </Story>
 </Preview>
 
-## Default selected
+### Default selected
 
 <Preview>
   <Story name="default selected">
@@ -77,7 +81,7 @@ import {
   </Story>
 </Preview>
 
-## Default divider
+### Default divider
 
 <Preview>
   <Story name="default divider" parameters={{ chromatic: { disable: true } }}>
@@ -96,7 +100,7 @@ import {
   </Story>
 </Preview>
 
-## Default large divider
+### Default large divider
 
 <Preview>
   <Story
@@ -118,7 +122,7 @@ import {
   </Story>
 </Preview>
 
-## Default segment title
+### Default segment title
 
 <Preview>
   <Story
@@ -140,7 +144,7 @@ import {
   </Story>
 </Preview>
 
-## Default theme with alternate colour variant
+### Default theme with alternate colour variant
 
 <Preview>
   <Story
@@ -167,7 +171,7 @@ import {
   </Story>
 </Preview>
 
-## Submenu direction left
+### Submenu direction left
 
 <Preview>
   <Story
@@ -192,8 +196,7 @@ import {
   </Story>
 </Preview>
 
-## Default icon
-
+### Default icon
 Menus with icons only must have a supplied keyboard shortcut. If no shortcut is supplied the menu item text is navigable by the first letter of each item.
 The menu must have focus for this to work
 
@@ -236,7 +239,7 @@ The menu must have focus for this to work
   </Story>
 </Preview>
 
-## Dark theme
+### Dark theme
 
 <Preview>
   <Story name="dark theme" parameters={{ chromatic: { disable: true } }}>
@@ -253,7 +256,7 @@ The menu must have focus for this to work
   </Story>
 </Preview>
 
-## Dark theme selected
+### Dark theme selected
 
 <Preview>
   <Story name="dark theme selected">
@@ -272,7 +275,7 @@ The menu must have focus for this to work
   </Story>
 </Preview>
 
-## Dark theme divider
+### Dark theme divider
 
 <Preview>
   <Story
@@ -294,7 +297,7 @@ The menu must have focus for this to work
   </Story>
 </Preview>
 
-## Dark theme large divider
+### Dark theme large divider
 
 <Preview>
   <Story
@@ -316,7 +319,7 @@ The menu must have focus for this to work
   </Story>
 </Preview>
 
-## Dark theme segment title
+### Dark theme segment title
 
 <Preview>
   <Story
@@ -338,7 +341,7 @@ The menu must have focus for this to work
   </Story>
 </Preview>
 
-## Dark theme with alternate colour variant
+### Dark theme with alternate colour variant
 
 <Preview>
   <Story
@@ -365,8 +368,7 @@ The menu must have focus for this to work
   </Story>
 </Preview>
 
-## No dropdown arrow on submenu
-
+### No dropdown arrow on submenu
 The example below has set the `showDropdownArrow` to false for the MenuItem with a submenu which means no dropdown arrow
 is rendered.
 
@@ -385,8 +387,7 @@ is rendered.
   </Story>
 </Preview>
 
-## Dark icon
-
+### Dark icon
 Menus with icons only must have a supplied keyboard shortcut. If no shortcut is supplied the menu item text is navigable by the first letter of each item.
 The menu must have focus for this to work
 
@@ -429,7 +430,7 @@ The menu must have focus for this to work
   </Story>
 </Preview>
 
-## Full navbar alignment example
+### Full navbar alignment example
 
 <Preview>
   <Story name="full navbar alignment example">
@@ -475,8 +476,7 @@ The menu must have focus for this to work
   </Story>
 </Preview>
 
-## Split submenu into separate component
-
+### Split submenu into separate component
 If you need to split out a submenu into a separate component, it must be done as shown below in order for the keyboard navigation to work as intended.
 
 <Preview>
@@ -504,8 +504,7 @@ If you need to split out a submenu into a separate component, it must be done as
   </Story>
 </Preview>
 
-## Submenu icon and text alignment
-
+### Submenu icon and text alignment
 In order to align text and icons within a submenu a `Box` component will need to be used to adjust the margin of the content.
 
 <Preview>
@@ -532,8 +531,7 @@ In order to align text and icons within a submenu a `Box` component will need to
   </Story>
 </Preview>
 
-## Scrollable submenu
-
+### Scrollable submenu
 A scrollable submenu can be added using the `ScrollableBlock` component. This can be used for all of the submenu items, or just a selection, as shown in `Menu Itme Four` below.
 Note that only one `ScrollableBlock` can be used within a single submenu.
 
@@ -583,7 +581,7 @@ Note that only one `ScrollableBlock` can be used within a single submenu.
   </Story>
 </Preview>
 
-## Scrollable submenu dark
+### Scrollable submenu dark
 
 <Preview>
   <Story
@@ -631,7 +629,7 @@ Note that only one `ScrollableBlock` can be used within a single submenu.
   </Story>
 </Preview>
 
-## Submenu with search
+### Submenu with search
 
 <Preview>
   <Story
@@ -659,26 +657,28 @@ Note that only one `ScrollableBlock` can be used within a single submenu.
   </Story>
 </Preview>
 
-## Menu Props
+## Props
+
+### Menu
 
 `Menu` extends the `Box` component so it also accepts all `Box` props.
 
 <Props of={Menu} />
 
-## MenuItem Props
+### MenuItem 
 
 `MenuItem` extends the `Box` component so it also accepts all `Box` props.
 
 <Props of={MenuItem} />
 
-## SubmenuBlock Props
+### SubmenuBlock 
 
 <Props of={SubmenuBlock} />
 
-## MenuDivider Props
+### MenuDivider 
 
 <Props of={MenuDivider} />
 
-## MenuSegmentTitle Props
+### MenuSegmentTitle 
 
 <Props of={MenuSegmentTitle} />

--- a/src/components/message/message.stories.mdx
+++ b/src/components/message/message.stories.mdx
@@ -15,6 +15,19 @@ import Link from '../link';
 # Message
 Presents a static message which stays on screen.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+```javascript
+import Message from "carbon-react/lib/components/message";
+```
+
+## Designer Notes
 Useful for messages which are longer or more important, where the user needs time to interpret them, or might need to refer back to them during an activity.
 
 Various types are available:
@@ -29,10 +42,7 @@ Various types are available:
 - Longer, time sensitive message that must be dismissed? [Try Toast](/?path=/docs/design-system-toast--default-story "Toast").
 - Error or warning message that interrupts activity? [Try Alert](/?path=/docs/alert--default-story "Alert").
 
-## Quick Start
-```jsx
-import Message from "carbon-react/lib/components/message";
-```
+## Examples
 
 ### Default
 
@@ -153,7 +163,7 @@ It is also possible to use the `List`, `ListItem` and `Typography` components to
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Message
 

--- a/src/components/mount-in-app/mount-in-app.stories.mdx
+++ b/src/components/mount-in-app/mount-in-app.stories.mdx
@@ -6,12 +6,18 @@ import MountInApp from '.';
 # Mount In App
 Mounts a component at a specific target in the DOM. Mount In App can also be used to integrate React components into pre-existing user interfaces.
 
-## Quick Start
-Import `MountInApp` into the project.
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
 
-```jsx
+## Quick Start
+
+```javascript
 import MountInApp from "carbon-react/lib/components/mount-in-app";
 ```
+
+## Examples
 
 ### Default
 <Preview>
@@ -26,4 +32,6 @@ import MountInApp from "carbon-react/lib/components/mount-in-app";
 </Preview>
 
 ## Props
+
+### Mount In App
 <Props of={MountInApp} />

--- a/src/components/multi-action-button/multi-action-button.stories.mdx
+++ b/src/components/multi-action-button/multi-action-button.stories.mdx
@@ -9,6 +9,20 @@ import { Accordion } from "../accordion";
 
 # Multi Action Button
 
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import MultiActionButton from "carbon-react/lib/components/multi-action-button";
+```
+
+## Designer Notes
+
 - Offers related actions to the user, but without taking up valuable space by showing them separately.
 - But, users may not always discover them, and could miss out.
 - Useful to show about 5 options or less.
@@ -16,11 +30,7 @@ import { Accordion } from "../accordion";
 - Don’t use this component if one option is more generic or important than the others.
 - Carbon has a Transparent configuration, with subtle visual style, which could be useful to present less important or infrequently used options to the user, without calling attention to them.
 
-## Quick Start
-
-```jsx
-import MultiActionButton from "carbon-react/lib/components/multi-action-button";
-```
+## Examples
 
 ### Default
 
@@ -141,7 +151,7 @@ Subtext only works when `size` is `large`
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### MultiActionButton
 

--- a/src/components/navigation-bar/navigation-bar.stories.mdx
+++ b/src/components/navigation-bar/navigation-bar.stories.mdx
@@ -8,7 +8,21 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 <Meta title="Design System/Navigation Bar" />
 
-# NavigationBar
+# Navigation Bar
+This component is used as a wrapper for the Menu component when used as a navigation layout.
+
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start 
+
+```javascript
+import NavigationBar from "carbon-react/lib/components/navigation-bar";
+```
+
+## Examples
 
 ### Light Theme
 
@@ -19,7 +33,6 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 </Preview>
 
 ### Light Theme Loading State
-
 If `isLoading={true}` the children will not be visible
 
 <Preview>
@@ -42,7 +55,6 @@ If `isLoading={true}` the children will not be visible
 </Preview>
 
 ### Dark Theme Loading State
-
 If `isLoading={true}` the children will not be visible
 
 <Preview>
@@ -57,7 +69,6 @@ If `isLoading={true}` the children will not be visible
 </Preview>
 
 ### With custom spacing
-
 The spacing props (see prop table below) accept either a number between 1 and 8 that is then multiplied by `8px` or any
 valid CSS string.
 
@@ -111,4 +122,7 @@ valid CSS string.
   </Story>
 </Preview>
 
-<StyledSystemProps spacing />
+## Props
+
+### Navigation Bar 
+<StyledSystemProps of={NavigationBar} noHeader spacing />

--- a/src/components/note/__internal__/note.stories.mdx
+++ b/src/components/note/__internal__/note.stories.mdx
@@ -14,18 +14,29 @@ import { EditorState, ContentState, convertFromHTML } from 'draft-js';
 The `Note` was created using the `draft-js` framework which allows rich text content to be rendered. It requires 
 consuming projects to install `draft-js` as a peer-dependency to enable it to work. 
 
-```jsx
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
 import Note from "carbon-react/lib/components/note";
 import { EditorState, ContentState, convertFromHTML } from 'draft-js';
 ```
 
-## Quick Start
+## Designer Notes
 To use `Note`, use the import path above and pass the content via the `noteContent` prop by utilising the static 
 methods provided by the `draft-js` (see the import above) framework https://draftjs.org/docs/api-reference-content-state#static-methods.
 
-### Default Usage:
+## Examples 
+
+### Default
 In its default form, the component can render plain text content by passing a value via the `noteContent` prop using 
 `EditorState.createWithContent(ContentState.createFromText(''))` to ensure the value is in the correct format.
+
 <Preview>
   <Story name="default" parameters={{ info: { disable: true }}}>
     {() => {
@@ -39,11 +50,12 @@ In its default form, the component can render plain text content by passing a va
   </Story>
 </Preview>
 
-### With rich text content:
+### With rich text content
 It is also possible to render rich text content: below is an example of how the component supports rendering `html`
 content but there is a range of supporting packages that will support converting 
 content to a format you prefer and back into one that `draft-js` supports, again utilising the `createWithContent` 
 static method.  
+
 <Preview>
   <Story name="with rich text" parameters={{ info: { disable: true }}}>
     {() => {
@@ -73,6 +85,7 @@ static method.
 
 ### With title
 An optional title can be provided using the `title` prop.
+
 <Preview>
   <Story name="title" parameters={{ info: { disable: true }}}>
     {() => {
@@ -101,8 +114,9 @@ An optional title can be provided using the `title` prop.
   </Story>
 </Preview>
 
-### With inline controls:
+### With inline controls
 Optional inline controls can be provided using the `inlineControl` prop. This should be an `ActionPopover`.
+
 <Preview>
   <Story name="inline controls" parameters={{ info: { disable: true }}}>
     {() => {
@@ -143,8 +157,9 @@ Optional inline controls can be provided using the `inlineControl` prop. This sh
   </Story>
 </Preview>
 
-### With status:
+### With status
 An optional status can be provided using the `status` prop.
+
 <Preview>
   <Story name="status" parameters={{ info: { disable: true }}}>
     {() => {
@@ -186,4 +201,7 @@ An optional status can be provided using the `status` prop.
   </Story>
 </Preview>
 
+## Props
+ 
+### Note
 <Props of={Note} />

--- a/src/components/pager/pager.stories.mdx
+++ b/src/components/pager/pager.stories.mdx
@@ -16,11 +16,18 @@ import useMediaQuery from "../../hooks/useMediaQuery/index.js"
 # Pager
 Pagination Component.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import Pager from "carbon-react/lib/components/pager"
 ```
+
+## Examples
 
 ### Default
 
@@ -247,5 +254,4 @@ using full-screen mode with device or viewport emulation.
 ## Props
 
 ### Pager
-
 <Props of={Pager} />

--- a/src/components/pages/pages.stories.mdx
+++ b/src/components/pages/pages.stories.mdx
@@ -11,13 +11,18 @@ import Button from '../button';
 # Pages
 Allows to slide to different pages in a full screen dialog.
 
-## Quick Start
-Import `DefaultPages` and `Page` into the project.
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
 
-```jsx
+## Quick Start
+
+```javascript
 import DefaultPages from "carbon-react/lib/components/pages";
 import Page from "carbon-react/lib/components/page/page";
 ```
+## Examples
 
 ### Default
 <Preview>
@@ -80,6 +85,7 @@ import Page from "carbon-react/lib/components/page/page";
 </Preview>
 
 ### Pages with Initial Page Index
+
 <Preview>
   <Story name="with Initial Page Index">
    {() => {
@@ -143,6 +149,7 @@ import Page from "carbon-react/lib/components/page/page";
 </Preview>
 
 ## Inside DialogFullScreen
+
 <Preview>
   <Story name="inside DialogFullScreen">
     {() => {

--- a/src/components/pill/pill.stories.mdx
+++ b/src/components/pill/pill.stories.mdx
@@ -9,11 +9,31 @@ import Box from "../box";
 
 Compact visual indicators that help things in common stand out.
 
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
 ```javascript
 import Pill from "carbon-react/lib/components/pill";
 ```
 
-## Status Pills
+## Examples
+
+### Default
+
+<Preview>
+  <Story name="default">
+    <Box mb={1}>
+      <Pill>default pill</Pill>
+    </Box>
+  </Story>
+</Preview>
+
+### Status Pills
 
 An automatic indicator of status, styled with utility colours to carry meaning.
 
@@ -428,7 +448,7 @@ An automatic indicator of status, styled with utility colours to carry meaning.
   </Story>
 </Preview>
 
-## Tag Pills
+### Tag Pills
 
 Applied by the user, and indicate something in common. Change the theme to see the available colours.
 
@@ -498,7 +518,7 @@ Applied by the user, and indicate something in common. Change the theme to see t
   </Story>
 </Preview>
 
-## Custom colors
+### Custom colors
 
 It's possible to change the color of the Pill by using the `borderColor` prop. It will override `colorVariant` value.
 See <LinkTo kind='Documentation/Colors' name="page">Colors</LinkTo> for more information.
@@ -585,4 +605,8 @@ See <LinkTo kind='Documentation/Colors' name="page">Colors</LinkTo> for more inf
   </Story>
 </Preview>
 
-<StyledSystemProps of={Pill} margin />
+## Props
+
+### Pill
+
+<StyledSystemProps of={Pill} margin noHeader />

--- a/src/components/pod/pod.stories.mdx
+++ b/src/components/pod/pod.stories.mdx
@@ -13,6 +13,21 @@ import PodManager from './pod-manager.component';
 # Pod
 Presents content grouped visually together. This can be text, or other components. A good example is a ‘tile’ showing contact information for an individual.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Related Components](#related-components)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import Pod from "carbon-react/lib/components/pod";
+```
+
+## Designer Notes
+
 Configure Pod and Fieldset components to work together, or choose the pre-configured Show/Edit Pod component:
 
 The ShowEditPod component automatically presents content as a read-only Pod, until the user clicks an edit icon, which shows the same information in an editable Fieldset.
@@ -30,19 +45,7 @@ Set the pod to flex to the width of its content, or take up the full width of it
 - Filling in a broad series of inputs? [Try Form](/?path=/docs/design-system-form--default-with-sticky-footer "Form").
 - Using Fieldset and Pod components together? [Try Show/Edit Pod](/?path=/docs/showeditpod--default-story "Show/Edit Pod").
 
-## Quick Start
-
-```jsx
-import Pod from "carbon-react/lib/components/pod";
-
-const MyComponent = () => (
-  return (
-    <Pod title="Title" subtitle="Subtitle">
-      Content
-    </Pod>
-  )
-);
-```
+## Examples
 
 ### Default
 
@@ -304,4 +307,5 @@ The `PodManager` does not work if `Pod` uses `collapsed` prop
 
 ## Props
 
+### Pod
 <Props of={Pod} />

--- a/src/components/popover-container/popover-container.stories.mdx
+++ b/src/components/popover-container/popover-container.stories.mdx
@@ -11,15 +11,23 @@ import Badge from '../badge';
 
 <Meta title="Design System/Popover Container" />
 
-# PopoverContainer
+# Popover Container
 
-```jsx
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
 import PopoverContainer from "carbon-react/lib/components/popover-container";
 ```
 
-### Quick Start
+## Examples
 
-To use `PopoverContainer`, import the `PopoverContainer` and pass the content as children.
+### Default
+
 <Preview>
   <Story name="default" parameters={{ info: { disable: true }}} >
     <div style={{height: 100}}>
@@ -33,6 +41,7 @@ To use `PopoverContainer`, import the `PopoverContainer` and pass the content as
 
 ### With title
 Use the `title` prop to set a title within the `PopoverContainer`.
+
 <Preview>
   <Story name="title" parameters={{ info: { disable: true }}} >
     <div style={{height: 100}}>
@@ -46,6 +55,7 @@ Use the `title` prop to set a title within the `PopoverContainer`.
 ### Right Aligned/Open Left
 Use the `position` prop to open the `PopoverContainer` to the left, this is useful if your open button is to the right
 of the screen.
+
 <Preview>
   <Story name="position" parameters={{ info: { disable: true }}} >
     <div style={{height: 100, float: 'right'}}>
@@ -58,6 +68,7 @@ of the screen.
 
 ### Cover Button
 Use the `shouldCoverButton` prop to hide the open button when the `PopoverContainer` is open.
+
 <Preview>
   <Story name="cover button" parameters={{ info: { disable: true }}} >
     <div style={{height: 100}}>
@@ -87,6 +98,7 @@ Use the `renderOpenComponent` and `renderCloseComponent` to render your own open
 
 ### Controlled
 You can use the `open`, `onOpen` and `onClose` props to control the open state of the `PopoverContainer`.
+
 <Preview>
   <Story name="controlled" parameters={{ info: { disable: true }}}>
     {() => {
@@ -112,7 +124,6 @@ You can use the `open`, `onOpen` and `onClose` props to control the open state o
 
 
 ### Complex content
-
 You can easily use many different components to create your own composition.
 
 <Preview>
@@ -143,11 +154,8 @@ You can easily use many different components to create your own composition.
   </Story>
 </Preview>
 
-
 ### Filter component
-
 If you want to use the `PopoverContainer` to create for example `Filter` component.
-
 You can do it easly in this way:
 
 <Preview>
@@ -251,4 +259,7 @@ You can do it easly in this way:
   </Story>
 </Preview>
 
+## Props
+
+### Popover Container
 <Props of={PopoverContainer} />

--- a/src/components/portrait/portrait.stories.mdx
+++ b/src/components/portrait/portrait.stories.mdx
@@ -14,11 +14,17 @@ import Portrait from ".";
 - Use initials rather than an avatar if you prefer.
 - Works with [Gravatar](http://en.gravatar.com/) as a source of avatars.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import Portrait from "carbon-react/lib/components/portrait";
 ```
+## Examples
 
 ### Default
 
@@ -90,6 +96,7 @@ Portrait also supports `gravatar`, to use it simply pass your email address regi
   </Story>
 </Preview>
 
-## Props:
+## Props
 
+### Portrait
 <Props of={Portrait} />

--- a/src/components/preview/preview.stories.mdx
+++ b/src/components/preview/preview.stories.mdx
@@ -8,13 +8,18 @@ import PreviewComponent from "./preview.component";
 
 Applies a preview loading state animation.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-Import `Preview` into the project.
-
-```jsx
+```javascript
 import Preview from "carbon-react/lib/components/preview";
 ```
+
+## Examples 
 
 ### Default
 
@@ -60,7 +65,7 @@ import Preview from "carbon-react/lib/components/preview";
 
 ## Props
 
-### Props for Preview
+### Preview
 
 <ArgsTable
   rows={[

--- a/src/components/profile/profile.stories.mdx
+++ b/src/components/profile/profile.stories.mdx
@@ -14,11 +14,18 @@ import Profile from ".";
 - Use initials rather than an avatar if you prefer.
 - Works with [Gravatar](http://en.gravatar.com/) as a source of avatars.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import Profile from "carbon-react/lib/components/profile";
 ```
+
+## Examples
 
 ### Default
 
@@ -60,6 +67,7 @@ To use an image, simply pass any valid image URL as a `src` prop.
   </Story>
 </Preview>
 
-## Props:
+## Props
 
+### Profile
 <Props of={Profile} />

--- a/src/components/row/row.stories.mdx
+++ b/src/components/row/row.stories.mdx
@@ -13,11 +13,18 @@ Useful to organise the UI of a page into a simple column-based layout.
 
 Configure the number of columns, the margin between them, and toggle separators visibility.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import { Row, Column } from "carbon-react/lib/components/row";
 ```
+
+## Examples
 
 ### Default
 
@@ -189,7 +196,7 @@ To span a `Column` over more than one column besides passing a `columnSpan` prop
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### Row
 

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -13,25 +13,30 @@ import StyledSystemProps from "../../../../.storybook/utils/styled-system-props"
 />
 
 # Filterable Select
-
-Select one of available options from the drop-down menu using filter
-
-## Overview
-
+Select one of available options from the drop-down menu using filter.
 Filterable Select is a Carbon styled implementation of WAI-ARIA Combobox with Inline Autocomplete.
 
-## Guidance, hints and tips
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
 
-Always insert `Option` Components inside the `FilterableSelect`, analogous to the `<select>` and `<option>` HTML Elements.
-
-If you type printable characters in the Textbox,
-you can filter through the existing options leaving only those that match the text you typed.
+## Quick Start
 
 ```javascript
 import { FilterableSelect, Option } from "carbon-react/lib/components/select";
 ```
 
-### Default usage:
+## Designer Notes
+Always insert `Option` Components inside the `FilterableSelect`, analogous to the `<select>` and `<option>` HTML Elements.
+
+If you type printable characters in the Textbox,
+you can filter through the existing options leaving only those that match the text you typed.
+
+## Examples
+
+### Default
 
 <Preview>
   <Story name="default">
@@ -62,7 +67,7 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### Controlled Usage:
+### Controlled Usage
 
 <Preview>
   <Story name="controlled" parameters={{ chromatic: { disable: true } }}>
@@ -104,7 +109,7 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### Open on focus:
+### Open on focus
 
 <Preview>
   <Story name="openOnFocus" parameters={{ chromatic: { disable: true } }}>
@@ -124,7 +129,7 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### Disabled:
+### Disabled
 
 <Preview>
   <Story name="disabled">
@@ -144,7 +149,7 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### Read Only:
+### Read Only
 
 <Preview>
   <Story name="readonly">
@@ -164,7 +169,7 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### With disabled portal:
+### With disabled portal
 
 <Preview>
   <Story
@@ -192,7 +197,7 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### With multiple columns:
+### With multiple columns
 
 <Preview>
   <Story
@@ -241,7 +246,7 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### With Action Button:
+### With Action Button
 
 Default Action Button will be rendered when the `listActionButton` prop is set to `true` on the Component.
 
@@ -305,8 +310,7 @@ A custom `Button` Component could be passed as the `listActionButton` value.
   </Story>
 </Preview>
 
-### With isLoading prop:
-
+### With isLoading prop
 When `isLoading` prop is passed, a loader will be appended at the end of the Select List. That functionality could be used to load the options asynchronously.
 
 <Preview>
@@ -365,8 +369,7 @@ When `isLoading` prop is passed, a loader will be appended at the end of the Sel
   </Story>
 </Preview>
 
-### Infinite scroll example:
-
+### Infinite scroll example
 The `isLoading` prop in combination with the `onListScrollBottom` prop can be used to implement infinite scroll.
 This prop will be called every time a user scrolls to the bottom of the list.
 
@@ -463,7 +466,6 @@ This prop will be called every time a user scrolls to the bottom of the list.
 </Preview>
 
 ### Required
-
 You can use the `required` prop to indicate if the field is mandatory.
 
 <Preview>
@@ -489,8 +491,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-### With object as value:
-
+### With object as value
 Option values could be passed as objects, useful when custom data is associated with an option.
 When the `id` property is set, objects will be compared based on that property (could be used when the list is recreated after an API call).
 If there is no `id` prop specified on an object, then the exact objects will be compared.
@@ -588,14 +589,13 @@ If there is no `id` prop specified on an object, then the exact objects will be 
   </Story>
 </Preview>
 
-## Props:
+## Props
 
-<StyledSystemProps of={FilterableSelect} margin />
+### Filterable Select 
+<StyledSystemProps of={FilterableSelect} noHeader margin />
 
 ### Props derived from the Textbox Component
-
 <Props of={SelectTextbox} />
 
 ### Props of the Option Component
-
 <Props of={Option} />

--- a/src/components/select/multi-select/multi-select.stories.mdx
+++ b/src/components/select/multi-select/multi-select.stories.mdx
@@ -12,25 +12,29 @@ import StyledSystemProps from "../../../../.storybook/utils/styled-system-props"
 />
 
 # MultiSelect
+Select multiple options from the drop-down menu. MultiSelect is a component that allows to choose multiple options from the drop-down list.
 
-Select multiple options from the drop-down menu.
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
 
-## Overview
-
-MultiSelect is a component that allows to choose multiple options from the drop-down list.
-
-## Guidance, hints and tips
-
-Always insert `Option` Components inside the `MultiSelect`, analogous to the `<select>` and `<option>` HTML Elements.
-
-If you type printable characters in the Textbox,
-you can filter through the existing options leaving only those that match the text you typed.
+## Quick Start
 
 ```javascript
 import { MultiSelect, Option } from "carbon-react/lib/components/select";
 ```
 
-### Default usage:
+## Designer Notes 
+Always insert `Option` Components inside the `MultiSelect`, analogous to the `<select>` and `<option>` HTML Elements.
+
+If you type printable characters in the Textbox,
+you can filter through the existing options leaving only those that match the text you typed.
+
+## Examples
+
+### Default
 
 <Preview>
   <Story name="default">
@@ -61,7 +65,7 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### Controlled Usage:
+### Controlled Usage
 
 <Preview>
   <Story name="controlled" parameters={{ chromatic: { disable: true } }}>
@@ -100,7 +104,7 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### Open on focus:
+### Open on focus
 
 <Preview>
   <Story name="openOnFocus" parameters={{ chromatic: { disable: true } }}>
@@ -120,7 +124,7 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### Disabled:
+### Disabled
 
 <Preview>
   <Story name="disabled">
@@ -145,7 +149,7 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### Read Only:
+### Read Only
 
 <Preview>
   <Story name="readonly">
@@ -170,7 +174,7 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
-### With disabled portal:
+### With disabled portal
 
 <Preview>
   <Story
@@ -247,7 +251,6 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
 </Preview>
 
 ### Required
-
 You can use the `required` prop to indicate if the field is mandatory.
 
 <Preview>
@@ -273,8 +276,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-### With object as value:
-
+### With object as value
 Option values could be passed as objects, useful when custom data is associated with an option.
 When the `id` property is set, objects will be compared based on that property (could be used when the list is recreated after an API call).
 If there is no `id` prop specified on an object, then the exact objects will be compared.
@@ -370,8 +372,7 @@ If there is no `id` prop specified on an object, then the exact objects will be 
   </Story>
 </Preview>
 
-### With isLoading prop:
-
+### With isLoading prop
 When `isLoading` prop is passed, a loader will be appended at the end of the Select List. That functionality could be used to load the options asynchronously.
 
 <Preview>
@@ -430,14 +431,13 @@ When `isLoading` prop is passed, a loader will be appended at the end of the Sel
   </Story>
 </Preview>
 
-## Props:
+## Props
 
-<StyledSystemProps of={MultiSelect} margin />
+### Multi Select 
+<StyledSystemProps of={MultiSelect} noHeader margin />
 
 ### Props derived from the Textbox Component
-
 <Props of={SelectTextbox} />
 
 ### Props of the Option Component
-
 <Props of={Option} />

--- a/src/components/select/simple-select/simple-select-sizes.stories.mdx
+++ b/src/components/select/simple-select/simple-select-sizes.stories.mdx
@@ -3,9 +3,11 @@ import { Select, Option } from '../';
 
 <Meta title="Design System/Select/Sizes" />
 
-## Simple Select Sizes:
+# Simple Select Sizes
 
-### Small:
+## Examples
+
+### Small
 
 <Preview>
   <Story name="small" parameters={{ info: { disable: true }}} >
@@ -27,7 +29,7 @@ import { Select, Option } from '../';
   </Story>
 </Preview>
 
-### Medium:
+### Medium
 
 <Preview>
   <Story name="medium" parameters={{ info: { disable: true }}} >
@@ -49,7 +51,7 @@ import { Select, Option } from '../';
   </Story>
 </Preview>
 
-### Large:
+### Large
 
 <Preview>
   <Story name="large" parameters={{ info: { disable: true }}} >

--- a/src/components/select/simple-select/simple-select.stories.mdx
+++ b/src/components/select/simple-select/simple-select.stories.mdx
@@ -9,19 +9,15 @@ import StyledSystemProps from "../../../../.storybook/utils/styled-system-props"
 <Meta title="Design System/Select" parameters={{ info: { disable: true } }} />
 
 # Simple Select
+Select one of available options from the drop-down menu. Simple Select is a Carbon styled equivalent of HTML Select Element.
 
-Select one of available options from the drop-down menu
-
-## Overview
-
-Simple Select is a Carbon styled equivalent of HTML Select Element.
-
-## Guidance, hints and tips
-
-Always insert `Option` Components inside the `Select`, analogous to the original `<select>` and `<option>` HTML Elements.
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
 
 ## Quick Start
-
 To use the `Select` component you have to import two components: `<Select />` and `<Option />`
 from `carbon-react/lib/components/select`.
 
@@ -29,7 +25,12 @@ from `carbon-react/lib/components/select`.
 import { Select, Option } from "carbon-react/lib/components/select";
 ```
 
-### Default usage:
+## Designer Notes
+Always insert `Option` Components inside the `Select`, analogous to the original `<select>` and `<option>` HTML Elements.
+
+## Examples 
+
+### Default
 
 <Preview>
   <Story name="default">
@@ -61,7 +62,6 @@ import { Select, Option } from "carbon-react/lib/components/select";
 </Preview>
 
 ### Required
-
 You can use the `required` prop to indicate if the field is mandatory.
 
 <Preview>
@@ -87,7 +87,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-### Controlled usage:
+### Controlled usage
 
 <Preview>
   <Story name="controlled" parameters={{ chromatic: { disable: true } }}>
@@ -129,8 +129,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-### With object as value:
-
+### With object as value
 Option values could be passed as objects, useful when custom data is associated with an option.
 When the `id` property is set, objects will be compared based on that property (could be used when the list is recreated after an API call).
 If there is no `id` prop specified on an object, then the exact objects will be compared.
@@ -228,8 +227,7 @@ If there is no `id` prop specified on an object, then the exact objects will be 
   </Story>
 </Preview>
 
-### With isLoading prop:
-
+### With isLoading prop
 When `isLoading` prop is passed, a loader will be appended at the end of the Select List. That functionality could be used to load the options asynchronously.
 
 <Preview>
@@ -290,8 +288,7 @@ When `isLoading` prop is passed, a loader will be appended at the end of the Sel
   </Story>
 </Preview>
 
-### Infinite scroll example:
-
+### Infinite scroll example
 The `isLoading` prop in combination with the `onListScrollBottom` prop can be used to implement infinite scroll.
 This prop will be called every time a user scrolls to the bottom of the list.
 
@@ -387,7 +384,7 @@ This prop will be called every time a user scrolls to the bottom of the list.
   </Story>
 </Preview>
 
-### Open on focus:
+### Open on focus
 
 <Preview>
   <Story name="openOnFocus" parameters={{ chromatic: { disable: true } }}>
@@ -407,7 +404,7 @@ This prop will be called every time a user scrolls to the bottom of the list.
   </Story>
 </Preview>
 
-### Disabled:
+### Disabled
 
 <Preview>
   <Story name="disabled">
@@ -427,7 +424,7 @@ This prop will be called every time a user scrolls to the bottom of the list.
   </Story>
 </Preview>
 
-### Read Only:
+### Read Only
 
 <Preview>
   <Story name="readonly">
@@ -447,7 +444,7 @@ This prop will be called every time a user scrolls to the bottom of the list.
   </Story>
 </Preview>
 
-### Transparent:
+### Transparent
 
 <Preview>
   <Story name="transparent">
@@ -467,7 +464,7 @@ This prop will be called every time a user scrolls to the bottom of the list.
   </Story>
 </Preview>
 
-### With disabled portal:
+### With disabled portal
 
 <Preview>
   <Story
@@ -495,7 +492,7 @@ This prop will be called every time a user scrolls to the bottom of the list.
   </Story>
 </Preview>
 
-### With multiple columns:
+### With multiple columns
 
 <Preview>
   <Story
@@ -544,7 +541,7 @@ This prop will be called every time a user scrolls to the bottom of the list.
   </Story>
 </Preview>
 
-### Option groups:
+### Option groups
 
 <Preview>
   <Story name="option groups" parameters={{ chromatic: { disable: true } }}>
@@ -568,7 +565,6 @@ This prop will be called every time a user scrolls to the bottom of the list.
 </Preview>
 
 ### Enabling the adaptive behaviour
-
 The inline label can change to be top aligned at a breakpoint. Enable this by passing in a number to the `adaptiveLabelBreakpoint` prop. This corresponds to a px screen width
 
 <Preview>
@@ -598,12 +594,13 @@ The inline label can change to be top aligned at a breakpoint. Enable this by pa
   </Story>
 </Preview>
 
-<StyledSystemProps of={Select} margin />
+## Props
+
+### Select 
+<StyledSystemProps noHeader of={Select} margin />
 
 ### Props derived from the Textbox Component
-
 <Props of={SelectTextbox} />
 
 ### Props of the Option Component
-
 <Props of={Option} />

--- a/src/components/settings-row/settings-row.stories.mdx
+++ b/src/components/settings-row/settings-row.stories.mdx
@@ -11,11 +11,18 @@ SettingsRow implements our UX design for settings pages.
 Useful to create a series of rows with a heading, explanatory text, and UI controls in each row.
 A good example is a settings page, or step-by-step wizard.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import SettingsRow from "carbon-react/lib/components/settings-row";
 ```
+
+## Example
 
 ### Default
 
@@ -35,6 +42,7 @@ All `children` are rendered in the input column to the right of the header colum
   </Story>
 </Preview>
 
-## Props:
+## Props
 
+### Settings Row 
 <Props of={SettingsRow} />

--- a/src/components/show-edit-pod/show-edit-pod.stories.mdx
+++ b/src/components/show-edit-pod/show-edit-pod.stories.mdx
@@ -12,6 +12,20 @@ import Textbox from '../../__experimental__/components/textbox';
 />
 
 # ShowEditPod
+
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+```javascript
+import ShowEditPod from "carbon-react/lib/components/show-edit-pod";
+```
+
+## Designer Notes
 Nest any Carbon input into this component.
 
 Configure Pod and Fieldset components to work together, or choose this pre-configured Show/Edit Pod component.
@@ -40,21 +54,7 @@ More guidance is available for each of the individual inputs you might place ins
 - Filling in a broad series of inputs? [Try Form](/?path=/docs/design-system-form--default-with-sticky-footer "Form").
 - Viewing content that’s grouped together visually? [Try Pod](/?path=/docs/pod--default-story "Pod").
 
-## Quick Start
-
-```jsx
-import ShowEditPod from "carbon-react/lib/components/show-edit-pod";
-
-const MyComponent = () => (
-  return (
-    <ShowEditPod title="Title">
-      <Content title="Content">
-        Content
-      </Content>
-    </ShowEditPod>
-  )
-);
-```
+## Examples
 
 ### Default
 
@@ -234,4 +234,5 @@ const MyComponent = () => (
 
 ## Props
 
+### Show Edit Pod
 <Props of={ShowEditPod} />

--- a/src/components/sidebar/sidebar.stories.mdx
+++ b/src/components/sidebar/sidebar.stories.mdx
@@ -9,6 +9,22 @@ import Typography from "../typography";
 
 # Sidebar
 
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
+
+
+## Quick Start
+
+```javascript
+import Sidebar from "carbon-react/lib/components/sidebar";
+```
+
+## Designer Notes 
+
 Useful to perform an action in context without navigating the user to a separate page.
 
 Useful if the user might need to refer back to the page behind the sidebar. For example, the user could select from a list of clients on the page, with detailed information on the client loading in the sidebar.
@@ -17,22 +33,18 @@ Several pre-set widths are available, and the height is always 100%. It’s best
 
 Choose whether a dark tint is applied behind the dialog which helps to focus the user on the sidebar, but don’t select this option if the user needs to refer back to the underlying page.
 
-## Related Components
-
-- Simple task in context? [Try Dialog](/?path=/docs/dialog--default-story "Try Dialog").
-- Complex task that needs more space? [Try Dialog Full Screen](/?path=/docs/dialog-full-screen--default-story "Try Dialog Full Screen").
-
-## Quick Start
-
 Sidebar is positioned on the right hand screen of the window by default.
 To position the sidebar on the left hand side pass `position='left'` to the component.
 
 The background behind the sidebar is disabled by default. To allow the user to interact
 with all the UI pass `enableBackgroundUI={ true }` to the component
 
-```jsx
-import Sidebar from "carbon-react/lib/components/sidebar";
-```
+## Related Components
+
+- Simple task in context? [Try Dialog](/?path=/docs/dialog--default-story "Try Dialog").
+- Complex task that needs more space? [Try Dialog Full Screen](/?path=/docs/dialog-full-screen--default-story "Try Dialog Full Screen").
+
+## Examples
 
 ### Default
 
@@ -118,4 +130,5 @@ If sidebar content does not fit the sidebar, scroll will appear. Default scroll 
 
 ## Props
 
+### Sidebar
 <Props of={Sidebar} />

--- a/src/components/split-button/split-button.stories.mdx
+++ b/src/components/split-button/split-button.stories.mdx
@@ -9,17 +9,27 @@ import { Accordion } from "../accordion";
 
 # Split Button
 
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import SplitButton from "carbon-react/lib/components/split-button";
+```
+
+## Designer Notes
 - Offers one more important action to the user, with some related actions also quickly accessible, but without taking up valuable space by showing them all separately.
 - But, users may not always discover the related items, and could miss out.
 - Useful to show about 5 options or less.
 - Only use this component for buttons that are very closely related (e.g. Save, Save and Email, Save and Print, Save and New).
 - Only use this component if one option is more generic or important than the others.
 
-## Quick Start
-
-```jsx
-import SplitButton from "carbon-react/lib/components/split-button";
-```
+## Examples
 
 ### Default
 
@@ -130,7 +140,7 @@ Subtext only works when `size` is `large`
   </Story>
 </Preview>
 
-## In overflow: hidden container
+### In overflow: hidden container
 
 <Preview>
   <Story
@@ -149,7 +159,7 @@ Subtext only works when `size` is `large`
   </Story>
 </Preview>
 
-## Props:
+## Props
 
 ### SplitButton
 

--- a/src/components/step-sequence/step-sequence.stories.mdx
+++ b/src/components/step-sequence/step-sequence.stories.mdx
@@ -16,36 +16,17 @@ Try to keep label text for each step as short as possible.
 
 For users on small screens or instances where horizontal space is limited, use the vertical version of this component.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-```jsx
+```javascript
 import { StepSequence, StepSequenceItem } from "carbon-react/lib/components/step-sequence";
-
-const MyComponent = () => (
-  return (
-    <StepSequence>
-      <StepSequenceItem
-        aria-label='Step 1 of 2'
-        hiddenCompleteLabel='Complete'
-        hiddenCurrentLabel='Current'
-        indicator='1'
-        status='complete'
-      >
-        Name
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label='Step 2 of 2'
-        hiddenCompleteLabel='Complete'
-        hiddenCurrentLabel='Current'
-        indicator='2'
-        status='incomplete'
-      >
-        Delivery Address
-      </StepSequenceItem>
-    </StepSequence>
-  )
-);
 ```
+## Examples
 
 ### Default
 

--- a/src/components/table-ajax/table-ajax.stories.mdx
+++ b/src/components/table-ajax/table-ajax.stories.mdx
@@ -37,7 +37,7 @@ This component is the same as [Table](/?path=/docs/table--default-story "Table")
 
 ## Quick Start
 
-```jsx
+```javascript
 import {
   TableAjax,
   TableRow,

--- a/src/components/table/table.stories.mdx
+++ b/src/components/table/table.stories.mdx
@@ -45,7 +45,7 @@ import { Table, TableCell, TableHeader, TableRow } from ".";
 
 ## Quick Start
 
-```jsx
+```javascript
 import {
   Table,
   TableRow,

--- a/src/components/tabs/tabs.stories.mdx
+++ b/src/components/tabs/tabs.stories.mdx
@@ -10,9 +10,22 @@ import { ActionPopover, ActionPopoverItem } from '../action-popover';
 <Meta title="Design System/Tabs" parameters={{ info: { disable: true } }} />
 
 # Tabs
+Switch between content panes or filtered views of tables.
+
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Related Components](#related-components)
+- [Examples](#examples)
+- [Props](#props)
 
 ## Quick Start
 
+```javascript
+import {Tabs, Tab} from "carbon-react/lib/components/tabs;
+```
+
+## Designer Notes 
 - Switch between variants of a page or different tables (e.g. separate tables showing unread and read emails).
 - There are two `position` options:
   - `top` - shows the tabs in a line, typically above a Table - best for short lists of tabs.
@@ -27,11 +40,9 @@ nested tabs, or using vertical and horizontal tabs at the same time.
 - Navigating the hierarchy of the app? [Try Menu](https://carbon.sage.com/?path=/docs/design-system-menu)
 - Positioning your primary navigation? [Try Navigation Bar](https://carbon.sage.com/?path=/docs/design-system-navigation-bar)
 
-```jsx
-import {Tabs, Tab} from "carbon-react/lib/components/tabs;
-```
+## Examples 
 
-### Default usage
+### Default
 The tabs widget also allows you to select a tab on page load. By default this is set to the first tab.
 
 <Preview>
@@ -1507,8 +1518,10 @@ By setting the `variant` prop to "alternate" it is possible to apply some additi
   </Story>
 </Preview>
 
-### Tabs Props
+## Props
+
+### Tabs
 <Props of={Tabs} />
 
-### Tab Props
+### Tab
 <Props of={Tab} />

--- a/src/components/text-editor/text-editor.stories.mdx
+++ b/src/components/text-editor/text-editor.stories.mdx
@@ -12,27 +12,34 @@ import Button from "../button";
 />
 
 # Text Editor
-
 The `TextEditor` was created using the `draftjs` framework. It requires consuming projects to install `draftjs` as a
 peer-dependency to enable it to work.
 
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
-To use the text editor , import the `TextEditor` and pass the content as as an immutable `EditorState` object.
-
-It can be used as a controlled component where the content of the input is controlled externally, as such both
-`onChange` and `value` props are required. The `labelText` and `labelId` props are also required in order to ensure
-accessibility requirements are met.
-
-```jsx
+```javascript
 import TextEditor, {
   EditorState,
   ContentState,
 } from "carbon-react/lib/components/text-editor";
 ```
 
-### Default usage:
+## Designer Notes 
+To use the text editor , import the `TextEditor` and pass the content as as an immutable `EditorState` object.
 
+It can be used as a controlled component where the content of the input is controlled externally, as such both
+`onChange` and `value` props are required. The `labelText` and `labelId` props are also required in order to ensure
+accessibility requirements are met.
+
+## Examples
+
+### Default
 In its basic format the `TextEditor` requires three props; `value`, `onChange` and `label` props. The initial
 editorState can be created empty using `EditorState.createEmpty()`, as it is below. It is also possible to render links
 in the input, this can be done by manually typing or pasting a valid url into the editor. Another feature of the
@@ -60,8 +67,7 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
-### With content:
-
+### With content
 The initial editorState can also be created with content using
 `EditorState.createWithContent(ContentState.createFromText(''))`, as it is below. Other options available for
 populating the content that can be found https://draftjs.org/docs/api-reference-content-state#static-methods.
@@ -95,7 +101,6 @@ editor can expects.
 </Preview>
 
 ### With optional Save/ Cancel buttons
-
 By passing the `onSave` callback prop it is possible to render the form control buttons as seen below. This callback
 will be executed when the `Save` button is clicked and there is content in the editor input, the button is disabled
 otherwise. Any `onCancel` callback prop passed will be called when the `Cancel` button is clicked.
@@ -126,7 +131,6 @@ otherwise. Any `onCancel` callback prop passed will be called when the `Cancel` 
 </Preview>
 
 ### With user defined character limit
-
 It is possible to override the default value for the character limit via the `characterLimit` prop. Setting this prop
 will prevent any input that would cause the content length to exceed it.
 
@@ -158,7 +162,6 @@ will prevent any input that would cause the content length to exceed it.
 </Preview>
 
 ### With validation
-
 It is possible apply validation to the `TextEditor` component by passing the desired string message to one of the `error`,
 `warning` or `info` props. When an `error` message is provided the border styling of the editor is updated to indicate
 this status.
@@ -257,6 +260,7 @@ which is multiplied by the line-height (21px).
   </Story>
 </Preview>
 
-### Text Editor Props
+## Props
 
+### Text Editor 
 <Props of={TextEditor} />

--- a/src/components/tile-select/tile-select.stories.mdx
+++ b/src/components/tile-select/tile-select.stories.mdx
@@ -15,12 +15,16 @@ import I18n from "i18n-js";
 # TileSelect
 Tile Select is an input visualized as a single or grouped set of tiles. It behaves like a `radio` or a `checkbox` depending on the mode it operates in.
 
-## Quick Start
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
 
+## Quick Start
 To use this component, import the `TileSelect` and `TileSelectGroup` if you want to have `TileSelects` grouped.
 
-```jsx
-import { TileSelectGroup, TileSelect } from "carbon-react/lib/components/radio-tile"
+```javascript
+import { TileSelectGroup, TileSelect } from "carbon-react/lib/components/tile-select"
 ```
 
 ## Examples

--- a/src/components/tile/tile.stories.mdx
+++ b/src/components/tile/tile.stories.mdx
@@ -18,18 +18,23 @@ import Hr from "../hr";
 <Meta title="Design System/Tile" parameters={{ info: { disable: true } }} />
 
 # Tile
-
 Tiles contain static content for visual scanning only, and don't contain controls.
+
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
 
 ## Quick Start
 
-```jsx
+```javascript
 import Tile from "carbon-react/lib/components/tile";
 import TileFooter from "carbon-react/lib/components/tile/tile-footer";
 ```
 
-## Default
+## Examples
 
+### Default
 By default, the Tile component will have a horizontal layout.
 
 <Preview>
@@ -42,8 +47,7 @@ By default, the Tile component will have a horizontal layout.
   </Story>
 </Preview>
 
-## Vertical
-
+### Vertical
 The Tile component can be also have a vertical layout.
 
 <Preview>
@@ -56,7 +60,7 @@ The Tile component can be also have a vertical layout.
   </Story>
 </Preview>
 
-## With TileFooter
+### With TileFooter
 
 <Preview>
   <Story name="with TileFooter">
@@ -156,8 +160,7 @@ The Tile component can be also have a vertical layout.
   </Story>
 </Preview>
 
-## With custom widths
-
+### With custom widths
 The Tile component can also have custom widths. Any child wrapped by a Tile component can be passed an optional `width` prop - this is a percent value, dictating the width of the child element within the tile.
 Please note that it will not have any effect if the Tile orientation is set to `vertical`.
 
@@ -198,8 +201,7 @@ Please note that it will not have any effect if the Tile orientation is set to `
   </Story>
 </Preview>
 
-## With inline styling
-
+### With inline styling
 The Tile component can also have inline styling applied to the content.
 
 <Preview>
@@ -239,7 +241,7 @@ The Tile component can also have inline styling applied to the content.
   </Story>
 </Preview>
 
-## With different padding and margin
+### With different padding and margin
 
 <Preview>
   <Story name="with different padding and margin">
@@ -266,35 +268,11 @@ The Tile component can also have inline styling applied to the content.
   </Story>
 </Preview>
 
-## Props for Tile
-
-<StyledSystemProps of={Tile} spacing spacingDefaults={{ p: 3 }} />
-
-## Props for TileFooter
-
-<StyledSystemProps of={TileFooter} spacing />
-
-# With Definition List
-
+### With Definition List
 The Definition List component should only be used inside of the Tile component. The purpose of the Definition List component is to mimic
 the same tags used in HTML5 but instead they are React elements.
 
-Please note that Dl, Dd and Dt use our common spacing props, the following are all available for use and each of these can be a number (which is a multiple of the base spacing constant, 8px) or any valid CSS string.
-
-### Margin props
-
-m, mt, mr, mb, ml, mx, my
-
-### Padding props
-
-p, pt, pr, pb, pl, px, py
-
-## Quick Start
-
-```jsx
-import Tile from "carbon-react/lib/components/tile";
-import { Dl, Dt, Dd } from "carbon-react/lib/components/definition-list";
-```
+Please note that Dl, Dd and Dt use our common spacing props.
 
 <Preview>
   <Story name="with Definition List - default">
@@ -334,8 +312,7 @@ import { Dl, Dt, Dd } from "carbon-react/lib/components/definition-list";
   </Story>
 </Preview>
 
-## With Definition List and custom `StyledDtDiv` width
-
+### With Definition List and custom `StyledDtDiv` width
 Providing a number value to the `w` prop, sets the width of the `<Dt />` element as a percentage. The remaining percentage is then assigned to `<Dd />` to occupy the available space.
 
 <Preview>
@@ -376,8 +353,7 @@ Providing a number value to the `w` prop, sets the width of the `<Dt />` element
   </Story>
 </Preview>
 
-## With Definition List with custom text alignment
-
+### With Definition List with custom text alignment
 In this example `dtTextAlign` has been provided the string 'left' and `ddTextAlign` has been provided the string 'right'.
 
 <Preview>
@@ -403,7 +379,7 @@ In this example `dtTextAlign` has been provided the string 'left' and `ddTextAli
   </Story>
 </Preview>
 
-## With Accordion and Definition List
+### With Accordion and Definition List
 
 <Preview>
   <Story parameters={{ chromatic: { disable: true } }} name="with Accordion">
@@ -430,7 +406,7 @@ In this example `dtTextAlign` has been provided the string 'left' and `ddTextAli
   </Story>
 </Preview>
 
-## With Accordion and TileFooter
+### With Accordion and TileFooter
 
 <Preview>
   <Story
@@ -466,16 +442,19 @@ In this example `dtTextAlign` has been provided the string 'left' and `ddTextAli
   </Story>
 </Preview>
 
-## Props of Definition List:
+## Props
 
-### Props of Dl:
+### Tile 
+<StyledSystemProps noHeader of={Tile} spacing spacingDefaults={{ p: 3 }} />
 
+### TileFooter
+<StyledSystemProps noHeader of={TileFooter} spacing />
+
+### Dl
 <StyledSystemProps of={Dl} noHeader spacing />
 
-### Props of Dd:
-
+### Dd
 <StyledSystemProps of={Dd} noHeader spacing />
 
-### Props of Dt:
-
+### Dt
 <StyledSystemProps of={Dt} noHeader spacing />

--- a/src/components/toast/toast.stories.mdx
+++ b/src/components/toast/toast.stories.mdx
@@ -8,19 +8,29 @@ import Button from '../button';
 <Meta title="Design System/Toast" parameters={{ info: { disable: true }, chromatic: { disable: true }}} />
 
 # Toast
+Toast is part of Carbon's Flashes components.
+Its purpose is to present quick confirmation of success or failure, relating to the task the user has just performed. Alternatively, use Toast messages for a longer, timely message that the user must dismiss.
+
+## Contents
+- [Quick Start](#quick-start)
+- [Designer Notes](#designer-notes)
+- [Examples](#examples)
+- [Props](#props)
 
 ## Quick Start
-
 To use toast, import the `Toast` and pass the content as children.
 
+```javascript
+import Toast from 'carbon-react/lib/components/toast';
+```
+
+## Designer Notes
 It can be used as a controlled component where the open state is controlled externally,
 in that case both `onDismiss` and `open` props are required.
 
 ### Controlled
 
-```jsx
-import Toast from 'carbon-react/lib/components/toast';
-
+```javascript
 const MyComponent = () => (
   <Toast
     variant='info'
@@ -37,9 +47,7 @@ It can be used as a uncontrolled component.
 
 ### Uncontrolled
 
-```jsx
-import Toast from 'carbon-react/lib/components/toast';
-
+```javascript
 const MyComponent = () => (
   <Toast
     variant='info'
@@ -50,14 +58,55 @@ const MyComponent = () => (
 );
 ```
 
-## Overview
-Toast is part of Carbon's Flashes components.
-Its purpose is to present quick confirmation of success or failure, relating to the task the user has just performed. Alternatively, use Toast messages for a longer, timely message that the user must dismiss.
-
-## Visuals
+## Examples
 Please note, by clicking a `toggle preview` button it will open example toast at the top of the page.
 
-### Variant Info:
+### Default
+
+<Preview>
+  <Story name="default" parameters={{ info: { disable: true }}} >
+  {() => {
+    const [isOpen, setIsOpen] = useState(false);
+    const handleToggle = () => {
+      if (!isOpen) {
+        window.scrollTo(0,0);
+      }
+      setIsOpen(!isOpen);
+      action('open')(!isOpen);
+    };
+    const StyledButton = styled(Button)`
+      position: absolute;
+      display: block;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      color: ${isOpen ? 'green' : 'blue'};
+      border: ${isOpen ? '2px solid green' : '2px solid blue'};
+    `;
+    return (
+      <div id="wrapper-default">
+        <StyledButton
+          id='button-default'
+          key='button'
+          onClick={ handleToggle }
+        >
+          Toggle - Preview is: { isOpen ? 'ON' : 'OFF' }
+        </StyledButton>
+        <Toast
+          id='toast-default'
+          variant='success'
+          open={ isOpen }
+        >
+          My message
+        </Toast>
+      </div>
+    )
+  }}
+  </Story>
+</Preview>
+
+### Variant Info
+
 <Preview>
   <Story
     name="variant-info"
@@ -103,7 +152,8 @@ Please note, by clicking a `toggle preview` button it will open example toast at
   </Story>
 </Preview>
 
-### Variant Error:
+### Variant Error
+
 <Preview>
   <Story
     name="variant-error"
@@ -149,7 +199,8 @@ Please note, by clicking a `toggle preview` button it will open example toast at
   </Story>
 </Preview>
 
-### Variant Warning:
+### Variant Warning
+
 <Preview>
   <Story
     name="variant-warning"
@@ -242,7 +293,7 @@ Please note, by clicking a `toggle preview` button it will open example toast at
   </Story>
 </Preview>
 
-### Variant Left Aligned:
+### Variant Left Aligned
 
 <Preview>
   <Story
@@ -295,7 +346,7 @@ Please note, by clicking a `toggle preview` button it will open example toast at
   </Story>
 </Preview>
 
-### Custom max width:
+### Custom max width
 
 <Preview>
   <Story name="custom-max-width" parameters={{ info: { disable: true } }}>
@@ -349,7 +400,7 @@ Please note, by clicking a `toggle preview` button it will open example toast at
   </Story>
 </Preview>
 
-### Dismissible:
+### Dismissible
 
 <Preview>
   <Story
@@ -405,7 +456,7 @@ Please note, by clicking a `toggle preview` button it will open example toast at
   </Story>
 </Preview>
 
-### Dismissible with timeout:
+### Dismissible with timeout
 
 <Preview>
   <Story
@@ -462,8 +513,7 @@ Please note, by clicking a `toggle preview` button it will open example toast at
   </Story>
 </Preview>
 
-### Grouped Delayed (stacking):
-
+### Grouped Delayed (stacking)
 One second delay
 
 <Preview>
@@ -547,8 +597,7 @@ One second delay
   </Story>
 </Preview>
 
-### Grouped (stacking):
-
+### Grouped (stacking)
 Please use `targetPortalId` prop to group multiple toasts so that they stack.
 
 <Preview>
@@ -622,51 +671,7 @@ Please use `targetPortalId` prop to group multiple toasts so that they stack.
   </Story>
 </Preview>
 
-### Default usage:
-
-<Preview>
-  <Story name="default" parameters={{ info: { disable: true }}} >
-  {() => {
-    const [isOpen, setIsOpen] = useState(false);
-    const handleToggle = () => {
-      if (!isOpen) {
-        window.scrollTo(0,0);
-      }
-      setIsOpen(!isOpen);
-      action('open')(!isOpen);
-    };
-    const StyledButton = styled(Button)`
-      position: absolute;
-      display: block;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      color: ${isOpen ? 'green' : 'blue'};
-      border: ${isOpen ? '2px solid green' : '2px solid blue'};
-    `;
-    return (
-      <div id="wrapper-default">
-        <StyledButton
-          id='button-default'
-          key='button'
-          onClick={ handleToggle }
-        >
-          Toggle - Preview is: { isOpen ? 'ON' : 'OFF' }
-        </StyledButton>
-        <Toast
-          id='toast-default'
-          variant='success'
-          open={ isOpen }
-        >
-          My message
-        </Toast>
-      </div>
-    )
-  }}
-  </Story>
-</Preview>
-
-## Props:
+## Props
 
 ### Toast
 

--- a/src/components/tooltip/tooltip.stories.mdx
+++ b/src/components/tooltip/tooltip.stories.mdx
@@ -10,16 +10,24 @@ import Button from "../button";
 />
 
 # Tooltip
-
 The `Tooltip` component is built using `tippyjs` to support features such as dynamic positioning where the tooltip will 
 flip if there is no space in its default placement; and the arrow and tooltip will track the target element when a user scrolls 
 or the window resizes.
 
-```jsx
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start 
+
+```javascript
 import Tooltip from "carbon-react/lib/components/tooltip";
 ```
 
-### Basic usage
+## Examples
+
+### Default 
 To use the Tooltip, pass in the component you want it to display on in via the `children` prop, any component passed in
 must support `forwardRef`. By default the Tooltip does not need to be controlled and will display when the target element
 is focused or hovered. The default `position` is "top" and `size` is "M". The `message` prop is the text displayed in the
@@ -174,6 +182,7 @@ when there is no space to render to the right anymore.
 </Preview>
 
 ### Large tooltip
+
 <Preview>
   <Story name="large tooltip">
     {() => {
@@ -276,6 +285,7 @@ css value. Any values passed to the `bgColor` prop will override the color appli
   </Story>
 </Preview>
 
-### Tooltip Props
+## Props
 
+### Tooltip
 <Props of={Tooltip} />

--- a/src/components/typography/typography.stories.mdx
+++ b/src/components/typography/typography.stories.mdx
@@ -8,6 +8,12 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 # Typography
 
+## Contents
+- [Quick Start](#quick-start)
+- [Props](#props)
+
+## Quick Start 
+
 ```javascript
 import Typography, {
   List,
@@ -135,6 +141,8 @@ It's also possible to create ordered and unordered lists using the `List`, `List
 
 ## Props
 
+### Typography
+
 <ArgsTable
   rows={[
     {
@@ -187,5 +195,7 @@ It's also possible to create ordered and unordered lists using the `List`, `List
     },
   ]}
 />
+
+### Styled System
 
 <StyledSystemProps noHeader spacing color />

--- a/src/components/vertical-divider/vertical-divider.stories.mdx
+++ b/src/components/vertical-divider/vertical-divider.stories.mdx
@@ -20,19 +20,19 @@ import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
 # VerticalDivider
 Provides a vertical dividing line to make the adjacent components feel distinctly separate from one another.
 
-## Quick Start
+## Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
 
+## Quick Start
 To use component, import the `VerticalDivider` and set the padding to align it with the other components.
 
-```jsx
+```javascript
   import VerticalDivider from 'carbon-react/lib/components/vertical-divider';
-
-  const MyComponent = () => (
-    <VerticalDivider />
-  );
 ```
 
-## Visuals
+## Examples
 
 ### Default
 By default the VerticalDivider has a height of `100%` and padding of `24px`.
@@ -253,7 +253,7 @@ applied to the slate.
   </Story>
 </Preview>
 
-## In a grid container
+### In a grid container
 This example is best viewed in the Canvas tab using full-screen mode with device or viewport emulation.
 
 <Preview>
@@ -364,6 +364,9 @@ This example is best viewed in the Canvas tab using full-screen mode with device
   </Story>
 </Preview>
 
+## Props
+
+### Vertical Divider 
 <StyledSystemProps
   of={VerticalDivider}
   spacing


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->

Update all the MDX documents in the design system folder so they follow a standard layout. This should make it easier for developers to find the information they are looking for and make the carbon library neater.

The proposed layout is as follows 

- Title 
  - Overview
  - Quick Start 
  - Developer notes (if needed
  - Examples
    - Titled examples with a brief description if needed 
  - Props
    - Titles for each of the prop tables with information if needed

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
The first commit covers the first 7 MDX files from Accordion -> Box

### Testing instructions
<!-- How can a reviewer test this PR? -->
Visit the docs tab of the relevant component 