### PR TITLE
feat(toast): centre toast by default - FE-3701

### DIFF
--- a/cypress/features/regression/designSystem/toast.feature
+++ b/cypress/features/regression/designSystem/toast.feature
@@ -57,13 +57,13 @@ Feature: Toast Design System component
     Then Toast component has no close icon
 
   @positive
-  Scenario: Confirm that isCenter property centers Toast
-    Given I open "Design System Toast" component page "centered" in no iframe
-    When I click on "button-variant-centered" Toggle Preview
-    Then Toast is centred
+  Scenario: Confirm that when isCenter property is false Toast is left aligned
+    Given I open "Design System Toast" component page "left aligned" in no iframe
+    When I click on "button-left-aligned" Toggle Preview
+    Then Toast is not centred
 
   @positive
-  Scenario: Confirm that Toast is not centered by default
+  Scenario: Confirm that Toast is centered by default
     Given I open "Design System Toast" component page "default story" in no iframe
     When I click on "button-default" Toggle Preview
-    Then Toast is not centred
+    Then Toast is centred

--- a/src/components/toast/toast.component.js
+++ b/src/components/toast/toast.component.js
@@ -156,7 +156,7 @@ Toast.defaultProps = {
   as: "warning",
   onDismiss: null,
   open: true,
-  isCenter: false,
+  isCenter: true,
 };
 
 export default Toast;

--- a/src/components/toast/toast.stories.js
+++ b/src/components/toast/toast.stories.js
@@ -1,12 +1,14 @@
 import React, { useState } from "react";
-import { text } from "@storybook/addon-knobs";
+import { select, text, boolean, withKnobs } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import Toast from ".";
 import Button from "../button";
+import OptionsHelper from "../../utils/helpers/options-helper";
 
 export default {
   title: "Design System/Toast/Test",
   component: Toast,
+  decorators: [withKnobs],
   parameters: {
     docs: { page: null },
     info: {
@@ -38,7 +40,8 @@ export const Default = () => {
       <Button onClick={handleOpen}>Open Toast</Button>
 
       <Toast
-        variant="warning"
+        variant={select("variant", OptionsHelper.colors, "warning")}
+        isCenter={boolean("isCenter", true)}
         id="toast-dismissible"
         open={isOpen}
         onDismiss={onDismissClick}
@@ -63,6 +66,7 @@ export const Visual = () => {
 
   return (
     <div>
+      {/* centered examples */}
       <Toast
         variant="info"
         id="toast-quick-start"
@@ -86,6 +90,14 @@ export const Visual = () => {
       <Toast variant="error" targetPortalId="visual" open={isOpen}>
         My Error
       </Toast>
+      <Toast
+        variant="warning"
+        targetPortalId="visual"
+        open={isOpen}
+        onDismiss={onDismissClick}
+      >
+        My Warning
+      </Toast>
       <Toast variant="warning" targetPortalId="visual" open={isOpen}>
         My Warning
       </Toast>
@@ -100,14 +112,75 @@ export const Visual = () => {
       <Toast variant="success" targetPortalId="visual" open={isOpen}>
         My Success
       </Toast>
+      {/* left-aligned examples */}
       <Toast
-        variant="warning"
-        targetPortalId="visual-center"
+        variant="info"
+        id="toast-quick-start"
         open={isOpen}
         onDismiss={onDismissClick}
-        isCenter
+        targetPortalId="visual-left-aligned"
+        isCenter={false}
       >
-        My text
+        {children}
+      </Toast>
+      <Toast
+        variant="info"
+        targetPortalId="visual-left-aligned"
+        isOpen={isOpen}
+        isCenter={false}
+      >
+        {children}
+      </Toast>
+      <Toast
+        variant="error"
+        targetPortalId="visual-left-aligned"
+        isCenter={false}
+        open={isOpen}
+        onDismiss={onDismissClick}
+      >
+        My Error
+      </Toast>
+      <Toast
+        variant="error"
+        targetPortalId="visual-left-aligned"
+        isCenter={false}
+        open={isOpen}
+      >
+        My Error
+      </Toast>
+      <Toast
+        variant="warning"
+        targetPortalId="visual-left-aligned"
+        isCenter={false}
+        open={isOpen}
+        onDismiss={onDismissClick}
+      >
+        My Warning
+      </Toast>
+      <Toast
+        variant="warning"
+        targetPortalId="visual-left-aligned"
+        isCenter={false}
+        open={isOpen}
+      >
+        My Warning
+      </Toast>
+      <Toast
+        variant="success"
+        targetPortalId="visual-left-aligned"
+        isCenter={false}
+        open={isOpen}
+        onDismiss={onDismissClick}
+      >
+        My Success
+      </Toast>
+      <Toast
+        variant="success"
+        targetPortalId="visual-left-aligned"
+        isCenter={false}
+        open={isOpen}
+      >
+        My Success
       </Toast>
     </div>
   );

--- a/src/components/toast/toast.stories.mdx
+++ b/src/components/toast/toast.stories.mdx
@@ -242,11 +242,11 @@ Please note, by clicking a `toggle preview` button it will open example toast at
   </Story>
 </Preview>
 
-### Variant Centered:
+### Variant Left Aligned:
 
 <Preview>
   <Story
-    name="centered"
+    name="left aligned"
     parameters={{ info: { disable: true }}}
   >
   {() => {
@@ -272,9 +272,9 @@ Please note, by clicking a `toggle preview` button it will open example toast at
       border: ${isOpen ? '2px solid green' : '2px solid blue'};
     `;
     return (
-      <div id="wrapper-centered">
+      <div id="wrapper-left-aligned">
         <StyledButton
-          id='button-variant-centered'
+          id='button-left-aligned'
           key='button'
           onClick={ handleToggle }
         >
@@ -282,10 +282,10 @@ Please note, by clicking a `toggle preview` button it will open example toast at
         </StyledButton>
         <Toast
           variant='warning'
-          id='toast-centered'
+          id='toast-left-aligned'
           open={ isOpen }
           onDismiss={ onDismissClick }
-          isCenter={ true }
+          isCenter={ false }
         >
           My text
         </Toast>


### PR DESCRIPTION
fixes FE-3701

### Proposed behaviour

To align with the Design System, toast should be centred by default.

### Current behaviour

Toast currently opens up on the left hand side of the screen.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
<del> - [ ] Screenshots are included in the PR if useful </del>
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

The purpose of this change is to align Carbon with the Design System.

### Testing instructions
- Visit `Design System -> Toast -> default` and the toast component should open in the centre of the page.
- Visit `Design System -> Toast -> left aligned` and the toast component should open to the left of the page.
