### PR TITLE
feat(tooltip-provider): add context and provider component FE-4074

### DIFF
--- a/src/__internal__/tooltip-provider/index.d.ts
+++ b/src/__internal__/tooltip-provider/index.d.ts
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+export interface ToolbarContextProps {
+  tooltipPosition: "top" | "bottom" | "left" | "right";
+}
+
+export interface TooltipProviderProps {
+  /** The position to display the tooltip */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
+  /** Control whether the tooltip is visible */
+  children: React.ReactNode;
+}
+
+declare const ToolbarContext: React.Context<ToolbarContextProps>;
+
+declare function TooltipProvider(props: TooltipProviderProps): JSX.Element;
+
+export { ToolbarContext };
+
+export default TooltipProvider;

--- a/src/__internal__/tooltip-provider/index.js
+++ b/src/__internal__/tooltip-provider/index.js
@@ -1,0 +1,15 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export const TooltipContext = React.createContext({});
+
+export const TooltipProvider = ({ children, tooltipPosition }) => (
+  <TooltipContext.Provider value={{ tooltipPosition }}>
+    {children}
+  </TooltipContext.Provider>
+);
+
+TooltipProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
+};

--- a/src/__internal__/validations/validation-icon.component.js
+++ b/src/__internal__/validations/validation-icon.component.js
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import PropTypes from "prop-types";
 import styledSystemPropTypes from "@styled-system/prop-types";
 
@@ -38,7 +38,7 @@ const ValidationIcon = ({
     hasFocus: groupHasFocus,
     hasMouseOver: groupHasMouseOver,
   } = useContext(InputGroupContext);
-  const [triggeredByIcon, setTriggeredByIcon] = React.useState(false);
+  const [triggeredByIcon, setTriggeredByIcon] = useState(false);
 
   const validationType = getValidationType({ error, warning, info });
 

--- a/src/components/checkbox/checkbox-group.component.js
+++ b/src/components/checkbox/checkbox-group.component.js
@@ -5,6 +5,7 @@ import tagComponent from "../../utils/helpers/tags";
 import { StyledCheckboxGroup } from "./checkbox.style";
 import Fieldset from "../../__internal__/fieldset";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import { TooltipProvider } from "../../__internal__/tooltip-provider";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
@@ -23,38 +24,41 @@ const CheckboxGroup = (props) => {
     legendWidth,
     legendAlign,
     legendSpacing,
+    tooltipPosition,
   } = props;
 
   return (
-    <Fieldset
-      legend={legend}
-      inline={legendInline}
-      legendWidth={legendWidth}
-      legendAlign={legendAlign}
-      legendSpacing={legendSpacing}
-      error={error}
-      warning={warning}
-      info={info}
-      isRequired={required}
-      {...tagComponent("checkboxgroup", props)}
-      blockGroupBehaviour={!(error || warning || info)}
-      {...filterStyledSystemMarginProps(props)}
-    >
-      <StyledCheckboxGroup
-        data-component="checkbox-group"
-        legendInline={legendInline}
+    <TooltipProvider tooltipPosition={tooltipPosition}>
+      <Fieldset
+        legend={legend}
+        inline={legendInline}
+        legendWidth={legendWidth}
+        legendAlign={legendAlign}
+        legendSpacing={legendSpacing}
+        error={error}
+        warning={warning}
+        info={info}
+        isRequired={required}
+        {...tagComponent("checkboxgroup", props)}
+        blockGroupBehaviour={!(error || warning || info)}
+        {...filterStyledSystemMarginProps(props)}
       >
-        {React.Children.map(children, (child) =>
-          React.cloneElement(child, {
-            inputName: groupName,
-            error: !!error,
-            warning: !!warning,
-            info: !!info,
-            ...child.props,
-          })
-        )}
-      </StyledCheckboxGroup>
-    </Fieldset>
+        <StyledCheckboxGroup
+          data-component="checkbox-group"
+          legendInline={legendInline}
+        >
+          {React.Children.map(children, (child) =>
+            React.cloneElement(child, {
+              inputName: groupName,
+              error: !!error,
+              warning: !!warning,
+              info: !!info,
+              ...child.props,
+            })
+          )}
+        </StyledCheckboxGroup>
+      </Fieldset>
+    </TooltipProvider>
   );
 };
 
@@ -91,6 +95,8 @@ CheckboxGroup.propTypes = {
   labelSpacing: PropTypes.oneOf([1, 2]),
   /** Flag to configure component as mandatory */
   required: PropTypes.bool,
+  /** Overrides the default tooltip position */
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
 };
 
 export default CheckboxGroup;

--- a/src/components/checkbox/checkbox-group.d.ts
+++ b/src/components/checkbox/checkbox-group.d.ts
@@ -23,6 +23,8 @@ interface CheckboxGroupProps extends ValidationPropTypes, MarginProps {
   labelSpacing?: 1 | 2;
   /** Flag to configure component as mandatory */
   required?: boolean;
+  /** Overrides the default tooltip */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 declare function CheckboxGroup(props: CheckboxGroupProps): JSX.Element;

--- a/src/components/checkbox/checkbox-group.spec.js
+++ b/src/components/checkbox/checkbox-group.spec.js
@@ -8,6 +8,7 @@ import {
 } from "../../__spec_helper__/test-utils";
 import CheckboxStyle, { StyledCheckboxGroup } from "./checkbox.style";
 import Fieldset from "../../__internal__/fieldset";
+import Tooltip from "../tooltip";
 
 const checkboxValues = ["required", "optional"];
 const groupName = "my-checkbox-group";
@@ -124,5 +125,17 @@ describe("CheckboxGroup", () => {
   it("blocks the group behaviour if no validation set on group", () => {
     const wrapper = render({});
     expect(wrapper.find(Fieldset).props().blockGroupBehaviour).toEqual(true);
+  });
+
+  describe("tooltipPosition", () => {
+    it("should override the default value", () => {
+      const wrapper = render(
+        { legend: "foo", error: "message", tooltipPosition: "bottom" },
+        mount
+      );
+      const { position } = wrapper.find(Tooltip).props();
+
+      expect(position).toEqual("bottom");
+    });
   });
 });

--- a/src/components/checkbox/checkbox-validations.stories.mdx
+++ b/src/components/checkbox/checkbox-validations.stories.mdx
@@ -36,6 +36,28 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="single checkbox - with tooltipPosition overriden - string validation"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() =>
+      ["error", "warning", "info"].map((type) => (
+        <Checkbox
+          id={`checkbox_${type}-tooltipPosition-override`}
+          key={`checkbox-${type}`}
+          {...{ [type]: "Message" }}
+          label={`Example checkbox (${type})`}
+          name={`checkbox-${type}-tooltipPosition-override`}
+          tooltipPosition="bottom"
+        />
+      ))
+    }
+  </Story>
+</Preview>
+
 ### As a boolean applied to single Checkbox
 
 <Preview>
