### PR TITLE
docs(routing): add usage with routing docs

### DIFF
--- a/docs/usage-with-routing.stories.mdx
+++ b/docs/usage-with-routing.stories.mdx
@@ -1,0 +1,133 @@
+<Meta title="Documentation/Usage with routing" />
+
+# Using Carbon components with routing libraries
+
+## Contents
+
+- [Usage with React Router v5](#usage-with-react-router-v5)
+- [Usage with React Router v6](#usage-with-react-router-v6)
+- [Supported components](#supported-components)
+
+## Introduction
+
+There is no code in Carbon to implement a specific routing library, we aim to let the user decide which library to use.
+
+React Router is one of the most popular routing libraries so we have provided examples below to help with implementing Carbon components as links using both v5 and v6 of this library. There are small but important differences in the implementation of each version.
+
+## Usage with React Router v5
+
+An example of how to use the Carbon `Button` and `Link` components as links with React Router v5 is shown below, this can be applied to any of the supported Carbon components.
+Note the use of the `useHistory` hook from `react-router-dom`.
+
+```jsx
+import React, { useCallback } from "react";
+import Button from "carbon-react/lib/components/button";
+import Link from "carbon-react/lib/components/link";
+
+import { BrowserRouter, Switch, Route, useHistory } from "react-router-dom";
+
+const CarbonButtonWithReactRouter = ({ to, children }) => {
+  const history = useHistory();
+  const onClick = useCallback(() => {
+    history.push(to);
+  }, [to, history]);
+
+  return <Button onClick={onClick}>{children}</Button>;
+};
+
+const CarbonLinkWithReactRouter = ({ to, children }) => {
+  const history = useHistory();
+  const onClick = useCallback(() => {
+    history.push(to);
+  }, [to, history]);
+
+  return <Link onClick={onClick}>{children}</Link>;
+};
+
+const Home = () => (
+  <div>
+    <CarbonButtonWithReactRouter to="settings">
+      Settings
+    </CarbonButtonWithReactRouter>
+  </div>
+);
+
+const Settings = () => (
+  <div>
+    <CarbonLinkWithReactRouter to="/">Home</CarbonLinkWithReactRouter>
+  </div>
+);
+
+const App = () => (
+  <BrowserRouter>
+    <Switch>
+      <Route exact path="/" element={<Home />} />
+      <Route path="/settings" element={<Settings />} />
+    </Switch>
+  </BrowserRouter>
+);
+```
+
+## Usage with React Router v6
+
+An example of how to use the Carbon `Button` and `Link` components as links with React Router v6 is shown below, this can be applied to any of the supported Carbon components.
+Note the use of the `useNavigate` hook from `react-router-dom`.
+
+```jsx
+import React, { useCallback } from "react";
+import Button from "carbon-react/lib/components/button";
+import Link from "carbon-react/lib/components/link";
+
+import { BrowserRouter, Routes, Route, useNavigate } from "react-router-dom";
+
+const CarbonButtonWithReactRouter = ({ to, children }) => {
+  const navigate = useNavigate();
+  const onClick = useCallback(() => {
+    navigate(to);
+  }, [to, navigate]);
+
+  return <Button onClick={onClick}>{children}</Button>;
+};
+
+const CarbonLinkWithReactRouter = ({ to, children }) => {
+  const navigate = useNavigate();
+  const onClick = useCallback(() => {
+    navigate(to);
+  }, [to, navigate]);
+
+  return <Link onClick={onClick}>{children}</Link>;
+};
+
+const Home = () => (
+  <div>
+    <CarbonButtonWithReactRouter to="settings">
+      Settings
+    </CarbonButtonWithReactRouter>
+  </div>
+);
+
+const Settings = () => (
+  <div>
+    <CarbonLinkWithReactRouter to="/">Home</CarbonLinkWithReactRouter>
+  </div>
+);
+
+const App = () => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="settings" element={<Settings />} />
+    </Routes>
+  </BrowserRouter>
+);
+```
+
+## Supported components
+
+There are many components that you can use this method with, including:
+
+- `ActionPopoverItem`
+- `Button`
+- `Link`
+- `MenuItem`
+- `Tab`

--- a/package-lock.json
+++ b/package-lock.json
@@ -23364,20 +23364,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -31509,16 +31495,6 @@
       "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
       "dev": true
     },
-    "mini-create-react-context": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
-      "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "tiny-warning": "^1.0.3"
-      }
-    },
     "mini-css-extract-plugin": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.7.0.tgz",
@@ -38224,65 +38200,6 @@
         }
       }
     },
-    "react-router": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
-      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-          "dev": true,
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        }
-      }
-    },
-    "react-router-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
-      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      }
-    },
     "react-select": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.1.0.tgz",
@@ -39205,12 +39122,6 @@
       "requires": {
         "global-dirs": "^0.1.1"
       }
-    },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -42005,18 +41916,6 @@
       "dev": true,
       "optional": true
     },
-    "tiny-invariant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==",
-      "dev": true
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "dev": true
-    },
     "tinycolor2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
@@ -42945,12 +42844,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "react-dnd-test-backend": "^10.0.2",
     "react-dnd-test-utils": "^10.0.2",
     "react-dom": "^16.12.0",
-    "react-router-dom": "^5.2.0",
     "react-test-renderer": "^16.12.0",
     "rimraf": "^3.0.2",
     "sass-loader": "7.0.3",

--- a/src/components/button/__snapshots__/button.spec.js.snap
+++ b/src/components/button/__snapshots__/button.spec.js.snap
@@ -638,6 +638,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   -ms-flex-pack: center;
   justify-content: center;
   vertical-align: middle;
+  outline-offset: 0;
   border: 2px solid transparent;
   box-sizing: border-box;
   font-weight: 600;
@@ -678,6 +679,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   className="c0"
   data-component="button"
   disabled={false}
+  draggable={false}
   role="button"
   size="medium"
   type="button"
@@ -750,6 +752,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   -ms-flex-pack: center;
   justify-content: center;
   vertical-align: middle;
+  outline-offset: 0;
   border: 2px solid transparent;
   box-sizing: border-box;
   font-weight: 600;
@@ -1364,6 +1367,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   className="c0"
   data-component="button"
   disabled={false}
+  draggable={false}
   role="button"
   size="medium"
   type="button"

--- a/src/components/button/button.component.js
+++ b/src/components/button/button.component.js
@@ -14,17 +14,11 @@ const renderStyledButton = (buttonProps) => {
     iconType,
     theme,
     forwardRef,
-    href,
     px,
     size,
     noWrap,
     ...styleProps
   } = buttonProps;
-
-  // added to support legacy link buttons
-  if (href) {
-    styleProps.href = href;
-  }
 
   let paddingX;
 
