### PR TITLE
ci(github-actions): create forked pr workflow - FE-4298

### DIFF
--- a/.github/workflows/chromatic-fork.yml
+++ b/.github/workflows/chromatic-fork.yml
@@ -1,0 +1,29 @@
+name: Forked PR
+on:
+  workflow_dispatch:
+    inputs:
+      number:
+        description: 'Pull Request Number'
+        required: true
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: 'refs/pull/${{ github.event.inputs.number }}/head'
+        fetch-depth: 0
+    - uses: octokit/request-action@v2.x
+      id: get_branch_name
+      with:
+        route: GET /repos/{owner}/{repo}/pulls/{pull_number}
+        owner: ${{ github.event.repository.owner.login }}
+        repo: ${{ github.event.repository.name }}
+        pull_number: ${{ github.event.inputs.number }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '>=14.16.0 14'
+    - run: npm ci
+    - run: npx chromatic --project-token ${{ secrets.CHROMATIC_PROJECT_TOKEN }} --exit-once-uploaded --branch-name="${{ fromJson(steps.get_branch_name.outputs.data).head.label }}"

--- a/.github/workflows/cypress-push.yml
+++ b/.github/workflows/cypress-push.yml
@@ -77,20 +77,3 @@ jobs:
           # Recommended: pass the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  chromatic:
-    runs-on: ubuntu-latest
-    needs: cypress
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '>=14.16.0 14'
-    - run: npm ci
-    - uses: chromaui/action@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-        exitOnceUploaded: true # We don't want it to fail CI, we'll be using the GitHub Check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,8 +134,12 @@ Your branch should meet the following criteria:
 #### GitHub Checks
 
 Our GitHub checks don't run on a forked PR because the Chromatic and Cypress Dashboard require credentials. When you submit a PR a project maintainer will review your code.
+##### Cypress
 If there are no changes that could expose our credentials they will use [`git-push-fork-to-upstream-branch`](https://github.com/jklukas/git-push-fork-to-upstream-branch) to
 copy your branch into our repo. Doing this will trigger a `push` build and your PR checks will be updated. This is documented on the [Circle CI blog](https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/).
+
+##### Chromatic
+If there are no changes that could expose our credentials they will start the `Forked PR` GitHub action. This will create a new chromatic build then update the PR checks.
 
 #### Preventing unnecessary builds
 


### PR DESCRIPTION
### Proposed behaviour
Allow carbon maintainers to start builds on forked PR's using GitHub actions.

### Current behaviour
Maintainers have to run the chromatic comparison locally.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
We'll do the same for Cypress in another PR.

### Testing instructions
Merge then run run a build for a forked PR.