### PR TITLE
feat(step-sequence): add styled system margin props to StepSequence - FE-3576

### DIFF
--- a/src/components/step-sequence/step-sequence.component.js
+++ b/src/components/step-sequence/step-sequence.component.js
@@ -1,7 +1,14 @@
 import PropTypes from "prop-types";
 import React from "react";
+import styledSystemPropTypes from "@styled-system/prop-types";
+
 import StepSequenceStyle from "./step-sequence.style";
 import OptionsHelper from "../../utils/helpers/options-helper";
+import { filterStyledSystemMarginProps } from "../../style/utils";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 const StepSequence = (props) => {
   return (
@@ -21,6 +28,7 @@ const StepSequence = (props) => {
 };
 
 StepSequence.propTypes = {
+  ...marginPropTypes,
   /** Step sequence items to be rendered */
   children: PropTypes.node,
   /** The direction that step sequence items should be rendered */

--- a/src/components/step-sequence/step-sequence.spec.js
+++ b/src/components/step-sequence/step-sequence.spec.js
@@ -1,9 +1,9 @@
 import React from "react";
-// import { shallow } from 'enzyme';
 import TestRenderer from "react-test-renderer";
 import StepSequence from "./step-sequence.component";
 import StepSequenceItem from "./step-sequence-item/step-sequence-item.component";
 import mintTheme from "../../style/themes/mint";
+import { testStyledSystemMargin } from "../../__spec_helper__/test-utils";
 
 describe("StepSequence", () => {
   const wrapper = (props) =>
@@ -29,5 +29,13 @@ describe("StepSequence", () => {
     expect(
       wrapper({ theme: mintTheme, orientation: "vertical" })
     ).toMatchSnapshot();
+  });
+
+  describe("styled system", () => {
+    testStyledSystemMargin((props) => (
+      <StepSequence {...props}>
+        <div>test</div>
+      </StepSequence>
+    ));
   });
 });

--- a/src/components/step-sequence/step-sequence.stories.mdx
+++ b/src/components/step-sequence/step-sequence.stories.mdx
@@ -1,10 +1,8 @@
-import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
-import { StepSequence, StepSequenceItem } from './';
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import { StepSequence, StepSequenceItem } from "./";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
-<Meta
-  title="Step Sequence"
-  parameters={{ info: { disable: true }}}
-/>
+<Meta title="Step Sequence" parameters={{ info: { disable: true } }} />
 
 # StepSequence
 
@@ -17,6 +15,7 @@ Try to keep label text for each step as short as possible.
 For users on small screens or instances where horizontal space is limited, use the vertical version of this component.
 
 ## Contents
+
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
@@ -24,8 +23,12 @@ For users on small screens or instances where horizontal space is limited, use t
 ## Quick Start
 
 ```javascript
-import { StepSequence, StepSequenceItem } from "carbon-react/lib/components/step-sequence";
+import {
+  StepSequence,
+  StepSequenceItem,
+} from "carbon-react/lib/components/step-sequence";
 ```
+
 ## Examples
 
 ### Default
@@ -34,47 +37,47 @@ import { StepSequence, StepSequenceItem } from "carbon-react/lib/components/step
   <Story name="default">
     <StepSequence>
       <StepSequenceItem
-        aria-label='Step 1 of 5'
-        hiddenCompleteLabel='Complete'
-        hiddenCurrentLabel='Current'
-        indicator='1'
-        status='complete'
+        aria-label="Step 1 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="1"
+        status="complete"
       >
         Name
       </StepSequenceItem>
       <StepSequenceItem
-        aria-label='Step 2 of 5'
-        hiddenCompleteLabel='Complete'
-        hiddenCurrentLabel='Current'
-        indicator='2'
-        status='complete'
+        aria-label="Step 2 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="2"
+        status="complete"
       >
         Delivery Address
       </StepSequenceItem>
       <StepSequenceItem
-        aria-label='Step 3 of 5'
-        hiddenCompleteLabel='Complete'
-        hiddenCurrentLabel='Current'
-        indicator='3'
-        status='current'
+        aria-label="Step 3 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="3"
+        status="current"
       >
         Delivery Details
       </StepSequenceItem>
       <StepSequenceItem
-        aria-label='Step 4 of 5'
-        hiddenCompleteLabel='Complete'
-        hiddenCurrentLabel='Current'
-        indicator='4'
-        status='incomplete'
+        aria-label="Step 4 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="4"
+        status="incomplete"
       >
         Payment
       </StepSequenceItem>
       <StepSequenceItem
-        aria-label='Step 5 of 5'
-        hiddenCompleteLabel='Complete'
-        hiddenCurrentLabel='Current'
-        indicator='5'
-        status='incomplete'
+        aria-label="Step 5 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="5"
+        status="incomplete"
       >
         Confirm
       </StepSequenceItem>
@@ -88,47 +91,47 @@ import { StepSequence, StepSequenceItem } from "carbon-react/lib/components/step
   <Story name="vertical">
     <StepSequence orientation="vertical">
       <StepSequenceItem
-        aria-label='Step 1 of 5'
-        hiddenCompleteLabel='Complete'
-        hiddenCurrentLabel='Current'
-        indicator='1'
-        status='complete'
+        aria-label="Step 1 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="1"
+        status="complete"
       >
         Name
       </StepSequenceItem>
       <StepSequenceItem
-        aria-label='Step 2 of 5'
-        hiddenCompleteLabel='Complete'
-        hiddenCurrentLabel='Current'
-        indicator='2'
-        status='complete'
+        aria-label="Step 2 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="2"
+        status="complete"
       >
         Delivery Address
       </StepSequenceItem>
       <StepSequenceItem
-        aria-label='Step 3 of 5'
-        hiddenCompleteLabel='Complete'
-        hiddenCurrentLabel='Current'
-        indicator='3'
-        status='current'
+        aria-label="Step 3 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="3"
+        status="current"
       >
         Delivery Details
       </StepSequenceItem>
       <StepSequenceItem
-        aria-label='Step 4 of 5'
-        hiddenCompleteLabel='Complete'
-        hiddenCurrentLabel='Current'
-        indicator='4'
-        status='incomplete'
+        aria-label="Step 4 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="4"
+        status="incomplete"
       >
         Payment
       </StepSequenceItem>
       <StepSequenceItem
-        aria-label='Step 5 of 5'
-        hiddenCompleteLabel='Complete'
-        hiddenCurrentLabel='Current'
-        indicator='5'
-        status='incomplete'
+        aria-label="Step 5 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="5"
+        status="incomplete"
       >
         Confirm
       </StepSequenceItem>
@@ -139,7 +142,9 @@ import { StepSequence, StepSequenceItem } from "carbon-react/lib/components/step
 ## Props
 
 ### StepSequence
-<Props of={StepSequence} />
+
+<StyledSystemProps of={StepSequence} margin noHeader />
 
 ### StepSequenceItem
+
 <Props of={StepSequenceItem} />

--- a/src/components/step-sequence/step-sequence.style.js
+++ b/src/components/step-sequence/step-sequence.style.js
@@ -1,4 +1,6 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
+import { baseTheme } from "../../style/themes";
 
 const StepSequenceStyle = styled.ol`
   display: flex;
@@ -12,6 +14,11 @@ const StepSequenceStyle = styled.ol`
       flex-direction: column;
       padding: 0;
     `};
+  ${margin}
 `;
+
+StepSequenceStyle.defaultProps = {
+  theme: baseTheme,
+};
 
 export default StepSequenceStyle;


### PR DESCRIPTION
### Proposed behaviour
StepSequence has margin styled system props available to use.

### Current behaviour
No styled system props for StepSequence.
### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [] <del>Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [x] Unit tests added or updated if required
- [ ]  <del>Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ]  <del>Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent
