### PR TITLE
docs(button): change no wrap story title to lowercase

### DIFF
--- a/src/components/button/button.stories.js
+++ b/src/components/button/button.stories.js
@@ -512,6 +512,10 @@ fullWidthButtons.story = {
   name: "full width buttons",
 };
 
+noWrapButtons.story = {
+  name: "no wrap buttons",
+};
+
 iconOnlyButtons.story = {
   name: "icon only buttons",
   parameters: {


### PR DESCRIPTION
Changes the title of the noWrap button test example to lowercase. This is inline with the rest of
our test examples.

### Proposed behaviour

Change the title of the noWrap button example in the Test directory for Button to all lowercase.
`no wrap buttons`

### Current behaviour

Current title is `No Wrap Buttons`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
<del> - [ ] Screenshots are included in the PR if useful </del>
<del> - [ ] All themes are supported if required </del>
<del> - [ ] Unit tests added or updated if required </del>
<del> - [ ] Cypress automation tests added or updated if required </del>
- [x] Storybook added or updated if required
<del> - [ ] Typescript `d.ts` file added or updated if required </del>
- [x] Carbon implementation and Design System documentation are congruent

### Additional context


### Testing instructions
Navigate to Buttons -> Test and noWrap button example should be called `no wrap buttons`
