### PR TITLE
feat(button-bar): create button-bar component - FE-4259

### DIFF
--- a/cypress/features/regression/accessibility/accessibilityDesignSystem.feature
+++ b/cypress/features/regression/accessibility/accessibilityDesignSystem.feature
@@ -65,6 +65,18 @@ Feature: Accessibility tests - Design System folder
       | dashed icon           |
 
   @accessibility
+  Scenario Outline: Design System Button Bar component <story> page
+    When I open "Design System Button Bar" component page "<story>" in no iframe
+    Then "Button Bar <story> page" component has no accessibility violations
+    Examples:
+      | story        |
+      | sizes        |
+      | with icons   |
+      | icons only   |
+      | icon buttons |
+      | full width   |
+
+  @accessibility
   Scenario: Design System Button component as a sibling story page
     When I open "Design System Button Test" component page "as a sibling" in no iframe
     Then "button" component has no accessibility violations

--- a/src/components/button-bar/button-bar-test.stories.mdx
+++ b/src/components/button-bar/button-bar-test.stories.mdx
@@ -1,0 +1,140 @@
+import { Meta, Story, Preview } from "@storybook/addon-docs";
+import { action } from "@storybook/addon-actions";
+import Button from "../button";
+import ButtonBar from "./";
+import IconButton from "../icon-button";
+import Icon from "../icon";
+import { ICONS } from "../icon/icon-config";
+import {
+  BUTTON_ICON_POSITIONS,
+  BUTTON_SIZES,
+  BUTTON_VARIANTS,
+} from "../button/button.config";
+import {
+  BUTTON_BAR_ICON_POSITIONS,
+  BUTTON_BAR_SIZES,
+} from "./button-bar.config";
+
+<Meta
+  title="Design System/Button Bar/Test"
+  parameters={{
+    info: { disable: true },
+    chromatic: { disable: true },
+  }}
+/>
+
+export const commonArgTypesButtonBar = {
+  size: {
+    options: BUTTON_BAR_SIZES,
+    control: { type: "select" },
+  },
+  iconPosition: {
+    options: BUTTON_BAR_ICON_POSITIONS,
+    control: { type: "select" },
+  },
+};
+
+export const commonArgsButtonBar = {
+  size: ButtonBar.defaultProps.size,
+  fullWidth: false,
+  iconPosition: Button.defaultProps.iconPosition,
+};
+
+export const ButtonBarStory = ({ ...args }) => (
+  <ButtonBar onClick={action("click")} {...args}>
+    <Button iconType="search">Example Button</Button>
+    <Button iconType="pdf">Example Button</Button>
+    <Button iconType="csv">Example Button</Button>
+  </ButtonBar>
+);
+
+export const generateButtonBarsWithDifferentIconPositionsAndSizes = () => {
+  return (
+    <>
+      <ButtonBar ml={2} mt={2}>
+        <IconButton onAction={() => {}}>
+          <Icon type="pdf" />
+        </IconButton>
+        <IconButton onAction={() => {}}>
+          <Icon type="csv" />
+        </IconButton>
+        <IconButton onAction={() => {}}>
+          <Icon type="search" />
+        </IconButton>
+      </ButtonBar>
+      {BUTTON_BAR_SIZES.map((size) => (
+        <ButtonBar key={size} size={size} ml={2} mt={2}>
+          <Button iconType="pdf" />
+          <Button iconType="csv" />
+          <Button iconType="search" />
+        </ButtonBar>
+      ))}
+      {BUTTON_BAR_ICON_POSITIONS.map((iconPosition) => (
+        <React.Fragment key={iconPosition}>
+          {BUTTON_BAR_SIZES.map((size) => (
+            <>
+              <ButtonBar
+                key={size + iconPosition}
+                iconPosition={iconPosition}
+                size={size}
+                ml={2}
+                mt={2}
+              >
+                <Button iconType="pdf">{iconPosition}</Button>
+                <Button iconType="csv">{iconPosition}</Button>
+                <Button iconType="search">{iconPosition}</Button>
+              </ButtonBar>
+            </>
+          ))}
+        </React.Fragment>
+      ))}
+      {BUTTON_BAR_ICON_POSITIONS.map((iconPosition) => (
+        <React.Fragment key={iconPosition}>
+          {BUTTON_BAR_SIZES.map((size) => (
+            <>
+              <ButtonBar
+                fullWidth
+                key={size + iconPosition + "fullWidth"}
+                iconPosition={iconPosition}
+                size={size}
+                ml={2}
+                mt={2}
+              >
+                <Button iconType="pdf">{iconPosition}</Button>
+                <Button iconType="csv">{iconPosition}</Button>
+                <Button iconType="search">{iconPosition}</Button>
+              </ButtonBar>
+            </>
+          ))}
+        </React.Fragment>
+      ))}
+    </>
+  );
+};
+
+# ButtonBar
+
+### Default
+
+<Preview>
+  <Story
+    name="default"
+    argTypes={commonArgTypesButtonBar}
+    args={commonArgsButtonBar}
+  >
+    {ButtonBarStory.bind({})}
+  </Story>
+</Preview>
+
+### Visual
+
+<Preview>
+  <Story
+    name="visual"
+    parameters={{
+      chromatic: { disable: false },
+    }}
+  >
+    {generateButtonBarsWithDifferentIconPositionsAndSizes.bind({})}
+  </Story>
+</Preview>

