### PR TITLE
feat(drawer): allows to use custom height - FE-3825

### DIFF
--- a/src/components/drawer/__internal__/__snapshots__/drawer.spec.js.snap
+++ b/src/components/drawer/__internal__/__snapshots__/drawer.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`Drawer uncontrolled matches snapshot 1`] = `
 <styled.div
   data-component="drawer"
+  height="100%"
 >
   <styled.div
     animationDuration="0.5s"

--- a/src/components/drawer/__internal__/drawer.component.js
+++ b/src/components/drawer/__internal__/drawer.component.js
@@ -27,6 +27,7 @@ const Drawer = ({
   backgroundColor,
   title,
   showControls,
+  height,
   ...props
 }) => {
   const drawerSidebarContentRef = useRef();
@@ -144,7 +145,7 @@ const Drawer = ({
   };
 
   return (
-    <StyledDrawerWrapper data-component="drawer" {...props}>
+    <StyledDrawerWrapper data-component="drawer" height={height} {...props}>
       <StyledDrawerContent
         expandedWidth={expandedWidth}
         animationDuration={animationDuration}
@@ -187,6 +188,8 @@ Drawer.propTypes = {
   animationDuration: PropTypes.string,
   /** Sets color of sidebar's background */
   backgroundColor: PropTypes.string,
+  /** Sets custom height to Drawer component */
+  height: PropTypes.string,
   /** Sets title heading of sidebar's content */
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /** Enables expand/collapse button that controls drawer */
@@ -197,6 +200,7 @@ Drawer.defaultProps = {
   expandedWidth: "40%",
   animationDuration: "400ms",
   defaultExpanded: true,
+  height: "100%",
 };
 
 export { SidebarContext };

--- a/src/components/drawer/__internal__/drawer.d.ts
+++ b/src/components/drawer/__internal__/drawer.d.ts
@@ -9,6 +9,7 @@ export interface DrawerPropTypes {
   animationDuration?: string;
   expandedWidth?: string;
   backgroundColor?: string;
+  height?: string;
   title?: string;
   showControls?: boolean;
   setTarget?: (tabId: string) => void;

--- a/src/components/drawer/__internal__/drawer.spec.js
+++ b/src/components/drawer/__internal__/drawer.spec.js
@@ -140,7 +140,6 @@ describe("Drawer", () => {
       const wrapper = render({ expandedWidth, showControls: true });
       const { button, content } = getElements(wrapper);
       button.simulate("click");
-
       assertStyleMatch(
         {
           width: expandedWidth,
@@ -148,6 +147,33 @@ describe("Drawer", () => {
         content.childAt(0),
         { modifier: "&.open" }
       );
+    });
+
+    describe("when height prop is provided", () => {
+      it("should render height 100% by default", () => {
+        const wrapper = render({ showControls: true });
+        const { button } = getElements(wrapper);
+        button.simulate("click");
+        assertStyleMatch(
+          {
+            height: "100%",
+          },
+          wrapper
+        );
+      });
+
+      it("should render custom height if provided", () => {
+        const height = "50%";
+        const wrapper = render({ height, showControls: true });
+        const { button } = getElements(wrapper);
+        button.simulate("click");
+        assertStyleMatch(
+          {
+            height: "50%",
+          },
+          wrapper
+        );
+      });
     });
 
     it("one click on button closes drawer sidebar", () => {

--- a/src/components/drawer/__internal__/drawer.stories.mdx
+++ b/src/components/drawer/__internal__/drawer.stories.mdx
@@ -91,6 +91,30 @@ import Drawer from 'carbon-react/lib/components/drawer';
   </Story>
 </Preview>
 
+### Custom height
+
+<Preview>
+  <Story name="custom height" parameters={{ info: { disable: true }, chromatic: { disable: true }}} >
+    return (
+      <Drawer
+        height='230px'
+        defaultExpanded
+        expandedWidth={ text('expandedWidth', '40%') }
+        animationDuration={ text('animationDuration', '0.5s') }
+        sidebar={ (
+          <ul>
+            <li>link a</li>
+            <li>link b</li>
+            <li>link c</li>
+          </ul>
+        ) }
+      >
+        content body content body content body content body content body content body content body
+      </Drawer>
+    )
+  </Story>
+</Preview>
+
 ### Custom Background Color (Red)
 
 <Preview>

--- a/src/components/drawer/__internal__/drawer.style.js
+++ b/src/components/drawer/__internal__/drawer.style.js
@@ -156,7 +156,7 @@ const StyledButton = styled.button.attrs({ type: "button" })`
 
 const StyledDrawerWrapper = styled.div`
   display: flex;
-  height: 100%;
+  height: ${({ height }) => height};
 `;
 
 StyledDrawerContent.defaultProps = {


### PR DESCRIPTION
This commit provide possibility to add custom height prop to our component
fixes: #3792

### Proposed behaviour
Allows to set custom height to Drawer component

### Current behaviour
there is no possibility to set custom height

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] <del> Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Testing instructions
New storybook story added
Storybook => Drawer => custom height
https://codesandbox.io/s/carbon-quickstart-forked-e530d?file=/src/index.js
