### PR TITLE
feat(icon): filter out unwanted props (FE-3599)

### DIFF
--- a/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
+++ b/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
@@ -326,7 +326,6 @@ exports[`SimpleColorPicker renders as expected 1`] = `
             color="#0073C1"
           >
             <span
-              checked={true}
               className="c10 c11"
               color="#0073C1"
               data-component="icon"

--- a/src/components/icon/icon.component.js
+++ b/src/components/icon/icon.component.js
@@ -51,26 +51,29 @@ const Icon = React.forwardRef(
       }
     };
 
+    const styleProps = {
+      bg,
+      bgTheme,
+      bgSize,
+      bgShape,
+      color,
+      disabled,
+      fontSize,
+      iconColor,
+      mr,
+      ml,
+      tabIndex,
+      type: iconType(),
+    };
+
     const icon = (
       <StyledIcon
         ref={ref}
-        bgSize={bgSize}
-        bgShape={bgShape}
-        bgTheme={bgTheme}
-        fontSize={fontSize}
-        iconColor={iconColor}
-        disabled={disabled}
-        color={color}
-        bg={bg}
-        type={iconType()}
         key="icon"
         className={className || null}
-        {...tagComponent("icon", rest)}
         data-element={iconType()}
-        mr={mr}
-        ml={ml}
-        tabIndex={tabIndex}
-        {...rest}
+        {...tagComponent("icon", rest)}
+        {...styleProps}
       />
     );
 
@@ -98,7 +101,11 @@ const Icon = React.forwardRef(
 );
 
 Icon.propTypes = {
-  /** Add classes to this component */
+  /**
+   * @private
+   * @ignore
+   * Add classes to this component
+   * */
   className: PropTypes.string,
   /** Icon type */
   type: PropTypes.string.isRequired,

--- a/src/components/icon/icon.d.ts
+++ b/src/components/icon/icon.d.ts
@@ -1,23 +1,39 @@
 import * as React from 'react';
 
 export interface IconProps {
-  className?: string;
+  /** Icon type */
   type: string;
+  /** Background size */
   bgSize?: 'small' | 'medium' | 'large';
+  /** Background shape */
   bgShape?: 'circle' | 'rounded-rect' | 'square';
+  /** Background color theme */
   bgTheme?: 'info' | 'error' | 'success' | 'warning' | 'business' | 'none';
+  /** Icon font size */
   fontSize?: 'small' | 'large';
+  /** Icon color */
   iconColor?: 'default' | 'on-light-background' | 'on-dark-background' | 'business-color';
+  /** Override iconColor, provide any color from palette or any valid css color value. */
   color?: string;
+  /** Override bgTheme, provide any color from palette or any valid css color value. */
   bg?: string;
+  /** Sets the icon in the disabled state */
   disabled?: boolean;
+  /** Margin right, given number will be multiplied by base spacing unit (8) */
   mr?: number;
+  /** Margin left, given number will be multiplied by base spacing unit (8) */
   ml?: number;
+  /** Aria label for accessibility purposes */
   ariaLabel?: string;
+  /** The message string to be displayed in the tooltip */
   tooltipMessage?: string;
+  /** The position to display the tooltip */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
+  /** Control whether the tooltip is visible */
   tooltipVisible?: boolean;
+  /** Override background color of the Tooltip, provide any color from palette or any valid css color value. */
   tooltipBgColor?: string;
+  /** Override font color of the Tooltip, provide any color from palette or any valid css color value. */
   tooltipFontColor?: string;
 }
 

--- a/src/components/portal/__snapshots__/__spec__.js.snap
+++ b/src/components/portal/__snapshots__/__spec__.js.snap
@@ -28,4 +28,4 @@ exports[`Portal when using default node to match snapshot  1`] = `
 </span>
 `;
 
-exports[`Portal when using default node will mount correctly on document 1`] = `"<div data-portal-exit=\\"guid-12345\\" class=\\"carbon-portal\\"><span font-size=\\"small\\" type=\\"tick\\" class=\\"sc-bdVaJa hItwjy\\" data-component=\\"icon\\" data-element=\\"tick\\"></span></div>"`;
+exports[`Portal when using default node will mount correctly on document 1`] = `"<div data-portal-exit=\\"guid-12345\\" class=\\"carbon-portal\\"><span class=\\"sc-bdVaJa hItwjy\\" data-element=\\"tick\\" data-component=\\"icon\\" font-size=\\"small\\" type=\\"tick\\"></span></div>"`;


### PR DESCRIPTION
### Proposed behaviour
Unnecessary props should not be passed as it could affect the display of the Component.

Typescript definition types should be documented.

### Current behaviour
All props defined on the Icon Component are being passed to the styled component.

Typescript definition types have no documentation.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
~~- [ ] Unit tests added or updated if required~~
~~- [ ] Cypress automation tests added or updated if required~~
~~- [ ] Storybook added or updated if required~~
- [x] Typescript `d.ts` file added or updated if required
~~- [ ] Carbon implementation and Design System documentation are congruent~~

Fixes #3709