### PR TITLE
fix(duelling-picklist): add error if children do not have 2 picklist FE-4059 

### DIFF
--- a/src/components/duelling-picklist/duelling-picklist.component.js
+++ b/src/components/duelling-picklist/duelling-picklist.component.js
@@ -11,6 +11,7 @@ import {
   StyledControlsContainer,
   StyledControl,
 } from "./duelling-picklist.style";
+import { Picklist } from "./picklist/picklist.component";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
@@ -61,7 +62,23 @@ const DuellingPicklist = ({
 
 DuellingPicklist.propTypes = {
   ...marginPropTypes,
-  children: PropTypes.node,
+  children: (props, propName) => {
+    const prop = props[propName];
+    let error;
+
+    if (
+      !prop ||
+      !Array.isArray(prop) ||
+      prop.filter((el) => el.type === Picklist).length !== 2
+    ) {
+      error = new Error(
+        // eslint-disable-next-line max-len
+        `\`${propName}\` must have two \`${Picklist.displayName}\`s`
+      );
+    }
+
+    return error;
+  },
   /** Indicate if component is disabled */
   disabled: PropTypes.bool,
   /** Place for components like Search or Filter placed above the left list */

--- a/src/components/duelling-picklist/duelling-picklist.context.js
+++ b/src/components/duelling-picklist/duelling-picklist.context.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+const FocusContext = React.createContext({});
+
+export default FocusContext;

--- a/src/components/duelling-picklist/duelling-picklist.spec.js
+++ b/src/components/duelling-picklist/duelling-picklist.spec.js
@@ -357,7 +357,7 @@ describe("DuellingPicklist", () => {
       ).toHaveLength(1);
     });
 
-    describe("rerender", () => {
+    describe("re-render", () => {
       it.each([
         ["happens when number of children is changed", [<div />], false],
         [
@@ -379,6 +379,21 @@ describe("DuellingPicklist", () => {
         const nextProps = { children: [<div />], disabled };
         expect(areEqual(prevProps, nextProps)).toBe(disabled);
       });
+    });
+  });
+
+  describe("children", () => {
+    it("should throw an error if there are not two Picklist components", () => {
+      jest.spyOn(global.console, "error").mockImplementation(() => {});
+      mount(
+        <DuellingPicklist>
+          <div>foo</div>
+        </DuellingPicklist>
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        "Warning: Failed prop type: `children` must have two `Picklist`s\n    in DuellingPicklist"
+      );
+      global.console.error.mockReset();
     });
   });
 });

--- a/src/components/duelling-picklist/picklist-group/picklist-group.spec.js
+++ b/src/components/duelling-picklist/picklist-group/picklist-group.spec.js
@@ -1,49 +1,58 @@
-import React from "react";
+import React, { useState } from "react";
 import { shallow, mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 
 import PicklistGroup from "./picklist-group.component";
 import PicklistItem from "../picklist-item/picklist-item.component";
 import { StyledGroupButton } from "./picklist-group.style";
+import FocusContext from "../duelling-picklist.context";
 import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
 import { StyledButton } from "../picklist-item/picklist-item.style";
 
-const index = 1;
 const handleKeyboardAccessibilityFn = jest.fn();
+const setElementToFocus = jest.fn();
+const index = 0;
 
 const render = (props, renderer = shallow) => {
+  const defaultContextValues = {
+    setElementToFocus,
+    elementToFocus: {},
+  };
   return renderer(
-    <PicklistGroup {...props}>
-      <PicklistItem
-        index={index}
-        handleKeyboardAccessibility={handleKeyboardAccessibilityFn}
-        type={props.type}
-        onChange={() => null}
-        item={1}
-      >
-        Item content
-      </PicklistItem>
-      <PicklistItem
-        index={index}
-        handleKeyboardAccessibility={handleKeyboardAccessibilityFn}
-        type={props.type}
-        onChange={() => null}
-        item={2}
-      >
-        Item content
-      </PicklistItem>
-    </PicklistGroup>
+    <FocusContext.Provider value={defaultContextValues}>
+      <PicklistGroup index={index} listIndex={index} {...props}>
+        <PicklistItem
+          handleKeyboardAccessibility={handleKeyboardAccessibilityFn}
+          type={props.type}
+          onChange={() => null}
+          item={1}
+        >
+          Item content
+        </PicklistItem>
+        <PicklistItem
+          handleKeyboardAccessibility={handleKeyboardAccessibilityFn}
+          type={props.type}
+          onChange={() => null}
+          item={2}
+        >
+          Item content
+        </PicklistItem>
+      </PicklistGroup>
+    </FocusContext.Provider>
   );
 };
 
 describe("PicklistGroup component", () => {
   describe("when type is 'add'", () => {
     it("should render an add icon in the button", () => {
-      const wrapper = render({
-        type: "add",
-        title: "Title",
-        onChange: () => null,
-      });
+      const wrapper = render(
+        {
+          type: "add",
+          title: "Title",
+          onChange: () => null,
+        },
+        mount
+      );
 
       expect(wrapper.find(StyledGroupButton).at(0).props().iconType).toEqual(
         "add"
@@ -53,11 +62,14 @@ describe("PicklistGroup component", () => {
 
   describe("when type is 'remove'", () => {
     it("should render a remove icon in the button", () => {
-      const wrapper = render({
-        type: "remove",
-        title: "Title",
-        onChange: () => null,
-      });
+      const wrapper = render(
+        {
+          type: "remove",
+          title: "Title",
+          onChange: () => null,
+        },
+        mount
+      );
 
       expect(wrapper.find(StyledGroupButton).at(0).props().iconType).toEqual(
         "remove"
@@ -73,7 +85,7 @@ describe("PicklistGroup component", () => {
     });
 
     describe("when clicked", () => {
-      it("should call the onChange prop", () => {
+      it("should call the onChange prop and the setElementToFocus context callback", () => {
         const wrapper = render(
           {
             type: "remove",
@@ -86,11 +98,12 @@ describe("PicklistGroup component", () => {
         wrapper.find(StyledGroupButton).props().onClick();
 
         expect(onChangeFn).toHaveBeenCalled();
+        expect(setElementToFocus).toHaveBeenCalledWith(0, 0);
       });
     });
 
     describe("when enter key pressed", () => {
-      it("should call the onChange prop", () => {
+      it("should call the onChange prop and the setElementToFocus context callback", () => {
         const wrapper = render(
           {
             type: "remove",
@@ -103,11 +116,12 @@ describe("PicklistGroup component", () => {
         wrapper.find(StyledGroupButton).simulate("keydown", { which: 13 });
 
         expect(onChangeFn).toHaveBeenCalled();
+        expect(setElementToFocus).toHaveBeenCalledWith(0, 0);
       });
     });
 
     describe("when space key pressed", () => {
-      it("should call the onChange prop", () => {
+      it("should call the onChange prop and the setElementToFocus context callback", () => {
         const wrapper = render(
           {
             type: "remove",
@@ -120,11 +134,12 @@ describe("PicklistGroup component", () => {
         wrapper.find(StyledGroupButton).simulate("keydown", { which: 32 });
 
         expect(onChangeFn).toHaveBeenCalled();
+        expect(setElementToFocus).toHaveBeenCalledWith(0, 0);
       });
     });
 
     describe("when other key pressed", () => {
-      it("should not call the onChange prop", () => {
+      it("should not call the onChange prop or the setElementToFocus context callback", () => {
         const wrapper = render(
           {
             type: "remove",
@@ -137,6 +152,7 @@ describe("PicklistGroup component", () => {
         wrapper.find(StyledGroupButton).simulate("keydown", { which: 70 });
 
         expect(onChangeFn).not.toHaveBeenCalled();
+        expect(setElementToFocus).not.toHaveBeenCalled();
       });
     });
 
@@ -301,6 +317,70 @@ describe("PicklistGroup component", () => {
             wrapper.find(PicklistItem).at(0).find(StyledButton)
           );
         });
+      });
+    });
+  });
+
+  describe("focus behavior", () => {
+    const MockComponent = (props) => {
+      const [focused, setFocused] = useState({});
+      const elementToFocus = (itemIndex, listIndex, groupIndex) => {
+        setFocused({ itemIndex, listIndex, groupIndex });
+        setElementToFocus(itemIndex, listIndex, groupIndex);
+      };
+
+      return (
+        <FocusContext.Provider
+          value={{ setElementToFocus: elementToFocus, elementToFocus: focused }}
+        >
+          <PicklistGroup
+            title="Title"
+            type="add"
+            onChange={() => null}
+            index={index}
+            listIndex={index}
+            {...props}
+          >
+            <PicklistItem
+              handleKeyboardAccessibility={handleKeyboardAccessibilityFn}
+              type="add"
+              onChange={() => null}
+              item={1}
+            >
+              Item content
+            </PicklistItem>
+            <PicklistItem
+              handleKeyboardAccessibility={handleKeyboardAccessibilityFn}
+              type="add"
+              onChange={() => null}
+              item={2}
+            >
+              Item content
+            </PicklistItem>
+          </PicklistGroup>
+        </FocusContext.Provider>
+      );
+    };
+
+    describe("when the first item button is clicked", () => {
+      it("calls the context callback with the correct parameters", () => {
+        const wrapper = mount(<MockComponent />);
+        act(() => {
+          wrapper.find(StyledButton).first().props().onClick();
+        });
+
+        expect(setElementToFocus).toHaveBeenCalledWith(0, 0, 0);
+      });
+    });
+
+    describe("when the last item button is clicked", () => {
+      it("calls the context callback with the correct parameters", () => {
+        const wrapper = mount(<MockComponent />);
+        act(() => {
+          wrapper.find(StyledButton).last().props().onClick();
+        });
+
+        expect(setElementToFocus).toHaveBeenCalledWith(1, 0, undefined);
       });
     });
   });

--- a/src/components/duelling-picklist/picklist-group/picklist-group.style.js
+++ b/src/components/duelling-picklist/picklist-group/picklist-group.style.js
@@ -1,6 +1,6 @@
 import styled, { css } from "styled-components";
 import baseTheme from "../../../style/themes/base";
-import Button from "../../button";
+import { ButtonWithForwardRef } from "../../button";
 import { StyledButton } from "../picklist-item/picklist-item.style";
 
 const StyledGroupWrapper = styled.div`
@@ -27,7 +27,7 @@ const StyledPicklistGroup = styled.li`
   margin-bottom: 4px;
 `;
 
-const StyledGroupButton = styled(Button)`
+const StyledGroupButton = styled(ButtonWithForwardRef)`
   ${({ iconType, theme }) => css`
     padding: 0;
     margin-right: 0;

--- a/src/components/duelling-picklist/picklist-item/picklist-item.spec.js
+++ b/src/components/duelling-picklist/picklist-item/picklist-item.spec.js
@@ -1,22 +1,24 @@
 import React from "react";
-import { shallow, mount } from "enzyme";
+import { mount } from "enzyme";
 
 import PicklistItem from "./picklist-item.component";
 import { StyledButton } from "./picklist-item.style";
 import StyledIcon from "../../icon/icon.style";
+import FocusContext from "../duelling-picklist.context";
 
-const index = 1;
 const handleKeyboardAccessibilityFn = jest.fn();
+const setElementToFocus = jest.fn();
 
-const render = (props, renderer = shallow) => {
-  return renderer(
-    <PicklistItem
-      index={index}
-      handleKeyboardAccessibility={handleKeyboardAccessibilityFn}
-      {...props}
-    >
-      Item content
-    </PicklistItem>
+const render = (props) => {
+  return mount(
+    <FocusContext.Provider value={{ setElementToFocus }}>
+      <PicklistItem
+        handleKeyboardAccessibility={handleKeyboardAccessibilityFn}
+        {...props}
+      >
+        Item content
+      </PicklistItem>
+    </FocusContext.Provider>
   );
 };
 
@@ -39,17 +41,64 @@ describe("PicklistItem component", () => {
 
   describe("when locked prop is true'", () => {
     it("should render a locked icon", () => {
-      const wrapper = render(
-        {
-          type: "remove",
-          onChange: jest.fn(),
-          item: 1,
-          locked: true,
-        },
-        mount
-      );
+      const wrapper = render({
+        type: "remove",
+        onChange: jest.fn(),
+        item: 1,
+        locked: true,
+      });
 
       expect(wrapper.find(StyledIcon).props().type).toEqual("locked");
+    });
+  });
+
+  describe("when item button is clicked", () => {
+    it("call the context with the expected arguments when isLastItem and isLastGroup", () => {
+      const wrapper = render({
+        type: "remove",
+        onChange: jest.fn(),
+        item: 1,
+        listIndex: 1,
+        groupIndex: 0,
+        index: 1,
+      });
+
+      wrapper.find(StyledButton).props().onClick();
+
+      expect(setElementToFocus).toHaveBeenCalledWith(1, 1, 0);
+    });
+
+    it("call the context with the expected arguments when isLastItem and isLastGroup are true", () => {
+      const wrapper = render({
+        type: "remove",
+        onChange: jest.fn(),
+        item: 1,
+        listIndex: 1,
+        groupIndex: 0,
+        index: 1,
+        isLastGroup: true,
+        isLastItem: true,
+      });
+
+      wrapper.find(StyledButton).props().onClick();
+
+      expect(setElementToFocus).toHaveBeenCalledWith(0, 0, undefined);
+    });
+
+    it("call the context with the expected arguments when isLastItem is true and isLastGroup is falsy", () => {
+      const wrapper = render({
+        type: "remove",
+        onChange: jest.fn(),
+        item: 1,
+        listIndex: 1,
+        groupIndex: 0,
+        index: 0,
+        isLastItem: true,
+      });
+
+      wrapper.find(StyledButton).props().onClick();
+
+      expect(setElementToFocus).toHaveBeenCalledWith(0, 0, undefined);
     });
   });
 });

--- a/src/components/duelling-picklist/picklist/picklist.component.js
+++ b/src/components/duelling-picklist/picklist/picklist.component.js
@@ -87,4 +87,6 @@ export const areEqual = (prevProps, nextProps) => {
   return !changesCounter;
 };
 
+Picklist.displayName = "Picklist";
+
 export default Picklist;


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Fixes bug where it is possible to have less or more than two `Picklist`s.

Adds `FocusContext` to allow the correct `PicklistItem` or `PicklistGroup` button to be focused when
a given `Picklist` child is moved. If the item or group is not the last one it focuses the next in the given `Picklist`, if it is the last it focuses the first in the other `Picklist`.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Focus is moved to the element before the first `Picklist` when an item button is clicked or receives a keydown event

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![item focus demo](https://user-images.githubusercontent.com/44157880/118943858-ef18d580-b94b-11eb-86b7-4e9f61bb0a69.gif)

![group focus demo](https://user-images.githubusercontent.com/44157880/118944270-5040a900-b94c-11eb-9491-e7b52ad1900b.gif)

### Testing instructions
<!-- How can a reviewer test this PR? -->
`design-system-duellingpicklist--grouped`
`design-system-duellingpicklist--default`