### PR TITLE
fix(switch): make value prop optional (FE-3224)

### DIFF
--- a/src/__experimental__/components/switch/switch.component.js
+++ b/src/__experimental__/components/switch/switch.component.js
@@ -137,7 +137,7 @@ Switch.propTypes = {
    */
   size: PropTypes.string,
   /** the value of the checkbox, passed on form submit */
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   /** Margin bottom, given number will be multiplied by base spacing unit (8) */
   mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */


### PR DESCRIPTION
### Proposed behaviour
fixes: #3265
<img width="630" alt="Screenshot 2021-02-12 at 14 21 33" src="https://user-images.githubusercontent.com/35449967/107779691-a1357580-6d3d-11eb-83ab-53da905f0111.png">

This fix removes isRequired from the prop-type declaration for value
<img width="630" alt="Screenshot 2021-02-12 at 14 20 03" src="https://user-images.githubusercontent.com/35449967/107779586-7a773f00-6d3d-11eb-9b98-2eaf2072467b.png">

### Current behaviour
Issue 3265 describes the current behaviour:
https://github.com/Sage/carbon/issues/3265

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
~- [ ] All themes are supported if required~
~- [ ] Unit tests added or updated if required~
~- [ ] Cypress automation tests added or updated if required~
~- [ ] Storybook added or updated if required~
~- [ ] Typescript `d.ts` file added or updated if required~
~- [ ] Carbon implementation and Design System documentation are congruent~

### Additional context
No unit test updates were required
switch.d.ts declaration is already correct

### Testing instructions
`npm start` 
navigate to  http://localhost:9001/?path=/docs/experimental-switch--default-story
Console will not show a warning about the Switch value prop
