### PR TITLE
ci(github-actions): use branch name from check output

### DIFF
--- a/.github/workflows/chromatic-fork.yml
+++ b/.github/workflows/chromatic-fork.yml
@@ -42,4 +42,4 @@ jobs:
       with:
         node-version: '>=14.16.0 14'
     - run: npm ci
-    - run: npx chromatic@latest --project-token ${{ secrets.CHROMATIC_PROJECT_TOKEN }} --exit-once-uploaded --branch-name="${{ needs.check.output.branch_name }}"
+    - run: npx chromatic@latest --project-token ${{ secrets.CHROMATIC_PROJECT_TOKEN }} --exit-once-uploaded --branch-name="${{ needs.check.outputs.branch_name }}"


### PR DESCRIPTION
### Proposed behaviour
Fix typo in workflow.

### Current behaviour
 The branch name is not being passed correctly.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
#4365
#4366
#4367
#4368
#4369



### Testing instructions
N/A
