### PR TITLE
ci(forked): only run cypress after check

### DIFF
--- a/.github/workflows/forked-ci.yml
+++ b/.github/workflows/forked-ci.yml
@@ -45,6 +45,7 @@ jobs:
       - run: npx chromatic@latest --project-token ${{ secrets.CHROMATIC_PROJECT_TOKEN }} --exit-once-uploaded --branch-name="${{ needs.check.outputs.branch_name }}"
 
   cypress:
+    needs: check
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
### Proposed behaviour
Only run Cypress after check has finished



