### PR TITLE
fix(radio-button): allow ref forwarding to allow access to the underlying input - FE-4095

### DIFF
--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -441,7 +441,7 @@ exports[`RadioButton base renders as expected 1`] = `
         <div
           checked={false}
           className="c2"
-          name="my-radio-group"
+          name="radio-button-name"
         >
           <div
             className="c3 c4"
@@ -459,7 +459,7 @@ exports[`RadioButton base renders as expected 1`] = `
                   checked={false}
                   className="c9 c10"
                   id="guid-12345"
-                  name="my-radio-group"
+                  name="radio-button-name"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}

--- a/src/__experimental__/components/radio-button/radio-button.component.js
+++ b/src/__experimental__/components/radio-button/radio-button.component.js
@@ -20,89 +20,97 @@ const radioButtonGroupPassedProps = {
   info: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 };
 
-const RadioButton = ({
-  checked,
-  disabled,
-  fieldHelp,
-  fieldHelpInline,
-  id,
-  inline,
-  inputWidth,
-  label,
-  labelAlign,
-  labelSpacing,
-  labelWidth,
-  name,
-  onChange,
-  onBlur,
-  value,
-  reverse,
-  required,
-  size,
-  error,
-  warning,
-  info,
-  ...props
-}) => {
-  const marginProps = filterStyledSystemMarginProps(props);
-  const handleChange = useCallback(
-    (ev) => {
-      onChange(ev);
-      // trigger focus, as Safari doesn't focus radioButtons on click by default
-      ev.target.focus();
+const RadioButton = React.forwardRef(
+  (
+    {
+      checked,
+      disabled,
+      fieldHelp,
+      fieldHelpInline,
+      id,
+      inline,
+      inputWidth,
+      label,
+      labelAlign,
+      labelSpacing,
+      labelWidth,
+      name,
+      onChange,
+      onBlur,
+      value,
+      reverse,
+      required,
+      size,
+      error,
+      warning,
+      info,
+      ...props
     },
-    [onChange]
-  );
+    ref
+  ) => {
+    const marginProps = filterStyledSystemMarginProps(props);
+    const handleChange = useCallback(
+      (ev) => {
+        onChange(ev);
+        // trigger focus, as Safari doesn't focus radioButtons on click by default
+        ev.target.focus();
+      },
+      [onChange]
+    );
 
-  const commonProps = {
-    disabled,
-    fieldHelpInline,
-    inputWidth,
-    labelSpacing,
-    error,
-    warning,
-    info,
-  };
+    const commonProps = {
+      disabled,
+      fieldHelpInline,
+      inputWidth,
+      labelSpacing,
+      error,
+      warning,
+      info,
+    };
 
-  const inputProps = {
-    ...commonProps,
-    checked,
-    fieldHelp,
-    name,
-    onChange: handleChange,
-    onBlur,
-    helpTag: "span",
-    labelAlign,
-    labelInline: true,
-    labelWidth,
-    inputId: id,
-    label,
-    inputValue: value,
-    inputType: "radio",
-    /**
-     * Invert the reverse prop, to ensure the FormField component renders the components
-     * in the desired order (other elements which use FormField render their sub-components the
-     * opposite way around by default)
-     */
-    reverse: !reverse,
-    required,
-  };
+    const inputProps = {
+      ...commonProps,
+      checked,
+      fieldHelp,
+      name,
+      onChange: handleChange,
+      onBlur,
+      helpTag: "span",
+      labelAlign,
+      labelInline: true,
+      labelWidth,
+      inputId: id,
+      label,
+      inputValue: value,
+      inputType: "radio",
+      /**
+       * Invert the reverse prop, to ensure the FormField component renders the components
+       * in the desired order (other elements which use FormField render their sub-components the
+       * opposite way around by default)
+       */
+      reverse: !reverse,
+      required,
+      inputRef: ref,
+    };
 
-  return (
-    <RadioButtonStyle
-      inline={inline}
-      reverse={reverse}
-      size={size}
-      {...commonProps}
-      {...marginProps}
-      {...tagComponent("radio-button", props)}
-    >
-      <CheckableInput {...inputProps}>
-        <RadioButtonSvg />
-      </CheckableInput>
-    </RadioButtonStyle>
-  );
-};
+    return (
+      <RadioButtonStyle
+        inline={inline}
+        reverse={reverse}
+        size={size}
+        {...commonProps}
+        {...marginProps}
+        {...tagComponent("radio-button", props)}
+      >
+        <CheckableInput {...inputProps}>
+          <RadioButtonSvg />
+        </CheckableInput>
+      </RadioButtonStyle>
+    );
+  }
+);
+
+RadioButton.displayName = "RadioButton";
 
 RadioButton.propTypes = {
   ...marginPropTypes,

--- a/src/__experimental__/components/radio-button/radio-button.d.ts
+++ b/src/__experimental__/components/radio-button/radio-button.d.ts
@@ -17,7 +17,7 @@ export interface RadioButtonProps extends CommonCheckableInputProps, MarginProps
   value: string;
 }
 
-declare function RadioButton(props: RadioButtonProps): JSX.Element;
+declare function RadioButton(props: RadioButtonProps & React.RefAttributes<HTMLInputElement>): JSX.Element;
 
 export { RadioButton as PrivateRadioButton };
 export default RadioButton;

--- a/src/__experimental__/components/radio-button/radio-button.spec.js
+++ b/src/__experimental__/components/radio-button/radio-button.spec.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import { mount } from "enzyme";
 import { ThemeProvider } from "styled-components";
 import TestRenderer from "react-test-renderer";
@@ -22,6 +22,7 @@ function render(props = {}, theme = mintTheme, renderer = mount) {
     error,
     info,
     warning,
+    name: "radio-button-name",
   };
   return renderer(
     <ThemeProvider theme={theme}>
@@ -48,6 +49,20 @@ describe("RadioButton", () => {
       const actual = console.error.calls.argsFor(0)[0];
       expect(actual).toMatch(expected);
     });
+  });
+
+  it("the input ref should be forwarded", () => {
+    let ref;
+    const WrapperComponent = () => {
+      ref = useRef();
+
+      return <RadioButton name="my-radio" value="test" ref={ref} />;
+    };
+    const wrapper = mount(<WrapperComponent />);
+
+    expect(ref.current).toEqual(
+      wrapper.find(HiddenCheckableInputStyle).getDOMNode()
+    );
   });
 
   describe("base", () => {

--- a/src/__internal__/checkable-input/checkable-input.component.js
+++ b/src/__internal__/checkable-input/checkable-input.component.js
@@ -18,7 +18,15 @@ class CheckableInput extends React.Component {
   }
 
   render() {
-    const { children, onChange, onBlur, required, label, ...rest } = this.props;
+    const {
+      children,
+      onChange,
+      onBlur,
+      required,
+      label,
+      inputRef,
+      ...rest
+    } = this.props;
     const id = this.inputId;
     const labelId = `${id}-label`;
     const helpId = `${id}-help`;
@@ -62,6 +70,7 @@ class CheckableInput extends React.Component {
       helpId,
       id,
       required,
+      inputRef,
     };
 
     return (
@@ -132,6 +141,11 @@ CheckableInput.propTypes = {
   ml: PropTypes.string,
   /** Flag to configure component as mandatory */
   required: PropTypes.bool,
+  /** A callback to retrieve the input reference */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
 };
 
 CheckableInput.defaultProps = {

--- a/src/__internal__/checkable-input/hidden-checkable-input.component.js
+++ b/src/__internal__/checkable-input/hidden-checkable-input.component.js
@@ -11,6 +11,7 @@ const HiddenCheckableInput = ({
   inputValue,
   role,
   tabindex,
+  inputRef,
   ...props
 }) => {
   const { onBlur, onFocus, onMouseEnter, onMouseLeave } = useContext(
@@ -60,6 +61,7 @@ const HiddenCheckableInput = ({
       onBlur={handleBlur}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      ref={inputRef}
     />
   );
 };
@@ -75,6 +77,11 @@ HiddenCheckableInput.propTypes = {
   inputValue: PropTypes.string,
   role: PropTypes.string,
   tabindex: PropTypes.number,
+  /** A callback to retrieve the input reference */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
 };
 
 export default React.memo(HiddenCheckableInput);


### PR DESCRIPTION
### Proposed behaviour
The component is wrapped in a forwardRef.
Type definition is updated to include refs.

### Current behaviour
RadioButton input cannot be directly accessed by Carbon developers.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-z6lrn