### PR TITLE
refactor(table): replace i18n-js with i18next

### DIFF
--- a/src/components/table/table.component.js
+++ b/src/components/table/table.component.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 import Immutable from "immutable";
-import I18n from "i18n-js";
 import ActionToolbar from "../action-toolbar";
 import Icon from "../icon";
 import Link from "../link";
@@ -16,6 +15,7 @@ import Pager from "../pager";
 import Loader from "../loader";
 import OptionsHelper from "../../utils/helpers/options-helper";
 import Logger from "../../utils/logger/logger";
+import I18n from "../../__internal__/i18n";
 
 let deprecatedWarnTriggered = false;
 
@@ -425,7 +425,12 @@ class Table extends React.Component {
     return (
       <TableRow key="__loading__" selectable={false} highlightable={false}>
         <TableCell colSpan="42" align="center">
-          {I18n.t("table.no_data", { defaultValue: "No results to display" })}
+          <I18n
+            params={[
+              "table.no_data",
+              { defaultValue: "No results to display" },
+            ]}
+          />
         </TableCell>
       </TableRow>
     );


### PR DESCRIPTION
### Proposed behaviour
Use i18next for the `table` component
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

### Current behaviour
i18n-js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
No test changes are required.
`table` component should be tested for regression.
Not able to create code sandbox because of `Could not find module in path: 'react-dnd-legacy' relative to '/node_modules/carbon-react/lib/components/drag-and-drop/with-drop/with-drop.js'` error.