### PR TITLE
feat(duelling-picklist): add support for reordering selected items by drag&drop - FE-4120

### DIFF
--- a/src/components/draggable/draggable-container.component.js
+++ b/src/components/draggable/draggable-container.component.js
@@ -101,7 +101,7 @@ DraggableContainer.propTypes = {
   /** Callback fired when order is changed */
   getOrder: PropTypes.func,
   /** Overrides the default rendered HTML tag of the DraggableContainer component */
-  as: PropTypes.string,
+  as: PropTypes.oneOf(["div", "ul"]),
   /**
    * The content of the component
    *

--- a/src/components/draggable/draggable-container.component.js
+++ b/src/components/draggable/draggable-container.component.js
@@ -25,7 +25,7 @@ const DropTarget = ({ children, getOrder, ...rest }) => {
   );
 };
 
-const DraggableContainer = ({ children, getOrder, ...rest }) => {
+const DraggableContainer = ({ children, getOrder, as, ...rest }) => {
   const [draggableItems, setDraggableItems] = useState(
     React.Children.toArray(children)
   );
@@ -75,12 +75,13 @@ const DraggableContainer = ({ children, getOrder, ...rest }) => {
 
   return (
     <DndProvider backend={Backend}>
-      <DropTarget getOrder={getItemsId} {...marginProps}>
+      <DropTarget as={as} getOrder={getItemsId} {...marginProps}>
         {draggableItems.map((item) =>
           React.cloneElement(
             item,
             {
               id: `${item.props.id}`,
+              as: as === "ul" ? "li" : undefined,
               findItem,
               moveItem,
             },
@@ -99,6 +100,8 @@ DraggableContainer.propTypes = {
   ...marginPropTypes,
   /** Callback fired when order is changed */
   getOrder: PropTypes.func,
+  /** Overrides the default rendered HTML tag of the DraggableContainer component */
+  as: PropTypes.string,
   /**
    * The content of the component
    *
@@ -129,5 +132,7 @@ DropTarget.propTypes = {
   children: PropTypes.node.isRequired,
   getOrder: PropTypes.func,
 };
+
+DraggableContainer.displayName = "DraggableContainer";
 
 export default DraggableContainer;

--- a/src/components/draggable/draggable-container.d.ts
+++ b/src/components/draggable/draggable-container.d.ts
@@ -9,7 +9,7 @@ type DraggableContainerChild =
 
 export interface DraggableContainerProps {
   /** Overrides the default rendered HTML tag of the DraggableContainer component */
-  as?: string;
+  as?: "div" | "ul";
   /** Callback fired when order is changed */
   getOrder?: (draggableItemIds: number[]) => void;
   /**

--- a/src/components/draggable/draggable-container.d.ts
+++ b/src/components/draggable/draggable-container.d.ts
@@ -8,6 +8,8 @@ type DraggableContainerChild =
   | undefined;
 
 export interface DraggableContainerProps {
+  /** Overrides the default rendered HTML tag of the DraggableContainer component */
+  as?: string;
   /** Callback fired when order is changed */
   getOrder?: (draggableItemIds: number[]) => void;
   /**

--- a/src/components/draggable/draggable-item.component.js
+++ b/src/components/draggable/draggable-item.component.js
@@ -3,6 +3,7 @@ import { useDrop, useDrag } from "react-dnd";
 import PropTypes from "prop-types";
 import styledSystemPropTypes from "@styled-system/prop-types";
 
+import { CSSTransition } from "react-transition-group";
 import { filterStyledSystemPaddingProps } from "../../style/utils";
 import { StyledDraggableItem } from "./draggable-item.style";
 
@@ -14,6 +15,7 @@ const DraggableItem = ({
   moveItem,
   children,
   py = 1,
+  as,
   ...rest
 }) => {
   const originalIndex = findItem(id).index;
@@ -45,15 +47,18 @@ const DraggableItem = ({
   const paddingProps = filterStyledSystemPaddingProps(rest);
 
   return (
-    <StyledDraggableItem
-      data-element="draggable"
-      isDragging={isDragging}
-      ref={(node) => drag(drop(node))}
-      py={py}
-      {...paddingProps}
-    >
-      {children}
-    </StyledDraggableItem>
+    <CSSTransition in timeout={{ appear: 0 }} classNames="draggable">
+      <StyledDraggableItem
+        data-element="draggable"
+        isDragging={isDragging}
+        ref={(node) => drag(drop(node))}
+        py={py}
+        as={as}
+        {...paddingProps}
+      >
+        {children}
+      </StyledDraggableItem>
+    </CSSTransition>
   );
 };
 
@@ -65,6 +70,8 @@ DraggableItem.propTypes = {
    * Use this prop to make `Draggable` works
    */
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  /** Overrides the default rendered HTML tag of the DraggableItem component */
+  as: PropTypes.string,
   /** The content of the component. */
   children: PropTypes.node.isRequired,
   /**

--- a/src/components/draggable/draggable-item.d.ts
+++ b/src/components/draggable/draggable-item.d.ts
@@ -9,6 +9,8 @@ export interface DraggableItemProps {
   id: number | string;
   /** The content of the component. */
   children: React.ReactNode;
+  /** Overrides the default rendered HTML tag of the DraggableItem component */
+  as?: string;
   findItem?: () => void;
   moveItem?: () => void;
 }

--- a/src/components/draggable/draggable-item.style.js
+++ b/src/components/draggable/draggable-item.style.js
@@ -1,14 +1,69 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { padding, margin } from "styled-system";
-
 import { baseTheme } from "../../style/themes";
 import Icon from "../icon";
 
+const StyledIcon = styled(Icon)`
+  margin-left: auto;
+`;
+
 const StyledDraggableContainer = styled.div`
+  ${({ as }) =>
+    as === "ul" &&
+    css`
+      padding-inline-start: 0;
+      width: 100%;
+      height: 100%;
+      overflow-x: visible;
+      margin: 0;
+      padding-right: 0;
+      ${({ theme }) =>
+        css`
+          scrollbar-color: ${theme.scrollbar.light.thumb}
+            ${theme.scrollbar.light.track};
+
+          &::-webkit-scrollbar {
+            width: 8px;
+          }
+
+          &::-webkit-scrollbar-thumb {
+            background-color: ${theme.scrollbar.light.thumb};
+          }
+
+          &::-webkit-scrollbar-track {
+            background-color: ${theme.scrollbar.light.track};
+          }
+        `}
+
+      ${StyledIcon}:last-of-type {
+        display: none;
+      }
+    `};
   ${margin}
 `;
 
 const StyledDraggableItem = styled.div`
+  ${({ as }) =>
+    as === "li" &&
+    css`
+      && {
+        border-bottom: none;
+        padding: 0;
+        &:not(:first-child) {
+          margin-top: 8px;
+        }
+      }
+
+      &.draggable-enter-active {
+        opacity: 0;
+        transform: translate(-16px);
+      }
+      &.draggable-enter-done {
+        opacity: 1;
+        transform: translate(0);
+        transition: all 300ms ease-in;
+      }
+    `}
   display: flex;
   align-items: center;
   border-bottom: 1px solid ${({ theme }) => theme.draggableItem.border};
@@ -16,10 +71,6 @@ const StyledDraggableItem = styled.div`
   cursor: move;
 
   opacity: ${({ isDragging }) => (isDragging ? "0" : "1")};
