### PR TITLE
fix(tabs-header): allow tabs to be scrollable when position is left and they overflow parent FE-3302

### DIFF
--- a/cypress/features/regression/themes/themes.feature
+++ b/cypress/features/regression/themes/themes.feature
@@ -107,7 +107,7 @@ Feature: Theming addon
   @positive
   Scenario Outline: I set Tabs component theme to <theme>
     When I open Test default "Tabs" component in noIFrame with "themeNames" json from "themes" using "<nameOfObject>" object name
-    Then "select-tab" element css "border-bottom-color" is set to "<theme>" common
+    Then "tab-selected-indicator" element css "box-shadow" is set to "<theme>" common
     Examples:
       | theme  | nameOfObject |
       | mint   | themeMint    |

--- a/cypress/support/step-definitions/themes-steps.js
+++ b/cypress/support/step-definitions/themes-steps.js
@@ -51,11 +51,9 @@ Then(
   "{string} element css {string} is set to {string} common",
   (componentName, css, themeName) => {
     cy.fixture("themes/themes.json").then((json) => {
-      getElementNoIframe(componentName).should(
-        "have.css",
-        css,
-        json.common[themeName]
-      );
+      getElementNoIframe(componentName)
+        .should("have.css", css)
+        .and("contains", json.common[themeName]);
     });
   }
 );

--- a/src/components/drawer/__internal__/drawer.stories.mdx
+++ b/src/components/drawer/__internal__/drawer.stories.mdx
@@ -882,6 +882,20 @@ You will need to override the targeting when using Tabs inside of the Drawer's s
                   title='Tab 4'
                   tabId='tab-4'
                 />
+                <Tab
+                  errorMessage='error'
+                  warningMessage='warning'
+                  infoMessage='info'
+                  title='Tab 5'
+                  tabId='tab-5'
+                />
+                <Tab
+                  errorMessage='error'
+                  warningMessage='warning'
+                  infoMessage='info'
+                  title='Tab 6'
+                  tabId='tab-6'
+                />
               </Tabs>
             ) }
           >
@@ -1022,6 +1036,86 @@ You will need to override the targeting when using Tabs inside of the Drawer's s
                 info={ infos.four }
                 onChange={ () => setInfos({ ...infos, four: !infos.four })}
               />
+            </div>
+             <div style={{ display: active === 'tab-5' ? 'block' : 'none' }}>
+              <Tabs setLocation={ false } extendedLine={ false }>
+                <Tab
+                  errorMessage='error'
+                  warningMessage='warning'
+                  infoMessage='info'
+                  title='Tab 1'
+                  tabId='tab-1'
+                >
+                  Content 13
+                </Tab>
+                <Tab
+                  errorMessage='error'
+                  warningMessage='warning'
+                  infoMessage='info'
+                  title='Tab 2'
+                  tabId='tab-2'
+                >
+                  Content 14
+                </Tab>
+                <Tab
+                  errorMessage='error'
+                  warningMessage='warning'
+                  infoMessage='info'
+                  title='Tab 3'
+                  tabId='tab-3'
+                >
+                  Content 15
+                </Tab>
+                <Tab
+                  errorMessage='error'
+                  warningMessage='warning'
+                  infoMessage='info'
+                  title='Tab 4'
+                  tabId='tab-4'
+                >
+                  Content 16
+                </Tab>
+              </Tabs>
+            </div>
+             <div style={{ display: active === 'tab-6' ? 'block' : 'none' }}>
+              <Tabs setLocation={ false } extendedLine={ false }>
+                <Tab
+                  errorMessage='error'
+                  warningMessage='warning'
+                  infoMessage='info'
+                  title='Tab 1'
+                  tabId='tab-1'
+                >
+                  Content 17
+                </Tab>
+                <Tab
+                  errorMessage='error'
+                  warningMessage='warning'
+                  infoMessage='info'
+                  title='Tab 2'
+                  tabId='tab-2'
+                >
+                  Content 18
+                </Tab>
+                <Tab
+                  errorMessage='error'
+                  warningMessage='warning'
+                  infoMessage='info'
+                  title='Tab 3'
+                  tabId='tab-3'
+                >
+                  Content 19
+                </Tab>
+                <Tab
+                  errorMessage='error'
+                  warningMessage='warning'
+                  infoMessage='info'
+                  title='Tab 4'
+                  tabId='tab-4'
+                >
+                  Content 20
+                </Tab>
+              </Tabs>
             </div>
           </div>
         </Drawer>

