### PR TITLE
fix(flat-table): fix styled-system pl support - FE-4160

### DIFF
--- a/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
@@ -18,8 +18,7 @@ const FlatTableCell = ({
   children,
   colspan,
   rowspan,
-  py,
-  px,
+  pl,
   expandable = false,
   onClick,
   onKeyDown,
@@ -48,8 +47,7 @@ const FlatTableCell = ({
       data-element="flat-table-cell"
       colSpan={colspan}
       rowSpan={rowspan}
-      py={py}
-      px={px}
+      pl={pl}
       onClick={expandable && onClick ? onClick : undefined}
       tabIndex={expandable && onClick ? 0 : undefined}
       onKeyDown={expandable && onKeyDown ? onKeyDown : undefined}

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.spec.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.spec.js
@@ -3,7 +3,10 @@ import { mount } from "enzyme";
 
 import { StyledFlatTableCell } from "./flat-table-cell.style";
 import FlatTableRowCell from "./flat-table-cell.component";
-import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  testStyledSystemPadding,
+} from "../../../__spec_helper__/test-utils";
 
 describe("FlatTableRowCell", () => {
   it("renders with proper width style rule when width prop is passed", () => {
@@ -124,4 +127,21 @@ describe("FlatTableRowCell", () => {
       });
     }
   );
+
+  describe("styled system", () => {
+    testStyledSystemPadding(
+      (props) => (
+        <table>
+          <tbody>
+            <tr>
+              <FlatTableRowCell {...props} />
+            </tr>
+          </tbody>
+        </table>
+      ),
+      {},
+      null,
+      { modifier: "&&& > div" }
+    );
+  });
 });

--- a/src/components/flat-table/flat-table-row/flat-table-row.component.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.js
@@ -171,6 +171,7 @@ const FlatTableRow = React.forwardRef(
                     reportCellWidth:
                       index < rowHeaderIndex ? reportCellWidth : undefined,
                     leftPosition: leftPositions[index],
+                    pl: index === firstCellIndex() && expandable ? "4px" : null,
                     ...child.props,
                   })
                 );

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.js
@@ -221,8 +221,6 @@ const StyledFlatTableRow = styled.tr`
         ${StyledFlatTableCell}:first-child > div,
         ${StyledFlatTableRowHeader}:first-child > div,
         ${StyledFlatTableCheckbox} + ${StyledFlatTableCell} > div {
-          padding-left: 4px;
-
           ${StyledIcon} {
             transition: transform 0.3s;
             ${!isExpanded &&

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -1798,7 +1798,6 @@ of the button control.
 <StyledSystemProps
   of={FlatTableCell}
   spacing
-  defaults={{ py: "10px", px: 3 }}
   noHeader
 />
 


### PR DESCRIPTION
pl prop is now available to use on a flat-table-cell component

fixes #4145

### Proposed behaviour

Allows `pl` prop to be used on a `flat-table-cell`.
<img width="980" alt="Screenshot 2021-06-18 at 13 48 23" src="https://user-images.githubusercontent.com/56251247/122563250-e47d5900-d03b-11eb-942a-5e07afa97774.png">

### Current behaviour

`pl` value is overwritten by a hard-coded `padding-left: 4px` value.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
Use codesandbox built on the PR.
