### PR TITLE
feat(dialog, dialog-full-screen): add help and and fix text wrapping - [ FE-4025 | FE-4026 ] 

### DIFF
--- a/cypress/features/regression/experimental/simpleColorPickerAction.feature
+++ b/cypress/features/regression/experimental/simpleColorPickerAction.feature
@@ -18,33 +18,33 @@ Feature: Simple Color Picker component
 
   @positive
   Scenario: When on last color, going forward selects first color
-    When I press rightarrow on the 10 color
+    When I press rightarrow on the 10 color in IFrame
     Then Experimental Simple Color Picker 1 element was picked up
 
   @positive
   Scenario: When on first color, going backward selects last color
-    When I press leftarrow on the 1 color
+    When I press leftarrow on the 1 color in IFrame
     Then Experimental Simple Color Picker 10 element was picked up
 
   @positive
   Scenario: Left arrow moves selection left
-    When I press leftarrow on the 3 color
+    When I press leftarrow on the 3 color in IFrame
     Then Experimental Simple Color Picker 2 element was picked up
 
   @positive
   Scenario: Right arrow moves selection right
-    When I press rightarrow on the 3 color
+    When I press rightarrow on the 3 color in IFrame
     Then Experimental Simple Color Picker 4 element was picked up
 
   @positive
   Scenario: Up arrow moves selection up
     Given I select 6 color
-    When I press uparrow on the 6 color
+    When I press uparrow on the 6 color in IFrame
     Then Experimental Simple Color Picker 1 element was picked up
 
   @positive
   Scenario: Down arrow moves selection down
-    When I press downarrow on the 3 color
+    When I press downarrow on the 3 color in IFrame
     Then Experimental Simple Color Picker 8 element was picked up
 
   @positive

--- a/cypress/features/regression/test/advancedColorPickerNoIFrame.feature
+++ b/cypress/features/regression/test/advancedColorPickerNoIFrame.feature
@@ -7,7 +7,7 @@ Feature: Advanced Color Picker component
 
   @positive
   Scenario Outline: <key> moves selection
-    When I press "<key>" onto focused element
+    When I press <key> on the 7 color
     Then Simple Color <index> element was picked up in noIframe
     Examples:
       | key        | index |
@@ -16,7 +16,7 @@ Feature: Advanced Color Picker component
       | uparrow    | 2     |
 
   @positive
-  Scenario: Down arrow moves selection down
-    Given I press "uparrow" onto focused element
-    When I press "downarrow" onto focused element
+  Scenario: down arrow moves selection down
+    Given I press uparrow on the 7 color
+    When I press downarrow on the 2 color
     Then Simple Color 7 element was picked up in noIframe

--- a/cypress/support/step-definitions/simple-color-picker-steps.js
+++ b/cypress/support/step-definitions/simple-color-picker-steps.js
@@ -2,7 +2,10 @@ import {
   simpleColorPickerDiv,
   simpleColorPickerLegendNoIFrame,
 } from "../../locators/simple-color-picker";
