### PR TITLE
feat(split-button): surface styled system margin props

### DIFF
--- a/src/components/split-button/__snapshots__/split-button.spec.js.snap
+++ b/src/components/split-button/__snapshots__/split-button.spec.js.snap
@@ -119,6 +119,76 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   margin: -1px;
 }
 
+.c7 > .c1 {
+  margin: 0;
+}
+
+.c7 > .c1:focus {
+  border: 3px solid #FFB500;
+  outline: none;
+  margin: -1px;
+}
+
+.c8 > .c1 {
+  margin: 0;
+}
+
+.c8 > .c1:focus {
+  border: 3px solid #FFB500;
+  outline: none;
+  margin: -1px;
+}
+
+.c9 > .c1 {
+  margin: 0;
+}
+
+.c9 > .c1:focus {
+  border: 3px solid #FFB500;
+  outline: none;
+  margin: -1px;
+}
+
+.c10 > .c1 {
+  margin: 0;
+}
+
+.c10 > .c1:focus {
+  border: 3px solid #FFB500;
+  outline: none;
+  margin: -1px;
+}
+
+.c11 > .c1 {
+  margin: 0;
+}
+
+.c11 > .c1:focus {
+  border: 3px solid #FFB500;
+  outline: none;
+  margin: -1px;
+}
+
+.c12 > .c1 {
+  margin: 0;
+}
+
+.c12 > .c1:focus {
+  border: 3px solid #FFB500;
+  outline: none;
+  margin: -1px;
+}
+
+.c13 > .c1 {
+  margin: 0;
+}
+
+.c13 > .c1:focus {
+  border: 3px solid #FFB500;
+  outline: none;
+  margin: -1px;
+}
+
 .c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -193,39 +263,39 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   margin-left: 0;
 }
 
