### PR TITLE
refactor(action-toolbar): replace i18n-js with i18next

### DIFF
--- a/src/components/action-toolbar/action-toolbar.component.js
+++ b/src/components/action-toolbar/action-toolbar.component.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
-import I18n from "i18n-js";
 import Link from "../link";
 import tagComponent from "../../utils/helpers/tags";
 import {
@@ -10,6 +9,7 @@ import {
   StyledActionToolbarActions,
 } from "./action-toolbar.style";
 import Logger from "../../utils/logger/logger";
+import I18n from "../../__internal__/i18n";
 
 let deprecatedWarnTriggered = false;
 
@@ -140,7 +140,9 @@ class ActionToolbar extends React.Component {
         <StyledActionToolbarTotal>
           <strong data-element="total">{this.state.total}</strong>
           &nbsp;
-          {I18n.t("action_toolbar.selected", { defaultValue: "Selected" })}
+          <I18n
+            params={["action_toolbar.selected", { defaultValue: "Selected" }]}
+          />
         </StyledActionToolbarTotal>
         <StyledActionToolbarActions disabled={!this.isActive()}>
           {this.actions()}

--- a/src/components/action-toolbar/action-toolbar.spec.js
+++ b/src/components/action-toolbar/action-toolbar.spec.js
@@ -5,6 +5,7 @@ import {
   elementsTagTest,
   rootTagTest,
 } from "../../utils/helpers/tags/tags-specs/tags-specs";
+import I18next from "../../__spec_helper__/I18next";
 
 describe("action toolbar", () => {
   let instance, spy, wrapper;
@@ -12,7 +13,10 @@ describe("action toolbar", () => {
   beforeEach(() => {
     wrapper = shallow(
       <ActionToolbar actions={{ foo: {}, bar: {} }} className="foo" />,
-      { context: {} }
+      { context: {} },
+      {
+        wrappingComponent: I18next,
+      }
     );
     instance = wrapper.instance();
   });
@@ -101,7 +105,9 @@ describe("action toolbar", () => {
         return <div>foo</div>;
       });
 
-      shallow(<ActionToolbar actions={{}}>{childFunction}</ActionToolbar>);
+      shallow(<ActionToolbar actions={{}}>{childFunction}</ActionToolbar>, {
+        wrappingComponent: I18next,
+      });
 
       expect(childFunction).toHaveBeenCalledWith({
         disabled: true,
@@ -115,14 +121,19 @@ describe("action toolbar", () => {
     describe("on component", () => {
       it("include correct component, element and role data tags", () => {
         wrapper = shallow(
-          <ActionToolbar actions={{}} data-element="bar" data-role="baz" />
+          <ActionToolbar actions={{}} data-element="bar" data-role="baz" />,
+          {
+            wrappingComponent: I18next,
+          }
         );
         rootTagTest(wrapper, "action-toolbar", "bar", "baz");
       });
     });
 
     describe("on internal elements", () => {
-      wrapper = shallow(<ActionToolbar actions={{ foo: "bar" }} />);
+      wrapper = shallow(<ActionToolbar actions={{ foo: "bar" }} />, {
+        wrappingComponent: I18next,
+      });
 
       elementsTagTest(wrapper, ["action", "total"]);
     });

--- a/src/components/table/table.spec.js
+++ b/src/components/table/table.spec.js
@@ -17,14 +17,6 @@ import BaseTheme from "../../style/themes/base";
 import mintTheme from "../../style/themes/mint";
 import Link from "../link";
 
-function RenderWrapper({ ...props }) {
-  return (
-    <I18next>
-      <Table {...props} />
-    </I18next>
-  );
-}
-
 describe("Table", () => {
   let instance, instancePager, instanceSortable, instanceCustomSort, spy, row;
 
@@ -45,7 +37,7 @@ describe("Table", () => {
 
     instancePager = mount(
       <ThemeProvider theme={BaseTheme}>
-        <RenderWrapper
+        <Table
           className="foo"
           paginate
           currentPage="1"
@@ -54,8 +46,11 @@ describe("Table", () => {
           onChange={spy}
         >
           <TableRow />
-        </RenderWrapper>
-      </ThemeProvider>
+        </Table>
+      </ThemeProvider>,
+      {
+        wrappingComponent: I18next,
+      }
     )
       .find(Table)
       .instance();
@@ -121,8 +116,11 @@ describe("Table", () => {
 
   describe("refresh", () => {
     beforeEach(() => {
-      instance.actionToolbarComponent = TestUtils.renderIntoDocument(
-        <ActionToolbar actions={{}} />
+      instance.actionToolbarComponent = shallow(
+        <ActionToolbar actions={{}} />,
+        {
+          wrappingComponent: I18next,
+        }
       );
       spyOn(instance, "resetHighlightedRow");
       spyOn(instance.actionToolbarComponent, "setState");
@@ -932,7 +930,7 @@ describe("Table", () => {
         expect(
           mount(
             <ThemeProvider theme={BaseTheme}>
-              <RenderWrapper
+              <Table
                 className="foo"
                 paginate
                 currentPage="1"
@@ -941,8 +939,11 @@ describe("Table", () => {
                 onChange={spy}
               >
                 <TableRow />
-              </RenderWrapper>
-            </ThemeProvider>
+              </Table>
+            </ThemeProvider>,
+            {
+              wrappingComponent: I18next,
+            }
           ).find(Pager).exists
         ).toBeTruthy();
       });
@@ -1094,7 +1095,9 @@ describe("Table", () => {
 
     describe("when aria-describedby is in the table props", () => {
       it("renders an aria-describedby attribute on the table element", () => {
-        const wrapper = mount(<RenderWrapper aria-describedby="description" />);
+        const wrapper = mount(<Table aria-describedby="description" />, {
+          wrappingComponent: I18next,
+        });
 
         const table = wrapper.find("table").hostNodes();
 
@@ -1104,7 +1107,9 @@ describe("Table", () => {
 
     describe("when aria-describedby is not in the table props", () => {
       it("does not render an aria-describedby attribute on the table element", () => {
-        const wrapper = mount(<RenderWrapper />);
+        const wrapper = mount(<Table />, {
+          wrappingComponent: I18next,
+        });
 
         const table = wrapper.find("table").hostNodes();
 
@@ -1239,7 +1244,10 @@ describe("Table", () => {
   describe("pagination", () => {
     it("renders to match the expected style for a table with a pager", () => {
       const wrapper = mount(
-        <RenderWrapper paginate currentPage="1" totalRecords={100} />
+        <Table paginate currentPage="1" totalRecords={100} />,
+        {
+          wrappingComponent: I18next,
+        }
       );
 
       assertStyleMatch(


### PR DESCRIPTION
### Proposed behaviour
Use i18next for the `action-toolbar` component
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

### Current behaviour
i18n-js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
No test changes are required.
`action-toolbar` component should be tested for regression.
Not able to create code sandbox because of `Could not find module in path: 'react-dnd-legacy' relative to '/node_modules/carbon-react/lib/components/drag-and-drop/with-drop/with-drop.js'` error.
https://codesandbox.io/s/carbon-quickstart-forked-gk4mc?file=/src/index.js:406-411