### PR TITLE
refactor(tile-select): replace i18n-js with i18next

### DIFF
--- a/src/components/tile-select/tile-select.component.js
+++ b/src/components/tile-select/tile-select.component.js
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
-import I18n from "i18n-js";
 import tagComponent from "../../utils/helpers/tags/tags";
+import useTranslation from "../../hooks/__internal__/useTranslation";
 import Button from "../button";
 
 import {
@@ -36,6 +36,8 @@ const TileSelect = (props) => {
     ...rest
   } = props;
 
+  const t = useTranslation();
+
   const handleDeselect = () =>
     onChange({
       target: {
@@ -52,7 +54,7 @@ const TileSelect = (props) => {
     return (
       checked && (
         <Button buttonType="tertiary" size="small" onClick={handleDeselect}>
-          {I18n.t("tileSelect.deselect", { defaultValue: "Deselect" })}
+          {t("tileSelect.deselect", "Deselect")}
         </Button>
       )
     );

--- a/src/components/tile-select/tile-select.spec.js
+++ b/src/components/tile-select/tile-select.spec.js
@@ -4,6 +4,7 @@ import RadioButtonMapper from "../../__experimental__/components/radio-button/ra
 import { TileSelect, TileSelectGroup } from ".";
 import { baseTheme } from "../../style/themes";
 import tint from "../../style/utils/tint";
+import I18next from "../../__spec_helper__/I18next";
 
 import {
   StyledTileSelectFieldset,
@@ -24,11 +25,19 @@ jest.mock("@tippyjs/react/headless");
 
 const radioValues = ["val1", "val2", "val3"];
 
+function RenderWrapper({ ...props }) {
+  return (
+    <I18next>
+      <TileSelect {...props} />
+    </I18next>
+  );
+}
+
 describe("TileSelect", () => {
   let wrapper;
 
   const render = (props) => {
-    wrapper = mount(<TileSelect {...props} />);
+    wrapper = mount(<RenderWrapper {...props} />);
   };
 
   beforeEach(() => {


### PR DESCRIPTION
### Proposed behaviour
Use i18next for the date component
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

https://codesandbox.io/s/carbon-quickstart-forked-yrbkg

### Current behaviour
i18n-js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
No test changes are required.
`tile-select` components should be tested for regression.