### PR TITLE
ci(codeql): add master push hook

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,10 @@
 name: CodeQL
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   analyze:


### PR DESCRIPTION
### Proposed behaviour
The CodeQL scanning requires scans of the base branch to compare pull requests against, so we need to add a push hook for the master branch to this workflow.

### Current behaviour
This workflow currently only runs for PRs.

![image](https://user-images.githubusercontent.com/14963680/109488717-d3eda680-7a7d-11eb-823c-6b19c984e64a.png)


### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
