### PR TITLE
test(select): add new tests for filterable and multi select FE-4230

### DIFF
--- a/cypress/features/regression/designSystem/filterableSelectEvents.feature
+++ b/cypress/features/regression/designSystem/filterableSelectEvents.feature
@@ -49,3 +49,10 @@ Feature: Design System Select filterable component
     Given I click on dropdown button in iframe
     When I hit ESC key
     Then "filterable" Select list is closed in iframe
+
+  @positive
+  Scenario: Check the onFilterChange events after typed string into the input
+    Given clear all actions in Actions Tab
+      And I focus default Select input
+    When I type "b" into default input
+    Then onFilterChange action was called in Actions Tab

--- a/cypress/features/regression/designSystem/multiSelectEvents.feature
+++ b/cypress/features/regression/designSystem/multiSelectEvents.feature
@@ -49,3 +49,10 @@ Feature: Design System Multi Select component
     Given I click on dropdown button in iframe
     When I hit ESC key
     Then multi Select list is closed in iframe
+
+  @positive
+  Scenario: Check the onFilterChange events after typed string into the input
+    Given clear all actions in Actions Tab
+      And I focus default Select input
+    When I type "b" into default input
+    Then onFilterChange action was called in Actions Tab  


### PR DESCRIPTION
### Proposed behaviour
Add new Cypress tests for the onFilterChange action events in Filterable Select and Multi Select.


### Current behaviour
These tests do not currently exist.

### Checklist
<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [x] Cypress automation tests added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
Run Cypress tests `cypress/features/regression/designSystem/filterableSelectEvents.feature` and `cypress/features/regression/designSystem/multiSelectEvents.feature`. New scenarios added test the onFilterChange action event.
