### PR TITLE
fix(FlatTable): fix gap between table content and sticky footer - FE-3986

### DIFF
--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FlatTable when rendered with proper table data should have expected structure and styles 1`] = `
-.c9 {
+.c10 {
   background-color: transparent;
   border-width: 0;
   border-bottom: 1px solid #CCD6DB;
@@ -20,35 +20,12 @@ exports[`FlatTable when rendered with proper table data should have expected str
   padding: 0;
 }
 
-.c9:first-child {
+.c10:first-child {
   padding-left: 1px;
 }
 
-.c9 > div {
+.c10 > div {
   box-sizing: border-box;
-}
-
-.c11 {
-  background-color: #fff;
-  border-width: 0;
-  border-bottom: 1px solid #CCD6DB;
-  text-overflow: ellipsis;
-  text-align: left;
-  vertical-align: middle;
-  white-space: nowrap;
-  padding: 0;
-}
-
-.c11 > div {
-  box-sizing: border-box;
-}
-
-.c11:first-of-type {
-  border-left: 1px solid #CCD6DB;
-}
-
-.c11:last-of-type {
-  border-right: 1px solid #CCD6DB;
 }
 
 .c12 {
@@ -74,11 +51,34 @@ exports[`FlatTable when rendered with proper table data should have expected str
   border-right: 1px solid #CCD6DB;
 }
 
-.c12:first-of-type + .c10 {
+.c13 {
+  background-color: #fff;
+  border-width: 0;
+  border-bottom: 1px solid #CCD6DB;
+  text-overflow: ellipsis;
+  text-align: left;
+  vertical-align: middle;
+  white-space: nowrap;
+  padding: 0;
+}
+
+.c13 > div {
+  box-sizing: border-box;
+}
+
+.c13:first-of-type {
   border-left: 1px solid #CCD6DB;
 }
 
-.c7 {
+.c13:last-of-type {
+  border-right: 1px solid #CCD6DB;
+}
+
+.c13:first-of-type + .c11 {
+  border-left: 1px solid #CCD6DB;
+}
+
+.c8 {
   background-color: #fff;
   border: 1px solid #CCD6DB;
   border-top: none;
@@ -94,7 +94,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
   padding: 0;
 }
 
-.c7 > div {
+.c8 > div {
   box-sizing: border-box;
   padding-top: 10px;
   padding-bottom: 10px;
@@ -102,11 +102,11 @@ exports[`FlatTable when rendered with proper table data should have expected str
   padding-right: 24px;
 }
 
-.c7.c7.c7 {
+.c8.c8.c8 {
   left: 0px;
 }
 
-.c5 {
+.c6 {
   border-collapse: separate;
   border-radius: 0px;
   border-spacing: 0;
@@ -115,8 +115,8 @@ exports[`FlatTable when rendered with proper table data should have expected str
   width: auto;
 }
 
-.c3 .c6,
-.c3 .c13 {
+.c4 .c7,
+.c4 .c14 {
   border-left: none;
   border-right: none;
   font-weight: 700;
@@ -125,7 +125,12 @@ exports[`FlatTable when rendered with proper table data should have expected str
   z-index: 1000;
 }
 
-.c1 {
+.c0 {
+  box-shadow: inset 0px 0px 0px 1px #CCD6DB;
+  box-sizing: border-box;
+}
+
+.c2 {
   border-collapse: separate;
   border-radius: 0px;
   border-spacing: 0;
@@ -133,51 +138,51 @@ exports[`FlatTable when rendered with proper table data should have expected str
   width: 100%;
 }
 
-.c1 .c4 {
+.c2 .c5 {
   height: 40px;
 }
 
-.c1 .c10 > div,
-.c1 .c8 > div,
-.c1 .c6 > div {
+.c2 .c11 > div,
+.c2 .c9 > div,
+.c2 .c7 > div {
   font-size: 14px;
   padding-left: 11px;
   padding-right: 11px;
 }
 
-.c0 {
-  height: 100%;
+.c1 {
+  max-height: 100%;
 }
 
-.c0 .c2 .c13,
-.c0 .c8,
-.c0 .c2 .c6 {
+.c1 .c3 .c14,
+.c1 .c9,
+.c1 .c3 .c7 {
   background-color: #335C6D;
   border-right: 1px solid #668592;
   color: #FFFFFF;
 }
 
 <div
-  className=""
+  className="c0"
 >
   <div
-    className="c0"
+    className="c1"
   >
     <table
-      className="c1"
+      className="c2"
       data-component="flat-table"
       size="medium"
     >
       <thead
-        className="c2 c3"
+        className="c3 c4"
       >
         <tr
-          className="c4 c5"
+          className="c5 c6"
           data-element="flat-table-row"
           onClick={[Function]}
         >
           <th
-            className="c6 c7"
+            className="c7 c8"
             data-element="flat-table-row-header"
           >
             <div>
@@ -185,7 +190,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
             </div>
           </th>
           <th
-            className="c8 c9"
+            className="c9 c10"
             data-element="flat-table-header"
           >
             <div>
@@ -193,7 +198,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
             </div>
           </th>
           <th
-            className="c8 c9"
+            className="c9 c10"
             data-element="flat-table-header"
           >
             <div>
@@ -201,7 +206,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
             </div>
           </th>
           <th
-            className="c8 c9"
+            className="c9 c10"
             data-element="flat-table-header"
           >
             <div>
@@ -212,12 +217,12 @@ exports[`FlatTable when rendered with proper table data should have expected str
       </thead>
       <tbody>
         <tr
-          className="c4 c5"
+          className="c5 c6"
           data-element="flat-table-row"
           onClick={[Function]}
         >
           <th
-            className="c6 c7"
+            className="c7 c8"
             data-element="flat-table-row-header"
           >
             <div>
@@ -225,7 +230,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
             </div>
           </th>
           <td
-            className="c10 c11"
+            className="c11 c12"
             data-element="flat-table-cell"
           >
             <div
@@ -235,7 +240,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
             </div>
           </td>
           <td
-            className="c10 c11"
+            className="c11 c12"
             data-element="flat-table-cell"
           >
             <div
@@ -245,7 +250,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
             </div>
           </td>
           <td
-            className="c10 c12"
+            className="c11 c13"
             data-element="flat-table-cell"
             rowSpan="2"
           >
@@ -257,12 +262,12 @@ exports[`FlatTable when rendered with proper table data should have expected str
           </td>
         </tr>
         <tr
-          className="c4 c5"
+          className="c5 c6"
           data-element="flat-table-row"
           onClick={[Function]}
         >
           <th
-            className="c6 c7"
+            className="c7 c8"
             data-element="flat-table-row-header"
           >
             <div>
@@ -270,7 +275,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
             </div>
           </th>
           <td
-            className="c10 c11"
+            className="c11 c12"
             colSpan="2"
             data-element="flat-table-cell"
           >

--- a/src/components/flat-table/flat-table.component.js
+++ b/src/components/flat-table/flat-table.component.js
@@ -4,9 +4,9 @@ import {
   StyledFlatTableWrapper,
   StyledFlatTable,
   StyledFlatTableFooter,
+  StyledFlatTableBox,
 } from "./flat-table.style";
 import { SidebarContext } from "../drawer";
-import Box from "../box";
 
 export const FlatTableThemeContext = React.createContext({});
 
@@ -20,8 +20,9 @@ const FlatTable = ({
   height,
   isZebra,
   size,
+  hasMaxHeight = false,
   ariaDescribedby,
-  ...props
+  ...rest
 }) => {
   const addDefaultHeight = !height && (hasStickyHead || hasStickyFooter);
   const tableStylingProps = {
@@ -38,10 +39,11 @@ const FlatTable = ({
     <SidebarContext.Consumer>
       {(context) => (
         <>
-          <Box
-            {...props}
+          <StyledFlatTableBox
+            {...rest}
             {...((hasStickyHead || hasStickyFooter) && { overflowY: "auto" })}
-            height={addDefaultHeight ? "100%" : height}
+            height={addDefaultHeight && !hasMaxHeight ? "100%" : height}
+            maxHeight={hasMaxHeight ? "100%" : undefined}
           >
             <StyledFlatTableWrapper
               isInSidebar={context && context.isInSidebar}
@@ -59,7 +61,7 @@ const FlatTable = ({
                 </FlatTableThemeContext.Provider>
               </StyledFlatTable>
             </StyledFlatTableWrapper>
-          </Box>
+          </StyledFlatTableBox>
           {footer && (
             <StyledFlatTableFooter hasStickyFooter={hasStickyFooter}>
               {footer}
@@ -97,6 +99,8 @@ FlatTable.propTypes = {
   isZebra: PropTypes.bool,
   /** Used to define the tables size Renders as: 'compact', 'small', 'medium' and 'large' */
   size: PropTypes.oneOf(["compact", "small", "medium", "large"]),
+  /** Applies max-height of 100% to FlatTable if true */
+  hasMaxHeight: PropTypes.bool,
 };
 
 FlatTable.defaultProps = {

--- a/src/components/flat-table/flat-table.d.ts
+++ b/src/components/flat-table/flat-table.d.ts
@@ -19,6 +19,8 @@ export interface FlatTableProps {
   isZebra?: boolean;
   /** Used to define the tables size Renders as: 'compact', 'small', 'medium' and 'large' */
   size?: 'compact' | 'small' | 'medium' | 'large';
+  /** Applies max-height of 100% to FlatTable if true */
+  hasMaxHeight?: boolean;
 }
 
 declare const FlatTable: React.FunctionComponent<FlatTableProps>;

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -17,6 +17,7 @@ import {
   StyledFlatTable,
   StyledFlatTableWrapper,
   StyledFlatTableFooter,
+  StyledFlatTableBox,
 } from "./flat-table.style";
 import { baseTheme } from "../../style/themes";
 import { SidebarContext } from "../drawer";
@@ -238,6 +239,47 @@ describe("FlatTable", () => {
     }
   );
 
+  describe("StyledFlatTableBox", () => {
+    let wrapper;
+    const Footer = () => <div>foo</div>;
+    it("applies correct styles when a div is larger than the FlatTable", () => {
+      wrapper = renderFlatTableWithDiv({ footer: <Footer /> }, mount);
+      assertStyleMatch(
+        {
+          boxShadow: "inset 0px 0px 0px 1px #CCD6DB",
+          boxSizing: "border-box",
+        },
+        wrapper.find(StyledFlatTableBox)
+      );
+    });
+
+    it("applies correct styles when hasMaxHeight is true", () => {
+      wrapper = renderFlatTableWithDiv(
+        { footer: <Footer />, hasMaxHeight: true },
+        mount
+      );
+      assertStyleMatch(
+        {
+          maxHeight: "100%",
+        },
+        wrapper.find(StyledFlatTableBox)
+      );
+    });
+
+    it("applies correct styles when hasMaxHeight is false", () => {
+      wrapper = renderFlatTableWithDiv(
+        { footer: <Footer />, hasMaxHeight: false },
+        mount
+      );
+      assertStyleMatch(
+        {
+          maxHeight: undefined,
+        },
+        wrapper.find(StyledFlatTableBox)
+      );
+    });
+  });
+
   describe("footer", () => {
     let wrapper;
 
@@ -288,5 +330,34 @@ function renderFlatTable(props = {}, renderer = TestRenderer.create) {
         </FlatTableRow>
       </FlatTableBody>
     </FlatTable>
+  );
+}
+
+function renderFlatTableWithDiv(props = {}, renderer = TestRenderer.create) {
+  return renderer(
+    <div style={{ height: "180px" }}>
+      <FlatTable {...props}>
+        <FlatTableHead>
+          <FlatTableRow>
+            <FlatTableRowHeader>row header</FlatTableRowHeader>
+            <FlatTableHeader>header1</FlatTableHeader>
+            <FlatTableHeader>header2</FlatTableHeader>
+            <FlatTableHeader>header3</FlatTableHeader>
+          </FlatTableRow>
+        </FlatTableHead>
+        <FlatTableBody>
+          <FlatTableRow>
+            <FlatTableRowHeader>row header</FlatTableRowHeader>
+            <FlatTableCell>cell1</FlatTableCell>
+            <FlatTableCell>cell2</FlatTableCell>
+            <FlatTableCell rowspan="2">cell3</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableRowHeader>row header</FlatTableRowHeader>
+            <FlatTableCell colspan="2">cell1</FlatTableCell>
+          </FlatTableRow>
+        </FlatTableBody>
+      </FlatTable>
+    </div>
   );
 }

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -344,6 +344,143 @@ Column width can be set by passing number as a `width` prop to the column header
   </Story>
 </Preview>
 
+In this example of FlatTable with `stickyFooter`, FlatTable has been placed inside of a `div` with a height
+of `180px`. There is not enough data to fill the flatTable but the style remains consistent and the footer
+remains sticky.
+
+<Preview>
+  <Story name="with sticky footer inside of larger div" parameters={{ chromatic: { disable: true }}}>
+    {() => {
+      const rows = [
+        <FlatTableRow key='0'>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>,
+        <FlatTableRow key='1'>
+          <FlatTableCell>Jane Doe</FlatTableCell>
+          <FlatTableCell>York</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableCell>2</FlatTableCell>
+        </FlatTableRow>
+      ];
+      const [recordsRange, setRecordsRange] = useState({ start: 0, end: 5 });
+      const [currentPage, setCurrentPage] = useState(1);
+      const renderRows = () => {
+        const { start, end } = recordsRange;
+        if (start < 0) return rows;
+        if (end > rows.length) return rows.slice(start, rows.length);
+        return rows.slice(start, end);
+      };
+      const handlePagination = (newPage, newPageSize) => {
+        const start = (newPage - 1) * newPageSize;
+        const end = start + newPageSize;
+        setRecordsRange({ start, end });
+        setCurrentPage(newPage);
+      };
+      return (
+        <div style={ { height: "180px", marginBottom: "16px" } }>
+          <FlatTable hasStickyHead hasStickyFooter footer={
+            <Pager
+              totalRecords={ rows.length }
+              showPageSizeSelection
+              pageSize={ 5 }
+              currentPage={ currentPage }
+              onPagination={ (next, size) => handlePagination(next, size) }
+              pageSizeSelectionOptions={ 
+                [
+                  { id: '1', name: 1 },
+                  { id: '5', name: 5 },
+                ]}
+            />
+          }>
+            <FlatTableHead>
+              <FlatTableRow>
+                <FlatTableHeader>Name</FlatTableHeader>
+                <FlatTableHeader>Location</FlatTableHeader>
+                <FlatTableHeader>Relationship Status</FlatTableHeader>
+                <FlatTableHeader>Dependents</FlatTableHeader>
+              </FlatTableRow>
+            </FlatTableHead>
+            <FlatTableBody>
+              { renderRows() }
+            </FlatTableBody>
+          </FlatTable>
+        </div>
+      );
+    }} 
+  </Story>
+</Preview>
+
+### With hasMaxHeight
+By using the `hasMaxHeight` prop you can automatically apply a max-height of 100% to the FlatTable.
+
+<Preview>
+  <Story name="with sticky footer and hasMaxHeight" parameters={{ chromatic: { disable: true }}}>
+    {() => {
+      const rows = [
+        <FlatTableRow key='0'>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>,
+        <FlatTableRow key='1'>
+          <FlatTableCell>Jane Doe</FlatTableCell>
+          <FlatTableCell>York</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableCell>2</FlatTableCell>
+        </FlatTableRow>
+      ];
+      const [recordsRange, setRecordsRange] = useState({ start: 0, end: 5 });
+      const [currentPage, setCurrentPage] = useState(1);
+      const renderRows = () => {
+        const { start, end } = recordsRange;
+        if (start < 0) return rows;
+        if (end > rows.length) return rows.slice(start, rows.length);
+        return rows.slice(start, end);
+      };
+      const handlePagination = (newPage, newPageSize) => {
+        const start = (newPage - 1) * newPageSize;
+        const end = start + newPageSize;
+        setRecordsRange({ start, end });
+        setCurrentPage(newPage);
+      };
+      return (
+        <div style={ { height: "180px", marginBottom: "16px" } }>
+          <FlatTable hasStickyHead hasStickyFooter hasMaxHeight footer={
+            <Pager
+              totalRecords={ rows.length }
+              showPageSizeSelection
+              pageSize={ 5 }
+              currentPage={ currentPage }
+              onPagination={ (next, size) => handlePagination(next, size) }
+              pageSizeSelectionOptions={ 
+                [
+                  { id: '1', name: 1 },
+                  { id: '5', name: 5 },
+                ]}
+            />
+          }>
+            <FlatTableHead>
+              <FlatTableRow>
+                <FlatTableHeader>Name</FlatTableHeader>
+                <FlatTableHeader>Location</FlatTableHeader>
+                <FlatTableHeader>Relationship Status</FlatTableHeader>
+                <FlatTableHeader>Dependents</FlatTableHeader>
+              </FlatTableRow>
+            </FlatTableHead>
+            <FlatTableBody>
+              { renderRows() }
+            </FlatTableBody>
+          </FlatTable>
+        </div>
+      );
+    }} 
+  </Story>
+</Preview>
+
 ### With clickable rows
 
 <Preview>

--- a/src/components/flat-table/flat-table.style.js
+++ b/src/components/flat-table/flat-table.style.js
@@ -7,6 +7,19 @@ import StyledFlatTableCheckbox from "./flat-table-checkbox/flat-table-checkbox.s
 import { baseTheme } from "../../style/themes";
 import { StyledFlatTableCell } from "./flat-table-cell/flat-table-cell.style";
 import cellSizes from "./cell-sizes.style";
+import Box from "../box";
+
+const StyledFlatTableBox = styled(Box)`
+  ${({ theme }) =>
+    css`
+      box-shadow: inset 0px 0px 0px 1px ${theme.table.secondary};
+      box-sizing: border-box;
+    `}
+`;
+
+StyledFlatTableBox.defaultProps = {
+  theme: baseTheme,
+};
 
 const StyledFlatTable = styled.table`
   border-collapse: separate;
@@ -75,7 +88,7 @@ const StyledFlatTableWrapper = styled.div`
   ${({ heightDefaulted }) =>
     !heightDefaulted &&
     css`
-      height: 100%;
+      max-height: 100%;
     `}
 
   ${({ colorTheme, theme }) => {
@@ -161,7 +174,7 @@ const StyledFlatTableFooter = styled.div`
     hasStickyFooter &&
     css`
       position: sticky;
-      bottom: -40px; ;
+      bottom: -40px;
     `}
 `;
 
@@ -169,4 +182,9 @@ StyledFlatTableFooter.defaultProps = {
   theme: baseTheme,
 };
 
-export { StyledFlatTableWrapper, StyledFlatTable, StyledFlatTableFooter };
+export {
+  StyledFlatTableWrapper,
+  StyledFlatTable,
+  StyledFlatTableFooter,
+  StyledFlatTableBox,
+};


### PR DESCRIPTION
Provides a fix for the gap between table content and sticky footer when certain design decisions are
applied to FlatTable.

fixes #3850

### Proposed behaviour

- Fixes the background when height is 100% but the FlatTable doesn't have enough data to fill the 100% height.
<img width="1438" alt="Screenshot 2021-04-01 at 13 45 01" src="https://user-images.githubusercontent.com/56251247/113295785-8b314380-92f0-11eb-866b-a385fcaaebca.png">

- Adds a `hasMaxHeight` prop that makes FlatTable have a max-height of 100%.
<img width="835" alt="Screenshot 2021-04-07 at 16 27 16" src="https://user-images.githubusercontent.com/56251247/113892690-2bd6a600-97be-11eb-93d5-3c69b8b42146.png">


### Current behaviour

![image](https://user-images.githubusercontent.com/56251247/113295830-9c7a5000-92f0-11eb-90d7-49cc47ecfe1e.png)

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required 
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
- `git checkout FE-3986-FlatTable_sticky_footer_gap`
- `npm i`
- `npm start` to start Storybook
- visit new story called "with hasMaxHeight"
-  example should match the acceptance criteria of FE-3986.
