### PR TITLE
fix(flat-table): fix thin focus outline in safari

### DIFF
--- a/src/components/flat-table/flat-table-row/flat-table-row.style.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.js
@@ -59,6 +59,7 @@ const StyledFlatTableRow = styled.tr`
     isRowInteractive &&
     css`
       cursor: pointer;
+      transition: outline 0.02s;
 
       :focus {
         outline: 2px solid ${theme.colors.focus};


### PR DESCRIPTION
### Proposed behaviour
Set outline transition greater than 0.01s.

### Current behaviour
When tabbing through rows the outline is thinner in safari but not when clicking on a row.

https://user-images.githubusercontent.com/77274590/115240400-016edc00-a120-11eb-9953-ae07a4a35055.mov

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
Browser: Safari.
https://codesandbox.io/s/carbon-quickstart-forked-cep7p