### PR TITLE
ci: use cypress-io/github-action@v2.10.0

### DIFF
--- a/.github/workflows/cypress-pr.yml
+++ b/.github/workflows/cypress-pr.yml
@@ -57,7 +57,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v2.10.0
         with:
           install: false
           start: npm start


### PR DESCRIPTION
# DO NOT RESTART BUILD ⚠️ 

Same as `master` but using `cypress-io/github-action@v2.10.0`

❌  Failed because of missing NPM files.


