### PR TITLE
test(menu): add missing cypress tests

### DIFF
--- a/cypress/features/regression/designSystem/menu.feature
+++ b/cypress/features/regression/designSystem/menu.feature
@@ -1,9 +1,9 @@
-Feature: Design System Menu component
-  I want to test the Design System Menu component
+Feature: Design Systems Menu component
+  I want to test the Design Systems Menu component
 
   @positive
   Scenario Outline: Test that the scroll block within a submenu is scrollable
-    Given I open "Design System Menu" component page "scrollable-submenu" in no iframe
+    Given I open "Design System Menu" component page "scrollable submenu" in no iframe
     When I open the "<position>" submenu
       And I scroll to the bottom of the block
     Then The last element is visible
@@ -11,11 +11,6 @@ Feature: Design System Menu component
       | position |
       | first    |
       | second   |
-
-  @positive
-  Scenario: Check the persistence of Menu component
-    Given I open "Design System Menu" component page "default divider" in no iframe
-    Then Menu elements are visible
 
   @positive
   Scenario: Check the size of the second expandable element of Menu
@@ -28,3 +23,23 @@ Feature: Design System Menu component
     Given I open "Design System Menu" component page "submenu with search" in no iframe
     When I hover over third expandable Menu component
     Then Inner menu search input has alternate "rgb(0, 51, 73)" background colour
+
+  @positive
+  Scenario: Check the size of divider is a large
+    Given I open "Design System Menu" component page "default large divider" in no iframe
+    When I hover over third expandable Menu component
+    Then Menu divider has 4 px size
+
+  @positive
+  Scenario: Check the segment title is visible within a submenu
+    Given I open "Design System Menu" component page "default segment title" in no iframe
+    When I hover over third expandable Menu component
+    Then "segment title" is visible
+
+  @positive
+  Scenario: Check alternate colour theme for submenu
+    Given I open "Design System Menu" component page "default theme alternate colour" in no iframe
+    When I hover over third expandable Menu component
+    Then "fourth" submenu has alternate colour theme
+      And "fifth" submenu has alternate colour theme
+      And "sixth" submenu has alternate colour theme

--- a/cypress/locators/menu/index.js
+++ b/cypress/locators/menu/index.js
@@ -1,10 +1,11 @@
-import { MENU_PREVIEW, SUBMENU, SCROLL_BLOCK } from "./locators";
+import { SUBMENU, SCROLL_BLOCK, MENU_DIVIDER, SEGMENT_TITLE } from "./locators";
 
 // component preview locators
-export const menuPreview = () => cy.get(MENU_PREVIEW);
 export const submenu = () => cy.get(SUBMENU);
 export const submenuBlock = () => cy.get(SUBMENU).find("ul");
 export const innerMenu = (index) =>
   submenuBlock().find(`li:nth-child(${index})`).find("div");
 export const scrollBlock = () => cy.get(SUBMENU).find(SCROLL_BLOCK);
 export const lastSubmenuElement = () => submenuBlock().find("li div").last();
+export const menuDivider = () => cy.get(MENU_DIVIDER);
+export const segmentTitle = () => cy.get(SEGMENT_TITLE);

--- a/cypress/locators/menu/locators.js
+++ b/cypress/locators/menu/locators.js
@@ -1,4 +1,5 @@
 // component preview locators
-export const MENU_PREVIEW = '[data-component="menu"]';
 export const SUBMENU = '[data-component="submenu-wrapper"]';
 export const SCROLL_BLOCK = '[data-component="submenu-scrollable-block"]';
+export const MENU_DIVIDER = '[data-component="menu-divider"]';
+export const SEGMENT_TITLE = '[data-component="menu-segment-title"]';

--- a/cypress/support/step-definitions/menu-steps.js
+++ b/cypress/support/step-definitions/menu-steps.js
@@ -1,16 +1,13 @@
 import {
-  menuPreview,
   submenuBlock,
   innerMenu,
   submenu,
   scrollBlock,
   lastSubmenuElement,
+  menuDivider,
+  segmentTitle,
 } from "../../locators/menu";
 import { positionOfElement } from "../helper";
-
-Then("Menu elements are visible", () => {
-  menuPreview().should("be.visible");
-});
 
 When("I hover over third expandable Menu component", () => {
   submenu().trigger("mouseover");
@@ -62,3 +59,22 @@ Then(
     );
   }
 );
+
+Then("Menu divider has {int} px size", (size) => {
+  menuDivider().should("have.css", "height", `${size}px`);
+});
+
+Then("{string} is visible", (text) => {
+  segmentTitle()
+    .should("have.text", text)
+    .and("be.visible")
+    .and("have.css", "color", "rgb(64, 102, 119)");
+});
+
+Then("{string} submenu has alternate colour theme", (position) => {
+  innerMenu(positionOfElement(position)).should(
+    "have.css",
+    "background-color",
+    "rgb(230, 235, 237)"
+  );
+});


### PR DESCRIPTION
### Proposed behaviour
Add missing cypress tests
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
We have some missing test cases for Menu component

- Large divider
- Segment title
- Default theme alternate colour
- Submenu direction left
### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

