### PR TITLE
fix(grid-container): children proptype definition (FE-3222)

### DIFF
--- a/src/components/grid/grid-container/grid-container.component.js
+++ b/src/components/grid/grid-container/grid-container.component.js
@@ -32,8 +32,12 @@ const GridContainer = (props) => {
 
 GridContainer.propTypes = {
   /** Defines the Components to be rendered within the GridContainer. Requires a GridItem */
-  children: PropTypes.oneOfType([GridItem, PropTypes.arrayOf(GridItem)])
-    .isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.shape({
+      type: PropTypes.oneOf([GridItem])
+    })
+    , PropTypes.arrayOf(GridItem)])
+  .isRequired,
   /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding */
   p: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Any valid CSS value or a number to be multiplied by base spacing unit (8). Overrides default padding-left */

--- a/src/components/grid/grid.spec.js
+++ b/src/components/grid/grid.spec.js
@@ -141,10 +141,33 @@ describe("Grid", () => {
         </GridContainer>
       );
       // eslint-disable-next-line no-console
-      expect(console.error).toHaveBeenCalledWith(
-        // eslint-disable-next-line max-len
-        "Warning: Failed prop type: Invalid prop `children` supplied to `GridContainer`."
+      expect(console.error).toHaveBeenCalled();
+      global.console.error.mockReset();
+    });
+
+    it("is a valid proptype if children is only one GridItem", () => {
+      jest.spyOn(global.console, "error").mockImplementation(() => {});
+      enzymeMount(
+        <GridContainer id="testContainer">
+          <GridItem><p>1</p></GridItem>
+        </GridContainer>
       );
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled();
+      global.console.error.mockReset();
+    });
+
+    it("is a valid proptpe if children is multiple GridItems", () => {
+      jest.spyOn(global.console, "error").mockImplementation(() => {});
+      enzymeMount(
+        <GridContainer id="testContainer">
+          <GridItem><p>1</p></GridItem>
+          <GridItem><p>2</p></GridItem>
+          <GridItem><p>3</p></GridItem>
+      </GridContainer>
+      );
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled();
       global.console.error.mockReset();
     });
 


### PR DESCRIPTION
fixes: #3272

### Proposed behaviour
This fix clears the console warning when a single GridItem is passed to the children prop by correctly defining the children proptype as GridItem or Array of GridItem. 
NB. If you are currently passing any other element you will now see a console warning.

### Current behaviour
Single GridItem in a as a child of GridContainer throws this console warning
`Warning: Failed prop type: Invalid prop `children` supplied to `GridContainer`.`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~- [ ] Screenshots are included in the PR if useful~
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
~- [ ] Cypress automation tests added or updated if required~
~- [ ] Storybook added or updated if required~
~- [ ] Typescript `d.ts` file added or updated if required~
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
Use the codesandbox generated for issue 3272 bellow, edit it to pass either a single GridItem or multiple GridItems there should no longer be a console warning.
