### PR TITLE
refactor(pod): remove collapse functionality (FE-1762)

### DIFF
--- a/cypress/features/regression/pod.feature
+++ b/cypress/features/regression/pod.feature
@@ -29,15 +29,6 @@ Feature: Pod component
       | !@#$%^*()_+-=~[];:.,?{}&"'<> | subtitleSpecialCharacter |
 
   @positive
-  Scenario Outline: Change Pod description to <description>
-    When I open Default "Pod Test" component in noIFrame with "pod" json from "commonComponents" using "<nameOfObject>" object name
-    Then Pod description on preview is set to <description>
-    Examples:
-      | description                  | nameOfObject                |
-      | mp150ú¿¡üßä                  | descriptionOtherLanguage    |
-      | !@#$%^*()_+-=~[];:.,?{}&"'<> | descriptionSpecialCharacter |
-
-  @positive
   Scenario Outline: Change Pod footer to <footer>
     When I open Default "Pod Test" component in noIFrame with "pod" json from "commonComponents" using "<nameOfObject>" object name
     Then Pod footer on preview is set to <footer>

--- a/cypress/fixtures/commonComponents/pod.json
+++ b/cypress/fixtures/commonComponents/pod.json
@@ -19,12 +19,6 @@
     "title": "title",
     "subtitle": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
   },
-  "descriptionOtherLanguage": {
-    "description": "mp150ú¿¡üßä"
-  },
-  "descriptionSpecialCharacter": {
-    "description": "!@#$%^*()_+-=~[];:.,?{}&\"'<>"
-  },
   "footerOtherLanguage": {
     "footer": "mp150ú¿¡üßä"
   },

--- a/cypress/locators/pod/index.js
+++ b/cypress/locators/pod/index.js
@@ -4,7 +4,6 @@ import {
   POD_FOOTER,
   POD_CONTENT,
   POD_SUBTITLE,
-  POD_DESCRIPTION,
 } from "./locators";
 
 // component preview locators
@@ -13,7 +12,6 @@ export const podPreview = () => cy.get(POD_DATA_COMPONENT).children();
 export const podFooter = () => podComponent().find(POD_FOOTER);
 export const podContent = () => podComponent().find(POD_CONTENT);
 export const podSubTitle = () => cy.get(POD_SUBTITLE);
-export const podDescription = () => cy.get(POD_DESCRIPTION);
 export const podEdit = () => podComponent().find(POD_EDIT_ICON);
 
 export const podEditIframe = () =>

--- a/cypress/locators/pod/locators.js
+++ b/cypress/locators/pod/locators.js
@@ -4,4 +4,3 @@ export const POD_FOOTER = '[data-element="footer"]';
 export const POD_EDIT_ICON = '[data-element="edit"]';
 export const POD_CONTENT = '[data-element="content"]';
 export const POD_SUBTITLE = '[data-element="subtitle"]';
-export const POD_DESCRIPTION = '[data-element="description"]';

