### PR TITLE
feat(date-picker): auto position pop up

### DIFF
--- a/cypress/features/regression/experimental/dateInput.feature
+++ b/cypress/features/regression/experimental/dateInput.feature
@@ -73,3 +73,13 @@ Feature: Experimental Date Input component
     Given I open "Experimental Date Input Test" component page "default"
     When I click onto date icon twice
     Then dayPickerDay is not visible
+
+  @positive
+  Scenario Outline: Show Date input at the <position> position
+    Given I open default "Experimental Date Input Test" component in noIFrame with "dateInput" json from "experimental" using "<marginTop>" object name
+    When I click dateInput in noIframe
+    Then Date input is visible at the <position>
+    Examples:
+      | position | marginTop |
+      | bottom   | small     |
+      | top      | large     |

--- a/cypress/fixtures/experimental/dateInput.json
+++ b/cypress/fixtures/experimental/dateInput.json
@@ -22,5 +22,11 @@
     "label": "label",
     "labelHelp": "labelHelp",
     "labelInline": true
+  },
+  "small": {
+    "mt": "0"
+  },
+  "large": {
+    "mt": "400"
   }
 }

--- a/cypress/locators/date-input/index.js
+++ b/cypress/locators/date-input/index.js
@@ -16,3 +16,5 @@ export const dateInputNoIFrame = () => cy.get(DATE_INPUT).parent();
 export const dateIcon = () => cy.iFrame(DATE_ICON);
 export const dayPickerWrapper = () => cy.iFrame(DAY_PICKER_WRAPPER);
 export const dayPickerDay = (date) => cy.iFrame(`div[aria-label="${date}"]`);
+export const dayPickerParentNoIFrame = () =>
+  cy.get(DAY_PICKER_WRAPPER).parent().parent();

--- a/cypress/support/step-definitions/date-input-steps.js
+++ b/cypress/support/step-definitions/date-input-steps.js
@@ -6,6 +6,7 @@ import {
   dayPickerWrapper,
   dateIcon,
   dateInputNoIFrame,
+  dayPickerParentNoIFrame,
 } from "../../locators/date-input/index";
 
 const DAY_PICKER_PREFIX = "DayPicker-Day--";
@@ -69,6 +70,10 @@ When("I click dateInput", () => {
   dateInput().click({ force: true });
 });
 
+When("I click dateInput in noIframe", () => {
+  dateInputNoIFrame().click({ force: true });
+});
+
 When("I choose date yesterday via DayPicker", () => {
   dayPickerDay(YESTERDAY_CALENDAR).click();
 });
@@ -115,4 +120,10 @@ When("I click dateInput twice", () => {
     .then(($el) => {
       $el.click();
     });
+});
+
+Then("Date input is visible at the {word}", (position) => {
+  dayPickerParentNoIFrame()
+    .should("have.attr", "data-popper-placement", `${position}-start`)
+    .and("be.visible");
 });

--- a/src/__experimental__/components/date/__snapshots__/date-picker.spec.js.snap
+++ b/src/__experimental__/components/date/__snapshots__/date-picker.spec.js.snap
@@ -9,7 +9,7 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
         "options": Object {
           "offset": Array [
             -11,
-            0,
+            5,
           ],
         },
       },
