### PR TITLE
fix(definition-list): fix conditional rendering logic

### DIFF
--- a/src/components/definition-list/definition-list.spec.js
+++ b/src/components/definition-list/definition-list.spec.js
@@ -83,8 +83,76 @@ describe("DefinitionList", () => {
         </Dl>
       );
 
-      expect(wrapper.find(Dt).at(1).exists()).toBe(true);
-      expect(wrapper.find(Dd).at(1).exists()).toBe(true);
+      expect(wrapper.find(Dt).length).toEqual(2);
+      expect(wrapper.find(Dd).length).toEqual(2);
+    });
+  });
+
+  describe("with conditionally rendered children", () => {
+    describe("with inline definitions", () => {
+      it("should render the correct amount of list items", () => {
+        wrapper = mount(
+          <Dl>
+            {true && (
+              <>
+                <Dt>First</Dt>
+                <Dd>1st Description</Dd>
+              </>
+            )}
+            {false && (
+              <>
+                <Dt>Second</Dt>
+                <Dd>2nd Description</Dd>
+              </>
+            )}
+            {true && (
+              <>
+                <Dt>Third</Dt>
+                <Dd>3rd Description</Dd>
+              </>
+            )}
+          </Dl>
+        );
+
+        expect(wrapper.find(Dt).length).toEqual(2);
+        expect(wrapper.find(Dd).length).toEqual(2);
+      });
+    });
+
+    describe("when mapping from an object", () => {
+      it("should render the correct amount of list items", () => {
+        const definitions = [
+          true && {
+            definition: "First",
+            description: "1st Description",
+          },
+          false && {
+            definition: "Second",
+            description: "2nd Description",
+          },
+          true && {
+            definition: "Third",
+            description: "3rd Description",
+          },
+        ];
+
+        wrapper = mount(
+          <Dl>
+            {definitions.map(
+              (x) =>
+                !!x && (
+                  <React.Fragment key={x.definition}>
+                    <Dt>{x.definition}</Dt>
+                    <Dd>{x.description}</Dd>
+                  </React.Fragment>
+                )
+            )}
+          </Dl>
+        );
+
+        expect(wrapper.find(Dt).length).toEqual(2);
+        expect(wrapper.find(Dd).length).toEqual(2);
+      });
     });
   });
 

--- a/src/components/definition-list/definition-list.stories.mdx
+++ b/src/components/definition-list/definition-list.stories.mdx
@@ -13,6 +13,7 @@ import { ActionPopover, ActionPopoverItem } from "../action-popover";
 # Definition List
 
 ## Contents
+
 - [Quick Start](#quick-start)
 - [Related Components](#related-components)
 - [Examples](#examples)
@@ -54,9 +55,7 @@ Definition List most of the time is in use with other components. Look at the ex
   <Story name="action popover and icon support">
     <Dl>
       <Dt>
-        <Box paddingTop="4px">
-          Term example
-        </Box>
+        <Box paddingTop="4px">Term example</Box>
       </Dt>
       <Dd>
         <Box display="inline-flex" alignItems="center">
@@ -65,9 +64,7 @@ Definition List most of the time is in use with other components. Look at the ex
         </Box>
       </Dd>
       <Dt>
-        <Box paddingTop="4px">
-          Term example
-        </Box>
+        <Box paddingTop="4px">Term example</Box>
       </Dt>
       <Dd>
         <Box display="inline-flex" alignItems="center">
@@ -85,7 +82,7 @@ Definition List most of the time is in use with other components. Look at the ex
 
 ### Conditional rendering with `<React.Fragment />`
 
-*CAUTION: don't use nested `<React.Fragment />`*
+_CAUTION: Direct children of `Dl` can only be `<React.Fragment />`, `Dt` or `Dd`_
 
 <Preview>
   <Story

--- a/src/components/definition-list/dl.component.js
+++ b/src/components/definition-list/dl.component.js
@@ -10,19 +10,19 @@ const Dl = ({
   w = 50,
   dtTextAlign = "right",
   ddTextAlign = "left",
-  ...props
+  ...rest
 }) => {
   const dlComponent = [];
   const listChildren = React.Children.toArray(children);
   let key = "";
 
-  const composeDlComponent = (array) => {
+  const composeDlComponent = (childrenArray) => {
     let dtLabel;
     let ddContent = [];
     let isLastChild;
     let nextItemIsNotDd;
 
-    array.forEach((child, index) => {
+    childrenArray.forEach((child, index) => {
       if (child.type === React.Fragment) {
         composeDlComponent(child.props.children);
       } else {
@@ -33,10 +33,10 @@ const Dl = ({
           ddContent.push(child);
         }
 
-        isLastChild = index === listChildren.length - 1;
+        isLastChild = index === childrenArray.length - 1;
         nextItemIsNotDd =
           !isLastChild &&
-          [Dt, React.Fragment].includes(listChildren[index + 1].type);
+          [Dt, React.Fragment].includes(childrenArray[index + 1].type);
 
         if (dtLabel && (nextItemIsNotDd || isLastChild)) {
           key = `${key + 1}`;
@@ -57,7 +57,7 @@ const Dl = ({
   };
 
   return (
-    <StyledDl w={w} data-component="dl" {...props}>
+    <StyledDl w={w} data-component="dl" {...rest}>
       {composeDlComponent(listChildren)}
     </StyledDl>
   );

--- a/src/components/definition-list/dt.component.js
+++ b/src/components/definition-list/dt.component.js
@@ -3,9 +3,9 @@ import propTypes from "@styled-system/prop-types";
 import PropTypes from "prop-types";
 import { StyledDt } from "./definition-list.style";
 
-const Dt = ({ pr = 3, children, mb = 2, ...props }) => {
+const Dt = ({ pr = 3, children, mb = 2, ...rest }) => {
   return (
-    <StyledDt data-element="dt" mb={mb} pr={pr} {...props}>
+    <StyledDt data-element="dt" mb={mb} pr={pr} {...rest}>
       {children}
     </StyledDt>
   );
@@ -13,8 +13,8 @@ const Dt = ({ pr = 3, children, mb = 2, ...props }) => {
 
 Dt.propTypes = {
   ...propTypes.space,
-  /** prop to render string for `<Dt />` */
-  children: PropTypes.string.isRequired,
+  /** Child elements */
+  children: PropTypes.node.isRequired,
 };
 
 export default Dt;


### PR DESCRIPTION
Fixes: #4013

### Proposed behaviour
Rewrite render logic in the definition list component to better handle conditional rendering. It now no longer wraps an unnecessary fragment around every `Dt` and `Dd` pair.

### Current behaviour
When conditionally rendered and wrapped in fragments, `Dt`s are duplicated in the DOM, and when only a single fragment is passed in as children the component errors.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
See the sandboxes in the attached issue for the before test, and the rebuild ones in the codesandbox bot comment below for the fixed versions.