### PR TITLE
fix(date-picker): month could not be changed in datepicker - FE-4274

### DIFF
--- a/cypress/features/regression/designSystem/dateInput.feature
+++ b/cypress/features/regression/designSystem/dateInput.feature
@@ -81,3 +81,27 @@ Feature: Design System Date Input component
       | position | nameOfObject |
       | bottom   | small        |
       | top      | large        |
+
+  @positive
+  Scenario Outline: Verify that <month> month is shown after navigation via arrows in DayPicker
+    Given I open default "Design System Date Input Test" component in noIFrame with "dateInput" json from "designSystem" using "default" object name
+      And I set dateInput to today
+      And I click dateInput
+    When I click "<arrow>" arrow
+    Then "<month>" month is shown in dayPicker
+    Examples:
+      | arrow         | month    |
+      | chevron_right | next     |
+      | chevron_left  | previous |
+
+  @positive
+  Scenario Outline: Verify that <month> month is shown after navigation via keyboard <keyboardKey> key in DayPicker
+    Given I open default "Design System Date Input Test" component in noIFrame with "dateInput" json from "designSystem" using "default" object name
+      And I set dateInput to today
+      And I click dateInput
+    When I press "<arrow>" key on focused "<keyboardKey>" arrow of dayPicker
+    Then "<month>" month is shown in dayPicker
+    Examples:
+      | arrow         | month    | keyboardKey |
+      | chevron_right | next     | rightarrow  |
+      | chevron_left  | previous | leftarrow   |

--- a/cypress/locators/date-input/index.js
+++ b/cypress/locators/date-input/index.js
@@ -1,14 +1,9 @@
 import {
-  MIN_DATE,
-  MAX_DATE,
   DATE_INPUT,
   DATE_ICON,
   DAY_PICKER_WRAPPER,
+  DAY_PICKER_HEADING,
 } from "./locators";
-
-// knobs locators
-export const minDate = () => cy.get(MIN_DATE);
-export const maxDate = () => cy.get(MAX_DATE);
 
 // component preview locators
 export const dateInput = () => cy.get(DATE_INPUT);
@@ -19,3 +14,4 @@ export const dateIcon = () => cy.get(DATE_ICON);
 export const dayPickerWrapper = () => cy.get(DAY_PICKER_WRAPPER);
 export const dayPickerParentNoIFrame = () =>
   cy.get(DAY_PICKER_WRAPPER).parent().parent();
+export const dayPickerHeading = () => cy.get(DAY_PICKER_HEADING).children();

--- a/cypress/locators/date-input/locators.js
+++ b/cypress/locators/date-input/locators.js
@@ -1,8 +1,5 @@
-// knobs locators
-export const MIN_DATE = 'textarea[name="minDate"]';
-export const MAX_DATE = 'textarea[name="maxDate"]';
-
 // component preview locators
 export const DATE_INPUT = '[data-element="input"]';
 export const DATE_ICON = 'span[data-component="icon"][data-element="calendar"]';
 export const DAY_PICKER_WRAPPER = 'div[class="DayPicker-wrapper"]';
+export const DAY_PICKER_HEADING = ".DayPicker-Caption";

--- a/cypress/support/step-definitions/date-input-steps.js
+++ b/cypress/support/step-definitions/date-input-steps.js
@@ -1,13 +1,14 @@
+import { getDataElementByValue } from "../../locators";
 import {
   dateInput,
   dayPickerDay,
-  minDate,
-  maxDate,
   dayPickerWrapper,
   dateIcon,
   dateInputNoIFrame,
   dayPickerParentNoIFrame,
+  dayPickerHeading,
 } from "../../locators/date-input/index";
+import { keyCode } from "../helper";
 
 const DAY_PICKER_PREFIX = "DayPicker-Day--";
 const TODAY_CALENDAR = Cypress.dayjs().format("ddd D MMM YYYY");
@@ -17,19 +18,14 @@ const YESTERDAY_CALENDAR = Cypress.dayjs()
 const TOMORROW_CALENDAR = Cypress.dayjs()
   .add(1, "days")
   .format("ddd D MMM YYYY");
-const TODAY_KNOBS = Cypress.dayjs().format("YYYY-MM-DD");
 const TODAY_DATE_INPUT = Cypress.dayjs().format("DD/MM/YYYY");
