### PR TITLE
refactor(hr): update styled system implementation

### DIFF
--- a/src/components/hr/hr.component.js
+++ b/src/components/hr/hr.component.js
@@ -4,6 +4,9 @@ import propTypes from "@styled-system/prop-types";
 
 import StyledHr from "./hr.style";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
+import { filterStyledSystemMarginProps } from "../../style/utils";
+
+const marginPropTypes = filterStyledSystemMarginProps(propTypes.space);
 
 const Hr = ({ adaptiveMxBreakpoint, ml, mr, ...props }) => {
   const largeScreen = useIsAboveBreakpoint(adaptiveMxBreakpoint);
@@ -27,8 +30,8 @@ const Hr = ({ adaptiveMxBreakpoint, ml, mr, ...props }) => {
 };
 
 Hr.propTypes = {
-  /** Styled system spacing props */
-  ...propTypes.space,
+  /** Filtered styled system margin props */
+  ...marginPropTypes,
   /** Breakpoint for adaptive left and right margins (below the breakpoint they go to 0).
    * Enables the adaptive behaviour when set */
   adaptiveMxBreakpoint: PropTypes.number,

--- a/src/components/hr/hr.d.ts
+++ b/src/components/hr/hr.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { SpacingProps } from '../../utils/helpers/options-helper';
+import { MarginSpacingProps } from '../../utils/helpers/options-helper';
 
-export interface HrProps extends SpacingProps {
+export interface HrProps extends MarginSpacingProps {
   /** Breakpoint for adaptive left and right margins (below the breakpoint they go to 0).
    * Enables the adaptive behaviour when set
    */

--- a/src/components/hr/hr.spec.js
+++ b/src/components/hr/hr.spec.js
@@ -4,7 +4,7 @@ import { mount } from "enzyme";
 import {
   assertStyleMatch,
   mockMatchMedia,
-  testStyledSystemSpacing,
+  testStyledSystemMargin,
 } from "../../__spec_helper__/test-utils";
 import Hr from "./hr.component";
 import StyledHr from "./hr.style";
@@ -20,7 +20,7 @@ describe("Hr", () => {
     wrapper = render();
   });
 
-  testStyledSystemSpacing((props) => <Hr {...props} />, {
+  testStyledSystemMargin((props) => <Hr {...props} />, {
     mt: "24px",
     mb: "24px",
   });

--- a/src/components/hr/hr.stories.mdx
+++ b/src/components/hr/hr.stories.mdx
@@ -98,7 +98,7 @@ The left and right margins can be set to 0 below a screen width breakpoint. This
 ### Hr
 <StyledSystemProps
   of={Hr}
-  spacing
+  margin
   noHeader
   defaults={{ mt: '3', mb: '3' }}
 />

--- a/src/components/hr/hr.style.js
+++ b/src/components/hr/hr.style.js
@@ -1,9 +1,9 @@
 import styled from "styled-components";
-import { space } from "styled-system";
+import { margin } from "styled-system";
 import baseTheme from "../../style/themes/base";
 
 const StyledHr = styled.hr`
-  ${space}
+  ${margin}
   width: inherit;
   border: 0;
   height: 1px;


### PR DESCRIPTION
BREAKING CHANGE: Use margin only. Padding has been removed.

### Proposed behaviour
`@styled-system/space` margin only (remove padding - breaking change).
Filter styled system margin props.

### Current behaviour
Uses no filtered `propTypes.space`.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
- Padding props have been removed from story page props section.
- https://codesandbox.io/s/carbon-quickstart-forked-gmr2k?file=/src/index.js