### PR TITLE
fix(select): various select fixes (FE-3552, FE-3385, FE-3615)

### DIFF
--- a/cypress/features/regression/designSystem/filterableSelect.feature
+++ b/cypress/features/regression/designSystem/filterableSelect.feature
@@ -106,3 +106,9 @@ Feature: Design System Filterable Select component
     Given I open "Design System Select filterable" component page "open on focus" in no iframe
     When I focus openOnFocus Select input
     Then "filterable" Select list is opened
+
+  @positive
+  Scenario: Value is cleared when the filter does not match any options 
+    Given I open "Design System Select filterable" component page "controlled" in no iframe
+    When I select value "xzw"
+    Then Select input has no value

--- a/cypress/support/step-definitions/select-steps.js
+++ b/cypress/support/step-definitions/select-steps.js
@@ -216,3 +216,7 @@ Then(
 Then("Select input has {string} value", (text) => {
   getDataElementByValue("input").should("have.attr", "value", text);
 });
+
+Then("Select input has no value", () => {
+  getDataElementByValue("input").should("have.attr", "value", "");
+});

--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -74,10 +74,16 @@ const FilterableSelect = React.forwardRef(
         setSelectedValue((previousValue) => {
           const match = findElementWithMatchingText(newFilterText, children);
 
-          if (!match || isDeleteEvent) {
+          if (!match) {
             setTextValue(newFilterText);
 
-            return previousValue;
+            return "";
+          }
+
+          if (isDeleteEvent) {
+            setTextValue(newFilterText);
+
+            return match.props.value;
           }
 
           if (onChange) {

--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -73,8 +73,9 @@ const FilterableSelect = React.forwardRef(
       (newFilterText, isDeleteEvent) => {
         setSelectedValue((previousValue) => {
           const match = findElementWithMatchingText(newFilterText, children);
+          const isFilterCleared = isDeleteEvent && newFilterText === "";
 
-          if (!match) {
+          if (!match || isFilterCleared) {
             setTextValue(newFilterText);
 
             return "";
@@ -255,7 +256,7 @@ const FilterableSelect = React.forwardRef(
       setMatchingText(value || defaultValue);
       // update text value only when children are changing
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [children]);
+    }, [value, children]);
 
     useEffect(() => {
       const clickEvent = "click";

--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -247,8 +247,9 @@ const FilterableSelect = React.forwardRef(
 
     useEffect(() => {
       setMatchingText(value || defaultValue);
+      // update text value only when children are changing
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [children]);
 
     useEffect(() => {
       const clickEvent = "click";

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -47,6 +47,27 @@ describe("FilterableSelect", () => {
 
       expect(wrapper.find(Textbox).prop("formattedValue")).toBe("green");
     });
+
+    describe("without available matching option", () => {
+      it("then the formatted value should be set to corresponding option text when it's available", () => {
+        const wrapper = mount(
+          <FilterableSelect
+            name="testSelect"
+            id="testSelect"
+            defaultValue="opt2"
+          >
+            <Option value="opt1" text="blue" key="blue" />
+          </FilterableSelect>
+        );
+
+        wrapper.setProps({
+          children: [<Option value="opt2" text="red" key="red" />],
+        });
+        wrapper.update();
+
+        expect(wrapper.find(Textbox).prop("formattedValue")).toBe("red");
+      });
+    });
   });
 
   describe("when the inputRef function prop is specified", () => {

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -160,6 +160,10 @@ describe("FilterableSelect", () => {
           target: { value: "blu" },
           nativeEvent: { inputType: deleteEventType },
         };
+        const mockClearEvent = {
+          target: { value: "" },
+          nativeEvent: { inputType: deleteEventType },
+        };
 
         it("the value should not be changed", () => {
           wrapper.find("input").simulate("focus");
@@ -167,6 +171,16 @@ describe("FilterableSelect", () => {
           expect(wrapper.find(Textbox).prop("value")).toBe("opt3");
           wrapper.find("input").simulate("change", mockDeleteEvent);
           expect(wrapper.find(Textbox).prop("value")).toBe("opt3");
+        });
+
+        describe("and the filter is cleared", () => {
+          it("the value should also be cleared", () => {
+            wrapper.find("input").simulate("focus");
+            wrapper.find("input").simulate("change", mockChangeEvent);
+            expect(wrapper.find(Textbox).prop("value")).toBe("opt3");
+            wrapper.find("input").simulate("change", mockClearEvent);
+            expect(wrapper.find(Textbox).prop("value")).toBe("");
+          });
         });
       }
     );

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -148,6 +148,28 @@ describe("FilterableSelect", () => {
         );
       });
     });
+
+    describe.each(["deleteContentBackward", "deleteContentForward", "delete"])(
+      'and the "%s" change event is a delete event type',
+      (deleteEventType) => {
+        const mockChangeEvent = {
+          target: { value: "blue" },
+          nativeEvent: { inputType: deleteEventType },
+        };
+        const mockDeleteEvent = {
+          target: { value: "blu" },
+          nativeEvent: { inputType: deleteEventType },
+        };
+
+        it("the value should not be changed", () => {
+          wrapper.find("input").simulate("focus");
+          wrapper.find("input").simulate("change", mockChangeEvent);
+          expect(wrapper.find(Textbox).prop("value")).toBe("opt3");
+          wrapper.find("input").simulate("change", mockDeleteEvent);
+          expect(wrapper.find(Textbox).prop("value")).toBe("opt3");
+        });
+      }
+    );
   });
 
   describe("when the Textbox Input has been clicked", () => {
@@ -404,8 +426,8 @@ describe("FilterableSelect", () => {
       expect(wrapper.update().find(SelectList).exists()).toBe(false);
     });
 
-    describe("and the visible text was changed", () => {
-      it("then the formattedValue prop in Textbox should be reverted to previous value", () => {
+    describe("and the changed visible text is not matching any option", () => {
+      it("then the formattedValue prop in Textbox should be cleared", () => {
         const selectedOptionTextValue = "green";
         const onChangeFn = jest.fn();
         const wrapper = renderSelect({
@@ -427,9 +449,7 @@ describe("FilterableSelect", () => {
         act(() => {
           wrapper.find(SelectList).prop("onSelectListClose")();
         });
-        expect(wrapper.update().find(Textbox).prop("formattedValue")).toBe(
-          selectedOptionTextValue
-        );
+        expect(wrapper.update().find(Textbox).prop("formattedValue")).toBe("");
       });
     });
   });

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -596,28 +596,56 @@ describe("FilterableSelect", () => {
     });
 
     describe("when a printable character has been typed in the Textbox", () => {
-      beforeEach(() => {
-        wrapper.find("input").simulate("change", { target: { value: "b" } });
-        wrapper.update();
-      });
-
-      it("then the onChange function should have been called with with the expected value", () => {
-        expect(onChangeFn).toHaveBeenCalledWith(expectedObject);
-      });
-
-      describe("and an an empty value has been passed", () => {
-        it("then the textbox displayed value should be cleared", () => {
-          expect(wrapper.find(Textbox).props().formattedValue).toBe("blue");
-          wrapper.setProps({ value: "" });
-          expect(wrapper.update().find(Textbox).props().formattedValue).toBe(
-            ""
-          );
+      describe("and the first filtered option starts with that character", () => {
+        beforeEach(() => {
+          wrapper.find("input").simulate("change", { target: { value: "b" } });
+          wrapper.update();
         });
 
-        it("then the textbox value should be cleared", () => {
-          expect(wrapper.find(Textbox).props().value).toBe("opt1");
-          wrapper.setProps({ value: "" });
-          expect(wrapper.update().find(Textbox).props().value).toBe(undefined);
+        it("then the onChange function should have been called with with the expected value", () => {
+          expect(onChangeFn).toHaveBeenCalledWith(expectedObject);
+        });
+
+        describe("and an an empty value has been passed", () => {
+          it("then the textbox displayed value should be cleared", () => {
+            expect(wrapper.find(Textbox).props().formattedValue).toBe("blue");
+            wrapper.setProps({ value: "" });
+            expect(wrapper.update().find(Textbox).props().formattedValue).toBe(
+              ""
+            );
+          });
+
+          it("then the textbox value should be cleared", () => {
+            expect(wrapper.find(Textbox).props().value).toBe("opt1");
+            wrapper.setProps({ value: "" });
+            expect(wrapper.update().find(Textbox).props().value).toBe(
+              undefined
+            );
+          });
+        });
+      });
+
+      describe("and the first filtered option does not start with that character", () => {
+        beforeEach(() => {
+          wrapper.find("input").simulate("change", { target: { value: "l" } });
+          wrapper.update();
+        });
+
+        it("then the onChange function should have been called with with the expected value", () => {
+          expect(onChangeFn).toHaveBeenCalledWith(expectedObject);
+        });
+
+        it("then the Textbox visible value should be changed to that character", () => {
+          expect(wrapper.find(Textbox).prop("formattedValue")).toBe("l");
+          wrapper.unmount();
+        });
+
+        describe("and the value changes without changing the filter text", () => {
+          it("then the Textbox visible value should still be set to that character", () => {
+            wrapper.setProps({ value: "opt3" });
+            expect(wrapper.find(Textbox).prop("formattedValue")).toBe("l");
+            wrapper.unmount();
+          });
         });
       });
     });

--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -77,22 +77,6 @@ const SimpleSelect = React.forwardRef(
       [name, id]
     );
 
-    const setMatchingText = useCallback(
-      (newValue) => {
-        const matchingOption = childOptions.find((child) =>
-          isExpectedOption(child, newValue)
-        );
-        let newText = "";
-
-        if (matchingOption) {
-          newText = matchingOption.props.text;
-        }
-
-        setTextValue(newText);
-      },
-      [childOptions]
-    );
-
     const selectValueStartingWithText = useCallback(
       (newFilterText) => {
         setSelectedValue((previousValue) => {
@@ -187,21 +171,23 @@ const SimpleSelect = React.forwardRef(
       [onKeyDown, onOpen, readOnly]
     );
 
-    const handleGlobalClick = useCallback(
-      (event) => {
-        const notInContainer =
-          containerRef.current && !containerRef.current.contains(event.target);
+    const handleGlobalClick = useCallback((event) => {
+      const notInContainer =
+        containerRef.current && !containerRef.current.contains(event.target);
 
-        if (notInContainer && !isClickTriggeredBySelect.current) {
-          setMatchingText(selectedValue);
-          setOpenState(false);
+      if (notInContainer && !isClickTriggeredBySelect.current) {
+        setOpenState((previousValue) => {
+          if (!previousValue) {
+            return false;
+          }
+
           filterText.current = "";
-        }
+          return false;
+        });
+      }
 
-        isClickTriggeredBySelect.current = false;
-      },
-      [setMatchingText, selectedValue]
-    );
+      isClickTriggeredBySelect.current = false;
+    }, []);
 
     useEffect(() => {
       const newValue = value || defaultValue;
@@ -221,8 +207,20 @@ const SimpleSelect = React.forwardRef(
       );
 
       setSelectedValue(newValue);
-      setMatchingText(newValue);
-    }, [value, defaultValue, setMatchingText, onChange]);
+    }, [value, defaultValue, onChange]);
+
+    useEffect(() => {
+      const matchingOption = childOptions.find((child) =>
+        isExpectedOption(child, selectedValue)
+      );
+      let newText = "";
+
+      if (matchingOption) {
+        newText = matchingOption.props.text;
+      }
+
+      setTextValue(newText);
+    }, [selectedValue, childOptions]);
 
     useEffect(() => {
       const clickEvent = "click";
@@ -329,7 +327,6 @@ const SimpleSelect = React.forwardRef(
     function onSelectListClose() {
       setOpenState(false);
       filterText.current = "";
-      setMatchingText(selectedValue);
     }
 
     function isNavigationKey(key) {

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -527,13 +527,13 @@ describe("SimpleSelect", () => {
 
   describe("when the onSelect is called in the SelectList", () => {
     const navigationKeyOptionObject = {
-      value: "Foo",
-      text: "Bar",
+      value: "opt2",
+      text: "green",
       selectionType: "navigationKey",
     };
     const clickOptionObject = {
-      value: "Foo",
-      text: "Bar",
+      value: "opt2",
+      text: "green",
       selectionType: "click",
     };
     const textboxProps = {
@@ -543,7 +543,7 @@ describe("SimpleSelect", () => {
     const expectedEventObject = {
       target: {
         ...textboxProps,
-        value: "Foo",
+        value: "opt2",
       },
     };
 
@@ -561,18 +561,31 @@ describe("SimpleSelect", () => {
     });
 
     describe('with "selectionType" as "navigationKey"', () => {
-      it("the SelectList should be open and the value should be selected", () => {
-        const wrapper = renderSelect();
+      const wrapper = renderSelect();
 
+      beforeAll(() => {
         wrapper.find("input").simulate("click");
         expect(wrapper.find(SelectList).exists()).toBe(true);
         act(() => {
           wrapper.find(SelectList).prop("onSelect")(navigationKeyOptionObject);
         });
         wrapper.update();
+      });
+
+      it("the SelectList should be open", () => {
         expect(wrapper.find(SelectList).exists()).toBe(true);
-        expect(wrapper.find(Textbox).prop("value")).toBe("Foo");
-        expect(wrapper.find(Textbox).prop("formattedValue")).toBe("Bar");
+      });
+
+      it("the expected value should be selected", () => {
+        expect(wrapper.find(Textbox).prop("value")).toBe(
+          navigationKeyOptionObject.value
+        );
+      });
+
+      it("the expected text should be displayed in the Textbox", () => {
+        expect(wrapper.find(Textbox).prop("formattedValue")).toBe(
+          navigationKeyOptionObject.text
+        );
       });
     });
 


### PR DESCRIPTION
### Proposed behaviour
Select visible value should not be cleared on reopening a modal.
Filterable Select should display text value when a default value is set and options are loaded asynchronously.
Filterable Select value should be cleared when the filter does not mach any option.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
~~- [ ] Storybook added or updated if required~~
~~- [ ] Typescript `d.ts` file added or updated if required~~
~~- [ ] Carbon implementation and Design System documentation are congruent~~

### Testing instructions
fix for value displayed on reopening select when in a modal:
https://codesandbox.io/s/carbon-quickstart-forked-f6ws0
fix for value not displayed on async option load:
https://codesandbox.io/s/carbon-quickstart-forked-yfd7c
fix for value not cleared on incorrect filter:
http://localhost:9001/?path=/docs/design-system-select-filterable--controlled