### PR TITLE
fix(date): set format based on translation

### DIFF
--- a/src/utils/helpers/date/__spec__.js
+++ b/src/utils/helpers/date/__spec__.js
@@ -72,6 +72,10 @@ describe("DateHelper", () => {
           expect(
             DateHelper.formatValue("01/31/2015", "DD/MM/YYYY", { locale: "us" })
           ).toEqual("31/01/2015");
+
+          expect(
+            DateHelper.formatValue("03/04/2015", "DD/MM/YYYY", { locale: "us" })
+          ).toEqual("03/04/2015");
         });
       });
 

--- a/src/utils/helpers/date/date.js
+++ b/src/utils/helpers/date/date.js
@@ -3,6 +3,7 @@ import moment from "moment";
 import { merge } from "lodash";
 
 const isoDateFormat = "YYYY-MM-DD";
+const defaultDateFormat = "DD/MM/YYYY";
 
 /**
  * DateHelper used to encapsulate the date parsing library into a single helper
@@ -205,10 +206,15 @@ const DateHelper = {
    * @param {Object} options Override Moment JS options
    * @return {Moment}
    */
-  _parseDate: (value, options) => {
+  _parseDate(value, options) {
     const opts = merge(DateHelper._defaultMomentOptions(), options);
     const val = opts.sanitize ? DateHelper.sanitizeDateInput(value) : value;
-    return moment(val, opts.formats, opts.locale, opts.strict);
+    return moment(
+      val,
+      [this._visibleFormat(), ...opts.formats],
+      opts.locale,
+      opts.strict
+    );
   },
 
   /**
@@ -224,14 +230,15 @@ const DateHelper = {
     });
   },
 
-  formatDateToCurrentLocale(value) {
-    const defaultDateFormat = "DD/MM/YYYY";
-
-    const visibleFormat = I18n.t("date.formats.javascript", {
+  _visibleFormat: () =>
+    I18n.t("date.formats.javascript", {
       defaultValue: defaultDateFormat,
-    }).toUpperCase();
+    }).toUpperCase(),
 
-    return DateHelper.formatValue(value, visibleFormat);
+  formatDateToCurrentLocale(value) {
+    return DateHelper.formatValue(value, this._visibleFormat(), {
+      formats: [this._visibleFormat()],
+    });
   },
 };
 


### PR DESCRIPTION
### Proposed behaviour
When the format is being specified in translations to `MM/DD/YYYY` the date is converted correctly.

### Current behaviour
When the format is being specified in translations to `MM/DD/YYYY` day is converted to month when it's less than 12.
E.g.: 3/12/2021 changes to 12/3/2021.
https://codesandbox.io/s/carbon-date-locale-deyrz?file=/src/App.js

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions

https://codesandbox.io/s/carbon-date-locale-11si7
