### PR TITLE
feat(multi-select): add isLoading prop

### DIFF
--- a/cypress/features/regression/designSystem/multiSelect.feature
+++ b/cypress/features/regression/designSystem/multiSelect.feature
@@ -96,3 +96,9 @@ Feature: Design System Multi Select component
     Then Multi select "first" pill has "Amber" value
       And Multi select "second" pill has "Black" value
       And Multi select "third" pill has "Green" value
+
+  @positive
+  Scenario: Lazy loading is visible after open the Multi Select
+    Given I open "Design System Select multiselect" component page "with is loading prop" in no iframe
+    When I click on dropdown button
+    Then Lazy loading is visible

--- a/src/components/select/multi-select/index.d.ts
+++ b/src/components/select/multi-select/index.d.ts
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import Option from '../option';
+import * as React from "react";
+import Option from "../option";
 
 export interface MultiSelectProps {
   /** Boolean to toggle where SelectList is rendered in relation to the Select Input */
@@ -25,7 +25,7 @@ export interface MultiSelectProps {
   /** Width of an input in percentage. Works only when labelInline is true */
   inputWidth?: number;
   /** Size of an input */
-  size?: 'small' | 'medium' | 'large';
+  size?: "small" | "medium" | "large";
   /** Placeholder string to be displayed in input */
   placeholder?: string;
   /** The selected value(s), when the component is operating in controlled mode */
@@ -52,6 +52,8 @@ export interface MultiSelectProps {
   onKeyDown?: () => void;
   /** Flag to configure component as mandatory */
   required?: boolean;
+  /** If true the loader animation is displayed in the option list */
+  isLoading?: boolean;
 }
 
 declare const MultiSelect: React.ComponentType<MultiSelectProps>;

--- a/src/components/select/multi-select/multi-select.component.js
+++ b/src/components/select/multi-select/multi-select.component.js
@@ -35,6 +35,7 @@ const MultiSelect = React.forwardRef(
       noResultsMessage,
       placeholder,
       disablePortal,
+      isLoading,
       ...textboxProps
     },
     inputRef
@@ -158,7 +159,8 @@ const MultiSelect = React.forwardRef(
         const matchingOption = React.Children.toArray(children).find((child) =>
           isExpectedOption(child, singleValue)
         );
-        const matchingOptionText = matchingOption.props.text;
+
+        const matchingOptionText = matchingOption && matchingOption.props.text;
 
         return (
           <StyledSelectPillContainer key={matchingOptionText}>
@@ -450,6 +452,7 @@ const MultiSelect = React.forwardRef(
         noResultsMessage={noResultsMessage}
         repositionTrigger={repositionTrigger}
         disablePortal={disablePortal}
+        isLoading={isLoading}
       >
         {children}
       </FilterableSelectList>
@@ -501,6 +504,8 @@ MultiSelect.propTypes = {
   openOnFocus: PropTypes.bool,
   /** A custom message to be displayed when any option does not match the filter text */
   noResultsMessage: PropTypes.string,
+  /** If true the loader animation is displayed in the option list */
+  isLoading: PropTypes.bool,
 };
 
 export default MultiSelect;

--- a/src/components/select/multi-select/multi-select.stories.mdx
+++ b/src/components/select/multi-select/multi-select.stories.mdx
@@ -322,6 +322,66 @@ If there is no `id` prop specified on an object, then the exact objects will be 
   </Story>
 </Preview>
 
+### With isLoading prop:
+
+When `isLoading` prop is passed, a loader will be appended at the end of the Select List. That functionality could be used to load the options asynchronously.
+
+<Preview>
+  <Story
+    name="with isLoading prop"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() => {
+      let preventLoading = useRef(false);
+      const [value, setValue] = useState([]);
+      const [isOpen, setIsOpen] = useState(false);
+      const [isLoading, setIsLoading] = useState(true);
+      const asyncList = [
+        <Option text="Amber" value="amber" key="Amber" />,
+        <Option text="Black" value="black" key="Black" />,
+        <Option text="Blue" value="blue" key="Blue" />,
+        <Option text="Brown" value="brown" key="Brown" />,
+        <Option text="Green" value="green" key="Green" />,
+      ];
+      const [optionList, setOptionList] = useState([]);
+      function loadList() {
+        if (preventLoading.current) {
+          return;
+        }
+        preventLoading.current = true;
+        setIsLoading(true);
+        setTimeout(() => {
+          setIsLoading(false);
+          setOptionList(asyncList);
+        }, 2000);
+      }
+      function clearData() {
+        setOptionList([]);
+        setValue([]);
+        preventLoading.current = false;
+      }
+      return (
+        <div>
+          <Button onClick={clearData} mb={2}>
+            reset
+          </Button>
+          <MultiSelect
+            name="isLoading"
+            id="isLoading"
+            label="label"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            onOpen={() => loadList()}
+            isLoading={isLoading}
+          >
+            {optionList}
+          </MultiSelect>
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
 ## Props:
 
 <StyledSystemProps of={MultiSelect} margin />


### PR DESCRIPTION
### Proposed behaviour
Add `isLoading` prop to `MultiSelect` to allow for the loader to be used on the dropdown. Add new story to show this: 


![image](https://user-images.githubusercontent.com/14963680/107544172-dc129e80-6bc1-11eb-95f1-e4c775ae52e6.png)


### Current behaviour
Loader cannot be used with `MultiSelect`

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
http://localhost:9001/?path=/docs/design-system-select-multiselect--with-is-loading-prop