### PR TITLE
feat(menu-item): add max width prop for truncation

### DIFF
--- a/src/components/menu/__internal__/submenu/submenu.component.js
+++ b/src/components/menu/__internal__/submenu/submenu.component.js
@@ -324,8 +324,8 @@ Submenu.propTypes = {
   clickToOpen: PropTypes.bool,
   /** The href to use for the menu item. */
   href: PropTypes.string,
-  /** Maximum width in px */
-  maxWidth: PropTypes.number,
+  /** Maximum width. Any valid CSS string */
+  maxWidth: PropTypes.string,
 };
 
 export default Submenu;

--- a/src/components/menu/__internal__/submenu/submenu.component.js
+++ b/src/components/menu/__internal__/submenu/submenu.component.js
@@ -33,6 +33,7 @@ const Submenu = React.forwardRef(
       showDropdownArrow = true,
       clickToOpen,
       href,
+      maxWidth,
       ...rest
     },
     ref
@@ -270,6 +271,7 @@ const Submenu = React.forwardRef(
           onKeyDown={handleKeyDown}
           clickToOpen={clickToOpen}
           href={href}
+          maxWidth={maxWidth}
         >
           {title}
         </StyledMenuItemWrapper>
@@ -322,6 +324,8 @@ Submenu.propTypes = {
   clickToOpen: PropTypes.bool,
   /** The href to use for the menu item. */
   href: PropTypes.string,
+  /** Maximum width in px */
+  maxWidth: PropTypes.number,
 };
 
 export default Submenu;

--- a/src/components/menu/menu-item/menu-item.component.js
+++ b/src/components/menu/menu-item/menu-item.component.js
@@ -34,6 +34,7 @@ const MenuItem = ({
   showDropdownArrow = true,
   ariaLabel,
   clickToOpen,
+  maxWidth,
   ...rest
 }) => {
   const menuContext = useContext(MenuContext);
@@ -101,12 +102,16 @@ const MenuItem = ({
     ref,
   };
 
+  const getTitle = (title) =>
+    maxWidth && typeof title === "string" ? title : "";
+
   if (submenu) {
     return (
       <StyledMenuItem
         role="presentation"
         menuType={menuContext.menuType}
         display="inline-block"
+        title={getTitle(submenu)}
         {...rest}
       >
         <Submenu
@@ -114,6 +119,7 @@ const MenuItem = ({
           submenuDirection={submenuDirection}
           showDropdownArrow={showDropdownArrow}
           clickToOpen={clickToOpen}
+          maxWidth={maxWidth}
           {...elementProps}
           {...rest}
         >
@@ -129,6 +135,7 @@ const MenuItem = ({
       menuType={menuContext.menuType}
       inSubmenu={submenuContext.handleKeyDown !== undefined}
       display="inline-block"
+      title={getTitle(children)}
       {...rest}
     >
       <StyledMenuItemWrapper
@@ -139,6 +146,7 @@ const MenuItem = ({
         {...elementProps}
         role="menuitem"
         ariaLabel={ariaLabel}
+        maxWidth={maxWidth}
       >
         {children}
       </StyledMenuItemWrapper>
@@ -206,6 +214,8 @@ MenuItem.propTypes = {
     }
     return PropTypes.string(props, ...rest);
   },
+  /** Maximum width in px */
+  maxWidth: PropTypes.number,
 };
 
 export default MenuItem;

--- a/src/components/menu/menu-item/menu-item.component.js
+++ b/src/components/menu/menu-item/menu-item.component.js
@@ -214,8 +214,8 @@ MenuItem.propTypes = {
     }
     return PropTypes.string(props, ...rest);
   },
-  /** Maximum width in px */
-  maxWidth: PropTypes.number,
+  /** Maximum width. Any valid CSS string */
+  maxWidth: PropTypes.string,
 };
 
 export default MenuItem;

--- a/src/components/menu/menu-item/menu-item.spec.js
+++ b/src/components/menu/menu-item/menu-item.spec.js
@@ -14,6 +14,7 @@ import { MenuContext } from "../menu.component";
 import SubmenuBlock from "../submenu-block";
 import StyledIcon from "../../icon/icon.style";
 import Icon from "../../icon/icon.component";
+import { StyledMenuItem } from "../menu.style";
 
 const events = {
   enter: {
@@ -92,6 +93,30 @@ describe("MenuItem", () => {
     expect(wrapper.find(StyledMenuItemWrapper).props().className).toBe(
       "carbon-menu-item--has-link"
     );
+  });
+
+  describe("with maxWidth prop set", () => {
+    beforeEach(() => {
+      wrapper = mount(<MenuItem maxWidth={100}>Item One</MenuItem>);
+    });
+
+    it("should add a title attribute with the full title", () => {
+      expect(wrapper.find(StyledMenuItem).props().title).toEqual("Item One");
+    });
+
+    it("should add the correct styles", () => {
+      assertStyleMatch(
+        {
+          maxWidth: "100px",
+          textOverflow: "ellipsis",
+          overflow: "hidden",
+          whiteSpace: "nowrap",
+          verticalAlign: "bottom",
+        },
+        wrapper.find(StyledMenuItemWrapper),
+        { modifier: "button" }
+      );
+    });
   });
 
   describe("submenu", () => {
@@ -260,6 +285,38 @@ describe("MenuItem", () => {
             false
           );
         });
+      });
+    });
+
+    describe("with maxWidth prop set", () => {
+      beforeEach(() => {
+        wrapper = mount(
+          <MenuContext.Provider value={{ menuType: "light" }}>
+            <MenuItem maxWidth={100} submenu="submenu title">
+              <MenuItem>Item one</MenuItem>
+            </MenuItem>
+          </MenuContext.Provider>
+        );
+      });
+
+      it("should add a title attribute with the full title", () => {
+        expect(wrapper.find(StyledMenuItem).at(0).props().title).toEqual(
+          "submenu title"
+        );
+      });
+
+      it("should add the correct styles", () => {
+        assertStyleMatch(
+          {
+            maxWidth: "100px",
+            textOverflow: "ellipsis",
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+            verticalAlign: "bottom",
+          },
+          wrapper.find(StyledMenuItemWrapper),
+          { modifier: "button" }
+        );
       });
     });
   });

--- a/src/components/menu/menu-item/menu-item.spec.js
+++ b/src/components/menu/menu-item/menu-item.spec.js
@@ -97,7 +97,7 @@ describe("MenuItem", () => {
 
   describe("with maxWidth prop set", () => {
     beforeEach(() => {
-      wrapper = mount(<MenuItem maxWidth={100}>Item One</MenuItem>);
+      wrapper = mount(<MenuItem maxWidth="100px">Item One</MenuItem>);
     });
 
     it("should add a title attribute with the full title", () => {
@@ -292,7 +292,7 @@ describe("MenuItem", () => {
       beforeEach(() => {
         wrapper = mount(
           <MenuContext.Provider value={{ menuType: "light" }}>
-            <MenuItem maxWidth={100} submenu="submenu title">
+            <MenuItem maxWidth="100px" submenu="submenu title">
               <MenuItem>Item one</MenuItem>
             </MenuItem>
           </MenuContext.Provider>

--- a/src/components/menu/menu-item/menu-item.style.js
+++ b/src/components/menu/menu-item/menu-item.style.js
@@ -15,6 +15,7 @@ const StyledMenuItemWrapper = styled.a`
     isSearch,
     href,
     clickToOpen,
+    maxWidth,
   }) => css`
     display: inline-block;
     font-size: 14px;
@@ -23,6 +24,18 @@ const StyledMenuItemWrapper = styled.a`
     position: relative;
     cursor: pointer;
     background-color: ${theme.menu.light.background};
+
+    a,
+    button {
+      ${maxWidth &&
+      css`
+        max-width: ${maxWidth}px;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+        vertical-align: bottom;
+      `}
+    }
 
     && a:focus,
     && button:focus {

--- a/src/components/menu/menu-item/menu-item.style.js
+++ b/src/components/menu/menu-item/menu-item.style.js
@@ -29,7 +29,7 @@ const StyledMenuItemWrapper = styled.a`
     button {
       ${maxWidth &&
       css`
-        max-width: ${maxWidth}px;
+        max-width: ${maxWidth};
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -682,6 +682,31 @@ Note that only one `ScrollableBlock` can be used within a single submenu.
   </Story>
 </Preview>
 
+### Truncated titles
+
+Menu items can be given a maximum width using the `maxWidth` prop. Text overflowing this width will be truncated.
+A title attribute is added to the item when using this prop, containing the full menu item text.
+
+<Preview>
+  <Story name="truncated titles">
+    <div style={{ minHeight: "150px" }}>
+      <Menu>
+        <MenuItem maxWidth={100} href="#">
+          A long menu item title
+        </MenuItem>
+        <MenuItem maxWidth={100} submenu="Menu Item Three">
+          <MenuItem maxWidth={150} href="#">
+            A long submenu menu item title
+          </MenuItem>
+        </MenuItem>
+        <MenuItem maxWidth={150} icon="home" href="#">
+          A long menu item title with icon
+        </MenuItem>
+      </Menu>
+    </div>
+  </Story>
+</Preview>
+
 ## Props
 
 ### Menu

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -691,15 +691,15 @@ A title attribute is added to the item when using this prop, containing the full
   <Story name="truncated titles">
     <div style={{ minHeight: "150px" }}>
       <Menu>
-        <MenuItem maxWidth={100} href="#">
+        <MenuItem maxWidth="100px" href="#">
           A long menu item title
         </MenuItem>
-        <MenuItem maxWidth={100} submenu="Menu Item Three">
-          <MenuItem maxWidth={150} href="#">
+        <MenuItem maxWidth="100px" submenu="Menu Item Three">
+          <MenuItem maxWidth="150px" href="#">
             A long submenu menu item title
           </MenuItem>
         </MenuItem>
-        <MenuItem maxWidth={150} icon="home" href="#">
+        <MenuItem maxWidth="150px" icon="home" href="#">
           A long menu item title with icon
         </MenuItem>
       </Menu>


### PR DESCRIPTION
### Proposed behaviour
Add a new `maxWidth` prop to `MenuItem`. If the title of the item exceeds the maximum width, it will automatically truncate.
This will also add a title attribute for hovering over the `MenuItem`.

![image](https://user-images.githubusercontent.com/14963680/117820134-24de0000-b262-11eb-88aa-b9432df8576e.png)


### Current behaviour
It is not currently possible to add truncation to `MenuItem` titles in this way.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
https://codesandbox.io/s/fervent-noyce-y162u