### PR TITLE
feat(radio-button): allow use of all styled system margin props (FE-3518)

### DIFF
--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
@@ -5,18 +5,6 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   margin-top: 16px;
 }
 
-.c5.c5.c5 {
-  margin-bottom: 16px;
-}
-
-.c14 + .c4 {
-  margin-top: 16px;
-}
-
-.c14.c14.c14 {
-  margin-bottom: 0;
-}
-
 .c7 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -44,7 +32,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   display: flex;
 }
 
-.c3 .c16 {
+.c3 .c14 {
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -53,27 +41,27 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   width: auto;
 }
 
-.c3 .c16 .c17,
-.c3 .c16 .c18 {
+.c3 .c14 .c15,
+.c3 .c14 .c16 {
   color: rgba(0,0,0,0.65);
   vertical-align: middle;
 }
 
-.c3 .c16 .c17:hover,
-.c3 .c16 .c18:hover,
-.c3 .c16 .c17:focus,
-.c3 .c16 .c18:focus {
+.c3 .c14 .c15:hover,
+.c3 .c14 .c16:hover,
+.c3 .c14 .c15:focus,
+.c3 .c14 .c16:focus {
   color: rgba(0,0,0,0.9);
 }
 
-.c3 .c15 {
+.c3 .c13 {
   -webkit-flex-basis: 100%;
   -ms-flex-preferred-size: 100%;
   flex-basis: 100%;
 }
 
 .c2 {
-  margin-top: 4px;
+  margin-bottom: 16px;
 }
 
 .c2 .c8 {
@@ -110,26 +98,34 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   box-shadow: 0 0 0 3px #FFB500;
 }
 
-.c2 .c16 {
+.c2 .c14 {
   width: auto;
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
 }
 
-.c2 .c15 {
+.c2 .c13 {
   margin-left: 16px;
   margin-top: 0;
   padding-left: 8px;
 }
 
-.c2 .c18 {
+.c2 .c16 {
   position: relative;
   display: inline-block;
 }
 
 .c2 .c10:checked ~ .c12 svg path {
   fill: rgba(0,0,0,0.90);
+}
+
+.c2:last-of-type {
+  margin-bottom: 0;
+}
+
+.c2.c2 .c4 {
+  margin: 0;
 }
 
 .c2 .c12 {
@@ -157,104 +153,13 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   r: 5;
 }
 
-.c2 .c16 {
+.c2 .c14 {
   -webkit-flex: 1 1 calc(100% - 44px);
   -ms-flex: 1 1 calc(100% - 44px);
   flex: 1 1 calc(100% - 44px);
 }
 
 .c2 .c10:checked + .c12 circle {
-  fill: rgba(0,0,0,0.9);
-}
-
-.c13 .c8 {
-  padding-top: 1px;
-}
-
-.c13 .c12 {
-  height: 16px;
-}
-
-.c13 svg {
-  background-color: #FFFFFF;
-  border: 1px solid #668592;
-}
-
-.c13 .c10,
-.c13 svg {
-  height: 16px;
-  position: absolute;
-  padding: 1px;
-}
-
-.c13 .c8,
-.c13 .c10,
-.c13 .c12,
-.c13 svg {
-  box-sizing: border-box;
-  min-width: 16px;
-  width: 16px;
-}
-
-.c13 .c10:not([disabled]):focus + .c12,
-.c13 .c10:not([disabled]):hover + .c12 {
-  box-shadow: 0 0 0 3px #FFB500;
-}
-
-.c13 .c16 {
-  width: auto;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-}
-
-.c13 .c15 {
-  margin-left: 16px;
-  margin-top: 0;
-  padding-left: 8px;
-}
-
-.c13 .c18 {
-  position: relative;
-  display: inline-block;
-}
-
-.c13 .c10:checked ~ .c12 svg path {
-  fill: rgba(0,0,0,0.90);
-}
-
-.c13 .c12 {
-  padding: 0;
-}
-
-.c13 .c12,
-.c13 svg {
-  border-radius: 50%;
-}
-
-.c13 .c8,
-.c13 .c10,
-.c13 .c12,
-.c13 svg {
-  height: 16px;
-  width: 16px;
-}
-
-.c13 svg {
-  padding: 1px;
-}
-
-.c13 circle {
-  r: 5;
-}
-
-.c13 .c16 {
-  -webkit-flex: 1 1 calc(100% - 44px);
-  -ms-flex: 1 1 calc(100% - 44px);
-  flex: 1 1 calc(100% - 44px);
-}
-
-.c13 .c10:checked + .c12 circle {
   fill: rgba(0,0,0,0.9);
 }
 
@@ -308,10 +213,8 @@ exports[`RadioButtonGroup renders as expected 1`] = `
       role="group"
     >
       <div
-        checked={false}
         className="c2"
         data-component="radio-button"
-        name="test-group"
       >
         <div
           checked={false}
@@ -373,10 +276,8 @@ exports[`RadioButtonGroup renders as expected 1`] = `
         </div>
       </div>
       <div
-        checked={false}
-        className="c13"
+        className="c2"
         data-component="radio-button"
-        name="test-group"
       >
         <div
           checked={false}
@@ -384,7 +285,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
           name="test-group"
         >
           <div
-            className="c4 c14"
+            className="c4 c5"
           >
             <div
               className="c6 c7"

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-mapper.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-mapper.spec.js.snap
@@ -6,10 +6,6 @@ Array [
   margin-top: 16px;
 }
 
-.c3.c3.c3 {
-  margin-bottom: 16px;
-}
-
 .c5 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -63,6 +59,10 @@ Array [
   -webkit-flex-basis: 100%;
   -ms-flex-preferred-size: 100%;
   flex-basis: 100%;
+}
+
+.c0 {
+  margin-bottom: 16px;
 }
 
 .c0 .c6 {
@@ -121,6 +121,10 @@ Array [
   fill: rgba(0,0,0,0.90);
 }
 
+.c0:last-of-type {
+  margin-bottom: 0;
+}
+
 .c0 .c10 {
   padding: 0;
 }
@@ -157,10 +161,8 @@ Array [
 }
 
 <div
-    checked={false}
     className="c0"
     data-component="radio-button"
-    name="test-group"
   >
     <div
       checked={false}
@@ -225,10 +227,6 @@ Array [
   margin-top: 16px;
 }
 
-.c3.c3.c3 {
-  margin-bottom: 16px;
-}
-
 .c5 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -282,6 +280,10 @@ Array [
   -webkit-flex-basis: 100%;
   -ms-flex-preferred-size: 100%;
   flex-basis: 100%;
+}
+
+.c0 {
+  margin-bottom: 16px;
 }
 
 .c0 .c6 {
@@ -340,6 +342,10 @@ Array [
   fill: rgba(0,0,0,0.90);
 }
 
+.c0:last-of-type {
+  margin-bottom: 0;
+}
+
 .c0 .c10 {
   padding: 0;
 }
@@ -376,10 +382,8 @@ Array [
 }
 
 <div
-    checked={false}
     className="c0"
     data-component="radio-button"
-    name="test-group"
   >
     <div
       checked={false}

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-mapper.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-mapper.spec.js.snap
@@ -125,6 +125,10 @@ Array [
   margin-bottom: 0;
 }
 
+.c0.c0 .c2 {
+  margin: 0;
+}
+
 .c0 .c10 {
   padding: 0;
 }
@@ -344,6 +348,10 @@ Array [
 
 .c0:last-of-type {
   margin-bottom: 0;
+}
+
+.c0.c0 .c2 {
+  margin: 0;
 }
 
 .c0 .c10 {

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -419,7 +419,6 @@ exports[`RadioButton base renders as expected 1`] = `
       role="group"
     >
       <div
-        checked={false}
         className="c1"
         data-component="radio-button"
       >

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -5,10 +5,6 @@ exports[`RadioButton base renders as expected 1`] = `
   margin-top: 16px;
 }
 
-.c4.c4.c4 {
-  margin-bottom: 0;
-}
-
 .c6 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -129,6 +125,10 @@ exports[`RadioButton base renders as expected 1`] = `
   cursor: not-allowed;
 }
 
+.c14.c14 .c3 {
+  margin: 0;
+}
+
 .c14 .c11 {
   padding: 0;
 }
@@ -197,6 +197,10 @@ exports[`RadioButton base renders as expected 1`] = `
 
 .c15 .c9:checked ~ .c11 svg path {
   fill: rgba(0,0,0,0.90);
+}
+
+.c15.c15 .c3 {
+  margin: 0;
 }
 
 .c15 .c11 {
@@ -273,6 +277,10 @@ exports[`RadioButton base renders as expected 1`] = `
   fill: rgba(0,0,0,0.90);
 }
 
+.c16.c16 .c3 {
+  margin: 0;
+}
+
 .c16 .c11 {
   padding: 0;
 }
@@ -303,7 +311,7 @@ exports[`RadioButton base renders as expected 1`] = `
 }
 
 .c1 {
-  margin-top: 4px;
+  margin-bottom: 16px;
 }
 
 .c1 .c7 {
@@ -360,6 +368,14 @@ exports[`RadioButton base renders as expected 1`] = `
 
 .c1 .c9:checked ~ .c11 svg path {
   fill: rgba(0,0,0,0.90);
+}
+
+.c1:last-of-type {
+  margin-bottom: 0;
+}
+
+.c1.c1 .c3 {
+  margin: 0;
 }
 
 .c1 .c11 {

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -1,14 +1,19 @@
 import React from "react";
 import PropTypes from "prop-types";
-
+import styledSystemPropTypes from "@styled-system/prop-types";
 import tagComponent from "../../../utils/helpers/tags";
 import Fieldset from "../../../__internal__/fieldset";
 import RadioButtonGroupStyle from "./radio-button-group.style";
 import RadioButtonMapper from "./radio-button-mapper.component";
 import Logger from "../../../utils/logger/logger";
 import useIsAboveBreakpoint from "../../../hooks/__internal__/useIsAboveBreakpoint";
+import filterStyledSystemMarginProps from "../../../style/utils/filter-styled-system-margin-props";
 
 let deprecatedWarnTriggered = false;
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 const RadioButtonGroup = (props) => {
   if (!deprecatedWarnTriggered) {
@@ -33,8 +38,6 @@ const RadioButtonGroup = (props) => {
     legendWidth,
     legendAlign,
     legendSpacing,
-    ml,
-    mb,
     labelSpacing = 1,
     adaptiveLegendBreakpoint,
     adaptiveSpacingBreakpoint,
@@ -42,9 +45,12 @@ const RadioButtonGroup = (props) => {
     styleOverride = {},
   } = props;
 
+  const marginProps = filterStyledSystemMarginProps(props);
+
   const isAboveLegendBreakpoint = useIsAboveBreakpoint(
     adaptiveLegendBreakpoint
   );
+
   const isAboveSpacingBreakpoint = useIsAboveBreakpoint(
     adaptiveSpacingBreakpoint
   );
@@ -54,7 +60,7 @@ const RadioButtonGroup = (props) => {
     inlineLegend = isAboveLegendBreakpoint;
   }
 
-  let marginLeft = ml;
+  let marginLeft = marginProps.ml;
   if (adaptiveSpacingBreakpoint && !isAboveSpacingBreakpoint) {
     marginLeft = undefined;
   }
@@ -70,17 +76,17 @@ const RadioButtonGroup = (props) => {
       legendWidth={legendWidth}
       legendAlign={legendAlign}
       legendSpacing={legendSpacing}
-      ml={marginLeft}
-      mb={mb}
       styleOverride={styleOverride}
       isRequired={required}
       {...tagComponent("radiogroup", props)}
+      {...marginProps}
+      ml={marginLeft}
     >
       <RadioButtonGroupStyle
         data-component="radio-button-group"
         role="group"
         inline={inline}
-        legendInline={legendInline}
+        legendInline={inlineLegend}
         styleOverride={styleOverride.content}
       >
         <RadioButtonMapper
@@ -89,10 +95,7 @@ const RadioButtonGroup = (props) => {
           onChange={onChange}
           value={value}
         >
-          {React.Children.map(children, (child, i) => {
-            const length = React.Children.count(children);
-            const isLastChild = i === length - 1;
-            const isFirstChild = i === 0;
+          {React.Children.map(children, (child) => {
             return React.cloneElement(child, {
               inline,
               labelSpacing,
@@ -100,8 +103,6 @@ const RadioButtonGroup = (props) => {
               warning: !!warning,
               info: !!info,
               required,
-              mt: !inline && isFirstChild ? "4px" : undefined,
-              mb: isLastChild ? 0 : undefined,
               ...child.props,
             });
           })}
@@ -112,6 +113,7 @@ const RadioButtonGroup = (props) => {
 };
 
 RadioButtonGroup.propTypes = {
+  ...marginPropTypes,
   /** The RadioButton objects to be rendered in the group */
   children: PropTypes.node.isRequired,
   /** Specifies the name prop to be applied to each button in the group */
@@ -146,10 +148,6 @@ RadioButtonGroup.propTypes = {
   legendAlign: PropTypes.oneOf(["left", "right"]),
   /** Spacing between legend and field for inline legend, number multiplied by base spacing unit (8) */
   legendSpacing: PropTypes.oneOf([1, 2]),
-  /** Margin left, any valid CSS value */
-  ml: PropTypes.string,
-  /** Margin bottom, given number will be multiplied by base spacing unit (8) */
-  mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
   /** Spacing between labels and radio buttons, given number will be multiplied by base spacing unit (8) */
   labelSpacing: PropTypes.oneOf([1, 2]),
   /** Breakpoint for adaptive legend (inline labels change to top aligned). Enables the adaptive behaviour when set */

--- a/src/__experimental__/components/radio-button/radio-button-group.d.ts
+++ b/src/__experimental__/components/radio-button/radio-button-group.d.ts
@@ -1,6 +1,7 @@
-import * as React from "react";
+import * as React from 'react';
+import { MarginSpacingProps } from '../../../utils/helpers/options-helper';
 
-export interface RadioButtonGroupProps {
+export interface RadioButtonGroupProps extends MarginSpacingProps {
   /** The RadioButton objects to be rendered in the group */
   children: React.ReactNode;
   /** Specifies the name prop to be applied to each button in the group */
@@ -35,10 +36,6 @@ export interface RadioButtonGroupProps {
   legendAlign?: "left" | "right";
   /** Spacing between legend and field for inline legend, number multiplied by base spacing unit (8) */
   legendSpacing?: 1 | 2;
-  /** Margin left, any valid CSS value */
-  ml?: string;
-  /** Margin bottom, given number will be multiplied by base spacing unit (8) */
-  mb?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
   /** Spacing between labels and radio buttons, given number will be multiplied by base spacing unit (8) */
   labelSpacing?: 1 | 2;
   /** Breakpoint for adaptive legend (inline labels change to top aligned). Enables the adaptive behaviour when set */

--- a/src/__experimental__/components/radio-button/radio-button-group.style.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.style.js
@@ -1,9 +1,11 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 const RadioButtonGroupStyle = styled.div`
-  ${({ inline }) => inline && "display: flex;"}
-
-  ${({ styleOverride }) => styleOverride};
+  ${({ inline, legendInline, styleOverride }) => css`
+    ${inline && "display: flex;"}
+    ${legendInline && "margin-top: 4px;"}
+    ${styleOverride};
+  `};
 `;
 
 export default RadioButtonGroupStyle;

--- a/src/__experimental__/components/radio-button/radio-button.component.js
+++ b/src/__experimental__/components/radio-button/radio-button.component.js
@@ -1,9 +1,15 @@
 import React, { useCallback } from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import tagComponent from "../../../utils/helpers/tags";
 import RadioButtonStyle from "./radio-button.style";
 import CheckableInput from "../../../__internal__/checkable-input/checkable-input.component";
 import RadioButtonSvg from "./radio-button-svg.component";
+import filterStyledSystemMarginProps from "../../../style/utils/filter-styled-system-margin-props";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 const radioButtonGroupPassedProps = {
   /** Props to be passed from RadioButtonGroup */
@@ -36,10 +42,9 @@ const RadioButton = ({
   error,
   warning,
   info,
-  mt,
-  mb = 2,
   ...props
 }) => {
+  const marginProps = filterStyledSystemMarginProps(props);
   const handleChange = useCallback(
     (ev) => {
       onChange(ev);
@@ -74,7 +79,6 @@ const RadioButton = ({
     inputLabel: label,
     inputValue: value,
     inputType: "radio",
-    mb,
     /**
      * Invert the reverse prop, to ensure the FormField component renders the components
      * in the desired order (other elements which use FormField render their sub-components the
@@ -90,8 +94,8 @@ const RadioButton = ({
       reverse={reverse}
       size={size}
       {...commonProps}
+      {...marginProps}
       {...tagComponent("radio-button", props)}
-      mt={mt}
     >
       <CheckableInput {...inputProps}>
         <RadioButtonSvg />
@@ -101,6 +105,7 @@ const RadioButton = ({
 };
 
 RadioButton.propTypes = {
+  ...marginPropTypes,
   /** Set the value of the radio button */
   checked: PropTypes.bool,
   /** Toggles disabling of input */
@@ -136,10 +141,6 @@ RadioButton.propTypes = {
   size: PropTypes.oneOf(["small", "large"]),
   /** the value of the Radio Button, passed on form submit */
   value: PropTypes.string.isRequired,
-  /** Margin top, given number will be multiplied by base spacing unit (8) */
-  mt: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
-  /** Margin bottom, given number will be multiplied by base spacing unit (8) */
-  mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 7]),
   children: (props, propName, componentName) => {
     if (props[propName]) {
       return new Error(

--- a/src/__experimental__/components/radio-button/radio-button.component.js
+++ b/src/__experimental__/components/radio-button/radio-button.component.js
@@ -4,14 +4,38 @@ import tagComponent from "../../../utils/helpers/tags";
 import RadioButtonStyle from "./radio-button.style";
 import CheckableInput from "../../../__internal__/checkable-input/checkable-input.component";
 import RadioButtonSvg from "./radio-button-svg.component";
-import OptionsHelper from "../../../utils/helpers/options-helper";
+
+const radioButtonGroupPassedProps = {
+  /** Props to be passed from RadioButtonGroup */
+  inline: PropTypes.bool,
+  required: PropTypes.bool,
+  error: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  warning: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  info: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+};
 
 const RadioButton = ({
+  checked,
+  disabled,
+  fieldHelp,
+  fieldHelpInline,
   id,
+  inline,
+  inputWidth,
   label,
+  labelAlign,
+  labelSpacing,
+  labelWidth,
+  name,
   onChange,
   onBlur,
   value,
+  reverse,
+  required,
+  size,
+  error,
+  warning,
+  info,
   mt,
   mb = 2,
   ...props
@@ -19,18 +43,33 @@ const RadioButton = ({
   const handleChange = useCallback(
     (ev) => {
       onChange(ev);
-      // specifically trigger focus, as Safari doesn't focus radioButtons on click by default
+      // trigger focus, as Safari doesn't focus radioButtons on click by default
       ev.target.focus();
     },
     [onChange]
   );
 
+  const commonProps = {
+    disabled,
+    fieldHelpInline,
+    inputWidth,
+    labelSpacing,
+    error,
+    warning,
+    info,
+  };
+
   const inputProps = {
-    ...props,
+    ...commonProps,
+    checked,
+    fieldHelp,
+    name,
     onChange: handleChange,
     onBlur,
     helpTag: "span",
+    labelAlign,
     labelInline: true,
+    labelWidth,
     inputId: id,
     inputLabel: label,
     inputValue: value,
@@ -41,14 +80,18 @@ const RadioButton = ({
      * in the desired order (other elements which use FormField render their sub-components the
      * opposite way around by default)
      */
-    reverse: !props.reverse,
+    reverse: !reverse,
+    required,
   };
 
   return (
     <RadioButtonStyle
+      inline={inline}
+      reverse={reverse}
+      size={size}
+      {...commonProps}
       {...tagComponent("radio-button", props)}
       mt={mt}
-      {...props}
     >
       <CheckableInput {...inputProps}>
         <RadioButtonSvg />
@@ -62,6 +105,8 @@ RadioButton.propTypes = {
   checked: PropTypes.bool,
   /** Toggles disabling of input */
   disabled: PropTypes.bool,
+  /** The fieldHelp content to display for the input */
+  fieldHelp: PropTypes.node,
   /** Displays fieldHelp inline with the radio button */
   fieldHelpInline: PropTypes.bool,
   /** Unique Identifier for the input. Will use a randomly generated GUID if none is provided */
@@ -71,7 +116,7 @@ RadioButton.propTypes = {
   /** The content of the label for the input */
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /** Sets label alignment - accepted values: 'left' (default), 'right' */
-  labelAlign: PropTypes.oneOf(OptionsHelper.alignBinary),
+  labelAlign: PropTypes.oneOf(["left", "right"]),
   /** Spacing between label and a field for inline label, given number will be multiplied by base spacing unit (8) */
   labelSpacing: PropTypes.oneOf([1, 2]),
   /** Sets percentage-based label width */
@@ -88,7 +133,7 @@ RadioButton.propTypes = {
    * Set the size of the radio button to 'small' (16x16 - default) or 'large' (24x24).
    * No effect when using Classic theme.
    */
-  size: PropTypes.oneOf(OptionsHelper.sizesBinary),
+  size: PropTypes.oneOf(["small", "large"]),
   /** the value of the Radio Button, passed on form submit */
   value: PropTypes.string.isRequired,
   /** Margin top, given number will be multiplied by base spacing unit (8) */
@@ -105,6 +150,7 @@ RadioButton.propTypes = {
     }
     return null;
   },
+  ...radioButtonGroupPassedProps,
 };
 
 RadioButton.defaultProps = {

--- a/src/__experimental__/components/radio-button/radio-button.d.ts
+++ b/src/__experimental__/components/radio-button/radio-button.d.ts
@@ -3,8 +3,9 @@ import {
   AlignBinaryType,
   SizesType,
 } from "../../../utils/helpers/options-helper/options-helper";
+import { MarginSpacingProps } from '../../../utils/helpers/options-helper';
 
-export interface RadioButtonProps {
+export interface RadioButtonProps extends MarginSpacingProps {
   checked?: boolean;
   disabled?: boolean;
   error?: boolean | string;
@@ -23,8 +24,6 @@ export interface RadioButtonProps {
   reverse?: boolean;
   size?: SizesType;
   value: string;
-  mt?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
-  mb?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
 }
 
 declare const RadioButton: React.FunctionComponent<RadioButtonProps>;

--- a/src/__experimental__/components/radio-button/radio-button.stories.mdx
+++ b/src/__experimental__/components/radio-button/radio-button.stories.mdx
@@ -543,4 +543,8 @@ Labels could be customized using the Typography Component
 />
 
 ### RadioButtonGroup
-<Props of={RadioButtonGroup} />
+<StyledSystemProps
+  of={ RadioButtonGroup }
+  margin
+  noHeader
+/>

--- a/src/__experimental__/components/radio-button/radio-button.stories.mdx
+++ b/src/__experimental__/components/radio-button/radio-button.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import StyledSystemProps from '../../../../.storybook/utils/styled-system-props';
 
-import { RadioButtonGroup, RadioButton } from '.';
+import { RadioButtonGroup, RadioButton, PrivateRadioButton } from '.';
 import Typography from '../../../components/typography';
 
 <Meta
@@ -533,6 +534,13 @@ Labels could be customized using the Typography Component
 </Preview>
 
 ## Props
+
+### RadioButton
+<StyledSystemProps
+  of={ PrivateRadioButton }
+  margin
+  noHeader
+/>
 
 ### RadioButtonGroup
 <Props of={RadioButtonGroup} />

--- a/src/__experimental__/components/radio-button/radio-button.style.js
+++ b/src/__experimental__/components/radio-button/radio-button.style.js
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
 import CheckboxStyle from "../checkbox/checkbox.style";
 import FieldHelpStyle from "../field-help/field-help.style";
 import HiddenCheckableInputStyle from "../../../__internal__/checkable-input/hidden-checkable-input.style";
@@ -6,9 +7,20 @@ import { StyledCheckableInput } from "../../../__internal__/checkable-input/chec
 import StyledCheckableInputSvgWrapper from "../../../__internal__/checkable-input/checkable-input-svg-wrapper.style";
 import { StyledLabelContainer } from "../label/label.style";
 import baseTheme from "../../../style/themes/base";
+import FormFieldStyle from "../form-field/form-field.style";
 
 const RadioButtonStyle = styled(CheckboxStyle)`
   ${({ disabled, fieldHelpInline, reverse, size, theme, inline }) => css`
+    margin-bottom: ${theme.space[2]}px;
+
+    :last-of-type {
+      margin-bottom: 0;
+    }
+
+    && ${FormFieldStyle} {
+      margin: 0;
+    }
+
     ${StyledCheckableInputSvgWrapper} {
       padding: 0;
     }
@@ -96,6 +108,8 @@ const RadioButtonStyle = styled(CheckboxStyle)`
       }
     `}
   `}
+
+  ${margin};
 `;
 
 RadioButtonStyle.defaultProps = {

--- a/src/style/utils/filter-styled-system-margin-props.js
+++ b/src/style/utils/filter-styled-system-margin-props.js
@@ -1,0 +1,22 @@
+import filterObjectProperties from "../../utils/helpers/filter-object-properties";
+
+const marginPropertyNames = [
+  "margin",
+  "m",
+  "marginLeft",
+  "ml",
+  "marginRight",
+  "mr",
+  "marginTop",
+  "mt",
+  "marginBottom",
+  "mb",
+  "marginX",
+  "mx",
+  "marginY",
+  "my",
+];
+
+export default function filterStyledSystemMarginProps(originalObject) {
+  return filterObjectProperties(originalObject, marginPropertyNames);
+}

--- a/src/utils/helpers/filter-object-properties/filter-object-properties.js
+++ b/src/utils/helpers/filter-object-properties/filter-object-properties.js
@@ -1,0 +1,8 @@
+export default function filterObjectProperties(originalObject, keyList) {
+  return Object.keys(originalObject)
+    .filter((key) => keyList.includes(key))
+    .reduce((acc, key) => {
+      acc[key] = originalObject[key];
+      return acc;
+    }, {});
+}

--- a/src/utils/helpers/filter-object-properties/filter-object-properties.spec.js
+++ b/src/utils/helpers/filter-object-properties/filter-object-properties.spec.js
@@ -1,0 +1,24 @@
+import filterObjectProperties from ".";
+
+const allProps = {
+  boolProp: true,
+  stringProp: "string",
+  anotherBoolProp: false,
+  objectProp: { a: true },
+};
+
+const keyList = ["boolProp", "stringProp", "objectProp"];
+
+describe("filterObjectProperties", () => {
+  describe("when filterObjectProperties method is called with an object and keyList", () => {
+    it("then an object containing only keyList keys should be returned", () => {
+      const expectedProps = {
+        boolProp: true,
+        stringProp: "string",
+        objectProp: { a: true },
+      };
+
+      expect(filterObjectProperties(allProps, keyList)).toEqual(expectedProps);
+    });
+  });
+});

--- a/src/utils/helpers/filter-object-properties/index.js
+++ b/src/utils/helpers/filter-object-properties/index.js
@@ -1,0 +1,1 @@
+export { default } from "./filter-object-properties";


### PR DESCRIPTION
### Proposed behaviour
Add styled-system margin props to RadioButton and RadioButtonGroup

Filter out props so proper ones are passed to subcomponents in which they should be instead of spreading them.
Add an util to filter out unnecessary object properties.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
1. npm start
2. open: http://localhost:9001/?path=/docs/experimental-radiobutton--with-legend-and-labels
