### PR TITLE
fix(content): add support for passing data tags to root of component FE-3710

### DIFF
--- a/src/components/content/content.component.js
+++ b/src/components/content/content.component.js
@@ -14,10 +14,12 @@ const Content = ({
   align = "left",
   titleWidth,
   bodyFullWidth = false,
+  ...rest
 }) => (
   <StyledContent
     align={align}
     bodyFullWidth={bodyFullWidth}
+    {...rest}
     data-component="content"
   >
     <StyledContentTitle

--- a/src/components/content/content.spec.js
+++ b/src/components/content/content.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { ThemeProvider } from "styled-components";
-import { mount } from "enzyme";
+import { mount, shallow } from "enzyme";
 import mintTheme from "../../style/themes/mint";
 import Content from "./content.component.js";
 import {
@@ -10,6 +10,7 @@ import {
 } from "./content.style.js";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import { baseTheme } from "../../style/themes";
+import { rootTagTest } from "../../utils/helpers/tags/tags-specs";
 
 describe("Content", () => {
   let wrapper;
@@ -196,6 +197,19 @@ describe("Content", () => {
           },
           wrapper.find(StyledContentBody)
         );
+      });
+    });
+  });
+
+  describe("tags", () => {
+    describe("on component", () => {
+      it("include correct component, element and role data tags", () => {
+        wrapper = shallow(
+          <Content data-element="bar" data-role="baz">
+            <div />
+          </Content>
+        );
+        rootTagTest(wrapper, "content", "bar", "baz");
       });
     });
   });


### PR DESCRIPTION
fix #3661

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds support back into component to allow consumers to pass data tags into the component's root
element
### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Any data tags passed to `Content` are not applied to the root element

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
