### PR TITLE
refactor: create internal useresizeobserverhook - FE-4170

### DIFF
--- a/src/__internal__/popover/popover.component.js
+++ b/src/__internal__/popover/popover.component.js
@@ -3,6 +3,8 @@ import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import { createPopper } from "@popperjs/core";
 
+import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
+
 const Popover = ({
   children,
   placement,
@@ -31,25 +33,9 @@ const Popover = ({
     popperElementRef = popperRef;
   }
 
-  /* istanbul ignore next */
-  const observer = useRef(
-    new ResizeObserver(() => {
-      if (popperInstance.current) {
-        popperInstance.current.update();
-      }
-    })
-  );
-
-  useEffect(() => {
-    const observerRef = observer.current;
-    const referenceRef = reference.current;
-    observer.current.observe(referenceRef);
-
-    return () => {
-      observerRef.unobserve(referenceRef);
-      observerRef.disconnect();
-    };
-  }, [reference]);
+  useResizeObserver(reference, () => {
+    popperInstance?.current?.update();
+  });
 
   useLayoutEffect(() => {
     if (reference.current) {

--- a/src/__internal__/popover/popover.spec.js
+++ b/src/__internal__/popover/popover.spec.js
@@ -3,9 +3,11 @@ import ReactDOM from "react-dom";
 import { mount } from "enzyme";
 import { createPopper } from "@popperjs/core";
 
+import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
 import Popover from "./popover.component";
 
 jest.mock("@popperjs/core");
+jest.mock("../../hooks/__internal__/useResizeObserver");
 
 const Component = (props) => {
   const [ref, setRef] = useState({});
@@ -76,8 +78,12 @@ describe("Popover", () => {
 
   describe("popper - ", () => {
     const destroyFunc = jest.fn();
+    const updateFunc = jest.fn();
 
-    createPopper.mockImplementation(() => ({ destroy: destroyFunc }));
+    createPopper.mockImplementation(() => ({
+      destroy: destroyFunc,
+      update: updateFunc,
+    }));
 
     it("popper instance is initialized again after props change", () => {
       jest.clearAllMocks();
@@ -97,6 +103,16 @@ describe("Popover", () => {
       myWrapper.unmount();
 
       expect(destroyFunc).toHaveBeenCalled();
+    });
+
+    it("popper instance is updated when reference element resizes", () => {
+      mount(<Component />);
+
+      useResizeObserver.mock.calls[
+        useResizeObserver.mock.calls.length - 1
+      ][1]();
+
+      expect(updateFunc).toHaveBeenCalled();
     });
 
     it("createPopper is called with proper arguments", () => {

--- a/src/components/accordion/accordion.component.js
+++ b/src/components/accordion/accordion.component.js
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import propTypes from "@styled-system/prop-types";
 
+import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
 import OptionsHelper from "../../utils/helpers/options-helper";
 import createGuid from "../../utils/helpers/guid";
 import Events from "../../utils/helpers/events";
@@ -62,25 +63,9 @@ const Accordion = React.forwardRef(
 
     const isExpanded = isControlled ? expanded : isExpandedInternal;
 
-    const observer = useRef(
-      new ResizeObserver(() => {
-        /* istanbul ignore else */
-        if (accordionContent.current) {
-          setContentHeight(accordionContent.current.scrollHeight);
-        }
-      })
-    );
-
-    useEffect(() => {
-      const observerRef = observer.current;
-      const referenceRef = accordionContent.current;
-      observerRef.observe(referenceRef);
-
-      return () => {
-        observerRef.unobserve(referenceRef);
-        observerRef.disconnect();
-      };
-    }, []);
+    useResizeObserver(accordionContent, () => {
+      setContentHeight(accordionContent.current.scrollHeight);
+    });
 
     useEffect(() => {
       setContentHeight(accordionContent.current.scrollHeight);

--- a/src/components/accordion/accordion.spec.js
+++ b/src/components/accordion/accordion.spec.js
@@ -9,7 +9,7 @@ import {
   testStyledSystemMargin,
 } from "../../__spec_helper__/test-utils";
 import baseTheme from "../../style/themes/base";
-
+import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
 import Textbox from "../../__experimental__/components/textbox";
 import { Accordion } from ".";
 import {
@@ -25,6 +25,8 @@ import {
 import AccordionGroup from "./accordion-group/accordion-group.component";
 import ValidationIcon from "../validations";
 import StyledValidationIcon from "../validations/validation-icon.style";
+
+jest.mock("../../hooks/__internal__/useResizeObserver");
 
 const contentHeight = 200;
 
@@ -231,58 +233,6 @@ describe("Accordion", () => {
     });
 
     describe("resize observer", () => {
-      const NativeResizeObserver = window.ResizeObserver;
-      let callbackMock;
-      const observeMock = jest.fn();
-      const unobserveMock = jest.fn();
-      const disconnectMock = jest.fn();
-
-      beforeEach(() => {
-        window.ResizeObserver = function (callback) {
-          callbackMock = callback;
-          return {
-            observe: (element) => {
-              observeMock(element);
-            },
-            unobserve: (element) => {
-              unobserveMock(element);
-            },
-            disconnect: () => {
-              disconnectMock();
-            },
-          };
-        };
-
-        wrapper = mount(
-          <AccordionGroup>
-            <Accordion title="Title_1" defaultExpanded>
-              <div>Foo</div>
-            </Accordion>
-          </AccordionGroup>
-        );
-      });
-
-      afterEach(() => {
-        window.ResizeObserver = NativeResizeObserver;
-      });
-
-      it("observes element on mount", () => {
-        act(() => render({ expanded: true }));
-        expect(observeMock).toHaveBeenCalledWith(
-          wrapper.find(StyledAccordionContent).getDOMNode()
-        );
-      });
-
-      it("unobserves element and disconnects on unmount", () => {
-        act(() => render({ expanded: true }));
-        const accordionContentRef = wrapper
-          .find(StyledAccordionContent)
-          .getDOMNode();
-        wrapper.unmount();
-        expect(unobserveMock).toHaveBeenCalledWith(accordionContentRef);
-        expect(disconnectMock).toHaveBeenCalled();
-      });
-
       it("recalculates the content height", () => {
         act(() => render({ expanded: true }));
         wrapper.update();
@@ -309,7 +259,9 @@ describe("Accordion", () => {
           global.innerWidth = 500;
           global.innerHeight = 500;
 
-          callbackMock();
+          useResizeObserver.mock.calls[
+            useResizeObserver.mock.calls.length - 1
+          ][1]();
         });
         wrapper.update();
 

--- a/src/hooks/__internal__/useResizeObserver/index.d.ts
+++ b/src/hooks/__internal__/useResizeObserver/index.d.ts
@@ -1,0 +1,6 @@
+import * as React from "react";
+
+export default function useResizeObserver(
+  ref: React.RefObject<HTMLElement>,
+  onResize: () => void
+): void;

--- a/src/hooks/__internal__/useResizeObserver/index.js
+++ b/src/hooks/__internal__/useResizeObserver/index.js
@@ -1,0 +1,20 @@
+import { useRef, useLayoutEffect } from "react";
+
+export default function useResizeObserver(ref, onResize) {
+  const observer = useRef(null);
+  const onResizeRef = useRef(null);
+  onResizeRef.current = onResize;
+
+  useLayoutEffect(() => {
+    const referenceRef = ref.current;
+    observer.current = new ResizeObserver(() => {
+      onResizeRef?.current();
+    });
+    observer.current.observe(referenceRef);
+
+    return () => {
+      observer.current.unobserve(referenceRef);
+      observer.current.disconnect();
+    };
+  }, [ref]);
+}

--- a/src/hooks/__internal__/useResizeObserver/index.spec.js
+++ b/src/hooks/__internal__/useResizeObserver/index.spec.js
@@ -1,0 +1,64 @@
+import React, { useRef } from "react";
+import { act } from "react-dom/test-utils";
+import { mount } from "enzyme";
+
+import useResizeObserver from ".";
+
+const TestComponent = ({ callback }) => {
+  const ref = useRef(null);
+  useResizeObserver(ref, callback);
+  return <div id="observed-node" ref={ref} />;
+};
+
+describe("resize observer", () => {
+  let wrapper;
+  const NativeResizeObserver = window.ResizeObserver;
+  let callbackMock;
+  const callbackProp = jest.fn();
+  const observeMock = jest.fn();
+  const unobserveMock = jest.fn();
+  const disconnectMock = jest.fn();
+
+  beforeEach(() => {
+    window.ResizeObserver = function (callback) {
+      callbackMock = callback;
+      return {
+        observe: (element) => {
+          observeMock(element);
+        },
+        unobserve: (element) => {
+          unobserveMock(element);
+        },
+        disconnect: () => {
+          disconnectMock();
+        },
+      };
+    };
+
+    wrapper = mount(<TestComponent callback={callbackProp} />);
+  });
+
+  afterEach(() => {
+    window.ResizeObserver = NativeResizeObserver;
+  });
+
+  it("observes element on mount", () => {
+    expect(observeMock).toHaveBeenCalledWith(
+      wrapper.find("#observed-node").getDOMNode()
+    );
+  });
+
+  it("unobserves element and disconnects on unmount", () => {
+    const observedNodeRef = wrapper.find("#observed-node").getDOMNode();
+    wrapper.unmount();
+    expect(unobserveMock).toHaveBeenCalledWith(observedNodeRef);
+    expect(disconnectMock).toHaveBeenCalled();
+  });
+
+  it("invokes callback passed as a second argument on resize", () => {
+    act(() => {
+      callbackMock();
+    });
+    expect(callbackProp).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Proposed behaviour
This PR creates internal hook `useResizeObserver`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-vwuyx?file=/src/index.js