### PR TITLE
feat(navigation-bar): add sticky position - FE-4268

### DIFF
--- a/src/components/navigation-bar/navigation-bar.component.js
+++ b/src/components/navigation-bar/navigation-bar.component.js
@@ -9,6 +9,8 @@ const NavigationBar = ({
   isLoading = false,
   children,
   ariaLabel,
+  stickyOffset = "0",
+  stickyPosition,
   ...props
 }) => {
   return (
@@ -17,6 +19,8 @@ const NavigationBar = ({
       aria-label={ariaLabel}
       navigationType={navigationType}
       data-component="navigation-bar"
+      stickyOffset={stickyOffset}
+      stickyPosition={stickyPosition}
       {...props}
     >
       {!isLoading && children}
@@ -30,10 +34,14 @@ NavigationBar.propTypes = {
   ...propTypes.flexbox,
   children: PropTypes.node,
   ariaLabel: PropTypes.string,
-  /** color scheme of navigation component */
+  /** Color scheme of navigation component */
   navigationType: PropTypes.oneOf(["light", "dark"]),
-  /** if 'true' the children will not be visible */
+  /** If 'true' the children will not be visible */
   isLoading: PropTypes.bool,
+  /** Defines the position of sticky navigation bar */
+  stickyPosition: PropTypes.oneOf(["top", "bottom"]),
+  /** Defines the offset of sticky navigation bar */
+  stickyOffset: PropTypes.string,
 };
 
 export default NavigationBar;

--- a/src/components/navigation-bar/navigation-bar.d.ts
+++ b/src/components/navigation-bar/navigation-bar.d.ts
@@ -7,6 +7,8 @@ export interface NavigationBarProp extends SpaceProps {
   ariaLabel?: string;
   navigationType?: "light" | "dark";
   isLoading?: boolean;
+  stickyPosition?: "top" | "bottom";
+  stickyOffset?: string;
 }
 
 declare function NavigationBar(props: NavigationBarProp): JSX.Element;

--- a/src/components/navigation-bar/navigation-bar.spec.js
+++ b/src/components/navigation-bar/navigation-bar.spec.js
@@ -125,4 +125,24 @@ describe("NavigationBar", () => {
       { media: query }
     );
   });
+
+  it.each([
+    ["top", undefined],
+    ["top", "10px"],
+    ["bottom", undefined],
+    ["bottom", "10px"],
+  ])("should set correct sticky offset", (position, offset) => {
+    wrapper = mount(
+      <NavigationBar stickyPosition={position} stickyOffset={offset}>
+        <div>test content</div>
+      </NavigationBar>
+    );
+    assertStyleMatch(
+      {
+        position: "sticky",
+        [position]: offset || "0",
+      },
+      wrapper
+    );
+  });
 });

--- a/src/components/navigation-bar/navigation-bar.stories.mdx
+++ b/src/components/navigation-bar/navigation-bar.stories.mdx
@@ -127,6 +127,96 @@ valid CSS string.
   </Story>
 </Preview>
 
+### Sticky
+
+The `stickyPosition` prop can be used to make the navigation bar stick to the top or bottom of it's nearest scrolling ancestor. Then the position relative to the top/bottom can be offset using the `stickyOffset` prop.
+
+<Preview>
+  <Story name="sticky" parameters={{ info: { disable: true } }}>
+    <div style={{ overflow: "scroll" }}>
+      <div
+        style={{
+          margin: "50px",
+          height: "250px",
+        }}
+      >
+        <NavigationBar
+          stickyPosition="top"
+          stickyOffset="25px"
+          aria-label="header"
+        >
+          <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
+            <SageIcon style={{ alignSelf: "center" }} />
+            <Box>
+              <VerticalDivider displayInline pr={0} />
+            </Box>
+            <Menu display="flex" flex="1">
+              <MenuItem flex="1" onClick={() => {}}>
+                Menu Item One
+              </MenuItem>
+              <MenuItem flex="0 0 auto" href="#">
+                Menu Item Two
+              </MenuItem>
+              <MenuItem flex="0 0 auto" submenu="Menu Item Three">
+                <MenuItem href="#">Item Submenu One</MenuItem>
+                <MenuItem href="#">Item Submenu Two</MenuItem>
+                <MenuDivider />
+                <MenuItem icon="settings" href="#">
+                  Item Submenu Three
+                </MenuItem>
+                <MenuItem href="#">Item Submenu Four</MenuItem>
+              </MenuItem>
+              <MenuItem flex="0 0 auto" submenu="Menu Item Four">
+                <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+                <MenuItem href="#">Item Submenu Two</MenuItem>
+              </MenuItem>
+            </Menu>
+          </Box>
+        </NavigationBar>
+        <div
+          style={{
+            height: "1000px",
+            background: "green",
+          }}
+        />
+        <NavigationBar
+          stickyPosition="bottom"
+          stickyOffset="25px"
+          aria-label="footer"
+        >
+          <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
+            <SageIcon style={{ alignSelf: "center" }} />
+            <Box>
+              <VerticalDivider displayInline pr={0} />
+            </Box>
+            <Menu display="flex" flex="1">
+              <MenuItem flex="1" onClick={() => {}}>
+                Menu Item One
+              </MenuItem>
+              <MenuItem flex="0 0 auto" href="#">
+                Menu Item Two
+              </MenuItem>
+              <MenuItem flex="0 0 auto" submenu="Menu Item Three">
+                <MenuItem href="#">Item Submenu One</MenuItem>
+                <MenuItem href="#">Item Submenu Two</MenuItem>
+                <MenuDivider />
+                <MenuItem icon="settings" href="#">
+                  Item Submenu Three
+                </MenuItem>
+                <MenuItem href="#">Item Submenu Four</MenuItem>
+              </MenuItem>
+              <MenuItem flex="0 0 auto" submenu="Menu Item Four">
+                <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+                <MenuItem href="#">Item Submenu Two</MenuItem>
+              </MenuItem>
+            </Menu>
+          </Box>
+        </NavigationBar>
+      </div>
+    </div>
+  </Story>
+</Preview>
+
 ## Props
 
 ### Navigation Bar

--- a/src/components/navigation-bar/navigation-bar.style.js
+++ b/src/components/navigation-bar/navigation-bar.style.js
@@ -36,6 +36,13 @@ const StyledNavigationBar = styled.nav`
     margin-right: 10px;
   }
 
+  ${({ stickyPosition, stickyOffset }) =>
+    stickyPosition &&
+    css`
+      position: sticky;
+      ${stickyPosition}: ${stickyOffset}
+    `};
+
   ${({ navigationType, theme }) => css`
     min-height: 40px;
     background-color: ${theme.navigationBar.light.background};


### PR DESCRIPTION
### Proposed behaviour
Allow Navigation Bar to use sticky options and specify position.

https://user-images.githubusercontent.com/77274590/132504285-b9497eac-018a-4441-9c8e-c22a3eb70753.mov

### Current behaviour
No sticky options and specify position.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-t47jo?file=/src/index.js

`npm run start`
http://localhost:9001/?path=/story/design-system-navigation-bar--sticky