### PR TITLE
refactor(drawer): add default value to DrawerSidebarContext - FE-4224

### DIFF
--- a/src/components/drawer/drawer.component.js
+++ b/src/components/drawer/drawer.component.js
@@ -16,7 +16,7 @@ import {
 } from "./drawer.style";
 import StickyFooter from "../../__internal__/sticky-footer";
 
-const DrawerSidebarContext = React.createContext();
+const DrawerSidebarContext = React.createContext({});
 
 const Drawer = ({
   defaultExpanded = true,

--- a/src/components/flat-table/flat-table-row/flat-table-row.component.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.js
@@ -129,10 +129,10 @@ const FlatTableRow = React.forwardRef(
 
     return (
       <DrawerSidebarContext.Consumer>
-        {(context) => (
+        {({ isInSidebar }) => (
           <>
             <StyledFlatTableRow
-              isInSidebar={context && context.isInSidebar}
+              isInSidebar={isInSidebar}
               expandable={expandable}
               isSubRow={isSubRow}
               isFirstSubRow={isFirstSubRow}

--- a/src/components/flat-table/flat-table.component.js
+++ b/src/components/flat-table/flat-table.component.js
@@ -43,7 +43,7 @@ const FlatTable = ({
 
   return (
     <DrawerSidebarContext.Consumer>
-      {(context) => (
+      {({ isInSidebar }) => (
         <StyledFlatTableRoot {...filterStyledSystemMarginProps(rest)}>
           <StyledFlatTableBox
             {...rest}
@@ -52,7 +52,7 @@ const FlatTable = ({
             maxHeight={hasMaxHeight ? "100%" : undefined}
           >
             <StyledFlatTableWrapper
-              isInSidebar={context && context.isInSidebar}
+              isInSidebar={isInSidebar}
               hasStickyHead={hasStickyHead}
               colorTheme={colorTheme}
               heightDefaulted={addDefaultHeight}

--- a/src/components/tabs/tabs.component.js
+++ b/src/components/tabs/tabs.component.js
@@ -40,11 +40,10 @@ const Tabs = ({
   const tabRefs = useRef([]);
   const previousSelectedTabId = useRef(selectedTabId);
   const [selectedTabIdState, setSelectedTabIdState] = useState();
-  const sidebarContext = useContext(DrawerSidebarContext);
+  const { isInSidebar } = useContext(DrawerSidebarContext);
   const [tabsErrors, setTabsErrors] = useState({});
   const [tabsWarnings, setTabsWarnings] = useState({});
   const [tabsInfos, setTabsInfos] = useState({});
-  const isInSidebar = !!sidebarContext?.isInSidebar;
 
   useLayoutEffect(() => {
     const selectedTab =
@@ -212,7 +211,7 @@ const Tabs = ({
 
       const tabTitle = (
         <TabTitle
-          position={sidebarContext ? "left" : position}
+          position={isInSidebar ? "left" : position}
           className={child.props.className || ""}
           dataTabId={tabId}
           id={refId}
@@ -248,10 +247,10 @@ const Tabs = ({
     return (
       <TabsHeader
         align={align}
-        position={sidebarContext ? "left" : position}
+        position={isInSidebar ? "left" : position}
         role="tablist"
         extendedLine={extendedLine}
-        alternateStyling={variant === "alternate" || !!sidebarContext}
+        alternateStyling={variant === "alternate" || isInSidebar}
         noRightBorder={["no right side", "no sides"].includes(borders)}
         isInSidebar={isInSidebar}
       >
@@ -279,7 +278,7 @@ const Tabs = ({
 
   /** Builds all tabs where non selected tabs have class of hidden */
   const renderTabs = () => {
-    if (sidebarContext) return null;
+    if (isInSidebar) return null;
 
     if (!renderHiddenTabs) {
       return visibleTab();
@@ -314,7 +313,7 @@ const Tabs = ({
   return (
     <StyledTabs
       className={className}
-      position={sidebarContext ? "left" : position}
+      position={isInSidebar ? "left" : position}
       updateErrors={updateErrors}
       updateWarnings={updateWarnings}
       {...tagComponent("tabs", rest)}

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -235,6 +235,7 @@ describe("Tabs", () => {
   describe('When "selectedTabId" is passed a valid "tabId"', () => {
     it("displays the specified Tab", () => {
       const wrapper = render({ selectedTabId: "uniqueid2" });
+
       expect(wrapper.find(Tab).at(1).props().isTabSelected).toEqual(true);
     });
   });


### PR DESCRIPTION
### Proposed behaviour
Adding default value to DrawerSidebarContext will allow us to use object destructuring

### Current behaviour
Default value is missing

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] <del> Screenshots are included in the PR if useful
- [ ] <del> All themes are supported if required
- [ ] <del> Unit tests added or updated if required
- [ ] <del> Cypress automation tests added or updated if required
- [ ] <del> Storybook added or updated if required
- [ ] <del> Typescript `d.ts` file added or updated if required
- [ ] <del> Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
I think we should just check all components that use DrawerSidebarContext and check if there are any changes. No changes should be visible. 
Components that uses DrawerSidebarContext:
- Drawer component
- Flat Table component
- Tabs

