### PR TITLE
refactor(form-summary): replace i18n-js with i18next

### DIFF
--- a/src/components/form/form-summary.component.js
+++ b/src/components/form/form-summary.component.js
@@ -1,8 +1,8 @@
 import React from "react";
-import I18n from "i18n-js";
 import PropTypes from "prop-types";
 
 import { StyledFormSummary, StyledInternalSummary } from "./form-summary.style";
+import useTranslation from "../../hooks/__internal__/useTranslation";
 import Icon from "../icon";
 
 const warningAppend = ({ errors, warnings }, type) =>
@@ -13,29 +13,23 @@ const translationKey = (props, type) =>
 
 const defaultTranslations = (errorCount, warningCount) => ({
   errors: {
-    defaultValue: {
-      one: "There is %{count} error",
-      other: "There are %{count} errors",
-    },
+    defaultValue: "There is {{count}} error",
+    defaultValue_plural: "There are {{count}} errors",
     count: parseInt(errorCount, 10),
   },
   warnings: {
-    defaultValue: {
-      one: "There is %{count} warning",
-      other: "There are %{count} warnings",
-    },
+    defaultValue: "There is {{count}} warning",
+    defaultValue_plural: "There are {{count}} warnings",
     count: parseInt(warningCount, 10),
   },
   errors_and_warnings: {
-    defaultValue: {
-      one: "and %{count} warning",
-      other: "and %{count} warnings",
-    },
+    defaultValue: "and {{count}} warning",
+    defaultValue_plural: "and {{count}} warnings",
     count: parseInt(warningCount, 10),
   },
 });
 
-const translation = (props, type) => {
+const translation = (props, type, t) => {
   const parsedKey = translationKey(props, type);
 
   const defaultTranslation = defaultTranslations(props.errors, props.warnings)[
@@ -43,15 +37,17 @@ const translation = (props, type) => {
   ];
   const location = `errors.messages.form_summary.${parsedKey}`;
 
-  return I18n.t(location, defaultTranslation);
+  return t(location, defaultTranslation);
 };
 
 const Summary = ({ type, ...props }) => {
+  const t = useTranslation();
+
   if (props[type] > 0) {
     return (
       <StyledInternalSummary type={type} data-element={type}>
         <Icon type={type.slice(0, -1)} />
-        <span>{translation(props, type)}</span>
+        <span>{translation(props, type, t)}</span>
       </StyledInternalSummary>
     );
   }

--- a/src/components/form/form.spec.js
+++ b/src/components/form/form.spec.js
@@ -17,13 +17,24 @@ import { StyledFormSummary, StyledInternalSummary } from "./form-summary.style";
 import Icon from "../icon";
 import Button from "../button";
 import { FieldsetStyle } from "../../__experimental__/components/fieldset/fieldset.style";
+import I18next from "../../__spec_helper__/I18next";
+
+jest.mock("lodash/debounce", () => jest.fn((fn) => fn));
+
+function RenderWrapper({ ...props }) {
+  return (
+    <I18next>
+      <Form {...props} />
+    </I18next>
+  );
+}
 
 describe("Form", () => {
   let wrapper;
 
   beforeEach(() => {
     jest.useFakeTimers();
-    wrapper = mount(<Form />);
+    wrapper = mount(<RenderWrapper />);
   });
 
   it("allows custom classes to be added to the Form", () => {
@@ -137,7 +148,7 @@ describe("Form", () => {
     };
 
     beforeEach(() => {
-      wrapper = mount(<Form stickyFooter />);
+      wrapper = mount(<RenderWrapper stickyFooter />);
       window.innerHeight = 1000;
       const footerNode = wrapper.find(StyledFormFooter).getDOMNode();
       jest
@@ -204,12 +215,14 @@ describe("Form", () => {
 
     beforeEach(() => {
       wrapper = shallow(
-        <Form
+        <RenderWrapper
           leftSideButtons={leftSideButtons}
           saveButton={saveButton}
           rightSideButtons={rightSideButtons}
         />
-      );
+      )
+        .find(Form)
+        .dive();
     });
 
     it("renders buttons passed as the leftSideButtons prop", () => {
@@ -398,7 +411,7 @@ describe("Form", () => {
 
   describe("tags", () => {
     const tagWrapper = mount(
-      <Form
+      <RenderWrapper
         data-element="bar"
         data-role="baz"
         saveButton={<div />}

--- a/src/components/table/table-row/table-row.spec.js
+++ b/src/components/table/table-row/table-row.spec.js
@@ -18,7 +18,6 @@ import {
   assertStyleMatch,
   carbonThemesJestTable,
 } from "../../../__spec_helper__/test-utils";
-import I18next from "../../../__spec_helper__/I18next";
 import { DraggableContext, WithDrop } from "../../drag-and-drop";
 import { ActionPopover, ActionPopoverItem } from "../../action-popover";
 import { MenuButton } from "../../action-popover/action-popover.style";


### PR DESCRIPTION
### Proposed behaviour
Use i18next for the date component
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

https://codesandbox.io/s/carbon-quickstart-forked-mmbdi

### Current behaviour
i18n-js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
No test changes are required.
`form-summary` components should be tested for regression.