### PR TITLE
feat(styled-system): add width util - FE-3679

### DIFF
--- a/.storybook/utils/styled-system-props.js
+++ b/.storybook/utils/styled-system-props.js
@@ -1,146 +1,160 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { PropsTable } from '@storybook/components';
-import { Props } from '@storybook/addon-docs/blocks';
+import React from "react";
+import PropTypes from "prop-types";
+import { PropsTable } from "@storybook/components";
+import { Props } from "@storybook/addon-docs/blocks";
 
 const generateStyledSystemMarginProps = (defaults) => {
   return [
-  {
-    name: 'm',
-    type: { summary: 'number | string' },
-    description: 'Margin, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.m || '-'
-    }
-  },
-  {
-    name: 'mt',
-    type: { summary: 'number | string' },
-    description: 'Margin top, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.mt || '-'
-    }
-  },
-  {
-    name: 'mr',
-    type: { summary: 'number | string' },
-    description: 'Margin right, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.mr || '-'
-    }
-  },
-  {
-    name: 'mb',
-    type: { summary: 'number | string' },
-    description: 'Margin bottom, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.mb || '-'
-    }
-  },
-  {
-    name: 'ml',
-    type: { summary: 'number | string' },
-    description: 'Margin left, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.ml || '-'
-    }
-  },
-  {
-    name: 'mx',
-    type: { summary: 'number | string' },
-    // eslint-disable-next-line max-len
-    description: 'Margin left/right, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.mx || '-'
-    }
-  },
-  {
-    name: 'my',
-    type: { summary: 'number | string' },
-    // eslint-disable-next-line max-len
-    description: 'Margin top/bottom, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.my || '-'
-    }
-  },
-];
+    {
+      name: "m",
+      type: { summary: "number | string" },
+      description:
+        "Margin, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.m || "-",
+      },
+    },
+    {
+      name: "mt",
+      type: { summary: "number | string" },
+      description:
+        "Margin top, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.mt || "-",
+      },
+    },
+    {
+      name: "mr",
+      type: { summary: "number | string" },
+      description:
+        "Margin right, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.mr || "-",
+      },
+    },
+    {
+      name: "mb",
+      type: { summary: "number | string" },
+      description:
+        "Margin bottom, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.mb || "-",
+      },
+    },
+    {
+      name: "ml",
+      type: { summary: "number | string" },
+      description:
+        "Margin left, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.ml || "-",
+      },
+    },
+    {
+      name: "mx",
+      type: { summary: "number | string" },
+      // eslint-disable-next-line max-len
+      description:
+        "Margin left/right, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.mx || "-",
+      },
+    },
+    {
+      name: "my",
+      type: { summary: "number | string" },
+      // eslint-disable-next-line max-len
+      description:
+        "Margin top/bottom, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.my || "-",
+      },
+    },
+  ];
 };
 
 const generateStyledSystemPaddingProps = (defaults) => {
   return [
-  {
-    name: 'p',
-    type: { summary: 'number | string' },
-    description: 'Padding, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.p || '-'
-    }
-  },
-  {
-    name: 'pt',
-    type: { summary: 'number | string' },
-    description: 'Padding top, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.pt || '-'
-    }
-  },
-  {
-    name: 'pr',
-    type: { summary: 'number | string' },
-    description: 'Padding right, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.pr || '-'
-    }
-  },
-  {
-    name: 'pb',
-    type: { summary: 'number | string' },
-    description: 'Padding bottom, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.pb || '-'
-    }
-  },
-  {
-    name: 'pl',
-    type: { summary: 'number | string' },
-    description: 'Padding left, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.pl || '-'
-    }
-  },
-  {
-    name: 'px',
-    type: { summary: 'number | string' },
-    // eslint-disable-next-line max-len
-    description: 'Padding left/right, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.px || '-'
-    }
-  },
-  {
-    name: 'py',
-    type: { summary: 'number | string' },
-    // eslint-disable-next-line max-len
-    description: 'Padding top/bottom, an integer multiplier of the base spacing constant (8px) or any valid CSS string.',
-    required: false,
-    defaultValue: {
-      summary: defaults.py || '-'
-    }
-  }
-];
+    {
+      name: "p",
+      type: { summary: "number | string" },
+      description:
+        "Padding, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.p || "-",
+      },
+    },
+    {
+      name: "pt",
+      type: { summary: "number | string" },
+      description:
+        "Padding top, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.pt || "-",
+      },
+    },
+    {
+      name: "pr",
+      type: { summary: "number | string" },
+      description:
+        "Padding right, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.pr || "-",
+      },
+    },
+    {
+      name: "pb",
+      type: { summary: "number | string" },
+      description:
+        "Padding bottom, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.pb || "-",
+      },
+    },
+    {
+      name: "pl",
+      type: { summary: "number | string" },
+      description:
+        "Padding left, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.pl || "-",
+      },
+    },
+    {
+      name: "px",
+      type: { summary: "number | string" },
+      // eslint-disable-next-line max-len
+      description:
+        "Padding left/right, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.px || "-",
+      },
+    },
+    {
+      name: "py",
+      type: { summary: "number | string" },
+      // eslint-disable-next-line max-len
+      description:
+        "Padding top/bottom, an integer multiplier of the base spacing constant (8px) or any valid CSS string.",
+      required: false,
+      defaultValue: {
+        summary: defaults.py || "-",
+      },
+    },
+  ];
 };
 
 const generateStyledSystemSpacingProps = (defaults) => {
@@ -150,290 +164,295 @@ const generateStyledSystemSpacingProps = (defaults) => {
   ];
 };
 
-const generateStyledSystemColorProps = (
-  defaults
-) => {
+const generateStyledSystemColorProps = (defaults) => {
   return [
     {
-      name: 'color',
-      type: { summary: 'string' },
-      description: 'Color, theme value or any valid CSS string.',
+      name: "color",
+      type: { summary: "string" },
+      description: "Color, theme value or any valid CSS string.",
       required: false,
       defaultValue: {
-        summary: defaults.color || '-'
-      }
+        summary: defaults.color || "-",
+      },
     },
     {
-      name: 'backgroundColor',
-      type: { summary: 'string' },
-      description: 'Background, theme value or any valid CSS string.',
+      name: "backgroundColor",
+      type: { summary: "string" },
+      description: "Background, theme value or any valid CSS string.",
       required: false,
       defaultValue: {
-        summary: defaults.backgroundColor || '-'
-      }
+        summary: defaults.backgroundColor || "-",
+      },
     },
     {
-      name: 'bg',
-      type: { summary: 'string' },
-      description: 'Shorthand for backgroundColor',
+      name: "bg",
+      type: { summary: "string" },
+      description: "Shorthand for backgroundColor",
       required: false,
       defaultValue: {
-        summary: defaults.bg || '-'
-      }
+        summary: defaults.bg || "-",
+      },
     },
     {
-      name: 'opacity',
-      type: { summary: 'decimal' },
-      description: 'Any decimal between 0 and 1.0',
+      name: "opacity",
+      type: { summary: "decimal" },
+      description: "Any decimal between 0 and 1.0",
       required: false,
       defaultValue: {
-        summary: defaults.opacity || '-'
-      }
-    }
+        summary: defaults.opacity || "-",
+      },
+    },
   ];
 };
 
-const generateStyledSystemLayoutProps = (
-  defaults
-) => {
+const generateStyledSystemWidthProps = (defaults) => [
+  {
+    name: "width",
+    type: { summary: "number | string" },
+    description:
+      "Numbers from 0-1 are converted to percentage widths. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive width styles. If theme.sizes is defined, the width prop will attempt to pick up values from the theme",
+    required: false,
+    defaultValue: {
+      summary: defaults.width || "-",
+    },
+  },
+];
+
+const generateStyledSystemLayoutProps = (defaults) => {
   return [
+    ...generateStyledSystemWidthProps(defaults),
     {
-      name: 'width',
-      type: { summary: 'number | string' },
-      description: 'Numbers from 0-1 are converted to percentage widths. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive width styles. If theme.sizes is defined, the width prop will attempt to pick up values from the theme',
+      name: "height",
+      type: { summary: "number | string" },
+      description:
+        "Numbers from 0-1 are converted to percentage heights. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive height styles. If theme.sizes is defined, the height prop will attempt to pick up values from the theme",
       required: false,
       defaultValue: {
-        summary: defaults.width || '-'
-      }
+        summary: defaults.height || "-",
+      },
     },
     {
-      name: 'height',
-      type: { summary: 'number | string' },
-      description: 'Numbers from 0-1 are converted to percentage heights. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive height styles. If theme.sizes is defined, the height prop will attempt to pick up values from the theme',
-      required: false,
-      defaultValue: {
-        summary: defaults.height || '-'
-      }
-    },
-    {
-      name: 'minWidth',
-      type: { summary: 'number | string' },
+      name: "minWidth",
+      type: { summary: "number | string" },
       // eslint-disable-next-line max-len
-      description: 'Numbers from 0-1 are converted to percentage widths. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive width styles. If theme.sizes is defined, the width prop will attempt to pick up values from the theme',
+      description:
+        "Numbers from 0-1 are converted to percentage widths. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive width styles. If theme.sizes is defined, the width prop will attempt to pick up values from the theme",
       required: false,
       defaultValue: {
-        summary: defaults.minWidth || '-'
-      }
+        summary: defaults.minWidth || "-",
+      },
     },
     {
-      name: 'maxWidth',
-      type: { summary: 'number | string' },
+      name: "maxWidth",
+      type: { summary: "number | string" },
       // eslint-disable-next-line max-len
-      description: 'Numbers from 0-1 are converted to percentage widths. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive width styles. If theme.sizes is defined, the width prop will attempt to pick up values from the theme',
+      description:
+        "Numbers from 0-1 are converted to percentage widths. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive width styles. If theme.sizes is defined, the width prop will attempt to pick up values from the theme",
       required: false,
       defaultValue: {
-        summary: defaults.maxWidth || '-'
-      }
+        summary: defaults.maxWidth || "-",
+      },
     },
     {
-      name: 'minHeight',
-      type: { summary: 'number | string' },
+      name: "minHeight",
+      type: { summary: "number | string" },
       // eslint-disable-next-line max-len
-      description: 'Numbers from 0-1 are converted to percentage heights. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive height styles. If theme.sizes is defined, the height prop will attempt to pick up values from the theme',
+      description:
+        "Numbers from 0-1 are converted to percentage heights. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive height styles. If theme.sizes is defined, the height prop will attempt to pick up values from the theme",
       required: false,
       defaultValue: {
-        summary: defaults.minWidth || '-'
-      }
+        summary: defaults.minWidth || "-",
+      },
     },
     {
-      name: 'maxHeight',
-      type: { summary: 'number | string' },
+      name: "maxHeight",
+      type: { summary: "number | string" },
       // eslint-disable-next-line max-len
-      description: 'Numbers from 0-1 are converted to percentage heights. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive height styles. If theme.sizes is defined, the height prop will attempt to pick up values from the theme',
+      description:
+        "Numbers from 0-1 are converted to percentage heights. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive height styles. If theme.sizes is defined, the height prop will attempt to pick up values from the theme",
       required: false,
       defaultValue: {
-        summary: defaults.maxWidth || '-'
-      }
+        summary: defaults.maxWidth || "-",
+      },
     },
     {
-      name: 'size',
-      type: { summary: 'number | string' },
+      name: "size",
+      type: { summary: "number | string" },
       // eslint-disable-next-line max-len
-      description: 'Width/Height, Numbers from 0-1 are converted to percentage values. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive styles. If theme.sizes is defined, the height and width props will attempt to pick up values from the theme',
+      description:
+        "Width/Height, Numbers from 0-1 are converted to percentage values. Numbers greater than 1 are converted to pixel values. String values are passed as raw CSS values. And arrays are converted to responsive styles. If theme.sizes is defined, the height and width props will attempt to pick up values from the theme",
       required: false,
       defaultValue: {
-        summary: defaults.size || '-'
-      }
+        summary: defaults.size || "-",
+      },
     },
     {
-      name: 'display',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string.',
+      name: "display",
+      type: { summary: "string" },
+      description: "Any valid CSS string.",
       required: false,
       defaultValue: {
-        summary: defaults.display || '-'
-      }
+        summary: defaults.display || "-",
+      },
     },
     {
-      name: 'verticalAlign',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string.',
+      name: "verticalAlign",
+      type: { summary: "string" },
+      description: "Any valid CSS string.",
       required: false,
       defaultValue: {
-        summary: defaults.verticalAlign || '-'
-      }
+        summary: defaults.verticalAlign || "-",
+      },
     },
     {
-      name: 'overflow',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string.',
+      name: "overflow",
+      type: { summary: "string" },
+      description: "Any valid CSS string.",
       required: false,
       defaultValue: {
-        summary: defaults.overflow || '-'
-      }
+        summary: defaults.overflow || "-",
+      },
     },
     {
-      name: 'overflowX',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string.',
+      name: "overflowX",
+      type: { summary: "string" },
+      description: "Any valid CSS string.",
       required: false,
       defaultValue: {
-        summary: defaults.overflowX || '-'
-      }
+        summary: defaults.overflowX || "-",
+      },
     },
     {
-      name: 'overflowY',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string.',
+      name: "overflowY",
+      type: { summary: "string" },
+      description: "Any valid CSS string.",
       required: false,
       defaultValue: {
-        summary: defaults.display || '-'
-      }
-    }
+        summary: defaults.display || "-",
+      },
+    },
   ];
 };
 
