### PR TITLE
feat(dialog-full-screen): add auto focus functionality - FE-3968

### DIFF
--- a/src/__internal__/full-screen-heading/full-screen-heading.component.js
+++ b/src/__internal__/full-screen-heading/full-screen-heading.component.js
@@ -4,20 +4,9 @@ import tagComponent from "../../utils/helpers/tags";
 import StyledFullScreenHeading, {
   StyledHeaderContainer,
 } from "./full-screen-heading.style";
-import IconButton from "../../components/icon-button";
-import Icon from "../../components/icon";
 
 const FullScreenHeading = React.forwardRef((props, ref) => {
-  const { children, showCloseIcon, onCancel, ...otherProps } = props;
-
-  const closeIcon = () => {
-    if (!showCloseIcon || !onCancel) return null;
-    return (
-      <IconButton data-element="close" onAction={onCancel}>
-        <Icon type="close" />
-      </IconButton>
-    );
-  };
+  const { children, ...otherProps } = props;
 
   return (
     <StyledFullScreenHeading
@@ -26,17 +15,12 @@ const FullScreenHeading = React.forwardRef((props, ref) => {
       ref={ref}
     >
       <StyledHeaderContainer>{children}</StyledHeaderContainer>
-      {closeIcon()}
     </StyledFullScreenHeading>
   );
 });
 
 FullScreenHeading.propTypes = {
   children: PropTypes.node,
-  /** Determines if the close icon is shown */
-  showCloseIcon: PropTypes.bool,
-  /** A custom close event handler */
-  onCancel: PropTypes.func,
 };
 
 export default FullScreenHeading;

--- a/src/__internal__/full-screen-heading/full-screen-heading.style.js
+++ b/src/__internal__/full-screen-heading/full-screen-heading.style.js
@@ -3,7 +3,6 @@ import {
   StyledHeader,
   StyledHeading,
 } from "../../components/heading/heading.style";
-import StyledIconButton from "../../components/icon-button/icon-button.style";
 import baseTheme from "../../style/themes/base";
 
 export const StyledHeaderContainer = styled.div`
@@ -41,10 +40,6 @@ const StyledFullScreenHeading = styled.div`
       padding-bottom: 0;
       margin: 22px 24px 0 0;
     }
-  }
-
-  ${StyledIconButton} {
-    margin-top: 26px;
   }
 `;
 

--- a/src/components/alert/alert.component.js
+++ b/src/components/alert/alert.component.js
@@ -37,8 +37,8 @@ Alert.propTypes = {
   ]),
   /** Determines if the close icon is shown */
   showCloseIcon: PropTypes.bool,
-  /** Function or reference to first element to focus */
-  focusFirstElement: PropTypes.func,
+  /** Optional reference to an element meant to be focused on open */
+  focusFirstElement: PropTypes.shape({ current: PropTypes.any }),
   /** Disables auto focus functionality on child elements */
   disableAutoFocus: PropTypes.bool,
 };

--- a/src/components/confirm/confirm.component.js
+++ b/src/components/confirm/confirm.component.js
@@ -132,8 +132,8 @@ Confirm.propTypes = {
   ]),
   /** Determines if the close icon is shown */
   showCloseIcon: PropTypes.bool,
-  /** Function or reference to first element to focus */
-  focusFirstElement: PropTypes.func,
+  /** Optional reference to an element meant to be focused on open */
+  focusFirstElement: PropTypes.shape({ current: PropTypes.any }),
   /** Disables auto focus functionality on child elements */
   disableAutoFocus: PropTypes.bool,
   /** A custom event handler when a confirmation takes place */

--- a/src/components/dialog-full-screen/dialog-full-screen.component.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.js
@@ -1,13 +1,18 @@
 import React, { useRef } from "react";
 import PropTypes from "prop-types";
+
 import Modal from "../modal";
 import Heading from "../heading";
 import FullScreenHeading from "../../__internal__/full-screen-heading";
 import StyledDialogFullScreen from "./dialog-full-screen.style";
 import StyledContent from "./content.style";
 import FocusTrap from "../../__internal__/focus-trap";
+import IconButton from "../icon-button";
+import Icon from "../icon";
 
 const DialogFullScreen = ({
+  disableAutoFocus,
+  focusFirstElement,
   open,
   children,
   title,
@@ -24,13 +29,22 @@ const DialogFullScreen = ({
   const headingRef = useRef();
   const contentRef = useRef();
 
+  const closeIcon = () => {
+    if (!showCloseIcon || !onCancel) return null;
+
+    return (
+      <IconButton
+        data-element="close"
+        aria-label="Close button"
+        onAction={onCancel}
+      >
+        <Icon type="close" />
+      </IconButton>
+    );
+  };
+
   const dialogTitle = () => (
-    <FullScreenHeading
-      hasContent={title}
-      ref={headingRef}
-      showCloseIcon={showCloseIcon}
-      onCancel={onCancel}
-    >
+    <FullScreenHeading hasContent={title} ref={headingRef}>
       {typeof title === "string" ? (
         <Heading
           title={title}
@@ -59,7 +73,11 @@ const DialogFullScreen = ({
       disableEscKey={disableEscKey}
       {...componentTags}
     >
-      <FocusTrap wrapperRef={dialogRef}>
+      <FocusTrap
+        autoFocus={!disableAutoFocus}
+        focusFirstElement={focusFirstElement}
+        wrapperRef={dialogRef}
+      >
         <StyledDialogFullScreen
           ref={dialogRef}
           data-element="dialog-full-screen"
@@ -74,6 +92,7 @@ const DialogFullScreen = ({
           >
             {children}
           </StyledContent>
+          {closeIcon()}
         </StyledDialogFullScreen>
       </FocusTrap>
     </Modal>
@@ -82,6 +101,7 @@ const DialogFullScreen = ({
 
 DialogFullScreen.defaultProps = {
   showCloseIcon: true,
+  disableAutoFocus: false,
 };
 
 DialogFullScreen.propTypes = {
@@ -89,6 +109,10 @@ DialogFullScreen.propTypes = {
   open: PropTypes.bool.isRequired,
   /** A custom close event handler */
   onCancel: PropTypes.func,
+  /** Optional reference to an element meant to be focused on open */
+  focusFirstElement: PropTypes.shape({ current: PropTypes.any }),
+  /** Disables auto focus functionality on child elements */
+  disableAutoFocus: PropTypes.bool,
   /** Determines if the Esc Key closes the Dialog */
   disableEscKey: PropTypes.bool,
   /** remove padding from content */

--- a/src/components/dialog-full-screen/dialog-full-screen.spec.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.spec.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import { mount } from "enzyme";
 import Modal from "../modal";
 import FullScreenHeading from "../../__internal__/full-screen-heading";
@@ -36,6 +36,48 @@ describe("DialogFullScreen", () => {
         <Button>Button</Button>
       </DialogFullScreen>
     );
+  });
+
+  describe("autoFocus", () => {
+    it("should focus the first element by default", () => {
+      mount(
+        <DialogFullScreen open>
+          <input type="text" />
+        </DialogFullScreen>
+      );
+
+      const firstFocusableElement = document.querySelector("input");
+      expect(document.activeElement).toBe(firstFocusableElement);
+    });
+
+    it("should not focus the first element when disableAutoFocus is passed", () => {
+      mount(
+        <DialogFullScreen open disableAutoFocus>
+          <input type="text" />
+        </DialogFullScreen>
+      );
+
+      const firstFocusableElement = document.querySelector("input");
+      expect(document.activeElement).not.toBe(firstFocusableElement);
+    });
+  });
+
+  describe("focusFirstElement", () => {
+    it("should focus on the element passes as focusFirstElement prop", () => {
+      const Component = () => {
+        const secondInputRef = useRef(null);
+        return (
+          <DialogFullScreen focusFirstElement={secondInputRef} open>
+            <input type="text" />
+            <input type="text" ref={secondInputRef} />
+          </DialogFullScreen>
+        );
+      };
+      mount(<Component />);
+
+      const secondFocusableElement = document.querySelectorAll("input")[1];
+      expect(document.activeElement).toEqual(secondFocusableElement);
+    });
   });
 
   describe("disableContentPadding", () => {

--- a/src/components/dialog-full-screen/dialog-full-screen.style.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.style.js
@@ -16,6 +16,14 @@ const StyledDialogFullScreen = styled.div`
   display: flex;
   flex-direction: column;
 
+  > ${StyledIconButton} {
+    margin: 0;
+    position: absolute;
+    right: 40px;
+    top: 26px;
+    z-index: 1;
+  }
+
   /**
     The following CSS is for a legacy use of the Pages component.
     Please do not remove this until Pages has been re-written.

--- a/src/components/dialog/dialog.component.js
+++ b/src/components/dialog/dialog.component.js
@@ -244,8 +244,8 @@ Dialog.propTypes = {
   ]),
   /** Determines if the close icon is shown */
   showCloseIcon: PropTypes.bool,
-  /** Function or reference to first element to focus */
-  focusFirstElement: PropTypes.func,
+  /** Optional reference to an element meant to be focused on open */
+  focusFirstElement: PropTypes.shape({ current: PropTypes.any }),
   /** Disables auto focus functionality on child elements */
   disableAutoFocus: PropTypes.bool,
   /**


### PR DESCRIPTION
### Proposed behaviour
First element in DialogFullScreen should be focused by default (same as in Dialog component)

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-33phq