### PR TITLE
fix(tile-select): ensure title, subtitle and adornment wrap at smaller screen resolution FE-4275

### DIFF
--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -16,6 +16,7 @@ import VerticalDivider from "../vertical-divider";
 import { SageIcon } from "../../../.storybook/welcome-page/footer/footer.style.js";
 import useMediaQuery from "../../hooks/useMediaQuery";
 import Search from "../search";
+import Icon from "../icon";
 
 <Meta title="Design System/Menu" parameters={{ info: { disable: true } }} />
 

--- a/src/components/tile-select/tile-select.component.js
+++ b/src/components/tile-select/tile-select.component.js
@@ -26,6 +26,8 @@ const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
 );
 
+const checkPropTypeIsNode = (prop) => typeof prop !== "string" && { as: "div" };
+
 const TileSelect = ({
   onChange,
   onBlur,
@@ -44,6 +46,7 @@ const TileSelect = ({
   customActionButton,
   actionButtonAdornment,
   footer,
+  prefixAdornment,
   ...rest
 }) => {
   const l = useLocale();
@@ -113,20 +116,17 @@ const TileSelect = ({
         />
         <StyledTileSelect disabled={disabled} checked={checked}>
           <Box display="flex" justifyContent="space-between">
-            <Box>
+            {prefixAdornment && <Box mr={3}>{prefixAdornment}</Box>}
+            <Box flexGrow="1">
               <StyledTitleContainer>
                 {title && (
-                  <StyledTitle
-                    {...(typeof title !== "string" && { as: "div" })}
-                  >
+                  <StyledTitle {...checkPropTypeIsNode(title)}>
                     {title}
                   </StyledTitle>
                 )}
 
                 {subtitle && (
-                  <StyledSubtitle
-                    {...(typeof subtitle !== "string" && { as: "div" })}
-                  >
+                  <StyledSubtitle {...checkPropTypeIsNode(subtitle)}>
                     {subtitle}
                   </StyledSubtitle>
                 )}
@@ -135,9 +135,7 @@ const TileSelect = ({
                   <StyledAdornment>{titleAdornment}</StyledAdornment>
                 )}
               </StyledTitleContainer>
-              <StyledDescription
-                {...(typeof description !== "string" && { as: "div" })}
-              >
+              <StyledDescription {...checkPropTypeIsNode(description)}>
                 {description}
               </StyledDescription>
               {footer && <StyledFooterWrapper>{footer}</StyledFooterWrapper>}
@@ -191,6 +189,8 @@ TileSelect.propTypes = {
   actionButtonAdornment: PropTypes.node,
   /** footer of the TileSelect */
   footer: PropTypes.node,
+  /** Component to render in the top left corner of TileSelect */
+  prefixAdornment: PropTypes.node,
 };
 
 TileSelect.displayName = "TileSelect";

--- a/src/components/tile-select/tile-select.component.js
+++ b/src/components/tile-select/tile-select.component.js
@@ -5,6 +5,7 @@ import styledSystemPropTypes from "@styled-system/prop-types";
 import tagComponent from "../../utils/helpers/tags/tags";
 import useLocale from "../../hooks/__internal__/useLocale";
 import Button from "../button";
+import Box from "../box";
 
 import {
   StyledTileSelectContainer,
@@ -57,11 +58,10 @@ const TileSelect = ({
       },
     });
 
-  const renderActionButton = () => {
-    if (customActionButton) return customActionButton(handleDeselect);
-
-    return (
-      checked && (
+  const renderActionButton = () => (
+    <StyledDeselectWrapper hasActionAdornment={!!actionButtonAdornment}>
+      {customActionButton && customActionButton(handleDeselect)}
+      {!customActionButton && checked && (
         <Button
           buttonType="tertiary"
           size="small"
@@ -70,9 +70,10 @@ const TileSelect = ({
         >
           {l.tileSelect.deselect()}
         </Button>
-      )
-    );
-  };
+      )}
+      {actionButtonAdornment}
+    </StyledDeselectWrapper>
+  );
 
   useEffect(() => {
     if (disabled && hasFocus) {
@@ -111,37 +112,40 @@ const TileSelect = ({
           {...rest}
         />
         <StyledTileSelect disabled={disabled} checked={checked}>
-          <StyledTitleContainer>
-            {title && (
-              <StyledTitle {...(typeof title !== "string" && { as: "div" })}>
-                {title}
-              </StyledTitle>
-            )}
+          <Box display="flex" justifyContent="space-between">
+            <Box>
+              <StyledTitleContainer>
+                {title && (
+                  <StyledTitle
+                    {...(typeof title !== "string" && { as: "div" })}
+                  >
+                    {title}
+                  </StyledTitle>
+                )}
 
-            {subtitle && (
-              <StyledSubtitle
-                {...(typeof subtitle !== "string" && { as: "div" })}
+                {subtitle && (
+                  <StyledSubtitle
+                    {...(typeof subtitle !== "string" && { as: "div" })}
+                  >
+                    {subtitle}
+                  </StyledSubtitle>
+                )}
+
+                {titleAdornment && (
+                  <StyledAdornment>{titleAdornment}</StyledAdornment>
+                )}
+              </StyledTitleContainer>
+              <StyledDescription
+                {...(typeof description !== "string" && { as: "div" })}
               >
-                {subtitle}
-              </StyledSubtitle>
-            )}
-
-            {titleAdornment && (
-              <StyledAdornment>{titleAdornment}</StyledAdornment>
-            )}
-          </StyledTitleContainer>
-          <StyledDescription
-            {...(typeof description !== "string" && { as: "div" })}
-          >
-            {description}
-          </StyledDescription>
-          {footer && <StyledFooterWrapper>{footer}</StyledFooterWrapper>}
+                {description}
+              </StyledDescription>
+              {footer && <StyledFooterWrapper>{footer}</StyledFooterWrapper>}
+            </Box>
+            {(customActionButton || checked) && renderActionButton()}
+          </Box>
         </StyledTileSelect>
       </StyledFocusWrapper>
-      <StyledDeselectWrapper hasActionAdornment={!!actionButtonAdornment}>
-        {renderActionButton()}
-        {actionButtonAdornment}
-      </StyledDeselectWrapper>
     </StyledTileSelectContainer>
   );
 };

--- a/src/components/tile-select/tile-select.d.ts
+++ b/src/components/tile-select/tile-select.d.ts
@@ -34,6 +34,8 @@ export interface TileSelectProps extends MarginProps {
   actionButtonAdornment?: React.ReactNode;
   /** footer of the TileSelect */
   footer?: React.ReactNode;
+  /** Component to render in the top left corner of TileSelect */
+  prefixAdornment?: React.ReactNode;
 }
 
 declare function TileSelect(props: TileSelectProps): JSX.Element;

--- a/src/components/tile-select/tile-select.spec.js
+++ b/src/components/tile-select/tile-select.spec.js
@@ -352,6 +352,21 @@ describe("TileSelect", () => {
       );
     });
   });
+
+  describe("prefixAdornment prop", () => {
+    it("renders the passed in node", () => {
+      const MyComp = () => <div>foo</div>;
+
+      render({
+        checked: true,
+        id: "id",
+        name: "name",
+        prefixAdornment: <MyComp />,
+      });
+
+      expect(wrapper.find(MyComp).exists()).toBeTruthy();
+    });
+  });
 });
 
 describe("TileSelectGroup", () => {

--- a/src/components/tile-select/tile-select.spec.js
+++ b/src/components/tile-select/tile-select.spec.js
@@ -21,6 +21,7 @@ import {
 } from "./tile-select.style";
 import Button from "../button";
 import Icon from "../icon";
+import StyledIcon from "../icon/icon.style";
 import {
   assertStyleMatch,
   testStyledSystemMargin,
@@ -237,6 +238,18 @@ describe("TileSelect", () => {
         wrapper.find(StyledFocusWrapper)
       );
     });
+
+    it("applies correct styles to title container", () => {
+      assertStyleMatch(
+        {
+          display: "inline-flex",
+          alignItems: "baseline",
+          flexWrap: "wrap",
+          marginRight: "16px",
+        },
+        wrapper.find(StyledTitleContainer)
+      );
+    });
   });
 
   describe("customActionButton render prop", () => {
@@ -277,8 +290,11 @@ describe("TileSelect", () => {
       });
 
       expect(
-        wrapper.find(StyledDeselectWrapper).props().children.length
-      ).toEqual(2);
+        wrapper.find(StyledDeselectWrapper).find(Button).exists()
+      ).toBeTruthy();
+      expect(
+        wrapper.find(StyledDeselectWrapper).find(Button).props().children
+      ).toEqual("Deselect");
       expect(
         wrapper.find(StyledDeselectWrapper).find(Icon).exists()
       ).toBeTruthy();
@@ -287,10 +303,18 @@ describe("TileSelect", () => {
         {
           marginRight: "16px",
           display: "flex",
-          alignItems: "center",
+          alignItems: "baseline",
           minHeight: "32px",
         },
         wrapper.find(StyledDeselectWrapper)
+      );
+
+      assertStyleMatch(
+        {
+          top: "2px",
+        },
+        wrapper.find(StyledDeselectWrapper),
+        { modifier: `${StyledIcon}` }
       );
     });
   });

--- a/src/components/tile-select/tile-select.stories.mdx
+++ b/src/components/tile-select/tile-select.stories.mdx
@@ -8,6 +8,7 @@ import Pill from "../pill/";
 import Icon from "../icon";
 import Button from "../button";
 import Box from "../box";
+import Image from "../image";
 import Typography from "../typography";
 
 <Meta
@@ -377,6 +378,10 @@ Same as in multi select example grouped by `TileSelectGroup`, `onChange`, `onBlu
   <Story name="single tile">
     {() => {
       const [isChecked, setIsChecked] = useState(false);
+      const handleChange = (e) => {
+        const { value } = e.target;
+        setIsChecked(value === null ? false : true);
+      };
       return (
         <TileSelect
           value="1"
@@ -387,7 +392,7 @@ Same as in multi select example grouped by `TileSelectGroup`, `onChange`, `onBlu
           subtitle="Subtitle"
           description="Short and descriptive description"
           checked={isChecked}
-          onChange={(e) => setIsChecked(e.target.checked)}
+          onChange={handleChange}
         />
       );
     }}