@@ -41,7 +35,6 @@ const renderStyledButton = (buttonProps) => {
 
   return (
     <StyledButton
-      as={!disabled && href ? "a" : "button"} // legacy link button feature
       buttonType={buttonType}
       disabled={disabled}
       role="button"
@@ -60,7 +53,7 @@ const renderStyledButton = (buttonProps) => {
 };
 
 const Button = (props) => {
-  const { disabled, to, iconType, renderRouterLink, size, subtext } = props;
+  const { size, subtext } = props;
 
   const { as, buttonType, ...rest } = props;
 
@@ -71,15 +64,6 @@ const Button = (props) => {
 
   if (subtext.length > 0 && size !== "large") {
     throw new Error("subtext prop has no effect unless the button is large");
-  }
-
-  // added to support legacy link buttons
-  if (!disabled && to && renderRouterLink) {
-    return renderRouterLink({
-      to,
-      type: iconType,
-      children: renderStyledButton(propsWithoutAs),
-    });
   }
 
   return renderStyledButton(propsWithoutAs);
@@ -155,12 +139,6 @@ Button.propTypes = {
   forwardRef: PropTypes.object,
   /** Button types for legacy theme: "primary" | "secondary" */
   as: PropTypes.oneOf(OptionsHelper.themesBinary),
-  /** Legacy - used to transform button into anchor */
-  href: PropTypes.string,
-  /** Legacy - transforms button into anchor, must be accompanied by a router link passed via `renderRouterLink` */
-  to: PropTypes.string,
-  /** Render prop that when coupled with the `to` prop will render the a routing anchor link */
-  renderRouterLink: PropTypes.func,
   /** Apply fullWidth style to the button */
   fullWidth: PropTypes.bool,
   /** If provided, the text inside a button will not wrap */

--- a/src/components/button/button.component.js
+++ b/src/components/button/button.component.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import PropTypes from "prop-types";
 import propTypes from "@styled-system/prop-types";
 
@@ -6,68 +6,6 @@ import Icon from "../icon";
 import StyledButton, { StyledButtonSubtext } from "./button.style";
 import tagComponent from "../../utils/helpers/tags";
 import OptionsHelper from "../../utils/helpers/options-helper";
-
-const renderStyledButton = (buttonProps) => {
-  const {
-    disabled,
-    buttonType,
-    iconType,
-    theme,
-    forwardRef,
-    px,
-    size,
-    noWrap,
-    ...styleProps
-  } = buttonProps;
-
-  let paddingX;
-
-  switch (size) {
-    case "small":
-      paddingX = 2;
-      break;
-    case "large":
-      paddingX = 4;
-      break;
-    default:
-      paddingX = 3;
-  }
-
-  return (
-    <StyledButton
-      buttonType={buttonType}
-      disabled={disabled}
-      role="button"
-      type="button"
-      iconType={iconType}
-      size={size}
-      px={px || paddingX}
-      noWrap={noWrap}
-      {...tagComponent("button", buttonProps)}
-      {...styleProps}
-      ref={forwardRef}
-    >
-      {renderChildren(buttonProps)}
-    </StyledButton>
-  );
-};
-
-const Button = (props) => {
-  const { size, subtext } = props;
-
-  const { as, buttonType, ...rest } = props;
-
-  const propsWithoutAs = {
-    ...rest,
-    buttonType: buttonType || as,
-  };
-
-  if (subtext.length > 0 && size !== "large") {
-    throw new Error("subtext prop has no effect unless the button is large");
-  }
-
-  return renderStyledButton(propsWithoutAs);
-};
 
 function renderChildren({
   // eslint-disable-next-line react/prop-types
@@ -116,6 +54,87 @@ function renderChildren({
   );
 }
 
+const renderStyledButton = (buttonProps) => {
+  const {
+    disabled,
+    buttonType,
+    iconType,
+    theme,
+    href,
+    ref,
+    px,
+    size,
+    noWrap,
+    ...rest
+  } = buttonProps;
+
+  let paddingX;
+
+  const handleLinkKeyDown = (event) => {
+    // If space key click link
+    if (event.key === " ") {
+      event.preventDefault();
+      ref.current.click();
+    }
+  };
+
+  if (href) {
+    rest.href = href;
+  }
+
+  switch (size) {
+    case "small":
+      paddingX = 2;
+      break;
+    case "large":
+      paddingX = 4;
+      break;
+    default:
+      paddingX = 3;
+  }
+
+  return (
+    <StyledButton
+      as={!disabled && href ? "a" : "button"}
+      onKeyDown={href && handleLinkKeyDown}
+      draggable={false}
+      buttonType={buttonType}
+      disabled={disabled}
+      role="button"
+      type={href ? undefined : "button"}
+      iconType={iconType}
+      size={size}
+      px={px || paddingX}
+      noWrap={noWrap}
+      {...tagComponent("button", buttonProps)}
+      {...rest}
+      ref={ref}
+    >
+      {renderChildren(buttonProps)}
+    </StyledButton>
+  );
+};
+
+const Button = (props) => {
+  const { size, subtext } = props;
+
+  const linkRef = useRef(null);
+
+  const { as, buttonType, forwardRef, ...rest } = props;
+
+  const propsWithoutAs = {
+    ...rest,
+    buttonType: buttonType || as,
+    ref: forwardRef || linkRef,
+  };
+
+  if (subtext.length > 0 && size !== "large") {
+    throw new Error("subtext prop has no effect unless the button is large");
+  }
+
+  return renderStyledButton(propsWithoutAs);
+};
+
 Button.propTypes = {
   /** Styled system spacing props */
   ...propTypes.space,
@@ -139,6 +158,8 @@ Button.propTypes = {
   forwardRef: PropTypes.object,
   /** Button types for legacy theme: "primary" | "secondary" */
   as: PropTypes.oneOf(OptionsHelper.themesBinary),
+  /** Used to transform button into anchor */
+  href: PropTypes.string,
   /** Apply fullWidth style to the button */
   fullWidth: PropTypes.bool,
   /** If provided, the text inside a button will not wrap */

--- a/src/components/button/button.d.ts
+++ b/src/components/button/button.d.ts
@@ -1,10 +1,22 @@
-import * as React from 'react';
-import { SpacingProps } from '../../utils/helpers/options-helper';
-import { IconTypes } from '../../utils/helpers/options-helper/options-helper';
+import * as React from "react";
+import { SpacingProps } from "../../utils/helpers/options-helper";
+import { IconTypes } from "../../utils/helpers/options-helper/options-helper";
 
 export interface ButtonProps extends SpacingProps {
-  as?: 'primary' | 'secondary' | 'tertiary' | 'dashed' | 'destructive' | 'darkBackground';
-  buttonType?: 'primary' | 'secondary' | 'tertiary' | 'dashed' | 'destructive' | 'darkBackground';
+  as?:
+    | "primary"
+    | "secondary"
+    | "tertiary"
+    | "dashed"
+    | "destructive"
+    | "darkBackground";
+  buttonType?:
+    | "primary"
+    | "secondary"
+    | "tertiary"
+    | "dashed"
+    | "destructive"
+    | "darkBackground";
   disabled?: boolean;
   destructive?: boolean;
   fullWidth?: boolean;
@@ -12,15 +24,20 @@ export interface ButtonProps extends SpacingProps {
   mb?: 0 | 1 | 2 | 3 | 4 | 5 | 7;
   /** Margin left, any valid CSS value */
   ml?: string;
-  size?: 'small' | 'medium' | 'large';
-  iconPosition?: 'before' | 'after';
+  size?: "small" | "medium" | "large";
+  iconPosition?: "before" | "after";
   iconType?: IconTypes;
   subtext?: string;
   children?: React.ReactNode;
-  renderRouterLink?: (args: object) => React.ReactNode;
+  /** Used to transform button into anchor */
+  href?: string;
   forwardRef?: () => void;
   onClick?: (event: React.MouseEvent<HTMLButtonElement | HTMLLinkElement>) => void;
   noWrap?: boolean;
 }
-declare const Button: React.ComponentType<ButtonProps | React.HTMLProps<HTMLButtonElement>>;
+
+declare const Button: React.ComponentType<
+  ButtonProps | React.HTMLProps<HTMLButtonElement>
+>;
+
 export default Button;

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -1,7 +1,9 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
-import Icon from "components/icon";
+import { act } from "react-dom/test-utils";
 import TestRenderer from "react-test-renderer";
+
+import Icon from "components/icon";
 import Button from "./button.component";
 import StyledButton from "./button.style";
 import BaseTheme from "../../style/themes/base";
@@ -552,5 +554,53 @@ describe("Button", () => {
         );
       }
     );
+  });
+
+  describe("using href prop to render as an anchor", () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = mount(<Button href="/">Test</Button>);
+    });
+
+    it("should render as an <a> element", () => {
+      expect(wrapper.find("a").exists()).toEqual(true);
+    });
+
+    describe("when space key pressed", () => {
+      it("should click the link", () => {
+        const preventDefaultSpy = jest.fn();
+
+        act(() => {
+          wrapper.find(StyledButton).at(0).props().onKeyDown({
+            key: " ",
+            which: 32,
+            preventDefault: preventDefaultSpy,
+          });
+        });
+
+        wrapper.update();
+
+        expect(preventDefaultSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe("when other key pressed", () => {
+      it("should not click the link", () => {
+        const preventDefaultSpy = jest.fn();
+
+        act(() => {
+          wrapper.find(StyledButton).at(0).props().onKeyDown({
+            key: "ArrowLeft",
+            which: 37,
+            preventDefault: jest.fn(),
+          });
+        });
+
+        wrapper.update();
+
+        expect(preventDefaultSpy).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -13,11 +13,6 @@ import {
 import { rootTagTest } from "../../utils/helpers/tags/tags-specs";
 import StyledIcon from "../icon/icon.style";
 
-const RouterLink = (props) => {
-  // eslint-disable-next-line jsx-a11y/anchor-has-content
-  return <a {...props} />;
-};
-
 const render = (props, renderer = shallow) => {
   return renderer(<Button {...props} />);
 };
@@ -518,31 +513,6 @@ describe("Button", () => {
       ).dive();
 
       rootTagTest(wrapper, "button", "bar", "baz");
-    });
-  });
-
-  // Legacy functionalities
-  describe("render", () => {
-    describe("with href", () => {
-      const wrapper = render({
-        href: "/foo",
-        children: "Anchor",
-      });
-
-      it("renders an anchor element instead of a button", () => {
-        expect(wrapper.find(StyledButton).props().as).toEqual("a");
-      });
-    });
-
-    describe("with to", () => {
-      const wrapper = render({
-        to: "/foo",
-        children: "To",
-        renderRouterLink: (routerProps) => <RouterLink {...routerProps} />,
-      });
-      it("renders a Button inside a Router Link component", () => {
-        expect(wrapper.type()).toEqual(RouterLink);
-      });
     });
   });
 

--- a/src/components/button/button.stories.js
+++ b/src/components/button/button.stories.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { text, select, boolean } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
-import { Link as RouterLink, BrowserRouter as Router } from "react-router-dom";
 import OptionsHelper from "../../utils/helpers/options-helper";
 import Button from ".";
 
@@ -42,8 +41,6 @@ const getKnobs = () => {
       OptionsHelper.buttonTypes,
       Button.defaultProps.as
     ),
-    href: text("href"),
-    to: text("to"),
     destructive: boolean("destructive", false),
     noWrap: boolean("noWrap", false),
     ...getIconKnobs(),
@@ -52,43 +49,17 @@ const getKnobs = () => {
 export const knobs = () => {
   const props = getKnobs();
   const { children } = props; // eslint-disable-line react/prop-types
-  return (
-    <Router>
-      <Button
-        {...props}
-        renderRouterLink={(routerProps) => (
-          <RouterLink {...routerProps} style={{ textDecoration: "none" }} />
-        )}
-      >
-        {children}
-      </Button>
-    </Router>
-  );
+  return <Button {...props}>{children}</Button>;
 };
 export const asASibling = () => {
   const props = getKnobs();
   const { children } = props; // eslint-disable-line react/prop-types
   return (
     <div>
-      <Router>
-        <Button
-          {...props}
-          renderRouterLink={(routerProps) => (
-            <RouterLink {...routerProps} style={{ textDecoration: "none" }} />
-          )}
-        >
-          {children}
-        </Button>
-        <Button
-          {...props}
-          renderRouterLink={(routerProps) => (
-            <RouterLink {...routerProps} style={{ textDecoration: "none" }} />
-          )}
-          ml={2}
-        >
-          {children}
-        </Button>
-      </Router>
+      <Button {...props}>{children}</Button>
+      <Button {...props} ml={2}>
+        {children}
+      </Button>
     </div>
   );
 };

--- a/src/components/button/button.stories.js
+++ b/src/components/button/button.stories.js
@@ -41,6 +41,7 @@ const getKnobs = () => {
       OptionsHelper.buttonTypes,
       Button.defaultProps.as
     ),
+    href: text("href"),
     destructive: boolean("destructive", false),
     noWrap: boolean("noWrap", false),
     ...getIconKnobs(),

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -402,6 +402,18 @@ Dashed buttons can be set to `noWrap` mode to prevent text wrapping.
   </Story>
 </Preview>
 
+## Button as a link
+
+Passing in the `href` prop will render an anchor with `role="button"` and the Button styles
+
+<Preview>
+  <Story name="as a link">
+    <Button buttonType="primary" href="/">
+      I'm a link
+    </Button>
+  </Story>
+</Preview>
+
 ## Shared Props
 
 Options shared between all of the above types of buttons. When setting padding we recommend using either the `p`, `py`

--- a/src/components/button/button.style.js
+++ b/src/components/button/button.style.js
@@ -22,6 +22,7 @@ const StyledButton = styled.button`
     `}
     justify-content: center;
     vertical-align: middle;
+    outline-offset: 0;
     ${stylingForType}
   `}
 

--- a/src/components/button/button.style.js
+++ b/src/components/button/button.style.js
@@ -109,8 +109,6 @@ StyledButton.propTypes = {
   children: PropTypes.node.isRequired,
   /** Apply disabled state to the button */
   disabled: PropTypes.bool,
-  /** Used to transform button into anchor */
-  href: PropTypes.string,
   /** Defines an Icon position within the button */
   iconPosition: PropTypes.oneOf([...OptionsHelper.buttonIconPositions, ""]),
   /** Defines an Icon type within the button (see Icon for options) */
@@ -119,8 +117,6 @@ StyledButton.propTypes = {
   size: PropTypes.oneOf(OptionsHelper.sizesRestricted),
   /** Second text child, renders under main text, only when size is "large" */
   subtext: PropTypes.string,
-  /** Used to transform button into anchor */
-  to: PropTypes.string,
 };
 
 export default StyledButton;

--- a/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
+++ b/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
@@ -24,6 +24,7 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
   -ms-flex-pack: center;
   justify-content: center;
   vertical-align: middle;
+  outline-offset: 0;
   border: 2px solid transparent;
   box-sizing: border-box;
   font-weight: 600;
@@ -116,6 +117,7 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
   <button
     class="c1"
     data-component="button"
+    draggable="false"
     role="button"
     type="button"
   >
@@ -130,6 +132,7 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
   <button
     class="c1"
     data-component="button"
+    draggable="false"
     role="button"
     type="button"
   >

--- a/src/components/link/link.component.js
+++ b/src/components/link/link.component.js
@@ -51,7 +51,7 @@ class InternalLink extends React.Component {
   }
 
   get componentProps() {
-    const props = {
+    return {
       onKeyDown: this.onKeyDown,
       onMouseDown: this.props.onMouseDown,
       disabled: this.props.disabled,
@@ -59,15 +59,8 @@ class InternalLink extends React.Component {
       tabIndex: this.tabIndex,
       target: this.props.target,
       ref: this.props.innerRef,
+      href: this.props.href,
     };
-
-    if (this.props.to) {
-      props.to = this.props.to;
-    } else {
-      props.href = this.props.href;
-    }
-
-    return props;
   }
 
   handleClick = (ev) => {
@@ -95,9 +88,7 @@ class InternalLink extends React.Component {
   createLinkBasedOnType = () => {
     let type = "a";
 
-    if (this.props.to && this.props.routerLink) {
-      type = this.props.routerLink;
-    } else if (this.props.onClick) {
+    if (this.props.onClick) {
       type = "button";
     }
 
@@ -146,14 +137,10 @@ InternalLink.propTypes = {
   onMouseDown: PropTypes.func,
   /** Whether to include the link in the tab order of the page */
   tabbable: PropTypes.bool,
-  /** Using `to` an passing in a component to the `routerLink` prop will render a routing link instead of a web href. */
-  to: PropTypes.string,
   /** A message to display as a tooltip to the link. */
   tooltipMessage: PropTypes.string,
   /** Positions the tooltip with the link. */
   tooltipPosition: PropTypes.oneOf(OptionsHelper.positions),
-  /** A routing component to render when the to prop is set */
-  routerLink: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /** Target property in which link should open ie: _blank, _self, _parent, _top */
   target: PropTypes.string,
   /** Ref to be forwarded

--- a/src/components/link/link.d.ts
+++ b/src/components/link/link.d.ts
@@ -1,23 +1,23 @@
-import * as React from 'react';
-import { IconTypes } from '../../utils/helpers/options-helper/options-helper';
+import * as React from "react";
+import { IconTypes } from "../../utils/helpers/options-helper/options-helper";
 
 export interface LinkProps {
   className?: string;
   disabled?: boolean;
   href?: string;
   icon?: IconTypes;
-  iconAlign?: 'left' | 'right';
+  iconAlign?: "left" | "right";
   onClick?: (...args: any[]) => any;
   onKeyDown?: (...args: any[]) => any;
   tabbable?: boolean;
-  to?: string;
   tooltipMessage?: string;
-  tooltipPosition?: 'bottom' | 'left' | 'right' | 'top';
+  tooltipPosition?: "bottom" | "left" | "right" | "top";
   children?: React.ReactNode;
-  routerLink?: React.ReactNode;
   target?: string;
   ariaLabel?: string;
 }
 
-declare const Link: React.ComponentType<LinkProps & React.HTMLProps<HTMLLinkElement>>;
+declare const Link: React.ComponentType<
+  LinkProps & React.HTMLProps<HTMLLinkElement>
+>;
 export default Link;

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -8,10 +8,6 @@ import Icon from "../icon";
 import StyledIcon from "../icon/icon.style";
 import Tooltip from "../tooltip";
 
-const RouterLink = (props) => {
-  // eslint-disable-next-line jsx-a11y/anchor-has-content
-  return <a {...props} />;
-};
 function renderLink(props, renderer = mount) {
   return renderer(<Link {...props}>Link Component</Link>);
 }
@@ -80,14 +76,6 @@ describe("Link", () => {
       wrapper.setProps({ href: "#" });
 
       expect(wrapper.find("a")).toHaveLength(1);
-    });
-  });
-
-  describe("when component received a `to` prop", () => {
-    it("should render a `<RouterLink />` element", () => {
-      wrapper.setProps({ to: "route", routerLink: RouterLink });
-
-      expect(wrapper.find(RouterLink)).toHaveLength(1);
     });
   });
 
@@ -164,11 +152,9 @@ describe("Link", () => {
 
     it("should trigger an `onKeyDown` prop", () => {
       wrapper.setProps({
-        to: "testRoute",
         onKeyDown: onKeyDownFn,
-        routerLink: RouterLink,
       });
-      wrapper.find(RouterLink).simulate("keydown", { keyCode: 13 });
+      wrapper.find("a").simulate("keydown", { keyCode: 13 });
 
       expect(onKeyDownFn).toHaveBeenCalled();
     });
@@ -179,36 +165,30 @@ describe("Link", () => {
           href: "#",
           onKeyDown: onKeyDownFn,
           onClick: onClickFn,
-          to: "foo",
-          routerLink: RouterLink,
         });
-        wrapper.find("a").simulate("keydown", { which: 13 });
+        wrapper.find("button").simulate("keydown", { which: 13 });
 
         expect(onClickFn).not.toHaveBeenCalled();
       });
     });
 
-    describe("and a `to` props has been received", () => {
+    describe("and a `onClick` prop has been received", () => {
       it("should trigger `onClick` prop", () => {
         wrapper.setProps({
-          to: "testRoute",
           onClick: onClickFn,
-          routerLink: RouterLink,
         });
-        wrapper.find(RouterLink).simulate("keydown", { which: 13 });
+        wrapper.find("button").simulate("keydown", { which: 13 });
 
         expect(onClickFn).toHaveBeenCalled();
       });
     });
 
-    describe("and component received a `to` prop but a `onClick` props is not available", () => {
+    describe("when a key is pressed but no onClick prop received", () => {
       beforeEach(() => {
         wrapper.setProps({
-          to: "testRoute",
           onKeyDown: onKeyDownFn,
-          routerLink: RouterLink,
         });
-        wrapper.find(RouterLink).simulate("keydown", { which: 13 });
+        wrapper.find("a").simulate("keydown", { which: 13 });
       });
 
       it("should trigger `onKeyDown` prop", () => {

--- a/src/components/link/link.stories.js
+++ b/src/components/link/link.stories.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { text, select, boolean } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
-import { Link as RouterLink, BrowserRouter as Router } from "react-router-dom";
 import OptionsHelper from "../../utils/helpers/options-helper";
 import Link from "./link.component";
 
@@ -26,7 +25,6 @@ export const Default = () => {
   const icon = select("icon", ["", ...OptionsHelper.icons], "");
   const iconAlign = select("iconAlign", OptionsHelper.alignBinary, "left");
   const tabbable = boolean("tabbable", true);
-  const to = text("to", "");
   const tooltipMessage = icon ? text("tooltipMessage", "") : undefined;
   const tooltipPosition = tooltipMessage
     ? select(
@@ -46,20 +44,16 @@ export const Default = () => {
       icon={icon}
       iconAlign={iconAlign}
       tabbable={tabbable}
-      to={to}
       tooltipMessage={tooltipMessage}
       tooltipPosition={tooltipPosition}
       onClick={onClick}
-      routerLink={to ? RouterLink : undefined}
       target={target}
     >
       {children}
     </Link>
   );
 
-  const routerLink = <Router>{link}</Router>;
-
-  return <div style={{ margin: "64px" }}>{to ? routerLink : link}</div>;
+  return <div style={{ margin: "64px" }}>{link}</div>;
 };
 
 Default.story = {

--- a/src/components/link/link.stories.mdx
+++ b/src/components/link/link.stories.mdx
@@ -1,97 +1,93 @@
-import { useState } from 'react';
-import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
-import Link, {InternalLink} from './link.component';
+import { useState } from "react";
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import Link, { InternalLink } from "./link.component";
 
-<Meta title="Link" parameters={{ info: { disable: true }}} />
+<Meta title="Link" parameters={{ info: { disable: true } }} />
 
 # Link
+
 Navigates the user to another location.
 
-Avoid using links for commands (performing an action like saving a form) - use them for navigating the user to a new location. 
+Avoid using links for commands (performing an action like saving a form) - use them for navigating the user to a new location.
 If you’re navigating the user away from your site, consider using an icon after the link, and open the link in a new window, so the user doesn’t lose their place.
 To make the meaning of a link clearer, you can add an icon before it. Just name one of the Carbon icons.
 Make your link names meaningful - for example, instead of ‘Click here’, try ‘Download Invoice 001’.
 WCAG guidelines recommend that Color is not used as the only visual means of conveying information, indicating an action. Carbon applies bold weight, but you could also use text decoration.
 
 ## Quick Start
+
 Import `Link` into the project.
 
 ```jsx
 import Link from "carbon-react/lib/components/link";
 
-const MyComponent = () => (
-  <Link>
-    This is a link
-  </Link>
-);
+const MyComponent = () => <Link>This is a link</Link>;
 ```
 
 ### Default
+
 <Preview>
   <Story name="default">
-    <Link>
-      This is a link
-    </Link>
+    <Link>This is a link</Link>
   </Story>
 </Preview>
 
 ### Disabled
+
 Setting the `disabled` prop to true disables the link.
 
 <Preview>
   <Story name="with Disabled">
-      <Link disabled>
-        This is a link
-      </Link>
+    <Link disabled>This is a link</Link>
   </Story>
 </Preview>
 
 ### href
+
 The `href` prop provides the ability for the Link to take the user to a different webpage or another part of the DOM.
 
 <Preview>
-  <Story name="with href" parameters={{ chromatic: { disable: true }}}>
-    <Link href='https://carbon.sage.com'>
-      This is a link
-    </Link>
+  <Story name="with href" parameters={{ chromatic: { disable: true } }}>
+    <Link href="https://carbon.sage.com">This is a link</Link>
   </Story>
 </Preview>
 
 ### Icon
+
 The `icon` prop allows you to render an icon.
 
 <Preview>
-  <Story name="with Icon" parameters={{ chromatic: { disable: true }}}>
-    <Link icon='settings'>
-      This is a link
-    </Link>
+  <Story name="with Icon" parameters={{ chromatic: { disable: true } }}>
+    <Link icon="settings">This is a link</Link>
   </Story>
 </Preview>
 
 ### Icon Align
+
 The `iconAlign` prop allows you to control if the icon renders to left or right of the Link.
 
 <Preview>
   <Story name="with IconAlign">
     {() => {
-      return ['left', 'right'].map(align =>
-      <div style={{margin: '64px'}}>
-        <Link icon='settings' iconAlign={`${align}`}>
-          This is a link
-        </Link>
-      </div>
-      )
+      return ["left", "right"].map((align) => (
+        <div style={{ margin: "64px" }}>
+          <Link icon="settings" iconAlign={`${align}`}>
+            This is a link
+          </Link>
+        </div>
+      ));
     }}
   </Story>
 </Preview>
 
 ### Tooltip
+
 By rendering an icon and providing a string to the `tooltipMessage` prop, a tooltip message can be displayed when hovering over the icon.
 
 <Preview>
-  <Story name="with Tooltip" parameters={{ chromatic: { disable: true }}}>
-    <div style={{margin: '64px'}}>
-      <Link icon='settings' tooltipMessage='This is a tooltip message'>
+  <Story name="with Tooltip" parameters={{ chromatic: { disable: true } }}>
+    <div style={{ margin: "64px" }}>
+      <Link icon="settings" tooltipMessage="This is a tooltip message">
         This is a link
       </Link>
     </div>
@@ -99,26 +95,27 @@ By rendering an icon and providing a string to the `tooltipMessage` prop, a tool
 </Preview>
 
 ### OnClick
+
 A custom `onClick` function can be passed to the Link component to render it as a button instead of an anchor.
 
 <Preview>
-  <Story name="with onClick" parameters={{ chromatic: { disable: true }}}>
-    <Link onClick={ ()=> {} }>
+  <Story name="with onClick" parameters={{ chromatic: { disable: true } }}>
+    <Link onClick={() => {}}>This is a link</Link>
+  </Story>
+</Preview>
+
+### Target
+
+Use the `target` prop to modify the behaviour when the Link component is clicked. In this example, target has been assigned '\_blank'.
+
+<Preview>
+  <Story name="with Target" parameters={{ chromatic: { disable: true } }}>
+    <Link href="https://carbon.sage.com" target="_blank">
       This is a link
     </Link>
   </Story>
 </Preview>
 
-### Target
-Use the `target` prop to modify the behaviour when the Link component is clicked. In this example, target has been assigned '_blank'.
-
-<Preview>
-  <Story name="with Target" parameters={{ chromatic: { disable: true }}}>
-      <Link href='https://carbon.sage.com' target='_blank'>
-        This is a link
-      </Link>
-  </Story>
-</Preview>
-
 ## Props
+
 <Props of={InternalLink} />

--- a/src/components/link/link.stories.mdx
+++ b/src/components/link/link.stories.mdx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import LinkTo from "@storybook/addon-links/react";
 import Link, { InternalLink } from "./link.component";
 
 <Meta title="Link" parameters={{ info: { disable: true } }} />
@@ -7,6 +8,8 @@ import Link, { InternalLink } from "./link.component";
 # Link
 
 Navigates the user to another location.
+
+To use `Link` with a routing library see our documentation on this here: <LinkTo kind='Documentation/Usage with routing'>Usage with routing</LinkTo>
 
 Avoid using links for commands (performing an action like saving a form) - use them for navigating the user to a new location.
 If you’re navigating the user away from your site, consider using an icon after the link, and open the link in a new window, so the user doesn’t lose their place.
@@ -106,7 +109,7 @@ A custom `onClick` function can be passed to the Link component to render it as 
 
 ### Target
 
-Use the `target` prop to modify the behaviour when the Link component is clicked. In this example, target has been assigned '\_blank'.
+Use the `target` prop to modify the behaviour when the Link component is clicked. In this example, target has been assigned `_blank`.
 
 <Preview>
   <Story name="with Target" parameters={{ chromatic: { disable: true } }}>

--- a/src/components/menu/menu-item/menu-item.component.js
+++ b/src/components/menu/menu-item/menu-item.component.js
@@ -23,13 +23,11 @@ const MenuItem = ({
   submenu,
   children,
   href,
-  to,
   onClick,
   target,
   submenuDirection = "right",
   icon,
   selected,
-  routerLink,
   onKeyDown,
   variant = "default",
   showDropdownArrow = true,
@@ -90,15 +88,14 @@ const MenuItem = ({
   const classes = useMemo(
     () =>
       classNames({
-        "carbon-menu-item--has-link": href || to || onClick,
+        "carbon-menu-item--has-link": href || onClick,
       }),
-    [href, to, onClick]
+    [href, onClick]
   );
 
   const elementProps = {
     className: classes,
     href,
-    to,
     target,
     onClick,
     icon,
@@ -106,10 +103,6 @@ const MenuItem = ({
     menuType: menuContext.menuType,
     tabbable: menuContext.isFirstElement,
   };
-
-  if (!submenu) {
-    elementProps.routerLink = routerLink;
-  }
 
   if (submenu) {
     return (
@@ -198,10 +191,6 @@ MenuItem.propTypes = {
   submenu: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
   /** The href to use for the menu item. */
   href: PropTypes.string,
-  /** The to link to use for the menu item. */
-  to: PropTypes.string,
-  /** The link element to use when providing the to value */
-  routerLink: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   /** onKeyDown handler */
   onKeyDown: PropTypes.func,
   /** The target to use for the menu item. */

--- a/src/components/menu/menu-item/menu-item.d.ts
+++ b/src/components/menu/menu-item/menu-item.d.ts
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import { IconTypes } from '../../../utils/helpers/options-helper/options-helper';
+import * as React from "react";
+import { IconTypes } from "../../../utils/helpers/options-helper/options-helper";
 
 export interface MenuItemProps {
   children: React.ReactNode;
@@ -10,12 +10,10 @@ export interface MenuItemProps {
   selected?: boolean;
   submenu?: React.ReactNode | boolean;
   href?: string;
-  to?: string;
-  routerLink?: React.ReactNode;
   keyboardOverride?: string;
   onKeyDown?: (event: React.KeyboardEvent<HTMLElement>) => void;
   target?: string;
-  variant?: 'default' | 'alternate';
+  variant?: "default" | "alternate";
   showDropdownArrow?: boolean;
   ariaLabel?: string;
 }

--- a/src/components/menu/menu-item/menu-item.spec.js
+++ b/src/components/menu/menu-item/menu-item.spec.js
@@ -103,18 +103,6 @@ describe("MenuItem", () => {
     );
   });
 
-  it("should provide prop `routerLink` correctly", () => {
-    const CustomRouterLink = () => <a href="/test">custom link</a>;
-
-    wrapper = mount(
-      <MenuItem routerLink={<CustomRouterLink />}>Item</MenuItem>
-    );
-
-    expect(
-      wrapper.find(StyledMenuItemWrapper).first().props().routerLink
-    ).toEqual(<CustomRouterLink />);
-  });
-
   describe("submenu", () => {
     it("should render Submenu if prop submenu is set", () => {
       wrapper = mount(
@@ -130,20 +118,6 @@ describe("MenuItem", () => {
       wrapper = mount(<MenuItem>Item One</MenuItem>);
 
       expect(wrapper.find(Link).exists()).toBe(true);
-    });
-
-    it("should not provide prop `routerLink` if prop `submenu` exists", () => {
-      const CustomRouterLink = () => <a href="/test">custom link</a>;
-
-      wrapper = mount(
-        <MenuItem submenu="submenu" routerLink={<CustomRouterLink />}>
-          <MenuItem>Submenu Item</MenuItem>
-        </MenuItem>
-      );
-
-      expect(
-        wrapper.find(StyledMenuItemWrapper).first().props().routerLink
-      ).toBe(undefined);
     });
 
     it('should render nested `<MenuItem />` with `submenuDirection="right"` as default if prop submenu exists', () => {

--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.js.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.js.snap
@@ -50,6 +50,7 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   vertical-align: middle;
+  outline-offset: 0;
   border: 2px solid transparent;
   box-sizing: border-box;
   font-weight: 600;
@@ -132,6 +133,7 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
       data-component="button"
       data-element="toggle-button"
       disabled={false}
+      draggable={false}
       onBlur={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}

--- a/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
+++ b/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
@@ -50,6 +50,7 @@ exports[`Option renders properly 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   vertical-align: middle;
+  outline-offset: 0;
   border: 2px solid transparent;
   box-sizing: border-box;
   font-weight: 600;
@@ -125,6 +126,7 @@ exports[`Option renders properly 1`] = `
     className="c1 c2"
     data-component="button"
     disabled={false}
+    draggable={false}
     onClick={[Function]}
     role="button"
     size="medium"

--- a/src/components/split-button/__snapshots__/split-button.spec.js.snap
+++ b/src/components/split-button/__snapshots__/split-button.spec.js.snap
@@ -50,6 +50,7 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   vertical-align: middle;
+  outline-offset: 0;
   border: 2px solid transparent;
   box-sizing: border-box;
   font-weight: 600;
@@ -136,6 +137,7 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   vertical-align: middle;
+  outline-offset: 0;
   border: 2px solid transparent;
   box-sizing: border-box;
   font-weight: 600;
@@ -294,6 +296,7 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
     data-component="button"
     data-element="main-button"
     disabled={false}
+    draggable={false}
     id="guid-12345"
     onFocus={[Function]}
     onMouseEnter={[Function]}


### PR DESCRIPTION
Fixes: #1756 

### Proposed behaviour
Remove Carbon support for rendering router links in `Button`, `Link` and `MenuItem`. 

Instead provide a documented example of how users can use Carbon components as links in React Router versions 5 and 6. This can be seen at: http://localhost:9001/?path=/docs/documentation-usage-with-routing--page

Also the `onClick` prop for `Link` will no longer render it as a `button` element, it will always render an `a` element now.

Fixed the accessibility for a `Button` rendering as a link. It now has `role="button"` and `draggable="false"` on the `<a>` element and pressing the space bar will follow the link rather than scroll the page

### Current behaviour
`Button`, `Link` and `MenuItem` have custom implementations on rendering router links via props.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
http://localhost:9001/?path=/docs/documentation-usage-with-routing--page

To test `Button` rendering as a link http://localhost:9001/?path=/story/design-system-button--as-a-link