### PR TITLE
feat(action-popover-item): support for download button - FE-3760

### DIFF
--- a/src/components/action-popover/action-popover-item.component.js
+++ b/src/components/action-popover/action-popover-item.component.js
@@ -12,6 +12,7 @@ import {
   MenuItemFactory,
   MenuItemIcon,
   SubMenuItemIcon,
+  StyledDiv,
 } from "./action-popover.style";
 import OptionsHelper from "../../utils/helpers/options-helper";
 import Events from "../../utils/helpers/events";
@@ -29,12 +30,15 @@ const MenuItem = ({
   theme,
   placement = "bottom",
   focusItem,
+  download,
+  href,
   ...rest
 }) => {
   const { setOpenPopover, isOpenPopover, focusButton } = useContext(
     ActionPopoverContext
   );
 
+  const isHref = !!href;
   const [containerPosition, setContainerPosition] = useState(null);
   const [guid] = useState(createGuid());
   const [isOpen, setOpen] = useState(false);
@@ -98,7 +102,7 @@ const MenuItem = ({
         e.stopPropagation();
       }
     },
-    [disabled, focusButton, onClickProp, ref, setOpenPopover]
+    [disabled, focusButton, onClickProp, setOpenPopover]
   );
 
   const onKeyDown = useCallback(
@@ -138,6 +142,7 @@ const MenuItem = ({
           }
           e.preventDefault();
         } else if (Events.isEnterKey(e)) {
+          if (isHref && download) ref.current.click(); // trigger download file
           onClick(e);
         }
       } else if (Events.isEnterKey(e)) {
@@ -146,10 +151,11 @@ const MenuItem = ({
     },
     [
       disabled,
+      download,
       focusButton,
+      isHref,
       isLeftAligned,
       onClick,
-      ref,
       setOpenPopover,
       submenu,
     ]
@@ -188,7 +194,7 @@ const MenuItem = ({
   };
 
   return (
-    <div
+    <StyledDiv
       {...rest}
       ref={ref}
       onClick={onClick}
@@ -198,6 +204,7 @@ const MenuItem = ({
       role="menuitem"
       {...(disabled && { "aria-disabled": true })}
       {...(submenu && itemSubmenuProps)}
+      {...(isHref && { as: "a", download, href })}
     >
       {submenu &&
         React.cloneElement(submenu, {
@@ -219,7 +226,7 @@ const MenuItem = ({
       {submenu && checkRef(ref) && !isLeftAligned && (
         <SubMenuItemIcon type="chevron_right" />
       )}
-    </div>
+    </StyledDiv>
   );
 };
 
@@ -262,6 +269,10 @@ const propTypes = {
   icon: PropTypes.oneOf(OptionsHelper.icons),
   /** Callback to run when item is clicked */
   onClick: PropTypes.func.isRequired,
+  /** allows to provide download prop that works dependent with href */
+  download: PropTypes.bool,
+  /** allows to provide href prop */
+  href: PropTypes.string,
   /** Submenu component for item */
   submenu(props, propName, componentName) {
     let error;

--- a/src/components/action-popover/action-popover-item.d.ts
+++ b/src/components/action-popover/action-popover-item.d.ts
@@ -8,6 +8,8 @@ export interface ActionPopoverItemProps {
   disabled?: boolean;
   onClick: () => void;
   submenu?: React.ReactNode;
+  href?: string;
+  download: boolean;
 }
 
 declare const ActionPopoverItem: React.FunctionComponent<ActionPopoverItemProps>;

--- a/src/components/action-popover/action-popover.spec.js
+++ b/src/components/action-popover/action-popover.spec.js
@@ -13,7 +13,12 @@ import {
   ActionPopoverMenu,
   ActionPopoverMenuButton,
 } from "./index";
-import { MenuButton, Menu, SubMenuItemIcon } from "./action-popover.style";
+import {
+  MenuButton,
+  Menu,
+  SubMenuItemIcon,
+  StyledDiv,
+} from "./action-popover.style";
 import Popover from "../../__internal__/popover";
 import { rootTagTest } from "../../utils/helpers/tags/tags-specs";
 import Icon from "../icon";
@@ -45,6 +50,8 @@ describe("ActionPopover", () => {
     const defaultProps = {
       children: [
         <ActionPopoverItem
+          href="#"
+          download
           key="item-1"
           icon="pdf"
           {...{ onClick: onClickWrapper("pdf") }}
@@ -205,6 +212,41 @@ describe("ActionPopover", () => {
 
   it("renders in ReactDOM", () => {
     render(null, DOM);
+  });
+
+  describe("if download prop and href prop are provided", () => {
+    it("should render as a link component", () => {
+      const clickFn = jest.fn();
+      wrapper = enzymeMount(
+        <ThemeProvider theme={mintTheme}>
+          <ActionPopover>
+            <ActionPopoverItem key="1" onClick={clickFn} href="#" download>
+              test download
+            </ActionPopoverItem>
+          </ActionPopover>
+        </ThemeProvider>
+      );
+
+      act(() => {
+        wrapper
+          .find(MenuButton)
+          .props()
+          .onClick({ stopPropagation: () => {} });
+      });
+
+      act(() => {
+        wrapper.update();
+      });
+
+      act(() => {
+        wrapper
+          .find(StyledDiv)
+          .props()
+          .onKeyDown({ which: 13, stopPropagation: jest.fn() });
+      });
+
+      expect(clickFn).toHaveBeenCalled();
+    });
   });
 
   it("displays the horizontal ellipsis icon as the menu button", () => {

--- a/src/components/action-popover/action-popover.stories.mdx
+++ b/src/components/action-popover/action-popover.stories.mdx
@@ -654,6 +654,44 @@ used actions, in this example "manage devices".
   </Story>
 </Preview>
 
+## with download button
+
+<Preview>
+  <Story name="with download button">
+    <div style={ { marginTop: '40px', height: '275px', maxWidth: '800px' } }>
+      <Table isZebra>
+        <TableRow>
+          <TableHeader colSpan='3'>Devices</TableHeader>
+        </TableRow>
+        <TableRow>
+          <TableCell>Mobile Phone</TableCell>
+          <TableCell>Online</TableCell>
+          <TableCell>
+            <ActionPopover
+              rightAlignMenu
+              renderButton={ ({ tabIndex, 'data-element': dataElement }) => (
+                <ActionPopoverMenuButton
+                  buttonType='tertiary'
+                  iconType='dropdown'
+                  iconPosition='after'
+                  size='small'
+                  tabIndex={ tabIndex }
+                  data-element={ dataElement }
+                >
+                  More
+                </ActionPopoverMenuButton>
+              ) }
+            >
+              <ActionPopoverItem download icon="download" href={"example-img.jpg"} onClick={ () => {} }>Download</ActionPopoverItem>
+              <ActionPopoverItem icon="settings" onClick={ () => {} }>Assign Owner</ActionPopoverItem>
+            </ActionPopover>
+          </TableCell>
+        </TableRow>
+      </Table>
+    </div>
+  </Story>
+</Preview>
+
 ## in overflow hidden container
 
 <Preview>

--- a/src/components/action-popover/action-popover.style.js
+++ b/src/components/action-popover/action-popover.style.js
@@ -15,6 +15,10 @@ const Menu = styled.div`
   z-index: ${({ theme }) => `${theme.zIndex.popover}`};
 `;
 
+const StyledDiv = styled.div`
+  text-decoration: none;
+`;
+
 const MenuItemFactory = (button) => styled(button)`
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
   box-sizing: border-box;
@@ -156,4 +160,5 @@ export {
   MenuItemDivider,
   SubMenuItemIcon,
   MenuButtonOverrideWrapper,
+  StyledDiv,
 };


### PR DESCRIPTION
### Proposed behaviour
adding possibility to add `download` and `href` props to `Action-Popover-Icon` component
![image](https://user-images.githubusercontent.com/19231884/109517156-3d36df00-7aa9-11eb-9c6b-3fb81f1c73f0.png)


### Current behaviour
No possibility

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Testing instructions
new story added to storybook: 
`storybook/action-popover/with-download-button`
