### PR TITLE
feat(typography): add support for white-space styling and truncation - FE-4158

### DIFF
--- a/src/components/typography/typography.component.js
+++ b/src/components/typography/typography.component.js
@@ -157,6 +157,10 @@ const Typography = styled.span.attrs(
     display,
     variant,
     listStyleType,
+    whiteSpace,
+    wordWrap,
+    textOverflow,
+    truncate,
   }) => css`
     font-style: normal;
     font-size: ${size};
@@ -166,10 +170,17 @@ const Typography = styled.span.attrs(
     line-height: ${lineHeight};
     margin: ${defaultMargin};
     padding: 0;
-    ${variant === "sup" && "vertical-align: super;"}
-    ${variant === "sub" && "vertical-align: sub;"}
-${display && `display: ${display};`}
-${listStyleType && `list-style-type: ${listStyleType};`}
+    white-space: ${truncate ? "nowrap" : whiteSpace};
+    word-wrap: ${wordWrap};
+    text-overflow: ${truncate ? "ellipsis" : textOverflow};
+    ${truncate &&
+    css`
+      overflow: hidden;
+    `};
+    ${variant === "sup" && "vertical-align: super;"};
+    ${variant === "sub" && "vertical-align: sub;"};
+    ${display && `display: ${display};`};
+    ${listStyleType && `list-style-type: ${listStyleType};`}; ;
   `}
   ${space}
 ${color}
@@ -223,5 +234,13 @@ Typography.propTypes = {
   display: PropTypes.string,
   /** Override the list-style-type */
   listStyleType: PropTypes.string,
+  /** Override the white-space type */
+  whiteSpace: PropTypes.string,
+  /** Override the word-wrap type */
+  wordWrap: PropTypes.string,
+  /** Override the text-overflow type */
+  textOverflow: PropTypes.string,
+  /** Apply truncation */
+  truncate: PropTypes.bool,
 };
 export default Typography;

--- a/src/components/typography/typography.d.ts
+++ b/src/components/typography/typography.d.ts
@@ -38,6 +38,14 @@ export interface TypographyProps extends SpaceProps, ColorProps {
   display?: string;
   /** Override the list-style-type */
   listStyleType?: string;
+  /** Override the white-space type */
+  whiteSpace?: string;
+  /** Override the word-wrap type */
+  wordWrap?: string;
+  /** Override the text-overflow type */
+  textOverflow?: string;
+  /** Apply truncation */
+  truncate?: boolean;
 }
 
 declare function Typography(attrs: StyledComponentProps<"div", {}, TypographyProps, "">): JSX.Element;

--- a/src/components/typography/typography.spec.js
+++ b/src/components/typography/typography.spec.js
@@ -507,6 +507,81 @@ describe("Typography", () => {
         );
       });
     });
+
+    it.each([
+      "normal",
+      "nowrap",
+      "pre",
+      "pre-wrap",
+      "pre-line",
+      "break-spaces",
+    ])("applies white-space of %s", (prop) => {
+      const wrapper = mount(
+        <ThemeProvider theme={mintTheme}>
+          <Typography whiteSpace={prop}>FooBar</Typography>
+        </ThemeProvider>
+      );
+
+      assertStyleMatch(
+        {
+          whiteSpace: prop,
+        },
+        wrapper.find(Typography)
+      );
+    });
+
+    it.each(["normal", "break-word", "initial", "inherit"])(
+      "applies word-wrap of %s",
+      (prop) => {
+        const wrapper = mount(
+          <ThemeProvider theme={mintTheme}>
+            <Typography wordWrap={prop}>FooBar</Typography>
+          </ThemeProvider>
+        );
+
+        assertStyleMatch(
+          {
+            wordWrap: prop,
+          },
+          wrapper.find(Typography)
+        );
+      }
+    );
+
+    it.each(["clip", "ellipsis", "string", "initial", "inherit"])(
+      "applies text-overflow of %s",
+      (prop) => {
+        const wrapper = mount(
+          <ThemeProvider theme={mintTheme}>
+            <Typography textOverflow={prop}>FooBar</Typography>
+          </ThemeProvider>
+        );
+
+        assertStyleMatch(
+          {
+            textOverflow: prop,
+          },
+          wrapper.find(Typography)
+        );
+      }
+    );
+
+    it("applies truncation when truncate prop is true", () => {
+      const wrapper = mount(
+        <ThemeProvider theme={mintTheme}>
+          <Typography truncate>FooBar</Typography>
+        </ThemeProvider>
+      );
+
+      assertStyleMatch(
+        {
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        },
+        wrapper.find(Typography)
+      );
+    });
   });
 
   testStyledSystemSpacing((props) => <Typography {...props} />);

--- a/src/components/typography/typography.stories.mdx
+++ b/src/components/typography/typography.stories.mdx
@@ -126,6 +126,18 @@ It's also possible to create ordered and unordered lists using the `List`, `List
   </Story>
 </Preview>
 
+## Example of truncate
+The `truncate` prop is a boolean prop that automatically applies the styles required to trunacte a piece of text.
+<Preview>
+  <Story name="truncate" parameters={{ info: { disable: true } }}>
+    <div style={{height: "80px", width: "80px", backgroundColor: "yellow"}}>
+      <Typography truncate>
+        The is an example of using the truncate prop. This is an example of some text with applied.
+      </Typography>
+    </div>
+  </Story>
+</Preview>
+
 ## Reccomended body text colors
 
 | Color                 | White Background | App Background | Notes              |
@@ -192,6 +204,26 @@ It's also possible to create ordered and unordered lists using the `List`, `List
       name: "listStyleType",
       type: { summary: "string" },
       description: "Override the list-style-type",
+    },
+    {
+      name: "whiteSpace",
+      type: { summary: "string" },
+      description: "Override the white-space type",
+    },
+    {
+      name: "wordWrap",
+      type: { summary: "string" },
+      description: "Override the word-wrap type",
+    },
+   {
+      name: "textOverflow",
+      type: { summary: "string" },
+      description: "Override the text-overflow type",
+    },
+   {
+      name: "truncate",
+      type: { summary: "boolean" },
+      description: "Applies styling for truncation",
     },
   ]}
 />


### PR DESCRIPTION
white-space is now able to be styled. Truncation is now also possible with the introduction of a
truncate prop.

fixes #4122

### Proposed behaviour
- Users can now style white-space using any valid CSS string
- Users can truncate text using the `truncate` prop

### Current behaviour
- white-space cannot be styled
- no way of truncating text

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
- Visit the Design System Folder
- Typography
- New examples have been created called:  `truncate`. 

Codesandbox - https://codesandbox.io/s/carbon-quickstart-forked-dhots?file=/src/index.js
