### PR TITLE
test: update cypress version to 6.4.0

### DIFF
--- a/.github/workflows/cypress-pr.yml
+++ b/.github/workflows/cypress-pr.yml
@@ -20,7 +20,7 @@ jobs:
             1, 2, 3, 4, 5,
             6, 7, 8, 9, 10,
             11, 12, 13, 14, 15,
-            16, 17, 18, 19
+            16, 17, 18, 19, 20
             ]
     container: cypress/browsers:node12.18.3-chrome87-ff82
     steps:

--- a/.github/workflows/cypress-push.yml
+++ b/.github/workflows/cypress-push.yml
@@ -21,7 +21,7 @@ jobs:
             1, 2, 3, 4, 5,
             6, 7, 8, 9, 10,
             11, 12, 13, 14, 15,
-            16, 17, 18, 19
+            16, 17, 18, 19, 20
             ]
     container: cypress/browsers:node12.18.3-chrome87-ff82
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4325,14 +4325,6 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-              "dev": true
-            }
           }
         },
         "cli-cursor": {
@@ -4344,6 +4336,12 @@
             "restore-cursor": "^1.0.1"
           }
         },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -4352,14 +4350,6 @@
           "requires": {
             "escape-string-regexp": "^1.0.5",
             "object-assign": "^4.1.0"
-          },
-          "dependencies": {
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-              "dev": true
-            }
           }
         },
         "onetime": {
@@ -17865,9 +17855,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.2.0.tgz",
-      "integrity": "sha512-m/rkcogYM9MTy8rbsZgyS5wT2L/J+B5V2bY2ztkDNMyqhk/oZgUF4KTWVLzkW2I+scg0iAddca95tLlt7XnAtw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.4.0.tgz",
+      "integrity": "sha512-SrsPsZ4IBterudkoFYBvkQmXOVxclh1/+ytbzpV8AH/D2FA+s2Qy5ISsaRzOFsbQa4KZWoi3AKwREmF1HucYkg==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -17884,6 +17874,7 @@
         "cli-table3": "~0.6.0",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
+        "dayjs": "^1.9.3",
         "debug": "^4.1.1",
         "eventemitter2": "^6.4.2",
         "execa": "^4.0.2",
@@ -17898,7 +17889,7 @@
         "lodash": "^4.17.19",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.5",
-        "moment": "^2.27.0",
+        "moment": "^2.29.1",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.4.1",
         "ramda": "~0.26.1",
@@ -17995,15 +17986,15 @@
           "dev": true
         },
         "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
           }
         },
         "has-flag": {
@@ -18035,15 +18026,6 @@
           "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
           "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
           "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
         },
         "string-width": {
           "version": "4.2.0",
@@ -18084,9 +18066,9 @@
           }
         },
         "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         }
       }
@@ -18325,6 +18307,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "dev": true
+    },
+    "dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==",
       "dev": true
     },
     "de-indent": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "cpy-cli": "^3.1.1",
     "cross-env": "^5.2.0",
     "css-loader": "1.0.0",
-    "cypress": "^6.2.0",
+    "cypress": "^6.4.0",
     "cypress-axe": "^0.8.1",
     "cypress-cucumber-preprocessor": "4.0.0",
     "cypress-plugin-tab": "^1.0.5",


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
- update `cypress` version to `6.4.0`
- bump the number of containers to be `20` instead of `19` to make `cypress` tests faster

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
- to be up to date we need to update cypress version to 6.4.0
- we removed Chromatic from a `cypress-pr.yml file`, so we can bump the number of containers to be 20 instead of 19 

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent
