### PR TITLE
fix(toast): add z-index

### DIFF
--- a/src/components/toast/toast.stories.mdx
+++ b/src/components/toast/toast.stories.mdx
@@ -75,7 +75,6 @@ Please note, by clicking a `toggle preview` button it will open example toast at
     const StyledButton = styled(Button)`
       position: absolute;
       display: block;
-      z-index: 9999;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
@@ -122,7 +121,6 @@ Please note, by clicking a `toggle preview` button it will open example toast at
     const StyledButton = styled(Button)`
       position: absolute;
       display: block;
-      z-index: 9999;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
@@ -169,7 +167,6 @@ Please note, by clicking a `toggle preview` button it will open example toast at
     const StyledButton = styled(Button)`
       position: absolute;
       display: block;
-      z-index: 9999;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
@@ -217,7 +214,6 @@ Please note, by clicking a `toggle preview` button it will open example toast at
     const StyledButton = styled(Button)`
       position: absolute;
       display: block;
-      z-index: 9999;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
@@ -269,7 +265,6 @@ Please note, by clicking a `toggle preview` button it will open example toast at
     const StyledButton = styled(Button)`
       position: absolute;
       display: block;
-      z-index: 9999;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
@@ -320,7 +315,6 @@ Please note, by clicking a `toggle preview` button it will open example toast at
       const StyledButton = styled(Button)`
         position: absolute;
         display: block;
-        z-index: 9999;
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
@@ -381,7 +375,6 @@ Please note, by clicking a `toggle preview` button it will open example toast at
     const StyledButton = styled(Button)`
       position: absolute;
       display: block;
-      z-index: 9999;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
@@ -438,7 +431,6 @@ Please note, by clicking a `toggle preview` button it will open example toast at
     const StyledButton = styled(Button)`
       position: absolute;
       display: block;
-      z-index: 9999;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
@@ -513,7 +505,6 @@ One second delay
     const StyledButton = styled(Button)`
       position: absolute;
       display: block;
-      z-index: 9999;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
@@ -590,7 +581,6 @@ Please use `targetPortalId` prop to group multiple toasts so that they stack.
     const StyledButton = styled(Button)`
       position: absolute;
       display: block;
-      z-index: 9999;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
@@ -648,7 +638,6 @@ Please use `targetPortalId` prop to group multiple toasts so that they stack.
     const StyledButton = styled(Button)`
       position: absolute;
       display: block;
-      z-index: 9999;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);

--- a/src/components/toast/toast.style.js
+++ b/src/components/toast/toast.style.js
@@ -1,24 +1,34 @@
 import styled, { css } from "styled-components";
+
 import MessageStyle from "../message/message.style";
 import MessageContentStyle from "../message/message-content/message-content.style";
 import TypeIcon from "../message/type-icon/type-icon.style";
 import StyledIconButton from "../icon-button/icon-button.style";
 import Portal from "../portal/portal";
+import baseTheme from "../../style/themes/base";
 
 const StyledPortal = styled(Portal)`
-  position: absolute;
-  top: 0;
+  ${({ theme }) => css`
+    position: absolute;
+    top: 0;
 
-  ${({ isCenter }) =>
-    isCenter &&
-    css`
-      display: flex;
-      position: absolute;
-      flex-direction: column;
-      align-items: center;
-      width: 100%;
-    `}
+    z-index: ${theme.zIndex.notification};
+
+    ${({ isCenter }) =>
+      isCenter &&
+      css`
+        display: flex;
+        position: absolute;
+        flex-direction: column;
+        align-items: center;
+        width: 100%;
+      `}
+  `}
 `;
+
+StyledPortal.defaultProps = {
+  theme: baseTheme,
+};
 
 const animationName = ".toast";
 const ToastStyle = styled(MessageStyle)`


### PR DESCRIPTION
Fixes: #3640
Fixes #3627 

### Proposed behaviour
Add z-index to `Toast` (notification z-index from theme).

### Current behaviour
`Toast` does not have a z-index applied

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
See sandbox here: https://codesandbox.io/s/exciting-architecture-zzsxz