### PR TITLE
fix(flat-table): ensure correct z-index is applied to flat-table-header - FE-4225

### DIFF
--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -27,10 +27,6 @@ exports[`FlatTable when rendered with proper table data should have expected str
   box-sizing: border-box;
 }
 
-.c11.c11.c11:first-child {
-  border-left: 1px solid #668592;
-}
-
 .c13 {
   background-color: #fff;
   border-width: 0;

--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -27,6 +27,10 @@ exports[`FlatTable when rendered with proper table data should have expected str
   box-sizing: border-box;
 }
 
+.c11.c11.c11:first-child {
+  border-left: 1px solid #668592;
+}
+
 .c13 {
   background-color: #fff;
   border-width: 0;

--- a/src/components/flat-table/flat-table-head/flat-table-head.component.js
+++ b/src/components/flat-table/flat-table-head/flat-table-head.component.js
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import StyledFlatTableHead from "./flat-table-head.style";
+import FlatTableRowHeader from "../flat-table-row-header";
 
 const getRefs = (length) => Array.from({ length }, () => React.createRef());
 
 const FlatTableHead = ({ children }) => {
   const [rowHeights, setRowHeights] = useState([]);
   const refs = getRefs(React.Children.count(children));
+  let hasFlatTableRowHeader;
 
   useEffect(() => {
     if (React.Children.count(children) > 1) {
@@ -21,13 +23,21 @@ const FlatTableHead = ({ children }) => {
 
   return (
     <StyledFlatTableHead>
-      {React.Children.map(children, (child, index) =>
-        React.cloneElement(child, {
+      {React.Children.map(children, (child, index) => {
+        /* Applies left border if preceding row has a FlatTableRowHeader and current one does not. 
+           This is only needed when the preceding row has rowSpans applied, 
+           as in any other use case the rows will all have FlatTableRowHeaders */
+        const previousRowHasHeader = !!hasFlatTableRowHeader;
+        hasFlatTableRowHeader = child.props.children.find(
+          (c) => c.type === FlatTableRowHeader
+        );
+        return React.cloneElement(child, {
           ...child.props,
           stickyOffset: rowHeights.slice(0, index).reduce((a, b) => a + b, 0),
           ref: refs[index],
-        })
-      )}
+          applyBorderLeft: previousRowHasHeader && !hasFlatTableRowHeader,
+        });
+      })}
     </StyledFlatTableHead>
   );
 };

--- a/src/components/flat-table/flat-table-header/flat-table-header.style.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.style.js
@@ -75,11 +75,13 @@ const StyledFlatTableHeader = styled.th`
       }
 
       &:first-child {
-        padding-right: 0.425em;
+        padding-right: 0.395em;
 
+        /* Styling for safari. Increased padding is required to ensure no gap is present between
+        the th elements. This includes FlatTableHeader and FlatTableRowHeader  */
         @media not all and (min-resolution:.001dpcm) {
           @supports (-webkit-appearance:none) and (stroke-color:transparent) {
-            padding-right: 0.6em;
+            padding-right: 0.9em;
           }
         }
     `
@@ -92,10 +94,6 @@ const StyledFlatTableHeader = styled.th`
           border-right-width: ${verticalBorderSizes[verticalBorder]};
         `
       }
-
-        &:first-child {
-          border-left: 1px solid ${theme.flatTable.dark.border};
-        }
       }
     }
   `}

--- a/src/components/flat-table/flat-table-header/flat-table-header.style.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.style.js
@@ -77,6 +77,12 @@ const StyledFlatTableHeader = styled.th`
       &:first-child {
         padding-right: 0.395em;
 
+        /* Applies specific styling for Firefox. Increased padding is required to ensure no gap is present between
+        the th elements. This includes FlatTableHeader and FlatTableRowHeader */
+        @-moz-document url-prefix() {
+          padding-right: 2px;
+        }
+
         /* Styling for safari. Increased padding is required to ensure no gap is present between
         the th elements. This includes FlatTableHeader and FlatTableRowHeader  */
         @media not all and (min-resolution:.001dpcm) {

--- a/src/components/flat-table/flat-table-header/flat-table-header.style.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.style.js
@@ -70,9 +70,12 @@ const StyledFlatTableHeader = styled.th`
       css`
       left: ${leftPosition}px;
       position: sticky;
+      &&& {
+        z-index: 1002;
+      }
 
       &:first-child {
-        padding-right: 0.395em;
+        padding-right: 0.425em;
 
         @media not all and (min-resolution:.001dpcm) {
           @supports (-webkit-appearance:none) and (stroke-color:transparent) {
@@ -89,6 +92,10 @@ const StyledFlatTableHeader = styled.th`
           border-right-width: ${verticalBorderSizes[verticalBorder]};
         `
       }
+
+        &:first-child {
+          border-left: 1px solid ${theme.flatTable.dark.border};
+        }
       }
     }
   `}

--- a/src/components/flat-table/flat-table-row/flat-table-row.component.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.js
@@ -32,6 +32,7 @@ const FlatTableRow = React.forwardRef(
       bgColor,
       horizontalBorderColor,
       horizontalBorderSize = "small",
+      applyBorderLeft,
     },
     ref
   ) => {
@@ -149,6 +150,7 @@ const FlatTableRow = React.forwardRef(
               bgColor={bgColor}
               horizontalBorderColor={horizontalBorderColor}
               horizontalBorderSize={horizontalBorderSize}
+              applyBorderLeft={applyBorderLeft}
               {...interactiveRowProps}
             >
               {React.Children.map(children, (child, index) => {
@@ -225,6 +227,8 @@ FlatTableRow.propTypes = {
   isFirstSubRow: PropTypes.bool,
   /** @ignore @private position in header if multiple rows */
   stickyOffset: PropTypes.number,
+  /** @ignore @private applies a border-left to the first child */
+  applyBorderLeft: PropTypes.bool,
 };
 
 export default FlatTableRow;

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -399,7 +399,7 @@ describe("FlatTableRow", () => {
       }
     });
 
-    it('applies an additional "padding-left" to the "FLatTableRow" and removes "border-left" from first child', () => {
+    it('applies an additional "padding-left" to the "FlatTableRow" and removes "border-left" from first child', () => {
       wrapper = renderRowWithContext();
       assertStyleMatch(
         {
@@ -410,7 +410,7 @@ describe("FlatTableRow", () => {
       );
     });
 
-    it('removes "border-right" from "FLatTableRow" first child', () => {
+    it('removes "border-right" from "FlatTableRow" first child', () => {
       wrapper = renderRowWithContext();
       assertStyleMatch(
         {

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -97,7 +97,7 @@ describe("FlatTableRow", () => {
           borderBottom: "1px solid transparent",
           borderLeft: `1px solid ${baseTheme.colors.focus}`,
           backgroundClip: "padding-box",
-          zIndex: "1001",
+          zIndex: "1002",
         },
         wrapper,
         { modifier: `:focus ${StyledFlatTableRowHeader}` }

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.js
@@ -19,7 +19,7 @@ const stickyColumnFocusStyling = (index, theme) => {
       index === 0 ? theme.colors.focus : theme.table.secondary
     };
     background-clip: padding-box;
-    z-index: ${theme.zIndex.overlay + 1};
+    z-index: ${theme.zIndex.overlay + 2};
 
     :before {
       content: "";

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.js
@@ -15,9 +15,8 @@ const horizontalBorderSizes = {
 const stickyColumnFocusStyling = (index, theme) => {
   return `
     border-bottom: 1px solid transparent;
-    border-left: 1px solid ${
-      index === 0 ? theme.colors.focus : theme.table.secondary
-    };
+    border-left: 1px solid
+      ${index === 0 ? theme.colors.focus : theme.table.secondary};
     background-clip: padding-box;
     z-index: ${theme.zIndex.overlay + 2};
 
@@ -73,6 +72,7 @@ const StyledFlatTableRow = styled.tr`
     isFirstSubRow,
     size,
     theme,
+    applyBorderLeft,
   }) => {
     const backgroundColor = bgColor ? toColor(theme, bgColor) : undefined;
     const customBorderColor = horizontalBorderColor
@@ -176,6 +176,14 @@ const StyledFlatTableRow = styled.tr`
         }
 
         th:nth-of-type(${rowHeaderIndex + 2}) {
+          border-left: 1px solid
+            ${customBorderColor || borderColor(colorTheme, theme)};
+        }
+      `}
+
+      ${applyBorderLeft &&
+      css`
+        th:first-of-type {
           border-left: 1px solid
             ${customBorderColor || borderColor(colorTheme, theme)};
         }

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -297,6 +297,20 @@ describe("FlatTable", () => {
         }
       );
     });
+
+    it("should apply left border if preceding row has a FlatTableRowHeader and current one does not and when the preceding row has a rowSpan applied", () => {
+      act(() => render());
+
+      assertStyleMatch(
+        {
+          borderLeft: "1px solid #668592",
+        },
+        wrapper.find(StyledFlatTableHead).find(StyledFlatTableRow).at(1),
+        {
+          modifier: `th:first-of-type`,
+        }
+      );
+    });
   });
 
   describe("when FlatTable is a child of Sidebar", () => {

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -249,6 +249,56 @@ describe("FlatTable", () => {
     });
   });
 
