### PR TITLE
fix(focus-trap): add mutation observer

### DIFF
--- a/src/__internal__/focus-trap/focus-trap.component.js
+++ b/src/__internal__/focus-trap/focus-trap.component.js
@@ -1,4 +1,4 @@
-import {
+import React, {
   useCallback,
   useContext,
   useEffect,
@@ -23,6 +23,7 @@ const FocusTrap = ({
   bespokeTrap,
   wrapperRef,
 }) => {
+  const trapRef = useRef(null);
   const firstOpen = useRef(true);
   const [focusableElements, setFocusableElements] = useState();
   const [firstElement, setFirstElement] = useState();
@@ -39,7 +40,7 @@ const FocusTrap = ({
     [focusableElements]
   );
 
-  useLayoutEffect(() => {
+  const updateFocusableElements = useCallback(() => {
     if (wrapperRef) {
       const ref = wrapperRef.current;
 
@@ -53,7 +54,26 @@ const FocusTrap = ({
         setLastElement(elements[elements.length - 1]);
       }
     }
-  }, [children, hasNewInputs, wrapperRef]);
+  }, [hasNewInputs, wrapperRef]);
+
+  useEffect(() => {
+    const observer = new MutationObserver(function () {
+      updateFocusableElements();
+    });
+
+    observer.observe(trapRef.current, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      characterData: true,
+    });
+
+    return () => observer.disconnect();
+  }, [updateFocusableElements]);
+
+  useLayoutEffect(() => {
+    updateFocusableElements();
+  }, [children, updateFocusableElements]);
 
   useEffect(() => {
     if (
@@ -112,7 +132,7 @@ const FocusTrap = ({
     };
   }, [firstElement, lastElement, focusableElements, bespokeTrap]);
 
-  return children;
+  return <div ref={trapRef}>{children}</div>;
 };
 
 FocusTrap.propTypes = {

--- a/src/__internal__/focus-trap/focus-trap.component.js
+++ b/src/__internal__/focus-trap/focus-trap.component.js
@@ -57,9 +57,7 @@ const FocusTrap = ({
   }, [hasNewInputs, wrapperRef]);
 
   useEffect(() => {
-    const observer = new MutationObserver(function () {
-      updateFocusableElements();
-    });
+    const observer = new MutationObserver(updateFocusableElements);
 
     observer.observe(trapRef.current, {
       subtree: true,

--- a/src/__internal__/focus-trap/focus-trap.spec.js
+++ b/src/__internal__/focus-trap/focus-trap.spec.js
@@ -439,7 +439,9 @@ describe("FocusTrap", () => {
           callback();
         };
       });
-      global.MutationObserver = mutationObserverMock;
+      jest
+        .spyOn(global, "MutationObserver")
+        .mockImplementation(mutationObserverMock);
 
       const ChangingChild = () => {
         const [loading, setLoading] = useState(true);
@@ -482,6 +484,8 @@ describe("FocusTrap", () => {
       expect(document.activeElement).toMatchObject(
         wrapper.find("button").at(0)
       );
+
+      jest.restoreAllMocks();
     });
   });
 });


### PR DESCRIPTION
Fixes: #4255

### Proposed behaviour
Add `MutationObserver` to `FocusTrap` to reset it when something in it's child tree changes.

### Current behaviour
The `FocusTrap` does not reset if it's children changes.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
Sandbox in issue rebuilt with this code in the codesandbox comment below