### PR TITLE
feat(content): add margin props

### DIFF
--- a/src/components/content/content.component.js
+++ b/src/components/content/content.component.js
@@ -1,10 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
+
 import {
   StyledContent,
   StyledContentTitle,
   StyledContentBody,
 } from "./content.style.js";
+import { filterStyledSystemMarginProps } from "../../style/utils";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 const Content = ({
   variant = "primary",
@@ -46,6 +53,7 @@ const Content = ({
 );
 
 Content.propTypes = {
+  ...marginPropTypes,
   /** Applies a theme to the Content Value: primary, secondary */
   variant: PropTypes.oneOf(["primary", "secondary"]),
   /** The body of the content component */

--- a/src/components/content/content.d.ts
+++ b/src/components/content/content.d.ts
@@ -1,8 +1,9 @@
-import * as React from 'react';
+import * as React from "react";
+import { MarginSpacingProps } from "../../utils/helpers/options-helper";
 
-export interface ContentProps {
-  align?: 'left' | 'center' | 'right';
-  variant?: 'primary' | 'secondary';
+export interface ContentProps extends MarginSpacingProps {
+  align?: "left" | "center" | "right";
+  variant?: "primary" | "secondary";
   bodyFullWidth?: boolean;
   children?: React.ReactNode;
   inline?: boolean;

--- a/src/components/content/content.spec.js
+++ b/src/components/content/content.spec.js
@@ -8,7 +8,10 @@ import {
   StyledContentTitle,
   StyledContentBody,
 } from "./content.style.js";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/test-utils";
 import { baseTheme } from "../../style/themes";
 import { rootTagTest } from "../../utils/helpers/tags/tags-specs";
 
@@ -22,6 +25,8 @@ describe("Content", () => {
       </ThemeProvider>
     );
   };
+
+  testStyledSystemMargin((props) => <Content {...props}>Foo</Content>);
 
   describe("render", () => {
     it("renders a title", () => {

--- a/src/components/content/content.stories.mdx
+++ b/src/components/content/content.stories.mdx
@@ -1,31 +1,35 @@
-import { Meta, Story, Preview, Props} from '@storybook/addon-docs/blocks';
-import Content from './content.component.js';
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import Content from "./content.component.js";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
-<Meta title="Design System/Content" parameters={{ info: { disable: true }}} />
+<Meta title="Design System/Content" parameters={{ info: { disable: true } }} />
 
 # Content
+
 Text content with simple styles and useful to show simple text content in a common arrangement.
-The Content component shows a title in bold, with plain text content children. Make sure that the colour of all text has a 
-contrast ratio of at least 4.5.1, to meet the [WCAG 2.0 AA standard](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html) 
+The Content component shows a title in bold, with plain text content children. Make sure that the colour of all text has a
+contrast ratio of at least 4.5.1, to meet the [WCAG 2.0 AA standard](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
 for text less than 19px in size. Webaim have a good online [Contrast Checker](http://webaim.org/resources/contrastchecker/).
 
 ## Contents
+
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
 
 ## Quick Start
 
-```js 
+```js
 import Content from "carbon-react/lib/components/content";
 ```
+
 ## Examples
 
 ### Default content
 
 <Preview>
   <Story name="default">
-    <Content title='Title' variant='primary'>
+    <Content title="Title" variant="primary">
       This is an example of some content
     </Content>
   </Story>
@@ -35,7 +39,7 @@ import Content from "carbon-react/lib/components/content";
 
 <Preview>
   <Story name="inline">
-    <Content title='Title' inline>
+    <Content title="Title" inline>
       This is an example of some content
     </Content>
   </Story>
@@ -45,7 +49,7 @@ import Content from "carbon-react/lib/components/content";
 
 <Preview>
   <Story name="secondary styling">
-    <Content title='Title' variant='secondary'>
+    <Content title="Title" variant="secondary">
       This is an example of some content
     </Content>
   </Story>
@@ -53,5 +57,6 @@ import Content from "carbon-react/lib/components/content";
 
 ## Props
 
-### Content 
-<Props of={Content} />
+### Content
+
+<StyledSystemProps of={Content} margin noHeader />

--- a/src/components/content/content.style.js
+++ b/src/components/content/content.style.js
@@ -1,8 +1,12 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
+
 import { baseTheme } from "../../style/themes";
 
 const StyledContent = styled.div`
   ${({ bodyFullWidth, align }) => css`
+    ${margin}
+
     & + & {
       margin-top: 15px;
     }
@@ -17,6 +21,8 @@ const StyledContent = styled.div`
     `}
   `}
 `;
+
+StyledContent.defaultProps = { theme: baseTheme };
 
 const StyledContentTitle = styled.div`
   ${({ theme, titleWidth, inline, variant, align }) => {


### PR DESCRIPTION
### Proposed behaviour
Add styled-system margin props to `Content`

### Current behaviour
`Content` has no spacing props at all.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-ez0b2