### PR TITLE
fix(sidebar): Support for Form with stickyFooter FE-4205

### DIFF
--- a/src/components/drawer/drawer.component.js
+++ b/src/components/drawer/drawer.component.js
@@ -16,7 +16,7 @@ import {
 } from "./drawer.style";
 import StickyFooter from "../../__internal__/sticky-footer";
 
-const SidebarContext = React.createContext();
+const DrawerSidebarContext = React.createContext();
 
 const Drawer = ({
   defaultExpanded = true,
@@ -177,9 +177,9 @@ const Drawer = ({
           scrollVariant="light"
           ref={scrollableContentRef}
         >
-          <SidebarContext.Provider value={{ isInSidebar: true }}>
+          <DrawerSidebarContext.Provider value={{ isInSidebar: true }}>
             {sidebar}
-          </SidebarContext.Provider>
+          </DrawerSidebarContext.Provider>
           {footer && (
             <StickyFooter
               containerRef={scrollableContentRef}
@@ -226,6 +226,6 @@ Drawer.propTypes = {
   stickyFooter: PropTypes.bool,
 };
 
-export { SidebarContext };
+export { DrawerSidebarContext };
 
 export default Drawer;

--- a/src/components/drawer/drawer.d.ts
+++ b/src/components/drawer/drawer.d.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-export interface SidebarContextProps {
+export interface DrawerSidebarContextProps {
   isInSidebar: boolean;
 }
 
@@ -37,8 +37,8 @@ export interface DrawerPropTypes {
   stickyFooter?: boolean;
 }
 
-declare const SidebarContext: React.Context<SidebarContextProps>;
+declare const DrawerSidebarContext: React.Context<DrawerSidebarContextProps>;
 declare function Drawer(props: DrawerPropTypes): JSX.Element;
 
-export { SidebarContext };
+export { DrawerSidebarContext };
 export default Drawer;

--- a/src/components/drawer/index.d.ts
+++ b/src/components/drawer/index.d.ts
@@ -1,1 +1,1 @@
-export { default, SidebarContext } from "./drawer";
+export { default, DrawerSidebarContext } from "./drawer";

--- a/src/components/drawer/index.js
+++ b/src/components/drawer/index.js
@@ -1,2 +1,2 @@
 export { default } from "./drawer.component";
-export { SidebarContext } from "./drawer.component";
+export { DrawerSidebarContext } from "./drawer.component";

--- a/src/components/flat-table/flat-table-row/flat-table-row.component.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.js
@@ -10,7 +10,7 @@ import PropTypes from "prop-types";
 
 import Event from "../../../utils/helpers/events";
 import StyledFlatTableRow from "./flat-table-row.style";
-import { SidebarContext } from "../../drawer";
+import { DrawerSidebarContext } from "../../drawer";
 import FlatTableCheckbox from "../flat-table-checkbox";
 import FlatTableRowHeader from "../flat-table-row-header";
 import { FlatTableThemeContext } from "../flat-table.component";
@@ -128,7 +128,7 @@ const FlatTableRow = React.forwardRef(
     }, [expanded]);
 
     return (
-      <SidebarContext.Consumer>
+      <DrawerSidebarContext.Consumer>
         {(context) => (
           <>
             <StyledFlatTableRow
@@ -191,7 +191,7 @@ const FlatTableRow = React.forwardRef(
               )}
           </>
         )}
-      </SidebarContext.Consumer>
+      </DrawerSidebarContext.Consumer>
     );
   }
 );

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -12,7 +12,7 @@ import { StyledFlatTableRowHeader } from "../flat-table-row-header/flat-table-ro
 import { StyledFlatTableCell } from "../flat-table-cell/flat-table-cell.style";
 import StyledFlatTableHeader from "../flat-table-header/flat-table-header.style";
 import StyledFlatTableCheckbox from "../flat-table-checkbox/flat-table-checkbox.style";
-import { SidebarContext } from "../../drawer";
+import { DrawerSidebarContext } from "../../drawer";
 import FlatTableCheckbox from "../flat-table-checkbox";
 import StyledIcon from "../../icon/icon.style";
 import FlatTableRowHeader from "../flat-table-row-header/flat-table-row-header.component";
@@ -1167,7 +1167,7 @@ function renderFlatTableRow(props = {}, renderer = mount) {
 
 function renderRowWithContext(props = {}) {
   return mount(
-    <SidebarContext.Provider value={{ isInSidebar: true }}>
+    <DrawerSidebarContext.Provider value={{ isInSidebar: true }}>
       <table>
         <tbody>
           <FlatTableRow {...props}>
@@ -1176,7 +1176,7 @@ function renderRowWithContext(props = {}) {
           </FlatTableRow>
         </tbody>
       </table>
-    </SidebarContext.Provider>
+    </DrawerSidebarContext.Provider>
   );
 }
 

--- a/src/components/flat-table/flat-table.component.js
+++ b/src/components/flat-table/flat-table.component.js
@@ -8,7 +8,7 @@ import {
   StyledFlatTableFooter,
   StyledFlatTableBox,
 } from "./flat-table.style";
-import { SidebarContext } from "../drawer";
+import { DrawerSidebarContext } from "../drawer";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 
 export const FlatTableThemeContext = React.createContext({});
@@ -42,7 +42,7 @@ const FlatTable = ({
   }
 
   return (
-    <SidebarContext.Consumer>
+    <DrawerSidebarContext.Consumer>
       {(context) => (
         <StyledFlatTableRoot {...filterStyledSystemMarginProps(rest)}>
           <StyledFlatTableBox
@@ -75,7 +75,7 @@ const FlatTable = ({
           )}
         </StyledFlatTableRoot>
       )}
-    </SidebarContext.Consumer>
+    </DrawerSidebarContext.Consumer>
   );
 };
 

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -25,7 +25,7 @@ import {
   StyledFlatTableBox,
 } from "./flat-table.style";
 import { baseTheme } from "../../style/themes";
-import { SidebarContext } from "../drawer";
+import { DrawerSidebarContext } from "../drawer";
 import { StyledFlatTableCell } from "./flat-table-cell/flat-table-cell.style";
 import StyledFlatTableRow from "./flat-table-row/flat-table-row.style";
 import OptionsHelper from "../../utils/helpers/options-helper/options-helper";
@@ -253,7 +253,7 @@ describe("FlatTable", () => {
     let wrapper;
     beforeEach(() => {
       wrapper = mount(
-        <SidebarContext.Provider value={{ isInSidebar: true }}>
+        <DrawerSidebarContext.Provider value={{ isInSidebar: true }}>
           <FlatTable>
             <tbody>
               <tr>
@@ -261,7 +261,7 @@ describe("FlatTable", () => {
               </tr>
             </tbody>
           </FlatTable>
-        </SidebarContext.Provider>
+        </DrawerSidebarContext.Provider>
       );
     });
 

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -22,7 +22,7 @@ import {
   ActionPopoverItem,
   ActionPopoverMenu,
 } from "../action-popover";
-import { SidebarContext } from "../drawer";
+import { DrawerSidebarContext } from "../drawer";
 import Box from "../box";
 
 <Meta
@@ -1664,7 +1664,7 @@ of the button control.
               <Icon type="pdf" />
             </IconButton>
           </BatchSelection>
-          <SidebarContext.Provider value={{ isInSidebar: true }}>
+          <DrawerSidebarContext.Provider value={{ isInSidebar: true }}>
             <FlatTable>
               <FlatTableHead>
                 <FlatTableRow>
@@ -1743,7 +1743,7 @@ of the button control.
                 </FlatTableRow>
               </FlatTableBody>
             </FlatTable>
-          </SidebarContext.Provider>
+          </DrawerSidebarContext.Provider>
         </>
       );
     }}

--- a/src/components/form/form.component.js
+++ b/src/components/form/form.component.js
@@ -1,4 +1,10 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  useContext,
+} from "react";
 import PropTypes from "prop-types";
 import throttle from "lodash/throttle";
 import styledSystemPropTypes from "@styled-system/prop-types";
@@ -11,6 +17,7 @@ import {
   StyledLeftButtons,
   StyledRightButtons,
 } from "./form.style";
+import { SidebarContext } from "../sidebar/sidebar.component";
 
 const SCROLL_THROTTLE = 50;
 
@@ -30,11 +37,10 @@ const Form = ({
   ...rest
 }) => {
   const [isFooterSticky, setIsFooterSticky] = useState(false);
-
+  const { isInSidebar } = useContext(SidebarContext);
   const formRef = useRef();
   const formFooterRef = useRef();
   const stickyListenersAddedRef = useRef(false);
-
   const checkStickyFooter = useCallback(
     throttle(() => {
       const { bottom } = formRef.current.getBoundingClientRect();
@@ -91,6 +97,7 @@ const Form = ({
       data-component="form"
       fieldSpacing={fieldSpacing}
       noValidate={noValidate}
+      isInSidebar={isInSidebar}
       {...rest}
     >
       {children}

--- a/src/components/form/form.spec.js
+++ b/src/components/form/form.spec.js
@@ -247,6 +247,27 @@ describe("Form", () => {
         assertThatFooterIsNotSticky();
       });
     });
+
+    describe("when stickyFooter is provided and it is used in Sidebar", () => {
+      it("should render correct styles", () => {
+        wrapper = mount(<StyledForm stickyFooter isInSidebar />);
+
+        assertStyleMatch(
+          {
+            position: "static !important",
+          },
+          wrapper
+        );
+
+        assertStyleMatch(
+          {
+            position: "absolute",
+          },
+          wrapper,
+          { modifier: `${StyledFormFooter}` }
+        );
+      });
+    });
   });
 
   describe("form buttons", () => {

--- a/src/components/form/form.style.js
+++ b/src/components/form/form.style.js
@@ -10,43 +10,6 @@ import baseTheme from "../../style/themes/base";
 import OptionsHelper from "../../utils/helpers/options-helper";
 import { FieldsetStyle } from "../../__experimental__/components/fieldset/fieldset.style";
 
-export const StyledForm = styled.form`
-  ${space}
-
-  & ${StyledFormField}, ${StyledFieldset}, ${FieldsetStyle}, > ${StyledButton} {
-    margin-top: 0;
-    margin-bottom: ${({ fieldSpacing, theme }) =>
-      theme.spacing * fieldSpacing}px;
-  }
-
-  ${({ stickyFooter }) =>
-    stickyFooter &&
-    css`
-      padding-bottom: 88px;
-    `}
-`;
-
-export const StyledRightButtons = styled.div`
-  display: flex;
-  margin-left: 16px;
-  ${({ buttonAlignment }) => buttonAlignment === "left" && "flex-grow: 1"};
-
-  ${StyledButton}:last-child {
-    margin-right: 0;
-  }
-`;
-
-export const StyledLeftButtons = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  margin-right: 16px;
-  ${({ buttonAlignment }) => buttonAlignment === "right" && "flex-grow: 1"};
-
-  ${StyledButton}:last-child {
-    margin-right: 0;
-  }
-`;
-
 const FormButtonAnimation = keyframes`
   0%   { transform: translateY(50px); }
   100% { transform: translateY(0px); }
@@ -78,6 +41,53 @@ export const StyledFormFooter = styled.div`
       z-index: 1000;
     `}
   `}
+`;
+
+export const StyledForm = styled.form`
+  ${space}
+
+  & ${StyledFormField}, ${StyledFieldset}, ${FieldsetStyle}, > ${StyledButton} {
+    margin-top: 0;
+    margin-bottom: ${({ fieldSpacing, theme }) =>
+      theme.spacing * fieldSpacing}px;
+  }
+
+  ${({ stickyFooter, isInSidebar }) =>
+    stickyFooter &&
+    css`
+      padding-bottom: 88px;
+
+      ${isInSidebar &&
+      css`
+        // important keyword is needed because original style is provided in inline style mode
+        position: static !important;
+
+        ${StyledFormFooter} {
+          position: absolute;
+        }
+      `}
+    `}
+`;
+
+export const StyledRightButtons = styled.div`
+  display: flex;
+  margin-left: 16px;
+  ${({ buttonAlignment }) => buttonAlignment === "left" && "flex-grow: 1"};
+
+  ${StyledButton}:last-child {
+    margin-right: 0;
+  }
+`;
+
+export const StyledLeftButtons = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-right: 16px;
+  ${({ buttonAlignment }) => buttonAlignment === "right" && "flex-grow: 1"};
+
+  ${StyledButton}:last-child {
+    margin-right: 0;
+  }
 `;
 
 StyledForm.propTypes = {

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -1,1 +1,2 @@
 export { default } from "./sidebar.component";
+export { SidebarContext } from "./sidebar.component";

--- a/src/components/sidebar/sidebar.component.js
+++ b/src/components/sidebar/sidebar.component.js
@@ -9,6 +9,8 @@ import FocusTrap from "../../__internal__/focus-trap";
 import SidebarHeader from "./__internal__/sidebar-header";
 import Box from "../box";
 
+export const SidebarContext = React.createContext({});
+
 const Sidebar = ({
   open,
   disableEscKey,
@@ -55,7 +57,9 @@ const Sidebar = ({
         scrollVariant="light"
         overflow="auto"
       >
-        {children}
+        <SidebarContext.Provider value={{ isInSidebar: true }}>
+          {children}
+        </SidebarContext.Provider>
       </Box>
     </SidebarStyle>
   );

--- a/src/components/sidebar/sidebar.d.ts
+++ b/src/components/sidebar/sidebar.d.ts
@@ -1,6 +1,9 @@
 import * as React from "react";
 import Modal, { ModalProps } from "../modal/modal";
 
+export interface SidebarContextProps {
+  isInSidebar: boolean;
+}
 export interface SidebarProps extends ModalProps {
   /** Set this prop to false to hide the translucent background when the dialog is open. */
   enableBackgroundUI?: boolean;
@@ -12,6 +15,7 @@ export interface SidebarProps extends ModalProps {
   size?: string;
 }
 
+declare const SidebarContext: React.Context<SidebarContextProps>;
 declare class Sidebar extends Modal<SidebarProps> {}
 
 export default Sidebar;

--- a/src/components/tabs/tabs.component.js
+++ b/src/components/tabs/tabs.component.js
@@ -14,7 +14,7 @@ import tagComponent from "../../utils/helpers/tags/tags";
 import StyledTabs from "./tabs.style";
 import TabsHeader from "./__internal__/tabs-header";
 import TabTitle from "./__internal__/tab-title";
-import { SidebarContext } from "../drawer";
+import { DrawerSidebarContext } from "../drawer";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 
 const marginPropTypes = filterStyledSystemMarginProps(
@@ -40,7 +40,7 @@ const Tabs = ({
   const tabRefs = useRef([]);
   const previousSelectedTabId = useRef(selectedTabId);
   const [selectedTabIdState, setSelectedTabIdState] = useState();
-  const sidebarContext = useContext(SidebarContext);
+  const sidebarContext = useContext(DrawerSidebarContext);
   const [tabsErrors, setTabsErrors] = useState({});
   const [tabsWarnings, setTabsWarnings] = useState({});
   const [tabsInfos, setTabsInfos] = useState({});

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -15,7 +15,7 @@ import {
   testStyledSystemMargin,
 } from "../../__spec_helper__/test-utils";
 import { StyledTabsHeaderWrapper } from "./__internal__/tabs-header/tabs-header.style";
-import { SidebarContext } from "../drawer";
+import { DrawerSidebarContext } from "../drawer";
 
 function render(props) {
   return mount(
@@ -666,7 +666,7 @@ describe("Tabs", () => {
     describe("custom targeting", () => {
       it("supports overriding the targeted content", () => {
         const wrapper = mount(
-          <SidebarContext.Provider value={{ isInSidebar: true }}>
+          <DrawerSidebarContext.Provider value={{ isInSidebar: true }}>
             <Tabs>
               <Tab
                 title="Tab Title 1"
@@ -678,7 +678,7 @@ describe("Tabs", () => {
                 TabContent
               </Tab>
             </Tabs>
-          </SidebarContext.Provider>
+          </DrawerSidebarContext.Provider>
         );
         act(() => {
           wrapper


### PR DESCRIPTION
### Proposed behaviour
Fixed Form Footer inside of Sidebar
fixes: #4211

### Current behaviour
When Form with Form Footer in sticky mode is provided to Sidebar, the footer getting out of component

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] <del> Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] <del> Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
In this ticket I renamed SidebarContext that was in Drawer component because it was confusing. New name for Drawer context is DrawerSidebarContext.
I added new context SidebarContext to Sidebar component

### Testing instructions
Testable in codesandbox
