### PR TITLE
fix(flat-table-row): allow null children

### DIFF
--- a/src/components/flat-table/flat-table-row/flat-table-row.component.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.js
@@ -98,32 +98,38 @@ const FlatTableRow = React.forwardRef(
               {...interactiveRowProps}
             >
               {React.Children.map(children, (child, index) => {
-                return React.cloneElement(child, {
-                  expandable: expandable && index === firstCellIndex(),
-                  onClick:
-                    expandable &&
-                    index === firstCellIndex() &&
-                    firstColumnExpandable
-                      ? () => toggleExpanded()
-                      : undefined,
-                  onKeyDown:
-                    expandable &&
-                    index === firstCellIndex() &&
-                    firstColumnExpandable
-                      ? handleCellKeyDown
-                      : undefined,
-                  ...child.props,
-                });
+                return (
+                  child &&
+                  React.cloneElement(child, {
+                    expandable: expandable && index === firstCellIndex(),
+                    onClick:
+                      expandable &&
+                      index === firstCellIndex() &&
+                      firstColumnExpandable
+                        ? () => toggleExpanded()
+                        : undefined,
+                    onKeyDown:
+                      expandable &&
+                      index === firstCellIndex() &&
+                      firstColumnExpandable
+                        ? handleCellKeyDown
+                        : undefined,
+                    ...child.props,
+                  })
+                );
               })}
             </StyledFlatTableRow>
             {isExpanded &&
               subRows &&
-              React.Children.map(subRows, (child, index) =>
-                React.cloneElement(child, {
-                  isSubRow: true,
-                  isFirstSubRow: index === 0,
-                  ...child.props,
-                })
+              React.Children.map(
+                subRows,
+                (child, index) =>
+                  child &&
+                  React.cloneElement(child, {
+                    isSubRow: true,
+                    isFirstSubRow: index === 0,
+                    ...child.props,
+                  })
               )}
           </>
         )}

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -414,6 +414,42 @@ describe("FlatTableRow", () => {
     });
   });
 
+  describe("with conditionally rendered children", () => {
+    describe("when child is null", () => {
+      it("should not render that child", () => {
+        const wrapper = mount(
+          <table>
+            <tbody>
+              <FlatTableRow>
+                <FlatTableCell>cell1</FlatTableCell>
+                {false && <FlatTableCell>cell2</FlatTableCell>}
+              </FlatTableRow>
+            </tbody>
+          </table>
+        );
+
+        expect(wrapper.find(FlatTableCell).length).toEqual(1);
+      });
+    });
+
+    describe("when child is not null", () => {
+      it("should render that child", () => {
+        const wrapper = mount(
+          <table>
+            <tbody>
+              <FlatTableRow>
+                <FlatTableCell>cell1</FlatTableCell>
+                {true && <FlatTableCell>cell2</FlatTableCell>}
+              </FlatTableRow>
+            </tbody>
+          </table>
+        );
+
+        expect(wrapper.find(FlatTableCell).length).toEqual(2);
+      });
+    });
+  });
+
   describe("when the row is expandable", () => {
     const SubRows = [
       <FlatTableRow>


### PR DESCRIPTION
Fixes: #3790

### Proposed behaviour
Allow null children in `FlatTableRow`. This was previously possible but we had a regression which now causes an error

### Current behaviour
Trying to have a null child of `FlatTableRow` causes the error: `Cannot read property 'props' of null`.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
Use the sandbox from the issue, build with changes in will be in the codesandboxbot comment below