### PR TITLE
feat(heading): add styled-system margin support - FE-3547

### DIFF
--- a/src/components/heading/heading.component.js
+++ b/src/components/heading/heading.component.js
@@ -1,5 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
+
+import { filterStyledSystemMarginProps } from "../../style/utils";
 import tagComponent from "../../utils/helpers/tags";
 import {
   StyledHeading,
@@ -15,8 +18,13 @@ import {
   StyledHeadingPills,
 } from "./heading.style";
 
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
+
 class Heading extends React.Component {
   static propTypes = {
+    ...marginPropTypes,
     /**
      * Children elements
      */
@@ -197,8 +205,10 @@ class Heading extends React.Component {
       return null;
     }
 
+    const marginProps = filterStyledSystemMarginProps(this.props);
+
     return (
-      <StyledHeading {...tagComponent("heading", this.props)}>
+      <StyledHeading {...tagComponent("heading", this.props)} {...marginProps}>
         <StyledHeader
           data-element="header-container"
           divider={this.props.divider}

--- a/src/components/heading/heading.spec.js
+++ b/src/components/heading/heading.spec.js
@@ -14,7 +14,10 @@ import {
   elementsTagTest,
   rootTagTest,
 } from "../../utils/helpers/tags/tags-specs";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/test-utils";
 import DefaultPages from "../pages/pages.component";
 import Page from "../pages/page/page.component";
 import mintTheme from "../../style/themes/mint";
@@ -22,6 +25,10 @@ import Hr from "../hr";
 import Pill from "../pill";
 
 describe("Heading", () => {
+  testStyledSystemMargin((props) => (
+    <Heading title="foo" subheader="subheader" {...props} />
+  ));
+
   it("renders a h1 with the title", () => {
     const wrapper = mount(
       <Heading

--- a/src/components/heading/heading.stories.mdx
+++ b/src/components/heading/heading.stories.mdx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import Heading from "./heading.component";
 import Tile from "../tile";
 import Dl from "../definition-list/dl.component";
 import Dt from "../definition-list/dt.component";
 import Dd from "../definition-list/dd.component";
-
 import Button from "../button/button.component";
 import Pill from "../pill/pill.component";
 
@@ -20,6 +21,7 @@ to meet the [WCAG 2.0 AA standard](https://www.w3.org/TR/UNDERSTANDING-WCAG20/vi
 Webaim have a good online Contrast Checker.
 
 ## Contents
+
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
@@ -29,6 +31,7 @@ Webaim have a good online Contrast Checker.
 ```javascript
 import Heading from "carbon-react/lib/components/heading";
 ```
+
 ## Examples
 
 ### Default
@@ -199,7 +202,7 @@ In this example, the Heading component has the Tile component and the Definition
 ### Heading with Help and Help Link
 
 <Preview>
-  <Story name="with help link" parameters={{ chromatic: { disable: true }}}>
+  <Story name="with help link" parameters={{ chromatic: { disable: true } }}>
     <div style={{ margin: "16px" }}>
       <Heading
         title="This is a Title"
@@ -225,5 +228,6 @@ In this example, the Heading component has the Tile component and the Definition
 
 ## Props
 
-### Heading 
-<Props of={Heading} />
+### Heading
+
+<StyledSystemProps of={Heading} margin noHeader />

--- a/src/components/heading/heading.style.js
+++ b/src/components/heading/heading.style.js
@@ -1,4 +1,6 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
+
 import Icon from "../icon";
 import StyledIcon from "../icon/icon.style";
 import baseTheme from "../../style/themes/base";
@@ -9,6 +11,7 @@ import Link from "../link";
 
 const StyledHeading = styled.div`
   width: 100%;
+  ${margin}
 `;
 
 StyledHeading.defaultProps = {


### PR DESCRIPTION
### Proposed behaviour
This PR adds styled-system margin prop support to Heading component

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-5cnk6?file=/src/index.js