### PR TITLE
refactor(list-action-button): replace i18n-js with i18next

### DIFF
--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -10,6 +10,15 @@ import Option from "../option/option.component";
 import SelectList from "../select-list/select-list.component";
 import Button from "../../button";
 import Label from "../../../__experimental__/components/label";
+import I18next from "../../../__spec_helper__/I18next";
+
+const RenderWrapper = React.forwardRef(({ ...props }, ref) => {
+  return (
+    <I18next>
+      <FilterableSelect {...props} ref={ref} />
+    </I18next>
+  );
+});
 
 describe("FilterableSelect", () => {
   testStyledSystemMargin((props) => getSelect(props));
@@ -27,12 +36,12 @@ describe("FilterableSelect", () => {
       mockRef = useRef();
 
       return (
-        <FilterableSelect name="testSelect" id="testSelect" ref={mockRef}>
+        <RenderWrapper name="testSelect" id="testSelect" ref={mockRef}>
           <Option value="opt1" text="red" />
           <Option value="opt2" text="green" />
           <Option value="opt3" text="blue" />
           <Option value="opt4" text="black" />
-        </FilterableSelect>
+        </RenderWrapper>
       );
     };
 
@@ -51,13 +60,9 @@ describe("FilterableSelect", () => {
     describe("without available matching option", () => {
       it("then the formatted value should be set to corresponding option text when it's available", () => {
         const wrapper = mount(
-          <FilterableSelect
-            name="testSelect"
-            id="testSelect"
-            defaultValue="opt2"
-          >
+          <RenderWrapper name="testSelect" id="testSelect" defaultValue="opt2">
             <Option value="opt1" text="blue" key="blue" />
-          </FilterableSelect>
+          </RenderWrapper>
         );
 
         wrapper.setProps({
@@ -863,11 +868,11 @@ function renderSelect(props = {}, renderer = mount) {
 
 function getSelect(props) {
   return (
-    <FilterableSelect name="testSelect" id="testSelect" {...props}>
+    <RenderWrapper name="testSelect" id="testSelect" {...props}>
       <Option value="opt1" text="red" />
       <Option value="opt2" text="green" />
       <Option value="opt3" text="blue" />
       <Option value="opt4" text="black" />
-    </FilterableSelect>
+    </RenderWrapper>
   );
 }

--- a/src/components/select/list-action-button/list-action-button.component.js
+++ b/src/components/select/list-action-button/list-action-button.component.js
@@ -1,12 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
-import I18n from "i18n-js";
 import StyledListActionButtonWrapper from "./list-action-button.style";
 import Button from "../../button";
+import useTranslation from "../../../hooks/__internal__/useTranslation";
 
 const ListActionButton = React.forwardRef(
   ({ listActionButton, onListAction }, ref) => {
-    const listActionButtonDefaultText = I18n.t("select.action_button_text", {
+    const t = useTranslation();
+    const listActionButtonDefaultText = t("select.action_button_text", {
       defaultValue: "Add New Item",
     });
 

--- a/src/components/select/list-action-button/list-action-button.spec.js
+++ b/src/components/select/list-action-button/list-action-button.spec.js
@@ -1,8 +1,17 @@
 import React, { useRef } from "react";
 import TestRenderer from "react-test-renderer";
-import { shallow, mount } from "enzyme";
+import { mount } from "enzyme";
 import ListActionButton from "./list-action-button.component";
 import Button from "../../button";
+import I18next from "../../../__spec_helper__/I18next";
+
+const RenderWrapper = React.forwardRef(({ ...props }, ref) => {
+  return (
+    <I18next>
+      <ListActionButton {...props} ref={ref} />
+    </I18next>
+  );
+});
 
 describe("Option", () => {
   it("renders properly", () => {
@@ -17,7 +26,7 @@ describe("Option", () => {
       mockRef = useRef();
 
       return (
-        <ListActionButton
+        <RenderWrapper
           listActionButton
           onListAction={defaultAction}
           ref={mockRef}
@@ -50,14 +59,14 @@ describe("Option", () => {
     describe("and that button has been clicked", () => {
       it("then the onListAction prop should have been called", () => {
         onListActionFn.mockClear();
-        wrapper.find('[data-element="test-button"]').simulate("click");
+        wrapper.find('[data-element="test-button"]').at(0).simulate("click");
         expect(onListActionFn).toHaveBeenCalled();
       });
     });
   });
 });
 
-function renderListActionButton(props, renderer = shallow) {
+function renderListActionButton(props, renderer = mount) {
   let { onListAction } = props;
   const defaultAction = () => {};
 
@@ -65,5 +74,5 @@ function renderListActionButton(props, renderer = shallow) {
     onListAction = defaultAction;
   }
 
-  return renderer(<ListActionButton onListAction={onListAction} {...props} />);
+  return renderer(<RenderWrapper onListAction={onListAction} {...props} />);
 }

--- a/src/components/select/select-list/select-list.spec.js
+++ b/src/components/select/select-list/select-list.spec.js
@@ -12,6 +12,15 @@ import Loader from "../../loader";
 import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
 import StyledSelectListContainer from "./select-list-container.style";
 import Popover from "../../../__internal__/popover";
+import I18next from "../../../__spec_helper__/I18next";
+
+function RenderWrapper({ ...props }) {
+  return (
+    <I18next>
+      <SelectList {...props} />
+    </I18next>
+  );
+}
 
 const escapeKeyDownEvent = new KeyboardEvent("keydown", {
   key: "Escape",
@@ -329,14 +338,14 @@ describe("SelectList", () => {
           const [options] = useState([]);
 
           return (
-            <SelectList
+            <RenderWrapper
               value="red"
               onSelect={() => {}}
               onSelectListClose={() => {}}
               isLoading
             >
               {options}
-            </SelectList>
+            </RenderWrapper>
           );
         };
         const wrapper = mount(<EmptySelect />);
@@ -353,14 +362,14 @@ describe("SelectList", () => {
     describe("and there is only one option", () => {
       it("that option should have the hidden prop", () => {
         const wrapper = mount(
-          <SelectList
+          <RenderWrapper
             value="red"
             onSelect={() => {}}
             onSelectListClose={() => {}}
             isLoading
           >
             <Option value="opt1" text="red" />
-          </SelectList>
+          </RenderWrapper>
         );
 
         expect(wrapper.find(Option).first().prop("hidden")).toBe(true);
@@ -605,10 +614,10 @@ describe("SelectList", () => {
   describe("when non option elements are provided as children", () => {
     it("then isHighlighted prop should not be set on them", () => {
       const wrapper = mount(
-        <SelectList onSelect={() => {}} onSelectListClose={() => {}}>
+        <RenderWrapper onSelect={() => {}} onSelectListClose={() => {}}>
           {false && ""}
           <li>not an option element</li>
-        </SelectList>
+        </RenderWrapper>
       );
       expect(wrapper.find("li").props().isHighlighted).toBe(undefined);
       wrapper.unmount();
@@ -668,11 +677,16 @@ function getSelectList(props) {
     const mockRef = useRef();
 
     return (
-      <SelectList ref={mockRef} {...defaultProps} {...props} {...wrapperProps}>
+      <RenderWrapper
+        ref={mockRef}
+        {...defaultProps}
+        {...props}
+        {...wrapperProps}
+      >
         <Option value="opt1" text="red" />
         <Option value="opt2" text="green" />
         <Option value="opt3" text="blue" />
-      </SelectList>
+      </RenderWrapper>
     );
   };
 
@@ -689,14 +703,19 @@ function getGroupedSelectList(props) {
     const mockRef = useRef();
 
     return (
-      <SelectList ref={mockRef} {...defaultProps} {...props} {...wrapperProps}>
+      <RenderWrapper
+        ref={mockRef}
+        {...defaultProps}
+        {...props}
+        {...wrapperProps}
+      >
         <OptionGroupHeader label="Heading one" />
         <Option value="opt1" text="red" />
         <Option value="opt2" text="green" />
         <OptionGroupHeader label="Heading two" />
         <Option value="opt3" text="blue" />
         <Option value="opt4" text="black" />
-      </SelectList>
+      </RenderWrapper>
     );
   };
 


### PR DESCRIPTION
### Proposed behaviour
Use i18next for the `list-action-button` component
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

### Current behaviour
i18n-js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
No test changes are required.
`list-action-button` component should be tested for regression.
https://codesandbox.io/s/carbon-quickstart-forked-pk2dj