### PR TITLE
fix(date-input): incorrect year in datepicker when date is not valid (FE-3708)

### DIFF
--- a/src/__experimental__/components/date/date.component.js
+++ b/src/__experimental__/components/date/date.component.js
@@ -340,7 +340,11 @@ class BaseDateInput extends React.Component {
   renderDatePicker = (dateRangeProps) => {
     if (!this.state.isDatePickerOpen) return null;
 
-    const { visibleValue } = this.state;
+    let { visibleValue } = this.state;
+
+    if (!DateHelper.isValidDate(visibleValue)) {
+      visibleValue = "";
+    }
 
     return (
       <div onClick={this.markCurrentDatepicker} role="presentation">

--- a/src/__experimental__/components/date/date.spec.js
+++ b/src/__experimental__/components/date/date.spec.js
@@ -333,6 +333,21 @@ describe("Date", () => {
     });
   });
 
+  describe("when the input value is changed with the DatePicker open with invalid date", () => {
+    it.each(["12/42/3213", "foo", "39"])(
+      "should pass an empty value to the DatePicker",
+      (mockValue) => {
+        simulateFocusOnInput(wrapper);
+        wrapper
+          .find("input[data-element='input']")
+          .simulate("change", { target: { value: mockValue } });
+        const picker = wrapper.find(DatePicker);
+        expect(picker.exists()).toBe(true);
+        expect(picker.props().inputDate).toBe("");
+      }
+    );
+  });
+
   describe('when the "handleDateSelect" prop is called on the opened "DatePicker"', () => {
     const mockDate = moment("2012-02-01");
 


### PR DESCRIPTION
### Proposed behaviour
Month and year should not change when incorrect date is provided.

### Current behaviour
When the date is changed to invalid when the DatePicker is open, incorrect year is displayed, e.g.: 31/02/2021 displays January 0031.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
~~- [ ] Cypress automation tests added or updated if required~~
~~- [ ] Storybook added or updated if required~~
~~- [ ] Typescript `d.ts` file added or updated if required~~
~~- [ ] Carbon implementation and Design System documentation are congruent~~

### Testing instructions
1. npm start
2. open http://localhost:9001/?path=/story/experimental-date-input--default-story
3. open the datepicker
4. change the month to February
5. replace the date in input with 31