### PR TITLE
refactor(search): update styled system implementation - FE-3519

### DIFF
--- a/src/__experimental__/components/search/search.component.js
+++ b/src/__experimental__/components/search/search.component.js
@@ -1,19 +1,29 @@
 import React, { useState, useMemo } from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import invariant from "invariant";
 import StyledSearch, {
   StyledSearchButton,
   StyledButtonIcon,
 } from "./search.style";
+import tagComponent from "../../../utils/helpers/tags";
+import { filterStyledSystemMarginProps } from "../../../style/utils";
 import Icon from "../../../components/icon";
 import Textbox from "../textbox";
 import Button from "../../../components/button";
 import Events from "../../../utils/helpers/events";
 
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
+
 const Search = ({
   defaultValue,
   onChange,
   onClick,
+  onFocus,
+  onBlur,
+  onKeyDown,
   value,
   id,
   name,
@@ -125,33 +135,39 @@ const Search = ({
 
   return (
     <StyledSearch
-      searchWidth={searchWidth}
-      showSearchButton={searchButton}
-      onFocus={handleOnFocus}
-      onClick={handleOnFocus}
-      onBlur={handleBlur}
-      onChange={handleChange}
-      onKeyDown={handleKeyDown}
       isFocused={isFocused}
+      searchWidth={searchWidth}
       searchIsActive={searchIsActive}
-      id={id}
-      data-component="search"
-      name={name}
-      variant={variant}
       searchHasValue={
         !isControlled
           ? searchValue && searchValue.length
           : value && value.length
       }
+      showSearchButton={searchButton}
+      variant={variant}
+      mb={0}
+      {...filterStyledSystemMarginProps(rest)}
+      {...tagComponent("search", rest)}
+      id={id}
+      onFocus={handleOnFocus}
+      onClick={handleOnFocus}
+      onBlur={handleBlur}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+      name={name}
     >
       <Textbox
-        {...rest}
         placeholder={placeholder}
         value={!isControlled ? searchValue : value}
         inputIcon={iconType}
         iconTabIndex={iconTabIndex}
         iconOnClick={handleIconClick}
         aria-label={ariaLabel}
+        onFocus={onFocus}
+        onClick={onClick}
+        onBlur={onBlur}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
       />
       {searchButton && (
         <StyledSearchButton>
@@ -171,6 +187,8 @@ const Search = ({
 };
 
 Search.propTypes = {
+  /** Filtered styled system margin props */
+  ...marginPropTypes,
   /** Prop for `uncontrolled` use */
   defaultValue: PropTypes.string,
   /** Prop for `controlled` use */
@@ -187,6 +205,8 @@ Search.propTypes = {
   /** Prop for specifing an input width length.
    * Leaving the `searchWidth` prop with no value will default the width to '100%' */
   searchWidth: PropTypes.string,
+  /** Prop for `onFocus` events */
+  onFocus: PropTypes.func,
   /** Prop for `onBlur` events */
   onBlur: PropTypes.func,
   /** Prop for `id` */

--- a/src/__experimental__/components/search/search.d.ts
+++ b/src/__experimental__/components/search/search.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
+import { MarginSpacingProps } from '../../../utils/helpers/options-helper';
 
-export interface SearchProps {
+export interface SearchProps extends MarginSpacingProps {
   /** Prop for `uncontrolled` use */
   defaultValue?: string;
   /** Prop for `controlled` use */

--- a/src/__experimental__/components/search/search.spec.js
+++ b/src/__experimental__/components/search/search.spec.js
@@ -5,7 +5,10 @@ import { Input } from "../input";
 import Button from "../../../components/button";
 import Search from "./search.component";
 import { StyledSearchButton } from "./search.style";
-import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../../__spec_helper__/test-utils";
 import StyledTextInput from "../input/input-presentation.style";
 import Icon from "../../../components/icon";
 import TextBox from "../textbox";
@@ -14,8 +17,11 @@ import { rootTagTest } from "../../../utils/helpers/tags/tags-specs";
 describe("Search", () => {
   let wrapper, onBlur, onChange, onClick, onKeyDown;
 
+  testStyledSystemMargin((props) => <Search value="" {...props} />);
+
   const renderWrapper = (props, render = shallow) =>
     render(<Search {...props} />);
+
   describe("styles", () => {
     it("matches the expected styles", () => {
       assertStyleMatch(

--- a/src/__experimental__/components/search/search.stories.mdx
+++ b/src/__experimental__/components/search/search.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Preview, Props} from '@storybook/addon-docs/blocks';
 import {useState} from 'react';
+import StyledSystemProps from "../../../../.storybook/utils/styled-system-props";
 import Search from '.';
 import Button from '../../../components/button';
 import Box from '../../../components/box';
@@ -150,4 +151,5 @@ In this example the `variant` prop is "dark" and no search button is present.
 ## Props
 
 ### Search
-<Props of={Search} />
+
+<StyledSystemProps of={Search} noHeader margin />

--- a/src/__experimental__/components/search/search.style.js
+++ b/src/__experimental__/components/search/search.style.js
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
 import StyledInputPresentation from "../input/input-presentation.style";
 import StyledInput from "../input/input.style";
 import StyledIcon from "../../../components/icon/icon.style";
@@ -26,6 +27,7 @@ const StyledSearch = styled.div`
         (!searchHasValue && isFocused) ||
         (!isFocused && searchHasValue && showSearchButton));
     return css`
+      ${margin}
       width: ${searchWidth ? `${searchWidth}` : "100%"};
       padding-bottom: 2px;
       background-color: transparent;
@@ -33,7 +35,6 @@ const StyledSearch = styled.div`
       display: inline-flex;
       font-size: 14px;
       font-weight: 700;
-      margin-bottom: 0px;
       :hover {
         border-bottom-color: ${theme.search.active};
         cursor: pointer;


### PR DESCRIPTION
### Proposed behaviour
@styled-system/space margin only on root element 
In order for this to work the props must only be spread on the root element only rather than passed down to the sub components.

### Current behaviour
No styled system support

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-5w8x2