### PR TITLE
feat(button): add noWrap prop - FE-3459

### DIFF
--- a/src/components/button/button.component.js
+++ b/src/components/button/button.component.js
@@ -17,6 +17,7 @@ const renderStyledButton = (buttonProps) => {
     href,
     px,
     size,
+    noWrap,
     ...styleProps
   } = buttonProps;
 
@@ -48,6 +49,7 @@ const renderStyledButton = (buttonProps) => {
       iconType={iconType}
       size={size}
       px={px || paddingX}
+      noWrap={noWrap}
       {...tagComponent("button", buttonProps)}
       {...styleProps}
       ref={forwardRef}
@@ -161,6 +163,8 @@ Button.propTypes = {
   renderRouterLink: PropTypes.func,
   /** Apply fullWidth style to the button */
   fullWidth: PropTypes.bool,
+  /** If provided, the text inside a button will not wrap */
+  noWrap: PropTypes.bool,
 };
 
 Button.defaultProps = {

--- a/src/components/button/button.d.ts
+++ b/src/components/button/button.d.ts
@@ -20,6 +20,7 @@ export interface ButtonProps extends SpacingProps {
   renderRouterLink?: (args: object) => React.ReactNode;
   forwardRef?: () => void;
   onClick?: (event: React.MouseEvent<HTMLButtonElement | HTMLLinkElement>) => void;
+  noWrap?: boolean;
 }
 declare const Button: React.ComponentType<ButtonProps | React.HTMLProps<HTMLButtonElement>>;
 export default Button;

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import Icon from "components/icon";
 import TestRenderer from "react-test-renderer";
 import Button from "./button.component";
@@ -286,6 +286,13 @@ describe("Button", () => {
       wrapper,
       { modifier: `:hover ${StyledIcon}` }
     );
+  });
+
+  describe('when "noWrap" prop is passed', () => {
+    it("renders with property whiteSpace: nowrap set", () => {
+      const wrapper = mount(<Button noWrap>Button</Button>);
+      assertStyleMatch({ whiteSpace: "nowrap" }, wrapper);
+    });
   });
 
   describe('when the "disabled" prop is passed', () => {

--- a/src/components/button/button.stories.js
+++ b/src/components/button/button.stories.js
@@ -45,6 +45,7 @@ const getKnobs = () => {
     href: text("href"),
     to: text("to"),
     destructive: boolean("destructive", false),
+    noWrap: boolean("noWrap", false),
     ...getIconKnobs(),
   };
 };
@@ -185,6 +186,61 @@ export const darkBackgroundButtonsIconsAfter = generateButtons(
   "darkBackground",
   "after"
 );
+
+export const noWrapButtons = () => {
+  const noWrap = boolean("noWrap", true);
+  return (
+    <>
+      {OptionsHelper.buttonTypes.map((buttonType) => {
+        return OptionsHelper.sizesRestricted.map((size) => {
+          return (
+            <div style={{ width: 100 }}>
+              <Button buttonType={buttonType} noWrap={noWrap} size={size}>
+                Long button text
+              </Button>
+              <Button
+                buttonType={buttonType}
+                noWrap={noWrap}
+                size={size}
+                iconType="bin"
+              >
+                Long button text
+              </Button>
+              <Button
+                buttonType={buttonType}
+                noWrap={noWrap}
+                size={size}
+                iconType="bin"
+                iconPosition="after"
+              >
+                Long button text
+              </Button>
+              <Button
+                buttonType={buttonType}
+                noWrap={noWrap}
+                size="large"
+                iconType="bin"
+                subtext="Even longer button subtext"
+              >
+                Long button text
+              </Button>
+              <Button
+                buttonType={buttonType}
+                noWrap={noWrap}
+                size="large"
+                iconType="bin"
+                iconPosition="after"
+                subtext="Even longer button subtext"
+              >
+                Long button text
+              </Button>
+            </div>
+          );
+        });
+      })}
+    </>
+  );
+};
 
 export const fullWidthButtons = () => {
   return (

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -1,230 +1,414 @@
-import { Meta, Story, Preview, Props} from '@storybook/addon-docs/blocks';
-import Button from '.';
-import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import Button from ".";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
-<Meta title="Design System/Button" />
+<Meta title="Design System/Button" parameters={{ info: { disable: true } }} />
 
 # Button
 
 ```javascript
-  import Button from 'carbon-react/lib/components/button';
+import Button from "carbon-react/lib/components/button";
 ```
 
 ## Primary Buttons
+
 For the single most prominent call to action on the page (e.g. Save, Submit, Continue).
+
 <Preview>
-  <Story name="primary" parameters={{ info: { disable: true }}} >
+  <Story name="primary">
     <>
-      <Button buttonType="primary" size="small">Small</Button>
-      <Button buttonType="primary" ml={2}>Medium</Button>
-      <Button buttonType="primary" size="large" ml={2}>Large</Button>
+      <Button buttonType="primary" size="small">
+        Small
+      </Button>
+      <Button buttonType="primary" ml={2}>
+        Medium
+      </Button>
+      <Button buttonType="primary" size="large" ml={2}>
+        Large
+      </Button>
     </>
   </Story>
 </Preview>
 
 Primary buttons can be destructive.
+
 <Preview>
-  <Story name="primary/destructive" parameters={{ info: { disable: true }}} >
+  <Story name="primary/destructive">
     <>
-      <Button buttonType="primary" destructive size="small">Small</Button>
-      <Button buttonType="primary" destructive ml={2}>Medium</Button>
-      <Button buttonType="primary" destructive size="large" ml={2}>Large</Button>
+      <Button buttonType="primary" destructive size="small">
+        Small
+      </Button>
+      <Button buttonType="primary" destructive ml={2}>
+        Medium
+      </Button>
+      <Button buttonType="primary" destructive size="large" ml={2}>
+        Large
+      </Button>
     </>
   </Story>
 </Preview>
 
 Primary buttons can be disabled.
+
 <Preview>
-  <Story name="primary/disabled" parameters={{ info: { disable: true }}} >
+  <Story name="primary/disabled">
     <>
-      <Button buttonType="primary" disabled size="small">Small</Button>
-      <Button buttonType="primary" disabled ml={2}>Medium</Button>
-      <Button buttonType="primary" disabled size="large" ml={2}>Large</Button>
+      <Button buttonType="primary" disabled size="small">
+        Small
+      </Button>
+      <Button buttonType="primary" disabled ml={2}>
+        Medium
+      </Button>
+      <Button buttonType="primary" disabled size="large" ml={2}>
+        Large
+      </Button>
     </>
   </Story>
 </Preview>
 
 Primary buttons can have an icon positioned before or after the text.
+
 <Preview>
-  <Story name="primary/icon" parameters={{ info: { disable: true }}} >
-  <>
-    <Button buttonType="primary" iconType="print">Medium</Button>
-    <Button buttonType="primary" destructive iconType="delete" iconPosition="after" ml={2}>Medium</Button>
-    <Button buttonType="primary" disabled iconType="print" iconPosition="after" ml={2}>Medium</Button>
+  <Story name="primary/icon">
+    <>
+      <Button buttonType="primary" iconType="print">
+        Medium
+      </Button>
+      <Button
+        buttonType="primary"
+        destructive
+        iconType="delete"
+        iconPosition="after"
+        ml={2}
+      >
+        Medium
+      </Button>
+      <Button
+        buttonType="primary"
+        disabled
+        iconType="print"
+        iconPosition="after"
+        ml={2}
+      >
+        Medium
+      </Button>
     </>
   </Story>
 </Preview>
 
 Primary buttons can be `fullWidth`.
+
 <Preview>
-  <Story name="primary/full-width" parameters={{ info: { disable: true }}} >
+  <Story name="primary/full-width">
     <>
-      <Button buttonType="primary" fullWidth>Full Width</Button>
+      <Button buttonType="primary" fullWidth>
+        Full Width
+      </Button>
     </>
   </Story>
 </Preview>
 
+Primary buttons can be set into `noWrap` mode to prevent text wrapping.
+
+<Preview>
+  <Story name="primary/noWrap">
+    <Button buttonType="primary" noWrap>
+      Long button text
+    </Button>
+  </Story>
+</Preview>
+
 ## Secondary Buttons
+
 Less prominent, there can be multiple secondary buttons on a page.
 Secondary buttons are transparent, rather than white.
 
 <Preview>
-  <Story name="secondary" parameters={{ info: { disable: true }}} >
+  <Story name="secondary">
     <>
-      <Button size="small" >Small</Button>
+      <Button size="small">Small</Button>
       <Button ml={2}>Medium</Button>
-      <Button size="large" ml={2}>Large</Button>
+      <Button size="large" ml={2}>
+        Large
+      </Button>
     </>
   </Story>
 </Preview>
 
 Secondary buttons can be destructive.
+
 <Preview>
-  <Story name="secondary/destructive" parameters={{ info: { disable: true }}} >
+  <Story name="secondary/destructive">
     <>
-      <Button destructive size="small">Small</Button>
-      <Button destructive ml={2}>Medium</Button>
-      <Button destructive size="large" ml={2}>Large</Button>
+      <Button destructive size="small">
+        Small
+      </Button>
+      <Button destructive ml={2}>
+        Medium
+      </Button>
+      <Button destructive size="large" ml={2}>
+        Large
+      </Button>
     </>
   </Story>
 </Preview>
 
 Secondary buttons can be disabled.
+
 <Preview>
-  <Story name="secondary/disabled" parameters={{ info: { disable: true }}} >
+  <Story name="secondary/disabled">
     <>
-      <Button size="small" disabled>Small</Button>
-      <Button disabled ml={2}>Medium</Button>
-      <Button size="large" disabled ml={2}>Large</Button>
+      <Button size="small" disabled>
+        Small
+      </Button>
+      <Button disabled ml={2}>
+        Medium
+      </Button>
+      <Button size="large" disabled ml={2}>
+        Large
+      </Button>
     </>
   </Story>
 </Preview>
 
 Secondary buttons can have an icon positioned before or after the text.
+
 <Preview>
-  <Story name="secondary/icon" parameters={{ info: { disable: true }}} >
-  <>
-    <Button iconType="print">Medium</Button>
-    <Button destructive iconType="delete" iconPosition="after" ml={2}>Medium</Button>
-    <Button disabled iconType="print" iconPosition="after" ml={2}>Medium</Button>
+  <Story name="secondary/icon">
+    <>
+      <Button iconType="print">Medium</Button>
+      <Button destructive iconType="delete" iconPosition="after" ml={2}>
+        Medium
+      </Button>
+      <Button disabled iconType="print" iconPosition="after" ml={2}>
+        Medium
+      </Button>
     </>
   </Story>
 </Preview>
 
 Secondary buttons can be `fullWidth`.
+
 <Preview>
-  <Story name="secondary/full-width" parameters={{ info: { disable: true }}} >
+  <Story name="secondary/full-width">
     <>
-      <Button buttonType="secondary" fullWidth>Full Width</Button>
+      <Button buttonType="secondary" fullWidth>
+        Full Width
+      </Button>
     </>
   </Story>
 </Preview>
 
+Secondary buttons can be set into `noWrap` mode to prevent text wrapping.
+
+<Preview>
+  <Story name="secondary/noWrap" parameters={{ chromatic: { disable: true } }}>
+    <Button buttonType="secondary" noWrap>
+      Long button text
+    </Button>
+  </Story>
+</Preview>
 
 ## Tertiary Buttons
+
 Tertiary or ‘ghost’ buttons are used for reversing actions, like ‘Cancel’ or ‘Back’.
 
 <Preview>
-  <Story name="tertiary" parameters={{ info: { disable: true }}} >
+  <Story name="tertiary">
     <>
-      <Button buttonType="tertiary" size="small">Small</Button>
-      <Button buttonType="tertiary" ml={2}>Medium</Button>
-      <Button buttonType="tertiary" size="large" ml={2}>Large</Button>
+      <Button buttonType="tertiary" size="small">
+        Small
+      </Button>
+      <Button buttonType="tertiary" ml={2}>
+        Medium
+      </Button>
+      <Button buttonType="tertiary" size="large" ml={2}>
+        Large
+      </Button>
     </>
   </Story>
 </Preview>
 
 Tertiary buttons can be destructive.
+
 <Preview>
-  <Story name="tertiary/destructive" parameters={{ info: { disable: true }}} >
+  <Story name="tertiary/destructive">
     <>
-      <Button buttonType="tertiary" destructive size="small">Small</Button>
-      <Button buttonType="tertiary" destructive ml={2}>Medium</Button>
-      <Button buttonType="tertiary" destructive size="large" ml={2}>Large</Button>
+      <Button buttonType="tertiary" destructive size="small">
+        Small
+      </Button>
+      <Button buttonType="tertiary" destructive ml={2}>
+        Medium
+      </Button>
+      <Button buttonType="tertiary" destructive size="large" ml={2}>
+        Large
+      </Button>
     </>
   </Story>
 </Preview>
 
 Tertiary buttons can be disabled.
+
 <Preview>
-  <Story name="tertiary/disabled" parameters={{ info: { disable: true }}} >
+  <Story name="tertiary/disabled">
     <>
-      <Button buttonType="tertiary" disabled size="small">Small</Button>
-      <Button buttonType="tertiary" disabled ml={2}>Medium</Button>
-      <Button buttonType="tertiary" disabled size="large" ml={2}>Large</Button>
+      <Button buttonType="tertiary" disabled size="small">
+        Small
+      </Button>
+      <Button buttonType="tertiary" disabled ml={2}>
+        Medium
+      </Button>
+      <Button buttonType="tertiary" disabled size="large" ml={2}>
+        Large
+      </Button>
     </>
   </Story>
 </Preview>
 
 Tertiary buttons can have an icon positioned before or after the text.
+
 <Preview>
-  <Story name="tertiary/icon" parameters={{ info: { disable: true }}} >
-  <>
-    <Button buttonType="tertiary" iconType="print">Medium</Button>
-    <Button buttonType="tertiary" destructive iconType="delete" iconPosition="after" ml={2}>Medium</Button>
-    <Button buttonType="tertiary" disabled iconType="print" iconPosition="after" ml={2}>Medium</Button>
+  <Story name="tertiary/icon">
+    <>
+      <Button buttonType="tertiary" iconType="print">
+        Medium
+      </Button>
+      <Button
+        buttonType="tertiary"
+        destructive
+        iconType="delete"
+        iconPosition="after"
+        ml={2}
+      >
+        Medium
+      </Button>
+      <Button
+        buttonType="tertiary"
+        disabled
+        iconType="print"
+        iconPosition="after"
+        ml={2}
+      >
+        Medium
+      </Button>
     </>
   </Story>
 </Preview>
 
 Tertiary buttons can be `fullWidth`.
+
 <Preview>
-  <Story name="tertiary/full-width" parameters={{ info: { disable: true }}} >
+  <Story name="tertiary/full-width">
     <>
-      <Button buttonType="tertiary" fullWidth>Full Width</Button>
+      <Button buttonType="tertiary" fullWidth>
+        Full Width
+      </Button>
     </>
   </Story>
 </Preview>
 
+Tertiary buttons can be set to `noWrap` mode to prevent text wrapping.
+
+<Preview>
+  <Story name="tertiary/noWrap" parameters={{ chromatic: { disable: true } }}>
+    <Button buttonType="tertiary" noWrap>
+      Long button text
+    </Button>
+  </Story>
+</Preview>
+
 ## Dashed Buttons
+
 Dashed buttons are used for adding new content that replaces empty states.
 
 <Preview>
-  <Story name="dashed" parameters={{ info: { disable: true }}} >
+  <Story name="dashed">
     <>
-      <Button buttonType="dashed" size="small">Small</Button>
-      <Button buttonType="dashed" ml={2}>Medium</Button>
-      <Button buttonType="dashed" size="large" ml={2}>Large</Button>
+      <Button buttonType="dashed" size="small">
+        Small
+      </Button>
+      <Button buttonType="dashed" ml={2}>
+        Medium
+      </Button>
+      <Button buttonType="dashed" size="large" ml={2}>
+        Large
+      </Button>
     </>
   </Story>
 </Preview>
 
 Dashed buttons can be disabled.
+
 <Preview>
-  <Story name="dashed/disabled" parameters={{ info: { disable: true }}} >
+  <Story name="dashed/disabled">
     <>
-      <Button buttonType="dashed" disabled size="small">Small</Button>
-      <Button buttonType="dashed" disabled ml={2}>Medium</Button>
-      <Button buttonType="dashed" disabled size="large" ml={2}>Large</Button>
+      <Button buttonType="dashed" disabled size="small">
+        Small
+      </Button>
+      <Button buttonType="dashed" disabled ml={2}>
+        Medium
+      </Button>
+      <Button buttonType="dashed" disabled size="large" ml={2}>
+        Large
+      </Button>
     </>
   </Story>
 </Preview>
 
 Dashed buttons can have an icon positioned before or after the text.
+
 <Preview>
-  <Story name="dashed/icon" parameters={{ info: { disable: true }}} >
-  <>
-    <Button buttonType="dashed" iconType="add" size="small">Small</Button>
-    <Button buttonType="dashed" iconType="add" iconPosition="after" ml={2}>Medium</Button>
-    <Button buttonType="dashed" disabled iconType="add" size="small" ml={2}>Small</Button>
-    <Button buttonType="dashed" disabled iconType="add" iconPosition="after" ml={2}>Medium</Button>
+  <Story name="dashed/icon">
+    <>
+      <Button buttonType="dashed" iconType="add" size="small">
+        Small
+      </Button>
+      <Button buttonType="dashed" iconType="add" iconPosition="after" ml={2}>
+        Medium
+      </Button>
+      <Button buttonType="dashed" disabled iconType="add" size="small" ml={2}>
+        Small
+      </Button>
+      <Button
+        buttonType="dashed"
+        disabled
+        iconType="add"
+        iconPosition="after"
+        ml={2}
+      >
+        Medium
+      </Button>
     </>
   </Story>
 </Preview>
 
 Dashed buttons can be `fullWidth`.
+
 <Preview>
-  <Story name="dashed/full-width" parameters={{ info: { disable: true }}} >
-    <Button buttonType="dashed" fullWidth>Full Width</Button>
+  <Story name="dashed/full-width">
+    <Button buttonType="dashed" fullWidth>
+      Full Width
+    </Button>
+  </Story>
+</Preview>
+
+Dashed buttons can be set to `noWrap` mode to prevent text wrapping.
+
+<Preview>
+  <Story name="dashed/noWrap" parameters={{ chromatic: { disable: true } }}>
+    <Button buttonType="dashed" noWrap>
+      Long button text
+    </Button>
   </Story>
 </Preview>
 
 ## Shared Props
-Options shared between all of the above types of buttons. When setting padding we recommend using either the `p`, `py` 
+
+Options shared between all of the above types of buttons. When setting padding we recommend using either the `p`, `py`
 or `px` props to ensure the spacing within the button is applied evenly.
 
 <StyledSystemProps
   of={Button}
   spacing
-  defaults={{ pt: '1px', pb: '1px', px: '24px' }}
+  defaults={{ pt: "1px", pb: "1px", px: "24px" }}
 />

--- a/src/components/button/button.style.js
+++ b/src/components/button/button.style.js
@@ -10,14 +10,20 @@ import StyledIcon from "../icon/icon.style";
 
 const StyledButton = styled.button`
   ${space}
-  align-items: center;
-  cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
-  display: inline-flex;
-  flex-direction: column;
-  flex-flow: wrap;
-  justify-content: center;
-  vertical-align: middle;
-  ${stylingForType}
+  ${({ disabled, noWrap }) => css`
+    align-items: center;
+    cursor: ${disabled ? "not-allowed" : "pointer"};
+    display: inline-flex;
+    flex-direction: column;
+    flex-flow: wrap;
+    ${noWrap &&
+    css`
+      white-space: nowrap;
+    `}
+    justify-content: center;
+    vertical-align: middle;
+    ${stylingForType}
+  `}
 
   &&& {
     ${({ mb, theme }) =>


### PR DESCRIPTION
### Proposed behaviour
Ability to prevent text wrapping with noWrap prop.
![image](https://user-images.githubusercontent.com/5004407/105748084-ebe37f00-5f41-11eb-83f1-c63b3a81c7c5.png)

### Current behaviour
Button will always wrap text inside in certain cases.
![image](https://user-images.githubusercontent.com/5004407/105748058-e1c18080-5f41-11eb-9648-18efb0fdac04.png)



### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [ ] <del>All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] <del>Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] <del>Carbon implementation and Design System documentation are congruent

### Additional context
Added noWrap prop which enables ``white-space: nowrap`` on button element.

### Testing instructions
Example provided with codesandbox
