### PR TITLE
docs(search): update stories with default values to not have same text used for placeholder FE-4069

### DIFF
--- a/src/__experimental__/components/search/search.spec.js
+++ b/src/__experimental__/components/search/search.spec.js
@@ -10,6 +10,7 @@ import {
   testStyledSystemMargin,
 } from "../../../__spec_helper__/test-utils";
 import StyledTextInput from "../input/input-presentation.style";
+import StyledInputIconToggle from "../input-icon-toggle/input-icon-toggle.style";
 import Icon from "../../../components/icon";
 import TextBox from "../textbox";
 import { rootTagTest } from "../../../utils/helpers/tags/tags-specs";
@@ -198,6 +199,17 @@ describe("Search", () => {
           borderBottom: "none",
         },
         wrapper
+      );
+    });
+
+    it("applies the expected styling to the close icon", () => {
+      wrapper = renderWrapper({ value: "FooBar" }, mount);
+      assertStyleMatch(
+        {
+          marginBottom: "-1px",
+        },
+        wrapper,
+        { modifier: `${StyledInputIconToggle}` }
       );
     });
   });

--- a/src/__experimental__/components/search/search.stories.mdx
+++ b/src/__experimental__/components/search/search.stories.mdx
@@ -57,7 +57,7 @@ import Search from 'carbon-react/lib/__experimental__/components/search';
 
 <Preview>
   <Story name="with SearchButton" parameters={{ info: { disable: true }}} >
-    <Search defaultValue="Search" searchButton/>
+    <Search defaultValue="Here is some text" searchButton/>
   </Story>
 </Preview>
 
@@ -73,7 +73,7 @@ import Search from 'carbon-react/lib/__experimental__/components/search';
 
 <Preview style={{backgroundColor: '#e6ebed'}}>
   <Story name="with SearchButton and colour background" parameters={{ info: { disable: true }, chromatic: { disable: true }}} >
-    <Search placeholder="Search..." defaultValue="Search" searchButton/>
+    <Search placeholder="Search..." defaultValue="Here is some text" searchButton/>
   </Story>
 </Preview>
 
@@ -91,7 +91,7 @@ In this example the `searchWidth` prop is 375px.
 
 <Preview>
   <Story name="with SearchButton and Custom Width using px" parameters={{ info: { disable: true }}} >
-    <Search defaultValue="Search" searchButton searchWidth="375px"/>
+    <Search defaultValue="Here is some text" searchButton searchWidth="375px"/>
   </Story>
 </Preview>
 
@@ -109,7 +109,7 @@ In this example the `searchWidth` prop is 70%.
 
 <Preview>
   <Story name="with SearchButton and Custom Width using %" parameters={{ info: { disable: true }}} >
-    <Search defaultValue="Search" searchButton searchWidth="70%"/>
+    <Search defaultValue="Here is some text" searchButton searchWidth="70%"/>
   </Story>
 </Preview>
 
@@ -122,7 +122,7 @@ In this example the `variant` prop is "dark" and `searchButton` is true.
       <div style={{padding: "32px", backgroundColor: "#003349"}}>
         <Search
           placeholder="Search..."
-          defaultValue="Search"
+          defaultValue="Here is some text"
           searchButton
           variant="dark"
         />

--- a/src/__experimental__/components/search/search.style.js
+++ b/src/__experimental__/components/search/search.style.js
@@ -6,6 +6,7 @@ import StyledIcon from "../../../components/icon/icon.style";
 import StyledButton from "../../../components/button/button.style";
 import { baseTheme } from "../../../style/themes";
 import StyledFormField from "../form-field/form-field.style";
+import StyledInputIconToggle from "../input-icon-toggle/input-icon-toggle.style";
 
 const StyledSearch = styled.div`
   ${({
@@ -154,6 +155,7 @@ const StyledSearch = styled.div`
             color: ${theme.search.icon};
           `
         }
+
         width: 20px;
         height: 20px;
         cursor: pointer;
@@ -169,7 +171,16 @@ const StyledSearch = styled.div`
               color: ${theme.search.iconHover};
             `
           }
-        };
+        }
+      }
+
+      ${StyledInputIconToggle} {
+        ${
+          searchHasValue &&
+          css`
+            margin-bottom: -1px;
+          `
+        }
       }
     `;
   }}


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Updates the `defaultValue` text so it isn't the same text used for `placeholder` to make it clearer
that there is what using each prop does.

The `InputIconToggle` is slightly out of alignment within the `Search` component, when it is focused
you can see it is slightly misaligned. Adding a transform to move it down vertically by 1% solves
the issue as it is trying to centre itself within the input but the input has a height of 35px

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Stories that use `defaultValue` all have text `Search` which is similar to the `placeholder` text.
The `InputIconToggle` is slightly out of alignment within the `Search` component, when it is focused
you can see it is slightly misaligned.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/119158979-b57cc300-ba4e-11eb-81cd-292838644453.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
`design-system-search--default-story` etc