### PR TITLE
chore(deps): add browserslist as workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3107,19 +3107,6 @@
         "@mdx-js/mdx": "1.6.22",
         "@mdx-js/react": "1.6.22",
         "loader-utils": "2.0.0"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        }
       }
     },
     "@mdx-js/mdx": {
@@ -3171,14 +3158,6 @@
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
             "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-              "dev": true
-            }
           }
         },
         "@babel/plugin-syntax-jsx": {
@@ -3203,6 +3182,12 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -4191,9 +4176,9 @@
       }
     },
     "@storybook/addon-docs": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.2.8.tgz",
-      "integrity": "sha512-IWnb10ImrzRMT2qw9785p3wYEI6U9gjsg6H2zKcRJQP5dEboqeX3OFjUKfXkaIWii4nz8MtJjBg5t4BdEYqLdw==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.2.9.tgz",
+      "integrity": "sha512-qOtwgiqI3LMqT0eXYNV6ykp7qSu0LQGeXxy3wOBGuDDqAizfgnAjomYEWGFcyKp5ahV7HCRCjxbixAklFPUmyw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.10",
@@ -4205,19 +4190,19 @@
         "@mdx-js/loader": "^1.6.22",
         "@mdx-js/mdx": "^1.6.22",
         "@mdx-js/react": "^1.6.22",
-        "@storybook/addons": "6.2.8",
-        "@storybook/api": "6.2.8",
-        "@storybook/builder-webpack4": "6.2.8",
-        "@storybook/client-api": "6.2.8",
-        "@storybook/client-logger": "6.2.8",
-        "@storybook/components": "6.2.8",
-        "@storybook/core": "6.2.8",
-        "@storybook/core-events": "6.2.8",
+        "@storybook/addons": "6.2.9",
+        "@storybook/api": "6.2.9",
+        "@storybook/builder-webpack4": "6.2.9",
+        "@storybook/client-api": "6.2.9",
+        "@storybook/client-logger": "6.2.9",
+        "@storybook/components": "6.2.9",
+        "@storybook/core": "6.2.9",
+        "@storybook/core-events": "6.2.9",
         "@storybook/csf": "0.0.1",
-        "@storybook/node-logger": "6.2.8",
-        "@storybook/postinstall": "6.2.8",
-        "@storybook/source-loader": "6.2.8",
-        "@storybook/theming": "6.2.8",
+        "@storybook/node-logger": "6.2.9",
+        "@storybook/postinstall": "6.2.9",
+        "@storybook/source-loader": "6.2.9",
+        "@storybook/theming": "6.2.9",
         "acorn": "^7.4.1",
         "acorn-jsx": "^5.3.1",
         "acorn-walk": "^7.2.0",
