### PR TITLE
refactor: change propTypes to be more specific

### DIFF
--- a/src/__experimental__/components/checkbox/checkbox.d.ts
+++ b/src/__experimental__/components/checkbox/checkbox.d.ts
@@ -2,6 +2,8 @@ import * as React from "react";
 import { SpaceProps } from "styled-system";
 import { CommonCheckableInputProps } from "../../../__internal__/checkable-input";
 
+export type CheckboxSize = "small" | "large";
+
 export interface CheckboxProps extends CommonCheckableInputProps, SpaceProps {
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint?: number;
@@ -12,7 +14,7 @@ export interface CheckboxProps extends CommonCheckableInputProps, SpaceProps {
   /** A message that the Help component will display */
   labelHelp?: string | React.ReactNode;
   /** Size of the checkbox */
-  size?: "small" | "large";
+  size?: CheckboxSize;
   /** The value of the checkbox, passed on form submit */
   value?: string;
 }

--- a/src/__experimental__/components/form-field/form-field.d.ts
+++ b/src/__experimental__/components/form-field/form-field.d.ts
@@ -2,6 +2,8 @@ import * as React from "react";
 import { SpaceProps } from "styled-system";
 import { ValidationPropTypes } from "../../../components/validations";
 
+export type FormFieldSize = "small" | "medium" | "large";
+
 export interface CommonFormFieldPropTypes
   extends SpaceProps,
     ValidationPropTypes {
@@ -36,7 +38,7 @@ export interface CommonFormFieldPropTypes
   /** If true the label switches position with the input */
   reverse?: boolean;
   /** Size of an input */
-  size?: "small" | "medium" | "large";
+  size?: FormFieldSize;
 }
 
 export interface FormFieldPropTypes extends CommonFormFieldPropTypes {

--- a/src/__experimental__/components/switch/switch.component.js
+++ b/src/__experimental__/components/switch/switch.component.js
@@ -98,7 +98,7 @@ Switch.propTypes = {
   /** The content of the label for the input */
   label: PropTypes.string,
   /** Sets label alignment - accepted values: 'left' (default), 'right' */
-  labelAlign: PropTypes.string,
+  labelAlign: PropTypes.oneOf(["left", "right"]),
   /** Help text */
   labelHelp: PropTypes.node,
   /** Displays label inline with the Switch */
@@ -135,7 +135,7 @@ Switch.propTypes = {
    * Set the size of the Switch to 'small' (16x16 - default) or 'large' (24x24).
    * No effect when using Classic theme.
    */
-  size: PropTypes.string,
+  size: PropTypes.oneOf(["small", "large"]),
   /** the value of the checkbox, passed on form submit */
   value: PropTypes.string,
   /** Margin bottom, given number will be multiplied by base spacing unit (8) */

--- a/src/__experimental__/components/switch/switch.d.ts
+++ b/src/__experimental__/components/switch/switch.d.ts
@@ -2,6 +2,9 @@ import * as React from "react";
 import { MarginProps } from "styled-system";
 import { CommonCheckableInputProps } from "../../../__internal__/checkable-input";
 
+export type SwitchSize = "small" | "large";
+export type LabelAlign = "left" | "right";
+
 export interface SwitchProps extends CommonCheckableInputProps, MarginProps {
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint?: number;
@@ -12,7 +15,7 @@ export interface SwitchProps extends CommonCheckableInputProps, MarginProps {
   /** Unique Identifier for the input. Will use a randomly generated GUID if none is provided */
   id?: string;
   /** Text alignment of the label */
-  labelAlign?: "left" | "right";
+  labelAlign?: LabelAlign;
   /** A message that the Help component will display */
   labelHelp?: React.ReactNode;
   /** When true label is inline */
@@ -22,7 +25,7 @@ export interface SwitchProps extends CommonCheckableInputProps, MarginProps {
   /** Margin bottom, given number will be multiplied by base spacing unit (8) */
   mb?: 0 | 1 | 2 | 3 | 4 | 5 | 7;
   /** Size of the switch */
-  size?: "small" | "large";
+  size?: SwitchSize;
   /** When true, validation icon will be placed on label instead of being placed on the input */
   validationOnLabel?: boolean;
   /** The value of the switch, passed on form submit */

--- a/src/__experimental__/components/textarea/textarea.d.ts
+++ b/src/__experimental__/components/textarea/textarea.d.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { MarginProps } from "styled-system";
 
 import { ValidationPropTypes } from "../../../components/validations";
+import { FormFieldSize } from "../form-field/form-field";
 
 export interface TextareaProps extends ValidationPropTypes, MarginProps {
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
@@ -49,7 +50,7 @@ export interface TextareaProps extends ValidationPropTypes, MarginProps {
   /** The number of visible text lines for the control */
   rows?: number;
   /** Size of an input */
-  size?: "small" | "medium" | "large";
+  size?: FormFieldSize;
   /** Message to be displayed in a Tooltip when the user hovers over the help icon */
   tooltipMessage?: string;
   /** When true, validation icon will be placed on label instead of being placed on the input */
@@ -62,5 +63,5 @@ export interface TextareaProps extends ValidationPropTypes, MarginProps {
 
 declare class Textarea extends React.Component<TextareaProps> {}
 
-export { Textarea as OriginalTextarea };
+export { Textarea as OriginalTextarea, FormFieldSize };
 export default Textarea;

--- a/src/__experimental__/components/textbox/textbox.d.ts
+++ b/src/__experimental__/components/textbox/textbox.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { SpaceProps } from "styled-system";
 import { ValidationPropTypes } from "../../../components/validations";
+import { FormFieldSize } from "../form-field/form-field";
 
 export interface CommonTextboxProps extends ValidationPropTypes {
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
@@ -57,7 +58,7 @@ export interface CommonTextboxProps extends ValidationPropTypes {
   /** Flag to configure component as mandatory */
   required?: boolean;
   /** Size of an input */
-  size?: "small" | "medium" | "large";
+  size?: FormFieldSize;
   /** When true, validation icon will be placed on label instead of being placed on the input */
   validationOnLabel?: boolean;
   /** The value of the Input */
@@ -78,5 +79,5 @@ export interface TextboxProps extends CommonTextboxProps, SpaceProps {
 declare function Textbox(props: TextboxProps): JSX.Element;
 declare function TextboxWithUniqueIdProps(props: TextboxProps & React.RefAttributes<HTMLInputElement>): JSX.Element;
 
-export { Textbox as OriginalTextbox };
+export { Textbox as OriginalTextbox, FormFieldSize };
 export default TextboxWithUniqueIdProps;

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.style.js
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.style.js
@@ -5,7 +5,7 @@ import baseTheme from "../../../style/themes/base";
 const StyledFlatTableCheckbox = styled.td`
   ${({ as, theme, leftPosition, makeCellSticky }) => css`
     ${as === "td" &&
-    `
+    css`
       background-color: ${theme.colors.white};
       border-width: 0;
       border-bottom: 1px solid ${theme.table.secondary};
@@ -26,7 +26,7 @@ const StyledFlatTableCheckbox = styled.td`
     `}
 
     ${as === "th" &&
-    `
+    css`
       background-color: transparent;
       border-width: 0;
       border-bottom: 1px solid ${theme.table.secondary};

--- a/src/components/icon/icon.d.ts
+++ b/src/components/icon/icon.d.ts
@@ -1,23 +1,207 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
-import { Positions } from "../../utils/helpers/options-helper";
+import * as OptionsHelper from "../../utils/helpers/options-helper";
+
+export type IconSize = "small" | "medium" | "large" | "extra-large";
+export type BackgroundShape = "circle" | "rounded-rect" | "square";
+export type BackgroundTheme = "info" | "error" | "success" | "warning" | "business" | "none";
+export type IconType =
+| "add"
+| "alert"
+| "analysis"
+| "arrow_down"
+| "arrow_left"
+| "arrow_left_boxed"
+| "arrow_left_small"
+| "arrow_right"
+| "arrow_right_small"
+| "arrow_up"
+| "attach"
+| "bank"
+| "basket"
+| "basket_with_squares"
+| "bin"
+| "blocked"
+| "blocked_square"
+| "block_arrow_right"
+| "bold"
+| "boxed_shapes"
+| "bulk_destroy"
+| "bullet_list"
+| "bullet_list_dotted"
+| "bullet_list_numbers"
+| "business"
+| "calendar"
+| "calendar_today"
+| "call"
+| "camera"
+| "card_view"
+| "caret_down"
+| "caret_left"
+| "caret_right"
+| "caret_up"
+| "caret_large_down"
+| "caret_large_left"
+| "caret_large_right"
+| "caret_large_up"
+| "cart"
+| "chat"
+| "chart_bar"
+| "chart_line"
+| "chart_pie"
+| "chat_notes"
+| "chevron_down"
+| "chevron_left"
+| "chevron_right"
+| "chevron_up"
+| "chevron_down_thick"
+| "chevron_left_thick"
+| "chevron_right_thick"
+| "chevron_up_thick"
+| "circles_connection"
+| "clock"
+| "close"
+| "coins"
+| "collaborate"
+| "computer_clock"
+| "connect"
+| "copy"
+| "credit_card"
+| "credit_card_slash"
+| "cross"
+| "cross_circle"
+| "csv"
+| "delete"
+| "delivery"
+| "disputed"
+| "disconnect"
+| "document_right_align"
+| "document_tick"
+| "document_vertical_lines"
+| "download"
+| "drag"
+| "drag_vertical"
+| "draft"
+| "dropdown"
+| "duplicate"
+| "edit"
+| "edited"
+| "email"
+| "email_switch"
+| "ellipsis_horizontal"
+| "ellipsis_vertical"
+| "error"
+| "error_square"
+| "euro"
+| "expand"
+| "factory"
+| "favourite"
+| "favourite_lined"
+| "fax"
+| "feedback"
+| "file_excel"
+| "file_generic"
+| "file_image"
+| "file_pdf"
+| "file_word"
+| "files_leaning"
+| "filter"
+| "filter_new"
+| "fit_height"
+| "fit_width"
+| "flag"
+| "folder"
+| "gift"
+| "graph"
+| "grid"
+| "help"
+| "hide"
+| "home"
+| "image"
+| "in_progress"
+| "in_transit"
+| "individual"
+| "info"
+| "italic"
+| "key"
+| "ledger"
+| "ledger_arrow_left"
+| "ledger_arrow_right"
+| "link"
+| "list_view"
+| "locked"
+| "location"
+| "logout"
+| "lookup"
+| "marker"
+| "message"
+| "messages"
+| "minus"
+| "minus_large"
+| "mobile"
+| "money_bag"
+| "pause_circle"
+| "pdf"
+| "people"
+| "people_switch"
+| "person"
+| "person_info"
+| "person_tick"
+| "phone"
+| "play"
+| "play_circle"
+| "plus"
+| "plus_large"
+| "pound"
+| "print"
+| "progress"
+| "progressed"
+| "question"
+| "refresh"
+| "refresh_clock"
+| "remove"
+| "save"
+| "scan"
+| "search"
+| "services"
+| "settings"
+| "share"
+| "shop"
+| "sort_down"
+| "sort_up"
+| "spanner"
+| "split"
+| "split_container"
+| "square_dot"
+| "stacked_boxes"
+| "stacked_squares"
+| "submitted"
+| "sync"
+| "tag"
+| "three_boxes"
+| "tick"
+| "tick_circle"
+| "unlocked"
+| "upload"
+| "uploaded"
+| "video"
+| "view"
+| "warning";
+export type IconColor = "default" | "on-light-background" | "on-dark-background" | "business-color";
+
 export interface IconProps extends MarginProps {
   /** Icon type */
-  type: string;
+  type: IconType;
   /** Background size */
-  bgSize?: "small" | "medium" | "large" | "extra-large";
+  bgSize?: IconSize;
   /** Background shape */
-  bgShape?: "circle" | "rounded-rect" | "square";
+  bgShape?: BackgroundShape;
   /** Background color theme */
-  bgTheme?: "info" | "error" | "success" | "warning" | "business" | "none";
+  bgTheme?: BackgroundTheme;
   /** Icon font size */
-  fontSize?: "small" | "medium" | "large" | "extra-large";
+  fontSize?: IconSize;
   /** Icon color */
-  iconColor?:
-    | "default"
-    | "on-light-background"
-    | "on-dark-background"
-    | "business-color";
+  iconColor?: IconColor;
   /** Override iconColor, provide any color from palette or any valid css color value. */
   color?: string;
   /** Override bgTheme, provide any color from palette or any valid css color value. */
@@ -29,7 +213,7 @@ export interface IconProps extends MarginProps {
   /** The message string to be displayed in the tooltip */
   tooltipMessage?: string;
   /** The position to display the tooltip */
-  tooltipPosition?: Positions;
+  tooltipPosition?: OptionsHelper.Positions;
   /** Control whether the tooltip is visible */
   tooltipVisible?: boolean;
   /** Override background color of the Tooltip, provide any color from palette or any valid css color value. */
@@ -37,7 +221,7 @@ export interface IconProps extends MarginProps {
   /** Override font color of the Tooltip, provide any color from palette or any valid css color value. */
   tooltipFontColor?: string;
   /** Overrides the default flip behaviour of the Tooltip */
-  tooltipFlipOverrides?: Positions[];
+  tooltipFlipOverrides?: OptionsHelper.Positions[];
 }
 
 declare function Icon(props: IconProps & React.RefAttributes<HTMLSpanElement>): JSX.Element;


### PR DESCRIPTION
### Proposed behaviour
PropTypes in various components are defined as strings, these props should have more specific types.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
~~- [ ] Unit tests added or updated if required~~
~~- [ ] Cypress automation tests added or updated if required~~
~~- [ ] Storybook added or updated if required~~
- [x] Typescript `d.ts` file added or updated if required
~~- [ ] Carbon implementation and Design System documentation are congruent~~
