### PR TITLE
ci: ignore chromatic for drafts

### DIFF
--- a/.github/workflows/chromatic-pr.yml
+++ b/.github/workflows/chromatic-pr.yml
@@ -1,17 +1,13 @@
-name: Chromatic Push
+name: Chromatic PR
 
 on:
-  push:
-    # We need these branches to update their baselines when they are merged into
-    branches:
-      - master
-      - '[0-9]+.x'
-      - '[0-9]+.x.x'
-      - '[0-9]+.[0-9]+.x'
-      - 'major/**'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   chromatic:
+    # if not a fork
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cypress-pr.yml
+++ b/.github/workflows/cypress-pr.yml
@@ -76,22 +76,3 @@ jobs:
           # Recommended: pass the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  chromatic:
-    # if not a fork
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: ubuntu-latest
-    needs: cypress
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '12'
-    - run: npm ci
-    - uses: chromaui/action@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-        exitOnceUploaded: true # We don't want it to fail CI, we'll be using the GitHub Check


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
- disable the `chromatic` run from `CI` when the state of PR is set to `Draft`

![Screenshot 2021-02-09 at 13 28 02](https://user-images.githubusercontent.com/34001198/107363626-b068b900-6ada-11eb-8ce9-fae962d19fca.png)


### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
To avoid unnecessary waste of resources of chromatic we decided to disable the `chromatic` run from `CI` when the state of PR is set to `Draft`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
<!-- How can a reviewer test this PR? -->
Check that `chromatic` shouldn't run on Draft