### PR TITLE
test: disable chrome update

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -33,6 +33,10 @@ module.exports = (on) => {
     if (browser.family === "chromium" && browser.name !== "electron") {
       launchOptions.args.push("--disable-site-isolation-trials");
       launchOptions.args.push("--disable-gpu");
+      // disable update for chrome for CI
+      launchOptions.args.push(
+        `--simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT'`
+      );
     }
     if (browser.name === "firefox") {
       // works only for macOS


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Add `--simulate-outdated-no-au` flag to disable `chromium` based browser to be able automatically updated.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
As `Cypress` team [recommended](https://github.com/cypress-io/cypress/issues/16693#issuecomment-848928505) we need to pass `--simulate-outdated-no-au` flag to disable `chromium` based browser to be able automatically updated.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent