### PR TITLE
fix(tabs): fix styling bug when tab has a sibling - FE-3479

### DIFF
--- a/src/components/tabs/__internal__/tab-title/tab-title.style.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.style.js
@@ -71,6 +71,11 @@ const StyledTitleContent = styled.div`
       css`
         padding-bottom: 6px;
       `}
+      ${hasSiblings &&
+      !(error || warning || info) &&
+      css`
+        min-height: 22px;
+      `}
     `}
 
     ${size === "large" &&
@@ -495,7 +500,6 @@ const StyledLayoutWrapper = styled.div`
 
       ${({ theme }) => css`
         position: relative;
-        top: -1px;
         ${hasCustomSibling &&
         css`
           left: 4px;


### PR DESCRIPTION
when a large tab has a sibling, that tab is 2px smaller than a large tab without a sibling.

fixes #3551

### Proposed behaviour

Apply a min-height of 22px to a large tab with siblings. 

<img width="207" alt="Screenshot 2021-02-25 at 17 19 17" src="https://user-images.githubusercontent.com/56251247/109191056-ac50c280-778d-11eb-8a61-7321d5e7e1f4.png">

### Current behaviour

A large tab with a sibling is only 20px in height and this is causing the gold border bottom to be 2px above where it should be when a large tab with a sibling is focused.

![image](https://user-images.githubusercontent.com/56251247/109190713-48c69500-778d-11eb-9058-532ff648fa6b.png)


### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
<del>- [ ] Typescript `d.ts` file added or updated if required </del>
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
https://codesandbox.io/s/charming-mirzakhani-1ggwr
