### PR TITLE
refactor(select-textbox): replace i18n-js with i18next

### DIFF
--- a/src/components/select/select-textbox/select-textbox.component.js
+++ b/src/components/select/select-textbox/select-textbox.component.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import I18n from "i18n-js";
 import Textbox from "../../../__experimental__/components/textbox";
 import OptionsHelper from "../../../utils/helpers/options-helper/options-helper";
+import useTranslation from "../../../hooks/__internal__/useTranslation";
 
 const SelectTextbox = ({
   value,
@@ -17,7 +17,8 @@ const SelectTextbox = ({
   required,
   ...restProps
 }) => {
-  const defaultPlaceholder = I18n.t("select.placeholder", {
+  const t = useTranslation();
+  const defaultPlaceholder = t("select.placeholder", {
     defaultValue: "Please Select...",
   });
 

--- a/src/components/select/select-textbox/select-textbox.spec.js
+++ b/src/components/select/select-textbox/select-textbox.spec.js
@@ -2,11 +2,20 @@ import React from "react";
 import { mount } from "enzyme";
 import SelectTextbox from "./select-textbox.component";
 import Textbox from "../../../__experimental__/components/textbox";
+import I18next from "../../../__spec_helper__/I18next";
+
+function RenderWrapper({ ...props }) {
+  return (
+    <I18next>
+      <SelectTextbox {...props} />
+    </I18next>
+  );
+}
 
 describe("SelectTextbox", () => {
   describe("when rendered", () => {
     it("it should contain a Textbox with expected props", () => {
-      const wrapper = mount(<SelectTextbox />);
+      const wrapper = mount(<RenderWrapper />);
 
       expect(wrapper.find(Textbox).exists()).toBe(true);
       expect(wrapper.find(Textbox).props().placeholder).toBe(
@@ -20,7 +29,7 @@ describe("SelectTextbox", () => {
   describe("when the onFocus prop has been passed and the input has been focused", () => {
     it("then that prop should be called", () => {
       const onFocusFn = jest.fn();
-      const wrapper = mount(<SelectTextbox onFocus={onFocusFn} />);
+      const wrapper = mount(<RenderWrapper onFocus={onFocusFn} />);
 
       wrapper.find("input").simulate("focus");
       expect(onFocusFn).toHaveBeenCalled();
@@ -30,7 +39,7 @@ describe("SelectTextbox", () => {
   describe("when the onBlur prop has been passed and the input has been unfocused", () => {
     it("then that prop should be called", () => {
       const onBlurFn = jest.fn();
-      const wrapper = mount(<SelectTextbox onBlur={onBlurFn} />);
+      const wrapper = mount(<RenderWrapper onBlur={onBlurFn} />);
 
       wrapper.find("input").simulate("blur");
       expect(onBlurFn).toHaveBeenCalled();
@@ -38,11 +47,11 @@ describe("SelectTextbox", () => {
   });
 
   // coverage filler for else path
-  const wrapper = mount(<SelectTextbox />);
+  const wrapper = mount(<RenderWrapper />);
   wrapper.find("input").simulate("blur");
 });
 
 describe("coverage filler for else path", () => {
-  const wrapper = mount(<SelectTextbox />);
+  const wrapper = mount(<RenderWrapper />);
   wrapper.find("input").simulate("focus");
 });


### PR DESCRIPTION
### Proposed behaviour
Use i18next for the `select-textbox` component
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

### Current behaviour
i18n-js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
No test changes are required.
`select-textbox` component should be tested for regression.