### PR TITLE
feat: add styled system margin to Pod and ShowEditPod - FE-3564 - v3

### DIFF
--- a/src/components/pod/pod.component.js
+++ b/src/components/pod/pod.component.js
@@ -1,10 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import I18n from "i18n-js";
+import styledSystemPropTypes from "@styled-system/prop-types";
+
+import { filterStyledSystemMarginProps } from "../../style/utils";
 import Event from "../../utils/helpers/events/events";
 import tagComponent from "../../utils/helpers/tags/tags";
 import PodContext from "./pod-context";
-
 import {
   StyledBlock,
   StyledCollapsibleContent,
@@ -19,6 +21,10 @@ import {
   StyledTitle,
   StyledArrow,
 } from "./pod.style.js";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 class Pod extends React.Component {
   state = {
@@ -46,7 +52,7 @@ class Pod extends React.Component {
       title,
       alignTitle,
       internalEditButton,
-      padding,
+      size,
       subtitle,
     } = this.props;
 
@@ -62,7 +68,7 @@ class Pod extends React.Component {
       <StyledHeader
         alignTitle={alignTitle}
         internalEditButton={internalEditButton}
-        padding={padding}
+        size={size}
         isCollapsed={isCollapsed}
         onClick={isCollapsable ? this.toggleCollapse : undefined}
       >
@@ -70,7 +76,9 @@ class Pod extends React.Component {
         {subtitle && (
           <StyledSubtitle data-element="subtitle">{subtitle}</StyledSubtitle>
         )}
-        {isCollapsable && <StyledArrow isCollapsed={isCollapsed} />}
+        {isCollapsable && (
+          <StyledArrow isCollapsed={isCollapsed} type="dropdown" />
+        )}
       </StyledHeader>
     );
   }
@@ -100,14 +108,14 @@ class Pod extends React.Component {
   }
 
   footer() {
-    const { footer, padding, variant } = this.props;
+    const { footer, size, variant } = this.props;
 
     if (!footer) {
       return null;
     }
 
     return (
-      <StyledFooter data-element="footer" padding={padding} variant={variant}>
+      <StyledFooter data-element="footer" size={size} variant={variant}>
         {footer}
       </StyledFooter>
     );
@@ -118,7 +126,7 @@ class Pod extends React.Component {
       onEdit,
       internalEditButton,
       variant,
-      padding,
+      size,
       border,
       displayEditButtonOnHover,
       triggerEditOnContent,
@@ -144,7 +152,7 @@ class Pod extends React.Component {
           isFocused={isFocused}
           isHovered={isHovered}
           noBorder={!border}
-          padding={padding}
+          size={size}
           variant={variant}
           {...this.linkProps()}
         >
@@ -210,7 +218,7 @@ class Pod extends React.Component {
       editContentFullWidth,
       internalEditButton,
       onEdit,
-      padding,
+      size,
       ...rest
     } = this.props;
 
@@ -237,7 +245,7 @@ class Pod extends React.Component {
             ? { ...this.editEvents(), tabIndex: "0" }
             : {})}
         >
-          <StyledContent data-element="content" padding={padding}>
+          <StyledContent data-element="content" size={size}>
             {this.podHeader()}
             {this.podContent()}
           </StyledContent>
@@ -250,6 +258,7 @@ class Pod extends React.Component {
 }
 
 Pod.propTypes = {
+  ...marginPropTypes,
   /**
    * Enables/disables the border around the pod.
    */
@@ -266,9 +275,9 @@ Pod.propTypes = {
   className: PropTypes.string,
 
   /**
-   * Determines the padding around the pod.
+   * Determines the size of the pod.
    */
-  padding: PropTypes.oneOf([
+  size: PropTypes.oneOf([
     "none",
     "extra-small",
     "small",
@@ -358,7 +367,7 @@ Pod.propTypes = {
 Pod.defaultProps = {
   border: true,
   variant: "primary",
-  padding: "medium",
+  size: "medium",
   alignTitle: "left",
 };
 

--- a/src/components/pod/pod.spec.js
+++ b/src/components/pod/pod.spec.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
 import { css } from "styled-components";
-import "jest-styled-components";
 import TestRenderer from "react-test-renderer";
 
 import Pod from "./pod.component";
@@ -19,7 +18,10 @@ import {
   StyledTitle,
   StyledArrow,
 } from "./pod.style.js";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/test-utils";
 import {
   elementsTagTest,
   rootTagTest,
@@ -35,6 +37,8 @@ describe("Pod", () => {
   beforeEach(() => {
     wrapper = shallow(<Pod />);
   });
+
+  testStyledSystemMargin((props) => <Pod {...props} />);
 
   describe("functionality", () => {
     it("sets the collapsed state same as collapsed prop on mount", () => {
@@ -748,9 +752,9 @@ describe("StyledFooter", () => {
     });
   });
 
-  describe("when padding prop is set", () => {
+  describe("when size prop is set", () => {
     it("should have expected padding", () => {
-      wrapper = renderStyledFooter({ padding: "medium" });
+      wrapper = renderStyledFooter({ size: "medium" });
       assertStyleMatch(
         {
           padding: "10px 15px",
@@ -775,11 +779,11 @@ describe("StyledHeader", () => {
   });
 
   describe("when the internalEditButton prop is set and alignTitle prop is set to right", () => {
-    it("should have expected margin right style dependent on the padding prop", () => {
+    it("should have expected margin right style dependent on the size prop", () => {
       wrapper = renderStyledHeader({
         internalEditButton: true,
         alignTitle: "right",
-        padding: "medium",
+        size: "medium",
       });
       assertStyleMatch(
         {

--- a/src/components/pod/pod.stories.js
+++ b/src/components/pod/pod.stories.js
@@ -21,11 +21,7 @@ export default {
 export const Default = () => {
   const border = boolean("border", Pod.defaultProps.border);
   const children = text("children", "This is some example content for a Pod");
-  const padding = select(
-    "padding",
-    OptionsHelper.sizesPod,
-    Pod.defaultProps.padding
-  );
+  const size = select("size", OptionsHelper.sizesPod, Pod.defaultProps.size);
   const title = text("title", "");
   const subtitle = text("subtitle", "");
   const alignTitle = title
@@ -55,7 +51,7 @@ export const Default = () => {
   return (
     <Pod
       border={border}
-      padding={padding}
+      size={size}
       title={title}
       subtitle={subtitle}
       alignTitle={alignTitle}

--- a/src/components/pod/pod.stories.mdx
+++ b/src/components/pod/pod.stories.mdx
@@ -1,19 +1,20 @@
-import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
-import Pod from './';
-import Heading from '../heading';
-import Button from '../button';
-import {Row, Column} from '../row';
-import PodManager from './pod-manager.component';
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 
-<Meta
-  title="Pod"
-  parameters={{ info: { disable: true }}}
-/>
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import Pod from "./";
+import Heading from "../heading";
+import Button from "../button";
+import { Row, Column } from "../row";
+import PodManager from "./pod-manager.component";
+
+<Meta title="Pod" parameters={{ info: { disable: true } }} />
 
 # Pod
+
 Presents content grouped visually together. This can be text, or other components. A good example is a ‘tile’ showing contact information for an individual.
 
 ## Contents
+
 - [Quick Start](#quick-start)
 - [Related Components](#related-components)
 - [Designer Notes](#designer-notes)
@@ -41,6 +42,7 @@ Choose from various visual options, including padding, borders, and primary, sec
 Set the pod to flex to the width of its content, or take up the full width of its container.
 
 ## Related Components
+
 - Editing a number of closely related inputs? [Try Fieldset](/?path=/docs/design-system-fieldset-address-fieldset-examples--canada "Fieldset").
 - Filling in a broad series of inputs? [Try Form](/?path=/docs/design-system-form--default-with-sticky-footer "Form").
 - Using Fieldset and Pod components together? [Try Show/Edit Pod](/?path=/docs/showeditpod--default-story "Show/Edit Pod").
@@ -51,9 +53,7 @@ Set the pod to flex to the width of its content, or take up the full width of it
 
 <Preview>
   <Story name="default">
-    <Pod title="Title">
-      Content
-    </Pod>
+    <Pod title="Title">Content</Pod>
   </Story>
 </Preview>
 
@@ -63,7 +63,7 @@ Pod accepts collapsed prop which sets the intial state of the Pod and allows it
 to be collapsible. If the prop is not passed the Pod will not be collapsible.
 
 <Preview>
-  <Story name="collapsable" >
+  <Story name="collapsable">
     <Pod title="Title" collapsed>
       Content
     </Pod>
@@ -71,47 +71,48 @@ to be collapsible. If the prop is not passed the Pod will not be collapsible.
 </Preview>
 
 ### PodManager
-If you want to have the same height of the Pods based on the heighest one, use `PodManager` to achieve it.
+
+If you want to have the same height of the Pods based on the highest one, use `PodManager` to achieve it.
 The `PodManager` does not work if `Pod` uses `collapsed` prop
 
 <Preview>
   <Story name="even Height with PodManager">
-    {()=>{
-    return (
-      <PodManager>
-        <Row>
-          <Column>
-            <Pod>
-              <Row>
-                <Column>
-                 <Button>Button 1</Button>
-                </Column>
-              </Row>
-              <Row>
-                <Column>
-                 <Button>Button 2</Button>
-                </Column>
-              </Row>
-            </Pod>
-          </Column>
-          <Column>
-            <Pod>
-              <Button>Button 3</Button>
-            </Pod>
-          </Column>
-        </Row>
-        </PodManager>
-    );
-    }}
+    <PodManager>
+      <Row>
+        <Column>
+          <Pod>
+            <Row>
+              <Column>
+                <Button>Button 1</Button>
+              </Column>
+            </Row>
+            <Row>
+              <Column>
+                <Button>Button 2</Button>
+              </Column>
+            </Row>
+          </Pod>
+        </Column>
+        <Column>
+          <Pod>
+            <Button>Button 3</Button>
+          </Pod>
+        </Column>
+      </Row>
+    </PodManager>
   </Story>
 </Preview>
-
 
 ### With subtitle, description and footer
 
 <Preview>
   <Story name="with subtitle description and footer">
-    <Pod title="Title" subtitle="Subtitle" description="Description" footer="Footer">
+    <Pod
+      title="Title"
+      subtitle="Subtitle"
+      description="Description"
+      footer="Footer"
+    >
       Content
     </Pod>
   </Story>
@@ -121,7 +122,13 @@ The `PodManager` does not work if `Pod` uses `collapsed` prop
 
 <Preview>
   <Story name="without border">
-    <Pod title="Title" subtitle="Subtitle" description="Description" footer="Footer" border={false}>
+    <Pod
+      title="Title"
+      subtitle="Subtitle"
+      description="Description"
+      footer="Footer"
+      border={false}
+    >
       Content
     </Pod>
   </Story>
@@ -130,8 +137,14 @@ The `PodManager` does not work if `Pod` uses `collapsed` prop
 ### With edit button
 
 <Preview>
-  <Story name="with edit button" parameters={{ chromatic: { disable: true }}}>
-    <Pod title="Title" subtitle="Subtitle" description="Description" footer="Footer" onEdit={() => {}}>
+  <Story name="with edit button" parameters={{ chromatic: { disable: true } }}>
+    <Pod
+      title="Title"
+      subtitle="Subtitle"
+      description="Description"
+      footer="Footer"
+      onEdit={() => {}}
+    >
       Content
     </Pod>
   </Story>
@@ -140,7 +153,10 @@ The `PodManager` does not work if `Pod` uses `collapsed` prop
 ### With edit button and displayEditButtonOnHover
 
 <Preview>
-  <Story parameters={{ chromatic: { disable: true }}} name="with displayEditButtonOnHover">
+  <Story
+    parameters={{ chromatic: { disable: true } }}
+    name="with displayEditButtonOnHover"
+  >
     <Pod
       title="Title"
       subtitle="Subtitle"
@@ -192,55 +208,47 @@ The `PodManager` does not work if `Pod` uses `collapsed` prop
 
 <Preview>
   <Story name="with different variants">
-    {() => [
-      'primary',
-      'secondary',
-      'tertiary',
-      'tile',
-      'transparent'
-    ].map(variant =>
-      <>
-        <Pod
-          title="Title"
-          subtitle="Subtitle"
-          description="Description"
-          footer="Footer"
-          onEdit={() => {}}
-          variant={variant}
-        >
-          {variant}
-        </Pod>
-        <div style={{ marginBottom: 24 }}/>
-      </>
-    )}
+    {() =>
+      ["primary", "secondary", "tertiary", "tile", "transparent"].map(
+        (variant) => (
+          <Pod
+            key={variant}
+            title="Title"
+            subtitle="Subtitle"
+            description="Description"
+            footer="Footer"
+            onEdit={() => {}}
+            variant={variant}
+            mb={3}
+          >
+            {variant}
+          </Pod>
+        )
+      )
+    }
   </Story>
 </Preview>
 
-### With different paddings
+### With different sizes
 
 <Preview>
-  <Story name="with different paddings">
-    {() => [
-      'extra-small',
-      'small',
-      'medium',
-      'large',
-      'extra-large'
-    ].map(padding =>
-      <>
+  <Story name="with different sizes">
+    {() =>
+      ["extra-small", "small", "medium", "large", "extra-large"].map((size) => (
         <Pod
+          key={size}
           title="Title"
           subtitle="Subtitle"
           description="Description"
           footer="Footer"
           onEdit={() => {}}
-          padding={padding}
+          size={size}
+          mb={3}
         >
-          {padding}
+          {size}
         </Pod>
-        <div style={{ marginBottom: 24 }}/>
-      </>
-    )}
+      ))
+    }
   </Story>
 </Preview>
 
@@ -248,58 +256,65 @@ The `PodManager` does not work if `Pod` uses `collapsed` prop
 
 <Preview>
   <Story name="with different title alignments">
-    {() => [
-      'left',
-      'center',
-      'right',
-    ].map(alignment =>
-      <>
+    {() =>
+      ["left", "center", "right"].map((alignment) => (
         <Pod
+          key={alignment}
           title="Title"
           subtitle="Subtitle"
           description="Description"
           footer="Footer"
           onEdit={() => {}}
           alignTitle={alignment}
+          mb={3}
         >
           {alignment}
         </Pod>
-        <div style={{ marginBottom: 24 }}/>
-      </>
-    )}
+      ))
+    }
   </Story>
 </Preview>
 
 ### Address pod
+
 <Preview>
   <Story name="address example">
-    <Pod
-      internalEditButton
-      variant='tertiary'
-    >
-      <h5 style={ { margin: 0 } }>Unit 1</h5>
+    <Pod internalEditButton variant="tertiary">
+      <h5 style={{ margin: 0 }}>Unit 1</h5>
       <div>South Nelson Industrial Estate</div>
       <div>Cramlington</div>
       <div>NE23 1WF</div>
       <div>United Kingdom</div>
-      <div style={ { fontWeight: 900, borderTop: '1px solid #ccd6db', marginTop: '15px', paddingTop: '5px' } }>
+      <div
+        style={{
+          fontWeight: 900,
+          borderTop: "1px solid #ccd6db",
+          marginTop: "15px",
+          paddingTop: "5px",
+        }}
+      >
         <Button
-          buttonType='tertiary'
-          size='small'
+          buttonType="tertiary"
+          size="small"
           styleOverride={{
             root: {
               paddingLeft: 0,
-              paddingRight: 0
-            }
+              paddingRight: 0,
+            },
           }}
-        >Select a different address</Button>
+        >
+          Select a different address
+        </Button>
       </div>
-      <div style={ { position: 'absolute', right: '8px', top: '8px' } }>
+      <div style={{ position: "absolute", right: "8px", top: "8px" }}>
         <Button
-          buttonType='tertiary'
-          size='small'
-          iconType='edit'
-          iconPosition='after'>Edit</Button>
+          buttonType="tertiary"
+          size="small"
+          iconType="edit"
+          iconPosition="after"
+        >
+          Edit
+        </Button>
       </div>
     </Pod>
   </Story>
@@ -308,4 +323,5 @@ The `PodManager` does not work if `Pod` uses `collapsed` prop
 ## Props
 
 ### Pod
-<Props of={Pod} />
+
+<StyledSystemProps of={Pod} margin noHeader />

--- a/src/components/pod/pod.style.js
+++ b/src/components/pod/pod.style.js
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
 
 import { baseTheme } from "../../style/themes";
 import Link from "../link";
@@ -11,6 +12,7 @@ const StyledPod = styled.div`
   width: 100%;
   text-align: ${({ alignTitle }) => alignTitle};
   ${({ internalEditButton }) => internalEditButton && "position: relative"};
+  ${margin}
 
   &:focus {
     outline: none;
@@ -88,7 +90,7 @@ const contentPaddings = {
 
 const StyledContent = styled.div`
   text-align: left;
-  padding: ${({ padding }) => contentPaddings[padding]};
+  padding: ${({ size }) => contentPaddings[size]};
 `;
 
 const StyledCollapsibleContent = styled.div``;
@@ -108,7 +110,7 @@ const footerPaddings = {
 };
 
 const StyledFooter = styled.div`
-  ${({ theme, variant, padding }) => css`
+  ${({ theme, variant, size }) => css`
     background-color: ${theme.pod.footerBackground};
     box-shadow: inset 0px 1px 1px 0 rgba(0, 0, 0, 0.1);
     color: ${theme.text.color};
@@ -118,7 +120,7 @@ const StyledFooter = styled.div`
       border-top: 1px solid ${theme.pod.border};
     `};
 
-    padding: ${footerPaddings[padding]};
+    padding: ${footerPaddings[size]};
   `}
 `;
 
@@ -153,7 +155,7 @@ const editBackgrounds = (variant, theme) =>
 const StyledEditAction = styled(Link)`
   ${({
     theme,
-    padding,
+    size,
     variant,
     noBorder,
     isFocused,
@@ -172,7 +174,7 @@ const StyledEditAction = styled(Link)`
       button {
         width: 15px;
         height: 15px;
-        padding: ${editPaddings[padding]}px;
+        padding: ${editPaddings[size]}px;
         background-color: transparent;
       }
 
@@ -205,7 +207,7 @@ const StyledEditAction = styled(Link)`
         border: none;
         > a,
         button {
-          padding: ${editPaddings[padding] +
+          padding: ${editPaddings[size] +
           (noBorder || internalEditButton ? 0 : 1)}px;
         }
       `};
@@ -227,7 +229,7 @@ const headerRightAlignMargins = {
 };
 
 const StyledHeader = styled.div`
-  ${({ alignTitle, internalEditButton, padding, isCollapsed }) => css`
+  ${({ alignTitle, internalEditButton, size, isCollapsed }) => css`
     margin-bottom: 24px;
     text-align: ${alignTitle};
 
@@ -240,7 +242,7 @@ const StyledHeader = styled.div`
     ${alignTitle === "right" &&
     internalEditButton &&
     css`
-      margin-right: ${headerRightAlignMargins[padding]}px;
+      margin-right: ${headerRightAlignMargins[size]}px;
     `};
   `}
 `;

--- a/src/components/show-edit-pod/show-edit-pod.component.js
+++ b/src/components/show-edit-pod/show-edit-pod.component.js
@@ -3,7 +3,9 @@ import PropTypes from "prop-types";
 import I18n from "i18n-js";
 import ReactDOM from "react-dom";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
+import styledSystemPropTypes from "@styled-system/prop-types";
 
+import { filterStyledSystemMarginProps } from "../../style/utils";
 import Pod from "../pod";
 import Form from "../form";
 import Button from "../button";
@@ -12,6 +14,10 @@ import Events from "../../utils/helpers/events";
 import { validProps } from "../../utils/ether";
 import tagComponent from "../../utils/helpers/tags";
 import StyledPod from "./show-edit-pod.style";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 class ShowEditPod extends React.Component {
   state = {
@@ -187,6 +193,7 @@ class ShowEditPod extends React.Component {
 }
 
 ShowEditPod.propTypes = {
+  ...marginPropTypes,
   /** Pod theme variant. */
   variant: PropTypes.string,
   /** Enable/disable the border on the Pod. */

--- a/src/components/show-edit-pod/show-edit-pod.spec.js
+++ b/src/components/show-edit-pod/show-edit-pod.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { mount } from "enzyme";
-import "jest-styled-components";
+
 import ShowEditPod from "./show-edit-pod.component";
 import Form from "../form";
 import Pod from "../pod";
@@ -9,9 +9,12 @@ import {
   elementsTagTest,
   rootTagTest,
 } from "../../utils/helpers/tags/tags-specs";
+import { testStyledSystemMargin } from "../../__spec_helper__/test-utils";
 import StyledDeleteButton from "./delete-button.style";
 
 describe("ShowEditPod", () => {
+  testStyledSystemMargin((props) => <ShowEditPod {...props} />);
+
   describe('when the "editing" prop is set on mount', () => {
     let wrapper;
     let container;

--- a/src/components/show-edit-pod/show-edit-pod.stories.mdx
+++ b/src/components/show-edit-pod/show-edit-pod.stories.mdx
@@ -1,19 +1,19 @@
-import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
-import styled from 'styled-components';
-import ShowEditPod from './';
-import Heading from '../heading';
-import Button from '../button';
-import Content from '../content';
-import Textbox from '../../__experimental__/components/textbox';
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
-<Meta
-  title="ShowEditPod"
-  parameters={{ info: { disable: true }}}
-/>
+import styled from "styled-components";
+import ShowEditPod from "./";
+import Heading from "../heading";
+import Button from "../button";
+import Content from "../content";
+import Textbox from "../../__experimental__/components/textbox";
+
+<Meta title="ShowEditPod" parameters={{ info: { disable: true } }} />
 
 # ShowEditPod
 
 ## Contents
+
 - [Quick Start](#quick-start)
 - [Designer Notes](#designer-notes)
 - [Related Components](#related-components)
@@ -21,11 +21,13 @@ import Textbox from '../../__experimental__/components/textbox';
 - [Props](#props)
 
 ## Quick Start
+
 ```javascript
 import ShowEditPod from "carbon-react/lib/components/show-edit-pod";
 ```
 
 ## Designer Notes
+
 Nest any Carbon input into this component.
 
 Configure Pod and Fieldset components to work together, or choose this pre-configured Show/Edit Pod component.
@@ -67,17 +69,9 @@ More guidance is available for each of the individual inputs you might place ins
       saveText="Save"
       deleteText="Delete"
       cancelText="Cancel"
-      editFields={
-        <Textbox
-          label="Field"
-          labelInline
-          labelAlign='right'
-        />
-      }
+      editFields={<Textbox label="Field" labelInline labelAlign="right" />}
     >
-      <Content title="Content title">
-        Content
-      </Content>
+      <Content title="Content title">Content</Content>
     </ShowEditPod>
   </Story>
 </Preview>
@@ -86,9 +80,10 @@ More guidance is available for each of the individual inputs you might place ins
 
 <Preview>
   <Story name="buttons alignment">
-    {() => ['left', 'right'].map(buttonAlign =>
-      <>
+    {() =>
+      ["left", "right"].map((buttonAlign) => (
         <ShowEditPod
+          key={buttonAlign}
           title={buttonAlign}
           editing={true}
           onDelete={() => {}}
@@ -96,21 +91,13 @@ More guidance is available for each of the individual inputs you might place ins
           deleteText="Delete"
           cancelText="Cancel"
           buttonAlign={buttonAlign}
-          editFields={
-            <Textbox
-              label="Field"
-              labelInline
-              labelAlign='right'
-            />
-          }
+          editFields={<Textbox label="Field" labelInline labelAlign="right" />}
+          mb={3}
         >
-          <Content title="Content title">
-            Content
-          </Content>
+          <Content title="Content title">Content</Content>
         </ShowEditPod>
-        <div style={{ marginBottom: 24 }}/>
-      </>
-    )}
+      ))
+    }
   </Story>
 </Preview>
 
@@ -126,17 +113,9 @@ More guidance is available for each of the individual inputs you might place ins
       deleteText="Delete"
       cancelText="Cancel"
       border
-      editFields={
-        <Textbox
-          label="Field"
-          labelInline
-          labelAlign='right'
-        />
-      }
+      editFields={<Textbox label="Field" labelInline labelAlign="right" />}
     >
-      <Content title="Content title">
-        Content
-      </Content>
+      <Content title="Content title">Content</Content>
     </ShowEditPod>
   </Story>
 </Preview>
@@ -145,44 +124,35 @@ More guidance is available for each of the individual inputs you might place ins
 
 <Preview>
   <Story name="various variants">
-    {() => [
-      'primary',
-      'secondary',
-      'tertiary',
-      'tile',
-      'transparent'
-    ].map(variant =>
-      <>
-        <ShowEditPod
-          title={variant}
-          onEdit={() => {}}
-          onDelete={() => {}}
-          saveText="Save"
-          deleteText="Delete"
-          cancelText="Cancel"
-          variant={variant}
-          editFields={
-            <Textbox
-              label="Field"
-              labelInline
-              labelAlign='right'
-            />
-          }
-        >
-          <Content title="Content title">
-            Content
-          </Content>
-        </ShowEditPod>
-        <div style={{ marginBottom: 24 }}/>
-      </>
-    )}
+    {() =>
+      ["primary", "secondary", "tertiary", "tile", "transparent"].map(
+        (variant) => (
+          <ShowEditPod
+            key={variant}
+            title={variant}
+            onEdit={() => {}}
+            onDelete={() => {}}
+            saveText="Save"
+            deleteText="Delete"
+            cancelText="Cancel"
+            variant={variant}
+            editFields={
+              <Textbox label="Field" labelInline labelAlign="right" />
+            }
+            mb={3}
+          >
+            <Content title="Content title">Content</Content>
+          </ShowEditPod>
+        )
+      )
+    }
   </Story>
 </Preview>
 
 ### Custom transition
 
 <Preview>
-  <Story name="custom transition" parameters={{ chromatic: { disable: true }}}>
+  <Story name="custom transition" parameters={{ chromatic: { disable: true } }}>
     {() => {
       const StyledContainer = styled.div`
         .custom-transition-name-enter {
@@ -203,7 +173,7 @@ More guidance is available for each of the individual inputs you might place ins
           opacity: 0;
           position: absolute;
         }
-        `
+      `;
       return (
         <StyledContainer>
           <ShowEditPod
@@ -215,19 +185,13 @@ More guidance is available for each of the individual inputs you might place ins
             cancelText="Cancel"
             transitionName="custom-transition-name"
             editFields={
-              <Textbox
-                label="Field"
-                labelInline
-                labelAlign='right'
-              />
+              <Textbox label="Field" labelInline labelAlign="right" />
             }
           >
-            <Content title="Content title">
-              Content
-            </Content>
+            <Content title="Content title">Content</Content>
           </ShowEditPod>
         </StyledContainer>
-      )
+      );
     }}
   </Story>
 </Preview>
@@ -235,4 +199,5 @@ More guidance is available for each of the individual inputs you might place ins
 ## Props
 
 ### Show Edit Pod
-<Props of={ShowEditPod} />
+
+<StyledSystemProps of={ShowEditPod} margin noHeader />


### PR DESCRIPTION
### Proposed behaviour
This PR add margin styled system props support to Pod and ShowEditPod

This PR also implements a breaking change where `padding` prop on mentioned components is changed to `size` prop

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-g83u1?file=/src/index.js
