### PR TITLE
refactor(form-summary): change the design of the validation message - FE-4262

### DIFF
--- a/src/components/form/__internal__/form-summary.component.js
+++ b/src/components/form/__internal__/form-summary.component.js
@@ -1,7 +1,11 @@
-import React from "react";
+import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 
-import { StyledFormSummary, StyledInternalSummary } from "./form-summary.style";
+import {
+  StyledFormSummary,
+  StyledInternalSummary,
+  StyledMessagePrefix,
+} from "./form-summary.style";
 import Icon from "../../icon";
 import useLocale from "../../../hooks/__internal__/useLocale";
 
@@ -11,13 +15,20 @@ const Summary = ({ type, errors, warnings }) => {
     errors,
     warnings,
   };
+  const message = useMemo(
+    () => l.errors.messages.formSummary(errors, warnings, type),
+    [l.errors.messages, errors, warnings, type]
+  );
 
   if (messages[type]) {
     return (
-      <StyledInternalSummary type={type} data-element={type}>
-        <Icon type={type.slice(0, -1)} />
-        <span>{l.errors.messages.formSummary(errors, warnings, type)}</span>
-      </StyledInternalSummary>
+      <>
+        <StyledMessagePrefix>{message[0]}</StyledMessagePrefix>
+        <StyledInternalSummary type={type} data-element={type}>
+          <Icon type={type.slice(0, -1)} />
+          <span>{message[1]}</span>
+        </StyledInternalSummary>
+      </>
     );
   }
   return null;

--- a/src/components/form/__internal__/form-summary.style.js
+++ b/src/components/form/__internal__/form-summary.style.js
@@ -24,10 +24,20 @@ export const StyledFormSummary = styled.div`
   }
 `;
 
+export const StyledMessagePrefix = styled.div`
+  &:first-of-type {
+    margin-left: 4px;
+  }
+  margin-right: 4px;
+`;
+
 export const StyledInternalSummary = styled.div`
   display: flex;
   align-items: center;
-  margin-right: 16px;
+  margin-right: 8px;
+  &:last-of-type {
+    margin-right: 16px;
+  }
   ${({ type, theme }) =>
     type === "warnings" &&
     css`