@@ -402,16 +407,20 @@ To render a `footer` pass anything renderable to the prop like in the example be
   <Story name="with a footer">
     {() => {
       const [isChecked, setIsChecked] = useState(false);
+       const handleChange = (e) => {
+        const { value } = e.target;
+        setIsChecked(value === null ? false : true);
+      };
       return (
         <TileSelect
           value="1"
           id="single-1"
           aria-label="single-1"
           name="single"
-          title="Title"
-          subtitle="Subtitle"
+          title="Title Short and descriptive description"
+          subtitle="Subtitle Short and descriptive description"
           checked={isChecked}
-          onChange={(e) => setIsChecked(e.target.checked)}
+          onChange={handleChange}
           description="Short and descriptive description"
           footer={
             <Box pt={1} display="flex" alignItems="baseline">
@@ -429,6 +438,36 @@ To render a `footer` pass anything renderable to the prop like in the example be
           }
         />
       );
+    }}
+  </Story>
+</Preview>
+
+### With a prefix adornment
+To render a prefixed adornment in the top left corner of the `TileSelect` you can pass any node in via the `prefixAdornment` prop. 
+
+<Preview>
+  <Story name="with a prefix adornment">
+    {() => {
+      const [isChecked, setIsChecked] = useState(false);
+      const handleChange = (e) => {
+        const { value } = e.target;
+        setIsChecked(value === null ? false : true);
+      };
+      return (
+        <TileSelect
+          value="1"
+          id="single-1"
+          aria-label="single-1"
+          name="single"
+          title="Title"
+          subtitle="Subtitle"
+          checked={isChecked}
+          prefixAdornment={<Image height="40px" width="40px" backgroundImage={`url(${require("../../../.assets/flexible.svg")})`} />}
+          titleAdornment={<Pill>Message</Pill>}
+          onChange={handleChange}
+          description="Short and descriptive description"
+        />
+      )
     }}
   </Story>
 </Preview>

