### PR TITLE
fix(numeral-date): prevent error being thrown when default date format is used FE-3225

### DIFF
--- a/src/__experimental__/components/numeral-date/numeral-date.component.js
+++ b/src/__experimental__/components/numeral-date/numeral-date.component.js
@@ -229,14 +229,16 @@ NumeralDate.propTypes = {
   ['mm', 'yyyy'] */
   dateFormat: (props, propName, componentName) => {
     const dateFormat = props[propName];
-    const isAllowed = OptionsHelper.dateFormats.find(
-      (allowedDateFormat) =>
-        JSON.stringify(allowedDateFormat) === JSON.stringify(dateFormat)
-    );
+    const isAllowed =
+      !dateFormat ||
+      OptionsHelper.dateFormats.find(
+        (allowedDateFormat) =>
+          JSON.stringify(allowedDateFormat) === JSON.stringify(dateFormat)
+      );
     if (!isAllowed) {
       return new Error(
         `Forbidden prop \`${propName}\` supplied to \`${componentName}\`. ` +
-          "Onle one of these date formats is allowed: " +
+          "Only one of these date formats is allowed: " +
           "['dd', 'mm', 'yyyy'], " +
           "['mm', 'dd', 'yyyy'], " +
           "['dd', 'mm'], " +

--- a/src/__experimental__/components/numeral-date/numeral-date.spec.js
+++ b/src/__experimental__/components/numeral-date/numeral-date.spec.js
@@ -6,7 +6,7 @@ import NumeralDate from "./numeral-date.component";
 import Textbox from "../textbox";
 import { StyledNumeralDate, StyledDateField } from "./numeral-date.style";
 import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
-import StyledInputPresentantion from "../input/input-presentation.style";
+import StyledInputPresentation from "../input/input-presentation.style";
 import FormField from "../form-field";
 import { rootTagTest } from "../../../utils/helpers/tags/tags-specs";
 import Label from "../label";
@@ -20,7 +20,6 @@ describe("NumeralDate", () => {
 
   const renderWrapper = (props) => {
     const defaultProps = {
-      dateFormat: ["dd"],
       defaultValue: { dd: "30" },
       onBlur,
       onChange,
@@ -38,7 +37,7 @@ describe("NumeralDate", () => {
       renderWrapper({ dateFormat: ["xx"] });
       const expected =
         "Forbidden prop `dateFormat` supplied to `NumeralDate`. " +
-        "Onle one of these date formats is allowed: " +
+        "Only one of these date formats is allowed: " +
         "['dd', 'mm', 'yyyy'], " +
         "['mm', 'dd', 'yyyy'], " +
         "['dd', 'mm'], " +
@@ -49,9 +48,25 @@ describe("NumeralDate", () => {
       const actual = console.error.calls.argsFor(0)[0];
       expect(actual).toMatch(expected);
     });
+
+    it("does not throw an error if no dateFormat is passed", () => {
+      spyOn(global.console, "error");
+      renderWrapper();
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled();
+    });
   });
 
   describe("invariant", () => {
+    beforeEach(() => {
+      jest.spyOn(global.console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      global.console.error.mockReset();
+    });
+
     it("throws when component changes from uncontrolled to controlled", () => {
       wrapper = renderWrapper({ value: undefined });
       expect(() => {
@@ -126,7 +141,7 @@ describe("NumeralDate", () => {
           width: "78px",
         },
         wrapper.find(StyledDateField).at(1),
-        { modifier: `${StyledInputPresentantion}` }
+        { modifier: `${StyledInputPresentation}` }
       );
     });
 
@@ -141,7 +156,7 @@ describe("NumeralDate", () => {
           width: "78px",
         },
         wrapper.find(StyledDateField).at(2),
-        { modifier: `${StyledInputPresentantion}` }
+        { modifier: `${StyledInputPresentation}` }
       );
     });
   });
@@ -187,6 +202,7 @@ describe("NumeralDate", () => {
         "renders internal validation when day field is blurred and has incorrect value",
         (value, isValid) => {
           wrapper = renderWrapper({
+            dateFormat: ["dd"],
             defaultValue: null,
             [internalValidationProp]: true,
           });
@@ -290,7 +306,7 @@ describe("NumeralDate", () => {
 
   describe("Clicking off the component", () => {
     it("calls onBlur if prop is passed", () => {
-      wrapper = renderWrapper({ defaultValue: undefined });
+      wrapper = renderWrapper({ defaultValue: undefined, dateFormat: ["dd"] });
       const input = wrapper.find("input");
       input.simulate("blur");
       jest.runAllTimers();
@@ -300,7 +316,7 @@ describe("NumeralDate", () => {
 
   describe("supports being a controlled component", () => {
     it("calls onChange prop with proper argument", () => {
-      wrapper = renderWrapper({ name: "Name", id: "Id" });
+      wrapper = renderWrapper({ name: "Name", id: "Id", dateFormat: ["dd"] });
       const input = wrapper.find("input");
       act(() => {
         input.simulate("change", { target: { value: "45" } });
@@ -317,13 +333,21 @@ describe("NumeralDate", () => {
     });
 
     it("passes value prop to the input", () => {
-      wrapper = renderWrapper({ defaultValue: undefined, value: { dd: "30" } });
+      wrapper = renderWrapper({
+        defaultValue: undefined,
+        value: { dd: "30" },
+        dateFormat: ["dd"],
+      });
       const input = wrapper.find("input");
       expect(input.props().value).toEqual("30");
     });
 
     it("passes empty string to the input if value is not provided", () => {
-      wrapper = renderWrapper({ defaultValue: undefined, value: undefined });
+      wrapper = renderWrapper({
+        defaultValue: undefined,
+        value: undefined,
+        dateFormat: ["dd"],
+      });
       const input = wrapper.find("input");
       expect(input.props().value).toEqual("");
     });
@@ -331,13 +355,13 @@ describe("NumeralDate", () => {
 
   describe("supports being a uncontrolled component", () => {
     it("accepts a default value", () => {
-      wrapper = renderWrapper();
+      wrapper = renderWrapper({ dateFormat: ["dd"] });
       const input = wrapper.find("input");
       expect(input.props().value).toEqual("30");
     });
 
     it("passes empty string to the input if defaultValue is not provided", () => {
-      wrapper = renderWrapper({ defaultValue: undefined });
+      wrapper = renderWrapper({ defaultValue: undefined, dateFormat: ["dd"] });
       const input = wrapper.find("input");
       expect(input.props().value).toEqual("");
     });
@@ -345,7 +369,7 @@ describe("NumeralDate", () => {
 
   describe("Valid characters", () => {
     beforeEach(() => {
-      wrapper = renderWrapper();
+      wrapper = renderWrapper({ dateFormat: ["dd"] });
     });
 
     afterEach(() => jest.clearAllMocks());

--- a/src/__experimental__/components/numeral-date/numeral-date.stories.mdx
+++ b/src/__experimental__/components/numeral-date/numeral-date.stories.mdx
@@ -18,15 +18,9 @@ Import `NumeralDate` into the project.
 
 ```jsx
 import NumeralDate from "carbon-react/lib/__experimental__/components/numeral-date";
-
-const MyComponent = () => (
-  <NumeralDate
-    dateFormat={["dd", "mm", "yyyy"]}
-    onChange={onChange}
-    value={{ dd: "27", mm: "04", yyyy: "1989" }}
-  />
-);
 ```
+
+## Examples
 
 ### Controlled
 
@@ -39,7 +33,6 @@ const MyComponent = () => (
           value={value}
           onChange={(e) => setValue(e.target.value)}
           label="Default"
-          dateFormat={["dd", "mm", "yyyy"]}
         />
       );
     }}


### PR DESCRIPTION
fixes #3264

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->

No error is thrown when no `dateFormat` value is passed

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

When no value is passed to the `dateFormat` prop it throws an error even though it has a default
value assigned in the top level prop destructure of the component. This is because at the point where
the prop types are checked the value is not initialised to the default.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
n/a
### Testing instructions
<!-- How can a reviewer test this PR? -->
The `controlled` story for `NumeralDate` has no `dateFormat` passed and instead relies on the default value, no error should be thrown about incorrect formats etc

https://codesandbox.io/s/carbon-quickstart-forked-2elgi?file=/src/index.js