+const NEXT_MONTH = Cypress.dayjs().add(1, "months").format("MMMM YYYY");
+const PREVIOUS_MONTH = Cypress.dayjs()
+  .subtract(1, "months")
+  .format("MMMM YYYY");
 
 When("I set dateInput to today", () => {
   dateInput().clear().type(TODAY_DATE_INPUT);
-});
-
-When("I set minDate to today", () => {
-  minDate().clear().type(TODAY_KNOBS);
-});
-
-When("I set maxDate to today", () => {
-  maxDate().clear().type(TODAY_KNOBS);
 });
 
 Then("the date before minDate is not available", () => {
@@ -107,3 +103,25 @@ Then("Date input is visible at the {word}", (position) => {
     .should("have.attr", "data-popper-placement", `${position}-start`)
     .and("be.visible");
 });
+
+When("I click {string} arrow", (monthArrow) => {
+  getDataElementByValue(monthArrow).click();
+});
+
+Then("{string} month is shown in dayPicker", (whichMonth) => {
+  if (whichMonth === "next") {
+    dayPickerHeading().should("have.text", NEXT_MONTH);
+  } else if (whichMonth === "previous") {
+    dayPickerHeading().should("have.text", PREVIOUS_MONTH);
+  } else {
+    throw new Error("Only Next or Previous month can be applied");
+  }
+});
+
+When(
+  "I press {string} key on focused {string} arrow of dayPicker",
+  (monthArrow, key) => {
+    dayPickerWrapper().focus();
+    getDataElementByValue(monthArrow).trigger("keydown", keyCode(key));
+  }
+);

--- a/src/components/date/date-picker.component.js
+++ b/src/components/date/date-picker.component.js
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
 import LocaleUtils from "react-day-picker/moment";
 import DayPicker from "react-day-picker";
+import isEqual from "lodash/isEqual";
 
 import Popover from "../../__internal__/popover";
 import DateHelper from "../../utils/helpers/date/date";
@@ -20,9 +21,17 @@ const DatePicker = ({
   disablePortal,
 }) => {
   const l = useLocale();
+  const locale = l.locale();
+  const formats = l.date.formats.inputs();
+  const format = l.date.formats.javascript();
   const [lastValidDate, setLastValidDate] = useState(
     DateHelper.formatDateString(new Date().toString())
   );
+  const [localeData, setLocaleData] = useState({
+    locale,
+    formats,
+    format,
+  });
   const ref = useRef(null);
 
   const popoverModifiers = useMemo(
@@ -43,11 +52,27 @@ const DatePicker = ({
     []
   );
 
-  const localeData = {
-    locale: l.locale(),
-    formats: l.date.formats.inputs(),
-    format: l.date.formats.javascript(),
-  };
+  useEffect(() => {
+    if (
+      localeData.format === format &&
+      isEqual(localeData.formats, formats) &&
+      localeData.locale === locale
+    ) {
+      return;
+    }
+    setLocaleData({
+      locale,
+      formats,
+      format,
+    });
+  }, [
+    localeData.format,
+    localeData.formats,
+    localeData.locale,
+    format,
+    formats,
+    locale,
+  ]);
 
   useEffect(() => {
     let monthDate;

--- a/src/components/date/date-picker.spec.js
+++ b/src/components/date/date-picker.spec.js
@@ -20,14 +20,6 @@ const secondDate = "2019-02-08";
 const invalidDate = "2019-02-";
 const noDate = "";
 const currentDate = moment().toDate();
-const wrappingComponent = (props) => (
-  <I18nProvider
-    {...props}
-    locale={{
-      locale: () => "fr-FR",
-    }}
-  />
-);
 
 describe("DatePicker", () => {
   let wrapper;
@@ -225,21 +217,32 @@ describe("StyledDayPicker", () => {
   describe("i18n", () => {
     describe("translation", () => {
       it("renders properly", () => {
-        const wrapper = render(
-          {
-            inputDate: firstDate,
-            selectedDate: new Date("2019-04-01"),
+        const wrapper = renderI18n({
+          inputDate: firstDate,
+          selectedDate: new Date("2019-04-01"),
+          locale: {
+            locale: () => "fr-FR",
           },
-          mount,
-          {
-            wrappingComponent,
-          }
-        );
+        });
         expect(wrapper.find(DayPicker).props().locale).toBe("fr-FR");
+        wrapper.setProps({
+          locale: {
+            locale: () => "en-GB",
+          },
+        });
+        expect(wrapper.find(DayPicker).props().locale).toBe("en-GB");
       });
     });
   });
 });
+
+function renderI18n({ locale, ...props }) {
+  return mount(
+    <I18nProvider locale={locale}>
+      <DatePicker inputElement={inputElement} {...props} />
+    </I18nProvider>
+  );
+}
 
 function render(props, renderer = shallow, params) {
   return renderer(


### PR DESCRIPTION
### Proposed behaviour
Fixed useEffect

### Current behaviour
Unable to move between months using the DateInput's arrows
https://codesandbox.io/s/stupefied-pine-nsmpq
https://www.loom.com/share/fd66ea73983748cd86d11286379e2e46

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
Resolves #4307

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-1tciy