### PR TITLE
refactor(fieldset): update styled system implementation - FE-3512

### DIFF
--- a/src/__experimental__/components/checkbox/__snapshots__/checkbox-group.spec.js.snap
+++ b/src/__experimental__/components/checkbox/__snapshots__/checkbox-group.spec.js.snap
@@ -134,8 +134,8 @@ exports[`CheckboxGroup renders as expected 1`] = `
 }
 
 .c0 {
-  border: none;
   margin: 0;
+  border: none;
   padding: 0;
   min-width: 0;
   min-inline-size: 0;

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
@@ -164,8 +164,8 @@ exports[`RadioButtonGroup renders as expected 1`] = `
 }
 
 .c0 {
-  border: none;
   margin: 0;
+  border: none;
   padding: 0;
   min-width: 0;
   min-inline-size: 0;

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -414,8 +414,8 @@ exports[`RadioButton base renders as expected 1`] = `
 }
 
 .c0 {
-  border: none;
   margin: 0;
+  border: none;
   padding: 0;
   min-width: 0;
   min-inline-size: 0;

--- a/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
+++ b/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
@@ -2,8 +2,8 @@
 
 exports[`SimpleColorPicker renders as expected 1`] = `
 .c0 {
-  border: none;
   margin: 0;
+  border: none;
   padding: 0;
   min-width: 0;
   min-inline-size: 0;

--- a/src/__internal__/fieldset/fieldset.component.js
+++ b/src/__internal__/fieldset/fieldset.component.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 
 import {
   StyledFieldset,
@@ -8,6 +9,11 @@ import {
 } from "./fieldset.style";
 import ValidationIcon from "../../components/validations/validation-icon.component";
 import { InputGroupBehaviour, InputGroupContext } from "../input-behaviour";
+import { filterStyledSystemMarginProps } from "../../style/utils";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 const Fieldset = ({
   legend,
@@ -19,8 +25,6 @@ const Fieldset = ({
   error,
   warning,
   info,
-  ml,
-  mb,
   styleOverride,
   isRequired,
   blockGroupBehaviour,
@@ -30,8 +34,7 @@ const Fieldset = ({
     <StyledFieldset
       data-component="fieldset"
       styleOverride={styleOverride.root}
-      ml={ml}
-      mb={mb}
+      m={0}
       {...rest}
     >
       <StyledFieldsetContent inline={inline}>
@@ -66,6 +69,8 @@ const Fieldset = ({
 );
 
 Fieldset.propTypes = {
+  /** Filtered styled system margin props */
+  ...marginPropTypes,
   /** Fieldset content */
   children: PropTypes.node.isRequired,
   /** The content for the Fieldset Legend */
@@ -90,10 +95,6 @@ Fieldset.propTypes = {
   legendAlign: PropTypes.oneOf(["left", "right"]),
   /** Spacing between legend and field for inline legend, number multiplied by base spacing unit (8) */
   legendSpacing: PropTypes.oneOf([1, 2]),
-  /** Margin left, any valid CSS value  */
-  ml: PropTypes.string,
-  /** Margin bottom, given number will be multiplied by base spacing unit (8) */
-  mb: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7]),
   /** Allows to override existing component styles */
   styleOverride: PropTypes.shape({
     root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),

--- a/src/__internal__/fieldset/fieldset.d.ts
+++ b/src/__internal__/fieldset/fieldset.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-
-export interface FieldsetProps {
+import { MarginSpacingProps } from '../../utils/helpers/options-helper';
+export interface FieldsetProps extends MarginSpacingProps {
   /** Fieldset content */
   children: React.ReactNode;
   /** The content for the Fieldset Legend */
@@ -25,10 +25,6 @@ export interface FieldsetProps {
   legendAlign?: 'left' | 'right';
   /** Spacing between legend and field for inline legend, number multiplied by base spacing unit (8) */
   legendSpacing?: 1 | 2;
-  /** Margin left, any valid CSS value */
-  ml?: string;
-  /** Margin bottom, given number will be multiplied by base spacing unit (8) */
-  mb?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
   /** Allows to override existing component styles */
   styleOverride?: {
     root?: object;

--- a/src/__internal__/fieldset/fieldset.spec.js
+++ b/src/__internal__/fieldset/fieldset.spec.js
@@ -7,23 +7,28 @@ import {
   StyledLegendContainer,
   StyledFieldsetContent,
 } from "./fieldset.style";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/test-utils";
 
 import ValidationIcon from "../../components/validations/validation-icon.component";
 
 const Component = () => <div />;
+const RenderComponent = (props) => (
+  <Fieldset {...props}>
+    <Component />
+  </Fieldset>
+);
 
-const render = (props) =>
-  mount(
-    <Fieldset {...props}>
-      <Component />
-    </Fieldset>
-  );
+const render = (props) => mount(<RenderComponent {...props} />);
 
 const validationTypes = ["error", "warning", "info"];
 
 describe("Fieldset", () => {
   let wrapper;
+
+  testStyledSystemMargin((props) => <RenderComponent {...props} />);
 
   it("renders passed on children", () => {
     wrapper = render();

--- a/src/__internal__/fieldset/fieldset.style.js
+++ b/src/__internal__/fieldset/fieldset.style.js
@@ -1,19 +1,15 @@
 import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
+import { margin } from "styled-system";
 import BaseTheme from "../../style/themes/base";
 
 const StyledFieldset = styled.fieldset`
-  ${({ ml, mb, theme }) => css`
-    border: none;
-    margin: 0;
-    padding: 0;
-    min-width: 0;
-    min-inline-size: 0;
-
-    ${ml && `margin-left: ${ml};`}
-    ${mb && `margin-bottom: ${mb * theme.spacing}px;`}
-    ${({ styleOverride }) => styleOverride};
-  `}
+  ${margin}
+  border: none;
+  padding: 0;
+  min-width: 0;
+  min-inline-size: 0;
+  ${({ styleOverride }) => styleOverride};
 `;
 
 StyledFieldset.defaultProps = {


### PR DESCRIPTION
### Proposed behaviour
@styled-system/space margin only on root element 
In order for this to work the props must only be spread on the root element only rather than passed down to the sub components.
Remove custom margin props

### Current behaviour
Custom margin props

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
Internal `Fieldset` is a part of `RadioButton`.
https://codesandbox.io/s/carbon-quickstart-forked-kkp18