### PR TITLE
fix(flat-table-row): add support for controlling expanded rows externally FE-4007

### DIFF
--- a/cypress/features/regression/designSystem/flatTable.feature
+++ b/cypress/features/regression/designSystem/flatTable.feature
@@ -245,3 +245,17 @@ Feature: Design Systems FlatTable component
       And I press "Enter" onto focused element
     Then 1 row is visible
       And Pagination input should have 1 value
+  
+  @positive
+  Scenario: You can collapse all rows by clicking on Collapse All
+    Given I open "Design System Flat Table Expandable" component page "controlled" in no iframe
+    When I click "Collapse All" button on preview 
+    Then The subrows are not visible
+
+  @positive 
+  Scenario: You can expand all rows by clicking on Expand All
+    Given I open "Design System Flat Table Expandable" component page "controlled" in no iframe
+      And I click "Collapse All" button on preview
+      And I wait 100
+    When I click "Expand All" button on preview
+    Then The subrows are visible

--- a/cypress/features/regression/dialogFullScreen.feature
+++ b/cypress/features/regression/dialogFullScreen.feature
@@ -61,9 +61,9 @@ Feature: Dialog Full Screen component
   @positive
   Scenario: Verify that nested dialog is closed by pressing Esc key
     Given I open nested "Dialog Full Screen Test" component in noIFrame with "dialogFullScreen" json from "commonComponents" using "default" object name
-      And I "Open Main Dialog" button on preview
+      And I click "Open Main Dialog" button on preview
       And I wait 500
-      And I "Open Nested Dialog" button on preview
+      And I click "Open Nested Dialog" button on preview
       And Dialog is visible
     When I hit ESC key in noIframe
     Then Dialog Full Screen is visible

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -111,7 +111,7 @@ When("I open component preview in noIFrame", () => {
   commonButtonPreviewNoIFrameRoot().click();
 });
 
-When("I {string} button on preview", (text) => {
+When("I click {string} button on preview", (text) => {
   getDataElementByValue("main-text").contains(text).click();
 });
 

--- a/src/components/flat-table/flat-table-expandable.stories.mdx
+++ b/src/components/flat-table/flat-table-expandable.stories.mdx
@@ -14,6 +14,7 @@ import {
 } from ".";
 import BatchSelection from "../batch-selection";
 import IconButton from "../icon-button";
+import Button from "../button";
 import Icon from "../icon";
 import Pager from "../pager";
 import {
@@ -1035,6 +1036,76 @@ truncated styling applied, this is because of the caret icon that is rendered wi
             </FlatTableRow>
           </FlatTableBody>
         </FlatTable>
+      );
+    }}
+  </Story>
+</Preview>
+
+### Controlled
+
+<Preview>
+  <Story
+    name="controlled"
+    parameters={{ chromatic: { disable: true } }}
+    >
+    {() => {
+      const [expanded, setExpanded] = useState(true);
+      const SubRows = [
+        <FlatTableRow>
+          <FlatTableCell>Child one</FlatTableCell>
+          <FlatTableCell>York</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>2</FlatTableCell>
+        </FlatTableRow>,
+        <FlatTableRow>
+          <FlatTableCell>Child two</FlatTableCell>
+          <FlatTableCell>Edinburgh</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>1</FlatTableCell>
+        </FlatTableRow>,
+      ];
+      return (
+        <>
+         <Button onClick={() => setExpanded((prev) => !prev)}>
+          {expanded ? "Collapse All" : "Expand All"}
+        </Button>
+        <FlatTable>
+          <FlatTableHead>
+            <FlatTableRow>
+              <FlatTableHeader>Name</FlatTableHeader>
+              <FlatTableHeader>Location</FlatTableHeader>
+              <FlatTableHeader>Relationship Status</FlatTableHeader>
+              <FlatTableHeader>Dependents</FlatTableHeader>
+            </FlatTableRow>
+          </FlatTableHead>
+          <FlatTableBody>
+            <FlatTableRow expanded={expanded} expandable subRows={SubRows}>
+              <FlatTableCell>John Doe</FlatTableCell>
+              <FlatTableCell>London</FlatTableCell>
+              <FlatTableCell>Single</FlatTableCell>
+              <FlatTableCell>0</FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow expanded={expanded} expandable subRows={SubRows}>
+              <FlatTableCell>Jane Doe</FlatTableCell>
+              <FlatTableCell>York</FlatTableCell>
+              <FlatTableCell>Married</FlatTableCell>
+              <FlatTableCell>2</FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow expanded={expanded} expandable subRows={SubRows}>
+              <FlatTableCell>John Smith</FlatTableCell>
+              <FlatTableCell>Edinburgh</FlatTableCell>
+              <FlatTableCell>Single</FlatTableCell>
+              <FlatTableCell>1</FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow expanded={expanded} expandable subRows={SubRows}>
+              <FlatTableCell>Jane Smith</FlatTableCell>
+              <FlatTableCell>Newcastle</FlatTableCell>
+              <FlatTableCell>Married</FlatTableCell>
+              <FlatTableCell>5</FlatTableCell>
+            </FlatTableRow>
+          </FlatTableBody>
+        </FlatTable>
+        </>
       );
     }}
   </Story>

--- a/src/components/flat-table/flat-table-row/flat-table-row.component.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.js
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useContext,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -117,6 +118,10 @@ const FlatTableRow = React.forwardRef(
         ]);
       }
     }, [rowHeaderIndex, stickyCellWidths]);
+
+    useEffect(() => {
+      setIsExpanded(expanded);
+    }, [expanded]);
 
     return (
       <SidebarContext.Consumer>

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -676,6 +676,45 @@ describe("FlatTableRow", () => {
           expect(onClickFn).toHaveBeenCalled();
         });
       });
+
+      describe("when used as a controlled component", () => {
+        it("should update the expanded state of the rows", () => {
+          const MockComponent = (props) => {
+            const [expanded, setExpanded] = React.useState(false);
+            return (
+              <>
+                <button type="button" onClick={() => setExpanded(!expanded)}>
+                  Change Expanded State
+                </button>
+                <table>
+                  <tbody>
+                    <FlatTableRow {...props} expanded={expanded}>
+                      <FlatTableCell>cell1</FlatTableCell>
+                      <FlatTableCell>cell2</FlatTableCell>
+                    </FlatTableRow>
+                  </tbody>
+                </table>
+              </>
+            );
+          };
+
+          const wrapper = mount(<MockComponent expandable subRows={SubRows} />);
+
+          act(() => {
+            wrapper.find("button").props().onClick();
+          });
+          wrapper.update();
+
+          expect(wrapper.find(StyledFlatTableRow).length).toEqual(3);
+
+          act(() => {
+            wrapper.find("button").props().onClick();
+          });
+          wrapper.update();
+
+          expect(wrapper.find(StyledFlatTableRow).length).toEqual(1);
+        });
+      });
     });
 
     describe("when focused and enter/space is pressed", () => {


### PR DESCRIPTION
fix #3875

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds `useEffect` to ensure `expandable` `FlatTableRows` update when the value of the `expanded` prop
changes

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`expandable` functionality cannot be controlled externally

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
`design-system-flat-table-expandable--controlled` added

https://codesandbox.io/s/nice-almeida-j22d6