### PR TITLE
feat(date): add styled-system margin support - FE-3508

### DIFF
--- a/src/__experimental__/components/date-range/__snapshots__/date-range.spec.js.snap
+++ b/src/__experimental__/components/date-range/__snapshots__/date-range.spec.js.snap
@@ -1,11 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StyledDateRange renders Date inputs correctly when the labels are inline 1`] = `
-.c2 {
-  width: 100%;
-  display: inline-block;
-}
-
 .c2 .c11 {
   -webkit-flex: none;
   -ms-flex: none;
@@ -113,11 +108,6 @@ exports[`StyledDateRange renders Date inputs correctly when the labels are inlin
 `;
 
 exports[`StyledDateRange renders Date inputs correctly when the labels are not inline 1`] = `
-.c2 {
-  width: 100%;
-  display: inline-block;
-}
-
 .c2 .c11 {
   -webkit-flex: none;
   -ms-flex: none;

--- a/src/__experimental__/components/date/__snapshots__/date.spec.js.snap
+++ b/src/__experimental__/components/date/__snapshots__/date.spec.js.snap
@@ -1,11 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StyledDateInput renders correctly for default theme 1`] = `
-.c0 {
-  width: 100%;
-  display: inline-block;
-}
-
 .c0 .c1 {
   -webkit-flex: none;
   -ms-flex: none;

--- a/src/__experimental__/components/date/date.component.js
+++ b/src/__experimental__/components/date/date.component.js
@@ -1,6 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import invariant from "invariant";
+import styledSystemPropTypes from "@styled-system/prop-types";
+
+import { filterStyledSystemMarginProps } from "../../../style/utils";
 import Events from "../../../utils/helpers/events";
 import DateHelper from "../../../utils/helpers/date";
 import tagComponent from "../../../utils/helpers/tags";
@@ -12,6 +15,17 @@ import { isEdge } from "../../../utils/helpers/browser-type-check";
 
 const defaultDateFormat = "DD/MM/YYYY";
 const hiddenDateFormat = "YYYY-MM-DD";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
+
+// Spacing props filtering is a temporary solution until FormField and all related components are refactored
+// FIXME FE-3370
+const filterOutSpacingProps = (obj) =>
+  Object.fromEntries(
+    Object.entries(obj).filter(([key]) => !styledSystemPropTypes.space[key])
+  );
 
 class BaseDateInput extends React.Component {
   isBlurBlocked = false;
@@ -417,9 +431,10 @@ class BaseDateInput extends React.Component {
         size={inputProps.size}
         labelInline={labelInline}
         {...tagComponent("date", this.props)}
+        {...filterStyledSystemMarginProps(this.props)}
       >
         <Textbox
-          {...inputProps}
+          {...filterOutSpacingProps(inputProps)}
           inputIcon="calendar"
           value={this.state.visibleValue}
           labelInline={labelInline}
@@ -467,6 +482,7 @@ const DateInput = withUniqueIdProps(BaseDateInput);
 
 BaseDateInput.propTypes = {
   ...Textbox.propTypes,
+  ...marginPropTypes,
   /** Boolean to allow the input to have an empty value */
   allowEmptyValue: PropTypes.bool,
   /** Automatically focus on component mount */

--- a/src/__experimental__/components/date/date.spec.js
+++ b/src/__experimental__/components/date/date.spec.js
@@ -2,6 +2,8 @@ import moment from "moment";
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { mount } from "enzyme";
+
+import { testStyledSystemMargin } from "../../../__spec_helper__/test-utils";
 import DateInput, { defaultDateFormat, BaseDateInput } from "./date.component";
 import InputIconToggle from "../input-icon-toggle";
 import DatePicker from "./date-picker.component";
@@ -25,6 +27,8 @@ describe("StyledDateInput", () => {
 describe("Date", () => {
   let wrapper;
   let container;
+
+  testStyledSystemMargin((props) => <DateInput {...props} />);
 
   describe("external validations", () => {
     it.each([["error"], ["warning"], ["info"]])(

--- a/src/__experimental__/components/date/date.stories.mdx
+++ b/src/__experimental__/components/date/date.stories.mdx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 
+import StyledSystemProps from "../../../../.storybook/utils/styled-system-props";
 import DateInput, { BaseDateInput } from ".";
 import { OriginalTextbox } from "../textbox";
 import Button from "../../../components/button";
@@ -18,6 +19,7 @@ import Box from "../../../components/box";
 - Carbon handles a range of formats, like dd/mm/yyyy, dd/mm/yy, dd/mm, or dd. Configuration can be regional, and copes with space, slash, full stop, or colon as separators.
 
 ## Contents
+
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
@@ -27,6 +29,7 @@ import Box from "../../../components/box";
 ```javascript
 import DateInput from "carbon-react/lib/__experimental__/components/date";
 ```
+
 ## Examples
 
 ### Default
@@ -167,7 +170,10 @@ import DateInput from "carbon-react/lib/__experimental__/components/date";
 ### With disabled portal
 
 <Preview>
-  <Story name="with disabled portal" parameters={{ chromatic: { disable: true }}}>
+  <Story
+    name="with disabled portal"
+    parameters={{ chromatic: { disable: true } }}
+  >
     <DateInput label="Date" value="2016-10-01" disablePortal />
   </Story>
 </Preview>
@@ -274,7 +280,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
 
 ### DateInput
 
-<Props of={BaseDateInput} />
+<StyledSystemProps of={BaseDateInput} noHeader margin />
 
 ### Textbox
 

--- a/src/__experimental__/components/date/date.style.js
+++ b/src/__experimental__/components/date/date.style.js
@@ -1,5 +1,7 @@
 import styled from "styled-components";
 import PropTypes from "prop-types";
+import { margin } from "styled-system";
+
 import baseTheme from "../../../style/themes/base";
 import InputPresentationStyle from "../input/input-presentation.style";
 import OptionsHelper from "../../../utils/helpers/options-helper";
@@ -11,8 +13,8 @@ const datePickerWidth = {
 };
 
 const StyledDateInput = styled.div`
-  width: 100%;
-  display: inline-block;
+  ${margin}
+
   & ${InputPresentationStyle} {
     flex: none;
     width: ${({ size }) => (size ? datePickerWidth[size] : "135px")};


### PR DESCRIPTION
### Proposed behaviour
This PR adds styled-system margin support to Date component

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent


### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-dnnin