### PR TITLE
feat(sidebar): implement ref forwarding

### DIFF
--- a/src/components/sidebar/index.d.ts
+++ b/src/components/sidebar/index.d.ts
@@ -1,1 +1,1 @@
-export { default } from "./sidebar";
+export { default, SidebarContext } from "./sidebar";

--- a/src/components/sidebar/sidebar.component.js
+++ b/src/components/sidebar/sidebar.component.js
@@ -11,76 +11,80 @@ import Box from "../box";
 
 export const SidebarContext = React.createContext({});
 
-const Sidebar = ({
-  open,
-  disableEscKey,
-  enableBackgroundUI,
-  header,
-  position,
-  size,
-  children,
-  onCancel,
-  ...rest
-}) => {
-  const sideBarRef = useRef();
+const Sidebar = React.forwardRef(
+  (
+    {
+      open,
+      disableEscKey,
+      enableBackgroundUI,
+      header,
+      position,
+      size,
+      children,
+      onCancel,
+      ...rest
+    },
+    ref
+  ) => {
+    const sidebarRef = ref || useRef();
+    const closeIcon = () => {
+      if (!onCancel) return null;
+      return (
+        <IconButton aria-label="close" onAction={onCancel} data-element="close">
+          <Icon type="close" />
+        </IconButton>
+      );
+    };
 
-  const closeIcon = () => {
-    if (!onCancel) return null;
-    return (
-      <IconButton aria-label="close" onAction={onCancel} data-element="close">
-        <Icon type="close" />
-      </IconButton>
-    );
-  };
+    const componentTags = {
+      "data-component": "sidebar",
+      "data-element": rest["data-element"],
+      "data-role": rest["data-role"],
+    };
 
-  const componentTags = {
-    "data-component": "sidebar",
-    "data-element": rest["data-element"],
-    "data-role": rest["data-role"],
-  };
-
-  const sidebar = (
-    <SidebarStyle
-      ref={sideBarRef}
-      position={position}
-      size={size}
-      data-element="sidebar"
-      role="complementary"
-      onCancel={onCancel}
-    >
-      {closeIcon()}
-      {header && <SidebarHeader>{header}</SidebarHeader>}
-      <Box
-        data-element="sidebar-content"
-        p={4}
-        pt="27px"
-        scrollVariant="light"
-        overflow="auto"
+    const sidebar = (
+      <SidebarStyle
+        ref={sidebarRef}
+        position={position}
+        size={size}
+        data-element="sidebar"
+        role="complementary"
+        onCancel={onCancel}
       >
-        <SidebarContext.Provider value={{ isInSidebar: true }}>
-          {children}
-        </SidebarContext.Provider>
-      </Box>
-    </SidebarStyle>
-  );
+        {closeIcon()}
+        {header && <SidebarHeader>{header}</SidebarHeader>}
+        <Box
+          data-element="sidebar-content"
+          p={4}
+          pt="27px"
+          scrollVariant="light"
+          overflow="auto"
+        >
+          <SidebarContext.Provider value={{ isInSidebar: true }}>
+            {children}
+          </SidebarContext.Provider>
+        </Box>
+      </SidebarStyle>
+    );
 
-  return (
-    <Modal
-      open={open}
-      onCancel={onCancel}
-      disableEscKey={disableEscKey}
-      enableBackgroundUI={enableBackgroundUI}
-      className="carbon-sidebar"
-      {...componentTags}
-    >
-      {enableBackgroundUI ? (
-        sidebar
-      ) : (
-        <FocusTrap wrapperRef={sideBarRef}>{sidebar}</FocusTrap>
-      )}
-    </Modal>
-  );
-};
+    return (
+      <Modal
+        open={open}
+        onCancel={onCancel}
+        disableEscKey={disableEscKey}
+        enableBackgroundUI={enableBackgroundUI}
+        className="carbon-sidebar"
+        {...componentTags}
+      >
+        {enableBackgroundUI ? (
+          sidebar
+        ) : (
+          <FocusTrap wrapperRef={sidebarRef}>{sidebar}</FocusTrap>
+        )}
+      </Modal>
+    );
+  }
+);
 
 Sidebar.propTypes = {
   /** Modal content */

--- a/src/components/sidebar/sidebar.d.ts
+++ b/src/components/sidebar/sidebar.d.ts
@@ -18,4 +18,5 @@ export interface SidebarProps extends ModalProps {
 declare const SidebarContext: React.Context<SidebarContextProps>;
 declare class Sidebar extends Modal<SidebarProps> {}
 
+export { SidebarContext };
 export default Sidebar;

--- a/src/components/sidebar/sidebar.d.ts
+++ b/src/components/sidebar/sidebar.d.ts
@@ -23,7 +23,7 @@ export interface SidebarProps {
 declare const SidebarContext: React.Context<SidebarContextProps>;
 
 declare function Sidebar(
-  props: SidebarProps
+  props: SidebarProps & React.RefAttributes<HTMLDivElement>
 ): JSX.Element;
 
 export { SidebarContext };

--- a/src/components/sidebar/sidebar.d.ts
+++ b/src/components/sidebar/sidebar.d.ts
@@ -1,14 +1,19 @@
 import * as React from "react";
-import Modal, { ModalProps } from "../modal/modal";
 
 export interface SidebarContextProps {
   isInSidebar: boolean;
 }
-export interface SidebarProps extends ModalProps {
+export interface SidebarProps {
+  /** Determines if the Esc Key closes the modal */
+  disableEscKey?: boolean;
   /** Set this prop to false to hide the translucent background when the dialog is open. */
   enableBackgroundUI?: boolean;
   /** Node that will be used as sidebar header. */
   header?: React.ReactNode;
+  /** A custom close event handler */
+  onCancel?: (ev: React.KeyboardEvent<HTMLElement>) => void;
+  /** Sets the open state of the modal */
+  open: boolean;
   /** Sets the position of sidebar, either left or right. */
   position?: string;
   /** Sets the size of the sidebar when open. */
@@ -16,7 +21,10 @@ export interface SidebarProps extends ModalProps {
 }
 
 declare const SidebarContext: React.Context<SidebarContextProps>;
-declare class Sidebar extends Modal<SidebarProps> {}
+
+declare function Sidebar(
+  props: SidebarProps
+): JSX.Element;
 
 export { SidebarContext };
 export default Sidebar;

--- a/src/components/sidebar/sidebar.spec.js
+++ b/src/components/sidebar/sidebar.spec.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import { mount } from "enzyme";
 import Sidebar from "./sidebar.component";
 import Textbox from "../textbox";
@@ -170,5 +170,23 @@ describe("SidebarStyle", () => {
         wrapper
       );
     });
+  });
+
+  it("the sidebar ref should be forwarded", () => {
+    let mockRef;
+
+    const WrapperComponent = () => {
+      mockRef = useRef();
+
+      return (
+        <Sidebar open ref={mockRef}>
+          test content
+        </Sidebar>
+      );
+    };
+
+    const wrapper = mount(<WrapperComponent />);
+
+    expect(mockRef.current).toBe(wrapper.find(SidebarStyle).getDOMNode());
   });
 });


### PR DESCRIPTION
### Proposed behaviour
Sidebar component should be wrapped in a `forwardRef` to allow access to underlying html element.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
~~- [ ] Cypress automation tests added or updated if required~~
~~- [ ] Storybook added or updated if required~~
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent