### PR TITLE
fix(flat-table-row): add support for setting tabindex on subrows with onclick handler passed FE-4202

### DIFF
--- a/src/components/flat-table/flat-table-expandable.stories.mdx
+++ b/src/components/flat-table/flat-table-expandable.stories.mdx
@@ -94,6 +94,72 @@ Flat table rows can be made expandable, with any number of sub rows.
   </Story>
 </Preview>
 
+### Keyboard accessible subrows
+In order to make the subrows keyboard accessible you will need to pass a callback to the `onClick` prop as in the example 
+below.
+
+<Preview>
+  <Story
+    name="keyboard accessible subrows"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() => {
+      const SubRows = [
+        <FlatTableRow onClick={() => {}}>
+          <FlatTableCell>Child one</FlatTableCell>
+          <FlatTableCell>York</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>2</FlatTableCell>
+        </FlatTableRow>,
+        <FlatTableRow onClick={() => {}}>
+          <FlatTableCell>Child two</FlatTableCell>
+          <FlatTableCell>Edinburgh</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>1</FlatTableCell>
+        </FlatTableRow>,
+      ];
+      return (
+        <FlatTable>
+          <FlatTableHead>
+            <FlatTableRow>
+              <FlatTableHeader>Name</FlatTableHeader>
+              <FlatTableHeader>Location</FlatTableHeader>
+              <FlatTableHeader>Relationship Status</FlatTableHeader>
+              <FlatTableHeader>Dependents</FlatTableHeader>
+            </FlatTableRow>
+          </FlatTableHead>
+          <FlatTableBody>
+            <FlatTableRow expandable subRows={SubRows}>
+              <FlatTableCell>John Doe</FlatTableCell>
+              <FlatTableCell>London</FlatTableCell>
+              <FlatTableCell>Single</FlatTableCell>
+              <FlatTableCell>0</FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow expandable subRows={SubRows}>
+              <FlatTableCell>Jane Doe</FlatTableCell>
+              <FlatTableCell>York</FlatTableCell>
+              <FlatTableCell>Married</FlatTableCell>
+              <FlatTableCell>2</FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow expandable subRows={SubRows}>
+              <FlatTableCell>John Smith</FlatTableCell>
+              <FlatTableCell>Edinburgh</FlatTableCell>
+              <FlatTableCell>Single</FlatTableCell>
+              <FlatTableCell>1</FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow expandable subRows={SubRows}>
+              <FlatTableCell>Jane Smith</FlatTableCell>
+              <FlatTableCell>Newcastle</FlatTableCell>
+              <FlatTableCell>Married</FlatTableCell>
+              <FlatTableCell>5</FlatTableCell>
+            </FlatTableRow>
+          </FlatTableBody>
+        </FlatTable>
+      );
+    }}
+  </Story>
+</Preview>
+
 ### Expandable by first column only
 Only clicking on the first column can expand the row with this option set.
 

--- a/src/components/flat-table/flat-table-row/flat-table-row.component.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.js
@@ -94,7 +94,7 @@ const FlatTableRow = React.forwardRef(
     if (onClick || expandable) {
       interactiveRowProps = {
         isRowInteractive: !firstColumnExpandable,
-        tabIndex: firstColumnExpandable || isSubRow ? undefined : 0,
+        tabIndex: firstColumnExpandable ? undefined : 0,
         onKeyDown,
         isFirstColumnInteractive: firstColumnExpandable,
         isExpanded,

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -738,6 +738,16 @@ describe("FlatTableRow", () => {
       expect(wrapper.find(StyledFlatTableRow).length).toEqual(1);
     });
 
+    it("then the component should have tabIndex of undefined if no onClick is passed and firstColumnExpandable", () => {
+      const wrapper = renderFlatTableRow({
+        expandable: true,
+        subRows: SubRows,
+        expandableArea: "firstColumn",
+      });
+
+      expect(wrapper.find(StyledFlatTableRow).prop("tabIndex")).toBe(undefined);
+    });
+
     describe("when clicked", () => {
       it("should expand the sub rows", () => {
         const wrapper = renderFlatTableRow({
@@ -770,6 +780,20 @@ describe("FlatTableRow", () => {
           wrapper.update();
 
           expect(onClickFn).toHaveBeenCalled();
+        });
+
+        it("then the component should have tabIndex of undefined if firstColumnExpandable", () => {
+          const onClickFn = jest.fn();
+          const wrapper = renderFlatTableRow({
+            expandable: true,
+            subRows: SubRows,
+            onClick: onClickFn,
+            expandableArea: "firstColumn",
+          });
+
+          expect(wrapper.find(StyledFlatTableRow).prop("tabIndex")).toBe(
+            undefined
+          );
         });
       });
 


### PR DESCRIPTION
fix #4214

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->

Now it is possible to override this behaviour if an `onClick` callback is set on the subrows

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently all have `tabIndex` set to `undefined` when a `FlatTableRow` has either `isSubRow` or `firstColumnExpandable` set. 

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/loving-mendel-5e3gn?file=/src/index.js

`keyboard accessible subrows` added to flat-table-expandable stories