### PR TITLE
feat(button): icon only button - FE-3240

### DIFF
--- a/src/components/button/__snapshots__/button.spec.js.snap
+++ b/src/components/button/__snapshots__/button.spec.js.snap
@@ -34,6 +34,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c3 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -48,6 +49,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c4 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -62,6 +64,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c5 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -76,6 +79,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c6 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -90,6 +94,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c7 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -104,6 +109,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c8 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -118,6 +124,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c9 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -132,6 +139,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c10 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -146,6 +154,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c11 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -160,6 +169,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c12 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -174,6 +184,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c13 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -188,6 +199,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c14 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -202,6 +214,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c15 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -216,6 +229,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c16 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -230,6 +244,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c17 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -244,6 +259,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c18 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -258,6 +274,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c19 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -271,7 +288,8 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 
 .c20 .c1 {
   margin-left: 0px;
-  margin-right: 8px;
+  margin-right: 0px;
+  margin-bottom: 1px;
   height: 16px;
 }
 
@@ -286,6 +304,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c21 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -300,6 +319,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c22 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -314,6 +334,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c23 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -328,6 +349,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c24 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -342,6 +364,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c25 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -356,6 +379,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c26 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -370,6 +394,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c27 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -384,6 +409,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c28 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -398,6 +424,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c29 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -412,6 +439,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c30 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -426,6 +454,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c31 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -440,6 +469,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c32 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -454,6 +484,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c33 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -468,6 +499,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c34 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -482,6 +514,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c35 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -496,6 +529,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c36 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -510,6 +544,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c37 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -524,6 +559,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c38 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -538,6 +574,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c39 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -552,6 +589,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c40 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -566,6 +604,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c41 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -580,6 +619,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c42 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -594,6 +634,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c43 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -608,10 +649,26 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c44 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
 .c44 .c1 svg {
+  margin-top: 0;
+}
+
+.c45:hover .c1 {
+  color: #FFFFFF;
+}
+
+.c45 .c1 {
+  margin-left: 0px;
+  margin-right: 8px;
+  margin-bottom: 0px;
+  height: 16px;
+}
+
+.c45 .c1 svg {
   margin-top: 0;
 }
 
@@ -668,6 +725,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c0 .c1 {
   margin-left: 8px;
   margin-right: 0px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -782,6 +840,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c0 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -796,6 +855,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c3 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -810,6 +870,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c4 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -824,6 +885,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c5 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -838,6 +900,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c6 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -852,6 +915,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c7 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -866,6 +930,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c8 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -880,6 +945,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c9 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -894,6 +960,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c10 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -908,6 +975,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c11 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -922,6 +990,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c12 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -936,6 +1005,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c13 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -950,6 +1020,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c14 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -964,6 +1035,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c15 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -978,6 +1050,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c16 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -992,6 +1065,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c17 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1006,6 +1080,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c18 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1019,7 +1094,8 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 
 .c19 .c1 {
   margin-left: 0px;
-  margin-right: 8px;
+  margin-right: 0px;
+  margin-bottom: 1px;
   height: 16px;
 }
 
@@ -1034,6 +1110,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c20 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1048,6 +1125,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c21 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1062,6 +1140,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c22 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1076,6 +1155,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c23 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1090,6 +1170,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c24 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1104,6 +1185,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c25 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1118,6 +1200,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c26 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1132,6 +1215,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c27 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1146,6 +1230,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c28 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1160,6 +1245,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c29 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1174,6 +1260,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c30 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1188,6 +1275,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c31 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1202,6 +1290,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c32 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1216,6 +1305,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c33 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1230,6 +1320,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c34 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1244,6 +1335,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c35 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1258,6 +1350,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c36 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1272,6 +1365,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c37 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1286,6 +1380,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c38 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1300,6 +1395,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c39 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1314,6 +1410,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c40 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1328,6 +1425,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c41 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1342,6 +1440,7 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c42 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -1356,10 +1455,26 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 .c43 .c1 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
 .c43 .c1 svg {
+  margin-top: 0;
+}
+
+.c44:hover .c1 {
+  color: #FFFFFF;
+}
+
+.c44 .c1 {
+  margin-left: 0px;
+  margin-right: 8px;
+  margin-bottom: 0px;
+  height: 16px;
+}
+
+.c44 .c1 svg {
   margin-top: 0;
 }
 

--- a/src/components/button/button.d.ts
+++ b/src/components/button/button.d.ts
@@ -17,6 +17,7 @@ export interface ButtonProps extends SpacingProps {
     | "dashed"
     | "destructive"
     | "darkBackground";
+  "aria-label"?: string;
   disabled?: boolean;
   destructive?: boolean;
   fullWidth?: boolean;
@@ -34,6 +35,8 @@ export interface ButtonProps extends SpacingProps {
   forwardRef?: () => void;
   onClick?: (event: React.MouseEvent<HTMLButtonElement | HTMLLinkElement>) => void;
   noWrap?: boolean;
+  iconTooltipMessage?: string;
+  iconTooltipPosition?: string;
 }
 
 declare const Button: React.ComponentType<

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -50,6 +50,20 @@ describe("Button", () => {
     );
   });
 
+  describe("when iconType specified with no children", () => {
+    it("icon matches the style for an icon only button", () => {
+      const wrapper = mount(<Button iconType="bin" />);
+
+      assertStyleMatch(
+        {
+          marginBottom: "1px",
+        },
+        wrapper,
+        { modifier: `${StyledIcon}` }
+      );
+    });
+  });
+
   describe.each(Object.entries(sizesPadding))(
     "spacing for %s button",
     (size, px) => {
@@ -105,6 +119,28 @@ describe("Button", () => {
             });
           }
         );
+      }
+    );
+  });
+
+  describe("When icon type is specified and button has no children", () => {
+    describe.each(OptionsHelper.buttonTypes)(
+      "and the button type is %s",
+      (buttonType) => {
+        let wrapper;
+        beforeEach(() => {
+          wrapper = render({
+            iconType: "filter",
+            buttonType,
+          }).dive();
+        });
+
+        it("contains an Icon", () => {
+          const assertion =
+            wrapper.find(Icon).exists() &&
+            wrapper.find(Icon).props().type === "filter";
+          expect(assertion).toEqual(true);
+        });
       }
     );
   });