-.c7:hover .c4 {
+.c14:hover .c4 {
   color: #FFFFFF;
 }
 
-.c7 .c4 {
+.c14 .c4 {
   margin-left: 0px;
   margin-right: 0px;
   margin-bottom: 0px;
   height: 16px;
 }
 
-.c7 .c4 svg {
+.c14 .c4 svg {
   margin-top: 0;
 }
 
-.c7,
-.c7 .c4 {
+.c14,
+.c14 .c4 {
   color: #FFFFFF;
 }
 
-.c1 + .c7 {
+.c1 + .c14 {
   margin-left: 0;
 }
 
-.c1 + .c7:focus {
+.c1 + .c14:focus {
   margin-left: -3px;
 }
 
-.c1 + .c7 .c4 {
+.c1 + .c14 .c4 {
   margin-left: 0;
 }
 
-.c8 .c1 {
+.c15 .c1 {
   background-color: #006300;
   border: 1px solid #006300;
   color: #FFFFFF;
@@ -238,16 +308,16 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   z-index: 1000;
 }
 
-.c8 .c1:focus,
-.c8 .c1:hover {
+.c15 .c1:focus,
+.c15 .c1:hover {
   background-color: #004500;
 }
 
-.c8 .c1 + .c11 .c1 {
+.c15 .c1 + .c18 .c1 {
   margin-top: 3px;
 }
 
-.c9 .c1 {
+.c16 .c1 {
   background-color: #006046;
   border: 1px solid #006046;
   color: #FFFFFF;
@@ -259,16 +329,16 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   z-index: 1000;
 }
 
-.c9 .c1:focus,
-.c9 .c1:hover {
+.c16 .c1:focus,
+.c16 .c1:hover {
   background-color: #00402E;
 }
 
-.c9 .c1 + .c11 .c1 {
+.c16 .c1 + .c18 .c1 {
   margin-top: 3px;
 }
 
-.c10 .c1 {
+.c17 .c1 {
   background-color: #005C9A;
   border: 1px solid #005C9A;
   color: #FFFFFF;
@@ -280,12 +350,12 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
   z-index: 1000;
 }
 
-.c10 .c1:focus,
-.c10 .c1:hover {
+.c17 .c1:focus,
+.c17 .c1:hover {
   background-color: #004472;
 }
 
-.c10 .c1 + .c11 .c1 {
+.c17 .c1 + .c18 .c1 {
   margin-top: 3px;
 }
 

--- a/src/components/split-button/split-button.component.js
+++ b/src/components/split-button/split-button.component.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import Icon from "../icon";
 import Button, { ButtonWithForwardRef } from "../button";
 import StyledSplitButton from "./split-button.style";
@@ -9,6 +10,11 @@ import { validProps } from "../../utils/ether/ether";
 import Events from "../../utils/helpers/events";
 import guid from "../../utils/helpers/guid";
 import Popover from "../../__internal__/popover";
+import { filterStyledSystemMarginProps } from "../../style/utils";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 const CONTENT_WIDTH_RATIO = 0.75;
 
@@ -239,6 +245,7 @@ class SplitButton extends Component {
         onMouseLeave={this.hideButtons}
         ref={this.splitButtonNode}
         {...this.componentTags()}
+        {...filterStyledSystemMarginProps(this.props)}
       >
         {this.renderMainButton}
         {this.renderAdditionalButtons}
@@ -248,6 +255,7 @@ class SplitButton extends Component {
 }
 
 SplitButton.propTypes = {
+  ...marginPropTypes,
   /** Button type: "primary" | "secondary" */
   buttonType: PropTypes.oneOf(["primary", "secondary"]),
   /** Button type: "primary" | "secondary" for legacy theme */

--- a/src/components/split-button/split-button.component.js
+++ b/src/components/split-button/split-button.component.js
@@ -6,7 +6,6 @@ import Button, { ButtonWithForwardRef } from "../button";
 import StyledSplitButton from "./split-button.style";
 import StyledSplitButtonToggle from "./split-button-toggle.style";
 import StyledSplitButtonChildrenContainer from "./split-button-children.style";
-import { validProps } from "../../utils/ether/ether";
 import Events from "../../utils/helpers/events";
 import guid from "../../utils/helpers/guid";
 import Popover from "../../__internal__/popover";
@@ -105,13 +104,29 @@ class SplitButton extends Component {
   };
 
   get mainButtonProps() {
-    const { ...props } = validProps(this);
-    props.onMouseEnter = this.hideButtons;
-    props.onFocus = this.hideButtons;
-    props.onTouchStart = this.hideButtons;
-    props.iconPosition = this.props.iconPosition;
+    const {
+      as,
+      buttonType,
+      disabled,
+      iconType,
+      onClick,
+      size,
+      subtext,
+    } = this.props;
 
-    return props;
+    return {
+      onMouseEnter: this.hideButtons,
+      onFocus: this.hideButtons,
+      onTouchStart: this.hideButtons,
+      iconPosition: this.props.iconPosition,
+      as,
+      buttonType,
+      disabled,
+      iconType,
+      onClick,
+      size,
+      subtext,
+    };
   }
 
   get toggleButtonProps() {

--- a/src/components/split-button/split-button.spec.js
+++ b/src/components/split-button/split-button.spec.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
 import TestRenderer from "react-test-renderer";
+
 import { ThemeProvider } from "styled-components";
 import SplitButton from "./split-button.component";
 import StyledSplitButtonToggle from "./split-button-toggle.style";
@@ -14,8 +15,11 @@ import {
 } from "../../utils/helpers/tags/tags-specs";
 import SmallTheme from "../../style/themes/small";
 import MediumTheme from "../../style/themes/medium";
-import { assertStyleMatch, keyboard } from "../../__spec_helper__/test-utils";
-import "jest-styled-components";
+import {
+  assertStyleMatch,
+  keyboard,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/test-utils";
 import guid from "../../utils/helpers/guid";
 
 jest.mock("../../utils/helpers/guid");
@@ -120,6 +124,12 @@ const buildSizeConfig = (name, size) => {
 
 describe("SplitButton", () => {
   let wrapper, toggle;
+
+  testStyledSystemMargin((props) => (
+    <SplitButton text="Test" {...props}>
+      <Button>Test</Button>
+    </SplitButton>
+  ));
 
   describe("render with custom className", () => {
     beforeEach(() => {

--- a/src/components/split-button/split-button.stories.mdx
+++ b/src/components/split-button/split-button.stories.mdx
@@ -4,6 +4,7 @@ import SplitButton from ".";
 import Button from "../button";
 import Box from "../box";
 import { Accordion } from "../accordion";
+import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
 
 <Meta title="Split Button" parameters={{ info: { disable: true } }} />
 
@@ -163,7 +164,11 @@ Subtext only works when `size` is `large`
 
 ### SplitButton
 
-<Props of={SplitButton} />
+<StyledSystemProps
+  of={SplitButton}
+  margin
+  noHeader
+/>
 
 ### Button
 

--- a/src/components/split-button/split-button.style.js
+++ b/src/components/split-button/split-button.style.js
@@ -1,8 +1,11 @@
 import styled from "styled-components";
+import { margin } from "styled-system";
 import StyledButton from "../button/button.style";
 import baseTheme from "../../style/themes/base";
 
 const StyledSplitButton = styled.div`
+  ${margin}
+
   display: inline-block;
   position: relative;
 


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Surfaces `styled-system/margin` props to allow consumers to adjust spacing of `SplitButton`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`SplitButton` does not support margin props

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-38b9d?file=/src/index.js