### PR TITLE
fix(flat-table): fix thin focus outline - FE-4049

### DIFF
--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -147,6 +147,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
 
 .c0 {
   height: 100%;
+  padding-bottom: 1px;
 }
 
 .c1 {

--- a/src/components/flat-table/flat-table.style.js
+++ b/src/components/flat-table/flat-table.style.js
@@ -75,6 +75,7 @@ StyledFlatTable.defaultProps = {
 const StyledFlatTableRoot = styled.div`
   ${margin};
   height: 100%;
+  padding-bottom: 1px;
 `;
 
 StyledFlatTableRoot.defaultProps = {


### PR DESCRIPTION
### Proposed behaviour
Wrapper has set overflow hidden and outline is cut.

### Current behaviour
![Zrzut ekranu 2021-04-20 o 14 38 19](https://user-images.githubusercontent.com/77274590/115397167-16ae3e00-a1e6-11eb-936f-6f739d5df962.png)
![Zrzut ekranu 2021-04-20 o 14 38 13](https://user-images.githubusercontent.com/77274590/115397165-157d1100-a1e6-11eb-9964-16491fee05df.png)

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-xz7zi