### PR TITLE
feat(tile-select): add props to  override action button and render sibling adornment FE-3042

### DIFF
--- a/src/components/tile-select/index.d.ts
+++ b/src/components/tile-select/index.d.ts
@@ -1,0 +1,2 @@
+export { TileSelect } from "./tile-select";
+export { TileSelectGroup } from "./tile-select-group";

--- a/src/components/tile-select/tile-select.component.js
+++ b/src/components/tile-select/tile-select.component.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import I18n from "i18n-js";
 import tagComponent from "../../utils/helpers/tags/tags";
+import Button from "../button";
 
 import {
   StyledTileSelectContainer,
@@ -12,7 +13,7 @@ import {
   StyledSubtitle,
   StyledAdornment,
   StyledDescription,
-  StyledDeselectButton,
+  StyledDeselectWrapper,
 } from "./tile-select.style";
 
 const TileSelect = (props) => {
@@ -30,6 +31,8 @@ const TileSelect = (props) => {
     titleAdornment,
     type,
     id,
+    customActionButton,
+    actionButtonAdornment,
     ...rest
   } = props;
 
@@ -43,6 +46,17 @@ const TileSelect = (props) => {
       },
     });
 
+  const renderActionButton = () => {
+    if (customActionButton) return customActionButton(handleDeselect);
+
+    return (
+      checked && (
+        <Button buttonType="tertiary" size="small" onClick={handleDeselect}>
+          {I18n.t("tileSelect.deselect", { defaultValue: "Deselect" })}
+        </Button>
+      )
+    );
+  };
   return (
     <StyledTileSelectContainer
       checked={checked}
@@ -74,15 +88,10 @@ const TileSelect = (props) => {
         </StyledTitleContainer>
         <StyledDescription>{description}</StyledDescription>
       </StyledTileSelect>
-      {checked && (
-        <StyledDeselectButton
-          buttonType="tertiary"
-          size="small"
-          onClick={handleDeselect}
-        >
-          {I18n.t("tileSelect.deselect", { defaultValue: "Deselect" })}
-        </StyledDeselectButton>
-      )}
+      <StyledDeselectWrapper hasActionAdornment={!!actionButtonAdornment}>
+        {renderActionButton()}
+        {actionButtonAdornment}
+      </StyledDeselectWrapper>
     </StyledTileSelectContainer>
   );
 };
@@ -111,14 +120,18 @@ TileSelect.propTypes = {
   name: PropTypes.string,
   /** Callback triggered when user selects or deselects this tile */
   onChange: PropTypes.func,
-  /** Callback triggered when the user blurrs this tile */
+  /** Callback triggered when the user blurs this tile */
   onBlur: PropTypes.func,
   /** determines if this tile is selected or unselected */
   checked: PropTypes.bool,
-  /** Custom classname passed to the root element of TileSelect */
+  /** Custom class name passed to the root element of TileSelect */
   className: PropTypes.string,
   /** Type of the TileSelect input */
   type: PropTypes.oneOf(["radio", "checkbox"]),
+  /** Render prop that allows overriding the default action button. `(onClick) => <Button onClick={onClick}>...</Button>` */
+  customActionButton: PropTypes.func,
+  /** An additional help info icon rendered next to the action button */
+  actionButtonAdornment: PropTypes.node,
 };
 
 TileSelect.displayName = "TileSelect";

