### PR TITLE
fix(search): stop event propagation for characters and numbers

### DIFF
--- a/src/__experimental__/components/search/search.component.js
+++ b/src/__experimental__/components/search/search.component.js
@@ -8,6 +8,7 @@ import StyledSearch, {
 import Icon from "../../../components/icon";
 import Textbox from "../textbox";
 import Button from "../../../components/button";
+import Events from "../../../utils/helpers/events";
 
 const Search = ({
   defaultValue,
@@ -116,6 +117,12 @@ const Search = ({
     setIsFocused(false);
   };
 
+  const handleKeyDown = (ev) => {
+    if (Events.isAlphabetKey(ev) || Events.isNumberKey(ev)) {
+      ev.stopPropagation();
+    }
+  };
+
   return (
     <StyledSearch
       searchWidth={searchWidth}
@@ -124,6 +131,7 @@ const Search = ({
       onClick={handleOnFocus}
       onBlur={handleBlur}
       onChange={handleChange}
+      onKeyDown={handleKeyDown}
       isFocused={isFocused}
       searchIsActive={searchIsActive}
       id={id}

--- a/src/__experimental__/components/search/search.spec.js
+++ b/src/__experimental__/components/search/search.spec.js
@@ -326,9 +326,13 @@ describe("Search", () => {
     });
 
     it("passes other event handlers down to the input", () => {
-      const keyDownParams = { target: { selectionStart: 1, selectionEnd: 2 } };
+      const keyDownParams = {
+        which: 65,
+        key: "a",
+        target: { selectionStart: 1, selectionEnd: 2 },
+      };
       const input = wrapper.find("input");
-      input.simulate("keydown", { keyDownParams });
+      input.simulate("keydown", keyDownParams);
       expect(onKeyDown).toHaveBeenCalled();
     });
 
@@ -470,6 +474,50 @@ describe("Search", () => {
       );
       const input = wrapper.find(TextBox);
       expect(input.prop("iconTabIndex")).toEqual(-1);
+    });
+  });
+
+  describe("when typing into the input", () => {
+    const stopPropagationFn = jest.fn();
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should stop propagation of the event for character keys", () => {
+      const keyDownParams = {
+        which: 65,
+        key: "a",
+        target: { selectionStart: 1, selectionEnd: 2 },
+        stopPropagation: stopPropagationFn,
+      };
+      const input = wrapper.find("input");
+      input.simulate("keydown", keyDownParams);
+      expect(stopPropagationFn).toHaveBeenCalled();
+    });
+
+    it("should stop propagation of the event for number keys", () => {
+      const keyDownParams = {
+        which: 50,
+        key: "2",
+        target: { selectionStart: 1, selectionEnd: 2 },
+        stopPropagation: stopPropagationFn,
+      };
+      const input = wrapper.find("input");
+      input.simulate("keydown", keyDownParams);
+      expect(stopPropagationFn).toHaveBeenCalled();
+    });
+
+    it("should not stop propagation of the event for other keys", () => {
+      const keyDownParams = {
+        which: 9,
+        key: "Tab",
+        target: { selectionStart: 1, selectionEnd: 2 },
+        stopPropagation: stopPropagationFn,
+      };
+      const input = wrapper.find("input");
+      input.simulate("keydown", keyDownParams);
+      expect(stopPropagationFn).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/menu/__internal__/submenu/submenu.component.js
+++ b/src/components/menu/__internal__/submenu/submenu.component.js
@@ -140,6 +140,10 @@ const Submenu = React.forwardRef(
             );
           }
 
+          // Defensive check in case an unhandled key event from a child component
+          // has bubbled up
+          if (nextIndex === undefined) return;
+
           // Check that next index contains a MenuItem
           // If not, call handleKeyDown again
           const nextChild = React.Children.toArray(formattedChildren)[

--- a/src/components/menu/__internal__/submenu/submenu.spec.js
+++ b/src/components/menu/__internal__/submenu/submenu.spec.js
@@ -41,6 +41,7 @@ const events = {
     key: "Enter",
     which: 13,
     preventDefault: jest.fn(),
+    bubbles: true,
   },
   space: {
     key: "Space",
@@ -800,6 +801,26 @@ describe("Submenu component", () => {
         { attachTo: container }
       );
     };
+
+    it("should not lose focus when enter key pressed", () => {
+      wrapper = renderWithSearch(true, "dark");
+
+      const searchInput = wrapper.find(StyledSearch).find("input");
+
+      searchInput.getDOMNode().focus();
+
+      expect(searchInput).toBeFocused();
+
+      act(() => {
+        wrapper.find(StyledSearch).at(0).props().onKeyDown(events.arrowUp);
+        searchInput
+          .getDOMNode()
+          .dispatchEvent(new KeyboardEvent("keydown", events.enter));
+      });
+      wrapper.update();
+
+      expect(searchInput).toBeFocused();
+    });
 
     it("should render with correct styles for search icon", () => {
       wrapper = renderWithSearch(true, "dark");


### PR DESCRIPTION
Fixes: #3830

### Proposed behaviour
Stop event propagation when typing characters or numbers into the `Search` input, these should not propagate and affect keyboard nav etc of components further up the tree

### Current behaviour
Error when typing into `Search` when it's inside of a submenu because the event bubbles up to the keyboard nav in `Submenu` when it shouldn't

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
Use the sandbox from the attached Github issue and check the console on http://localhost:9001/?path=/story/design-system-menu--submenu-with-search