--- a/src/components/button-bar/button-bar.component.js
+++ b/src/components/button-bar/button-bar.component.js
@@ -1,0 +1,63 @@
+import React from "react";
+import PropTypes from "prop-types";
+import propTypes from "@styled-system/prop-types";
+import StyledButtonBar from "./button-bar.style";
+import Button from "../button";
+import IconButton from "../icon-button";
+
+const ButtonBar = ({ children, size, iconPosition, buttonType, ...rest }) => {
+  const getBtnProps = (child) => {
+    const btnProps = {
+      ...child.props,
+      buttonType: "secondary",
+      size,
+      iconPosition,
+      fullWidth: false,
+      "aria-label":
+        child.type === IconButton
+          ? child.props?.ariaLabel || child.props?.children?.props?.type
+          : "",
+    };
+    return btnProps;
+  };
+
+  return (
+    <StyledButtonBar {...rest} size={size}>
+      {React.Children.map(children, (child) => (
+        <child.type {...getBtnProps(child)} />
+      ))}
+    </StyledButtonBar>
+  );
+};
+
+ButtonBar.propTypes = {
+  /** Assigns a size to the button: "small" | "medium" | "large" */
+  size: PropTypes.oneOf(["small", "medium", "large"]),
+  /** Defines an Icon position related to the children: "before" | "after" */
+  iconPosition: PropTypes.oneOf(["before", "after"]),
+  /** Styled system spacing props */
+  ...propTypes.space,
+  /** Apply fullWidth style to the button bar */
+  fullWidth: PropTypes.bool,
+
+  /** The Button / IconButton elements the button bar displays */
+  children: (props) => {
+    let error = null;
+    React.Children.forEach(props.children, (child) => {
+      if (child.type !== Button && child.type !== IconButton) {
+        error = new Error(
+          "ButtonBar accepts only `Button` or `IconButton` elements."
+        );
+      }
+    });
+    return error;
+  },
+};
+
+ButtonBar.defaultProps = {
+  size: "medium",
+  iconPosition: "before",
+  fullWidth: false,
+};
+
+export default ButtonBar;

--- a/src/components/button-bar/button-bar.config.js
+++ b/src/components/button-bar/button-bar.config.js
@@ -1,0 +1,2 @@
+export const BUTTON_BAR_SIZES = ["small", "medium", "large"];
+export const BUTTON_BAR_ICON_POSITIONS = ["before", "after"];

--- a/src/components/button-bar/button-bar.d.ts
+++ b/src/components/button-bar/button-bar.d.ts
@@ -1,0 +1,24 @@
+import Button from "components/button/button";
+import IconButton from "components/icon-button";
+import { SpaceProps } from "styled-system";
+
+type ButtonBarChild =
+  | typeof Button
+  | typeof IconButton
+  | boolean
+  | null
+  | undefined;
+
+export interface ButtonBarProps extends SpaceProps {
+  children: ButtonBarChild | ButtonBarChild[];
+  /** Apply fullWidth style to the button bar */
+  fullWidth?: boolean;
+  /** Defines an Icon position for buttons: "before" | "after" */
+  iconPosition?: "before" | "after";
+  /** Assigns a size to the buttons: "small" | "medium" | "large" */
+  size?: "small" | "medium" | "large";
+}
+
+declare function ButtonBar(props: ButtonBarProps): JSX.Element;
+
+export default ButtonBar;

