### PR TITLE
chore(utils): add disconnect icon to options helper definition file - FE-3381

### DIFF
--- a/src/utils/helpers/options-helper/options-helper.d.ts
+++ b/src/utils/helpers/options-helper/options-helper.d.ts
@@ -70,6 +70,7 @@ export type IconTypes =
 | 'delete'
 | 'delivery'
 | 'disputed'
+| 'disconnect'
 | 'document_right_align'
 | 'document_tick'
 | 'document_vertical_lines'


### PR DESCRIPTION
The disconnect icon has been added to the options helper definition file for our TypeScript users.

fixes FE-3381

### Proposed behaviour

Add the `disconnect` icon to the list of icons in the definition file.

### Current behaviour

The `disconnect` icon is currently missing from the definition file.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
<del> [ ] Screenshots are included in the PR if useful </del>
<del> [ ] All themes are supported if required </del>
<del> [ ] Unit tests added or updated if required </del>
<del> [ ] Cypress automation tests added or updated if required </del>
<del> [ ] Storybook added or updated if required </del>
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
A TypeScript project inside of a Codesandbox has been provided. Disconnect icon has been passed in to icon. No errors in console and icon should display as expected.

https://codesandbox.io/s/dank-pond-to6cv
