### PR TITLE
fix(pod): update incorrect type definition from padding to size

### DIFF
--- a/src/components/pod/pod.d.ts
+++ b/src/components/pod/pod.d.ts
@@ -8,7 +8,7 @@ export interface PodProps {
   /** Custom className */
   className?: string;
   /** Determines the padding around the pod */
-  padding?:
+  size?:
     | "none"
     | "extra-small"
     | "small"


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
`pod.d.ts` file has definition for `size`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`pod.d.ts` file has definition for `padding` prop but should be `size`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Typescript `d.ts` file added or updated if required

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