--- a/src/components/button-bar/button-bar.spec.js
+++ b/src/components/button-bar/button-bar.spec.js
@@ -1,0 +1,233 @@
+import React from "react";
+import { mount } from "enzyme";
+import TestRenderer from "react-test-renderer";
+import Icon from "components/icon";
+import Button from "../button/button.component";
+import ButtonBar from "./button-bar.component";
+import {
+  assertStyleMatch,
+  expectError,
+} from "../../__spec_helper__/test-utils";
+import IconButton from "../icon-button/icon-button.component";
+
+const renderButtonBar = (text, numberOfBtns = 1, props = {}, btnProps = {}) => {
+  const buttons = [];
+  for (let i = 0; i < numberOfBtns; i++) {
+    buttons.push(<Button {...btnProps}>{text}</Button>);
+  }
+  return mount(<ButtonBar {...props}>{buttons}</ButtonBar>);
+};
+
+const renderButtonWithIconBar = (icons, props = {}) => {
+  const buttons = [];
+  for (const icon of icons) {
+    buttons.push(
+      <IconButton onAction={() => {}}>
+        <Icon type={icon} />
+      </IconButton>
+    );
+  }
+  return mount(<ButtonBar {...props}>{buttons}</ButtonBar>);
+};
+
+describe("Button Bar", () => {
+  describe("when no props other than children are passed into the component", () => {
+    it("renders the default props and children", () => {
+      const wrapper = renderButtonBar({}, "Button", 3);
+      expect(wrapper.contains(<Icon type="filter" />)).toBeFalsy();
+      expect(wrapper.props().size).toEqual("medium");
+      expect(wrapper.props().iconPosition).toEqual("before");
+    });
+  });
+
+  describe("when props are passed to the compontent", () => {
+    it("renders proper props and children", () => {
+      const wrapper = renderButtonBar("Large", 3, {
+        size: "large",
+        iconPosition: "after",
+      });
+      expect(wrapper.props().size).toEqual("large");
+      expect(wrapper.props().iconPosition).toEqual("after");
+    });
+  });
+
+  describe("with a single-button", () => {
+    const wrapper = renderButtonBar("Single");
+    it("renders correctly", () => {
+      expect(wrapper.containsMatchingElement(<span>Single</span>)).toBeTruthy();
+    });
+  });
+
+  describe("with fullWidth", () => {
+    it("renders correctly with single button", () => {
+      const wrapper = renderButtonBar("fullWidth", 1, { fullWidth: true });
+      expect(wrapper.props().fullWidth).toBeTruthy();
+    });
+    it("renders correctly with multiple buttons", () => {
+      const wrapper = TestRenderer.create(
+        <ButtonBar fullWidth>
+          <Button>fullWidth</Button>
+          <Button>fullWidth</Button>
+        </ButtonBar>
+      );
+      assertStyleMatch({ width: "100%" }, wrapper.toJSON());
+    });
+    it("renders correctly with small size", () => {
+      const wrapper = TestRenderer.create(
+        <ButtonBar fullWidth size="small">
+          <Button>fullWidth</Button>
+          <Button>fullWidth</Button>
+        </ButtonBar>
+      );
+      assertStyleMatch({ width: "100%" }, wrapper.toJSON());
+    });
+    it("renders correctly with large size", () => {
+      const wrapper = TestRenderer.create(
+        <ButtonBar fullWidth size="large">
+          <Button>fullWidth</Button>
+          <Button>fullWidth</Button>
+        </ButtonBar>
+      );
+      assertStyleMatch({ width: "100%" }, wrapper.toJSON());
+    });
+  });
+
+  describe("with different sizes passed to the component", () => {
+    it("renders a small button bar", () => {
+      const wrapper = renderButtonBar("Small", 1, { size: "small" });
+      expect(wrapper.props().size).toEqual("small");
+      expect(wrapper.containsMatchingElement(<span>Small</span>)).toBeTruthy();
+    });
+
+    it("renders a medium button bar", () => {
+      const wrapper = renderButtonBar("Medium", 1, { size: "medium" });
+      expect(wrapper.props().size).toEqual("medium");
+      expect(wrapper.containsMatchingElement(<span>Medium</span>)).toBeTruthy();
+    });
+
+    it("renders a large button bar", () => {
+      const wrapper = renderButtonBar("Large", 1, { size: "large" });
+      expect(wrapper.props().size).toEqual("large");
+      expect(wrapper.containsMatchingElement(<span>Large</span>)).toBeTruthy();
+    });
+  });
+
+  describe("with icons", () => {
+    it("renders an icon correctly", () => {
+      const wrapper = renderButtonBar("Image", 1, {}, { iconType: "filter" });
+      const assertion =
+        wrapper.find(Icon).exists() &&
+        wrapper.find(Icon).props().type === "filter";
+      expect(assertion).toEqual(true);
+    });
+
+    it("renders an icon correctly after the text", () => {
+      const wrapper = renderButtonBar(
+        "After",
+        1,
+        { iconPosition: "after" },
+        { iconType: "filter" }
+      );
+      const assertion =
+        wrapper.find(Icon).exists() &&
+        wrapper.find(Icon).props().type === "filter";
+      expect(assertion).toEqual(true);
+      const button = wrapper.find("Button");
+      expect(button.props().iconPosition).toEqual("after");
+    });
+  });
+
+  describe("with IconButtons", () => {
+    it("renders an icon correctly", () => {
+      const wrapper = mount(
+        <ButtonBar>
+          <IconButton onAction={() => {}}>
+            <Icon type="csv" />
+          </IconButton>
+        </ButtonBar>
+      );
+      const assertion =
+        wrapper.find(Icon).exists() &&
+        wrapper.find(Icon).props().type === "csv";
+      expect(assertion).toEqual(true);
+    });
+
+    it("renders multiple icons correctly", () => {
+      const wrapper = renderButtonWithIconBar(["csv", "pdf"]);
+      expect(wrapper.find(Icon)).toHaveLength(2);
+    });
+  });
+
+  describe("with children of wrong type", () => {
+    const errorMessage =
+      "Warning: Failed prop type: ButtonBar accepts only `Button` or `IconButton` elements.";
+    it("throws an error", () => {
+      const assert = expectError(errorMessage);
+      mount(
+        <ButtonBar>
+          <div>Div</div>
+        </ButtonBar>
+      );
+      assert();
+    });
+  });
+
+  describe("with different button props", () => {
+    it("Button types on button bar are always of type 'secondary'", () => {
+      const wrapper = mount(
+        <ButtonBar>
+          <Button buttonType="primary">primary</Button>
+          <Button buttonType="tertiary" fullWidth>
+            tertiary
+          </Button>
+        </ButtonBar>
+      );
+      wrapper
+        .find("Button")
+        .forEach((button) =>
+          expect(button.props().buttonType).toEqual("secondary")
+        );
+    });
+
+    it("Buttons cannot be 'fullWidth'", () => {
+      const wrapper = renderButtonBar("Button", 1, {}, { fullWidth: true });
+      const buttons = wrapper.find("Button");
+      buttons.forEach((button) => expect(button.props().fullWidth).toBeFalsy());
+    });
+
+    it("Size is always defined by ButtonBar, not the Buttons", () => {
+      const wrapper = mount(
+        <ButtonBar size="small">
+          <Button size="small">Small</Button>
+          <Button size="medium">Medium</Button>
+          <Button size="large">Large</Button>
+        </ButtonBar>
+      );
+      wrapper
+        .find("Button")
+        .forEach((button) => expect(button.props().size).toEqual("small"));
+    });
+
+    it("Disabled button works correctly", () => {
+      const wrapper = renderButtonBar("Small", 1, {}, { disabled: true });
+      expect(wrapper.find("Button").props().disabled).toBeTruthy();
+    });
+
+    it("Destructive button works correctly", () => {
+      const wrapper = renderButtonBar("Small", 1, {}, { destructive: true });
+      expect(wrapper.find("Button").props().destructive).toBeTruthy();
+    });
+
+    it("Subtext works correctly", () => {
+      const wrapper = renderButtonBar(
+        "Sub",
+        1,
+        { size: "large" },
+        { subtext: "subtext" }
+      );
+      expect(
+        wrapper.containsMatchingElement(<span>subtext</span>)
+      ).toBeTruthy();
+    });
+  });
+});

