### PR TITLE
feat(link): add `isSkipLink` prop - FE-3735

### DIFF
--- a/cypress/features/regression/link.feature
+++ b/cypress/features/regression/link.feature
@@ -34,3 +34,14 @@ Feature: Link component
   Scenario: Change type of icon for a Link component to feedback
     When I open default "Link Test" component in noIFrame with "link" json from "commonComponents" using "icon" object name
     Then icon on link component preview is "feedback"
+
+  @positive
+  Scenario: Check skip link is visible when focused
+    Given I open "Link" component page "is skip link" in no iframe
+    When I hit Tab key 1 times in no Iframe
+    Then Skip link is visible
+
+  @positive
+  Scenario: Check skip link is not visible without focus
+    When I open "Link" component page "is skip link" in no iframe
+    Then Skip link is not visible

--- a/cypress/locators/link/index.js
+++ b/cypress/locators/link/index.js
@@ -1,4 +1,4 @@
-import LINK_PREVIEW from "./locators";
+import { LINK_PREVIEW, SKIP_LINK } from "./locators";
 
 // component preview locators
 export const linkPreview = () => cy.get(LINK_PREVIEW);
@@ -9,3 +9,4 @@ export const linkChildren = () =>
     .find('span[class="carbon-link__content"]');
 export const linkIcon = () =>
   cy.get(LINK_PREVIEW).children().find('[data-component="icon"]');
+export const skipLink = () => cy.get(SKIP_LINK).find("a");

--- a/cypress/locators/link/locators.js
+++ b/cypress/locators/link/locators.js
@@ -1,4 +1,3 @@
 // component preview locators
-const LINK_PREVIEW = '[data-component="link"]';
-
-export default LINK_PREVIEW;
+export const LINK_PREVIEW = '[data-component="link"]';
+export const SKIP_LINK = '[data-element="skip-link"]';

