### PR TITLE
chore(deps): upgrade storybook addon info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3315,9 +3315,9 @@
       }
     },
     "@babel/standalone": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.8.3.tgz",
-      "integrity": "sha512-WRYZUuGBYpmfUL50f2h3Cvw7s1F4wTVT5iIeT01tHo+LyB9QwrTJ6GF5J6YrtJHQqxMxt8zEl1d7I0Uhyz9NyQ==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.12.12.tgz",
+      "integrity": "sha512-sHuNDN9NvPHsDAmxPD3RpsIeqCoFSW+ySa6+3teInrYe9y0Gn5swLQ2ZE7Zk6L8eBBESZM2ob1l98qWauQfDMA==",
       "dev": true
     },
     "@babel/template": {
@@ -8514,15 +8514,15 @@
       }
     },
     "@storybook/addon-info": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-5.3.4.tgz",
-      "integrity": "sha512-WCQnvCSEILQl3SNqgx3pyTz/1u+WWdFp1D2Hf0Y7ymFZgXEvIUjaBK3kG9nUedBMR4pItvwmAJF2XCZEI41r/g==",
+      "version": "5.3.21",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-5.3.21.tgz",
+      "integrity": "sha512-A/K9HzmoXMuOUxH3AozTvjNZwTlYVHob2OaDRfMza0gYMzG0tOrxqcdNTigeAWAjS//Z0G3enue6rHulQZK/+g==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "5.3.4",
-        "@storybook/client-logger": "5.3.4",
-        "@storybook/components": "5.3.4",
-        "@storybook/theming": "5.3.4",
+        "@storybook/addons": "5.3.21",
+        "@storybook/client-logger": "5.3.21",
+        "@storybook/components": "5.3.21",
+        "@storybook/theming": "5.3.21",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
         "marksy": "^8.0.0",
