### PR TITLE
fix(tile): address spelling mistake with horizontal in the options for orientation prop

### DIFF
--- a/src/components/tile/tile.d.ts
+++ b/src/components/tile/tile.d.ts
@@ -13,7 +13,7 @@ export interface TileProps extends SpaceProps {
    */
   children?: React.ReactNode;
   /** The orientation of the tile - set to either horizontal or vertical */
-  orientation?: "horizonta" | "vertical";
+  orientation?: "horizontal" | "vertical";
   /**
    * Set a pixel with for the Tile component. If both are set to non-zero values, this
    * takes precedence over the percentage-based "width" prop.


### PR DESCRIPTION
Currently horizontal is spelt incorrectly in the ts file for tile. This is causing error for our ts
users using tile.

fixes FE-4313

### Proposed behaviour
`horizontal` is spelt correctly

### Current behaviour
`horizontal` is not spelt correctly

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
N/A

### Testing instructions
https://codesandbox.io/s/nervous-sea-d23km?file=/src/index.tsx

Codesandbox should not display any errors relating to the `orientation` prop value being incorrect.
