### PR TITLE
feat(pager): add alternate variant styling FE-3415

### DIFF
--- a/src/components/pager/__internal__/pager.component.js
+++ b/src/components/pager/__internal__/pager.component.js
@@ -22,6 +22,7 @@ const Pager = ({
   onFirst,
   onPrevious,
   onLast,
+  variant,
   ...props
 }) => {
   const [pageCount, setPageCount] = useState(1);
@@ -149,7 +150,7 @@ const Pager = ({
   };
 
   return (
-    <StyledPagerContainer data-component="pager">
+    <StyledPagerContainer data-component="pager" variant={variant}>
       <StyledPagerSizeOptions>{pageSizeOptions()}</StyledPagerSizeOptions>
       <PagerNavigation
         {...props}
@@ -196,6 +197,8 @@ Pager.propTypes = {
       name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     })
   ),
+  /** What variant the Pager background should be */
+  variant: PropTypes.oneOf(["default", "alternate"]),
 };
 
 Pager.defaultProps = {

--- a/src/components/pager/__internal__/pager.component.js
+++ b/src/components/pager/__internal__/pager.component.js
@@ -212,6 +212,7 @@ Pager.defaultProps = {
     { id: "50", name: 50 },
     { id: "100", name: 100 },
   ],
+  variant: "default",
 };
 
 export default Pager;

--- a/src/components/pager/__internal__/pager.d.ts
+++ b/src/components/pager/__internal__/pager.d.ts
@@ -11,6 +11,7 @@ export interface PagerPropTypes {
   pageSize?: number | string;
   showPageSizeSelection?: boolean;
   pageSizeSelectionOptions?: object;
+  variant?: "default" | "alternate";
 }
 
 declare const Pager: React.FunctionComponent<PagerPropTypes>;

--- a/src/components/pager/__internal__/pager.spec.js
+++ b/src/components/pager/__internal__/pager.spec.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
-import "jest-styled-components";
 import { ThemeProvider } from "styled-components";
 import TestRenderer from "react-test-renderer";
 import I18n from "i18n-js";
@@ -401,6 +400,17 @@ describe("Pager", () => {
             justifyContent: "space-between",
             alignItems: "center",
             borderTopWidth: "0",
+          },
+          wrapper
+        );
+      });
+
+      it("matches the expected style", () => {
+        const wrapper = render({ ...props, variant: "alternate" }, mount);
+
+        assertStyleMatch(
+          {
+            backgroundColor: baseTheme.pager.alternate,
           },
           wrapper
         );

--- a/src/components/pager/__internal__/pager.stories.js
+++ b/src/components/pager/__internal__/pager.stories.js
@@ -56,7 +56,14 @@ export const Default = () => {
     Pager.defaultProps.pageSize
   );
   const currentPage = text("currentPage", "1");
-
+  const variant = select(
+    "variant",
+    {
+      default: "default",
+      alternate: "alternate",
+    },
+    "default"
+  );
   return (
     <Pager
       showPageSizeSelection={showPageSizeSelection}
@@ -75,6 +82,7 @@ export const Default = () => {
         { id: "50", name: 50 },
         { id: "100", name: 100 },
       ]}
+      variant={variant}
     />
   );
 };

--- a/src/components/pager/__internal__/pager.stories.mdx
+++ b/src/components/pager/__internal__/pager.stories.mdx
@@ -10,7 +10,7 @@ import {
 } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
-<Meta title="Design System/Pager" />
+<Meta title="Design System/Pager" parameters={{ info: { disable: true }}}/>
 
 # Pager
 Pagination Component.
@@ -18,7 +18,7 @@ Pagination Component.
 ### Default usage:
 
 <Preview>
