### PR TITLE
docs(getting-started): remove base css

### DIFF
--- a/docs/getting-started.stories.mdx
+++ b/docs/getting-started.stories.mdx
@@ -12,7 +12,6 @@
 [Peer Dependencies](#peer-dependencies)
 * [Fonts](#fonts)
 * [React and React DOM](#react-and-react-dom)
-* [Base CSS](#base-css)
 * [Theming](#theming)
 * [AppWrapper](#appwrapper)
 * [Quickstart](#quickstart)
@@ -155,11 +154,7 @@ React and React DOM are imported from the [React library](https://reactjs.org/),
 import React from 'react';
 import ReactDOM from 'react-dom';
 ```
-#### Base CSS
-Carbon provides some baseline CSS that is applied to `body` and other elements. You should import this into the root of your project.
-```js
-import 'carbon-react/lib/utils/css';	
-```
+
 #### Theming
 Carbon uses the `ThemeProvider` from the [styled-components library](https://styled-components.com/docs/advanced#theming) to supply theme styles to your components. Themes are define within the Carbon library.
 ```js


### PR DESCRIPTION
### Proposed behaviour
Update getting started guide to remove references to base.css, which was removed in https://github.com/Sage/carbon/pull/3642

### Current behaviour
Getting started incorrectly includes instructions for base.css

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~- [ ] Screenshots are included in the PR if useful~
~- [ ] All themes are supported if required~
~- [ ] Unit tests added or updated if required~
~- [ ] Cypress automation tests added or updated if required~
~- [ ] Storybook added or updated if required~
~- [ ] Typescript `d.ts` file added or updated if required~
~- [ ] Carbon implementation and Design System documentation are congruent~

### Additional context
n/a

### Testing instructions
Read the document
