### PR TITLE
fix(flat-table-row-header): fix pl and px props not being applied - FE-4192

### DIFF
--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -89,11 +89,11 @@ exports[`FlatTable when rendered with proper table data should have expected str
   z-index: 1000;
 }
 
-.c9.c9.c9 {
+.c9.c9.c9.c9 {
   left: 0px;
 }
 
-.c9.c9.c9 > div {
+.c9.c9.c9.c9 > div {
   box-sizing: border-box;
   padding-top: 10px;
   padding-bottom: 10px;

--- a/src/components/flat-table/flat-table-expandable.stories.mdx
+++ b/src/components/flat-table/flat-table-expandable.stories.mdx
@@ -301,6 +301,73 @@ Rows with row headers can also be made expandable.
   </Story>
 </Preview>
 
+### With row headers with custom paddings
+Rows with row headers can also be made expandable and can also have custom paddings. 
+In this example `Child one` has `pl={8}` and `Child two` has `pl={5}` as well as having an icon.
+
+<Preview>
+  <Story name="row headers with custom paddings">
+    {() => {
+      const SubRows = [
+        <FlatTableRow>
+          <FlatTableRowHeader px={8}>Child one</FlatTableRowHeader>
+          <FlatTableCell>York</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableCell>2</FlatTableCell>
+        </FlatTableRow>,
+        <FlatTableRow>
+          <FlatTableRowHeader pl={5}>
+            <Icon type="individual"/> Child two
+          </FlatTableRowHeader>
+          <FlatTableCell>Edinburgh</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>1</FlatTableCell>
+        </FlatTableRow>,
+      ];
+      return (
+        <div style={{ width: "380px", overflowX: "auto" }}>
+          <FlatTable>
+            <FlatTableHead>
+              <FlatTableRow>
+                <FlatTableRowHeader px={8}>Name</FlatTableRowHeader>
+                <FlatTableHeader>Location</FlatTableHeader>
+                <FlatTableHeader>Relationship Status</FlatTableHeader>
+                <FlatTableHeader>Dependents</FlatTableHeader>
+              </FlatTableRow>
+            </FlatTableHead>
+            <FlatTableBody>
+              <FlatTableRow expandable subRows={SubRows} expanded>
+                <FlatTableRowHeader>John Doe</FlatTableRowHeader>
+                <FlatTableCell>London</FlatTableCell>
+                <FlatTableCell>Single</FlatTableCell>
+                <FlatTableCell>0</FlatTableCell>
+              </FlatTableRow>
+              <FlatTableRow expandable subRows={SubRows} expanded>
+                <FlatTableRowHeader>Jane Doe</FlatTableRowHeader>
+                <FlatTableCell>York</FlatTableCell>
+                <FlatTableCell>Married</FlatTableCell>
+                <FlatTableCell>2</FlatTableCell>
+              </FlatTableRow>
+              <FlatTableRow expandable subRows={SubRows}>
+                <FlatTableRowHeader>John Smith</FlatTableRowHeader>
+                <FlatTableCell>Edinburgh</FlatTableCell>
+                <FlatTableCell>Single</FlatTableCell>
+                <FlatTableCell>1</FlatTableCell>
+              </FlatTableRow>
+              <FlatTableRow expandable subRows={SubRows}>
+                <FlatTableRowHeader>Jane Smith</FlatTableRowHeader>
+                <FlatTableCell>Newcastle</FlatTableCell>
+                <FlatTableCell>Married</FlatTableCell>
+                <FlatTableCell>5</FlatTableCell>
+              </FlatTableRow>
+            </FlatTableBody>
+          </FlatTable>
+        </div>
+      );
+    }}
+  </Story>
+</Preview>
+
 ### With pagination
 Tables with pagination can have expandable rows.
 

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.spec.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.spec.js
@@ -22,7 +22,7 @@ describe("FlatTableRowHeader", () => {
     ),
     { py: "10px", px: 3 },
     null,
-    { modifier: "&&& > div" }
+    { modifier: "&&&& > div" }
   );
 
   it("renders with proper width style rule when width prop is passed", () => {
@@ -47,7 +47,7 @@ describe("FlatTableRowHeader", () => {
         width: "40px",
       },
       wrapper.find(StyledFlatTableRowHeader),
-      { modifier: "&&& > div" }
+      { modifier: "&&&& > div" }
     );
   });
 
@@ -127,7 +127,7 @@ describe("FlatTableRowHeader", () => {
           whiteSpace: "nowrap",
         },
         wrapper.find(StyledFlatTableRowHeader),
-        { modifier: "&&& > div" }
+        { modifier: "&&&& > div" }
       );
     });
 
@@ -169,7 +169,7 @@ describe("FlatTableRowHeader", () => {
             borderRightWidth: expectedValue,
           },
           wrapper,
-          { modifier: "&&&" }
+          { modifier: "&&&&" }
         );
       });
     }
@@ -192,7 +192,7 @@ describe("FlatTableRowHeader", () => {
             borderRightColor: expectedValue,
           },
           wrapper,
-          { modifier: "&&&" }
+          { modifier: "&&&&" }
         );
       });
     }

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.js
@@ -39,7 +39,7 @@ const StyledFlatTableRowHeader = styled.th`
       width: ${colWidth}px;
     `}
 
-    &&& {
+    &&&& {
       > div {
         box-sizing: border-box;
 


### PR DESCRIPTION
pl and px values were being overwritten by a hard-coded 30px padding-left value from flat-table-row

fixes FE-4192

### Proposed behaviour
- Allow `pl` and `px` values to be used when `FlatTableRowHeader` is nested inside of a `FlatTableRow`.
<img width="839" alt="Screenshot 2021-06-25 at 16 26 33" src="https://user-images.githubusercontent.com/56251247/123447765-2117fa00-d5d2-11eb-8eea-cd4a8cf9fd07.png">

### Current behaviour
- `pl` and `px` values are overwritten by a hard-coded `padding-left: 30px` value when `FlatTableRowHeader` is nested inside of a `FlatTableRow`.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
https://codesandbox.io/s/youthful-germain-1n0rq

New example has also been created in storybook to demonstrate this too. It can be found:
Design System -> Flat Table -> Expandable -> With row headers with custom paddings
