### PR TITLE
fix(filterable-select): list not closed on click outside in Safari (FE-4228)

### DIFF
--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -294,6 +294,7 @@ const FilterableSelect = React.forwardRef(
       if (
         isTextboxActive &&
         textboxRef &&
+        filterText.length &&
         textValue.length > filterText.length &&
         textStartsWithFilter
       ) {

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -351,6 +351,26 @@ describe("FilterableSelect", () => {
     });
   });
 
+  describe("when the filter text is part of the text value", () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = renderSelect({ defaultValue: "opt1" });
+    });
+
+    it("then that text should be selected", () => {
+      const changeEventObject = { target: { value: "gre" } };
+
+      wrapper.find("input").simulate("click");
+      wrapper.find("input").simulate("change", changeEventObject);
+      act(() => {
+        wrapper.find(SelectList).prop("onSelectListClose")();
+      });
+
+      expect(wrapper.find("input").getDOMNode().selectionStart).toBe(3);
+    });
+  });
+
   describe("when the onSelect is called in the open SelectList", () => {
     const navigationKeyOptionObject = {
       value: "Foo",


### PR DESCRIPTION
Safari triggers focus on the input when the text is selected programatically.
Fixed by not selecting the text when the filter is empty.

### Proposed behaviour
FilterableSelect list closed

### Current behaviour
FilterableSelect reopening after typing text not matching any option and clicking outside of the list.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
~~- [ ] Cypress automation tests added or updated if required~~
~~- [ ] Storybook added or updated if required~~
~~- [ ] Typescript `d.ts` file added or updated if required~~
~~- [ ] Carbon implementation and Design System documentation are congruent~~

### Testing instructions
1. run npm start
2. open http://localhost:9001/?path=/story/design-system-select-filterable--open-on-focus
3. type something not matching any option
4. click outside of the list or use the tab key