@@ -375,449 +375,109 @@ exports[`StyledDayPicker i18n translation renders properly 1`] = `
       }
     }
   >
-    <styled.div
-      theme={
+    <DayPicker
+      canChangeMonth={true}
+      captionElement={
+        <Caption
+          classNames={
+            Object {
+              "body": "DayPicker-Body",
+              "caption": "DayPicker-Caption",
+              "container": "DayPicker",
+              "day": "DayPicker-Day",
+              "disabled": "disabled",
+              "footer": "DayPicker-Footer",
+              "interactionDisabled": "DayPicker--interactionDisabled",
+              "month": "DayPicker-Month",
+              "navBar": "DayPicker-NavBar",
+              "navButtonInteractionDisabled": "DayPicker-NavButton--interactionDisabled",
+              "navButtonNext": "DayPicker-NavButton DayPicker-NavButton--next",
+              "navButtonPrev": "DayPicker-NavButton DayPicker-NavButton--prev",
+              "outside": "outside",
+              "selected": "selected",
+              "today": "today",
+              "todayButton": "DayPicker-TodayButton",
+              "week": "DayPicker-Week",
+              "weekNumber": "DayPicker-WeekNumber",
+              "weekday": "DayPicker-Weekday",
+              "weekdays": "DayPicker-Weekdays",
+              "weekdaysRow": "DayPicker-WeekdaysRow",
+              "wrapper": "DayPicker-wrapper",
+            }
+          }
+        />
+      }
+      classNames={
         Object {
-          "accordion": Object {
-            "background": "#E6EBED",
-            "border": "#CCD6DB",
-          },
-          "anchorNavigation": Object {
-            "divider": "#CCD6DB",
-            "navItemHoverBackground": "#E6EBED",
-          },
-          "batchSelection": Object {
-            "lightTheme": "#B3C2C8",
-          },
-          "card": Object {
-            "footerBackground": "#F2F5F6",
-            "footerBorder": "#CCD6DB",
-          },
-          "carousel": Object {
-            "activeSelectorBackground": "#668592",
-            "inactiveSelectorBackground": "#CCD6DB",
-          },
-          "checkable": Object {
-            "checked": "rgba(0,0,0,0.90)",
-          },
-          "colors": Object {
-            "asterisk": "#C7384F",
-            "base": "#00A376",
-            "black": "#000000",
-            "border": "#668592",
-            "brand": "#00DC00",
-            "dashedBorder": "#99ADB6",
-            "dashedButtonText": "rgba(0, 0, 0, 0.9)",
-            "dashedHoverBackground": "#CCD6DB",
-            "destructive": Object {
-              "hover": "#9F2D3F",
-            },
-            "disabled": "#66C266",
-            "error": "#C7384F",
-            "focus": "#FFB500",
-            "focusedIcon": "#335C6D",
-            "focusedLinkBackground": "#FFDA80",
-            "hoveredTabKeyline": "#4DB84D",
-            "info": "#0073C2",
-            "previewBackground": "#BFCCD2",
-            "primary": "#008200",
-            "secondary": "#006300",
-            "slate": "#003349",
-            "success": "#00B000",
-            "tertiary": "#004500",
-            "warning": "#E96400",
-            "white": "#FFFFFF",
-            "whiteMix": "#E6F5E6",
-            "withOpacity": "rgba(0,163,118,0.55)",
-          },
-          "content": Object {
-            "secondaryColor": "#668592",
-          },
-          "definitionList": Object {
-            "ddText": "rgba(0,0,0,0.65)",
-            "dtTextDark": "rgba(0,0,0,0.9)",
-            "dtTextLight": "rgba(0,0,0,0.65)",
-          },
-          "disabled": Object {
-            "background": "#E6EBED",
-            "border": "#CCD6DB",
-            "button": "#E6EBED",
-            "buttonText": "rgba(0,0,0,.2)",
-            "disabled": "rgba(0,0,0,0.55)",
-            "input": "#F2F5F6",
-            "switch": "#E4EAEC",
-            "text": "rgba(0,0,0,0.3)",
-          },
-          "draggableItem": Object {
-            "border": "#E6EBED",
-          },
-          "drawer": Object {
-            "background": "#EDF1F2",
-            "divider": "#D9E0E4",
-          },
-          "editor": Object {
-            "border": "#668592",
-            "button": Object {
-              "hover": "#CCD6DB",
-            },
-            "counter": "rgba(0,0,0,0.55)",
-            "placeholder": "rgba(0,0,0,0.30)",
-            "toolbar": Object {
-              "background": "#F2F5F6",
-            },
-          },
-          "flatTable": Object {
-            "dark": Object {
-              "border": "#668592",
-              "headerBackground": "#335C6D",
-            },
-            "drawerSidebar": Object {
-              "headerBackground": "#EDF1F2",
-              "highlighted": "#CCD6DB",
-              "hover": "#D9E0E4",
-              "selected": "#B3C2C8",
-            },
-            "headerIconColor": "#99ADB6",
-            "highlighted": "#E6EBED",
-            "hover": "#F2F5F6",
-            "light": Object {
-              "border": "#B3C2C8",
-              "headerBackground": "#CCD6DB",
-            },
-            "selected": "#D9E0E4",
-            "subRow": Object {
-              "background": "#FAFBFB",
-              "shadow": "rgba(0, 20, 29, 0.1)",
-            },
-            "transparentBase": Object {
-              "border": "#F2F5F6",
-              "headerBackground": "#F2F5F6",
-            },
-            "transparentWhite": Object {
-              "border": "#fff",
-              "headerBackground": "#fff",
-            },
-          },
-          "form": Object {
-            "invalid": "#F2F5F6",
-          },
-          "help": Object {
-            "color": "rgba(0,0,0,0.65)",
-            "hover": "rgba(0,0,0,0.9)",
-          },
-          "hr": Object {
-            "background": "#CCD6DB",
-          },
-          "icon": Object {
-            "default": "rgba(0,0,0,0.65)",
-            "defaultHover": "rgba(0,0,0,0.90)",
-            "disabled": "rgba(0,0,0,0.30)",
-            "onLightBackground": "#668592",
-            "onLightBackgroundHover": "#335C6D",
-          },
-          "menu": Object {
-            "dark": Object {
-              "divider": "#1A475B",
-              "searchIcon": "#8CA3AD",
-              "searchIconHover": "#BFCCD2",
-              "selected": "#1A475B",
-              "submenuBackground": "#001A25",
-              "title": "#99ADB6",
-            },
-            "divider": "#E6EBED",
-            "focus": "#F2F5F6",
-            "itemColor": "rgba(0,0,0,0.9)",
-            "itemColorDisabled": "rgba(0,0,0,0.3)",
-            "light": Object {
-              "background": "#E6EBED",
-              "divider": "#CCD6DB",
-              "selected": "#D9E0E4",
-              "title": "#406677",
-            },
-          },
-          "name": "base",
-          "navigationBar": Object {
-            "dark": Object {
-              "background": "#003349",
-              "borderBottom": "#003349",
-            },
-            "light": Object {
-              "background": "#E6EBED",
-              "borderBottom": "#D9E0E4",
-            },
-          },
-          "note": Object {
-            "timeStamp": "rgba(0,0,0,0.65)",
-          },
-          "numeralDate": Object {
-            "error": "#C7384F",
-            "passive": "#668592",
-          },
-          "pager": Object {
-            "active": "rgba(0,0,0,0.90)",
-            "alternate": "#EDF1F2",
-            "disabled": "rgba(0,0,0,0.3)",
-          },
-          "palette": Object {
-            "amethyst": "#582C83",
-            "amethystShade": [Function],
-            "amethystTint": [Function],
-            "blackOpacity": [Function],
-            "brilliantGreen": "#00DC00",
-            "brilliantGreenShade": [Function],
-            "brilliantGreenTint": [Function],
-            "carrotOrange": "#E96400",
-            "carrotOrangeShade": [Function],
-            "carrotOrangeTint": [Function],
-            "errorRed": "#C7384F",
-            "errorRedShade": [Function],
-            "errorRedTint": [Function],
-            "genericGreen": "#009900",
-            "genericGreenShade": [Function],
-            "genericGreenTint": [Function],
-            "gold": "#FFB500",
-            "goldShade": [Function],
-            "goldTint": [Function],
-            "navyBlue": "#004B87",
-            "navyBlueShade": [Function],
-            "navyBlueTint": [Function],
-            "plum": "#8246AF",
-            "plumShade": [Function],
-            "plumTint": [Function],
-            "productBlue": "#0077C8",
-            "productBlueShade": [Function],
-            "productBlueTint": [Function],
-            "productGreen": "#00A376",
-            "productGreenShade": [Function],
-            "productGreenTint": [Function],
-            "slate": "#003349",
-            "slateShade": [Function],
-            "slateTint": [Function],
-            "whiteOpacity": [Function],
-          },
-          "pill": Object {
-            "errorButtonFocus": "#9F2D3F",
-            "neutral": "#4D7080",
-            "neutralBackgroundFocus": "#1A475B",
-            "warning": "#ED8333",
-            "warningButtonFocus": "#E96400",
-          },
-          "pod": Object {
-            "border": "#CCD6DB",
-            "footerBackground": "#F2F5F6",
-            "hoverBackground": "#D9E0E4",
-            "secondaryBackground": "#F2F5F6",
-            "tertiaryBackground": "#E6EBED",
-            "tileBackground": "#FFFFFF",
-          },
-          "popoverContainer": Object {
-            "iconColor": "rgba(0,0,0,0.90)",
-          },
-          "portrait": Object {
-            "background": "#F2F5F6",
-            "border": "#8099A4",
-            "initials": "rgba(0,0,0,0.65)",
-          },
-          "readOnly": Object {
-            "textboxBackground": "#FAFBFB",
-            "textboxBorder": "#CCD6DB",
-            "textboxText": "rgba(0,0,0,0.74)",
-          },
-          "scrollbar": Object {
-            "dark": Object {
-              "thumb": "#99ADB6",
-              "track": "#335C6D",
-            },
-            "light": Object {
-              "thumb": "#668592",
-              "track": "#F2F5F6",
-            },
-          },
-          "search": Object {
-            "active": "#FFB500",
-            "button": "#255BC7",
-            "darkVariantBorder": "#8CA3AD",
-            "darkVariantPlaceholder": "#8CA3AD",
-            "darkVariantText": "#FFFFFF",
-            "icon": "#8CA3AD",
-            "iconDarkVariant": "#8CA3AD",
-            "iconDarkVariantHover": "#BFCCD2",
-            "iconHover": "#335C6D",
-            "passive": "#738F9B",
-            "searchActive": "#668592",
-          },
-          "select": Object {
-            "border": "#bfccd2",
-            "optionHeader": "rgba(0,0,0,0.55)",
-            "selected": "#F2F5F6",
-            "tableHeaderBorder": "#CCD6DB",
-          },
-          "shadows": Object {
-            "cards": "0 3px 3px 0 rgba(0,20,29,0.2),0 2px 4px 0 rgba(0,20,29,0.15)",
-            "cardsIE": "0 3px 3px 0 rgba(0,20,29,0.2),0 2px 4px 0 rgba(0,20,29,0.15), 0 0 1px 0 rgba(0,20,29,0.15)",
-            "depth1": "0 5px 5px 0 rgba(0,20,29,0.2), 0 10px 10px 0 rgba(0,20,29,0.1)",
-            "depth2": "0 10px 20px 0 rgba(0,20,29,0.2), 0 20px 40px 0 rgba(0,20,29,0.1)",
-            "depth3": "0 10px 30px 0 rgba(0,20,29,0.1), 0 30px 60px 0 rgba(0,20,29,0.1)",
-            "depth4": "0 10px 40px 0 rgba(0,20,29,0.04), 0 50px 80px 0 rgba(0,20,29,0.1)",
-          },
-          "space": Array [
-            0,
-            8,
-            16,
-            24,
-            32,
-            40,
-            48,
-            56,
-            64,
-            72,
-            80,
-          ],
-          "spacing": 8,
-          "switch": Object {
-            "off": "#CCD6DB",
-          },
-          "tab": Object {
-            "altHover": "#D9E0E4",
-            "background": "#CCD6DB",
-          },
-          "table": Object {
-            "dragging": "#E6EBED",
-            "header": "#335C6D",
-            "hover": "#E6EBED",
-            "primary": "#F2F5F6",
-            "secondary": "#CCD6DB",
-            "selected": "#D9E0E4",
-            "tertiary": "#1A475B",
-            "zebra": "#FAFBFB",
-          },
-          "text": Object {
-            "color": "rgba(0,0,0,0.9)",
-            "placeholder": "rgba(0,0,0,0.55)",
-            "size": "14px",
-          },
-          "tile": Object {
-            "border": "#CCD6DB",
-            "footerBackground": "#F2F5F6",
-            "separator": "#E6EBED",
-          },
-          "tileSelect": Object {
-            "border": "#BFCCD2",
-            "descriptionColor": "rgba(0,0,0,0.55)",
-            "disabledBackground": "#E6EBED",
-            "disabledText": "rgba(0,0,0,0.3)",
-            "hoverBackground": "#F2F5F6",
-          },
-          "zIndex": Object {
-            "aboveAll": 9999,
-            "fullScreenModal": 5000,
-            "header": 4000,
-            "modal": 3000,
-            "notification": 6000,
-            "overlay": 1000,
-            "popover": 2000,
-            "smallOverlay": 10,
-          },
+          "body": "DayPicker-Body",
+          "caption": "DayPicker-Caption",
+          "container": "DayPicker",
+          "day": "DayPicker-Day",
+          "disabled": "disabled",
+          "footer": "DayPicker-Footer",
+          "interactionDisabled": "DayPicker--interactionDisabled",
+          "month": "DayPicker-Month",
+          "navBar": "DayPicker-NavBar",
+          "navButtonInteractionDisabled": "DayPicker-NavButton--interactionDisabled",
+          "navButtonNext": "DayPicker-NavButton DayPicker-NavButton--next",
+          "navButtonPrev": "DayPicker-NavButton DayPicker-NavButton--prev",
+          "outside": "outside",
+          "selected": "selected",
+          "today": "today",
+          "todayButton": "DayPicker-TodayButton",
+          "week": "DayPicker-Week",
+          "weekNumber": "DayPicker-WeekNumber",
+          "weekday": "DayPicker-Weekday",
+          "weekdays": "DayPicker-Weekdays",
+          "weekdaysRow": "DayPicker-WeekdaysRow",
+          "wrapper": "DayPicker-wrapper",
         }
       }
-    >
-      <DayPicker
-        canChangeMonth={true}
-        captionElement={
-          <Caption
-            classNames={
-              Object {
-                "body": "DayPicker-Body",
-                "caption": "DayPicker-Caption",
-                "container": "DayPicker",
-                "day": "DayPicker-Day",
-                "disabled": "disabled",
-                "footer": "DayPicker-Footer",
-                "interactionDisabled": "DayPicker--interactionDisabled",
-                "month": "DayPicker-Month",
-                "navBar": "DayPicker-NavBar",
-                "navButtonInteractionDisabled": "DayPicker-NavButton--interactionDisabled",
-                "navButtonNext": "DayPicker-NavButton DayPicker-NavButton--next",
-                "navButtonPrev": "DayPicker-NavButton DayPicker-NavButton--prev",
-                "outside": "outside",
-                "selected": "selected",
-                "today": "today",
-                "todayButton": "DayPicker-TodayButton",
-                "week": "DayPicker-Week",
-                "weekNumber": "DayPicker-WeekNumber",
-                "weekday": "DayPicker-Weekday",
-                "weekdays": "DayPicker-Weekdays",
-                "weekdaysRow": "DayPicker-WeekdaysRow",
-                "wrapper": "DayPicker-wrapper",
-              }
-            }
-          />
+      disabledDays={null}
+      enableOutsideDays={true}
+      fixedWeeks={true}
+      initialMonth={2019-04-01T00:00:00.000Z}
+      inline={true}
+      labels={
+        Object {
+          "nextMonth": "Next Month",
+          "previousMonth": "Previous Month",
         }
-        classNames={
-          Object {
-            "body": "DayPicker-Body",
-            "caption": "DayPicker-Caption",
-            "container": "DayPicker",
-            "day": "DayPicker-Day",
-            "disabled": "disabled",
-            "footer": "DayPicker-Footer",
-            "interactionDisabled": "DayPicker--interactionDisabled",
-            "month": "DayPicker-Month",
-            "navBar": "DayPicker-NavBar",
-            "navButtonInteractionDisabled": "DayPicker-NavButton--interactionDisabled",
-            "navButtonNext": "DayPicker-NavButton DayPicker-NavButton--next",
-            "navButtonPrev": "DayPicker-NavButton DayPicker-NavButton--prev",
-            "outside": "outside",
-            "selected": "selected",
-            "today": "today",
-            "todayButton": "DayPicker-TodayButton",
-            "week": "DayPicker-Week",
-            "weekNumber": "DayPicker-WeekNumber",
-            "weekday": "DayPicker-Weekday",
-            "weekdays": "DayPicker-Weekdays",
-            "weekdaysRow": "DayPicker-WeekdaysRow",
-            "wrapper": "DayPicker-wrapper",
-          }
+      }
+      locale="fr"
+      localeUtils={
+        Object {
+          "formatDay": [Function],
+          "formatMonthTitle": [Function],
+          "formatWeekdayLong": [Function],
+          "formatWeekdayShort": [Function],
+          "getFirstDayOfWeek": [Function],
+          "getMonths": [Function],
         }
-        disabledDays={null}
-        enableOutsideDays={true}
-        fixedWeeks={true}
-        initialMonth={2019-04-01T00:00:00.000Z}
-        inline={true}
-        labels={
-          Object {
-            "nextMonth": "Next Month",
-            "previousMonth": "Previous Month",
-          }
-        }
-        locale="fr"
-        localeUtils={
-          Object {
-            "formatDay": [Function],
-            "formatMonthTitle": [Function],
-            "formatWeekdayLong": [Function],
-            "formatWeekdayShort": [Function],
-            "getFirstDayOfWeek": [Function],
-            "getMonths": [Function],
-          }
-        }
-        navbarElement={<Navbar />}
-        numberOfMonths={1}
-        onDayClick={[Function]}
-        pagedNavigation={false}
-        renderDay={[Function]}
-        reverseMonths={false}
-        selectedDays={2019-04-01T00:00:00.000Z}
-        showWeekNumbers={false}
-        tabIndex={0}
-        weekdayElement={[Function]}
-      />
-    </styled.div>
+      }
+      navbarElement={<Navbar />}
+      numberOfMonths={1}
+      onDayClick={[Function]}
+      pagedNavigation={false}
+      renderDay={[Function]}
+      reverseMonths={false}
+      selectedDays={2019-04-01T00:00:00.000Z}
+      showWeekNumbers={false}
+      tabIndex={0}
+      weekdayElement={[Function]}
+    />
   </styled.div>
 </Popover>
 `;
 
 exports[`StyledDayPicker renders presentational div and context provider for its children 1`] = `
+.c0 {
+  position: absolute;
+  height: 352px;
+  width: 352px;
+  z-index: 2000;
+}
+
 .c0 .DayPicker {
   z-index: 1000;
   top: calc(100% + 1px);
@@ -828,10 +488,8 @@ exports[`StyledDayPicker renders presentational div and context provider for its
   display: block;
   font-size: 14px;
   font-weight: 800;
