### PR TITLE
feat(simple-select): add prop to specify the open direction of a select list - FE-4316

### DIFF
--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -47,6 +47,8 @@ const FilterableSelect = React.forwardRef(
       "data-element": dataElement,
       "data-role": dataRole,
       tooltipPosition,
+      listPlacement = "bottom-start",
+      flipEnabled = true,
       ...textboxProps
     },
     inputRef
@@ -496,6 +498,8 @@ const FilterableSelect = React.forwardRef(
         tableHeader={tableHeader}
         multiColumn={multiColumn}
         loaderDataRole="filterable-select-list-loader"
+        listPlacement={listPlacement}
+        flipEnabled={flipEnabled}
       >
         {children}
       </FilterableSelectList>
@@ -567,6 +571,26 @@ FilterableSelect.propTypes = {
   onListScrollBottom: PropTypes.func,
   /** Overrides the default tooltip position */
   tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
+  /** Placement of the select list in relation to the input element */
+  listPlacement: PropTypes.oneOf([
+    "auto",
+    "auto-start",
+    "auto-end",
+    "top",
+    "top-start",
+    "top-end",
+    "bottom",
+    "bottom-start",
+    "bottom-end",
+    "right",
+    "right-start",
+    "right-end",
+    "left",
+    "left-start",
+    "left-end",
+  ]),
+  /** Use the opposite list placement if the set placement does not fit */
+  flipEnabled: PropTypes.bool,
 };
 
 FilterableSelect.defaultProps = {

--- a/src/components/select/filterable-select/filterable-select.d.ts
+++ b/src/components/select/filterable-select/filterable-select.d.ts
@@ -44,6 +44,25 @@ export interface FilterableSelectProps
   value?: string | Record<string, unknown>;
   /** Overrides the default tooltip position */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
+  /** Placement of the select list in relation to the input element */
+  listPlacement?:
+    | "auto"
+    | "auto-start"
+    | "auto-end"
+    | "top"
+    | "top-start"
+    | "top-end"
+    | "bottom"
+    | "bottom-start"
+    | "bottom-end"
+    | "right"
+    | "right-start"
+    | "right-end"
+    | "left"
+    | "left-start"
+    | "left-end";
+  /** Use the opposite list placement if the set placement does not fit */
+  flipEnabled?: bool;
 }
 
 declare function FilterableSelect(

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -236,6 +236,48 @@ describe("FilterableSelect", () => {
         expect(wrapper.find(SelectList).exists()).toBe(true);
       });
 
+      it.each([
+        "auto",
+        "auto-start",
+        "auto-end",
+        "top",
+        "top-start",
+        "top-end",
+        "bottom",
+        "bottom-start",
+        "bottom-end",
+        "right",
+        "right-start",
+        "right-end",
+        "left",
+        "left-start",
+        "left-end",
+      ])("the listPlacement prop should be passed", (listPlacement) => {
+        const wrapper = renderSelect({ listPlacement });
+
+        wrapper
+          .find(Textbox)
+          .find('[type="dropdown"]')
+          .first()
+          .simulate("click");
+        expect(wrapper.find(SelectList).prop("listPlacement")).toBe(
+          listPlacement
+        );
+      });
+
+      it("the flipEnabled prop should be passed", () => {
+        const wrapper = renderSelect({ flipEnabled: false });
+
+        wrapper
+          .find(Textbox)
+          .find('[type="dropdown"]')
+          .first()
+          .simulate("click");
+        expect(wrapper.find(SelectList).prop("flipEnabled")).toBe(false);
+        wrapper.setProps({ flipEnabled: true });
+        expect(wrapper.find(SelectList).prop("flipEnabled")).toBe(true);
+      });
+
       describe("twice", () => {
         it("the SelectList should not be rendered", () => {
           const wrapper = renderSelect();

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -74,6 +74,41 @@ you can filter through the existing options leaving only those that match the te
   </Story>
 </Preview>
 
+### List placement
+
+You can use `listPlacement` prop to set the position of the select list relative to the input element.
+
+<Preview>
+  <Story name="list placement">
+    <FilterableSelect
+      name="simple"
+      id="simple"
+      label="label"
+      labelInline
+      onOpen={action("onOpen")}
+      onChange={action("onChange")}
+      onClick={action("onClick")}
+      onFilterChange={action("onFilterChange")}
+      onFocus={action("onFocus")}
+      onBlur={action("onBlur")}
+      onKeyDown={action("onKeyDown")}
+      listPlacement="top-start"
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
+    </FilterableSelect>
+  </Story>
+</Preview>
+
 ### Controlled Usage
 
 <Preview>

--- a/src/components/select/multi-select/multi-select.component.js
+++ b/src/components/select/multi-select/multi-select.component.js
@@ -51,6 +51,8 @@ const MultiSelect = React.forwardRef(
       "data-component": dataComponent,
       "data-element": dataElement,
       "data-role": dataRole,
+      listPlacement = "bottom-start",
+      flipEnabled = true,
       ...textboxProps
     },
     inputRef
@@ -485,6 +487,8 @@ const MultiSelect = React.forwardRef(
         isLoading={isLoading}
         tableHeader={tableHeader}
         multiColumn={multiColumn}
+        listPlacement={listPlacement}
+        flipEnabled={flipEnabled}
         loaderDataRole="multi-select-list-loader"
       >
         {children}
@@ -558,6 +562,26 @@ MultiSelect.propTypes = {
   isLoading: PropTypes.bool,
   /** Overrides the default tooltip position */
   tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
+  /** Placement of the select list in relation to the input element */
+  listPlacement: PropTypes.oneOf([
+    "auto",
+    "auto-start",
+    "auto-end",
+    "top",
+    "top-start",
+    "top-end",
+    "bottom",
+    "bottom-start",
+    "bottom-end",
+    "right",
+    "right-start",
+    "right-end",
+    "left",
+    "left-start",
+    "left-end",
+  ]),
+  /** Use the opposite list placement if the set placement does not fit */
+  flipEnabled: PropTypes.bool,
 };
 
 MultiSelect.defaultProps = {

--- a/src/components/select/multi-select/multi-select.d.ts
+++ b/src/components/select/multi-select/multi-select.d.ts
@@ -39,6 +39,25 @@ export interface MultiSelectProps
   value?: string[] | Record<string, unknown>[];
   /** Overrides the default tooltip position */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
+  /** Placement of the select list in relation to the input element */
+  listPlacement?:
+    | "auto"
+    | "auto-start"
+    | "auto-end"
+    | "top"
+    | "top-start"
+    | "top-end"
+    | "bottom"
+    | "bottom-start"
+    | "bottom-end"
+    | "right"
+    | "right-start"
+    | "right-end"
+    | "left"
+    | "left-start"
+    | "left-end";
+  /** Use the opposite list placement if the set placement does not fit */
+  flipEnabled?: bool;
 }
 
 declare function MultiSelect(

--- a/src/components/select/multi-select/multi-select.spec.js
+++ b/src/components/select/multi-select/multi-select.spec.js
@@ -103,6 +103,38 @@ describe("MultiSelect", () => {
   });
 
   it.each([
+    "auto",
+    "auto-start",
+    "auto-end",
+    "top",
+    "top-start",
+    "top-end",
+    "bottom",
+    "bottom-start",
+    "bottom-end",
+    "right",
+    "right-start",
+    "right-end",
+    "left",
+    "left-start",
+    "left-end",
+  ])("the listPlacement prop should be passed", (listPlacement) => {
+    const wrapper = renderSelect({ listPlacement });
+
+    wrapper.find(Textbox).find('[type="dropdown"]').first().simulate("click");
+    expect(wrapper.find(SelectList).prop("listPlacement")).toBe(listPlacement);
+  });
+
+  it("the flipEnabled prop should be passed", () => {
+    const wrapper = renderSelect({ flipEnabled: false });
+
+    wrapper.find(Textbox).find('[type="dropdown"]').first().simulate("click");
+    expect(wrapper.find(SelectList).prop("flipEnabled")).toBe(false);
+    wrapper.setProps({ flipEnabled: true });
+    expect(wrapper.find(SelectList).prop("flipEnabled")).toBe(true);
+  });
+
+  it.each([
     ["small", "32px"],
     ["medium", "40px"],
     ["large", "48px"],

--- a/src/components/select/multi-select/multi-select.stories.mdx
+++ b/src/components/select/multi-select/multi-select.stories.mdx
@@ -73,6 +73,41 @@ you can filter through the existing options leaving only those that match the te
   </Story>
 </Preview>
 
+### List placement
+
+You can use `listPlacement` prop to set the position of the select list relative to the input element.
+
+<Preview>
+  <Story name="list placement">
+    <MultiSelect
+      name="simple"
+      id="simple"
+      label="label"
+      labelInline
+      onOpen={action("onOpen")}
+      onChange={action("onChange")}
+      onClick={action("onClick")}
+      onFilterChange={action("onFilterChange")}
+      onFocus={action("onFocus")}
+      onBlur={action("onBlur")}
+      onKeyDown={action("onKeyDown", { depth: 2 })}
+      listPlacement="top-start"
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
+    </MultiSelect>
+  </Story>
+</Preview>
+
 ### Controlled Usage
 
 <Preview>

--- a/src/components/select/select-list/select-list-container.style.js
+++ b/src/components/select/select-list/select-list-container.style.js
@@ -8,9 +8,18 @@ const StyledSelectListContainer = styled.div`
   ${({ placement }) => placement === "top-start" && "bottom: 0"};
   min-width: 100%;
   max-width: 870px;
-  transition: height 0.15s ease-out;
   height: ${({ height }) => height};
   overflow: hidden;
+  animation: fadeIn 250ms ease-out;
+
+  @keyframes fadeIn {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
 `;
 
 StyledSelectListContainer.defaultProps = {

--- a/src/components/select/select-list/select-list.component.js
+++ b/src/components/select/select-list/select-list.component.js
@@ -25,7 +25,7 @@ import StyledSelectListContainer from "./select-list-container.style";
 import Loader from "../../loader";
 import Option from "../option/option.component";
 
-const popoverModifiers = [
+const fixedPopoverModifiers = [
   {
     name: "offset",
     options: {
@@ -59,6 +59,8 @@ const SelectList = React.forwardRef(
       multiColumn,
       tableHeader,
       loaderDataRole,
+      listPlacement = "bottom-start",
+      flipEnabled = true,
       ...listProps
     },
     listContainerRef
@@ -387,6 +389,14 @@ const SelectList = React.forwardRef(
       }
     }, [children, currentOptionsListIndex, isLoading, lastOptionIndex]);
 
+    const popoverModifiers = [
+      ...fixedPopoverModifiers,
+      {
+        name: "flip",
+        enabled: flipEnabled,
+      },
+    ];
+
     function isNavigationKey(keyEvent) {
       return (
         keyEvent === "ArrowDown" ||
@@ -419,7 +429,7 @@ const SelectList = React.forwardRef(
 
     return (
       <Popover
-        placement="bottom-start"
+        placement={listPlacement}
         disablePortal={disablePortal}
         reference={anchorRef}
         onFirstUpdate={setPlacementCallback}
@@ -497,6 +507,26 @@ SelectList.propTypes = {
   multiColumn: PropTypes.bool,
   /** Data role for loader component */
   loaderDataRole: PropTypes.string,
+  /** Placement of the select list relative to the input element */
+  listPlacement: PropTypes.oneOf([
+    "auto",
+    "auto-start",
+    "auto-end",
+    "top",
+    "top-start",
+    "top-end",
+    "bottom",
+    "bottom-start",
+    "bottom-end",
+    "right",
+    "right-start",
+    "right-end",
+    "left",
+    "left-start",
+    "left-end",
+  ]),
+  /** Use the opposite list placement if the set placement does not fit */
+  flipEnabled: PropTypes.bool,
 };
 
 export default SelectList;

--- a/src/components/select/select-list/select-list.spec.js
+++ b/src/components/select/select-list/select-list.spec.js
@@ -670,6 +670,28 @@ describe("SelectList", () => {
         wrapper
       );
     });
+
+    it.each([
+      "auto",
+      "auto-start",
+      "auto-end",
+      "top",
+      "top-start",
+      "top-end",
+      "bottom",
+      "bottom-start",
+      "bottom-end",
+      "right",
+      "right-start",
+      "right-end",
+      "left",
+      "left-start",
+      "left-end",
+    ])("passes listPlacement prop as a placement prop", (listPlacement) => {
+      const wrapper = renderSelectList({ listPlacement });
+
+      expect(wrapper.find(Popover).prop("placement")).toBe(listPlacement);
+    });
   });
 
   describe("when non option elements are provided as children", () => {

--- a/src/components/select/simple-select/simple-select-test.stories.js
+++ b/src/components/select/simple-select/simple-select-test.stories.js
@@ -20,6 +20,28 @@ export default {
         disabled: true,
       },
     },
+    listPlacement: {
+      options: [
+        "auto",
+        "auto-start",
+        "auto-end",
+        "top",
+        "top-start",
+        "top-end",
+        "bottom",
+        "bottom-start",
+        "bottom-end",
+        "right",
+        "right-start",
+        "right-end",
+        "left",
+        "left-start",
+        "left-end",
+      ],
+      control: {
+        type: "select",
+      },
+    },
   },
 };
 
@@ -67,9 +89,14 @@ Default.argTypes = {
   isLoading: { table: { disable: true }, control: false },
   onListScrollBottom: { table: { disable: true }, control: false },
   tooltipPosition: { table: { disable: true }, control: false },
+  "data-component": { table: { disable: true }, control: false },
+  "data-element": { table: { disable: true }, control: false },
+  "data-role": { table: { disable: true }, control: false },
 };
 Default.args = {
   mt: 0,
+  listPlacement: undefined,
+  flipEnabled: true,
 };
 
 export { Default };

--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -49,6 +49,8 @@ const SimpleSelect = React.forwardRef(
       "data-component": dataComponent,
       "data-element": dataElement,
       "data-role": dataRole,
+      listPlacement = "bottom-start",
+      flipEnabled = true,
       ...props
     },
     inputRef
@@ -404,6 +406,8 @@ const SimpleSelect = React.forwardRef(
         tableHeader={tableHeader}
         multiColumn={multiColumn}
         loaderDataRole="simple-select-list-loader"
+        listPlacement={listPlacement}
+        flipEnabled={flipEnabled}
       >
         {children}
       </SelectList>
@@ -471,6 +475,26 @@ SimpleSelect.propTypes = {
   onListScrollBottom: PropTypes.func,
   /** Overrides the default tooltip position */
   tooltipPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
+  /** Placement of the select list in relation to the input element */
+  listPlacement: PropTypes.oneOf([
+    "auto",
+    "auto-start",
+    "auto-end",
+    "top",
+    "top-start",
+    "top-end",
+    "bottom",
+    "bottom-start",
+    "bottom-end",
+    "right",
+    "right-start",
+    "right-end",
+    "left",
+    "left-start",
+    "left-end",
+  ]),
+  /** Use the opposite list placement if the set placement does not fit */
+  flipEnabled: PropTypes.bool,
 };
 
 SimpleSelect.defaultProps = {

--- a/src/components/select/simple-select/simple-select.d.ts
+++ b/src/components/select/simple-select/simple-select.d.ts
@@ -37,6 +37,25 @@ export interface SimpleSelectProps
   value?: string | Record<string, unknown>;
   /** Overrides the default tooltip position */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
+  /** Placement of the select list in relation to the input element */
+  listPlacement?:
+    | "auto"
+    | "auto-start"
+    | "auto-end"
+    | "top"
+    | "top-start"
+    | "top-end"
+    | "bottom"
+    | "bottom-start"
+    | "bottom-end"
+    | "right"
+    | "right-start"
+    | "right-end"
+    | "left"
+    | "left-start"
+    | "left-end";
+  /** Use the opposite list placement if the set placement does not fit */
+  flipEnabled?: bool;
 }
 
 declare function SimpleSelect(

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -410,6 +410,40 @@ describe("SimpleSelect", () => {
         expect(wrapper.find(SelectList).exists()).toBe(false);
       });
     });
+
+    it.each([
+      "auto",
+      "auto-start",
+      "auto-end",
+      "top",
+      "top-start",
+      "top-end",
+      "bottom",
+      "bottom-start",
+      "bottom-end",
+      "right",
+      "right-start",
+      "right-end",
+      "left",
+      "left-start",
+      "left-end",
+    ])("the listPlacement prop should be passed", (listPlacement) => {
+      const wrapper = renderSelect({ listPlacement });
+
+      wrapper.find("input").simulate("click");
+      expect(wrapper.find(SelectList).prop("listPlacement")).toBe(
+        listPlacement
+      );
+    });
+
+    it("the flipEnabled prop should be passed", () => {
+      const wrapper = renderSelect({ flipEnabled: false });
+
+      wrapper.find("input").simulate("click");
+      expect(wrapper.find(SelectList).prop("flipEnabled")).toBe(false);
+      wrapper.setProps({ flipEnabled: true });
+      expect(wrapper.find(SelectList).prop("flipEnabled")).toBe(true);
+    });
   });
 
   describe("when the Dropdown Icon in the Textbox has been clicked", () => {

--- a/src/components/select/simple-select/simple-select.stories.mdx
+++ b/src/components/select/simple-select/simple-select.stories.mdx
@@ -95,6 +95,40 @@ You can use the `required` prop to indicate if the field is mandatory.
   </Story>
 </Preview>
 
+### List placement
+
+You can use `listPlacement` prop to set the position of the select list relative to the input element.
+
+<Preview>
+  <Story name="list placement">
+    <Select
+      name="simple"
+      id="simple"
+      label="label"
+      labelInline
+      onOpen={action("onOpen")}
+      onChange={action("onChange", { depth: 2 })}
+      onClick={action("onClick", { depth: 2 })}
+      onFocus={action("onFocus", { depth: 2 })}
+      onBlur={action("onBlur", { depth: 2 })}
+      onKeyDown={action("onKeyDown", { depth: 2 })}
+      listPlacement="top-start"
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
+    </Select>
+  </Story>
+</Preview>
+
 ### Controlled usage
 
 <Preview>


### PR DESCRIPTION
### Proposed behaviour
- Add `listPlacement` prop passed to Popover component `placement` prop.
- Add `flipEnabled` prop to enforce list placement if the set placement doesn't fit.
- Change the list opening animation from accordion to fading.

### Current behaviour
No way to set the select options list position.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Carbon implementation and Design System documentation are congruent

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-ngpvp
