### PR TITLE
refactor(multi-step-wizard): add deprecation warning - FE-4011

### DIFF
--- a/src/components/multi-step-wizard/multi-step-wizard.js
+++ b/src/components/multi-step-wizard/multi-step-wizard.js
@@ -5,6 +5,7 @@ import {
   StyledMultiStepWizard,
   StyledMultiStepWizardContent,
 } from "./multi-step-wizard.style";
+import Logger from "../../utils/logger/logger";
 
 /**
  * A MultiStepWizard widget.
@@ -60,7 +61,19 @@ import {
  * @class MultiStepWizard
  * @constructor
  */
+let deprecatedWarnTriggered = false;
 class MultiStepWizard extends React.Component {
+  constructor(props) {
+    super(props);
+    if (!deprecatedWarnTriggered) {
+      deprecatedWarnTriggered = true;
+      // eslint-disable-next-line max-len
+      Logger.deprecate(
+        "`Multi Step Wizard` component is deprecated and will soon be removed. Please use Step Sequence instead."
+      );
+    }
+  }
+
   static propTypes = {
     /**
      * Individual steps

--- a/src/components/multi-step-wizard/multi-step-wizard.stories.mdx
+++ b/src/components/multi-step-wizard/multi-step-wizard.stories.mdx
@@ -1,12 +1,17 @@
 import { useState } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
-
+import DeprecationWarning from '../../__internal__/DeprecationWarning';
+import LinkTo from '@storybook/addon-links/react';
 import MultiStepWizard from "./multi-step-wizard";
 
 <Meta
   title="Test/Multi Step Wizard"
   parameters={{ info: { disable: true }, chromatic: { disable: true }}}
 />
+
+<DeprecationWarning>
+  Multi Step Wizard is due to be deprecated. Please use the <LinkTo kind='step-sequence' story='default'>Step Sequence</LinkTo> component in place of Multi Step Wizard.
+</DeprecationWarning>
 
 ### Default
 


### PR DESCRIPTION
deprecation warning added to console and MDX example

### Proposed behaviour
Add deprecation warning to `Multi Step Wizard` component
<img width="1092" alt="Screenshot 2021-04-14 at 15 54 55" src="https://user-images.githubusercontent.com/56251247/114731571-c5133880-9d39-11eb-8415-753a75610d15.png">

<img width="836" alt="Screenshot 2021-04-14 at 15 55 29" src="https://user-images.githubusercontent.com/56251247/114731674-d8260880-9d39-11eb-9da1-22128b608959.png">

### Current behaviour
Component currently has no deprecation warning

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
<del> - [ ] All themes are supported if required </del>
<del> - [ ] Unit tests added or updated if required </del>
<del> - [ ] Cypress automation tests added or updated if required </del>
- [x] Storybook added or updated if required
<del> - [ ] Typescript `d.ts` file added or updated if required </del>
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
- Visit Multi Step Wizard story on Storybook
- Story should have a deprecation warning at the top of the page (as per `Proposed behaviour` screenshot)
- Console warning should also be present (as per `Proposed behaviour` screenshot)