### PR TITLE
ci(forked-ci): fix number input

### DIFF
--- a/.github/workflows/forked-ci.yml
+++ b/.github/workflows/forked-ci.yml
@@ -56,6 +56,6 @@ jobs:
           repo: ${{ github.event.repository.name }}
           workflow_id: "cypress.yml"
           ref: "master"
-          inputs: '{"number": "${{ github.event.pull_request.number }}", "branch": "${{ needs.check.outputs.branch_name }}"}'
+          inputs: '{"number": "${{ github.event.inputs.number }}", "branch": "${{ needs.check.outputs.branch_name }}"}'
         env:
           GITHUB_TOKEN: ${{ secrets.CYPRESS_WORKFLOW_TOKEN }}


### PR DESCRIPTION
### Proposed behaviour
Correct line setting the PR number in the forked CI process

### Current behaviour
It is currently setting it incorrectly, this workflow does not have access to `github.event.pull_request.number`

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent