### PR TITLE
fix(flat-table-row): reduce z-index value when onclick passed to row

### DIFF
--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -97,7 +97,7 @@ describe("FlatTableRow", () => {
           borderBottom: "1px solid transparent",
           borderLeft: `1px solid ${baseTheme.colors.focus}`,
           backgroundClip: "padding-box",
-          zIndex: "2000",
+          zIndex: "1001",
         },
         wrapper,
         { modifier: `:focus ${StyledFlatTableRowHeader}` }
@@ -1131,10 +1131,14 @@ describe("FlatTableRow", () => {
       it("should add the correct padding to child row cells", () => {
         const wrapper = mount(
           <FlatTableThemeContext.Provider value={{ size: "compact" }}>
-            <FlatTableRow expandable expanded subRows={SubRows}>
-              <FlatTableCell>cell1</FlatTableCell>
-              <FlatTableCell>cell2</FlatTableCell>
-            </FlatTableRow>
+            <table>
+              <tbody>
+                <FlatTableRow expandable expanded subRows={SubRows}>
+                  <FlatTableCell>cell1</FlatTableCell>
+                  <FlatTableCell>cell2</FlatTableCell>
+                </FlatTableRow>
+              </tbody>
+            </table>
           </FlatTableThemeContext.Provider>
         );
 

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.js
@@ -19,7 +19,7 @@ const stickyColumnFocusStyling = (index, theme) => {
       index === 0 ? theme.colors.focus : theme.table.secondary
     };
     background-clip: padding-box;
-    z-index: ${theme.zIndex.popover};
+    z-index: ${theme.zIndex.overlay + 1};
 
     :before {
       content: "";


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Reduces the `z-index` value when an `onClick` is passed from `2000` to `1001`. When it is at 2000 it
overlaps modals

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
clickable rows have a z-index of 2000 which overlaps carbon Modals

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-7kjq2?file=/src/index.js --> proposed change
https://codesandbox.io/s/charming-shadow-lcjp7?file=/src/index.js --> current behaviour v77.11.0

Test that focus outline is still correct for `story/design-system-flat-table--with-row-header` in safari