### PR TITLE
refactor(form): rewrite sticky footer and add height prop

### DIFF
--- a/cypress/features/regression/dialog.feature
+++ b/cypress/features/regression/dialog.feature
@@ -50,13 +50,6 @@ Feature: Dialog component
     Then closeIcon is not visible
 
   @positive
-  Scenario: Verify that stickyFormFooter is not visible when scrolled to the bottom
-    Given I open "Form" component page "In dialog with sticky footer"
-      And I click on Open Preview button
-    When I scroll to the bottom of the dialog
-    Then The footer is not sticky
-
-  @positive
   Scenario: Disable escape key
     Given I open default "Dialog Test" component with "dialog" json from "commonComponents" using "disableEscKey" object name
       And I wait 500

--- a/cypress/locators/dialog/index.js
+++ b/cypress/locators/dialog/index.js
@@ -1,14 +1,8 @@
-import {
-  ALERT_DIALOG,
-  STICKY_FORM_FOOTER_ELEMENT,
-  DIALOG_TITLE,
-  OPEN_PREVIEW,
-} from "./locators";
+import { ALERT_DIALOG, DIALOG_TITLE, OPEN_PREVIEW } from "./locators";
 
 // component preview locators
 export const alertDialogPreview = () => cy.get(ALERT_DIALOG);
 export const alertChildren = () =>
   alertDialogPreview().find("div:nth-child(2)").children();
 export const dialogTitle = () => cy.get(DIALOG_TITLE);
-export const dialogStickyFormFooter = () => cy.get(STICKY_FORM_FOOTER_ELEMENT);
 export const openPreviewButton = () => cy.get(OPEN_PREVIEW);

--- a/cypress/locators/dialog/locators.js
+++ b/cypress/locators/dialog/locators.js
@@ -1,5 +1,4 @@
 // component preview locators
 export const ALERT_DIALOG = '[data-element="dialog"]';
 export const DIALOG_TITLE = "#carbon-dialog-title";
-export const STICKY_FORM_FOOTER_ELEMENT = '[data-element="form-footer"]';
 export const OPEN_PREVIEW = '[data-component="button"]';

--- a/cypress/support/step-definitions/dialog-steps.js
+++ b/cypress/support/step-definitions/dialog-steps.js
@@ -1,6 +1,5 @@
 import {
   alertDialogPreview as dialogPreview,
-  dialogStickyFormFooter,
   openPreviewButton,
 } from "../../locators/dialog/index";
 import { backgroundUILocator } from "../../locators/index";