-  margin-top: 3px;
   overflow: hidden;
   padding: 24px;
-  position: absolute;
   text-align: center;
   -webkit-user-select: none;
   -moz-user-select: none;

--- a/src/__experimental__/components/date/date-picker.component.js
+++ b/src/__experimental__/components/date/date-picker.component.js
@@ -9,7 +9,7 @@ import Popover from "../../../__internal__/popover";
 import DateHelper from "../../../utils/helpers/date/date";
 import Navbar from "./navbar";
 import Weekday from "./weekday";
-import { StyledDayPicker, StyledPopoverContainer } from "./day-picker.style";
+import StyledDayPicker from "./day-picker.style";
 
 const DatePicker = ({
   inputElement,
@@ -36,7 +36,7 @@ const DatePicker = ({
       {
         name: "offset",
         options: {
-          offset: [-overhang, 0],
+          offset: [-overhang, 5],
         },
       },
       {
@@ -99,11 +99,9 @@ const DatePicker = ({
       modifiers={popoverModifiers}
       disablePortal={disablePortal}
     >
-      <StyledPopoverContainer>
-        <StyledDayPicker>
-          <DayPicker {...datePickerProps} ref={ref} />
-        </StyledDayPicker>
-      </StyledPopoverContainer>
+      <StyledDayPicker>
+        <DayPicker {...datePickerProps} ref={ref} />
+      </StyledDayPicker>
     </Popover>
   );
 };

--- a/src/__experimental__/components/date/date-picker.spec.js
+++ b/src/__experimental__/components/date/date-picker.spec.js
@@ -8,7 +8,7 @@ import { shallow, mount } from "enzyme";
 import DayPicker from "react-day-picker";
 
 import DatePicker from "./date-picker.component";
-import { StyledDayPicker } from "./day-picker.style";
+import StyledDayPicker from "./day-picker.style";
 import Popover from "../../../__internal__/popover";
 
 const inputElement = {
@@ -43,7 +43,7 @@ describe("DatePicker", () => {
 
         expect(
           wrapper.find(Popover).props().modifiers[0].options.offset
-        ).toEqual([-11, 0]);
+        ).toEqual([-11, 5]);
       });
 
       describe("when size prop is small", () => {
@@ -55,7 +55,7 @@ describe("DatePicker", () => {
 
           expect(
             wrapper.find(Popover).props().modifiers[0].options.offset
-          ).toEqual([-8, 0]);
+          ).toEqual([-8, 5]);
         });
       });
 
@@ -67,7 +67,7 @@ describe("DatePicker", () => {
 
         expect(
           wrapper.find(Popover).props().modifiers[0].options.offset
-        ).toEqual([-13, 0]);
+        ).toEqual([-13, 5]);
       });
     });
   });

