### PR TITLE
feat(tooltip): add support for background and font color overrides FE-3377

### DIFF
--- a/src/components/help/help.component.js
+++ b/src/components/help/help.component.js
@@ -20,6 +20,8 @@ const Help = (props) => {
     tooltipPosition,
     isFocused,
     type,
+    tooltipBgColor,
+    tooltipFontColor,
   } = props;
 
   useEffect(() => {
@@ -72,6 +74,8 @@ const Help = (props) => {
         tooltipMessage={children}
         tooltipPosition={tooltipPosition}
         tooltipVisible={isFocused || isTooltipVisible}
+        tooltipBgColor={tooltipBgColor}
+        tooltipFontColor={tooltipFontColor}
       />
     </StyledHelp>
   );
@@ -96,6 +100,10 @@ Help.propTypes = {
   isFocused: PropTypes.bool,
   /** Icon to display, can be received from label component */
   type: PropTypes.oneOf(OptionsHelper.icons),
+  /** Override background color of the Tooltip, provide any color from palette or any valid css color value. */
+  tooltipBgColor: PropTypes.string,
+  /** Override font color of the Tooltip, provide any color from palette or any valid css color value. */
+  tooltipFontColor: PropTypes.string,
 };
 
 Help.defaultProps = {

--- a/src/components/help/help.d.ts
+++ b/src/components/help/help.d.ts
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { IconTypes } from "../../utils/helpers/options-helper/options-helper";
+
+export interface HelpProps {
+  className?: string;
+  children?: string;
+  helpId?: string;
+  tabIndex?: number | string;
+  as?: string;
+  href?: string;
+  isFocused?: boolean;
+  type?: IconTypes;
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
+  tooltipBgColor?: string;
+  tooltipFontColor?: string;
+}
+
+declare const Help: React.ComponentType<HelpProps>;
+export default Help;

--- a/src/components/help/help.stories.js
+++ b/src/components/help/help.stories.js
@@ -28,10 +28,18 @@ export const Default = () => {
     : undefined;
   const href = text("href", "http://www.sage.com");
   const type = select("type", OptionsHelper.icons, "help");
+  const tooltipBgColor = text("tooltipBgColor", undefined);
+  const tooltipFontColor = text("tooltipFontColor", undefined);
 
   return (
     <div style={{ marginLeft: "125px" }}>
-      <Help tooltipPosition={tooltipPosition} href={href} type={type}>
+      <Help
+        tooltipPosition={tooltipPosition}
+        href={href}
+        type={type}
+        tooltipBgColor={tooltipBgColor}
+        tooltipFontColor={tooltipFontColor}
+      >
         {children}
       </Help>
     </div>

--- a/src/components/help/help.stories.mdx
+++ b/src/components/help/help.stories.mdx
@@ -24,7 +24,7 @@ const MyComponent = () => (
 
 ### Default
 <Preview>
-  <Story name="default">
+  <Story name="default" parameters={{chromatic: { disable: true }}}>
     <div style={ { margin: '64px' } }>
       <Help>
         Some helpful text goes here
@@ -51,10 +51,25 @@ Hover over the help component to see the different positions.
   </Story>
 </Preview>
 
+### Help with Tooltip color overrides
+The tooltip background and font colors can be overridden using the `tooltipBgColor` and `tooltipFontColor` props. These 
+props accept and valid css color value.
+
+<Preview>
+  <Story name="with Tooltip color overrides" parameters={{chromatic: { disable: true }}}>
+    <div style={ { margin: '64px 300px' } }>
+      <Help tooltipBgColor="lightblue" tooltipFontColor="black">
+        The background and font color are overridden
+      </Help>
+    </div>
+  </Story>
+</Preview>
+
+
 ## Help with Icons
 Using the `type` prop, different icons can be specified. In this example type has been assigned `error`, `add`, `minus` and `settings`
 <Preview>
-  <Story name="with Icons">
+  <Story name="with Icons" parameters={{chromatic: { disable: true }}}>
     {() => {
       return [
         'error',
@@ -75,7 +90,7 @@ Using the `type` prop, different icons can be specified. In this example type ha
 ## Help with href
 Using the `href` prop, a link can be specified.
 <Preview>
-  <Story name="with href">
+  <Story name="with href" parameters={{chromatic: { disable: true }}}>
     <div style={ { margin: '64px' } }>
       <Help href='https://carbon.sage.com'>
         This is the Help component with a href.

--- a/src/components/help/index.d.ts
+++ b/src/components/help/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './help';

--- a/src/components/icon/icon.component.js
+++ b/src/components/icon/icon.component.js
@@ -22,6 +22,8 @@ const Icon = React.forwardRef(
       tooltipMessage,
       tooltipPosition,
       tooltipVisible,
+      tooltipBgColor,
+      tooltipFontColor,
       tabIndex,
       isPartOfInput,
       inputSize,
@@ -83,6 +85,8 @@ const Icon = React.forwardRef(
           isVisible={visible}
           isPartOfInput={isPartOfInput}
           inputSize={inputSize}
+          bgColor={tooltipBgColor}
+          fontColor={tooltipFontColor}
         >
           {icon}
         </Tooltip>
@@ -138,6 +142,10 @@ Icon.propTypes = {
   tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
   /** Control whether the tooltip is visible */
   tooltipVisible: PropTypes.bool,
+  /** Override background color of the Tooltip, provide any color from palette or any valid css color value. */
+  tooltipBgColor: PropTypes.string,
+  /** Override font color of the Tooltip, provide any color from palette or any valid css color value. */
+  tooltipFontColor: PropTypes.string,
   /** @ignore @private */
   isPartOfInput: PropTypes.bool,
   /** @ignore @private */

--- a/src/components/icon/icon.d.ts
+++ b/src/components/icon/icon.d.ts
@@ -17,6 +17,8 @@ export interface IconProps {
   tooltipMessage?: string;
   tooltipPosition?: "top" | "bottom" | "left" | "right";
   tooltipVisible?: boolean;
+  tooltipBgColor?: string;
+  tooltipFontColor?: string;
 }
 
 declare const Icon: React.ComponentType<IconProps>;

--- a/src/components/icon/icon.stories.js
+++ b/src/components/icon/icon.stories.js
@@ -27,6 +27,8 @@ const commonKnobs = () => {
     tooltipPosition: tooltipMessage
       ? select("tooltipPosition", OptionsHelper.positions, "top")
       : undefined,
+    tooltipBgColor: text("tooltipBgColor", undefined),
+    tooltipFontColor: text("tooltipFontColor", undefined),
   };
 };
 

--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -46,12 +46,14 @@ const MyComponent = () => (
 
 ### With tooltip
 The Icon supports rendering tooltips internally, just pass a string to `tooltipMessage` to enable this feature. Other props, 
-such as `tooltipPosition` and `tooltipVisible` are also surfaced.
+such as `tooltipPosition`, `tooltipVisible` , `tooltipBgColor` and `tooltipFontColor` are also surfaced.
 
 <Preview>
   <Story name="with tooltip">
-    <div style={{ margin: 60 }}>
-      <Icon type="add" tooltipMessage="Hey I'm a tooltip!" />
+    <div style={{ margin: 60, display: "inline" }}>
+      <Icon mr={8} type="add" tooltipMessage="Hey I'm a default tooltip!" />
+      <Icon mr={4} ml={4} type="add" tooltipMessage="Hey I'm a tooltip with a different position!" tooltipPosition="bottom" />
+      <Icon ml={8} type="add" tooltipMessage="Hey I'm a tooltip with a different color!" tooltipBgColor="lightblue" tooltipFontColor="black" />
     </div>
   </Story>
 </Preview>

--- a/src/components/icon/index.d.ts
+++ b/src/components/icon/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './icon';

--- a/src/components/tooltip/tooltip-pointer.style.js
+++ b/src/components/tooltip/tooltip-pointer.style.js
@@ -2,12 +2,14 @@ import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
 import baseTheme from "../../style/themes/base";
 import OptionsHelper from "../../utils/helpers/options-helper/options-helper";
+import { toColor } from "../../style/utils/color";
 
-const pointerColor = (type, theme) =>
-  type === "error" ? theme.colors.error : theme.colors.black;
-
+const pointerColor = (type, theme, bgColor) => {
+  if (bgColor) return toColor(theme, bgColor);
+  return type === "error" ? theme.colors.error : theme.colors.black;
+};
 const StyledTooltipPointer = styled.div`
-  ${({ position, theme, type }) => css`
+  ${({ position, theme, type, bgColor }) => css`
     position: absolute;
     width: 0;
     height: 0;
@@ -16,7 +18,7 @@ const StyledTooltipPointer = styled.div`
     css`
       border-left: 8px solid transparent;
       border-right: 8px solid transparent;
-      border-top: 8px solid ${pointerColor(type, theme)};
+      border-top: 8px solid ${pointerColor(type, theme, bgColor)};
       bottom: -${theme.spacing}px;
       @-moz-document url-prefix() {
         bottom: -7px;
@@ -27,7 +29,7 @@ const StyledTooltipPointer = styled.div`
     css`
       border-left: 8px solid transparent;
       border-right: 8px solid transparent;
-      border-bottom: 8px solid ${pointerColor(type, theme)};
+      border-bottom: 8px solid ${pointerColor(type, theme, bgColor)};
       top: -${theme.spacing}px;
       @-moz-document url-prefix() {
         top: -7px;
@@ -38,7 +40,7 @@ const StyledTooltipPointer = styled.div`
     css`
       border-top: 8px solid transparent;
       border-bottom: 8px solid transparent;
-      border-right: 8px solid ${pointerColor(type, theme)};
+      border-right: 8px solid ${pointerColor(type, theme, bgColor)};
       left: -${theme.spacing}px;
       @-moz-document url-prefix() {
         left: -7px;
@@ -49,7 +51,7 @@ const StyledTooltipPointer = styled.div`
     css`
       border-top: 8px solid transparent;
       border-bottom: 8px solid transparent;
-      border-left: 8px solid ${pointerColor(type, theme)};
+      border-left: 8px solid ${pointerColor(type, theme, bgColor)};
       right: -${theme.spacing}px;
       @-moz-document url-prefix() {
         right: -7px;

--- a/src/components/tooltip/tooltip.component.js
+++ b/src/components/tooltip/tooltip.component.js
@@ -19,6 +19,8 @@ const Tooltip = React.forwardRef(
       isPartOfInput,
       inputSize,
       id,
+      bgColor,
+      fontColor,
       ...rest
     },
     ref
@@ -42,6 +44,8 @@ const Tooltip = React.forwardRef(
           {...attrs}
           position={currentPosition}
           ref={tooltipRef}
+          bgColor={bgColor}
+          fontColor={fontColor}
         >
           <StyledPointer
             key="pointer"
@@ -50,6 +54,7 @@ const Tooltip = React.forwardRef(
             position={currentPosition}
             data-popper-arrow=""
             data-element="tooltip-pointer"
+            bgColor={bgColor}
           />
           <div>{content}</div>
         </StyledTooltip>
@@ -84,6 +89,10 @@ Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
   /** Defines the size of the tooltip content */
   size: PropTypes.oneOf(["medium", "large"]),
+  /** Override background color of the Tooltip, provide any color from palette or any valid css color value. */
+  bgColor: PropTypes.string,
+  /** Override font color of the Tooltip, provide any color from palette or any valid css color value. */
+  fontColor: PropTypes.string,
   /** @ignore @private */
   isPartOfInput: PropTypes.bool,
   /** @ignore @private */

--- a/src/components/tooltip/tooltip.d.ts
+++ b/src/components/tooltip/tooltip.d.ts
@@ -17,6 +17,8 @@ export interface TooltipProps {
     size?: 'medium' | 'large';
     isPartOfInput?: boolean;
     inputSize?: 'small' | 'medium' | 'large';
+    bgColor?: string;
+    fontColor?: string;
 }
 
 declare const Tooltip: React.FunctionComponent<TooltipProps>;

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -56,7 +56,7 @@ describe("Tooltip", () => {
               color: "#FFFFFF",
               display: "inline-block",
               padding: "8px 12px",
-              wordBreak: "normal",
+              wordBreak: "break-word",
               whiteSpace: "pre-wrap",
               fontSize: "14px",
               lineHeight: "1.5rem",

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -91,6 +91,43 @@ describe("Tooltip", () => {
           }
         );
       });
+
+      describe("color props", () => {
+        it("overrides default background when a valid css string is passed via 'bgColor'", () => {
+          assertStyleMatch(
+            { backgroundColor: "pink" },
+            render({ bgColor: "pink" }).find(StyledTooltipWrapper)
+          );
+
+          assertStyleMatch(
+            { borderTop: "8px solid pink" },
+            render({ bgColor: "pink" }).find(StyledTooltipPointer)
+          );
+        });
+
+        it("overrides the type prop if background color passed via 'bgColor'", () => {
+          assertStyleMatch(
+            { backgroundColor: "pink" },
+            render({ type: "error", bgColor: "pink" }).find(
+              StyledTooltipWrapper
+            )
+          );
+
+          assertStyleMatch(
+            { borderTop: "8px solid pink" },
+            render({ type: "error", bgColor: "pink" }).find(
+              StyledTooltipPointer
+            )
+          );
+        });
+
+        it("overrides default font color when a valid css string is passed via 'fontColor'", () => {
+          assertStyleMatch(
+            { color: "pink" },
+            render({ fontColor: "pink" }).find(StyledTooltipWrapper)
+          );
+        });
+      });
     });
 
     describe("when the tooltip targets a component that is a part of an input", () => {

--- a/src/components/tooltip/tooltip.stories.js
+++ b/src/components/tooltip/tooltip.stories.js
@@ -27,6 +27,8 @@ const props = () => {
     position: select("position", OptionsHelper.positions, "top"),
     type: select("type", ["error", "default"], "default"),
     size: select("size", ["medium", "large"], "medium"),
+    bgColor: text("bgColor", undefined),
+    fontColor: text("fontColor", undefined),
   };
 };
 

--- a/src/components/tooltip/tooltip.stories.mdx
+++ b/src/components/tooltip/tooltip.stories.mdx
@@ -206,6 +206,39 @@ or if no value is passed it will default to a black background.
   </Story>
 </Preview>
 
+### Color overrides
+The `Tooltip` background and font color can be overridden via the `bgColor` and `fontColor` props and accept any valid 
+css value. Any values passed to the `bgColor` prop will override the color applied by the `type`
+
+<Preview>
+  <Story name="color overrides">
+     {() => {
+      const Component = forwardRef(({ children }, ref) => (
+        <button
+          tabIndex="0"
+          style={{
+            backgroundColor: "#00815D",
+            color: "white",
+            cursor: "pointer",
+            border: "none",
+            padding: "8px"
+          }}
+          ref={ref}
+        >
+          {children}
+        </button>
+      ))
+      return (
+        <div style={{ padding: "60px" }}>
+          <Tooltip message="I am a tooltip!" bgColor="lightblue" fontColor="black">
+            <Component>target</Component>
+          </Tooltip>
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
 ### Tooltip Props
 
 <Props of={Tooltip} />

--- a/src/components/tooltip/tooltip.style.js
+++ b/src/components/tooltip/tooltip.style.js
@@ -57,7 +57,7 @@ const StyledTooltipWrapper = styled.div`
     color: ${theme.colors.white};
     display: inline-block;
     padding: 8px 12px;
-    word-break: normal;
+    word-break: break-word;
     white-space: pre-wrap;
     font-size: ${size === "medium" ? "14px" : "16px"};
     line-height: 1.5rem;
@@ -74,7 +74,7 @@ StyledTooltipWrapper.propTypes = {
 
 StyledTooltipWrapper.defaultProps = {
   theme: baseTheme,
-  size: "M",
+  size: "medium",
   inputSize: "medium",
   position: "top",
 };

--- a/src/components/tooltip/tooltip.style.js
+++ b/src/components/tooltip/tooltip.style.js
@@ -1,6 +1,7 @@
 import styled, { css, keyframes } from "styled-components";
 import PropTypes from "prop-types";
 import baseTheme from "../../style/themes/base";
+import { toColor } from "../../style/utils/color";
 
 const fadeIn = keyframes`
   0% {
@@ -12,8 +13,10 @@ const fadeIn = keyframes`
   }
 `;
 
-const tooltipColor = (type, theme) =>
-  type === "error" ? theme.colors.error : theme.colors.black;
+const tooltipColor = (type, theme, bgColor) => {
+  if (bgColor) return toColor(theme, bgColor);
+  return type === "error" ? theme.colors.error : theme.colors.black;
+};
 
 const tooltipOffset = (position, inputSize, isPartOfInput) => {
   if (!isPartOfInput) {
@@ -46,7 +49,16 @@ const tooltipOffset = (position, inputSize, isPartOfInput) => {
 };
 
 const StyledTooltipWrapper = styled.div`
-  ${({ position, size, theme, type, isPartOfInput, inputSize }) => css`
+  ${({
+    position,
+    size,
+    theme,
+    type,
+    isPartOfInput,
+    inputSize,
+    bgColor,
+    fontColor,
+  }) => css`
     bottom: auto;
     right: auto;
     max-width: 300px;
@@ -54,7 +66,7 @@ const StyledTooltipWrapper = styled.div`
     animation: ${fadeIn} 0.2s linear;
     z-index: ${theme.zIndex.popover};
     text-align: left;
-    color: ${theme.colors.white};
+    color: ${fontColor ? toColor(theme, fontColor) : theme.colors.white};
     display: inline-block;
     padding: 8px 12px;
     word-break: break-word;
@@ -62,7 +74,7 @@ const StyledTooltipWrapper = styled.div`
     font-size: ${size === "medium" ? "14px" : "16px"};
     line-height: 1.5rem;
     font-weight: 400;
-    background-color: ${tooltipColor(type, theme)};
+    background-color: ${tooltipColor(type, theme, bgColor)};
     ${tooltipOffset(position, inputSize, isPartOfInput)};
   `}
 `;


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds support to `Tooltip` for overriding background and font colour.
Adds support for leveraging the colour overrides in `Icon` and `Help`
Adds `word-break: break-word` to tooltip wrapper to prevent long content strings overflowing to fix `FE-2020`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No colour override support in `Tooltip`, `Icon` and `Help`
Long strings do not wrap in `Tooltip` wrapper

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/107818207-2be29880-6d6f-11eb-86c9-cd29bdc838af.png)

![image](https://user-images.githubusercontent.com/44157880/107818283-49affd80-6d6f-11eb-875f-171be18e340e.png)


![image](https://user-images.githubusercontent.com/44157880/107818325-5a607380-6d6f-11eb-9d3f-b4bd4f4f022f.png)

Word wrap FE-2020 fix:
![image](https://user-images.githubusercontent.com/44157880/107818470-91368980-6d6f-11eb-8eef-2d86b50c1ecc.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
Stories will colour overrides have been added to `Tooltip`, `Icon` and `Help`

https://codesandbox.io/s/carbon-quickstart-forked-f8ist?file=/src/index.js