### PR TITLE
refactor(configurable-items): replace i18n-js with i18next

### DIFF
--- a/src/components/configurable-items/configurable-items.component.js
+++ b/src/components/configurable-items/configurable-items.component.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
-import I18n from "i18n-js";
 import { withTheme } from "styled-components";
 import tagComponent from "../../utils/helpers/tags/tags";
 import { DraggableContext } from "../drag-and-drop";
@@ -14,6 +13,7 @@ import {
 import Form from "../form";
 import baseTheme from "../../style/themes/base";
 import Logger from "../../utils/logger/logger";
+import I18n from "../../__internal__/i18n";
 
 let deprecatedWarnTriggered = false;
 
@@ -44,7 +44,7 @@ class ConfigurableItems extends React.Component {
         buttonType="tertiary"
         onClick={this.onReset}
       >
-        {I18n.t("actions.reset", { defaultValue: "Reset Columns" })}
+        <I18n params={["actions.reset", { defaultValue: "Reset Columns" }]} />
       </ConfigurableItemsButtonReset>
     );
   };

--- a/src/components/configurable-items/configurable-items.spec.js
+++ b/src/components/configurable-items/configurable-items.spec.js
@@ -3,6 +3,7 @@ import { mount } from "enzyme";
 import { ConfigurableItems } from ".";
 import { DraggableContext } from "../drag-and-drop";
 import Form from "../form";
+import I18next from "../../__spec_helper__/I18next";
 
 describe("ConfigurableItems", () => {
   let wrapper;
@@ -21,7 +22,10 @@ describe("ConfigurableItems", () => {
           onSave={onSave}
         >
           <p className="child-node">Foo</p>
-        </ConfigurableItems>
+        </ConfigurableItems>,
+        {
+          wrappingComponent: I18next,
+        }
       );
     });
     it("renders child nodes", () => {
@@ -38,7 +42,10 @@ describe("ConfigurableItems", () => {
           onClick={onClick}
           onDrag={onDrag}
           onSave={onSave}
-        />
+        />,
+        {
+          wrappingComponent: I18next,
+        }
       );
     });
     it("passes the onDrag prop through to the DraggableContext", () => {
@@ -54,7 +61,10 @@ describe("ConfigurableItems", () => {
           onClick={onClick}
           onDrag={onDrag}
           onSave={onSave}
-        />
+        />,
+        {
+          wrappingComponent: I18next,
+        }
       );
     });
     it("passes the onSave prop through to the Form onSubmit prop", () => {
@@ -78,7 +88,10 @@ describe("ConfigurableItems", () => {
             onDrag={onDrag}
             onReset={onReset}
             onSave={onSave}
-          />
+          />,
+          {
+            wrappingComponent: I18next,
+          }
         );
       });
 
@@ -100,7 +113,10 @@ describe("ConfigurableItems", () => {
             onClick={onClick}
             onDrag={onDrag}
             onSave={onSave}
-          />
+          />,
+          {
+            wrappingComponent: I18next,
+          }
         );
         form = wrapper.find(Form);
       });
@@ -121,7 +137,10 @@ describe("ConfigurableItems", () => {
           onClick={onClick}
           onDrag={onDrag}
           onSave={onSave}
-        />
+        />,
+        {
+          wrappingComponent: I18next,
+        }
       );
 
       it("includes the correct component, element and role data tags", () => {


### PR DESCRIPTION
### Proposed behaviour
Use i18next for the `configurable-items` component
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

### Current behaviour
i18n-js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
No test changes are required.
`configurable-items` component should be tested for regression.
Not able to create code sandbox because of `Could not find module in path: 'react-dnd-legacy' relative to '/node_modules/carbon-react/lib/components/drag-and-drop/with-drop/with-drop.js'` error.
https://codesandbox.io/s/carbon-quickstart-forked-tq5ge?file=/src/index.js