### PR TITLE
fix(simple-color-picker): add guard to prevent calling onBlur when undefined FE-4124

### DIFF
--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.component.js
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.component.js
@@ -175,7 +175,7 @@ const SimpleColorPicker = (props) => {
   const handleOnBlur = (ev) => {
     ev.preventDefault();
 
-    if (!blurBlocked) {
+    if (!blurBlocked && onBlur) {
       onBlur(ev);
     }
   };

--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.stories.mdx
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.stories.mdx
@@ -48,7 +48,7 @@ import SimpleColorPicker from "carbon-react/lib/__experimental__/components/simp
         setState(target.value);
       };
       return (
-        <SimpleColorPicker legend="Legend" onChange={onChange} value={state}>
+        <SimpleColorPicker name="picker-default-example" legend="Legend" onChange={onChange} value={state}>
           {colors.map(({ color, label }) => (
             <SimpleColor
               value={color}
@@ -73,7 +73,7 @@ import SimpleColorPicker from "carbon-react/lib/__experimental__/components/simp
         setState(target.value);
       };
       return (
-        <SimpleColorPicker legend="Legend" onChange={onChange} value={state}>
+        <SimpleColorPicker name="picker-disabled-example" legend="Legend" onChange={onChange} value={state}>
           {[
             { color: "transparent", label: "transparent" },
             { color: "#0073C1", label: "blue" },
@@ -110,6 +110,7 @@ You can use the `required` prop to indicate if the field is mandatory.
           required
           onChange={onChange}
           value={state}
+          name="picker-required-example"
         >
           {[
             { color: "transparent", label: "transparent" },


### PR DESCRIPTION
fix #4062

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds guard in `handleOnBlur` function to prevent calling `onBlur` prop if not defined

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Calls onBlur when not defined

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
Check `SimpleColorPicker` stories