### PR TITLE
fix(tile-select): incorrect ts type definitions (FE-4108)

### DIFF
--- a/src/components/tile-select/tile-select-group.d.ts
+++ b/src/components/tile-select/tile-select-group.d.ts
@@ -13,9 +13,9 @@ export interface TileSelectGroupProps extends MarginProps {
   /** The name to apply to the input - only for single select mode. */
   name?: string;
   /** A callback triggered when one of tiles is selected - only for single select mode. */
-  onChange?: (ev: React.ChangeEvent<HTMLElement>) => void;
+  onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   /** A callback triggered when one of tiles is blurred - only for single select mode. */
-  onBlur?: (ev: React.SyntheticEvent<HTMLElement>) => void;
+  onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
   /** When passed as true TileSelectGroup serves only visual purpose */
   /** It wraps TileSelects in fieldset element and renders the legend and description props content */
   /** onChange, onBlur, value, checked and name props are meant to be passed individually on each of the TileSelects */

--- a/src/components/tile-select/tile-select.d.ts
+++ b/src/components/tile-select/tile-select.d.ts
@@ -9,7 +9,7 @@ export interface TileSelectProps extends MarginProps {
   /** subtitle of the TileSelect */
   subtitle?: string;
   /** description of the TileSelect */
-  description?: string;
+  description?: React.ReactNode;
   /** disables the TileSelect input */
   disabled?: boolean;
   /** the value that is represented by this TileSelect */
@@ -19,9 +19,9 @@ export interface TileSelectProps extends MarginProps {
   /** input name */
   name?: string;
   /** Callback triggered when user selects or deselects this tile */
-  onChange?: (ev: React.ChangeEvent<HTMLElement>) => void;
+  onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   /** Callback triggered when the user blurs this tile */
-  onBlur?: (ev: React.SyntheticEvent<HTMLElement>) => void;
+  onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
   /** determines if this tile is selected or unselected */
   checked?: boolean;
   /** Custom class name passed to the root element of TileSelect */
@@ -32,6 +32,8 @@ export interface TileSelectProps extends MarginProps {
   customActionButton?: (onClick: () => void) => JSX.Element;
   /** An additional help info icon rendered next to the action button */
   actionButtonAdornment?: React.ReactNode;
+  /** footer of the TileSelect */
+  footer?: React.ReactNode;
 }
 
 declare function TileSelect(props: TileSelectProps): JSX.Element;


### PR DESCRIPTION
### Proposed behaviour
Fix incorrect type definitions for the onChange, onBlur and description props.
Add footer prop type definition.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
~~- [ ] Unit tests added or updated if required~~
~~- [ ] Cypress automation tests added or updated if required~~
~~- [ ] Storybook added or updated if required~~
- [x] Typescript `d.ts` file added or updated if required
~~- [ ] Carbon implementation and Design System documentation are congruent~~
