### PR TITLE
refactor(tile-footer): remove support for styled system margin props FE-3579

### DIFF
--- a/cypress/features/regression/test/tile.feature
+++ b/cypress/features/regression/test/tile.feature
@@ -11,15 +11,6 @@ Feature: Tile component
       | transparent | rgba(0, 0, 0, 0)   | asTransparent |
 
   @positive
-  Scenario Outline: Change Tile pixelWidth to <pixelWidth>
-    When I open Test default "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
-    Then Tile pixel width is set to <pixelWidth>
-    Examples:
-      | pixelWidth | nameOfObject   |
-      | 100        | pixelWidth100  |
-      | 1999       | pixelWidth1999 |
-
-  @positive
   Scenario Outline: Change Tile width to <width>
     When I open Test default "Tile" component in noIFrame with "tile" json from "commonComponents" using "<nameOfObject>" object name
     Then Tile width is set to <width>

--- a/cypress/fixtures/commonComponents/tile.json
+++ b/cypress/fixtures/commonComponents/tile.json
@@ -14,12 +14,6 @@
   "width90": {
     "width_Default": 90
   },
-  "pixelWidth100": {
-    "pixelWidth_Default": 100
-  },
-  "pixelWidth1999": {
-    "pixelWidth_Default": 1999
-  },  
   "contentOneChildrenOtherLanguage": {
     "contentOneChildren_TileContent": "mp150ú¿¡üßä"
   },

--- a/src/components/detail/detail.stories.mdx
+++ b/src/components/detail/detail.stories.mdx
@@ -90,7 +90,7 @@ Detail can be nested inside of components. Inside of this example it is nested i
 In this example, Detail is nested inside of the `Tile` component.
 <Preview>
   <Story name="inside of tile">
-    <Tile width={60}>
+    <Tile width="60%">
       <div style={{paddingTop: '16px'}}>
         <Detail>
           This example of Detail just has children.

--- a/src/components/heading/heading.stories.mdx
+++ b/src/components/heading/heading.stories.mdx
@@ -138,7 +138,7 @@ In this example, the Heading component has the Tile component and the Definition
 <Preview>
   <Story name="with children as component">
     <Heading title="This is a Title" subheader="This is a subheader">
-      <Tile width={95}>
+      <Tile width="95%">
         <Dl>
           <Dt>Drink</Dt>
           <Dd>Coffee</Dd>

--- a/src/components/tile/tile-footer/tile-footer.component.js
+++ b/src/components/tile/tile-footer/tile-footer.component.js
@@ -1,7 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
-import propTypes from "@styled-system/prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import StyledTileFooter from "./tile-footer.style";
+import { filterStyledSystemPaddingProps } from "../../../style/utils";
+
+const paddingPropTypes = filterStyledSystemPaddingProps(
+  styledSystemPropTypes.space
+);
 
 const TileFooter = ({ variant, children, ...props }) => {
   return (
@@ -12,7 +17,7 @@ const TileFooter = ({ variant, children, ...props }) => {
 };
 
 TileFooter.propTypes = {
-  ...propTypes.space,
+  ...paddingPropTypes,
   /** set which background color variant should be used */
   variant: PropTypes.oneOf(["default", "transparent"]),
   children: PropTypes.node,

--- a/src/components/tile/tile-footer/tile-footer.d.ts
+++ b/src/components/tile/tile-footer/tile-footer.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { SpacingProps } from 'utils/helpers/options-helper/options-helper';
+import { PaddingSpacingProps } from 'utils/helpers/options-helper/options-helper';
 
-export interface TileFooterProps extends SpacingProps {
+export interface TileFooterProps extends PaddingSpacingProps {
   /** set which background color variant should be used */
   variant?: 'default' | 'transparent';
   children?: React.ReactNode;

--- a/src/components/tile/tile-footer/tile-footer.spec.js
+++ b/src/components/tile/tile-footer/tile-footer.spec.js
@@ -1,7 +1,10 @@
 import React from "react";
 import { mount } from "enzyme";
 import TileFooter from "./tile-footer.component";
-import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemPadding,
+} from "../../../__spec_helper__/test-utils";
 import StyledTileFooter from "./tile-footer.style";
 import { baseTheme } from "../../../style/themes";
 
@@ -11,6 +14,8 @@ const renderWrapper = (props, renderType = mount) => {
 
 describe("TileFooter", () => {
   let wrapper;
+
+  testStyledSystemPadding((props) => <TileFooter {...props} />);
 
   beforeEach(() => {
     wrapper = renderWrapper();
@@ -40,7 +45,7 @@ describe("TileFooter", () => {
     );
   });
 
-  it("should render correct background if `transparent` variant is provied", () => {
+  it("should render correct background if `transparent` variant is provided", () => {
     wrapper = renderWrapper({ variant: "transparent" });
   });
 });

--- a/src/components/tile/tile-footer/tile-footer.style.js
+++ b/src/components/tile/tile-footer/tile-footer.style.js
@@ -1,9 +1,9 @@
 import styled, { css } from "styled-components";
-import { space } from "styled-system";
+import { padding } from "styled-system";
 import { baseTheme } from "../../../style/themes";
 
 const StyledTileFooter = styled.div`
-  ${space}
+  ${padding}
 
   ${({ variant, theme }) => css`
     background: ${variant === "transparent"

--- a/src/components/tile/tile.component.js
+++ b/src/components/tile/tile.component.js
@@ -72,15 +72,10 @@ Tile.propTypes = {
   /** The orientation of the tile - set to either horizontal or vertical */
   orientation: PropTypes.oneOf(OptionsHelper.orientation),
   /**
-   * Set a pixel with for the Tile component. If both are set to non-zero values, this
-   * takes precedence over the percentage-based "width" prop.
-   */
-  pixelWidth: PropTypes.number,
-  /**
    * Set a percentage-based width for the whole Tile component, relative to its parent.
    * If unset or zero, this will default to 100%.
    */
-  width: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 export default Tile;

--- a/src/components/tile/tile.d.ts
+++ b/src/components/tile/tile.d.ts
@@ -13,7 +13,7 @@ export interface TileProps extends SpacingProps {
    */
   children?: React.ReactNode;
   /** The orientation of the tile - set to either horizontal or vertical */
-  orientation?: 'horizonta' | 'vertical';
+  orientation?: 'horizontal' | 'vertical';
   /**
    * Set a pixel with for the Tile component. If both are set to non-zero values, this
    * takes precedence over the percentage-based "width" prop.
@@ -23,7 +23,7 @@ export interface TileProps extends SpacingProps {
    * Set a percentage-based width for the whole Tile component, relative to its parent.
    * If unset or zero, this will default to 100%.
    */
-  width?: number;
+  width?: string | number;
 }
 
 declare const Tile: React.FunctionComponent<TileProps>;

--- a/src/components/tile/tile.spec.js
+++ b/src/components/tile/tile.spec.js
@@ -1,14 +1,14 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import "jest-styled-components";
 import { mount } from "enzyme";
 import { css } from "styled-components";
 import Tile from ".";
-import { StyledTile, TileContent } from "./tile.style";
+import { TileContent } from "./tile.style";
 import Content from "../content";
 import {
   assertStyleMatch,
   testStyledSystemSpacing,
+  testStyledSystemWidth,
 } from "../../__spec_helper__/test-utils";
 import { baseTheme } from "../../style/themes";
 
@@ -64,6 +64,13 @@ describe("Tile", () => {
   });
 
   describe("styles", () => {
+    testStyledSystemSpacing(
+      (props) => <Tile {...props} headerSpace={{ p: 3 }} />,
+      { p: 3 }
+    );
+
+    testStyledSystemWidth((props) => <Tile {...props} />);
+
     describe("as", () => {
       it('renders a white background when as === "tile"', () => {
         const wrapper = render({ as: "tile" }).toJSON();
@@ -94,35 +101,6 @@ describe("Tile", () => {
           assertStyleMatch({ flexDirection: "column" }, wrapper);
         });
       });
-
-      describe("width", () => {
-        it("sets width to 100% when width prop is undefined", () => {
-          const wrapper = render().toJSON();
-
-          assertStyleMatch({ width: "100%" }, wrapper);
-        });
-
-        it("sets width to 100% when width prop is 0", () => {
-          const wrapper = render({ width: 0 }).toJSON();
-
-          assertStyleMatch({ width: "100%" }, wrapper);
-        });
-
-        it("sets width to the passed percentage value when width prop is non-zero", () => {
-          const wrapper = render({ width: 25 }).toJSON();
-
-          assertStyleMatch({ width: "25%" }, wrapper);
-        });
-
-        it.each([1, 150, 500])(
-          "is overridden when the pixelWidth prop is set to %s",
-          (pixelWidth) => {
-            const wrapper = render({ pixelWidth, width: 25 }).toJSON();
-
-            assertStyleMatch({ width: `${pixelWidth}px` }, wrapper);
-          }
-        );
-      });
     });
   });
 
@@ -134,12 +112,13 @@ describe("Tile", () => {
         ).toJSON();
       }
 
-      // eslint-disable-next-line max-len
-      testStyledSystemSpacing(
-        (props) => <Tile {...props} headerSpace={{ p: 3 }} />,
-        { p: 3 },
-        (wrapper) => wrapper.find(StyledTile)
-      );
+      testStyledSystemSpacing((props) => (
+        <TileContent {...props}>Test</TileContent>
+      ));
+
+      testStyledSystemWidth((props) => (
+        <TileContent {...props}>Test</TileContent>
+      ));
 
       it("has the correct base styles", () => {
         const wrapper = renderTileContent();
@@ -247,14 +226,6 @@ describe("Tile", () => {
             `,
           }
         );
-      });
-
-      describe("width", () => {
-        it("sets width to the passed percentage value and flex-grow to 0 when width prop is non-zero", () => {
-          const wrapper = renderTileContent({ width: 25 });
-
-          assertStyleMatch({ flexGrow: "0", width: "25%" }, wrapper);
-        });
       });
     });
   });

--- a/src/components/tile/tile.stories.js
+++ b/src/components/tile/tile.stories.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { text, number, select } from "@storybook/addon-knobs";
+import { text, select } from "@storybook/addon-knobs";
 import OptionsHelper from "../../utils/helpers/options-helper";
 import Tile from ".";
 import Content from "../content";
@@ -20,13 +20,6 @@ export default {
 };
 
 export const Default = () => {
-  const percentageOpts = {
-    range: true,
-    min: 0,
-    max: 100,
-    step: 1,
-  };
-
   const tileProps = {
     as: select("as", OptionsHelper.tileThemes, "tile", "Default"),
     orientation: select(
@@ -35,27 +28,21 @@ export const Default = () => {
       "horizontal",
       "Default"
     ),
-    pixelWidth: number(
-      "pixelWidth",
-      0,
-      { ...percentageOpts, max: 2000 },
-      "Default"
-    ),
-    width: number("width", 0, percentageOpts, "Default"),
+    width: text("width", "", "Default"),
   };
 
   const contentOneProps = {
     key: "one",
     children: text("contentOneChildren", "Test Body One", "TileContent One"),
     title: text("contentOneTitle", "Test Title One", "TileContent One"),
-    width: number("contentOneWidth", 0, percentageOpts, "TileContent One"),
+    width: text("contentOneWidth", "", "TileContent One"),
   };
 
   const contentTwoProps = {
     key: "two",
     children: text("contentTwoChildren", "Test Body Two", "TileContent Two"),
     title: text("contentTwoTitle", "Test Title Two", "TileContent Two"),
-    width: number("contentTwoWidth", 0, percentageOpts, "TileContent Two"),
+    width: text("contentTwoWidth", "", "TileContent Two"),
   };
 
   const contentThreeProps = {
@@ -66,7 +53,7 @@ export const Default = () => {
       "TileContent Three"
     ),
     title: text("contentThreeTitle", "Test Title Three", "TileContent Three"),
-    width: number("contentThreeWidth", 0, percentageOpts, "TileContent Three"),
+    width: text("contentThreeWidth", "", "TileContent Three"),
   };
 
   const tileContent = [

--- a/src/components/tile/tile.stories.mdx
+++ b/src/components/tile/tile.stories.mdx
@@ -67,7 +67,7 @@ The Tile component can be also have a vertical layout.
 <Preview>
   <Story name="with TileFooter">
     <div>
-      <Tile orientation="vertical" pixelWidth={400}>
+      <Tile orientation="vertical" width={400}>
         <Content>
           <Typography pb={2} variant="h4" fontWeight="bold">
             Example header
@@ -87,7 +87,7 @@ The Tile component can be also have a vertical layout.
         </Content>
       </Tile>
       <Box my={3} />
-      <Tile px={0} pb={0} orientation="vertical" pixelWidth={400}>
+      <Tile px={0} pb={0} orientation="vertical" width={400}>
         <Content>
           <Box px={3}>
             <Typography pb={2} variant="h4" fontWeight="bold">
@@ -109,7 +109,7 @@ The Tile component can be also have a vertical layout.
         </Content>
       </Tile>
       <Box my={3} />
-      <Tile px={0} pb={0} orientation="vertical" pixelWidth={420}>
+      <Tile px={0} pb={0} orientation="vertical" width={420}>
         <Content>
           <Box px={3}>
             <Typography pb={2} variant="h4" fontWeight="bold">
@@ -163,19 +163,21 @@ The Tile component can be also have a vertical layout.
 </Preview>
 
 ### With custom widths
-The Tile component can also have custom widths. Any child wrapped by a Tile component can be passed an optional `width` prop - this is a percent value, dictating the width of the child element within the tile.
+The Tile component can also have a custom `width` which accepts either numbers or strings: any decimal between 0 and 1.0 
+will be converted into a percentage, any number grater will be be treated as pixels and any valid CSS string will also work. 
+Any child wrapped by a Tile component can be passed an optional `width` prop.
 Please note that it will not have any effect if the Tile orientation is set to `vertical`.
 
 <Preview>
   <Story name="custom Widths">
-    <Tile as="tile" orientation="horizontal" pixelWidth={0} width={75}>
+    <Tile as="tile" orientation="horizontal" width="75%">
       <Content
         align="left"
         variant="primary"
         bodyFullWidth={false}
         inline={false}
         title="Test Title One"
-        width={40}
+        width="40%"
       >
         Test Body One
       </Content>
@@ -185,7 +187,7 @@ Please note that it will not have any effect if the Tile orientation is set to `
         bodyFullWidth={false}
         inline={false}
         title="Test Title Two"
-        width={80}
+        width="80%"
       >
         Test Body Two
       </Content>
@@ -195,7 +197,7 @@ Please note that it will not have any effect if the Tile orientation is set to `
         bodyFullWidth={false}
         inline={false}
         title="Test Title Three"
-        width={120}
+        width="120%"
       >
         Test Body Three
       </Content>
@@ -208,14 +210,14 @@ The Tile component can also have inline styling applied to the content.
 
 <Preview>
   <Story name="with Inline">
-    <Tile as="tile" orientation="horizontal" pixelWidth={0} width={0}>
+    <Tile as="tile" orientation="horizontal" width={0}>
       <Content
         align="left"
         variant="primary"
         bodyFullWidth={false}
         inline={true}
         title="Test Title One"
-        width={80}
+        width="80%"
       >
         Test Body One
       </Content>
@@ -225,7 +227,7 @@ The Tile component can also have inline styling applied to the content.
         bodyFullWidth={false}
         inline={true}
         title="Test Title Two"
-        width={80}
+        width="80%"
       >
         Test Body Two
       </Content>
@@ -235,7 +237,7 @@ The Tile component can also have inline styling applied to the content.
         bodyFullWidth={false}
         inline={true}
         title="Test Title Three"
-        width={80}
+        width="80%"
       >
         Test Body Three
       </Content>
@@ -249,22 +251,22 @@ The Tile component can also have inline styling applied to the content.
   <Story name="with different padding and margin">
     <>
       <Tile p={0} m={0} as="tile" orientation="horizontal">
-        <Content width={50}>Example content</Content>
+        <Content width="50%">Example content</Content>
       </Tile>
       <Tile p={1} m={1} as="tile" orientation="horizontal">
-        <Content width={50}>Example content</Content>
+        <Content width="50%">Example content</Content>
       </Tile>
       <Tile p={2} m={2} as="tile" orientation="horizontal">
-        <Content width={50}>Example content</Content>
+        <Content width="50%">Example content</Content>
       </Tile>
       <Tile p={3} m={3} as="tile" orientation="horizontal">
-        <Content width={50}>Example content</Content>
+        <Content width="50%">Example content</Content>
       </Tile>
       <Tile p={4} m={4} as="tile" orientation="horizontal">
-        <Content width={50}>Example content</Content>
+        <Content width="50%">Example content</Content>
       </Tile>
       <Tile p={5} m={5} as="tile" orientation="horizontal">
-        <Content width={50}>Example content</Content>
+        <Content width="50%">Example content</Content>
       </Tile>
     </>
   </Story>
@@ -278,7 +280,7 @@ Please note that Dl, Dd and Dt use our common spacing props.
 
 <Preview>
   <Story name="with Definition List - default">
-    <Tile width={95}>
+    <Tile width="95%">
       <Dl>
         <Dt>Drink</Dt>
         <Dd>Coffee</Dd>
@@ -319,7 +321,7 @@ Providing a number value to the `w` prop, sets the width of the `<Dt />` element
 
 <Preview>
   <Story name="with Definition List and custom width">
-    <Tile width={95}>
+    <Tile width="95%">
       <Dl w={40}>
         <Dt>Drink</Dt>
         <Dd>Coffee</Dd>
@@ -360,7 +362,7 @@ In this example `dtTextAlign` has been provided the string 'left' and `ddTextAli
 
 <Preview>
   <Story name="with Definition and custom text alignment">
-    <Tile width={40}>
+    <Tile width="40%">
       <Dl w={40} dtTextAlign="left" ddTextAlign="right">
         <Dt>Coffee Subscription</Dt>
         <Dd>£7.00 a month</Dd>
@@ -385,7 +387,7 @@ In this example `dtTextAlign` has been provided the string 'left' and `ddTextAli
 
 <Preview>
   <Story name="with Definition List and ActionPopover and Icon support">
-    <Tile width={60}>
+    <Tile width="60%">
       <Dl>
       <Dt>
         <Box paddingTop="4px" display="inline-flex" alignItems="center">
@@ -509,7 +511,7 @@ In this example `dtTextAlign` has been provided the string 'left' and `ddTextAli
 ## Props
 
 ### Tile
-<StyledSystemProps noHeader of={Tile} spacing spacingDefaults={{ p: 3 }} />
+<StyledSystemProps noHeader of={Tile} spacing width spacingDefaults={{ p: 3 }} />
 
 ### TileFooter
 <StyledSystemProps noHeader of={TileFooter} padding />

--- a/src/components/tile/tile.stories.mdx
+++ b/src/components/tile/tile.stories.mdx
@@ -512,7 +512,7 @@ In this example `dtTextAlign` has been provided the string 'left' and `ddTextAli
 <StyledSystemProps noHeader of={Tile} spacing spacingDefaults={{ p: 3 }} />
 
 ### TileFooter
-<StyledSystemProps noHeader of={TileFooter} spacing />
+<StyledSystemProps noHeader of={TileFooter} padding />
 
 ### Dl
 <StyledSystemProps of={Dl} noHeader spacing />

--- a/src/components/tile/tile.style.js
+++ b/src/components/tile/tile.style.js
@@ -2,9 +2,10 @@ import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
 import { space } from "styled-system";
 import baseTheme from "../../style/themes/base";
+import computeWidth from "../../style/utils/width";
 
 const TileContent = styled.div`
-  ${({ width, isHorizontal, isVertical, theme }) => css`
+  ${({ isHorizontal, isVertical, theme, width }) => css`
     ${space}
     box-sizing: border-box;
     position: relative;
@@ -46,36 +47,36 @@ const TileContent = styled.div`
       }
     `}
 
-    ${width && width !== 0
-      ? `
+    ${width &&
+    css`
       flex-grow: 0;
-      width: ${width}%;
-    `
-      : ""}
+      ${computeWidth}
+    `}
   `}
 `;
 
 const StyledTile = styled.div`
-  ${({ isHorizontal, pixelWidth, tileTheme, theme, width }) => css`
+  ${({ isHorizontal, tileTheme, theme, width }) => css`
     ${space}
     box-sizing: border-box;
-    background-color: ${
-      tileTheme === "tile" ? theme.colors.white : "transparent"
-    };
+    background-color: ${tileTheme === "tile"
+      ? theme.colors.white
+      : "transparent"};
     border: 1px solid ${theme.tile.border};
     display: flex;
     flex-direction: ${isHorizontal ? "row" : "column"};
     position: relative;
     width: 100%;
 
-    ${width && width !== 0 ? `width: ${width}%;` : ""}
-    ${pixelWidth && pixelWidth !== 0 ? `width: ${pixelWidth}px;` : ""}
-    }
+    ${width &&
+    css`
+      ${computeWidth}
+    `}
   `}
 `;
 
 TileContent.propTypes = {
-  width: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 TileContent.defaultProps = {
@@ -86,7 +87,7 @@ StyledTile.propTypes = {
   orientation: PropTypes.string,
   padding: PropTypes.string,
   tileTheme: PropTypes.string,
-  width: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 StyledTile.defaultProps = {

--- a/src/components/vertical-divider/vertical-divider.stories.mdx
+++ b/src/components/vertical-divider/vertical-divider.stories.mdx
@@ -226,7 +226,7 @@ applied to the slate.
 
 <Preview>
   <Story name='in a tile'>
-    <Tile pixelWidth={800} orientation='vertical'>
+    <Tile width={800} orientation='vertical'>
       <Content title='Test Title One'>
         Test Body One
       </Content>


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Updates `TileFooter` to only support `styled-system/padding` and removes support for `margin`

BREAKING CHANGE: `margin` props no longer supported in `TileFooter`

Adds support for `styled-system` width for `Tile` and `TileContent`

BREAKING CHANGE: `pixelWidth` prop has been removed

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`TileFooter` supports all `spacing` props

`Tile` does not support `styled-system` `width`, instead has `pixelWidth` and `width` props to handle percentage and pixel dimensions

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
Tile stories should all be the same as master
https://codesandbox.io/s/carbon-quickstart-forked-d663h?file=/src/index.js