--- a/src/components/button-bar/button-bar.stories.mdx
+++ b/src/components/button-bar/button-bar.stories.mdx
@@ -1,0 +1,148 @@
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import ButtonBar from ".";
+import Button from "../button";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import IconButton from "../icon-button/icon-button.component";
+import Icon from "../icon";
+import {
+  BUTTON_BAR_SIZES,
+  BUTTON_BAR_ICON_POSITIONS,
+} from "./button-bar.config";
+
+<Meta
+  title="Design System/Button Bar"
+  parameters={{ info: { disable: true }, chromatic: { disable: true } }}
+/>
+
+# Button Bar
+
+A Button bar groups together multiple buttons.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quickstart
+
+```javascript
+import ButtonBar from "carbon-react/lib/components/button-bar";
+```
+
+## Examples
+
+Button bars of different sizes.
+
+<Preview>
+  <Story name="sizes">
+    <ButtonBar size="small" ml={2} mt={2}>
+      <Button>Small</Button>
+      <Button>Small</Button>
+      <Button>Small</Button>
+    </ButtonBar>
+    <ButtonBar ml={2} mt={2}>
+      <Button>Medium</Button>
+      <Button>Medium</Button>
+      <Button>Medium</Button>
+    </ButtonBar>
+    <ButtonBar size="large" ml={2} mt={2}>
+      <Button>Large</Button>
+      <Button>Large</Button>
+      <Button>Large</Button>
+    </ButtonBar>
+    <ButtonBar size="large" ml={2} mt={2}>
+      <Button subtext="subtext 1">Large</Button>
+      <Button subtext="subtext 2">Large</Button>
+      <Button subtext="subtext 3">Large</Button>
+    </ButtonBar>
+  </Story>
+</Preview>
+
+Button bars with different icon positions.
+
+<Preview>
+  <Story name="with icons">
+    {BUTTON_BAR_ICON_POSITIONS.map((iconPosition) =>
+      BUTTON_BAR_SIZES.map((size) => (
+        <ButtonBar
+          iconPosition={iconPosition}
+          size={size}
+          key={size + iconPosition}
+          ml={2}
+          mt={2}
+        >
+          <Button iconType="csv">{iconPosition}</Button>
+          <Button iconType="pdf">{iconPosition}</Button>
+          <Button iconType="delete">{iconPosition}</Button>
+        </ButtonBar>
+      ))
+    )}
+  </Story>
+</Preview>
+
+<Preview>
+  <Story name="icons only">
+    {BUTTON_BAR_SIZES.map((size) => (
+      <ButtonBar size={size} key={size} ml={2} mt={2}>
+        <Button iconType="pdf" />
+        <Button iconType="csv" />
+        <Button iconType="delete" />
+      </ButtonBar>
+    ))}
+  </Story>
+</Preview>
+
+`IconButton` components on a button bar.
+
+<Preview>
+  <Story name="icon buttons">
+    <ButtonBar ml={2} mt={2}>
+      <IconButton onAction={() => {}}>
+        <Icon type="csv" />
+      </IconButton>
+      <IconButton onAction={() => {}}>
+        <Icon type="pdf" />
+      </IconButton>
+      <IconButton onAction={() => {}}>
+        <Icon type="bin" />
+      </IconButton>
+    </ButtonBar>
+  </Story>
+</Preview>
+
+Button bars can be `fullWidth`.
+
+<Preview>
+  <Story name="fullWidth">
+    <ButtonBar fullWidth size="small" ml={2} mt={2}>
+      <Button fullWidth>Small full width</Button>
+      <Button>Small full width</Button>
+      <Button>Small full width</Button>
+    </ButtonBar>
+    <ButtonBar fullWidth ml={2} mt={2}>
+      <Button as="primary">Medium full width</Button>
+      <Button>Medium full width</Button>
+      <Button>Medium full width</Button>
+    </ButtonBar>
+    <ButtonBar fullWidth size="large" ml={2} mt={2}>
+      <Button>Large full width</Button>
+      <Button>Large full width</Button>
+      <Button>Large full width</Button>
+    </ButtonBar>
+  </Story>
+</Preview>
+
+## Props
+
+Options shared between all of the above types of button bars. When setting padding we recommend using either the `p`, `py`
+or `px` props to ensure the spacing within the button bar is applied evenly.
+
+### Button Bar
+
+<StyledSystemProps
+  of={ButtonBar}
+  spacing
+  defaults={{ pt: "1px", pb: "1px", px: "24px" }}
+  noHeader
+/>

