### PR TITLE
refactor(batch-selection): replace i18n-js with i18next

### DIFF
--- a/src/components/batch-selection/batch-selection.component.js
+++ b/src/components/batch-selection/batch-selection.component.js
@@ -1,10 +1,10 @@
 import React from "react";
-import I18n from "i18n-js";
 import PropTypes from "prop-types";
 import {
   StyledBatchSelection,
   StyledSelectionCount,
 } from "./batch-selection.style";
+import useTranslation from "../../hooks/__internal__/useTranslation";
 
 const BatchSelection = ({
   disabled,
@@ -13,10 +13,10 @@ const BatchSelection = ({
   selectedCount,
   hidden,
 }) => {
+  const t = useTranslation();
   const getTextForCount = (count) =>
-    I18n.t("batch_selection.selected", {
+    t("batch_selection.selected", "selected", {
       count: Number(count),
-      defaultValue: "selected",
     });
 
   return (

--- a/src/components/batch-selection/batch-selection.spec.js
+++ b/src/components/batch-selection/batch-selection.spec.js
@@ -9,6 +9,15 @@ import IconButton from "../icon-button";
 import StyledIcon from "../icon/icon.style";
 import StyledIconButton from "../icon-button/icon-button.style";
 import { baseTheme } from "../../style/themes";
+import I18next from "../../__spec_helper__/I18next";
+
+function RenderWrapper({ ...props }) {
+  return (
+    <I18next>
+      <BatchSelection {...props} />
+    </I18next>
+  );
+}
 
 describe("BatchSelection component", () => {
   let wrapper;
@@ -126,10 +135,10 @@ describe("BatchSelection component", () => {
 
 function renderBatchSelection(props = {}, renderer = mount) {
   return renderer(
-    <BatchSelection {...props}>
+    <RenderWrapper {...props}>
       <IconButton onAction={() => {}}>
         <Icon type="edit" />
       </IconButton>
-    </BatchSelection>
+    </RenderWrapper>
   );
 }


### PR DESCRIPTION
### Proposed behaviour
Use i18next for the date component
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

### Current behaviour
i18n-js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
No test changes are required.
`batch-selection` components should be tested for regression.