### PR TITLE
refactor(confirm): replace i18n-js with i18next

### DIFF
--- a/src/__internal__/i18n/i18n.component.js
+++ b/src/__internal__/i18n/i18n.component.js
@@ -1,0 +1,14 @@
+import PropTypes from "prop-types";
+import useTranslation from "../../hooks/__internal__/useTranslation";
+
+const I18n = ({ params }) => {
+  const t = useTranslation();
+
+  return t(...params);
+};
+
+I18n.propTypes = {
+  params: PropTypes.array.isRequired,
+};
+
+export default I18n;

--- a/src/__internal__/i18n/i18n.spec.js
+++ b/src/__internal__/i18n/i18n.spec.js
@@ -1,0 +1,38 @@
+import React from "react";
+import { mount } from "enzyme";
+import i18n from "i18next";
+import I18n from "./i18n.component";
+import I18next from "../../__spec_helper__/I18next";
+
+describe("I18n", () => {
+  it("return default value", () => {
+    const defaultValue = "Default translation";
+    const wrapper = mount(<I18n params={["test", { defaultValue }]} />, {
+      wrappingComponent: I18next,
+    });
+
+    expect(wrapper.text()).toBe(defaultValue);
+  });
+
+  it("return key", () => {
+    const key = "test";
+    const wrapper = mount(<I18n params={[key]} />, {
+      wrappingComponent: I18next,
+    });
+
+    expect(wrapper.text()).toBe(key);
+  });
+
+  it("return translation", () => {
+    const resources = {
+      testValue: "test value",
+    };
+    i18n.addResourceBundle("en", "carbon", resources);
+
+    const wrapper = mount(<I18n params={["testValue"]} />, {
+      wrappingComponent: I18next,
+    });
+
+    expect(wrapper.text()).toBe(resources.testValue);
+  });
+});

--- a/src/__internal__/i18n/index.js
+++ b/src/__internal__/i18n/index.js
@@ -1,0 +1,1 @@
+export { default } from "./i18n.component";

--- a/src/components/confirm/confirm.component.js
+++ b/src/components/confirm/confirm.component.js
@@ -1,5 +1,4 @@
 import React from "react";
-import I18n from "i18n-js";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import Dialog from "../dialog";
@@ -7,6 +6,7 @@ import { StyledConfirmButtons, StyledConfirmHeading } from "./confirm.style";
 import Button from "../button/button.component";
 import Icon from "../icon";
 import Loader from "../loader";
+import I18n from "../../__internal__/i18n";
 
 class Confirm extends Dialog {
   // ** Returns main classes for the component combined with dialog main classes. */
@@ -41,7 +41,9 @@ class Confirm extends Dialog {
         destructive={this.props.destructive}
         disabled={this.props.disableCancel}
       >
-        {this.props.cancelLabel || I18n.t("confirm.no", { defaultValue: "No" })}
+        {this.props.cancelLabel || (
+          <I18n params={["confirm.no", { defaultValue: "No" }]} />
+        )}
       </Button>
     );
   }
@@ -59,8 +61,9 @@ class Confirm extends Dialog {
         {this.props.isLoadingConfirm ? (
           <Loader isInsideButton isActive />
         ) : (
-          this.props.confirmLabel ||
-          I18n.t("confirm.yes", { defaultValue: "Yes" })
+          this.props.confirmLabel || (
+            <I18n params={["confirm.yes", { defaultValue: "Yes" }]} />
+          )
         )}
       </Button>
     );

--- a/src/components/confirm/confirm.spec.js
+++ b/src/components/confirm/confirm.spec.js
@@ -12,6 +12,7 @@ import Icon from "../icon";
 import Loader from "../loader";
 import IconButton from "../icon-button";
 import StyledIconButton from "../icon-button/icon-button.style";
+import I18next from "../../__spec_helper__/I18next";
 
 describe("Confirm", () => {
   let wrapper, onCancel, onConfirm;
@@ -29,7 +30,10 @@ describe("Confirm", () => {
         subtitle="Confirm Subtitle"
         data-element="bar"
         data-role="baz"
-      />
+      />,
+      {
+        wrappingComponent: I18next,
+      }
     );
   });
 
@@ -58,7 +62,10 @@ describe("Confirm", () => {
           subtitle="Confirm Subtitle"
           data-element="bar"
           data-role="baz"
-        />
+        />,
+        {
+          wrappingComponent: I18next,
+        }
       );
     });
 
