### PR TITLE
fix(flat-table): scrolling content in table header - FE-4193

### DIFF
--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -119,8 +119,6 @@ exports[`FlatTable when rendered with proper table data should have expected str
   border-left: none;
   border-right: none;
   font-weight: 700;
-  left: 0;
-  top: 0;
   z-index: 1000;
 }
 

--- a/src/components/flat-table/flat-table-head/flat-table-head.style.js
+++ b/src/components/flat-table/flat-table-head/flat-table-head.style.js
@@ -8,8 +8,6 @@ const StyledFlatTableHead = styled.thead`
     border-left: none;
     border-right: none;
     font-weight: 700;
-    left: 0;
-    top: 0;
     z-index: ${({ theme }) => theme.zIndex.overlay};
   }
 `;

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -168,6 +168,8 @@ describe("FlatTable", () => {
       assertStyleMatch(
         {
           zIndex: "1002",
+          top: "0",
+          left: "0",
         },
         wrapper.find(StyledFlatTableWrapper),
         { modifier: `${StyledFlatTableHead} ${StyledFlatTableRowHeader}` }

--- a/src/components/flat-table/flat-table.style.js
+++ b/src/components/flat-table/flat-table.style.js
@@ -176,6 +176,8 @@ const StyledFlatTableWrapper = styled.div`
       ${StyledFlatTableHead} ${StyledFlatTableRowHeader},
       ${StyledFlatTableHead} ${StyledFlatTableCheckbox} {
         z-index: ${({ theme }) => theme.zIndex.overlay + 2};
+        top: 0;
+        left: 0;
       }
     `}
 `;


### PR DESCRIPTION
### Proposed behaviour

fixes: #4190

### Current behaviour
There was an issue if there was not enough space for the table and scroll appears.
It causes that text inside of sticky header was scrolling when user used scroll

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] <del> Storybook added or updated if required
- [ ] <del> Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
Testable in codesandbox
