### PR TITLE
fix(filterable-select): check event has a data element attribute before checking the value FE-3802

### DIFF
--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -388,7 +388,10 @@ const FilterableSelect = React.forwardRef(
     function handleTextboxMouseDown(event) {
       isMouseDownReported.current = true;
 
-      if (event.target.attributes["data-element"].value === "input") {
+      if (
+        event.target.attributes["data-element"] &&
+        event.target.attributes["data-element"].value === "input"
+      ) {
         isMouseDownOnInput.current = true;
       }
     }


### PR DESCRIPTION
fix #3754

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds a guard to check that `event.target.attributes["data-element"]` is not undefined before
checking if the value is `"input"`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Throws `Uncaught TypeError: Cannot read property 'value' of undefined` when input icon is clicked

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
`design-system-select-filterable--default-story` click input icon when list is open, no error should be thrown