### PR TITLE
refactor(menu): rewrite keyboard nav - FE-3695

### DIFF
--- a/cypress/features/regression/designSystem/menu.feature
+++ b/cypress/features/regression/designSystem/menu.feature
@@ -15,31 +15,31 @@ Feature: Design Systems Menu component
   @positive
   Scenario: Check the size of the second expandable element of Menu
     Given I open "Design System Menu" component page "default divider" in no iframe
-    When I hover over third expandable Menu component
+    When I click third expandable Menu component
     Then Menu third expandable element has inner elements
 
   @positive
   Scenario: Check that menu search has an alternate background colour
     Given I open "Design System Menu" component page "submenu with search" in no iframe
-    When I hover over third expandable Menu component
+    When I click third expandable Menu component
     Then Inner menu search input has alternate "rgb(0, 51, 73)" background colour
 
   @positive
   Scenario: Check the size of divider is a large
     Given I open "Design System Menu" component page "default large divider" in no iframe
-    When I hover over third expandable Menu component
+    When I click third expandable Menu component
     Then Menu divider has 4 px size
 
   @positive
   Scenario: Check the segment title is visible within a submenu
     Given I open "Design System Menu" component page "default segment title" in no iframe
-    When I hover over third expandable Menu component
+    When I click third expandable Menu component
     Then "segment title" is visible
 
   @positive
   Scenario: Check alternate colour theme for submenu
     Given I open "Design System Menu" component page "default theme alternate colour" in no iframe
-    When I hover over third expandable Menu component
+    When I click third expandable Menu component
     Then "fourth" submenu has alternate colour theme
       And "fifth" submenu has alternate colour theme
       And "sixth" submenu has alternate colour theme

--- a/cypress/features/regression/designSystem/menu.feature
+++ b/cypress/features/regression/designSystem/menu.feature
@@ -15,31 +15,31 @@ Feature: Design Systems Menu component
   @positive
   Scenario: Check the size of the second expandable element of Menu
     Given I open "Design System Menu" component page "default divider" in no iframe
-    When I click third expandable Menu component
+    When I hover over third expandable Menu component
     Then Menu third expandable element has inner elements
 
   @positive
   Scenario: Check that menu search has an alternate background colour
     Given I open "Design System Menu" component page "submenu with search" in no iframe
-    When I click third expandable Menu component
+    When I hover over third expandable Menu component
     Then Inner menu search input has alternate "rgb(0, 51, 73)" background colour
 
   @positive
   Scenario: Check the size of divider is a large
     Given I open "Design System Menu" component page "default large divider" in no iframe
-    When I click third expandable Menu component
+    When I hover over third expandable Menu component
     Then Menu divider has 4 px size
 
   @positive
   Scenario: Check the segment title is visible within a submenu
     Given I open "Design System Menu" component page "default segment title" in no iframe
-    When I click third expandable Menu component
+    When I hover over third expandable Menu component
     Then "segment title" is visible
 
   @positive
   Scenario: Check alternate colour theme for submenu
     Given I open "Design System Menu" component page "default theme alternate colour" in no iframe
-    When I click third expandable Menu component
+    When I hover over third expandable Menu component
     Then "fourth" submenu has alternate colour theme
       And "fifth" submenu has alternate colour theme
       And "sixth" submenu has alternate colour theme

--- a/cypress/features/regression/designSystem/menu.feature
+++ b/cypress/features/regression/designSystem/menu.feature
@@ -43,3 +43,28 @@ Feature: Design Systems Menu component
     Then "fourth" submenu has alternate colour theme
       And "fifth" submenu has alternate colour theme
       And "sixth" submenu has alternate colour theme
+
+  @negative
+  Scenario: Check the default menu clickToOpen element does not open on hover
+    Given I open "Design System Menu" component page "submenu options" in no iframe
+    When I hover over default menu "sixth" expandable Menu component
+    Then Menu "sixth" expandable component submenu is not visible
+
+  @positive
+  Scenario: Check the default menu clickToOpen element opens on mouse click
+    Given I open "Design System Menu" component page "submenu options" in no iframe
+    When I click default menu "sixth" expandable Menu component
+    Then Menu "sixth" expandable element has inner elements
+
+  @positive
+  Scenario Outline: Check the default menu clickToOpen element opens using the "<key>" key
+    Given I open "Design System Menu" component page "submenu options" in no iframe
+      And I press tab from default menu "fourth" expandable Menu component 2 times
+    When I press "<key>" onto focused element
+    Then Menu "sixth" expandable element has inner elements
+    Examples:
+      | key       |
+      | Enter     |
+      | Space     |
+      | downarrow |
+      | uparrow   |

--- a/cypress/locators/menu/index.js
+++ b/cypress/locators/menu/index.js
@@ -1,4 +1,10 @@
-import { SUBMENU, SCROLL_BLOCK, MENU_DIVIDER, SEGMENT_TITLE } from "./locators";
+import {
+  SUBMENU,
+  SCROLL_BLOCK,
+  MENU_DIVIDER,
+  SEGMENT_TITLE,
+  MENU,
+} from "./locators";
 
 // component preview locators
 export const submenu = () => cy.get(SUBMENU);
@@ -9,3 +15,7 @@ export const scrollBlock = () => cy.get(SUBMENU).find(SCROLL_BLOCK);
 export const lastSubmenuElement = () => submenuBlock().find("li div").last();
 export const menuDivider = () => cy.get(MENU_DIVIDER);
 export const segmentTitle = () => cy.get(SEGMENT_TITLE);
+export const menuComponent = (index) =>
+  cy.get(MENU).first().find(`li:nth-child(${index})`);
+export const submenuItem = (index) =>
+  menuComponent(index).find(SUBMENU).find("ul > li");

--- a/cypress/locators/menu/locators.js
+++ b/cypress/locators/menu/locators.js
@@ -3,3 +3,4 @@ export const SUBMENU = '[data-component="submenu-wrapper"]';
 export const SCROLL_BLOCK = '[data-component="submenu-scrollable-block"]';
 export const MENU_DIVIDER = '[data-component="menu-divider"]';
 export const SEGMENT_TITLE = '[data-component="menu-segment-title"]';
+export const MENU = '[data-component="menu"]';

--- a/cypress/support/helper.js
+++ b/cypress/support/helper.js
@@ -196,5 +196,6 @@ export function keyCode(type) {
     Tab: { key: "Tab", keyCode: 9, which: 9 },
     Home: { keyCode: 36, which: 36 },
     End: { keyCode: 35, which: 35 },
+    Esc: { keyCode: 27, which: 27 },
   }[type];
 }

--- a/cypress/support/step-definitions/menu-steps.js
+++ b/cypress/support/step-definitions/menu-steps.js
@@ -9,8 +9,8 @@ import {
 } from "../../locators/menu";
 import { positionOfElement } from "../helper";
 
-When("I hover over third expandable Menu component", () => {
-  submenu().trigger("mouseover");
+When("I click third expandable Menu component", () => {
+  submenu().trigger("click");
 });
 
 Then("Menu third expandable element has inner elements", () => {
@@ -38,7 +38,7 @@ Then("Menu third expandable element has inner elements", () => {
 });
 
 When("I open the {string} submenu", (position) => {
-  submenu().eq(positionOfElement(position)).trigger("mouseover");
+  submenu().eq(positionOfElement(position)).trigger("click");
 });
 
 When("I scroll to the bottom of the block", () => {

--- a/cypress/support/step-definitions/menu-steps.js
+++ b/cypress/support/step-definitions/menu-steps.js
@@ -6,8 +6,10 @@ import {
   lastSubmenuElement,
   menuDivider,
   segmentTitle,
+  menuComponent,
+  submenuItem,
 } from "../../locators/menu";
-import { positionOfElement } from "../helper";
+import { positionOfElement, keyCode } from "../helper";
 
 When("I hover over third expandable Menu component", () => {
   submenu().trigger("mouseover");
@@ -77,4 +79,47 @@ Then("{string} submenu has alternate colour theme", (position) => {
     "background-color",
     "rgb(230, 235, 237)"
   );
+});
+
+When(
+  "I hover over default menu {string} expandable Menu component",
+  (position) => {
+    menuComponent(positionOfElement(position)).trigger("mouseover", {
+      force: true,
+    });
+  }
+);
+
+Then(
+  "Menu {string} expandable component submenu is not visible",
+  (position) => {
+    submenuItem(positionOfElement(position))
+      .should("have.length", 0)
+      .and("not.exist");
+  }
+);
+
+When("I click default menu {string} expandable Menu component", (position) => {
+  menuComponent(positionOfElement(position)).click();
+});
+
+Given(
+  "I press tab from default menu {string} expandable Menu component {int} times",
+  (position, times) => {
+    menuComponent(positionOfElement(position)).click();
+    cy.focused().trigger("keydown", keyCode("Esc"));
+    for (let i = 0; i < times; i++) {
+      cy.focused().tab();
+    }
+  }
+);
+
+Then("Menu {string} expandable element has inner elements", (position) => {
+  submenuItem(positionOfElement(position)).should("have.length", 2);
+  innerMenu(positionOfElement("second"))
+    .should("have.attr", "data-component", "link")
+    .and("be.visible");
+  innerMenu(positionOfElement("third"))
+    .should("have.attr", "data-component", "link")
+    .and("be.visible");
 });

--- a/cypress/support/step-definitions/menu-steps.js
+++ b/cypress/support/step-definitions/menu-steps.js
@@ -9,8 +9,8 @@ import {
 } from "../../locators/menu";
 import { positionOfElement } from "../helper";
 
-When("I click third expandable Menu component", () => {
-  submenu().trigger("click");
+When("I hover over third expandable Menu component", () => {
+  submenu().trigger("mouseover");
 });
 
 Then("Menu third expandable element has inner elements", () => {
@@ -38,7 +38,7 @@ Then("Menu third expandable element has inner elements", () => {
 });
 
 When("I open the {string} submenu", (position) => {
-  submenu().eq(positionOfElement(position)).trigger("click");
+  submenu().eq(positionOfElement(position)).trigger("mouseover");
 });
 
 When("I scroll to the bottom of the block", () => {

--- a/src/components/menu/__internal__/keyboard-navigation/index.js
+++ b/src/components/menu/__internal__/keyboard-navigation/index.js
@@ -1,11 +1,8 @@
 import Events from "../../../../utils/helpers/events";
 import MenuItem from "../../menu-item";
 
-function characterNavigation(event, focusableItems, currentFocusedIndex) {
-  event.stopPropagation();
-  let firstMatch;
-  let nextMatch;
-  const selectedKey = event.key.toLowerCase();
+function characterNavigation(inputString, focusableItems, currentFocusedIndex) {
+  if (!inputString || inputString === "") return currentFocusedIndex;
 
   const getNodeText = (node) => {
     if (node instanceof Array) return node.map(getNodeText).join("");
@@ -25,68 +22,34 @@ function characterNavigation(event, focusableItems, currentFocusedIndex) {
     return getNodeText(element.children);
   };
 
-  focusableItems.forEach((child, i) => {
-    if (
-      child &&
-      child.type === MenuItem &&
-      getMenuText(child.props).toLowerCase().startsWith(selectedKey)
-    ) {
-      if (firstMatch === undefined) {
-        firstMatch = i;
-      }
-      if (i > currentFocusedIndex && !nextMatch) {
-        nextMatch = i;
-      }
-    }
-  });
+  const itemsList = focusableItems.map(
+    (item) =>
+      item && item.type === MenuItem && getMenuText(item.props).toLowerCase()
+  );
 
-  if (nextMatch !== undefined) {
-    return nextMatch;
-  }
+  const matchingItem = itemsList.find(
+    (item) => item && item.startsWith(inputString)
+  );
 
-  if (firstMatch !== undefined) {
-    return firstMatch;
-  }
-
-  return currentFocusedIndex;
+  return itemsList.indexOf(matchingItem) === -1
+    ? currentFocusedIndex
+    : itemsList.indexOf(matchingItem);
 }
 
-function menuKeyboardNavigation(event, focusableItems, currentFocusedIndex) {
-  if (Events.isRightKey(event)) {
-    event.preventDefault();
-    if (currentFocusedIndex === focusableItems.length - 1) {
-      return 0;
-    }
-    return currentFocusedIndex + 1;
-  }
-
-  if (Events.isLeftKey(event)) {
-    event.preventDefault();
-    if (currentFocusedIndex === 0) {
-      return focusableItems.length - 1;
-    }
-    return currentFocusedIndex - 1;
-  }
+function menuKeyboardNavigation(event, focusableItems) {
+  let nextIndex;
 
   if (Events.isHomeKey(event)) {
     event.preventDefault();
-    return 0;
+    nextIndex = 0;
   }
 
   if (Events.isEndKey(event)) {
     event.preventDefault();
-    return focusableItems.length - 1;
+    nextIndex = focusableItems.length - 1;
   }
 
-  if (Events.isAlphabetKey(event) || Events.isNumberKey(event)) {
-    return characterNavigation(event, focusableItems, currentFocusedIndex);
-  }
-
-  if (Events.isTabKey(event)) {
-    return undefined;
-  }
-
-  return currentFocusedIndex;
+  return nextIndex;
 }
 
 export { characterNavigation, menuKeyboardNavigation };

--- a/src/components/menu/__internal__/keyboard-navigation/index.js
+++ b/src/components/menu/__internal__/keyboard-navigation/index.js
@@ -2,7 +2,7 @@ import Events from "../../../../utils/helpers/events";
 import MenuItem from "../../menu-item";
 
 function characterNavigation(inputString, focusableItems, currentFocusedIndex) {
-  if (!inputString || inputString === "") return currentFocusedIndex;
+  if (!inputString) return currentFocusedIndex;
 
   const getNodeText = (node) => {
     if (node instanceof Array) return node.map(getNodeText).join("");
@@ -11,10 +11,6 @@ function characterNavigation(inputString, focusableItems, currentFocusedIndex) {
     return node;
   };
   const getMenuText = (element) => {
-    if (element.keyboardOverride) {
-      return element.keyboardOverride;
-    }
-
     if (element.submenu) {
       return element.submenu;
     }
@@ -24,32 +20,33 @@ function characterNavigation(inputString, focusableItems, currentFocusedIndex) {
 
   const itemsList = focusableItems.map(
     (item) =>
-      item && item.type === MenuItem && getMenuText(item.props).toLowerCase()
+      item &&
+      item.type === MenuItem &&
+      getMenuText(item.props) &&
+      getMenuText(item.props).toLowerCase()
   );
 
   const matchingItem = itemsList.find(
     (item) => item && item.startsWith(inputString)
   );
 
-  return itemsList.indexOf(matchingItem) === -1
-    ? currentFocusedIndex
-    : itemsList.indexOf(matchingItem);
+  const matchingIndex = itemsList.indexOf(matchingItem);
+
+  return matchingIndex === -1 ? currentFocusedIndex : matchingIndex;
 }
 
 function menuKeyboardNavigation(event, focusableItems) {
-  let nextIndex;
-
   if (Events.isHomeKey(event)) {
     event.preventDefault();
-    nextIndex = 0;
+    return 0;
   }
 
   if (Events.isEndKey(event)) {
     event.preventDefault();
-    nextIndex = focusableItems.length - 1;
+    return focusableItems.length - 1;
   }
 
-  return nextIndex;
+  return undefined;
 }
 
 export { characterNavigation, menuKeyboardNavigation };

--- a/src/components/menu/__internal__/keyboard-navigation/index.spec.js
+++ b/src/components/menu/__internal__/keyboard-navigation/index.spec.js
@@ -27,70 +27,52 @@ describe("Menu keyboard navigation", () => {
   ];
 
   describe("characterNavigation", () => {
-    describe("when a non character key event passed in", () => {
+    describe("when an empty string passed in", () => {
       it("should return the current index", () => {
-        const result = characterNavigation(
-          getMockEvent("ArrowRight"),
-          focusableItems,
-          0
-        );
+        const result = characterNavigation("", focusableItems, 0);
+        expect(result).toEqual(0);
+      });
+    });
+
+    describe("when an irrelevant character passed in ", () => {
+      // E.g. none of the items start with this letter
+      it("should return the current index", () => {
+        const result = characterNavigation("h", focusableItems, 0);
         expect(result).toEqual(0);
       });
     });
 
     describe("when a character key event passed in", () => {
       it("should return the correct index", () => {
-        const result = characterNavigation(
-          getMockEvent("b"),
-          focusableItems,
-          0
-        );
+        const result = characterNavigation("b", focusableItems, 0);
         expect(result).toEqual(1);
       });
     });
 
     describe("when the keyboard override of a submenu passed in", () => {
       it("should return the correct index", () => {
-        const result = characterNavigation(
-          getMockEvent("1"),
-          focusableItems,
-          0
-        );
+        const result = characterNavigation("1", focusableItems, 0);
         expect(result).toEqual(6);
       });
     });
 
     describe("when a character key event passed in", () => {
       it("should return the correct index when menu contains other nodes", () => {
-        const result = characterNavigation(
-          getMockEvent("r"),
-          focusableItems,
-          0
-        );
+        const result = characterNavigation("r", focusableItems, 0);
         expect(result).toEqual(7);
       });
     });
 
     describe("when there are multiple menu items starting with the same letter", () => {
       it("should return the index of the next item starting with that letter", () => {
-        let result = characterNavigation(getMockEvent("b"), focusableItems, 0);
-        expect(result).toEqual(1);
-
-        result = characterNavigation(getMockEvent("b"), focusableItems, 1);
-        expect(result).toEqual(4);
-
-        result = characterNavigation(getMockEvent("b"), focusableItems, 4);
+        const result = characterNavigation("b", focusableItems, 0);
         expect(result).toEqual(1);
       });
     });
 
     describe("when the starting letter of a submenu passed in", () => {
       it("should return the correct index", () => {
-        const result = characterNavigation(
-          getMockEvent("s"),
-          focusableItems,
-          0
-        );
+        const result = characterNavigation("s", focusableItems, 0);
         expect(result).toEqual(5);
       });
     });
@@ -98,61 +80,13 @@ describe("Menu keyboard navigation", () => {
 
   describe("menuKeyboardNavigation", () => {
     describe("when in invalid key event passed in", () => {
-      it("should return the current focused index", () => {
+      it("should return undefined", () => {
         const result = menuKeyboardNavigation(
           getMockEvent("shift"),
           focusableItems,
           1
         );
-        expect(result).toEqual(1);
-      });
-    });
-
-    describe("when the ArrowRight key event passed in", () => {
-      describe("when current index is not the last", () => {
-        it("should return the next index", () => {
-          const result = menuKeyboardNavigation(
-            getMockEvent("ArrowRight", 39),
-            focusableItems,
-            0
-          );
-          expect(result).toEqual(1);
-        });
-      });
-
-      describe("when current index is the last", () => {
-        it("should return the first index", () => {
-          const result = menuKeyboardNavigation(
-            getMockEvent("ArrowRight", 39),
-            focusableItems,
-            7
-          );
-          expect(result).toEqual(0);
-        });
-      });
-    });
-
-    describe("when the ArrowLeft key event passed in", () => {
-      describe("when current index is not the first", () => {
-        it("should return the next index", () => {
-          const result = menuKeyboardNavigation(
-            getMockEvent("ArrowLeft", 37),
-            focusableItems,
-            2
-          );
-          expect(result).toEqual(1);
-        });
-      });
-
-      describe("when current index is the first", () => {
-        it("should return the last index", () => {
-          const result = menuKeyboardNavigation(
-            getMockEvent("ArrowLeft", 37),
-            focusableItems,
-            0
-          );
-          expect(result).toEqual(7);
-        });
+        expect(result).toEqual(undefined);
       });
     });
 
@@ -179,13 +113,13 @@ describe("Menu keyboard navigation", () => {
     });
 
     describe("when an alphabet key event passed in", () => {
-      it("should return the correct index", () => {
+      it("should return undefined", () => {
         const result = menuKeyboardNavigation(
           getMockEvent("c", 67),
           focusableItems,
           0
         );
-        expect(result).toEqual(3);
+        expect(result).toEqual(undefined);
       });
     });
 

--- a/src/components/menu/__internal__/keyboard-navigation/index.spec.js
+++ b/src/components/menu/__internal__/keyboard-navigation/index.spec.js
@@ -20,7 +20,7 @@ describe("Menu keyboard navigation", () => {
     <MenuItem>Carrot</MenuItem>,
     <MenuItem>Broccoli</MenuItem>,
     <MenuItem submenu="submenu">Sub item</MenuItem>,
-    <MenuItem keyboardOverride="1">Parsnip</MenuItem>,
+    <MenuItem>Parsnip</MenuItem>,
     <MenuItem>
       <span>Rhubarb</span> <Box>and</Box> Ginger
     </MenuItem>,
@@ -49,13 +49,6 @@ describe("Menu keyboard navigation", () => {
       });
     });
 
-    describe("when the keyboard override of a submenu passed in", () => {
-      it("should return the correct index", () => {
-        const result = characterNavigation("1", focusableItems, 0);
-        expect(result).toEqual(6);
-      });
-    });
-
     describe("when a character key event passed in", () => {
       it("should return the correct index when menu contains other nodes", () => {
         const result = characterNavigation("r", focusableItems, 0);
@@ -79,7 +72,7 @@ describe("Menu keyboard navigation", () => {
   });
 
   describe("menuKeyboardNavigation", () => {
-    describe("when in invalid key event passed in", () => {
+    describe("when an invalid key event passed in", () => {
       it("should return undefined", () => {
         const result = menuKeyboardNavigation(
           getMockEvent("shift"),

--- a/src/components/menu/__internal__/spec-helper/index.js
+++ b/src/components/menu/__internal__/spec-helper/index.js
@@ -1,0 +1,24 @@
+import { act } from "react-dom/test-utils";
+import StyledMenuItemWrapper from "../../menu-item/menu-item.style";
+
+const events = {
+  space: {
+    key: "Space",
+    which: 32,
+    preventDefault: jest.fn(),
+  },
+};
+
+const openSubmenu = (wrapper) => {
+  const menuItem = wrapper.find('[data-component="submenu-wrapper"]').find("a");
+
+  menuItem.getDOMNode().focus();
+
+  act(() => {
+    wrapper.find(StyledMenuItemWrapper).at(0).props().onKeyDown(events.space);
+  });
+
+  wrapper.update();
+};
+
+export default openSubmenu;

--- a/src/components/menu/__internal__/submenu/submenu.component.js
+++ b/src/components/menu/__internal__/submenu/submenu.component.js
@@ -31,6 +31,8 @@ const Submenu = React.forwardRef(
       onKeyDown,
       variant = "default",
       showDropdownArrow = true,
+      clickToOpen,
+      href,
       ...rest
     },
     ref
@@ -84,7 +86,9 @@ const Submenu = React.forwardRef(
           ) {
             event.preventDefault();
             setSubmenuOpen(true);
-            setSubmenuFocusIndex(0);
+            if (!href) {
+              setSubmenuFocusIndex(0);
+            }
           }
 
           if (!event.defaultPrevented) {
@@ -155,9 +159,28 @@ const Submenu = React.forwardRef(
             setCharacterString("");
           }
 
+          if (href && index === undefined) {
+            if (
+              Events.isEnterKey(event) ||
+              (Events.isTabKey(event) && Events.isShiftKey(event))
+            ) {
+              closeSubmenu();
+              return;
+            }
+
+            if (
+              Events.isSpaceKey(event) ||
+              Events.isDownKey(event) ||
+              Events.isUpKey(event) ||
+              Events.isTabKey(event)
+            ) {
+              nextIndex = 0;
+            }
+          }
+
           // Defensive check in case an unhandled key event from a child component
           // has bubbled up
-          if (nextIndex === undefined) return;
+          if (!nextIndex && nextIndex !== 0) return;
 
           // Check that next index contains a MenuItem
           // If not, call handleKeyDown again
@@ -178,6 +201,7 @@ const Submenu = React.forwardRef(
         restartCharacterTimeout,
         formattedChildren,
         closeSubmenu,
+        href,
         menuContext,
         numberOfChildren,
         onKeyDown,
@@ -224,7 +248,9 @@ const Submenu = React.forwardRef(
       <StyledSubmenuWrapper
         data-component="submenu-wrapper"
         role="menuitem"
-        onClick={() => setSubmenuOpen(true)}
+        onMouseOver={!clickToOpen ? () => setSubmenuOpen(true) : undefined}
+        onMouseLeave={() => closeSubmenu()}
+        onClick={clickToOpen ? () => setSubmenuOpen(true) : undefined}
         ref={submenuRef}
         isSubmenuOpen={submenuOpen}
       >
@@ -242,6 +268,8 @@ const Submenu = React.forwardRef(
           hasSubmenu
           showDropdownArrow={showDropdownArrow}
           onKeyDown={handleKeyDown}
+          clickToOpen={clickToOpen}
+          href={href}
         >
           {title}
         </StyledMenuItemWrapper>
@@ -290,6 +318,10 @@ Submenu.propTypes = {
   variant: PropTypes.oneOf(["default", "alternate"]),
   /** Flag to display the dropdown arrow when an item has a submenu */
   showDropdownArrow: PropTypes.bool,
+  /** When set the submenu opens by click instead of hover */
+  clickToOpen: PropTypes.bool,
+  /** The href to use for the menu item. */
+  href: PropTypes.string,
 };
 
 export default Submenu;

--- a/src/components/menu/__internal__/submenu/submenu.spec.js
+++ b/src/components/menu/__internal__/submenu/submenu.spec.js
@@ -142,20 +142,166 @@ describe("Submenu component", () => {
   });
 
   describe("when closed", () => {
-    beforeEach(() => {
-      wrapper = render("light");
-    });
-
     it("should not render the submenu", () => {
+      wrapper = render("light");
       expect(wrapper.find(StyledSubmenu).exists()).toEqual(false);
     });
 
-    describe("when clicked", () => {
+    describe("on mouse over", () => {
       it("should open the submenu", () => {
-        wrapper.find("a").getDOMNode().click();
+        wrapper = render("light");
+        expect(wrapper.find(StyledSubmenu).exists()).toEqual(false);
+
+        act(() => {
+          wrapper
+            .find('[data-component="submenu-wrapper"]')
+            .at(0)
+            .props()
+            .onMouseOver();
+        });
         wrapper.update();
 
         expect(wrapper.find(StyledSubmenu).exists()).toEqual(true);
+      });
+    });
+
+    describe("on mouse out", () => {
+      it("should close the submenu", () => {
+        wrapper = render("light");
+        openSubmenu(wrapper);
+        expect(wrapper.find(StyledSubmenu).exists()).toEqual(true);
+
+        act(() => {
+          wrapper
+            .find('[data-component="submenu-wrapper"]')
+            .at(0)
+            .props()
+            .onMouseLeave();
+        });
+
+        wrapper.update();
+
+        expect(wrapper.find(StyledSubmenu).exists()).toEqual(false);
+      });
+    });
+
+    describe("when clicked", () => {
+      it("should not open the submenu", () => {
+        wrapper = render("light");
+        wrapper.find("a").getDOMNode().click();
+        wrapper.update();
+
+        expect(wrapper.find(StyledSubmenu).exists()).toEqual(false);
+      });
+    });
+
+    describe("when clickToOpen prop set", () => {
+      beforeEach(() => {
+        wrapper = render("light", { clickToOpen: true });
+      });
+
+      describe("on mouse over", () => {
+        it("should not set the onMouseOver function", () => {
+          expect(wrapper.find(StyledSubmenu).exists()).toEqual(false);
+
+          expect(
+            wrapper.find('[data-component="submenu-wrapper"]').at(0).props()
+              .onMouseOver
+          ).toEqual(undefined);
+        });
+      });
+
+      describe("when clicked", () => {
+        it("should open the submenu", () => {
+          wrapper.find("a").getDOMNode().click();
+          wrapper.update();
+
+          expect(wrapper.find(StyledSubmenu).exists()).toEqual(true);
+        });
+      });
+    });
+
+    describe("when href prop set", () => {
+      beforeEach(() => {
+        wrapper = render("light", { href: "/path" });
+      });
+
+      describe("when opening submenu with keyboard", () => {
+        it("should leave the focus on the menu item", () => {
+          openSubmenu(wrapper);
+
+          expect(
+            wrapper.find('[data-component="submenu-wrapper"]').find("a").at(0)
+          ).toBeFocused();
+        });
+
+        it("should close the submenu when enter is pressed", () => {
+          openSubmenu(wrapper);
+
+          act(() => {
+            wrapper
+              .find(StyledMenuItemWrapper)
+              .at(0)
+              .props()
+              .onKeyDown(events.enter);
+          });
+
+          wrapper.update();
+
+          expect(wrapper.find(StyledSubmenu).exists()).toEqual(false);
+        });
+
+        it("should close the submenu when shift-tab is pressed", () => {
+          openSubmenu(wrapper);
+
+          act(() => {
+            wrapper
+              .find(StyledMenuItemWrapper)
+              .at(0)
+              .props()
+              .onKeyDown(events.shiftTab);
+          });
+
+          wrapper.update();
+
+          expect(wrapper.find(StyledSubmenu).exists()).toEqual(false);
+        });
+
+        it("should focus the first menu item when tab is pressed", () => {
+          openSubmenu(wrapper);
+
+          act(() => {
+            wrapper
+              .find(StyledMenuItemWrapper)
+              .at(0)
+              .props()
+              .onKeyDown(events.tab);
+          });
+
+          wrapper.update();
+
+          expect(wrapper.find(StyledSubmenu).exists()).toEqual(true);
+
+          expect(
+            wrapper.find('[data-component="submenu-wrapper"]').find("a").at(1)
+          ).toBeFocused();
+        });
+
+        it("should do nothing when character key pressed", () => {
+          openSubmenu(wrapper);
+
+          act(() => {
+            wrapper
+              .find(StyledMenuItemWrapper)
+              .at(0)
+              .props()
+              .onKeyDown(events.b);
+          });
+
+          wrapper.update();
+
+          expect(wrapper.find(StyledSubmenu).exists()).toEqual(true);
+        });
       });
     });
   });
@@ -883,6 +1029,7 @@ describe("Submenu component", () => {
       expect(wrapper.find(MenuItem).length).toEqual(4);
     });
   });
+
   describe("when it has Search as a child", () => {
     const renderWithSearch = (menuType, props) => {
       return mount(
@@ -907,16 +1054,15 @@ describe("Submenu component", () => {
     };
 
     it("should not lose focus when enter key pressed", () => {
-      wrapper = renderWithSearch(true, "dark");
+      wrapper = renderWithSearch("dark");
+      openSubmenu(wrapper);
 
       const searchInput = wrapper.find(StyledSearch).find("input");
-
       searchInput.getDOMNode().focus();
 
       expect(searchInput).toBeFocused();
 
       act(() => {
-        wrapper.find(StyledSearch).at(0).props().onKeyDown(events.arrowUp);
         searchInput
           .getDOMNode()
           .dispatchEvent(new KeyboardEvent("keydown", events.enter));

--- a/src/components/menu/menu-divider/menu-divider.spec.js
+++ b/src/components/menu/menu-divider/menu-divider.spec.js
@@ -7,10 +7,11 @@ import { MenuContext } from "../menu.component";
 import { MenuItem } from "..";
 import { baseTheme } from "../../../style/themes";
 import StyledDivider from "./menu-divider.style";
+import openSubmenu from "../__internal__/spec-helper";
 
 const menuContextValues = (menuType) => ({
   menuType,
-  openSubmenu: true,
+  handleKeyDown: () => null,
 });
 
 describe("MenuDivider", () => {
@@ -35,12 +36,14 @@ describe("MenuDivider", () => {
 
   it("should get menuType from menu context", () => {
     wrapper = render("light");
+    openSubmenu(wrapper);
 
     expect(wrapper.find(StyledDivider).props().menuType).toBe("light");
   });
 
   it('should have correct styles if menuType="light"', () => {
     wrapper = render("light");
+    openSubmenu(wrapper);
 
     assertStyleMatch(
       {
@@ -53,6 +56,7 @@ describe("MenuDivider", () => {
 
   it('should have correct styles if menuType="dark"', () => {
     wrapper = render("dark");
+    openSubmenu(wrapper);
 
     assertStyleMatch(
       {

--- a/src/components/menu/menu-item/menu-item.component.js
+++ b/src/components/menu/menu-item/menu-item.component.js
@@ -33,7 +33,6 @@ const MenuItem = ({
   variant = "default",
   showDropdownArrow = true,
   ariaLabel,
-  isSearch,
   ...rest
 }) => {
   const menuContext = useContext(MenuContext);
@@ -72,19 +71,13 @@ const MenuItem = ({
         ref.current.focus();
       }
 
-      if (!submenu && Events.isSpaceKey(event)) {
-        ref.current.click();
-      }
-
-      if (!event.defaultPrevented) {
-        if (submenuContext.handleKeyDown !== undefined) {
-          submenuContext.handleKeyDown(event);
-        } else {
-          menuContext.handleKeyDown(event);
-        }
+      if (submenuContext.handleKeyDown !== undefined) {
+        submenuContext.handleKeyDown(event);
+      } else {
+        menuContext.handleKeyDown(event);
       }
     },
-    [menuContext, onKeyDown, ref, submenu, submenuContext]
+    [menuContext, onKeyDown, ref, submenuContext]
   );
 
   const classes = useMemo(
@@ -103,7 +96,6 @@ const MenuItem = ({
     icon,
     selected,
     menuType: menuContext.menuType,
-    tabbable: menuContext.isFirstElement,
   };
 
   if (submenu) {
@@ -121,7 +113,6 @@ const MenuItem = ({
           {...(typeof submenu !== "boolean" && { title: submenu })}
           icon={icon}
           submenuDirection={submenuDirection}
-          tabbable={menuContext.isFirstElement}
           onKeyDown={handleKeyDown}
           className={classes}
           showDropdownArrow={showDropdownArrow}

--- a/src/components/menu/menu-item/menu-item.component.js
+++ b/src/components/menu/menu-item/menu-item.component.js
@@ -33,6 +33,7 @@ const MenuItem = ({
   variant = "default",
   showDropdownArrow = true,
   ariaLabel,
+  clickToOpen,
   ...rest
 }) => {
   const menuContext = useContext(MenuContext);
@@ -95,7 +96,9 @@ const MenuItem = ({
     onClick,
     icon,
     selected,
-    menuType: menuContext.menuType,
+    variant,
+    onKeyDown: handleKeyDown,
+    ref,
   };
 
   if (submenu) {
@@ -107,15 +110,12 @@ const MenuItem = ({
         {...rest}
       >
         <Submenu
-          {...rest}
-          ref={ref}
-          variant={variant}
           {...(typeof submenu !== "boolean" && { title: submenu })}
-          icon={icon}
           submenuDirection={submenuDirection}
-          onKeyDown={handleKeyDown}
-          className={classes}
           showDropdownArrow={showDropdownArrow}
+          clickToOpen={clickToOpen}
+          {...elementProps}
+          {...rest}
         >
           {childrenItems}
         </Submenu>
@@ -132,13 +132,11 @@ const MenuItem = ({
       {...rest}
     >
       <StyledMenuItemWrapper
-        ref={ref}
-        onKeyDown={handleKeyDown}
         as={isChildrenSearch ? "div" : Link}
         data-component="menu-item"
         isSearch={isChildrenSearch}
+        menuType={menuContext.menuType}
         {...elementProps}
-        variant={variant}
         role="menuitem"
         ariaLabel={ariaLabel}
       >
@@ -183,6 +181,8 @@ MenuItem.propTypes = {
   selected: PropTypes.bool,
   /** A title for the menu item that has a submenu. */
   submenu: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
+  /** When set the submenu opens by click instead of hover */
+  clickToOpen: PropTypes.bool,
   /** The href to use for the menu item. */
   href: PropTypes.string,
   /** onKeyDown handler */
@@ -193,15 +193,6 @@ MenuItem.propTypes = {
   showDropdownArrow: PropTypes.bool,
   /** set the colour variant for a menuType */
   variant: PropTypes.oneOf(["default", "alternate"]),
-  /** Either a keyboard override or child text must be provided to facilitate keyboard navigation. */
-  keyboardOverride: (props, propName, ...rest) => {
-    if (props.icon && !props.children && !props.keyboardOverride) {
-      return new Error(
-        "Either a keyboard override or child text must be provided to facilitate keyboard navigation."
-      );
-    }
-    return PropTypes.string(props, propName, ...rest);
-  },
   /** If no text is provided an ariaLabel should be given to facilitate accessibility. */
   ariaLabel: (props, ...rest) => {
     if (

--- a/src/components/menu/menu-item/menu-item.d.ts
+++ b/src/components/menu/menu-item/menu-item.d.ts
@@ -10,7 +10,6 @@ export interface MenuItemProps {
   selected?: boolean;
   submenu?: React.ReactNode | boolean;
   href?: string;
-  keyboardOverride?: string;
   onKeyDown?: (event: React.KeyboardEvent<HTMLElement>) => void;
   target?: string;
   variant?: "default" | "alternate";

--- a/src/components/menu/menu-item/menu-item.spec.js
+++ b/src/components/menu/menu-item/menu-item.spec.js
@@ -21,12 +21,6 @@ const events = {
     which: 13,
     preventDefault: jest.fn(),
   },
-  space: {
-    key: "Space",
-    which: 32,
-    preventDefault: jest.fn(),
-    defaultPrevented: true,
-  },
   escape: {
     key: "Escape",
     which: 27,
@@ -37,9 +31,8 @@ const events = {
 const mockMenuhandleKeyDown = jest.fn();
 const mockSubmenuhandleKeyDown = jest.fn();
 
-const menuContextValues = (isFirstElement, isFocused) => ({
+const menuContextValues = (isFocused) => ({
   handleKeyDown: mockMenuhandleKeyDown,
-  isFirstElement,
   menuType: "light",
   isFocused,
 });
@@ -53,11 +46,9 @@ describe("MenuItem", () => {
   let container;
   let wrapper;
 
-  const renderMenuContext = (isFirstElement, isFocused, props) => {
+  const renderMenuContext = (isFocused, props) => {
     return mount(
-      <MenuContext.Provider
-        value={menuContextValues(isFirstElement, isFocused)}
-      >
+      <MenuContext.Provider value={menuContextValues(isFocused)}>
         <MenuItem {...props}>Item One</MenuItem>
       </MenuContext.Provider>,
       { attachTo: container }
@@ -277,7 +268,7 @@ describe("MenuItem", () => {
     let menuItem;
 
     it("should be focused", () => {
-      wrapper = renderMenuContext(false, true);
+      wrapper = renderMenuContext(true);
       menuItem = wrapper.find(MenuItem).find("a");
 
       expect(menuItem).toBeFocused();
@@ -288,7 +279,7 @@ describe("MenuItem", () => {
     describe("when onKeyDown prop passed in", () => {
       it("should call onKeyDown", () => {
         const onKeyDownFn = jest.fn();
-        wrapper = renderMenuContext(false, false, { onKeyDown: onKeyDownFn });
+        wrapper = renderMenuContext(false, { onKeyDown: onKeyDownFn });
 
         act(() => {
           wrapper
@@ -306,7 +297,7 @@ describe("MenuItem", () => {
 
     describe("when escape key pressed", () => {
       it("should focus the current menu item", () => {
-        wrapper = renderMenuContext(false, false);
+        wrapper = renderMenuContext(false);
 
         act(() => {
           wrapper
@@ -320,26 +311,6 @@ describe("MenuItem", () => {
         const menuItem = wrapper.find(MenuItem).find("a");
 
         expect(menuItem).toBeFocused();
-      });
-    });
-
-    describe("when space key pressed", () => {
-      it("should call onClick", () => {
-        const onClickFn = jest.fn();
-
-        wrapper = renderMenuContext(false, false, { onClick: onClickFn });
-
-        act(() => {
-          wrapper
-            .find(StyledMenuItemWrapper)
-            .at(0)
-            .props()
-            .onKeyDown(events.space);
-        });
-
-        wrapper.update();
-
-        expect(onClickFn).toHaveBeenCalled();
       });
     });
 

--- a/src/components/menu/menu-item/menu-item.spec.js
+++ b/src/components/menu/menu-item/menu-item.spec.js
@@ -384,22 +384,15 @@ describe("MenuItem", () => {
 
   describe("icon only menus and submenus", () => {
     it("should render an icon into the menu item", () => {
-      wrapper = mount(
-        <MenuItem icon="settings" ariaLabel="Settings" keyboardOverride="s" />
-      );
+      wrapper = mount(<MenuItem icon="settings" ariaLabel="Settings" />);
 
       expect(wrapper.find(StyledIcon).first().exists()).toBe(true);
     });
 
     it("should render an icon into the submenu item", () => {
       wrapper = mount(
-        <MenuItem
-          icon="settings"
-          submenu
-          ariaLabel="Settings"
-          keyboardOverride="s"
-        >
-          <MenuItem icon="home" ariaLabel="Home" keyboardOverride="s" />
+        <MenuItem icon="settings" submenu ariaLabel="Settings">
+          <MenuItem icon="home" ariaLabel="Home" />
         </MenuItem>
       );
 
@@ -408,13 +401,8 @@ describe("MenuItem", () => {
 
     it("should render an icon into the submenu item with text", () => {
       wrapper = mount(
-        <MenuItem
-          icon="settings"
-          submenu="Settings"
-          ariaLabel="Settings"
-          keyboardOverride="s"
-        >
-          <MenuItem icon="home" ariaLabel="Home" keyboardOverride="s" />
+        <MenuItem icon="settings" submenu="Settings" ariaLabel="Settings">
+          <MenuItem icon="home" ariaLabel="Home" />
         </MenuItem>
       );
 
@@ -422,16 +410,14 @@ describe("MenuItem", () => {
     });
 
     it("add aria-label when it is set", () => {
-      wrapper = mount(
-        <MenuItem icon="settings" ariaLabel="Settings" keyboardOverride="s" />
-      );
+      wrapper = mount(<MenuItem icon="settings" ariaLabel="Settings" />);
 
       expect(wrapper.find(Icon).props().ariaLabel).toBe("Settings");
     });
 
     it("give error when `aria-label` is not set and menu item has no child text", () => {
       jest.spyOn(global.console, "error").mockImplementation(() => {});
-      wrapper = mount(<MenuItem icon="settings" keyboardOverride="s" />);
+      wrapper = mount(<MenuItem icon="settings" />);
       // eslint-disable-next-line no-console
       expect(console.error).toHaveBeenCalledWith(
         "Warning: Failed prop type: If no text is provided an ariaLabel" +
@@ -440,20 +426,9 @@ describe("MenuItem", () => {
       global.console.error.mockReset();
     });
 
-    it("give error when `keyboardOverride` is not set and menu item has no child text", () => {
-      jest.spyOn(global.console, "error").mockImplementation(() => {});
-      wrapper = mount(<MenuItem icon="settings" ariaLabel="Settings" />);
-      // eslint-disable-next-line no-console
-      expect(console.error).toHaveBeenCalledWith(
-        "Warning: Failed prop type: Either a keyboard override or child" +
-          " text must be provided to facilitate keyboard navigation.\n    in MenuItem"
-      );
-      global.console.error.mockReset();
-    });
-
     it("give error when no children or icon is given", () => {
       jest.spyOn(global.console, "error").mockImplementation(() => {});
-      wrapper = mount(<MenuItem keyboardOverride="a" ariaLabel="a" />);
+      wrapper = mount(<MenuItem ariaLabel="a" />);
       // eslint-disable-next-line no-console
       expect(console.error).toHaveBeenCalledWith(
         "Warning: Failed prop type: Either prop `icon` must be defined or this node must have children.\n    in MenuItem"

--- a/src/components/menu/menu-item/menu-item.style.js
+++ b/src/components/menu/menu-item/menu-item.style.js
@@ -13,6 +13,8 @@ const StyledMenuItemWrapper = styled.a`
     variant,
     showDropdownArrow,
     isSearch,
+    href,
+    clickToOpen,
   }) => css`
     display: inline-block;
     font-size: 14px;
@@ -136,17 +138,31 @@ const StyledMenuItemWrapper = styled.a`
 
       ${hasSubmenu &&
       css`
-        :hover &,
-        :hover {
-          background-color: ${theme.menu.dark.submenuBackground};
-          color: ${theme.colors.white};
-
-          a,
-          button,
-          [data-component="icon"] {
+        ${!href &&
+        css`
+          && :hover {
+            background-color: ${theme.menu.dark.submenuBackground};
             color: ${theme.colors.white};
+
+            a,
+            button,
+            [data-component="icon"] {
+              color: ${theme.colors.white};
+            }
           }
-        }
+
+          && a:focus,
+          && button:focus {
+            background-color: ${theme.menu.dark.submenuBackground};
+            color: ${theme.colors.white};
+
+            a,
+            button,
+            [data-component="icon"] {
+              color: ${theme.colors.white};
+            }
+          }
+        `}
 
         ${isOpen &&
         css`
@@ -165,24 +181,41 @@ const StyledMenuItemWrapper = styled.a`
 
     ${hasSubmenu &&
     css`
+      a:hover,
+      button:hover {
+        ${!(href || clickToOpen) &&
+        css`
+          cursor: default;
+        `}
+      }
+
       ${menuType === "light" &&
       css`
-        :hover &,
-        :hover {
-          background-color: ${theme.colors.white};
-          color: ${theme.colors.black};
-
-          a,
-          button,
-          [data-component="icon"] {
+        ${!href &&
+        css`
+          && :hover {
+            background-color: ${theme.colors.white};
             color: ${theme.colors.black};
+
+            a,
+            button,
+            [data-component="icon"] {
+              color: ${theme.colors.black};
+            }
           }
 
-          a:focus,
-          button:focus {
-            color: ${theme.colors.white};
+          && a:focus,
+          && button:focus {
+            background-color: ${theme.colors.white};
+            color: ${theme.colors.black};
+
+            a,
+            button,
+            [data-component="icon"] {
+              color: ${theme.colors.black};
+            }
           }
-        }
+        `}
 
         ${isOpen &&
         css`
@@ -193,13 +226,21 @@ const StyledMenuItemWrapper = styled.a`
 
       ${showDropdownArrow &&
       css`
-        > a {
+        > a,
+        > button {
           padding-right: 32px;
-          &:focus::before {
-            border-top-color: ${theme.colors.white};
-          }
+
+          ${href &&
+          css`
+            &:hover::before,
+            &:focus::before {
+              border-top-color: ${theme.colors.white};
+            }
+          `}
         }
-        a::before {
+
+        a::before,
+        button::before {
           display: block;
           margin-top: -2px;
           pointer-events: none;
@@ -216,8 +257,9 @@ const StyledMenuItemWrapper = styled.a`
           border-bottom: 4px solid transparent;
           border-left: 4px solid transparent;
         }
-      `}
+      `};
     `}
+
     ${isSearch &&
     css`
       padding: 2px 16px;

--- a/src/components/menu/menu-segment-title/menu-segment-title.spec.js
+++ b/src/components/menu/menu-segment-title/menu-segment-title.spec.js
@@ -7,10 +7,11 @@ import { MenuContext } from "../menu.component";
 import { MenuItem } from "..";
 import StyledTitle from "./menu-segment-title.style";
 import { baseTheme } from "../../../style/themes";
+import openSubmenu from "../__internal__/spec-helper";
 
 const menuContextValues = (menuType) => ({
   menuType,
-  openSubmenu: true,
+  handleKeyDown: () => null,
 });
 
 describe("Title", () => {
@@ -35,12 +36,14 @@ describe("Title", () => {
 
   it("should get menuType from menu context", () => {
     wrapper = render("light");
+    openSubmenu(wrapper);
 
     expect(wrapper.find(StyledTitle).prop("menuType")).toBe("light");
   });
 
   it("should have correct styles as default", () => {
     wrapper = render("light");
+    openSubmenu(wrapper);
 
     assertStyleMatch(
       {
@@ -57,6 +60,7 @@ describe("Title", () => {
 
   it('should have correct styles if menuType="light" and "alternate" variant', () => {
     wrapper = render("light", "alternate");
+    openSubmenu(wrapper);
 
     assertStyleMatch(
       {
@@ -69,6 +73,7 @@ describe("Title", () => {
 
   it('should have correct styles if menuType="dark"', () => {
     wrapper = render("dark");
+    openSubmenu(wrapper);
 
     assertStyleMatch(
       {
@@ -80,6 +85,7 @@ describe("Title", () => {
 
   it('should have correct styles if menuType="dark"  and "alternate" variant', () => {
     wrapper = render("dark", "alternate");
+    openSubmenu(wrapper);
 
     assertStyleMatch(
       {

--- a/src/components/menu/menu.component.js
+++ b/src/components/menu/menu.component.js
@@ -12,11 +12,10 @@ const Menu = ({ menuType = "light", children, ...rest }) => {
   const ref = useRef();
 
   const handleKeyDown = useCallback(
-    (event, index) => {
+    (event) => {
       const newIndex = menuKeyboardNavigation(
         event,
-        React.Children.toArray(children),
-        index
+        React.Children.toArray(children)
       );
 
       setFocusedItemIndex(newIndex);

--- a/src/components/menu/menu.component.js
+++ b/src/components/menu/menu.component.js
@@ -9,12 +9,10 @@ const MenuContext = React.createContext({});
 
 const Menu = ({ menuType = "light", children, ...rest }) => {
   const [focusedItemIndex, setFocusedItemIndex] = useState(undefined);
-  const [openSubmenuIndex, setOpenSubmenuIndex] = useState(undefined);
   const ref = useRef();
 
   const handleKeyDown = useCallback(
-    (event, index, submenuOpen = false) => {
-      setOpenSubmenuIndex(undefined);
+    (event, index) => {
       const newIndex = menuKeyboardNavigation(
         event,
         React.Children.toArray(children),
@@ -22,9 +20,6 @@ const Menu = ({ menuType = "light", children, ...rest }) => {
       );
 
       setFocusedItemIndex(newIndex);
-      if (submenuOpen) {
-        setOpenSubmenuIndex(newIndex);
-      }
     },
     [children]
   );
@@ -33,7 +28,6 @@ const Menu = ({ menuType = "light", children, ...rest }) => {
     // Reset the state of the menu when clicking elsewhere
     if (!Events.composedPath(event).includes(ref.current)) {
       setFocusedItemIndex(undefined);
-      setOpenSubmenuIndex(undefined);
       document.removeEventListener("click", onClickOutside);
     }
   }, []);
@@ -49,24 +43,19 @@ const Menu = ({ menuType = "light", children, ...rest }) => {
   return (
     <StyledMenuWrapper
       data-component="menu"
-      role="menubar"
       menuType={menuType}
       {...rest}
       ref={ref}
     >
       {React.Children.map(children, (child, index) => {
-        const isFirstElement = index === 0;
         const isFocused = focusedItemIndex === index;
 
         return (
           <MenuContext.Provider
             value={{
               menuType,
-              isFirstElement,
-              handleKeyDown: (ev, submenuOpen) =>
-                handleKeyDown(ev, index, submenuOpen),
+              handleKeyDown: (ev) => handleKeyDown(ev, index),
               isFocused,
-              openSubmenu: isFocused && index === openSubmenuIndex,
             }}
           >
             {child}

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -13,24 +13,11 @@ import {
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import baseTheme from "../../style/themes/base";
 import StyledMenuItemWrapper from "./menu-item/menu-item.style";
-import {
-  StyledSubmenu,
-  StyledSubmenuWrapper,
-} from "./__internal__/submenu/submenu.style";
 
 const events = {
-  tab: {
-    key: "Tab",
-    which: 9,
-  },
-  arrowRight: {
-    key: "ArrowRight",
-    which: 39,
-    preventDefault: jest.fn(),
-  },
-  enter: {
-    key: "Enter",
-    which: 13,
+  end: {
+    key: "End",
+    which: 35,
     preventDefault: jest.fn(),
   },
 };
@@ -115,7 +102,7 @@ describe("Menu", () => {
     const render = (props) => {
       return mount(
         <Menu {...props}>
-          <MenuItem>test element one</MenuItem>
+          <MenuItem>test one</MenuItem>
           <MenuItem submenu="one">
             <MenuItem>test element one</MenuItem>
             <MenuItem>test element two</MenuItem>
@@ -144,115 +131,33 @@ describe("Menu", () => {
       }
     });
 
-    describe("handleKeyDown", () => {
-      describe("when a submenu is open and the next item is a submenu", () => {
-        beforeEach(() => {
-          menuWrapper = render();
-          act(() => {
-            menuWrapper
-              .find(StyledMenuItemWrapper)
-              .at(0)
-              .props()
-              .onKeyDown(events.tab);
-          });
-
-          menuWrapper.update();
-
-          act(() => {
-            menuWrapper
-              .find(StyledMenuItemWrapper)
-              .at(0)
-              .props()
-              .onKeyDown(events.arrowRight);
-          });
-
-          menuWrapper.update();
-
-          act(() => {
-            menuWrapper
-              .find(StyledMenuItemWrapper)
-              .at(1)
-              .props()
-              .onKeyDown(events.enter);
-          });
-
-          menuWrapper.update();
-        });
-
-        it("should open the next submenu on right key press", () => {
-          expect(
-            menuWrapper
-              .find(StyledSubmenuWrapper)
-              .at(0)
-              .find(StyledSubmenu)
-              .exists()
-          ).toEqual(true);
-
-          act(() => {
-            menuWrapper
-              .find(StyledMenuItemWrapper)
-              .at(1)
-              .props()
-              .onKeyDown(events.arrowRight);
-          });
-
-          menuWrapper.update();
-          expect(
-            menuWrapper
-              .find(StyledSubmenuWrapper)
-              .at(0)
-              .find(StyledSubmenu)
-              .exists()
-          ).toEqual(false);
-          expect(
-            menuWrapper
-              .find(StyledSubmenuWrapper)
-              .at(1)
-              .find(StyledSubmenu)
-              .exists()
-          ).toEqual(true);
-        });
-      });
-    });
-
-    describe("when a user clicks outside of the menu", () => {
-      it("should reset the focus state of the menu", () => {
+    describe("when a user presses end key", () => {
+      it("should focus the last item", () => {
         menuWrapper = render();
+        menuWrapper
+          .find(StyledMenuItemWrapper)
+          .at(0)
+          .find("a")
+          .getDOMNode()
+          .focus();
+
+        expect(
+          menuWrapper.find(StyledMenuItemWrapper).at(0).find("a")
+        ).toBeFocused();
 
         act(() => {
           menuWrapper
             .find(StyledMenuItemWrapper)
             .at(0)
             .props()
-            .onKeyDown(events.tab);
-        });
-
-        menuWrapper.update();
-
-        act(() => {
-          menuWrapper
-            .find(StyledMenuItemWrapper)
-            .at(0)
-            .props()
-            .onKeyDown(events.arrowRight);
+            .onKeyDown(events.end);
         });
 
         menuWrapper.update();
 
         expect(
-          menuWrapper.find(StyledMenuItemWrapper).at(1).find("a")
+          menuWrapper.find(StyledMenuItemWrapper).at(2).find("a")
         ).toBeFocused();
-
-        act(() => {
-          document.dispatchEvent(
-            new Event("click", {
-              detail: {
-                enzymeTestingTarget: document.body,
-              },
-            })
-          );
-        });
-        menuWrapper.update();
         wrapper.unmount();
       });
     });

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -16,9 +16,11 @@ import Search from "../../__experimental__/components/search";
 <Meta title="Design System/Menu" parameters={{ info: { disable: true } }} />
 
 # Menu
+
 Provides navigation for an app, which can be used via mouse or keyboard.
 
 ## Contents
+
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
@@ -42,7 +44,7 @@ import {
   <Story name="default" parameters={{ chromatic: { disable: true } }}>
     <div style={{ minHeight: "150px" }}>
       <Menu>
-        <MenuItem onClick={() => {}}>Menu Item One</MenuItem>
+        <MenuItem href="#">Menu Item One</MenuItem>
         <MenuItem href="#">Menu Item Two</MenuItem>
         <MenuItem submenu="Menu Item Three">
           <MenuItem href="#">Item Submenu One</MenuItem>
@@ -197,6 +199,7 @@ import {
 </Preview>
 
 ### Default icon
+
 Menus with icons only must have a supplied keyboard shortcut. If no shortcut is supplied the menu item text is navigable by the first letter of each item.
 The menu must have focus for this to work
 
@@ -369,6 +372,7 @@ The menu must have focus for this to work
 </Preview>
 
 ### No dropdown arrow on submenu
+
 The example below has set the `showDropdownArrow` to false for the MenuItem with a submenu which means no dropdown arrow
 is rendered.
 
@@ -388,6 +392,7 @@ is rendered.
 </Preview>
 
 ### Dark icon
+
 Menus with icons only must have a supplied keyboard shortcut. If no shortcut is supplied the menu item text is navigable by the first letter of each item.
 The menu must have focus for this to work
 
@@ -477,6 +482,7 @@ The menu must have focus for this to work
 </Preview>
 
 ### Split submenu into separate component
+
 If you need to split out a submenu into a separate component, it must be done as shown below in order for the keyboard navigation to work as intended.
 
 <Preview>
@@ -505,6 +511,7 @@ If you need to split out a submenu into a separate component, it must be done as
 </Preview>
 
 ### Submenu icon and text alignment
+
 In order to align text and icons within a submenu a `Box` component will need to be used to adjust the margin of the content.
 
 <Preview>
@@ -532,6 +539,7 @@ In order to align text and icons within a submenu a `Box` component will need to
 </Preview>
 
 ### Scrollable submenu
+
 A scrollable submenu can be added using the `ScrollableBlock` component. This can be used for all of the submenu items, or just a selection, as shown in `Menu Itme Four` below.
 Note that only one `ScrollableBlock` can be used within a single submenu.
 
@@ -665,20 +673,20 @@ Note that only one `ScrollableBlock` can be used within a single submenu.
 
 <Props of={Menu} />
 
-### MenuItem 
+### MenuItem
 
 `MenuItem` extends the `Box` component so it also accepts all `Box` props.
 
 <Props of={MenuItem} />
 
-### SubmenuBlock 
+### SubmenuBlock
 
 <Props of={SubmenuBlock} />
 
-### MenuDivider 
+### MenuDivider
 
 <Props of={MenuDivider} />
 
-### MenuSegmentTitle 
+### MenuSegmentTitle
 
 <Props of={MenuSegmentTitle} />

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -173,6 +173,59 @@ import {
   </Story>
 </Preview>
 
+### Submenu options
+
+<Preview>
+  <Story name="submenu options" parameters={{ chromatic: { disable: true } }}>
+    <div style={{ minHeight: "150px" }}>
+      <Menu>
+        <MenuItem href="#">Menu Item One</MenuItem>
+        <MenuItem href="#">Menu Item Two</MenuItem>
+        <MenuItem submenu="No action or link">
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+          <MenuDivider />
+          <MenuItem icon="settings" href="#">
+            Item Submenu Three
+          </MenuItem>
+          <MenuItem href="#">Item Submenu Four</MenuItem>
+        </MenuItem>
+        <MenuItem submenu="With href" href="#">
+          <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+        </MenuItem>
+        <MenuItem submenu="With clickToOpen prop" clickToOpen>
+          <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+        </MenuItem>
+      </Menu>
+    </div>
+    <div style={{ minHeight: "150px", marginTop: "50px" }}>
+      <Menu menuType="dark">
+        <MenuItem href="#">Menu Item One</MenuItem>
+        <MenuItem href="#">Menu Item Two</MenuItem>
+        <MenuItem submenu="No action or link">
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+          <MenuDivider />
+          <MenuItem icon="settings" href="#">
+            Item Submenu Three
+          </MenuItem>
+          <MenuItem href="#">Item Submenu Four</MenuItem>
+        </MenuItem>
+        <MenuItem submenu="With href" href="#">
+          <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+        </MenuItem>
+        <MenuItem submenu="With clickToOpen prop" clickToOpen>
+          <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+        </MenuItem>
+      </Menu>
+    </div>
+  </Story>
+</Preview>
+
 ### Submenu direction left
 
 <Preview>
@@ -200,9 +253,6 @@ import {
 
 ### Default icon
 
-Menus with icons only must have a supplied keyboard shortcut. If no shortcut is supplied the menu item text is navigable by the first letter of each item.
-The menu must have focus for this to work
-
 <Preview>
   <Story name="default icon">
     <div style={{ minHeight: "250px" }}>
@@ -210,30 +260,15 @@ The menu must have focus for this to work
         <MenuItem icon="home" href="#">
           Home
         </MenuItem>
-        <MenuItem
-          icon="person"
-          href="#"
-          keyboardOverride="a"
-          ariaLabel="Account"
-        />
+        <MenuItem icon="person" href="#" ariaLabel="Account" />
         <MenuItem icon="settings" submenu="Settings">
           <MenuItem href="#">Item Submenu One</MenuItem>
           <MenuItem href="#">Item Submenu Two</MenuItem>
           <MenuDivider />
-          <MenuItem
-            icon="settings"
-            href="#"
-            ariaLabel="settings"
-            keyboardOverride="s"
-          />
+          <MenuItem icon="settings" href="#" ariaLabel="settings" />
           <MenuItem href="#">Item Submenu Four</MenuItem>
         </MenuItem>
-        <MenuItem
-          icon="arrow_right"
-          submenu
-          keyboardOverride="a"
-          ariaLabel="Actions"
-        >
+        <MenuItem icon="arrow_right" submenu ariaLabel="Actions">
           <MenuItem href="#">Item Submenu One</MenuItem>
           <MenuItem href="#">Item Submenu Two</MenuItem>
         </MenuItem>
@@ -393,9 +428,6 @@ is rendered.
 
 ### Dark icon
 
-Menus with icons only must have a supplied keyboard shortcut. If no shortcut is supplied the menu item text is navigable by the first letter of each item.
-The menu must have focus for this to work
-
 <Preview>
   <Story name="dark icon">
     <div style={{ minHeight: "250px" }}>
@@ -403,30 +435,15 @@ The menu must have focus for this to work
         <MenuItem icon="home" href="#">
           Home
         </MenuItem>
-        <MenuItem
-          icon="person"
-          href="#"
-          keyboardOverride="a"
-          ariaLabel="Account"
-        />
+        <MenuItem icon="person" href="#" ariaLabel="Account" />
         <MenuItem icon="settings" submenu="Settings">
           <MenuItem href="#">Item Submenu One</MenuItem>
           <MenuItem href="#">Item Submenu Two</MenuItem>
           <MenuDivider />
-          <MenuItem
-            icon="settings"
-            href="#"
-            ariaLabel="settings"
-            keyboardOverride="s"
-          />
+          <MenuItem icon="settings" href="#" ariaLabel="settings" />
           <MenuItem href="#">Item Submenu Four</MenuItem>
         </MenuItem>
-        <MenuItem
-          icon="arrow_right"
-          submenu
-          keyboardOverride="a"
-          ariaLabel="Actions"
-        >
+        <MenuItem icon="arrow_right" submenu ariaLabel="Actions">
           <MenuItem href="#">Item Submenu One</MenuItem>
           <MenuItem href="#">Item Submenu Two</MenuItem>
         </MenuItem>


### PR DESCRIPTION
Fixes: #3517

### Proposed behaviour
Update `Menu`/`Submenu` keyboard navigation to behave as described in this issue: https://github.com/Sage/carbon/issues/3517

Hovering over the submenu item no longer opens the submenu, you must click it instead, clicking anywhere outside of the submenu will close it.

Character navigation has been removed completely from the top level menu, and has been updated for submenus to search for multiple characters typed in quick succession. The user has 1.5 seconds from typing a character, to type another one or the search string will reset. This is to try and match the default HTML behaviour in a select list

Removed `keyboardOverride` prop from `MenuItem` - this option does not follow accessibility guidelines and the user would have had no idea which key to press to navigate to the item.

### Current behaviour
The keyboard navigation currently follows the guidance here: https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-1/menubar-1.html

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
http://localhost:9001/?path=/story/design-system-menu--default-story

Sandbox to assist in testing submenu character navigation: https://codesandbox.io/s/cold-grass-dte1m

Sandbox for testing submenu hover states: https://codesandbox.io/s/thirsty-stonebraker-bi3u2