### PR TITLE
feat(filterable-select): add filterText and onFilterChanged props

### DIFF
--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -893,6 +893,28 @@ describe("FilterableSelect", () => {
       });
     });
   });
+
+  describe("when the filter text is controlled", () => {
+    const onFilterChangedFn = jest.fn();
+
+    const wrapper = renderSelect({
+      openOnFocus: true,
+      filterText: "filter",
+      onFilterChanged: onFilterChangedFn,
+    });
+
+    it("should call the onFilterChanged callback when the filter changes", () => {
+      wrapper.find("input").simulate("change", { target: { value: "r" } });
+
+      expect(onFilterChangedFn).toHaveBeenCalledWith("r");
+
+      wrapper.find("input").simulate("keyDown", {
+        key: "ArrowDown",
+      });
+
+      expect(onFilterChangedFn).toHaveBeenCalled();
+    });
+  });
 });
 
 describe("coverage filler for else path", () => {


### PR DESCRIPTION
Fixes: #3755

### Proposed behaviour
Add `filterText` and `onFilterChanged` props to `FilterableSelect` to allow controlled usage.

### Current behaviour
These props were not available.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