--- a/src/components/tile-select/tile-select.style.js
+++ b/src/components/tile-select/tile-select.style.js
@@ -126,6 +126,7 @@ const StyledDeselectWrapper = styled.div`
     position: relative;
     top: -4px;
     right: 8px;
+    height: fit-content;
 
     ${hasActionAdornment &&
     `

--- a/src/components/tile-select/tile-select.style.js
+++ b/src/components/tile-select/tile-select.style.js
@@ -4,6 +4,7 @@ import Fieldset from "../fieldset";
 import { Input } from "../../__internal__/input";
 import tint from "../../style/utils/tint";
 import { LegendContainerStyle } from "../fieldset/fieldset.style";
+import StyledIcon from "../icon/icon.style";
 import { baseTheme } from "../../style/themes";
 
 const StyledTitle = styled.h3`
@@ -11,6 +12,7 @@ const StyledTitle = styled.h3`
   font-weight: 900;
   margin: 0;
   margin-right: 16px;
+  margin-bottom: 8px;
 `;
 
 const StyledSubtitle = styled.h4`
@@ -18,14 +20,12 @@ const StyledSubtitle = styled.h4`
   font-weight: 700;
   margin: 0;
   margin-right: 16px;
+  margin-bottom: 8px;
 `;
 
 const StyledAdornment = styled.div`
-  position: absolute;
-  left: 100%;
-  top: 50%;
-  transform: translateY(-50%);
   z-index: 500;
+  margin-bottom: 8px;
 `;
 
 const StyledDescription = styled.p`
@@ -114,24 +114,29 @@ const StyledTileSelectInput = styled(Input)`
 
 const StyledTitleContainer = styled.div`
   display: inline-flex;
-  align-items: flex-end;
-  margin-bottom: 8px;
+  align-items: baseline;
+  flex-wrap: wrap;
+  margin-right: 16px;
   position: relative;
 `;
 
 const StyledDeselectWrapper = styled.div`
   ${({ hasActionAdornment, theme }) => css`
