### PR TITLE
feat(profile): add styled-system margin props - FE-3568

### DIFF
--- a/src/components/profile/profile.component.js
+++ b/src/components/profile/profile.component.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import classNames from "classnames";
 import { acronymize } from "../../utils/ether/ether";
 import tagComponent from "../../utils/helpers/tags/tags";
@@ -10,6 +11,11 @@ import {
   ProfileAvatarStyle,
   ProfileEmailStyle,
 } from "./profile.style";
+import { filterStyledSystemMarginProps } from "../../style/utils";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 class Profile extends React.Component {
   /** Determines whether a `src` prop has been supplied */
@@ -26,6 +32,10 @@ class Profile extends React.Component {
   get initials() {
     if (this.props.initials) return this.props.initials;
     return acronymize(this.props.name);
+  }
+
+  get marginProps() {
+    return filterStyledSystemMarginProps(this.props);
   }
 
   /** Returns the avatar portion of the profile. */
@@ -72,6 +82,7 @@ class Profile extends React.Component {
         className={this.classes}
         hasSrc={this.hasSrc}
         {...tagComponent("profile", this.props)}
+        {...this.marginProps}
       >
         {this.avatar}
         {this.text}
@@ -81,6 +92,7 @@ class Profile extends React.Component {
 }
 
 Profile.propTypes = {
+  ...marginPropTypes,
   /** [Legacy] A custom class name for the component */
   className: PropTypes.string,
   /** Custom source URL */

--- a/src/components/profile/profile.spec.js
+++ b/src/components/profile/profile.spec.js
@@ -15,7 +15,10 @@ import {
   ProfileAvatarStyle,
 } from "./profile.style";
 
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/test-utils";
 
 describe("Profile", () => {
   let instance;
@@ -140,4 +143,10 @@ describe("ProfileDetailStyle", () => {
       );
     });
   });
+});
+
+describe("styled-system", () => {
+  testStyledSystemMargin((props) => (
+    <Profile name="profile" email="foo" {...props} />
+  ));
 });

--- a/src/components/profile/profile.stories.mdx
+++ b/src/components/profile/profile.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 import Profile from ".";
 
@@ -70,4 +71,4 @@ To use an image, simply pass any valid image URL as a `src` prop.
 ## Props
 
 ### Profile
-<Props of={Profile} />
+<StyledSystemProps of={Profile} noHeader margin />

--- a/src/components/profile/profile.style.js
+++ b/src/components/profile/profile.style.js
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
 import Portrait from "../portrait";
 import baseTheme from "../../style/themes/base";
 import profileConfigSizes from "./profile.config";
@@ -21,6 +22,8 @@ const ProfileStyle = styled.div`
     `};
 
   display: ${({ hasSrc }) => (hasSrc ? "flex" : "")};
+
+  ${margin}
 `;
 
 const ProfileDetailsStyle = styled.div`


### PR DESCRIPTION
### Proposed behaviour
Adds styled-system margin props to the `Profile` component

### Current behaviour
`Profile` component currently does not have access to the styled-system props

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
<del> - [ ] Screenshots are included in the PR if useful </del>
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
<del> - [ ] Cypress automation tests added or updated if required </del>
- [x] Storybook added or updated if required
<del> - [ ] Typescript `d.ts` file added or updated if required </del>
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
https://codesandbox.io/s/reverent-elgamal-7mfrf

- apply the styled-system margin props to the Profile component. Styles should behave as expected.