--- a/src/components/button-bar/button-bar.style.js
+++ b/src/components/button-bar/button-bar.style.js
@@ -1,0 +1,75 @@
+import styled, { css } from "styled-components";
+import { space } from "styled-system";
+import PropTypes from "prop-types";
+import propTypes from "@styled-system/prop-types";
+import BaseTheme from "../../style/themes/base";
+import StyledIcon from "../icon/icon.style";
+
+const ButtonBar = styled.div`
+  ${space}
+  ${stylingForType}
+`;
+
+function stylingForType({ theme, size }) {
+  return css`
+    ${({ fullWidth }) =>
+      fullWidth &&
+      css`
+        width: 100%;
+        display: flex;
+        button {
+          box-sizing: content-box;
+          padding: 0;
+          width: 100%;
+          ${size === "small" && "min-height: 28px"}
+          ${size === "medium" && "min-height: 36px"}
+          ${size === "large" && "min-height: 44px"}
+        }
+      `}
+
+    button {
+      margin: 0;
+      border: 2px solid ${theme.colors.primary};
+
+      &:not(:last-of-type) {
+        border-right-color: transparent;
+      }
+      &:not(:first-of-type) {
+        margin-left: -2px;
+      }
+      &:focus {
+        position: relative;
+        z-index: 2;
+        border-right-color: ${theme.colors.primary};
+      }
+      &:hover {
+        background-color: ${theme.colors.secondary};
+        border-color: ${theme.colors.secondary};
+        & + button {
+          border-left-color: ${theme.colors.secondary};
+        }
+        & ${StyledIcon} {
+          color: white;
+        }
+      }
+      & ${StyledIcon} {
+        color: ${theme.colors.primary};
+      }
+    }
+  `;
+}
+
+ButtonBar.defaultProps = {
+  theme: BaseTheme,
+  size: "medium",
+};
+
+ButtonBar.propTypes = {
+  /** Styled system spacing props */
+  ...propTypes.space,
+  /** Assigns a size to the button: "small" | "medium" | "large" */
+  size: PropTypes.oneOf(["small", "medium", "large"]),
+  children: PropTypes.node.isRequired,
+};
+
+export default ButtonBar;