@@ -4240,15 +4225,612 @@
         "util-deprecate": "^1.0.2"
       },
       "dependencies": {
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+        "@storybook/addons": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.2.9.tgz",
+          "integrity": "sha512-GnmEKbJwiN1jncN9NSA8CuR1i2XAlasPcl/Zn0jkfV9WitQeczVcJCPw86SGH84AD+tTBCyF2i9UC0KaOV1YBQ==",
           "dev": true,
           "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
+            "@storybook/api": "6.2.9",
+            "@storybook/channels": "6.2.9",
+            "@storybook/client-logger": "6.2.9",
+            "@storybook/core-events": "6.2.9",
+            "@storybook/router": "6.2.9",
+            "@storybook/theming": "6.2.9",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.2.9.tgz",
+          "integrity": "sha512-okkA3HAScE9tGnYBrjTOcgzT+L1lRHNoEh3ZfGgh1u/XNEyHGNkj4grvkd6nX7BzRcYQ/l2VkcKCqmOjUnSkVQ==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/channels": "6.2.9",
+            "@storybook/client-logger": "6.2.9",
+            "@storybook/core-events": "6.2.9",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.2.9",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.2.9",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^5.1.0",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/builder-webpack4": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/builder-webpack4/-/builder-webpack4-6.2.9.tgz",
+          "integrity": "sha512-swECic1huVdj+B+iRJIQ8ds59HuPVE4fmhI+j/nhw0CQCsgAEKqDlOQVYEimW6nZX8GO4WxNm6tiiRzxixejbw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.10",
+            "@babel/plugin-proposal-class-properties": "^7.12.1",
+            "@babel/plugin-proposal-decorators": "^7.12.12",
+            "@babel/plugin-proposal-export-default-from": "^7.12.1",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+            "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+            "@babel/plugin-proposal-optional-chaining": "^7.12.7",
+            "@babel/plugin-proposal-private-methods": "^7.12.1",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-arrow-functions": "^7.12.1",
+            "@babel/plugin-transform-block-scoping": "^7.12.12",
+            "@babel/plugin-transform-classes": "^7.12.1",
+            "@babel/plugin-transform-destructuring": "^7.12.1",
+            "@babel/plugin-transform-for-of": "^7.12.1",
+            "@babel/plugin-transform-parameters": "^7.12.1",
+            "@babel/plugin-transform-shorthand-properties": "^7.12.1",
+            "@babel/plugin-transform-spread": "^7.12.1",
+            "@babel/plugin-transform-template-literals": "^7.12.1",
+            "@babel/preset-env": "^7.12.11",
+            "@babel/preset-react": "^7.12.10",
+            "@babel/preset-typescript": "^7.12.7",
+            "@storybook/addons": "6.2.9",
+            "@storybook/api": "6.2.9",
+            "@storybook/channel-postmessage": "6.2.9",
+            "@storybook/channels": "6.2.9",
+            "@storybook/client-api": "6.2.9",
+            "@storybook/client-logger": "6.2.9",
+            "@storybook/components": "6.2.9",
+            "@storybook/core-common": "6.2.9",
+            "@storybook/core-events": "6.2.9",
+            "@storybook/node-logger": "6.2.9",
+            "@storybook/router": "6.2.9",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.2.9",
+            "@storybook/ui": "6.2.9",
+            "@types/node": "^14.0.10",
+            "@types/webpack": "^4.41.26",
+            "autoprefixer": "^9.8.6",
+            "babel-loader": "^8.2.2",
+            "babel-plugin-macros": "^2.8.0",
+            "babel-plugin-polyfill-corejs3": "^0.1.0",
+            "case-sensitive-paths-webpack-plugin": "^2.3.0",
+            "core-js": "^3.8.2",
+            "css-loader": "^3.6.0",
+            "dotenv-webpack": "^1.8.0",
+            "file-loader": "^6.2.0",
+            "find-up": "^5.0.0",
+            "fork-ts-checker-webpack-plugin": "^4.1.6",
+            "fs-extra": "^9.0.1",
+            "glob": "^7.1.6",
+            "glob-promise": "^3.4.0",
+            "global": "^4.4.0",
+            "html-webpack-plugin": "^4.0.0",
+            "pnp-webpack-plugin": "1.6.4",
+            "postcss": "^7.0.35",
+            "postcss-flexbugs-fixes": "^4.2.1",
+            "postcss-loader": "^4.2.0",
+            "raw-loader": "^4.0.2",
+            "react-dev-utils": "^11.0.3",
+            "stable": "^0.1.8",
+            "style-loader": "^1.3.0",
+            "terser-webpack-plugin": "^3.1.0",
+            "ts-dedent": "^2.0.0",
+            "url-loader": "^4.1.1",
+            "util-deprecate": "^1.0.2",
+            "webpack": "4",
+            "webpack-dev-middleware": "^3.7.3",
+            "webpack-filter-warnings-plugin": "^1.2.1",
+            "webpack-hot-middleware": "^2.25.0",
+            "webpack-virtual-modules": "^0.2.2"
+          }
+        },
+        "@storybook/channel-postmessage": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.2.9.tgz",
+          "integrity": "sha512-OqV+gLeeCHR0KExsIz0B7gD17Cjd9D+I75qnBsLWM9inWO5kc/WZ5svw8Bvjlcm6snWpvxUaT8L+svuqcPSmww==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "6.2.9",
+            "@storybook/client-logger": "6.2.9",
+            "@storybook/core-events": "6.2.9",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "qs": "^6.10.0",
+            "telejson": "^5.1.0"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.2.9.tgz",
+          "integrity": "sha512-6dC8Fb2ipNyOQXnUZMDeEUaJGH5DMLzyHlGLhVyDtrO5WR6bO8mQdkzf4+5dSKXgCBNX0BSkssXth4pDjn18rg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-api": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.2.9.tgz",
+          "integrity": "sha512-aLvEUVkbvv6Qo/2mF4rFCecdqi2CGOUDdsV1a6EFIVS/9gXFdpirsOwKHo9qNjacGdWPlBYGCUcbrw+DvNaSFA==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.2.9",
+            "@storybook/channel-postmessage": "6.2.9",
+            "@storybook/channels": "6.2.9",
+            "@storybook/client-logger": "6.2.9",
+            "@storybook/core-events": "6.2.9",
+            "@storybook/csf": "0.0.1",
+            "@types/qs": "^6.9.5",
+            "@types/webpack-env": "^1.16.0",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "stable": "^0.1.8",
+            "store2": "^2.12.0",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.2.9.tgz",
+          "integrity": "sha512-IfOQZuvpjh66qBInQCJOb9S0dTGpzZ/Cxlcvokp+PYt95KztaWN3mPm+HaDQCeRsrWNe0Bpm1zuickcJ6dBOXg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.2.9.tgz",
+          "integrity": "sha512-hnV1MI2aB2g1sJ7NJphpxi7TwrMZQ/tpCJeHnkjmzyC6ez1MXqcBXGrEEdSXzRfAxjQTOEpu6H1mnns0xMP0Ag==",
+          "dev": true,
+          "requires": {
+            "@popperjs/core": "^2.6.0",
+            "@storybook/client-logger": "6.2.9",
+            "@storybook/csf": "0.0.1",
+            "@storybook/theming": "6.2.9",
+            "@types/color-convert": "^2.0.0",
+            "@types/overlayscrollbars": "^1.12.0",
+            "@types/react-syntax-highlighter": "11.0.5",
+            "color-convert": "^2.0.1",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "markdown-to-jsx": "^7.1.0",
+            "memoizerific": "^1.11.3",
+            "overlayscrollbars": "^1.13.1",
+            "polished": "^4.0.5",
+            "prop-types": "^15.7.2",
+            "react-colorful": "^5.0.1",
+            "react-popper-tooltip": "^3.1.1",
+            "react-syntax-highlighter": "^13.5.3",
+            "react-textarea-autosize": "^8.3.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.2.9.tgz",
+          "integrity": "sha512-pzbyjWvj0t8m0kR2pC9GQne4sZn7Y/zfcbm6/31CL+yhzOQjfJEj3n4ZFUlxikXqQJPg1aWfypfyaeaLL0QyuA==",
+          "dev": true,
+          "requires": {
+            "@storybook/core-client": "6.2.9",
+            "@storybook/core-server": "6.2.9"
+          }
+        },
+        "@storybook/core-client": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.2.9.tgz",
+          "integrity": "sha512-jW841J5lCe1Ub5ZMtzYPgCy/OUddFxxVYeHLZyuNxlH5RoiQQxbDpuFlzuZMYGuIzD6eZw+ANE4w5vW/y5oBfA==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.2.9",
+            "@storybook/channel-postmessage": "6.2.9",
+            "@storybook/client-api": "6.2.9",
+            "@storybook/client-logger": "6.2.9",
+            "@storybook/core-events": "6.2.9",
+            "@storybook/csf": "0.0.1",
+            "@storybook/ui": "6.2.9",
+            "ansi-to-html": "^0.6.11",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "unfetch": "^4.2.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-common": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-6.2.9.tgz",
+          "integrity": "sha512-ve0Qb4EMit8jGibfZBprmaU2i4LtpB4vSMIzD9nB1YeBmw2cGhHubtmayZ0TwcV3fPQhtYH9wwRWuWyzzHyQyw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.10",
+            "@babel/plugin-proposal-class-properties": "^7.12.1",
+            "@babel/plugin-proposal-decorators": "^7.12.12",
+            "@babel/plugin-proposal-export-default-from": "^7.12.1",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+            "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+            "@babel/plugin-proposal-optional-chaining": "^7.12.7",
+            "@babel/plugin-proposal-private-methods": "^7.12.1",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-arrow-functions": "^7.12.1",
+            "@babel/plugin-transform-block-scoping": "^7.12.12",
+            "@babel/plugin-transform-classes": "^7.12.1",
+            "@babel/plugin-transform-destructuring": "^7.12.1",
+            "@babel/plugin-transform-for-of": "^7.12.1",
+            "@babel/plugin-transform-parameters": "^7.12.1",
+            "@babel/plugin-transform-shorthand-properties": "^7.12.1",
+            "@babel/plugin-transform-spread": "^7.12.1",
+            "@babel/preset-env": "^7.12.11",
+            "@babel/preset-react": "^7.12.10",
+            "@babel/preset-typescript": "^7.12.7",
+            "@babel/register": "^7.12.1",
+            "@storybook/node-logger": "6.2.9",
+            "@storybook/semver": "^7.3.2",
+            "@types/glob-base": "^0.3.0",
+            "@types/micromatch": "^4.0.1",
+            "@types/node": "^14.0.10",
+            "@types/pretty-hrtime": "^1.0.0",
+            "babel-loader": "^8.2.2",
+            "babel-plugin-macros": "^3.0.1",
+            "babel-plugin-polyfill-corejs3": "^0.1.0",
+            "chalk": "^4.1.0",
+            "core-js": "^3.8.2",
+            "express": "^4.17.1",
+            "file-system-cache": "^1.0.5",
+            "find-up": "^5.0.0",
+            "fork-ts-checker-webpack-plugin": "^6.0.4",
+            "glob": "^7.1.6",
+            "glob-base": "^0.3.0",
+            "interpret": "^2.2.0",
+            "json5": "^2.1.3",
+            "lazy-universal-dotenv": "^3.0.1",
+            "micromatch": "^4.0.2",
+            "pkg-dir": "^5.0.0",
+            "pretty-hrtime": "^1.0.3",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2",
+            "webpack": "4"
+          },
+          "dependencies": {
+            "babel-plugin-macros": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+              "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.12.5",
+                "cosmiconfig": "^7.0.0",
+                "resolve": "^1.19.0"
+              }
+            },
+            "fork-ts-checker-webpack-plugin": {
+              "version": "6.2.10",
+              "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.2.10.tgz",
+              "integrity": "sha512-HveFCHWSH2WlYU1tU3PkrupvW8lNFMTfH3Jk0TfC2mtktE9ibHGcifhCsCFvj+kqlDfNIlwmNLiNqR9jnSA7OQ==",
+              "dev": true,
+              "requires": {
+                "@babel/code-frame": "^7.8.3",
+                "@types/json-schema": "^7.0.5",
+                "chalk": "^4.1.0",
+                "chokidar": "^3.4.2",
+                "cosmiconfig": "^6.0.0",
+                "deepmerge": "^4.2.2",
+                "fs-extra": "^9.0.0",
+                "glob": "^7.1.6",
+                "memfs": "^3.1.2",
+                "minimatch": "^3.0.4",
+                "schema-utils": "2.7.0",
+                "semver": "^7.3.2",
+                "tapable": "^1.0.0"
+              },
+              "dependencies": {
+                "cosmiconfig": {
+                  "version": "6.0.0",
+                  "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+                  "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+                  "dev": true,
+                  "requires": {
+                    "@types/parse-json": "^4.0.0",
+                    "import-fresh": "^3.1.0",
+                    "parse-json": "^5.0.0",
+                    "path-type": "^4.0.0",
+                    "yaml": "^1.7.2"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.2.9.tgz",
+          "integrity": "sha512-xQmbX/oYQK1QsAGN8hriXX5SUKOoTUe3L4dVaVHxJqy7MReRWJpprJmCpbAPJzWS6WCbDFfCM5kVEexHLOzJlQ==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/core-server": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-6.2.9.tgz",
+          "integrity": "sha512-DzihO73pj1Ro0Y4tq9hjw2mLMUYeSRPrx7CndCOBxcTHCKQ8Kd7Dee3wJ49t5/19V7TW1+4lYR59GAy73FeOAQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.10",
+            "@babel/plugin-transform-template-literals": "^7.12.1",
+            "@babel/preset-react": "^7.12.10",
+            "@storybook/addons": "6.2.9",
+            "@storybook/builder-webpack4": "6.2.9",
+            "@storybook/core-client": "6.2.9",
+            "@storybook/core-common": "6.2.9",
+            "@storybook/node-logger": "6.2.9",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.2.9",
+            "@storybook/ui": "6.2.9",
+            "@types/node": "^14.0.10",
+            "@types/node-fetch": "^2.5.7",
+            "@types/pretty-hrtime": "^1.0.0",
+            "@types/webpack": "^4.41.26",
+            "airbnb-js-shims": "^2.2.1",
+            "babel-loader": "^8.2.2",
+            "better-opn": "^2.1.1",
+            "boxen": "^4.2.0",
+            "case-sensitive-paths-webpack-plugin": "^2.3.0",
+            "chalk": "^4.1.0",
+            "cli-table3": "0.6.0",
+            "commander": "^6.2.1",
+            "core-js": "^3.8.2",
+            "cpy": "^8.1.1",
+            "css-loader": "^3.6.0",
+            "detect-port": "^1.3.0",
+            "dotenv-webpack": "^1.8.0",
+            "express": "^4.17.1",
+            "file-loader": "^6.2.0",
+            "file-system-cache": "^1.0.5",
+            "find-up": "^5.0.0",
+            "fs-extra": "^9.0.1",
+            "global": "^4.4.0",
+            "html-webpack-plugin": "^4.0.0",
+            "ip": "^1.1.5",
+            "node-fetch": "^2.6.1",
+            "pnp-webpack-plugin": "1.6.4",
+            "pretty-hrtime": "^1.0.3",
+            "prompts": "^2.4.0",
+            "read-pkg-up": "^7.0.1",
+            "regenerator-runtime": "^0.13.7",
+            "resolve-from": "^5.0.0",
+            "serve-favicon": "^2.5.0",
+            "style-loader": "^1.3.0",
+            "telejson": "^5.1.0",
+            "terser-webpack-plugin": "^3.1.0",
+            "ts-dedent": "^2.0.0",
+            "url-loader": "^4.1.1",
+            "util-deprecate": "^1.0.2",
+            "webpack": "4",
+            "webpack-dev-middleware": "^3.7.3",
+            "webpack-virtual-modules": "^0.2.2"
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.2.9.tgz",
+          "integrity": "sha512-ryRBChWZf1A5hOVONErJZosS25IdMweoMVFAUAcj91iC0ynoSA6YL2jmoE71jQchxEXEgkDeRkX9lR/GlqFGZQ==",
+          "dev": true,
+          "requires": {
+            "@types/npmlog": "^4.1.2",
+            "chalk": "^4.1.0",
+            "core-js": "^3.8.2",
+            "npmlog": "^4.1.2",
+            "pretty-hrtime": "^1.0.3"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.2.9.tgz",
+          "integrity": "sha512-7Bn1OFoItCl8whXRT8N1qp1Lky7kzXJ3aslWp5E8HcM8rxh4OYXfbaeiyJEJxBTGC5zxgY+tAEXHFjsAviFROg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/client-logger": "6.2.9",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.2.9.tgz",
+          "integrity": "sha512-183oJW7AD7Fhqg5NT4ct3GJntwteAb9jZnQ6yhf9JSdY+fk8OhxRbPf7ov0au2gYACcGrWDd9K5pYQsvWlP5gA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.27",
+            "@storybook/client-logger": "6.2.9",
+            "core-js": "^3.8.2",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.27",
+            "global": "^4.4.0",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/ui": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-6.2.9.tgz",
+          "integrity": "sha512-jq2xmw3reIqik/6ibUSbNKGR+Xvr9wkAEwexiOl+5WQ5BeYJpw4dmDmsFQf+SQuWaSEUUPolbzkakRQM778Kdg==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@storybook/addons": "6.2.9",
+            "@storybook/api": "6.2.9",
+            "@storybook/channels": "6.2.9",
+            "@storybook/client-logger": "6.2.9",
+            "@storybook/components": "6.2.9",
+            "@storybook/core-events": "6.2.9",
+            "@storybook/router": "6.2.9",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.2.9",
+            "@types/markdown-to-jsx": "^6.11.3",
+            "copy-to-clipboard": "^3.3.1",
+            "core-js": "^3.8.2",
+            "core-js-pure": "^3.8.2",
+            "downshift": "^6.0.15",
+            "emotion-theming": "^10.0.27",
+            "fuse.js": "^3.6.1",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "markdown-to-jsx": "^6.11.4",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "qs": "^6.10.0",
+            "react-draggable": "^4.4.3",
+            "react-helmet-async": "^1.0.7",
+            "react-sizeme": "^3.0.1",
+            "regenerator-runtime": "^0.13.7",
+            "resolve-from": "^5.0.0",
+            "store2": "^2.12.0"
+          },
+          "dependencies": {
+            "markdown-to-jsx": {
+              "version": "6.11.4",
+              "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz",
+              "integrity": "sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==",
+              "dev": true,
+              "requires": {
+                "prop-types": "^15.6.2",
+                "unquote": "^1.1.0"
+              }
+            }
+          }
+        },
+        "@types/node": {
+          "version": "14.17.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.1.tgz",
+          "integrity": "sha512-/tpUyFD7meeooTRwl3sYlihx2BrJE7q9XF71EguPFIySj9B7qgnRtHsHTho+0AUm4m1SvWGm6uSncrR94q6Vtw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
           }
         }
       }
@@ -5619,9 +6201,9 @@
       }
     },
     "@storybook/postinstall": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@storybook/postinstall/-/postinstall-6.2.8.tgz",
-      "integrity": "sha512-VaFQ622qSSpBqZpx+BGFGY52VKk4gnlpFs9r6+TgqaoFv9DpRWnj95fhkdtYuumzVhMiJLerdYdKgR/NsM+hJg==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/@storybook/postinstall/-/postinstall-6.2.9.tgz",
+      "integrity": "sha512-HjAjXZV+WItonC7lVrfrUsQuRFZNz1g1lE0GgsEK2LdC5rAcD/JwJxjiWREwY+RGxKL9rpWgqyxVQajpIJRjhA==",
       "dev": true,
       "requires": {
         "core-js": "^3.8.2"
@@ -5687,13 +6269,13 @@
       }
     },
     "@storybook/source-loader": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-6.2.8.tgz",
-      "integrity": "sha512-e5rOLRPN39mTeRNv5FfIxR7XMb8bhx6kk0SS2ciojkcTg9aLLnguZSfm9E/OBLp/be8//TX4y5m3PwNQSXUrLg==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-6.2.9.tgz",
+      "integrity": "sha512-cx499g7BG2oeXvRFx45r0W0p2gKEy/e88WsUFnqqfMKZBJ8K0R/lx5DI0l1hq+TzSrE6uGe0/uPlaLkJNIro7g==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "6.2.8",
-        "@storybook/client-logger": "6.2.8",
+        "@storybook/addons": "6.2.9",
+        "@storybook/client-logger": "6.2.9",
         "@storybook/csf": "0.0.1",
         "core-js": "^3.8.2",
         "estraverse": "^5.2.0",
