### PR TITLE
fix(simple-color-picker): set cursor to not-allowed when component is disabled - FE-4198

### DIFF
--- a/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
+++ b/src/__experimental__/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
@@ -212,6 +212,10 @@ exports[`SimpleColorPicker renders as expected 1`] = `
   cursor: pointer;
 }
 
+.c7:disabled:hover {
+  cursor: not-allowed;
+}
+
 .c7:focus + .c8 {
   box-shadow: inset 0px 0px 0px 3px #FFFFFF;
   border: 2px solid #FFB500;

--- a/src/__experimental__/components/simple-color-picker/simple-color-input/simple-color-input.style.js
+++ b/src/__experimental__/components/simple-color-picker/simple-color-input/simple-color-input.style.js
@@ -14,6 +14,10 @@ const StyledSimpleColorInput = styled(SimpleColorInput)`
     cursor: pointer;
   }
 
+  &:disabled:hover {
+    cursor: not-allowed;
+  }
+
   &:focus + ${StyledColorSampleBox} {
     box-shadow: inset 0px 0px 0px 3px ${({ theme }) => theme.colors.white};
     border: 2px solid ${({ theme }) => theme.colors.focus};


### PR DESCRIPTION
Setting cursor to not-allowed brings this behaviour inline with our other components when disabled

fixes FE-4198

### Proposed behaviour
<img width="283" alt="Screenshot 2021-07-14 at 14 22 50" src="https://user-images.githubusercontent.com/56251247/125629342-4d8f6c24-bb70-4b15-ab97-77f334624be1.png">

### Current behaviour
<img width="239" alt="Screenshot 2021-07-14 at 14 23 44" src="https://user-images.githubusercontent.com/56251247/125629485-4fd7cf2a-fff2-477c-ab85-baed188bec58.png">


### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
- Visit the `experimental-simple-color-picker--disabled` story for `simple-color-picker`
- Hover over the component and mouse pointer should be `not-allowed`
