### PR TITLE
chore(eslint): add security rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,9 @@
     "max-len": "off",
     "max-params": ["error", 5],
     "multiline-ternary": "off",
+    "no-eval": "error",
+    "no-implied-eval": "error",
+    "no-new-func": "error",
     "no-param-reassign": ["error", { "props": false }],
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "no-restricted-syntax": "off",
@@ -107,7 +110,7 @@
     "jasmine": true,
     "cypress/globals": true
   },
-  "extends": ["airbnb", "prettier", "prettier/react"],
+  "extends": ["plugin:no-unsanitized/DOM", "airbnb", "prettier", "prettier/react"],
   "plugins": ["cypress", "react", "react-hooks"],
   "globals": {
     "jest": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20287,6 +20287,12 @@
         }
       }
     },
+    "eslint-plugin-no-unsanitized": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-3.1.4.tgz",
+      "integrity": "sha512-WF1+eZo2Sh+bQNjZuVNwT0dA61zuJORsLh+1Sww7+O6GOPw+WPWIIRfTWNqrmaXaDMhM4SXAqYPcNlhRMiH13g==",
+      "dev": true
+    },
     "eslint-plugin-react": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "eslint-plugin-cypress": "^2.0.1",
     "eslint-plugin-import": "2.13.0",
     "eslint-plugin-jsx-a11y": "6.1.1",
+    "eslint-plugin-no-unsanitized": "^3.1.4",
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "^2.3.0",
     "events": "~1.1.1",


### PR DESCRIPTION
### Proposed behaviour
Add some Eslint rules to assist with security, i.e. to prevent code that could enable code injection attacks, such as the use of `eval` 

See https://github.com/mozilla/eslint-plugin-no-unsanitized for the Mozilla plugin added here

### Current behaviour
N/A

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
