### PR TITLE
fix(flat-table-row): ensure any cells preceding row headers are also positioned sticky FE-3763

### DIFF
--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -102,6 +102,10 @@ exports[`FlatTable when rendered with proper table data should have expected str
   padding-right: 24px;
 }
 
+.c7.c7.c7 {
+  left: 0px;
+}
+
 .c5 {
   border-collapse: separate;
   border-radius: 0px;

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useLayoutEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import propTypes from "@styled-system/prop-types";
 
@@ -18,10 +18,24 @@ const FlatTableCell = ({
   expandable = false,
   onClick,
   onKeyDown,
+  reportCellWidth,
+  cellIndex,
+  leftPosition,
   ...rest
 }) => {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    if (ref.current && reportCellWidth) {
+      reportCellWidth(ref.current.offsetWidth, cellIndex);
+    }
+  }, [reportCellWidth, cellIndex]);
+
   return (
     <StyledFlatTableCell
+      leftPosition={leftPosition || 0}
+      makeCellSticky={!!reportCellWidth}
+      ref={ref}
       align={align}
       data-element="flat-table-cell"
       colSpan={colspan}
@@ -66,6 +80,24 @@ FlatTableCell.propTypes = {
    * @ignore
    */
   onKeyDown: PropTypes.func,
+  /**
+   * @private
+   * @ignore
+   * Sets the left position when sticky column found
+   */
+  leftPosition: PropTypes.number,
+  /**
+   * @private
+   * @ignore
+   * Index of cell within row
+   */
+  cellIndex: PropTypes.number,
+  /**
+   * @private
+   * @ignore
+   * Callback to report the offsetWidth
+   */
+  reportCellWidth: PropTypes.func,
 };
 
 FlatTableCell.defaultProps = {

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
@@ -4,7 +4,7 @@ import { space } from "styled-system";
 import baseTheme from "../../../style/themes/base";
 
 const StyledFlatTableCell = styled.td`
-  ${({ align, theme, rowSpan }) => css`
+  ${({ align, theme, rowSpan, leftPosition, makeCellSticky }) => css`
     background-color: #fff;
     border-width: 0;
     border-bottom: 1px solid ${theme.table.secondary};
@@ -33,15 +33,14 @@ const StyledFlatTableCell = styled.td`
         border-left: 1px solid ${theme.table.secondary};
       }
     `}
-  `}
 
-  ${({ leftPosition, makeCellSticky }) =>
-    makeCellSticky &&
+    ${makeCellSticky &&
     css`
       top: auto;
       left: ${leftPosition}px;
       position: sticky;
     `}
+  `}
 `;
 
 const StyledCellContent = styled.div`

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
@@ -16,7 +16,7 @@ const StyledFlatTableCell = styled.td`
 
     > div {
       box-sizing: border-box;
-      ${space};
+      ${space}
     }
 
     &:first-of-type {
@@ -34,6 +34,14 @@ const StyledFlatTableCell = styled.td`
       }
     `}
   `}
+
+  ${({ leftPosition, makeCellSticky }) =>
+    makeCellSticky &&
+    css`
+      top: auto;
+      left: ${leftPosition}px;
+      position: sticky;
+    `}
 `;
 
 const StyledCellContent = styled.div`

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.component.js
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.component.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useLayoutEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import StyledFlatTableCheckbox from "./flat-table-checkbox.style";
 import { Checkbox } from "../../../__experimental__/components/checkbox";
