### PR TITLE
fix(button-toggle): fix hover styling on disabled state - FE-4214

### DIFF
--- a/src/components/button-toggle-group/__snapshots__/button-toggle-group.spec.js.snap
+++ b/src/components/button-toggle-group/__snapshots__/button-toggle-group.spec.js.snap
@@ -46,13 +46,13 @@ input:focus ~ .c6 {
   z-index: 100;
 }
 
-input:not(:checked) ~ .c6:hover {
+input:not(:checked):not(:disabled) ~ .c6:hover {
   background-color: #006046;
   border-color: #006046;
   color: #FFFFFF;
 }
 
-input:not(:checked) ~ .c6:hover .c8 {
+input:not(:checked):not(:disabled) ~ .c6:hover .c8 {
   color: #FFFFFF;
 }
 

--- a/src/components/button-toggle/__snapshots__/button-toggle.spec.js.snap
+++ b/src/components/button-toggle/__snapshots__/button-toggle.spec.js.snap
@@ -46,13 +46,13 @@ input:focus ~ .c2 {
   z-index: 100;
 }
 
-input:not(:checked) ~ .c2:hover {
+input:not(:checked):not(:disabled) ~ .c2:hover {
   background-color: #006300;
   border-color: #006300;
   color: #FFFFFF;
 }
 
-input:not(:checked) ~ .c2:hover .c8 {
+input:not(:checked):not(:disabled) ~ .c2:hover .c8 {
   color: #FFFFFF;
 }
 
@@ -192,13 +192,13 @@ input:focus ~ .c2 {
   z-index: 100;
 }
 
-input:not(:checked) ~ .c2:hover {
+input:not(:checked):not(:disabled) ~ .c2:hover {
   background-color: #005C9A;
   border-color: #005C9A;
   color: #FFFFFF;
 }
 
-input:not(:checked) ~ .c2:hover .c4 {
+input:not(:checked):not(:disabled) ~ .c2:hover .c4 {
   color: #FFFFFF;
 }
 
@@ -290,13 +290,13 @@ input:focus ~ .c2 {
   z-index: 100;
 }
 
-input:not(:checked) ~ .c2:hover {
+input:not(:checked):not(:disabled) ~ .c2:hover {
   background-color: #006046;
   border-color: #006046;
   color: #FFFFFF;
 }
 
-input:not(:checked) ~ .c2:hover .c4 {
+input:not(:checked):not(:disabled) ~ .c2:hover .c4 {
   color: #FFFFFF;
 }
 

--- a/src/components/button-toggle/button-toggle.style.js
+++ b/src/components/button-toggle/button-toggle.style.js
@@ -73,7 +73,7 @@ const StyledButtonToggleLabel = styled.label`
       z-index: 100;
     }
 
-    input:not(:checked) ~ &:hover {
+    input:not(:checked):not(:disabled) ~ &:hover {
       background-color: ${theme.colors.secondary};
       border-color: ${theme.colors.secondary};
       color: ${theme.colors.white};


### PR DESCRIPTION
### Proposed behaviour
This PR fixes incorrect hover styling on disabled ButtonToggle

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
Styling of the ButtonToggle should not change when hovered while in disabled state
https://codesandbox.io/s/carbon-quickstart-forked-77jel?file=/src/index.js
