### PR TITLE
ci(cypress): set up single manually triggered workflow

### DIFF
--- a/.github/workflows/cypress-pr.yml
+++ b/.github/workflows/cypress-pr.yml
@@ -3,76 +3,19 @@ name: Cypress PR
 on: pull_request
 
 jobs:
-  cypress:
-     # if not a fork
+  trigger-cypress:
+    # if not a fork
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: ubuntu-18.04
-    timeout-minutes: 15
-    strategy:
-      # when one test fails, DO NOT cancel the other
-      # containers, because this will kill Cypress processes
-      # leaving the Dashboard hanging ...
-      # https://github.com/cypress-io/github-action/issues/48
-      fail-fast: false
-      matrix:
-        # run 20 copies of the current job in parallel
-        containers: [
-            1, 2, 3, 4, 5,
-            6, 7, 8, 9, 10,
-            11, 12, 13, 14, 15,
-            16, 17, 18, 19, 20
-            ]
-    container: cypress/browsers:node14.17.0-chrome91-ff89
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      # Restore the previous NPM modules and Cypress binary archives.
-      # Any updated archives will be saved automatically after the entire
-      # workflow successfully finishes.
-      # See https://github.com/actions/cache
-      - name: Cache central NPM modules
-        uses: actions/cache@v2
+      - uses: octokit/request-action@v2.x
+        id: dispatch_cypress
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Cache Cypress binary
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            cypress-${{ runner.os }}-cypress-
-      - name: install dependencies and verify Cypress
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
+          owner: ${{ github.event.repository.owner.login }}
+          repo: ${{ github.event.repository.name }}
+          workflow_id: "cypress.yml"
+          ref: "master"
+          inputs: '{"number": "${{ github.event.pull_request.number }}", "branch": "${{ github.head_ref }}"}'
         env:
-          # make sure every Cypress install prints minimal information
-          CI: 1
-        run: |
-          npm ci
-          npx cypress cache path
-          npx cypress cache list
-          npx cypress verify
-          npx cypress info
-      # because of "record" and "parallel" parameters
-      # these containers will load balance all found tests among themselves
-      - name: Cypress run
-        uses: cypress-io/github-action@v2.10.2
-        with:
-          install: false
-          start: npm start
-          # quote the url to be safe against YML parsing surprises
-          wait-on: 'http://localhost:9001'
-          wait-on-timeout: 250
-          record: true
-          parallel: true
-          group: ubuntu-regression
-          quiet: true
-          browser: chrome
-        env:
-          # pass the Dashboard record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          CI: 'true'
-          # Recommended: pass the GitHub token lets this action correctly
-          # determine the unique run id necessary to re-run the checks
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CYPRESS_WORKFLOW_TOKEN }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,10 +1,14 @@
-name: Cypress Push
+name: Cypress
 
 on:
-  push:
-    branches:
-      - trigger-integration # This is the branch that we use to test PR's from forks
-
+  workflow_dispatch:
+    inputs:
+      number:
+        description: "Pull Request Number"
+        required: true
+      branch:
+        description: "Branch Name"
+        required: true
 jobs:
   cypress:
     runs-on: ubuntu-latest
@@ -17,20 +21,37 @@ jobs:
       fail-fast: false
       matrix:
         # run 20 copies of the current job in parallel
-        containers: [
-            1, 2, 3, 4, 5,
-            6, 7, 8, 9, 10,
-            11, 12, 13, 14, 15,
-            16, 17, 18, 19, 20
-            ]
+        containers:
+          [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+          ]
     container: cypress/browsers:node14.17.0-chrome91-ff89
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      # Restore the previous NPM modules and Cypress binary archives.
-      # Any updated archives will be saved automatically after the entire
-      # workflow successfully finishes.
-      # See https://github.com/actions/cache
+        with:
+          ref: "refs/pull/${{ github.event.inputs.number }}/head"
+          fetch-depth: 0
+
       - name: Cache central NPM modules
         uses: actions/cache@v2
         with:
@@ -55,15 +76,12 @@ jobs:
           npx cypress cache list
           npx cypress verify
           npx cypress info
-      # because of "record" and "parallel" parameters
-      # these containers will load balance all found tests among themselves
       - name: Cypress run
         uses: cypress-io/github-action@v2.10.2
         with:
           install: false
           start: npm start
-          # quote the url to be safe against YML parsing surprises
-          wait-on: 'http://localhost:9001'
+          wait-on: "http://localhost:9001"
           wait-on-timeout: 250
           record: true
           parallel: true
@@ -71,9 +89,7 @@ jobs:
           quiet: true
           browser: chrome
         env:
-          # pass the Dashboard record key as an environment variable
+          COMMIT_INFO_BRANCH: ${{ github.event.inputs.branch }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          CI: 'true'
-          # Recommended: pass the GitHub token lets this action correctly
-          # determine the unique run id necessary to re-run the checks
+          CI: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/forked-ci.yml
+++ b/.github/workflows/forked-ci.yml
@@ -44,86 +44,18 @@ jobs:
       - run: npm ci
       - run: npx chromatic@latest --project-token ${{ secrets.CHROMATIC_PROJECT_TOKEN }} --exit-once-uploaded --branch-name="${{ needs.check.outputs.branch_name }}"
 
-  cypress:
+  trigger-cypress:
     needs: check
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        containers:
-          [
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-          ]
-    container: cypress/browsers:node14.17.0-chrome91-ff89
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: octokit/request-action@v2.x
+        id: dispatch_cypress
         with:
-          ref: "refs/pull/${{ github.event.inputs.number }}/head"
-          fetch-depth: 0
-      - name: Cache central NPM modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Cache Cypress binary
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            cypress-${{ runner.os }}-cypress-
-      - name: install dependencies and verify Cypress
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
+          owner: ${{ github.event.repository.owner.login }}
+          repo: ${{ github.event.repository.name }}
+          workflow_id: "cypress.yml"
+          ref: "master"
+          inputs: '{"number": "${{ github.event.pull_request.number }}", "branch": "${{ needs.check.outputs.branch_name }}"}'
         env:
-          # make sure every Cypress install prints minimal information
-          CI: 1
-        run: |
-          npm ci
-          npx cypress cache path
-          npx cypress cache list
-          npx cypress verify
-          npx cypress info
-      # because of "record" and "parallel" parameters
-      # these containers will load balance all found tests among themselves
-      - name: Cypress run
-        uses: cypress-io/github-action@v2.10.2
-        with:
-          install: false
-          start: npm start
-          # quote the url to be safe against YML parsing surprises
-          wait-on: "http://localhost:9001"
-          wait-on-timeout: 250
-          record: true
-          parallel: true
-          group: ubuntu-regression
-          quiet: true
-          browser: chrome
-        env:
-          # pass the Dashboard record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          CI: "true"
-          # Recommended: pass the GitHub token lets this action correctly
-          # determine the unique run id necessary to re-run the checks
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CYPRESS_WORKFLOW_TOKEN }}


### PR DESCRIPTION
### Proposed behaviour
Remove duplicated Cypress workflow and have it in one place: `cypress.yml`. 

For non-forked branches, this will be triggered from `cypress-pr.yml` which is run on `pull_request`.

For forked branches, this will be triggered manually via the `forked-ci.yml` workflow. Note this workflow will still run both Cypress and Chromatic on the relevant PR branch.

### Current behaviour
Duplicate Cypress workflows and different ones for forked and non-forked branches.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