--- a/src/components/tabs/__internal__/tab-title/tab-title.component.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.component.js
@@ -4,6 +4,7 @@ import {
   StyledTabTitle,
   StyledTitleContent,
   StyledLayoutWrapper,
+  StyledSelectedIndicator,
 } from "./tab-title.style";
 import tagComponent from "../../../../utils/helpers/tags/tags";
 import ValidationIcon from "../../../validations/validation-icon.component";
@@ -42,6 +43,8 @@ const TabTitle = React.forwardRef(
   ) => {
     const keys = useRef([]);
     const isHref = !!href;
+    const hasAlternateStyling = alternateStyling || isInSidebar;
+    const hasFailedValidation = error || warning || info;
 
     if (siblings && !keys.current.length) {
       siblings.forEach(() => keys.current.push(createGuid()));
@@ -143,7 +146,7 @@ const TabTitle = React.forwardRef(
           hasSiblings={!!siblings}
           isTabSelected={isTabSelected}
           hasCustomLayout={!!customLayout}
-          alternateStyling={alternateStyling || isInSidebar}
+          alternateStyling={hasAlternateStyling}
         >
           {renderContent()}
           {isHref && <Icon type="link" />}
@@ -174,6 +177,13 @@ const TabTitle = React.forwardRef(
             )}
           </StyledLayoutWrapper>
         </StyledTitleContent>
+        {!(hasFailedValidation || hasAlternateStyling) && isTabSelected && (
+          <StyledSelectedIndicator
+            data-element="tab-selected-indicator"
+            position={position}
+            size={size}
+          />
+        )}
       </StyledTabTitle>
     );
   }

--- a/src/components/tabs/__internal__/tab-title/tab-title.spec.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.spec.js
@@ -6,6 +6,7 @@ import {
   StyledTabTitle,
   StyledTitleContent,
   StyledLayoutWrapper,
+  StyledSelectedIndicator,
 } from "./tab-title.style";
 import { aegeanTheme, baseTheme } from "../../../../style/themes";
 import { assertStyleMatch } from "../../../../__spec_helper__/test-utils";
