### PR TITLE
 feat(inline-inputs): add labelWidth and inputWidth props (FE-4279)

### DIFF
--- a/src/__internal__/input/input-presentation.style.js
+++ b/src/__internal__/input/input-presentation.style.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import baseTheme from "../../style/themes/base";
 import sizes from "./input-sizes.style";
 import StyledInput from "./input.style";
-import StyledInlineInputs from "../../components/inline-inputs/inline-inputs.style";
 
 export const StyledInputPresentationContainer = styled.div`
   flex: 0 0 ${({ inputWidth }) => inputWidth}%;
@@ -45,10 +44,6 @@ const InputPresentationStyle = styled.div`
       && {
         outline: 3px solid ${theme.colors.focus};
         z-index: 2;
-      }
-
-      ${StyledInlineInputs} && {
-        position: relative;
       }
     `}
 

--- a/src/components/form/form.stories.mdx
+++ b/src/components/form/form.stories.mdx
@@ -10,6 +10,7 @@ import { RadioButton, RadioButtonGroup } from "../radio-button";
 import DateInput from "../date";
 import { Select, Option } from "../select";
 import { Checkbox } from "../checkbox";
+import InlineInputs from "../inline-inputs";
 import Hr from "../../components/hr";
 import Switch from "../switch";
 import Button from "../button";
@@ -47,25 +48,31 @@ When `stickyFooter` prop is set as true, footer becomes stickied to the bottom o
 
 <Preview>
   <Story name="default with sticky footer">
-    <Form
-      onSubmit={() => console.log("submit")}
-      leftSideButtons={
-        <Button onClick={() => console.log("cancel")}>Cancel</Button>
-      }
-      saveButton={
-        <Button buttonType="primary" type="submit">
-          Save
-        </Button>
-      }
-      stickyFooter
-    >
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
+    <Form>
+      <Textbox label="Text Input" labelInline />
+      <Select label="Select Input" labelInline>
+        <Option value="1" text="option 1" key="1" />
+        <Option value="2" text="option 2" key="1" />
+        <Option value="3" text="option 3" key="1" />
+      </Select>
+      <InlineInputs label="Inline Inputs" gutter="none" labelWidth="30">
+        <Textbox />
+        <Textbox />
+        <Select>
+          <Option value="1" text="option 1" key="1" />
+          <Option value="2" text="option 2" key="1" />
+          <Option value="3" text="option 3" key="1" />
+        </Select>
+      </InlineInputs>
+      <InlineInputs label="Inline Inputs with a gutter" gutter="large" labelWidth="30">
+        <Textbox />
+        <Textbox />
+        <Select>
+          <Option value="1" text="option 1" key="1" />
+          <Option value="2" text="option 2" key="1" />
+          <Option value="3" text="option 3" key="1" />
+        </Select>
+      </InlineInputs>
     </Form>
   </Story>
 </Preview>

--- a/src/components/form/form.stories.mdx
+++ b/src/components/form/form.stories.mdx
@@ -48,31 +48,25 @@ When `stickyFooter` prop is set as true, footer becomes stickied to the bottom o
 
 <Preview>
   <Story name="default with sticky footer">
-    <Form>
-      <Textbox label="Text Input" labelInline />
-      <Select label="Select Input" labelInline>
-        <Option value="1" text="option 1" key="1" />
-        <Option value="2" text="option 2" key="1" />
-        <Option value="3" text="option 3" key="1" />
-      </Select>
-      <InlineInputs label="Inline Inputs" gutter="none" labelWidth="30">
-        <Textbox />
-        <Textbox />
-        <Select>
-          <Option value="1" text="option 1" key="1" />
-          <Option value="2" text="option 2" key="1" />
-          <Option value="3" text="option 3" key="1" />
-        </Select>
-      </InlineInputs>
-      <InlineInputs label="Inline Inputs with a gutter" gutter="large" labelWidth="30">
-        <Textbox />
-        <Textbox />
-        <Select>
-          <Option value="1" text="option 1" key="1" />
-          <Option value="2" text="option 2" key="1" />
-          <Option value="3" text="option 3" key="1" />
-        </Select>
-      </InlineInputs>
+    <Form
+      onSubmit={() => console.log("submit")}
+      leftSideButtons={
+        <Button onClick={() => console.log("cancel")}>Cancel</Button>
+      }
+      saveButton={
+        <Button buttonType="primary" type="submit">
+          Save
+        </Button>
+      }
+      stickyFooter
+    >
+      <Textbox label="Textbox" />
+      <Textbox label="Textbox" />
+      <Textbox label="Textbox" />
+      <Textbox label="Textbox" />
+      <Textbox label="Textbox" />
+      <Textbox label="Textbox" />
+      <Textbox label="Textbox" />
     </Form>
   </Story>
 </Preview>
@@ -618,6 +612,41 @@ Please click on "Show code" below to see how to set these components up for alig
         labelWidth={10}
         inputWidth={30}
       />
+    </Form>
+  </Story>
+</Preview>
+
+### With labels inline
+
+<Preview>
+  <Story name="with labels inline">
+    <Form
+      saveButton={
+        <Button buttonType="primary" type="submit">
+          Save
+        </Button>
+      }
+      stickyFooter
+    >
+      <Textbox label="Textbox" labelInline labelWidth="30" />
+      <InlineInputs label="Inline Inputs" gutter="none" labelWidth="30">
+        <Textbox />
+        <Textbox />
+        <Select>
+          <Option value="1" text="option 1" key="1" />
+          <Option value="2" text="option 2" key="1" />
+          <Option value="3" text="option 3" key="1" />
+        </Select>
+      </InlineInputs>
+      <InlineInputs label="Inline Inputs with a gutter" gutter="large" labelWidth="30">
+        <Textbox />
+        <Textbox />
+        <Select>
+          <Option value="1" text="option 1" key="1" />
+          <Option value="2" text="option 2" key="1" />
+          <Option value="3" text="option 3" key="1" />
+        </Select>
+      </InlineInputs>
     </Form>
   </Story>
 </Preview>

--- a/src/components/form/form.style.js
+++ b/src/components/form/form.style.js
@@ -8,6 +8,7 @@ import { StyledFieldset } from "../../__internal__/fieldset/fieldset.style";
 import StyledButton from "../button/button.style";
 import baseTheme from "../../style/themes/base";
 import { FieldsetStyle } from "../fieldset/fieldset.style";
+import StyledInlineInputs from "../inline-inputs/inline-inputs.style";
 import { FORM_BUTTON_ALIGNMENTS } from "./form.config";
 import StyledSearch from "../search/search.style";
 
@@ -49,6 +50,15 @@ export const StyledForm = styled.form`
 
   & ${StyledFormField}, ${StyledFieldset}, ${FieldsetStyle}, > ${StyledButton} {
     margin-top: 0;
+    margin-bottom: ${({ fieldSpacing, theme }) =>
+      theme.spacing * fieldSpacing}px;
+  }
+
+  ${StyledInlineInputs} {
+    ${StyledFormField} {
+      margin-bottom: 0;
+    }
+
     margin-bottom: ${({ fieldSpacing, theme }) =>
       theme.spacing * fieldSpacing}px;
   }