+  describe("When FlatTable has sticky header and uses FlatTableRowHeaders so that the second column is made sticky", () => {
+    let wrapper;
+    const render = () => {
+      wrapper = mount(
+        <FlatTable hasStickyHead>
+          <FlatTableHead>
+            <FlatTableRow>
+              <FlatTableHeader rowSpan={2}>heading one</FlatTableHeader>
+              <FlatTableRowHeader rowSpan={2}>heading two</FlatTableRowHeader>
+              <FlatTableHeader colspan={2}>heading three</FlatTableHeader>
+              <FlatTableHeader rowSpan={2} />
+              <FlatTableHeader colspan={2}>heading four</FlatTableHeader>
+            </FlatTableRow>
+            <FlatTableRow>
+              <FlatTableHeader>header 1</FlatTableHeader>
+              <FlatTableHeader>heading 2</FlatTableHeader>
+              <FlatTableHeader>heading 3</FlatTableHeader>
+              <FlatTableHeader>heading 4</FlatTableHeader>
+            </FlatTableRow>
+          </FlatTableHead>
+          <FlatTableBody>
+            <FlatTableRow>
+              <FlatTableCell>name</FlatTableCell>
+              <FlatTableRowHeader>unique id</FlatTableRowHeader>
+              <FlatTableCell>city</FlatTableCell>
+              <FlatTableCell>status</FlatTableCell>
+              <FlatTableCell>0</FlatTableCell>
+              <FlatTableCell>0</FlatTableCell>
+              <FlatTableCell>0</FlatTableCell>
+            </FlatTableRow>
+          </FlatTableBody>
+        </FlatTable>
+      );
+    };
+
+    it("should not overlap the first column of FlatTableHeader by applying expected z-index", () => {
+      act(() => render());
+
+      assertStyleMatch(
+        {
+          zIndex: "1002",
+        },
+        wrapper.find(StyledFlatTableHeader),
+        {
+          modifier: `&&&`,
+        }
+      );
+    });
+  });
+
   describe("when FlatTable is a child of Sidebar", () => {
     let wrapper;
     beforeEach(() => {

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -584,6 +584,123 @@ It is possible to have one or any number of header rows set to sticky.
   </Story>
 </Preview>
 
+### With stickyHead, rowSpan and colspan
+
+Is it possible to combine the `stickyHead` prop along with the `rowSpan` and `colspan`props.
+
+<Preview>
+  <Story name="with stickyHead rowSpan and colspan">
+    <div
+      style={{
+        height: "380px",
+        width: "310px",
+        overflowX: "auto"
+      }}
+    >
+      <FlatTable hasStickyHead>
+        <FlatTableHead>
+          <FlatTableRow>
+            <FlatTableHeader rowSpan={2}>Name</FlatTableHeader>
+            <FlatTableRowHeader rowSpan={2}>Code</FlatTableRowHeader>
+            <FlatTableHeader colspan={2}>Jun 21</FlatTableHeader>
+            <FlatTableHeader rowSpan={2}></FlatTableHeader>
+            <FlatTableHeader colspan={2}>YTD</FlatTableHeader>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableHeader>Debit</FlatTableHeader>
+            <FlatTableHeader>Credit</FlatTableHeader>
+            <FlatTableHeader>Debit</FlatTableHeader>
+            <FlatTableHeader>Credit</FlatTableHeader>
+          </FlatTableRow>
+        </FlatTableHead>
+        <FlatTableBody>
+          <FlatTableRow>
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableRowHeader>000001</FlatTableRowHeader>
+            <FlatTableCell>London</FlatTableCell>
+            <FlatTableCell>Single</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableRowHeader>000001</FlatTableRowHeader>
+            <FlatTableCell>London</FlatTableCell>
+            <FlatTableCell>Single</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableRowHeader>000001</FlatTableRowHeader>
+            <FlatTableCell>London</FlatTableCell>
+            <FlatTableCell>Single</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableRowHeader>000001</FlatTableRowHeader>
+            <FlatTableCell>London</FlatTableCell>
+            <FlatTableCell>Single</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableRowHeader>000001</FlatTableRowHeader>
+            <FlatTableCell>London</FlatTableCell>
+            <FlatTableCell>Single</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableRowHeader>000001</FlatTableRowHeader>
+            <FlatTableCell>London</FlatTableCell>
+            <FlatTableCell>Single</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableRowHeader>000001</FlatTableRowHeader>
+            <FlatTableCell>London</FlatTableCell>
+            <FlatTableCell>Single</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableRowHeader>000001</FlatTableRowHeader>
+            <FlatTableCell>London</FlatTableCell>
+            <FlatTableCell>Single</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableRowHeader>000001</FlatTableRowHeader>
+            <FlatTableCell>London</FlatTableCell>
+            <FlatTableCell>Single</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+            <FlatTableCell>0</FlatTableCell>
+          </FlatTableRow>
+        </FlatTableBody>
+      </FlatTable>
+    </div>
+  </Story>
+</Preview>
+
 ### With stickyFooter prop set to true
 
 <Preview>


### PR DESCRIPTION
z-index has been increased to 1002 when hasStickyHead to prevent content being hidden on scrolling
horizontally

fixes #4226

### Proposed behaviour
![flat-table-z-index-fixed](https://user-images.githubusercontent.com/56251247/127873245-fa29397a-3850-49ee-9d56-de99d46dc9da.gif)

### Current behaviour
![flat-table-scroll-bug](https://user-images.githubusercontent.com/56251247/126497839-4e758189-687a-4821-af9f-31f375606d85.gif)

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
https://codesandbox.io/s/winter-thunder-b1s6r

Story called `With stickyHead, rowSpan and colspan` has also been added to the `Flat-Table` MDX doc.