### PR TITLE
fix(note): add decorator to content to ensure correct html applied

### DIFF
--- a/src/components/note/note.component.js
+++ b/src/components/note/note.component.js
@@ -14,6 +14,7 @@ import {
 import StatusWithTooltip from "./__internal__/status-with-tooltip";
 import { ActionPopover } from "../action-popover";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import { getDecoratedValue } from "../text-editor/__internal__/utils";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
@@ -63,7 +64,7 @@ const Note = ({
       )}
 
       <StyledNoteContent>
-        <Editor readOnly editorState={noteContent} />
+        <Editor readOnly editorState={getDecoratedValue(noteContent)} />
       </StyledNoteContent>
 
       {name && createdDate && (

--- a/src/components/note/note.style.js
+++ b/src/components/note/note.style.js
@@ -47,8 +47,8 @@ const StyledTitle = styled.header`
 
 const StyledFooterContent = styled.div`
   line-height: 21px;
-  align-items: baseline
-    ${({ theme }) => `
+  align-items: baseline;
+  ${({ theme }) => `
     &:first-of-type {
       font-weight: bold;
       font-size: 14px;


### PR DESCRIPTION
fix #4137

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds `getDecoratedValue` util to wrap `noteContent` and ensure decorator used to rneder link as
correct html element
### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Valid url strings are not rendered as correct html

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/editor-and-note-with-json-085j5
- add a link (eg www.foo.com), save it so it is stored in `localStorage`
- refresh and then click save again on editor, the note should render a link
- compare to sandbox in linked issue which will not render the link
