### PR TITLE
refactor(date-range): update styled system implementation - FE-3509

### DIFF
--- a/src/__experimental__/components/date-range/__snapshots__/date-range.spec.js.snap
+++ b/src/__experimental__/components/date-range/__snapshots__/date-range.spec.js.snap
@@ -6,7 +6,7 @@ exports[`StyledDateRange renders Date inputs correctly when the labels are inlin
   display: inline-block;
 }
 
-.c2 .c4 {
+.c2 .c11 {
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -20,6 +20,76 @@ exports[`StyledDateRange renders Date inputs correctly when the labels are inlin
 }
 
 .c3 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c4 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c4 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c5 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c5 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c6 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c6 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c7 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c7 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c8 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c8 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c9 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c9 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c10 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c10 .c1:first-child {
   margin-right: 15px;
 }
 
@@ -48,7 +118,7 @@ exports[`StyledDateRange renders Date inputs correctly when the labels are not i
   display: inline-block;
 }
 
-.c2 .c4 {
+.c2 .c11 {
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -68,10 +138,80 @@ exports[`StyledDateRange renders Date inputs correctly when the labels are not i
 .c3 .c1 {
   width: auto;
   display: inline-block;
-  vertical-align: top;
+  vertical-align: bottom;
 }
 
 .c3 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c4 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c4 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c5 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c5 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c6 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c6 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c7 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c7 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c8 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c8 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c9 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.c9 .c1:first-child {
+  margin-right: 15px;
+}
+
+.c10 .c1 {
+  width: auto;
+  display: inline-block;
+  vertical-align: top;
+}
+
+.c10 .c1:first-child {
   margin-right: 15px;
 }
 

--- a/src/__experimental__/components/date-range/date-range.component.js
+++ b/src/__experimental__/components/date-range/date-range.component.js
@@ -1,11 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 
 import { assign } from "lodash";
 import DateInput from "../date";
+import { filterStyledSystemMarginProps } from "../../../style/utils";
 import tagComponent from "../../../utils/helpers/tags";
 import StyledDateRange from "./date-range.style";
 import DateHelper from "../../../utils/helpers/date";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 class DateRange extends React.Component {
   today = DateHelper.todayFormatted("YYYY-MM-DD");
@@ -182,6 +188,7 @@ class DateRange extends React.Component {
       <StyledDateRange
         {...tagComponent("date-range", this.props)}
         labelsInline={this.props.labelsInline}
+        {...filterStyledSystemMarginProps(this.props)}
       >
         <DateInput
           {...this.dateProps("start")}
@@ -203,6 +210,8 @@ class DateRange extends React.Component {
 }
 
 DateRange.propTypes = {
+  /** Filtered styled system margin props */
+  ...marginPropTypes,
   /**
    * Optional label for endDate field
    */

--- a/src/__experimental__/components/date-range/date-range.d.ts
+++ b/src/__experimental__/components/date-range/date-range.d.ts
@@ -1,7 +1,8 @@
 import * as React from "react";
 import DateInput from "../date";
+import { MarginSpacingProps } from '../../../utils/helpers/options-helper';
 
-export interface DateRangeProps {
+export interface DateRangeProps extends MarginSpacingProps {
   /** Optional label for endDate field */
   endLabel?: string;
   /** Specify a callback triggered on change */

--- a/src/__experimental__/components/date-range/date-range.spec.js
+++ b/src/__experimental__/components/date-range/date-range.spec.js
@@ -9,6 +9,7 @@ import {
   elementsTagTest,
   rootTagTest,
 } from "../../../utils/helpers/tags/tags-specs";
+import { testStyledSystemMargin } from "../../../__spec_helper__/test-utils";
 import StyledDateRange from "./date-range.style";
 import StyledDateInput from "../date/date.style";
 
@@ -46,6 +47,10 @@ describe("DateRange", () => {
     spyOn(startInput.instance(), "handleBlur");
     spyOn(endInput.instance(), "handleBlur");
   });
+
+  testStyledSystemMargin((props) => (
+    <DateRange value={["2016-10-10", "2016-11-11"]} {...props} />
+  ));
 
   describe("onChange", () => {
     describe("when the start date changes", () => {

--- a/src/__experimental__/components/date-range/date-range.style.js
+++ b/src/__experimental__/components/date-range/date-range.style.js
@@ -1,7 +1,10 @@
 import styled from "styled-components";
+import { margin } from "styled-system";
 import StyledDateInput from "../date/date.style";
+import baseTheme from "../../../style/themes/base";
 
 const StyledDateRange = styled.div`
+  ${margin}
   & ${StyledDateInput} {
     width: auto;
     display: inline-block;
@@ -12,5 +15,9 @@ const StyledDateRange = styled.div`
     margin-right: 15px;
   }
 `;
+
+StyledDateRange.defaultProps = {
+  theme: baseTheme,
+};
 
 export default StyledDateRange;


### PR DESCRIPTION
### Proposed behaviour
- @styled-system/space margin only on root element 
- In order for this to work the props must only be spread on the root element only rather than passed down to the sub components.

### Current behaviour
No margin support

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-wczdb?file=/src/index.js