--- a/cypress/support/step-definitions/pod-steps.js
+++ b/cypress/support/step-definitions/pod-steps.js
@@ -1,7 +1,6 @@
 import {
   podContent,
   podSubTitle,
-  podDescription,
   podEditIframe,
   podEdit,
   podFooter,
@@ -19,10 +18,6 @@ Then("Pod title on preview is set to {word}", (text) => {
 
 Then("Pod subtitle on preview is set to {word}", (text) => {
   podSubTitle().should("have.text", text);
-});
-
-Then("Pod description on preview is set to {word}", (text) => {
-  podDescription().should("have.text", text);
 });
 
 Then("Pod footer on preview is set to {word}", (text) => {

--- a/src/components/pod/pod.component.js
+++ b/src/components/pod/pod.component.js
@@ -18,7 +18,6 @@ import {
   StyledHeader,
   StyledSubtitle,
   StyledTitle,
-  StyledArrow,
 } from "./pod.style.js";
 
 const marginPropTypes = filterStyledSystemMarginProps(
@@ -27,16 +26,11 @@ const marginPropTypes = filterStyledSystemMarginProps(
 
 class Pod extends React.Component {
   state = {
-    isCollapsed: this.props.collapsed,
     isHovered: false,
     isFocused: false,
   };
 
   static contextType = PodContext;
-
-  toggleCollapse = () => {
-    this.setState((prevState) => ({ isCollapsed: !prevState.isCollapsed }));
-  };
 
   toggleHoverState = (val) => {
     this.setState({ isHovered: val });
@@ -59,24 +53,15 @@ class Pod extends React.Component {
       return null;
     }
 
-    const { isCollapsed } = this.state;
-
-    const isCollapsable = isCollapsed !== undefined;
-
     return (
       <StyledHeader
         alignTitle={alignTitle}
         internalEditButton={internalEditButton}
         size={size}
-        isCollapsed={isCollapsed}
-        onClick={isCollapsable ? this.toggleCollapse : undefined}
       >
         <StyledTitle data-element="title">{title}</StyledTitle>
         {subtitle && (
           <StyledSubtitle data-element="subtitle">{subtitle}</StyledSubtitle>
-        )}
-        {isCollapsable && (
-          <StyledArrow isCollapsed={isCollapsed} type="dropdown" />
         )}
       </StyledHeader>
     );
@@ -93,17 +78,6 @@ class Pod extends React.Component {
       );
     }
     return null;
-  }
-
-  podContent() {
-    if (this.state.isCollapsed) return null;
-
-    return (
-      <>
-        {this.podDescription()}
-        <div>{this.props.children}</div>
-      </>
-    );
   }
 
   footer() {
@@ -264,7 +238,8 @@ class Pod extends React.Component {
         >
           <StyledContent data-element="content" size={size}>
             {this.podHeader()}
-            {this.podContent()}
+            {this.podDescription()}
+            <div>{this.props.children}</div>
           </StyledContent>
           {this.footer()}
         </StyledBlock>
@@ -315,15 +290,6 @@ Pod.propTypes = {
   ]),
 
   /**
-   * The collapsed state of the pod
-   *
-   * undefined - Pod is not collapsible |
-   * true - Pod is closed |
-   * false - Pod is open
-   */
-  collapsed: PropTypes.bool,
-
-  /**
    * Title for the pod h4 element
    * always shown
    */
@@ -341,7 +307,6 @@ Pod.propTypes = {
 
   /**
    * Description for the pod
-   * Not shown if collapsed
    */
   description: PropTypes.string,
 

--- a/src/components/pod/pod.component.js
+++ b/src/components/pod/pod.component.js
@@ -10,7 +10,6 @@ import PodContext from "./pod-context";
 import {
   StyledBlock,
   StyledContent,
-  StyledDescription,
   StyledEditAction,
   StyledEditContainer,
   StyledFooter,
@@ -65,19 +64,6 @@ class Pod extends React.Component {
         )}
       </StyledHeader>
     );
-  }
-
-  podDescription() {
-    const { description } = this.props;
-
-    if (description) {
-      return (
-        <StyledDescription data-element="description">
-          {description}
-        </StyledDescription>
-      );
-    }
-    return null;
   }
 
   footer() {
@@ -238,7 +224,6 @@ class Pod extends React.Component {
         >
           <StyledContent data-element="content" size={size}>
             {this.podHeader()}
-            {this.podDescription()}
             <div>{this.props.children}</div>
           </StyledContent>
           {this.footer()}
@@ -304,11 +289,6 @@ Pod.propTypes = {
    * Aligns the title to left, right or center
    */
   alignTitle: PropTypes.oneOf(["left", "center", "right"]),
-
-  /**
-   * Description for the pod
-   */
-  description: PropTypes.string,
 
   /**
    * A component to render as a Pod footer.

--- a/src/components/pod/pod.d.ts
+++ b/src/components/pod/pod.d.ts
@@ -23,8 +23,6 @@ export interface PodProps {
   subtitle?: string;
   /** Aligns the title to left, right or center */
   alignTitle?: "left" | "center" | "right";
-  /** Description for the pod */
-  description?: string;
   /** A component to render as a Pod footer */
   footer?: string | React.ReactNode;
   /** Supplies an edit action to the pod */

--- a/src/components/pod/pod.d.ts
+++ b/src/components/pod/pod.d.ts
@@ -17,8 +17,6 @@ export interface PodProps {
     | "extra-large";
   /** Prop to apply a theme to the Pod */
   variant?: "primary" | "secondary" | "tertiary" | "tile" | "transparent";
-  /** The collapsed state of the pod */
-  collapsed?: boolean;
   /** Title for the pod h4 element always shown */
   title?: string | React.ReactNode;
   /** Optional subtitle for the pod */

--- a/src/components/pod/pod.spec.js
+++ b/src/components/pod/pod.spec.js
@@ -15,7 +15,6 @@ import {
   StyledHeader,
   StyledSubtitle,
   StyledTitle,
-  StyledArrow,
 } from "./pod.style.js";
 import {
   assertStyleMatch,
@@ -40,13 +39,6 @@ describe("Pod", () => {
 
   testStyledSystemMargin((props) => <Pod {...props} />);
 
-  describe("functionality", () => {
-    it("sets the collapsed state same as collapsed prop on mount", () => {
-      const initialWrapper = shallow(<Pod collapsed />);
-      expect(initialWrapper.state().isCollapsed).toBeTruthy();
-    });
-  });
-
   describe("podHeader", () => {
     it("is not rendered if title prop not passed", () => {
       expect(wrapper.find(StyledHeader).exists()).toBeFalsy();
@@ -60,17 +52,6 @@ describe("Pod", () => {
     it("renders subtitle when subtitle is passed as a prop", () => {
       wrapper.setProps({ title: "Title", subtitle: "Subtitle" });
       expect(wrapper.find(StyledSubtitle).props().children).toEqual("Subtitle");
-    });
-
-    it("adds an additional collapsible arrow to the the header when pod is collapsible", () => {
-      wrapper.setProps({ title: "Title" });
-      wrapper.setState({ isCollapsed: true });
-      expect(wrapper.find(StyledArrow).exists()).toBeTruthy();
-    });
-
-    it("does not add additional collapsible arrow when pod is NOT collapsible", () => {
-      wrapper.setProps({ title: "Title" });
-      expect(wrapper.find(StyledArrow).exists()).toBeFalsy();
     });
   });
 
@@ -89,58 +70,6 @@ describe("Pod", () => {
       },
       wrapper.find(StyledPod)
     );
-  });
-
-  describe("collapsability", () => {
-    const ContentComp = () => <div />;
-
-    it("initializes component as collapsed when collapsed prop is passed as true", () => {
-      const collapsableWrapper = shallow(
-        <Pod collapsed>
-          <ContentComp />
-        </Pod>
-      );
-      expect(collapsableWrapper.find(ContentComp).exists()).toEqual(false);
-    });
-
-    it("initializes component as not collapsed when collapsed prop is passed as false", () => {
-      const collapsableWrapper = mount(
-        <Pod collapsed={false}>
-          <ContentComp />
-        </Pod>
-      );
-      expect(collapsableWrapper.find(ContentComp).exists()).toEqual(true);
-    });
-
-    it("clicking on Header toggles isCollapsed state", () => {
-      const collapsableWrapper = mount(
-        <Pod collapsed title="Title">
-          <ContentComp />
-        </Pod>
-      );
-
-      collapsableWrapper.find(StyledHeader).simulate("click");
-      expect(collapsableWrapper.find(ContentComp).exists()).toEqual(true);
-      collapsableWrapper.find(StyledHeader).simulate("click");
-      expect(collapsableWrapper.find(ContentComp).exists()).toEqual(false);
-    });
-
-    it("the Arrow icon should be flipped", () => {
-      wrapper = mount(
-        <Pod collapsed title="collapsed">
-          <ContentComp />
-        </Pod>
-      );
-
-      assertStyleMatch(
-        {
-          transform: "rotate(180deg)",
-        },
-        wrapper.find(StyledArrow)
-      );
-
-      wrapper.unmount();
-    });
   });
 
   describe("podDescription", () => {
@@ -802,19 +731,6 @@ describe("StyledHeader", () => {
       assertStyleMatch(
         {
           marginRight: "30px",
-        },
-        wrapper
-      );
-    });
-  });
-
-  describe("when isCollapsed prop is set", () => {
-    it("should have cursor pointer and no margin bottom", () => {
-      wrapper = renderStyledHeader({ isCollapsed: true });
-      assertStyleMatch(
-        {
-          marginBottom: "0",
-          cursor: "pointer",
         },
         wrapper
       );

--- a/src/components/pod/pod.spec.js
+++ b/src/components/pod/pod.spec.js
@@ -7,7 +7,6 @@ import Pod from "./pod.component";
 import Button from "../button";
 import {
   StyledBlock,
-  StyledDescription,
   StyledEditAction,
   StyledEditContainer,
   StyledFooter,
@@ -70,19 +69,6 @@ describe("Pod", () => {
       },
       wrapper.find(StyledPod)
     );
-  });
-
-  describe("podDescription", () => {
-    it("renders a description when description prop is passed", () => {
-      wrapper.setProps({ description: "Description" });
-      expect(wrapper.find(StyledDescription).props().children).toEqual(
-        "Description"
-      );
-    });
-
-    it("does not render description when description prop is not passed", () => {
-      expect(wrapper.find(StyledDescription).exists()).toEqual(false);
-    });
   });
 
   describe("podFooter", () => {

--- a/src/components/pod/pod.stories.js
+++ b/src/components/pod/pod.stories.js
@@ -27,7 +27,6 @@ export const Default = () => {
   const alignTitle = title
     ? select("alignTitle", POD_ALIGNMENTS, Pod.defaultProps.alignTitle)
     : undefined;
-  const description = text("description", "");
   const footer = text("footer", "");
   const onEdit = boolean("onEdit", false);
   const onDelete = boolean("onDelete", false);
@@ -54,7 +53,6 @@ export const Default = () => {
       title={title}
       subtitle={subtitle}
       alignTitle={alignTitle}
-      description={description}
       footer={footer}
       onEdit={onEdit ? action("edit") : undefined}
       onDelete={onDelete ? action("delete") : undefined}

--- a/src/components/pod/pod.stories.mdx
+++ b/src/components/pod/pod.stories.mdx
@@ -132,14 +132,13 @@ and then set `height` prop to `100%` on each `Pod` so that it fills the entire h
   </Story>
 </Preview>
 
-### With subtitle, description and footer
+### With subtitle and footer
 
 <Preview>
-  <Story name="with subtitle description and footer">
+  <Story name="with subtitle and footer">
     <Pod
       title="Title"
       subtitle="Subtitle"
-      description="Description"
       footer="Footer"
     >
       Content
@@ -154,7 +153,6 @@ and then set `height` prop to `100%` on each `Pod` so that it fills the entire h
     <Pod
       title="Title"
       subtitle="Subtitle"
-      description="Description"
       footer="Footer"
       border={false}
     >
@@ -170,7 +168,6 @@ and then set `height` prop to `100%` on each `Pod` so that it fills the entire h
     <Pod
       title="Title"
       subtitle="Subtitle"
-      description="Description"
       footer="Footer"
       onEdit={() => {}}
     >
@@ -189,7 +186,6 @@ and then set `height` prop to `100%` on each `Pod` so that it fills the entire h
     <Pod
       title="Title"
       subtitle="Subtitle"
-      description="Description"
       footer="Footer"
       onEdit={() => {}}
       displayEditButtonOnHover
@@ -206,7 +202,6 @@ and then set `height` prop to `100%` on each `Pod` so that it fills the entire h
     <Pod
       title="Title"
       subtitle="Subtitle"
-      description="Description"
       footer="Footer"
       onEdit={() => {}}
       editContentFullWidth
@@ -223,7 +218,6 @@ and then set `height` prop to `100%` on each `Pod` so that it fills the entire h
     <Pod
       title="Title"
       subtitle="Subtitle"
-      description="Description"
       footer="Footer"
       internalEditButton
       onEdit={() => {}}
@@ -244,7 +238,6 @@ and then set `height` prop to `100%` on each `Pod` so that it fills the entire h
             key={variant}
             title="Title"
             subtitle="Subtitle"
-            description="Description"
             footer="Footer"
             onEdit={() => {}}
             variant={variant}
@@ -268,7 +261,6 @@ and then set `height` prop to `100%` on each `Pod` so that it fills the entire h
           key={size}
           title="Title"
           subtitle="Subtitle"
-          description="Description"
           footer="Footer"
           onEdit={() => {}}
           size={size}
@@ -291,7 +283,6 @@ and then set `height` prop to `100%` on each `Pod` so that it fills the entire h
           key={alignment}
           title="Title"
           subtitle="Subtitle"
-          description="Description"
           footer="Footer"
           onEdit={() => {}}
           alignTitle={alignment}

--- a/src/components/pod/pod.stories.mdx
+++ b/src/components/pod/pod.stories.mdx
@@ -59,19 +59,6 @@ Set the pod to flex to the width of its content, or take up the full width of it
   </Story>
 </Preview>
 
-### Collapsable
-
-Pod accepts collapsed prop which sets the intial state of the Pod and allows it
-to be collapsible. If the prop is not passed the Pod will not be collapsible.
-
-<Preview>
-  <Story name="collapsable">
-    <Pod title="Title" collapsed>
-      Content
-    </Pod>
-  </Story>
-</Preview>
-
 ### Custom height
 
 <Preview>

--- a/src/components/pod/pod.style.js
+++ b/src/components/pod/pod.style.js
@@ -3,7 +3,6 @@ import { margin } from "styled-system";
 
 import { baseTheme } from "../../style/themes";
 import Link from "../link";
-import Icon from "../icon";
 import StyledIcon from "../icon/icon.style";
 
 const StyledPod = styled.div`
@@ -230,15 +229,9 @@ const headerRightAlignMargins = {
 };
 
 const StyledHeader = styled.div`
-  ${({ alignTitle, internalEditButton, size, isCollapsed }) => css`
+  ${({ alignTitle, internalEditButton, size }) => css`
     margin-bottom: 24px;
     text-align: ${alignTitle};
-
-    ${isCollapsed === true &&
-    css`
-      margin-bottom: 0;
-      cursor: pointer;
-    `};
 
     ${alignTitle === "right" &&
     internalEditButton &&
@@ -258,12 +251,6 @@ const StyledTitle = styled.h4`
   display: inline;
   font-size: 18px;
   font-weight: 600;
-`;
-
-const StyledArrow = styled(Icon).attrs({ type: "dropdown" })`
-  position: relative;
-  top: -1px;
-  ${({ isCollapsed }) => isCollapsed && "transform: rotate(180deg)"};
 `;
 
 StyledBlock.defaultProps = {
@@ -296,10 +283,6 @@ StyledSubtitle.defaultProps = {
 StyledTitle.defaultProps = {
   theme: baseTheme,
 };
-StyledArrow.defaultProps = {
-  theme: baseTheme,
-  type: "dropdown",
-};
 
 export {
   StyledBlock,
@@ -312,5 +295,4 @@ export {
   StyledHeader,
   StyledSubtitle,
   StyledTitle,
-  StyledArrow,
 };

--- a/src/components/pod/pod.style.js
+++ b/src/components/pod/pod.style.js
@@ -95,12 +95,6 @@ const StyledContent = styled.div`
   flex-grow: 1;
 `;
 
-const StyledDescription = styled.div`
-  background: none;
-  margin-bottom: 10px;
-  font-size: 13px;
-`;
-
 const footerPaddings = {
   "extra-small": "6px",
   small: "10px",
@@ -259,9 +253,6 @@ StyledBlock.defaultProps = {
 StyledContent.defaultProps = {
   theme: baseTheme,
 };
-StyledDescription.defaultProps = {
-  theme: baseTheme,
-};
 StyledEditAction.defaultProps = {
   theme: baseTheme,
 };
@@ -287,7 +278,6 @@ StyledTitle.defaultProps = {
 export {
   StyledBlock,
   StyledContent,
-  StyledDescription,
   StyledEditAction,
   StyledEditContainer,
   StyledFooter,


### PR DESCRIPTION
### Proposed behaviour
Remove the pod collapse functionality, it could be re-created using the Accordion Component.
Remove the "description" prop, this is just a styled text that could be rendered in Pod children.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent