### PR TITLE
feat(card): add styled-system padding props (FE-3463)

### DIFF
--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -7,7 +7,7 @@ import RadioButtonGroupStyle from "./radio-button-group.style";
 import RadioButtonMapper from "./radio-button-mapper.component";
 import Logger from "../../../utils/logger/logger";
 import useIsAboveBreakpoint from "../../../hooks/__internal__/useIsAboveBreakpoint";
-import filterStyledSystemMarginProps from "../../../style/utils/filter-styled-system-margin-props";
+import { filterStyledSystemMarginProps } from "../../../style/utils";
 
 let deprecatedWarnTriggered = false;
 

--- a/src/__experimental__/components/radio-button/radio-button.component.js
+++ b/src/__experimental__/components/radio-button/radio-button.component.js
@@ -5,7 +5,7 @@ import tagComponent from "../../../utils/helpers/tags";
 import RadioButtonStyle from "./radio-button.style";
 import CheckableInput from "../../../__internal__/checkable-input/checkable-input.component";
 import RadioButtonSvg from "./radio-button-svg.component";
-import filterStyledSystemMarginProps from "../../../style/utils/filter-styled-system-margin-props";
+import { filterStyledSystemMarginProps } from "../../../style/utils";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space

--- a/src/components/card/card-footer/card-footer.component.js
+++ b/src/components/card/card-footer/card-footer.component.js
@@ -20,7 +20,7 @@ const CardFooter = ({ spacing, children, ...props }) => {
 
 CardFooter.propTypes = {
   children: PropTypes.node.isRequired,
-  /** size of card for applying padding (small | medium | large) */
+  /** Predefined size of CardFooter for applying padding (small | medium | large). For more granular control these can be over-ridden by Spacing props from styled-system (see table below). */
   spacing: PropTypes.oneOf(sizesRestricted),
 };
 

--- a/src/components/card/card-row/card-row.component.js
+++ b/src/components/card/card-row/card-row.component.js
@@ -1,19 +1,37 @@
 import React from "react";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import PropTypes from "prop-types";
 import StyledCardRow from "./card-row.style";
 import OptionsHelper from "../../../utils/helpers/options-helper/options-helper";
+import { filterStyledSystemPaddingProps } from "../../../style/utils";
 
-const CardRow = ({ children, spacing, ...props }) => {
+const paddingPropTypes = filterStyledSystemPaddingProps(
+  styledSystemPropTypes.space
+);
+
+const paddingSizes = {
+  small: 2,
+  medium: 3,
+  large: 4,
+};
+
+const CardRow = ({ children, spacing = "medium", ...props }) => {
   return (
-    <StyledCardRow data-element="card-row" spacing={spacing} {...props}>
+    <StyledCardRow
+      data-element="card-row"
+      py={paddingSizes[spacing]}
+      {...props}
+    >
       {children}
     </StyledCardRow>
   );
 };
 
 CardRow.propTypes = {
+  /** Styled system padding props */
+  ...paddingPropTypes,
   children: PropTypes.node.isRequired,
-  /** size of card for applying margin (small | medium | large) */
+  /** Spacing prop is set in Card and defines the padding for the CardRow (the first CardRow has no padding by default). For more granular control of CardRow padding these can be over-ridden by Padding props from styled-system (see table below). */
   spacing: PropTypes.oneOf(OptionsHelper.sizesRestricted),
 };
 

--- a/src/components/card/card-row/card-row.spec.js
+++ b/src/components/card/card-row/card-row.spec.js
@@ -2,7 +2,10 @@ import React from "react";
 import { shallow } from "enzyme";
 import TestRenderer from "react-test-renderer";
 import CardRow from "./card-row.component";
-import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemPadding,
+} from "../../../__spec_helper__/test-utils";
 import "jest-styled-components";
 
 describe("CardRow", () => {
@@ -22,21 +25,26 @@ describe("CardRow", () => {
   });
 
   describe.each([
-    ["small", "16px 0"],
-    ["medium", "24px 0"],
-    ["large", "32px 0"],
+    ["small", "16px"],
+    ["medium", "24px"],
+    ["large", "32px"],
   ])('when the "spacing" prop is set to %s', (size, expectedVal) => {
     const wrapper = renderCardRow({ spacing: size }, TestRenderer.create);
 
-    it(`then the margin should be set to ${expectedVal}`, () => {
+    it(`then the padding should be set to ${expectedVal}`, () => {
       assertStyleMatch(
         {
-          margin: expectedVal,
+          paddingTop: expectedVal,
+          paddingBottom: expectedVal,
         },
         wrapper.toJSON()
       );
     });
   });
+});
+
+describe("when the styled system padding is set", () => {
+  testStyledSystemPadding((props) => <CardRow {...props}>Test</CardRow>);
 });
 
 function renderCardRow(props = {}, renderer = shallow) {

--- a/src/components/card/card-row/card-row.style.js
+++ b/src/components/card/card-row/card-row.style.js
@@ -1,22 +1,14 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
+import { padding } from "styled-system";
 import PropTypes from "prop-types";
 import OptionsHelper from "../../../utils/helpers/options-helper/options-helper";
 import BaseTheme from "../../../style/themes/base";
 
 const { sizesRestricted } = OptionsHelper;
 
-const marginSizes = {
-  small: "16px 0",
-  medium: "24px 0",
-  large: "32px 0",
-};
-
 const StyledCardRow = styled.div`
+  ${padding}
   display: flex;
-
-  ${({ spacing }) => css`
-    margin: ${marginSizes[spacing]};
-  `}
 `;
 
 StyledCardRow.propTypes = {
@@ -24,7 +16,6 @@ StyledCardRow.propTypes = {
 };
 
 StyledCardRow.defaultProps = {
-  spacing: "medium",
   theme: BaseTheme,
 };
 

--- a/src/components/card/card.component.js
+++ b/src/components/card/card.component.js
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 import OptionsHelper from "../../utils/helpers/options-helper";
 import StyledCard from "./card.style";
 import Icon from "../icon";
+import CardRow from "./card-row/card-row.component";
+import CardFooter from "./card-footer/card-footer.component";
 
 const { sizesRestricted } = OptionsHelper;
 
@@ -22,9 +24,27 @@ const Card = ({
   };
 
   const renderChildren = () => {
-    return React.Children.map(children, (child) =>
-      React.cloneElement(child, { spacing })
-    );
+    return React.Children.map(children, (child, index) => {
+      if (index === 0) {
+        const childProps = {
+          spacing,
+          ...child.props,
+        };
+
+        if (child.type !== CardFooter) {
+          const pad =
+            React.Children.toArray(children).filter(
+              (row) => row.type === CardRow
+            ).length === 1
+              ? "pt"
+              : "py";
+
+          childProps[pad] = 0;
+        }
+        return React.cloneElement(child, childProps);
+      }
+      return React.cloneElement(child, { spacing });
+    });
   };
 
   const onClickHandler = interactive ? handleClick : null;

--- a/src/components/card/card.spec.js
+++ b/src/components/card/card.spec.js
@@ -2,6 +2,7 @@ import React from "react";
 import { mount, shallow } from "enzyme";
 import TestRenderer from "react-test-renderer";
 import Card from "./card.component";
+import CardRow from "./card-row/card-row.component";
 import CardFooter from "./card-footer/card-footer.component";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import Icon from "../icon";
@@ -50,6 +51,55 @@ describe("Card", () => {
         });
       }
     );
+
+    describe("when spacing prop is not set, styled-system props are used", () => {
+      it("there is only one child row", () => {
+        const cardRows = [
+          <CardRow className="mockedContent" key="content1">
+            content
+          </CardRow>,
+        ];
+        const wrapper = renderCard({
+          children: cardRows,
+        });
+        expect(
+          wrapper.find(".mockedContent").at(0).props().pt
+        ).not.toBeUndefined();
+      });
+
+      it("there is multiple child rows", () => {
+        const cardRows = [
+          <CardRow className="mockedContent" key="content1">
+            content
+          </CardRow>,
+          <CardRow className="mockedContent" key="content2">
+            content
+          </CardRow>,
+        ];
+        const wrapper = renderCard({
+          children: cardRows,
+        });
+
+        expect(
+          wrapper.find(".mockedContent").at(0).props().py
+        ).not.toBeUndefined();
+      });
+
+      it("there is one footer row child", () => {
+        const cardFooter = [
+          <CardFooter className="mockedContent" key="content1">
+            content
+          </CardFooter>,
+        ];
+        const wrapper = renderCard({
+          children: cardFooter,
+        });
+
+        expect(
+          wrapper.find(".mockedContent").at(0).props()[("py", "pt")]
+        ).toBeUndefined();
+      });
+    });
   });
 
   describe('when the "draggable" prop is set to true', () => {

--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -86,7 +86,7 @@ they may wrap into a grid depending on the available width and height of their c
           <Icon type="image" />
         </CardColumn>
       </CardRow>
-      <CardRow>
+      <CardRow pt={2} pb={2}>
         <CardColumn>
           <Typography variant="h5" weight="bold">
               Stripe Balance
@@ -120,7 +120,7 @@ they may wrap into a grid depending on the available width and height of their c
           <Icon type="image" />
         </CardColumn>
       </CardRow>
-      <CardRow>
+      <CardRow pt={4} pb={4}>
         <CardColumn>
           <Typography variant="h5" weight="bold">
               Stripe Balance
@@ -214,6 +214,49 @@ Click on the card to see the effect
       </div>
       )
     }}
+  </Story>
+</Preview>
+
+## Different `<CardRow />` padding
+
+<Preview>
+  <Story name="different CardRow padding" parameters={{ chromatic: { disable: true }}}>
+    <Card >
+      <CardRow pt={2} pb={0}>
+        <CardColumn align="left">
+          <Heading title="Stripe - [account name]" divider={false} />
+          <Typography variant="h5">user.name@sage.com</Typography>
+        </CardColumn>
+        <CardColumn align="right">
+          <Icon type="image" />
+        </CardColumn>
+      </CardRow>
+      <CardRow pt={0} pb={4}>
+        <CardColumn>
+          <Typography variant="h5" weight="bold">
+              Stripe Balance
+          </Typography>
+          <Heading title="£ 0.00" divider={false} />
+          <Typography>LAST ENTRY: 5 DAYS AGO</Typography>
+        </CardColumn>
+      </CardRow>
+      <CardRow pt={0} pb={4}>
+        <CardColumn>
+          <Typography variant="h5" weight="bold">
+              Stripe Balance
+          </Typography>
+          <Heading title="£ 0.00" divider={false} />
+          <Typography>LAST ENTRY: 15 DAYS AGO</Typography>
+        </CardColumn>
+      </CardRow>
+      <CardFooter>
+        <CardColumn>
+          <Link icon="link" href="https://carbon.sage.com/">
+            View Stripe Dashboard
+          </Link>
+        </CardColumn>
+      </CardFooter>
+    </Card>
   </Story>
 </Preview>
 
@@ -380,7 +423,7 @@ Click on the card to see the effect
 
 ## Props for `<CardRow />`
 
-<Props of={CardRow} />
+<StyledSystemProps padding of={CardRow} />
 
 ## Props for `<CardColumn />`
 

--- a/src/style/utils/filter-styled-system-padding-props.js
+++ b/src/style/utils/filter-styled-system-padding-props.js
@@ -1,0 +1,22 @@
+import filterObjectProperties from "../../utils/helpers/filter-object-properties";
+
+const paddingPropertyNames = [
+  "padding",
+  "p",
+  "paddingLeft",
+  "pl",
+  "paddingRight",
+  "pr",
+  "paddingTop",
+  "pt",
+  "paddingBottom",
+  "pb",
+  "paddingX",
+  "px",
+  "paddingY",
+  "py",
+];
+
+export default function filterStyledSystemPaddingProps(originalObject) {
+  return filterObjectProperties(originalObject, paddingPropertyNames);
+}

--- a/src/style/utils/index.js
+++ b/src/style/utils/index.js
@@ -1,0 +1,4 @@
+import filterStyledSystemPaddingProps from "./filter-styled-system-padding-props";
+import filterStyledSystemMarginProps from "./filter-styled-system-margin-props";
+
+export { filterStyledSystemPaddingProps, filterStyledSystemMarginProps };


### PR DESCRIPTION
fixes: #3519

### Proposed behaviour
Replaces margin with `styled-system/padding` in `CardRow`
<img width="630" alt="Screenshot 2021-02-12 at 15 29 23" src="https://user-images.githubusercontent.com/35449967/107787688-591b5080-6d47-11eb-8a43-efbe58cf6dc3.png">


### Current behaviour
Described in the linked issue https://github.com/Sage/carbon/issues/3519

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
~- [ ] Cypress automation tests added or updated if required~
~- [ ] Storybook added or updated if required~
~- [ ] Typescript `d.ts` file added or updated if required~
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/a

### Testing instructions
Use the generated codesandbox
https://codesandbox.io/s/carbon-quickstart-forked-yqvpx?file=/src/index.js
