### PR TITLE
docs(menu): alter story to remove aria false positive

### DIFF
--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -714,7 +714,7 @@ A title attribute is added to the item when using this prop, containing the full
   <Story name="truncated titles">
     <div style={{ minHeight: "150px" }}>
       <Menu>
-        <MenuItem maxWidth="132px" href="#">
+        <MenuItem maxWidth="168px" href="#">
           A long menu item title
         </MenuItem>
         <MenuItem maxWidth="148px" submenu="Menu Item Three">
@@ -722,8 +722,8 @@ A title attribute is added to the item when using this prop, containing the full
             A long submenu menu item title
           </MenuItem>
         </MenuItem>
-        <MenuItem maxWidth="182px" icon="home" href="#">
-          A long menu item title with icon
+        <MenuItem maxWidth="180px" icon="home" href="#">
+          A long menu item title
         </MenuItem>
       </Menu>
     </div>


### PR DESCRIPTION
### Proposed behaviour
Altering a `Menu` story to remove the false positive from the accessibility tests:

![image](https://user-images.githubusercontent.com/14963680/130044687-39bc38d4-3e4c-40b9-9b11-7210ef72d276.png)


### Current behaviour
We currently have a false positive on the `design-system-menu--truncated-titles` story for an "incomplete" test:

![image](https://user-images.githubusercontent.com/14963680/130044851-a1010b5b-6015-4af9-b796-19dbe725e20f.png)


### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Testing instructions