-`;
-
-const StyledIcon = styled(Icon)`
-  margin-left: auto;
 `;
 
 StyledDraggableContainer.defaultProps = {

--- a/src/components/draggable/draggable.spec.js
+++ b/src/components/draggable/draggable.spec.js
@@ -278,3 +278,26 @@ describe("Draggable Checkbox", () => {
     });
   });
 });
+
+describe("Draggable Container as unordered list", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(
+      <DraggableContainer as="ul">
+        <DraggableItem key="1" id={1}>
+          simple content
+        </DraggableItem>
+        <DraggableItem key="2" id={2}>
+          simple content
+        </DraggableItem>
+      </DraggableContainer>
+    );
+  });
+
+  it("renders unordered list and list items correctly", () => {
+    const ul = wrapper.find("ul");
+    expect(ul.exists()).toBe(true);
+    expect(wrapper.find("li").length).toEqual(2);
+  });
+});

--- a/src/components/duelling-picklist/duelling-picklist-test.stories.js
+++ b/src/components/duelling-picklist/duelling-picklist-test.stories.js
@@ -209,7 +209,7 @@ export const Draggable = () => {
       type={type}
       item={item}
       onChange={onChange}
-      as={draggable && "div"}
+      as="div"
     >
       {draggable && <Icon key={item.key} type="drag" ml={2} />}
       <div style={{ display: "flex", width: "100%" }}>

--- a/src/components/duelling-picklist/duelling-picklist-test.stories.js
+++ b/src/components/duelling-picklist/duelling-picklist-test.stories.js
@@ -278,6 +278,142 @@ export const Draggable = () => {
   );
 };
 
+export const AlternativeSearch = () => {
+  const mockData = useMemo(() => {
+    const arr = [];
+    for (let i = 0; i < 20; i++) {
+      const data = {
+        key: i.toString(),
+        title: `Content ${i + 1}`,
+        description: `Description ${i + 1}`,
+      };
+      arr.push(data);
+    }
+    return arr;
+  }, []);
+  const allItems = useMemo(() => {
+    return mockData.reduce((obj, item) => {
+      obj[item.key] = item;
+      return obj;
+    }, {});
+  }, [mockData]);
+  const [isEachItemSelected, setIsEachItemSelected] = useState(false);
+  const [order] = useState(mockData.map(({ key }) => key));
+  const [notSelectedItems, setNotSelectedItems] = useState(allItems);
+  const [notSelectedSearch, setNotSelectedSearch] = useState({});
+  const [selectedItems, setSelectedItems] = useState({});
+  const [searchQuery, setSearchQuery] = useState("");
+  const isSearchMode = Boolean(searchQuery.length);
+  const onAdd = useCallback(
+    (item) => {
+      const { [item.key]: removed, ...rest } = notSelectedItems;
+      setNotSelectedItems(rest);
+      setSelectedItems({ ...selectedItems, [item.key]: item });
+      const { [item.key]: removed2, ...rest2 } = notSelectedSearch;
+      setNotSelectedSearch(rest2);
+    },
+    [notSelectedItems, notSelectedSearch, selectedItems]
+  );
+  const onRemove = useCallback(
+    (item) => {
+      const { [item.key]: removed, ...rest } = selectedItems;
+      setSelectedItems(rest);
+      setNotSelectedItems({ ...notSelectedItems, [item.key]: item });
+      if (isSearchMode && item.title.includes(searchQuery)) {
+        setNotSelectedSearch({ ...notSelectedSearch, [item.key]: item });
+      }
+    },
+    [
+      isSearchMode,
+      notSelectedItems,
+      notSelectedSearch,
+      searchQuery,
+      selectedItems,
+    ]
+  );
+  const handleSearch = useCallback(
+    (ev) => {
+      setSearchQuery(ev.target.value);
+      const tempNotSelectedItems = Object.keys(notSelectedItems).reduce(
+        (items, key) => {
+          const item = notSelectedItems[key];
+          if (item.title.includes(ev.target.value)) {
+            items[item.key] = item;
+          }
+          return items;
+        },
+        {}
+      );
+      setNotSelectedSearch(tempNotSelectedItems);
+    },
+    [notSelectedItems]
+  );
+  const renderItems = (list, type, handler) =>
+    order.reduce((items, key) => {
+      const item = list[key];
+      if (item) {
+        items.push(
+          <PicklistItem key={key} type={type} item={item} onChange={handler}>
+            <div style={{ display: "flex", width: "100%" }}>
+              <div style={{ width: "50%" }}>
+                <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+                  {item.title}
+                </p>
+              </div>
+              <div style={{ width: "50%" }}>
+                <p style={{ margin: 0 }}>{item.description}</p>
+              </div>
+            </div>
+          </PicklistItem>
+        );
+      }
+      return items;
+    }, []);
+  return (
+    <>
+      <Box display="flex" alignItems="center" justifyContent="space-between">
+        <Checkbox
+          onChange={() => setIsEachItemSelected(!isEachItemSelected)}
+          checked={isEachItemSelected}
+          label="Example checkbox"
+        />
+        <Box width="calc(50% + 80px)">
+          <Search
+            tabIndex={isEachItemSelected ? -1 : 0}
+            placeholder="Search"
+            name="search_name"
+            onChange={handleSearch}
+            value={searchQuery}
+            id="search_id"
+          />
+        </Box>
+      </Box>
+      <DuellingPicklist
+        leftLabel={`List 1 (${Object.keys(notSelectedItems).length})`}
+        rightLabel={`List 2 (${Object.keys(selectedItems).length})`}
+        disabled={isEachItemSelected}
+      >
+        <Picklist
+          disabled={isEachItemSelected}
+          placeholder={<div>Your own placeholder</div>}
+        >
+          {renderItems(
+            isSearchMode ? notSelectedSearch : notSelectedItems,
+            "add",
+            onAdd
+          )}
+        </Picklist>
+        <Picklist
+          disabled={isEachItemSelected}
+          placeholder={<PicklistPlaceholder text="Nothing to see here" />}
+        >
+          {renderItems(selectedItems, "remove", onRemove)}
+        </Picklist>
+      </DuellingPicklist>
+    </>
+  );
+};
+
 export const Grouped = () => {
   const mockData = {
     groupA: [
@@ -515,29 +651,6 @@ export const InDialog = () => {
     </>
   );
 };
-
-# Duelling picklist
-
-### Default
-
-<Preview>
-  <Story
-    name="default"
-    parameters={{
-      chromatic: {
-        disable: false,
-      },
-    }}
-  >
-    {DuelingPicklistStory.bind({})}
-  </Story>
-</Preview>
-
-### Draggable
-
-<Preview>
-  <Story name="draggable">{Draggable.bind({})}</Story>
-</Preview>
 
 Grouped.story = {
   name: "grouped",

--- a/src/components/duelling-picklist/duelling-picklist.component.js
+++ b/src/components/duelling-picklist/duelling-picklist.component.js
@@ -12,6 +12,7 @@ import {
 } from "./duelling-picklist.style";
 import { Picklist } from "./picklist/picklist.component";
 import FocusContext from "./duelling-picklist.context";
+import { DraggableContainer } from "../draggable";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
@@ -97,10 +98,14 @@ DuellingPicklist.propTypes = {
     if (
       !prop ||
       !Array.isArray(prop) ||
-      prop.filter((el) => el.type === Picklist).length !== 2
+      (prop.filter((el) => el.type === Picklist).length !== 2 &&
+        !(
+          prop.filter((el) => el.type === Picklist).length === 1 &&
+          prop.filter((el) => el.type === DraggableContainer).length === 1
+        ))
     ) {
       error = new Error(
-        `\`${propName}\` must have two \`${Picklist.displayName}\`s`
+        `\`${propName}\` must have two \`${Picklist.displayName}\`s or one ${Picklist.displayName} and one ${DraggableContainer.displayName}`
       );
     }
 