-    position: absolute;
-    top: ${2 * theme.spacing}px;
-    right: ${theme.spacing}px;
     z-index: 200;
+    position: relative;
+    top: -4px;
+    right: 8px;
 
     ${hasActionAdornment &&
     `
       margin-right: ${2 * theme.spacing}px;
       display: flex;
-      align-items: center;
+      align-items: baseline;
       min-height: ${4 * theme.spacing}px;
+
+      ${StyledIcon} {
+        top: 2px;
+      }
     `}
   `}
 `;


### PR DESCRIPTION
fix #4219

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Adds `flow-wrap` style property to container for `title`, `subtitle` and `adornment` to ensure they
wrap at smaller resolution or if any text is too long. Adds flex `Box` to wrap the the above content
and the action button so they render in correct layout.

Adds `prefixAdornment` prop to allow implementation teams to render a node in the top left corner of
`TileSelect` before other content.

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Content does not wrap (see linked issue)
No support for prefix adornment

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/130652326-76ac8989-0649-4d28-87ce-18c4518a95cd.png)

![image](https://user-images.githubusercontent.com/44157880/130652390-bad6cbac-61f2-49e6-8a0e-b483d28e5941.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
`design-system-tile-select--with-a-prefix-adornment` added.

Demo of wrapping:
https://codesandbox.io/s/eloquent-snyder-6d2gt?file=/src/index.js