### PR TITLE
fix(textbox): fix not triggered onClick handler - FE-2919

### DIFF
--- a/src/__experimental__/components/input/input-presentation.component.js
+++ b/src/__experimental__/components/input/input-presentation.component.js
@@ -16,9 +16,7 @@ import {
 let deprecatedWarnTriggered = false;
 
 const InputPresentation = (props) => {
-  const { hasFocus, onMouseDown, onMouseEnter, onMouseLeave } = useContext(
-    InputContext
-  );
+  const { hasFocus, onMouseEnter, onMouseLeave } = useContext(InputContext);
 
   const {
     onMouseEnter: onGroupMouseEnter,
@@ -57,7 +55,6 @@ const InputPresentation = (props) => {
       <InputPresentationStyle
         hasFocus={hasFocus}
         role="presentation"
-        onMouseDown={onMouseDown}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         styleOverride={styleOverride}

--- a/src/__experimental__/components/textarea/__snapshots__/textarea.spec.js.snap
+++ b/src/__experimental__/components/textarea/__snapshots__/textarea.spec.js.snap
@@ -134,7 +134,6 @@ exports[`Textarea when rendered should render default 1`] = `
         <div
           className="c5"
           disabled={false}
-          onMouseDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           readOnly={false}

--- a/src/__internal__/input-behaviour/useInputBehaviour.js
+++ b/src/__internal__/input-behaviour/useInputBehaviour.js
@@ -14,12 +14,6 @@ const useInputBehaviour = (blockGroupBehaviour) => {
     inputRef.current = input.current;
   }, []);
 
-  // use mouse down rather than click to accommodate click and drag events too
-  const onMouseDown = useCallback(() => {
-    // use a zero timeout to ensure focus is applied even on click and drag events
-    setTimeout(() => inputRef && inputRef.current && inputRef.current.focus());
-  }, []);
-
   const onMouseEnter = useCallback(() => setHasMouseOver(true), []);
 
   const onMouseLeave = useCallback(() => setHasMouseOver(false), []);
@@ -30,7 +24,6 @@ const useInputBehaviour = (blockGroupBehaviour) => {
       hasMouseOver,
       onFocus: blockGroupBehaviour ? undefined : onFocus,
       onBlur: blockGroupBehaviour ? undefined : onBlur,
-      onMouseDown,
       onMouseEnter: blockGroupBehaviour ? undefined : onMouseEnter,
       onMouseLeave: blockGroupBehaviour ? undefined : onMouseLeave,
       inputRef: assignInput,
@@ -40,7 +33,6 @@ const useInputBehaviour = (blockGroupBehaviour) => {
       hasMouseOver,
       onFocus,
       onBlur,
-      onMouseDown,
       blockGroupBehaviour,
       onMouseEnter,
       onMouseLeave,

--- a/src/__internal__/input-behaviour/useInputBehaviour.spec.js
+++ b/src/__internal__/input-behaviour/useInputBehaviour.spec.js
@@ -71,16 +71,6 @@ describe("useInputBehaviour", () => {
       wrapper.update();
       expect(wrapper.find(Input).props().hasMouseOver).toBe(false);
     });
-
-    it("focuses the element on mousedown event", () => {
-      jest.useFakeTimers();
-      act(() => {
-        wrapper.find(Input).props().onMouseDown();
-      });
-      wrapper.update();
-      jest.runAllTimers();
-      expect(document.activeElement).toBe(wrapper.find(Input).getDOMNode());
-    });
   });
 
   describe("group behaviour disabled", () => {


### PR DESCRIPTION
### Current behaviour
When an input icon is clicked the click event is not propagated and not reported in action panel.

The issue could be also reproduced when clicking on a padding of the InputPresentation container (11px from the edge of the component).


### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent
out the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
