### PR TITLE
fix(search): fix outline appearing onClick around the X icon - FE-3999

### DIFF
--- a/src/__experimental__/components/search/search.component.js
+++ b/src/__experimental__/components/search/search.component.js
@@ -123,6 +123,10 @@ const Search = ({
     }
   };
 
+  const handleMouseDown = (ev) => {
+    ev.preventDefault();
+  };
+
   const handleBlur = () => {
     setIsFocused(false);
   };
@@ -162,6 +166,7 @@ const Search = ({
         inputIcon={iconType}
         iconTabIndex={iconTabIndex}
         iconOnClick={handleIconClick}
+        iconOnMouseDown={handleMouseDown}
         aria-label={ariaLabel}
         onFocus={onFocus}
         onClick={onClick}
@@ -202,7 +207,7 @@ Search.propTypes = {
   onKeyDown: PropTypes.func,
   /** Prop boolean to state whether the `search` icon renders */
   searchButton: PropTypes.bool,
-  /** Prop for specifing an input width length.
+  /** Prop for specifying an input width length.
    * Leaving the `searchWidth` prop with no value will default the width to '100%' */
   searchWidth: PropTypes.string,
   /** Prop for `onFocus` events */

--- a/src/__experimental__/components/search/search.d.ts
+++ b/src/__experimental__/components/search/search.d.ts
@@ -16,7 +16,7 @@ export interface SearchProps extends MarginSpacingProps {
   onKeyDown?: (ev: React.SyntheticEvent) => void;
   /** Prop boolean to state whether the `search` icon renders */
   searchButton?: boolean;
-  /** Prop for specifing an input width length.
+  /** Prop for specifying an input width length.
    * Leaving the `searchWidth` prop with no value will default the width to '100%'
    */
   searchWidth?: string;

--- a/src/__experimental__/components/search/search.spec.js
+++ b/src/__experimental__/components/search/search.spec.js
@@ -354,6 +354,21 @@ describe("Search", () => {
         });
       });
 
+      it("calls preventDefault", () => {
+        const preventDefault = jest.fn();
+        act(() => {
+          const icon = wrapper
+            .find(Icon)
+            .findWhere((n) => n.props().type === "cross")
+            .hostNodes();
+          icon.simulate("mousedown", { preventDefault });
+        });
+
+        wrapper.update();
+
+        expect(preventDefault).toHaveBeenCalled();
+      });
+
       it("clears the input value", () => {
         wrapper = renderWrapper(
           {

--- a/src/__experimental__/components/textbox/textbox.component.js
+++ b/src/__experimental__/components/textbox/textbox.component.js
@@ -21,6 +21,7 @@ const Textbox = ({
   childOfForm,
   isOptional,
   iconOnClick,
+  iconOnMouseDown,
   iconTabIndex,
   styleOverride,
   validationOnLabel,
@@ -76,6 +77,7 @@ const Textbox = ({
             {...removeParentProps(props)}
             useValidationIcon={!validationOnLabel}
             onClick={iconOnClick || props.onClick}
+            onMouseDown={iconOnMouseDown}
             inputIcon={inputIcon}
             iconTabIndex={iconTabIndex}
           />
@@ -176,6 +178,8 @@ Textbox.propTypes = {
   positionedChildren: PropTypes.node,
   /** Optional handler for click event on Textbox icon */
   iconOnClick: PropTypes.func,
+  /** Optional handler for mousedown event on Textbox icon */
+  iconOnMouseDown: PropTypes.func,
   /** Overrides the default tabindex of the component */
   iconTabIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Handler for onClick events */

--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -440,6 +440,7 @@ const FilterableSelect = React.forwardRef(
         formattedValue: textValue,
         onClick: handleTextboxClick,
         iconOnClick: handleDropdownIconClick,
+        iconOnMouseDown: handleTextboxMouseDown,
         onFocus: handleTextboxFocus,
         onBlur: handleTextboxBlur,
         onKeyDown: handleTextboxKeydown,

--- a/src/components/select/multi-select/multi-select.component.js
+++ b/src/components/select/multi-select/multi-select.component.js
@@ -425,6 +425,7 @@ const MultiSelect = React.forwardRef(
         onFocus: handleTextboxFocus,
         onBlur: handleTextboxBlur,
         iconOnClick: handleDropdownIconClick,
+        iconOnMouseDown: handleTextboxMouseDown,
         onKeyDown: handleTextboxKeydown,
         onChange: handleTextboxChange,
         ...textboxProps,


### PR DESCRIPTION
Fixes a styling bug where the X icon appears a golden outline onClick

fixes #3857

### Proposed behaviour
Focus outline should only appear around 'X' icon when icon is navigated to via the keyboard.

### Current behaviour
Focus outline appears onClick.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
<del> - [ ] Screenshots are included in the PR if useful </del>
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
<del> - [ ] Storybook added or updated if required </del>
<del> - [ ] Typescript `d.ts` file added or updated if required </del>
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-dojtr?file=/src/index.js
