### PR TITLE
feat(icon): allow hover state to be disabled - FE-4080

### DIFF
--- a/src/components/icon/icon.component.js
+++ b/src/components/icon/icon.component.js
@@ -22,6 +22,7 @@ const Icon = React.forwardRef(
       disabled,
       fontSize,
       iconColor,
+      hover,
       type,
       tooltipMessage,
       tooltipPosition,
@@ -67,6 +68,7 @@ const Icon = React.forwardRef(
       iconColor,
       tabIndex,
       type: iconType(),
+      hover,
       ...filterStyledSystemMarginProps(rest),
     };
 
@@ -147,6 +149,8 @@ Icon.propTypes = {
   disabled: PropTypes.bool,
   /** Aria label for accessibility purposes */
   ariaLabel: PropTypes.string,
+  /** Allows the hover state */
+  hover: PropTypes.bool,
   /** The message string to be displayed in the tooltip */
   tooltipMessage: PropTypes.string,
   /** The position to display the tooltip */
@@ -185,6 +189,7 @@ Icon.defaultProps = {
   bgSize: "small",
   fontSize: "small",
   disabled: false,
+  hover: true,
 };
 
 export default Icon;

--- a/src/components/icon/icon.d.ts
+++ b/src/components/icon/icon.d.ts
@@ -24,6 +24,8 @@ export interface IconProps extends MarginProps {
   bg?: string;
   /** Sets the icon in the disabled state */
   disabled?: boolean;
+  /** Allows the hover state */
+  hover?: boolean;
   /** Aria label for accessibility purposes */
   ariaLabel?: string;
   /** The message string to be displayed in the tooltip */

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -127,6 +127,31 @@ describe("Icon component", () => {
     });
   });
 
+  it("renders properly colored Icon when hover is disabled", () => {
+    const color = "red";
+    const bgColor = "green";
+    const wrapper = mount(
+      <Icon color={color} bg={bgColor} type="message" hover={false} />
+    );
+    assertStyleMatch(
+      {
+        backgroundColor: toColor(baseTheme, bgColor),
+        color: toColor(baseTheme, color),
+      },
+      wrapper.find(StyledIcon)
+    );
+    expect(wrapper.find(StyledIcon)).not.toHaveStyleRule(
+      "color",
+      shade(0.2, toColor(baseTheme, color)),
+      { modifier: ":hover" }
+    );
+    expect(wrapper.find(StyledIcon)).not.toHaveStyleRule(
+      "background-color",
+      shade(0.2, toColor(baseTheme, bgColor)),
+      { modifier: ":hover" }
+    );
+  });
+
   describe("custom colors", () => {
     const correctColors = [
       "red",

--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -131,10 +131,7 @@ These props will override `iconColor` and `bgTheme` prop values.
 See <LinkTo kind='Documentation/Colors' name="page">Colors</LinkTo> for more information.
 
 <Preview>
-  <Story
-    name="custom colors"
-    parameters={{ info: { disable: true }, chromatic: { disable: true } }}
-  >
+  <Story name="custom colors">
     <>
       <Box mb={1}>
         <Icon type="add" color="blackOpacity65" />
@@ -149,6 +146,29 @@ See <LinkTo kind='Documentation/Colors' name="page">Colors</LinkTo> for more inf
         <Icon type="add" bg="red" />
         <Icon type="add" color="white" bg="#123456" />
         <Icon type="add" color="white" bg="rgb(0, 123, 10)" />
+      </Box>
+    </>
+  </Story>
+</Preview>
+
+### Without hover state
+
+<Preview>
+  <Story name="without hover state">
+    <>
+      <Box mb={1}>
+        <Icon type="add" color="blackOpacity65" hover={false} />
+        <Icon type="add" color="brilliantGreenShade20" hover={false} />
+        <Icon type="add" color="red" hover={false} />
+        <Icon type="add" color="#123456" hover={false} />
+        <Icon type="add" color="rgb(0, 123, 10)" hover={false} />
+      </Box>
+      <Box mb={1}>
+        <Icon type="add" color="white" bg="blackOpacity65" hover={false} />
+        <Icon type="add" bg="brilliantGreenShade20" hover={false} />
+        <Icon type="add" bg="red" hover={false} />
+        <Icon type="add" color="white" bg="#123456" hover={false} />
+        <Icon type="add" color="white" bg="rgb(0, 123, 10)" hover={false} />
       </Box>
     </>
   </Story>

--- a/src/components/icon/icon.style.js
+++ b/src/components/icon/icon.style.js
@@ -94,6 +94,7 @@ const StyledIcon = styled.span`
     bgTheme,
     theme,
     color,
+    hover,
     bg,
     iconColor,
     bgSize,
@@ -141,10 +142,13 @@ const StyledIcon = styled.span`
       background-color: ${bgColor};
       vertical-align: middle;
 
-      &:hover {
-        color: ${finalHoverColor};
-        background-color: ${bgHoverColor};
-      }
+      ${hover &&
+      css`
+        &:hover {
+          color: ${finalHoverColor};
+          background-color: ${bgHoverColor};
+        }
+      `}
 
       ${bgTheme !== "none" &&
       css`
@@ -192,6 +196,7 @@ const StyledIcon = styled.span`
 StyledIcon.propTypes = {
   theme: PropTypes.object,
   type: PropTypes.string,
+  hover: PropTypes.bool,
   disabled: PropTypes.bool,
   bgSize: PropTypes.oneOf(["small", "medium", "large", "extra-large"]),
   bgShape: PropTypes.oneOf(OptionsHelper.shapes),
@@ -207,6 +212,7 @@ StyledIcon.propTypes = {
 };
 
 StyledIcon.defaultProps = {
+  hover: true,
   theme: baseTheme,
 };
 

--- a/src/components/popover-container/popover-container.spec.js
+++ b/src/components/popover-container/popover-container.spec.js
@@ -232,6 +232,7 @@ describe("PopoverContainer", () => {
         bgSize: "small",
         disabled: false,
         fontSize: "small",
+        hover: true,
         type: "settings",
       });
       expect(openIcon.prop("aria-haspopup")).toEqual(true);

--- a/src/components/portal/__snapshots__/portal.spec.js.snap
+++ b/src/components/portal/__snapshots__/portal.spec.js.snap
@@ -22,6 +22,7 @@ exports[`Portal when using default node to match snapshot  1`] = `
       bgSize="small"
       disabled={false}
       fontSize="small"
+      hover={true}
       tooltipMessage="Test"
       tooltipPosition="top"
       type="tick"
@@ -30,4 +31,4 @@ exports[`Portal when using default node to match snapshot  1`] = `
 </span>
 `;
 
-exports[`Portal when using default node when an element with id 'root' does not exist will mount on body 1`] = `"<div id=\\"root\\"><div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><span class=\\"sc-bdVaJa jyaunv\\" data-element=\\"tick\\" data-component=\\"icon\\" font-size=\\"small\\" type=\\"tick\\"></span></div></div>"`;
+exports[`Portal when using default node when an element with id 'root' does not exist will mount on body 1`] = `"<div id=\\"root\\"><div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><span class=\\"sc-bdVaJa tTFaT\\" data-element=\\"tick\\" data-component=\\"icon\\" font-size=\\"small\\" type=\\"tick\\"></span></div></div>"`;


### PR DESCRIPTION
### Proposed behaviour
Icons allow hover state to be disabled

### Current behaviour
Icons do not allow hover state to be disabled

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
Resolves: #4001

### Testing instructions
<!-- How can a reviewer test this PR? -->