@@ -5704,22 +6286,124 @@
         "regenerator-runtime": "^0.13.7"
       },
       "dependencies": {
+        "@storybook/addons": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.2.9.tgz",
+          "integrity": "sha512-GnmEKbJwiN1jncN9NSA8CuR1i2XAlasPcl/Zn0jkfV9WitQeczVcJCPw86SGH84AD+tTBCyF2i9UC0KaOV1YBQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.2.9",
+            "@storybook/channels": "6.2.9",
+            "@storybook/client-logger": "6.2.9",
+            "@storybook/core-events": "6.2.9",
+            "@storybook/router": "6.2.9",
+            "@storybook/theming": "6.2.9",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.2.9.tgz",
+          "integrity": "sha512-okkA3HAScE9tGnYBrjTOcgzT+L1lRHNoEh3ZfGgh1u/XNEyHGNkj4grvkd6nX7BzRcYQ/l2VkcKCqmOjUnSkVQ==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/channels": "6.2.9",
+            "@storybook/client-logger": "6.2.9",
+            "@storybook/core-events": "6.2.9",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.2.9",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.2.9",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^5.1.0",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.2.9.tgz",
+          "integrity": "sha512-6dC8Fb2ipNyOQXnUZMDeEUaJGH5DMLzyHlGLhVyDtrO5WR6bO8mQdkzf4+5dSKXgCBNX0BSkssXth4pDjn18rg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.2.9.tgz",
+          "integrity": "sha512-IfOQZuvpjh66qBInQCJOb9S0dTGpzZ/Cxlcvokp+PYt95KztaWN3mPm+HaDQCeRsrWNe0Bpm1zuickcJ6dBOXg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.2.9.tgz",
+          "integrity": "sha512-xQmbX/oYQK1QsAGN8hriXX5SUKOoTUe3L4dVaVHxJqy7MReRWJpprJmCpbAPJzWS6WCbDFfCM5kVEexHLOzJlQ==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.2.9.tgz",
+          "integrity": "sha512-7Bn1OFoItCl8whXRT8N1qp1Lky7kzXJ3aslWp5E8HcM8rxh4OYXfbaeiyJEJxBTGC5zxgY+tAEXHFjsAviFROg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/client-logger": "6.2.9",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.2.9",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.2.9.tgz",
+          "integrity": "sha512-183oJW7AD7Fhqg5NT4ct3GJntwteAb9jZnQ6yhf9JSdY+fk8OhxRbPf7ov0au2gYACcGrWDd9K5pYQsvWlP5gA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.27",
+            "@storybook/client-logger": "6.2.9",
+            "core-js": "^3.8.2",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.27",
+            "global": "^4.4.0",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
         "estraverse": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
           "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
           "dev": true
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
         }
       }
     },
