### PR TITLE
fix(note): ensure date aligns when no edited status

### DIFF
--- a/src/components/note/note.spec.js
+++ b/src/components/note/note.spec.js
@@ -223,6 +223,17 @@ describe("Note", () => {
         wrapper.find(StyledFooterContent),
         { modifier: ":first-of-type" }
       );
+
+      assertStyleMatch(
+        {
+          fontSize: "12px",
+          color: baseTheme.note.timeStamp,
+          cursor: "pointer",
+          marginLeft: "24px",
+        },
+        wrapper.find(StyledFooterContent),
+        { modifier: ":last-of-type:not(:first-of-type)" }
+      );
     });
 
     it('renders the "name" and "createdDate" when props have value', () => {

--- a/src/components/note/note.style.js
+++ b/src/components/note/note.style.js
@@ -80,7 +80,7 @@ const StyledFooterContent = styled.div`
         color: ${theme.note.timeStamp};
       }
 
-      &:last-of-type {
+      &:last-of-type:not(:first-of-type) {
         font-size: 12px;
         color: ${theme.note.timeStamp};
         cursor: pointer;


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Fixes `createdDate` alignment when no `name` and `status` props passed

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
--> 
`createdDate` alignment when no `name` and `status` props passed is wrong

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
Example of issue:
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/124762849-40e0e380-df2b-11eb-913d-458f6e6abfc5.png)

fix:

![image](https://user-images.githubusercontent.com/44157880/124763026-71288200-df2b-11eb-824f-6a2e346e67a1.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-oi132?file=/src/index.js