### PR TITLE
fix(card): extend styled system margin props in ts interface

### DIFF
--- a/src/components/card/card.d.ts
+++ b/src/components/card/card.d.ts
@@ -1,7 +1,8 @@
 import * as React from "react";
+import { MarginProps } from "styled-system";
 import * as OptionsHelper from "../../utils/helpers/options-helper/options-helper";
 
-export interface CardProps {
+export interface CardProps extends MarginProps {
   /** action to be executed when card is clicked or enter pressed */
   action?: (ev: React.MouseEvent<HTMLDivElement>) => void;
   children: React.ReactNode;


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Update `card.d.ts` to extend `styled-system` `MarginProps` interface

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`styled-system` `MarginProps` interface missing from `card.d.ts`
### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Typescript `d.ts` file added or updated if required

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
