### PR TITLE
feat(filterable-select): add open on focus functionality (FE-3366)

### DIFF
--- a/cypress/features/regression/designSystem/filterableSelect.feature
+++ b/cypress/features/regression/designSystem/filterableSelect.feature
@@ -94,3 +94,15 @@ Feature: Design System Filterable Select component
     When I click on dropdown button
     Then option list has 11 elements
       And visible options on Select list are "Amber", "Black", "Blue"
+
+  @positive
+  Scenario: Select dropdown list is visible when click on it with openOnFocus attr is set to true
+    Given I open "Design System Select filterable" component page "open on focus" in no iframe
+    When I click openOnFocus Select input
+    Then "filterable" Select list is opened
+
+  @positive
+  Scenario: Select dropdown list is visible when focus on it with openOnFocus attr is set to true
+    Given I open "Design System Select filterable" component page "open on focus" in no iframe
+    When I focus openOnFocus Select input
+    Then "filterable" Select list is opened

--- a/cypress/support/step-definitions/select-steps.js
+++ b/cypress/support/step-definitions/select-steps.js
@@ -35,6 +35,10 @@ When("I focus openOnFocus Select input", () => {
   openOnFocusID().focus();
 });
 
+When("I click openOnFocus Select input", () => {
+  openOnFocusID().click();
+});
+
 Then("{string} Select list is opened", (name) => {
   selectDataComponent(name).should("have.attr", "aria-expanded", "true");
   selectList().should("be.visible");

--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -23,11 +23,15 @@ const FilterableSelect = React.forwardRef(
       onChange,
       onClick,
       onKeyDown,
+      onFocus,
+      onBlur,
+      openOnFocus,
       noResultsMessage,
       disablePortal,
       listActionButton,
       onListAction,
       isLoading,
+      disabled,
       readOnly,
       onListScrollBottom,
       ...textboxProps
@@ -39,6 +43,9 @@ const FilterableSelect = React.forwardRef(
     const containerRef = useRef();
     const listboxRef = useRef();
     const isControlled = useRef(value !== undefined);
+    const isMouseDownReported = useRef(false);
+    const isInputFocused = useRef(false);
+    const isMouseDownOnInput = useRef(false);
     const [textboxRef, setTextboxRef] = useState();
     const [isOpen, setOpen] = useState(false);
     const [textValue, setTextValue] = useState("");
@@ -172,6 +179,8 @@ const FilterableSelect = React.forwardRef(
         const notInList =
           listboxRef.current && !listboxRef.current.contains(event.target);
 
+        isMouseDownReported.current = false;
+
         if (notInContainer && notInList) {
           setMatchingText(selectedValue);
           setOpen(false);
@@ -247,31 +256,17 @@ const FilterableSelect = React.forwardRef(
       const textStartsWithFilter = textValue
         .toLowerCase()
         .startsWith(filterText.toLowerCase());
+      const isTextboxActive = !disabled && !readOnly;
 
       if (
+        isTextboxActive &&
         textboxRef &&
         textValue.length > filterText.length &&
         textStartsWithFilter
       ) {
         textboxRef.selectionStart = filterText.length;
       }
-    }, [textValue, filterText, textboxRef]);
-
-    function handleTextboxClick(event) {
-      if (onClick) {
-        onClick(event);
-      }
-    }
-
-    function handleDropdownIconClick(event) {
-      if (onClick) {
-        onClick(event);
-      }
-
-      setOpen((isAlreadyOpen) => {
-        return !isAlreadyOpen;
-      });
-    }
+    }, [textValue, filterText, textboxRef, disabled, readOnly]);
 
     const onSelectOption = useCallback(
       (optionData) => {
@@ -309,6 +304,81 @@ const FilterableSelect = React.forwardRef(
       setMatchingText(selectedValue);
     }, [selectedValue, setMatchingText]);
 
+    function handleTextboxClick(event) {
+      isMouseDownReported.current = false;
+
+      if (onClick) {
+        onClick(event);
+      }
+    }
+
+    function handleDropdownIconClick(event) {
+      isMouseDownReported.current = false;
+
+      if (onClick) {
+        onClick(event);
+      }
+
+      setOpen((isAlreadyOpen) => {
+        return !isAlreadyOpen;
+      });
+    }
+
+    function handleTextboxFocus(event) {
+      const triggerFocus = () => onFocus(event);
+
+      if (openOnFocus) {
+        setOpen((isAlreadyOpen) => {
+          if (isAlreadyOpen) {
+            return true;
+          }
+
+          if (onOpen) {
+            onOpen();
+          }
+          if (onFocus && !isInputFocused.current) {
+            triggerFocus();
+            isInputFocused.current = true;
+          }
+
+          if (isMouseDownReported.current && !isMouseDownOnInput.current) {
+            return false;
+          }
+
+          return true;
+        });
+      } else if (onFocus && !isInputFocused.current) {
+        triggerFocus();
+        isInputFocused.current = true;
+      }
+    }
+
+    function handleTextboxBlur(event) {
+      isMouseDownOnInput.current = false;
+
+      if (isMouseDownReported.current) {
+        return;
+      }
+
+      isInputFocused.current = false;
+
+      if (onBlur) {
+        onBlur(event);
+      }
+    }
+
+    function handleTextboxMouseDown(event) {
+      isMouseDownReported.current = true;
+
+      if (event.target.attributes["data-element"].value === "input") {
+        isMouseDownOnInput.current = true;
+      }
+    }
+
+    function handleListMouseDown() {
+      isMouseDownReported.current = true;
+    }
+
     function findElementWithMatchingText(textToMatch, list) {
       return list.find((child) => {
         const { text } = child.props;
@@ -336,14 +406,18 @@ const FilterableSelect = React.forwardRef(
       return {
         id,
         name,
+        disabled,
         readOnly,
         inputRef: assignInput,
         selectedValue,
         formattedValue: textValue,
         onClick: handleTextboxClick,
         iconOnClick: handleDropdownIconClick,
+        onFocus: handleTextboxFocus,
+        onBlur: handleTextboxBlur,
         onKeyDown: handleTextboxKeydown,
         onChange: handleTextboxChange,
+        onMouseDown: handleTextboxMouseDown,
         ...textboxProps,
       };
     }
@@ -364,6 +438,7 @@ const FilterableSelect = React.forwardRef(
         anchorElement={textboxRef && textboxRef.parentElement}
         onSelect={onSelectOption}
         onSelectListClose={onSelectListClose}
+        onMouseDown={handleListMouseDown}
         filterText={filterText}
         highlightedValue={highlightedValue}
         noResultsMessage={noResultsMessage}
@@ -410,6 +485,8 @@ FilterableSelect.propTypes = {
   children: PropTypes.node.isRequired,
   /** A custom callback for when the dropdown menu opens */
   onOpen: PropTypes.func,
+  /** If true the Component opens on focus */
+  openOnFocus: PropTypes.bool,
   /** A custom message to be displayed when any option does not match the filter text */
   noResultsMessage: PropTypes.string,
   /** True for default text button or a Button Component to be rendered */

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -655,6 +655,120 @@ describe("FilterableSelect", () => {
       expect(wrapper.find(SelectList).exists()).toBe(true);
     });
   });
+
+  describe('when the "onBlur" prop has been passed and the input has been blurred', () => {
+    it("then that prop should be called", () => {
+      const onBlurFn = jest.fn();
+      const wrapper = renderSelect({ onBlur: onBlurFn });
+
+      wrapper.find("input").simulate("blur");
+      expect(onBlurFn).toHaveBeenCalled();
+    });
+
+    describe("and there is a mouseDown reported on open list", () => {
+      it("then that prop should not be called", () => {
+        const onBlurFn = jest.fn();
+        const wrapper = renderSelect({ onBlur: onBlurFn, openOnFocus: true });
+
+        wrapper.find("input").simulate("focus");
+        wrapper.find(Option).first().simulate("mousedown");
+        wrapper.find("input").simulate("blur");
+        expect(onBlurFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when the "openOnFocus" prop is set', () => {
+    describe("and the Textbox Input is focused", () => {
+      it("the SelectList should be rendered", () => {
+        const wrapper = renderSelect({ openOnFocus: true });
+
+        wrapper.find("input").simulate("focus");
+        expect(wrapper.find(SelectList).exists()).toBe(true);
+      });
+
+      describe.each(["readOnly", "disabled"])(
+        'with the "%s" prop passed',
+        (prop) => {
+          it("the SelectList should not be rendered", () => {
+            const obj = { [prop]: true, openOnFocus: true };
+            const wrapper = renderSelect(obj);
+
+            wrapper.find("input").simulate("focus");
+            expect(wrapper.find(SelectList).exists()).toBe(false);
+          });
+        }
+      );
+
+      describe('with the "onFocus" prop passed', () => {
+        it("then that prop should be called", () => {
+          const onFocusFn = jest.fn();
+          const wrapper = renderSelect({
+            onFocus: onFocusFn,
+            openOnFocus: true,
+          });
+
+          wrapper.find("input").simulate("focus");
+          expect(onFocusFn).toHaveBeenCalled();
+        });
+      });
+
+      describe('with the "onOpen" prop passed', () => {
+        let wrapper;
+        let onOpenFn;
+
+        beforeEach(() => {
+          onOpenFn = jest.fn();
+          wrapper = renderSelect({ onOpen: onOpenFn, openOnFocus: true });
+        });
+
+        it("then that prop should have been called", () => {
+          wrapper.find("input").simulate("focus");
+          expect(onOpenFn).toHaveBeenCalled();
+        });
+
+        describe("and with the SelectList already open", () => {
+          it("then that prop should not be called", () => {
+            wrapper.find("input").simulate("focus");
+            onOpenFn.mockReset();
+            expect(wrapper.find(SelectList).exists()).toBe(true);
+            wrapper.find("input").simulate("focus");
+            expect(onOpenFn).not.toHaveBeenCalled();
+          });
+        });
+
+        describe("and the focus triggered by mouseDown on the input", () => {
+          it("then that prop should have been called", () => {
+            wrapper.find("input").simulate("mouseDown");
+            wrapper.find("input").simulate("focus");
+            expect(onOpenFn).toHaveBeenCalled();
+          });
+        });
+      });
+    });
+
+    describe("and the focus triggered by mouseDown on the Dropdown Icon", () => {
+      describe('with the "onOpen" prop passed', () => {
+        const onOpenFn = jest.fn();
+        const wrapper = renderSelect({ onOpen: onOpenFn, openOnFocus: true });
+
+        it("then that prop should have been called", () => {
+          wrapper
+            .find(Textbox)
+            .find('[type="dropdown"]')
+            .first()
+            .simulate("mouseDown");
+          wrapper.find("input").simulate("focus");
+          expect(onOpenFn).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});
+
+describe("coverage filler for else path", () => {
+  const wrapper = renderSelect();
+  wrapper.find("input").simulate("blur");
 });
 
 function renderSelect(props = {}, renderer = mount) {

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -98,6 +98,26 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
   </Story>
 </Preview>
 
+### Open on focus:
+
+<Preview>
+  <Story name="openOnFocus" parameters={{ chromatic: { disable: true }}} >
+    <FilterableSelect name='openOnFocus' id='openOnFocus' openOnFocus>
+      <Option text='Amber' value='1' />
+      <Option text='Black' value='2' />
+      <Option text='Blue' value='3' />
+      <Option text='Brown' value='4' />
+      <Option text='Green' value='5' />
+      <Option text='Orange' value='6' />
+      <Option text='Pink' value='7' />
+      <Option text='Purple' value='8' />
+      <Option text='Red' value='9' />
+      <Option text='White' value='10' />
+      <Option text='Yellow' value='11' />
+    </FilterableSelect>
+  </Story>
+</Preview>
+
 ### Disabled:
 
 <Preview>

--- a/src/components/select/select-textbox/select-textbox.spec.js
+++ b/src/components/select/select-textbox/select-textbox.spec.js
@@ -41,3 +41,8 @@ describe("SelectTextbox", () => {
   const wrapper = mount(<SelectTextbox />);
   wrapper.find("input").simulate("blur");
 });
+
+describe("coverage filler for else path", () => {
+  const wrapper = mount(<SelectTextbox />);
+  wrapper.find("input").simulate("focus");
+});


### PR DESCRIPTION
### Proposed behaviour
Add open on focus functionality that reflects the same functionality of the SimpleSelect and Multiselect.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
1. run `npm start`
2. open http://localhost:9001/?path=/docs/design-system-select-filterable--open-on-focus