### PR TITLE
build: run builds on all commits to master FE-4029

### DIFF
--- a/docs/testing-styleguide.md
+++ b/docs/testing-styleguide.md
@@ -93,8 +93,6 @@ Where functionality is already tested in unit testing, this does not need to be 
 
 [Chromatic](https://www.chromatic.com/builds?appId=5ecf782fe724630022d27d7d) is used to test for visual regressions during each build by comparing snapshots of the storybook canvas with previous baseline snapshots. Chromatic automatically snapshots every story canvas. You should not need to run Chromatic locally.
 
-For releasing a group of `BREAKING CHANGES` we agreed to create a `major/**` branch to avoid draining `chromatic` resources. After creating the `major/**` branch we need to run `git checkout major/**` and run `npx chromatic --project-token=CHROMATIC_PROJECT_TOKEN` to manually trigger a `chromatic` build on the `major/**` branch to perform a comparison with `master`. It allows us to merge the `BREAKING CHANGES` into the `major/**` branch without running `chromatic`.
-
 ##### Cypress File Structure
 ```
 .

--- a/package.json
+++ b/package.json
@@ -200,7 +200,9 @@
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
       "@semantic-release/npm",
-      "@semantic-release/git",
+      ["@semantic-release/git", {
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+      }],
       "@semantic-release/github"
     ]
   }


### PR DESCRIPTION


### Proposed behaviour

New semantic release commits will be in the format

```
chore(release): 68.21.0
```



### Current behaviour

Commit format is 

```
chore(release): 68.21.0 [skip ci]
```

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
Existing branches will need to be re-created or use `npx chrmatic --patch-build=$head...$base`

Fixes FE-4029
### Testing instructions
Check next carbon release after merge.
