### PR TITLE
refactor(fieldset): update styled system implementation - FE-3511

### DIFF
--- a/src/__experimental__/components/fieldset/__snapshots__/fieldset.spec.js.snap
+++ b/src/__experimental__/components/fieldset/__snapshots__/fieldset.spec.js.snap
@@ -3,6 +3,8 @@
 exports[`Fieldset renders correctly 1`] = `
 <styled.fieldset
   data-component="fieldset"
+  m={0}
+  theme="[ theme object ]"
 >
   <styled.div
     data-component="fieldset-style"

--- a/src/__experimental__/components/fieldset/fieldset.component.js
+++ b/src/__experimental__/components/fieldset/fieldset.component.js
@@ -1,5 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
+import { filterStyledSystemMarginProps } from "../../../style/utils";
 import { validProps } from "../../../utils/ether";
 import tagComponent from "../../../utils/helpers/tags";
 import {
@@ -8,6 +10,10 @@ import {
   FieldsetContentStyle,
 } from "./fieldset.style";
 import Logger from "../../../utils/logger/logger";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 let deprecatedWarnTriggered = false;
 
@@ -43,6 +49,8 @@ const Fieldset = (props) => {
     <FieldsetStyle
       {...tagComponent("fieldset", props)}
       {...safeProps}
+      m={0}
+      {...filterStyledSystemMarginProps(props)}
       styleOverride={props.styleOverride.root}
     >
       <FieldsetContentStyle
@@ -57,6 +65,8 @@ const Fieldset = (props) => {
 };
 
 Fieldset.propTypes = {
+  /** Filtered styled system margin props */
+  ...marginPropTypes,
   /** Child elements */
   children: PropTypes.node,
   /** The text for the fieldsets legend element. */

--- a/src/__experimental__/components/fieldset/fieldset.d.ts
+++ b/src/__experimental__/components/fieldset/fieldset.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
+import { MarginSpacingProps } from '../../../utils/helpers/options-helper';
 
-export interface FieldsetProps {
+export interface FieldsetProps extends MarginSpacingProps {
   /** Child elements */
   children?: React.ReactNode;
   /** The text for the fieldsets legend element. */

--- a/src/__experimental__/components/fieldset/fieldset.spec.js
+++ b/src/__experimental__/components/fieldset/fieldset.spec.js
@@ -7,7 +7,11 @@ import {
   FieldsetStyle,
   FieldsetContentStyle,
 } from "./fieldset.style";
-import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../../__spec_helper__/test-utils";
+import { noThemeSnapshot } from "../../../__spec_helper__/enzyme-snapshot-helper";
 
 function render(props, renderer = shallow) {
   return renderer(
@@ -20,8 +24,14 @@ function render(props, renderer = shallow) {
 const basicWrapper = render();
 
 describe("Fieldset", () => {
+  testStyledSystemMargin((props) => (
+    <Fieldset {...props}>
+      <Textbox />
+    </Fieldset>
+  ));
+
   it("renders correctly", () => {
-    expect(basicWrapper).toMatchSnapshot();
+    expect(noThemeSnapshot(basicWrapper)).toMatchSnapshot();
   });
 
   describe("Fieldset Legend", () => {

--- a/src/__experimental__/components/fieldset/fieldset.stories.mdx
+++ b/src/__experimental__/components/fieldset/fieldset.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 
 import Fieldset from "./";
+import StyledSystemProps from "../../../../.storybook/utils/styled-system-props";
 import { RadioButton, RadioButtonGroup } from "../radio-button";
 import { Select, Option } from "../../../components/select";
 import Textbox from "../textbox";
@@ -227,4 +228,4 @@ You can manipulate the spacings beetwen `Fieldset` components by passing `fieldS
 ## Props
 
 ### Fieldset
-<Props of={Fieldset} />
+<StyledSystemProps of={Fieldset} noHeader margin />

--- a/src/__experimental__/components/fieldset/fieldset.style.js
+++ b/src/__experimental__/components/fieldset/fieldset.style.js
@@ -1,12 +1,14 @@
 import styled from "styled-components";
+import { margin } from "styled-system";
 import FormFieldStyle from "../form-field/form-field.style";
 import ValidationIconStyle from "../../../components/validations/validation-icon.style";
 import StyledIcon from "../../../components/icon/icon.style";
 import CheckboxStyle from "../checkbox/checkbox.style";
+import baseTheme from "../../../style/themes/base";
 
 const FieldsetStyle = styled.fieldset`
+  ${margin}
   border: none;
-  margin: 0;
   padding: 0;
 
   &&&& ${FormFieldStyle} {
@@ -21,6 +23,10 @@ const FieldsetStyle = styled.fieldset`
 
   ${({ styleOverride }) => styleOverride};
 `;
+
+FieldsetStyle.defaultProps = {
+  theme: baseTheme,
+};
 
 const LegendContainerStyle = styled.div`
   ${({ inline }) =>


### PR DESCRIPTION
### Proposed behaviour
@styled-system/space margin only on root element 
In order for this to work the props must only be spread on the root element only rather than passed down to the sub components.

### Current behaviour
No styled-system support

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-u9h51