@@ -7498,6 +8182,75 @@
         }
       }
     },
+    "babel-loader": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
+      "integrity": "sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "^3.3.1",
+        "loader-utils": "^1.4.0",
+        "make-dir": "^3.1.0",
+        "schema-utils": "^2.6.5"
+      },
+      "dependencies": {
+        "find-cache-dir": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+          "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
+          }
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "babel-plugin-add-module-exports": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.2.tgz",
@@ -8468,16 +9221,30 @@
       }
     },
     "browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
+      },
+      "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30001230",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
+          "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.740",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.740.tgz",
+          "integrity": "sha512-Mi2m55JrX2BFbNZGKYR+2ItcGnR4O5HhrvgoRRyZQlaMGQULqDhoGkLWHzJoshSzi7k1PUofxcDbNhlFrDZNhg==",
+          "dev": true
+        }
       }
     },
     "bser": {
@@ -10515,6 +11282,55 @@
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
       "dev": true
+    },
+    "css-loader": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
+      "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "cssesc": "^3.0.0",
+        "icss-utils": "^4.1.1",
+        "loader-utils": "^1.2.3",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.32",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^3.0.2",
+        "postcss-modules-scope": "^2.2.0",
+        "postcss-modules-values": "^3.0.0",
+        "postcss-value-parser": "^4.1.0",
+        "schema-utils": "^2.7.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "css-select": {
       "version": "2.1.0",
