### PR TITLE
feat(tile-select): expand prop types for title, subtitle and description to node FE-4005

### DIFF
--- a/src/components/tile-select/tile-select.component.js
+++ b/src/components/tile-select/tile-select.component.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState } from "react";
 import I18n from "i18n-js";
 import styledSystemPropTypes from "@styled-system/prop-types";
 import tagComponent from "../../utils/helpers/tags/tags";
@@ -15,6 +15,8 @@ import {
   StyledAdornment,
   StyledDescription,
   StyledDeselectWrapper,
+  StyledFooterWrapper,
+  StyledFocusWrapper,
 } from "./tile-select.style";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 
@@ -22,25 +24,27 @@ const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
 );
 
-const TileSelect = (props) => {
-  const {
-    onChange,
-    onBlur,
-    value,
-    name,
-    checked,
-    className,
-    disabled,
-    title,
-    subtitle,
-    description,
-    titleAdornment,
-    type,
-    id,
-    customActionButton,
-    actionButtonAdornment,
-    ...rest
-  } = props;
+const TileSelect = ({
+  onChange,
+  onBlur,
+  onFocus,
+  value,
+  name,
+  checked,
+  className,
+  disabled,
+  title,
+  subtitle,
+  description,
+  titleAdornment,
+  type,
+  id,
+  customActionButton,
+  actionButtonAdornment,
+  footer,
+  ...rest
+}) => {
+  const [hasFocus, setHasFocus] = useState(false);
 
   const handleDeselect = () =>
     onChange({
@@ -69,47 +73,59 @@ const TileSelect = (props) => {
       checked={checked}
       className={className}
       disabled={disabled}
-      {...tagComponent("tile-select", props)}
+      {...tagComponent("tile-select", rest)}
       {...filterStyledSystemMarginProps(rest)}
     >
-      <StyledTileSelectInput
-        onChange={onChange}
-        onBlur={onBlur}
-        checked={checked}
-        name={name}
-        type={type}
-        value={value}
-        disabled={disabled}
-        aria-checked={checked}
-        id={id}
-        {...rest}
-      />
-      <StyledTileSelect disabled={disabled} checked={checked}>
-        <StyledTitleContainer>
-          {title && (
-            <StyledTitle {...(typeof title !== "string" && { as: "div" })}>
-              {title}
-            </StyledTitle>
-          )}
+      <StyledFocusWrapper hasFocus={hasFocus} checked={checked}>
+        <StyledTileSelectInput
+          onChange={onChange}
+          onBlur={(ev) => {
+            setHasFocus(false);
+            /* istanbul ignore else */
+            if (onBlur) onBlur(ev);
+          }}
+          onFocus={(ev) => {
+            setHasFocus(true);
+            /* istanbul ignore else */
+            if (onFocus) onFocus(ev);
+          }}
+          checked={checked}
+          name={name}
+          type={type}
+          value={value}
+          disabled={disabled}
+          aria-checked={checked}
+          id={id}
+          {...rest}
+        />
+        <StyledTileSelect disabled={disabled} checked={checked}>
+          <StyledTitleContainer>
+            {title && (
+              <StyledTitle {...(typeof title !== "string" && { as: "div" })}>
+                {title}
+              </StyledTitle>
+            )}
 
-          {subtitle && (
-            <StyledSubtitle
-              {...(typeof subtitle !== "string" && { as: "div" })}
-            >
-              {subtitle}
-            </StyledSubtitle>
-          )}
+            {subtitle && (
+              <StyledSubtitle
+                {...(typeof subtitle !== "string" && { as: "div" })}
+              >
+                {subtitle}
+              </StyledSubtitle>
+            )}
 
-          {titleAdornment && (
-            <StyledAdornment>{titleAdornment}</StyledAdornment>
-          )}
-        </StyledTitleContainer>
-        <StyledDescription
-          {...(typeof description !== "string" && { as: "div" })}
-        >
-          {description}
-        </StyledDescription>
-      </StyledTileSelect>
+            {titleAdornment && (
+              <StyledAdornment>{titleAdornment}</StyledAdornment>
+            )}
+          </StyledTitleContainer>
+          <StyledDescription
+            {...(typeof description !== "string" && { as: "div" })}
+          >
+            {description}
+          </StyledDescription>
+          {footer && <StyledFooterWrapper>{footer}</StyledFooterWrapper>}
+        </StyledTileSelect>
+      </StyledFocusWrapper>
       <StyledDeselectWrapper hasActionAdornment={!!actionButtonAdornment}>
         {renderActionButton()}
         {actionButtonAdornment}
@@ -145,6 +161,8 @@ TileSelect.propTypes = {
   onChange: PropTypes.func,
   /** Callback triggered when the user blurs this tile */
   onBlur: PropTypes.func,
+  /** Callback triggered when the user focuses this tile */
+  onFocus: PropTypes.func,
   /** determines if this tile is selected or unselected */
   checked: PropTypes.bool,
   /** Custom class name passed to the root element of TileSelect */
@@ -155,6 +173,8 @@ TileSelect.propTypes = {
   customActionButton: PropTypes.func,
   /** An additional help info icon rendered next to the action button */
   actionButtonAdornment: PropTypes.node,
+  /** footer of the TileSelect */
+  footer: PropTypes.node,
 };
 
 TileSelect.displayName = "TileSelect";

--- a/src/components/tile-select/tile-select.component.js
+++ b/src/components/tile-select/tile-select.component.js
@@ -86,15 +86,29 @@ const TileSelect = (props) => {
       />
       <StyledTileSelect disabled={disabled} checked={checked}>
         <StyledTitleContainer>
-          {title && <StyledTitle>{title}</StyledTitle>}
+          {title && (
+            <StyledTitle {...(typeof title !== "string" && { as: "div" })}>
+              {title}
+            </StyledTitle>
+          )}
 
-          {subtitle && <StyledSubtitle>{subtitle}</StyledSubtitle>}
+          {subtitle && (
+            <StyledSubtitle
+              {...(typeof subtitle !== "string" && { as: "div" })}
+            >
+              {subtitle}
+            </StyledSubtitle>
+          )}
 
           {titleAdornment && (
             <StyledAdornment>{titleAdornment}</StyledAdornment>
           )}
         </StyledTitleContainer>
-        <StyledDescription>{description}</StyledDescription>
+        <StyledDescription
+          {...(typeof description !== "string" && { as: "div" })}
+        >
+          {description}
+        </StyledDescription>
       </StyledTileSelect>
       <StyledDeselectWrapper hasActionAdornment={!!actionButtonAdornment}>
         {renderActionButton()}
@@ -112,13 +126,13 @@ TileSelect.defaultProps = {
 TileSelect.propTypes = {
   ...marginPropTypes,
   /** title of the TileSelect */
-  title: PropTypes.string,
+  title: PropTypes.node,
   /** adornment to be rendered next to the title */
   titleAdornment: PropTypes.node,
   /** subtitle of the TileSelect */
-  subtitle: PropTypes.string,
+  subtitle: PropTypes.node,
   /** description of the TileSelect */
-  description: PropTypes.string,
+  description: PropTypes.node,
   /** disables the TileSelect input */
   disabled: PropTypes.bool,
   /** the value that is represented by this TileSelect */

--- a/src/components/tile-select/tile-select.spec.js
+++ b/src/components/tile-select/tile-select.spec.js
@@ -15,6 +15,7 @@ import {
   StyledSubtitle,
   StyledAdornment,
   StyledDescription,
+  StyledTitleContainer,
 } from "./tile-select.style";
 import Button from "../button";
 import Icon from "../icon";
@@ -79,20 +80,56 @@ describe("TileSelect", () => {
     });
   });
 
-  it("renders title element when title prop is passed", () => {
+  it("renders title element as h3 when title prop is passed as string", () => {
     render({ title: "Title" });
+    expect(wrapper.find(StyledTitleContainer).find("h3").exists()).toBeTruthy();
     expect(wrapper.find(StyledTitle).prop("children")).toBe("Title");
   });
 
-  it("renders subtitle element when subtitle prop is passed", () => {
+  it("renders title element as a div when title prop is passed as node", () => {
+    render({ title: <h1>Title</h1> });
+    expect(wrapper.find(StyledTitleContainer).find("h3").exists()).toBeFalsy();
+    expect(wrapper.find(StyledTitle).prop("as")).toBe("div");
+    expect(wrapper.find(StyledTitle).prop("children")).toStrictEqual(
+      <h1>Title</h1>
+    );
+  });
+
+  it("renders subtitle element as h4 when subtitle prop is passed as string", () => {
     render({ subtitle: "Subtitle" });
+    expect(wrapper.find(StyledTitleContainer).find("h4").exists()).toBeTruthy();
     expect(wrapper.find(StyledSubtitle).prop("children")).toBe("Subtitle");
+  });
+
+  it("renders subtitle element as a div when subtitle prop is passed as node", () => {
+    render({ subtitle: <h2>Sub Title</h2> });
+    expect(wrapper.find(StyledTitleContainer).find("h4").exists()).toBeFalsy();
+    expect(wrapper.find(StyledSubtitle).prop("as")).toBe("div");
+    expect(wrapper.find(StyledSubtitle).prop("children")).toStrictEqual(
+      <h2>Sub Title</h2>
+    );
   });
 
   it("renders title adornment element when titleAdornment prop is passed", () => {
     const MyComp = () => <div />;
     render({ titleAdornment: <MyComp /> });
     expect(wrapper.find(StyledAdornment).find(MyComp).exists()).toBe(true);
+  });
+
+  it("renders description element as p when description prop is passed as string", () => {
+    render({ description: "description" });
+    expect(wrapper.find(StyledDescription).prop("as")).toBe(undefined);
+    expect(wrapper.find(StyledDescription).prop("children")).toBe(
+      "description"
+    );
+  });
+
+  it("renders description element as div when description prop is passed as node", () => {
+    render({ description: <strong>description</strong> });
+    expect(wrapper.find(StyledDescription).prop("as")).toBe("div");
+    expect(wrapper.find(StyledDescription).prop("children")).toStrictEqual(
+      <strong>description</strong>
+    );
   });
 
   describe("styles", () => {

--- a/src/components/tile-select/tile-select.spec.js
+++ b/src/components/tile-select/tile-select.spec.js
@@ -16,6 +16,8 @@ import {
   StyledAdornment,
   StyledDescription,
   StyledTitleContainer,
+  StyledFocusWrapper,
+  StyledFooterWrapper,
 } from "./tile-select.style";
 import Button from "../button";
 import Icon from "../icon";
@@ -80,6 +82,33 @@ describe("TileSelect", () => {
     });
   });
 
+  it("calls onFocus callback if prop is passed and input is focused", () => {
+    const mockCb = jest.fn();
+    render({
+      onFocus: mockCb,
+      checked: true,
+      id: "id",
+      name: "name",
+    });
+
+    wrapper.find(StyledTileSelectInput).simulate("focus");
+    expect(mockCb).toHaveBeenCalled();
+  });
+
+  it("calls onBlur callback if prop is passed and input is blurred", () => {
+    const mockCb = jest.fn();
+    render({
+      onBlur: mockCb,
+      checked: true,
+      id: "id",
+      name: "name",
+    });
+
+    wrapper.find(StyledTileSelectInput).simulate("focus");
+    wrapper.find(StyledTileSelectInput).simulate("blur");
+    expect(mockCb).toHaveBeenCalled();
+  });
+
   it("renders title element as h3 when title prop is passed as string", () => {
     render({ title: "Title" });
     expect(wrapper.find(StyledTitleContainer).find("h3").exists()).toBeTruthy();
@@ -137,11 +166,17 @@ describe("TileSelect", () => {
       render({ checked: true });
       assertStyleMatch(
         {
-          borderColor: baseTheme.colors.primary,
           background: tint(baseTheme.colors.primary)(95),
-          zIndex: "10",
         },
         wrapper.find(StyledTileSelect)
+      );
+
+      assertStyleMatch(
+        {
+          borderColor: baseTheme.colors.primary,
+          zIndex: "10",
+        },
+        wrapper.find(StyledFocusWrapper)
       );
     });
 
@@ -186,13 +221,14 @@ describe("TileSelect", () => {
     });
 
     it("renders proper outline when focused", () => {
+      wrapper.find(StyledTileSelectInput).simulate("focus");
+
       assertStyleMatch(
         {
           outline: `3px solid ${baseTheme.colors.focus}`,
           zIndex: "15",
         },
-        wrapper.find(StyledTileSelectInput),
-        { modifier: `&:focus + ${StyledTileSelect}` }
+        wrapper.find(StyledFocusWrapper)
       );
     });
   });
@@ -249,6 +285,40 @@ describe("TileSelect", () => {
           minHeight: "32px",
         },
         wrapper.find(StyledDeselectWrapper)
+      );
+    });
+  });
+
+  describe("footer prop", () => {
+    beforeEach(() => {
+      render({
+        checked: true,
+        id: "id",
+        name: "name",
+        footer: (
+          <>
+            <Icon type="info" />
+            <Button>Foo</Button>
+          </>
+        ),
+      });
+    });
+
+    it("renders the component at the bottom of the tile", () => {
+      expect(
+        wrapper.find(StyledFooterWrapper).find(Icon).exists()
+      ).toBeTruthy();
+      expect(
+        wrapper.find(StyledFooterWrapper).find(Button).exists()
+      ).toBeTruthy();
+
+      assertStyleMatch(
+        {
+          width: "fit-content",
+          position: "relative",
+          zIndex: "200",
+        },
+        wrapper.find(StyledFooterWrapper)
       );
     });
   });

--- a/src/components/tile-select/tile-select.stories.mdx
+++ b/src/components/tile-select/tile-select.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
 import { useState } from "react";
 
 import { TileSelect, TileSelectGroup } from ".";
@@ -6,6 +6,8 @@ import Pill from "../pill/"
 import Icon from "../icon";
 import Button from "../button";
 import I18n from "i18n-js";
+import Box from "../box";
+import Typography from "../typography";
 import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
 
 <Meta
@@ -324,6 +326,32 @@ Same as in multi select example grouped by `TileSelectGroup`, `onChange`, `onBlu
     }}
   </Story>
 </Preview>
+
+### With a footer
+To render a `footer` pass anything renderable to the prop like in the example below. 
+
+<Preview>
+  <Story name="with a footer">
+    {() => {
+      const [isChecked, setIsChecked] = useState(false);
+      return (
+        <TileSelect
+          value="1"
+          id="single-1"
+          aria-label="single-1"
+          name="single"
+          title="Title"
+          subtitle="Subtitle"
+          checked={isChecked}
+          onChange={e => setIsChecked(e.target.checked)}
+          description="Short and descriptive description"
+          footer={<Box pt={1} display="flex" alignItems="baseline">Here is some &nbsp;<Typography variant="strong">footer text</Typography><Button ml={1} buttonType="tertiary" iconPosition="after" iconType="home">Footer Button</Button></Box>}
+        />
+      )
+    }}
+  </Story>
+</Preview>
+
 
 ### With custom spacing
 The `TileSelect` and `TileSelectGroup` components support the custom margin spacing (see prop table below). The  modifiers 

--- a/src/components/tile-select/tile-select.style.js
+++ b/src/components/tile-select/tile-select.style.js
@@ -35,17 +35,14 @@ const StyledDescription = styled.p`
 `;
 
 const StyledTileSelect = styled.div`
-  position: relative;
-  border: 1px solid ${({ theme }) => theme.tileSelect.border};
   background-color: ${({ theme }) => theme.colors.white};
   padding: 24px;
   ${({ checked, theme }) =>
     checked &&
     css`
-      border-color: ${theme.colors.primary};
       background: ${tint(theme.colors.primary)(95)};
-      z-index: 10;
     `}
+
   ${({ disabled, theme }) =>
     disabled &&
     css`
@@ -58,7 +55,25 @@ const StyledTileSelect = styled.div`
         fill: ${theme.colors.black};
         opacity: 0.3;
       }
-    `};
+    `}
+`;
+
+const StyledFocusWrapper = styled.div`
+  ${({ checked, theme, hasFocus }) => css`
+    position: relative;
+    border: 1px solid ${theme.tileSelect.border};
+    ${checked &&
+    css`
+      border-color: ${theme.colors.primary};
+      z-index: 10;
+    `}
+
+    ${hasFocus &&
+    css`
+      outline: 3px solid ${theme.colors.focus};
+      z-index: 15;
+    `}
+  `}
 `;
 
 const StyledTileSelectContainer = styled.div`
@@ -66,7 +81,7 @@ const StyledTileSelectContainer = styled.div`
 
   width: 100%;
   position: relative;
-  & + & ${StyledTileSelect} {
+  & + & ${StyledFocusWrapper} {
     margin-top: -1px;
   }
   ${({ checked, disabled, theme }) =>
@@ -79,6 +94,12 @@ const StyledTileSelectContainer = styled.div`
     `}
 `;
 
+const StyledFooterWrapper = styled.div`
+  width: fit-content;
+  position: relative;
+  z-index: 200;
+`;
+
 const StyledTileSelectInput = styled(Input)`
   position: absolute;
   top: 0;
@@ -89,10 +110,6 @@ const StyledTileSelectInput = styled(Input)`
   margin: 0;
   z-index: 100;
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
-  &:focus + ${StyledTileSelect} {
-    outline: 3px solid ${({ theme }) => theme.colors.focus};
-    z-index: 15;
-  }
 `;
 
 const StyledTitleContainer = styled.div`
@@ -173,6 +190,10 @@ StyledDeselectWrapper.defaultProps = {
   theme: baseTheme,
 };
 
+StyledFocusWrapper.defaultProps = {
+  theme: baseTheme,
+};
+
 export {
   StyledTileSelectFieldset,
   StyledGroupDescription,
@@ -185,4 +206,6 @@ export {
   StyledAdornment,
   StyledDescription,
   StyledDeselectWrapper,
+  StyledFooterWrapper,
+  StyledFocusWrapper,
 };


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Updates prop types for `title`, `subtitle` and `description` to be type node
Adds `footer` prop of type node to support rendering content at the bottom of a given `TileSelect`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Prop types for `title`, `subtitle` and `description` are `string`
No `footer` prop available

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
The `footer` container has no spacing applied to it, this should be achieved by applying `padding`/`margin` to the component passed in

<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/115049407-9a101c80-9ed2-11eb-891c-70d189a54556.png)

![image](https://user-images.githubusercontent.com/44157880/115049565-c5930700-9ed2-11eb-842a-329990d5ca37.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
`design-system-tile-select--with-a-footer` added
https://codesandbox.io/s/carbon-quickstart-forked-bviry?file=/src/index.js