### PR TITLE
fix(flat-table-head): ensure table head row children are an array before running find function FE-4326

### DIFF
--- a/src/components/flat-table/flat-table-head/flat-table-head.component.js
+++ b/src/components/flat-table/flat-table-head/flat-table-head.component.js
@@ -28,9 +28,9 @@ const FlatTableHead = ({ children }) => {
            This is only needed when the preceding row has rowSpans applied, 
            as in any other use case the rows will all have FlatTableRowHeaders */
         const previousRowHasHeader = !!hasFlatTableRowHeader;
-        hasFlatTableRowHeader = child.props.children.find(
-          (c) => c.type === FlatTableRowHeader
-        );
+        hasFlatTableRowHeader = React.Children.toArray(
+          child.props.children
+        ).find((c) => c.type === FlatTableRowHeader);
         return React.cloneElement(child, {
           ...child.props,
           stickyOffset: rowHeights.slice(0, index).reduce((a, b) => a + b, 0),

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -462,6 +462,33 @@ describe("FlatTable", () => {
     });
   });
 
+  describe("when FlatTableHead rows have only one child", () => {
+    it("does not throw an error", () => {
+      expect(() => {
+        mount(
+          <FlatTable>
+            <FlatTableHead>
+              <FlatTableRow>
+                <FlatTableHeader>Name</FlatTableHeader>
+              </FlatTableRow>
+              <FlatTableRow>
+                <FlatTableHeader>City</FlatTableHeader>
+              </FlatTableRow>
+            </FlatTableHead>
+            <FlatTableBody>
+              <FlatTableRow>
+                <FlatTableCell>John Doe</FlatTableCell>
+              </FlatTableRow>
+              <FlatTableRow>
+                <FlatTableCell>John Doe</FlatTableCell>
+              </FlatTableRow>
+            </FlatTableBody>
+          </FlatTable>
+        );
+      }).not.toThrow();
+    });
+  });
+
   describe("footer", () => {
     let wrapper;
 


### PR DESCRIPTION
fix #4378

### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork 
it with the new built version of carbon.
-->
Uses `React.Children.toArray` before running `find` on row children as they are not always an array such as when there are multiple rows and only one column

### Current behaviour
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Throws an error when there are multiple rows within an `FlatTableHead` but only one column

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