--- a/src/__experimental__/components/date/date.stories.js
+++ b/src/__experimental__/components/date/date.stories.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
-import { boolean, text } from "@storybook/addon-knobs";
+import { boolean, number, text } from "@storybook/addon-knobs";
 import DateInput from "./date.component";
 import { getCommonTextboxProps } from "../textbox/textbox.stories";
 
@@ -46,6 +46,7 @@ export const Default = (props) => {
       onBlur={(ev) => action("onBlur")(ev)}
       onKeyDown={(ev) => action("onKeyDown")(ev)}
       allowEmptyValue={allowEmptyValue}
+      mt={number("mt", 0)}
       {...props}
     />
   );

--- a/src/__experimental__/components/date/day-picker.style.js
+++ b/src/__experimental__/components/date/day-picker.style.js
@@ -1,16 +1,12 @@
 import styled from "styled-components";
 import baseTheme from "../../../style/themes/base";
 
-const StyledPopoverContainer = styled.div`
-  position: absolute;
-  z-index: ${({ theme }) => theme.zIndex.popover};
-`;
-
-StyledPopoverContainer.defaultProps = {
-  theme: baseTheme,
-};
-
 const StyledDayPicker = styled.div`
+  position: absolute;
+  height: 352px;
+  width: 352px;
+  z-index: ${({ theme }) => theme.zIndex.popover};
+
   .DayPicker {
     z-index: 1000;
     top: calc(100% + 1px);
@@ -21,10 +17,8 @@ const StyledDayPicker = styled.div`
     display: block;
     font-size: 14px;
     font-weight: 800;
-    margin-top: 3px;
     overflow: hidden;
     padding: 24px;
-    position: absolute;
     text-align: center;
     user-select: none;
   }
@@ -124,4 +118,4 @@ StyledDayPicker.defaultProps = {
   theme: baseTheme,
 };
 
-export { StyledDayPicker, StyledPopoverContainer };
+export default StyledDayPicker;


### PR DESCRIPTION
### Proposed behaviour
Auto position date picker pop up top or bottom depending on available space: 

![image](https://user-images.githubusercontent.com/14963680/111794519-389e6300-88be-11eb-8aac-55d284f397e2.png)

![image](https://user-images.githubusercontent.com/14963680/111794559-405e0780-88be-11eb-8126-8591bb0fe7af.png)


### Current behaviour
Date picker pop up is always positioned bottom, even if it goes out of it's container.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
http://localhost:9001/?path=/docs/experimental-date-input--default-story