### PR TITLE
feat(text-editor): surface styled system margin props FE-3578

### DIFF
--- a/src/components/text-editor/text-editor.component.js
+++ b/src/components/text-editor/text-editor.component.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import {
   ContentState,
   EditorState,
@@ -23,6 +24,7 @@ import {
   blockStyleFn,
 } from "./__internal__/utils";
 import {
+  StyledEditorWrapper,
   StyledEditorOutline,
   StyledEditorContainer,
 } from "./text-editor.style";
@@ -32,6 +34,11 @@ import Label from "../../__experimental__/components/label";
 import Events from "../../utils/helpers/events/events";
 import createGuid from "../../utils/helpers/guid";
 import LabelWrapper from "./__internal__/label-wrapper";
+import { filterStyledSystemMarginProps } from "../../style/utils";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 const NUMBERS = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
 const INLINE_STYLES = ["BOLD", "ITALIC"];
@@ -50,6 +57,7 @@ const TextEditor = React.forwardRef(
       info,
       toolbarElements,
       rows,
+      ...rest
     },
     ref
   ) => {
@@ -287,7 +295,7 @@ const TextEditor = React.forwardRef(
     ]);
 
     return (
-      <>
+      <StyledEditorWrapper {...rest}>
         <LabelWrapper onClick={() => handleEditorFocus(true)}>
           <Label labelId={labelId.current} isRequired={required}>
             {labelText}
@@ -335,12 +343,13 @@ const TextEditor = React.forwardRef(
             />
           </StyledEditorContainer>
         </StyledEditorOutline>
-      </>
+      </StyledEditorWrapper>
     );
   }
 );
 
 TextEditor.propTypes = {
+  ...marginPropTypes,
   /** The maximum characters that the input will accept */
   characterLimit: PropTypes.number,
   /** The text for the editor's label */

--- a/src/components/text-editor/text-editor.d.ts
+++ b/src/components/text-editor/text-editor.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { MarginSpacingProps } from "../../utils/helpers/options-helper";
 
-export interface TextEditorProps {
+export interface TextEditorProps extends MarginSpacingProps {
   characterLimit?: number;
   labelText: string;
   onChange: (event: object) => void;

--- a/src/components/text-editor/text-editor.spec.js
+++ b/src/components/text-editor/text-editor.spec.js
@@ -3,7 +3,10 @@ import { Editor, Modifier } from "draft-js";
 import { act } from "react-dom/test-utils";
 import { mount } from "enzyme";
 import { ThemeProvider } from "styled-components";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/test-utils";
 import mintTheme from "../../style/themes/mint";
 import TextEditor, {
   TextEditorContentState,
@@ -101,6 +104,15 @@ describe("TextEditor", () => {
 
   let wrapper;
   describe("Styles", () => {
+    testStyledSystemMargin((props) => (
+      <TextEditor
+        value={createContent()}
+        labelText="Text Editor Label"
+        labelId="foo"
+        {...props}
+      />
+    ));
+
     it("match the expected as default", () => {
       wrapper = render();
 

--- a/src/components/text-editor/text-editor.stories.mdx
+++ b/src/components/text-editor/text-editor.stories.mdx
@@ -1,10 +1,11 @@
-import { Meta, Props, Preview, Story } from "@storybook/addon-docs/blocks";
+import { Meta, Preview, Story } from "@storybook/addon-docs/blocks";
 import { useState, useRef } from "react";
 import TextEditor, {
   TextEditorState as EditorState,
   TextEditorContentState as ContentState,
 } from "./text-editor.component";
 import Button from "../button";
+import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
 
 <Meta
   title="Design System/Text Editor"
@@ -119,8 +120,8 @@ otherwise. Any `onCancel` callback prop passed will be called when the `Cancel` 
             value={value}
             ref={ref}
             toolbarElements={[
-              <Button buttonType="tertiary" onClick={ () => console.log('cancel') }>Cancel</Button>,
-              <Button buttonType='primary' type="button" onClick={ () => console.log('save') } ml={2}>Save</Button>
+              <Button key="cancel button" buttonType="tertiary" onClick={ () => console.log('cancel') }>Cancel</Button>,
+              <Button key="save button" buttonType='primary' type="button" onClick={ () => console.log('save') } ml={2}>Save</Button>
             ]}
             labelText="Text Editor Label"
           />
@@ -263,4 +264,9 @@ which is multiplied by the line-height (21px).
 ## Props
 
 ### Text Editor 
-<Props of={TextEditor} />
+
+<StyledSystemProps
+  of={TextEditor}
+  margin
+  noHeader
+/>

--- a/src/components/text-editor/text-editor.style.js
+++ b/src/components/text-editor/text-editor.style.js
@@ -1,8 +1,17 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
 import baseTheme from "../../style/themes/base";
 import { isSafari } from "../../utils/helpers/browser-type-check";
 
 const lineHeight = 21;
+
+const StyledEditorWrapper = styled.div`
+  ${margin}
+`;
+
+StyledEditorWrapper.defaultProps = {
+  theme: baseTheme,
+};
 
 const StyledEditorContainer = styled.div`
   ${({ theme, hasError, rows }) => css`
@@ -70,4 +79,4 @@ StyledEditorOutline.defaultProps = {
   theme: baseTheme,
 };
 
-export { StyledEditorContainer, StyledEditorOutline };
+export { StyledEditorWrapper, StyledEditorContainer, StyledEditorOutline };


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Surfaces `styled-system/margin` props to allow adjusting of spacing for `TextEditor`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No margin props supported on `TextEditor`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-lo9i0?file=/src/index.js