### PR TITLE
fix(menu-item): stop hover css applying to span

### DIFF
--- a/src/components/menu/menu-item/menu-item.style.js
+++ b/src/components/menu/menu-item/menu-item.style.js
@@ -155,12 +155,11 @@ const StyledMenuItemWrapper = styled.a`
       css`
         ${!href &&
         css`
-          && :hover {
+          && a:hover,
+          && button:hover {
             background-color: ${theme.menu.dark.submenuBackground};
             color: ${theme.colors.white};
 
-            a,
-            button,
             [data-component="icon"] {
               color: ${theme.colors.white};
             }
@@ -208,12 +207,11 @@ const StyledMenuItemWrapper = styled.a`
       css`
         ${!href &&
         css`
-          && :hover {
+          && a:hover,
+          && b:hover {
             background-color: ${theme.colors.white};
             color: ${theme.colors.black};
 
-            a,
-            button,
             [data-component="icon"] {
               color: ${theme.colors.black};
             }


### PR DESCRIPTION
Fixes: #4178

### Proposed behaviour
Apply hover background and text colour CSS to the menu item `a` or `button` only.

![image](https://user-images.githubusercontent.com/14963680/122791926-983b4e80-d2b1-11eb-8cb5-9c8a52034aff.png)


### Current behaviour
It is possible to hover over a `span` containing the menu item title, which will apply background and text colour CSS to the span. 

When this is within a menu item with truncated text, this causes the span to cover up part of the focus outline:

![image](https://user-images.githubusercontent.com/14963680/122791878-8b1e5f80-d2b1-11eb-94d8-936462556db5.png)


### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
Sandbox to assist testing here: https://codesandbox.io/s/quizzical-lewin-yz35y?file=/src/index.js

The built version is in the codesandbox bot comment below.