@@ -115,20 +116,22 @@ describe("TabTitle", () => {
     describe("with borders", () => {
       it("applies proper styling", () => {
         wrapper = render({ size: "large", borders: true }, mount);
+
         assertStyleMatch(
           {
             borderTop: `1px solid ${baseTheme.tab.background}`,
             borderLeft: `1px solid ${baseTheme.tab.background}`,
+            borderRight: `1px solid ${baseTheme.tab.background}`,
           },
           wrapper.find(StyledTitleContent)
         );
 
         assertStyleMatch(
           {
-            borderRight: `1px solid ${baseTheme.tab.background}`,
+            marginLeft: "-1px",
           },
           wrapper.find(StyledTabTitle),
-          { modifier: `:last-of-type ${StyledTitleContent}` }
+          { modifier: ":not(:first-of-type)" }
         );
       });
 
@@ -148,6 +151,17 @@ describe("TabTitle", () => {
           { paddingBottom: "6px" },
           wrapper.find(StyledTitleContent)
         );
+
+        assertStyleMatch(
+          {
+            bottom: "0px",
+            left: "0px",
+            boxShadow: `inset 0px -4px 0px ${baseTheme.colors.primary}`,
+            width: "100%",
+            height: "4px",
+          },
+          wrapper.find(StyledSelectedIndicator)
+        );
       });
 
       it('applies proper styling when size is not "large" and isTabSelected is true', () => {
@@ -165,6 +179,17 @@ describe("TabTitle", () => {
         assertStyleMatch(
           { padding: "10px 16px" },
           wrapper.find(StyledTitleContent)
+        );
+
+        assertStyleMatch(
+          {
+            bottom: "0px",
+            left: "0px",
+            boxShadow: `inset 0px -2px 0px ${baseTheme.colors.primary}`,
+            width: "100%",
+            height: "2px",
+          },
+          wrapper.find(StyledSelectedIndicator)
         );
       });
     });
@@ -214,21 +239,45 @@ describe("TabTitle", () => {
     });
 
     describe("with borders", () => {
-      it("applies proper styling", () => {
-        wrapper = mount(
-          <StyledTabTitle
-            title="Tab Title 1"
-            dataTabId="uniqueid1"
-            position="left"
-            borders
-          />
-        );
-        assertStyleMatch(
-          { borderBottom: `1px solid ${baseTheme.tab.background}` },
-          wrapper.find(StyledTabTitle),
-          { modifier: `:last-of-type ${StyledTitleContent}` }
-        );
-      });
+      it.each(["default", "large"])(
+        "applies proper styling when isTabSelected and size is %s",
+        (size) => {
+          wrapper = render(
+            { borders: true, isTabSelected: true, position: "left", size },
+            mount
+          );
+
+          assertStyleMatch(
+            {
+              borderTop: `1px solid ${baseTheme.tab.background}`,
+              borderLeft: `1px solid ${baseTheme.tab.background}`,
+              borderBottom: `1px solid ${baseTheme.tab.background}`,
+            },
+            wrapper.find(StyledTitleContent)
+          );
+
+          assertStyleMatch(
+            {
+              marginTop: "-1px",
+            },
+            wrapper.find(StyledTabTitle),
+            { modifier: ":not(:first-of-type)" }
+          );
+
+          assertStyleMatch(
+            {
+              top: "0px",
+              right: "0px",
+              boxShadow: `inset ${
+                size === "large" ? "-4px" : "-2px"
+              } 0px 0px 0px ${baseTheme.colors.primary}`,
+              height: "100%",
+              width: size === "large" ? "4px" : "2px",
+            },
+            wrapper.find(StyledSelectedIndicator)
+          );
+        }
+      );
     });
   });
 
@@ -263,19 +312,24 @@ describe("TabTitle", () => {
       wrapper = render({ isTabSelected: true, size: "large" }, mount);
 
       assertStyleMatch(
-        { borderBottomWidth: "4px" },
-        wrapper.find(StyledTabTitle)
-      );
-      assertStyleMatch(
         { paddingBottom: "6px" },
         wrapper.find(StyledTitleContent)
       );
     });
 
-    it('set border-bottom to "none" when it has error or warning', () => {
+    it("does not apply selected styling", () => {
       wrapper = render({ isTabSelected: true, error: true }, mount);
 
-      assertStyleMatch({ borderBottom: "none" }, wrapper.find(StyledTabTitle));
+      expect(wrapper.find(StyledSelectedIndicator).exists()).toBeFalsy();
+    });
+
+    it("does not apply selected styling when it has error or warning when size is large", () => {
+      wrapper = render(
+        { isTabSelected: true, error: true, size: "large" },
+        mount
+      );
+
+      expect(wrapper.find(StyledSelectedIndicator).exists()).toBeFalsy();
     });
 
     describe("when position prop is set to left", () => {
@@ -284,7 +338,6 @@ describe("TabTitle", () => {
 
         assertStyleMatch(
           {
-            borderRightColor: baseTheme.colors.primary,
             backgroundColor: baseTheme.colors.white,
           },
           wrapper.find(StyledTabTitle)
@@ -293,32 +346,28 @@ describe("TabTitle", () => {
         assertStyleMatch(
           {
             backgroundColor: baseTheme.colors.white,
-            borderRightColor: baseTheme.colors.primary,
           },
           wrapper.find(StyledTabTitle),
           { modifier: ":hover" }
         );
       });
 
-      it("applies proper styling when size is large", () => {
-        wrapper = render(
-          { position: "left", isTabSelected: true, size: "large" },
-          mount
-        );
-
-        assertStyleMatch(
-          { borderRightWidth: "4px" },
-          wrapper.find(StyledTabTitle)
-        );
-      });
-
-      it('set border-bottom to "none" when it has error or warning', () => {
+      it("does not apply selected styling when it has error or warning", () => {
         wrapper = render(
           { isTabSelected: true, error: true, position: "left" },
           mount
         );
 
-        assertStyleMatch({ borderRight: "none" }, wrapper.find(StyledTabTitle));
+        expect(wrapper.find(StyledSelectedIndicator).exists()).toBeFalsy();
+      });
+
+      it("does not apply selected styling when it has error or warning and size is large", () => {
+        wrapper = render(
+          { isTabSelected: true, error: true, position: "left", size: "large" },
+          mount
+        );
+
+        expect(wrapper.find(StyledSelectedIndicator).exists()).toBeFalsy();
       });
     });
   });
@@ -970,6 +1019,27 @@ describe("TabTitle", () => {
           },
           wrapper.find(StyledTabTitle),
           { modifier: ":hover" }
+        );
+      });
+
+      it("applies proper styling when borders prop is true", () => {
+        wrapper = render(
+          {
+            borders: true,
+            isTabSelected: true,
+            position: "left",
+            alternateStyling: true,
+          },
+          mount
+        );
+
+        assertStyleMatch(
+          {
+            borderTop: `1px solid ${baseTheme.tab.background}`,
+            borderLeft: `1px solid ${baseTheme.tab.background}`,
+            borderBottom: `1px solid ${baseTheme.tab.background}`,
+          },
+          wrapper.find(StyledTitleContent)
         );
       });
 

--- a/src/components/tabs/__internal__/tab-title/tab-title.style.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.style.js
@@ -20,6 +20,7 @@ const StyledTitleContent = styled.div`
     error,
     warning,
     info,
+    alternateStyling,
   }) => css`
     line-height: 20px;
     margin: 0;
@@ -43,6 +44,13 @@ const StyledTitleContent = styled.div`
     css`
       border-top: 1px solid ${theme.tab.background};
       border-left: 1px solid ${theme.tab.background};
+      border-right: 1px solid ${theme.tab.background};
+
+      ${position === "left" &&
+      css`
+        border-bottom: 1px solid ${theme.tab.background};
+        ${!alternateStyling && `margin-right: -1px;`}
+      `}
 
       ${noLeftBorder &&
       css`
@@ -78,6 +86,10 @@ const StyledTitleContent = styled.div`
     css`
       font-size: 16px;
       padding: 22px 24px;
+      ${!isTabSelected &&
+      !alternateStyling &&
+      (error || warning || info) &&
+      `margin-right: -2px;`}
     `}
 
     ${size === "default" &&
@@ -89,6 +101,12 @@ const StyledTitleContent = styled.div`
       css`
         padding-bottom: 8px;
       `}
+
+      ${position === "left" &&
+      !isTabSelected &&
+      !alternateStyling &&
+      (error || warning || info) &&
+      `margin-right: -2px;`}
     `}
   `}
 
@@ -254,7 +272,7 @@ const StyledTitleContent = styled.div`
           `}
           ${(error || warning || info) &&
           css`
-            padding-right: ${size === "large" ? "26px;" : "18px;"};
+            padding-right: ${size === "large" ? "26px" : "18px"};
           `};
       `}
 
@@ -283,26 +301,39 @@ const StyledTabTitle = styled.li`
   display: inline-block;
   font-weight: bold;
   height: 100%;
+  position: relative;
 
-  ${({ theme, position, borders, noRightBorder }) =>
-    position === "top" &&
-    css`
-      ${borders &&
-      !noRightBorder &&
-      css`
-        &:last-of-type {
-          ${StyledTitleContent} {
-            border-right: 1px solid ${theme.tab.background};
-          }
-        }
-      `}
+  ${({ position, borders, noRightBorder, noLeftBorder }) => `
+      ${
+        position === "top" &&
+        css`
+          ${borders &&
+          !(noRightBorder || noLeftBorder) &&
+          css`
+            &:not(:first-of-type) {
+              margin-left: -1px;
+            }
+          `}
+        `
+      }
+      ${
+        position === "left" &&
+        css`
+          ${borders &&
+          css`
+            &:not(:first-of-type) {
+              margin-top: -1px;
+            }
+          `}
+        `
+      }
     `}
 
   &:first-child {
     margin-left: 0;
   }
 
-  ${({ isTabSelected, theme, error, warning, info }) =>
+  ${({ isTabSelected, theme }) =>
     !isTabSelected &&
     css`
       &:hover,
@@ -310,7 +341,6 @@ const StyledTabTitle = styled.li`
         background: ${theme.tab.background};
         color: ${theme.text.color};
         outline: none;
-        ${error || warning || info ? "border-bottom: none;" : ""}
       }
     `}
 
@@ -323,25 +353,46 @@ const StyledTabTitle = styled.li`
     info,
     size,
     isInSidebar,
+    position,
   }) =>
     isTabSelected &&
     css`
+    ${!isInSidebar && "z-index: 1;"}
     color: ${theme.text.color};
     background-color: ${theme.colors.white};
-    border-bottom: 2px solid ${
-      alternateStyling ? `${theme.tab.background}` : `${theme.colors.primary}`
-    };
+
+    ${
+      alternateStyling &&
+      css`
+        border-bottom: 2px solid ${theme.tab.background};
+      `
+    }
+
+    ${
+      !alternateStyling &&
+      css`
+        padding-bottom: 2px;
+      `
+    }
+
     ${
       size === "large" &&
       css`
-        border-bottom-width: 4px;
+        ${position === "top" &&
+        `
+          padding-bottom: ${alternateStyling ? "3px" : "4px"};
+          `}
       `
     }
-    ${error || warning || info ? "border-bottom: none;" : ""}
+    ${
+      (error || warning || info) &&
+      css`
+        padding-bottom: 0px;
+      `
+    }
 
     &:focus {
       outline: ${isInSidebar ? "none;" : `2px solid ${theme.colors.focus};`}
-      z-index: 10;
     }
 
     &:hover {
@@ -371,15 +422,6 @@ const StyledTabTitle = styled.li`
       background-color: transparent;
       border-bottom: 0px;
 
-      ${borders &&
-      css`
-        &:last-of-type {
-          ${StyledTitleContent} {
-            border-bottom: 1px solid ${theme.tab.background};
-          }
-        }
-      `}
-
       ${!borders &&
       css`
         ${StyledTitleContent} {
@@ -387,11 +429,12 @@ const StyledTabTitle = styled.li`
         }
       `}
 
-    ${!alternateStyling &&
+      ${!alternateStyling &&
       css`
         border-right: 2px solid ${theme.tab.background};
       `}
-    display: block;
+
+      display: block;
       height: auto;
       margin-left: 0px;
 
@@ -399,70 +442,54 @@ const StyledTabTitle = styled.li`
         margin-top: 0;
       }
 
-      ${error || warning || info ? "border-right: none;" : ""}
-
       &:hover {
-        ${borders &&
-        css`
-          &:last-of-type {
-            ${StyledTitleContent} {
-              border-bottom: 1px solid ${theme.tab.background};
-            }
-          }
-        `}
-        border-right-color: ${alternateStyling
-          ? `${theme.tab.background};`
-          : ""}
-      ${error || warning || info ? "border-right: none;" : ""}
+        ${alternateStyling && `border-right-color: ${theme.tab.background};`}
       }
 
       ${({ isTabSelected }) =>
         isTabSelected &&
         css`
-      border-right-color: ${
-        alternateStyling
-          ? `${theme.tab.background};`
-          : `${theme.colors.primary};`
-      }
-      background-color: ${theme.colors.white};
-      ${error || warning || info ? "border-right: none;" : ""}
+          ${alternateStyling &&
+          css`
+            border-right-color: ${theme.tab.background};
+          `}
 
-      ${
-        size === "large" &&
-        css`
-          border-right-width: 4px;
+          ${!alternateStyling &&
+          css`
+            border-right: none;
+            padding-bottom: 0px;
 
-          & ${StyledTitleContent} {
-            padding-right: 22px;
+            ${StyledTitleContent} {
+              ${!(error || warning || info) && `margin-right: 2px;`}
+              border-right: none;
+            }
+          `}
+    
+          background-color: ${theme.colors.white};
+
+          ${size === "large" &&
+          css`
+            & ${StyledTitleContent} {
+              padding-right: 22px;
+            }
+          `}
+
+          &:hover {
+            ${alternateStyling &&
+            ` border-right-color: ${theme.tab.background};`}
+            background-color: ${theme.colors.white};
+            ${(error || warning || info) &&
+            `border-right-color: ${theme.colors.error};`}
           }
-        `
-      }
 
-      &:hover {
-        border-right-color: ${
-          alternateStyling
-            ? `${theme.tab.background};`
-            : `${theme.colors.primary};`
-        }
-        background-color: ${theme.colors.white};
-        ${
-          error || warning || info
-            ? `border-right-color: ${theme.colors.error};`
-            : ""
-        }
-      }
-
-      &:focus {
-        ${
-          error || warning || info
-            ? `border-right-color: ${theme.colors.error};`
-            : ""
-        }
-      }
-    `}
+          &:focus {
+            ${(error || warning || info) &&
+            `border-right-color: ${theme.colors.error};`}
+          }
+        `}
     `}
 