@@ -14259,9 +15075,9 @@
       }
     },
     "gensync": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
     "get-assigned-identifiers": {
@@ -21633,6 +22449,46 @@
       "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
       "dev": true
     },
+    "loader-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+      "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+      "dev": true,
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      }
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        }
+      }
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -22011,6 +22867,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
+      "dev": true
+    },
+    "markdown-to-jsx": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
+      "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
       "dev": true
     },
     "marked": {
@@ -25950,14 +26812,6 @@
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
             "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-              "dev": true
-            }
           }
         },
         "@babel/helper-plugin-utils": {
@@ -25989,6 +26843,12 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -26014,6 +26874,14 @@
         "unist-util-remove-position": "^2.0.0",
         "vfile-location": "^3.0.0",
         "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "trim": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+          "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+          "dev": true
+        }
       }
     },
     "remark-slug": {
@@ -27860,6 +28728,16 @@
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
     },
+    "style-loader": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
+      "integrity": "sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^2.7.0"
+      }
+    },
     "style-to-object": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
@@ -28573,12 +29451,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-1.0.4.tgz",
       "integrity": "sha512-whw60l7r+8ZU8Tu/Uc2yxtc4ZTZbR/PF3u1IPNKGQ6p8EICLb3Z2lAgoqw9bqYd8IkgnsaOcLzYHFckjqNsf0g==",
-      "dev": true
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
       "dev": true
     },
     "trim-newlines": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "axe-core": "^3.5.5",
     "babel-eslint": "10.0.3",
     "babel-jest": "^26.6.3",
+    "browserslist": "^4.16.6",
     "carbon-state-management": "^1.0.0",
     "chalk": "^4.1.1",
     "chromatic": "^5.6.1",


### PR DESCRIPTION
### Proposed behaviour
Add `browserslist` as a temporary fix for https://github.com/Sage/carbon/security/dependabot/package-lock.json/browserslist/open 

We can remove it once the packages using browserslist have been upgraded to fix the vuln.

### Current behaviour
We have a vulnerable version of `browserslist` being used by multiple packages.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
