### PR TITLE
fix(tile-select): prevent focus outline when tile select is disabled

### DIFF
--- a/src/components/tile-select/tile-select.component.js
+++ b/src/components/tile-select/tile-select.component.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import I18n from "i18n-js";
 import styledSystemPropTypes from "@styled-system/prop-types";
 import tagComponent from "../../utils/helpers/tags/tags";
@@ -67,6 +67,12 @@ const TileSelect = ({
       )
     );
   };
+
+  useEffect(() => {
+    if (disabled && hasFocus) {
+      setHasFocus(false);
+    }
+  }, [disabled, hasFocus]);
 
   return (
     <StyledTileSelectContainer

--- a/src/components/tile-select/tile-select.spec.js
+++ b/src/components/tile-select/tile-select.spec.js
@@ -381,6 +381,24 @@ describe("TileSelectGroup", () => {
     });
   });
 
+  describe("when input becomes disabled", () => {
+    it("removes the focus outline", () => {
+      wrapper = mount(<TileSelect />);
+
+      wrapper.find(StyledTileSelectInput).first().simulate("focus");
+      expect(wrapper.find(StyledFocusWrapper).first().prop("hasFocus")).toEqual(
+        true
+      );
+
+      wrapper.setProps({ disabled: true });
+      wrapper.update();
+
+      expect(wrapper.find(StyledFocusWrapper).first().prop("hasFocus")).toEqual(
+        false
+      );
+    });
+  });
+
   describe("propTypes", () => {
     it("validates the incorrect children prop", () => {
       jest.spyOn(global.console, "error").mockImplementation(() => {});


### PR DESCRIPTION
fix #4227

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds `useEffect` to set `hasFocus` to false if `disabled` prop is set

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Focus outline remains when `disabled` prop is set on `TileSelect`

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/optimistic-mendeleev-f4i19?file=/src/index.js