### PR TITLE
fix: added missing null check to element resize

### DIFF
--- a/src/utils/helpers/element-resize/__spec__.js
+++ b/src/utils/helpers/element-resize/__spec__.js
@@ -16,6 +16,11 @@ describe("ElementResize", () => {
         ElementResize.addListener(null, callback);
         expect(element.__resizeListenerCallbacks__).toEqual(undefined);
       });
+      it("does nothing on removal", () => {
+        expect(() =>
+          ElementResize.removeListener(null, callback)
+        ).not.toThrow();
+      });
     });
     describe("no listener yet set", () => {
       it("creates an object to watch", () => {

--- a/src/utils/helpers/element-resize/element-resize.js
+++ b/src/utils/helpers/element-resize/element-resize.js
@@ -82,6 +82,10 @@ const ElementResize = {
    * @param {Function} fn - the callback
    */
   removeListener: (element, callback) => {
+    if (!element) {
+      return;
+    }
+
     if (element.__resizeListenerCallbacks__) {
       // remove the event listener from the array
       element.__resizeListenerCallbacks__.splice(


### PR DESCRIPTION
The form component uses a throttle function that triggers a call to ElementResize's `removeListener` function. By the time that the function is executed, the element might be removed from the DOM which results an unhandled error.

### Proposed behaviour
ElementResize's `removeListener` function should not throw an error if it is called with a `null` element. This can happen when the `Form` component is placed in a dialog, which gets removed from the DOM.

### Current behaviour
The empty element parameter scenario is not handled in the `removeListener` function (although it is in the `addListener` function) and a "null-pointer" exception is thrown when it is called with a `null` element argument.

### Checklist

- [x] Commits follow our style guide
- N/A Screenshots are included in the PR if useful
- N/A All themes are supported if required
- [x] Unit tests added or updated if required
- N/A Cypress automation tests added or updated if required
- N/A Storybook added or updated if required
- N/A Typescript `d.ts` file added or updated if required
- N/A Carbon implementation and Design System documentation are congruent

### Testing instructions
It is difficult to manually test, I couldn't isolate the issue into a codesandbox repository.