### PR TITLE
fix(dl): support for conditional rendering - FE- 3600

### DIFF
--- a/src/components/definition-list/definition-list.spec.js
+++ b/src/components/definition-list/definition-list.spec.js
@@ -70,6 +70,24 @@ describe("DefinitionList", () => {
     );
   });
 
+  describe("if composed with React Fragment", () => {
+    it("should render correctly", () => {
+      wrapper = mount(
+        <Dl>
+          <Dt>Title</Dt>
+          <Dd>Description</Dd>
+          <>
+            <Dt>Title inside of React Fragment</Dt>
+            <Dd>Description inside of React Fragment</Dd>
+          </>
+        </Dl>
+      );
+
+      expect(wrapper.find(Dt).at(1).exists()).toBe(true);
+      expect(wrapper.find(Dd).at(1).exists()).toBe(true);
+    });
+  });
+
   describe("styles", () => {
     it("matches the expected default styles of Dl", () => {
       wrapper = renderWrapper("Dl", {});

--- a/src/components/definition-list/definition-list.stories.js
+++ b/src/components/definition-list/definition-list.stories.js
@@ -21,11 +21,12 @@ export default {
 export const Default = () => {
   return (
     <Dl data-component="definition-list">
-      <Dt>Name</Dt>
-      <Dd>Daniel Dipper</Dd>
-
-      <Dt>Phone</Dt>
-      <Dd>Yes, I have a phone</Dd>
+      <Dt>Title</Dt>
+      <Dd>Description</Dd>
+      <>
+        <Dt>Title inside of React Fragment</Dt>
+        <Dd>Description inside of React Fragment</Dd>
+      </>
     </Dl>
   );
 };

--- a/src/components/definition-list/definition-list.stories.mdx
+++ b/src/components/definition-list/definition-list.stories.mdx
@@ -1,0 +1,64 @@
+import { Meta, Story, Preview, Props} from '@storybook/addon-docs/blocks';
+import {useState} from 'react';
+import { Dl, Dt, Dd } from "./"
+import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
+
+<Meta title="Design System/Definition List" parameters={{ info: { disable: true }}} />
+
+# Definition List
+
+## Related Components
+Definition List most of the time is in use with other components. Look at the examples below
+
+- [Tile component with Definition List](/?path=/docs/design-system-tile--with-definition-list-default "Tile component with Definition List").
+- [Accordion component with Definition List](/?path=/docs/design-system-accordion--with-a-definition-list "Accordion component with Definition List").
+
+## Quick Start
+
+```js
+import { Dl, Dt, Dd } from "carbon-react/lib/components/definition-list";
+```
+
+### Default
+
+<Preview>
+  <Story name="default">
+    <Dl>
+      <Dt>First</Dt>
+      <Dd>Description</Dd>
+      <Dt>Second</Dt>
+      <Dd>Description</Dd>
+      <Dt>Third</Dt>
+      <Dd>Description</Dd>
+    </Dl>
+  </Story>
+</Preview>
+
+### Conditional rendering with `<React.Fragment />`
+*CAUTION: don't use nested `<React.Fragment />`*
+
+<Preview>
+  <Story name="with conditional rendering" parameters={{ chromatic: { disable: true }}}>
+      <Dl>
+        <Dt>First</Dt>
+        <Dd>Description</Dd>
+        <Dt>Second</Dt>
+        <Dd>Description</Dd>
+        {(true && <>
+          <Dt>Third inside of React Fragment</Dt>
+          <Dd>Description inside of React Fragment</Dd>
+        </>)}
+      </Dl>
+  </Story>
+</Preview>
+
+## Props
+
+### Dl
+<StyledSystemProps of={Dl} noHeader spacing/>
+
+### Dt
+<StyledSystemProps of={Dt} noHeader spacing/>
+
+### Dd
+<StyledSystemProps of={Dd} noHeader spacing/>

--- a/src/components/definition-list/dl.component.js
+++ b/src/components/definition-list/dl.component.js
@@ -14,36 +14,51 @@ const Dl = ({
 }) => {
   const dlComponent = [];
   const listChildren = React.Children.toArray(children);
-  let dtLabel;
-  let ddContent = [];
+  let key = "";
 
-  listChildren.forEach((child, index) => {
-    if (child.type === Dt) {
-      dtLabel = child;
-    }
+  const composeDlComponent = (array) => {
+    let dtLabel;
+    let ddContent = [];
+    let isLastChild;
+    let nextItemIsNotDd;
 
-    if (child.type === Dd) {
-      ddContent.push(child);
-    }
-    const isLastChild = index === listChildren.length - 1;
-    const nextItemIsDt = !isLastChild && listChildren[index + 1].type === Dt;
+    array.forEach((child, index) => {
+      if (child.type === React.Fragment) {
+        composeDlComponent(child.props.children);
+      } else {
+        if (child.type === Dt) {
+          dtLabel = child;
+        }
+        if (child.type === Dd) {
+          ddContent.push(child);
+        }
 
-    if (dtLabel && (nextItemIsDt || isLastChild)) {
-      dlComponent.push(
-        <React.Fragment key={child.props.key || index}>
-          <StyledDtDiv dtTextAlign={dtTextAlign}>{dtLabel}</StyledDtDiv>
+        isLastChild = index === listChildren.length - 1;
+        nextItemIsNotDd =
+          !isLastChild &&
+          [Dt, React.Fragment].includes(listChildren[index + 1].type);
 
-          <StyledDdDiv ddTextAlign={ddTextAlign}>{ddContent}</StyledDdDiv>
-        </React.Fragment>
-      );
-      dtLabel = undefined;
-      ddContent = [];
-    }
-  });
+        if (dtLabel && (nextItemIsNotDd || isLastChild)) {
+          key = `${key + 1}`;
+
+          dlComponent.push(
+            <React.Fragment key={child.props.key || key}>
+              <StyledDtDiv dtTextAlign={dtTextAlign}>{dtLabel}</StyledDtDiv>
+              <StyledDdDiv ddTextAlign={ddTextAlign}>{ddContent}</StyledDdDiv>
+            </React.Fragment>
+          );
+
+          ddContent = [];
+        }
+      }
+    });
+
+    return dlComponent;
+  };
 
   return (
     <StyledDl w={w} data-component="dl" {...props}>
-      {dlComponent}
+      {composeDlComponent(listChildren)}
     </StyledDl>
   );
 };


### PR DESCRIPTION
### Proposed behaviour
Add support for conditional rendering with using of `<React.Fragment />` component 

![definition-list-conditional-rendering](https://user-images.githubusercontent.com/19231884/108726745-0fd9b680-7528-11eb-99d3-4696f370f4b1.jpg)


### Current behaviour
`<React.Fragment />` and content of the component don't render

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [ ] <dl> All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] <del> Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Additional context
I also created MDX file as it didn't exist. The MDX is located in storybook: `Design System/Defitnion List`

### Testing instructions
MDX in storybook 
`Design System/Definition List`
