### PR TITLE
fix(select): change placeholder color - FE-3551 

### DIFF
--- a/src/__experimental__/components/input/__snapshots__/input.spec.js.snap
+++ b/src/__experimental__/components/input/__snapshots__/input.spec.js.snap
@@ -21,19 +21,19 @@ exports[`Input renders with an input 1`] = `
 }
 
 .c0::-webkit-input-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c0::-moz-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c0:-ms-input-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c0::placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c0:invalid,

--- a/src/__experimental__/components/search/search.style.js
+++ b/src/__experimental__/components/search/search.style.js
@@ -71,15 +71,9 @@ const StyledSearch = styled.div`
       }
 
       ${StyledInput} {
-        ::-moz-placeholder {
-              color: ${theme.search.placeholder};
-              opacity: 1;
-            }
-        ::placeholder {
-            color: ${theme.search.placeholder};
-          }
         ${
           darkVariant &&
+          !isFocused &&
           css`
             ::-moz-placeholder {
               color: ${theme.search.darkVariantPlaceholder};
@@ -88,6 +82,12 @@ const StyledSearch = styled.div`
             ::placeholder {
               color: ${theme.search.darkVariantPlaceholder};
             }
+          `
+        }
+
+        ${
+          darkVariant &&
+          css`
             ${!isFocused &&
             searchHasValue &&
             !showSearchButton &&

--- a/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
+++ b/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
@@ -174,19 +174,19 @@ exports[`SimpleColorPicker renders as expected 1`] = `
 }
 
 .c5::-webkit-input-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c5::-moz-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c5:-ms-input-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c5::placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c5:invalid,

--- a/src/__experimental__/components/textarea/__snapshots__/textarea.spec.js.snap
+++ b/src/__experimental__/components/textarea/__snapshots__/textarea.spec.js.snap
@@ -21,19 +21,19 @@ exports[`Textarea when rendered should render default 1`] = `
 }
 
 .c7::-webkit-input-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c7::-moz-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c7:-ms-input-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c7::placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c7:invalid,

--- a/src/components/pager/__internal__/__snapshots__/pager.spec.js.snap
+++ b/src/components/pager/__internal__/__snapshots__/pager.spec.js.snap
@@ -21,19 +21,19 @@ exports[`Pager renders the Pager correctly with the Mint Theme 1`] = `
 }
 
 .c12::-webkit-input-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c12::-moz-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c12:-ms-input-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c12::placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c12:invalid,
@@ -128,36 +128,20 @@ exports[`Pager renders the Pager correctly with the Mint Theme 1`] = `
   outline: solid 3px #FFB500;
 }
 
+.c3 {
+  position: relative;
+}
+
 .c3 .c11 {
   cursor: pointer;
-  color: transparent;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  text-shadow: 0 0 0 rgba(0,0,0,0.9);
-  padding-left: 11px;
-}
-
-.c3 .c11::-webkit-input-placeholder {
-  text-shadow: 0 0 0 rgba(0,0,0,0.3);
-}
-
-.c3 .c11::-moz-placeholder {
-  text-shadow: 0 0 0 rgba(0,0,0,0.3);
-}
-
-.c3 .c11:-ms-input-placeholder {
-  text-shadow: 0 0 0 rgba(0,0,0,0.3);
-}
-
-.c3 .c11::placeholder {
-  text-shadow: 0 0 0 rgba(0,0,0,0.3);
 }
 
 .c3 .c9 {
   cursor: pointer;
-  padding-left: 0;
   padding-right: 0;
 }
 
@@ -215,6 +199,10 @@ exports[`Pager renders the Pager correctly with the Mint Theme 1`] = `
 
 .c4 {
   height: 26px;
+}
+
+.c4 .c9 {
+  padding-left: 0;
 }
 
 .c0 {
@@ -662,19 +650,19 @@ exports[`Pager renders the Pager without pageSizeSelection 1`] = `
 }
 
 .c15::-webkit-input-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c15::-moz-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c15:-ms-input-placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c15::placeholder {
-  color: rgba(0,0,0,0.3);
+  color: rgba(0,0,0,0.55);
 }
 
 .c15:invalid,
@@ -748,34 +736,14 @@ exports[`Pager renders the Pager without pageSizeSelection 1`] = `
 
 .c17 .c14 {
   cursor: pointer;
-  color: transparent;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  text-shadow: 0 0 0 rgba(0,0,0,0.9);
-  padding-left: 11px;
-}
-
-.c17 .c14::-webkit-input-placeholder {
-  text-shadow: 0 0 0 rgba(0,0,0,0.3);
-}
-
-.c17 .c14::-moz-placeholder {
-  text-shadow: 0 0 0 rgba(0,0,0,0.3);
-}
-
-.c17 .c14:-ms-input-placeholder {
-  text-shadow: 0 0 0 rgba(0,0,0,0.3);
-}
-
-.c17 .c14::placeholder {
-  text-shadow: 0 0 0 rgba(0,0,0,0.3);
 }
 
 .c17 .c12 {
   cursor: pointer;
-  padding-left: 0;
   padding-right: 0;
 }
 
@@ -785,6 +753,10 @@ exports[`Pager renders the Pager without pageSizeSelection 1`] = `
 
 .c10 {
   display: block;
+}
+
+.c18 .c12 {
+  padding-left: 0;
 }
 
 .c0 {
@@ -889,7 +861,7 @@ exports[`Pager renders the Pager without pageSizeSelection 1`] = `
   width: 13px;
 }
 
-.c1 .c12 .c18 {
+.c1 .c12 .c19 {
   margin-left: 0;
   width: 20px;
   height: 24px;

--- a/src/components/pager/__internal__/pager.style.js
+++ b/src/components/pager/__internal__/pager.style.js
@@ -7,6 +7,10 @@ import baseTheme from "../../../style/themes/base";
 
 const StyledSelect = styled(Select)`
   height: 26px;
+
+  ${StyledInputPresentation} {
+    padding-left: 0;
+  }
 `;
 
 const StyledPagerContainer = styled.div`

--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -6,6 +6,7 @@ import SelectTextbox, {
 } from "../select-textbox/select-textbox.component";
 import guid from "../../../utils/helpers/guid";
 import withFilter from "../utils/with-filter.hoc";
+import StyledSelect from "../select.style";
 import SelectList from "../select-list/select-list.component";
 import isExpectedOption from "../utils/is-expected-option";
 
@@ -454,11 +455,15 @@ const FilterableSelect = React.forwardRef(
     );
 
     return (
-      <div
+      <StyledSelect
         data-component="filterable-select"
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         ref={containerRef}
+        hasTextCursor
+        readOnly={readOnly}
+        disabled={disabled}
+        {...textboxProps}
       >
         <SelectTextbox
           aria-controls={isOpen ? selectListId.current : ""}
@@ -468,7 +473,7 @@ const FilterableSelect = React.forwardRef(
           {...getTextboxProps()}
         />
         {!disablePortal && isOpen && selectList}
-      </div>
+      </StyledSelect>
     );
   }
 );

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -2,6 +2,7 @@ import React, { useRef } from "react";
 import { act } from "react-dom/test-utils";
 import { mount } from "enzyme";
 
+import { testStyledSystemMargin } from "../../../__spec_helper__/test-utils";
 import SelectTextbox from "../select-textbox/select-textbox.component";
 import FilterableSelect from "./filterable-select.component";
 import Textbox from "../../../__experimental__/components/textbox";
