### PR TITLE
ci: use cypress/included:7.4.0

### DIFF
--- a/.github/workflows/cypress-pr.yml
+++ b/.github/workflows/cypress-pr.yml
@@ -22,7 +22,7 @@ jobs:
             11, 12, 13, 14, 15,
             16, 17, 18, 19, 20
             ]
-    container: cypress/browsers:node14.16.0-chrome89-ff86
+    container: cypress/included:7.4.0
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
# DO NOT RESTART BUILD ⚠️ 
- use cypress/included:7.4.0

```
npm WARN tar ENOENT: no such file or directory, open '/home/runner/work/carbon/carbon/node_modules/npm/node_modules/node-gyp/gyp/tools/emacs/testdata/media.gyp'
npm ERR! cb() never called!

npm ERR! This is an error with npm itself. Please report this error at:
npm ERR!     <https://npm.community>

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2021-05-25T14_16_38_021Z-debug.log
```
https://github.com/npm/cli/wiki/%22cb()-never-called%3F--I'm-having-the-same-problem!%22
```
npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path /__w/carbon/carbon/node_modules/npm/node_modules/abbrev/package.json
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, open '/__w/carbon/carbon/node_modules/npm/node_modules/abbrev/package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /github/home/.npm/_logs/2021-05-25T14_17_48_277Z-debug.log
Error: Process completed with exit code 254.
```