### PR TITLE
refactor(flat-table): update styled system implementation

### DIFF
--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FlatTable when rendered with proper table data should have expected structure and styles 1`] = `
-.c9 {
+.c10 {
   background-color: transparent;
   border-width: 0;
   border-bottom: 1px solid #CCD6DB;
@@ -20,35 +20,12 @@ exports[`FlatTable when rendered with proper table data should have expected str
   padding: 0;
 }
 
-.c9:first-child {
+.c10:first-child {
   padding-left: 1px;
 }
 
-.c9 > div {
+.c10.c10.c10 > div {
   box-sizing: border-box;
-}
-
-.c11 {
-  background-color: #fff;
-  border-width: 0;
-  border-bottom: 1px solid #CCD6DB;
-  text-overflow: ellipsis;
-  text-align: left;
-  vertical-align: middle;
-  white-space: nowrap;
-  padding: 0;
-}
-
-.c11 > div {
-  box-sizing: border-box;
-}
-
-.c11:first-of-type {
-  border-left: 1px solid #CCD6DB;
-}
-
-.c11:last-of-type {
-  border-right: 1px solid #CCD6DB;
 }
 
 .c12 {
@@ -62,7 +39,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
   padding: 0;
 }
 
-.c12 > div {
+.c12.c12.c12 > div {
   box-sizing: border-box;
 }
 
@@ -74,11 +51,34 @@ exports[`FlatTable when rendered with proper table data should have expected str
   border-right: 1px solid #CCD6DB;
 }
 
-.c12:first-of-type + .c10 {
+.c13 {
+  background-color: #fff;
+  border-width: 0;
+  border-bottom: 1px solid #CCD6DB;
+  text-overflow: ellipsis;
+  text-align: left;
+  vertical-align: middle;
+  white-space: nowrap;
+  padding: 0;
+}
+
+.c13.c13.c13 > div {
+  box-sizing: border-box;
+}
+
+.c13:first-of-type {
   border-left: 1px solid #CCD6DB;
 }
 
-.c7 {
+.c13:last-of-type {
+  border-right: 1px solid #CCD6DB;
+}
+
+.c13:first-of-type + .c11 {
+  border-left: 1px solid #CCD6DB;
+}
+
+.c8 {
   background-color: #fff;
   border: 1px solid #CCD6DB;
   border-top: none;
@@ -94,7 +94,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
   padding: 0;
 }
 
-.c7 > div {
+.c8.c8.c8 > div {
   box-sizing: border-box;
   padding-top: 10px;
   padding-bottom: 10px;
@@ -102,11 +102,11 @@ exports[`FlatTable when rendered with proper table data should have expected str
   padding-right: 24px;
 }
 
-.c7.c7.c7 {
+.c8.c8.c8 {
   left: 0px;
 }
 
-.c5 {
+.c6 {
   border-collapse: separate;
   border-radius: 0px;
   border-spacing: 0;
@@ -115,8 +115,8 @@ exports[`FlatTable when rendered with proper table data should have expected str
   width: auto;
 }
 
-.c3 .c6,
-.c3 .c13 {
+.c4 .c7,
+.c4 .c14 {
   border-left: none;
   border-right: none;
   font-weight: 700;
@@ -125,7 +125,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
   z-index: 1000;
 }
 
-.c1 {
+.c2 {
   border-collapse: separate;
   border-radius: 0px;
   border-spacing: 0;
@@ -133,13 +133,13 @@ exports[`FlatTable when rendered with proper table data should have expected str
   width: 100%;
 }
 
-.c1 .c4 {
+.c2 .c5 {
   height: 40px;
 }
 
-.c1 .c10 > div,
-.c1 .c8 > div,
-.c1 .c6 > div {
+.c2 .c11 > div,
+.c2 .c9 > div,
+.c2 .c7 > div {
   font-size: 14px;
   padding-left: 11px;
   padding-right: 11px;
@@ -149,140 +149,148 @@ exports[`FlatTable when rendered with proper table data should have expected str
   height: 100%;
 }
 
-.c0 .c2 .c13,
-.c0 .c8,
-.c0 .c2 .c6 {
+.c1 {
+  height: 100%;
+}
+
+.c1 .c3 .c14,
+.c1 .c9,
+.c1 .c3 .c7 {
   background-color: #335C6D;
   border-right: 1px solid #668592;
   color: #FFFFFF;
 }
 
 <div
-  className=""
+  className="c0"
 >
   <div
-    className="c0"
+    className=""
   >
-    <table
+    <div
       className="c1"
-      data-component="flat-table"
-      size="medium"
     >
-      <thead
-        className="c2 c3"
+      <table
+        className="c2"
+        data-component="flat-table"
+        size="medium"
       >
-        <tr
-          className="c4 c5"
-          data-element="flat-table-row"
-          onClick={[Function]}
+        <thead
+          className="c3 c4"
         >
-          <th
-            className="c6 c7"
-            data-element="flat-table-row-header"
+          <tr
+            className="c5 c6"
+            data-element="flat-table-row"
+            onClick={[Function]}
           >
-            <div>
-              row header
-            </div>
-          </th>
-          <th
-            className="c8 c9"
-            data-element="flat-table-header"
-          >
-            <div>
-              header1
-            </div>
-          </th>
-          <th
-            className="c8 c9"
-            data-element="flat-table-header"
-          >
-            <div>
-              header2
-            </div>
-          </th>
-          <th
-            className="c8 c9"
-            data-element="flat-table-header"
-          >
-            <div>
-              header3
-            </div>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          className="c4 c5"
-          data-element="flat-table-row"
-          onClick={[Function]}
-        >
-          <th
-            className="c6 c7"
-            data-element="flat-table-row-header"
-          >
-            <div>
-              row header
-            </div>
-          </th>
-          <td
-            className="c10 c11"
-            data-element="flat-table-cell"
-          >
-            <div
-              className=""
+            <th
+              className="c7 c8"
+              data-element="flat-table-row-header"
             >
-              cell1
-            </div>
-          </td>
-          <td
-            className="c10 c11"
-            data-element="flat-table-cell"
-          >
-            <div
-              className=""
+              <div>
+                row header
+              </div>
+            </th>
+            <th
+              className="c9 c10"
+              data-element="flat-table-header"
             >
-              cell2
-            </div>
-          </td>
-          <td
-            className="c10 c12"
-            data-element="flat-table-cell"
-            rowSpan="2"
-          >
-            <div
-              className=""
+              <div>
+                header1
+              </div>
+            </th>
+            <th
+              className="c9 c10"
+              data-element="flat-table-header"
             >
-              cell3
-            </div>
-          </td>
-        </tr>
-        <tr
-          className="c4 c5"
-          data-element="flat-table-row"
-          onClick={[Function]}
-        >
-          <th
-            className="c6 c7"
-            data-element="flat-table-row-header"
-          >
-            <div>
-              row header
-            </div>
-          </th>
-          <td
-            className="c10 c11"
-            colSpan="2"
-            data-element="flat-table-cell"
-          >
-            <div
-              className=""
+              <div>
+                header2
+              </div>
+            </th>
+            <th
+              className="c9 c10"
+              data-element="flat-table-header"
             >
-              cell1
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+              <div>
+                header3
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            className="c5 c6"
+            data-element="flat-table-row"
+            onClick={[Function]}
+          >
+            <th
+              className="c7 c8"
+              data-element="flat-table-row-header"
+            >
+              <div>
+                row header
+              </div>
+            </th>
+            <td
+              className="c11 c12"
+              data-element="flat-table-cell"
+            >
+              <div
+                className=""
+              >
+                cell1
+              </div>
+            </td>
+            <td
+              className="c11 c12"
+              data-element="flat-table-cell"
+            >
+              <div
+                className=""
+              >
+                cell2
+              </div>
+            </td>
+            <td
+              className="c11 c13"
+              data-element="flat-table-cell"
+              rowSpan="2"
+            >
+              <div
+                className=""
+              >
+                cell3
+              </div>
+            </td>
+          </tr>
+          <tr
+            className="c5 c6"
+            data-element="flat-table-row"
+            onClick={[Function]}
+          >
+            <th
+              className="c7 c8"
+              data-element="flat-table-row-header"
+            >
+              <div>
+                row header
+              </div>
+            </th>
+            <td
+              className="c11 c12"
+              colSpan="2"
+              data-element="flat-table-cell"
+            >
+              <div
+                className=""
+              >
+                cell1
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
@@ -1,12 +1,17 @@
 import React, { useLayoutEffect, useRef } from "react";
 import PropTypes from "prop-types";
-import propTypes from "@styled-system/prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 
 import {
   StyledFlatTableCell,
   StyledCellContent,
 } from "./flat-table-cell.style";
+import { filterStyledSystemPaddingProps } from "../../../style/utils";
 import Icon from "../../icon";
+
+const paddingPropTypes = filterStyledSystemPaddingProps(
+  styledSystemPropTypes.space
+);
 
 const FlatTableCell = ({
   align,
@@ -56,8 +61,8 @@ const FlatTableCell = ({
 };
 
 FlatTableCell.propTypes = {
-  /** Styled system spacing props */
-  ...propTypes.space,
+  /** Styled system padding props */
+  ...paddingPropTypes,
   /** Content alignment */
   align: PropTypes.oneOf(["center", "left", "right"]),
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.d.ts
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { SpacingProps } from '../../../utils/helpers/options-helper';
+import { PaddingSpacingProps } from '../../../utils/helpers/options-helper';
 
-export interface FlatTableCellProps extends SpacingProps {
+export interface FlatTableCellProps extends PaddingSpacingProps {
   /** Content alignment */
   align?: 'center' | 'left' | 'right';
   children?: React.ReactNode | string;

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
@@ -1,5 +1,5 @@
 import styled, { css } from "styled-components";
-import { space } from "styled-system";
+import { padding } from "styled-system";
 
 import baseTheme from "../../../style/themes/base";
 
@@ -14,9 +14,9 @@ const StyledFlatTableCell = styled.td`
     white-space: nowrap;
     padding: 0;
 
-    > div {
+    &&& > div {
       box-sizing: border-box;
-      ${space}
+      ${padding}
     }
 
     &:first-of-type {

--- a/src/components/flat-table/flat-table-header/flat-table-header.component.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.component.js
@@ -1,8 +1,13 @@
 import React, { useLayoutEffect, useRef } from "react";
 import PropTypes from "prop-types";
-import propTypes from "@styled-system/prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 
 import StyledFlatTableHeader from "./flat-table-header.style";
+import { filterStyledSystemPaddingProps } from "../../../style/utils";
+
+const paddingPropTypes = filterStyledSystemPaddingProps(
+  styledSystemPropTypes.space
+);
 
 const FlatTableHeader = ({
   align,
@@ -45,8 +50,8 @@ const FlatTableHeader = ({
 };
 
 FlatTableHeader.propTypes = {
-  /** Styled system spacing props */
-  ...propTypes.space,
+  /** Styled system padding props */
+  ...paddingPropTypes,
   /** Content alignment */
   align: PropTypes.oneOf(["center", "left", "right"]),
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),

--- a/src/components/flat-table/flat-table-header/flat-table-header.d.ts
+++ b/src/components/flat-table/flat-table-header/flat-table-header.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { SpacingProps } from '../../../utils/helpers/options-helper';
+import { PaddingSpacingProps } from '../../../utils/helpers/options-helper';
 
-export interface FlatTableHeaderProps extends SpacingProps {
+export interface FlatTableHeaderProps extends PaddingSpacingProps {
   /** Content alignment */
   align?: 'center' | 'left' | 'right';
   children?: React.ReactNode | string;

--- a/src/components/flat-table/flat-table-header/flat-table-header.spec.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.spec.js
@@ -19,7 +19,7 @@ describe("FlatTableHeader", () => {
         width: "40px",
       },
       wrapper.find(StyledFlatTableHeader),
-      { modifier: " > div" }
+      { modifier: "&&& > div" }
     );
   });
 });

--- a/src/components/flat-table/flat-table-header/flat-table-header.style.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.style.js
@@ -1,5 +1,5 @@
 import styled, { css } from "styled-components";
-import { space } from "styled-system";
+import { padding } from "styled-system";
 
 import baseTheme from "../../../style/themes/base";
 
@@ -28,9 +28,9 @@ const StyledFlatTableHeader = styled.th`
       padding-left: 1px;
     }
 
-    > div {
+    &&& > div {
       box-sizing: border-box;
-      ${space}
+      ${padding}
       ${colWidth &&
       css`
         width: ${colWidth}px;

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
@@ -1,9 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
-import propTypes from "@styled-system/prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 
 import StyledFlatTableRowHeader from "./flat-table-row-header.style";
+import { filterStyledSystemPaddingProps } from "../../../style/utils";
 import Icon from "../../icon";
+
+const paddingPropTypes = filterStyledSystemPaddingProps(
+  styledSystemPropTypes.space
+);
 
 const FlatTableRowHeader = ({
   align,
@@ -39,8 +44,8 @@ const FlatTableRowHeader = ({
 };
 
 FlatTableRowHeader.propTypes = {
-  /** Styled system spacing props */
-  ...propTypes.space,
+  /** Styled system padding props */
+  ...paddingPropTypes,
   /** Content alignment */
   align: PropTypes.oneOf(["center", "left", "right"]),
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.d.ts
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { SpacingProps } from '../../../utils/helpers/options-helper';
+import { PaddingSpacingProps } from '../../../utils/helpers/options-helper';
 
-export interface FlatTableRowHeaderProps extends SpacingProps {
+export interface FlatTableRowHeaderProps extends PaddingSpacingProps {
   /** Content alignment */
   align?: string;
   children?: React.ReactNode | string;

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.spec.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.spec.js
@@ -5,16 +5,16 @@ import StyledFlatTableRowHeader from "./flat-table-row-header.style";
 import FlatTableRowHeader from "./flat-table-row-header.component";
 import {
   assertStyleMatch,
-  testStyledSystemSpacing,
+  testStyledSystemPadding,
 } from "../../../__spec_helper__/test-utils";
 import StyledIcon from "../../icon/icon.style";
 
 describe("FlatTableRowHeader", () => {
-  testStyledSystemSpacing(
+  testStyledSystemPadding(
     (props) => <FlatTableRowHeader {...props} />,
     { py: "10px", px: 3 },
     null,
-    { modifier: " > div" }
+    { modifier: "&&& > div" }
   );
 
   it("renders with proper width style rule when width prop is passed", () => {
@@ -31,7 +31,7 @@ describe("FlatTableRowHeader", () => {
         width: "40px",
       },
       wrapper.find(StyledFlatTableRowHeader),
-      { modifier: " > div" }
+      { modifier: "&&& > div" }
     );
   });
 

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.js
@@ -1,5 +1,5 @@
 import styled, { css } from "styled-components";
-import { space } from "styled-system";
+import { padding } from "styled-system";
 
 import baseTheme from "../../../style/themes/base";
 
@@ -22,13 +22,13 @@ const StyledFlatTableRowHeader = styled.th`
       width: ${colWidth}px;
     `}
 
-    > div {
+    &&& > div {
       box-sizing: border-box;
       ${colWidth &&
       css`
         width: ${colWidth}px;
       `}
-      ${space}
+      ${padding}
     }
 
     &&& {

--- a/src/components/flat-table/flat-table-row/__snapshots__/flat-table-row.spec.js.snap
+++ b/src/components/flat-table/flat-table-row/__snapshots__/flat-table-row.spec.js.snap
@@ -12,7 +12,7 @@ exports[`FlatTableRow should have expected styles 1`] = `
   padding: 0;
 }
 
-.c1 > div {
+.c1.c1.c1 > div {
   box-sizing: border-box;
 }
 

--- a/src/components/flat-table/flat-table.component.js
+++ b/src/components/flat-table/flat-table.component.js
@@ -1,14 +1,20 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import {
+  StyledFlatTableRoot,
   StyledFlatTableWrapper,
   StyledFlatTable,
   StyledFlatTableFooter,
 } from "./flat-table.style";
 import { SidebarContext } from "../drawer";
 import Box from "../box";
+import { filterStyledSystemMarginProps } from "../../style/utils";
 
 export const FlatTableThemeContext = React.createContext({});
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 const FlatTable = ({
   caption,
@@ -37,9 +43,8 @@ const FlatTable = ({
   return (
     <SidebarContext.Consumer>
       {(context) => (
-        <>
+        <StyledFlatTableRoot {...props}>
           <Box
-            {...props}
             {...((hasStickyHead || hasStickyFooter) && { overflowY: "auto" })}
             height={addDefaultHeight ? "100%" : height}
           >
@@ -65,13 +70,14 @@ const FlatTable = ({
               {footer}
             </StyledFlatTableFooter>
           )}
-        </>
+        </StyledFlatTableRoot>
       )}
     </SidebarContext.Consumer>
   );
 };
 
 FlatTable.propTypes = {
+  ...marginPropTypes,
   /** The HTML id of the element that contains a description of this table. */
   ariaDescribedby: PropTypes.string,
   /** A string to render as the table's caption */

--- a/src/components/flat-table/flat-table.d.ts
+++ b/src/components/flat-table/flat-table.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-
-export interface FlatTableProps {
+import { MarginSpacingProps } from '../../utils/helpers/options-helper';
+export interface FlatTableProps extends MarginSpacingProps {
   /** The HTML id of the element that contains a description of this table. */
   ariaDescribedby?: string;
   /** A string to render as the table's caption */

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -8,7 +8,10 @@ import FlatTableRow from "./flat-table-row/flat-table-row.component";
 import FlatTableHeader from "./flat-table-header/flat-table-header.component";
 import FlatTableCell from "./flat-table-cell/flat-table-cell.component";
 import FlatTableRowHeader from "./flat-table-row-header/flat-table-row-header.component";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/test-utils";
 import StyledFlatTableHeader from "./flat-table-header/flat-table-header.style";
 import StyledFlatTableHead from "./flat-table-head/flat-table-head.style";
 import StyledFlatTableRowHeader from "./flat-table-row-header/flat-table-row-header.style";
@@ -23,7 +26,33 @@ import { SidebarContext } from "../drawer";
 import { StyledFlatTableCell } from "./flat-table-cell/flat-table-cell.style";
 import StyledFlatTableRow from "./flat-table-row/flat-table-row.style";
 import OptionsHelper from "../../utils/helpers/options-helper/options-helper";
+import Box from "../box";
 import cellSizes from "./cell-sizes.style";
+
+const RenderComponent = (props) => (
+  <FlatTable {...props}>
+    <FlatTableHead>
+      <FlatTableRow>
+        <FlatTableRowHeader>row header</FlatTableRowHeader>
+        <FlatTableHeader>header1</FlatTableHeader>
+        <FlatTableHeader>header2</FlatTableHeader>
+        <FlatTableHeader>header3</FlatTableHeader>
+      </FlatTableRow>
+    </FlatTableHead>
+    <FlatTableBody>
+      <FlatTableRow>
+        <FlatTableRowHeader>row header</FlatTableRowHeader>
+        <FlatTableCell>cell1</FlatTableCell>
+        <FlatTableCell>cell2</FlatTableCell>
+        <FlatTableCell rowspan="2">cell3</FlatTableCell>
+      </FlatTableRow>
+      <FlatTableRow>
+        <FlatTableRowHeader>row header</FlatTableRowHeader>
+        <FlatTableCell colspan="2">cell1</FlatTableCell>
+      </FlatTableRow>
+    </FlatTableBody>
+  </FlatTable>
+);
 
 describe("FlatTable", () => {
   it("ariaDescribedby prop should have been propagated to the table", () => {
@@ -55,7 +84,7 @@ describe("FlatTable", () => {
     });
 
     it("should have the overflow-y css property set to to auto", () => {
-      expect(wrapper).toHaveStyleRule("overflow-y", "auto");
+      expect(wrapper.find(Box)).toHaveStyleRule("overflow-y", "auto");
     });
 
     it('then all Headers should have proper styling if `colorTheme="dark"`', () => {
@@ -262,31 +291,12 @@ describe("FlatTable", () => {
       );
     });
   });
+
+  describe("styled system", () => {
+    testStyledSystemMargin(RenderComponent);
+  });
 });
 
 function renderFlatTable(props = {}, renderer = TestRenderer.create) {
-  return renderer(
-    <FlatTable {...props}>
-      <FlatTableHead>
-        <FlatTableRow>
-          <FlatTableRowHeader>row header</FlatTableRowHeader>
-          <FlatTableHeader>header1</FlatTableHeader>
-          <FlatTableHeader>header2</FlatTableHeader>
-          <FlatTableHeader>header3</FlatTableHeader>
-        </FlatTableRow>
-      </FlatTableHead>
-      <FlatTableBody>
-        <FlatTableRow>
-          <FlatTableRowHeader>row header</FlatTableRowHeader>
-          <FlatTableCell>cell1</FlatTableCell>
-          <FlatTableCell>cell2</FlatTableCell>
-          <FlatTableCell rowspan="2">cell3</FlatTableCell>
-        </FlatTableRow>
-        <FlatTableRow>
-          <FlatTableRowHeader>row header</FlatTableRowHeader>
-          <FlatTableCell colspan="2">cell1</FlatTableCell>
-        </FlatTableRow>
-      </FlatTableBody>
-    </FlatTable>
-  );
+  return renderer(<RenderComponent {...props} />);
 }

--- a/src/components/flat-table/flat-table.style.js
+++ b/src/components/flat-table/flat-table.style.js
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
 import StyledFlatTableHeader from "./flat-table-header/flat-table-header.style";
 import StyledFlatTableRow from "./flat-table-row/flat-table-row.style";
 import StyledFlatTableRowHeader from "./flat-table-row-header/flat-table-row-header.style";
@@ -69,6 +70,15 @@ const StyledFlatTable = styled.table`
 StyledFlatTable.defaultProps = {
   theme: baseTheme,
   size: "medium",
+};
+
+const StyledFlatTableRoot = styled.div`
+  ${margin};
+  height: 100%;
+`;
+
+StyledFlatTableRoot.defaultProps = {
+  theme: baseTheme,
 };
 
 const StyledFlatTableWrapper = styled.div`
@@ -169,4 +179,9 @@ StyledFlatTableFooter.defaultProps = {
   theme: baseTheme,
 };
 
-export { StyledFlatTableWrapper, StyledFlatTable, StyledFlatTableFooter };
+export {
+  StyledFlatTableRoot,
+  StyledFlatTableWrapper,
+  StyledFlatTable,
+  StyledFlatTableFooter,
+};


### PR DESCRIPTION
BREAKING CHANGE: FlatTable uses margin. FlatTableCell FlatTableHeader FlatTableRowHeader use padding

### Proposed behaviour
`@styled-system/space` margin only (remove padding - breaking change).
Filter styled system margin props.

### Current behaviour
Uses no filtered `propTypes.space`.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-uc7mp