-const generateStyledSystemFlexBoxProps = (
-  defaults
-) => {
+const generateStyledSystemFlexBoxProps = (defaults) => {
   return [
     {
-      name: 'alignItems',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string.',
+      name: "alignItems",
+      type: { summary: "string" },
+      description: "Any valid CSS string.",
       required: false,
       defaultValue: {
-        summary: defaults.alignItems || '-'
-      }
+        summary: defaults.alignItems || "-",
+      },
     },
     {
-      name: 'alignContent',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string.',
+      name: "alignContent",
+      type: { summary: "string" },
+      description: "Any valid CSS string.",
       required: false,
       defaultValue: {
-        summary: defaults.alignContent || '-'
-      }
+        summary: defaults.alignContent || "-",
+      },
     },
     {
-      name: 'justifyItems',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string',
+      name: "justifyItems",
+      type: { summary: "string" },
+      description: "Any valid CSS string",
       required: false,
       defaultValue: {
-        summary: defaults.justifyItems || '-'
-      }
+        summary: defaults.justifyItems || "-",
+      },
     },
     {
-      name: 'justifyContent',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string',
+      name: "justifyContent",
+      type: { summary: "string" },
+      description: "Any valid CSS string",
       required: false,
       defaultValue: {
-        summary: defaults.justifyContent || '-'
-      }
+        summary: defaults.justifyContent || "-",
+      },
     },
     {
-      name: 'flexWrap',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string',
+      name: "flexWrap",
+      type: { summary: "string" },
+      description: "Any valid CSS string",
       required: false,
       defaultValue: {
-        summary: defaults.flexWrap || '-'
-      }
+        summary: defaults.flexWrap || "-",
+      },
     },
     {
-      name: 'flexDirection',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string',
+      name: "flexDirection",
+      type: { summary: "string" },
+      description: "Any valid CSS string",
       required: false,
       defaultValue: {
-        summary: defaults.flexDirection || '-'
-      }
+        summary: defaults.flexDirection || "-",
+      },
     },
     {
-      name: 'flex',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string',
+      name: "flex",
+      type: { summary: "string" },
+      description: "Any valid CSS string",
       required: false,
       defaultValue: {
-        summary: defaults.flex || '-'
-      }
+        summary: defaults.flex || "-",
+      },
     },
     {
-      name: 'flexGrow',
-      type: { summary: 'number' },
-      description: 'Any number greater than 0.',
+      name: "flexGrow",
+      type: { summary: "number" },
+      description: "Any number greater than 0.",
       required: false,
       defaultValue: {
-        summary: defaults.flexGrow || '-'
-      }
+        summary: defaults.flexGrow || "-",
+      },
     },
     {
-      name: 'flexShrink',
-      type: { summary: 'number' },
-      description: 'Any number greater than 0.',
+      name: "flexShrink",
+      type: { summary: "number" },
+      description: "Any number greater than 0.",
       required: false,
       defaultValue: {
-        summary: defaults.flexShrink || '-'
-      }
+        summary: defaults.flexShrink || "-",
+      },
     },
     {
-      name: 'flexBasis',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string',
+      name: "flexBasis",
+      type: { summary: "string" },
+      description: "Any valid CSS string",
       required: false,
       defaultValue: {
-        summary: defaults.flexBasis || '-'
-      }
+        summary: defaults.flexBasis || "-",
+      },
     },
     {
-      name: 'justifySelf',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string',
+      name: "justifySelf",
+      type: { summary: "string" },
+      description: "Any valid CSS string",
       required: false,
       defaultValue: {
-        summary: defaults.justifySelf || '-'
-      }
+        summary: defaults.justifySelf || "-",
+      },
     },
     {
-      name: 'alignSelf',
-      type: { summary: 'string' },
-      description: 'Any valid CSS string',
+      name: "alignSelf",
+      type: { summary: "string" },
+      description: "Any valid CSS string",
       required: false,
       defaultValue: {
-        summary: defaults.alignSelf || '-'
-      }
+        summary: defaults.alignSelf || "-",
+      },
     },
     {
-      name: 'order',
-      type: { summary: 'number' },
-      description: 'Any number greater than 0.',
+      name: "order",
+      type: { summary: "number" },
+      description: "Any number greater than 0.",
       required: false,
       defaultValue: {
-        summary: defaults.order || '-'
-      }
-    }
+        summary: defaults.order || "-",
+      },
+    },
   ];
 };
 
