### PR TITLE
docs(flat-table): improve custom cell padding example - FE-4187

### DIFF
--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -164,21 +164,21 @@ Padding can be set on each cell individually by using the spacing props syntax. 
     <FlatTable>
       <FlatTableHead>
         <FlatTableRow>
-          <FlatTableHeader px={5} py={2}>
+          <FlatTableHeader px={1} py={2}>
             Name
           </FlatTableHeader>
-          <FlatTableHeader py={2}>Location</FlatTableHeader>
-          <FlatTableHeader py={2}>Relationship Status</FlatTableHeader>
-          <FlatTableHeader py={2}>Dependents</FlatTableHeader>
+          <FlatTableHeader px={2} py={2}>Location</FlatTableHeader>
+          <FlatTableHeader px={3} py={2}>Relationship Status</FlatTableHeader>
+          <FlatTableHeader px={4} py={2}>Dependents</FlatTableHeader>
         </FlatTableRow>
       </FlatTableHead>
       <FlatTableBody>
         {[1, 2, 3, 4].map((key) => (
           <FlatTableRow key={key}>
-            <FlatTableCell px={5}>John Doe</FlatTableCell>
-            <FlatTableCell>London</FlatTableCell>
-            <FlatTableCell>Single</FlatTableCell>
-            <FlatTableCell>5</FlatTableCell>
+            <FlatTableCell px={key}>John Doe</FlatTableCell>
+            <FlatTableCell pl={key}>London</FlatTableCell>
+            <FlatTableCell p={key}>Single</FlatTableCell>
+            <FlatTableCell pl={key}>5</FlatTableCell>
           </FlatTableRow>
         ))}
       </FlatTableBody>


### PR DESCRIPTION
Better demonstrates the possibilities of using custom paddings in FlatTable

fixes FE-4187

### Proposed behaviour
<img width="997" alt="Screenshot 2021-07-14 at 13 34 03" src="https://user-images.githubusercontent.com/56251247/125622729-e571362e-366f-432c-a671-080e951f41aa.png">


### Current behaviour
<img width="998" alt="Screenshot 2021-07-14 at 13 34 28" src="https://user-images.githubusercontent.com/56251247/125622784-fa2c70b7-f0b7-4749-8c91-abb53cdc9268.png">


### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
- Build should pass
- No Cypress tests should be affected
- Chromatic snapshot should match the new version of this story
- No other stories should be affected by this change