### PR TITLE
fix(day-picker): fix bottom of focus border is cut off by the date picker

### DIFF
--- a/src/__experimental__/components/input/__snapshots__/input.spec.js.snap
+++ b/src/__experimental__/components/input/__snapshots__/input.spec.js.snap
@@ -12,6 +12,7 @@ exports[`Input renders with an input 1`] = `
   font-size: 14px;
   outline: none;
   padding: 0;
+  margin: 0;
   width: 30px;
 }
 

--- a/src/__experimental__/components/input/input.style.js
+++ b/src/__experimental__/components/input/input.style.js
@@ -10,6 +10,7 @@ const StyledInput = styled.input`
   font-size: ${({ theme }) => theme.text.size};
   outline: none;
   padding: 0;
+  margin: 0;
   width: 30px;
 
   &:-webkit-autofill {

--- a/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
+++ b/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
@@ -165,6 +165,7 @@ exports[`SimpleColorPicker renders as expected 1`] = `
   font-size: 14px;
   outline: none;
   padding: 0;
+  margin: 0;
   width: 30px;
 }
 

--- a/src/__experimental__/components/textarea/__snapshots__/textarea.spec.js.snap
+++ b/src/__experimental__/components/textarea/__snapshots__/textarea.spec.js.snap
@@ -12,6 +12,7 @@ exports[`Textarea when rendered should render default 1`] = `
   font-size: 14px;
   outline: none;
   padding: 0;
+  margin: 0;
   width: 30px;
 }
 


### PR DESCRIPTION
### Proposed behaviour
Set the input margin value to avoid automatic margin setting by the browser.

### Current behaviour
When the date input is brought into focus in either the Date Input or Date Picker the date picker covers the bottom part of the focus outline border. This occurs in Safari only.

### Checklist

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-fmezl?file=/src/index.js
