### PR TITLE
fix(pager): update show select value when page size prop is changed

### DIFF
--- a/src/components/pager/pager.component.js
+++ b/src/components/pager/pager.component.js
@@ -53,6 +53,7 @@ const Pager = ({
 
   useEffect(() => {
     setCurrentPageSize(Number(pageSize));
+    setValue(pageSize);
   }, [pageSize]);
 
   useEffect(() => {

--- a/src/components/pager/pager.spec.js
+++ b/src/components/pager/pager.spec.js
@@ -11,6 +11,7 @@ import {
   StyledPagerLinkStyles,
   StyledPagerSizeOptionsInner,
   StyledPagerSummary,
+  StyledSelect,
 } from "./pager.style";
 import NumberInput from "../number";
 import StyledOption from "../select/option/option.style";
@@ -161,6 +162,14 @@ describe("Pager", () => {
       const last = navLinks.last();
       last.simulate("click");
       expect(onLast).toHaveBeenCalledTimes(1);
+    });
+
+    it("updates value when pageSize prop is changed", () => {
+      wrapper = getWrapper();
+      expect(wrapper.find(StyledSelect).prop("value")).toBe("10");
+      wrapper.setProps({ pageSize: 25 });
+      wrapper.update();
+      expect(wrapper.find(StyledSelect).prop("value")).toBe("25");
     });
   });
 


### PR DESCRIPTION
### Proposed behaviour
Update show select value when page size prop is changed

### Current behaviour
Show select value is not updated when page size prop is changed
https://codesandbox.io/s/beautiful-oskar-yxjes?file=/src/index.js

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
Resolves #4344

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-fkwhb