-  ${({ alternateStyling, theme, isTabSelected }) =>
+  ${({ alternateStyling, theme, isTabSelected, isInSidebar }) =>
     alternateStyling &&
     css`
       &:focus {
@@ -479,6 +506,8 @@ const StyledTabTitle = styled.li`
       css`
         background-color: ${theme.tab.background};
       `}
+
+      ${isInSidebar && `padding-bottom: 1px;`}
     `}
 `;
 
@@ -526,6 +555,35 @@ const StyledLayoutWrapper = styled.div`
     `}
 `;
 
+const StyledSelectedIndicator = styled.div`
+  position: absolute;
+  z-index: 5;
+
+  ${({ position, size, theme }) =>
+    position === "top" &&
+    css`
+    bottom: 0px;
+    left: 0px
+    box-shadow: inset 0px ${size === "large" ? "-4px" : "-2px"} 0px ${
+      theme.colors.primary
+    };
+    width: 100%;
+    height: ${size === "large" ? "4px" : "2px"};
+  `}
+
+  ${({ position, size, theme }) =>
+    position === "left" &&
+    css`
+    top: 0px;
+    right: 0px
+    box-shadow: inset ${size === "large" ? "-4px" : "-2px"} 0px 0px 0px ${
+      theme.colors.primary
+    };
+    height: 100%;
+    width: ${size === "large" ? "4px" : "2px"};
+  `}
+`;
+
 StyledTabTitle.propTypes = {
   position: PropTypes.oneOf(["top", "left"]),
   size: PropTypes.oneOf(["default", "large"]),
@@ -568,4 +626,20 @@ StyledTitleContent.defaultProps = {
   borders: false,
 };
 
-export { StyledTabTitle, StyledTitleContent, StyledLayoutWrapper };
+StyledSelectedIndicator.propTypes = {
+  position: PropTypes.oneOf(["top", "left"]),
+  size: PropTypes.oneOf(["default", "large"]),
+};
+
+StyledSelectedIndicator.defaultProps = {
+  theme: BaseTheme,
+  position: "top",
+  size: "default",
+};
+
+export {
+  StyledTabTitle,
+  StyledTitleContent,
+  StyledLayoutWrapper,
+  StyledSelectedIndicator,
+};

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.component.js
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.component.js
@@ -1,6 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import StyledTabsHeader from "./tabs-header.style";
+import {
+  StyledTabsHeaderWrapper,
+  StyledTabsHeaderList,
+} from "./tabs-header.style";
 
 const TabsHeader = ({
   align = "left",
@@ -13,17 +16,19 @@ const TabsHeader = ({
   isInSidebar = false,
 }) => {
   return (
-    <StyledTabsHeader
-      align={align}
-      position={position}
-      role={role}
-      extendedLine={extendedLine}
-      alternateStyling={alternateStyling}
-      noRightBorder={noRightBorder}
-      isInSidebar={isInSidebar}
-    >
-      {children}
-    </StyledTabsHeader>
+    <StyledTabsHeaderWrapper isInSidebar={isInSidebar} position={position}>
+      <StyledTabsHeaderList
+        align={align}
+        position={position}
+        role={role}
+        extendedLine={extendedLine}
+        alternateStyling={alternateStyling}
+        noRightBorder={noRightBorder}
+        isInSidebar={isInSidebar}
+      >
+        {children}
+      </StyledTabsHeaderList>
+    </StyledTabsHeaderWrapper>
   );
 };
 

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.spec.js
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.spec.js
@@ -1,13 +1,16 @@
 import React from "react";
 import { mount, shallow } from "enzyme";
 import TabsHeader from "./tabs-header.component";
-import StyledTabsHeader from "./tabs-header.style";
+import {
+  StyledTabsHeaderWrapper,
+  StyledTabsHeaderList,
+} from "./tabs-header.style";
 import TabTitle from "../tab-title/tab-title.component";
 import baseTheme from "../../../../style/themes/base";
 import { assertStyleMatch } from "../../../../__spec_helper__/test-utils";
 
-function render(props) {
-  return shallow(
+function render(props, renderer = shallow) {
+  return renderer(
     <TabsHeader {...props}>
       <TabTitle title="title-1" tabId="tabId-1" />
       <TabTitle title="title-2" tabId="tabId-2" />
@@ -16,7 +19,7 @@ function render(props) {
 }
 
 function renderStyles(props) {
-  return mount(<StyledTabsHeader {...props} />);
+  return mount(<StyledTabsHeaderList {...props} />);
 }
 
 describe("TabsHeader", () => {
@@ -35,27 +38,39 @@ describe("TabsHeader", () => {
   });
 
   it("renders children correctly", () => {
-    expect(render().children()).toHaveLength(2);
+    expect(render().find(StyledTabsHeaderList).children()).toHaveLength(2);
   });
 
   it("renders children correctly", () => {
-    expect(render().children()).toHaveLength(2);
+    expect(render().find(StyledTabsHeaderList).children()).toHaveLength(2);
   });
 
   it("has the role of a role prop value", () => {
-    expect(render({ role: "tablist" }).props().role).toEqual("tablist");
+    expect(
+      render({ role: "tablist" }).find(StyledTabsHeaderList).props().role
+    ).toEqual("tablist");
   });
 
   describe("when position prop is set to left", () => {
     it("applies proper styles", () => {
+      const wrapper = render({ position: "left" }, mount);
+
       assertStyleMatch(
         {
           flexDirection: "column",
           boxShadow: `inset -2px 0px 0px 0px ${baseTheme.tab.background}`,
-          width: "20%",
           margin: "0 10px 0",
         },
-        renderStyles({ position: "left" })
+        wrapper.find(StyledTabsHeaderList)
+      );
+
+      assertStyleMatch(
+        {
+          width: "20%",
+          overflowY: "auto",
+          padding: "2px",
+        },
+        wrapper.find(StyledTabsHeaderWrapper)
       );
     });
 
@@ -122,12 +137,18 @@ describe("TabsHeader", () => {
   });
 
   describe("custom target styling", () => {
+    const wrapper = render({ isInSidebar: true, position: "left" }, mount);
+    assertStyleMatch(
+      {
+        margin: "auto",
+      },
+      wrapper.find(StyledTabsHeaderList)
+    );
     assertStyleMatch(
       {
         width: "100%",
-        margin: "auto",
       },
-      renderStyles({ isInSidebar: true, position: "left" })
+      wrapper.find(StyledTabsHeaderWrapper)
     );
   });
 });

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.style.js
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.style.js
@@ -27,6 +27,7 @@ const StyledTabsHeaderWrapper = styled.div`
       css`
         width: 100%;
         margin: auto;
+        padding: 0px;
       `}
     `}
 `;

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.style.js
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.style.js
@@ -10,7 +10,28 @@ const computeLineWidth = ({ alternateStyling, isInSidebar, position }) => {
   return alternateStyling ? "-1px" : "-2px";
 };
 
