### PR TITLE
feat(portrait): adds prop to specify fallback icon - FE-4041

### DIFF
--- a/cypress/features/regression/portrait.feature
+++ b/cypress/features/regression/portrait.feature
@@ -9,3 +9,13 @@ Feature: Portrait default component
 			| alt                          | nameOfObject        |
 			| mp150ú¿¡üßä                  | altOtherLanguage    |
 			| !@#$%^*()_+-=~[];:.,?{}&"'<> | altSpecialCharacter |
+
+	@positive
+	Scenario Outline: Render specified icon type <iconType>
+		When I open default "Portrait Test" component in noIFrame with "portrait" json from "commonComponents" using "<nameOfObject>" object name
+		Then <iconType> icon component should be rendered
+		Examples:
+			| iconType   | nameOfObject  |
+			| individual | iconTypeNone  |
+			| image      | iconTypeImage |
+			| copy       | iconTypeCopy  |

--- a/cypress/fixtures/commonComponents/portrait.json
+++ b/cypress/fixtures/commonComponents/portrait.json
@@ -1,8 +1,17 @@
 {
   "altOtherLanguage": {
-    "alt": "mp150ú¿¡üßä"
+    "alt": "mp150ú¿¡üßä",
+    "initials": "AZ"
   },
   "altSpecialCharacter": {
-    "alt": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
+    "alt": "!@#$%^*()_+-=~[];:.,?{}&\"'<>",
+    "initials": "AZ"
+  },
+  "iconTypeNone": {},
+  "iconTypeImage": {
+    "iconType": "image"
+  },
+  "iconTypeCopy": {
+    "iconType": "copy"
   }
 }

--- a/cypress/support/step-definitions/portrait-steps.js
+++ b/cypress/support/step-definitions/portrait-steps.js
@@ -1,6 +1,11 @@
+import { icon } from "../../locators/index";
 import { portraitPreview, portraitInitials } from "../../locators/portrait";
 
 Then("Portrait alt on preview is set to {word}", (text) => {
   portraitPreview().children().should("have.attr", "alt", `${text}`);
   portraitInitials().children().should("have.attr", "alt", `${text}`);
+});
+
+Then("{word} icon component should be rendered", (iconType) => {
+  icon().should("have.attr", "data-element", iconType).and("be.visible");
 });

--- a/src/components/portrait/portrait.component.js
+++ b/src/components/portrait/portrait.component.js
@@ -16,6 +16,7 @@ import { filterStyledSystemMarginProps } from "../../style/utils";
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
 );
+
 class Portrait extends React.Component {
   state = {
     externalError: false,
@@ -44,6 +45,7 @@ class Portrait extends React.Component {
       alt,
       darkBackground,
       gravatar,
+      iconType,
       initials,
       shape,
       size,
@@ -63,7 +65,7 @@ class Portrait extends React.Component {
 
     let portrait = (
       <StyledIcon
-        type="individual"
+        type={iconType}
         size={size}
         shape={shape}
         darkBackground={darkBackground}
@@ -168,6 +170,8 @@ Portrait.propTypes = {
   initials: PropTypes.string,
   /** Use a dark background. */
   darkBackground: PropTypes.bool,
+  /** The icon to render as fallback */
+  iconType: PropTypes.string,
   /** Prop for `onClick` events. */
   onClick: PropTypes.func,
   /** The message to be displayed within the tooltip */
@@ -193,6 +197,7 @@ Portrait.defaultProps = {
   shape: "square",
   darkBackground: false,
   alt: "",
+  iconType: "individual",
 };
 
 export default Portrait;

--- a/src/components/portrait/portrait.spec.js
+++ b/src/components/portrait/portrait.spec.js
@@ -142,14 +142,33 @@ describe("PortraitComponent", () => {
       shape: "square",
       darkBackground: false,
     };
+    const expectedCustomIconProps = {
+      type: "image",
+      size: "XXL",
+      shape: "square",
+      darkBackground: false,
+    };
 
     const testSuccess = (element) =>
       renderFindTypeSuccess(element, StyledIcon, expectedProps);
+    const testCustomIconSuccess = (element) =>
+      renderFindTypeSuccess(element, StyledIcon, expectedCustomIconProps);
     const testFail = (element) => renderFindTypeFail(element, StyledIcon);
 
     it("renders icon when not supplied with Gravatar or src or initials", () => {
       testSuccess(
         <Portrait size="XXL" shape="square" darkBackground={false} />
+      );
+    });
+
+    it("renders specified icon when not supplied with Gravatar, src or initials", () => {
+      testCustomIconSuccess(
+        <Portrait
+          size="XXL"
+          shape="square"
+          darkBackground={false}
+          iconType="image"
+        />
       );
     });
 

--- a/src/components/portrait/portrait.stories.js
+++ b/src/components/portrait/portrait.stories.js
@@ -38,7 +38,8 @@ function commonKnobs() {
     ),
     gravatar: source === "gravatar" ? text("gravatar") : undefined,
     src: source === "src" ? text("src") : undefined,
-    initials: text("initials", "AZ"),
+    initials: text("initials", ""),
+    iconType: select("iconType", OptionsHelper.icons),
     onClick: (ev) => action("click")(ev),
   };
 }

--- a/src/components/portrait/portrait.stories.mdx
+++ b/src/components/portrait/portrait.stories.mdx
@@ -69,6 +69,16 @@ Portrait also supports `gravatar`, to use it simply pass your email address regi
   </Story>
 </Preview>
 
+### IconType
+
+Portrait also supports the declaration of a icon to fallback on when `src`, `gravatar` and `initials` are falsy.
+
+<Preview>
+  <Story name="iconType">
+    <Portrait iconType="image" />
+  </Story>
+</Preview>
+
 ### With tooltip
 
 By providing a node element to the `tooltipMessage` prop, a tooltip can be displayed when hovering over the Portrait.


### PR DESCRIPTION
### Proposed behaviour
Hi Carbon Team,

We have a use case for the `Portrait` component that instead of falling back onto the normal portrait's **"individual"** icon should fall back to the **"image"** icon.

This would be easy for us to implement given you can accept our proposed change to introduce a `icon` prop that defaults to "individual". Therefore, no breaking change is introduced, but we would be able to specify the specific icon we would like.

Thank You and regards,
**Neville (from the Xtrem Bauxite Team)**
