### PR TITLE
chore(table): add deprecation notice

### DIFF
--- a/src/components/action-toolbar/action-toolbar.component.js
+++ b/src/components/action-toolbar/action-toolbar.component.js
@@ -9,6 +9,9 @@ import {
   StyledActionToolbarTotal,
   StyledActionToolbarActions,
 } from "./action-toolbar.style";
+import Logger from "../../utils/logger/logger";
+
+let deprecatedWarnTriggered = false;
 
 /**
  * A ActionToolbar widget.
@@ -51,6 +54,13 @@ class ActionToolbar extends React.Component {
     this.actions = this.actions.bind(this);
     this.isActive = this.isActive.bind(this);
     this.buildAction = this.buildAction.bind(this);
+
+    if (!deprecatedWarnTriggered) {
+      deprecatedWarnTriggered = true;
+      Logger.deprecate(
+        "`ActionToolbar` component is deprecated and will soon be removed."
+      );
+    }
   }
 
   state = {

--- a/src/components/table-ajax/table-ajax.component.js
+++ b/src/components/table-ajax/table-ajax.component.js
@@ -11,7 +11,20 @@ import {
 } from "../table";
 import Logger from "../../utils/logger";
 
+let deprecatedWarnTriggered = false;
+
 class TableAjax extends Table {
+  constructor(props) {
+    super(props);
+    if (!deprecatedWarnTriggered) {
+      deprecatedWarnTriggered = true;
+      // eslint-disable-next-line max-len
+      Logger.deprecate(
+        "`TableAjax` component is deprecated and will soon be removed."
+      );
+    }
+  }
+
   /**
    * Timeout for firing ajax request
    *

--- a/src/components/table-ajax/table-ajax.stories.mdx
+++ b/src/components/table-ajax/table-ajax.stories.mdx
@@ -13,6 +13,28 @@ import { TableAjax, TableRow, TableCell, TableHeader } from ".";
 
 This component is the same as [Table](/?path=/docs/table--default-story "Table"), but uses Ajax. Ajax loads data from a specified source as needed, rather than data in the page markup.
 
+<Preview>
+  <div
+    style={{
+      backgroundColor: "red",
+      textAlign: "center",
+      color: "white",
+      padding: 20,
+      fontWeight: "bold",
+      marginBottom: 10,
+    }}
+  >
+    TableAjax will soon be deprecated, please use{" "}
+    <a
+      tabIndex={0}
+      href="https://carbon.sage.com/?path=/story/design-system-flat-table--default-story"
+    >
+      FlatTable
+    </a>{" "}
+    with your own custom data fetching instead.
+  </div>
+</Preview>
+
 ## Quick Start
 
 ```jsx

--- a/src/components/table/table.component.js
+++ b/src/components/table/table.component.js
@@ -15,8 +15,22 @@ import DraggableTableCell from "./draggable-table-cell";
 import Pager from "../pager";
 import Loader from "../loader";
 import OptionsHelper from "../../utils/helpers/options-helper";
+import Logger from "../../utils/logger/logger";
+
+let deprecatedWarnTriggered = false;
 
 class Table extends React.Component {
+  constructor(props) {
+    super(props);
+    if (!deprecatedWarnTriggered) {
+      deprecatedWarnTriggered = true;
+      // eslint-disable-next-line max-len
+      Logger.deprecate(
+        "`Table` component is deprecated and will soon be removed. Please use `FlatTable` instead: https://carbon.sage.com/?path=/story/design-system-flat-table--default-story"
+      );
+    }
+  }
+
   state = {
     selectedCount: 0,
   };

--- a/src/components/table/table.stories.mdx
+++ b/src/components/table/table.stories.mdx
@@ -21,6 +21,28 @@ import { Table, TableCell, TableHeader, TableRow } from ".";
 - The Selectable configuration places a checkbox at the start of each row, and the ability for a user to select one or more rows. This is useful to allow the user to perform single or batch actions.
 - The Highlightable configuration allows the user to click an option, and for the option to be marked visually. This could be useful if the user can select an option which then loads in a Sidebar, for example.
 
+<Preview>
+  <div
+    style={{
+      backgroundColor: "red",
+      textAlign: "center",
+      color: "white",
+      padding: 20,
+      fontWeight: "bold",
+      marginBottom: 10,
+    }}
+  >
+    Table will soon be deprecated, please use{" "}
+    <a
+      tabIndex={0}
+      href="https://carbon.sage.com/?path=/story/design-system-flat-table--default-story"
+    >
+      FlatTable
+    </a>{" "}
+    instead.
+  </div>
+</Preview>
+
 ## Quick Start
 
 ```jsx


### PR DESCRIPTION
### Proposed behaviour
Add deprecation notices to `Table` and `ActionToolbar`, which is only used in `Table` and not documented for usage outside of `Table`

They have been replaced with `FlatTable` and `BatchSelection` respectively.

![image](https://user-images.githubusercontent.com/14963680/109158631-89adb200-776b-11eb-966b-68e96820a6b7.png)

![image](https://user-images.githubusercontent.com/14963680/109160931-5d476500-776e-11eb-9648-7f6379b67601.png)


### Current behaviour
No deprecation notices on these components.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
http://localhost:9001/?path=/docs/table--default-story