-const StyledTabHeaders = styled.ul`
+const StyledTabsHeaderWrapper = styled.div`
+  ${({ position, isInSidebar }) =>
+    position === "left" &&
+    css`
+      overflow-y: auto;
+      padding: 2px;
+
+      ${!isInSidebar &&
+      css`
+        width: 20%;
+        margin: 0 10px 0;
+      `}
+
+      ${isInSidebar &&
+      css`
+        width: 100%;
+        margin: auto;
+      `}
+    `}
+`;
+
+const StyledTabsHeaderList = styled.ul`
   display: flex;
   box-shadow: inset 0px ${computeLineWidth} 0px 0px
     ${({ theme }) => theme.tab.background};
@@ -44,13 +65,11 @@ const StyledTabHeaders = styled.ul`
 
       ${!isInSidebar &&
       css`
-        width: 20%;
         margin: 0 10px 0;
       `}
 
     ${isInSidebar &&
       css`
-        width: 100%;
         margin: auto;
       `}
 
@@ -62,16 +81,26 @@ const StyledTabHeaders = styled.ul`
     `}
 `;
 
-StyledTabHeaders.defaultProps = {
+StyledTabsHeaderWrapper.defaultProps = {
+  position: "top",
+};
+
+StyledTabsHeaderWrapper.propTypes = {
+  position: PropTypes.oneOf(["top", "left"]),
+  isInSidebar: PropTypes.bool,
+};
+
+StyledTabsHeaderList.defaultProps = {
   align: "left",
   position: "top",
   extendedLine: true,
   theme: baseTheme,
 };
 
-StyledTabHeaders.propTypes = {
+StyledTabsHeaderList.propTypes = {
   align: PropTypes.oneOf(OptionsHelper.alignBinary),
   position: PropTypes.oneOf(["top", "left"]),
+  isInSidebar: PropTypes.bool,
 };
 
-export default StyledTabHeaders;
+export { StyledTabsHeaderWrapper, StyledTabsHeaderList };


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
fix #3352
Adds `overflow-y: auto` to `TabsHeader` to allow `Tabs` to be scrollable when they overflow parent and `position="left"`

fix #3773
Adds border on all sides and a -1px margin to remove the double borders on all `TabTitle` that are
not `first-of-type` when `borders` prop is true, refactors `isTabSelected` styling to use
`box-shadow` instead of borders

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No ability to scroll when tabs overflow a parent height

Borders are only applied on one side when they are adjacent to each other, the `isTabSelected` styling has incorrect height and width

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/110972355-cffe3600-8353-11eb-89b8-16f1309112df.png)

![image](https://user-images.githubusercontent.com/44157880/110972389-dab8cb00-8353-11eb-8d43-461187016f7e.png)

![image](https://user-images.githubusercontent.com/44157880/110972437-e906e700-8353-11eb-98fd-043ca7b134b5.png)

![image](https://user-images.githubusercontent.com/44157880/110972473-f1f7b880-8353-11eb-9a0f-8de1cc503584.png)

![image](https://user-images.githubusercontent.com/44157880/110972532-fe7c1100-8353-11eb-801c-d2da015cae78.png)

![image](https://user-images.githubusercontent.com/44157880/110972580-0b990000-8354-11eb-98ab-ca80e10be98f.png)

![image](https://user-images.githubusercontent.com/44157880/110972646-1e133980-8354-11eb-8c06-18fc59b297c6.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
All Tabs stories should be tested
Extra tab controls added to the `design-system-drawer--with-tab-controls` story to demonstrate scrollable enhancement