@@ -515,6 +551,17 @@ describe("Button", () => {
       ).dive();
 
       rootTagTest(wrapper, "button", "bar", "baz");
+    });
+  });
+
+  describe("aria-label", () => {
+    it("should be present when button has only an icon", () => {
+      const wrapper = shallow(
+        <Button aria-label="Bin" iconType="bin" />
+      ).dive();
+
+      const ariaLink = wrapper.find('[aria-label="Bin"]');
+      expect(ariaLink.exists()).toBe(true);
     });
   });
 

--- a/src/components/button/button.stories.js
+++ b/src/components/button/button.stories.js
@@ -214,6 +214,28 @@ export const noWrapButtons = () => {
   );
 };
 
+export const iconOnlyButtons = () => {
+  const binIcon = "bin";
+  return (
+    <>
+      {OptionsHelper.buttonTypes.map((buttonType) => {
+        return OptionsHelper.sizesRestricted.map((size) => {
+          return (
+            <div style={{ width: 100 }}>
+              <Button
+                buttonType={buttonType}
+                size={size}
+                iconType={binIcon}
+                aria-label={binIcon}
+              />
+            </div>
+          );
+        });
+      })}
+    </>
+  );
+};
+
 export const fullWidthButtons = () => {
   return (
     <>
@@ -488,4 +510,14 @@ knobs.story = {
 
 fullWidthButtons.story = {
   name: "full width buttons",
+};
+
+iconOnlyButtons.story = {
+  name: "icon only buttons",
+  parameters: {
+    chromatic: {
+      disable: true,
+    },
+    knobs: { escapeHTML: false },
+  },
 };

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -414,6 +414,67 @@ Passing in the `href` prop will render an anchor with `role="button"` and the Bu
   </Story>
 </Preview>
 
+### Icon Only Button
+
+Buttons can be rendered with just an icon.
+
+<Preview>
+  <Story name="icon only button">
+    <>
+      <Button 
+        buttonType="primary" 
+        size="small" 
+        iconType="bin" 
+        aria-label="Delete"
+      />
+      <Button 
+        destructive
+        ml={2} 
+        iconType="bin"
+        aria-label="Delete"
+      />
+      <Button 
+        buttonType="dashed" 
+        size="large" 
+        ml={2} 
+        iconType="bin" 
+        aria-label="Delete"
+      />
+    </>
+  </Story>
+</Preview>
+
+Icon only buttons can also display a tooltip message when the icon is hovered over. This can be acheived by passing a string to the `iconTooltipMessage` prop.
+
+<Preview>
+  <Story name="icon only button with tooltip" parameters={{ chromatic: { disable: true }}}>
+    <>
+      <Button 
+        buttonType="primary" 
+        size="small" 
+        iconType="bin" 
+        iconTooltipMessage="This is a tooltip"
+        aria-label="Delete"
+      />
+      <Button 
+        destructive
+        ml={2} 
+        iconType="bin"
+        iconTooltipMessage="This is a tooltip"
+        aria-label="Delete"
+      />
+      <Button 
+        buttonType="dashed"       
+        size="large" 
+        ml={2} 
+        iconType="bin" 
+        iconTooltipMessage="This is a tooltip"
+        aria-label="Delete"
+      />
+    </>
+  </Story>
+</Preview>
+
 ## Shared Props
 
 Options shared between all of the above types of buttons. When setting padding we recommend using either the `p`, `py`

--- a/src/components/button/button.style.js
+++ b/src/components/button/button.style.js
@@ -40,10 +40,15 @@ const StyledButton = styled.button`
       width: 100%;
     `}
 
-  ${({ iconPosition, theme }) => css`
+  ${({ iconOnly, iconPosition, theme }) => css`
     ${StyledIcon} {
-      margin-left: ${iconPosition === "before" ? "0px" : `${theme.spacing}px`};
-      margin-right: ${iconPosition === "before" ? `${theme.spacing}px` : "0px"};
+      margin-left: ${!iconOnly && iconPosition === "after"
+        ? `${theme.spacing}px`
+        : "0px"};
+      margin-right: ${!iconOnly && iconPosition === "before"
+        ? `${theme.spacing}px`
+        : "0px"};
+      margin-bottom: ${iconOnly ? "1px" : "0px"};
       height: ${additionalIconStyle};
       svg {
         margin-top: 0;

--- a/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
+++ b/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
@@ -54,6 +54,7 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
 .c1 .c2 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -330,6 +331,7 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
 .c16 .c13 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 

--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.js.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.js.snap
@@ -80,6 +80,7 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
 .c3 .c4 {
   margin-left: 8px;
   margin-right: 0px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -128,7 +129,6 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
     <button
       aria-expanded={false}
       aria-haspopup="true"
-      aria-label="Show more"
       className="c2 c3"
       data-component="button"
       data-element="toggle-button"

--- a/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
+++ b/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
@@ -80,6 +80,7 @@ exports[`Option renders properly 1`] = `
 .c2 .c3 {
   margin-left: 8px;
   margin-right: 0px;
+  margin-bottom: 0px;
   height: 16px;
 }
 

--- a/src/components/split-button/__snapshots__/split-button.spec.js.snap
+++ b/src/components/split-button/__snapshots__/split-button.spec.js.snap
@@ -80,6 +80,7 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
 .c2 .c4 {
   margin-left: 0px;
   margin-right: 8px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -92,8 +93,9 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
 }
 
 .c6 .c4 {
-  margin-left: 8px;
+  margin-left: 0px;
   margin-right: 0px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -167,8 +169,9 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
 }
 
 .c3 .c4 {
-  margin-left: 8px;
+  margin-left: 0px;
   margin-right: 0px;
+  margin-bottom: 0px;
   height: 16px;
 }
 
@@ -193,8 +196,9 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
 }
 
 .c7 .c4 {
-  margin-left: 8px;
+  margin-left: 0px;
   margin-right: 0px;
+  margin-bottom: 0px;
   height: 16px;
 }
 


### PR DESCRIPTION
Enables button component to allow only an icon to be rendered.

fixes #3236

### Proposed behaviour

Allows only an icon to be rendered inside of the button component without any console errors.

<img width="279" alt="Screenshot 2021-02-09 at 15 44 20" src="https://user-images.githubusercontent.com/56251247/107388401-b9af5100-6aed-11eb-9c76-2defca9ad91f.png">

<img width="350" alt="Screenshot 2021-02-09 at 15 44 56" src="https://user-images.githubusercontent.com/56251247/107388453-c6cc4000-6aed-11eb-9c3e-2b2cd36e692a.png">

### Current behaviour

If only an icon is rendered inside of a button, this warning is displayed.
`Warning: Failed prop type: The prop `children` is marked as required in `Button`, but its value is `undefined`.`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions

- `git checkout FE-3240-button_displays_prop_type_error`
- `npm i`
- `npm start` to start storybook.
- Visit Design System -> Button
- Two new examples have been created. Icon Only Button and Icon Only Button with Tooltip.
