### PR TITLE
refactor(show-edit-pod): replace i18n-js with i18next

### DIFF
--- a/src/components/show-edit-pod/show-edit-pod.component.js
+++ b/src/components/show-edit-pod/show-edit-pod.component.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import I18n from "i18n-js";
 import ReactDOM from "react-dom";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 
@@ -11,6 +10,7 @@ import StyledDeleteButton from "./delete-button.style";
 import Events from "../../utils/helpers/events";
 import { validProps } from "../../utils/ether";
 import tagComponent from "../../utils/helpers/tags";
+import I18n from "../../__internal__/i18n";
 import StyledPod from "./show-edit-pod.style";
 
 class ShowEditPod extends React.Component {
@@ -63,9 +63,9 @@ class ShowEditPod extends React.Component {
   };
 
   deleteButton() {
-    const label =
-      this.props.deleteText ||
-      I18n.t("actions.delete", { defaultValue: "Delete" });
+    const label = this.props.deleteText || (
+      <I18n params={["actions.delete", { defaultValue: "Delete" }]} />
+    );
 
     return (
       <StyledDeleteButton

--- a/src/components/show-edit-pod/show-edit-pod.spec.js
+++ b/src/components/show-edit-pod/show-edit-pod.spec.js
@@ -293,7 +293,9 @@ describe("ShowEditPod", () => {
         onDelete,
         editing: true,
       });
-      additionalComponent = mount(wrapper.find(Form).props().rightSideButtons);
+      additionalComponent = mount(wrapper.find(Form).props().rightSideButtons, {
+        wrappingComponent: I18next,
+      });
 
       expect(additionalComponent.type()).toBe(StyledDeleteButton);
     });
@@ -320,7 +322,10 @@ describe("ShowEditPod", () => {
           editing: true,
         });
         additionalComponent = mount(
-          wrapper.find(Form).props().rightSideButtons
+          wrapper.find(Form).props().rightSideButtons,
+          {
+            wrappingComponent: I18next,
+          }
         );
 
         expect(additionalComponent.text()).toBe("Delete");


### PR DESCRIPTION
### Proposed behaviour
Use i18next for the `show-edit-pod` component
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

### Current behaviour
i18n-js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
No test changes are required.
`show-edit-pod` component should be tested for regression.
https://codesandbox.io/s/carbon-quickstart-forked-w75dd?file=/src/index.js:1179-1239