-  <Story name="default" parameters={{ info: { disable: true }}} >
+  <Story name="default">
     {() => {
       const totalRecords = text('totalRecords', '100');
       const showPageSizeSelection = boolean(
@@ -59,7 +59,7 @@ Pagination Component.
 ### With disabled Page Size Selection:
 
 <Preview>
-  <Story name="disabled-page-size" parameters={{ info: { disable: true }}} >
+  <Story name="disabled-page-size">
     <Pager
       totalRecords={ 100 }
       onPagination={ () => {} }
@@ -71,7 +71,7 @@ Pagination Component.
 When no totalRecords provided.
 
 <Preview>
-  <Story name="loading-state" parameters={{ info: { disable: true }}} >
+  <Story name="loading-state">
     <Pager
       onPagination={ () => {} }
     />
@@ -82,7 +82,7 @@ When no totalRecords provided.
 Shows 1, 2 or 5 items per page.
 
 <Preview>
-  <Story name="page-size-selection-options" parameters={{ info: { disable: true }}} >
+  <Story name="page-size-selection-options">
     <Pager
       onPagination={ () => {} }
       totalRecords={ 100 }
@@ -103,7 +103,7 @@ Shows 1, 2 or 5 items per page.
 Due to the fact that it is last page, next and last links are disabled.
 
 <Preview>
-  <Story name="current-page-last-page" parameters={{ info: { disable: true }}} >
+  <Story name="current-page-last-page">
     <Pager
       onPagination={ () => {} }
       totalRecords={ 100 }
@@ -116,12 +116,27 @@ Due to the fact that it is last page, next and last links are disabled.
 ### With currentPage pre-set to page 5
 
 <Preview>
-  <Story name="current-page" parameters={{ info: { disable: true }}} >
+  <Story name="current-page">
     <Pager
       onPagination={ () => {} }
       totalRecords={ 100 }
       showPageSizeSelection={ true }
       currentPage={ 5 }
+    />
+  </Story>
+</Preview>
+
+### Alternate background
+
+<Preview>
+  <Story name="alternate">
+    <Pager
+      totalRecords={ 100 }
+      showPageSizeSelection
+      pageSize={ 10 }
+      currentPage={ 1 }
+      onPagination={ () => {} }
+      variant="alternate"
     />
   </Story>
 </Preview>

--- a/src/components/pager/__internal__/pager.style.js
+++ b/src/components/pager/__internal__/pager.style.js
@@ -198,7 +198,6 @@ const StyledPagerSummary = styled.div`
 
 StyledPagerContainer.defaultProps = {
   theme: baseTheme,
-  variant: "default",
 };
 
 StyledPagerSizeOptions.defaultProps = {

--- a/src/components/pager/__internal__/pager.style.js
+++ b/src/components/pager/__internal__/pager.style.js
@@ -23,7 +23,7 @@ const StyledPagerContainer = styled.div`
   height: 39px;
   max-height: 39px;
 
-  ${({ theme }) => {
+  ${({ theme, variant }) => {
     return (
       theme.table &&
       theme.colors &&
@@ -31,7 +31,9 @@ const StyledPagerContainer = styled.div`
         border-width: 1px 1px 1px 1px;
         border-style: none solid solid solid;
         border-color: ${theme.table.secondary};
-        background-color: ${theme.table.zebra};
+        background-color: ${variant === "alternate"
+          ? theme.pager.alternate
+          : theme.table.zebra};
 
         .carbon-input-icon {
           border: none;
@@ -196,6 +198,7 @@ const StyledPagerSummary = styled.div`
 
 StyledPagerContainer.defaultProps = {
   theme: baseTheme,
+  variant: "default",
 };
 
 StyledPagerSizeOptions.defaultProps = {

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -231,6 +231,7 @@ export default (palette) => {
     pager: {
       active: "rgba(0,0,0,0.90)",
       disabled: "rgba(0,0,0,0.3)",
+      alternate: palette.slateTint(93),
     },
 
     icon: {


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds `variant` prop to support `alternate` styled `Pager` background

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No alternate background is supported

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/107638025-ec308980-6c66-11eb-81ef-f141e4ecf7b8.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
Added an Alternate Pager story