@@ -73,6 +95,39 @@ For more information check our [Validations](?path=/docs/documentation-validatio
                 id={`checkbox_${type}-${label}`}
                 key={`checkbox_${type}-${label}`}
                 name={`checkbox_${type}-${label}`}
+                label={label}
+              />
+            ))}
+          </CheckboxGroup>
+        </div>
+      ))
+    }
+  </Story>
+</Preview>
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="group checkbox - with tooltipPosition overriden - string validation"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() =>
+      ["error", "warning", "info"].map((type) => (
+        <div key={`checkbox-group-${type}`} style={{ marginBottom: 16 }}>
+          <CheckboxGroup
+            id={`checkbox-group-${type}`}
+            name={`checkbox-group-${type}`}
+            groupName={`checkbox-group-${type}`}
+            {...{ [type]: "Message" }}
+            legend={`Group ${type}`}
+            tooltipPosition="bottom"
+          >
+            {["One", "Two", "Three"].map((label) => (
+              <Checkbox
+                id={`checkbox_${type}-${label}-tooltipPosition-override`}
+                key={`checkbox_${type}-${label}`}
+                name={`checkbox_${type}-${label}-tooltipPosition-override`}
                 label={label}
               />
             ))}

--- a/src/components/checkbox/checkbox.component.js
+++ b/src/components/checkbox/checkbox.component.js
@@ -7,6 +7,7 @@ import CheckableInput from "../../__internal__/checkable-input/checkable-input.c
 import CheckboxSvg from "./checkbox-svg.component";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import { TooltipProvider } from "../../__internal__/tooltip-provider";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
@@ -37,6 +38,7 @@ const Checkbox = ({
   disabled,
   inputWidth,
   size,
+  tooltipPosition,
   ...props
 }) => {
   const largeScreen = useIsAboveBreakpoint(adaptiveSpacingBreakpoint);
@@ -68,28 +70,31 @@ const Checkbox = ({
     disabled,
     inputWidth,
     labelWidth,
+    tooltipPosition,
   };
 
   return (
-    <CheckboxStyle
-      {...tagComponent("checkbox", props)}
-      disabled={disabled}
-      labelSpacing={labelSpacing}
-      inputWidth={inputWidth}
-      labelWidth={labelWidth}
-      adaptiveSpacingSmallScreen={adaptiveSpacingSmallScreen}
-      error={error}
-      warning={warning}
-      info={info}
-      fieldHelpInline={fieldHelpInline}
-      reverse={reverse}
-      size={size}
-      {...props}
-    >
-      <CheckableInput {...inputProps}>
-        <CheckboxSvg />
-      </CheckableInput>
-    </CheckboxStyle>
+    <TooltipProvider tooltipPosition={tooltipPosition}>
+      <CheckboxStyle
+        {...tagComponent("checkbox", props)}
+        disabled={disabled}
+        labelSpacing={labelSpacing}
+        inputWidth={inputWidth}
+        labelWidth={labelWidth}
+        adaptiveSpacingSmallScreen={adaptiveSpacingSmallScreen}
+        error={error}
+        warning={warning}
+        info={info}
+        fieldHelpInline={fieldHelpInline}
+        reverse={reverse}
+        size={size}
+        {...props}
+      >
+        <CheckableInput {...inputProps}>
+          <CheckboxSvg />
+        </CheckableInput>
+      </CheckboxStyle>
+    </TooltipProvider>
   );
 };
 
@@ -151,6 +156,8 @@ Checkbox.propTypes = {
   adaptiveSpacingBreakpoint: PropTypes.number,
   /** Flag to configure component as mandatory */
   required: PropTypes.bool,
+  /** Overrides the default tooltip position */
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
 };
 
 Checkbox.defaultProps = {

--- a/src/components/checkbox/checkbox.d.ts
+++ b/src/components/checkbox/checkbox.d.ts
@@ -19,6 +19,8 @@ export interface CheckboxProps extends CommonCheckableInputProps, MarginProps {
   name?: string;
   /** The value of the checkbox, passed on form submit */
   value?: string;
+  /** Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 declare function Checkbox(props: CheckboxProps): JSX.Element;

--- a/src/components/checkbox/checkbox.spec.js
+++ b/src/components/checkbox/checkbox.spec.js
@@ -507,4 +507,16 @@ describe("Checkbox", () => {
       expect(tooltip.prop("message")).toEqual(text);
     });
   });
+
+  describe("tooltipPosition", () => {
+    it("should override the default value", () => {
+      const wrapper = render(
+        { label: "foo", error: "message", tooltipPosition: "bottom" },
+        mount
+      );
+      const { position } = wrapper.find(Tooltip).props();
+
+      expect(position).toEqual("bottom");
+    });
+  });
 });

--- a/src/components/date-range/date-range.component.js
+++ b/src/components/date-range/date-range.component.js
@@ -225,6 +225,7 @@ class DateRange extends React.Component {
           data-element="start-date"
           ref={this.startDateInputRef}
           labelWidth={this.inlineLabelWidth} // Textbox only applies this when labelsInLine prop is true
+          tooltipPosition={this.props.tooltipPosition}
         />
         <DateInput
           {...this.dateProps("end")}
@@ -232,6 +233,7 @@ class DateRange extends React.Component {
           data-element="end-date"
           ref={this.endDateInputRef}
           labelWidth={this.inlineLabelWidth} // Textbox only applies this when labelsInLine prop is true
+          tooltipPosition={this.props.tooltipPosition}
         />
       </StyledDateRange>
     );
@@ -299,6 +301,8 @@ DateRange.propTypes = {
   name: PropTypes.string,
   /** An optional string prop to provide an id to the component */
   id: PropTypes.string,
+  /** Overrides the default tooltip position */
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
 };
 
 export default DateRange;

--- a/src/components/date-range/date-range.d.ts
+++ b/src/components/date-range/date-range.d.ts
@@ -77,6 +77,8 @@ export interface DateRangeProps extends MarginProps {
   value?: string[];
   /** When true, validation icons will be placed on labels instead of being placed on the inputs */
   validationOnLabel?: boolean;
+  /** Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 declare class DateRange extends React.Component<DateRangeProps> {}

--- a/src/components/date-range/date-range.spec.js
+++ b/src/components/date-range/date-range.spec.js
@@ -11,6 +11,7 @@ import {
 } from "../../__spec_helper__/test-utils";
 import StyledDateRange from "./date-range.style";
 import StyledDateInput from "../date/date.style";
+import Tooltip from "../tooltip";
 
 jest.useFakeTimers();
 
@@ -429,6 +430,36 @@ describe("StyledDateRange", () => {
     );
     assertStyleMatch({ verticalAlign: "bottom" }, wrapper, {
       modifier: `& ${StyledDateInput}`,
+    });
+  });
+
+  describe("tooltipPosition", () => {
+    it("overrides the default value when icon is on input", () => {
+      const { position } = renderDateRange(
+        { startError: "message", tooltipPosition: "top" },
+        mount
+      )
+        .find(Tooltip)
+        .props();
+
+      expect(position).toEqual("top");
+    });
+
+    it("overrides the default value when icon is on label", () => {
+      const { position } = renderDateRange(
+        {
+          startLabel: "start",
+          endLabel: "end",
+          validationOnLabel: true,
+          startError: "message",
+          tooltipPosition: "top",
+        },
+        mount
+      )
+        .find(Tooltip)
+        .props();
+
+      expect(position).toEqual("top");
     });
   });
 });

--- a/src/components/date-range/date-range.stories.mdx
+++ b/src/components/date-range/date-range.stories.mdx
@@ -103,6 +103,32 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - component"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() =>
+      [
+        { startError: "Start Error", endError: "End Error" },
+        { startWarning: "Start Warning", endWarning: "End Warning" },
+        { startInfo: "Start Info", endInfo: "End Info" },
+      ].map((validation) => (
+        <DateRange
+          key={`${Object.keys(validation)[0]}-string-component`}
+          startLabel="Start"
+          endLabel="End"
+          value={["2016-10-01", "2016-10-30"]}
+          {...validation}
+          tooltipPosition="top"
+        />
+      ))
+    }
+  </Story>
+</Preview>
+
 #### As a string, displayed on label
 
 <Preview>
@@ -120,6 +146,33 @@ For more information check our [Validations](?path=/docs/documentation-validatio
           value={["2016-10-01", "2016-10-30"]}
           validationOnLabel
           {...validation}
+        />
+      ))
+    }
+  </Story>
+</Preview>
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - label"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() =>
+      [
+        { startError: "Start Error", endError: "End Error" },
+        { startWarning: "Start Warning", endWarning: "End Warning" },
+        { startInfo: "Start Info", endInfo: "End Info" },
+      ].map((validation) => (
+        <DateRange
+          key={`${Object.keys(validation)[0]}-string-label`}
+          startLabel="Start"
+          endLabel="End"
+          value={["2016-10-01", "2016-10-30"]}
+          validationOnLabel
+          {...validation}
+          tooltipPosition="top"
         />
       ))
     }

--- a/src/components/date/date.component.js
+++ b/src/components/date/date.component.js
@@ -486,6 +486,7 @@ class BaseDateInput extends React.Component {
       labelInline,
       adaptiveLabelBreakpoint,
       disablePortal,
+      tooltipPosition,
       ...inputProps
     } = this.props;
 
@@ -520,6 +521,7 @@ class BaseDateInput extends React.Component {
           })}
           inputRef={this.assignInput}
           adaptiveLabelBreakpoint={adaptiveLabelBreakpoint}
+          tooltipPosition={tooltipPosition}
           {...events}
         />
         {this.renderHiddenInput()}

--- a/src/components/date/date.d.ts
+++ b/src/components/date/date.d.ts
@@ -20,6 +20,8 @@ export interface DateInputProps extends TextboxProps {
   onFocus?: (ev: React.FocusEvent<HTMLInputElement>) => void;
   /** The current date YYYY-MM-DD */
   value?: string;
+  /** Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 declare class DateInput extends React.Component<DateInputProps> {}

--- a/src/components/date/date.spec.js
+++ b/src/components/date/date.spec.js
@@ -16,6 +16,7 @@ import { isEdge } from "../../utils/helpers/browser-type-check";
 import Label from "../../__internal__/label";
 import StyledInputPresentation from "../../__internal__/input/input-presentation.style";
 import enGB from "../../locales/en-gb";
+import Tooltip from "../tooltip";
 
 moment.suppressDeprecationWarnings = true;
 jest.useFakeTimers();
@@ -824,6 +825,29 @@ describe("Date", () => {
         wrapper.update();
         expect(wrapper.find(Textbox).props().value).toEqual("12/12/2012");
       });
+    });
+  });
+
+  describe("tooltipPosition", () => {
+    it("overrides the default position when validation is on input", () => {
+      const { position } = render({ error: "message", tooltipPosition: "top" })
+        .find(Tooltip)
+        .props();
+
+      expect(position).toEqual("top");
+    });
+
+    it("overrides the default position when validation is on label", () => {
+      const { position } = render({
+        label: "foo",
+        validationOnLabel: true,
+        error: "message",
+        tooltipPosition: "top",
+      })
+        .find(Tooltip)
+        .props();
+
+      expect(position).toEqual("top");
     });
   });
 });

--- a/src/components/date/date.stories.mdx
+++ b/src/components/date/date.stories.mdx
@@ -224,6 +224,29 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - component"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() =>
+      ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-component`}>
+          <DateInput
+            label="Date"
+            value="2016-10-01"
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="top"
+          />
+        </div>
+      ))
+    }
+  </Story>
+</Preview>
+
 #### As a string, displayed on label
 
 <Preview>
@@ -245,6 +268,30 @@ For more information check our [Validations](?path=/docs/documentation-validatio
             readOnly
             {...{ [validationType]: "Message" }}
             mb={2}
+          />
+        </div>
+      ))
+    }
+  </Story>
+</Preview>
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - label"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() =>
+      ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-component`}>
+          <DateInput
+            label="Date"
+            value="2016-10-01"
+            validationOnLabel
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="top"
           />
         </div>
       ))

--- a/src/components/decimal/decimal.stories.mdx
+++ b/src/components/decimal/decimal.stories.mdx
@@ -322,6 +322,38 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - component"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() => {
+      const [state, setState] = useState({
+        error: "0.01",
+        warning: "0.01",
+        info: "0.01",
+      });
+      const handleChange = (validation) => (e) => {
+        setState({ ...state, [validation]: e.target.value.rawValue });
+      };
+      return ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-component`}>
+          <Decimal
+            label="Decimal"
+            value={state[validationType]}
+            onChange={handleChange(validationType)}
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="bottom"
+          />
+        </div>
+      ));
+    }}
+  </Story>
+</Preview>
+
 #### As a string, displayed on label
 
 <Preview>
@@ -352,6 +384,39 @@ For more information check our [Validations](?path=/docs/documentation-validatio
             readOnly
             {...{ [validationType]: "Message" }}
             mb={2}
+          />
+        </div>
+      ));
+    }}
+  </Story>
+</Preview>
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - label"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() => {
+      const [state, setState] = useState({
+        error: "0.01",
+        warning: "0.01",
+        info: "0.01",
+      });
+      const handleChange = (validation) => (e) => {
+        setState({ ...state, [validation]: e.target.value.rawValue });
+      };
+      return ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-label`}>
+          <Decimal
+            label="Decimal"
+            value={state[validationType]}
+            onChange={handleChange(validationType)}
+            validationOnLabel
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="bottom"
           />
         </div>
       ));

--- a/src/components/grouped-character/grouped-character.stories.mdx
+++ b/src/components/grouped-character/grouped-character.stories.mdx
@@ -379,6 +379,40 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - component"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() => {
+      const [state, setState] = useState({
+        error: "1231231",
+        warning: "1231231",
+        info: "1231231",
+      });
+      const handleChange = (validation) => (e) => {
+        setState({ ...state, [validation]: e.target.value.rawValue });
+      };
+      return ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-component`}>
+          <GroupedCharacter
+            label="GroupedCharacter"
+            value={state[validationType]}
+            onChange={handleChange(validationType)}
+            groups={[2, 2, 3]}
+            separator="-"
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="bottom"
+          />
+        </div>
+      ));
+    }}
+  </Story>
+</Preview>
+
 #### As a string, displayed on label
 
 <Preview>
@@ -413,6 +447,41 @@ For more information check our [Validations](?path=/docs/documentation-validatio
             readOnly
             {...{ [validationType]: "Message" }}
             mb={2}
+          />
+        </div>
+      ));
+    }}
+  </Story>
+</Preview>
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - label"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() => {
+      const [state, setState] = useState({
+        error: "1231231",
+        warning: "1231231",
+        info: "1231231",
+      });
+      const handleChange = (validation) => (e) => {
+        setState({ ...state, [validation]: e.target.value.rawValue });
+      };
+      return ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-label`}>
+          <GroupedCharacter
+            label="GroupedCharacter"
+            value={state[validationType]}
+            onChange={handleChange(validationType)}
+            groups={[2, 2, 3]}
+            separator="-"
+            validationOnLabel
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="top"
           />
         </div>
       ));

--- a/src/components/icon/icon.component.js
+++ b/src/components/icon/icon.component.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import styledSystemPropTypes from "@styled-system/prop-types";
 import tagComponent from "../../utils/helpers/tags";
@@ -7,6 +7,7 @@ import Tooltip from "../tooltip";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import Logger from "../../utils/logger";
 import { ICON_TOOLTIP_POSITIONS } from "./icon-config";
+import { TooltipContext } from "../../__internal__/tooltip-provider";
 
 let deprecatedWarnTriggered = false;
 
@@ -97,10 +98,14 @@ const Icon = React.forwardRef(
     if (tooltipMessage) {
       const visible = disabled ? false : tooltipVisible;
 
+      const { tooltipPosition: tooltipPositionFromContext } = useContext(
+        TooltipContext
+      );
+
       return (
         <Tooltip
           message={tooltipMessage}
-          position={tooltipPosition}
+          position={tooltipPositionFromContext || tooltipPosition}
           type={type}
           isVisible={visible}
           isPartOfInput={isPartOfInput}

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -17,6 +17,7 @@ import browserTypeCheck, {
 } from "../../utils/helpers/browser-type-check";
 import styledColor from "../../style/utils/color.js";
 import Tooltip from "../tooltip";
+import { TooltipProvider } from "../../__internal__/tooltip-provider";
 
 jest.mock("../../utils/helpers/browser-type-check");
 jest.mock("@tippyjs/react/headless", () => ({
@@ -555,6 +556,16 @@ describe("Icon component", () => {
         expect(wrapper.find(Tooltip).props().position).toEqual(position);
       }
     );
+
+    it('tooltips "position" can be overriden by context', () => {
+      const wrapper = mount(
+        <TooltipProvider tooltipPosition="top">
+          <Icon tooltipMessage="foo" type="home" tooltipPosition="left" />
+        </TooltipProvider>
+      );
+
+      expect(wrapper.find(Tooltip).props().position).toBe("top");
+    });
 
     it("supports being controlled via tooltipVisible prop", () => {
       const wrapper = mount(

--- a/src/components/number/number.stories.mdx
+++ b/src/components/number/number.stories.mdx
@@ -185,6 +185,29 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - component"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() =>
+      ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-component`}>
+          <Number
+            label="Number"
+            value="123456"
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="bottom"
+          />
+        </div>
+      ))
+    }
+  </Story>
+</Preview>
+
 #### As a string, displayed on label
 
 <Preview>
@@ -206,6 +229,30 @@ For more information check our [Validations](?path=/docs/documentation-validatio
             readOnly
             {...{ [validationType]: "Message" }}
             mb={2}
+          />
+        </div>
+      ))
+    }
+  </Story>
+</Preview>
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - label"
+    parameters={{ chromatic: { disable: true } }}  
+  >
+    {() =>
+      ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-label`}>
+          <Number
+            label="Number"
+            value="123456"
+            validationOnLabel
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="top"
           />
         </div>
       ))

--- a/src/components/numeral-date/numeral-date.component.js
+++ b/src/components/numeral-date/numeral-date.component.js
@@ -59,6 +59,7 @@ const NumeralDate = ({
   size,
   enableInternalError,
   enableInternalWarning,
+  tooltipPosition,
   ...rest
 }) => {
   const l = useLocale();
@@ -221,6 +222,7 @@ const NumeralDate = ({
                       info,
                     })}
                   size={size}
+                  tooltipPosition={tooltipPosition}
                 />
               </StyledDateField>
             );
@@ -310,6 +312,8 @@ NumeralDate.propTypes = {
   required: PropTypes.bool,
   /** Size of an input */
   size: PropTypes.oneOf(["small", "medium", "large"]),
+  /** Overrides the default tooltip position */
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
 };
 
 export default NumeralDate;

--- a/src/components/numeral-date/numeral-date.d.ts
+++ b/src/components/numeral-date/numeral-date.d.ts
@@ -74,6 +74,8 @@ export interface NumeralDateProps extends ValidationPropTypes, MarginProps {
   size?: "small" | "medium" | "large";
   /** When true, validation icons will be placed on labels instead of being placed on the inputs */
   validationOnLabel?: boolean;
+  /** Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 declare function NumeralDate(props: NumeralDateProps): JSX.Element;

--- a/src/components/numeral-date/numeral-date.stories.mdx
+++ b/src/components/numeral-date/numeral-date.stories.mdx
@@ -305,6 +305,33 @@ You can use the `size` prop to set the size of the field.
   </Story>
 </Preview>
 
+### Overriding tooltip position
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="overriding tooltip position"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    <>
+      <NumeralDate
+        dateFormat={["dd", "mm", "yyyy"]}
+        error="Tooltip position set to top"
+        label="As string"
+        tooltipPosition="top"
+      />
+      <NumeralDate
+        dateFormat={["dd", "mm", "yyyy"]}
+        error="Tooltip position set to right"
+        label="As string - displayed on a label"
+        validationOnLabel
+        tooltipPosition="right"
+      />
+    </>
+  </Story>
+</Preview>
+
 ## Props 
 
 ### NumeralDate

--- a/src/components/radio-button/radio-button-group.component.js
+++ b/src/components/radio-button/radio-button-group.component.js
@@ -7,6 +7,7 @@ import RadioButtonGroupStyle from "./radio-button-group.style";
 import RadioButtonMapper from "./radio-button-mapper.component";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import { TooltipProvider } from "../../__internal__/tooltip-provider";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
@@ -32,6 +33,7 @@ const RadioButtonGroup = (props) => {
     adaptiveLegendBreakpoint,
     adaptiveSpacingBreakpoint,
     required,
+    tooltipPosition,
   } = props;
 
   const marginProps = filterStyledSystemMarginProps(props);
@@ -55,47 +57,49 @@ const RadioButtonGroup = (props) => {
   }
 
   return (
-    <Fieldset
-      legend={legend}
-      error={error}
-      warning={warning}
-      info={info}
-      inline={inlineLegend}
-      legendWidth={legendWidth}
-      legendAlign={legendAlign}
-      legendSpacing={legendSpacing}
-      isRequired={required}
-      {...tagComponent("radiogroup", props)}
-      {...marginProps}
-      ml={marginLeft}
-      blockGroupBehaviour={!(error || warning || info)}
-    >
-      <RadioButtonGroupStyle
-        data-component="radio-button-group"
-        role="radiogroup"
-        inline={inline}
-        legendInline={inlineLegend}
+    <TooltipProvider tooltipPosition={tooltipPosition}>
+      <Fieldset
+        legend={legend}
+        error={error}
+        warning={warning}
+        info={info}
+        inline={inlineLegend}
+        legendWidth={legendWidth}
+        legendAlign={legendAlign}
+        legendSpacing={legendSpacing}
+        isRequired={required}
+        {...tagComponent("radiogroup", props)}
+        {...marginProps}
+        ml={marginLeft}
+        blockGroupBehaviour={!(error || warning || info)}
       >
-        <RadioButtonMapper
-          name={name}
-          onBlur={onBlur}
-          onChange={onChange}
-          value={value}
+        <RadioButtonGroupStyle
+          data-component="radio-button-group"
+          role="radiogroup"
+          inline={inline}
+          legendInline={inlineLegend}
         >
-          {React.Children.map(children, (child) => {
-            return React.cloneElement(child, {
-              inline,
-              labelSpacing,
-              error: !!error,
-              warning: !!warning,
-              info: !!info,
-              required,
-              ...child.props,
-            });
-          })}
-        </RadioButtonMapper>
-      </RadioButtonGroupStyle>
-    </Fieldset>
+          <RadioButtonMapper
+            name={name}
+            onBlur={onBlur}
+            onChange={onChange}
+            value={value}
+          >
+            {React.Children.map(children, (child) => {
+              return React.cloneElement(child, {
+                inline,
+                labelSpacing,
+                error: !!error,
+                warning: !!warning,
+                info: !!info,
+                required,
+                ...child.props,
+              });
+            })}
+          </RadioButtonMapper>
+        </RadioButtonGroupStyle>
+      </Fieldset>
+    </TooltipProvider>
   );
 };
 
@@ -143,6 +147,8 @@ RadioButtonGroup.propTypes = {
   adaptiveSpacingBreakpoint: PropTypes.number,
   /** Flag to configure component as mandatory */
   required: PropTypes.bool,
+  /** Overrides the default tooltip position */
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
 };
 
 export default RadioButtonGroup;

--- a/src/components/radio-button/radio-button-group.d.ts
+++ b/src/components/radio-button/radio-button-group.d.ts
@@ -35,6 +35,8 @@ export interface RadioButtonGroupProps
   required?: boolean;
   /** value of the selected RadioButton */
   value?: string;
+  /** Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 declare function RadioButtonGroup(props: RadioButtonGroupProps): JSX.Element;

--- a/src/components/radio-button/radio-button-group.spec.js
+++ b/src/components/radio-button/radio-button-group.spec.js
@@ -9,6 +9,7 @@ import { RadioButton, RadioButtonGroup } from ".";
 import RadioButtonGroupStyle from "./radio-button-group.style";
 import Fieldset from "../../__internal__/fieldset";
 import Label from "../../__internal__/label";
+import Tooltip from "../tooltip";
 
 const buttonValues = ["test-1", "test-2"];
 const name = "test-group";
@@ -191,6 +192,19 @@ describe("RadioButtonGroup", () => {
     it("the isRequired prop is passed to the fieldset", () => {
       const fieldset = wrapper.find(Fieldset);
       expect(fieldset.prop("isRequired")).toBe(true);
+    });
+  });
+
+  describe("tooltipPosition", () => {
+    it("overrides the default position when value is passed", () => {
+      const { position } = render(
+        { error: "message", tooltipPosition: "bottom" },
+        mount
+      )
+        .find(Tooltip)
+        .props();
+
+      expect(position).toEqual("bottom");
     });
   });
 });

--- a/src/components/radio-button/radio-button.component.js
+++ b/src/components/radio-button/radio-button.component.js
@@ -6,6 +6,7 @@ import RadioButtonStyle from "./radio-button.style";
 import CheckableInput from "../../__internal__/checkable-input/checkable-input.component";
 import RadioButtonSvg from "./radio-button-svg.component";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import { TooltipProvider } from "../../__internal__/tooltip-provider";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
@@ -44,6 +45,7 @@ const RadioButton = React.forwardRef(
       error,
       warning,
       info,
+      tooltipPosition,
       ...props
     },
     ref
@@ -94,18 +96,20 @@ const RadioButton = React.forwardRef(
     };
 
     return (
-      <RadioButtonStyle
-        inline={inline}
-        reverse={reverse}
-        size={size}
-        {...commonProps}
-        {...marginProps}
-        {...tagComponent("radio-button", props)}
-      >
-        <CheckableInput {...inputProps}>
-          <RadioButtonSvg />
-        </CheckableInput>
-      </RadioButtonStyle>
+      <TooltipProvider tooltipPosition={tooltipPosition}>
+        <RadioButtonStyle
+          inline={inline}
+          reverse={reverse}
+          size={size}
+          {...commonProps}
+          {...marginProps}
+          {...tagComponent("radio-button", props)}
+        >
+          <CheckableInput {...inputProps}>
+            <RadioButtonSvg />
+          </CheckableInput>
+        </RadioButtonStyle>
+      </TooltipProvider>
     );
   }
 );
@@ -159,6 +163,8 @@ RadioButton.propTypes = {
     }
     return null;
   },
+  /** Overrides the default tooltip position */
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
   ...radioButtonGroupPassedProps,
 };
 

--- a/src/components/radio-button/radio-button.d.ts
+++ b/src/components/radio-button/radio-button.d.ts
@@ -14,6 +14,8 @@ export interface RadioButtonProps extends CommonCheckableInputProps, MarginProps
   size?: "small" | "large";
   /** the value of the Radio Button, passed on form submit */
   value: string;
+  /** Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 declare function RadioButton(props: RadioButtonProps & React.RefAttributes<HTMLInputElement>): JSX.Element;

--- a/src/components/radio-button/radio-button.spec.js
+++ b/src/components/radio-button/radio-button.spec.js
@@ -12,6 +12,7 @@ import guid from "../../utils/helpers/guid/guid";
 import baseTheme from "../../style/themes/base";
 import mintTheme from "../../style/themes/mint";
 import RadioButtonStyle from "./radio-button.style";
+import Tooltip from "../tooltip";
 
 jest.mock("../../utils/helpers/guid");
 guid.mockImplementation(() => "guid-12345");
@@ -189,6 +190,23 @@ describe("RadioButton", () => {
           { modifier: "svg" }
         );
       });
+    });
+  });
+
+  describe("tooltipPosition", () => {
+    it("overrides the default position when value is passed", () => {
+      const { position } = mount(
+        <RadioButton
+          value="foo"
+          label="foo"
+          error="message"
+          tooltipPosition="bottom"
+        />
+      )
+        .find(Tooltip)
+        .props();
+
+      expect(position).toEqual("bottom");
     });
   });
 

--- a/src/components/radio-button/radio-button.stories.mdx
+++ b/src/components/radio-button/radio-button.stories.mdx
@@ -413,6 +413,29 @@ Validations can be added to the radio buttons as strings or booleans.
   </Story> 
 </Preview>
 
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="with validations on buttons - tooltipPosition overriden"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    <RadioButtonGroup
+      name="validations-on-buttons-group-tooltip-position-override"
+      onChange={ () => console.log('change') }
+      legend="Radio group legend"
+    >
+    <RadioButton 
+      id="validations-on-buttons-radio-1-tooltip-position-override" 
+      value="radio1"
+      label="Radio Option 1"
+      error="message"
+      tooltipPosition="right"
+    />
+  </RadioButtonGroup>
+  </Story> 
+</Preview>
+
 ### With validations on radio group
 Validations can be added to the radio group as a string or boolean.
 
@@ -440,7 +463,29 @@ Validations can be added to the radio group as a string or boolean.
         label="Radio Option 3"
       />
     </RadioButtonGroup>
-    
+  </Story>
+</Preview>
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="with validations on group - tooltipPosition overriden"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    <RadioButtonGroup
+      name="validations-on-group-group-tooltip-position-override"
+      onChange={ () => console.log('change') }
+      legend="Radio group legend"
+      error="message"
+      tooltipPosition="top"
+    >
+      <RadioButton 
+        id="validations-on-group-radio-1-tooltip-position-override" 
+        value="radio1"
+        label="Radio Option 1"
+      />
+    </RadioButtonGroup>
   </Story>
 </Preview>
 

--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -38,6 +38,7 @@ const FilterableSelect = React.forwardRef(
       onListScrollBottom,
       tableHeader,
       multiColumn,
+      tooltipPosition,
       ...textboxProps
     },
     inputRef
@@ -452,6 +453,7 @@ const FilterableSelect = React.forwardRef(
         onKeyDown: handleTextboxKeydown,
         onChange: handleTextboxChange,
         onMouseDown: handleTextboxMouseDown,
+        tooltipPosition,
         ...textboxProps,
       };
     }
@@ -546,6 +548,8 @@ FilterableSelect.propTypes = {
   isLoading: PropTypes.bool,
   /** A callback that is triggered when a user scrolls to the bottom of the list */
   onListScrollBottom: PropTypes.func,
+  /** Overrides the default tooltip position */
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
 };
 
 export default FilterableSelect;

--- a/src/components/select/filterable-select/filterable-select.d.ts
+++ b/src/components/select/filterable-select/filterable-select.d.ts
@@ -35,6 +35,8 @@ export interface FilterableSelectProps extends FormInputPropTypes {
   tableHeader?: React.ReactNode;
   /** The selected value(s), when the component is operating in controlled mode */
   value?: string | object;
+  /** Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 declare function FilterableSelect(props: FilterableSelectProps & React.RefAttributes<HTMLInputElement>): JSX.Element;

--- a/src/components/select/multi-select/multi-select.component.js
+++ b/src/components/select/multi-select/multi-select.component.js
@@ -41,6 +41,7 @@ const MultiSelect = React.forwardRef(
       isLoading,
       tableHeader,
       multiColumn,
+      tooltipPosition,
       ...textboxProps
     },
     inputRef
@@ -443,6 +444,7 @@ const MultiSelect = React.forwardRef(
         iconOnMouseDown: handleTextboxMouseDown,
         onKeyDown: handleTextboxKeydown,
         onChange: handleTextboxChange,
+        tooltipPosition,
         ...textboxProps,
       };
     }
@@ -535,6 +537,8 @@ MultiSelect.propTypes = {
   noResultsMessage: PropTypes.string,
   /** If true the loader animation is displayed in the option list */
   isLoading: PropTypes.bool,
+  /** Overrides the default tooltip position */
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
 };
 
 export default MultiSelect;

--- a/src/components/select/multi-select/multi-select.d.ts
+++ b/src/components/select/multi-select/multi-select.d.ts
@@ -28,6 +28,8 @@ export interface MultiSelectProps extends FormInputPropTypes {
   tableHeader?: React.ReactNode;
   /** The selected value(s), when the component is operating in controlled mode */
   value?: string[] | object[];
+  /** Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 declare function MultiSelect(props: MultiSelectProps & React.RefAttributes<HTMLInputElement>): JSX.Element;

--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -41,6 +41,7 @@ const SimpleSelect = React.forwardRef(
       onListScrollBottom,
       tableHeader,
       multiColumn,
+      tooltipPosition,
       ...props
     },
     inputRef
@@ -376,6 +377,7 @@ const SimpleSelect = React.forwardRef(
         onKeyDown: handleTextboxKeydown,
         onChange: handleTextboxChange,
         onBlur: handleTextboxBlur,
+        tooltipPosition,
         ...props,
       };
     }
@@ -452,6 +454,8 @@ SimpleSelect.propTypes = {
   isLoading: PropTypes.bool,
   /** A callback that is triggered when a user scrolls to the bottom of the list */
   onListScrollBottom: PropTypes.func,
+  /** Overrides the default tooltip position */
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
 };
 
 SimpleSelect.defaultProps = {

--- a/src/components/select/simple-select/simple-select.d.ts
+++ b/src/components/select/simple-select/simple-select.d.ts
@@ -30,6 +30,8 @@ export interface SimpleSelectProps extends FormInputPropTypes {
   transparent?: boolean;
   /** The selected value(s), when the component is operating in controlled mode */
   value?: string | object;
+  /** Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 declare function SimpleSelect(props: SimpleSelectProps & React.RefAttributes<HTMLInputElement>): JSX.Element;

--- a/src/components/switch/switch.component.js
+++ b/src/components/switch/switch.component.js
@@ -5,6 +5,7 @@ import SwitchStyle from "./switch.style";
 import CheckableInput from "../../__internal__/checkable-input";
 import SwitchSlider from "./__internal__/switch-slider.component";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
+import { TooltipProvider } from "../../__internal__/tooltip-provider";
 
 const Switch = ({
   id,
@@ -21,6 +22,7 @@ const Switch = ({
   labelInline,
   name,
   adaptiveLabelBreakpoint,
+  tooltipPosition,
   ...rest
 }) => {
   const isControlled = checked !== undefined;
@@ -67,18 +69,20 @@ const Switch = ({
     labelInline && !reverse ? true : validationOnLabel;
 
   return (
-    <SwitchStyle {...tagComponent("Switch", rest)} {...switchProps}>
-      <CheckableInput
-        validationOnLabel={shouldValidationBeOnLabel && !disabled}
-        {...inputProps}
-      >
-        <SwitchSlider
-          useValidationIcon={!shouldValidationBeOnLabel && !disabled}
-          {...switchProps}
-          loading={loading}
-        />
-      </CheckableInput>
-    </SwitchStyle>
+    <TooltipProvider tooltipPosition={tooltipPosition}>
+      <SwitchStyle {...tagComponent("Switch", rest)} {...switchProps}>
+        <CheckableInput
+          validationOnLabel={shouldValidationBeOnLabel && !disabled}
+          {...inputProps}
+        >
+          <SwitchSlider
+            useValidationIcon={!shouldValidationBeOnLabel && !disabled}
+            {...switchProps}
+            loading={loading}
+          />
+        </CheckableInput>
+      </SwitchStyle>
+    </TooltipProvider>
   );
 };
 
@@ -148,6 +152,8 @@ Switch.propTypes = {
   adaptiveLabelBreakpoint: PropTypes.number,
   /** Flag to configure component as mandatory */
   required: PropTypes.bool,
+  /** Overrides the default tooltip position */
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
 };
 
 Switch.defaultProps = {

--- a/src/components/switch/switch.d.ts
+++ b/src/components/switch/switch.d.ts
@@ -30,6 +30,8 @@ export interface SwitchProps extends CommonCheckableInputProps, MarginProps {
   validationOnLabel?: boolean;
   /** The value of the switch, passed on form submit */
   value?: string;
+  /** Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 declare function Switch(props: SwitchProps): JSX.Element;

--- a/src/components/switch/switch.spec.js
+++ b/src/components/switch/switch.spec.js
@@ -24,6 +24,7 @@ import SwitchStyle from "./switch.style";
 import SwitchSlider from "./__internal__/switch-slider.component";
 import Label from "../../__internal__/label";
 import I18nProvider from "../i18n-provider";
+import Tooltip from "../tooltip";
 
 jest.mock("../../utils/helpers/guid");
 guid.mockImplementation(() => "guid-12345");
@@ -511,6 +512,39 @@ describe("Switch", () => {
       expect(
         wrapper.find(StyledSwitchSlider).find(StyledValidationIcon).exists()
       ).toEqual(false);
+    });
+  });
+
+  describe("tooltipPosition", () => {
+    it("overrides the default placement when icon is on input", () => {
+      const { position } = render(
+        {
+          label: "My Label",
+          labelHelp: "Please help me?",
+          tooltipPosition: "top",
+        },
+        mount
+      )
+        .find(Tooltip)
+        .props();
+
+      expect(position).toEqual("top");
+    });
+
+    it("overrides the default placement when icon is on label", () => {
+      const { position } = render(
+        {
+          label: "My Label",
+          labelHelp: "Please help me?",
+          tooltipPosition: "top",
+          validationOnLabel: true,
+        },
+        mount
+      )
+        .find(Tooltip)
+        .props();
+
+      expect(position).toEqual("top");
     });
   });
 

--- a/src/components/switch/switch.stories.mdx
+++ b/src/components/switch/switch.stories.mdx
@@ -266,6 +266,30 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="single switch - string validation - tooltipPosition overriden"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() => {
+      const [isChecked, setIsChecked] = useState(false);
+      return ["error", "warning", "info"].map((type) => (
+        <Switch
+          id={`switch${type}-tooltipPosition-override`}
+          key={`switch-${type}`}
+          {...{ [type]: "Message" }}
+          label={`Example switch (${type})`}
+          name={`switch-${type}-tooltipPosition-override`}
+          onChange={(e) => setIsChecked((state) => !state)}
+          tooltipPosition="top"
+        />
+      ));
+    }}
+  </Story>
+</Preview>
+
 #### As a string with validationOnLabel
 
 <Preview>
@@ -281,6 +305,31 @@ For more information check our [Validations](?path=/docs/documentation-validatio
           name={`switch-${type}-label`}
           validationOnLabel
           onChange={(e) => setIsChecked((state) => !state)}
+        />
+      ));
+    }}
+  </Story>
+</Preview>
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="single switch - string validation - validationOnLabel - tooltipPosition overriden"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() => {
+      const [isChecked, setIsChecked] = useState(false);
+      return ["error", "warning", "info"].map((type) => (
+        <Switch
+          id={`switch${type}-label-tooltipPosition-override`}
+          key={`switch-${type}-label`}
+          {...{ [type]: "Message" }}
+          label={`Example switch (${type})`}
+          name={`switch-${type}-label-tooltipPosition-override`}
+          validationOnLabel
+          onChange={(e) => setIsChecked((state) => !state)}
+          tooltipPosition="top"
         />
       ));
     }}

--- a/src/components/textarea/textarea.component.js
+++ b/src/components/textarea/textarea.component.js
@@ -12,6 +12,7 @@ import InputIconToggle from "../../__internal__/input-icon-toggle";
 import guid from "../../utils/helpers/guid/guid";
 import StyledTextarea from "./textarea.style";
 import LocaleContext from "../../__internal__/i18n-context";
+import { TooltipProvider } from "../../__internal__/tooltip-provider";
 
 const getFormatNumber = (value, locale) =>
   new Intl.NumberFormat(locale).format(value);
@@ -146,61 +147,64 @@ class Textarea extends React.Component {
       adaptiveLabelBreakpoint,
       inputWidth,
       labelWidth,
+      tooltipPosition,
       ...props
     } = this.props;
 
     return (
-      <InputBehaviour>
-        <StyledTextarea
-          labelInline={labelInline}
-          {...filterStyledSystemMarginProps(props)}
-        >
-          <FormField
-            label={label}
-            disabled={disabled}
-            id={this.id}
+      <TooltipProvider tooltipPosition={tooltipPosition}>
+        <InputBehaviour>
+          <StyledTextarea
             labelInline={labelInline}
-            labelWidth={labelWidth}
-            isRequired={props.required}
-            useValidationIcon={validationOnLabel}
-            adaptiveLabelBreakpoint={adaptiveLabelBreakpoint}
-            {...filterOutSpacingProps(props)}
+            {...filterStyledSystemMarginProps(props)}
           >
-            <InputPresentation
-              type="text"
-              size={size}
+            <FormField
+              label={label}
               disabled={disabled}
-              readOnly={readOnly}
-              inputWidth={
-                typeof inputWidth === "number" ? inputWidth : 100 - labelWidth
-              }
-              {...props}
+              id={this.id}
+              labelInline={labelInline}
+              labelWidth={labelWidth}
+              isRequired={props.required}
+              useValidationIcon={validationOnLabel}
+              adaptiveLabelBreakpoint={adaptiveLabelBreakpoint}
+              {...filterOutSpacingProps(props)}
             >
-              <Input
-                ref={this._input}
-                maxLength={
-                  enforceCharacterLimit && characterLimit
-                    ? characterLimit
-                    : undefined
-                }
-                onChange={onChange}
+              <InputPresentation
+                type="text"
+                size={size}
                 disabled={disabled}
                 readOnly={readOnly}
-                labelInline={labelInline}
-                placeholder={disabled ? "" : placeholder}
-                rows={rows}
-                cols={cols}
-                id={this.id}
-                as="textarea"
+                inputWidth={
+                  typeof inputWidth === "number" ? inputWidth : 100 - labelWidth
+                }
                 {...props}
-              />
-              {children}
-              {this.renderValidation()}
-            </InputPresentation>
-          </FormField>
-          {this.characterCount}
-        </StyledTextarea>
-      </InputBehaviour>
+              >
+                <Input
+                  ref={this._input}
+                  maxLength={
+                    enforceCharacterLimit && characterLimit
+                      ? characterLimit
+                      : undefined
+                  }
+                  onChange={onChange}
+                  disabled={disabled}
+                  readOnly={readOnly}
+                  labelInline={labelInline}
+                  placeholder={disabled ? "" : placeholder}
+                  rows={rows}
+                  cols={cols}
+                  id={this.id}
+                  as="textarea"
+                  {...props}
+                />
+                {children}
+                {this.renderValidation()}
+              </InputPresentation>
+            </FormField>
+            {this.characterCount}
+          </StyledTextarea>
+        </InputBehaviour>
+      </TooltipProvider>
     );
   }
 }
@@ -275,6 +279,8 @@ Textarea.propTypes = {
   adaptiveLabelBreakpoint: PropTypes.number,
   /** Flag to configure component as mandatory */
   required: PropTypes.bool,
+  /** Overrides the default tooltip position */
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
 };
 
 Textarea.defaultProps = {

--- a/src/components/textarea/textarea.d.ts
+++ b/src/components/textarea/textarea.d.ts
@@ -58,6 +58,8 @@ export interface TextareaProps extends ValidationPropTypes, MarginProps {
   value?: string;
   /** Whether to display the character count message in red */
   warnOverLimit?: boolean;
+  /** Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 declare class Textarea extends React.Component<TextareaProps> {}

--- a/src/components/textarea/textarea.spec.js
+++ b/src/components/textarea/textarea.spec.js
@@ -14,6 +14,7 @@ import Label from "../../__internal__/label";
 import ValidationIcon from "../../__internal__/validations/validation-icon.component";
 import guid from "../../utils/helpers/guid";
 import { StyledLabelContainer } from "../../__internal__/label/label.style";
+import Tooltip from "../tooltip";
 
 jest.mock("../../utils/helpers/guid");
 guid.mockImplementation(() => "guid-12345");
@@ -62,6 +63,18 @@ describe("Textarea", () => {
         ).toBe(true);
       });
 
+      it("overrides the tooltip position when the input and a value is passed in via tooltipPosition", () => {
+        wrapper = renderTextarea({
+          children: "mock content",
+          label: "Label",
+          [validationProp]: "Message",
+          tooltipPosition: "bottom",
+        });
+        expect(
+          wrapper.find(InputPresentation).find(Tooltip).props().position
+        ).toEqual("bottom");
+      });
+
       it("renders a validation icon on the label if validationOnLabel passed as true", () => {
         wrapper = renderTextarea({
           children: "mock content",
@@ -70,6 +83,20 @@ describe("Textarea", () => {
           validationOnLabel: true,
         });
         expect(wrapper.find(Label).find(ValidationIcon).exists()).toBe(true);
+      });
+
+      it("overrides the tooltip position when on the label and a value is passed in via tooltipPosition", () => {
+        wrapper = renderTextarea({
+          children: "mock content",
+          label: "Label",
+          [validationProp]: "Message",
+          validationOnLabel: true,
+          tooltipPosition: "bottom",
+        });
+        expect(
+          wrapper.find(Label).find(ValidationIcon).find(Tooltip).props()
+            .position
+        ).toEqual("bottom");
       });
     }
   );

--- a/src/components/textarea/textarea.stories.mdx
+++ b/src/components/textarea/textarea.stories.mdx
@@ -221,6 +221,28 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - component"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() =>
+      ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-component`}>
+          <Textarea
+            label="Textarea"
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="bottom"
+          />
+        </div>
+      ))
+    }
+  </Story>
+</Preview>
+
 #### As a string, displayed on label
 
 <Preview>
@@ -240,6 +262,29 @@ For more information check our [Validations](?path=/docs/documentation-validatio
             readOnly
             {...{ [validationType]: "Message" }}
             mb={2}
+          />
+        </div>
+      ))
+    }
+  </Story>
+</Preview>
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - label"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() =>
+      ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-label`}>
+          <Textarea
+            label="Textarea"
+            validationOnLabel
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="top"
           />
         </div>
       ))

--- a/src/components/textbox/__snapshots__/textbox.spec.js.snap
+++ b/src/components/textbox/__snapshots__/textbox.spec.js.snap
@@ -1,37 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Textbox renders with InputPresentation and Input and correct props passed to Input 1`] = `
-<InputBehaviour>
-  <FormField
-    id="mocked-guid"
-    labelWidth={30}
-    name="mocked-guid"
-    size="medium"
-    useValidationIcon={false}
-  >
-    <InputPresentation
+<TooltipProvider>
+  <InputBehaviour>
+    <FormField
       id="mocked-guid"
-      inputWidth={70}
+      labelWidth={30}
       name="mocked-guid"
       size="medium"
-      type="text"
+      useValidationIcon={false}
     >
-      southpaw children
-      <ForwardRef
-        aria-invalid={false}
+      <InputPresentation
         id="mocked-guid"
+        inputWidth={70}
         name="mocked-guid"
         size="medium"
-        value="foobar"
-      />
-      normal children
-      <InputIconToggle
-        id="mocked-guid"
-        name="mocked-guid"
-        size="medium"
-        useValidationIcon={true}
-      />
-    </InputPresentation>
-  </FormField>
-</InputBehaviour>
+        type="text"
+      >
+        southpaw children
+        <ForwardRef
+          aria-invalid={false}
+          id="mocked-guid"
+          name="mocked-guid"
+          size="medium"
+          value="foobar"
+        />
+        normal children
+        <InputIconToggle
+          id="mocked-guid"
+          name="mocked-guid"
+          size="medium"
+          useValidationIcon={true}
+        />
+      </InputPresentation>
+    </FormField>
+  </InputBehaviour>
+</TooltipProvider>
 `;

--- a/src/components/textbox/textbox.component.js
+++ b/src/components/textbox/textbox.component.js
@@ -12,6 +12,7 @@ import FormField from "../../__internal__/form-field";
 import withUniqueIdProps from "../../utils/helpers/with-unique-id-props";
 import { InputBehaviour } from "../../__internal__/input-behaviour";
 import StyledPrefix from "./__internal__/prefix.style";
+import { TooltipProvider } from "../../__internal__/tooltip-provider";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
@@ -46,51 +47,56 @@ const Textbox = ({
   required,
   positionedChildren,
   inputRef,
+  tooltipPosition,
   ...props
 }) => {
   return (
-    <InputBehaviour>
-      <FormField
-        childOfForm={childOfForm}
-        isOptional={isOptional}
-        {...filterOutPaddingProps(props)}
-        useValidationIcon={validationOnLabel}
-        labelWidth={labelWidth}
-        adaptiveLabelBreakpoint={adaptiveLabelBreakpoint}
-        isRequired={required}
-      >
-        <InputPresentation
-          type="text"
-          {...removeParentProps(props)}
-          inputWidth={inputWidth || 100 - labelWidth}
-          positionedChildren={positionedChildren}
+    <TooltipProvider tooltipPosition={tooltipPosition}>
+      <InputBehaviour>
+        <FormField
+          childOfForm={childOfForm}
+          isOptional={isOptional}
+          {...filterOutPaddingProps(props)}
+          useValidationIcon={validationOnLabel}
+          labelWidth={labelWidth}
+          adaptiveLabelBreakpoint={adaptiveLabelBreakpoint}
+          isRequired={required}
         >
-          {leftChildren}
-          {prefix ? (
-            <StyledPrefix data-element="textbox-prefix">{prefix}</StyledPrefix>
-          ) : null}
-          <Input
-            {...(required && { required })}
+          <InputPresentation
+            type="text"
             {...removeParentProps(props)}
-            placeholder={
-              props.disabled || props.readOnly ? "" : props.placeholder
-            }
-            aria-invalid={!!props.error}
-            inputRef={inputRef}
-            value={visibleValue(value, formattedValue)}
-          />
-          {children}
-          <InputIconToggle
-            {...removeParentProps(props)}
-            useValidationIcon={!validationOnLabel}
-            onClick={iconOnClick || props.onClick}
-            onMouseDown={iconOnMouseDown}
-            inputIcon={inputIcon}
-            iconTabIndex={iconTabIndex}
-          />
-        </InputPresentation>
-      </FormField>
-    </InputBehaviour>
+            inputWidth={inputWidth || 100 - labelWidth}
+            positionedChildren={positionedChildren}
+          >
+            {leftChildren}
+            {prefix ? (
+              <StyledPrefix data-element="textbox-prefix">
+                {prefix}
+              </StyledPrefix>
+            ) : null}
+            <Input
+              {...(required && { required })}
+              {...removeParentProps(props)}
+              placeholder={
+                props.disabled || props.readOnly ? "" : props.placeholder
+              }
+              aria-invalid={!!props.error}
+              inputRef={inputRef}
+              value={visibleValue(value, formattedValue)}
+            />
+            {children}
+            <InputIconToggle
+              {...removeParentProps(props)}
+              useValidationIcon={!validationOnLabel}
+              onClick={iconOnClick || props.onClick}
+              onMouseDown={iconOnMouseDown}
+              inputIcon={inputIcon}
+              iconTabIndex={iconTabIndex}
+            />
+          </InputPresentation>
+        </FormField>
+      </InputBehaviour>
+    </TooltipProvider>
   );
 };
 
@@ -205,6 +211,8 @@ Textbox.propTypes = {
   required: PropTypes.bool,
   /** A callback to retrieve the input reference */
   inputRef: PropTypes.func,
+  /** Overrides the default tooltip position */
+  tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
 };
 
 Textbox.defaultProps = {

--- a/src/components/textbox/textbox.d.ts
+++ b/src/components/textbox/textbox.d.ts
@@ -67,6 +67,8 @@ export interface CommonTextboxProps extends ValidationPropTypes {
   value?: string | string[] | object | object[];
   /** A callback to retrieve the input reference */
   inputRef?: (input: React.RefObject<HTMLInputElement>) => void;
+  /** Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 export interface TextboxProps extends CommonTextboxProps, SpaceProps {

--- a/src/components/textbox/textbox.spec.js
+++ b/src/components/textbox/textbox.spec.js
@@ -13,6 +13,7 @@ import StyledValidationIcon from "../../__internal__/validations/validation-icon
 import StyledPrefix from "./__internal__/prefix.style";
 import Label from "../../__internal__/label";
 import FormFieldStyle from "../../__internal__/form-field/form-field.style";
+import Tooltip from "../tooltip";
 
 jest.mock("../../utils/helpers/guid", () => () => "mocked-guid");
 
@@ -80,6 +81,33 @@ describe("Textbox", () => {
         ).toBe(true);
       }
     );
+
+    describe("overriding the tooltip position", () => {
+      it.each([
+        ["top", true],
+        ["bottom", true],
+        ["left", true],
+        ["top", false],
+        ["bottom", false],
+        ["left", false],
+      ])(
+        "should pass the expected value rather than the default ('right')",
+        (tooltipPosition, onLabel) => {
+          const wrapper = mount(
+            <Textbox
+              label="Label"
+              error="Message"
+              validationOnLabel={onLabel}
+              tooltipPosition={tooltipPosition}
+            />
+          );
+
+          const { position } = wrapper.find(Tooltip).props();
+
+          expect(position).toEqual(tooltipPosition);
+        }
+      );
+    });
   });
 
   describe("when the prefix prop is set", () => {

--- a/src/components/textbox/textbox.stories.mdx
+++ b/src/components/textbox/textbox.stories.mdx
@@ -211,6 +211,29 @@ For more information check our [Validations](?path=/docs/documentation-validatio
   </Story>
 </Preview>
 
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - component"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() =>
+      ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-component`}>
+          <Textbox
+            label="Textbox"
+            value="Textbox"
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="bottom"
+          />
+        </div>
+      ))
+    }
+  </Story>
+</Preview>
+
 #### As a string, displayed on label
 
 <Preview>
@@ -232,6 +255,30 @@ For more information check our [Validations](?path=/docs/documentation-validatio
             readOnly
             {...{ [validationType]: "Message" }}
             mb={2}
+          />
+        </div>
+      ))
+    }
+  </Story>
+</Preview>
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Preview>
+  <Story
+    name="validations - string - with tooltipPosition overriden - label"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() =>
+      ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-label`}>
+          <Textbox
+            label="Textbox"
+            value="Textbox"
+            validationOnLabel
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="bottom"
           />
         </div>
       ))


### PR DESCRIPTION
fixes #3864
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
- Adds new `TooltipContext` and `TooltipProvider` component. The intention is that this will help to
avoid prop chaining tooltip props from root to a component composed lower in the tree
- Adds support for overriding the `tooltipPosition` via context to `Icon `component. This will prevent prop chaining the
value down several levels to the `Icon`
- Adds `TooltipProvider` and surfaces `tooltipPosition` prop in `Textbox` and `Textarea`
- Adds examples of functionality to `Textbox` based components
- `RadioButton` `Checkbox` and `Switch` integrates `TooltipProvider` and surfaces `tooltipPosition` prop

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No support fro overriding default tooltip position for icons rendered as part of inputs

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
Default position:
![image](https://user-images.githubusercontent.com/44157880/129346664-ff4e6762-defd-438e-8d97-a1c5c13ab15d.png)

Override:
![image](https://user-images.githubusercontent.com/44157880/129346712-fbea9919-4723-4b4a-9a71-e5e2ff01385e.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-g4spg?file=/src/index.js for select components

Stories added:
`design-system-radiobutton--with-validations-on-buttons-tooltip-position-overriden`
`design-system-radiobutton--with-validations-on-group-tooltip-position-overriden`
`design-system-numeral-date--overriding-tooltip-position`
`design-system-date-input--validations-string-with-tooltip-position-overriden-component`
`design-system-date-input--validations-string-with-tooltip-position-overriden-label`
`design-system-date-range--validations-string-with-tooltip-position-overriden-component`
`design-system-date-range--validations-string-with-tooltip-position-overriden-label`
`design-system-checkbox-validations--single-checkbox-with-tooltip-position-overriden-string-validation`
`design-system-checkbox-validations--group-checkbox-with-tooltip-position-overriden-string-validation`
`design-system-switch--single-switch-string-validation-tooltip-position-overriden`
`design-system-switch--single-switch-string-validation-validation-on-label-tooltip-position-overriden`
`design-system-textarea--validations-string-with-tooltip-position-overriden-component`
`design-system-textarea--validations-string-with-tooltip-position-overridern-label`
`design-system-textbox--validations-string-with-tooltip-position-overriden-component`
`design-system-textbox--validations-string-with-tooltip-position-overriden-label`
`groupedcharacter--validations-string-with-tooltip-position-overriden-component`
`groupedcharacter--validations-string-with-tooltip-position-overriden-label`
`decimal-input--validations-string-with-tooltip-position-overriden-component`
`decimal-input--validations-string-with-tooltip-position-overriden-label`
`number-input--validations-string-with-tooltip-position-overriden-component`
`number-input--validations-string-with-tooltip-position-overriden-label`