### PR TITLE
chore(docker): remove X11 from cypress up - FE-4129

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -56,7 +56,7 @@ Before starting please ensure you have the latest version of [docker](https://do
 
 You will need to be able to access storybook, either from https://carbon.sage.com or from your local machine.
 If you are using your local machine, please run `npm ci`. Once complete you can use `npm start` or if you have limited RAM
-you can use `npm run build-storybook && npm run storybook:static` which will build the storybook and serve it without starting the storybook development server.
+you can use `npm run build-storybook && npm run start:static` which will build the storybook and serve it without starting the storybook development server.
 
 ### Replicating GitHub Actions
 

--- a/cypress/docker-compose.yml
+++ b/cypress/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - install
   # Open Cypress and attach to a X11 server
   # docker-compose --profile open up
+  # Unable to open X display? ensure you have added 127.0.0.1 to xhost allow list
+  # xhost +127.0.0.1
   open:
     image: "cypress/browsers:node14.16.0-chrome90-ff88"
     environment:
@@ -23,21 +25,22 @@ services:
     volumes:
       - ../:/e2e
       - cache:/root/.cache/Cypress/
-      - /tmp/.X11-unix:/tmp/.X11-unix
     profiles:
       - open
   # Run Cypress tests using the Cypress dashboard
   # CYPRESS_RECORD_KEY=FAKE-FAKE-FAKE-FAKE-FAKE BUILD_ID=$(uuidgen) docker-compose --profile run up
   run:
     deploy:
+      # Change this value to adjust the parallelisation
       replicas: 3
     image: "cypress/browsers:node14.16.0-chrome90-ff88"
     environment:
       - CYPRESS_baseUrl=http://host.docker.internal:9001/
       - CYPRESS_RECORD_KEY=${CYPRESS_RECORD_KEY}
     command: npx cypress run --record --parallel --browser chrome --ci-build-id ${BUILD_ID}
+    # Run specific Cypress test(s) using the Cypress dashboard
+    # command: npx cypress run --record --parallel --browser chrome --ci-build-id ${BUILD_ID} --spec cypress/features/regression/accessibility/accessibility*
     working_dir: /e2e
-    network_mode: host
     volumes:
       - ../:/e2e
       - cache:/root/.cache/Cypress/


### PR DESCRIPTION
### Proposed behaviour

Only use `X11` when running `cypress open`.

### Current behaviour

Cypress tires to connect to X11 when running `cypress up`.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
https://github.com/Sage/carbon/pull/4099

### Testing instructions
Please try the instructions in the `cypress/README.md`