### PR TITLE
fix(simple-color-picker, simple-color): update onkeydown and onmousedown to not use synthetic event

### DIFF
--- a/src/__experimental__/components/search/search.d.ts
+++ b/src/__experimental__/components/search/search.d.ts
@@ -17,15 +17,15 @@ export interface SearchProps extends MarginProps {
   /** Prop for `onClick` events.
    *  `onClick` events are triggered when the `searchButton` is clicked
    */
-  onClick?: (ev: React.SyntheticEvent) => void;
+  onClick?: (ev: React.MouseEvent<HTMLElement>) => void;
   /** Prop for `onKeyDown` events */
-  onKeyDown?: (ev: React.SyntheticEvent) => void;
+  onKeyDown?: (ev: React.KeyboardEvent<HTMLInputElement>) => void;
   /** Prop for a placeholder */
   placeholder?: string;
   /** Prop boolean to state whether the `search` icon renders */
   searchButton?: boolean;
   /**
-   * Prop for specifing an input width length.
+   * Prop for specifying an input width length.
    * Leaving the `searchWidth` prop with no value will default the width to '100%'
    */
   searchWidth?: string;

--- a/src/__experimental__/components/simple-color-picker/simple-color-picker.d.ts
+++ b/src/__experimental__/components/simple-color-picker/simple-color-picker.d.ts
@@ -21,7 +21,7 @@ export interface SimpleColorPickerProps extends ValidationPropTypes, MarginProps
   /** Prop for `onChange` events */
   onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   /** Prop for `onKeyDown` events */
-  onKeyDown?: (ev: React.SyntheticEvent) => void;
+  onKeyDown?: (ev: React.KeyboardEvent<HTMLInputElement>) => void;
   /** Prop for `onBlur` events */
   onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
   /** Flag to configure component as mandatory */

--- a/src/__experimental__/components/simple-color-picker/simple-color/simple-color.d.ts
+++ b/src/__experimental__/components/simple-color-picker/simple-color/simple-color.d.ts
@@ -10,7 +10,7 @@ export interface SimpleColorProps {
   /** Prop for `onBlur` events */
   onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
   /** Prop for `onMouseDown` events */
-  onMouseDown?: (ev: React.SyntheticEvent) => void;
+  onMouseDown?: (ev: React.MouseEvent<HTMLInputElement>) => void;
   /** determines if this color option is selected or unselected */
   checked?: boolean;
   /** [Legacy] Custom classname */


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Update type definitions for `onKeyDown` in `SimpleColorPicker` and `onMouseDown` in `SimpleColor` to not use `SyntheticEvent` type for callback parameter.
Update `onClick` and `onKeydown` in `Search` to not use `SyntheticEvent`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
All callbacks use `SyntheticEvent` type for event parameter

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Typescript `d.ts` file added or updated if required

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