--- a/src/components/button-bar/index.d.ts
+++ b/src/components/button-bar/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from "./button-bar";

--- a/src/components/button-bar/index.js
+++ b/src/components/button-bar/index.js
@@ -1,0 +1,1 @@
+export { default } from "./button-bar.component";

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -54,7 +54,6 @@ describe("Button", () => {
   describe("when iconType specified with no children", () => {
     it("icon matches the style for an icon only button", () => {
       const wrapper = mount(<Button iconType="bin" />);
-
       assertStyleMatch(
         {
           marginBottom: "1px",

--- a/src/components/button/button.style.js
+++ b/src/components/button/button.style.js
@@ -77,18 +77,21 @@ function additionalIconStyle({ iconType }) {
 }
 
 function stylingForIconOnly(size) {
-  let width = "";
+  let dimension = "";
   switch (size) {
     case "small":
-      width = "32px";
+      dimension = "32px";
       break;
     case "large":
-      width = "48px";
+      dimension = "48px";
       break;
     default:
-      width = "40px";
+      dimension = "40px";
   }
-  return `padding-left: 0px; padding-right: 0px; width: ${width};`;
+  return `
+  padding: 0px; 
+  width: ${dimension}; 
+  min-height: ${dimension}`;
 }
 
 function stylingForType({
@@ -109,7 +112,6 @@ function stylingForType({
     }
 
     ${buttonTypes(theme, disabled, destructive)[buttonType]};
-    ${iconOnly && stylingForIconOnly(size)}
 
     ${size === "small" &&
     css`
@@ -128,6 +130,7 @@ function stylingForType({
       font-size: 16px;
       min-height: 48px;
     `}
+    ${iconOnly && stylingForIconOnly(size)}
   `;
 }
 


### PR DESCRIPTION
### Proposed behaviour
**Use case**
The design system offers a Button Bar that is currently not available in Carbon.
It must be seen as a new variation and does not correspond to Button Toggle.

**Acceptance Criteria**
There should be a way to add a Button Bar to a product using Carbon.
It should match the Design specified here: https://brand.sage.com/d/NdbrveWvNheA/components#/basics/buttons/variations
Ensure only Button or IconButton children for this component.
We refer to Buttons v 0.1.0. This version should be implemented.
Storybook MDX updated with a compatibility table showing which version of the Design System is implemented

### Current behaviour
There is no such component, buttons would need to be added separately and be styled by the user.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
Screenshot:
![image](https://user-images.githubusercontent.com/87973304/128854285-d0897998-e539-40fa-9f28-73d2ef885b23.png)

### Testing instructions