### PR TITLE
fix(search): correct onClick prop ts type

### DIFF
--- a/src/__experimental__/components/search/search.d.ts
+++ b/src/__experimental__/components/search/search.d.ts
@@ -17,7 +17,10 @@ export interface SearchProps extends MarginProps {
   /** Prop for `onClick` events.
    *  `onClick` events are triggered when the `searchButton` is clicked
    */
-  onClick?: (ev: React.MouseEvent<HTMLElement>) => void;
+  onClick?: (
+    ev: React.ChangeEvent<HTMLInputElement> &
+      React.MouseEvent<HTMLButtonElement>
+  ) => void;
   /** Prop for `onKeyDown` events */
   onKeyDown?: (ev: React.KeyboardEvent<HTMLInputElement>) => void;
   /** Prop for a placeholder */


### PR DESCRIPTION
Fixes: #4185

### Proposed behaviour
Correct the TypeScript type on the `Search` component `onClick` prop so that `event.target.value` is accessible.

### Current behaviour
The current type gives a ts error when you try to access `event.target.value`

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
https://codesandbox.io/s/peaceful-swanson-yyoe5?file=/src/index.tsx