### PR TITLE
refactor(select-textbox): replace i18n-js with i18next

### DIFF
--- a/src/__spec_helper__/test-utils.js
+++ b/src/__spec_helper__/test-utils.js
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 
 import { carbonThemeList } from "../style/themes";
 import { mockMatchMedia } from "./mock-match-media";
+import I18next from "./I18next";
 
 const isUpper = (char) => char.toUpperCase() === char;
 const humpToDash = (acc, char) =>
@@ -191,7 +192,9 @@ const testStyledSystemMargin = (
   assertOpts
 ) => {
   describe("default props", () => {
-    const wrapper = mount(component());
+    const wrapper = mount(component(), {
+      wrappingComponent: I18next,
+    });
     const StyleElement = styleContainer ? styleContainer(wrapper) : wrapper;
 
     it("should set the correct margins", () => {
@@ -235,10 +238,14 @@ const testStyledSystemMargin = (
     'when a custom spacing is specified using the "%s" styled system props',
     (styledSystemProp, propName) => {
       it(`then that ${propName} should have been set correctly`, () => {
-        let wrapper = mount(component());
+        let wrapper = mount(component(), {
+          wrappingComponent: I18next,
+        });
 
         const props = { [styledSystemProp]: 2 };
-        wrapper = mount(component({ ...props }));
+        wrapper = mount(component({ ...props }), {
+          wrappingComponent: I18next,
+        });
 
         expect(
           assertStyleMatch(
@@ -259,7 +266,9 @@ const testStyledSystemPadding = (
   assertOpts
 ) => {
   describe("default props", () => {
-    const wrapper = mount(component());
+    const wrapper = mount(component(), {
+      wrappingComponent: I18next,
+    });
     const StyleElement = styleContainer ? styleContainer(wrapper) : wrapper;
 
     it("should set the correct paddings", () => {
@@ -305,10 +314,14 @@ const testStyledSystemPadding = (
     'when a custom spacing is specified using the "%s" styled system props',
     (styledSystemProp, propName) => {
       it(`then that ${propName} should have been set correctly`, () => {
-        let wrapper = mount(component());
+        let wrapper = mount(component(), {
+          wrappingComponent: I18next,
+        });
 
         const props = { [styledSystemProp]: 2 };
-        wrapper = mount(component({ ...props }));
+        wrapper = mount(component({ ...props }), {
+          wrappingComponent: I18next,
+        });
 
         expect(
           assertStyleMatch(
@@ -337,10 +350,14 @@ const testStyledSystemColor = (component, styleContainer) => {
     'when a prop is specified using the "%s" styled system props',
     (styledSystemProp, propName, value) => {
       it(`then ${propName} should have been set correctly`, () => {
-        let wrapper = mount(component());
+        let wrapper = mount(component(), {
+          wrappingComponent: I18next,
+        });
 
         const props = { [styledSystemProp]: value };
-        wrapper = mount(component({ ...props }));
+        wrapper = mount(component({ ...props }), {
+          wrappingComponent: I18next,
+        });
         // Some props need to have camelcase so used toHaveStyleRule rather than assertStyleMatch
         expect(wrapper).toHaveStyleRule(
           propName,
@@ -357,10 +374,14 @@ const testStyledSystemLayout = (component, styleContainer) => {
     'when a prop is specified using the "%s" styled system props',
     (styledSystemProp, propName, value) => {
       it(`then ${propName} should have been set correctly`, () => {
-        let wrapper = mount(component());
+        let wrapper = mount(component(), {
+          wrappingComponent: I18next,
+        });
 
         const props = { [styledSystemProp]: value };
-        wrapper = mount(component({ ...props }));
+        wrapper = mount(component({ ...props }), {
+          wrappingComponent: I18next,
+        });
         // Some props need to have camelcase so used toHaveStyleRule rather than assertStyleMatch
         expect(wrapper).toHaveStyleRule(
           propName,
@@ -377,10 +398,14 @@ const testStyledSystemFlexBox = (component, styleContainer) => {
     'when a prop is specified using the "%s" styled system props',
     (styledSystemProp, propName, value) => {
       it(`then ${propName} should have been set correctly`, () => {
-        let wrapper = mount(component());
+        let wrapper = mount(component(), {
+          wrappingComponent: I18next,
+        });
 
         const props = { [styledSystemProp]: value };
-        wrapper = mount(component({ ...props }));
+        wrapper = mount(component({ ...props }), {
+          wrappingComponent: I18next,
+        });
 
         expect(
           assertStyleMatch(

--- a/src/components/select/multi-select/multi-select.spec.js
+++ b/src/components/select/multi-select/multi-select.spec.js
@@ -11,6 +11,7 @@ import SelectList from "../select-list/select-list.component";
 import { StyledSelectList } from "../select-list/select-list.style";
 import Pill from "../../pill";
 import Label from "../../../__experimental__/components/label";
+import I18next from "../../../__spec_helper__/I18next";
 
 describe("MultiSelect", () => {
   testStyledSystemMargin((props) => getSelect(props));
@@ -20,7 +21,9 @@ describe("MultiSelect", () => {
     let domNode;
 
     beforeEach(() => {
-      wrapper = mount(getSelect({ openOnFocus: true }));
+      wrapper = mount(getSelect({ openOnFocus: true }), {
+        wrappingComponent: I18next,
+      });
       domNode = wrapper.getDOMNode();
       document.body.appendChild(domNode);
     });
@@ -71,7 +74,9 @@ describe("MultiSelect", () => {
       );
     };
 
-    const wrapper = mount(<WrapperComponent />);
+    const wrapper = mount(<WrapperComponent />, {
+      wrappingComponent: I18next,
+    });
 
     expect(mockRef.current).toBe(wrapper.find("input").getDOMNode());
   });
@@ -614,7 +619,10 @@ describe("MultiSelect", () => {
               <Option value={{ id: "id1", value: "opt1" }} text="red" />
               <Option value={{ id: "id2", value: "opt2" }} text="green" />
               <Option value={{ id: "id3", value: "opt3" }} text="blue" />
-            </MultiSelect>
+            </MultiSelect>,
+            {
+              wrappingComponent: I18next,
+            }
           );
 
           wrapper.find("input").simulate("focus");
@@ -720,7 +728,9 @@ describe("coverage filler for else path", () => {
 });
 
 function renderSelect(props = {}, renderer = mount) {
-  return renderer(getSelect(props));
+  return renderer(getSelect(props), {
+    wrappingComponent: I18next,
+  });
 }
 
 function getSelect(props) {

--- a/src/components/select/select-textbox/select-textbox.component.js
+++ b/src/components/select/select-textbox/select-textbox.component.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import I18n from "i18n-js";
 import Textbox from "../../../__experimental__/components/textbox";
 import OptionsHelper from "../../../utils/helpers/options-helper/options-helper";
+import useTranslation from "../../../hooks/__internal__/useTranslation";
 
 const SelectTextbox = ({
   value,
@@ -17,7 +17,8 @@ const SelectTextbox = ({
   required,
   ...restProps
 }) => {
-  const defaultPlaceholder = I18n.t("select.placeholder", {
+  const t = useTranslation();
+  const defaultPlaceholder = t("select.placeholder", {
     defaultValue: "Please Select...",
   });
 

--- a/src/components/select/select-textbox/select-textbox.spec.js
+++ b/src/components/select/select-textbox/select-textbox.spec.js
@@ -2,11 +2,20 @@ import React from "react";
 import { mount } from "enzyme";
 import SelectTextbox from "./select-textbox.component";
 import Textbox from "../../../__experimental__/components/textbox";
+import I18next from "../../../__spec_helper__/I18next";
+
+function RenderWrapper({ ...props }) {
+  return (
+    <I18next>
+      <SelectTextbox {...props} />
+    </I18next>
+  );
+}
 
 describe("SelectTextbox", () => {
   describe("when rendered", () => {
     it("it should contain a Textbox with expected props", () => {
-      const wrapper = mount(<SelectTextbox />);
+      const wrapper = mount(<RenderWrapper />);
 
       expect(wrapper.find(Textbox).exists()).toBe(true);
       expect(wrapper.find(Textbox).props().placeholder).toBe(
@@ -20,7 +29,7 @@ describe("SelectTextbox", () => {
   describe("when the onFocus prop has been passed and the input has been focused", () => {
     it("then that prop should be called", () => {
       const onFocusFn = jest.fn();
-      const wrapper = mount(<SelectTextbox onFocus={onFocusFn} />);
+      const wrapper = mount(<RenderWrapper onFocus={onFocusFn} />);
 
       wrapper.find("input").simulate("focus");
       expect(onFocusFn).toHaveBeenCalled();
@@ -30,7 +39,7 @@ describe("SelectTextbox", () => {
   describe("when the onBlur prop has been passed and the input has been unfocused", () => {
     it("then that prop should be called", () => {
       const onBlurFn = jest.fn();
-      const wrapper = mount(<SelectTextbox onBlur={onBlurFn} />);
+      const wrapper = mount(<RenderWrapper onBlur={onBlurFn} />);
 
       wrapper.find("input").simulate("blur");
       expect(onBlurFn).toHaveBeenCalled();
@@ -38,11 +47,11 @@ describe("SelectTextbox", () => {
   });
 
   // coverage filler for else path
-  const wrapper = mount(<SelectTextbox />);
+  const wrapper = mount(<RenderWrapper />);
   wrapper.find("input").simulate("blur");
 });
 
 describe("coverage filler for else path", () => {
-  const wrapper = mount(<SelectTextbox />);
+  const wrapper = mount(<RenderWrapper />);
   wrapper.find("input").simulate("focus");
 });

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -16,6 +16,7 @@ import StyledInput from "../../../__experimental__/components/input/input.style"
 import InputPresentationStyle from "../../../__experimental__/components/input/input-presentation.style";
 import { baseTheme } from "../../../style/themes";
 import Label from "../../../__experimental__/components/label";
+import I18next from "../../../__spec_helper__/I18next";
 
 describe("SimpleSelect", () => {
   describe("disablePortal", () => {
@@ -64,7 +65,9 @@ describe("SimpleSelect", () => {
       );
     };
 
-    const wrapper = mount(<WrapperComponent />);
+    const wrapper = mount(<WrapperComponent />, {
+      wrappingComponent: I18next,
+    });
 
     expect(mockRef.current).toBe(wrapper.find("input").getDOMNode());
   });
@@ -635,7 +638,9 @@ describe("SimpleSelect", () => {
     let domNode;
 
     beforeEach(() => {
-      wrapper = mount(getSelect());
+      wrapper = mount(getSelect(), {
+        wrappingComponent: I18next,
+      });
       domNode = wrapper.getDOMNode();
       document.body.appendChild(domNode);
     });
@@ -774,7 +779,9 @@ describe("SimpleSelect", () => {
 });
 
 function renderSelect(props = {}, renderer = mount) {
-  return renderer(getSelect(props));
+  return renderer(getSelect(props), {
+    wrappingComponent: I18next,
+  });
 }
 
 function getSelect(props) {


### PR DESCRIPTION
### Proposed behaviour
Use i18next for the `select-textbox` component
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

### Current behaviour
i18n-js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
No test changes are required.
`select-textbox` component should be tested for regression.
https://codesandbox.io/s/carbon-quickstart-forked-k9gwf