### PR TITLE
feat(card): add styled-system margin support - FE-3534

### DIFF
--- a/src/components/card/card-footer/card-footer.component.js
+++ b/src/components/card/card-footer/card-footer.component.js
@@ -1,5 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
+
 import OptionsHelper from "../../../utils/helpers/options-helper";
 import StyledCardFooter from "./card-footer.style";
 
@@ -19,6 +21,7 @@ const CardFooter = ({ spacing, children, ...props }) => {
 };
 
 CardFooter.propTypes = {
+  ...styledSystemPropTypes.space,
   children: PropTypes.node.isRequired,
   /** Predefined size of CardFooter for applying padding (small | medium | large). For more granular control these can be over-ridden by Spacing props from styled-system (see table below). */
   spacing: PropTypes.oneOf(sizesRestricted),

--- a/src/components/card/card.component.js
+++ b/src/components/card/card.component.js
@@ -1,5 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
+
+import { filterStyledSystemMarginProps } from "../../style/utils";
 import OptionsHelper from "../../utils/helpers/options-helper";
 import StyledCard from "./card.style";
 import Icon from "../icon";
@@ -7,6 +10,10 @@ import CardRow from "./card-row/card-row.component";
 import CardFooter from "./card-footer/card-footer.component";
 
 const { sizesRestricted } = OptionsHelper;
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 const Card = ({
   action,
@@ -16,6 +23,7 @@ const Card = ({
   draggable,
   spacing,
   dataRole,
+  ...rest
 }) => {
   const handleClick = (ev) => {
     if (!draggable && action) {
@@ -63,6 +71,7 @@ const Card = ({
       onClick={onClickHandler}
       tabIndex={0}
       data-role={dataRole}
+      {...rest}
     >
       {draggable && <Icon type="drag" />}
       {renderChildren()}
@@ -74,6 +83,7 @@ Card.defaultProps = {
 };
 
 Card.propTypes = {
+  ...marginPropTypes,
   /** action to be executed when card is clicked or enter pressed */
   action: PropTypes.func,
   children: PropTypes.node.isRequired,

--- a/src/components/card/card.spec.js
+++ b/src/components/card/card.spec.js
@@ -4,7 +4,10 @@ import TestRenderer from "react-test-renderer";
 import Card from "./card.component";
 import CardRow from "./card-row/card-row.component";
 import CardFooter from "./card-footer/card-footer.component";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/test-utils";
 import Icon from "../icon";
 import Link from "../link";
 import OptionsHelper from "../../utils/helpers/options-helper/options-helper";
@@ -12,6 +15,8 @@ import { rootTagTest } from "../../utils/helpers/tags/tags-specs";
 import StyledCardFooter from "./card-footer/card-footer.style";
 
 describe("Card", () => {
+  testStyledSystemMargin((props) => <Card {...props}>Content</Card>);
+
   describe("when the content is added as children", () => {
     it("then that content should be rendered inside the component", () => {
       const content = (

--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -528,7 +528,7 @@ Click on the card to see the effect
 
 ### Card
 
-<Props of={Card} />
+<StyledSystemProps noHeader margin of={Card} />
 
 ### CardRow
 

--- a/src/components/card/card.style.js
+++ b/src/components/card/card.style.js
@@ -1,5 +1,7 @@
 import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
+import { margin } from "styled-system";
+
 import baseTheme from "../../style/themes/base";
 import OptionsHelper from "../../utils/helpers/options-helper";
 
@@ -21,6 +23,7 @@ const StyledCard = styled.div`
     vertical-align: top;
     width: ${cardWidth};
     outline: none;
+    ${margin}
 
     ${interactive &&
     css`


### PR DESCRIPTION
### Proposed behaviour
This PR adds styled-system margin prop support to Card component

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent


### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-m74fx
