### PR TITLE
fix(radio-button, checkable-input): fix invalid values in ARIA attributes - FE-1700

### DIFF
--- a/src/__experimental__/components/checkbox/__snapshots__/checkbox-group.spec.js.snap
+++ b/src/__experimental__/components/checkbox/__snapshots__/checkbox-group.spec.js.snap
@@ -176,8 +176,8 @@ exports[`CheckboxGroup renders as expected 1`] = `
               className="c9 c10"
             >
               <input
-                aria-describedby="cId-required-help"
-                aria-labelledby="cId-required-label"
+                aria-describedby="cId-required help"
+                aria-labelledby="cId-required label"
                 className="c11 c12"
                 id="cId-required"
                 name="check-required"
@@ -228,8 +228,8 @@ exports[`CheckboxGroup renders as expected 1`] = `
               className="c9 c10"
             >
               <input
-                aria-describedby="cId-optional-help"
-                aria-labelledby="cId-optional-label"
+                aria-describedby="cId-optional help"
+                aria-labelledby="cId-optional label"
                 className="c11 c12"
                 id="cId-optional"
                 name="check-optional"

--- a/src/__experimental__/components/checkbox/__snapshots__/checkbox.spec.js.snap
+++ b/src/__experimental__/components/checkbox/__snapshots__/checkbox.spec.js.snap
@@ -661,8 +661,8 @@ exports[`Checkbox base theme renders as expected 1`] = `
           className="c6 c7"
         >
           <input
-            aria-describedby="guid-12345-help"
-            aria-labelledby="guid-12345-label"
+            aria-describedby="guid-12345 help"
+            aria-labelledby="guid-12345 label"
             className="c8 c9"
             id="guid-12345"
             name="my-checkbox"

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-group.spec.js.snap
@@ -210,7 +210,6 @@ exports[`RadioButtonGroup renders as expected 1`] = `
 <fieldset
   className="c0"
   data-component="radiogroup"
-  role="radiogroup"
 >
   <legend
     className="c1"
@@ -224,7 +223,7 @@ exports[`RadioButtonGroup renders as expected 1`] = `
   <div
     className="c3"
     data-component="radio-button-group"
-    role="group"
+    role="radiogroup"
   >
     <div
       className="c4"
@@ -244,8 +243,8 @@ exports[`RadioButtonGroup renders as expected 1`] = `
             >
               <input
                 aria-checked={false}
-                aria-describedby="rId-0-help"
-                aria-labelledby="rId-0-label"
+                aria-describedby="rId-0 help"
+                aria-labelledby="rId-0 label"
                 checked={false}
                 className="c12 c13"
                 id="rId-0"
@@ -305,8 +304,8 @@ exports[`RadioButtonGroup renders as expected 1`] = `
             >
               <input
                 aria-checked={false}
-                aria-describedby="rId-1-help"
-                aria-labelledby="rId-1-label"
+                aria-describedby="rId-1 help"
+                aria-labelledby="rId-1 label"
                 checked={false}
                 className="c12 c13"
                 id="rId-1"

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button-mapper.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button-mapper.spec.js.snap
@@ -182,8 +182,8 @@ Array [
           >
             <input
               aria-checked={false}
-              aria-describedby="rId-0-help"
-              aria-labelledby="rId-0-label"
+              aria-describedby="rId-0 help"
+              aria-labelledby="rId-0 label"
               checked={false}
               className="c8 c9"
               id="rId-0"
@@ -405,8 +405,8 @@ Array [
           >
             <input
               aria-checked={false}
-              aria-describedby="rId-1-help"
-              aria-labelledby="rId-1-label"
+              aria-describedby="rId-1 help"
+              aria-labelledby="rId-1 label"
               checked={false}
               className="c8 c9"
               id="rId-1"

--- a/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
+++ b/src/__experimental__/components/radio-button/__snapshots__/radio-button.spec.js.snap
@@ -434,12 +434,11 @@ exports[`RadioButton base renders as expected 1`] = `
 <fieldset
   className="c0"
   data-component="radiogroup"
-  role="radiogroup"
 >
   <div
     className="c1"
     data-component="radio-button-group"
-    role="group"
+    role="radiogroup"
   >
     <div
       className="c2"
@@ -459,8 +458,8 @@ exports[`RadioButton base renders as expected 1`] = `
             >
               <input
                 aria-checked={false}
-                aria-describedby="guid-12345-help"
-                aria-labelledby="guid-12345-label"
+                aria-describedby="guid-12345 help"
+                aria-labelledby="guid-12345 label"
                 checked={false}
                 className="c10 c11"
                 id="guid-12345"

--- a/src/__experimental__/components/radio-button/radio-button-group.component.js
+++ b/src/__experimental__/components/radio-button/radio-button-group.component.js
@@ -56,7 +56,6 @@ const RadioButtonGroup = (props) => {
 
   return (
     <Fieldset
-      role="radiogroup"
       legend={legend}
       error={error}
       warning={warning}
@@ -73,7 +72,7 @@ const RadioButtonGroup = (props) => {
     >
       <RadioButtonGroupStyle
         data-component="radio-button-group"
-        role="group"
+        role="radiogroup"
         inline={inline}
         legendInline={inlineLegend}
       >

--- a/src/__experimental__/components/switch/__snapshots__/switch.spec.js.snap
+++ b/src/__experimental__/components/switch/__snapshots__/switch.spec.js.snap
@@ -755,8 +755,8 @@ exports[`Switch base theme renders as expected 1`] = `
         >
           <input
             aria-checked={false}
-            aria-describedby="guid-12345-help"
-            aria-labelledby="guid-12345-label"
+            aria-describedby="guid-12345 help"
+            aria-labelledby="guid-12345 label"
             checked={false}
             className="c8 c9"
             id="guid-12345"

--- a/src/__internal__/checkable-input/checkable-input.component.js
+++ b/src/__internal__/checkable-input/checkable-input.component.js
@@ -40,8 +40,8 @@ const CheckableInput = ({
   warning,
 }) => {
   const { current: id } = useRef(inputId || guid());
-  const labelId = `${id}-label`;
-  const helpId = `${id}-help`;
+  const labelId = `${id} label`;
+  const helpId = `${id} help`;
   const isRadio = inputType === "radio";
 
   const formFieldProps = {

--- a/src/__internal__/checkable-input/checkable-input.spec.js
+++ b/src/__internal__/checkable-input/checkable-input.spec.js
@@ -46,7 +46,7 @@ describe("CheckableInput", () => {
           .find(Label)
           .find("label");
 
-        expect(labelWrapper.prop("id")).toBe("foo-label");
+        expect(labelWrapper.prop("id")).toBe("foo label");
       });
     });
   });


### PR DESCRIPTION
resolves the errors in axe relating to ARIA attributes must conform to valid values.

fixes FE-1700

### Proposed behaviour
No accessibility errors present for `radio-button` in Storybook.
<img width="864" alt="Screenshot 2021-07-01 at 15 04 00" src="https://user-images.githubusercontent.com/56251247/124137424-94f84d80-da7d-11eb-9ba6-00c1e9a2ba03.png">


### Current behaviour
Axe throws errors: 
- Ensures all ARIA attributes have valid values
- Ensures elements with an ARIA role that require child roles contain them
<img width="518" alt="Screenshot 2021-07-01 at 15 03 19" src="https://user-images.githubusercontent.com/56251247/124137345-8316aa80-da7d-11eb-8f32-6f7a9566cf62.png">

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
Check all `radio-button` stories for accessibility warnings in the Storybook `accessibility` tab.
