### PR TITLE
fix(select): option not scrolled using keyboard navigation when options are changed (FE-4244)

### DIFF
--- a/src/components/select/select-list/select-list.component.js
+++ b/src/components/select/select-list/select-list.component.js
@@ -72,15 +72,6 @@ const SelectList = React.forwardRef(
     const tableRef = useRef();
     const listActionButtonRef = useRef();
 
-    const optionRefs = useRef(
-      React.Children.map(children, (child) => {
-        if (child?.type === Option || child?.type === OptionRow) {
-          return React.createRef();
-        }
-        return null;
-      }).filter((child) => child)
-    );
-
     const setPlacementCallback = useCallback(
       (popper) => {
         placement.current = popper.placement;
@@ -98,6 +89,17 @@ const SelectList = React.forwardRef(
     const childrenList = useMemo(() => React.Children.toArray(children), [
       children,
     ]);
+
+    const optionRefList = useMemo(
+      () =>
+        React.Children.map(children, (child) => {
+          if (child?.type === Option || child?.type === OptionRow) {
+            return React.createRef();
+          }
+          return null;
+        }).filter((child) => child),
+      [children]
+    );
 
     const lastOptionIndex = useMemo(() => {
       let lastIndex = 0;
@@ -263,13 +265,19 @@ const SelectList = React.forwardRef(
             onSelect: handleSelect,
             isHighlighted: currentOptionsListIndex === index,
             hidden: isLoading && React.Children.count(children) === 1,
-            ref: optionRefs.current[index],
+            ref: optionRefList[index],
           };
 
           return React.cloneElement(child, newProps);
         }),
 
-      [children, currentOptionsListIndex, handleSelect, isLoading]
+      [
+        children,
+        currentOptionsListIndex,
+        handleSelect,
+        isLoading,
+        optionRefList,
+      ]
     );
 
     const assignListWidth = useCallback(() => {
@@ -338,12 +346,19 @@ const SelectList = React.forwardRef(
         updateListScrollTop(
           indexOfMatch,
           multiColumn ? tableRef.current : listRef.current,
-          optionRefs.current
+          optionRefList
         );
 
         return indexOfMatch;
       });
-    }, [childrenList, filterText, getIndexOfMatch, lastFilter, multiColumn]);
+    }, [
+      childrenList,
+      filterText,
+      getIndexOfMatch,
+      lastFilter,
+      multiColumn,
+      optionRefList,
+    ]);
 
     useEffect(() => {
       if (!highlightedValue) {
@@ -355,9 +370,15 @@ const SelectList = React.forwardRef(
       updateListScrollTop(
         indexOfMatch,
         multiColumn ? tableRef.current : listRef.current,
-        optionRefs.current
+        optionRefList
       );
-    }, [childrenList, getIndexOfMatch, highlightedValue, multiColumn]);
+    }, [
+      childrenList,
+      getIndexOfMatch,
+      highlightedValue,
+      multiColumn,
+      optionRefList,
+    ]);
 
     useEffect(() => {
       if (isLoading && currentOptionsListIndex === lastOptionIndex) {

--- a/src/components/select/select-list/update-list-scroll.js
+++ b/src/components/select/select-list/update-list-scroll.js
@@ -1,5 +1,9 @@
 export default function updateListScrollTop(indexOfCurrent, list, options) {
-  if (!list || !options[indexOfCurrent]) {
+  if (
+    !list ||
+    !options[indexOfCurrent] ||
+    options[indexOfCurrent].current === null
+  ) {
     list.scrollTop = 0;
 
     return;

--- a/src/components/select/select-list/update-list-scroll.spec.js
+++ b/src/components/select/select-list/update-list-scroll.spec.js
@@ -35,6 +35,17 @@ describe("updateListScrollTop", () => {
       });
     });
 
+    describe("and the option ref is null", () => {
+      it("should change the scrollTop property of that list to 0", () => {
+        const itemIndex = 0;
+
+        list.scrollTop = 500;
+        updateListScrollTop(itemIndex, list, [{ current: null }]);
+
+        expect(list.scrollTop).toBe(0);
+      });
+    });
+
     describe("and the combined items height is less than the list height", () => {
       it("should change the scrollTop property of that list to 0", () => {
         const itemIndex = 2;


### PR DESCRIPTION
### Proposed behaviour
Container is not scrolled because the option ref is pointing to an incorrect ref.
Option ref list should be updated every time the option list is changed, so the proper ref is pointed when traversing options with keyboard.

### Current behaviour
When the option list is dynamically loaded, traversing it with keyboard does not scroll the container to show current option.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
~~- [ ] Cypress automation tests added or updated if required~~
~~- [ ] Storybook added or updated if required~~
~~- [ ] Typescript `d.ts` file added or updated if required~~
~~- [ ] Carbon implementation and Design System documentation are congruent~~

### Additional context
Fixes #4270
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
1. run npm start
2. open http://localhost:9001/?path=/story/design-system-select--with-is-loading-prop
3. traverse the list with keyboard
4. repeat for http://localhost:9001/?path=/story/design-system-select--with-infinite-scroll
5. do the same for FilterableSelect