### PR TITLE
refactor(menu): replace box with styled system

### DIFF
--- a/cypress/locators/menu/locators.js
+++ b/cypress/locators/menu/locators.js
@@ -1,5 +1,5 @@
 // component preview locators
 export const SUBMENU = '[data-component="submenu-wrapper"]';
-export const SCROLL_BLOCK = '[data-component="submenu-scrollable-block"]';
+export const SCROLL_BLOCK = '[data-component="submenu-scrollable-block"] > div';
 export const MENU_DIVIDER = '[data-component="menu-divider"]';
 export const SEGMENT_TITLE = '[data-component="menu-segment-title"]';

--- a/src/components/menu/index.d.ts
+++ b/src/components/menu/index.d.ts
@@ -1,5 +1,6 @@
-export { default as Menu } from './menu';
-export { default as MenuItem } from './menu-item/menu-item';
-export { default as SubmenuBlock } from './submenu-block/submenu-block';
-export { default as MenuDivider } from './menu-divider/menu-divider';
-export { default as MenuSegmentTitle } from './menu-segment-title/menu-segment-title';
+export { default as Menu } from "./menu";
+export { default as MenuItem } from "./menu-item/menu-item";
+export { default as ScrollableBlock } from "./scrollable-block/scrollable-block";
+export { default as SubmenuBlock } from "./submenu-block/submenu-block";
+export { default as MenuDivider } from "./menu-divider/menu-divider";
+export { default as MenuSegmentTitle } from "./menu-segment-title/menu-segment-title";

--- a/src/components/menu/menu-item/menu-item.component.js
+++ b/src/components/menu/menu-item/menu-item.component.js
@@ -6,11 +6,12 @@ import React, {
   useContext,
 } from "react";
 import PropTypes from "prop-types";
+import propTypes from "@styled-system/prop-types";
 import classNames from "classnames";
+
 import StyledMenuItemWrapper from "./menu-item.style";
 import OptionHelper from "../../../utils/helpers/options-helper";
 import Link from "../../link";
-import Box from "../../box";
 import Events from "../../../utils/helpers/events";
 import { MenuContext } from "../menu.component";
 import Submenu from "../__internal__/submenu/submenu.component";
@@ -158,7 +159,10 @@ const MenuItem = ({
 };
 
 MenuItem.propTypes = {
-  ...Box.propTypes,
+  /** Styled system flex props */
+  ...propTypes.flexbox,
+  /** Styled system layout props */
+  ...propTypes.layout,
   /** Either prop `icon` must be defined or this node must have children.
    * @type node
    */

--- a/src/components/menu/menu-item/menu-item.d.ts
+++ b/src/components/menu/menu-item/menu-item.d.ts
@@ -1,7 +1,11 @@
 import * as React from "react";
 import { IconTypes } from "../../../utils/helpers/options-helper/options-helper";
+import {
+  LayoutProps,
+  FlexBoxProps,
+} from "../../../utils/helpers/options-helper";
 
-export interface MenuItemProps {
+export interface MenuItemProps extends LayoutProps, FlexBoxProps {
   children: React.ReactNode;
   className?: string;
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;

--- a/src/components/menu/menu-item/menu-item.spec.js
+++ b/src/components/menu/menu-item/menu-item.spec.js
@@ -4,7 +4,11 @@ import { act } from "react-dom/test-utils";
 
 import { MenuItem } from "..";
 import Link from "../../link";
-import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
+import {
+  testStyledSystemLayout,
+  testStyledSystemFlexBox,
+  assertStyleMatch,
+} from "../../../__spec_helper__/test-utils";
 import { baseTheme } from "../../../style/themes";
 import StyledMenuItemWrapper from "./menu-item.style";
 import Submenu from "../__internal__/submenu/submenu.component";
@@ -88,6 +92,9 @@ describe("MenuItem", () => {
       wrapper = null;
     }
   });
+
+  testStyledSystemLayout((props) => <MenuItem {...props}>Item One</MenuItem>);
+  testStyledSystemFlexBox((props) => <MenuItem {...props}>Item One</MenuItem>);
 
   it("should render children correctly", () => {
     wrapper = shallow(<MenuItem>Item One</MenuItem>);

--- a/src/components/menu/menu.component.js
+++ b/src/components/menu/menu.component.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import PropTypes from "prop-types";
+import propTypes from "@styled-system/prop-types";
 
 import { StyledMenuWrapper } from "./menu.style";
 import { menuKeyboardNavigation } from "./__internal__/keyboard-navigation";
@@ -78,6 +79,10 @@ const Menu = ({ menuType = "light", children, ...rest }) => {
 };
 
 Menu.propTypes = {
+  /** Styled system flex props */
+  ...propTypes.flexbox,
+  /** Styled system layout props */
+  ...propTypes.layout,
   /** Defines the color scheme of the component */
   menuType: PropTypes.oneOf(["light", "dark"]),
   /** Children elements */

--- a/src/components/menu/menu.d.ts
+++ b/src/components/menu/menu.d.ts
@@ -1,8 +1,9 @@
-import * as React from 'react';
+import * as React from "react";
+import { LayoutProps, FlexBoxProps } from "../../utils/helpers/options-helper";
 
-export interface MenuProps {
+export interface MenuProps extends LayoutProps, FlexBoxProps {
   children: React.ReactNode;
-  menuType?: 'light' | 'dark';
+  menuType?: "light" | "dark";
 }
 
 declare const Menu: React.ComponentType<MenuProps>;

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -10,7 +10,11 @@ import {
   StyledVerticalWrapper,
   StyledDivider,
 } from "../vertical-divider/vertical-divider.style";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  testStyledSystemLayout,
+  testStyledSystemFlexBox,
+  assertStyleMatch,
+} from "../../__spec_helper__/test-utils";
 import baseTheme from "../../style/themes/base";
 import StyledMenuItemWrapper from "./menu-item/menu-item.style";
 import {
@@ -45,6 +49,9 @@ describe("Menu", () => {
       </Menu>
     );
   });
+
+  testStyledSystemLayout((props) => <Menu {...props} />);
+  testStyledSystemFlexBox((props) => <Menu {...props} />);
 
   it("should render with correct `data-component`", () => {
     expect(wrapper.prop("data-component")).toEqual("menu");

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -676,6 +676,10 @@ Note that only one `ScrollableBlock` can be used within a single submenu.
 
 <StyledSystemProps of={MenuItem} flexBox layout noHeader />
 
+### ScrollableBlock
+
+<Props of={ScrollableBlock} />
+
 ### SubmenuBlock
 
 <Props of={SubmenuBlock} />

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -674,9 +674,7 @@ Note that only one `ScrollableBlock` can be used within a single submenu.
 
 ### MenuItem
 
-`MenuItem` extends the `Box` component so it also accepts all `Box` props.
-
-<Props of={MenuItem} />
+<StyledSystemProps of={MenuItem} flexBox layout noHeader />
 
 ### SubmenuBlock
 

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import {
   Menu,
   MenuItem,
@@ -16,9 +17,11 @@ import Search from "../../__experimental__/components/search";
 <Meta title="Design System/Menu" parameters={{ info: { disable: true } }} />
 
 # Menu
+
 Provides navigation for an app, which can be used via mouse or keyboard.
 
 ## Contents
+
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
@@ -197,6 +200,7 @@ import {
 </Preview>
 
 ### Default icon
+
 Menus with icons only must have a supplied keyboard shortcut. If no shortcut is supplied the menu item text is navigable by the first letter of each item.
 The menu must have focus for this to work
 
@@ -369,6 +373,7 @@ The menu must have focus for this to work
 </Preview>
 
 ### No dropdown arrow on submenu
+
 The example below has set the `showDropdownArrow` to false for the MenuItem with a submenu which means no dropdown arrow
 is rendered.
 
@@ -388,6 +393,7 @@ is rendered.
 </Preview>
 
 ### Dark icon
+
 Menus with icons only must have a supplied keyboard shortcut. If no shortcut is supplied the menu item text is navigable by the first letter of each item.
 The menu must have focus for this to work
 
@@ -477,6 +483,7 @@ The menu must have focus for this to work
 </Preview>
 
 ### Split submenu into separate component
+
 If you need to split out a submenu into a separate component, it must be done as shown below in order for the keyboard navigation to work as intended.
 
 <Preview>
@@ -505,6 +512,7 @@ If you need to split out a submenu into a separate component, it must be done as
 </Preview>
 
 ### Submenu icon and text alignment
+
 In order to align text and icons within a submenu a `Box` component will need to be used to adjust the margin of the content.
 
 <Preview>
@@ -532,6 +540,7 @@ In order to align text and icons within a submenu a `Box` component will need to
 </Preview>
 
 ### Scrollable submenu
+
 A scrollable submenu can be added using the `ScrollableBlock` component. This can be used for all of the submenu items, or just a selection, as shown in `Menu Itme Four` below.
 Note that only one `ScrollableBlock` can be used within a single submenu.
 
@@ -661,24 +670,22 @@ Note that only one `ScrollableBlock` can be used within a single submenu.
 
 ### Menu
 
-`Menu` extends the `Box` component so it also accepts all `Box` props.
+<StyledSystemProps of={Menu} flexBox layout noHeader />
 
-<Props of={Menu} />
-
-### MenuItem 
+### MenuItem
 
 `MenuItem` extends the `Box` component so it also accepts all `Box` props.
 
 <Props of={MenuItem} />
 
-### SubmenuBlock 
+### SubmenuBlock
 
 <Props of={SubmenuBlock} />
 
-### MenuDivider 
+### MenuDivider
 
 <Props of={MenuDivider} />
 
-### MenuSegmentTitle 
+### MenuSegmentTitle
 
 <Props of={MenuSegmentTitle} />

--- a/src/components/menu/menu.style.js
+++ b/src/components/menu/menu.style.js
@@ -1,4 +1,6 @@
 import styled, { css } from "styled-components";
+import { layout, flexbox } from "styled-system";
+
 import {
   StyledVerticalWrapper,
   StyledDivider,
@@ -6,11 +8,14 @@ import {
 import { baseTheme } from "../../style/themes";
 import Box from "../box";
 
-const StyledMenuWrapper = styled(Box).attrs({ as: "ul" })`
+const StyledMenuWrapper = styled.ul`
   line-height: 40px;
   list-style: none;
   margin: 0;
   padding: 0;
+
+  ${layout}
+  ${flexbox}
 
   ${StyledVerticalWrapper} {
     ${({ menuType, theme }) => css`

--- a/src/components/menu/menu.style.js
+++ b/src/components/menu/menu.style.js
@@ -6,7 +6,6 @@ import {
   StyledDivider,
 } from "../vertical-divider/vertical-divider.style";
 import { baseTheme } from "../../style/themes";
-import Box from "../box";
 
 const StyledMenuWrapper = styled.ul`
   line-height: 40px;
@@ -37,7 +36,10 @@ const StyledMenuWrapper = styled.ul`
   }
 `;
 
-const StyledMenuItem = styled(Box).attrs({ as: "li" })`
+const StyledMenuItem = styled.li`
+  ${layout}
+  ${flexbox}
+  
   ${({ inSubmenu }) => css`
     ${inSubmenu &&
     css`

--- a/src/components/menu/scrollable-block/index.d.ts
+++ b/src/components/menu/scrollable-block/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from "./scrollable-block";
+export * from "./scrollable-block";

--- a/src/components/menu/scrollable-block/scrollable-block.component.js
+++ b/src/components/menu/scrollable-block/scrollable-block.component.js
@@ -4,8 +4,14 @@ import PropTypes from "prop-types";
 import { MenuContext } from "../menu.component";
 import SubmenuContext from "../__internal__/submenu/submenu.context";
 import StyledScrollableBlock from "./scrollable-block.style";
+import Box from "../../box";
 
-const ScrollableBlock = ({ children, variant = "default", ...rest }) => {
+const ScrollableBlock = ({
+  children,
+  height,
+  variant = "default",
+  ...rest
+}) => {
   const menuContext = useContext(MenuContext);
   const submenuContext = useContext(SubmenuContext);
   const { blockIndex, focusIndex, handleKeyDown } = submenuContext;
@@ -15,30 +21,34 @@ const ScrollableBlock = ({ children, variant = "default", ...rest }) => {
       data-component="submenu-scrollable-block"
       menuType={menuContext.menuType}
       variant={variant}
-      overflowY="scroll"
-      p={0}
-      scrollVariant={menuContext.menuType}
       {...rest}
     >
-      {React.Children.map(children, (child, index) => {
-        let isFocused = false;
-        const blockItemFocused = focusIndex >= blockIndex;
+      <Box
+        overflowY="scroll"
+        scrollVariant={menuContext.menuType}
+        height={height}
+        p={0}
+      >
+        {React.Children.map(children, (child, index) => {
+          let isFocused = false;
+          const blockItemFocused = focusIndex >= blockIndex;
 
-        if (blockItemFocused) {
-          isFocused = focusIndex - blockIndex === index;
-        }
+          if (blockItemFocused) {
+            isFocused = focusIndex - blockIndex === index;
+          }
 
-        return (
-          <SubmenuContext.Provider
-            value={{
-              isFocused,
-              handleKeyDown,
-            }}
-          >
-            {child}
-          </SubmenuContext.Provider>
-        );
-      })}
+          return (
+            <SubmenuContext.Provider
+              value={{
+                isFocused,
+                handleKeyDown,
+              }}
+            >
+              {child}
+            </SubmenuContext.Provider>
+          );
+        })}
+      </Box>
     </StyledScrollableBlock>
   );
 };
@@ -46,6 +56,8 @@ const ScrollableBlock = ({ children, variant = "default", ...rest }) => {
 ScrollableBlock.propTypes = {
   /** Children elements */
   children: PropTypes.node.isRequired,
+  /** Styled system height prop */
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** set the colour variant for a menuType */
   variant: PropTypes.oneOf(["default", "alternate"]),
 };

--- a/src/components/menu/scrollable-block/scrollable-block.d.ts
+++ b/src/components/menu/scrollable-block/scrollable-block.d.ts
@@ -1,0 +1,10 @@
+import * as React from "react";
+
+export interface ScrollableBlockProps {
+  children: React.ReactNode;
+  height?: string | number;
+  variant?: "default" | "alternate";
+}
+
+declare const ScrollableBlock: React.ComponentType<ScrollableBlockProps>;
+export default ScrollableBlock;

--- a/src/components/menu/scrollable-block/scrollable-block.style.js
+++ b/src/components/menu/scrollable-block/scrollable-block.style.js
@@ -1,9 +1,8 @@
 import styled, { css } from "styled-components";
 import { baseTheme } from "../../../style/themes";
-import Box from "../../box";
 import StyledMenuItemWrapper from "../menu-item/menu-item.style";
 
-const StyledScrollableBlock = styled(Box)`
+const StyledScrollableBlock = styled.div`
   ${({ menuType, variant, theme }) => css`
     && ${StyledMenuItemWrapper} {
       background-color: ${variant === "default"


### PR DESCRIPTION
### Proposed behaviour
`Menu` 
- Remove extension of `Box`
- Add styled-system flexbox and layout props

`MenuItem` 
- Remove extension of `Box`
- Add styled-system flexbox and layout props

`ScrollableBlock`
- Remove extension of `Box`
- Instead compose `Box` internally and pass only new `height` prop down to it

### Current behaviour
`Menu`, `MenuItem` and `ScrollableBlock` all currently extend `Box`

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
http://localhost:9001/?path=/docs/design-system-menu--default-story

Sandbox for testing `ScrollableBlock`: https://codesandbox.io/s/epic-dew-05zzd