### PR TITLE
fix(flat-table): fix an alignment gap between the colapse icon and the text

### DIFF
--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -180,7 +180,9 @@ exports[`FlatTable when rendered with proper table data should have expected str
             className="c7 c8"
             data-element="flat-table-row-header"
           >
-            <div>
+            <div
+              className=""
+            >
               row header
             </div>
           </th>
@@ -220,7 +222,9 @@ exports[`FlatTable when rendered with proper table data should have expected str
             className="c7 c8"
             data-element="flat-table-row-header"
           >
-            <div>
+            <div
+              className=""
+            >
               row header
             </div>
           </th>
@@ -265,7 +269,9 @@ exports[`FlatTable when rendered with proper table data should have expected str
             className="c7 c8"
             data-element="flat-table-row-header"
           >
-            <div>
+            <div
+              className=""
+            >
               row header
             </div>
           </th>

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
@@ -81,6 +81,7 @@ const StyledCellContent = styled.div`
     css`
       display: flex;
       align-items: center;
+      line-height: 1em;
     `}
 `;
 

--- a/src/components/flat-table/flat-table-head/flat-table-head.style.js
+++ b/src/components/flat-table/flat-table-head/flat-table-head.style.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import baseTheme from "../../../style/themes/base";
-import StyledFlatTableRowHeader from "../flat-table-row-header/flat-table-row-header.style";
+import { StyledFlatTableRowHeader } from "../flat-table-row-header/flat-table-row-header.style";
 import StyledFlatTableCheckbox from "../flat-table-checkbox/flat-table-checkbox.style";
 
 const StyledFlatTableHead = styled.thead`

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
@@ -2,7 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import propTypes from "@styled-system/prop-types";
 
-import StyledFlatTableRowHeader from "./flat-table-row-header.style";
+import {
+  StyledFlatTableRowHeader,
+  StyledFlatTableRowHeaderContent,
+} from "./flat-table-row-header.style";
 import Icon from "../../icon";
 
 const FlatTableRowHeader = ({
@@ -34,14 +37,15 @@ const FlatTableRowHeader = ({
       expandable={expandable}
       {...rest}
     >
-      <div
+      <StyledFlatTableRowHeaderContent
         title={
           truncate && !title && typeof children === "string" ? children : title
         }
+        expandable={expandable}
       >
         {expandable && <Icon type="chevron_down_thick" />}
         {children}
-      </div>
+      </StyledFlatTableRowHeaderContent>
     </StyledFlatTableRowHeader>
   );
 };

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.spec.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.spec.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { mount } from "enzyme";
 
-import StyledFlatTableRowHeader from "./flat-table-row-header.style";
+import { StyledFlatTableRowHeader } from "./flat-table-row-header.style";
 import FlatTableRowHeader from "./flat-table-row-header.component";
 import {
   assertStyleMatch,

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.js
@@ -57,4 +57,18 @@ StyledFlatTableRowHeader.defaultProps = {
   theme: baseTheme,
 };
 
-export default StyledFlatTableRowHeader;
+const StyledFlatTableRowHeaderContent = styled.div`
+  ${({ expandable }) =>
+    expandable &&
+    css`
+      display: flex;
+      align-items: center;
+      line-height: 1em;
+    `}
+`;
+
+StyledFlatTableRowHeaderContent.defaultProps = {
+  theme: baseTheme,
+};
+
+export { StyledFlatTableRowHeader, StyledFlatTableRowHeaderContent };

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -8,7 +8,7 @@ import FlatTableCell from "../flat-table-cell/flat-table-cell.component";
 import StyledFlatTableRow from "./flat-table-row.style";
 import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
 import { baseTheme } from "../../../style/themes";
-import StyledFlatTableRowHeader from "../flat-table-row-header/flat-table-row-header.style";
+import { StyledFlatTableRowHeader } from "../flat-table-row-header/flat-table-row-header.style";
 import { StyledFlatTableCell } from "../flat-table-cell/flat-table-cell.style";
 import StyledFlatTableHeader from "../flat-table-header/flat-table-header.style";
 import StyledFlatTableCheckbox from "../flat-table-checkbox/flat-table-checkbox.style";

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.js
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 import { baseTheme } from "../../../style/themes";
 import { StyledFlatTableCell } from "../flat-table-cell/flat-table-cell.style";
-import StyledFlatTableRowHeader from "../flat-table-row-header/flat-table-row-header.style";
+import { StyledFlatTableRowHeader } from "../flat-table-row-header/flat-table-row-header.style";
 import StyledFlatTableCheckbox from "../flat-table-checkbox/flat-table-checkbox.style";
 import StyledFlatTableHeader from "../flat-table-header/flat-table-header.style";
 import StyledIcon from "../../icon/icon.style";

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -11,7 +11,7 @@ import FlatTableRowHeader from "./flat-table-row-header/flat-table-row-header.co
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import StyledFlatTableHeader from "./flat-table-header/flat-table-header.style";
 import StyledFlatTableHead from "./flat-table-head/flat-table-head.style";
-import StyledFlatTableRowHeader from "./flat-table-row-header/flat-table-row-header.style";
+import { StyledFlatTableRowHeader } from "./flat-table-row-header/flat-table-row-header.style";
 import StyledFlatTableCheckbox from "./flat-table-checkbox/flat-table-checkbox.style";
 import {
   StyledFlatTable,

--- a/src/components/flat-table/flat-table.style.js
+++ b/src/components/flat-table/flat-table.style.js
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 import StyledFlatTableHeader from "./flat-table-header/flat-table-header.style";
 import StyledFlatTableRow from "./flat-table-row/flat-table-row.style";
-import StyledFlatTableRowHeader from "./flat-table-row-header/flat-table-row-header.style";
+import { StyledFlatTableRowHeader } from "./flat-table-row-header/flat-table-row-header.style";
 import StyledFlatTableHead from "./flat-table-head/flat-table-head.style";
 import StyledFlatTableCheckbox from "./flat-table-checkbox/flat-table-checkbox.style";
 import { baseTheme } from "../../style/themes";


### PR DESCRIPTION
### Proposed behaviour
Set `text-align: 1em` of the wrappers.

![Zrzut ekranu 2021-04-14 o 17 46 02](https://user-images.githubusercontent.com/77274590/114743371-eb8e9f00-9d4c-11eb-8a89-7739afe527cf.png)


### Current behaviour
There is an alignment gap between the "colapse" icon and the folder name if we configure the expand only on the first column.
![issue](https://user-images.githubusercontent.com/77274590/114744173-b33b9080-9d4d-11eb-8380-0c59659853d5.png)

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
Fixes: #3887

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-8qwsf?file=/src/index.js
<!-- How can a reviewer test this PR? -->
