### PR TITLE
refactor(button): extracting  ButtonTypes to options-helper

### DIFF
--- a/src/components/button/button.d.ts
+++ b/src/components/button/button.d.ts
@@ -1,22 +1,10 @@
 import * as React from "react";
 import { SpacingProps } from "../../utils/helpers/options-helper";
-import { IconTypes } from "../../utils/helpers/options-helper/options-helper";
+import { IconTypes, ButtonTypes } from "../../utils/helpers/options-helper/options-helper";
 
 export interface ButtonProps extends SpacingProps {
-  as?:
-    | "primary"
-    | "secondary"
-    | "tertiary"
-    | "dashed"
-    | "destructive"
-    | "darkBackground";
-  buttonType?:
-    | "primary"
-    | "secondary"
-    | "tertiary"
-    | "dashed"
-    | "destructive"
-    | "darkBackground";
+  as?: ButtonTypes;
+  buttonType?: ButtonTypes;
   "aria-label"?: string;
   disabled?: boolean;
   destructive?: boolean;

--- a/src/utils/helpers/options-helper/options-helper.d.ts
+++ b/src/utils/helpers/options-helper/options-helper.d.ts
@@ -353,3 +353,11 @@ export interface FlexBoxProps {
   alignSelf?: string;
   order?: number;
 }
+
+export type ButtonTypes =
+| "primary"
+| "secondary"
+| "tertiary"
+| "dashed"
+| "destructive"
+| "darkBackground";


### PR DESCRIPTION
### Proposed behaviour
This change extracts the union type for the `as` and `buttonType` prop into the options-helper file so that other apps consuming this code can use the definition instead of manually redefining the possible values.

### Current behaviour

Code needing to have a Typescript definition of either `as` or `buttonType` prop current have to manually declare the possible union types allowed, which could lead to potential bugs if a future Carbon release were to change these in future.

### Checklist

- [x] Commits follow our style guide
- [ ] <s>Screenshots are included in the PR if useful</s>
- [ ] <s>All themes are supported if required</s>
- [ ] <s>Unit tests added or updated if required</s>
- [ ] <s>Cypress automation tests added or updated if required</s>
- [ ] <s>Storybook added or updated if required</s>
- [x] Typescript `d.ts` file added or updated if required
- [ ] <s>Carbon implementation and Design System documentation are congruent</s>

### Additional context

### Testing instructions
