### PR TITLE
feat(popover-container): surface styled system padding props FE-3565

### DIFF
--- a/src/components/popover-container/popover-container.component.js
+++ b/src/components/popover-container/popover-container.component.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import { Transition } from "react-transition-group";
 import {
   PopoverContainerWrapperStyle,
@@ -11,6 +12,11 @@ import {
 } from "./popover-container.style";
 import Icon from "../icon";
 import createGuid from "../../utils/helpers/guid";
+import { filterStyledSystemPaddingProps } from "../../style/utils";
+
+const paddingPropTypes = filterStyledSystemPaddingProps(
+  styledSystemPropTypes.space
+);
 
 const PopoverContainer = ({
   children,
@@ -23,6 +29,7 @@ const PopoverContainer = ({
   renderCloseComponent,
   shouldCoverButton,
   ariaDescribedBy,
+  ...rest
 }) => {
   const isControlled = open !== undefined;
   const [isOpenInternal, setIsOpenInternal] = useState(false);
@@ -92,6 +99,8 @@ const PopoverContainer = ({
             shouldCoverButton={shouldCoverButton}
             aria-labelledby={popoverContainerId}
             aria-describedby={ariaDescribedBy}
+            p="16px 24px"
+            {...filterStyledSystemPaddingProps(rest)}
           >
             <PopoverContainerHeaderStyle>
               <PopoverContainerTitleStyle
@@ -111,6 +120,7 @@ const PopoverContainer = ({
 };
 
 PopoverContainer.propTypes = {
+  ...paddingPropTypes,
   /** A function that will render the open component
    *
    * `({dataElement, tabIndex, onClick, ref, ariaLabel, isOpen}) => ()`

--- a/src/components/popover-container/popover-container.d.ts
+++ b/src/components/popover-container/popover-container.d.ts
@@ -1,8 +1,7 @@
 import * as React from 'react';
+import { AlignBinaryType, PaddingSpacingProps } from '../../utils/helpers/options-helper';
 
-import { AlignBinaryType } from '../../utils/helpers/options-helper/options-helper';
-
-export interface PopoverContainerProps {
+export interface PopoverContainerProps extends PaddingSpacingProps {
   /** The element that will open popover-container */
   renderOpenComponent?: React.ReactNode | Node;
   /** The element that will close popover-container */

--- a/src/components/popover-container/popover-container.spec.js
+++ b/src/components/popover-container/popover-container.spec.js
@@ -14,7 +14,10 @@ import {
 } from "./popover-container.style";
 import StyledIcon from "../icon/icon.style";
 import PopoverContainer from "./popover-container.component";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemPadding,
+} from "../../__spec_helper__/test-utils";
 import { baseTheme } from "../../style/themes";
 import Icon from "../icon";
 import guid from "../../utils/helpers/guid";
@@ -36,6 +39,16 @@ const renderAttached = (props, renderMethod = mount) => {
 };
 
 describe("PopoverContainer", () => {
+  testStyledSystemPadding(
+    (props) => (
+      <PopoverContainer open title="PopoverContainerSettings" {...props}>
+        <div id="myChildren">children</div>
+      </PopoverContainer>
+    ),
+    { p: "16px 24px" },
+    (wrapper) => wrapper.find(PopoverContainerContentStyle)
+  );
+
   jest.useFakeTimers();
   let wrapper;
 

--- a/src/components/popover-container/popover-container.stories.mdx
+++ b/src/components/popover-container/popover-container.stories.mdx
@@ -8,6 +8,7 @@ import Button from '../button';
 import Link from '../link';
 import Pill from '../pill';
 import Badge from '../badge';
+import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
 
 <Meta title="Design System/Popover Container" />
 
@@ -32,10 +33,9 @@ import PopoverContainer from "carbon-react/lib/components/popover-container";
   <Story name="default" parameters={{ info: { disable: true }}} >
     <div style={{height: 100}}>
       <PopoverContainer>
-      Contents
-      </PopoverContainer>
-         
-      </div>
+        Contents
+      </PopoverContainer>      
+    </div>
   </Story>
 </Preview>
 
@@ -262,4 +262,9 @@ You can do it easly in this way:
 ## Props
 
 ### Popover Container
-<Props of={PopoverContainer} />
+
+<StyledSystemProps
+  of={PopoverContainer}
+  padding
+  noHeader
+/>

--- a/src/components/popover-container/popover-container.style.js
+++ b/src/components/popover-container/popover-container.style.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { padding } from "styled-system";
 import { baseTheme } from "../../style/themes";
 import IconButton from "../icon-button";
 import StyledIcon from "../icon/icon.style";
@@ -22,9 +23,10 @@ const PopoverContainerHeaderStyle = styled.div`
 `;
 
 const PopoverContainerContentStyle = styled.div`
+  ${padding}
+
   background: ${({ theme }) => theme.colors.white};
   box-shadow: ${({ theme }) => theme.shadows.depth1};
-  padding: 16px 24px;
   min-width: 300px;
   position: absolute;
   z-index: ${({ theme }) => theme.zIndex.popover};


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Surfaces `styled-system/padding` props on `PopoverContainer` to allow adjustments to the spacing of
its content

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`PopoverContainer` does not support `padding` props

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-7bl6g