### PR TITLE
fix(pod): fix footer text colour when pod is hovered - FE-3505

### DIFF
--- a/src/components/pod/__snapshots__/pod.spec.js.snap
+++ b/src/components/pod/__snapshots__/pod.spec.js.snap
@@ -5,6 +5,7 @@ exports[`StyledBlock should match expected styles 1`] = `
   box-sizing: border-box;
   width: 100%;
   border: 1px solid #CCD6DB;
+  outline: none;
 }
 
 <div
@@ -115,9 +116,8 @@ exports[`StyledEditContainer when internalEditButton prop is set should have exp
 exports[`StyledFooter should match expected styles 1`] = `
 .c0 {
   background-color: #F2F5F6;
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
   box-shadow: inset 0px 1px 1px 0 rgba(0,0,0,0.1);
+  color: rgba(0,0,0,0.9);
 }
 
 <div

--- a/src/components/pod/pod.spec.js
+++ b/src/components/pod/pod.spec.js
@@ -164,12 +164,12 @@ describe("Pod", () => {
   });
 
   describe("podFooter", () => {
-    it("renders footer when footer prop is pased", () => {
+    it("renders footer when footer prop is passed", () => {
       wrapper.setProps({ footer: "Footer" });
       expect(wrapper.find(StyledFooter).props().children).toEqual("Footer");
     });
 
-    it("does not render footer when footer prop is not pased", () => {
+    it("does not render footer when footer prop is not passed", () => {
       expect(wrapper.find(StyledFooter).exists()).toEqual(false);
     });
   });
@@ -180,7 +180,7 @@ describe("Pod", () => {
       expect(wrapper.find(StyledEditAction).exists()).toEqual(true);
     });
 
-    it("does not render edit action button when onEdit prop is not pased", () => {
+    it("does not render edit action button when onEdit prop is not passed", () => {
       expect(wrapper.find(StyledEditAction).exists()).toEqual(false);
     });
 
@@ -725,12 +725,23 @@ describe("StyledFooter", () => {
     expect(wrapper.toJSON()).toMatchSnapshot();
   });
 
+  it("should match expected styles when pod is hovered", () => {
+    wrapper = renderStyledFooter({ isHovered: true });
+    assertStyleMatch(
+      {
+        color: `${baseTheme.text.color}`,
+      },
+      wrapper
+    );
+  });
+
   describe("when variant prop is set to tile", () => {
     it("should have expected border top style", () => {
       wrapper = renderStyledFooter({ variant: "tile" });
       assertStyleMatch(
         {
           borderTop: `1px solid ${baseTheme.pod.border}`,
+          color: `${baseTheme.text.color}`,
         },
         wrapper
       );

--- a/src/components/pod/pod.style.js
+++ b/src/components/pod/pod.style.js
@@ -70,6 +70,11 @@ const StyledBlock = styled.div`
       border: none;
       ${noBorder ? "" : "padding: 1px"};
     `};
+    ${!isFocused &&
+    (!internalEditButton || contentTriggersEdit) &&
+    css`
+      outline: none;
+    `};
   `}
 `;
 
@@ -105,9 +110,8 @@ const footerPaddings = {
 const StyledFooter = styled.div`
   ${({ theme, variant, padding }) => css`
     background-color: ${theme.pod.footerBackground};
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
     box-shadow: inset 0px 1px 1px 0 rgba(0, 0, 0, 0.1);
+    color: ${theme.text.color};
 
     ${variant === "tile" &&
     css`


### PR DESCRIPTION

fixes #3584

### Proposed behaviour

Footer text colour should stay the same colour when `pod` is hovered over.
<img width="301" alt="Screenshot 2021-03-12 at 10 39 20" src="https://user-images.githubusercontent.com/56251247/110928863-40d72b00-831f-11eb-9f58-3ee4f6bebe05.png">

![pod-no-blue-outline](https://user-images.githubusercontent.com/56251247/110944242-180d6080-8334-11eb-808b-6e7d83600eb2.gif)

### Current behaviour

Footer text colour changes to white making the text unreadable.
<img width="275" alt="Screenshot 2021-03-08 at 16 06 42" src="https://user-images.githubusercontent.com/56251247/110355211-e2fdc700-8030-11eb-9115-5df0f0d50548.png">

![pod-with-blue-outline](https://user-images.githubusercontent.com/56251247/110944293-2e1b2100-8334-11eb-9241-14badd46a3e9.gif)

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
<del>- [ ] Cypress automation tests added or updated if required </del>
- [x] Storybook added or updated if required
<del>- [ ] Typescript `d.ts` file added or updated if required </del>
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
- Visit Pod -> `With edit button and displayEditButtonOnHover`
- Hover over the `pod` and the text in the Footer should say the same colour. 
- Footer shouldn't have rounded corners.
- `pod` shouldn't have a blue outline once clicked.
