### PR TITLE
build(npm): add a warning i18n-js will be removed soon

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "clean-lib": "rimraf ./lib",
     "copy-files": "cpy \"**/\" \"!**/(*.js|*.md|*.mdx|*.stories.*|*.snap|docgenInfo.json)\" ../lib/ --cwd=src --parents",
     "commit": "git-cz",
-    "chromatic": "chromatic"
+    "chromatic": "chromatic",
+    "postinstall": "node postinstall.js"
   },
   "repository": {
     "type": "git",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,4 @@
+console.log(
+  "\x1b[33m%s\x1b[0m",
+  'The dependency "i18n-js" will be removed soon. There is nothing for you to do at this time. Please visit https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md for details.'
+);


### PR DESCRIPTION
### Proposed behaviour

Add a warning into carbon before we merge
https://github.com/Sage/carbon/pull/3855

More information here
https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md

### Testing instructions
Warning message after `npm install`

```
The dependency "i18n-js" will be removed soon. There is nothing for you to do at this time.
Please visit https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md for details.
```

![Zrzut ekranu 2021-03-31 o 12 10 29](https://user-images.githubusercontent.com/77274590/113131077-075a5700-921d-11eb-9ac6-d720f35fec9d.png)

