### PR TITLE
fix(loader): destructure props and only spread rest props on root element FE-4183

### DIFF
--- a/src/components/loader/loader.component.js
+++ b/src/components/loader/loader.component.js
@@ -11,17 +11,24 @@ const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
 );
 
-const Loader = (props) => {
-  const marginProps = filterStyledSystemMarginProps(props);
+const Loader = ({ isInsideButton, isActive, size, ...rest }) => {
   return (
-    <StyledLoader
-      {...props}
-      {...tagComponent("loader", props)}
-      {...marginProps}
-    >
-      <StyledLoaderSquare {...props} />
-      <StyledLoaderSquare {...props} />
-      <StyledLoaderSquare {...props} />
+    <StyledLoader {...rest} {...tagComponent("loader", rest)}>
+      <StyledLoaderSquare
+        isInsideButton={isInsideButton}
+        isActive={isActive}
+        size={size}
+      />
+      <StyledLoaderSquare
+        isInsideButton={isInsideButton}
+        isActive={isActive}
+        size={size}
+      />
+      <StyledLoaderSquare
+        isInsideButton={isInsideButton}
+        isActive={isActive}
+        size={size}
+      />
     </StyledLoader>
   );
 };


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Destructure the props so they are not spread to all elements within component
### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
The `Loader` component spreads all props to root and sub-elements meaning any `data-` selectors are also passed to every element etc.
### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
Currently what happens in master:
![Screenshot 2021-06-18 at 09 33 56](https://user-images.githubusercontent.com/44157880/122540914-ff8e9f80-d020-11eb-9098-4900852e14a2.png)

After update:
![image](https://user-images.githubusercontent.com/44157880/122541356-7461d980-d021-11eb-892d-7387756e5ed8.png)


### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-el4yz inspect the console and confirm data- tags are only on root element