### PR TITLE
docs(dialogfullscreen): disable test stories in chromatic

### DIFF
--- a/src/components/dialog-full-screen/dialog-full-screen.stories.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.js
@@ -13,6 +13,9 @@ export default {
     info: {
       disable: true,
     },
+    chromatic: {
+      disable: true,
+    },
     knobs: { escapeHTML: false },
   },
 };
@@ -123,9 +126,4 @@ Default.story = {
 
 Nested.story = {
   name: "nested",
-  parameters: {
-    chromatic: {
-      disable: true,
-    },
-  },
 };


### PR DESCRIPTION
### Proposed behaviour
Disable the default test story for `DialogFullScreen` in Chromatic because it keeps making the build on master fail (because the guid changes on every build).

We have other `DialogFullScreen` stories captured by Chromatic so we're not losing any coverage here.

### Current behaviour


### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