@@ -38,10 +48,6 @@ export const StyledInternalSummary = styled.div`
     css`
       color: ${theme.colors.error};
     `}
-
-  &:first-of-type {
-    margin-left: 4px;
-  }
 
   ${StyledIcon} {
     margin-right: 4px;

--- a/src/components/form/form.spec.js
+++ b/src/components/form/form.spec.js
@@ -21,6 +21,7 @@ import StyledFormField from "../../__internal__/form-field/form-field.style";
 import {
   StyledFormSummary,
   StyledInternalSummary,
+  StyledMessagePrefix,
 } from "./__internal__/form-summary.style";
 import Icon from "../icon";
 import Button from "../button";
@@ -447,7 +448,8 @@ describe("Form", () => {
         wrapper.setProps({ errorCount: 1 });
         const errorSummary = wrapper.find('[data-element="errors"]');
         expect(errorSummary.find(Icon).props().type).toBe("error");
-        expect(errorSummary.find("span").at(1).text()).toBe("There is 1 error");
+        expect(wrapper.find(StyledMessagePrefix).text()).toBe("There is");
+        expect(errorSummary.find("span").at(1).text()).toBe("1 error");
 
         assertStyleMatch(
           {
@@ -463,9 +465,8 @@ describe("Form", () => {
         wrapper.setProps({ warningCount: 1 });
         const warningSummary = wrapper.find('[data-element="warnings"]');
         expect(warningSummary.find(Icon).props().type).toBe("warning");
-        expect(warningSummary.find("span").at(1).text()).toBe(
-          "There is 1 warning"
-        );
+        expect(wrapper.find(StyledMessagePrefix).text()).toBe("There is");
+        expect(warningSummary.find("span").at(1).text()).toBe("1 warning");
 
         assertStyleMatch(
           {
@@ -506,24 +507,38 @@ describe("Form", () => {
 
     describe("when either errorCount or warningCount or both are set on Form", () => {
       it.each([
-        [1, 0, "There is 1 error", null],
-        [2, 0, "There are 2 errors", null],
-        [0, 1, null, "There is 1 warning"],
-        [0, 2, null, "There are 2 warnings"],
-        [1, 1, "There is 1 error", "and 1 warning"],
-        [2, 1, "There are 2 errors", "and 1 warning"],
-        [2, 2, "There are 2 errors", "and 2 warnings"],
+        [1, 0, "There is", "1 error", null, null],
+        [2, 0, "There are", "2 errors", null, null],
+        [0, 1, null, null, "There is", "1 warning"],
+        [0, 2, null, null, "There are", "2 warnings"],
+        [1, 1, "There are", "1 error", "and", "1 warning"],
+        [2, 1, "There are", "2 errors", "and", "1 warning"],
+        [2, 2, "There are", "2 errors", "and", "2 warnings"],
       ])(
         "properly pluralized translation of error and warning messages is rendered",
-        (errorCount, warningCount, errMessage, warnMessage) => {
+        (
+          errorCount,
+          warningCount,
+          errPrefix,
+          errMessage,
+          warnPrefix,
+          warnMessage
+          // eslint-disable-next-line max-params
+        ) => {
           wrapper.setProps({ errorCount, warningCount });
           const warningPosition = errorCount ? 1 : 0;
           if (errorCount) {
+            expect(wrapper.find(StyledMessagePrefix).at(0).text()).toBe(
+              errPrefix
+            );
             expect(wrapper.find(StyledInternalSummary).at(0).text()).toBe(
               errMessage
             );
           }
           if (warningCount) {
+            expect(
+              wrapper.find(StyledMessagePrefix).at(warningPosition).text()
+            ).toBe(warnPrefix);
             expect(
               wrapper.find(StyledInternalSummary).at(warningPosition).text()
             ).toBe(warnMessage);

--- a/src/components/form/form.stories.mdx
+++ b/src/components/form/form.stories.mdx
@@ -659,18 +659,18 @@ Please click on "Show code" below to see how to set these components up for alig
 
 ## Translation keys
 
-The following keys are available to override the translations for this component by passing in a custom locale object to the 
+The following keys are available to override the translations for this component by passing in a custom locale object to the
 [i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
 
 <TranslationKeysTable
-  translationData={
-    [
-      {
-        name: "error.messages.formSummary",
-        description: "The text to displayed when there are errors or warnings present in the form",
-        type: "func",
-        returnType: "string when validation failures and null when no failures"
-      },
-    ]
-  }
+  translationData={[
+    {
+      name: "error.messages.formSummary",
+      description:
+        "The text to displayed when there are errors or warnings present in the form",
+      type: "func",
+      returnType:
+        "an array of strings when validation failures and null when no failures",
+    },
+  ]}
 />

--- a/src/components/i18n-provider/i18n-provider.d.ts
+++ b/src/components/i18n-provider/i18n-provider.d.ts
@@ -24,13 +24,17 @@ export interface I18nProviderProps {
     };
     date: {
       formats: {
-        inputs: () => [string],
-        javascript: () => string,
-      }
-    },
+        inputs: () => [string];
+        javascript: () => string;
+      };
+    };
     errors: {
       messages: {
-        formSummary: (errors: number, warnings: number, type: string) => string;
+        formSummary: (
+          errors: number,
+          warnings: number,
+          type: string
+        ) => [string, string];
       };
     };
     message: {

--- a/src/locales/en-gb.js
+++ b/src/locales/en-gb.js
@@ -95,17 +95,17 @@ export default {
         (errors, warnings, type) => {
           const errorPlural = isSingular(errors) ? "error" : "errors";
           const warningPlural = isSingular(warnings) ? "warning" : "warnings";
-          const isErrorPlural = isSingular(errors) ? "is" : "are";
+          const isErrorPlural = isSingular(errors) && !warnings ? "is" : "are";
           const isWarningPlural = isSingular(warnings) ? "is" : "are";
 
           if (errors && warnings && type === "warnings") {
-            return `and ${warnings} ${warningPlural}`;
+            return ["and", `${warnings} ${warningPlural}`];
           }
           if (errors) {
-            return `There ${isErrorPlural} ${errors} ${errorPlural}`;
+            return [`There ${isErrorPlural}`, `${errors} ${errorPlural}`];
           }
           if (warnings) {
-            return `There ${isWarningPlural} ${warnings} ${warningPlural}`;
+            return [`There ${isWarningPlural}`, `${warnings} ${warningPlural}`];
           }
           return null;
         },


### PR DESCRIPTION
BREAKING CHANGE: `errors.messages.formSummary` key returns an array of strings instead of a string

### Proposed behaviour
<img width="505" alt="Zrzut ekranu 2021-09-6 o 13 15 39" src="https://user-images.githubusercontent.com/77274590/132225441-02d9d9d2-73c7-493a-bfef-04762e66aa05.png">


### Current behaviour
<img width="526" alt="Zrzut ekranu 2021-09-6 o 13 15 45" src="https://user-images.githubusercontent.com/77274590/132225457-229b533f-975b-49bf-906b-794b8d4d35f7.png">

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-9xjd9