--- a/src/components/tile-select/tile-select.d.ts
+++ b/src/components/tile-select/tile-select.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import * as React from "react";
 
 export interface TileSelectProps {
     /** title of the TileSelect */
@@ -19,14 +19,18 @@ export interface TileSelectProps {
     name?: string;
     /** Callback triggered when user selects or deselects this tile */
     onChange?: (ev: React.ChangeEvent<HTMLElement>) => void;
-    /** Callback triggered when the user blurrs this tile */
+    /** Callback triggered when the user blurs this tile */
     onBlur?: (ev: React.SyntheticEvent<HTMLElement>) => void;
     /** determines if this tile is selected or unselected */
     checked?: boolean;
-    /** Custom classname passed to the root element of TileSelect */
+    /** Custom class name passed to the root element of TileSelect */
     className?: string;
      /** Type of the TileSelect input */
-    type: 'radio' | 'checkbox';
+    type: "radio" | "checkbox";
+    /** Render prop that allows overriding the default action button. */
+    customActionButton?: (onClick: () => void) => JSX.Element;
+    /** An additional help info icon rendered next to the action button */
+    actionButtonAdornment?: React.ReactNode;
 }
 
 declare const TileSelect: React.FunctionComponent<TileSelectProps>;

--- a/src/components/tile-select/tile-select.spec.js
+++ b/src/components/tile-select/tile-select.spec.js
@@ -10,12 +10,14 @@ import {
   StyledTileSelectContainer,
   StyledTileSelect,
   StyledTileSelectInput,
-  StyledDeselectButton,
+  StyledDeselectWrapper,
   StyledTitle,
   StyledSubtitle,
   StyledAdornment,
   StyledDescription,
 } from "./tile-select.style";
+import Button from "../button";
+import Icon from "../icon";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 
 jest.mock("@tippyjs/react/headless");
@@ -42,7 +44,9 @@ describe("TileSelect", () => {
 
   it("renders deselect button when TileSelect is checked", () => {
     render({ checked: true });
-    expect(wrapper.find(StyledDeselectButton).exists()).toBe(true);
+    expect(wrapper.find(StyledDeselectWrapper).find(Button).exists()).toBe(
+      true
+    );
   });
 
   it("clicking on the deselect button invokes passed onChange callback", () => {
@@ -53,7 +57,7 @@ describe("TileSelect", () => {
       id: "id",
       name: "name",
     });
-    wrapper.find(StyledDeselectButton).prop("onClick")();
+    wrapper.find(StyledDeselectWrapper).find(Button).prop("onClick")();
     expect(onChangeMock).toHaveBeenCalledWith({
       target: {
         id: "id",
@@ -141,6 +145,62 @@ describe("TileSelect", () => {
         },
         wrapper.find(StyledTileSelectInput),
         { modifier: `&:focus + ${StyledTileSelect}` }
+      );
+    });
+  });
+
+  describe("customActionButton render prop", () => {
+    it("clicking it invokes passed onChange callback", () => {
+      const onChangeMock = jest.fn();
+      render({
+        onChange: onChangeMock,
+        checked: true,
+        id: "id",
+        name: "name",
+        customActionButton: (onClick) => <Button onClick={onClick}>Foo</Button>,
+      });
+      wrapper.find(StyledDeselectWrapper).find(Button).prop("onClick")();
+
+      expect(wrapper.find(StyledDeselectWrapper).find(Button).text()).toEqual(
+        "Foo"
+      );
+      expect(onChangeMock).toHaveBeenCalledWith({
+        target: {
+          id: "id",
+          name: "name",
+          value: null,
+          checked: false,
+        },
+      });
+    });
+  });
+
+  describe("actionButtonAdornment prop", () => {
+    it("renders the component next to the action Button", () => {
+      const onChangeMock = jest.fn();
+      render({
+        onChange: onChangeMock,
+        checked: true,
+        id: "id",
+        name: "name",
+        actionButtonAdornment: <Icon type="info" />,
+      });
+
+      expect(
+        wrapper.find(StyledDeselectWrapper).props().children.length
+      ).toEqual(2);
+      expect(
+        wrapper.find(StyledDeselectWrapper).find(Icon).exists()
+      ).toBeTruthy();
+
+      assertStyleMatch(
+        {
+          marginRight: "16px",
+          display: "flex",
+          alignItems: "center",
+          minHeight: "32px",
+        },
+        wrapper.find(StyledDeselectWrapper)
       );
     });
   });

--- a/src/components/tile-select/tile-select.stories.mdx
+++ b/src/components/tile-select/tile-select.stories.mdx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import { TileSelect, TileSelectGroup } from ".";
 import Pill from "../pill/"
 import Icon from "../icon";
+import Button from "../button";
+import I18n from "i18n-js";
 
 <Meta
   title="Design System/Tile Select"
@@ -19,37 +21,11 @@ To use this component, import the `TileSelect` and `TileSelectGroup` if you want
 
 ```jsx
 import { TileSelectGroup, TileSelect } from "carbon-react/lib/components/radio-tile"
-
-const MyComponent = () => (
-  const [value, setValue] = useState(null);
-  <TileSelectGroup
-    name="MyInputName"
-    value={value}
-    legend="Tile Select"
-    description="Pick one of the available options"
-    onChange={(e) => setValue(e.target.value)}
-  >
-    <TileSelect
-      value="1"
-      title="Title"
-      subtitle="Subtitle"
-      description="Short and descriptive description"
-    />
-    <TileSelect
-      value="2"
-      title="Title"
-      subtitle="Subtitle"
-      titleAdornment={<Pill>Message</Pill>}
-      description="Short and descriptive description"
-    />
-  </TileSelectGroup>
-);
 ```
 
 ## Examples
 
 ### Single Select
-
 By default, when grouped with the `TileSelectGroup`, this component operates in single select mode and `TileSelect` inputs are of type `radio`.
 
 In this mode all input props like `onChange`, `onBlur`, `name` and currently selected `value` are meant to be passed on the `TileSelectGroup`.
@@ -109,6 +85,142 @@ These props are then internally distributed on each of the `TileSelects` making 
   </Story>
 </Preview>
 
+#### Custom action button
+It is possible to overide the default action button via the `customActionButton` prop. It is a render prop which allows 
+access to the `onClick` functionality.
+
+<Preview>
+  <Story name="with custom action button">
+    {() => {
+      const [value, setValue] = useState(null);
+      const [activated, setActivated] = useState(false);
+      const [removed, setRemoved] = useState(false);
+      return (
+        <TileSelectGroup
+          name="Tile Select"
+          value={value}
+          legend="Tile Select"
+          description="Pick one of the available options"
+          onChange={(e) => setValue(e.target.value)}
+        >
+          <TileSelect
+            value="1"
+            id="1"
+            aria-label="1"
+            title="Title"
+            subtitle="Subtitle"
+            titleAdornment={<Pill pillRole="status" colorVariant="neutral">{activated ? "Active" : "Inactive"}</Pill>}
+            description="Short and descriptive description"
+            customActionButton={activated ? undefined : (onClick) => (
+              <Button
+                onClick={() => {
+                  setValue("1");
+                  setActivated(true);
+                }}
+                buttonType="tertiary"
+                type="button"
+                size="small"
+              >
+                {I18n.t("tileSelect.reactivate", { defaultValue: "Reactivate" })}
+              </Button>
+            )}
+          />
+          <TileSelect
+            value="2"
+            id="2"
+            aria-label="2"
+            title="Title"
+            subtitle="Subtitle"
+            titleAdornment={removed ? undefined : <Pill pillRole="status" colorVariant="neutral">Active</Pill>}
+            description="Short and descriptive description"
+            customActionButton={(onClick) => (
+              <Button
+                onClick={() => {
+                  setRemoved(true);
+                  onClick();
+                }}
+                buttonType="tertiary"
+                type="button"
+                size="small"
+                destructive
+                disabled={removed}
+              >
+                {I18n.t("tileSelect.remove", { defaultValue: "Remove" })}
+              </Button>
+            )}
+          />
+        </TileSelectGroup>
+      )
+    }}
+  </Story>
+</Preview>
+
+#### Action button adornment
+It is possible to render an additional adornment next to the action button through the `actionButtonAdornment` prop.
+
+<Preview>
+  <Story name="with action button adornment">
+    {() => {
+      const [value, setValue] = useState(null);
+      return (
+        <TileSelectGroup
+          name="Tile Select"
+          value={value}
+          legend="Tile Select"
+          description="Pick one of the available options"
+          onChange={(e) => setValue(e.target.value)}
+        >
+          <TileSelect
+            value="1"
+            id="1"
+            aria-label="1"
+            title="Title"
+            subtitle="Subtitle"
+            titleAdornment={<Pill pillRole="status" colorVariant="neutral">Inactive</Pill>}
+            description="Short and descriptive description"
+            customActionButton={(onClick) => (
+              <Button
+                onClick={() => setValue("1")}
+                buttonType="tertiary"
+                type="button"
+                px={1}
+                size="small"
+                disabled
+              >
+                {I18n.t("tileSelect.reactivate", { defaultValue: "Reactivate" })}
+              </Button>
+            )}
+            actionButtonAdornment={<Icon type="info" tooltipMessage="This tile cannot be reactivated at this time" />}
+          />
+          <TileSelect
+            value="2"
+            id="2"
+            aria-label="2"
+            title="Title"
+            subtitle="Subtitle"
+            titleAdornment={<Icon type='info' tooltipMessage="Short and non descriptive message" />}
+            description="Short and descriptive description"
+            customActionButton={(onClick) => (
+              <Button
+                onClick={onClick}
+                buttonType="tertiary"
+                type="button"
+                px={1}
+                size="small"
+                destructive
+                disabled
+              >
+                {I18n.t("tileSelect.remove", { defaultValue: "Remove" })}
+              </Button>
+            )}
+            actionButtonAdornment={<Icon type="info" tooltipMessage="This tile cannot be removed at this time" />}
+          />
+        </TileSelectGroup>
+      )
+    }}
+  </Story>
+</Preview>
+
 ### Multi select
 To enable multi select mode on a `TileSelectGroup` `multiSelect` boolean prop has to be passed as `true`, `TileSelects` in this mode are of type `checkbox`.
 
@@ -117,7 +229,7 @@ In multi select mode all input props like `onChange`, `onBlur`, `name`, `value` 
 In this mode `TileSelectGroup` serves only a visual purpose - it only renders `legend` and `description` props and applies spacing to each of the `TileSelects`
 
 <Preview>
-  <Story name="single Select">
+  <Story name="multi Select">
     {() => {
       const [value1, setValue1] = useState(false);
       const [value2, setValue2] = useState(false);

--- a/src/components/tile-select/tile-select.style.js
+++ b/src/components/tile-select/tile-select.style.js
@@ -1,9 +1,7 @@
 import styled, { css } from "styled-components";
 import Fieldset from "../../__experimental__/components/fieldset";
 import { Input } from "../../__experimental__/components/input";
-import Button from "../button";
 import tint from "../../style/utils/tint";
-
 import { LegendContainerStyle } from "../../__experimental__/components/fieldset/fieldset.style";
 import { baseTheme } from "../../style/themes";
 
@@ -101,11 +99,21 @@ const StyledTitleContainer = styled.div`
   position: relative;
 `;
 
-const StyledDeselectButton = styled(Button)`
-  position: absolute;
-  top: 16px;
-  right: 8px;
-  z-index: 200;
+const StyledDeselectWrapper = styled.div`
+  ${({ hasActionAdornment, theme }) => css`
+    position: absolute;
+    top: ${2 * theme.spacing}px;
+    right: ${theme.spacing}px;
+    z-index: 200;
+
+    ${hasActionAdornment &&
+    `
+      margin-right: ${2 * theme.spacing}px;
+      display: flex;
+      align-items: center;
+      min-height: ${4 * theme.spacing}px;
+    `}
+  `}
 `;
 
 const StyledTileSelectFieldset = styled(Fieldset)`
@@ -147,6 +155,9 @@ StyledTileSelectInput.defaultProps = {
 StyledDescription.defaultProps = {
   theme: baseTheme,
 };
+StyledDeselectWrapper.defaultProps = {
+  theme: baseTheme,
+};
 
 export {
   StyledTileSelectFieldset,
@@ -159,5 +170,5 @@ export {
   StyledSubtitle,
   StyledAdornment,
   StyledDescription,
-  StyledDeselectButton,
+  StyledDeselectWrapper,
 };


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds `customActionButton` render prop that supports overriding the default action button. Adds
`actionButtonAdornment` prop to support rendering components as sibling to action button

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No support for overriding action button or rendering any siblings with it

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/108396999-66d14a00-720f-11eb-8e83-6cedc935007c.png)

![image](https://user-images.githubusercontent.com/44157880/108397035-7355a280-720f-11eb-9769-c442088f1da9.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-n8z1r?file=/src/index.js

Additional examples have also been added to Tile-Select story