### PR TITLE
test: add watchForFileChanges env

### DIFF
--- a/.github/workflows/cypress-pr.yml
+++ b/.github/workflows/cypress-pr.yml
@@ -6,7 +6,10 @@ jobs:
   cypress:
      # if not a fork
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: 
+      image: cypress/browsers:node14.16.0-chrome89-ff86
+      options: "--privileged"
     timeout-minutes: 15
     strategy:
       # when one test fails, DO NOT cancel the other
@@ -22,10 +25,15 @@ jobs:
             11, 12, 13, 14, 15,
             16, 17, 18, 19, 20
             ]
-    container: cypress/browsers:node14.16.0-chrome89-ff86
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Increase watchers
+        run: | 
+          echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf && sysctl -p
+      - name: Check amaunt of watchers
+        run: |
+          sysctl fs.inotify
       # Restore the previous NPM modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire
       # workflow successfully finishes.

--- a/.github/workflows/cypress-push.yml
+++ b/.github/workflows/cypress-push.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   cypress:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: 
+      image: cypress/browsers:node14.16.0-chrome89-ff86
+      options: "--privileged"
     timeout-minutes: 15
     strategy:
       # when one test fails, DO NOT cancel the other
@@ -23,10 +26,15 @@ jobs:
             11, 12, 13, 14, 15,
             16, 17, 18, 19, 20
             ]
-    container: node14.16.0-chrome89-ff86
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Increase watchers
+        run: | 
+          echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf && sysctl -p
+      - name: Check amaunt of watchers
+        run: |
+          sysctl fs.inotify
       # Restore the previous NPM modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire
       # workflow successfully finishes.
@@ -45,7 +53,7 @@ jobs:
           key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
           restore-keys: |
             cypress-${{ runner.os }}-cypress-
-      - name: install dependencies and verify Cypress
+      - name: Install dependencies and verify Cypress
         env:
           # make sure every Cypress install prints minimal information
           CI: 1

--- a/cypress/features/regression/experimental/dateInput.feature
+++ b/cypress/features/regression/experimental/dateInput.feature
@@ -31,6 +31,7 @@ Feature: Experimental Date Input component
   @positive
   Scenario: Change Date Input component minDate
     Given I open "Experimental Date Input Test" component page "default"
+      And I wait 100
       And I set minDate to today
       And I set dateInput to today
     When I choose date yesterday via DayPicker
@@ -39,6 +40,7 @@ Feature: Experimental Date Input component
   @positive
   Scenario: Change Date Input component maxDate
     Given I open "Experimental Date Input Test" component page "default"
+      And I wait 100
       And I set maxDate to today
       And I set dateInput to today
     When I choose date tomorrow via DayPicker
@@ -47,6 +49,7 @@ Feature: Experimental Date Input component
   @positive
   Scenario: Check Date Input today date
     Given I open "Experimental Date Input Test" component page "default"
+      And I wait 100
     When I set dateInput to today
     Then the date is set to today
 

--- a/cypress/locators/index.js
+++ b/cypress/locators/index.js
@@ -29,7 +29,7 @@ export const actionsTab = () => cy.get(FORM).find("button").contains("Actions");
 export const knobsNameTab = (name) =>
   cy.get(TAB_LIST).eq(1).find("button").contains(name);
 export const eventInAction = (event) =>
-  cy.get(FORM).find("span").contains(event);
+  cy.get(FORM).find("span").contains(event).wait(100);
 
 // component preview locators
 export const storyRoot = () => cy.iFrame(STORY_ROOT);

--- a/cypress/support/step-definitions/accordion-steps.js
+++ b/cypress/support/step-definitions/accordion-steps.js
@@ -86,6 +86,7 @@ Then("accordionRow is expanded", () => {
 
 Then("accordionRow has golden border outline", () => {
   accordionDefaultTitle()
+    .wait(100)
     .should("have.css", "outline", "rgb(255, 181, 0) solid 2px")
     .and("be.visible");
 });
@@ -93,6 +94,7 @@ Then("accordionRow has golden border outline", () => {
 Then("Accordion {int} row is focused", (index) => {
   accordionTitleContainerByPosition(index)
     .parent()
+    .wait(100)
     .should("have.css", "outline", "rgb(255, 181, 0) solid 2px")
     .and("be.visible");
 });

--- a/cypress/support/step-definitions/action-popover-steps.js
+++ b/cypress/support/step-definitions/action-popover-steps.js
@@ -30,7 +30,7 @@ When(
   "I press keyboard {string} key times {int} on actionPopover open icon",
   (key, times) => {
     for (let i = 0; i < times; i++) {
-      actionPopoverButton().first().trigger("keydown", keyCode(key));
+      actionPopoverButton().wait(100).first().trigger("keydown", keyCode(key));
     }
   }
 );
@@ -68,7 +68,7 @@ When("I press Enter onto {int} submenu actionPopoverInnerItem", (element) => {
 });
 
 When("I press {word} on first element", (key) => {
-  actionPopoverButton().first().trigger("keydown", keyCode(key));
+  actionPopoverButton().wait(100).first().trigger("keydown", keyCode(key));
 });
 
 Then("{string} action was called in Actions Tab for actionPopover", (event) => {

--- a/cypress/support/step-definitions/badge-steps.js
+++ b/cypress/support/step-definitions/badge-steps.js
@@ -26,6 +26,7 @@ When("I click onto Badge component", () => {
 
 Then("Badge component cross icon has proper color", () => {
   badgeNoIFrame()
+    .wait(100)
     .should("have.css", "background")
     .then(($el) => {
       expect($el).contains("rgb(0, 129, 93)");

--- a/cypress/support/step-definitions/batch-selection-steps.js
+++ b/cypress/support/step-definitions/batch-selection-steps.js
@@ -22,5 +22,6 @@ When("I focus Batch selection {string} button", (index) => {
 Then("Batch selection component {string} button is focused", (index) => {
   batchSelectionButtonsByPosition(positionOfElement(index))
     .parent()
+    .wait(100)
     .should("have.css", "outline", "rgb(255, 181, 0) solid 3px");
 });

--- a/cypress/support/step-definitions/common-steps.js
+++ b/cypress/support/step-definitions/common-steps.js
@@ -184,6 +184,7 @@ Then(
   "closeIcon has the border outline color {string} and width {string}",
   (color, width) => {
     closeIconButton()
+      .wait(100)
       .should("have.css", "outline-color", color)
       .and("have.css", "outline-width", width);
   }
@@ -237,12 +238,12 @@ When("I close Sidebar", () => {
 
 When("I press keyboard {string} key times {int}", (key, times) => {
   for (let i = 0; i < times; i++) {
-    cy.focused().trigger("keydown", keyCode(key));
+    cy.focused().wait(100).trigger("keydown", keyCode(key));
   }
 });
 
 When("I press {string} onto focused element", (key) => {
-  cy.focused().trigger("keydown", keyCode(key));
+  cy.focused().wait(100).trigger("keydown", keyCode(key));
 });
 
 When("I press Tab onto focused element", () => {

--- a/cypress/support/step-definitions/flat-table-steps.js
+++ b/cypress/support/step-definitions/flat-table-steps.js
@@ -89,6 +89,7 @@ Then(
     cy.wait(500, { log: DEBUG_FLAG }); // wait was added due to changing animation
     flatTableBodyRowByPosition(index)
       .focus()
+      .wait(100)
       .should("have.css", "outline-color", gold);
   }
 );
@@ -96,6 +97,7 @@ Then(
 Then("press Enter key on the row element", () => {
   flatTableBodyRowByPositionInIframe(2)
     .focus()
+    .wait(100)
     .trigger("keydown", { keyCode: 13, which: 13, force: true });
 });
 
@@ -236,11 +238,12 @@ When("I click on the first cell", () => {
 });
 
 Then("The first cell in the third content row has focus", () => {
-  flatTableCell(8).should("have.css", "outline-color", gold);
+  flatTableCell(8).wait(100).should("have.css", "outline-color", gold);
 });
 
 Then("The {word} content row has focus", (position) => {
   flatTableBodyRowByPosition(positionOfElement(position))
+    .wait(100)
     .should("have.focus")
     .and("have.css", "outline-color", gold);
 });
@@ -248,6 +251,7 @@ Then("The {word} content row has focus", (position) => {
 Then("The {word} subrow action popover has focus", (position) => {
   flatTableSubrowByPosition(positionOfElement(position))
     .find('[data-component="action-popover-button"]')
+    .wait(100)
     .should("have.focus")
     .and("have.css", "outline", `${gold} solid 2px`);
 });

--- a/cypress/support/step-definitions/link-steps.js
+++ b/cypress/support/step-definitions/link-steps.js
@@ -19,7 +19,7 @@ Then("icon on link component preview is {string}", (iconName) => {
 });
 
 Then("Link is tabbable", () => {
-  linkPreview().children().should("have.attr", "tabindex", "0");
+  linkPreview().children().wait(100).should("have.attr", "tabindex", "0");
 });
 
 Then("Link is not tabbable", () => {

--- a/cypress/support/step-definitions/loader-steps.js
+++ b/cypress/support/step-definitions/loader-steps.js
@@ -37,5 +37,7 @@ Then("I focus loader button", () => {
 });
 
 Then("loader button has golden border outline", () => {
-  loaderInsideButton().should("have.css", "outline-color", "rgb(255, 181, 0)");
+  loaderInsideButton()
+    .wait(100)
+    .should("have.css", "outline-color", "rgb(255, 181, 0)");
 });

--- a/cypress/support/step-definitions/pill-steps.js
+++ b/cypress/support/step-definitions/pill-steps.js
@@ -17,13 +17,13 @@ When("I focus Pill close icon", () => {
 });
 
 Then("Pill close icon has golden border outline", () => {
-  pillCloseIcon().should(
-    "have.css",
-    "box-shadow",
-    "rgb(255, 181, 0) 0px 0px 0px 3px"
-  );
+  pillCloseIcon()
+    .wait(100)
+    .should("have.css", "box-shadow", "rgb(255, 181, 0) 0px 0px 0px 3px");
 });
 
 Then("Pill close icon has {string} backgroundColor", (backgroundColor) => {
-  pillCloseIcon().should("have.css", "background-color", backgroundColor);
+  pillCloseIcon()
+    .wait(100)
+    .should("have.css", "background-color", backgroundColor);
 });

--- a/cypress/support/step-definitions/search-steps.js
+++ b/cypress/support/step-definitions/search-steps.js
@@ -73,11 +73,14 @@ When("I focus on cross icon", () => {
 Then("Cross icon has golden border", () => {
   searchCrossIcon()
     .parent()
+    .wait(100)
     .should("have.css", "outline", "rgb(255, 181, 0) solid 3px");
 });
 
 Then("search icon has golden border", () => {
-  searchButton().should("have.css", "outline", "rgb(255, 181, 0) solid 3px");
+  searchButton()
+    .wait(100)
+    .should("have.css", "outline", "rgb(255, 181, 0) solid 3px");
 });
 
 Then("search icon has proper inner color", () => {

--- a/cypress/support/step-definitions/split-button-steps.js
+++ b/cypress/support/step-definitions/split-button-steps.js
@@ -133,6 +133,7 @@ Then(
   "Split Button expandable {string} element has golden border on focus",
   (element) => {
     additionalButton(positionOfElement(element))
+      .wait(100)
       .should("have.css", "background-color", "rgb(0, 64, 46)")
       .and("have.css", "outline", "rgb(255, 181, 0) solid 3px");
   }


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
To avoid failing as below on CI we need to add an `env` as `watchForFileChanges` and set it to `false`. 

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
We are facing the new issue on CI as:
<img width="837" alt="Screenshot 2021-05-24 at 12 32 04" src="https://user-images.githubusercontent.com/34001198/119340530-ec431b00-bc92-11eb-9134-7d4ee8e5392f.png">


### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent