### PR TITLE
fix(select-list): add data role to internal loader component

### DIFF
--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -478,6 +478,7 @@ const FilterableSelect = React.forwardRef(
         onListScrollBottom={onListScrollBottom}
         tableHeader={tableHeader}
         multiColumn={multiColumn}
+        loaderDataRole="filterable-select-list-loader"
       >
         {children}
       </FilterableSelectList>

--- a/src/components/select/multi-select/multi-select.component.js
+++ b/src/components/select/multi-select/multi-select.component.js
@@ -458,6 +458,7 @@ const MultiSelect = React.forwardRef(
         isLoading={isLoading}
         tableHeader={tableHeader}
         multiColumn={multiColumn}
+        loaderDataRole="multi-select-list-loader"
       >
         {children}
       </FilterableSelectList>

--- a/src/components/select/select-list/select-list.component.js
+++ b/src/components/select/select-list/select-list.component.js
@@ -58,6 +58,7 @@ const SelectList = React.forwardRef(
       onListScrollBottom,
       multiColumn,
       tableHeader,
+      loaderDataRole,
       ...listProps
     },
     listContainerRef
@@ -375,7 +376,7 @@ const SelectList = React.forwardRef(
 
     const loader = () => (
       <StyledSelectLoaderContainer key="loader" as={multiColumn ? "div" : "li"}>
-        <Loader />
+        <Loader data-role={loaderDataRole} />
       </StyledSelectLoaderContainer>
     );
 
@@ -472,6 +473,8 @@ SelectList.propTypes = {
   tableHeader: PropTypes.node,
   /** When true component will work in multi column mode, children should consist of OptionRow components in this mode */
   multiColumn: PropTypes.bool,
+  /** Data role for loader component */
+  loaderDataRole: PropTypes.string,
 };
 
 export default SelectList;

--- a/src/components/select/select-list/select-list.spec.js
+++ b/src/components/select/select-list/select-list.spec.js
@@ -349,8 +349,12 @@ describe("SelectList", () => {
       const wrapper = renderSelectList({
         isLoading: true,
         onListAction: () => {},
+        loaderDataRole: "select-list-loader",
       });
       expect(wrapper.find("li").last().find(Loader).exists()).toBe(true);
+      expect(wrapper.find("li").last().find(Loader).prop("data-role")).toEqual(
+        "select-list-loader"
+      );
     });
 
     it("and is in multiColum mode, then a Loader Component should be rendered as the last element of the list", () => {

--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -396,6 +396,7 @@ const SimpleSelect = React.forwardRef(
         onListScrollBottom={onListScrollBottom}
         tableHeader={tableHeader}
         multiColumn={multiColumn}
+        loaderDataRole="simple-select-list-loader"
       >
         {children}
       </SelectList>


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds data role to `SelectList` `Loader` when `isLoading` prop is true.
`SimpleSelect` -> `simple-select-list-loader`
`MultiSelect` -> `multi-select-list-loader`
`FilterableSelect` -> `filterable-select-list-loader`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No selector surfaced on `Loader` rendered internally within the `SelectList`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
