### PR TITLE
ci(github-actions): prevent escape chars

### DIFF
--- a/.github/workflows/chromatic-fork.yml
+++ b/.github/workflows/chromatic-fork.yml
@@ -6,24 +6,40 @@ on:
         description: 'Pull Request Number'
         required: true
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      branch_name: ${{ fromJson(steps.get_pull.outputs.data).head.label }}
+    steps:
+      - id: get_pull
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/{owner}/{repo}/pulls/{pull_number}
+          owner: ${{ github.event.repository.owner.login }}
+          repo: ${{ github.event.repository.name }}
+          pull_number: ${{ github.event.inputs.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - id: escape
+        name: Check for escape chars
+        run: |
+          if ${{ contains(fromJson(steps.get_pull.outputs.data).head.label, '"') }}
+          then
+            exit 1
+          else
+              exit 0
+          fi
+        
   chromatic:
+    needs: check
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
         ref: 'refs/pull/${{ github.event.inputs.number }}/head'
         fetch-depth: 0
-    - uses: octokit/request-action@v2.x
-      id: get_branch_name
-      with:
-        route: GET /repos/{owner}/{repo}/pulls/{pull_number}
-        owner: ${{ github.event.repository.owner.login }}
-        repo: ${{ github.event.repository.name }}
-        pull_number: ${{ github.event.inputs.number }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/setup-node@v1
       with:
         node-version: '>=14.16.0 14'
     - run: npm ci
-    - run: npx chromatic@latest --project-token ${{ secrets.CHROMATIC_PROJECT_TOKEN }} --exit-once-uploaded --branch-name="${{ fromJson(steps.get_branch_name.outputs.data).head.label }}"
+    - run: npx chromatic@latest --project-token ${{ secrets.CHROMATIC_PROJECT_TOKEN }} --exit-once-uploaded --branch-name="${{ needs.check.output.branch_name }}"


### PR DESCRIPTION
### Proposed behaviour
This introduces a new `check` which prevents the `chromatic` build from running if the third-party pr has a `"` char in the PR label.

### Current behaviour
If there is a `"` in the branch name and a carbon maintainer started the workflow it could execute arbitrary code. 

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
#4365
#4366
#4367
#4368

### Testing instructions
N/A
