### PR TITLE
chore: remove check-version

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@
 .idea
 .travis.yml
 .vscode
-check-version.js
 CONTRIBUTING.md
 gulpfile.js
 jest.conf.json

--- a/check-version.js
+++ b/check-version.js
@@ -1,9 +1,0 @@
-var exec = require('child_process').exec;
-
-exec("npm -v", function(err, stdout, stderr) {
-  if (parseFloat(stdout) < 5) {
-    console.error("Using npm version: " + stdout);
-    console.error("You need to be using at least npm version 5. To upgrade use `npm install npm@latest -g`.\n");
-    process.exit(1);
-  }
-});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint ./src",
     "lint-ts": "./node_modules/.bin/tslint 'src/**/*.ts'",
     "precompile": "npm run clean-lib && npm run copy-files && npm run babel",
-    "prepublishOnly": "node check-version.js && npm run precompile",
+    "prepublishOnly": "npm run precompile",
     "watch": "npm run clean-lib && npm run copy-files -- --watch & npm run babel -- --watch",
     "build-storybook": "build-storybook -c .storybook -s .assets",
     "babel": "cross-env NODE_ENV=production babel ./src --config-file ./babel.config.js --out-dir ./lib --ignore '**/*/__spec__.js','**/*.spec.js','**/__definition__.js' --quiet",

--- a/src/style/__spec__.js
+++ b/src/style/__spec__.js
@@ -4,7 +4,7 @@ import generatePalette from "./palette";
 
 const assertCorrectColorMix = (config, paletteObject) => {
   Object.keys(config).forEach((col) => {
-    const match = /([a-z]+)([\d]{0,2})/i.exec(col);
+    const match = col.match(/([a-z]+)([\d]{0,2})/i);
 
     const func = match[1],
       weight = Number(match[2]);


### PR DESCRIPTION
### Proposed behaviour
Remove `check-version.js` completely as it isn't needed anymore.

Replace `RegExp.exec` with a `.match` to avoid a vunerability false positive on Fortify

### Current behaviour
`check-version.js` exists

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
