### PR TITLE
refactor(help): change the children proptype from string to node - FE-4280

### DIFF
--- a/.storybook/welcome-page/loves-carbon/loves-carbon.style.js
+++ b/.storybook/welcome-page/loves-carbon/loves-carbon.style.js
@@ -1,6 +1,6 @@
-import styled from 'styled-components';
-import { StyledComponentHeader } from '../components-demo/component-heading/component-heading.style'; 
-import Link from '../../../src/components/link/link.style';
+import styled from "styled-components";
+import { StyledComponentHeader } from "../components-demo/component-heading/component-heading.style";
+import { StyledLink } from "../../../src/components/link/link.style";
 
 export const Wrapper = styled.div`
   margin: 0 auto;
@@ -11,10 +11,10 @@ export const Wrapper = styled.div`
 `;
 
 export const LovesCarbonWrapper = styled.div`
-  background-color: #E6EBED;
+  background-color: #e6ebed;
   width: 100%;
 
-  && ${Link} a {
+  && ${StyledLink} a {
     font-size: 18px;
     font-weight: bold;
   }
@@ -33,4 +33,3 @@ export const Image = styled.img`
     width: 50%;
   }
 `;
-

--- a/src/components/help/help-test.stories.mdx
+++ b/src/components/help/help-test.stories.mdx
@@ -54,6 +54,8 @@ export const HelpStory = ({
         tooltipFlipOverrides={flipOverrides}
         children={children || childrenSpecialCharacters}
         href={href || hrefSpecialCharacters}
+        aria-label={children}
+        value={children}
         {...args}
       />
     </div>

--- a/src/components/help/help.component.js
+++ b/src/components/help/help.component.js
@@ -73,9 +73,8 @@ const Help = ({
       onMouseLeave={handleFocusBlur(false)}
       {...tagComponent("help", rest)}
       tabIndex={tabIndex}
-      value={children}
-      aria-label={children}
       {...filterStyledSystemMarginProps(rest)}
+      {...rest}
     >
       <Icon
         type={type}
@@ -95,7 +94,7 @@ Help.propTypes = {
   /** [Legacy] A custom class name for the component. */
   className: PropTypes.string,
   /** Message to display in tooltip */
-  children: PropTypes.string,
+  children: PropTypes.node,
   /** The unique id of the component (used with aria-describedby for accessibility) */
   helpId: PropTypes.string,
   /** Overrides the default tabindex of the component */

--- a/src/components/help/help.d.ts
+++ b/src/components/help/help.d.ts
@@ -1,11 +1,12 @@
+import * as React from "react";
 import { IconType } from "components/icon/icon";
 import { MarginProps } from "styled-system";
 
 export interface HelpProps extends MarginProps {
   /** Overrides the default 'as' attribute of the Help component */
   as?: string;
-  /** Message to display in tooltip */
-  children?: string;
+  /** The message to be displayed within the tooltip */
+  children?: React.ReactNode;
   /** [Legacy] A custom class name for the component. */
   className?: string;
   /** The unique id of the component (used with aria-describedby for accessibility) */

--- a/src/components/help/help.spec.js
+++ b/src/components/help/help.spec.js
@@ -33,7 +33,7 @@ describe("Help", () => {
     });
 
     it("passes the children as a prop", () => {
-      const mockMessage = "Help Message";
+      const mockMessage = <span>Help Message</span>;
       wrapper = mount(<Help>{mockMessage}</Help>);
       tooltip = wrapper.find(Tooltip);
       expect(tooltip.props().message).toBe(mockMessage);

--- a/src/components/help/help.stories.mdx
+++ b/src/components/help/help.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import Icon from "../icon";
 import Help from ".";
 
 <Meta title="Help" parameters={{ info: { disable: true } }} />
@@ -32,6 +33,23 @@ import Help from "carbon-react/lib/components/help";
   <Story name="default" parameters={{ chromatic: { disable: true } }}>
     <div style={{ margin: "64px" }}>
       <Help>Some helpful text goes here</Help>
+    </div>
+  </Story>
+</Preview>
+
+### Help with Tooltip custom message
+
+<Preview>
+  <Story
+    name="with Tooltip custom message"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    <div style={{ margin: "64px" }}>
+      <Help>
+        <Icon type="add" color="red" />
+        <Icon type="add" color="green" />
+        <Icon type="add" color="blue" /> Some <em>helpful</em> text goes here
+      </Help>
     </div>
   </Story>
 </Preview>

--- a/src/components/icon/icon.component.js
+++ b/src/components/icon/icon.component.js
@@ -169,8 +169,8 @@ Icon.propTypes = {
   disabled: PropTypes.bool,
   /** Aria label for accessibility purposes */
   ariaLabel: PropTypes.string,
-  /** The message string to be displayed in the tooltip */
-  tooltipMessage: PropTypes.string,
+  /** The message node to be displayed in the tooltip */
+  tooltipMessage: PropTypes.node,
   /** The position to display the tooltip */
   tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
   /** Control whether the tooltip is visible */

--- a/src/components/icon/icon.component.js
+++ b/src/components/icon/icon.component.js
@@ -169,7 +169,7 @@ Icon.propTypes = {
   disabled: PropTypes.bool,
   /** Aria label for accessibility purposes */
   ariaLabel: PropTypes.string,
-  /** The message node to be displayed in the tooltip */
+  /** The message to be displayed within the tooltip */
   tooltipMessage: PropTypes.node,
   /** The position to display the tooltip */
   tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),

--- a/src/components/icon/icon.d.ts
+++ b/src/components/icon/icon.d.ts
@@ -8,7 +8,12 @@ export type BgSize =
   | "large"
   | "extra-large";
 export type TooltipPositions = "top" | "bottom" | "left" | "right";
-export type FontSize = "extra-small" | "small" | "medium" | "large" | "extra-large";
+export type FontSize =
+  | "extra-small"
+  | "small"
+  | "medium"
+  | "large"
+  | "extra-large";
 export type BackgroundShape = "circle" | "rounded-rect" | "square";
 export type BackgroundTheme =
   | "info"
@@ -230,8 +235,8 @@ export interface IconProps extends MarginProps {
   disabled?: boolean;
   /** Aria label for accessibility purposes */
   ariaLabel?: string;
-  /** The message string to be displayed in the tooltip */
-  tooltipMessage?: string;
+  /** The message to be displayed within the tooltip */
+  tooltipMessage?: React.ReactNode;
   /** The position to display the tooltip */
   tooltipPosition?: TooltipPositions;
   /** Control whether the tooltip is visible */

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -546,6 +546,14 @@ describe("Icon component", () => {
       expect(wrapper.find(Tooltip).props().message).toEqual("foo");
     });
 
+    it("renders when a custom tooltipMessage is passed", () => {
+      const customMessage = <span>foo</span>;
+      const wrapper = mount(
+        <Icon type="home" tooltipMessage={customMessage} />
+      );
+      expect(wrapper.find(Tooltip).props().message).toEqual(customMessage);
+    });
+
     it.each(["top", "bottom", "left", "right"])(
       "renders in a given tooltipPosition",
       (position) => {

--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -50,13 +50,22 @@ import Icon from "carbon-react/lib/components/icon";
 
 ### With tooltip
 
-The Icon supports rendering tooltips internally, just pass a string to `tooltipMessage` to enable this feature. Other props,
+The Icon supports rendering tooltips internally, just pass a node to `tooltipMessage` to enable this feature. Other props,
 such as `tooltipPosition`, `tooltipVisible` , `tooltipBgColor`, `tooltipFontColor` and `tooltipFlipOverrides` are also surfaced.
 
 <Preview>
   <Story name="with tooltip">
     <div style={{ margin: 60, display: "inline" }}>
       <Icon mr={8} type="add" tooltipMessage="Hey I'm a default tooltip!" />
+      <Icon
+        mr={8}
+        type="add"
+        tooltipMessage={
+          <>
+            Hey I'm a <em>custom</em> tooltip!
+          </>
+        }
+      />
       <Icon
         mr={8}
         type="add"

--- a/src/components/link/link.stories.mdx
+++ b/src/components/link/link.stories.mdx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs";
 import LinkTo from "@storybook/addon-links/react";
-import Link, { InternalLink } from "./link.component";
+import Link from "./link.component";
 import Box from "../box";
 import { Menu, MenuItem } from "../menu";
 import Typography from "../typography";
@@ -197,4 +197,4 @@ Use the `target` prop to modify the behaviour when the Link component is clicked
 
 ### Link
 
-<Props of={InternalLink} />
+<Props of={Link} />


### PR DESCRIPTION
### Proposed behaviour
The Help component accepts children of node type and no longer renders `aria-label` and `value` based on the string.
`aria-label` and `value` must be defined as separate props.

### Current behaviour
The Help component accepts children of string type and renders `aria-label` and `value` based on the string.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
fix #4286

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-es8pl