### PR TITLE
docs(translation-keys-table): add util to support rendering translation keys in storybook FE-4159

### DIFF
--- a/.storybook/utils/translation-keys-table.js
+++ b/.storybook/utils/translation-keys-table.js
@@ -1,0 +1,31 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { ArgsTable } from "@storybook/components";
+
+const generateTranslationRows = (translationData) => {
+  return translationData.map(({ name, description, type, returnType }) => ({
+    name: name,
+    description,
+    type: {
+      summary: type,
+      detail: `expects ${returnType} to be returned`,
+    },
+  }));
+};
+
+const TranslationKeysTable = ({ translationData }) => (
+  <ArgsTable rows={generateTranslationRows(translationData)} />
+);
+
+TranslationKeysTable.propTypes = {
+  translationData: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired,
+      returnType: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+};
+
+export default TranslationKeysTable;

--- a/src/components/i18n-provider/i18n-provider.component.js
+++ b/src/components/i18n-provider/i18n-provider.component.js
@@ -81,6 +81,20 @@ I18nProvider.propTypes = {
     table: PropTypes.shape({
       noData: PropTypes.func,
     }),
+    textEditor: PropTypes.shape({
+      tooltipMessages: PropTypes.shape({
+        bold: PropTypes.func,
+        italic: PropTypes.func,
+        bulletList: PropTypes.func,
+        numberList: PropTypes.func,
+      }),
+      ariaLabels: PropTypes.shape({
+        bold: PropTypes.func,
+        italic: PropTypes.func,
+        bulletList: PropTypes.func,
+        numberList: PropTypes.func,
+      }),
+    }),
     titleSelect: PropTypes.shape({
       deselect: PropTypes.func,
     }),

--- a/src/components/i18n-provider/i18n-provider.d.ts
+++ b/src/components/i18n-provider/i18n-provider.d.ts
@@ -65,6 +65,20 @@ export interface I18nProviderProps {
     table: {
       noData: () => string;
     };
+    textEditor: {
+      tooltipMessages: {
+        bold: () => string;
+        italic: () => string;
+        bulletList: () => string;
+        numberList: () => string;
+      };
+      ariaLabels: {
+        bold: () => string;
+        italic: () => string;
+        bulletList: () => string;
+        numberList: () => string;
+      };
+    };
     titleSelect: {
       deselect: () => string;
     };

--- a/src/components/text-editor/__internal__/toolbar/toolbar.component.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.component.js
@@ -9,6 +9,7 @@ import ToolbarButton from "./toolbar-button";
 import Events from "../../../../utils/helpers/events/events";
 import Icon from "../../../icon";
 import Tooltip from "../../../tooltip";
+import useLocale from "../../../../hooks/__internal__/useLocale";
 
 const BOLD = "BOLD";
 const ITALIC = "ITALIC";
@@ -22,6 +23,8 @@ const Toolbar = ({
   setBlockStyle,
   setInlineStyle,
 }) => {
+  const { textEditor } = useLocale();
+  const { tooltipMessages, ariaLabels } = textEditor;
   const controlRefs = [useRef(), useRef(), useRef(), useRef()];
   const [focusIndex, setFocusIndex] = useState(0);
   const [tabbable, setTabbable] = useState(true);
@@ -104,11 +107,11 @@ const Toolbar = ({
       <StyledEditorStyleControls>
         <Tooltip
           isVisible={activeTooltip === "Bold"}
-          message="Bold"
+          message={tooltipMessages.bold()}
           position="top"
         >
           <ToolbarButton
-            ariaLabel="bold"
+            ariaLabel={ariaLabels.bold()}
             onKeyDown={(ev) => handleKeyDown(ev, BOLD)}
             onMouseDown={(ev) => handleInlineStyleChange(ev, BOLD)}
             activated={activeControls.BOLD}
@@ -124,11 +127,11 @@ const Toolbar = ({
         </Tooltip>
         <Tooltip
           isVisible={activeTooltip === "Italic"}
-          message="Italic"
+          message={tooltipMessages.italic()}
           position="top"
         >
           <ToolbarButton
-            ariaLabel="italic"
+            ariaLabel={ariaLabels.italic()}
             onKeyDown={(ev) => handleKeyDown(ev, ITALIC)}
             onMouseDown={(ev) => handleInlineStyleChange(ev, ITALIC)}
             activated={activeControls.ITALIC}
@@ -144,11 +147,11 @@ const Toolbar = ({
         </Tooltip>
         <Tooltip
           isVisible={activeTooltip === "Bulleted List"}
-          message="Bulleted List"
+          message={tooltipMessages.bulletList()}
           position="top"
         >
           <ToolbarButton
-            ariaLabel="bullet-list"
+            ariaLabel={ariaLabels.bulletList()}
             onKeyDown={(ev) => handleKeyDown(ev, UNORDERED_LIST)}
             onMouseDown={(ev) => handleBlockType(ev, UNORDERED_LIST)}
             activated={activeControls[UNORDERED_LIST]}
@@ -164,11 +167,11 @@ const Toolbar = ({
         </Tooltip>
         <Tooltip
           isVisible={activeTooltip === "Numbered List"}
-          message="Numbered List"
+          message={tooltipMessages.numberList()}
           position="top"
         >
           <ToolbarButton
-            ariaLabel="number-list"
+            ariaLabel={ariaLabels.numberList()}
             onKeyDown={(ev) => handleKeyDown(ev, ORDERED_LIST)}
             onMouseDown={(ev) => handleBlockType(ev, ORDERED_LIST)}
             activated={activeControls[ORDERED_LIST]}

--- a/src/components/text-editor/text-editor.stories.mdx
+++ b/src/components/text-editor/text-editor.stories.mdx
@@ -7,6 +7,7 @@ import TextEditor, {
 import Button from "../button";
 import EditorLinkPreview from "../link-preview";
 import StyledSystemProps from '../../../.storybook/utils/styled-system-props';
+import TranslationKeys from '../../../.storybook/utils/translation-keys-table';
 
 <Meta
   title="Design System/Text Editor"
@@ -337,4 +338,65 @@ icon. This example has mocked some functionality: previews will display for any 
   of={TextEditor}
   margin
   noHeader
+/>
+
+## Translation keys
+
+It is possible to override the default translations for the Toolbar controls by passing in a custom locale object to the 
+[I18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page). Within this custom locale object you should 
+define a `textEditor` object with `ariaLabels` and `tooltipMessages` properties, these in turn should have the properties 
+defined in the table below as functions that return the desired translation strings.
+
+<TranslationKeys
+  translationData={
+    [
+      {
+        name: "ariaLabels.bold",
+        type: "func",
+        description: "text to be read out by a screen reader when bold toolbar button is navigated to",
+        returnType: "string"
+      },
+      {
+        name: "ariaLabels.italic",
+        type: "func",
+        description: "text to be read out by a screen reader when italic toolbar button is navigated to",
+        returnType: "string"
+      },
+      {
+        name: "ariaLabels.bulletList",
+        type: "func",
+        description: "text to be read out by a screen reader when bullet list toolbar button is navigated to",
+        returnType: "string"
+      },
+      {
+        name: "ariaLabels.numberList",
+        type: "func",
+        description: "text to be read out by a screen reader when number list toolbar button is navigated to",
+        returnType: "string"
+      },
+      {
+        name: "tooltipMessages.bold",
+        type: "func",
+        description: "visible when the user hovers over the bold toolbar button",
+        returnType: "string"
+      },
+      {
+        name: "tooltipMessages.italic",
+        type: "func",
+        description: "visible when the user hovers over the italic toolbar button",
+        returnType: "string"
+      },
+      {
+        name: "tooltipMessages.bulletList",
+        type: "func",
+        description: "visible when the user hovers over the bullet list toolbar button",
+        returnType: "string"
+      },
+      {
+        name: "tooltipMessages.numberList",
+        type: "func",
+        description: "visible when the user hovers over the number list toolbar button",
+        returnType: "string"
+      },
+    ]}
 />

--- a/src/locales/en-gb.js
+++ b/src/locales/en-gb.js
@@ -146,6 +146,20 @@ export default {
   table: {
     noData: () => "No results to display",
   },
+  textEditor: {
+    tooltipMessages: {
+      bold: () => "Bold",
+      italic: () => "Italic",
+      bulletList: () => "Bulleted List",
+      numberList: () => "Numbered List",
+    },
+    ariaLabels: {
+      bold: () => "bold",
+      italic: () => "italic",
+      bulletList: () => "bullet-list",
+      numberList: () => "number-list",
+    },
+  },
   tileSelect: {
     deselect: () => "Deselect",
   },


### PR DESCRIPTION
fix #4121

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->

Adds util to support generating translation key tables in storybook

Adds `textEditor` object to `en-gb.js` locale file with `tooltipMessages` and `ariaLabels`
properties. This will support implementation teams in overriding the default translations for the
`ToolbarButton`'s Tooltip and the `ariaLabel` using their own locale object and the `I18nProvider`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No util for generating translation key tables exists
No support for translation overriding in `TextEditor`
### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/129580119-62f498cc-1457-416a-b058-e2645e477b86.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-xgvtj?file=/src/index.js