--- a/cypress/support/step-definitions/link-steps.js
+++ b/cypress/support/step-definitions/link-steps.js
@@ -1,4 +1,9 @@
-import { linkPreview, linkChildren, linkIcon } from "../../locators/link";
+import {
+  linkPreview,
+  linkChildren,
+  linkIcon,
+  skipLink,
+} from "../../locators/link";
 
 Then("children on preview is {word}", (children) => {
   linkChildren().should("have.text", children);
@@ -40,4 +45,17 @@ Then("Link is tabbable", () => {
 
 Then("Link is not tabbable", () => {
   linkPreview().children().should("have.attr", "tabindex", "-1");
+});
+
+Then("Skip link is visible", () => {
+  skipLink()
+    .should("be.visible")
+    .and("have.css", "background-color", "rgb(255, 255, 255)")
+    .and("have.css", "font-size", "16px")
+    .and("have.css", "padding-left", "24px")
+    .and("have.css", "padding-right", "24px");
+});
+
+Then("Skip link is not visible", () => {
+  skipLink().should("not.have.css", "background-color", "rgb(255, 255, 255)");
 });

--- a/src/__experimental__/components/date/__snapshots__/date-picker.spec.js.snap
+++ b/src/__experimental__/components/date/__snapshots__/date-picker.spec.js.snap
@@ -361,6 +361,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
           "hoverBackground": "#F2F5F6",
         },
         "zIndex": Object {
+          "aboveAll": 9999,
           "fullScreenModal": 5000,
           "header": 4000,
           "modal": 3000,
@@ -704,6 +705,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
             "hoverBackground": "#F2F5F6",
           },
           "zIndex": Object {
+            "aboveAll": 9999,
             "fullScreenModal": 5000,
             "header": 4000,
             "modal": 3000,

--- a/src/components/link/link.component.js
+++ b/src/components/link/link.component.js
@@ -79,7 +79,9 @@ class InternalLink extends React.Component {
     <>
       {this.renderLinkIcon()}
 
-      <span className="carbon-link__content">{this.props.children}</span>
+      <span className="carbon-link__content">
+        {this.props.isSkipLink ? "Skip to main content" : this.props.children}
+      </span>
 
       {this.renderLinkIcon("right")}
     </>
@@ -100,15 +102,17 @@ class InternalLink extends React.Component {
   };
 
   render() {
-    const { disabled, className, iconAlign, children } = this.props;
+    const { disabled, className, iconAlign, children, isSkipLink } = this.props;
 
     return (
       <LinkStyle
+        isSkipLink={isSkipLink}
         disabled={disabled}
         className={className}
         iconAlign={iconAlign}
         hasContent={Boolean(children)}
         {...tagComponent("link", this.props)}
+        {...(isSkipLink && { "data-element": "skip-link" })}
       >
         {this.createLinkBasedOnType()}
       </LinkStyle>
@@ -141,6 +145,8 @@ InternalLink.propTypes = {
   tooltipMessage: PropTypes.string,
   /** Positions the tooltip with the link. */
   tooltipPosition: PropTypes.oneOf(OptionsHelper.positions),
+  /** Allows to create skip link */
+  isSkipLink: PropTypes.bool,
   /** Target property in which link should open ie: _blank, _self, _parent, _top */
   target: PropTypes.string,
   /** Ref to be forwarded

--- a/src/components/link/link.d.ts
+++ b/src/components/link/link.d.ts
@@ -15,6 +15,7 @@ export interface LinkProps {
   children?: React.ReactNode;
   target?: string;
   ariaLabel?: string;
+  isSkipLink?: boolean;
 }
 
 declare const Link: React.ComponentType<

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -7,6 +7,7 @@ import LinkStyle from "./link.style";
 import Icon from "../icon";
 import StyledIcon from "../icon/icon.style";
 import Tooltip from "../tooltip";
+import { baseTheme } from "../../style/themes";
 
 function renderLink(props, renderer = mount) {
   return renderer(<Link {...props}>Link Component</Link>);
@@ -25,6 +26,47 @@ describe("Link", () => {
 
   it("renders as expected", () => {
     expect(render()).toMatchSnapshot();
+  });
+
+  describe("If `isSkipLink` provided", () => {
+    const skipLinkWrapper = mount(
+      <Link href="#test" isSkipLink>
+        Test Content
+      </Link>
+    );
+
+    it("should render `Skip to main content` text inside of Link", () => {
+      expect(skipLinkWrapper.text()).toBe("Skip to main content");
+    });
+
+    it("should render correct designs", () => {
+      assertStyleMatch(
+        {
+          position: "absolute",
+          paddingLeft: "24px",
+          paddingRight: "24px",
+          lineHeight: "36px",
+          fontSize: "16px",
+          left: "-999em",
+          textColor: baseTheme.colors.text,
+          zIndex: `${baseTheme.zIndex.aboveAll}`,
+          boxShadow: `inset 0 0 0 2px ${baseTheme.colors.primary}`,
+          border: `2px solid ${baseTheme.colors.white}`,
+        },
+        skipLinkWrapper,
+        { modifier: "a" }
+      );
+
+      assertStyleMatch(
+        {
+          top: "8px",
+          left: "8px",
+          textColors: baseTheme.colors.text,
+        },
+        skipLinkWrapper,
+        { modifier: "a:focus" }
+      );
+    });
   });
 
   describe("The `disabled` prop", () => {

--- a/src/components/link/link.stories.mdx
+++ b/src/components/link/link.stories.mdx
@@ -2,6 +2,9 @@ import { useState } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import LinkTo from "@storybook/addon-links/react";
 import Link, { InternalLink } from "./link.component";
+import Box from '../box';
+import {Menu, MenuItem} from '../menu';
+import Typography from '../typography';
 
 <Meta title="Link" parameters={{ info: { disable: true } }} />
 
@@ -42,6 +45,43 @@ Setting the `disabled` prop to true disables the link.
 <Preview>
   <Story name="with Disabled">
     <Link disabled>This is a link</Link>
+  </Story>
+</Preview>
+
+### isSkipLink
+`Skip Link` is specific use case for the `Link` component, specifically to enhance keyboard accessibility. 
+The `Skip Link` has been created to allow users to use keyboard controls to skip over something like a `Menu`. 
+It allows a user to jump into the main content without going through the whole `Menu` component, button by button. 
+To show how it works, press the TAB key and you will be able to see how `Skip Link` will displays.
+
+<Preview>
+  <Story name="isSkipLink" parameters={{ chromatic: { disable: true } }}>
+    <Link href="#main-content" isSkipLink>This is a link</Link>
+    <Menu>
+      <MenuItem>Menu Item 1</MenuItem>
+      <MenuItem>Menu Item 2</MenuItem>
+      <MenuItem>Menu Item 3</MenuItem>
+      <MenuItem>Menu Item 4</MenuItem>
+      <MenuItem>Menu Item 5</MenuItem>
+    </Menu>
+    <Box py={2} id="main-content">
+      <Typography mb={1} variant="h1"> This is header of main content container </Typography>
+      <Typography variant="p"> 
+        Laborum anim magna pariatur ea mollit elit cillum exercitation irure consectetur. 
+        Lorem qui dolor reprehenderit reprehenderit ut ad. 
+        Esse magna aliquip ea culpa nulla laborum deserunt cupidatat ullamco fugiat in enim. 
+        Sunt velit tempor anim occaecat. Culpa ut consectetur sunt tempor eu est deserunt veniam. 
+        Voluptate commodo consequat ipsum aliquip elit aute pariatur occaecat eiusmod culpa dolore voluptate Lorem commodo.
+        Consectetur anim exercitation esse irure est amet adipisicing cupidatat laborum non commodo id.
+        Ex id nostrud aute deserunt. 
+        Qui non aute ea eu commodo anim labore dolor minim enim cillum eiusmod commodo ipsum. 
+        Consectetur ipsum consectetur Lorem tempor proident cillum eu minim. 
+        Adipisicing in nostrud sit Lorem ex aute tempor aliquip aute. 
+        Duis dolore laboris labore exercitation enim dolore anim occaecat anim laboris dolor ut. 
+        Lorem ullamco adipisicing duis aute non minim. Adipisicing consequat labore non aliquip anim.
+      </Typography>
+      <Link href="www.carbon.sage.com">Carbon Page</Link>
+    </Box>
   </Story>
 </Preview>
 

--- a/src/components/link/link.style.js
+++ b/src/components/link/link.style.js
@@ -4,41 +4,62 @@ import baseTheme from "../../style/themes/base";
 import StyledIcon from "../icon/icon.style";
 
 const LinkStyle = styled.div`
-  display: inline-block;
-  a,
-  button {
-    font-size: 14px;
-    text-decoration: underline;
-    color: ${({ theme }) => theme.colors.primary};
+  ${({ isSkipLink, theme, iconAlign, hasContent, disabled }) => css`
     display: inline-block;
-    ${StyledIcon} {
-      position: relative;
-      vertical-align: middle;
-      ${({ iconAlign, hasContent }) =>
-        iconAlign === "left" &&
+
+    ${isSkipLink &&
+    css`
+      a {
+        position: absolute;
+        padding-left: 24px;
+        padding-right: 24px;
+        line-height: 36px;
+        left: -999em;
+        z-index: ${theme.zIndex.aboveAll};
+        box-shadow: inset 0 0 0 2px ${theme.colors.primary};
+        border: 2px solid ${theme.colors.white};
+      }
+
+      a:focus {
+        top: 8px;
+        left: 8px;
+      }
+    `}
+
+    a,
+  button {
+      font-size: ${isSkipLink ? "16px" : "14px"};
+      text-decoration: underline;
+      color: ${isSkipLink ? theme.text.color : theme.colors.primary};
+      display: inline-block;
+      ${StyledIcon} {
+        position: relative;
+        vertical-align: middle;
+        ${iconAlign === "left" &&
         css`
           margin-right: ${hasContent ? "5px" : 0};
         `}
-      ${({ iconAlign, hasContent }) =>
-        iconAlign === "right" &&
+        ${iconAlign === "right" &&
         css`
           margin-right: 0;
           margin-left: ${hasContent ? "5px" : 0};
         `}
-    }
-    &:hover {
-      cursor: pointer;
-      color: ${({ theme }) => theme.colors.secondary};
-    }
-    ${({ theme }) => css`
+      }
+
+      &:hover {
+        cursor: pointer;
+        color: ${isSkipLink ? theme.text.color : theme.colors.secondary};
+      }
+
       &:focus {
         color: ${theme.text.color};
-        background-color: ${theme.colors.focusedLinkBackground};
+        background-color: ${isSkipLink
+          ? theme.colors.white
+          : theme.colors.focusedLinkBackground};
         outline: none;
       }
-    `}
-    ${({ disabled, theme }) =>
-      disabled &&
+
+      ${disabled &&
       css`
         color: ${theme.disabled.text};
         &:hover,
@@ -47,12 +68,14 @@ const LinkStyle = styled.div`
           color: ${theme.disabled.text};
         }
       `}
-  }
-  button {
-    background-color: transparent;
-    border: none;
-    padding: 0;
-  }
+    }
+
+    button {
+      background-color: transparent;
+      border: none;
+      padding: 0;
+    }
+  `}
 `;
 
 LinkStyle.defaultProps = {

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -356,6 +356,7 @@ export default (palette) => {
       header: 4000,
       fullScreenModal: 5000,
       notification: 6000,
+      aboveAll: 9999,
     },
   };
 };


### PR DESCRIPTION
It allows to create a skip link

### Proposed behaviour
![Zrzut ekranu 2021-03-05 151730](https://user-images.githubusercontent.com/19231884/110128243-e0983480-7dc6-11eb-960a-16956d9921a5.jpg)


### Current behaviour
Not support for skip link

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Testing instructions
New story added into storybook
storybook => link => isSkipLink