@@ -36,10 +35,6 @@ Then("Dialog is visible", () => {
 
 When("I scroll to the bottom of the dialog", () => {
   dialogPreview().children().eq(1).scrollTo("bottom");
-});
-
-Then("The footer is not sticky", () => {
-  dialogStickyFormFooter().should("not.have.class", "sticky");
 });
 
 When("I click on Open Preview button", () => {

--- a/src/components/dialog-full-screen/content.style.js
+++ b/src/components/dialog-full-screen/content.style.js
@@ -1,22 +1,65 @@
 import styled, { css } from "styled-components";
-import { StyledFormFooter } from "../form/form.style";
+import { StyledFormFooter, StyledFormContent } from "../form/form.style";
 
 const StyledContent = styled.div`
   overflow-y: auto;
   padding: 0 16px;
   flex: 1;
 
+  ${({ headingHeight }) => css`
+    ${StyledFormContent}.sticky {
+      height: calc(100vh - ${headingHeight + 72}px);
+
+      padding-right: 16px;
+      padding-left: 16px;
+      margin-right: -16px;
+      margin-left: -16px;
+
+      @media screen and (min-width: 600px) {
+        padding-right: 24px;
+        padding-left: 24px;
+        margin-right: -24px;
+        margin-left: -24px;
+      }
+      @media screen and (min-width: 960px) {
+        padding-right: 32px;
+        padding-left: 32px;
+        margin-right: -32px;
+        margin-left: -32px;
+      }
+      @media screen and (min-width: 1260px) {
+        padding-right: 40px;
+        padding-left: 40px;
+        margin-right: -40px;
+        margin-left: -40px;
+      }
+    }
+  `}
+
   ${StyledFormFooter}.sticky {
     padding: 16px;
 
+    margin-right: -16px;
+    margin-left: -16px;
+    width: calc(100% + 32px);
+
     @media screen and (min-width: 600px) {
       padding: 16px 24px;
+      margin-right: -24px;
+      margin-left: -24px;
+      width: calc(100% + 48px);
     }
     @media screen and (min-width: 960px) {
       padding: 16px 32px;
+      margin-right: -32px;
+      margin-left: -32px;
+      width: calc(100% + 64px);
     }
     @media screen and (min-width: 1260px) {
       padding: 16px 40px;
+      margin-right: -40px;
+      margin-left: -40px;
+      width: calc(100% + 80px);
     }
   }
 

--- a/src/components/dialog-full-screen/dialog-full-screen.component.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.js
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 
 import Modal from "../modal";
@@ -9,6 +9,7 @@ import StyledContent from "./content.style";
 import FocusTrap from "../../__internal__/focus-trap";
 import IconButton from "../icon-button";
 import Icon from "../icon";
+import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
 
 const DialogFullScreen = ({
   disableAutoFocus,
@@ -28,6 +29,20 @@ const DialogFullScreen = ({
   ...rest
 }) => {
   const dialogRef = useRef();
+  const headingRef = useRef();
+  const [headingHeight, setHeadingHeight] = useState(101);
+
+  const updateheadingHeight = () => {
+    setHeadingHeight(headingRef.current.offsetHeight);
+  };
+
+  useEffect(() => {
+    if (open && headingRef.current) {
+      updateheadingHeight();
+    }
+  }, [open]);
+
+  useResizeObserver(headingRef, updateheadingHeight, !headingRef.current);
 
   const closeIcon = () => {
     if (!showCloseIcon || !onCancel) return null;
@@ -44,7 +59,7 @@ const DialogFullScreen = ({
   };
 
   const dialogTitle = () => (
-    <FullScreenHeading hasContent={title}>
+    <FullScreenHeading hasContent={title} ref={headingRef}>
       {typeof title === "string" ? (
         <Heading
           title={title}
@@ -90,6 +105,7 @@ const DialogFullScreen = ({
             data-element="content"
             ref={contentRef}
             disableContentPadding={disableContentPadding}
+            headingHeight={headingHeight}
           >
             {children}
           </StyledContent>

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -284,7 +284,6 @@ describe("Dialog", () => {
           bottom: "-30px",
           marginBottom: "-30px",
           width: "calc(100% + 70px)",
-          position: "sticky",
           paddingLeft: "35px",
           paddingRight: "35px",
         },

--- a/src/components/dialog/dialog.stories.mdx
+++ b/src/components/dialog/dialog.stories.mdx
@@ -65,6 +65,7 @@ A configuration shows a close icon at the top right of the Dialog. Sometimes use
           >
             <Form
               stickyFooter={true}
+              height="500px"
               leftSideButtons={
                 <Button onClick={() => setIsOpen(false)}>Cancel</Button>
               }
@@ -111,6 +112,7 @@ When mixing editable and non-editable content, you can use the <LinkTo kind='Box
           >
             <Form
               stickyFooter={true}
+              height="500px"
               leftSideButtons={
                 <Button onClick={() => setIsOpen(false)}>Cancel</Button>
               }
@@ -182,6 +184,7 @@ When mixing editable and non-editable content, you can use the <LinkTo kind='Box
           >
             <Form
               stickyFooter={true}
+              height="500px"
               leftSideButtons={
                 <Button onClick={() => setIsOpen(false)}>Cancel</Button>
               }

--- a/src/components/dialog/dialog.style.js
+++ b/src/components/dialog/dialog.style.js
@@ -1,7 +1,11 @@
 import styled, { css } from "styled-components";
 
 import baseTheme from "../../style/themes/base";
-import { StyledForm, StyledFormFooter } from "../form/form.style";
+import {
+  StyledForm,
+  StyledFormFooter,
+  StyledFormContent,
+} from "../form/form.style";
 import {
   StyledHeaderContent,
   StyledHeading,
@@ -55,9 +59,18 @@ const DialogStyle = styled.div`
     `};
 
   ${StyledForm} {
-    height: 100%;
     padding-bottom: 0px;
     box-sizing: border-box;
+  }
+
+  ${StyledFormContent}.sticky {
+    height: calc(100vh - 210px);
+    padding-right: ${HORIZONTAL_PADDING}px;
+    padding-left: ${HORIZONTAL_PADDING}px;
+    padding-top: 20px;
+    margin-right: -${HORIZONTAL_PADDING}px;
+    margin-left: -${HORIZONTAL_PADDING}px;
+    margin-top: -20px;
   }
 
   ${StyledFormFooter}.sticky {
@@ -65,7 +78,6 @@ const DialogStyle = styled.div`
     bottom: -${CONTENT_BOTTOM_PADDING}px;
     margin-bottom: -${CONTENT_BOTTOM_PADDING}px;
     width: calc(100% + ${2 * HORIZONTAL_PADDING}px);
-    position: sticky;
     padding-left: ${HORIZONTAL_PADDING}px;
     padding-right: ${HORIZONTAL_PADDING}px;
   }

--- a/src/components/form/form.component.js
+++ b/src/components/form/form.component.js
@@ -1,25 +1,16 @@
-import React, {
-  useState,
-  useRef,
-  useEffect,
-  useCallback,
-  useContext,
-} from "react";
+import React, { useRef, useContext } from "react";
 import PropTypes from "prop-types";
-import throttle from "lodash/throttle";
 import styledSystemPropTypes from "@styled-system/prop-types";
 
-import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
 import FormSummary from "./__internal__/form-summary.component";
 import {
   StyledForm,
+  StyledFormContent,
   StyledFormFooter,
   StyledLeftButtons,
   StyledRightButtons,
 } from "./form.style";
 import { SidebarContext } from "../sidebar/sidebar.component";
-
-const SCROLL_THROTTLE = 50;
 
 const Form = ({
   children,
@@ -37,63 +28,14 @@ const Form = ({
   height,
   ...rest
 }) => {
-  const [isFooterSticky, setIsFooterSticky] = useState(false);
   const { isInSidebar } = useContext(SidebarContext);
   const formRef = useRef();
   const formFooterRef = useRef();
-  const stickyListenersAddedRef = useRef(false);
-  const checkStickyFooter = useCallback(
-    throttle(() => {
-      const { bottom } = formRef.current.getBoundingClientRect();
-      let isBottomBelowScreen;
-
-      if (dialogRef) {
-        isBottomBelowScreen =
-          bottom > dialogRef.current.getBoundingClientRect().bottom;
-      } else {
-        isBottomBelowScreen = bottom > window.innerHeight;
-      }
-
-      if (isBottomBelowScreen) {
-        setIsFooterSticky(true);
-      } else {
-        setIsFooterSticky(false);
-      }
-    }, SCROLL_THROTTLE),
-    []
-  );
-
-  useResizeObserver(formRef, checkStickyFooter, !stickyFooter);
-
-  const addStickyFooterListeners = useCallback(() => {
-    window.addEventListener("resize", checkStickyFooter, true);
-    window.addEventListener("scroll", checkStickyFooter, true);
-    stickyListenersAddedRef.current = true;
-  }, [checkStickyFooter]);
-
-  const removeStickyFooterListeners = useCallback(() => {
-    window.removeEventListener("resize", checkStickyFooter, true);
-    window.removeEventListener("scroll", checkStickyFooter, true);
-    stickyListenersAddedRef.current = false;
-  }, [checkStickyFooter]);
-
-  useEffect(() => {
-    if (stickyFooter && !stickyListenersAddedRef.current) {
-      addStickyFooterListeners();
-      checkStickyFooter();
-    }
-    return () => removeStickyFooterListeners();
-  }, [
-    addStickyFooterListeners,
-    checkStickyFooter,
-    removeStickyFooterListeners,
-    stickyFooter,
-  ]);
 
   return (
     <StyledForm
       ref={formRef}
-      stickyFooter={stickyFooter && isFooterSticky}
+      stickyFooter={stickyFooter}
       onSubmit={onSubmit}
       data-component="form"
       fieldSpacing={fieldSpacing}
@@ -102,12 +44,18 @@ const Form = ({
       height={height}
       {...rest}
     >
-      {children}
+      <StyledFormContent
+        data-element="form-content"
+        stickyFooter={stickyFooter}
+        className={stickyFooter ? "sticky" : ""}
+      >
+        {children}
+      </StyledFormContent>
       <StyledFormFooter
         data-element="form-footer"
-        className={isFooterSticky ? "sticky" : ""}
+        className={stickyFooter ? "sticky" : ""}
         ref={formFooterRef}
-        stickyFooter={isFooterSticky}
+        stickyFooter={stickyFooter}
         buttonAlignment={buttonAlignment}
       >
         {leftSideButtons && (

--- a/src/components/form/form.component.js
+++ b/src/components/form/form.component.js
@@ -34,6 +34,7 @@ const Form = ({
   dialogRef,
   fieldSpacing = 3,
   noValidate = true,
+  height,
   ...rest
 }) => {
   const [isFooterSticky, setIsFooterSticky] = useState(false);
@@ -98,6 +99,7 @@ const Form = ({
       fieldSpacing={fieldSpacing}
       noValidate={noValidate}
       isInSidebar={isInSidebar}
+      height={height}
       {...rest}
     >
       {children}
@@ -168,6 +170,9 @@ Form.propTypes = {
    * Used to detect if FormFooter should be sticky when used in Dialog component
    */
   dialogRef: PropTypes.shape({ current: PropTypes.any }),
+
+  /** Height of the form (any valid CSS value) */
+  height: PropTypes.string,
 };
 
 export default Form;

--- a/src/components/form/form.d.ts
+++ b/src/components/form/form.d.ts
@@ -24,6 +24,8 @@ export interface FormProps extends SpaceProps {
   stickyFooter?: boolean;
   /** The total number of warnings present in the form */
   warningCount?: number;
+  /** Height of the form (any valid CSS value) */
+  height?: string;
 }
 
 declare function Form(props: FormProps): JSX.Element;

--- a/src/components/form/form.spec.js
+++ b/src/components/form/form.spec.js
@@ -1,10 +1,7 @@
 import React, { useRef } from "react";
 import { mount, shallow } from "enzyme";
-import { act } from "react-dom/test-utils";
 
 import baseTheme from "../../style/themes/base";
-
-import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
 import {
   assertStyleMatch,
   testStyledSystemSpacing,
@@ -15,6 +12,7 @@ import {
   StyledRightButtons,
   StyledFormFooter,
   StyledForm,
+  StyledFormContent,
 } from "./form.style";
 import FormSummary from "./__internal__/form-summary.component";
 import StyledFormField from "../../__internal__/form-field/form-field.style";
@@ -44,19 +42,6 @@ describe("Form", () => {
   it("allows custom classes to be added to the Form", () => {
     wrapper.setProps({ className: "foo" });
     expect(wrapper.find(StyledForm).hasClass("foo")).toBeTruthy();
-  });
-
-  it("cleans up event listeners after unmounting", () => {
-    wrapper.update();
-    const removeEventListenerSpy = jest.spyOn(window, "removeEventListener");
-
-    wrapper.unmount();
-
-    expect(
-      removeEventListenerSpy.mock.calls.filter(
-        (call) => call[0] === "scroll" || call[0] === "resize"
-      )
-    ).toHaveLength(2);
   });
 
   describe("when search used in Form component", () => {
@@ -122,21 +107,9 @@ describe("Form", () => {
   });
 
   describe("when stickyFooter prop is true", () => {
-    const dispatchScrollEvent = () => {
-      act(() => {
-        jest.runAllTimers();
-        window.dispatchEvent(new Event("scroll"));
-      });
-    };
     const assertThatFooterIsSticky = () => {
       wrapper.update();
       expect(wrapper.find(StyledFormFooter).hasClass("sticky")).toBe(true);
-      assertStyleMatch(
-        {
-          paddingBottom: "88px",
-        },
-        wrapper.find(StyledForm)
-      );
 
       assertStyleMatch(
         {
@@ -144,28 +117,8 @@ describe("Form", () => {
           boxShadow: "0 -4px 12px 0 rgba(0,0,0,0.05)",
           boxSizing: "border-box",
           padding: "16px 32px",
-          bottom: "0",
-          left: "0",
-          position: "fixed",
           width: "100%",
-        },
-        wrapper.find(StyledFormFooter)
-      );
-    };
-
-    const assertThatFooterIsNotSticky = () => {
-      wrapper.update();
-      assertStyleMatch(
-        {
-          backgroundColor: undefined,
-          boxShadow: undefined,
-          boxSizing: undefined,
-          padding: undefined,
-          bottom: undefined,
-          left: undefined,
-          position: undefined,
-          width: undefined,
-          zIndex: undefined,
+          zIndex: "1000",
         },
         wrapper.find(StyledFormFooter)
       );
@@ -174,92 +127,10 @@ describe("Form", () => {
     describe("without container", () => {
       beforeEach(() => {
         wrapper = mount(<Form stickyFooter />);
-        window.innerHeight = 1000;
       });
 
-      afterEach(() => {
-        window.innerHeight = 768;
-      });
-
-      it("renders footer with sticky styles if form bottom is below the window", () => {
-        const formNode = wrapper.find(StyledForm).getDOMNode();
-        jest
-          .spyOn(formNode, "getBoundingClientRect")
-          .mockImplementation(() => ({
-            bottom: 1051,
-          }));
-
-        dispatchScrollEvent();
+      it("renders footer with sticky styles", () => {
         assertThatFooterIsSticky();
-      });
-
-      it("renders form footer without sticky styles if form bottom is above the bottom of window", () => {
-        const formNode = wrapper.find(StyledForm).getDOMNode();
-        jest
-          .spyOn(formNode, "getBoundingClientRect")
-          .mockImplementation(() => ({
-            top: 100,
-            bottom: 900,
-          }));
-
-        dispatchScrollEvent();
-        assertThatFooterIsNotSticky();
-      });
-
-      it("does not change stickyFooter state if it does not need to change", () => {
-        const formNode = wrapper.find(StyledForm).getDOMNode();
-        jest
-          .spyOn(formNode, "getBoundingClientRect")
-          .mockImplementation(() => ({
-            bottom: 1100,
-          }));
-
-        dispatchScrollEvent();
-        assertThatFooterIsSticky();
-
-        jest
-          .spyOn(formNode, "getBoundingClientRect")
-          .mockImplementation(() => ({
-            bottom: 1101,
-          }));
-
-        dispatchScrollEvent();
-        assertThatFooterIsSticky();
-      });
-
-      it("render stickyFooter with sticky rules on resize if form bottom is above the bottom of window", () => {
-        const formNode = wrapper.find(StyledForm).getDOMNode();
-        jest
-          .spyOn(formNode, "getBoundingClientRect")
-          .mockImplementation(() => ({
-            bottom: 1051,
-          }));
-
-        act(() => {
-          useResizeObserver.mock.calls[
-            useResizeObserver.mock.calls.length - 1
-          ][1]();
-        });
-
-        assertThatFooterIsSticky();
-      });
-
-      it("renders form footer without sticky styles on resize if form bottom is above the bottom of window", () => {
-        const formNode = wrapper.find(StyledForm).getDOMNode();
-        jest
-          .spyOn(formNode, "getBoundingClientRect")
-          .mockImplementation(() => ({
-            top: 100,
-            bottom: 900,
-          }));
-
-        act(() => {
-          useResizeObserver.mock.calls[
-            useResizeObserver.mock.calls.length - 1
-          ][1]();
-        });
-
-        assertThatFooterIsNotSticky();
       });
     });
 
@@ -279,40 +150,8 @@ describe("Form", () => {
         wrapper = mount(<Component />);
       });
 
-      it("renders footer with sticky styles if form bottom is below the container", () => {
-        const containerNode = wrapper.find("#test-container").getDOMNode();
-        jest
-          .spyOn(containerNode, "getBoundingClientRect")
-          .mockImplementation(() => ({
-            bottom: 1000,
-          }));
-        const formNode = wrapper.find(StyledForm).getDOMNode();
-        jest
-          .spyOn(formNode, "getBoundingClientRect")
-          .mockImplementation(() => ({
-            bottom: 1050,
-          }));
-
-        dispatchScrollEvent();
+      it("renders footer with sticky styles", () => {
         assertThatFooterIsSticky();
-      });
-
-      it("renders form footer without sticky styles if form bottom is above the bottom of window", () => {
-        const containerNode = wrapper.find("#test-container").getDOMNode();
-        jest
-          .spyOn(containerNode, "getBoundingClientRect")
-          .mockImplementation(() => ({
-            bottom: 1100,
-          }));
-        const formNode = wrapper.find(StyledForm).getDOMNode();
-        jest
-          .spyOn(formNode, "getBoundingClientRect")
-          .mockImplementation(() => ({
-            bottom: 1050,
-          }));
-
-        dispatchScrollEvent();
-        assertThatFooterIsNotSticky();
       });
     });
 
@@ -322,17 +161,28 @@ describe("Form", () => {
 
         assertStyleMatch(
           {
-            position: "static !important",
+            height: "calc(100vh - 184px)",
+            paddingRight: "32px",
+            paddingLeft: "32px",
+            paddingTop: "27px",
+            marginRight: "-32px",
+            marginLeft: "-32px",
+            marginTop: "-27px",
           },
-          wrapper
+          wrapper,
+          { modifier: `${StyledFormContent}.sticky` }
         );
 
         assertStyleMatch(
           {
-            position: "absolute",
+            marginLeft: "-32px",
+            marginBottom: "-32px",
+            width: "calc(100% + 64px)",
+            paddingLeft: "32px",
+            paddingRight: "32px",
           },
           wrapper,
-          { modifier: `${StyledFormFooter}` }
+          { modifier: `${StyledFormFooter}.sticky` }
         );
       });
     });

--- a/src/components/form/form.spec.js
+++ b/src/components/form/form.spec.js
@@ -73,6 +73,19 @@ describe("Form", () => {
     });
   });
 
+  describe("when height prop is set", () => {
+    it("sets the correct height onto StyledForm", () => {
+      wrapper = mount(<StyledForm height="100px" />);
+
+      assertStyleMatch(
+        {
+          height: "100px",
+        },
+        wrapper.find(StyledForm)
+      );
+    });
+  });
+
   describe("When `fieldSpacing` applied", () => {
     wrapper = mount(<StyledForm />);
 

--- a/src/components/form/form.stories.mdx
+++ b/src/components/form/form.stories.mdx
@@ -621,10 +621,9 @@ Please click on "Show code" below to see how to set these components up for alig
           Save
         </Button>
       }
-      stickyFooter
     >
-      <Textbox label="Textbox" labelInline labelWidth="30" />
-      <InlineInputs label="Inline Inputs" gutter="none" labelWidth="30">
+      <Textbox label="Textbox" labelInline labelWidth={30} />
+      <InlineInputs label="Inline Inputs" gutter="none" labelWidth={30}>
         <Textbox />
         <Textbox />
         <Select>
@@ -636,7 +635,7 @@ Please click on "Show code" below to see how to set these components up for alig
       <InlineInputs
         label="Inline Inputs with a gutter"
         gutter="large"
-        labelWidth="30"
+        labelWidth={30}
       >
         <Textbox />
         <Textbox />

--- a/src/components/form/form.style.js
+++ b/src/components/form/form.style.js
@@ -48,6 +48,12 @@ export const StyledFormFooter = styled.div`
 export const StyledForm = styled.form`
   ${space}
 
+  ${({ height }) =>
+    height &&
+    css`
+      height: ${height};
+    `}
+
   & ${StyledFormField}, ${StyledFieldset}, ${FieldsetStyle}, > ${StyledButton} {
     margin-top: 0;
     margin-bottom: ${({ fieldSpacing, theme }) =>

--- a/src/components/form/form.style.js
+++ b/src/components/form/form.style.js
@@ -1,4 +1,4 @@
-import styled, { css, keyframes } from "styled-components";
+import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
 
 import { space } from "styled-system";
@@ -12,13 +12,17 @@ import StyledInlineInputs from "../inline-inputs/inline-inputs.style";
 import { FORM_BUTTON_ALIGNMENTS } from "./form.config";
 import StyledSearch from "../search/search.style";
 
-const FormButtonAnimation = keyframes`
-  0%   { transform: translateY(50px); }
-  100% { transform: translateY(0px); }
+export const StyledFormContent = styled.div`
+  ${({ stickyFooter }) => css`
+    ${stickyFooter &&
+    css`
+      overflow-y: auto;
+      height: calc(100vh - 72px);
+    `}
+  `}
 `;
 
 export const StyledFormFooter = styled.div`
-  margin-top: 48px;
   align-items: center;
   display: flex;
 
@@ -29,16 +33,17 @@ export const StyledFormFooter = styled.div`
     `}
 
   ${({ stickyFooter, theme }) => css`
+    ${!stickyFooter &&
+    css`
+      margin-top: 48px;
+    `}
+
     ${stickyFooter &&
     css`
-      animation: ${FormButtonAnimation} 0.25s ease;
       background-color: ${theme.colors.white};
       box-shadow: 0 -4px 12px 0 rgba(0, 0, 0, 0.05);
       box-sizing: border-box;
       padding: 16px 32px;
-      bottom: 0;
-      left: 0;
-      position: fixed;
       width: 100%;
       z-index: 1000;
     `}
@@ -73,18 +78,30 @@ export const StyledForm = styled.form`
     margin-bottom: 0px;
   }
 
-  ${({ stickyFooter, isInSidebar }) =>
+  ${({ stickyFooter, isInSidebar, theme }) =>
     stickyFooter &&
     css`
-      padding-bottom: 88px;
+      display: flex;
+      flex-direction: column;
 
       ${isInSidebar &&
       css`
-        // important keyword is needed because original style is provided in inline style mode
-        position: static !important;
+        ${StyledFormContent}.sticky {
+          height: calc(100vh - 184px);
+          padding-right: ${theme.space[4]}px;
+          padding-left: ${theme.space[4]}px;
+          padding-top: 27px;
+          margin-right: -${theme.space[4]}px;
+          margin-left: -${theme.space[4]}px;
+          margin-top: -27px;
+        }
 
-        ${StyledFormFooter} {
-          position: absolute;
+        ${StyledFormFooter}.sticky {
+          margin-left: -${theme.space[4]}px;
+          margin-bottom: -${theme.space[4]}px;
+          width: calc(100% + ${2 * theme.space[4]}px);
+          padding-left: ${theme.space[4]}px;
+          padding-right: ${theme.space[4]}px;
         }
       `}
     `}


### PR DESCRIPTION
BREAKING CHANGE: Sticky footers on Form will no longer disappear on
scrolling to the bottom of the form.

The new height prop on Form can be used to set the size of a Form
with a sticky footer, particularly within a Dialog

### Proposed behaviour
Rewrite the sticky footer to not use `position: fixed`, it is now positioned underneath the form content on the page, so the scroll box for the content is above it. This means keyboard focus can no longer be lost underneath the sticky footer.

This means it will no longer animate away and turn into a normal footer when you scroll to the bottom of the form. 

Also add. new `height` prop to `Form` which is needed to correctly set the height of a `Form` within a `Dialog`.

![image](https://user-images.githubusercontent.com/14963680/133109763-13043fb3-6166-46af-86c7-13d83b217aee.png)


### Current behaviour
Currently the sticky footer just uses CSS position sticky to appear "above" the bottom of the form. This means that keyboard focus can be lost underneath the sticky footer.

![image](https://user-images.githubusercontent.com/14963680/133110138-8189c295-fd3f-4d53-8ee7-55d96c39eb04.png)


### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
Look at `Form`, `Dialog` and `DialogFullScreen` stories. 
