### PR TITLE
test: add an alias to make test stable

### DIFF
--- a/cypress/support/step-definitions/anchor-navigation-steps.js
+++ b/cypress/support/step-definitions/anchor-navigation-steps.js
@@ -8,7 +8,8 @@ When("I click onto {string} tab", (anchorNaviIndex) => {
 });
 
 Then("{string} anchor navigation section is visible", (anchorName) => {
-  anchorNavigationStickyMainPage(anchorName).should("be.visible");
+  anchorNavigationStickyMainPage(anchorName).as("anchorNavigation");
+  cy.get("@anchorNavigation").should("be.visible");
 });
 
 When("I scroll window to the {string} position", (anchorName) => {


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
add an `alias` -> `as("anchorNavigation")`

```javascript
Then("{string} anchor navigation section is visible", (anchorName) => {
  anchorNavigationStickyMainPage(anchorName).as("anchorNavigation");
  cy.get("@anchorNavigation").should("be.visible");
});
```

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Tests for `AnchorNavigation` component are not stable.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent