### PR TITLE
fix: only warn about deprecated props when used FE-4219

### DIFF
--- a/src/components/confirm/confirm.component.js
+++ b/src/components/confirm/confirm.component.js
@@ -36,7 +36,7 @@ const Confirm = ({
   title,
   ...rest
 }) => {
-  if (!deprecatedWarnTriggered && destructive) {
+  if (destructive && !deprecatedWarnTriggered) {
     deprecatedWarnTriggered = true;
     Logger.deprecate(
       "`destructive` prop is deprecated and will soon be removed. Please use `cancelButtonDestructive` and `confirmButtonDestructive` props."

--- a/src/components/icon/icon.component.js
+++ b/src/components/icon/icon.component.js
@@ -39,7 +39,7 @@ const Icon = React.forwardRef(
     },
     ref
   ) => {
-    if (!deprecatedWarnTriggered && (iconColor || bgTheme)) {
+    if ((iconColor || bgTheme) && !deprecatedWarnTriggered) {
       deprecatedWarnTriggered = true;
       Logger.deprecate(
         "`iconColor` and `bgTheme` props are deprecated and will soon be removed"


### PR DESCRIPTION
### Proposed behaviour

Only warn about deprecated props when used.

### Current behaviour

Deprecations are used even if the prop is not used.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
Clutters test output

### Testing instructions
Check there are no deprecation warnings in this sandbox https://codesandbox.io/s/carbon-quickstart-forked-2wo3x add the deprecated props to see the warning.