### PR TITLE
fix(numeral-date): update size prop type to have correct oneOf syntax

### DIFF
--- a/src/__experimental__/components/numeral-date/numeral-date.component.js
+++ b/src/__experimental__/components/numeral-date/numeral-date.component.js
@@ -307,7 +307,7 @@ NumeralDate.propTypes = {
   /** Flag to configure component as mandatory */
   required: PropTypes.bool,
   /** Size of an input */
-  size: PropTypes.oneOf("small", "medium", "large"),
+  size: PropTypes.oneOf(["small", "medium", "large"]),
 };
 
 export default NumeralDate;


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
--> 
`size` prop type does not pass an array to `PropTypes.oneOf`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Update `size` prop type to pass an array to `PropTypes.oneOf`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
Should not see the below error in the console when viewing `NumeralDate` stories

```
Warning: Invalid arguments supplied to oneOf, expected an array, got 3 arguments. A common mistake is to write oneOf(x, y, z) instead of oneOf([x, y, z]).
```