### PR TITLE
docs(definition-list): add action popover and icon example - FE-3004

### DIFF
--- a/src/components/definition-list/definition-list.stories.mdx
+++ b/src/components/definition-list/definition-list.stories.mdx
@@ -1,9 +1,14 @@
-import { Meta, Story, Preview, Props} from '@storybook/addon-docs/blocks';
-import {useState} from 'react';
-import { Dl, Dt, Dd } from "./"
-import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
+import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Dl, Dt, Dd } from "./";
+import Icon from "../icon";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import Box from "../box";
+import { ActionPopover, ActionPopoverItem } from "../action-popover";
 
-<Meta title="Design System/Definition List" parameters={{ info: { disable: true }}} />
+<Meta
+  title="Design System/Definition List"
+  parameters={{ info: { disable: true } }}
+/>
 
 # Definition List
 
@@ -20,12 +25,13 @@ import { Dl, Dt, Dd } from "carbon-react/lib/components/definition-list";
 ```
 
 ## Related Components
+
 Definition List most of the time is in use with other components. Look at the examples below
 
 - [Tile component with Definition List](/?path=/docs/design-system-tile--with-definition-list-default "Tile component with Definition List").
 - [Accordion component with Definition List](/?path=/docs/design-system-accordion--with-a-definition-list "Accordion component with Definition List").
 
-## Examples 
+## Examples
 
 ### Default
 
@@ -42,31 +48,75 @@ Definition List most of the time is in use with other components. Look at the ex
   </Story>
 </Preview>
 
+### Action popover and icon support
+
+<Preview>
+  <Story name="action popover and icon support">
+    <Dl>
+      <Dt>
+        <Box paddingTop="4px">
+          Term example
+        </Box>
+      </Dt>
+      <Dd>
+        <Box display="inline-flex" alignItems="center">
+          <Box mr={1}>Details example</Box>
+          <Icon type="tick" />
+        </Box>
+      </Dd>
+      <Dt>
+        <Box paddingTop="4px">
+          Term example
+        </Box>
+      </Dt>
+      <Dd>
+        <Box display="inline-flex" alignItems="center">
+          <Icon mr={1} type="tick" />
+          <Box mr={2}>Details example</Box>
+          <ActionPopover rightAlignMenu>
+            <ActionPopoverItem>Option 1</ActionPopoverItem>
+            <ActionPopoverItem>Option 2</ActionPopoverItem>
+          </ActionPopover>
+        </Box>
+      </Dd>
+    </Dl>
+  </Story>
+</Preview>
+
 ### Conditional rendering with `<React.Fragment />`
+
 *CAUTION: don't use nested `<React.Fragment />`*
 
 <Preview>
-  <Story name="with conditional rendering" parameters={{ chromatic: { disable: true }}}>
-      <Dl>
-        <Dt>First</Dt>
-        <Dd>Description</Dd>
-        <Dt>Second</Dt>
-        <Dd>Description</Dd>
-        {(true && <>
+  <Story
+    name="with conditional rendering"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    <Dl>
+      <Dt>First</Dt>
+      <Dd>Description</Dd>
+      <Dt>Second</Dt>
+      <Dd>Description</Dd>
+      {true && (
+        <>
           <Dt>Third inside of React Fragment</Dt>
           <Dd>Description inside of React Fragment</Dd>
-        </>)}
-      </Dl>
+        </>
+      )}
+    </Dl>
   </Story>
 </Preview>
 
 ## Props
 
 ### Dl
-<StyledSystemProps of={Dl} noHeader spacing/>
+
+<StyledSystemProps of={Dl} noHeader spacing />
 
 ### Dt
-<StyledSystemProps of={Dt} noHeader spacing/>
+
+<StyledSystemProps of={Dt} noHeader spacing />
 
 ### Dd
-<StyledSystemProps of={Dd} noHeader spacing/>
+
+<StyledSystemProps of={Dd} noHeader spacing />

--- a/src/components/tile/tile.stories.mdx
+++ b/src/components/tile/tile.stories.mdx
@@ -12,6 +12,8 @@ import { Accordion } from "../accordion";
 import TileFooter from "./tile-footer";
 import Typography from "../typography";
 import Box from "../box";
+import {ActionPopover, ActionPopoverItem} from "../action-popover";
+import Icon from "../icon";
 import VerticalDivider from "../vertical-divider";
 import Hr from "../hr";
 
@@ -379,6 +381,68 @@ In this example `dtTextAlign` has been provided the string 'left' and `ddTextAli
   </Story>
 </Preview>
 
+## With Definition List and ActionPopover and Icon support
+
+<Preview>
+  <Story name="with Definition List and ActionPopover and Icon support">
+    <Tile width={60}>
+      <Dl>
+      <Dt>
+        <Box paddingTop="4px" display="inline-flex" alignItems="center">
+          Term example
+        </Box>
+      </Dt>
+      <Dd>
+        <Box display="inline-flex" alignItems="center">
+          <Icon type="tick" mr={1}/>
+          <Box>Details example</Box>
+        </Box>
+      </Dd>
+      <Dt>
+        <Box paddingTop="4px">
+          Term example
+        </Box>
+      </Dt>
+      <Dd>
+        <Box display="inline-flex" alignItems="center">
+          <Box mr={1}>Details example</Box>
+          <Icon type="tick" />
+        </Box>
+      </Dd>
+      <Dt>
+        <Box paddingTop="4px">
+          Term example
+        </Box>
+      </Dt>
+      <Dd>
+        <Box display="inline-flex" alignItems="center">
+          <Icon mr={1} type="tick" />
+          <Box mr={2}>Details example</Box>
+          <ActionPopover rightAlignMenu>
+            <ActionPopoverItem>Option 1</ActionPopoverItem>
+            <ActionPopoverItem>Option 2</ActionPopoverItem>
+          </ActionPopover>
+        </Box>
+      </Dd>
+      <Dt>
+        <Box paddingTop="4px">
+          Term example
+        </Box>
+      </Dt>
+      <Dd>
+        <Box display="inline-flex" alignItems="center">
+          <Box mr={2}>Details example</Box>
+          <ActionPopover rightAlignMenu>
+            <ActionPopoverItem>Option 1</ActionPopoverItem>
+            <ActionPopoverItem>Option 2</ActionPopoverItem>
+          </ActionPopover>
+        </Box>
+      </Dd>
+    </Dl>
+    </Tile>
+  </Story>
+</Preview>
+
 ### With Accordion and Definition List
 
 <Preview>
@@ -444,7 +508,7 @@ In this example `dtTextAlign` has been provided the string 'left' and `ddTextAli
 
 ## Props
 
-### Tile 
+### Tile
 <StyledSystemProps noHeader of={Tile} spacing spacingDefaults={{ p: 3 }} />
 
 ### TileFooter


### PR DESCRIPTION
### Proposed behaviour
Available example of how to use ActionPopover and Icon within DefinitionList.
![image](https://user-images.githubusercontent.com/5004407/111516207-f0fbc800-8753-11eb-8026-6166d9b39e5a.png)

### Current behaviour
No available example of how to use ActionPopover and Icon within DefinitionList.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [ ] <del>All themes are supported if required
- [ ] <del>Unit tests added or updated if required
- [ ] <del>Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] <del>Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
http://localhost:9001/?path=/docs/design-system-definition-list--action-popover-and-icon-support
