### PR TITLE
feat(simple-color-picker): add styled system margin - FE-3520

### DIFF
--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.component.js
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.component.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import Events from "../../../utils/helpers/events";
 import tagComponent from "../../../utils/helpers/tags/tags";
 import Fieldset from "../../../__internal__/fieldset";
@@ -8,6 +9,11 @@ import RadioButtonMapper from "../radio-button/radio-button-mapper.component";
 import { StyledContent, StyledColorOptions } from "./simple-color-picker.style";
 import ValidationIcon from "../../../components/validations/validation-icon.component";
 import { InputGroupContext } from "../../../__internal__/input-behaviour";
+import { filterStyledSystemMarginProps } from "../../../style/utils";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
 
 const SimpleColorPicker = (props) => {
   const {
@@ -26,6 +32,7 @@ const SimpleColorPicker = (props) => {
     childWidth = 58,
     validationOnLegend,
     required,
+    ...rest
   } = props;
 
   const myRef = useRef(null);
@@ -200,6 +207,7 @@ const SimpleColorPicker = (props) => {
       isRequired={required}
       {...(validationOnLegend && validationProps)}
       {...tagComponent("simple-color-picker", props)}
+      {...filterStyledSystemMarginProps(rest)}
     >
       <StyledContent>
         <InputGroupContext.Consumer>
@@ -240,6 +248,8 @@ const SimpleColorPicker = (props) => {
 };
 
 SimpleColorPicker.propTypes = {
+  /** Filtered styled system margin props */
+  ...marginPropTypes,
   /** The SimpleColor components to be rendered in the group */
   children: (props, propName, componentName) => {
     let error;

--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.d.ts
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.d.ts
@@ -1,8 +1,9 @@
 import * as React from "react";
+import { MarginProps } from "styled-system";
 import { ValidationPropTypes } from "../../../components/validations";
 import { SimpleColorProps } from "./simple-color/simple-color";
 
-export interface SimpleColorPickerProps extends ValidationPropTypes {
+export interface SimpleColorPickerProps extends ValidationPropTypes, MarginProps {
   /** The SimpleColor components to be rendered in the group */
   children: React.ReactElement<SimpleColorProps> | Array<React.ReactElement<SimpleColorProps>>;
   /** prop that represents childWidth */

--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.spec.js
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.spec.js
@@ -6,7 +6,10 @@ import { SimpleColor, SimpleColorPicker } from ".";
 import { StyledColorOptions } from "./simple-color-picker.style";
 import baseTheme from "../../../style/themes/base";
 import { StyledLegendContainer } from "../../../__internal__/fieldset/fieldset.style";
-import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../../__spec_helper__/test-utils";
 import StyledValidationIcon from "../../../components/validations/validation-icon.style";
 import Fieldset from "../../../__internal__/fieldset";
 
@@ -50,7 +53,19 @@ describe("SimpleColorPicker", () => {
     expect(render()).toMatchSnapshot();
   });
 
-  describe("it renders childs in rows based on maxWidth and childWith", () => {
+  describe("Styled System", () => {
+    testStyledSystemMargin((props) => (
+      <SimpleColorPicker
+        legend="SimpleColorPicker Legend"
+        name="test"
+        {...props}
+      >
+        <SimpleColor id="foo" key="bar" value="#00A376" defaultChecked />
+      </SimpleColorPicker>
+    ));
+  });
+
+  describe("it renders children in rows based on maxWidth and childWith", () => {
     let wrapper, onChange, secondColor;
 
     describe("onKeyDown", () => {

--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.stories.mdx
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.stories.mdx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
-
+import StyledSystemProps from "../../../../.storybook/utils/styled-system-props";
 import { SimpleColorPicker, SimpleColor } from ".";
 import Box from "../../../components/box";
 
@@ -251,11 +251,49 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
+#### With margin
+
+<Preview>
+  <Story name="with margin">
+    {() => {
+      const [state, setState] = useState("transparent");
+      const onChange = ({ target }) => {
+        setState(target.value);
+      };
+      const colors = [
+        { color: "transparent", label: "transparent" },
+        { color: "#0073C1", label: "blue" },
+        { color: "#582C83", label: "purple" },
+      ];
+      return ["error", "warning", "info"].map((validationType) => (
+        <SimpleColorPicker
+          key={`${validationType}-boolean-component`}
+          name={`picker-${validationType}-validation-boolean`}
+          legend="Legend"
+          onChange={onChange}
+          {...{ [validationType]: true }}
+          value={state}
+          m={4}
+        >
+          {colors.map(({ color, label }) => (
+            <SimpleColor
+              value={color}
+              key={color}
+              aria-label={label}
+              id={`${validationType}-${color}`}
+            />
+          ))}
+        </SimpleColorPicker>
+      ));
+    }}
+  </Story>
+</Preview>
+
 ## Props
 
 ### SimpleColorPicker
 
-<Props of={SimpleColorPicker} />
+<StyledSystemProps of={SimpleColorPicker} noHeader margin />
 
 ### SimpleColor
 


### PR DESCRIPTION
### Proposed behaviour
- Add styled-system margin props to component

### Current behaviour
- Component currently does not have styled-system props available to use

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context


### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-wdsm2
