### PR TITLE
docs: use primary color for theme selector

### DIFF
--- a/.storybook/theme-selector/register.js
+++ b/.storybook/theme-selector/register.js
@@ -59,7 +59,7 @@ export const ThemeSwitcher = memo(
         setThemeName(themeName);
         addons.getChannel().emit(FORCE_RE_RENDER);
       },
-      right: <ThemeIcon background={modernThemes[themeName].colors.base} />,
+      right: <ThemeIcon background={modernThemes[themeName].colors.primary} />,
     }));
 
     return (


### PR DESCRIPTION
### Proposed behaviour
Use the primary color for theme selector.
![image](https://user-images.githubusercontent.com/2328042/107505438-98ee0680-6b94-11eb-8d8b-04a5fbfb014e.png)


### Current behaviour
The theme selector is using the base color.
![image](https://user-images.githubusercontent.com/2328042/107505505-b4591180-6b94-11eb-8545-166b6277edec.png)

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
View storybook preview deployed by chromatic.
