### PR TITLE
feat: add `rel` prop to Link component -  FE-3803

### DIFF
--- a/cypress/features/regression/link.feature
+++ b/cypress/features/regression/link.feature
@@ -45,3 +45,8 @@ Feature: Link component
   Scenario: Check skip link is not visible without focus
     When I open "Link" component page "is skip link" in no iframe
     Then Skip link is not visible
+
+  @positive
+  Scenario: Check rel attr is able to be used in a link component
+    When I open "Link" component page "with rel" in no iframe
+    Then link has a rel attribute

--- a/cypress/locators/link/index.js
+++ b/cypress/locators/link/index.js
@@ -10,3 +10,4 @@ export const linkChildren = () =>
 export const linkIcon = () =>
   cy.get(LINK_PREVIEW).children().find('[data-component="icon"]');
 export const skipLink = () => cy.get(SKIP_LINK).find("a");
+export const relLink = () => linkPreview().find("a");

--- a/cypress/support/step-definitions/link-steps.js
+++ b/cypress/support/step-definitions/link-steps.js
@@ -3,6 +3,7 @@ import {
   linkChildren,
   linkIcon,
   skipLink,
+  relLink,
 } from "../../locators/link";
 
 Then("children on preview is {word}", (children) => {
@@ -58,4 +59,8 @@ Then("Skip link is visible", () => {
 
 Then("Skip link is not visible", () => {
   skipLink().should("not.have.css", "background-color", "rgb(255, 255, 255)");
+});
+
+Then("link has a rel attribute", () => {
+  relLink().should("have.attr", "rel", "noreferrer noopener");
 });

--- a/src/components/link/link.component.js
+++ b/src/components/link/link.component.js
@@ -60,6 +60,7 @@ class InternalLink extends React.Component {
       target: this.props.target,
       ref: this.props.innerRef,
       href: this.props.href,
+      rel: this.props.rel,
     };
   }
 
@@ -156,6 +157,8 @@ InternalLink.propTypes = {
   innerRef: PropTypes.object,
   /** Aria label for accessibility purposes */
   ariaLabel: PropTypes.string,
+  /** allows to set rel property in <a> tag */
+  rel: PropTypes.string,
 };
 
 InternalLink.defaultProps = {

--- a/src/components/link/link.d.ts
+++ b/src/components/link/link.d.ts
@@ -16,6 +16,7 @@ export interface LinkProps {
   target?: string;
   ariaLabel?: string;
   isSkipLink?: boolean;
+  rel?: string;
 }
 
 declare const Link: React.ComponentType<

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -105,11 +105,20 @@ describe("Link", () => {
   });
 
   describe("when component received a `target` prop", () => {
-    it("should render an `<a>`  element with target attribute", () => {
+    it("should render an `<a>` element with target attribute", () => {
       const target = "_blank";
       wrapper.setProps({ target });
 
       expect(wrapper.find("a").prop("target")).toBe(target);
+    });
+  });
+
+  describe("when component received a `rel` prop", () => {
+    it("should render an `<a>` element with rel attribute", () => {
+      const rel = "alternate";
+      wrapper.setProps({ rel });
+
+      expect(wrapper.find("a").prop("rel")).toBe(rel);
     });
   });
 

--- a/src/components/link/link.stories.mdx
+++ b/src/components/link/link.stories.mdx
@@ -95,6 +95,17 @@ The `href` prop provides the ability for the Link to take the user to a differen
   </Story>
 </Preview>
 
+### rel
+
+The `rel` prop provides the ability for the Link to set relationship between the current document 
+and the linked document
+
+<Preview>
+  <Story name="with rel" parameters={{ chromatic: { disable: true } }}>
+    <Link href="https://carbon.sage.com/" target="_blank" rel="noreferrer noopener">This is a link</Link>
+  </Story>
+</Preview>
+
 ### Icon
 
 The `icon` prop allows you to render an icon.


### PR DESCRIPTION
fixes: #3748
It allows users to put `rel` as a property in our link component
rel is a default property supported by `a` tag

### Current behaviour

no possibility to add rel property

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] <del> Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
New story added into storybook
Link -> rel
