### PR TITLE
fix(tile): add box sizing to container to ensure it respects parent width FE-3389

### DIFF
--- a/cypress/features/regression/test/tile.feature
+++ b/cypress/features/regression/test/tile.feature
@@ -16,7 +16,6 @@ Feature: Tile component
     Then Tile pixel width is set to <pixelWidth>
     Examples:
       | pixelWidth | nameOfObject   |
-      | 1          | pixelWidth1    |
       | 100        | pixelWidth100  |
       | 1999       | pixelWidth1999 |
 

--- a/cypress/fixtures/commonComponents/tile.json
+++ b/cypress/fixtures/commonComponents/tile.json
@@ -14,9 +14,6 @@
   "width90": {
     "width_Default": 90
   },
-  "pixelWidth1": {
-    "pixelWidth_Default": 1
-  },
   "pixelWidth100": {
     "pixelWidth_Default": 100
   },

--- a/src/components/tile/__snapshots__/tile.spec.js.snap
+++ b/src/components/tile/__snapshots__/tile.spec.js.snap
@@ -43,6 +43,7 @@ exports[`Tile renders base styles 1`] = `
 
 .c0 {
   padding: 24px;
+  box-sizing: border-box;
   background-color: #FFFFFF;
   border: 1px solid #CCD6DB;
   display: -webkit-box;

--- a/src/components/tile/tile.spec.js
+++ b/src/components/tile/tile.spec.js
@@ -114,11 +114,14 @@ describe("Tile", () => {
           assertStyleMatch({ width: "25%" }, wrapper);
         });
 
-        it("is overridden when the pixelWidth prop is set", () => {
-          const wrapper = render({ pixelWidth: 500, width: 25 }).toJSON();
+        it.each([1, 150, 500])(
+          "is overridden when the pixelWidth prop is set to %s",
+          (pixelWidth) => {
+            const wrapper = render({ pixelWidth, width: 25 }).toJSON();
 
-          assertStyleMatch({ width: "500px" }, wrapper);
-        });
+            assertStyleMatch({ width: `${pixelWidth}px` }, wrapper);
+          }
+        );
       });
     });
   });

--- a/src/components/tile/tile.style.js
+++ b/src/components/tile/tile.style.js
@@ -57,8 +57,8 @@ const TileContent = styled.div`
 
 const StyledTile = styled.div`
   ${({ isHorizontal, pixelWidth, tileTheme, theme, width }) => css`
-    ${space};
-    
+    ${space}
+    box-sizing: border-box;
     background-color: ${
       tileTheme === "tile" ? theme.colors.white : "transparent"
     };


### PR DESCRIPTION
fixes #3458

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds `box-sizing: border-box` to Tile container to prevent it overflowing a parent's width

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Tile does not respect the parent width

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/107648395-2d7b6600-6c74-11eb-900f-7b7087a29478.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-cwzmv?file=/src/index.js