### PR TITLE
fix(tabs): add missing colon to tab-title styles FE-4112

### DIFF
--- a/src/components/tabs/__internal__/tab-title/tab-title.style.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.style.js
@@ -562,26 +562,24 @@ const StyledSelectedIndicator = styled.div`
   ${({ position, size, theme }) =>
     position === "top" &&
     css`
-    bottom: 0px;
-    left: 0px
-    box-shadow: inset 0px ${size === "large" ? "-4px" : "-2px"} 0px ${
-      theme.colors.primary
-    };
-    width: 100%;
-    height: ${size === "large" ? "4px" : "2px"};
-  `}
+      bottom: 0px;
+      left: 0px;
+      box-shadow: inset 0px ${size === "large" ? "-4px" : "-2px"} 0px
+        ${theme.colors.primary};
+      width: 100%;
+      height: ${size === "large" ? "4px" : "2px"};
+    `}
 
   ${({ position, size, theme }) =>
     position === "left" &&
     css`
-    top: 0px;
-    right: 0px
-    box-shadow: inset ${size === "large" ? "-4px" : "-2px"} 0px 0px 0px ${
-      theme.colors.primary
-    };
-    height: 100%;
-    width: ${size === "large" ? "4px" : "2px"};
-  `}
+      top: 0px;
+      right: 0px;
+      box-shadow: inset ${size === "large" ? "-4px" : "-2px"} 0px 0px 0px
+        ${theme.colors.primary};
+      height: 100%;
+      width: ${size === "large" ? "4px" : "2px"};
+    `}
 `;
 
 StyledTabTitle.propTypes = {

--- a/src/components/tabs/tab/tab.d.ts
+++ b/src/components/tabs/tab/tab.d.ts
@@ -31,7 +31,7 @@ export interface TabProps extends PaddingProps {
   /** Allows Tab to be a link */
   href?: string;
   /** Overrides default layout with a one defined in this prop */
-  customLayout: React.ReactNode;
+  customLayout?: React.ReactNode;
 }
 
 export interface TabAllProps {


### PR DESCRIPTION
fix #4048

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
There is a missing semi-colon meaning the styles for `TabTitle` are incorrectly applied when it is
selected

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Styles are not applies correctly when a TabTitle is selected
### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
