### PR TITLE
fix(heading): remove as prop from heading title wrapper FE-3769

### DIFF
--- a/cypress/features/regression/heading.feature
+++ b/cypress/features/regression/heading.feature
@@ -55,3 +55,8 @@ Feature: Heading component
       | backLink                     | nameOfObject             |
       | mp150ú¿¡üßä                  | backLinkOtherLanguage    |
       | !@#$%^*()_+-=~[];:.,?{}&"'<> | backLinkSpecialCharacter |
+
+  @positive
+  Scenario: Heading title has h1 HTML tag
+    Given I open "Heading" component page "default story" in no iframe
+    Then Heading title has h1 HTML tag

--- a/cypress/locators/heading/index.js
+++ b/cypress/locators/heading/index.js
@@ -8,3 +8,4 @@ import {
 export const headingPreview = () => cy.get(HEADING_PREVIEW);
 export const subheaderPreview = () => cy.get(SUBHEADER_PREVIEW);
 export const separatorPreview = () => cy.get(SEPARATOR_PREVIEW);
+export const headingTitle = () => headingPreview().find("div > h1");

--- a/cypress/support/step-definitions/heading-steps.js
+++ b/cypress/support/step-definitions/heading-steps.js
@@ -2,6 +2,7 @@ import {
   headingPreview,
   subheaderPreview,
   separatorPreview,
+  headingTitle,
 } from "../../locators/heading";
 import { helpIcon, link, getDataElementByValue } from "../../locators";
 
@@ -31,4 +32,8 @@ Then("separator is visible", () => {
 
 Then("separator is not visible", () => {
   separatorPreview().should("not.exist");
+});
+
+Then("Heading title has h1 HTML tag", () => {
+  headingTitle().contains("This is a Title");
 });

--- a/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
+++ b/src/components/dialog-full-screen/__snapshots__/dialog-full-screen.spec.js.snap
@@ -203,19 +203,17 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
 }
 
 .c7 {
-  display: inline-block;
-  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
 .c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   margin-bottom: 15px;
   margin-bottom: 20px;
 }
@@ -387,14 +385,14 @@ exports[`DialogFullScreen dialogTitle has a Ref to the scrollable content and th
         <div
           class="c7"
         >
-          <span
+          <h1
             class="c8"
             color="blackOpacity90"
             data-element="title"
             text-decoration="none"
           >
             my custom heading
-          </span>
+          </h1>
         </div>
       </div>
       <hr

--- a/src/components/heading/heading.component.js
+++ b/src/components/heading/heading.component.js
@@ -148,7 +148,12 @@ class Heading extends React.Component {
     }
 
     return (
-      <StyledSubHeader data-element="subtitle" id={this.props.subtitleId}>
+      <StyledSubHeader
+        data-element="subtitle"
+        id={this.props.subtitleId}
+        hasBackLink={!!this.props.backLink}
+        hasSeparator={this.props.separator}
+      >
         {this.props.subheader}
       </StyledSubHeader>
     );
@@ -203,13 +208,13 @@ class Heading extends React.Component {
           data-element="header-container"
           divider={this.props.divider}
           subheader={this.props.subheader}
+          hasBackLink={!!this.props.backLink}
         >
           {this.back}
           <StyledHeaderContent>
             <StyledHeadingTitle
               withMargin={this.props.pills || this.props.help}
               variant="h1"
-              as="span"
               data-element="title"
               id={this.props.titleId}
             >
@@ -217,9 +222,9 @@ class Heading extends React.Component {
             </StyledHeadingTitle>
             {this.help}
             {this.pills}
-            {this.separator}
-            {this.subheader}
           </StyledHeaderContent>
+          {this.separator}
+          {this.subheader}
         </StyledHeader>
         {this.divider}
         {this.props.children}

--- a/src/components/heading/heading.spec.js
+++ b/src/components/heading/heading.spec.js
@@ -2,6 +2,7 @@ import React from "react";
 import { shallow, mount } from "enzyme";
 import Heading from "./heading.component";
 import {
+  StyledHeader,
   StyledSubHeader,
   StyledSeparator,
   StyledHeadingTitle,
@@ -42,7 +43,7 @@ describe("Heading", () => {
     expect(help.props().href).toEqual("/bar");
   });
 
-  it("renders a back link", () => {
+  it("renders a back link and applies correct styling to header and subheader", () => {
     const wrapper = mount(
       <Heading
         className="custom"
@@ -57,6 +58,23 @@ describe("Heading", () => {
 
     const link = wrapper.find(Link);
     expect(link.prop("href")).toEqual("/foobar");
+
+    assertStyleMatch(
+      {
+        display: "grid",
+        gridTemplateColumns: "min-content auto",
+      },
+      wrapper.find(StyledHeader)
+    );
+
+    assertStyleMatch(
+      {
+        marginTop: "5px",
+        gridRow: "2",
+        gridColumn: "2",
+      },
+      wrapper.find(StyledSubHeader)
+    );
   });
 
   it("renders a back link as a button with an outline", () => {
@@ -193,6 +211,18 @@ describe("Heading", () => {
     it("renders a separator after the title", () => {
       const wrapper = mount(<Heading title="foo" separator />);
       expect(wrapper.find(StyledSeparator).length).toEqual(1);
+    });
+
+    it("applies the correct style to the subheader", () => {
+      const wrapper = mount(<Heading title="foo" separator subheader="bar" />);
+
+      assertStyleMatch(
+        {
+          gridRow: "3",
+          marginTop: "0px",
+        },
+        wrapper.find(StyledSubHeader)
+      );
     });
   });
 

--- a/src/components/heading/heading.style.js
+++ b/src/components/heading/heading.style.js
@@ -16,15 +16,12 @@ StyledHeading.defaultProps = {
 };
 
 const StyledHeaderContent = styled.div`
-  display: inline-block;
-  width: 100%;
+  display: inline-flex;
+  align-items: flex-end;
 `;
 
 const StyledHeader = styled.div`
-  display: flex;
-  align-items: flex-start;
-
-  ${({ divider, subheader }) => css`
+  ${({ divider, subheader, hasBackLink }) => css`
     ${subheader &&
     css`
       margin-bottom: 16px;
@@ -39,6 +36,12 @@ const StyledHeader = styled.div`
     !subheader &&
     css`
       margin-bottom: 20px;
+    `}
+
+    ${hasBackLink &&
+    css`
+      display: grid;
+      grid-template-columns: min-content auto;
     `}
   `}
 `;
@@ -85,6 +88,20 @@ const StyledHeadingPills = styled.span`
 
 const StyledSubHeader = styled.div`
   margin-top: 5px;
+  grid-row: 2;
+
+  ${({ hasBackLink }) =>
+    hasBackLink &&
+    css`
+      grid-column: 2;
+    `}
+
+  ${({ hasSeparator }) =>
+    hasSeparator &&
+    css`
+      grid-row: 3;
+      margin-top: 0px;
+    `}
 `;
 
 const StyledHeadingIcon = styled(Icon)`


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
`StyledHeadingTitle` has `as="span"` from `StyledHeadingTitle` as it is overriding the `Typography` `h1` `variant`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`StyledHeadingTitle` has `as="span"`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
