### PR TITLE
feat(duelling-picklist): add support for styled-system margin interface FE-3543

### DIFF
--- a/src/components/duelling-picklist/duelling-picklist.component.js
+++ b/src/components/duelling-picklist/duelling-picklist.component.js
@@ -1,5 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
+import { filterStyledSystemMarginProps } from "../../style/utils";
 
 import {
   StyledDuellingPicklistOverlay,
@@ -10,6 +12,8 @@ import {
   StyledControl,
 } from "./duelling-picklist.style";
 
+const marginPropTypes = filterStyledSystemMarginProps(styledSystemPropTypes);
+
 const DuellingPicklist = ({
   children,
   disabled,
@@ -17,6 +21,7 @@ const DuellingPicklist = ({
   rightControls,
   leftLabel,
   rightLabel,
+  ...rest
 }) => {
   const shouldDisplayLabels = leftLabel || rightLabel;
   const shouldDisplayControls = leftControls || rightControls;
@@ -25,6 +30,7 @@ const DuellingPicklist = ({
     <StyledDuellingPicklistOverlay
       disabled={disabled}
       data-component="duelling-picklist"
+      {...filterStyledSystemMarginProps(rest)}
     >
       {shouldDisplayLabels && (
         <StyledLabelContainer>
@@ -52,6 +58,7 @@ const DuellingPicklist = ({
 };
 
 DuellingPicklist.propTypes = {
+  ...marginPropTypes,
   children: PropTypes.node,
   /** Indicate if component is disabled */
   disabled: PropTypes.bool,

--- a/src/components/duelling-picklist/duelling-picklist.d.ts
+++ b/src/components/duelling-picklist/duelling-picklist.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { MarginSpacingProps } from "../../utils/helpers/options-helper";
 
-export interface DuellingPicklistProps {
+export interface DuellingPicklistProps extends MarginSpacingProps {
   children?: React.ReactNode;
   /** Indicate if component is disabled */
   disabled?: boolean;

--- a/src/components/duelling-picklist/duelling-picklist.spec.js
+++ b/src/components/duelling-picklist/duelling-picklist.spec.js
@@ -2,7 +2,10 @@ import React from "react";
 import { mount } from "enzyme";
 import { CSSTransition } from "react-transition-group";
 
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/test-utils";
 import {
   DuellingPicklist,
   Picklist,
@@ -87,6 +90,14 @@ describe("DuellingPicklist", () => {
       </DuellingPicklist>
     );
   };
+
+  testStyledSystemMargin((props) => (
+    <DuellingPicklist {...props}>
+      <Picklist />
+      <PicklistDivider />
+      <Picklist />
+    </DuellingPicklist>
+  ));
 
   const renderAttached = ({
     disabled,

--- a/src/components/duelling-picklist/duelling-picklist.stories.mdx
+++ b/src/components/duelling-picklist/duelling-picklist.stories.mdx
@@ -5,6 +5,7 @@ import PicklistItem from "./picklist-item/picklist-item.component";
 import PicklistDivider from "./picklist-divider/picklist-divider.component";
 import PicklistPlaceholder from "./picklist-placeholder/picklist-placeholder.component";
 import DuellingPicklist from "./duelling-picklist.component";
+import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
 
 <Meta
   title="Design System/DuellingPicklist"
@@ -163,7 +164,7 @@ Same as above but as a children of `Dialog` component.
 
 ### DuellingPicklist
 
-<Props of={DuellingPicklist} />
+<StyledSystemProps of={DuellingPicklist} noheader margin />
 
 ### PicklistDivider
 

--- a/src/components/duelling-picklist/duelling-picklist.style.js
+++ b/src/components/duelling-picklist/duelling-picklist.style.js
@@ -1,7 +1,11 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
+import { baseTheme } from "../../style/themes";
 import { StyledPicklist } from "./picklist/picklist.style";
 
 const StyledDuellingPicklistOverlay = styled.div`
+  ${margin}
+
   transition: opacity 0.3s;
 
   ${({ disabled }) =>
@@ -64,6 +68,10 @@ const StyledPicklistPlaceholder = styled.div`
   justify-content: center;
   align-items: center;
 `;
+
+StyledDuellingPicklistOverlay.defaultProps = {
+  theme: baseTheme,
+};
 
 export {
   StyledDuellingPicklist,


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds support for `styled-system/margin` interface to the root element of `DuellingPicklist`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`DuellingPicklist` does not support `styled-system/margin` interface

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-c9ku5?file=/src/index.js