@@ -11,6 +12,8 @@ import Button from "../../button";
 import Label from "../../../__experimental__/components/label";
 
 describe("FilterableSelect", () => {
+  testStyledSystemMargin((props) => getSelect(props));
+
   it('the Textbox should have type of "text"', () => {
     const wrapper = renderSelect();
 

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -1,22 +1,26 @@
-import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
-import { action } from '@storybook/addon-actions';
-import { useState, useRef } from 'react';
-import Button from '../../button';
-import Dialog from '../../dialog';
-import { FilterableSelect, Option } from '../';
-import SelectTextbox from '../select-textbox/select-textbox.component';
+import { Meta, Props, Preview, Story } from "@storybook/addon-docs/blocks";
+import { action } from "@storybook/addon-actions";
+import { useState, useRef } from "react";
+import Button from "../../button";
+import Dialog from "../../dialog";
+import { FilterableSelect, Option } from "../";
+import SelectTextbox from "../select-textbox/select-textbox.component";
+import StyledSystemProps from "../../../../.storybook/utils/styled-system-props";
 
-<Meta title="Design System/Select/Filterable" parameters={{ info: { disable: true }}} />
+<Meta
+  title="Design System/Select/Filterable"
+  parameters={{ info: { disable: true } }}
+/>
 
 # Filterable Select
 
 Select one of available options from the drop-down menu using filter
 
-## Overview 
+## Overview
 
 Filterable Select is a Carbon styled implementation of WAI-ARIA Combobox with Inline Autocomplete.
 
-## Guidance, hints and tips 
+## Guidance, hints and tips
 
 Always insert `Option` Components inside the `FilterableSelect`, analogous to the `<select>` and `<option>` HTML Elements.
 
@@ -32,28 +36,28 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
 <Preview>
   <Story name="default">
     <FilterableSelect
-      name='simple'
-      id='simple'
-      label='label'
+      name="simple"
+      id="simple"
+      label="label"
       labelInline
-      onOpen={ action('onOpen') }
-      onChange={ action('onChange') }
-      onClick={ action('onClick') }
-      onFocus={ action('onFocus') }
-      onBlur={ action('onBlur') }
-      onKeyDown={ action('onKeyDown') }
+      onOpen={action("onOpen")}
+      onChange={action("onChange")}
+      onClick={action("onClick")}
+      onFocus={action("onFocus")}
+      onBlur={action("onBlur")}
+      onKeyDown={action("onKeyDown")}
     >
-      <Option text='Amber' value='1' />
-      <Option text='Black' value='2' />
-      <Option text='Blue' value='3' />
-      <Option text='Brown' value='4' />
-      <Option text='Green' value='5' />
-      <Option text='Orange' value='6' />
-      <Option text='Pink' value='7' />
-      <Option text='Purple' value='8' />
-      <Option text='Red' value='9' />
-      <Option text='White' value='10' />
-      <Option text='Yellow' value='11' />
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
     </FilterableSelect>
   </Story>
 </Preview>
@@ -61,36 +65,38 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
 ### Controlled Usage:
 
 <Preview>
-  <Story name="controlled" parameters={{ chromatic: { disable: true }}}>
+  <Story name="controlled" parameters={{ chromatic: { disable: true } }}>
     {() => {
-      const [value, setValue] = useState('');
+      const [value, setValue] = useState("");
       function onChangeHandler(event) {
         setValue(event.target.value);
-        action('value set');
-      };
+        action("value set");
+      }
       function clearValue() {
-        setValue('');
+        setValue("");
       }
       return (
         <div>
-          <Button onClick={ clearValue } mb={ 2 }>clear</Button>
+          <Button onClick={clearValue} mb={2}>
+            clear
+          </Button>
           <FilterableSelect
-            id='controlled'
-            name='controlled'
-            value={ value }
-            onChange={ onChangeHandler }
+            id="controlled"
+            name="controlled"
+            value={value}
+            onChange={onChangeHandler}
           >
-            <Option text='Amber' value='1' />
-            <Option text='Black' value='2' />
-            <Option text='Blue' value='3' />
-            <Option text='Brown' value='4' />
-            <Option text='Green' value='5' />
-            <Option text='Orange' value='6' />
-            <Option text='Pink' value='7' />
-            <Option text='Purple' value='8' />
-            <Option text='Red' value='9' />
-            <Option text='White' value='10' />
-            <Option text='Yellow' value='11' />
+            <Option text="Amber" value="1" />
+            <Option text="Black" value="2" />
+            <Option text="Blue" value="3" />
+            <Option text="Brown" value="4" />
+            <Option text="Green" value="5" />
+            <Option text="Orange" value="6" />
+            <Option text="Pink" value="7" />
+            <Option text="Purple" value="8" />
+            <Option text="Red" value="9" />
+            <Option text="White" value="10" />
+            <Option text="Yellow" value="11" />
           </FilterableSelect>
         </div>
       );
@@ -122,18 +128,18 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
 
 <Preview>
   <Story name="disabled">
-    <FilterableSelect name='disabled' id='disabled' defaultValue='3' disabled>
-      <Option text='Amber' value='1' />
-      <Option text='Black' value='2' />
-      <Option text='Blue' value='3' />
-      <Option text='Brown' value='4' />
-      <Option text='Green' value='5' />
-      <Option text='Orange' value='6' />
-      <Option text='Pink' value='7' />
-      <Option text='Purple' value='8' />
-      <Option text='Red' value='9' />
-      <Option text='White' value='10' />
-      <Option text='Yellow' value='11' />
+    <FilterableSelect name="disabled" id="disabled" defaultValue="3" disabled>
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
     </FilterableSelect>
   </Story>
 </Preview>
@@ -142,18 +148,18 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
 
 <Preview>
   <Story name="readonly">
-    <FilterableSelect name='readonly' id='readonly' defaultValue='4' readOnly>
-      <Option text='Amber' value='1' />
-      <Option text='Black' value='2' />
-      <Option text='Blue' value='3' />
-      <Option text='Brown' value='4' />
-      <Option text='Green' value='5' />
-      <Option text='Orange' value='6' />
-      <Option text='Pink' value='7' />
-      <Option text='Purple' value='8' />
-      <Option text='Red' value='9' />
-      <Option text='White' value='10' />
-      <Option text='Yellow' value='11' />
+    <FilterableSelect name="readonly" id="readonly" defaultValue="4" readOnly>
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
     </FilterableSelect>
   </Story>
 </Preview>
@@ -161,45 +167,61 @@ import { FilterableSelect, Option } from "carbon-react/lib/components/select";
 ### With disabled portal:
 
 <Preview>
-  <Story name="withDisabledPortal" parameters={{ chromatic: { disable: true }}} >
-    <FilterableSelect disablePortal name='withDisabledPortal' id='withDisabledPortal' defaultValue='4'>
-      <Option text='Amber' value='1' />
-      <Option text='Black' value='2' />
-      <Option text='Blue' value='3' />
-      <Option text='Brown' value='4' />
-      <Option text='Green' value='5' />
-      <Option text='Orange' value='6' />
-      <Option text='Pink' value='7' />
-      <Option text='Purple' value='8' />
-      <Option text='Red' value='9' />
-      <Option text='White' value='10' />
-      <Option text='Yellow' value='11' />
+  <Story
+    name="withDisabledPortal"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    <FilterableSelect
+      disablePortal
+      name="withDisabledPortal"
+      id="withDisabledPortal"
+      defaultValue="4"
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
     </FilterableSelect>
   </Story>
 </Preview>
 
 ### With Action Button:
+
 Default Action Button will be rendered when the `listActionButton` prop is set to `true` on the Component.
 
-A custom `Button` Component could be passed as the `listActionButton` value. 
+A custom `Button` Component could be passed as the `listActionButton` value.
 
 <Preview>
-  <Story name="with action button" parameters={{ chromatic: { disable: true }}} > 
+  <Story
+    name="with action button"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
-      const [value, setValue] = useState('');
+      const [value, setValue] = useState("");
       const [isOpen, setIsOpen] = useState(false);
       const [optionList, setOptionList] = useState([
-        <Option text='Amber' value='amber' key='Amber' />,
-        <Option text='Black' value='black' key='Black' />,
-        <Option text='Blue' value='blue' key='Blue' />,
-        <Option text='Brown' value='brown' key='Brown' />,
-        <Option text='Green' value='green' key='Green' />,
+        <Option text="Amber" value="amber" key="Amber" />,
+        <Option text="Black" value="black" key="Black" />,
+        <Option text="Blue" value="blue" key="Blue" />,
+        <Option text="Brown" value="brown" key="Brown" />,
+        <Option text="Green" value="green" key="Green" />,
       ]);
       function addNew() {
         const counter = optionList.length.toString();
         setOptionList((optionList) => [
           ...optionList,
-          <Option text={ `New${counter}` } value={ `val${counter}` } key={ `New${counter}` }/>
+          <Option
+            text={`New${counter}`}
+            value={`val${counter}`}
+            key={`New${counter}`}
+          />,
         ]);
         setIsOpen(false);
         setValue(`val${counter}`);
@@ -207,22 +229,26 @@ A custom `Button` Component could be passed as the `listActionButton` value.
       return (
         <>
           <FilterableSelect
-            name='action'
-            id='action'
-            label='label'
-            value={ value }
-            onChange={ (event) => setValue(event.target.value) }
-            listActionButton={<Button iconType='add' iconPosition='after'>Add a New Element</Button>}
-            onListAction={ () => setIsOpen(true) }
+            name="action"
+            id="action"
+            label="label"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            listActionButton={
+              <Button iconType="add" iconPosition="after">
+                Add a New Element
+              </Button>
+            }
+            onListAction={() => setIsOpen(true)}
           >
-            { optionList }
+            {optionList}
           </FilterableSelect>
           <Dialog
-            open={ isOpen }
-            onCancel={ () => setIsOpen(false) }
-            title='Dialog component triggered on action'
+            open={isOpen}
+            onCancel={() => setIsOpen(false)}
+            title="Dialog component triggered on action"
           >
-            <Button onClick={ addNew }>Add new</Button>
+            <Button onClick={addNew}>Add new</Button>
           </Dialog>
         </>
       );
@@ -231,21 +257,25 @@ A custom `Button` Component could be passed as the `listActionButton` value.
 </Preview>
 
 ### With isLoading prop:
+
 When `isLoading` prop is passed, a loader will be appended at the end of the Select List. That functionality could be used to load the options asynchronously.
 
 <Preview>
-  <Story name="with isLoading prop" parameters={{ chromatic: { disable: true }}} > 
+  <Story
+    name="with isLoading prop"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
       let preventLoading = useRef(false);
-      const [value, setValue] = useState('');
+      const [value, setValue] = useState("");
       const [isOpen, setIsOpen] = useState(false);
       const [isLoading, setIsLoading] = useState(true);
       const asyncList = [
-        <Option text='Amber' value='amber' key='Amber' />,
-        <Option text='Black' value='black' key='Black' />,
-        <Option text='Blue' value='blue' key='Blue' />,
-        <Option text='Brown' value='brown' key='Brown' />,
-        <Option text='Green' value='green' key='Green' />,
+        <Option text="Amber" value="amber" key="Amber" />,
+        <Option text="Black" value="black" key="Black" />,
+        <Option text="Blue" value="blue" key="Blue" />,
+        <Option text="Brown" value="brown" key="Brown" />,
+        <Option text="Green" value="green" key="Green" />,
       ];
       const [optionList, setOptionList] = useState([]);
       function loadList() {
@@ -256,27 +286,29 @@ When `isLoading` prop is passed, a loader will be appended at the end of the Sel
         setIsLoading(true);
         setTimeout(() => {
           setIsLoading(false);
-          setOptionList(asyncList)
+          setOptionList(asyncList);
         }, 2000);
       }
       function clearData() {
         setOptionList([]);
-        setValue('');
+        setValue("");
         preventLoading.current = false;
       }
       return (
         <div>
-          <Button onClick={ clearData } mb={ 2 }>reset</Button>
+          <Button onClick={clearData} mb={2}>
+            reset
+          </Button>
           <FilterableSelect
-            name='isLoading'
-            id='isLoading'
-            label='label'
-            value={ value }
-            onChange={ (event) => setValue(event.target.value) }
-            onOpen={ () => loadList() }
-            isLoading={ isLoading }
+            name="isLoading"
+            id="isLoading"
+            label="label"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            onOpen={() => loadList()}
+            isLoading={isLoading}
           >
-            { optionList }
+            {optionList}
           </FilterableSelect>
         </div>
       );
@@ -285,31 +317,47 @@ When `isLoading` prop is passed, a loader will be appended at the end of the Sel
 </Preview>
 
 ### Infinite scroll example:
+
 The `isLoading` prop in combination with the `onListScrollBottom` prop can be used to implement infinite scroll.
 This prop will be called every time a user scrolls to the bottom of the list.
 
 <Preview>
-  <Story name="with infinite scroll" parameters={{ chromatic: { disable: true }}} > 
+  <Story
+    name="with infinite scroll"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
       let preventLoading = useRef(false);
       let preventLazyLoading = useRef(false);
       let lazyLoadingCounter = useRef(0);
-      const [value, setValue] = useState('');
+      const [value, setValue] = useState("");
       const [isOpen, setIsOpen] = useState(false);
       const [isLoading, setIsLoading] = useState(true);
       const asyncList = [
-        <Option text='Amber' value='amber' key='Amber' />,
-        <Option text='Black' value='black' key='Black' />,
-        <Option text='Blue' value='blue' key='Blue' />,
-        <Option text='Brown' value='brown' key='Brown' />,
-        <Option text='Green' value='green' key='Green' />,
+        <Option text="Amber" value="amber" key="Amber" />,
+        <Option text="Black" value="black" key="Black" />,
+        <Option text="Blue" value="blue" key="Blue" />,
+        <Option text="Brown" value="brown" key="Brown" />,
+        <Option text="Green" value="green" key="Green" />,
       ];
       const getLazyLoaded = () => {
         const counter = lazyLoadingCounter.current;
         return [
-          <Option text={`Lazy Loaded A${counter}`} value={`lazyA${counter}`} key={`lazyA${counter}`} />,
-          <Option text={`Lazy Loaded B${counter}`} value={`lazyB${counter}`} key={`lazyB${counter}`} />,
-          <Option text={`Lazy Loaded C${counter}`} value={`lazyC${counter}`} key={`lazyC${counter}`} />,
+          <Option
+            text={`Lazy Loaded A${counter}`}
+            value={`lazyA${counter}`}
+            key={`lazyA${counter}`}
+          />,
+          <Option
+            text={`Lazy Loaded B${counter}`}
+            value={`lazyB${counter}`}
+            key={`lazyB${counter}`}
+          />,
+          <Option
+            text={`Lazy Loaded C${counter}`}
+            value={`lazyC${counter}`}
+            key={`lazyC${counter}`}
+          />,
         ];
       };
       const [optionList, setOptionList] = useState([]);
@@ -321,7 +369,7 @@ This prop will be called every time a user scrolls to the bottom of the list.
         setIsLoading(true);
         setTimeout(() => {
           setIsLoading(false);
-          setOptionList(asyncList)
+          setOptionList(asyncList);
         }, 2000);
       }
       function onLazyLoading() {
@@ -339,23 +387,25 @@ This prop will be called every time a user scrolls to the bottom of the list.
       }
       function clearData() {
         setOptionList([]);
-        setValue('');
+        setValue("");
         preventLoading.current = false;
       }
       return (
         <div>
-          <Button onClick={ clearData } mb={ 2 }>reset</Button>
+          <Button onClick={clearData} mb={2}>
+            reset
+          </Button>
           <FilterableSelect
-            name='infiniteScroll'
-            id='infiniteScroll'
-            label='label'
-            value={ value }
-            onChange={ (event) => setValue(event.target.value) }
-            onOpen={ () => loadList() }
-            isLoading={ isLoading }
-            onListScrollBottom={ onLazyLoading }
+            name="infiniteScroll"
+            id="infiniteScroll"
+            label="label"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            onOpen={() => loadList()}
+            isLoading={isLoading}
+            onListScrollBottom={onLazyLoading}
           >
-            { optionList }
+            {optionList}
           </FilterableSelect>
         </div>
       );
@@ -370,47 +420,99 @@ You can use the `required` prop to indicate if the field is mandatory.
 <Preview>
   <Story name="required">
     <FilterableSelect
-      name='required-select'
-      id='required-select'
-      label='Foreground Color'
+      name="required-select"
+      id="required-select"
+      label="Foreground Color"
       required
     >
-      <Option text='Amber' value='1' />
-      <Option text='Black' value='2' />
-      <Option text='Blue' value='3' />
-      <Option text='Brown' value='4' />
-      <Option text='Green' value='5' />
-      <Option text='Orange' value='6' />
-      <Option text='Pink' value='7' />
-      <Option text='Purple' value='8' />
-      <Option text='Red' value='9' />
-      <Option text='White' value='10' />
-      <Option text='Yellow' value='11' />
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
     </FilterableSelect>
   </Story>
 </Preview>
 
 ### With object as value:
+
 Option values could be passed as objects, useful when custom data is associated with an option.
 When the `id` property is set, objects will be compared based on that property (could be used when the list is recreated after an API call).
 If there is no `id` prop specified on an object, then the exact objects will be compared.
 
 <Preview>
-  <Story name="with object as value" parameters={{ chromatic: { disable: true }}} >
+  <Story
+    name="with object as value"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
-      const [value, setValue] = useState({ id: 'Green', value: 5, text: 'Green' });
+      const [value, setValue] = useState({
+        id: "Green",
+        value: 5,
+        text: "Green",
+      });
       const optionList = useRef([
-        <Option text='Amber' key='Amber' value={ { id: 'Amber', value: 1, text: 'Amber' } } />,
-        <Option text='Black' key='Black' value={ { id: 'Black', value: 2, text: 'Black' } } />,
-        <Option text='Blue' key='Blue' value={ { id: 'Blue', value: 3, text: 'Blue' } } />,
-        <Option text='Brown' key='Brown' value={ { id: 'Brown', value: 4, text: 'Brown' } } />,
-        <Option text='Green' key='Green' value={ { id: 'Green', value: 5, text: 'Green' } } />,
-        <Option text='Orange' key='Orange' value={ { id: 'Orange', value: 6, text: 'Orange' } } />,
-        <Option text='Pink' key='Pink' value={ { id: 'Pink', value: 7, text: 'Pink' } } />,
-        <Option text='Purple' key='Purple' value={ { id: 'Purple', value: 8, text: 'Purple' } } />,
-        <Option text='Red' key='Red' value={ { id: 'Red', value: 9, text: 'Red' } } />,
-        <Option text='White' key='White' value={ { id: 'White', value: 10, text: 'White' } } />,
-        <Option text='Yellow' key='Yellow' value={ { id: 'Yellow', value: 11, text: 'Yellow' } } />
+        <Option
+          text="Amber"
+          key="Amber"
+          value={{ id: "Amber", value: 1, text: "Amber" }}
+        />,
+        <Option
+          text="Black"
+          key="Black"
+          value={{ id: "Black", value: 2, text: "Black" }}
+        />,
+        <Option
+          text="Blue"
+          key="Blue"
+          value={{ id: "Blue", value: 3, text: "Blue" }}
+        />,
+        <Option
+          text="Brown"
+          key="Brown"
+          value={{ id: "Brown", value: 4, text: "Brown" }}
+        />,
+        <Option
+          text="Green"
+          key="Green"
+          value={{ id: "Green", value: 5, text: "Green" }}
+        />,
+        <Option
+          text="Orange"
+          key="Orange"
+          value={{ id: "Orange", value: 6, text: "Orange" }}
+        />,
+        <Option
+          text="Pink"
+          key="Pink"
+          value={{ id: "Pink", value: 7, text: "Pink" }}
+        />,
+        <Option
+          text="Purple"
+          key="Purple"
+          value={{ id: "Purple", value: 8, text: "Purple" }}
+        />,
+        <Option
+          text="Red"
+          key="Red"
+          value={{ id: "Red", value: 9, text: "Red" }}
+        />,
+        <Option
+          text="White"
+          key="White"
+          value={{ id: "White", value: 10, text: "White" }}
+        />,
+        <Option
+          text="Yellow"
+          key="Yellow"
+          value={{ id: "Yellow", value: 11, text: "Yellow" }}
+        />,
       ]);
       function onChangeHandler(event) {
         setValue(event.target.value);
@@ -420,14 +522,16 @@ If there is no `id` prop specified on an object, then the exact objects will be 
       }
       return (
         <div>
-          <Button onClick={ clearValue } mb={ 2 }>clear</Button>
+          <Button onClick={clearValue} mb={2}>
+            clear
+          </Button>
           <FilterableSelect
-            id='with-object'
-            name='with-object'
-            value={ value }
-            onChange={ onChangeHandler }
+            id="with-object"
+            name="with-object"
+            value={value}
+            onChange={onChangeHandler}
           >
-            { optionList.current }
+            {optionList.current}
           </FilterableSelect>
         </div>
       );
@@ -437,12 +541,12 @@ If there is no `id` prop specified on an object, then the exact objects will be 
 
 ## Props:
 
-<Props of={ FilterableSelect } />
+<StyledSystemProps of={FilterableSelect} margin />
 
 ### Props derived from the Textbox Component
 
-<Props of={ SelectTextbox } />
+<Props of={SelectTextbox} />
 
 ### Props of the Option Component
 
-<Props of={ Option } />
+<Props of={Option} />

--- a/src/components/select/multi-select/multi-select.component.js
+++ b/src/components/select/multi-select/multi-select.component.js
@@ -7,9 +7,8 @@ import SelectTextbox, {
 import guid from "../../../utils/helpers/guid";
 import withFilter from "../utils/with-filter.hoc";
 import SelectList from "../select-list/select-list.component";
-import StyledMultiSelect, {
-  StyledSelectPillContainer,
-} from "./multi-select.style";
+import StyledSelect from "../select.style";
+import StyledSelectPillContainer from "./multi-select.style";
 import Pill from "../../pill";
 import isExpectedOption from "../utils/is-expected-option";
 import isExpectedValue from "../utils/is-expected-value";
@@ -457,11 +456,15 @@ const MultiSelect = React.forwardRef(
     );
 
     return (
-      <StyledMultiSelect
+      <StyledSelect
         data-component="multiselect"
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         ref={containerRef}
+        disabled={disabled}
+        readOnly={readOnly}
+        hasTextCursor
+        {...textboxProps}
       >
         <SelectTextbox
           aria-controls={isOpen ? selectListId.current : ""}
@@ -471,7 +474,7 @@ const MultiSelect = React.forwardRef(
           {...getTextboxProps()}
         />
         {!disablePortal && isOpen && selectList}
-      </StyledMultiSelect>
+      </StyledSelect>
     );
   }
 );

--- a/src/components/select/multi-select/multi-select.spec.js
+++ b/src/components/select/multi-select/multi-select.spec.js
@@ -2,6 +2,7 @@ import React, { useRef } from "react";
 import { act } from "react-dom/test-utils";
 import { mount } from "enzyme";
 
+import { testStyledSystemMargin } from "../../../__spec_helper__/test-utils";
 import MultiSelect from "./multi-select.component";
 import Textbox from "../../../__experimental__/components/textbox";
 import SelectTextbox from "../select-textbox/select-textbox.component";
@@ -11,6 +12,8 @@ import Pill from "../../pill";
 import Label from "../../../__experimental__/components/label";
 
 describe("MultiSelect", () => {
+  testStyledSystemMargin((props) => getSelect(props));
+
   it("the input ref should be forwarded", () => {
     let mockRef;
 

--- a/src/components/select/multi-select/multi-select.stories.mdx
+++ b/src/components/select/multi-select/multi-select.stories.mdx
@@ -1,21 +1,25 @@
-import { Meta, Props, Preview, Story } from '@storybook/addon-docs/blocks';
-import { action } from '@storybook/addon-actions';
-import { useState, useRef } from 'react';
+import { Meta, Props, Preview, Story } from "@storybook/addon-docs/blocks";
+import { action } from "@storybook/addon-actions";
+import { useState, useRef } from "react";
 import Button from "../../button";
-import { MultiSelect, Option } from '../';
-import SelectTextbox from '../select-textbox/select-textbox.component';
+import { MultiSelect, Option } from "../";
+import SelectTextbox from "../select-textbox/select-textbox.component";
+import StyledSystemProps from "../../../../.storybook/utils/styled-system-props";
 
-<Meta title="Design System/Select/MultiSelect" parameters={{ info: { disable: true }}} />
+<Meta
+  title="Design System/Select/MultiSelect"
+  parameters={{ info: { disable: true } }}
+/>
 
 # MultiSelect
 
 Select multiple options from the drop-down menu.
 
-## Overview 
+## Overview
 
 MultiSelect is a component that allows to choose multiple options from the drop-down list.
 
-## Guidance, hints and tips 
+## Guidance, hints and tips
 
 Always insert `Option` Components inside the `MultiSelect`, analogous to the `<select>` and `<option>` HTML Elements.
 
@@ -31,28 +35,28 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
 <Preview>
   <Story name="default">
     <MultiSelect
-      name='simple'
-      id='simple'
-      label='label'
+      name="simple"
+      id="simple"
+      label="label"
       labelInline
-      onOpen={ action('onOpen') }
-      onChange={ action('onChange') }
-      onClick={ action('onClick') }
-      onFocus={ action('onFocus') }
-      onBlur={ action('onBlur') }
-      onKeyDown={ action('onKeyDown', { depth: 2 }) }
+      onOpen={action("onOpen")}
+      onChange={action("onChange")}
+      onClick={action("onClick")}
+      onFocus={action("onFocus")}
+      onBlur={action("onBlur")}
+      onKeyDown={action("onKeyDown", { depth: 2 })}
     >
-      <Option text='Amber' value='1' />
-      <Option text='Black' value='2' />
-      <Option text='Blue' value='3' />
-      <Option text='Brown' value='4' />
-      <Option text='Green' value='5' />
-      <Option text='Orange' value='6' />
-      <Option text='Pink' value='7' />
-      <Option text='Purple' value='8' />
-      <Option text='Red' value='9' />
-      <Option text='White' value='10' />
-      <Option text='Yellow' value='11' />
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
     </MultiSelect>
   </Story>
 </Preview>
@@ -60,36 +64,36 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
 ### Controlled Usage:
 
 <Preview>
-  <Story name="controlled" parameters={{ chromatic: { disable: true }}} >
+  <Story name="controlled" parameters={{ chromatic: { disable: true } }}>
     {() => {
       const [value, setValue] = useState([]);
       function onChangeHandler(event) {
         setValue(event.target.value);
-        action('value set');
-      };
+        action("value set");
+      }
       return (
         <MultiSelect
-          id='controlled'
-          name='controlled'
-          value={ value }
-          onChange={ onChangeHandler }
-          onOpen={ action('onOpen') }
-          onClick={ action('onClick') }
-          onFocus={ action('onFocus') }
-          onBlur={ action('onBlur') }
-          onKeyDown={ action('onKeyDown', { depth: 2 }) }
+          id="controlled"
+          name="controlled"
+          value={value}
+          onChange={onChangeHandler}
+          onOpen={action("onOpen")}
+          onClick={action("onClick")}
+          onFocus={action("onFocus")}
+          onBlur={action("onBlur")}
+          onKeyDown={action("onKeyDown", { depth: 2 })}
         >
-          <Option text='Amber' value='1' />
-          <Option text='Black' value='2' />
-          <Option text='Blue' value='3' />
-          <Option text='Brown' value='4' />
-          <Option text='Green' value='5' />
-          <Option text='Orange' value='6' />
-          <Option text='Pink' value='7' />
-          <Option text='Purple' value='8' />
-          <Option text='Red' value='9' />
-          <Option text='White' value='10' />
-          <Option text='Yellow' value='11' />
+          <Option text="Amber" value="1" />
+          <Option text="Black" value="2" />
+          <Option text="Blue" value="3" />
+          <Option text="Brown" value="4" />
+          <Option text="Green" value="5" />
+          <Option text="Orange" value="6" />
+          <Option text="Pink" value="7" />
+          <Option text="Purple" value="8" />
+          <Option text="Red" value="9" />
+          <Option text="White" value="10" />
+          <Option text="Yellow" value="11" />
         </MultiSelect>
       );
     }}
@@ -99,19 +103,19 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
 ### Open on focus:
 
 <Preview>
-  <Story name="openOnFocus" parameters={{ chromatic: { disable: true }}} >
-    <MultiSelect name='openOnFocus' id='openOnFocus' openOnFocus>
-      <Option text='Amber' value='1' />
-      <Option text='Black' value='2' />
-      <Option text='Blue' value='3' />
-      <Option text='Brown' value='4' />
-      <Option text='Green' value='5' />
-      <Option text='Orange' value='6' />
-      <Option text='Pink' value='7' />
-      <Option text='Purple' value='8' />
-      <Option text='Red' value='9' />
-      <Option text='White' value='10' />
-      <Option text='Yellow' value='11' />
+  <Story name="openOnFocus" parameters={{ chromatic: { disable: true } }}>
+    <MultiSelect name="openOnFocus" id="openOnFocus" openOnFocus>
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
     </MultiSelect>
   </Story>
 </Preview>
@@ -120,18 +124,23 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
 
 <Preview>
   <Story name="disabled">
-    <MultiSelect name='disabled' id='select-disabled' defaultValue={ ['1', '3'] } disabled>
-      <Option text='Amber' value='1' />
-      <Option text='Black' value='2' />
-      <Option text='Blue' value='3' />
-      <Option text='Brown' value='4' />
-      <Option text='Green' value='5' />
-      <Option text='Orange' value='6' />
-      <Option text='Pink' value='7' />
-      <Option text='Purple' value='8' />
-      <Option text='Red' value='9' />
-      <Option text='White' value='10' />
-      <Option text='Yellow' value='11' />
+    <MultiSelect
+      name="disabled"
+      id="select-disabled"
+      defaultValue={["1", "3"]}
+      disabled
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
     </MultiSelect>
   </Story>
 </Preview>
@@ -140,18 +149,23 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
 
 <Preview>
   <Story name="readonly">
-    <MultiSelect name='readonly' id='readonly' defaultValue={ ['1', '3'] } readOnly>
-      <Option text='Amber' value='1' />
-      <Option text='Black' value='2' />
-      <Option text='Blue' value='3' />
-      <Option text='Brown' value='4' />
-      <Option text='Green' value='5' />
-      <Option text='Orange' value='6' />
-      <Option text='Pink' value='7' />
-      <Option text='Purple' value='8' />
-      <Option text='Red' value='9' />
-      <Option text='White' value='10' />
-      <Option text='Yellow' value='11' />
+    <MultiSelect
+      name="readonly"
+      id="readonly"
+      defaultValue={["1", "3"]}
+      readOnly
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
     </MultiSelect>
   </Story>
 </Preview>
@@ -159,19 +173,27 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
 ### With disabled portal:
 
 <Preview>
-  <Story name="withDisabledPortal" parameters={{ chromatic: { disable: true }}}>
-    <MultiSelect disablePortal name='withDisabledPortal' id='withDisabledPortal' defaultValue={ ['1', '3'] }>
-      <Option text='Amber' value='1' />
-      <Option text='Black' value='2' />
-      <Option text='Blue' value='3' />
-      <Option text='Brown' value='4' />
-      <Option text='Green' value='5' />
-      <Option text='Orange' value='6' />
-      <Option text='Pink' value='7' />
-      <Option text='Purple' value='8' />
-      <Option text='Red' value='9' />
-      <Option text='White' value='10' />
-      <Option text='Yellow' value='11' />
+  <Story
+    name="withDisabledPortal"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    <MultiSelect
+      disablePortal
+      name="withDisabledPortal"
+      id="withDisabledPortal"
+      defaultValue={["1", "3"]}
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
     </MultiSelect>
   </Story>
 </Preview>
@@ -179,50 +201,101 @@ import { MultiSelect, Option } from "carbon-react/lib/components/select";
 ### Required
 
 You can use the `required` prop to indicate if the field is mandatory.
+
 <Preview>
   <Story name="required">
-   <MultiSelect
-      name='required-select'
-      id='required-select'
-      label='Foreground Color'
+    <MultiSelect
+      name="required-select"
+      id="required-select"
+      label="Foreground Color"
       required
     >
-      <Option text='Amber' value='1' />
-      <Option text='Black' value='2' />
-      <Option text='Blue' value='3' />
-      <Option text='Brown' value='4' />
-      <Option text='Green' value='5' />
-      <Option text='Orange' value='6' />
-      <Option text='Pink' value='7' />
-      <Option text='Purple' value='8' />
-      <Option text='Red' value='9' />
-      <Option text='White' value='10' />
-      <Option text='Yellow' value='11' />
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
     </MultiSelect>
   </Story>
 </Preview>
 
 ### With object as value:
+
 Option values could be passed as objects, useful when custom data is associated with an option.
 When the `id` property is set, objects will be compared based on that property (could be used when the list is recreated after an API call).
 If there is no `id` prop specified on an object, then the exact objects will be compared.
 
 <Preview>
-  <Story name="with object as value" parameters={{ chromatic: { disable: true }}} >
+  <Story
+    name="with object as value"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
-      const [value, setValue] = useState([{ id: 'Green', value: 5, text: 'Green' }]);
+      const [value, setValue] = useState([
+        { id: "Green", value: 5, text: "Green" },
+      ]);
       const optionList = useRef([
-        <Option text='Amber' key='Amber' value={ { id: 'Amber', value: 1, text: 'Amber' } } />,
-        <Option text='Black' key='Black' value={ { id: 'Black', value: 2, text: 'Black' } } />,
-        <Option text='Blue' key='Blue' value={ { id: 'Blue', value: 3, text: 'Blue' } } />,
-        <Option text='Brown' key='Brown' value={ { id: 'Brown', value: 4, text: 'Brown' } } />,
-        <Option text='Green' key='Green' value={ { id: 'Green', value: 5, text: 'Green' } } />,
-        <Option text='Orange' key='Orange' value={ { id: 'Orange', value: 6, text: 'Orange' } } />,
-        <Option text='Pink' key='Pink' value={ { id: 'Pink', value: 7, text: 'Pink' } } />,
-        <Option text='Purple' key='Purple' value={ { id: 'Purple', value: 8, text: 'Purple' } } />,
-        <Option text='Red' key='Red' value={ { id: 'Red', value: 9, text: 'Red' } } />,
-        <Option text='White' key='White' value={ { id: 'White', value: 10, text: 'White' } } />,
-        <Option text='Yellow' key='Yellow' value={ { id: 'Yellow', value: 11, text: 'Yellow' } } />
+        <Option
+          text="Amber"
+          key="Amber"
+          value={{ id: "Amber", value: 1, text: "Amber" }}
+        />,
+        <Option
+          text="Black"
+          key="Black"
+          value={{ id: "Black", value: 2, text: "Black" }}
+        />,
+        <Option
+          text="Blue"
+          key="Blue"
+          value={{ id: "Blue", value: 3, text: "Blue" }}
+        />,
+        <Option
+          text="Brown"
+          key="Brown"
+          value={{ id: "Brown", value: 4, text: "Brown" }}
+        />,
+        <Option
+          text="Green"
+          key="Green"
+          value={{ id: "Green", value: 5, text: "Green" }}
+        />,
+        <Option
+          text="Orange"
+          key="Orange"
+          value={{ id: "Orange", value: 6, text: "Orange" }}
+        />,
+        <Option
+          text="Pink"
+          key="Pink"
+          value={{ id: "Pink", value: 7, text: "Pink" }}
+        />,
+        <Option
+          text="Purple"
+          key="Purple"
+          value={{ id: "Purple", value: 8, text: "Purple" }}
+        />,
+        <Option
+          text="Red"
+          key="Red"
+          value={{ id: "Red", value: 9, text: "Red" }}
+        />,
+        <Option
+          text="White"
+          key="White"
+          value={{ id: "White", value: 10, text: "White" }}
+        />,
+        <Option
+          text="Yellow"
+          key="Yellow"
+          value={{ id: "Yellow", value: 11, text: "Yellow" }}
+        />,
       ]);
       function onChangeHandler(event) {
         setValue(event.target.value);
@@ -232,14 +305,16 @@ If there is no `id` prop specified on an object, then the exact objects will be 
       }
       return (
         <div>
-          <Button onClick={ clearValue } mb={ 2 }>clear</Button>
+          <Button onClick={clearValue} mb={2}>
+            clear
+          </Button>
           <MultiSelect
-            id='with-object'
-            name='with-object'
-            value={ value }
-            onChange={ onChangeHandler }
+            id="with-object"
+            name="with-object"
+            value={value}
+            onChange={onChangeHandler}
           >
-            { optionList.current }
+            {optionList.current}
           </MultiSelect>
         </div>
       );
@@ -249,12 +324,12 @@ If there is no `id` prop specified on an object, then the exact objects will be 
 
 ## Props:
 
-<Props of={ MultiSelect } />
+<StyledSystemProps of={MultiSelect} margin />
 
 ### Props derived from the Textbox Component
 
-<Props of={ SelectTextbox } />
+<Props of={SelectTextbox} />
 
 ### Props of the Option Component
 
-<Props of={ Option } />
+<Props of={Option} />

--- a/src/components/select/multi-select/multi-select.style.js
+++ b/src/components/select/multi-select/multi-select.style.js
@@ -2,11 +2,7 @@ import styled from "styled-components";
 import StyledPill from "../../pill/pill.style";
 import { baseTheme } from "../../../style/themes";
 
-const StyledMultiSelect = styled.div`
-  position: relative;
-`;
-
-export const StyledSelectPillContainer = styled.div`
+const StyledSelectPillContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -21,4 +17,4 @@ StyledSelectPillContainer.defaultProps = {
   theme: baseTheme,
 };
 
-export default StyledMultiSelect;
+export default StyledSelectPillContainer;

--- a/src/components/select/select.style.js
+++ b/src/components/select/select.style.js
@@ -1,25 +1,18 @@
 import styled, { css } from "styled-components";
-import { space } from "styled-system";
+import { margin } from "styled-system";
 
-import InputPresentationStyle from "../../../__experimental__/components/input/input-presentation.style";
-import StyledInput from "../../../__experimental__/components/input/input.style";
-import InputIconToggleStyle from "../../../__experimental__/components/input-icon-toggle/input-icon-toggle.style";
-import { baseTheme } from "../../../style/themes";
-import sizes from "../../../__experimental__/components/input/input-sizes.style";
+import InputPresentationStyle from "../../__experimental__/components/input/input-presentation.style";
+import StyledInput from "../../__experimental__/components/input/input.style";
+import InputIconToggleStyle from "../../__experimental__/components/input-icon-toggle/input-icon-toggle.style";
+import { baseTheme } from "../../style/themes";
 
-const StyledSimpleSelect = styled.div`
-  ${space}
+const StyledSelect = styled.div`
+  position: relative;
+  ${margin}
 
   ${StyledInput} {
-    cursor: pointer;
-    color: transparent;
+    cursor: ${({ hasTextCursor }) => (hasTextCursor ? "text" : "pointer")};
     user-select: none;
-    text-shadow: 0 0 0 ${({ theme }) => theme.text.color};
-    padding-left: ${({ size }) => sizes[size].horizontalPadding};
-
-    ::placeholder {
-      text-shadow: 0 0 0 ${({ theme }) => theme.text.placeholder};
-    }
 
     ${({ disabled }) =>
       disabled &&
@@ -32,15 +25,14 @@ const StyledSimpleSelect = styled.div`
     ${({ readOnly }) =>
       readOnly &&
       css`
-        cursor: default;
+        cursor: ${({ hasTextCursor }) => (hasTextCursor ? "text" : "default")};
         color: ${({ theme }) => theme.readOnly.textboxText};
         text-shadow: none;
       `}
   }
 
   ${InputPresentationStyle} {
-    cursor: pointer;
-    padding-left: 0;
+    cursor: ${({ hasTextCursor }) => (hasTextCursor ? "text" : "pointer")};
     padding-right: 0;
 
     ${({ disabled }) =>
@@ -52,7 +44,7 @@ const StyledSimpleSelect = styled.div`
     ${({ readOnly }) =>
       readOnly &&
       css`
-        cursor: default;
+        cursor: ${({ hasTextCursor }) => (hasTextCursor ? "text" : "default")};
       `}
   }
 
@@ -80,9 +72,9 @@ const StyledSimpleSelect = styled.div`
     `}
 `;
 
-StyledSimpleSelect.defaultProps = {
+StyledSelect.defaultProps = {
   size: "medium",
   theme: baseTheme,
 };
 
-export default StyledSimpleSelect;
+export default StyledSelect;

--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -9,7 +9,7 @@ import PropTypes from "prop-types";
 import propTypes from "@styled-system/prop-types";
 import invariant from "invariant";
 
-import StyledSimpleSelect from "./simple-select.style";
+import StyledSelect from "../select.style";
 import SelectTextbox, {
   formInputPropTypes,
 } from "../select-textbox/select-textbox.component";
@@ -386,7 +386,7 @@ const SimpleSelect = React.forwardRef(
     );
 
     return (
-      <StyledSimpleSelect
+      <StyledSelect
         data-component="simple-select"
         transparent={transparent}
         disabled={disabled}
@@ -404,7 +404,7 @@ const SimpleSelect = React.forwardRef(
           positionedChildren={disablePortal && isOpen && selectList}
         />
         {!disablePortal && isOpen && selectList}
-      </StyledSimpleSelect>
+      </StyledSelect>
     );
   }
 );

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -4,7 +4,7 @@ import { mount } from "enzyme";
 
 import {
   assertStyleMatch,
-  testStyledSystemSpacing,
+  testStyledSystemMargin,
 } from "../../../__spec_helper__/test-utils";
 import SimpleSelect from "./simple-select.component";
 import Textbox from "../../../__experimental__/components/textbox";
@@ -46,7 +46,7 @@ describe("SimpleSelect", () => {
     expect(wrapper.find(Textbox).prop("type")).toBe("select");
   });
 
-  testStyledSystemSpacing((props) => getSelect(props));
+  testStyledSystemMargin((props) => getSelect(props));
 
   it("the input ref should be forwarded", () => {
     let mockRef;
@@ -69,18 +69,6 @@ describe("SimpleSelect", () => {
     expect(mockRef.current).toBe(wrapper.find("input").getDOMNode());
   });
 
-  it("the input text should have proper paddings", () => {
-    const wrapper = renderSelect();
-
-    assertStyleMatch(
-      {
-        paddingLeft: "11px",
-      },
-      wrapper,
-      { modifier: `${StyledInput}` }
-    );
-  });
-
   it("the input toggle icon should have proper left margin", () => {
     const wrapper = renderSelect();
 
@@ -98,7 +86,6 @@ describe("SimpleSelect", () => {
 
     assertStyleMatch(
       {
-        paddingLeft: "0",
         paddingRight: "0",
       },
       wrapper,
@@ -113,18 +100,9 @@ describe("SimpleSelect", () => {
       {
         cursor: "pointer",
         userSelect: "none",
-        textShadow: `0 0 0 ${baseTheme.text.color}`,
       },
       wrapper,
       { modifier: `${StyledInput}` }
-    );
-
-    assertStyleMatch(
-      {
-        textShadow: `0 0 0 ${baseTheme.text.placeholder}`,
-      },
-      wrapper,
-      { modifier: `${StyledInput}::placeholder` }
     );
   });
 

--- a/src/components/select/simple-select/simple-select.stories.mdx
+++ b/src/components/select/simple-select/simple-select.stories.mdx
@@ -130,26 +130,78 @@ You can use the `required` prop to indicate if the field is mandatory.
 </Preview>
 
 ### With object as value:
+
 Option values could be passed as objects, useful when custom data is associated with an option.
 When the `id` property is set, objects will be compared based on that property (could be used when the list is recreated after an API call).
 If there is no `id` prop specified on an object, then the exact objects will be compared.
 
 <Preview>
-  <Story name="with object as value" parameters={{ chromatic: { disable: true }}} >
+  <Story
+    name="with object as value"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
-      const [value, setValue] = useState({ id: 'Green', value: 5, text: 'Green' });
+      const [value, setValue] = useState({
+        id: "Green",
+        value: 5,
+        text: "Green",
+      });
       const optionList = useRef([
-        <Option text='Amber' key='Amber' value={ { id: 'Amber', value: 1, text: 'Amber' } } />,
-        <Option text='Black' key='Black' value={ { id: 'Black', value: 2, text: 'Black' } } />,
-        <Option text='Blue' key='Blue' value={ { id: 'Blue', value: 3, text: 'Blue' } } />,
-        <Option text='Brown' key='Brown' value={ { id: 'Brown', value: 4, text: 'Brown' } } />,
-        <Option text='Green' key='Green' value={ { id: 'Green', value: 5, text: 'Green' } } />,
-        <Option text='Orange' key='Orange' value={ { id: 'Orange', value: 6, text: 'Orange' } } />,
-        <Option text='Pink' key='Pink' value={ { id: 'Pink', value: 7, text: 'Pink' } } />,
-        <Option text='Purple' key='Purple' value={ { id: 'Purple', value: 8, text: 'Purple' } } />,
-        <Option text='Red' key='Red' value={ { id: 'Red', value: 9, text: 'Red' } } />,
-        <Option text='White' key='White' value={ { id: 'White', value: 10, text: 'White' } } />,
-        <Option text='Yellow' key='Yellow' value={ { id: 'Yellow', value: 11, text: 'Yellow' } } />
+        <Option
+          text="Amber"
+          key="Amber"
+          value={{ id: "Amber", value: 1, text: "Amber" }}
+        />,
+        <Option
+          text="Black"
+          key="Black"
+          value={{ id: "Black", value: 2, text: "Black" }}
+        />,
+        <Option
+          text="Blue"
+          key="Blue"
+          value={{ id: "Blue", value: 3, text: "Blue" }}
+        />,
+        <Option
+          text="Brown"
+          key="Brown"
+          value={{ id: "Brown", value: 4, text: "Brown" }}
+        />,
+        <Option
+          text="Green"
+          key="Green"
+          value={{ id: "Green", value: 5, text: "Green" }}
+        />,
+        <Option
+          text="Orange"
+          key="Orange"
+          value={{ id: "Orange", value: 6, text: "Orange" }}
+        />,
+        <Option
+          text="Pink"
+          key="Pink"
+          value={{ id: "Pink", value: 7, text: "Pink" }}
+        />,
+        <Option
+          text="Purple"
+          key="Purple"
+          value={{ id: "Purple", value: 8, text: "Purple" }}
+        />,
+        <Option
+          text="Red"
+          key="Red"
+          value={{ id: "Red", value: 9, text: "Red" }}
+        />,
+        <Option
+          text="White"
+          key="White"
+          value={{ id: "White", value: 10, text: "White" }}
+        />,
+        <Option
+          text="Yellow"
+          key="Yellow"
+          value={{ id: "Yellow", value: 11, text: "Yellow" }}
+        />,
       ]);
       function onChangeHandler(event) {
         setValue(event.target.value);
@@ -159,14 +211,16 @@ If there is no `id` prop specified on an object, then the exact objects will be 
       }
       return (
         <div>
-          <Button onClick={ clearValue } mb={ 2 }>clear</Button>
+          <Button onClick={clearValue} mb={2}>
+            clear
+          </Button>
           <Select
-            id='with-object'
-            name='with-object'
-            value={ value }
-            onChange={ onChangeHandler }
+            id="with-object"
+            name="with-object"
+            value={value}
+            onChange={onChangeHandler}
           >
-            { optionList.current }
+            {optionList.current}
           </Select>
         </div>
       );
@@ -175,23 +229,29 @@ If there is no `id` prop specified on an object, then the exact objects will be 
 </Preview>
 
 ### With isLoading prop:
+
 When `isLoading` prop is passed, a loader will be appended at the end of the Select List. That functionality could be used to load the options asynchronously.
 
 <Preview>
-  <Story name="with isLoading prop" parameters={{ chromatic: { disable: true }}} > 
+  <Story
+    name="with isLoading prop"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
       let preventLoading = useRef(false);
-      const [value, setValue] = useState('black');
+      const [value, setValue] = useState("black");
       const [isOpen, setIsOpen] = useState(false);
       const [isLoading, setIsLoading] = useState(true);
       const asyncList = [
-        <Option text='Amber' value='amber' key='Amber' />,
-        <Option text='Black' value='black' key='Black' />,
-        <Option text='Blue' value='blue' key='Blue' />,
-        <Option text='Brown' value='brown' key='Brown' />,
-        <Option text='Green' value='green' key='Green' />,
+        <Option text="Amber" value="amber" key="Amber" />,
+        <Option text="Black" value="black" key="Black" />,
+        <Option text="Blue" value="blue" key="Blue" />,
+        <Option text="Brown" value="brown" key="Brown" />,
+        <Option text="Green" value="green" key="Green" />,
       ];
-      const [optionList, setOptionList] = useState([<Option text='Black' value='black' key='Black' />]);
+      const [optionList, setOptionList] = useState([
+        <Option text="Black" value="black" key="Black" />,
+      ]);
       function loadList() {
         if (preventLoading.current) {
           return;
@@ -200,27 +260,29 @@ When `isLoading` prop is passed, a loader will be appended at the end of the Sel
         setIsLoading(true);
         setTimeout(() => {
           setIsLoading(false);
-          setOptionList(asyncList)
+          setOptionList(asyncList);
         }, 2000);
       }
       function clearData() {
-        setOptionList([<Option text='Black' value='black' key='Black' />]);
-        setValue('black');
+        setOptionList([<Option text="Black" value="black" key="Black" />]);
+        setValue("black");
         preventLoading.current = false;
       }
       return (
         <div>
-          <Button onClick={ clearData } mb={ 2 }>reset</Button>
+          <Button onClick={clearData} mb={2}>
+            reset
+          </Button>
           <Select
-            name='isLoading'
-            id='isLoading'
-            label='label'
-            value={ value }
-            onChange={ (event) => setValue(event.target.value) }
-            onOpen={ () => loadList() }
-            isLoading={ isLoading }
+            name="isLoading"
+            id="isLoading"
+            label="label"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            onOpen={() => loadList()}
+            isLoading={isLoading}
           >
-            { optionList }
+            {optionList}
           </Select>
         </div>
       );
@@ -229,31 +291,47 @@ When `isLoading` prop is passed, a loader will be appended at the end of the Sel
 </Preview>
 
 ### Infinite scroll example:
+
 The `isLoading` prop in combination with the `onListScrollBottom` prop can be used to implement infinite scroll.
 This prop will be called every time a user scrolls to the bottom of the list.
 
 <Preview>
-  <Story name="with infinite scroll" parameters={{ chromatic: { disable: true }}} > 
+  <Story
+    name="with infinite scroll"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
       let preventLoading = useRef(false);
       let preventLazyLoading = useRef(false);
       let lazyLoadingCounter = useRef(0);
-      const [value, setValue] = useState('');
+      const [value, setValue] = useState("");
       const [isOpen, setIsOpen] = useState(false);
       const [isLoading, setIsLoading] = useState(true);
       const asyncList = [
-        <Option text='Amber' value='amber' key='Amber' />,
-        <Option text='Black' value='black' key='Black' />,
-        <Option text='Blue' value='blue' key='Blue' />,
-        <Option text='Brown' value='brown' key='Brown' />,
-        <Option text='Green' value='green' key='Green' />,
+        <Option text="Amber" value="amber" key="Amber" />,
+        <Option text="Black" value="black" key="Black" />,
+        <Option text="Blue" value="blue" key="Blue" />,
+        <Option text="Brown" value="brown" key="Brown" />,
+        <Option text="Green" value="green" key="Green" />,
       ];
       const getLazyLoaded = () => {
         const counter = lazyLoadingCounter.current;
         return [
-          <Option text={`Lazy Loaded A${counter}`} value={`lazyA${counter}`} key={`lazyA${counter}`} />,
-          <Option text={`Lazy Loaded B${counter}`} value={`lazyB${counter}`} key={`lazyB${counter}`} />,
-          <Option text={`Lazy Loaded C${counter}`} value={`lazyC${counter}`} key={`lazyC${counter}`} />,
+          <Option
+            text={`Lazy Loaded A${counter}`}
+            value={`lazyA${counter}`}
+            key={`lazyA${counter}`}
+          />,
+          <Option
+            text={`Lazy Loaded B${counter}`}
+            value={`lazyB${counter}`}
+            key={`lazyB${counter}`}
+          />,
+          <Option
+            text={`Lazy Loaded C${counter}`}
+            value={`lazyC${counter}`}
+            key={`lazyC${counter}`}
+          />,
         ];
       };
       const [optionList, setOptionList] = useState([]);
@@ -265,7 +343,7 @@ This prop will be called every time a user scrolls to the bottom of the list.
         setIsLoading(true);
         setTimeout(() => {
           setIsLoading(false);
-          setOptionList(asyncList)
+          setOptionList(asyncList);
         }, 2000);
       }
       function onLazyLoading() {
@@ -283,23 +361,25 @@ This prop will be called every time a user scrolls to the bottom of the list.
       }
       function clearData() {
         setOptionList([]);
-        setValue('');
+        setValue("");
         preventLoading.current = false;
       }
       return (
         <div>
-          <Button onClick={ clearData } mb={ 2 }>reset</Button>
+          <Button onClick={clearData} mb={2}>
+            reset
+          </Button>
           <Select
-            name='infiniteScroll'
-            id='infiniteScroll'
-            label='label'
-            value={ value }
-            onChange={ (event) => setValue(event.target.value) }
-            onOpen={ () => loadList() }
-            isLoading={ isLoading }
-            onListScrollBottom={ onLazyLoading }
+            name="infiniteScroll"
+            id="infiniteScroll"
+            label="label"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            onOpen={() => loadList()}
+            isLoading={isLoading}
+            onListScrollBottom={onLazyLoading}
           >
-            { optionList }
+            {optionList}
           </Select>
         </div>
       );
@@ -469,7 +549,7 @@ The inline label can change to be top aligned at a breakpoint. Enable this by pa
   </Story>
 </Preview>
 
-<StyledSystemProps of={Select} spacing />
+<StyledSystemProps of={Select} margin />
 
 ### Props derived from the Textbox Component
 

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -173,7 +173,7 @@ export default (palette) => {
 
     text: {
       color: palette.blackOpacity(0.9),
-      placeholder: palette.blackOpacity(0.3),
+      placeholder: palette.blackOpacity(0.55),
       size: "14px",
     },
 
@@ -292,7 +292,6 @@ export default (palette) => {
       active: palette.gold,
       button: "#255BC7",
       passive: palette.slateTint(45),
-      placeholder: palette.slateTint(55),
       icon: palette.slateTint(55),
       iconHover: palette.slateTint(20),
       searchActive: "#668592",


### PR DESCRIPTION
### Proposed behaviour
This PR changes placeholder color in `Select`, `MultiSelect` and `Filterable` 
This PR also adds `margin` props support to `MultiSelect` and `Filterable` - FE-3571
This PR also changes placeholder color for all the inputs from `blackOpacity30` to `blackOpacity55`

Fixes #3532

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
DesignSystem -> Select stories

Margin props - play around with adding margin props in codesandbox
https://codesandbox.io/s/carbon-quickstart-forked-bpotd?file=/src/index.js