--- a/src/components/inline-inputs/inline-inputs.component.js
+++ b/src/components/inline-inputs/inline-inputs.component.js
@@ -20,9 +20,23 @@ const columnWrapper = (children) => {
 };
 
 const InlineInputs = (props) => {
-  const { label, htmlFor, children, className, gutter } = props;
+  const {
+    label,
+    htmlFor,
+    children,
+    className,
+    gutter,
+    inputWidth,
+    labelWidth,
+  } = props;
 
   const labelId = useRef(createGuid());
+  const widthProps = { inputWidth };
+
+  if (labelWidth) {
+    widthProps.labelWidth = labelWidth;
+    widthProps.inputWidth = inputWidth || 100 - labelWidth;
+  }
 
   function renderLabel() {
     if (!label) return null;
@@ -47,6 +61,7 @@ const InlineInputs = (props) => {
       gutter={gutter}
       data-component="inline-inputs"
       className={className}
+      {...widthProps}
     >
       {renderLabel()}
       <Row gutter={gutter}>{columnWrapper(renderChildren())}</Row>
@@ -75,6 +90,10 @@ InlineInputs.propTypes = {
     "large",
     "extra-large",
   ]),
+  /** Width of the inline inputs container in percentage */
+  inputWidth: PropTypes.number,
+  /** Width of a label in percentage */
+  labelWidth: PropTypes.number,
 };
 
 InlineInputs.defaultProps = {

--- a/src/components/inline-inputs/inline-inputs.d.ts
+++ b/src/components/inline-inputs/inline-inputs.d.ts
@@ -9,8 +9,12 @@ export interface InlineInputsProps {
   gutter?: "none" | "extra-small" | "small"| "medium-small"| "medium"| "medium-large"| "large"| "extra-large";
   /** The id of the corresponding input control for the label */
   htmlFor?: string;
+  /** Width of the inline inputs container in percentage */
+  inputWidth?: number;
   /** Defines the label text for the heading. */
   label?: string;
+  /** Width of a label in percentage */
+  labelWidth?: number;
 }
 
 declare function InlineInputs(props: InlineInputsProps): JSX.Element;

--- a/src/components/inline-inputs/inline-inputs.spec.js
+++ b/src/components/inline-inputs/inline-inputs.spec.js
@@ -8,6 +8,7 @@ import Textbox from "../textbox";
 import InlineInputs from "./inline-inputs.component";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import { StyledLabelContainer } from "../../__internal__/label/label.style";
+import InputPresentation from "../../__internal__/input/input-presentation.style";
 
 describe("Inline Inputs", () => {
   let wrapper;
@@ -82,16 +83,6 @@ describe("Inline Inputs", () => {
         { modifier: "input" }
       );
     });
-
-    it("then columns should have negative margin to create 1px borders between inputs", () => {
-      assertStyleMatch(
-        {
-          marginLeft: "-1px",
-        },
-        wrapper,
-        { modifier: `${StyledColumn} + ${StyledColumn}` }
-      );
-    });
   });
 
   describe("when a gutter prop is passed in", () => {
@@ -103,6 +94,24 @@ describe("Inline Inputs", () => {
 
     it("then the gutter prop should be passed down to the row component", () => {
       expect(wrapper.find("Row").props().gutter).toEqual(gutterValue);
+    });
+  });
+
+  describe("when a gutter prop is set to none", () => {
+    const gutterValue = "none";
+
+    beforeEach(() => {
+      wrapper = render({ gutter: gutterValue }, mount);
+    });
+
+    it("then the borderLeft css property of the adjacent input should be set to none", () => {
+      assertStyleMatch(
+        {
+          borderLeft: "none",
+        },
+        wrapper,
+        { modifier: `${StyledColumn} + ${StyledColumn} ${InputPresentation}` }
+      );
     });
   });
 

--- a/src/components/inline-inputs/inline-inputs.spec.js
+++ b/src/components/inline-inputs/inline-inputs.spec.js
@@ -35,7 +35,7 @@ describe("Inline Inputs", () => {
     it("then the label should have specific styles", () => {
       assertStyleMatch(
         {
-          marginRight: "15px",
+          paddingRight: "16px",
           width: "auto",
         },
         wrapper,
@@ -113,6 +113,50 @@ describe("Inline Inputs", () => {
 
     it('then the gutter prop on the row component should be "none"', () => {
       expect(wrapper.find("Row").props().gutter).toEqual("none");
+    });
+  });
+
+  describe("when a labelWidth prop is passed in", () => {
+    const labelWidth = 30;
+
+    beforeEach(() => {
+      wrapper = render({ labelWidth }, mount);
+    });
+
+    it("then the label should have percentage width of this prop value", () => {
+      assertStyleMatch(
+        {
+          width: `${labelWidth}%`,
+        },
+        wrapper,
+        { modifier: `${StyledLabelContainer}` }
+      );
+    });
+
+    it("then the inline input container width should cover the rest of the percentage", () => {
+      assertStyleMatch(
+        {
+          flex: `0 0 ${100 - labelWidth}%`,
+        },
+        wrapper
+      );
+    });
+  });
+
+  describe("when a inputWidth prop is passed in", () => {
+    const inputWidth = 70;
+
+    beforeEach(() => {
+      wrapper = render({ inputWidth }, mount);
+    });
+
+    it("then the inline input container should have percentage width of this prop value", () => {
+      assertStyleMatch(
+        {
+          flex: `0 0 ${inputWidth}%`,
+        },
+        wrapper
+      );
     });
   });
 

--- a/src/components/inline-inputs/inline-inputs.style.js
+++ b/src/components/inline-inputs/inline-inputs.style.js
@@ -1,6 +1,7 @@
 import styled, { css } from "styled-components";
 import StyledRow from "../row/row.style";
 import StyledColumn from "../row/column/column.style";
+import InputPresentation from "../../__internal__/input/input-presentation.style";
 
 import { StyledLabelContainer } from "../../__internal__/label/label.style";
 import baseTheme from "../../style/themes/base";
@@ -44,10 +45,6 @@ const StyledInlineInputs = styled.div`
     flex-grow: 1;
   }
 
-  ${StyledColumn} + ${StyledColumn} {
-    margin-left: -1px;
-  }
-
   ${({ gutter }) =>
     css`
       ${StyledRow} {
@@ -59,6 +56,13 @@ const StyledInlineInputs = styled.div`
           padding-left: ${spacings[gutter]}px;
         }
       }
+
+      ${gutter === "none" &&
+      css`
+        ${StyledColumn} + ${StyledColumn} ${InputPresentation} {
+          border-left: none;
+        }
+      `}
     `}
 `;
 

--- a/src/components/inline-inputs/inline-inputs.style.js
+++ b/src/components/inline-inputs/inline-inputs.style.js
@@ -20,10 +20,16 @@ const StyledInlineInputs = styled.div`
   display: flex;
   align-items: center;
 
+  ${({ inputWidth }) =>
+    inputWidth &&
+    `
+    flex: 0 0 ${inputWidth}%;
+  `}
+
   ${StyledLabelContainer} {
     margin-bottom: 0;
-    margin-right: 15px;
-    width: auto;
+    padding-right: 16px;
+    width: ${({ labelWidth }) => (labelWidth ? `${labelWidth}%` : "auto")};
   }
 
   input {

--- a/src/components/table/__snapshots__/table.spec.js.snap
+++ b/src/components/table/__snapshots__/table.spec.js.snap
@@ -17,7 +17,7 @@ exports[`Table when the table size is compact renders a table to match the expec
 }
 
 .c0 .c2 .c1,
-.c0 .c2 .sc-cSHVUG {
+.c0 .c2 .sc-gqjmRU {
   font-size: 13px;
   padding-left: 8px;
   padding-right: 8px;
@@ -72,7 +72,7 @@ exports[`Table when the table size is small renders a table to match the expecte
 }
 
 .c0 .c2 .c1,
-.c0 .c2 .sc-cSHVUG {
+.c0 .c2 .sc-gqjmRU {
   font-size: 14px;
   padding-left: 8px;
   padding-right: 8px;

--- a/src/components/table/table-row/__snapshots__/table-row.spec.js.snap
+++ b/src/components/table/table-row/__snapshots__/table-row.spec.js.snap
@@ -341,7 +341,7 @@ exports[`TableRow render if is not classic theme renders a row to match the snap
 }
 
 .c0 .c1 .c3,
-.c0 .c1 .sc-cSHVUG {
+.c0 .c1 .sc-gqjmRU {
   font-size: 14px;
   padding-left: 11px;
   padding-right: 11px;


### PR DESCRIPTION
### Proposed behaviour
Inline inputs should have the ability to set label and content width the same way as other form elements 
![Screenshot 2021-08-27 at 17 53 43](https://user-images.githubusercontent.com/22885392/131155049-84dab035-0353-4997-87d2-fb3a4c24f463.png)

### Current behaviour
Inline inputs could not be aligned with other form elements when their labels are in-line
![Screenshot 2021-08-27 at 17 53 30](https://user-images.githubusercontent.com/22885392/131155029-27d4aeff-48b9-4534-9b37-f0349417df10.png)


### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
~~- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required~~
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
Resolves #4300 

### Testing instructions
1. run npm start
2. open http://localhost:9001/?path=/story/design-system-form--default-with-sticky-footer
3. open http://localhost:9001/?path=/story/design-system-inline-inputs--default-story