@@ -81,7 +88,10 @@ describe("Confirm", () => {
             confirmLabel="Delete"
             cancelLabel="Cancel"
             destructive
-          />
+          />,
+          {
+            wrappingComponent: I18next,
+          }
         );
         expect(wrapper.instance().props.destructive).toBeTruthy();
         const button = wrapper
@@ -118,7 +128,10 @@ describe("Confirm", () => {
             onConfirm={() => {}}
             open
             onCancel={onCancelFn}
-          />
+          />,
+          {
+            wrappingComponent: I18next,
+          }
         );
         domNode = wrapper.getDOMNode();
         document.body.appendChild(domNode);
@@ -142,7 +155,10 @@ describe("Confirm", () => {
             onConfirm={() => {}}
             open
             onCancel={onCancelFn}
-          />
+          />,
+          {
+            wrappingComponent: I18next,
+          }
         );
 
         assertStyleMatch(
@@ -157,7 +173,12 @@ describe("Confirm", () => {
 
     describe("if `isLoadingConfirm` button is provided", () => {
       it("should not render confirm button", () => {
-        wrapper = mount(<Confirm onConfirm={() => {}} isLoadingConfirm open />);
+        wrapper = mount(
+          <Confirm onConfirm={() => {}} isLoadingConfirm open />,
+          {
+            wrappingComponent: I18next,
+          }
+        );
 
         expect(wrapper.find(Loader).exists()).toBe(true);
       });
@@ -166,7 +187,10 @@ describe("Confirm", () => {
     describe("if `cancelButtonType` is tertiary", () => {
       it("should render confirm button with left margin 3px", () => {
         wrapper = mount(
-          <Confirm cancelButtonType="tertiary" onConfirm={() => {}} open />
+          <Confirm cancelButtonType="tertiary" onConfirm={() => {}} open />,
+          {
+            wrappingComponent: I18next,
+          }
         );
 
         assertStyleMatch(
@@ -186,7 +210,10 @@ describe("Confirm", () => {
           onConfirm={() => {}}
           open
           disableCancel
-        />
+        />,
+        {
+          wrappingComponent: I18next,
+        }
       );
 
       expect(wrapper.find(IconButton).exists()).toBe(false);
@@ -200,14 +227,19 @@ describe("Confirm", () => {
           onConfirm={() => {}}
           open
           disableCancel
-        />
+        />,
+        {
+          wrappingComponent: I18next,
+        }
       );
 
       expect(wrapper.find(IconButton).exists()).toBe(false);
     });
 
     describe("when custom labels are not defined", () => {
-      wrapper = mount(<Confirm open onConfirm={() => {}} />);
+      wrapper = mount(<Confirm open onConfirm={() => {}} />, {
+        wrappingComponent: I18next,
+      });
 
       it("returns default values", () => {
         expect(
@@ -228,7 +260,10 @@ describe("Confirm", () => {
             onConfirm={onConfirm}
             confirmLabel="Delete"
             cancelLabel="Cancel"
-          />
+          />,
+          {
+            wrappingComponent: I18next,
+          }
         );
       });
 
@@ -264,7 +299,10 @@ describe("Confirm", () => {
           title="Confirm title"
           iconType="error"
           showCloseIcon={false}
-        />
+        />,
+        {
+          wrappingComponent: I18next,
+        }
       );
       const iconError = wrapper.find(StyledConfirmHeading).at(0);
       expect(iconError.find(Icon).props().type).toBe("error");
@@ -291,7 +329,10 @@ describe("Confirm", () => {
           title="Confirm title"
           iconType="warning"
           showCloseIcon={false}
-        />
+        />,
+        {
+          wrappingComponent: I18next,
+        }
       );
       const iconError = wrapper.find(StyledConfirmHeading).at(0);
       expect(iconError.find(Icon).props().type).toBe("warning");


### PR DESCRIPTION
### Proposed behaviour
Use i18next for the `confirm` component
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

### Current behaviour
i18n-js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-plk99
No test changes are required.
`confirm` component should be tested for regression.