### PR TITLE
refactor(decimal): get locale from i18n provider if not passed in props - FE-4318

### DIFF
--- a/src/components/decimal/decimal.component.js
+++ b/src/components/decimal/decimal.component.js
@@ -6,17 +6,20 @@ import styledSystemPropTypes from "@styled-system/prop-types";
 import invariant from "invariant";
 import Textbox from "../textbox";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import LocaleContext from "../../__internal__/i18n-context";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
 );
 class Decimal extends React.Component {
+  static contextType = LocaleContext;
+
   static maxPrecision = 15;
 
   emptyValue = this.props.allowEmptyValue ? "" : "0.00";
 
-  constructor(props) {
-    super(props);
+  constructor(props, context) {
+    super(props, context);
 
     const isControlled = this.isControlled();
     const value = isControlled
@@ -166,9 +169,13 @@ class Decimal extends React.Component {
 
     const separator = this.getSeparator("decimal");
     const [integer, remainder] = value.split(".");
-    const formattedInteger = Intl.NumberFormat(this.props.locale, {
-      maximumFractionDigits: 0,
-    }).format(integer);
+
+    const formattedInteger = Intl.NumberFormat(
+      this.props.locale || this.context.locale(),
+      {
+        maximumFractionDigits: 0,
+      }
+    ).format(integer);
 
     let formattedNumber = formattedInteger;
     if (remainder && remainder.length > this.props.precision) {
@@ -222,13 +229,13 @@ class Decimal extends React.Component {
 
   getSeparator(separatorType) {
     const numberWithGroupAndDecimalSeparator = 10000.1;
-    return Intl.NumberFormat(this.props.locale)
+    return Intl.NumberFormat(this.props.locale || this.context.locale())
       .formatToParts(numberWithGroupAndDecimalSeparator)
       .find((part) => part.type === separatorType).value;
   }
 
   render() {
-    const { name, defaultValue, ...rest } = this.props;
+    const { name, defaultValue, locale, ...rest } = this.props;
     return (
       <>
         <Textbox
@@ -314,7 +321,7 @@ Decimal.propTypes = {
   /** Flag to configure component as mandatory */
   required: PropTypes.bool,
   /**
-   * The locale string - default en
+   * Override the locale string, default from I18nProvider
    */
   locale: PropTypes.string,
 };
@@ -323,7 +330,6 @@ Decimal.defaultProps = {
   align: "right",
   precision: 2,
   allowEmptyValue: false,
-  locale: "en",
 };
 
 export default Decimal;

--- a/src/components/decimal/decimal.spec.js
+++ b/src/components/decimal/decimal.spec.js
@@ -7,6 +7,7 @@ import { testStyledSystemMargin } from "../../__spec_helper__/test-utils";
 import Textbox from "../textbox/textbox.component";
 import Label from "../../__internal__/label";
 import FormFieldStyle from "../../__internal__/form-field/form-field.style";
+import I18nProvider from "../i18n-provider";
 
 // These have been written in a way that we can change our testing library or component implementation with relative
 // ease without having to touch the tests.
@@ -1347,6 +1348,30 @@ describe("Decimal", () => {
           },
         })
       );
+    });
+  });
+
+  describe("i18n", () => {
+    describe("translation", () => {
+      it("renders properly", () => {
+        mount(
+          <I18nProvider
+            locale={{
+              locale: () => "fr-FR",
+            }}
+          >
+            <Decimal />
+          </I18nProvider>
+        );
+        expect(value()).toBe("0,00");
+        wrapper.setProps({
+          locale: {
+            locale: () => "en-GB",
+          },
+        });
+        wrapper.find('input[data-element="input"]').simulate("blur");
+        expect(value()).toBe("0.00");
+      });
     });
   });
 });

--- a/src/components/decimal/decimal.spec.js
+++ b/src/components/decimal/decimal.spec.js
@@ -1369,7 +1369,7 @@ describe("Decimal", () => {
             locale: () => "en-GB",
           },
         });
-        wrapper.find('input[data-element="input"]').simulate("blur");
+        blur();
         expect(value()).toBe("0.00");
       });
     });

--- a/src/components/decimal/decimal.stories.mdx
+++ b/src/components/decimal/decimal.stories.mdx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs";
 
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 import Decimal from ".";
 import { OriginalTextbox } from "../textbox";
 import Button from "../button";
@@ -470,3 +471,19 @@ It is possible to use the `tooltipPosition` to override the default placement of
 Due to the `Textbox` component being used internally by the `Decimal` component, most of the `Textbox` props are appliable to `Decimal`
 
 <Props of={OriginalTextbox} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "locale",
+      description: "The locale code to display the correct format",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/switch/switch.stories.mdx
+++ b/src/components/switch/switch.stories.mdx
@@ -367,24 +367,24 @@ It is possible to use the `tooltipPosition` to override the default placement of
 
 ## Translation keys
 
-The following keys are available to override the translations for this component by passing in a custom locale object to the 
+The following keys are available to override the translations for this component by passing in a custom locale object to the
 [i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
 
 <TranslationKeysTable
-  translationData={
-    [
-      {
-        name: "switch.on",
-        description: "The text fto display o indicate action would move component to on state",
-        type: "func",
-        returnType: "string"
-      },
-      {
-        name: "switch.off",
-        description: "The text to display to indicate action would move component to off state",
-        type: "func",
-        returnType: "string"
-      },
-    ]
-  }
+  translationData={[
+    {
+      name: "switch.on",
+      description:
+        "The text to display to indicate action would move component to on state",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "switch.off",
+      description:
+        "The text to display to indicate action would move component to off state",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
 />


### PR DESCRIPTION
### Proposed behaviour
Get locale from i18n provider if not passed in props.

### Current behaviour
Locale is provided only in props.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
https://codesandbox.io/s/carbon-quickstart-forked-lsrqo?file=/src/index.js