### PR TITLE
feat(draggable): add styled-system props support - FE-3541

### DIFF
--- a/src/components/draggable/draggable-container.component.js
+++ b/src/components/draggable/draggable-container.component.js
@@ -2,10 +2,15 @@ import React, { useState } from "react";
 import { DndProvider, useDrop } from "react-dnd";
 import Backend from "react-dnd-html5-backend";
 import PropTypes from "prop-types";
-import DraggableItem from "./draggable-item.component";
-import { StyledIcon } from "./draggable-item.style";
+import styledSystemPropTypes from "@styled-system/prop-types";
 
-const DropTarget = ({ children, getOrder }) => {
+import { filterStyledSystemMarginProps } from "../../style/utils";
+import DraggableItem from "./draggable-item.component";
+import { StyledIcon, StyledDraggableContainer } from "./draggable-item.style";
+
+const marginPropTypes = filterStyledSystemMarginProps(styledSystemPropTypes);
+
+const DropTarget = ({ children, getOrder, ...rest }) => {
   const [, drop] = useDrop({
     accept: "draggableItem",
     drop() {
@@ -13,10 +18,14 @@ const DropTarget = ({ children, getOrder }) => {
     },
   });
 
-  return <div ref={drop}>{children}</div>;
+  return (
+    <StyledDraggableContainer ref={drop} {...rest}>
+      {children}
+    </StyledDraggableContainer>
+  );
 };
 
-const DraggableContainer = ({ children, getOrder }) => {
+const DraggableContainer = ({ children, getOrder, ...rest }) => {
   const [draggableItems, setDraggableItems] = useState(
     React.Children.toArray(children)
   );
@@ -53,9 +62,11 @@ const DraggableContainer = ({ children, getOrder }) => {
     getOrder(draggableItemIds);
   };
 
+  const marginProps = filterStyledSystemMarginProps(rest);
+
   return (
     <DndProvider backend={Backend}>
-      <DropTarget getOrder={getItemsId}>
+      <DropTarget getOrder={getItemsId} {...marginProps}>
         {draggableItems.map((item) =>
           React.cloneElement(
             item,
@@ -76,6 +87,7 @@ const DraggableContainer = ({ children, getOrder }) => {
 };
 
 DraggableContainer.propTypes = {
+  ...marginPropTypes,
   /** Callback fired when order is changed */
   getOrder: PropTypes.func,
   /**
@@ -100,6 +112,7 @@ DraggableContainer.propTypes = {
 };
 
 DropTarget.propTypes = {
+  ...marginPropTypes,
   children: PropTypes.node.isRequired,
   getOrder: PropTypes.func,
 };

--- a/src/components/draggable/draggable-item.component.js
+++ b/src/components/draggable/draggable-item.component.js
@@ -1,9 +1,21 @@
 import React from "react";
 import { useDrop, useDrag } from "react-dnd";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
+
+import { filterStyledSystemPaddingProps } from "../../style/utils";
 import { StyledDraggableItem } from "./draggable-item.style";
 
-const DraggableItem = ({ id, findItem, moveItem, children }) => {
+const paddingPropTypes = filterStyledSystemPaddingProps(styledSystemPropTypes);
+
+const DraggableItem = ({
+  id,
+  findItem,
+  moveItem,
+  children,
+  py = 1,
+  ...rest
+}) => {
   const originalIndex = findItem(id).index;
   const [{ isDragging }, drag] = useDrag({
     item: { type: "draggableItem", id, originalIndex },
@@ -30,11 +42,15 @@ const DraggableItem = ({ id, findItem, moveItem, children }) => {
     },
   });
 
+  const paddingProps = filterStyledSystemPaddingProps(rest);
+
   return (
     <StyledDraggableItem
       data-element="draggable"
       isDragging={isDragging}
       ref={(node) => drag(drop(node))}
+      py={py}
+      {...paddingProps}
     >
       {children}
     </StyledDraggableItem>
@@ -42,6 +58,7 @@ const DraggableItem = ({ id, findItem, moveItem, children }) => {
 };
 
 DraggableItem.propTypes = {
+  ...paddingPropTypes,
   /**
    * The id of the `DraggableItem`.
    *
@@ -50,7 +67,15 @@ DraggableItem.propTypes = {
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   /** The content of the component. */
   children: PropTypes.node.isRequired,
+  /**
+   * @private
+   * @ignore
+   */
   findItem: PropTypes.func,
+  /**
+   * @private
+   * @ignore
+   */
   moveItem: PropTypes.func,
 };
 

--- a/src/components/draggable/draggable-item.style.js
+++ b/src/components/draggable/draggable-item.style.js
@@ -1,12 +1,18 @@
 import styled from "styled-components";
+import { padding, margin } from "styled-system";
+
 import { baseTheme } from "../../style/themes";
 import Icon from "../icon";
+
+const StyledDraggableContainer = styled.div`
+  ${margin}
+`;
 
 const StyledDraggableItem = styled.div`
   display: flex;
   align-items: center;
   border-bottom: 1px solid ${({ theme }) => theme.draggableItem.border};
-  padding: 8px 0;
+  ${padding}
   cursor: move;
 
   opacity: ${({ isDragging }) => (isDragging ? "0" : "1")};
@@ -16,8 +22,12 @@ const StyledIcon = styled(Icon)`
   margin-left: auto;
 `;
 
+StyledDraggableContainer.defaultProps = {
+  theme: baseTheme,
+};
+
 StyledDraggableItem.defaultProps = {
   theme: baseTheme,
 };
 
-export { StyledDraggableItem, StyledIcon };
+export { StyledDraggableContainer, StyledDraggableItem, StyledIcon };

--- a/src/components/draggable/draggable.spec.js
+++ b/src/components/draggable/draggable.spec.js
@@ -2,11 +2,19 @@ import React from "react";
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { render } from "react-dom";
+
 import DraggableContainer from "./draggable-container.component";
 import DraggableItem from "./draggable-item.component";
 import { Checkbox } from "../../__experimental__/components/checkbox";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
-import { StyledDraggableItem } from "./draggable-item.style";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+  testStyledSystemPadding,
+} from "../../__spec_helper__/test-utils";
+import {
+  StyledDraggableContainer,
+  StyledDraggableItem,
+} from "./draggable-item.style";
 
 describe("Draggable Checkbox", () => {
   let wrapper;
@@ -29,6 +37,33 @@ describe("Draggable Checkbox", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
+
+  testStyledSystemMargin(
+    (props) => (
+      <DraggableContainer {...props}>
+        <DraggableItem key="1" id={1}>
+          simple content
+        </DraggableItem>
+        <DraggableItem key="2" id={2}>
+          simple content
+        </DraggableItem>
+      </DraggableContainer>
+    ),
+    null,
+    (component) => component.find(StyledDraggableContainer)
+  );
+
+  testStyledSystemPadding(
+    (props) => (
+      <DraggableContainer>
+        <DraggableItem {...props} key="1`" id={1}>
+          simple content
+        </DraggableItem>
+      </DraggableContainer>
+    ),
+    { py: "8px" },
+    (component) => component.find(StyledDraggableItem)
+  );
 
   it("should return an array with id's", () => {
     wrapper.setProps({ getOrder });

--- a/src/components/draggable/draggable.stories.mdx
+++ b/src/components/draggable/draggable.stories.mdx
@@ -1,4 +1,6 @@
-import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import { DraggableContainer, DraggableItem } from ".";
 import { Checkbox } from "../../__experimental__/components/checkbox";
 
@@ -8,29 +10,36 @@ import { Checkbox } from "../../__experimental__/components/checkbox";
 />
 
 # Draggable
-Pick, move and replace an order. Draggable is a great component if you need to have interactive components 
+
+Pick, move and replace an order. Draggable is a great component if you need to have interactive components
 with possibility to change their order with drag and drop mechanics
 
 ## Contents
+
 - [Quick Start](#quick-start)
 - [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
-## Quick Start 
+## Quick Start
+
 To use the Draggable component you have to import two components: `<DraggableContainer />` and `<DraggableItem />`.
 
 ```javascript
-import { DraggableContainer, DraggableItem } from "carbon-react/lib/components/draggable";
+import {
+  DraggableContainer,
+  DraggableItem,
+} from "carbon-react/lib/components/draggable";
 ```
 
-## Designer Notes 
+## Designer Notes
+
 - Always use `DraggableItem` inside of the `DraggableContainer`
 - `DraggableItem` doesn't work without `DraggableContainer`
 - `DraggableItem` requires an `id` to be passed to the component
 - The whole `<DraggableItem />` is draggable
 - The first: `<DraggableContainer />` is a required container to let content inside of `<DraggableItem />` be draggable.
-- `<DraggableItem />` Is a component that access every child to be put in. 
+- `<DraggableItem />` Is a component that access every child to be put in.
 
 ## Examples
 
@@ -39,10 +48,18 @@ import { DraggableContainer, DraggableItem } from "carbon-react/lib/components/d
 <Preview>
   <Story name="default">
     <DraggableContainer>
-      <DraggableItem key="1" id={1}>Some content goes here</DraggableItem>
-      <DraggableItem key="2" id={2}>Some content goes here</DraggableItem>
-      <DraggableItem key="3" id={3}>Some content goes here</DraggableItem>
-      <DraggableItem key="4" id={4}>Some content goes here</DraggableItem>
+      <DraggableItem key="1" id={1}>
+        Some content goes here
+      </DraggableItem>
+      <DraggableItem key="2" id={2}>
+        Some content goes here
+      </DraggableItem>
+      <DraggableItem key="3" id={3}>
+        Some content goes here
+      </DraggableItem>
+      <DraggableItem key="4" id={4}>
+        Some content goes here
+      </DraggableItem>
     </DraggableContainer>
   </Story>
 </Preview>
@@ -65,19 +82,29 @@ import { DraggableContainer, DraggableItem } from "carbon-react/lib/components/d
         <Checkbox label="checkbox four" mb={0} />
       </DraggableItem>
     </DraggableContainer>
-  </Story>  
+  </Story>
 </Preview>
 
 ### With getOrder callback
 
 <Preview>
-  <Story name="with getOrder callback" id="design-system-draggable-test--default" />
+  <Story
+    name="with getOrder callback"
+    id="design-system-draggable-test--default"
+  />
 </Preview>
 
 ## Props
 
 ### DraggableContainer
-<Props of={DraggableContainer} />
 
-### DraggableItem 
-<Props of={DraggableItem} exclude={['findItem', 'moveItem', 'getOrder']} />
+<StyledSystemProps of={DraggableContainer} noHeader margin />
+
+### DraggableItem
+
+<StyledSystemProps
+  of={DraggableItem}
+  noHeader
+  padding
+  defaults={{ py: "8px" }}
+/>


### PR DESCRIPTION
### Proposed behaviour
This PR adds styled-system props support to Draggable

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-6n58s?file=/src/index.js