### PR TITLE
fix(simple-select): update icon position - 3824

### DIFF
--- a/src/__experimental__/components/input-icon-toggle/input-icon-toggle.style.js
+++ b/src/__experimental__/components/input-icon-toggle/input-icon-toggle.style.js
@@ -4,17 +4,6 @@ import BaseTheme from "../../../style/themes/base";
 import OptionsHelper from "../../../utils/helpers/options-helper";
 import sizes from "../input/input-sizes.style";
 
-const getWidth = (size) => {
-  switch (size) {
-    case "small":
-      return "32px";
-    case "large":
-      return "48px";
-    default:
-      return "40px";
-  }
-};
-
 const InputIconToggleStyle = styled.span.attrs(({ onClick }) => ({
   // eslint-disable-next-line consistent-return
   onKeyDown: (e) => {
@@ -33,7 +22,7 @@ const InputIconToggleStyle = styled.span.attrs(({ onClick }) => ({
   ${({ size }) => css`
     margin-right: -${sizes[size].horizontalPadding};
     margin-left: -${sizes[size].horizontalPadding};
-    width: ${getWidth(size)};
+    width: ${sizes[size].height};
   `}
 
   &:focus {

--- a/src/components/select/multi-select/multi-select.component.js
+++ b/src/components/select/multi-select/multi-select.component.js
@@ -7,8 +7,10 @@ import SelectTextbox, {
 import guid from "../../../utils/helpers/guid";
 import withFilter from "../utils/with-filter.hoc";
 import SelectList from "../select-list/select-list.component";
-import StyledSelect from "../select.style";
-import StyledSelectPillContainer from "./multi-select.style";
+import {
+  StyledSelectPillContainer,
+  StyledSelectMultiSelect,
+} from "./multi-select.style";
 import Pill from "../../pill";
 import isExpectedOption from "../utils/is-expected-option";
 import isExpectedValue from "../utils/is-expected-value";
@@ -460,7 +462,7 @@ const MultiSelect = React.forwardRef(
     );
 
     return (
-      <StyledSelect
+      <StyledSelectMultiSelect
         data-component="multiselect"
         aria-expanded={isOpen}
         aria-haspopup="listbox"
@@ -478,7 +480,7 @@ const MultiSelect = React.forwardRef(
           {...getTextboxProps()}
         />
         {!disablePortal && isOpen && selectList}
-      </StyledSelect>
+      </StyledSelectMultiSelect>
     );
   }
 );

--- a/src/components/select/multi-select/multi-select.spec.js
+++ b/src/components/select/multi-select/multi-select.spec.js
@@ -2,7 +2,10 @@ import React, { useRef } from "react";
 import { act } from "react-dom/test-utils";
 import { mount } from "enzyme";
 
-import { testStyledSystemMargin } from "../../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../../__spec_helper__/test-utils";
 import MultiSelect from "./multi-select.component";
 import Textbox from "../../../__experimental__/components/textbox";
 import SelectTextbox from "../select-textbox/select-textbox.component";
@@ -11,6 +14,7 @@ import SelectList from "../select-list/select-list.component";
 import { StyledSelectList } from "../select-list/select-list.style";
 import Pill from "../../pill";
 import Label from "../../../__experimental__/components/label";
+import InputPresentationStyle from "../../../__experimental__/components/input/input-presentation.style";
 
 describe("MultiSelect", () => {
   testStyledSystemMargin((props) => getSelect(props));
@@ -96,6 +100,21 @@ describe("MultiSelect", () => {
       );
       expect(wrapper.find(SelectList).exists()).toBe(true);
     });
+  });
+
+  it.each([
+    ["small", "32px"],
+    ["medium", "40px"],
+    ["large", "48px"],
+  ])("the input toggle icon should have proper left margin", (a, expected) => {
+    const wrapper = renderSelect({ size: a });
+    assertStyleMatch(
+      {
+        paddingRight: expected,
+      },
+      wrapper,
+      { modifier: `${InputPresentationStyle}` }
+    );
   });
 
   describe('when the "value" prop is passed', () => {

--- a/src/components/select/multi-select/multi-select.style.js
+++ b/src/components/select/multi-select/multi-select.style.js
@@ -1,6 +1,10 @@
 import styled from "styled-components";
 import StyledPill from "../../pill/pill.style";
 import { baseTheme } from "../../../style/themes";
+import InputIconToggleStyle from "../../../__experimental__/components/input-icon-toggle/input-icon-toggle.style";
+import StyledSelect from "../select.style";
+import InputPresentationStyle from "../../../__experimental__/components/input/input-presentation.style";
+import sizes from "../../../__experimental__/components/input/input-sizes.style";
 
 const StyledSelectPillContainer = styled.div`
   display: flex;
@@ -13,8 +17,21 @@ const StyledSelectPillContainer = styled.div`
   }
 `;
 
+const StyledSelectMultiSelect = styled(StyledSelect)`
+  ${InputIconToggleStyle} {
+    margin-right: 0;
+    position: absolute;
+    right: 0;
+    height: 100%;
+  }
+
+  ${InputPresentationStyle} {
+    padding-right: ${({ size }) => sizes[size].height};
+  }
+`;
+
 StyledSelectPillContainer.defaultProps = {
   theme: baseTheme,
 };
 
-export default StyledSelectPillContainer;
+export { StyledSelectPillContainer, StyledSelectMultiSelect };

--- a/src/components/select/select.style.js
+++ b/src/components/select/select.style.js
@@ -5,54 +5,55 @@ import InputPresentationStyle from "../../__experimental__/components/input/inpu
 import StyledInput from "../../__experimental__/components/input/input.style";
 import InputIconToggleStyle from "../../__experimental__/components/input-icon-toggle/input-icon-toggle.style";
 import { baseTheme } from "../../style/themes";
+import sizes from "../../__experimental__/components/input/input-sizes.style";
 
 const StyledSelect = styled.div`
-  position: relative;
-  ${margin}
+  ${({ hasTextCursor, disabled, theme, readOnly, transparent, size }) => css`
+    ${margin}
 
-  ${StyledInput} {
-    cursor: ${({ hasTextCursor }) => (hasTextCursor ? "text" : "pointer")};
+    position: relative;
 
-    ${({ disabled }) =>
-      disabled &&
+    ${StyledInput} {
+      cursor: ${hasTextCursor ? "text" : "pointer"};
+
+      ${disabled &&
       css`
         cursor: not-allowed;
-        color: ${({ theme }) => theme.disabled.disabled};
+        color: ${theme.disabled.disabled};
         text-shadow: none;
       `}
 
-    ${({ readOnly }) =>
-      readOnly &&
+      ${readOnly &&
       css`
-        cursor: ${({ hasTextCursor }) => (hasTextCursor ? "text" : "default")};
-        color: ${({ theme }) => theme.readOnly.textboxText};
+        cursor: ${hasTextCursor ? "text" : "default"};
+        color: ${theme.readOnly.textboxText};
         text-shadow: none;
       `}
-  }
+    }
 
-  ${InputPresentationStyle} {
-    cursor: ${({ hasTextCursor }) => (hasTextCursor ? "text" : "pointer")};
-    padding-right: 0;
+    ${InputPresentationStyle} {
+      cursor: ${hasTextCursor ? "text" : "pointer"};
+      padding-right: ${sizes[size].height};
 
-    ${({ disabled }) =>
-      disabled &&
+      ${disabled &&
       css`
         cursor: not-allowed;
       `}
 
-    ${({ readOnly }) =>
-      readOnly &&
+      ${readOnly &&
       css`
-        cursor: ${({ hasTextCursor }) => (hasTextCursor ? "text" : "default")};
+        cursor: ${hasTextCursor ? "text" : "default"};
       `}
-  }
+    }
 
-  ${InputIconToggleStyle} {
-    margin-right: 0;
-  }
+    ${InputIconToggleStyle} {
+      margin-right: 0;
+      position: absolute;
+      right: 0;
+      height: 100%;
+    }
 
-  ${({ transparent }) =>
-    transparent &&
+    ${transparent &&
     css`
       ${InputPresentationStyle} {
         background: transparent;
@@ -69,6 +70,7 @@ const StyledSelect = styled.div`
         width: auto;
       }
     `}
+  `}
 `;
 
 StyledSelect.defaultProps = {

--- a/src/components/select/select.style.js
+++ b/src/components/select/select.style.js
@@ -5,10 +5,9 @@ import InputPresentationStyle from "../../__experimental__/components/input/inpu
 import StyledInput from "../../__experimental__/components/input/input.style";
 import InputIconToggleStyle from "../../__experimental__/components/input-icon-toggle/input-icon-toggle.style";
 import { baseTheme } from "../../style/themes";
-import sizes from "../../__experimental__/components/input/input-sizes.style";
 
 const StyledSelect = styled.div`
-  ${({ hasTextCursor, disabled, theme, readOnly, transparent, size }) => css`
+  ${({ hasTextCursor, disabled, theme, readOnly, transparent }) => css`
     ${margin}
 
     position: relative;
@@ -33,7 +32,7 @@ const StyledSelect = styled.div`
 
     ${InputPresentationStyle} {
       cursor: ${hasTextCursor ? "text" : "pointer"};
-      padding-right: ${sizes[size].height};
+      padding-right: 0;
 
       ${disabled &&
       css`
@@ -48,9 +47,6 @@ const StyledSelect = styled.div`
 
     ${InputIconToggleStyle} {
       margin-right: 0;
-      position: absolute;
-      right: 0;
-      height: 100%;
     }
 
     ${transparent &&
@@ -67,7 +63,6 @@ const StyledSelect = styled.div`
 
       ${InputIconToggleStyle} {
         margin-left: 0;
-        width: auto;
       }
     `}
   `}

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -125,12 +125,15 @@ describe("SimpleSelect", () => {
     );
   });
 
-  it("the input text should have proper paddings", () => {
-    const wrapper = renderSelect();
-
+  it.each([
+    ["small", "32px"],
+    ["medium", "40px"],
+    ["large", "48px"],
+  ])("the input toggle icon should have proper left margin", (a, expected) => {
+    const wrapper = renderSelect({ size: a });
     assertStyleMatch(
       {
-        paddingRight: "0",
+        paddingRight: expected,
       },
       wrapper,
       { modifier: `${InputPresentationStyle}` }

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -125,21 +125,6 @@ describe("SimpleSelect", () => {
     );
   });
 
-  it.each([
-    ["small", "32px"],
-    ["medium", "40px"],
-    ["large", "48px"],
-  ])("the input toggle icon should have proper left margin", (a, expected) => {
-    const wrapper = renderSelect({ size: a });
-    assertStyleMatch(
-      {
-        paddingRight: expected,
-      },
-      wrapper,
-      { modifier: `${InputPresentationStyle}` }
-    );
-  });
-
   it("the input text should have proper styling for the transparent type", () => {
     const wrapper = renderSelect({ transparent: true });
 
@@ -206,16 +191,6 @@ describe("SimpleSelect", () => {
         },
         wrapper,
         { modifier: `${StyledInput}` }
-      );
-    });
-
-    it("then the input toggle text should have width set to auto", () => {
-      assertStyleMatch(
-        {
-          width: "auto",
-        },
-        wrapper,
-        { modifier: `${InputIconToggleStyle}` }
       );
     });
   });


### PR DESCRIPTION
### Proposed behaviour
![multi-select](https://user-images.githubusercontent.com/19231884/112342847-e052d100-8cc2-11eb-8988-28d2141f4d7b.png)


### Current behaviour
Icon Dropdown is placed in the bottom-right corner and sometimes jump into bottom-left corner

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] <del> Storybook added or updated if required
- [ ] <del> Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Testing instructions
You can check this behavior by going to 
Storybook => Multi-Select => and then pick some items from a list 

https://codesandbox.io/s/carbon-quickstart-forked-8vt2r