-import { experimentalSimpleColorPickerInputInIframe } from "../../locators/advanced-color-picker/index";
+import {
+  experimentalSimpleColorPickerInputInIframe,
+  experimentalSimpleColorPickerInput,
+} from "../../locators/advanced-color-picker/index";
 import {
   getKnobsInput,
   commonDataElementInputPreviewNoIframe,
@@ -39,11 +42,15 @@ When("I select {int} color", (index) => {
   experimentalSimpleColorPickerInputInIframe(index).click();
 });
 
-When("I press {word} on the {int} color", (key, index) => {
+When("I press {word} on the {int} color in IFrame", (key, index) => {
   experimentalSimpleColorPickerInputInIframe(index).trigger(
     "keydown",
     keyCode(key)
   );
+});
+
+When("I press {word} on the {int} color", (key, index) => {
+  experimentalSimpleColorPickerInput(index).trigger("keydown", keyCode(key));
 });
 
 Then("It renders with all colors", () => {

--- a/src/__internal__/focus-trap/focus-trap.component.js
+++ b/src/__internal__/focus-trap/focus-trap.component.js
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useRef,
@@ -13,6 +14,7 @@ import {
   isRadio,
   setElementFocus,
 } from "./focus-trap-utils";
+import { ModalContext } from "../../components/modal/modal.component";
 
 const FocusTrap = ({
   children,
@@ -25,7 +27,7 @@ const FocusTrap = ({
   const [focusableElements, setFocusableElements] = useState();
   const [firstElement, setFirstElement] = useState();
   const [lastElement, setLastElement] = useState();
-
+  const { isAnimationComplete } = useContext(ModalContext);
   const hasNewInputs = useCallback(
     (candidate) => {
       if (!focusableElements || candidate.length !== focusableElements.length) {
@@ -54,11 +56,16 @@ const FocusTrap = ({
   }, [children, hasNewInputs, wrapperRef]);
 
   useEffect(() => {
-    if (autoFocus && firstOpen.current && (focusFirstElement || firstElement)) {
+    if (
+      autoFocus &&
+      firstOpen.current &&
+      isAnimationComplete &&
+      (focusFirstElement || firstElement)
+    ) {
       setElementFocus(focusFirstElement || firstElement);
       firstOpen.current = false;
     }
-  }, [autoFocus, firstElement, focusFirstElement]);
+  }, [autoFocus, firstElement, focusFirstElement, isAnimationComplete]);
 
   useEffect(() => {
     const trapFn = (ev) => {

--- a/src/__internal__/focus-trap/focus-trap.spec.js
+++ b/src/__internal__/focus-trap/focus-trap.spec.js
@@ -6,6 +6,7 @@ import {
   RadioButton,
   RadioButtonGroup,
 } from "../../__experimental__/components/radio-button";
+import { ModalContext } from "../../components/modal/modal.component";
 
 jest.useFakeTimers();
 
@@ -14,11 +15,13 @@ const MockComponent = ({ children, ...rest }) => {
   const ref = useRef();
 
   return (
-    <FocusTrap wrapperRef={ref} {...rest}>
-      <div ref={ref} id="myComponent">
-        {children}
-      </div>
-    </FocusTrap>
+    <ModalContext.Provider value={{ isAnimationComplete: true }}>
+      <FocusTrap wrapperRef={ref} {...rest}>
+        <div ref={ref} id="myComponent">
+          {children}
+        </div>
+      </FocusTrap>
+    </ModalContext.Provider>
   );
 };
 
@@ -419,9 +422,11 @@ describe("FocusTrap", () => {
     it("renders without wrapperRef provided", () => {
       expect(() => {
         mount(
-          <FocusTrap>
-            <div id="myComponent">Content</div>
-          </FocusTrap>
+          <ModalContext.Provider value={{ isAnimationComplete: true }}>
+            <FocusTrap>
+              <div id="myComponent">Content</div>
+            </FocusTrap>
+          </ModalContext.Provider>
         );
       }).not.toThrow();
     });

--- a/src/components/advanced-color-picker/advanced-color-picker.spec.js
+++ b/src/components/advanced-color-picker/advanced-color-picker.spec.js
@@ -10,6 +10,7 @@ import {
   testStyledSystemMargin,
 } from "../../__spec_helper__/test-utils";
 import { noThemeSnapshot } from "../../__spec_helper__/enzyme-snapshot-helper";
+import { ModalContext } from "../modal/modal.component";
 
 jest.mock("../../utils/helpers/guid");
 guid.mockImplementation(() => "guid-12345");
@@ -43,6 +44,8 @@ describe("AdvancedColorPicker", () => {
   function render(props = {}) {
     wrapper = mount(<AdvancedColorPicker {...props} />, {
       attachTo: htmlElement,
+      wrappingComponent: ModalContext.Provider,
+      wrappingComponentProps: { value: { isAnimationComplete: true } },
     });
   }
 
@@ -105,10 +108,12 @@ describe("AdvancedColorPicker", () => {
 
   describe("when controlled", () => {
     describe("when dialog is open", () => {
+      jest.useFakeTimers();
       describe("handleFocus focus trap callback", () => {
         describe("when key other than tab pressed", () => {
           it("should not change the focus", () => {
             render({ ...requiredProps, open: true });
+            jest.runAllTimers();
             const { defaultSimpleColor } = getElements();
 
             expect(document.activeElement).toBe(defaultSimpleColor);
@@ -132,6 +137,7 @@ describe("AdvancedColorPicker", () => {
         describe("when shift tab keys pressed on the selected color input", () => {
           it("should switch focus to the close button", () => {
             render({ ...requiredProps, open: true });
+            jest.runAllTimers();
             const { closeIcon, defaultSimpleColor } = getElements();
 
             expect(document.activeElement).toBe(defaultSimpleColor);
@@ -152,7 +158,7 @@ describe("AdvancedColorPicker", () => {
             };
 
             render(extraProps);
-
+            jest.runAllTimers();
             const { simpleColors } = getElements();
 
             expect(document.activeElement).toBe(simpleColors[0]);
@@ -191,7 +197,7 @@ describe("AdvancedColorPicker", () => {
             };
 
             render(extraProps);
-
+            jest.runAllTimers();
             const { simpleColors } = getElements();
 
             expect(document.activeElement).toBe(simpleColors[7]);
@@ -215,7 +221,7 @@ describe("AdvancedColorPicker", () => {
             };
 
             render(extraProps);
-
+            jest.runAllTimers();
             const { simpleColors } = getElements();
 
             expect(document.activeElement).toBe(simpleColors[7]);
@@ -239,7 +245,7 @@ describe("AdvancedColorPicker", () => {
           };
 
           render(extraProps);
-
+          jest.runAllTimers();
           const { simpleColors } = getElements();
 
           expect(document.activeElement).toBe(simpleColors[7]);

--- a/src/components/dialog-full-screen/dialog-full-screen.component.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.js
@@ -24,6 +24,7 @@ const DialogFullScreen = ({
   disableEscKey,
   onCancel,
   contentRef,
+  help,
   ...rest
 }) => {
   const dialogRef = useRef();
@@ -51,6 +52,7 @@ const DialogFullScreen = ({
           subheader={subtitle}
           subtitleId="carbon-dialog-subtitle"
           divider={false}
+          help={help}
         />
       ) : (
         title
@@ -114,6 +116,8 @@ DialogFullScreen.propTypes = {
   disableAutoFocus: PropTypes.bool,
   /** Determines if the Esc Key closes the Dialog */
   disableEscKey: PropTypes.bool,
+  /** Adds Help tooltip to Header */
+  help: PropTypes.string,
   /** remove padding from content */
   disableContentPadding: PropTypes.bool,
   /** Child elements */

--- a/src/components/dialog-full-screen/dialog-full-screen.spec.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.spec.js
@@ -13,6 +13,7 @@ import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import IconButton from "../icon-button";
 import StyledIconButton from "../icon-button/icon-button.style";
 import { StyledHeader, StyledHeading } from "../heading/heading.style";
+import Help from "../help";
 
 jest.mock("../../utils/helpers/guid");
 
@@ -67,12 +68,15 @@ describe("DialogFullScreen", () => {
   });
 
   describe("autoFocus", () => {
+    jest.useFakeTimers();
     it("should focus the first element by default", () => {
       mount(
         <DialogFullScreen open>
           <input type="text" />
         </DialogFullScreen>
       );
+
+      jest.runAllTimers();
 
       const firstFocusableElement = document.querySelector("input");
       expect(document.activeElement).toBe(firstFocusableElement);
@@ -85,6 +89,8 @@ describe("DialogFullScreen", () => {
         </DialogFullScreen>
       );
 
+      jest.runAllTimers();
+
       const firstFocusableElement = document.querySelector("input");
       expect(document.activeElement).not.toBe(firstFocusableElement);
     });
@@ -92,6 +98,7 @@ describe("DialogFullScreen", () => {
 
   describe("focusFirstElement", () => {
     it("should focus on the element passes as focusFirstElement prop", () => {
+      jest.useFakeTimers();
       const Component = () => {
         const secondInputRef = useRef(null);
         return (
@@ -102,6 +109,8 @@ describe("DialogFullScreen", () => {
         );
       };
       mount(<Component />);
+
+      jest.runAllTimers();
 
       const secondFocusableElement = document.querySelectorAll("input")[1];
       expect(document.activeElement).toEqual(secondFocusableElement);
@@ -230,6 +239,20 @@ describe("DialogFullScreen", () => {
         const heading = fullScreenHeading.find(Heading);
 
         expect(heading.props().title).toEqual("my custom heading");
+      });
+    });
+
+    describe("when prop help is passed", () => {
+      it("should render Help component", () => {
+        wrapper = mount(
+          <DialogFullScreen
+            open
+            title="This is test title"
+            help="this is help text"
+          />
+        );
+
+        expect(wrapper.find(Help).exists()).toBe(true);
       });
     });
   });

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 
 import DialogFullScreen from ".";
@@ -630,6 +630,53 @@ to have a possibility to manage active `Tabs` group
             title="An example of a long header"
             subtitle="Subtitle"
             headerChildren={HeaderChildren}
+          >
+            <Form
+              stickyFooter={true}
+              leftSideButtons={
+                <Button onClick={() => setIsOpen(false)}>Cancel</Button>
+              }
+              saveButton={
+                <Button buttonType="primary" type="submit">
+                  Save
+                </Button>
+              }
+            >
+              <div>
+                This is an example of a full screen Dialog with a Form as
+                content
+              </div>
+              <Textbox label="First Name" />
+              <Textbox label="Middle Name" />
+              <Textbox label="Surname" />
+              <Textbox label="Birth Place" />
+              <Textbox label="Favourite Colour" />
+              <Textbox label="Address" />
+            </Form>
+          </DialogFullScreen>
+        </>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With help
+
+<Preview>
+  <Story name="with help">
+    {() => {
+      const [isOpen, setIsOpen] = useState(true);
+      return (
+        <>
+          <Button onClick={() => setIsOpen(!isOpen)}>
+            Open DialogFullScreen
+          </Button>
+          <DialogFullScreen
+            open={isOpen}
+            onCancel={() => setIsOpen(false)}
+            title="An example of a long header"
+            subtitle="Subtitle"
+            help="Some help text"
           >
             <Form
               stickyFooter={true}

--- a/src/components/dialog-full-screen/dialog-full-screen.style.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.style.js
@@ -3,7 +3,11 @@ import baseTheme from "../../style/themes/base";
 import StyledContent from "./content.style";
 import StyledIconButton from "../icon-button/icon-button.style";
 import StyledFullScreenHeading from "../../__internal__/full-screen-heading/full-screen-heading.style";
-import { StyledHeader, StyledHeading } from "../heading/heading.style";
+import {
+  StyledHeader,
+  StyledHeaderContent,
+  StyledHeading,
+} from "../heading/heading.style";
 
 const StyledDialogFullScreen = styled.div`
   background-color: ${({ theme }) => theme.disabled.input};
@@ -15,6 +19,10 @@ const StyledDialogFullScreen = styled.div`
   z-index: ${({ theme }) => theme.zIndex.fullScreenModal};
   display: flex;
   flex-direction: column;
+
+  ${StyledHeaderContent} {
+    align-items: baseline;
+  }
 
   > ${StyledIconButton} {
     margin: 0;

--- a/src/components/dialog/dialog.component.js
+++ b/src/components/dialog/dialog.component.js
@@ -33,6 +33,7 @@ const Dialog = ({
   showCloseIcon,
   bespokeFocusTrap,
   disableClose,
+  help,
   ...rest
 }) => {
   const dialogRef = useRef();
@@ -132,6 +133,7 @@ const Dialog = ({
             subheader={subtitle}
             subtitleId="carbon-dialog-subtitle"
             divider={false}
+            help={help}
           />
         ) : (
           title
@@ -227,6 +229,8 @@ Dialog.propTypes = {
   disableClose: PropTypes.bool,
   /** Allows developers to specify a specific height for the dialog. */
   height: PropTypes.string,
+  /** Adds Help tooltip to Header */
+  help: PropTypes.string,
   /** Title displayed at top of dialog */
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /** Subtitle displayed at top of dialog */

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -11,6 +11,7 @@ import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import Form from "../form";
 import { StyledFormFooter } from "../form/form.style";
 import IconButton from "../icon-button";
+import Help from "../help";
 
 describe("Dialog", () => {
   let onCancel;
@@ -53,7 +54,7 @@ describe("Dialog", () => {
 
     it("does not bind if component is not open on mount", () => {
       wrapper = mount(
-        <Dialog>
+        <Dialog open={false}>
           <div />
         </Dialog>
       );
@@ -74,7 +75,7 @@ describe("Dialog", () => {
 
     it("does not remove the event listener if it was not in use on unmount", () => {
       wrapper = mount(
-        <Dialog>
+        <Dialog open={false}>
           <div />
         </Dialog>
       );
@@ -85,7 +86,7 @@ describe("Dialog", () => {
 
     it("adds event listeners on modal open", () => {
       wrapper = mount(
-        <Dialog>
+        <Dialog open={false}>
           <div />
         </Dialog>
       );
@@ -271,6 +272,16 @@ describe("Dialog", () => {
         wrapper = mount(<Dialog onCancel={onCancel} open />);
         expect(wrapper.find(DialogTitleStyle).exists()).toBe(false);
         expect(wrapper.find(Heading).exists()).toBe(false);
+      });
+    });
+
+    describe("when prop help is passed", () => {
+      it("should render Help component", () => {
+        wrapper = mount(
+          <Dialog open title="This is test title" help="this is help text" />
+        );
+
+        expect(wrapper.find(Help).exists()).toBe(true);
       });
     });
   });

--- a/src/components/dialog/dialog.stories.mdx
+++ b/src/components/dialog/dialog.stories.mdx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import LinkTo from "@storybook/addon-links/react";
 import Box from "../box";
@@ -150,6 +150,50 @@ When mixing editable and non-editable content, you can use the <LinkTo kind='Des
                   disabled={isDisabled}
                 />
               </RadioButtonGroup>
+              <Box p="24px" bg="slateTint90" ml="88px">
+                <Textbox labelInline label="Property Name" />
+                <Fieldset>
+                  <Textbox labelInline label="Address Line 1" />
+                  <Textbox labelInline label="Address Line 2" />
+                  <Textbox labelInline label="Town" />
+                  <Textbox labelInline label="City" />
+                  <Textbox labelInline label="Postcode" />
+                </Fieldset>
+              </Box>
+            </Form>
+          </Dialog>
+        </>
+      );
+    }}
+  </Story>
+</Preview>
+
+### With help 
+
+<Preview>
+  <Story name="with help">
+    {() => {
+      const [isOpen, setIsOpen] = useState(false);
+      return (
+        <>
+          <Button onClick={() => setIsOpen(!isOpen)}>Open Dialog</Button>
+          <Dialog
+            open={isOpen}
+            onCancel={() => setIsOpen(false)}
+            title="Add an address"
+            help="Some help text"
+          >
+            <Form
+              stickyFooter={true}
+              leftSideButtons={
+                <Button onClick={() => setIsOpen(false)}>Cancel</Button>
+              }
+              saveButton={
+                <Button buttonType="primary" type="submit">
+                  Save
+                </Button>
+              }
+            >
               <Box p="24px" bg="slateTint90" ml="88px">
                 <Textbox labelInline label="Property Name" />
                 <Fieldset>

--- a/src/components/dialog/dialog.style.js
+++ b/src/components/dialog/dialog.style.js
@@ -91,7 +91,6 @@ const DialogTitleStyle = styled.div`
       color: ${({ theme }) => theme.text.color};
       display: block;
       overflow: hidden;
-      white-space: nowrap;
       text-overflow: ellipsis;
       padding: ${({ hasSubtitle }) => !hasSubtitle && "4px 0px"};
     }

--- a/src/components/dialog/dialog.style.js
+++ b/src/components/dialog/dialog.style.js
@@ -2,7 +2,11 @@ import styled, { css } from "styled-components";
 
 import baseTheme from "../../style/themes/base";
 import { StyledForm, StyledFormFooter } from "../form/form.style";
-import { StyledHeading, StyledHeadingTitle } from "../heading/heading.style";
+import {
+  StyledHeaderContent,
+  StyledHeading,
+  StyledHeadingTitle,
+} from "../heading/heading.style";
 import StyledIconButton from "../icon-button/icon-button.style";
 
 const dialogSizes = {
@@ -83,6 +87,10 @@ const DialogTitleStyle = styled.div`
   padding: 23px ${HORIZONTAL_PADDING}px 0;
   border-bottom: 1px solid #ccd6db;
   ${({ showCloseIcon }) => showCloseIcon && "padding-right: 85px"};
+
+  ${StyledHeaderContent} {
+    align-items: baseline;
+  }
 
   ${StyledHeading} {
     margin-bottom: 20px;

--- a/src/components/modal/__snapshots__/modal.spec.js.snap
+++ b/src/components/modal/__snapshots__/modal.spec.js.snap
@@ -14,6 +14,8 @@ exports[`Modal enableBackgroundUI when enableBackgroundUI is false renders child
         appear={true}
         classNames="modal-background"
         key="modal"
+        onEntered={[Function]}
+        onExiting={[Function]}
         timeout={500}
       >
         <styled.div

--- a/src/components/modal/modal.component.js
+++ b/src/components/modal/modal.component.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback } from "react";
+import React, { useEffect, useRef, useCallback, useState } from "react";
 import PropTypes from "prop-types";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 
@@ -6,6 +6,8 @@ import Events from "../../utils/helpers/events";
 import StyledPortal from "../portal/portal.style";
 import ModalManager from "./__internal__/modal-manager";
 import { StyledModal, StyledModalBackground } from "./modal.style";
+
+export const ModalContext = React.createContext({});
 
 const Modal = ({
   children,
@@ -21,6 +23,7 @@ const Modal = ({
   const listenerAdded = useRef(false);
   const modalRegistered = useRef(false);
   const originalOverflow = useRef(undefined);
+  const [isAnimationComplete, setAnimationComplete] = useState(false);
 
   const setOverflow = useCallback(() => {
     if (
@@ -168,6 +171,8 @@ const Modal = ({
               appear
               classNames="modal-background"
               timeout={timeout}
+              onEntered={() => setAnimationComplete(true)}
+              onExiting={() => setAnimationComplete(false)}
             >
               {background}
             </CSSTransition>
@@ -176,7 +181,9 @@ const Modal = ({
         <TransitionGroup>
           {content && (
             <CSSTransition appear classNames="modal" timeout={timeout}>
-              {content}
+              <ModalContext.Provider value={{ isAnimationComplete }}>
+                {content}
+              </ModalContext.Provider>
             </CSSTransition>
           )}
         </TransitionGroup>


### PR DESCRIPTION
### Proposed behaviour
- add help prop 
- wrap text
![dialog_dialog-full-screen_help](https://user-images.githubusercontent.com/19231884/116392640-f5220780-a820-11eb-9484-4e0a51545fac.png)

Fixes #3828
Fixes #3831

### Current behaviour
help prop doesn't exist

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
DialogFullScreen: https://5ecf782fe724630022d27d7d-oskymkvuxe.chromatic.com/?path=/story/dialog-full-screen--with-help
Dialog: https://5ecf782fe724630022d27d7d-oskymkvuxe.chromatic.com/?path=/story/dialog--with-help