### PR TITLE
fix: will update pager after enter key is pressed - FE-3342

### DIFF
--- a/cypress/features/regression/designSystem/flatTable.feature
+++ b/cypress/features/regression/designSystem/flatTable.feature
@@ -227,3 +227,21 @@ Feature: Design Systems FlatTable component
       And I press keyboard "Enter" key times 1
       And I continue to hit Tab key 7 times in no Iframe
     Then The fourth content row has focus
+
+  @positive
+  Scenario: Five rows are visible without Enter key pressed 
+    Given I open "Design System Flat Table" component page "paginated" in no iframe
+      And 5 rows are visible
+    When I type 1 in pagination input
+      And I hit Tab key 2 times in no Iframe
+    Then 5 rows are visible
+      And Pagination input should have 5 value
+
+  @positive
+  Scenario: One row is visible after Enter key is pressed
+    Given I open "Design System Flat Table" component page "paginated" in no iframe
+      And 5 rows are visible
+    When I type 1 in pagination input
+      And I press "Enter" onto focused element
+    Then 1 row is visible
+      And Pagination input should have 1 value

--- a/cypress/locators/flat-table/index.js
+++ b/cypress/locators/flat-table/index.js
@@ -4,6 +4,7 @@ import {
   FLAT_TABLE_SUBROW,
   FLAT_TABLE_PAGE_SIZE_SELECT,
   FLAT_TABLE_PAGE_SELECT_LIST,
+  PAGE_SELECT,
 } from "./locators";
 
 // component preview locators
@@ -36,3 +37,4 @@ export const flatTablePageSizeSelect = () =>
   cy.get(FLAT_TABLE_PAGE_SIZE_SELECT);
 export const flatTablePageSelectListPosition = () =>
   cy.get(FLAT_TABLE_PAGE_SELECT_LIST).parent();
+export const pageSelectDataComponent = () => cy.get(PAGE_SELECT);

--- a/cypress/locators/flat-table/locators.js
+++ b/cypress/locators/flat-table/locators.js
@@ -6,3 +6,4 @@ export const FLAT_TABLE_SUBROW = '[data-element="flat-table-sub-row"]';
 export const FLAT_TABLE_PAGE_SIZE_SELECT = '[data-element="dropdown"]';
 export const FLAT_TABLE_PAGE_SELECT_LIST =
   '[data-element="select-list-wrapper"]';
+export const PAGE_SELECT = '[data-element="page-select"]';

--- a/cypress/support/step-definitions/flat-table-steps.js
+++ b/cypress/support/step-definitions/flat-table-steps.js
@@ -12,6 +12,7 @@ import {
   flatTableSubrows,
   flatTablePageSizeSelect,
   flatTablePageSelectListPosition,
+  pageSelectDataComponent,
 } from "../../locators/flat-table";
 
 import DEBUG_FLAG from "..";
@@ -267,4 +268,16 @@ Then("pageSizeSelectList is visible at the {word}", (position) => {
   flatTablePageSelectListPosition()
     .should("have.attr", "data-popper-placement", `${position}-start`)
     .and("be.visible");
+});
+
+Then("{int} row/rows is/are visible", (int) => {
+  flatTableBodyRows().should("have.length", int).and("be.visible");
+});
+
+Then("I type {int} in pagination input", (value) => {
+  pageSelectDataComponent().find("input").type(value);
+});
+
+Then("Pagination input should have {int} value", (value) => {
+  pageSelectDataComponent().find("input").should("have.value", value);
 });

--- a/src/components/pager/pager.component.js
+++ b/src/components/pager/pager.component.js
@@ -10,6 +10,7 @@ import {
   StyledPagerSizeOptionsInner,
   StyledSelect,
 } from "./pager.style";
+import Events from "../../utils/helpers/events/events";
 
 const Pager = ({
   currentPage = 1,
@@ -38,6 +39,7 @@ const Pager = ({
 }) => {
   const [page, setPage] = useState(currentPage);
   const [currentPageSize, setCurrentPageSize] = useState(pageSize);
+  const [value, setValue] = useState(pageSize);
 
   const getPageCount = useCallback(() => {
     if (Number(totalRecords) < 0 || Number.isNaN(Number(totalRecords))) {
@@ -121,19 +123,25 @@ const Pager = ({
 
   const handleOnPagination = useCallback(
     (e) => {
+      setValue(e.target.value);
       setCurrentPageSize(Number(e.target.value));
       onPagination(1, Number(e.target.value), "page-select");
     },
     [onPagination]
   );
 
+  const handleKeyDown = useCallback(
+    (e) => Events.isEnterKey(e) && handleOnPagination(e),
+    [handleOnPagination]
+  );
+
   const sizeSelector = () => {
     return (
       <StyledSelect
-        value={String(currentPageSize)}
-        onChange={(ev) => {
-          handleOnPagination(ev);
-        }}
+        value={String(value)}
+        onChange={(ev) => setValue(ev.target.value)}
+        onBlur={() => setValue(currentPageSize)}
+        onKeyDown={handleKeyDown}
         data-element="page-select"
         id="page-select"
       >
@@ -142,6 +150,7 @@ const Pager = ({
             key={sizeOption.id}
             text={sizeOption.id}
             value={String(sizeOption.name)}
+            onClick={handleOnPagination}
           />
         ))}
       </StyledSelect>

--- a/src/components/select/option/option.component.js
+++ b/src/components/select/option/option.component.js
@@ -3,9 +3,17 @@ import PropTypes from "prop-types";
 import StyledOption from "./option.style";
 
 const Option = React.forwardRef(
-  ({ text, children, onSelect, value, isHighlighted, hidden }, ref) => {
+  (
+    { text, children, onSelect, value, isHighlighted, hidden, onClick },
+    ref
+  ) => {
     function handleClick() {
-      onSelect({ text, value });
+      if (!onClick) {
+        onSelect({ text, value });
+      } else {
+        onSelect();
+        onClick({ target: { text, value } });
+      }
     }
 
     return (
@@ -31,6 +39,11 @@ Option.propTypes = {
   children: PropTypes.node,
   /** The option's invisible internal value */
   value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
+  /**
+   * @private
+   * @ignore
+   * Callback to return value when the element is clicked (prop added by the SelectList component) */
+  onClick: PropTypes.func,
   /**
    * @private
    * @ignore


### PR DESCRIPTION
Fixes: #3413

### Proposed behaviour
Change current behavior to update pager after enter button pressed
![pager](https://user-images.githubusercontent.com/19231884/111784294-8f566d80-88bb-11eb-9c04-f5cb999ebd88.gif)

### Current behaviour
Pager updates onChange (if you change page size with your arrow keys)

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] <del> Storybook added or updated if required
- [ ] <del> Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Testing instructions
<!-- How can a reviewer test this PR? -->
Newe behaviour can be visible on storybook `paginated` story