@@ -8,11 +8,28 @@ const FlatTableCheckbox = ({
   checked,
   onChange,
   selectable = true,
+  leftPosition,
+  cellIndex,
+  reportCellWidth,
 }) => {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    if (ref.current && reportCellWidth) {
+      reportCellWidth(ref.current.offsetWidth, cellIndex);
+    }
+  }, [reportCellWidth, cellIndex]);
+
   const dataElement = `flat-table-checkbox-${as === "td" ? "cell" : "header"}`;
 
   return (
-    <StyledFlatTableCheckbox data-element={dataElement} as={as}>
+    <StyledFlatTableCheckbox
+      ref={ref}
+      makeCellSticky={!!reportCellWidth}
+      leftPosition={leftPosition || 0}
+      data-element={dataElement}
+      as={as}
+    >
       {selectable && (
         <Checkbox
           onClick={(e) => e.stopPropagation()}
@@ -35,6 +52,24 @@ FlatTableCheckbox.propTypes = {
   onChange: PropTypes.func,
   /** Whether to render the checkbox or not, defaults to true */
   selectable: PropTypes.bool,
+  /**
+   * @private
+   * @ignore
+   * Sets the left position when sticky column found
+   */
+  leftPosition: PropTypes.number,
+  /**
+   * @private
+   * @ignore
+   * Index of cell within row
+   */
+  cellIndex: PropTypes.number,
+  /**
+   * @private
+   * @ignore
+   * Callback to report the offsetWidth
+   */
+  reportCellWidth: PropTypes.func,
 };
 
 export default FlatTableCheckbox;

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.style.js
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.style.js
@@ -47,6 +47,14 @@ const StyledFlatTableCheckbox = styled.td`
   ${StyledCheckbox} {
     padding-top: 0px;
   }
+
+  ${({ leftPosition, makeCellSticky }) =>
+    makeCellSticky &&
+    css`
+      top: auto;
+      left: ${leftPosition}px;
+      position: sticky;
+    `}
 `;
 
 StyledFlatTableCheckbox.defaultProps = {

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.style.js
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.style.js
@@ -3,7 +3,7 @@ import StyledCheckbox from "../../../__experimental__/components/checkbox/checkb
 import baseTheme from "../../../style/themes/base";
 
 const StyledFlatTableCheckbox = styled.td`
-  ${({ as, theme }) => css`
+  ${({ as, theme, leftPosition, makeCellSticky }) => css`
     ${as === "td" &&
     `
       background-color: ${theme.colors.white};
@@ -40,6 +40,13 @@ const StyledFlatTableCheckbox = styled.td`
       vertical-align: middle;
       white-space: nowrap;
     `}
+
+    ${makeCellSticky &&
+    css`
+      top: auto;
+      left: ${leftPosition}px;
+      position: sticky;
+    `}
   `}
 
   width: 18px;
@@ -47,14 +54,6 @@ const StyledFlatTableCheckbox = styled.td`
   ${StyledCheckbox} {
     padding-top: 0px;
   }
-
-  ${({ leftPosition, makeCellSticky }) =>
-    makeCellSticky &&
-    css`
-      top: auto;
-      left: ${leftPosition}px;
-      position: sticky;
-    `}
 `;
 
 StyledFlatTableCheckbox.defaultProps = {

--- a/src/components/flat-table/flat-table-header/flat-table-header.component.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.component.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useLayoutEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import propTypes from "@styled-system/prop-types";
 
@@ -12,10 +12,24 @@ const FlatTableHeader = ({
   width,
   py,
   px,
+  reportCellWidth,
+  cellIndex,
+  leftPosition,
   ...rest
 }) => {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    if (ref.current && reportCellWidth) {
+      reportCellWidth(ref.current.offsetWidth, cellIndex);
+    }
+  }, [reportCellWidth, cellIndex]);
+
   return (
     <StyledFlatTableHeader
+      ref={ref}
+      leftPosition={leftPosition || 0}
+      makeCellSticky={!!reportCellWidth}
       align={align}
       data-element="flat-table-header"
       colSpan={colspan}
@@ -42,6 +56,24 @@ FlatTableHeader.propTypes = {
   rowspan: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /** Column width, pass a number to set a fixed width in pixels */
   width: PropTypes.number,
+  /**
+   * @private
+   * @ignore
+   * Sets the left position when sticky column found
+   */
+  leftPosition: PropTypes.number,
+  /**
+   * @private
+   * @ignore
+   * Index of cell within row
+   */
+  cellIndex: PropTypes.number,
+  /**
+   * @private
+   * @ignore
+   * Callback to report the offsetWidth
+   */
+  reportCellWidth: PropTypes.func,
 };
 
 FlatTableHeader.defaultProps = {

--- a/src/components/flat-table/flat-table-header/flat-table-header.style.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.style.js
@@ -4,7 +4,7 @@ import { space } from "styled-system";
 import baseTheme from "../../../style/themes/base";
 
 const StyledFlatTableHeader = styled.th`
-  ${({ align, theme, colWidth }) => css`
+  ${({ align, theme, colWidth, leftPosition, makeCellSticky }) => css`
     background-color: transparent;
     border-width: 0;
     border-bottom: 1px solid ${theme.table.secondary};
@@ -30,24 +30,29 @@ const StyledFlatTableHeader = styled.th`
 
     > div {
       box-sizing: border-box;
-      ${space};
+      ${space}
       ${colWidth &&
       css`
         width: ${colWidth}px;
       `}
     }
-  `}
 
-  ${({ leftPosition, makeCellSticky }) =>
-    makeCellSticky &&
+    ${makeCellSticky &&
     css`
       top: auto;
       left: ${leftPosition}px;
       position: sticky;
+
       &:first-child {
-        padding-left: 2px;
-      }
+        padding-right: 0.395em;
+
+        @media not all and (min-resolution:.001dpcm) {
+          @supports (-webkit-appearance:none) and (stroke-color:transparent) {
+            padding-right: 0.6em;
+          }
+        }
     `}
+  `}
 `;
 
 StyledFlatTableHeader.defaultProps = {

--- a/src/components/flat-table/flat-table-header/flat-table-header.style.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.style.js
@@ -21,9 +21,9 @@ const StyledFlatTableHeader = styled.th`
     ${colWidth &&
     css`
       width: ${colWidth}px;
-    `};
+    `}
 
-    /* accomodate for no border in the header first cell */
+    /* accommodate for no border in the header first cell */
     &:first-child {
       padding-left: 1px;
     }
@@ -34,9 +34,20 @@ const StyledFlatTableHeader = styled.th`
       ${colWidth &&
       css`
         width: ${colWidth}px;
-      `};
+      `}
     }
   `}
+
+  ${({ leftPosition, makeCellSticky }) =>
+    makeCellSticky &&
+    css`
+      top: auto;
+      left: ${leftPosition}px;
+      position: sticky;
+      &:first-child {
+        padding-left: 2px;
+      }
+    `}
 `;
 
 StyledFlatTableHeader.defaultProps = {

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import propTypes from "@styled-system/prop-types";
 
@@ -17,11 +17,8 @@ const FlatTableRowHeader = ({
   leftPosition,
   ...rest
 }) => {
-  const ref = useRef(null);
-
   return (
     <StyledFlatTableRowHeader
-      ref={ref}
       leftPosition={leftPosition || 0}
       align={align}
       data-element="flat-table-row-header"

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import PropTypes from "prop-types";
 import propTypes from "@styled-system/prop-types";
 
@@ -14,10 +14,15 @@ const FlatTableRowHeader = ({
   expandable = false,
   onClick,
   onKeyDown,
+  leftPosition,
   ...rest
 }) => {
+  const ref = useRef(null);
+
   return (
     <StyledFlatTableRowHeader
+      ref={ref}
+      leftPosition={leftPosition || 0}
       align={align}
       data-element="flat-table-row-header"
       colWidth={width}

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.js
@@ -4,7 +4,7 @@ import { space } from "styled-system";
 import baseTheme from "../../../style/themes/base";
 
 const StyledFlatTableRowHeader = styled.th`
-  ${({ align, theme, colWidth }) => css`
+  ${({ align, theme, colWidth, leftPosition }) => css`
     background-color: #fff;
     border: 1px solid ${theme.table.secondary};
     border-top: none;
@@ -30,13 +30,11 @@ const StyledFlatTableRowHeader = styled.th`
       `}
       ${space}
     }
-  `}
 
-  ${({ leftPosition }) => `
-      &&& {
-        left: ${leftPosition}px;
-      }
-    `}
+    &&& {
+      left: ${leftPosition}px;
+    }
+  `}
 `;
 
 StyledFlatTableRowHeader.defaultProps = {

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.js
@@ -20,17 +20,23 @@ const StyledFlatTableRowHeader = styled.th`
     ${colWidth &&
     css`
       width: ${colWidth}px;
-    `};
+    `}
 
     > div {
       box-sizing: border-box;
       ${colWidth &&
       css`
         width: ${colWidth}px;
-      `};
-      ${space};
+      `}
+      ${space}
     }
   `}
+
+  ${({ leftPosition }) => `
+      &&& {
+        left: ${leftPosition}px;
+      }
+    `}
 `;
 
 StyledFlatTableRowHeader.defaultProps = {

--- a/src/components/flat-table/flat-table-row/flat-table-row.component.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.js
@@ -1,11 +1,18 @@
-import React, { useCallback, useLayoutEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import PropTypes from "prop-types";
 
 import Event from "../../../utils/helpers/events";
 import StyledFlatTableRow from "./flat-table-row.style";
 import { SidebarContext } from "../../drawer";
 import FlatTableCheckbox from "../flat-table-checkbox";
-import FlatTableRowHeader from "../flat-table-row-header/flat-table-row-header.component";
+import FlatTableRowHeader from "../flat-table-row-header";
+import { FlatTableThemeContext } from "../flat-table.component";
 
 const FlatTableRow = React.forwardRef(
   (
@@ -32,6 +39,7 @@ const FlatTableRow = React.forwardRef(
     const rowHeaderIndex = childrenArray.findIndex(
       (child) => child.type === FlatTableRowHeader
     );
+    const colorTheme = useContext(FlatTableThemeContext);
 
     const reportCellWidth = useCallback(
       (width, index) => {
@@ -48,10 +56,8 @@ const FlatTableRow = React.forwardRef(
 
     let interactiveRowProps = {};
 
-    const firstCellIndex = () => {
-      if (childrenArray[0].type === FlatTableCheckbox) return 1;
-      return 0;
-    };
+    const firstCellIndex = () =>
+      childrenArray[0].type === FlatTableCheckbox ? 1 : 0;
 
     const toggleExpanded = () => setIsExpanded(!isExpanded);
 
@@ -128,6 +134,7 @@ const FlatTableRow = React.forwardRef(
               firstCellIndex={firstCellIndex()}
               ref={rowRef}
               rowHeaderIndex={rowHeaderIndex}
+              colorTheme={colorTheme}
               {...interactiveRowProps}
             >
               {React.Children.map(children, (child, index) => {

--- a/src/components/flat-table/flat-table-row/flat-table-row.component.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.js
@@ -1,10 +1,11 @@
-import React, { useRef, useState } from "react";
+import React, { useCallback, useLayoutEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 
 import Event from "../../../utils/helpers/events";
 import StyledFlatTableRow from "./flat-table-row.style";
 import { SidebarContext } from "../../drawer";
 import FlatTableCheckbox from "../flat-table-checkbox";
+import FlatTableRowHeader from "../flat-table-row-header/flat-table-row-header.component";
 
 const FlatTableRow = React.forwardRef(
   (
@@ -25,12 +26,30 @@ const FlatTableRow = React.forwardRef(
     const [isExpanded, setIsExpanded] = useState(expanded);
     const rowRef = ref || useRef();
     const firstColumnExpandable = expandableArea === "firstColumn";
+    const [stickyCellWidths, setStickyCellWidths] = useState([]);
+    const [leftPositions, setLeftPositions] = useState([]);
+    const childrenArray = React.Children.toArray(children);
+    const rowHeaderIndex = childrenArray.findIndex(
+      (child) => child.type === FlatTableRowHeader
+    );
+
+    const reportCellWidth = useCallback(
+      (width, index) => {
+        const copiedArray = stickyCellWidths;
+        if (copiedArray[index] !== undefined) {
+          copiedArray[index] = width;
+        } else {
+          copiedArray.push(width);
+        }
+        setStickyCellWidths(copiedArray);
+      },
+      [stickyCellWidths]
+    );
 
     let interactiveRowProps = {};
 
     const firstCellIndex = () => {
-      if (React.Children.toArray(children)[0].type === FlatTableCheckbox)
-        return 1;
+      if (childrenArray[0].type === FlatTableCheckbox) return 1;
       return 0;
     };
 
@@ -80,6 +99,19 @@ const FlatTableRow = React.forwardRef(
       }
     }
 
+    useLayoutEffect(() => {
+      if (stickyCellWidths.length && rowHeaderIndex !== -1) {
+        setLeftPositions([
+          0,
+          ...Array.from({ length: rowHeaderIndex }).map(
+            (_, index) =>
+              stickyCellWidths.slice(0, index + 1).reduce((a, b) => a + b, 0),
+            0
+          ),
+        ]);
+      }
+    }, [rowHeaderIndex, stickyCellWidths]);
+
     return (
       <SidebarContext.Consumer>
         {(context) => (
@@ -95,6 +127,7 @@ const FlatTableRow = React.forwardRef(
               onClick={handleClick}
               firstCellIndex={firstCellIndex()}
               ref={rowRef}
+              rowHeaderIndex={rowHeaderIndex}
               {...interactiveRowProps}
             >
               {React.Children.map(children, (child, index) => {
@@ -114,6 +147,10 @@ const FlatTableRow = React.forwardRef(
                       firstColumnExpandable
                         ? handleCellKeyDown
                         : undefined,
+                    cellIndex: index,
+                    reportCellWidth:
+                      index < rowHeaderIndex ? reportCellWidth : undefined,
+                    leftPosition: leftPositions[index],
                     ...child.props,
                   })
                 );

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -15,6 +15,8 @@ import StyledFlatTableCheckbox from "../flat-table-checkbox/flat-table-checkbox.
 import { SidebarContext } from "../../drawer";
 import FlatTableCheckbox from "../flat-table-checkbox";
 import StyledIcon from "../../icon/icon.style";
+import FlatTableRowHeader from "../flat-table-row-header/flat-table-row-header.component";
+import FlatTableHeader from "../flat-table-header/flat-table-header.component";
 
 const events = {
   enter: {
@@ -77,6 +79,18 @@ describe("FlatTableRow", () => {
     });
 
     it("then the Row Header should have proper outline when the Row is focused", () => {
+      wrapper = mount(
+        <table>
+          <thead>
+            <FlatTableRow onClick={() => {}}>
+              <FlatTableRowHeader>test 1</FlatTableRowHeader>
+              <FlatTableHeader>test 2</FlatTableHeader>
+              <FlatTableCell>test 3</FlatTableCell>
+            </FlatTableRow>
+          </thead>
+        </table>
+      );
+
       assertStyleMatch(
         {
           borderBottom: "1px solid transparent",
@@ -95,7 +109,7 @@ describe("FlatTableRow", () => {
           display: "block",
           left: "0px",
           top: "-1px",
-          height: "100%",
+          height: "99%",
           width: "101%",
           position: "absolute",
           zIndex: "1000",
@@ -447,6 +461,112 @@ describe("FlatTableRow", () => {
 
         expect(wrapper.find(FlatTableCell).length).toEqual(2);
       });
+    })
+  })
+
+  describe("when FlatTableRowHeader is used", () => {
+    it("sets any preceding columns to sticky as well", () => {
+      const wrapper = mount(
+        <table>
+          <thead>
+            <FlatTableRow>
+              <FlatTableHeader>test 1</FlatTableHeader>
+              <FlatTableCell>test 2</FlatTableCell>
+              <FlatTableCheckbox />
+              <FlatTableRowHeader>test 3</FlatTableRowHeader>
+              <FlatTableHeader>test 4</FlatTableHeader>
+              <FlatTableCell>test 5</FlatTableCell>
+            </FlatTableRow>
+          </thead>
+        </table>
+      );
+      act(() =>
+        wrapper.find(FlatTableHeader).at(0).props().reportCellWidth(200, 0)
+      );
+
+      assertStyleMatch(
+        {
+          position: "sticky",
+        },
+        wrapper.find(StyledFlatTableHeader).at(0)
+      );
+
+      assertStyleMatch(
+        {
+          position: "sticky",
+        },
+        wrapper.find(StyledFlatTableCell).at(0)
+      );
+
+      assertStyleMatch(
+        {
+          position: "sticky",
+        },
+        wrapper.find(StyledFlatTableCheckbox)
+      );
+
+      assertStyleMatch(
+        {
+          position: undefined,
+        },
+        wrapper.find(StyledFlatTableHeader).at(1)
+      );
+
+      assertStyleMatch(
+        {
+          position: undefined,
+        },
+        wrapper.find(StyledFlatTableCell).at(1)
+      );
+    });
+
+    it("applies the correct focus styling when the row is interactive", () => {
+      const wrapper = mount(
+        <table>
+          <thead>
+            <FlatTableRow onClick={() => {}}>
+              <FlatTableHeader>test 1</FlatTableHeader>
+              <FlatTableCell>test 2</FlatTableCell>
+              <FlatTableCheckbox />
+              <FlatTableRowHeader>test 3</FlatTableRowHeader>
+              <FlatTableHeader>test 4</FlatTableHeader>
+              <FlatTableCell>test 5</FlatTableCell>
+            </FlatTableRow>
+          </thead>
+        </table>
+      );
+
+      assertStyleMatch(
+        {
+          borderLeft: undefined,
+        },
+        wrapper,
+        { modifier: `:focus ${StyledFlatTableRowHeader}` }
+      );
+
+      assertStyleMatch(
+        {
+          borderLeft: `1px solid ${baseTheme.colors.focus}`,
+        },
+        wrapper,
+        { modifier: `:focus ${StyledFlatTableCell}:nth-of-type(1)` }
+      );
+
+      assertStyleMatch(
+        {
+          borderTop: `2px solid ${baseTheme.colors.focus}`,
+          borderBottom: `1px solid ${baseTheme.colors.focus}`,
+          display: "block",
+          left: "0px",
+          top: "-1px",
+          height: "99%",
+          width: "101%",
+          position: "absolute",
+          zIndex: "1000",
+        },
+        wrapper.find(FlatTableRow),
+        { modifier: `:focus ${StyledFlatTableCell}:nth-of-type(1):before` }
+      );
     });
   });
 

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.js
@@ -9,7 +9,9 @@ import StyledIcon from "../../icon/icon.style";
 const stickyColumnFocusStyling = (index, theme) => {
   return `
     border-bottom: 1px solid transparent;
-    ${index === 0 ? `border-left: 1px solid ${theme.colors.focus};` : ""}
+    border-left: 1px solid ${
+      index === 0 ? theme.colors.focus : theme.table.secondary
+    };
     background-clip: padding-box;
     z-index: ${theme.zIndex.overlay};
 
@@ -26,6 +28,23 @@ const stickyColumnFocusStyling = (index, theme) => {
       z-index: ${theme.zIndex.overlay};
     }
   `;
+};
+
+const borderColor = (colorTheme, theme) => {
+  switch (colorTheme) {
+    case "light":
+      return theme.flatTable.light.border;
+
+    case "transparent-base":
+      return theme.flatTable.transparentBase.border;
+
+    case "transparent-white":
+      return theme.flatTable.transparentWhite.border;
+
+    // default theme is "dark"
+    default:
+      return theme.flatTable.dark.border;
+  }
 };
 
 const StyledFlatTableRow = styled.tr`
@@ -53,8 +72,7 @@ const StyledFlatTableRow = styled.tr`
         css`
           ${Array.from({ length: rowHeaderIndex }).map((_, index) => {
             return `
-              ${StyledFlatTableCell}:nth-of-type(${index + 1}),
-              ${StyledFlatTableCheckbox}:nth-of-type(${index + 1}) {
+              td:nth-of-type(${index + 1}) {
                 ${stickyColumnFocusStyling(index, theme)}
               }
             `;
@@ -85,6 +103,18 @@ const StyledFlatTableRow = styled.tr`
         :hover {
           background-color: ${theme.flatTable.hover};
         }
+      }
+    `}
+
+    ${({ colorTheme, rowHeaderIndex, theme }) =>
+    ![-1, 0].includes(rowHeaderIndex) &&
+    css`
+      td:nth-of-type(${rowHeaderIndex + 1}) {
+        border-left: 1px solid ${theme.table.secondary};
+      }
+
+      th:nth-of-type(${rowHeaderIndex + 2}) {
+        border-left: 1px solid ${borderColor(colorTheme, theme)};
       }
     `}
 

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.js
@@ -6,6 +6,28 @@ import StyledFlatTableCheckbox from "../flat-table-checkbox/flat-table-checkbox.
 import StyledFlatTableHeader from "../flat-table-header/flat-table-header.style";
 import StyledIcon from "../../icon/icon.style";
 
+const stickyColumnFocusStyling = (index, theme) => {
+  return `
+    border-bottom: 1px solid transparent;
+    ${index === 0 ? `border-left: 1px solid ${theme.colors.focus};` : ""}
+    background-clip: padding-box;
+    z-index: ${theme.zIndex.overlay};
+
+    :before {
+      content: "";
+      border-top: 2px solid ${theme.colors.focus};
+      border-bottom: 1px solid ${theme.colors.focus};
+      display: block;
+      left: 0px;
+      top: -1px;
+      height: 99%;
+      width: 101%;
+      position: absolute;
+      z-index: ${theme.zIndex.overlay};
+    }
+  `;
+};
+
 const StyledFlatTableRow = styled.tr`
   border-collapse: separate;
   border-radius: 0px;
@@ -14,7 +36,7 @@ const StyledFlatTableRow = styled.tr`
   table-layout: fixed;
   width: auto;
 
-  ${({ isRowInteractive, theme }) =>
+  ${({ isRowInteractive, theme, rowHeaderIndex }) =>
     isRowInteractive &&
     css`
       cursor: pointer;
@@ -24,24 +46,20 @@ const StyledFlatTableRow = styled.tr`
         outline-offset: -1px;
 
         ${StyledFlatTableRowHeader} {
-          border-bottom: 1px solid transparent;
-          border-left: 1px solid ${theme.colors.focus};
-          background-clip: padding-box;
-          z-index: ${theme.zIndex.overlay};
-
-          :before {
-            content: "";
-            border-top: 2px solid ${theme.colors.focus};
-            border-bottom: 1px solid ${theme.colors.focus};
-            display: block;
-            left: 0px;
-            top: -1px;
-            height: 100%;
-            width: 101%;
-            position: absolute;
-            z-index: ${theme.zIndex.overlay};
-          }
+          ${stickyColumnFocusStyling(rowHeaderIndex, theme)}
         }
+
+        ${![-1, 0].includes(rowHeaderIndex) &&
+        css`
+          ${Array.from({ length: rowHeaderIndex }).map((_, index) => {
+            return `
+              ${StyledFlatTableCell}:nth-of-type(${index + 1}),
+              ${StyledFlatTableCheckbox}:nth-of-type(${index + 1}) {
+                ${stickyColumnFocusStyling(index, theme)}
+              }
+            `;
+          })}
+        `}
       }
 
       :hover {

--- a/src/components/flat-table/flat-table.component.js
+++ b/src/components/flat-table/flat-table.component.js
@@ -8,6 +8,8 @@ import {
 import { SidebarContext } from "../drawer";
 import Box from "../box";
 
+export const FlatTableThemeContext = React.createContext({});
+
 const FlatTable = ({
   caption,
   children,
@@ -52,7 +54,9 @@ const FlatTable = ({
                 {...tableStylingProps}
               >
                 {caption ? <caption>{caption}</caption> : null}
-                {children}
+                <FlatTableThemeContext.Provider value={colorTheme}>
+                  {children}
+                </FlatTableThemeContext.Provider>
               </StyledFlatTable>
             </StyledFlatTableWrapper>
           </Box>

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -602,25 +602,25 @@ It is possible to utilise the selected and onClick props on the FlatTableRow to 
           </FlatTableHead>
           <FlatTableBody>
             <FlatTableRow onClick={ () => handleHighlightRow('one') } highlighted={ highlightedRow === 'one' }>
-              <FlatTableRowHeader>John Doe</FlatTableRowHeader>
+              <FlatTableCell>John Doe</FlatTableCell>
               <FlatTableCell>London</FlatTableCell>
               <FlatTableCell>Single</FlatTableCell>
               <FlatTableCell>0</FlatTableCell>
             </FlatTableRow>
             <FlatTableRow onClick={ () => handleHighlightRow('two') } highlighted={ highlightedRow === 'two' }>
-              <FlatTableRowHeader>Jane Doe</FlatTableRowHeader>
+              <FlatTableCell>Jane Doe</FlatTableCell>
               <FlatTableCell>York</FlatTableCell>
               <FlatTableCell>Married</FlatTableCell>
               <FlatTableCell>2</FlatTableCell>
             </FlatTableRow>
             <FlatTableRow onClick={ () => handleHighlightRow('three') }highlighted={ highlightedRow === 'three' }>
-              <FlatTableRowHeader>John Smith</FlatTableRowHeader>
+              <FlatTableCell>John Smith</FlatTableCell>
               <FlatTableCell>Edinburgh</FlatTableCell>
               <FlatTableCell>Single</FlatTableCell>
               <FlatTableCell>1</FlatTableCell>
             </FlatTableRow>
             <FlatTableRow onClick={ () => handleHighlightRow('four') } highlighted={ highlightedRow === 'four' }>
-              <FlatTableRowHeader>Jane Smith</FlatTableRowHeader>
+              <FlatTableCell>Jane Smith</FlatTableCell>
               <FlatTableCell>Newcastle</FlatTableCell>
               <FlatTableCell>Married</FlatTableCell>
               <FlatTableCell>5</FlatTableCell>

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -94,6 +94,7 @@ import {
 </Preview>
 
 ### With row headers
+Any cells preceding the `FlatTableRowHeader`s will automatically also be made sticky as seen in the example below.
 
 <Preview>
   <Story name="with row header" parameters={{ chromatic: { disable: true }}}>
@@ -101,6 +102,7 @@ import {
       <FlatTable>
         <FlatTableHead>
           <FlatTableRow>
+            <FlatTableHeader>ID Number</FlatTableHeader>
             <FlatTableRowHeader>Name</FlatTableRowHeader>
             <FlatTableHeader>Location</FlatTableHeader>
             <FlatTableHeader>Relationship Status</FlatTableHeader>
@@ -109,24 +111,28 @@ import {
         </FlatTableHead>
         <FlatTableBody>
           <FlatTableRow>
+            <FlatTableCell>000001</FlatTableCell>
             <FlatTableRowHeader>John Doe</FlatTableRowHeader>
             <FlatTableCell>London</FlatTableCell>
             <FlatTableCell>Single</FlatTableCell>
             <FlatTableCell>0</FlatTableCell>
           </FlatTableRow>
           <FlatTableRow>
+            <FlatTableCell>000002</FlatTableCell>
             <FlatTableRowHeader>Jane Doe</FlatTableRowHeader>
             <FlatTableCell>York</FlatTableCell>
             <FlatTableCell>Married</FlatTableCell>
             <FlatTableCell>2</FlatTableCell>
           </FlatTableRow>
           <FlatTableRow>
+            <FlatTableCell>000003</FlatTableCell>
             <FlatTableRowHeader>John Smith</FlatTableRowHeader>
             <FlatTableCell>Edinburgh</FlatTableCell>
             <FlatTableCell>Single</FlatTableCell>
             <FlatTableCell>1</FlatTableCell>
           </FlatTableRow>
           <FlatTableRow>
+            <FlatTableCell>000004</FlatTableCell>
             <FlatTableRowHeader>Jane Smith</FlatTableRowHeader>
             <FlatTableCell>Newcastle</FlatTableCell>
             <FlatTableCell>Married</FlatTableCell>
@@ -452,7 +458,7 @@ Column width can be set by passing number as a `width` prop to the column header
   </Story>
 </Preview>
 
-### With a cell spanning the whole column 
+### With a cell spanning the whole column
 
 <Preview>
   <Story name="with rowspan">


### PR DESCRIPTION
fix #3721
fix #3716
fix #3564

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Any `FlatTableCell`, `FlatTableCheckbox` or `FlatTableHeader` children that precede a
`FlatTableRowHeader` will also be positioned `sticky`. They will also be passed a callback to
`reportCellWidth` which will allow each column to calculate the correct `left` positioning based on
the sum of the offsetWidths of the columns before it

Fixes focus styling of `FlatTableRowHeader` when a row has focus

Adds `border-left` to the cell directly after a `FlatTableRowHeader` to fix style defect, passes
context from `FlatTable` to `FlatTablerow` to ensure that the border has the correct colour defined
by `colorTheme` prop

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Any preceding columns are not made sticky when a `FlatTableRowHeader` is used
Styling is wrong when is incorrect when row has focus a `FlatTableRowHeader` is used

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/112173684-b24f8d00-8bed-11eb-88f6-7bb0bbf50dda.png)

![image](https://user-images.githubusercontent.com/44157880/112173739-c09da900-8bed-11eb-9d70-82ec41eb4fd2.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
will add a codesandbox to demonstrate focus style updates

`design-system-flat-table--with-row-header` has been refactored to demonstrate the fix to sticky columns