### PR TITLE
fix(menu): add aria-role to fix accessibility violations - FE-3422

### DIFF
--- a/src/components/link/link.component.js
+++ b/src/components/link/link.component.js
@@ -79,7 +79,13 @@ class InternalLink extends React.Component {
     <>
       {this.renderLinkIcon()}
 
-      <span className="carbon-link__content">
+      <span
+        {...(!this.props.children && {
+          "aria-label": this.props.ariaLabel,
+          role: "link",
+        })}
+        className="carbon-link__content"
+      >
         {this.props.isSkipLink ? "Skip to main content" : this.props.children}
       </span>
 

--- a/src/components/menu/menu-full-screen/menu-full-screen.component.js
+++ b/src/components/menu/menu-full-screen/menu-full-screen.component.js
@@ -26,7 +26,7 @@ const MenuFullscreen = ({
   const { menuType } = useContext(MenuContext);
 
   return (
-    <li>
+    <li aria-label="menu fullscreen" role="menuitem">
       <Portal>
         <FocusTrap wrapperRef={menuWrapperRef}>
           <StyledMenuFullscreen

--- a/src/components/menu/menu-item/menu-item.component.js
+++ b/src/components/menu/menu-item/menu-item.component.js
@@ -154,6 +154,7 @@ const MenuItem = ({
           clickToOpen={clickToOpen}
           maxWidth={maxWidth}
           asPassiveItem={asPassiveItem}
+          ariaLabel={ariaLabel}
           {...elementProps}
           {...rest}
         >

--- a/src/components/menu/menu.component.js
+++ b/src/components/menu/menu.component.js
@@ -42,6 +42,7 @@ const Menu = ({ menuType = "light", children, ...rest }) => {
   return (
     <StyledMenuWrapper
       data-component="menu"
+      role="menubar"
       menuType={menuType}
       {...rest}
       ref={ref}

--- a/src/components/pod/__snapshots__/pod.spec.js.snap
+++ b/src/components/pod/__snapshots__/pod.spec.js.snap
@@ -402,6 +402,7 @@ exports[`ActionButtons StyledEditAction when isHovered prop is set should match 
   >
     <span
       className="carbon-link__content"
+      role="link"
     />
   </a>
 </span>


### PR DESCRIPTION
### Proposed behaviour
Adding aria-role to menu will fix accessibility violations that are visible in storybook story
<img width="592" alt="Zrzut ekranu 2021-07-20 o 15 04 35" src="https://user-images.githubusercontent.com/19231884/126329149-9b316d06-58be-4289-bfd7-b1473defb035.png">

### Current behaviour
<img width="568" alt="Zrzut ekranu 2021-07-20 o 15 06 33" src="https://user-images.githubusercontent.com/19231884/126329293-d6cea0ec-36a3-4e20-975c-56d0d35b98e2.png">

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [ ] <del> Unit tests added or updated if required
- [ ] <del> Cypress automation tests added or updated if required
- [ ] <del> Storybook added or updated if required
- [ ] <del> Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