@@ -8534,6 +8534,177 @@
         "react-is": "^16.8.3",
         "react-lifecycles-compat": "^3.0.4",
         "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@storybook/addons": {
+          "version": "5.3.21",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.21.tgz",
+          "integrity": "sha512-Ji/21WADTLVbTbiKcZ64BcL0Es+h1Afxx3kNmGJqPSTUYroCwIFCT9mUzCqU6G+YyWaISAmTii5UJkTwMkChwA==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "5.3.21",
+            "@storybook/channels": "5.3.21",
+            "@storybook/client-logger": "5.3.21",
+            "@storybook/core-events": "5.3.21",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/api": {
+          "version": "5.3.21",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.21.tgz",
+          "integrity": "sha512-K1o4an/Rx8daKRDooks6qzN6ZGyqizeacZZbair3F8CsSfTgrr2zCcf9pgKojLQa9koEmMHlcdb2KnS+GwPEgA==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@storybook/channels": "5.3.21",
+            "@storybook/client-logger": "5.3.21",
+            "@storybook/core-events": "5.3.21",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "5.3.21",
+            "@storybook/theming": "5.3.21",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^2.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "prop-types": "^15.6.2",
+            "react": "^16.8.3",
+            "semver": "^6.0.0",
+            "shallow-equal": "^1.1.0",
+            "store2": "^2.7.1",
+            "telejson": "^3.2.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "5.3.21",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.21.tgz",
+          "integrity": "sha512-OXoFs9XtBVg/cCk6lYMrxkzaNlJRf54ABdorp7YAAj7S9tRL1JxOZHxmjNQwEoiRvssmem2rAWtEAxfuEANsAA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "5.3.21",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.21.tgz",
+          "integrity": "sha512-OzQkwpZ5SK9cXD9Mv6lxPGPot+hSZvnkEW12kpt1AHfJz4ET26YTDOI3oetPsjfRJo6qYLeQX8+wF7rklfXbzA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/components": {
+          "version": "5.3.21",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.3.21.tgz",
+          "integrity": "sha512-42QQk6qZl6wrtajP8yNCfmNS2t8Iod5QY+4V/l6iNnnT9O+j6cWOlnO+ZyvjNv0Xm0zIOt+VyVjdkKh8FUjQmA==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "5.3.21",
+            "@storybook/theming": "5.3.21",
+            "@types/react-syntax-highlighter": "11.0.4",
+            "@types/react-textarea-autosize": "^4.3.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "markdown-to-jsx": "^6.11.4",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "popper.js": "^1.14.7",
+            "prop-types": "^15.7.2",
+            "react": "^16.8.3",
+            "react-dom": "^16.8.3",
+            "react-focus-lock": "^2.1.0",
+            "react-helmet-async": "^1.0.2",
+            "react-popper-tooltip": "^2.8.3",
+            "react-syntax-highlighter": "^11.0.2",
+            "react-textarea-autosize": "^7.1.0",
+            "simplebar-react": "^1.0.0-alpha.6",
+            "ts-dedent": "^1.1.0"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "5.3.21",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.21.tgz",
+          "integrity": "sha512-/Zsm1sKAh6pzQv8jQUmuhM7nuM01ZljIRKy8p2HjPNlMjDB5yaRkBfyeAUXUg+qXNI6aHVWa4jGdPEdwwY4oLA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/router": {
+          "version": "5.3.21",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.21.tgz",
+          "integrity": "sha512-c29m5UikK5Q1lyd6FltOGFhIcpd6PIb855YS3OUNe3F6ZA1tfJ+aNKrCBc65d1c+fvCGG76dYYYv0RvwEmKXXg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@storybook/csf": "0.0.1",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/theming": {
+          "version": "5.3.21",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.21.tgz",
+          "integrity": "sha512-FZbxjizqdO9lV5LUixPio/7+6UdPiswCzTJn8Hcot9uwwgfnrViRdN7xyjmSYRqv9nHP3OlYbtdeCAgZ4aPq8g==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.0.20",
+            "@emotion/styled": "^10.0.17",
+            "@storybook/client-logger": "5.3.21",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.19",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "prop-types": "^15.7.2",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^1.1.0"
+          }
+        },
+        "@types/react-syntax-highlighter": {
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz",
+          "integrity": "sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==",
+          "dev": true,
+          "requires": {
+            "@types/react": "*"
+          }
+        },
+        "polished": {
+          "version": "3.6.7",
+          "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.7.tgz",
+          "integrity": "sha512-b4OViUOihwV0icb9PHmWbR+vPqaSzSAEbgLskvb7ANPATVXGiYv/TQFHQo65S53WU9i5EQ1I03YDOJW7K0bmYg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
       }
     },
     "@storybook/addon-knobs": {
@@ -31709,9 +31880,9 @@
       "dev": true
     },
     "nested-object-assign": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/nested-object-assign/-/nested-object-assign-1.0.3.tgz",
-      "integrity": "sha512-kgq1CuvLyUcbcIuTiCA93cQ2IJFSlRwXcN+hLcb2qLJwC2qrePHGZZa7IipyWqaWF6tQjdax2pQnVxdq19Zzwg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nested-object-assign/-/nested-object-assign-1.0.4.tgz",
+      "integrity": "sha512-FlZ7oN9ICt+fbcJ4ag2IsALIcalfE/E16ttdSA8peBiHJI+oEKdOcafqDnUbeUe5NwWGn/m9zZGO9qrAGzfesg==",
       "dev": true
     },
     "next-tick": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@storybook/addon-actions": "^5.3.3",
     "@storybook/addon-docs": "^5.3.3",
     "@storybook/addon-google-analytics": "^5.3.3",
-    "@storybook/addon-info": "^5.3.3",
+    "@storybook/addon-info": "^5.3.6",
     "@storybook/addon-knobs": "^5.3.3",
     "@storybook/addon-links": "^6.1.11",
     "@storybook/addon-notes": "^5.3.3",


### PR DESCRIPTION
### Proposed behaviour
Upgrade `@storybook/addon-info` to fix our latest dependabot alert. It's dependency `nested-object-assign` needs to be upgraded to `1.0.4` which this update does.

### Current behaviour
N/A

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
