### PR TITLE
feat(portrait): add styled-system margin - FE-3566

### DIFF
--- a/src/components/portrait/portrait-gravatar.component.js
+++ b/src/components/portrait/portrait-gravatar.component.js
@@ -1,10 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import MD5 from "crypto-js/md5";
 import { StyledPortraitGravatar } from "./portrait.style";
 import sizeParams from "./portrait-size.config";
 import OptionsHelper from "../../utils/helpers/options-helper";
 
+import { filterStyledSystemMarginProps } from "../../style/utils";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 class PortraitGravatar extends React.Component {
   /** Generates the Gravatar URL for the specified email address and dimensions. */
   gravatarSrc() {
@@ -36,6 +42,7 @@ class PortraitGravatar extends React.Component {
 }
 
 PortraitGravatar.propTypes = {
+  ...marginPropTypes,
   /** The theme to use. */
   theme: PropTypes.object,
   /** The user's email address for the Gravatar. */

--- a/src/components/portrait/portrait-initials.component.js
+++ b/src/components/portrait/portrait-initials.component.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import { withTheme } from "styled-components";
 import sizeParams from "./portrait-size.config";
 import BaseTheme from "../../style/themes/base";
@@ -10,6 +11,12 @@ import {
   StyledPortraitInitialsImg,
   getColorsForInitials,
 } from "./portrait.style";
+
+import { filterStyledSystemMarginProps } from "../../style/utils";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 class PortraitInitials extends React.Component {
   /** Cache of the initials graphic. */
@@ -111,6 +118,7 @@ class PortraitInitials extends React.Component {
 }
 
 PortraitInitials.propTypes = {
+  ...marginPropTypes,
   /** The theme to use. */
   theme: PropTypes.object,
   /** The user's initials to render. */

--- a/src/components/portrait/portrait.component.js
+++ b/src/components/portrait/portrait.component.js
@@ -1,11 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
-
+import styledSystemPropTypes from "@styled-system/prop-types";
 import tagComponent from "../../utils/helpers/tags";
 import PortraitGravatar from "./portrait-gravatar.component";
 import PortraitInitials from "./portrait-initials.component";
 import { StyledCustomImg, StyledIcon } from "./portrait.style";
 
+import { filterStyledSystemMarginProps } from "../../style/utils";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 class Portrait extends React.Component {
   state = {
     externalError: false,
@@ -19,6 +24,10 @@ class Portrait extends React.Component {
     if (relevantPropsChanged) {
       this.setState({ externalError: false }); // eslint-disable-line react/no-did-update-set-state
     }
+  }
+
+  getMarginProps() {
+    return filterStyledSystemMarginProps(this.props);
   }
 
   externalImageLoadFailed() {
@@ -47,6 +56,7 @@ class Portrait extends React.Component {
           alt={alt}
           errorCallback={() => this.externalImageLoadFailed()}
           {...tagProps}
+          {...this.getMarginProps()}
         />
       );
     }
@@ -61,6 +71,7 @@ class Portrait extends React.Component {
           data-element="user-image"
           onError={() => this.externalImageLoadFailed()}
           {...tagProps}
+          {...this.getMarginProps()}
         />
       );
     }
@@ -74,6 +85,7 @@ class Portrait extends React.Component {
           darkBackground={darkBackground}
           alt={alt}
           {...tagProps}
+          {...this.getMarginProps()}
         />
       );
     }
@@ -85,12 +97,14 @@ class Portrait extends React.Component {
         shape={shape}
         darkBackground={darkBackground}
         {...tagProps}
+        {...this.getMarginProps()}
       />
     );
   }
 }
 
 Portrait.propTypes = {
+  ...marginPropTypes,
   /** The size of the Portrait. */
   size: PropTypes.oneOf(["XS", "S", "M", "ML", "L", "XL", "XXL"]),
   /** A custom image URL. */

--- a/src/components/portrait/portrait.spec.js
+++ b/src/components/portrait/portrait.spec.js
@@ -10,6 +10,7 @@ import { rootTagTest } from "../../utils/helpers/tags/tags-specs";
 import { StyledIcon, StyledCustomImg } from "./portrait.style";
 import PortraitInitials from "./portrait-initials.component";
 import PortraitGravatar from "./portrait-gravatar.component";
+import { testStyledSystemMargin } from "../../__spec_helper__/test-utils";
 
 const mockCanvasDataURL = "data:image/png";
 
@@ -351,5 +352,9 @@ describe("PortraitComponent", () => {
         rendered.root.findAllByProps({ "data-element": "user-image" }).length
       ).toBeGreaterThan(0);
     });
+  });
+
+  describe("styled-system", () => {
+    testStyledSystemMargin((props) => <Portrait {...props} />);
   });
 });

--- a/src/components/portrait/portrait.stories.mdx
+++ b/src/components/portrait/portrait.stories.mdx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
-
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import Portrait from ".";
 
 <Meta
@@ -96,7 +96,21 @@ Portrait also supports `gravatar`, to use it simply pass your email address regi
   </Story>
 </Preview>
 
+### With margin
+Margins can be applied to the `portrait` component using styled-system. 
+To see a full list of available margin props, please visit the props table at the bottom of this page.
+
+[Vist Props Table](#props)
+<Preview>
+  <Story name="with margin">
+    <Portrait m={3} />
+    <Portrait darkBackground m={2} />
+    <Portrait shape="circle" m="25px"/>
+    <Portrait size="L" m="30px" />
+  </Story>
+</Preview>
+
 ## Props
 
 ### Portrait
-<Props of={Portrait} />
+<StyledSystemProps of={Portrait} noHeader margin />

--- a/src/components/portrait/portrait.style.js
+++ b/src/components/portrait/portrait.style.js
@@ -1,6 +1,7 @@
 import React from "react";
 import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
+import { margin } from "styled-system";
 import sizeParams from "./portrait-size.config";
 import BaseTheme from "../../style/themes/base";
 import Icon from "../icon";
@@ -80,6 +81,8 @@ export const StyledPortraitInitials = styled.div`
     css`
       border: 1px solid ${theme.portrait.border};
     `}
+    
+  ${margin}
 `;
 
 StyledPortraitInitials.propTypes = {
@@ -95,6 +98,8 @@ StyledPortraitInitials.defaultProps = {
 
 export const StyledPortraitInitialsImg = styled.img`
   display: block;
+
+  ${margin}
 `;
 
 StyledPortraitInitialsImg.propTypes = {
@@ -107,6 +112,8 @@ export const StyledPortraitGravatar = styled.img`
   vertical-align: middle;
   ${stylingForSize}
   ${stylingForShape}
+
+  ${margin}
 `;
 
 StyledPortraitGravatar.propTypes = {
@@ -124,6 +131,8 @@ export const StyledCustomImg = styled.img`
   display: block;
   ${stylingForSize}
   ${stylingForShape}
+
+  ${margin}
 `;
 
 StyledCustomImg.propTypes = {
@@ -148,6 +157,8 @@ export const StyledIcon = styled(({ darkBackground, ...rest }) => (
         border: 1px dashed ${theme.portrait.border};
       `}
   }
+
+  ${margin}
 `;
 
 StyledIcon.propTypes = {


### PR DESCRIPTION
### Proposed behaviour
Add styled-system margin to `portrait` component

### Current behaviour
Styled-system is not available to use on this component

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
<del> - [ ] Screenshots are included in the PR if useful </del>
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
<del> - [ ] Cypress automation tests added or updated if required </del>
- [x] Storybook added or updated if required
<del> - [ ] Typescript `d.ts` file added or updated if required </del>
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
https://codesandbox.io/s/adoring-lake-ke74p