@@ -441,33 +460,27 @@ const StyledSystemProps = ({
   of,
   spacing,
   color,
+  width,
   layout,
   flexBox,
   defaults = {},
   noHeader,
   margin,
-  padding
+  padding,
 }) => {
   let sections = {};
-  if(spacing)
-  sections['Spacing'] = generateStyledSystemSpacingProps(defaults);
-  if(margin)
-  sections['Margin'] = generateStyledSystemMarginProps(defaults);
-  if(padding)
-  sections['Padding'] = generateStyledSystemPaddingProps(defaults);
-  if(color)
-  sections['Color'] = generateStyledSystemColorProps(defaults);
-  if(layout)
-  sections['Layout'] = generateStyledSystemLayoutProps(defaults);
-  if(flexBox)
-  sections['FlexBox'] = generateStyledSystemFlexBoxProps(defaults);
+  if (spacing) sections["Spacing"] = generateStyledSystemSpacingProps(defaults);
+  if (margin) sections["Margin"] = generateStyledSystemMarginProps(defaults);
+  if (padding) sections["Padding"] = generateStyledSystemPaddingProps(defaults);
+  if (color) sections["Color"] = generateStyledSystemColorProps(defaults);
+  if (width) sections["Width"] = generateStyledSystemWidthProps(defaults);
+  if (layout) sections["Layout"] = generateStyledSystemLayoutProps(defaults);
+  if (flexBox) sections["FlexBox"] = generateStyledSystemFlexBoxProps(defaults);
   return (
     <>
       {!noHeader && <h2>Props</h2>}
-      {of && <Props of={ of } />}
-      <PropsTable
-        sections={ sections }
-      />
+      {of && <Props of={of} />}
+      <PropsTable sections={sections} />
     </>
   );
 };
@@ -476,6 +489,7 @@ StyledSystemProps.propTypes = {
   of: PropTypes.oneOfType([PropTypes.node, PropTypes.func, PropTypes.object]),
   noHeader: PropTypes.bool,
   spacing: PropTypes.bool,
+  width: PropTypes.bool,
   layout: PropTypes.bool,
   flex: PropTypes.bool,
   defaults: PropTypes.object,

--- a/src/__spec_helper__/test-utils.js
+++ b/src/__spec_helper__/test-utils.js
@@ -146,8 +146,10 @@ const colorProps = [
   ["opacity", "opacity", "0.5"],
 ];
 
+const widthProps = ["width", "width", "200px"];
+
 const layoutProps = [
-  ["width", "width", "200px"],
+  widthProps,
   ["height", "height", "200px"],
   ["minWidth", "min-width", "120px"],
   ["maxWidth", "max-width", "120px"],
@@ -352,6 +354,24 @@ const testStyledSystemColor = (component, styleContainer) => {
   );
 };
 
+const testStyledSystemWidth = (component, styleContainer) => {
+  describe("when a width prop is specified using styled system props", () => {
+    it("then width should have been set correctly", () => {
+      const [styledSystemProp, propName, value] = widthProps;
+      let wrapper = mount(component());
+
+      const props = { [styledSystemProp]: value };
+      wrapper = mount(component({ ...props }));
+
+      expect(wrapper).toHaveStyleRule(
+        propName,
+        value,
+        styleContainer ? styleContainer(wrapper) : wrapper
+      );
+    });
+  });
+};
+
 const testStyledSystemLayout = (component, styleContainer) => {
   describe.each(layoutProps)(
     'when a prop is specified using the "%s" styled system props',
@@ -412,6 +432,7 @@ export {
   testStyledSystemMargin,
   testStyledSystemPadding,
   testStyledSystemColor,
+  testStyledSystemWidth,
   testStyledSystemLayout,
   testStyledSystemFlexBox,
 };

--- a/src/style/utils/width.js
+++ b/src/style/utils/width.js
@@ -1,0 +1,10 @@
+// eslint-disable-next-line no-restricted-imports
+import { layout } from "styled-system";
+
+/*
+ * styled-system/layout allows users to use a width, height, minWidth, maxWidth, minHeight, maxHeight,
+ * size, display, verticalAlign, overflow, overflowX and overflowY props most of which are usually not needed.
+ * That's why the purpose of this function is to pass only the`width` prop to the `layout` function.
+ */
+
+export default ({ width }) => layout({ width });


### PR DESCRIPTION
### Proposed behaviour
This PR adds additional `width` util that uses only `width` prop in styled-system's `layout` styling function.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent
