### PR TITLE
fix(filterable-select): call onChange when value is deleted or not matched - FE-3985

### DIFF
--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -71,6 +71,15 @@ const FilterableSelect = React.forwardRef(
       [name, id]
     );
 
+    const triggerChange = useCallback(
+      (newValue) => {
+        if (onChange) {
+          onChange(createCustomEvent(newValue));
+        }
+      },
+      [onChange, createCustomEvent]
+    );
+
     const updateValues = useCallback(
       (newFilterText, isDeleteEvent) => {
         setSelectedValue((previousValue) => {
@@ -79,6 +88,7 @@ const FilterableSelect = React.forwardRef(
 
           if (!match || isFilterCleared) {
             setTextValue(newFilterText);
+            triggerChange("");
 
             return "";
           }
@@ -89,9 +99,7 @@ const FilterableSelect = React.forwardRef(
             return match.props.value;
           }
 
-          if (onChange) {
-            onChange(createCustomEvent(match.props.value));
-          }
+          triggerChange(match.props.value);
 
           if (
             match.props.text
@@ -112,7 +120,7 @@ const FilterableSelect = React.forwardRef(
           return match.props.value;
         });
       },
-      [children, createCustomEvent, onChange]
+      [children, triggerChange]
     );
 
     const setMatchingText = useCallback(
@@ -303,10 +311,7 @@ const FilterableSelect = React.forwardRef(
         }
 
         setTextValue(text);
-
-        if (onChange) {
-          onChange(createCustomEvent(newValue));
-        }
+        triggerChange(newValue);
 
         if (selectionType !== "navigationKey") {
           setOpen(false);
@@ -314,7 +319,7 @@ const FilterableSelect = React.forwardRef(
           textboxRef.select();
         }
       },
-      [createCustomEvent, onChange, textboxRef]
+      [textboxRef, triggerChange]
     );
 
     const onSelectListClose = useCallback(() => {

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -372,6 +372,12 @@ describe("FilterableSelect", () => {
         value: "Foo",
       },
     };
+    const expectedDeleteEventObject = {
+      target: {
+        ...textboxProps,
+        value: "",
+      },
+    };
 
     describe('with "selectionType" as "click"', () => {
       it("the SelectList should be closed", () => {
@@ -411,10 +417,15 @@ describe("FilterableSelect", () => {
     });
 
     describe("and the onChange prop is passed", () => {
-      it("then that prop should be called with the same value", () => {
-        const onChangeFn = jest.fn();
-        const wrapper = renderSelect({ ...textboxProps, onChange: onChangeFn });
+      const onChangeFn = jest.fn();
+      let wrapper;
 
+      beforeEach(() => {
+        onChangeFn.mockClear();
+        wrapper = renderSelect({ ...textboxProps, onChange: onChangeFn });
+      });
+
+      it("then that prop should be called with the same value", () => {
         wrapper
           .find(Textbox)
           .find('[type="dropdown"]')
@@ -424,6 +435,27 @@ describe("FilterableSelect", () => {
           wrapper.find(SelectList).prop("onSelect")(clickOptionObject);
         });
         expect(onChangeFn).toHaveBeenCalledWith(expectedEventObject);
+      });
+
+      it("then should be called when value is deleted", () => {
+        act(() => {
+          wrapper.find("input").simulate("change", {
+            target: { value: "" },
+            nativeEvent: { inputType: "delete" },
+          });
+        });
+
+        expect(onChangeFn).toHaveBeenCalledWith(expectedDeleteEventObject);
+      });
+
+      it("then should be called when value is not matched", () => {
+        act(() => {
+          wrapper.find("input").simulate("change", {
+            target: { value: "aaaaa" },
+          });
+        });
+
+        expect(onChangeFn).toHaveBeenCalledWith(expectedDeleteEventObject);
       });
     });
   });


### PR DESCRIPTION
### Proposed behaviour
Call onChange when value is deleted or not matched.

### Current behaviour
The onChange event is not called when the textbox content is deleted.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
Resolves:  #3854

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-eh7hk