--- a/src/components/duelling-picklist/duelling-picklist.spec.js
+++ b/src/components/duelling-picklist/duelling-picklist.spec.js
@@ -31,6 +31,7 @@ import {
 import { StyledPicklist } from "./picklist/picklist.style";
 import { areEqual } from "./picklist/picklist.component";
 import StyledPicklistDivider from "./picklist-divider/picklist-divider.style";
+import { DraggableContainer, DraggableItem } from "../draggable";
 
 const EmptyComponent = () => <div />;
 
@@ -860,7 +861,19 @@ describe("DuellingPicklist", () => {
   });
 
   describe("children", () => {
-    it("should throw an error if there are not two Picklist components", () => {
+    it("should not throw an error if there are one Picklist and one DraggableContainer selected", () => {
+      jest.spyOn(global.console, "error").mockImplementation(() => {});
+      mount(
+        <DuellingPicklist>
+          <Picklist placeholder="placeholder" />
+          <DraggableContainer />
+        </DuellingPicklist>
+      );
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toBeCalled();
+      global.console.error.mockReset();
+    });
+    it("should throw an error if there are invalid components components", () => {
       jest.spyOn(global.console, "error").mockImplementation(() => {});
       mount(
         <DuellingPicklist>
@@ -869,8 +882,38 @@ describe("DuellingPicklist", () => {
       );
       // eslint-disable-next-line no-console
       expect(console.error).toHaveBeenCalledWith(
-        "Warning: Failed prop type: `children` must have two `Picklist`s\n    in DuellingPicklist"
+        `Warning: Failed prop type: \`children\` must have two \`Picklist\`s or one Picklist and one DraggableContainer
+    in DuellingPicklist`
       );
+      global.console.error.mockReset();
+    });
+    it("should not throw an error if there are one Picklist and one DraggableContainer selected", () => {
+      jest.spyOn(global.console, "error").mockImplementation(() => {});
+      mount(
+        <DuellingPicklist>
+          <Picklist placeholder="placeholder" />
+          <Picklist
+            as="div"
+            placeholder={<PicklistPlaceholder text="Nothing to see here" />}
+          >
+            <DraggableContainer as="ul" getOrder={() => {}}>
+              <DraggableItem key="draggable-key" id="draggable-id">
+                <PicklistItem
+                  key="item-key"
+                  type="remove"
+                  onChange={jest.fn()}
+                  item="item"
+                  as="div"
+                >
+                  <div>Child</div>
+                </PicklistItem>
+              </DraggableItem>
+            </DraggableContainer>
+          </Picklist>
+        </DuellingPicklist>
+      );
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toBeCalled();
       global.console.error.mockReset();
     });
   });

--- a/src/components/duelling-picklist/duelling-picklist.stories.mdx
+++ b/src/components/duelling-picklist/duelling-picklist.stories.mdx
@@ -80,6 +80,14 @@ The `Search` component can be placed outside of the picklist controls and positi
   </Story>
 </Canvas>
 
+### Draggable
+
+Example of composed Duelling Picklist components with draggable selected items
+
+<Preview>
+  <Story id="design-system-duellingpicklist-test--draggable" name="Draggable" />
+</Preview>
+
 ### Grouped
 
 Picklist items can be organised into selectable groups. Whole groups can be moved from one list to another at once, or group items can be moved individually.

--- a/src/components/duelling-picklist/duelling-picklist.stories.mdx
+++ b/src/components/duelling-picklist/duelling-picklist.stories.mdx
@@ -88,6 +88,14 @@ Example of composed Duelling Picklist components with draggable selected items
   <Story id="design-system-duellingpicklist-test--draggable" name="Draggable" />
 </Preview>
 
+### Draggable
+
+Example of composed Duelling Picklist components with draggable selected items
+
+<Preview>
+  <Story id="design-system-duellingpicklist-test--draggable" name="Draggable" />
+</Preview>
+
 ### Grouped
 
 Picklist items can be organised into selectable groups. Whole groups can be moved from one list to another at once, or group items can be moved individually.

--- a/src/components/duelling-picklist/duelling-picklist.style.js
+++ b/src/components/duelling-picklist/duelling-picklist.style.js
@@ -21,6 +21,17 @@ const StyledDuellingPicklist = styled.div`
   justify-content: space-between;
   align-items: stretch;
   position: relative;
+
+  ${StyledPicklist}:first-of-type {
+    padding-right: 36px;
+  }
+
+  ${StyledPicklist}:last-of-type {
+    padding-left: 36px;
+  }
+  ${StyledPicklist}:only-of-type {
+    padding-left: 4px;
+  }
 `;
 
 const StyledLabelContainer = styled.div`
@@ -61,6 +72,10 @@ const StyledPicklistPlaceholder = styled.div`
 `;
 
 StyledDuellingPicklistOverlay.defaultProps = {
+  theme: baseTheme,
+};
+
+StyledDuellingPicklist.defaultProps = {
   theme: baseTheme,
 };
 

--- a/src/components/duelling-picklist/duelling-picklist.style.js
+++ b/src/components/duelling-picklist/duelling-picklist.style.js
@@ -1,6 +1,7 @@
 import styled, { css } from "styled-components";
 import { margin } from "styled-system";
 import { baseTheme } from "../../style/themes";
+import { StyledPicklist } from "./picklist/picklist.style";
 
 const StyledDuellingPicklistOverlay = styled.div`
   ${margin}

--- a/src/components/duelling-picklist/picklist-item/picklist-item.component.js
+++ b/src/components/duelling-picklist/picklist-item/picklist-item.component.js
@@ -26,6 +26,7 @@ const PicklistItem = React.forwardRef(
       groupIndex,
       isLastGroup,
       isLastItem,
+      as,
       ...rest
     },
     ref
@@ -84,6 +85,7 @@ const PicklistItem = React.forwardRef(
         {...(type === "add" ? { enter: false } : {})}
       >
         <StyledPicklistItem
+          as={as}
           onKeyDown={handleKeydown}
           data-element="picklist-item"
           locked={locked}
@@ -127,6 +129,8 @@ PicklistItem.propTypes = {
   locked: PropTypes.bool,
   /** Tooltip message for the locked icon (only present when locked prop is true) */
   tooltipMessage: PropTypes.string,
+  /** Overrides the default rendered HTML tag of the PicklistItem component */
+  as: PropTypes.string,
   /** @private @ignore */
   highlighted: PropTypes.bool,
   /** @private @ignore */

--- a/src/components/duelling-picklist/picklist-item/picklist-item.component.js
+++ b/src/components/duelling-picklist/picklist-item/picklist-item.component.js
@@ -130,7 +130,7 @@ PicklistItem.propTypes = {
   /** Tooltip message for the locked icon (only present when locked prop is true) */
   tooltipMessage: PropTypes.string,
   /** Overrides the default rendered HTML tag of the PicklistItem component */
-  as: PropTypes.string,
+  as: PropTypes.oneOf(["div", "li"]),
   /** @private @ignore */
   highlighted: PropTypes.bool,
   /** @private @ignore */

--- a/src/components/duelling-picklist/picklist-item/picklist-item.d.ts
+++ b/src/components/duelling-picklist/picklist-item/picklist-item.d.ts
@@ -15,6 +15,8 @@ export interface PicklistItemProps {
   locked?: boolean;
   /** Tooltip message for the locked icon (only present when locked prop is true) */
   tooltipMessage?: string;
+  /** Overrides the default rendered HTML tag of the PicklistItem component */
+  as?: string;
 }
 
 declare function PicklistItem(

--- a/src/components/duelling-picklist/picklist-item/picklist-item.d.ts
+++ b/src/components/duelling-picklist/picklist-item/picklist-item.d.ts
@@ -16,7 +16,7 @@ export interface PicklistItemProps {
   /** Tooltip message for the locked icon (only present when locked prop is true) */
   tooltipMessage?: string;
   /** Overrides the default rendered HTML tag of the PicklistItem component */
-  as?: string;
+  as?: "div";
 }
 
 declare function PicklistItem(

--- a/src/components/duelling-picklist/picklist-item/picklist-item.spec.js
+++ b/src/components/duelling-picklist/picklist-item/picklist-item.spec.js
@@ -101,4 +101,17 @@ describe("PicklistItem component", () => {
       expect(setElementToFocus).toHaveBeenCalledWith(0, 0, undefined);
     });
   });
+  describe("as div", () => {
+    it("renders correctly with div instead of li", () => {
+      const wrapper = render({
+        type: "add",
+        onChange: jest.fn(),
+        item: 1,
+        as: "div",
+      });
+
+      expect(wrapper.find(PicklistItem).exists()).toEqual(true);
+      expect(wrapper.find("li").exists()).toEqual(false);
+    });
+  });
 });

--- a/src/components/duelling-picklist/picklist/picklist.component.js
+++ b/src/components/duelling-picklist/picklist/picklist.component.js
@@ -7,12 +7,16 @@ import FocusContext from "../duelling-picklist.context";
 import Events from "../../../__internal__/utils/helpers/events";
 import PicklistGroup from "../picklist-group/picklist-group.component";
 
-export const Picklist = ({ disabled, children, placeholder, index }) => {
+export const Picklist = ({ as, disabled, children, placeholder, index }) => {
   const { elementToFocus, setElementToFocus } = useContext(FocusContext);
 
-  const isEmpty = useMemo(() => !React.Children.toArray(children).length, [
-    children,
-  ]);
+  const isEmpty = useMemo(() => {
+    const childrenArr = React.Children.toArray(children);
+    return (
+      !childrenArr.length ||
+      (as === "div" && !childrenArr[0]?.props?.children?.length)
+    );
+  }, [as, children]);
 
   const filteredChildren = React.Children.toArray(children);
 
@@ -50,7 +54,7 @@ export const Picklist = ({ disabled, children, placeholder, index }) => {
     (child, childIndex) =>
       child &&
       React.cloneElement(child, {
-        ref: refs[childIndex],
+        ref: as !== "div" ? refs[childIndex] : null,
         disabled,
         index: childIndex,
         listIndex: index,
@@ -75,17 +79,24 @@ export const Picklist = ({ disabled, children, placeholder, index }) => {
 
   return (
     <StyledPicklist
+      as={as}
       data-element="picklist"
       scrollVariant="light"
       onKeyDown={handleKeyDown}
     >
-      {isEmpty && <StyledEmptyContainer>{placeholder}</StyledEmptyContainer>}
+      {isEmpty && (
+        <StyledEmptyContainer as={as === "div" && "div"}>
+          {placeholder}
+        </StyledEmptyContainer>
+      )}
       <TransitionGroup component={null}>{content}</TransitionGroup>
     </StyledPicklist>
   );
 };
 
 Picklist.propTypes = {
+  /** Overrides the default rendered HTML tag of the Picklist component */
+  as: PropTypes.string,
   /** List of PicklistItem elements */
   children: PropTypes.node,
   /** Placeholder to be rendered when list is empty */

--- a/src/components/duelling-picklist/picklist/picklist.component.js
+++ b/src/components/duelling-picklist/picklist/picklist.component.js
@@ -96,7 +96,7 @@ export const Picklist = ({ as, disabled, children, placeholder, index }) => {
 
 Picklist.propTypes = {
   /** Overrides the default rendered HTML tag of the Picklist component */
-  as: PropTypes.string,
+  as: PropTypes.oneOf(["div", "ul"]),
   /** List of PicklistItem elements */
   children: PropTypes.node,
   /** Placeholder to be rendered when list is empty */

--- a/src/components/duelling-picklist/picklist/picklist.d.ts
+++ b/src/components/duelling-picklist/picklist/picklist.d.ts
@@ -7,6 +7,7 @@ export interface PicklistProps {
   placeholder?: React.ReactNode;
   /** Indicate if component is disabled */
   disabled?: boolean;
+  as?: "div";
 }
 
 declare function areEqual(


### PR DESCRIPTION
### Proposed behaviour
**Use case**

As a user
I want to be able to reorder the items I have selected using the duelling pick list.

Context (original request from Attie Snyders):

I would like to propose an update to the Duelling Pick-list Pattern for some of our use cases. It is to allow you to reorder assigned items. Some context are sequence or order sensitive. So when adding items in the correct order using the duelling pick-list, it works, but when you need to change the order, the only current way is to remove all items and re-add them in the correct order. This isn't a great experience.

I am proposing that we allow a reorder icon (similar to table rows that you can reorder) in the Duelling Pick-list to make this experience better for users.

**Acceptance Criteria**

I can click and drag a selected item to reorder.
I cannot reorder the unselected items on the left.
The cursor should act in the same way we use for other drag & drop UI elements.
This functionality should be optional (for implementors).
No version available in Design System yet.
Storybook MDX updated with a compatibility table showing which version of the Design System is implemented

### Current behaviour
It's not implemented

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
![image](https://user-images.githubusercontent.com/87973304/130952978-4975af66-5f19-43a4-b90d-b0bf6444fa2b.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
