### PR TITLE
fix(flat-table): apply height and maxHeight props to root element

### DIFF
--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FlatTable when rendered with proper table data should have expected structure and styles 1`] = `
-.c11 {
+.c10 {
   background-color: transparent;
   border-width: 0;
   box-sizing: border-box;
@@ -19,12 +19,33 @@ exports[`FlatTable when rendered with proper table data should have expected str
   padding: 0;
 }
 
-.c11:first-child {
+.c10:first-child {
   padding-left: 1px;
 }
 
-.c11.c11.c11 > div {
+.c10.c10.c10 > div {
   box-sizing: border-box;
+}
+
+.c12 {
+  background-color: #fff;
+  border-width: 0;
+  border-bottom: 1px solid #CCD6DB;
+  text-align: left;
+  vertical-align: middle;
+  padding: 0;
+}
+
+.c12.c12.c12 > div {
+  box-sizing: border-box;
+}
+
+.c12:first-of-type {
+  border-left: 1px solid #CCD6DB;
+}
+
+.c12:last-of-type {
+  border-right: 1px solid #CCD6DB;
 }
 
 .c13 {
@@ -48,32 +69,11 @@ exports[`FlatTable when rendered with proper table data should have expected str
   border-right: 1px solid #CCD6DB;
 }
 
-.c14 {
-  background-color: #fff;
-  border-width: 0;
-  border-bottom: 1px solid #CCD6DB;
-  text-align: left;
-  vertical-align: middle;
-  padding: 0;
-}
-
-.c14.c14.c14 > div {
-  box-sizing: border-box;
-}
-
-.c14:first-of-type {
+.c13:first-of-type + .c11 {
   border-left: 1px solid #CCD6DB;
 }
 
-.c14:last-of-type {
-  border-right: 1px solid #CCD6DB;
-}
-
-.c14:first-of-type + .c12 {
-  border-left: 1px solid #CCD6DB;
-}
-
-.c9 {
+.c8 {
   background-color: #fff;
   border: 1px solid #CCD6DB;
   border-top: none;
@@ -89,11 +89,11 @@ exports[`FlatTable when rendered with proper table data should have expected str
   z-index: 1000;
 }
 
-.c9.c9.c9.c9 {
+.c8.c8.c8.c8 {
   left: 0px;
 }
 
-.c9.c9.c9.c9 > div {
+.c8.c8.c8.c8 > div {
   box-sizing: border-box;
   padding-top: 10px;
   padding-bottom: 10px;
@@ -101,7 +101,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
   padding-right: 24px;
 }
 
-.c7 {
+.c6 {
   border-collapse: separate;
   border-radius: 0px;
   border-spacing: 0;
@@ -110,12 +110,12 @@ exports[`FlatTable when rendered with proper table data should have expected str
   width: auto;
 }
 
-.c7 .c10 {
+.c6 .c9 {
   border-bottom: 1px solid #668592;
 }
 
-.c5 .c8,
-.c5 .c15 {
+.c4 .c7,
+.c4 .c14 {
   border-left: none;
   border-right: none;
   font-weight: 700;
@@ -124,12 +124,13 @@ exports[`FlatTable when rendered with proper table data should have expected str
   z-index: 1000;
 }
 
-.c1 {
+.c0 {
+  height: 100%;
   box-shadow: inset 0px 0px 0px 1px #CCD6DB;
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   border-collapse: separate;
   border-radius: 0px;
   border-spacing: 0;
@@ -137,29 +138,25 @@ exports[`FlatTable when rendered with proper table data should have expected str
   width: 100%;
 }
 
-.c3 .c6 {
+.c2 .c5 {
   height: 40px;
 }
 
-.c3 .c12 > div,
-.c3 .c10 > div,
-.c3 .c8 > div {
+.c2 .c11 > div,
+.c2 .c9 > div,
+.c2 .c7 > div {
   font-size: 14px;
   padding-left: 11px;
   padding-right: 11px;
 }
 
-.c0 {
-  height: 100%;
-}
-
-.c2 {
+.c1 {
   max-height: 100%;
 }
 
-.c2 .c4 .c15,
-.c2 .c10,
-.c2 .c4 .c8 {
+.c1 .c3 .c14,
+.c1 .c9,
+.c1 .c3 .c7 {
   background-color: #335C6D;
   border-right: 1px solid #668592;
   color: #FFFFFF;
@@ -167,29 +164,30 @@ exports[`FlatTable when rendered with proper table data should have expected str
 }
 
 <div
-  className="c0"
+  className=""
 >
   <div
-    className="c1"
+    className="c0"
+    height="100%"
   >
     <div
-      className="c2"
+      className="c1"
     >
       <table
-        className="c3"
+        className="c2"
         data-component="flat-table"
         size="medium"
       >
         <thead
-          className="c4 c5"
+          className="c3 c4"
         >
           <tr
-            className="c6 c7"
+            className="c5 c6"
             data-element="flat-table-row"
             onClick={[Function]}
           >
             <th
-              className="c8 c9"
+              className="c7 c8"
               data-element="flat-table-row-header"
             >
               <div
@@ -199,7 +197,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
               </div>
             </th>
             <th
-              className="c10 c11"
+              className="c9 c10"
               data-element="flat-table-header"
             >
               <div>
@@ -207,7 +205,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
               </div>
             </th>
             <th
-              className="c10 c11"
+              className="c9 c10"
               data-element="flat-table-header"
             >
               <div>
@@ -215,7 +213,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
               </div>
             </th>
             <th
-              className="c10 c11"
+              className="c9 c10"
               data-element="flat-table-header"
             >
               <div>
@@ -226,12 +224,12 @@ exports[`FlatTable when rendered with proper table data should have expected str
         </thead>
         <tbody>
           <tr
-            className="c6 c7"
+            className="c5 c6"
             data-element="flat-table-row"
             onClick={[Function]}
           >
             <th
-              className="c8 c9"
+              className="c7 c8"
               data-element="flat-table-row-header"
             >
               <div
@@ -241,7 +239,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
               </div>
             </th>
             <td
-              className="c12 c13"
+              className="c11 c12"
               data-element="flat-table-cell"
             >
               <div
@@ -251,7 +249,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
               </div>
             </td>
             <td
-              className="c12 c13"
+              className="c11 c12"
               data-element="flat-table-cell"
             >
               <div
@@ -261,7 +259,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
               </div>
             </td>
             <td
-              className="c12 c14"
+              className="c11 c13"
               data-element="flat-table-cell"
               rowSpan="2"
             >
@@ -273,12 +271,12 @@ exports[`FlatTable when rendered with proper table data should have expected str
             </td>
           </tr>
           <tr
-            className="c6 c7"
+            className="c5 c6"
             data-element="flat-table-row"
             onClick={[Function]}
           >
             <th
-              className="c8 c9"
+              className="c7 c8"
               data-element="flat-table-row-header"
             >
               <div
@@ -288,7 +286,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
               </div>
             </th>
             <td
-              className="c12 c13"
+              className="c11 c12"
               colSpan="2"
               data-element="flat-table-cell"
             >

--- a/src/components/flat-table/flat-table.component.js
+++ b/src/components/flat-table/flat-table.component.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import styledSystemPropTypes from "@styled-system/prop-types";
 import {
-  StyledFlatTableRoot,
   StyledFlatTableWrapper,
   StyledFlatTable,
   StyledFlatTableFooter,
@@ -10,6 +9,7 @@ import {
 } from "./flat-table.style";
 import { SidebarContext } from "../drawer";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import Box from "../box";
 
 export const FlatTableThemeContext = React.createContext({});
 const marginPropTypes = filterStyledSystemMarginProps(
@@ -20,12 +20,12 @@ const FlatTable = ({
   caption,
   children,
   hasStickyHead,
-  colorTheme,
+  colorTheme = "dark",
   footer,
   hasStickyFooter = false,
   height,
   isZebra,
-  size,
+  size = "medium",
   hasMaxHeight = false,
   ariaDescribedby,
   ...rest
@@ -44,12 +44,15 @@ const FlatTable = ({
   return (
     <SidebarContext.Consumer>
       {(context) => (
-        <StyledFlatTableRoot {...filterStyledSystemMarginProps(rest)}>
+        <Box
+          {...filterStyledSystemMarginProps(rest)}
+          height={addDefaultHeight && !hasMaxHeight ? "100%" : height}
+          maxHeight={hasMaxHeight ? "100%" : undefined}
+        >
           <StyledFlatTableBox
             {...rest}
             {...((hasStickyHead || hasStickyFooter) && { overflowY: "auto" })}
-            height={addDefaultHeight && !hasMaxHeight ? "100%" : height}
-            maxHeight={hasMaxHeight ? "100%" : undefined}
+            height={footer ? "calc(100% - 40px)" : "100%"}
           >
             <StyledFlatTableWrapper
               isInSidebar={context && context.isInSidebar}
@@ -73,7 +76,7 @@ const FlatTable = ({
               {footer}
             </StyledFlatTableFooter>
           )}
-        </StyledFlatTableRoot>
+        </Box>
       )}
     </SidebarContext.Consumer>
   );
@@ -108,11 +111,6 @@ FlatTable.propTypes = {
   size: PropTypes.oneOf(["compact", "small", "medium", "large"]),
   /** Applies max-height of 100% to FlatTable if true */
   hasMaxHeight: PropTypes.bool,
-};
-
-FlatTable.defaultProps = {
-  colorTheme: "dark",
-  size: "medium",
 };
 
 export default FlatTable;

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -371,30 +371,18 @@ describe("FlatTable", () => {
         wrapper.find(StyledFlatTableBox)
       );
     });
+  });
+
+  describe("hasMaxHeight prop", () => {
+    let wrapper;
 
     it("applies correct styles when hasMaxHeight is true", () => {
-      wrapper = renderFlatTableWithDiv(
-        { footer: <Footer />, hasMaxHeight: true },
-        mount
-      );
+      wrapper = renderFlatTableWithDiv({ hasMaxHeight: true }, mount);
       assertStyleMatch(
         {
           maxHeight: "100%",
         },
-        wrapper.find(StyledFlatTableBox)
-      );
-    });
-
-    it("applies correct styles when hasMaxHeight is false", () => {
-      wrapper = renderFlatTableWithDiv(
-        { footer: <Footer />, hasMaxHeight: false },
-        mount
-      );
-      assertStyleMatch(
-        {
-          maxHeight: undefined,
-        },
-        wrapper.find(StyledFlatTableBox)
+        wrapper
       );
     });
   });

--- a/src/components/flat-table/flat-table.stories.js
+++ b/src/components/flat-table/flat-table.stories.js
@@ -47,11 +47,7 @@ export const Default = () => {
   );
   const firstColumnWidth = number("first column width", 150);
   const secondColumnWidth = number("second column width", 120);
-  const size = select(
-    "size",
-    OptionsHelper.tableSizes,
-    FlatTable.defaultProps.size
-  );
+  const size = select("size", OptionsHelper.tableSizes, "medium");
   const processed = getTableData();
   // used to show how the table behaves constrained or on lower resolutions
   const tableSizeConstraints = {

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -377,34 +377,71 @@ Setting a custom background color will also override hover, highlight and row se
     <FlatTable>
       <FlatTableHead>
         <FlatTableRow>
-          <FlatTableHeader verticalBorder="small" verticalBorderColor="#335CDC">Name</FlatTableHeader>
-          <FlatTableHeader verticalBorder="medium" verticalBorderColor="goldTint10">Location</FlatTableHeader>
-          <FlatTableHeader verticalBorder="large">Relationship Status</FlatTableHeader>
+          <FlatTableHeader verticalBorder="small" verticalBorderColor="#335CDC">
+            Name
+          </FlatTableHeader>
+          <FlatTableHeader
+            verticalBorder="medium"
+            verticalBorderColor="goldTint10"
+          >
+            Location
+          </FlatTableHeader>
+          <FlatTableHeader verticalBorder="large">
+            Relationship Status
+          </FlatTableHeader>
           <FlatTableHeader>Dependents</FlatTableHeader>
         </FlatTableRow>
       </FlatTableHead>
       <FlatTableBody>
         <FlatTableRow>
-          <FlatTableCell verticalBorder="small" verticalBorderColor="#335CDC">John Doe</FlatTableCell>
-          <FlatTableCell verticalBorder="medium" verticalBorderColor="goldTint10">London</FlatTableCell>
+          <FlatTableCell verticalBorder="small" verticalBorderColor="#335CDC">
+            John Doe
+          </FlatTableCell>
+          <FlatTableCell
+            verticalBorder="medium"
+            verticalBorderColor="goldTint10"
+          >
+            London
+          </FlatTableCell>
           <FlatTableCell verticalBorder="large">Single</FlatTableCell>
           <FlatTableCell>0</FlatTableCell>
         </FlatTableRow>
         <FlatTableRow>
-          <FlatTableCell verticalBorder="small" verticalBorderColor="#335CDC">Jane Doe</FlatTableCell>
-          <FlatTableCell verticalBorder="medium" verticalBorderColor="goldTint10">York</FlatTableCell>
+          <FlatTableCell verticalBorder="small" verticalBorderColor="#335CDC">
+            Jane Doe
+          </FlatTableCell>
+          <FlatTableCell
+            verticalBorder="medium"
+            verticalBorderColor="goldTint10"
+          >
+            York
+          </FlatTableCell>
           <FlatTableCell verticalBorder="large">Married</FlatTableCell>
           <FlatTableCell>2</FlatTableCell>
         </FlatTableRow>
         <FlatTableRow>
-          <FlatTableCell verticalBorder="small" verticalBorderColor="#335CDC">John Smith</FlatTableCell>
-          <FlatTableCell verticalBorder="medium" verticalBorderColor="goldTint10">Edinburgh</FlatTableCell>
+          <FlatTableCell verticalBorder="small" verticalBorderColor="#335CDC">
+            John Smith
+          </FlatTableCell>
+          <FlatTableCell
+            verticalBorder="medium"
+            verticalBorderColor="goldTint10"
+          >
+            Edinburgh
+          </FlatTableCell>
           <FlatTableCell verticalBorder="large">Single</FlatTableCell>
           <FlatTableCell>1</FlatTableCell>
         </FlatTableRow>
         <FlatTableRow>
-          <FlatTableCell verticalBorder="small" verticalBorderColor="#335CDC">Jane Smith</FlatTableCell>
-          <FlatTableCell verticalBorder="medium" verticalBorderColor="goldTint10">Newcastle</FlatTableCell>
+          <FlatTableCell verticalBorder="small" verticalBorderColor="#335CDC">
+            Jane Smith
+          </FlatTableCell>
+          <FlatTableCell
+            verticalBorder="medium"
+            verticalBorderColor="goldTint10"
+          >
+            Newcastle
+          </FlatTableCell>
           <FlatTableCell verticalBorder="large">Married</FlatTableCell>
           <FlatTableCell>5</FlatTableCell>
         </FlatTableRow>
@@ -647,10 +684,7 @@ of `180px`. There is not enough data to fill the flatTable but the style remains
 remains sticky.
 
 <Preview>
-  <Story
-    name="with sticky footer inside of larger div"
-    parameters={{ chromatic: { disable: true } }}
-  >
+  <Story name="with sticky footer inside of larger div">
     {() => {
       const rows = [
         <FlatTableRow key="0">
@@ -681,7 +715,7 @@ remains sticky.
         setCurrentPage(newPage);
       };
       return (
-        <div style={{ height: "180px", marginBottom: "16px" }}>
+        <div style={{ height: "220px", marginBottom: "16px" }}>
           <FlatTable
             hasStickyHead
             hasStickyFooter
@@ -1537,7 +1571,7 @@ of the button control.
         setCurrentPage(newPage);
       };
       return (
-        <div style={{ height: "200px" }}>
+        <div style={{ height: "240px" }}>
           <FlatTable
             hasStickyHead
             hasStickyFooter
@@ -1795,11 +1829,7 @@ of the button control.
 
 ### FlatTableCell
 
-<StyledSystemProps
-  of={FlatTableCell}
-  spacing
-  noHeader
-/>
+<StyledSystemProps of={FlatTableCell} spacing noHeader />
 
 ### FlatTableRowHeader
 

--- a/src/components/flat-table/flat-table.style.js
+++ b/src/components/flat-table/flat-table.style.js
@@ -1,5 +1,4 @@
 import styled, { css } from "styled-components";
-import { margin } from "styled-system";
 import StyledFlatTableHeader from "./flat-table-header/flat-table-header.style";
 import StyledFlatTableRow from "./flat-table-row/flat-table-row.style";
 import { StyledFlatTableRowHeader } from "./flat-table-row-header/flat-table-row-header.style";
@@ -83,15 +82,6 @@ const StyledFlatTable = styled.table`
 StyledFlatTable.defaultProps = {
   theme: baseTheme,
   size: "medium",
-};
-
-const StyledFlatTableRoot = styled.div`
-  ${margin};
-  height: 100%;
-`;
-
-StyledFlatTableRoot.defaultProps = {
-  theme: baseTheme,
 };
 
 const StyledFlatTableWrapper = styled.div`
@@ -198,7 +188,6 @@ StyledFlatTableFooter.defaultProps = {
 };
 
 export {
-  StyledFlatTableRoot,
   StyledFlatTableWrapper,
   StyledFlatTable,
   StyledFlatTableFooter,


### PR DESCRIPTION
Fixes: #4217

### Proposed behaviour
Apply the `height` and `maxHeight` props to the root element of the `FlatTable`. 

### Current behaviour
The root element always has `height: 100%` so the height prop no longer works correctly, as it is passed down further to a non-root element.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
Regression test of all other `FlatTable` stories will be needed.

https://codesandbox.io/s/thirsty-sound-08j9b to test the particular issue raised which triggered this change