### PR TITLE
chore(pod): remove title html attribute (FE-4172)

### DIFF
--- a/src/components/pod/pod.component.js
+++ b/src/components/pod/pod.component.js
@@ -219,6 +219,7 @@ class Pod extends React.Component {
       internalEditButton,
       onEdit,
       size,
+      title,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
### Proposed behaviour
Remove the `title` attribute incorrectly passed to the styled-component through the rest spread.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
~~- [ ] Unit tests added or updated if required~~
~~- [ ] Cypress automation tests added or updated if required~~
~~- [ ] Storybook added or updated if required~~
~~- [ ] Typescript `d.ts` file added or updated if required~~
~~- [ ] Carbon implementation and Design System documentation are congruent~~
