### PR TITLE
refactor(pod): replace i18n-js with i18next

### DIFF
--- a/src/components/pod/pod.component.js
+++ b/src/components/pod/pod.component.js
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import I18n from "i18n-js";
 import Event from "../../utils/helpers/events/events";
 import tagComponent from "../../utils/helpers/tags/tags";
 import PodContext from "./pod-context";
+import I18n from "../../__internal__/i18n";
 
 import {
   StyledBlock,
@@ -148,7 +148,7 @@ class Pod extends React.Component {
           variant={variant}
           {...this.linkProps()}
         >
-          {I18n.t("actions.edit", { defaultValue: "Edit" })}
+          <I18n params={["actions.edit", { defaultValue: "Edit" }]} />
         </StyledEditAction>
       </StyledEditContainer>
     );

--- a/src/components/pod/pod.spec.js
+++ b/src/components/pod/pod.spec.js
@@ -24,6 +24,7 @@ import {
   elementsTagTest,
   rootTagTest,
 } from "../../utils/helpers/tags/tags-specs/tags-specs";
+import I18next from "../../__spec_helper__/I18next";
 import { baseTheme } from "../../style/themes";
 import PodManager from "./pod-manager.component";
 import PodContext from "./pod-context";
@@ -33,12 +34,16 @@ describe("Pod", () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<Pod />);
+    wrapper = shallow(<Pod />, {
+      wrappingComponent: I18next,
+    });
   });
 
   describe("functionality", () => {
     it("sets the collapsed state same as collapsed prop on mount", () => {
-      const initialWrapper = shallow(<Pod collapsed />);
+      const initialWrapper = shallow(<Pod collapsed />, {
+        wrappingComponent: I18next,
+      });
       expect(initialWrapper.state().isCollapsed).toBeTruthy();
     });
   });
@@ -76,7 +81,10 @@ describe("Pod", () => {
         <PodContext.Provider value={{ heightOfTheLongestPod: "100" }}>
           <Pod>test</Pod>
         </PodContext.Provider>
-      </PodManager>
+      </PodManager>,
+      {
+        wrappingComponent: I18next,
+      }
     );
 
     assertStyleMatch(
@@ -94,7 +102,10 @@ describe("Pod", () => {
       const collapsableWrapper = shallow(
         <Pod collapsed>
           <ContentComp />
-        </Pod>
+        </Pod>,
+        {
+          wrappingComponent: I18next,
+        }
       );
       expect(
         collapsableWrapper.find(StyledCollapsibleContent).exists()
@@ -106,7 +117,10 @@ describe("Pod", () => {
       const collapsableWrapper = shallow(
         <Pod collapsed={false}>
           <ContentComp />
-        </Pod>
+        </Pod>,
+        {
+          wrappingComponent: I18next,
+        }
       );
       expect(
         collapsableWrapper.find(StyledCollapsibleContent).exists()
@@ -118,7 +132,10 @@ describe("Pod", () => {
       const collapsableWrapper = shallow(
         <Pod collapsed title="Title">
           <ContentComp />
-        </Pod>
+        </Pod>,
+        {
+          wrappingComponent: I18next,
+        }
       );
       collapsableWrapper.find(StyledHeader).props().onClick();
       expect(
@@ -136,7 +153,10 @@ describe("Pod", () => {
       wrapper = mount(
         <Pod collapsed title="collapsed">
           <ContentComp />
-        </Pod>
+        </Pod>,
+        {
+          wrappingComponent: I18next,
+        }
       );
 
       assertStyleMatch(
@@ -373,12 +393,16 @@ describe("Pod", () => {
         prop2: "value2",
       };
 
-      instance = shallow(<Pod {...someRandomProps} />);
+      instance = shallow(<Pod {...someRandomProps} />, {
+        wrappingComponent: I18next,
+      });
       expect(instance.find(StyledPod).props()).toMatchObject(someRandomProps);
     });
 
     it("does not apply title prop to containing elements", () => {
-      instance = shallow(<Pod title="some-title" />);
+      instance = shallow(<Pod title="some-title" />, {
+        wrappingComponent: I18next,
+      });
       expect(wrapper.is("[title]")).toBe(false);
     });
 
@@ -388,7 +412,10 @@ describe("Pod", () => {
           <Button>Button</Button>
           <Button>Button</Button>
           <Button>Button</Button>
-        </Pod>
+        </Pod>,
+        {
+          wrappingComponent: I18next,
+        }
       );
 
       expect(instance.find(Button).length).toEqual(3);
@@ -410,7 +437,9 @@ describe("Pod", () => {
 
   describe("if internal edit button is enabled", () => {
     it("renders the Pod with relative position", () => {
-      wrapper = mount(<Pod internalEditButton />);
+      wrapper = mount(<Pod internalEditButton />, {
+        wrappingComponent: I18next,
+      });
       assertStyleMatch({ position: "relative" }, wrapper);
       wrapper.unmount();
     });
@@ -432,7 +461,10 @@ describe("Pod", () => {
           onEdit={() => {}}
           subtitle="subtitle"
           title="title"
-        />
+        />,
+        {
+          wrappingComponent: I18next,
+        }
       );
 
       elementsTagTest(tagWrapper, ["edit", "footer", "subtitle", "title"]);

--- a/src/components/show-edit-pod/show-edit-pod.spec.js
+++ b/src/components/show-edit-pod/show-edit-pod.spec.js
@@ -9,6 +9,7 @@ import {
   elementsTagTest,
   rootTagTest,
 } from "../../utils/helpers/tags/tags-specs";
+import I18next from "../../__spec_helper__/I18next";
 import StyledDeleteButton from "./delete-button.style";
 
 describe("ShowEditPod", () => {
@@ -349,7 +350,12 @@ describe("ShowEditPod", () => {
 
   describe("tags", () => {
     describe("on component", () => {
-      const wrapper = mount(<ShowEditPod data-element="bar" data-role="baz" />);
+      const wrapper = mount(
+        <ShowEditPod data-element="bar" data-role="baz" />,
+        {
+          wrappingComponent: I18next,
+        }
+      );
 
       it("include correct component, element and role data tags", () => {
         rootTagTest(wrapper.find(Pod), "show-edit-pod", "bar", "baz");
@@ -357,7 +363,9 @@ describe("ShowEditPod", () => {
     });
 
     describe("on internal elements", () => {
-      const wrapper = mount(<ShowEditPod editing onEdit={() => {}} />);
+      const wrapper = mount(<ShowEditPod editing onEdit={() => {}} />, {
+        wrappingComponent: I18next,
+      });
       const form = wrapper.find('[data-component="form"]').hostNodes();
       expect(form.type()).toEqual("form");
       elementsTagTest(form, ["edit-form"]);
@@ -368,5 +376,6 @@ describe("ShowEditPod", () => {
 function renderShowEditPod(props, renderer = mount) {
   return renderer(<ShowEditPod {...props} />, {
     attachTo: document.getElementById("enzymeContainer"),
+    wrappingComponent: I18next,
   });
 }


### PR DESCRIPTION
### Proposed behaviour
Use i18next for the `pod` component
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

### Current behaviour
i18n-js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
No test changes are required.
`pod` component should be tested for regression.
https://codesandbox.io/s/carbon-quickstart-forked-vplvh
![Zrzut ekranu 2021-03-15 o 11 54 31](https://user-images.githubusercontent.com/77274590/111142686-3ddd7400-8585-11eb-95cb-ca57d39e661e.png)
