### PR TITLE
feat(settings-row): add support for styled system margin props FE-3572

### DIFF
--- a/src/components/settings-row/settings-row.component.js
+++ b/src/components/settings-row/settings-row.component.js
@@ -1,13 +1,19 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import Heading from "../heading";
 import tagComponent from "../../utils/helpers/tags";
+import { filterStyledSystemMarginProps } from "../../style/utils";
 
 import {
   StyledSettingsRow,
   StyledSettingsRowHeader,
   StyledSettingsRowInput,
 } from "./settings-row.style";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 const SettingsRow = ({
   title,
@@ -35,6 +41,8 @@ const SettingsRow = ({
       className={className}
       hasDivider={divider}
       {...tagComponent("settings-row", rest)}
+      m={0}
+      {...filterStyledSystemMarginProps(rest)}
     >
       <StyledSettingsRowHeader>{heading()}</StyledSettingsRowHeader>
       <StyledSettingsRowInput>{children}</StyledSettingsRowInput>
@@ -43,6 +51,7 @@ const SettingsRow = ({
 };
 
 SettingsRow.propTypes = {
+  ...marginPropTypes,
   /**  This component supports children. */
   children: PropTypes.node,
   /**  The CSS classes to apply to the component. */

--- a/src/components/settings-row/settings-row.spec.js
+++ b/src/components/settings-row/settings-row.spec.js
@@ -9,10 +9,15 @@ import {
 } from "./settings-row.style";
 import Heading from "../heading";
 import { rootTagTest } from "../../utils/helpers/tags/tags-specs";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/test-utils";
 import baseTheme from "../../style/themes/base";
 
 describe("SettingsRow", () => {
+  testStyledSystemMargin((props) => <SettingsRow {...props} />, { m: "0" });
+
   describe("render", () => {
     const name = "foobar-row";
     const title = "Some Title";

--- a/src/components/settings-row/settings-row.stories.mdx
+++ b/src/components/settings-row/settings-row.stories.mdx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
 
 import SettingsRow from ".";
 
@@ -45,4 +46,9 @@ All `children` are rendered in the input column to the right of the header colum
 ## Props
 
 ### Settings Row 
-<Props of={SettingsRow} />
+
+<StyledSystemProps
+  of={SettingsRow}
+  margin
+  noHeader
+/>

--- a/src/components/settings-row/settings-row.style.js
+++ b/src/components/settings-row/settings-row.style.js
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
 import baseTheme from "../../style/themes/base";
 import {
   StyledHeader,
@@ -7,12 +8,13 @@ import {
 } from "../heading/heading.style";
 
 export const StyledSettingsRow = styled.div`
+  ${margin}
+
   clear: both;
   color: ${({ theme }) => theme.palette.slateTint(20)};
   display: flex;
   font-size: 14px;
   justify-content: space-between;
-  margin: 0;
   padding: 0;
   position: relative;
 


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Surfaces `styled-system/margin` props on `SettingsRow` component

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
--> 
`styled-system/margin` props not surfaced on `SettingsRow` component

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
`d.ts` file will be added as part of work to update definitions throughout carbon

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-k1755