### PR TITLE
feat(menu-item): add callback for submenu toggle

### DIFF
--- a/src/components/menu/__internal__/submenu/submenu.component.js
+++ b/src/components/menu/__internal__/submenu/submenu.component.js
@@ -34,6 +34,8 @@ const Submenu = React.forwardRef(
       href,
       maxWidth,
       asPassiveItem,
+      onSubmenuOpen,
+      onSubmenuClose,
       ...rest
     },
     ref
@@ -73,12 +75,18 @@ const Submenu = React.forwardRef(
       startCharacterTimeout();
     }, [startCharacterTimeout]);
 
+    const openSubmenu = useCallback(() => {
+      setSubmenuOpen(true);
+      if (onSubmenuOpen) onSubmenuOpen();
+    }, [onSubmenuOpen]);
+
     const closeSubmenu = useCallback(() => {
       setSubmenuOpen(false);
+      if (onSubmenuClose) onSubmenuClose();
       setSubmenuFocusIndex(undefined);
       setBlockDoubleFocus(false);
       setCharacterString("");
-    }, []);
+    }, [onSubmenuClose]);
 
     const handleKeyDown = useCallback(
       (event, index = submenuFocusIndex) => {
@@ -90,7 +98,7 @@ const Submenu = React.forwardRef(
             Events.isUpKey(event)
           ) {
             event.preventDefault();
-            setSubmenuOpen(true);
+            openSubmenu();
             if (!href) {
               setSubmenuFocusIndex(0);
             }
@@ -208,6 +216,7 @@ const Submenu = React.forwardRef(
         menuContext,
         arrayOfFormattedChildren,
         numberOfChildren,
+        openSubmenu,
         closeSubmenu,
         onKeyDown,
         characterString,
@@ -302,9 +311,9 @@ const Submenu = React.forwardRef(
       <StyledSubmenuWrapper
         data-component="submenu-wrapper"
         role="menuitem"
-        onMouseOver={!clickToOpen ? () => setSubmenuOpen(true) : undefined}
+        onMouseOver={!clickToOpen ? () => openSubmenu() : undefined}
         onMouseLeave={() => closeSubmenu()}
-        onClick={clickToOpen ? () => setSubmenuOpen(true) : undefined}
+        onClick={clickToOpen ? () => openSubmenu() : undefined}
         ref={submenuRef}
         isSubmenuOpen={submenuOpen}
       >
@@ -387,6 +396,10 @@ Submenu.propTypes = {
   maxWidth: PropTypes.string,
   /** Used to set a submenu parent to passive styling in MenuFullscreen */
   asPassiveItem: PropTypes.bool,
+  /** Callback triggered when submenu opens. Only valid with submenu prop */
+  onSubmenuOpen: PropTypes.func,
+  /** Callback triggered when submenu closes. Only valid with submenu prop */
+  onSubmenuClose: PropTypes.func,
 };
 
 export default Submenu;

--- a/src/components/menu/__internal__/submenu/submenu.spec.js
+++ b/src/components/menu/__internal__/submenu/submenu.spec.js
@@ -216,6 +216,60 @@ describe("Submenu component", () => {
       });
     });
 
+    describe("when onSubmenuOpen prop set", () => {
+      let mockCallback;
+
+      beforeEach(() => {
+        mockCallback = jest.fn();
+
+        wrapper = render("light", { onSubmenuOpen: mockCallback });
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+      });
+
+      describe("when submenu opens", () => {
+        it("should trigger the callback", () => {
+          openSubmenu(wrapper);
+
+          expect(mockCallback).toHaveBeenCalledWith();
+        });
+      });
+    });
+
+    describe("when onSubmenuClose prop set", () => {
+      let mockCallback;
+
+      beforeEach(() => {
+        mockCallback = jest.fn();
+
+        wrapper = render("light", { onSubmenuClose: mockCallback });
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+      });
+
+      describe("when submenu closes", () => {
+        it("should trigger the callback", () => {
+          openSubmenu(wrapper);
+
+          act(() => {
+            wrapper
+              .find(StyledMenuItemWrapper)
+              .at(0)
+              .props()
+              .onKeyDown(events.shiftTab);
+          });
+
+          wrapper.update();
+
+          expect(mockCallback).toHaveBeenCalledWith();
+        });
+      });
+    });
+
     describe("when href prop set", () => {
       beforeEach(() => {
         wrapper = render("light", { href: "/path" });

--- a/src/components/menu/menu-item/menu-item.component.js
+++ b/src/components/menu/menu-item/menu-item.component.js
@@ -35,6 +35,8 @@ const MenuItem = ({
   clickToOpen,
   maxWidth,
   menuOpen,
+  onSubmenuOpen,
+  onSubmenuClose,
   ...rest
 }) => {
   const menuContext = useContext(MenuContext);
@@ -155,6 +157,8 @@ const MenuItem = ({
           maxWidth={maxWidth}
           asPassiveItem={asPassiveItem}
           ariaLabel={ariaLabel}
+          onSubmenuOpen={onSubmenuOpen}
+          onSubmenuClose={onSubmenuClose}
           {...elementProps}
           {...rest}
         >
@@ -261,6 +265,10 @@ MenuItem.propTypes = {
     }
     return PropTypes.string(props, ...rest);
   },
+  /** Callback triggered when submenu opens. Only valid with submenu prop */
+  onSubmenuOpen: PropTypes.func,
+  /** Callback triggered when submenu closes. Only valid with submenu prop */
+  onSubmenuClose: PropTypes.func,
 };
 
 export default MenuItem;

--- a/src/components/menu/menu-item/menu-item.d.ts
+++ b/src/components/menu/menu-item/menu-item.d.ts
@@ -25,6 +25,10 @@ export interface MenuItemBaseProps extends LayoutProps, FlexboxProps {
   showDropdownArrow?: boolean;
   /** If no text is provided an ariaLabel should be given to facilitate accessibility. */
   ariaLabel?: string;
+  /** Callback triggered when submenu opens. Only valid with submenu prop */
+  onSubmenuOpen?: () => void;
+  /** Callback triggered when submenu closes. Only valid with submenu prop */
+  onSubmenuClose?: () => void;
 }
 
 export interface MenuWithChildren extends MenuItemBaseProps {

--- a/src/components/menu/menu-item/menu-item.spec.js
+++ b/src/components/menu/menu-item/menu-item.spec.js
@@ -263,6 +263,42 @@ describe("MenuItem", () => {
       });
     });
 
+    describe("with onSubmenuOpen prop set", () => {
+      it("should pass the onSubmenuOpen prop to Submenu", () => {
+        const mockCallback = jest.fn();
+
+        wrapper = mount(
+          <MenuContext.Provider value={{ menuType: "light" }}>
+            <MenuItem submenu="submenu" onSubmenuOpen={mockCallback}>
+              <MenuItem>Item one</MenuItem>
+            </MenuItem>
+          </MenuContext.Provider>
+        );
+
+        expect(wrapper.find(Submenu).props().onSubmenuOpen).toEqual(
+          mockCallback
+        );
+      });
+    });
+
+    describe("with onSubmenuClose prop set", () => {
+      it("should pass the onSubmenuClose prop to Submenu", () => {
+        const mockCallback = jest.fn();
+
+        wrapper = mount(
+          <MenuContext.Provider value={{ menuType: "light" }}>
+            <MenuItem submenu="submenu" onSubmenuClose={mockCallback}>
+              <MenuItem>Item one</MenuItem>
+            </MenuItem>
+          </MenuContext.Provider>
+        );
+
+        expect(wrapper.find(Submenu).props().onSubmenuClose).toEqual(
+          mockCallback
+        );
+      });
+    });
+
     describe("showDropdownArrow", () => {
       describe("when true (default)", () => {
         it("should pass the showDropdownArrow prop to Submenu", () => {


### PR DESCRIPTION
Fixes: #4303

### Proposed behaviour
Add `onSubmenuOpen` and `onSubmenuClose` to `MenuItem`. These are callbacks triggered when the submenu is opened or closed.

### Current behaviour
No prop to trigger custom actions when submenus open/close.

### Checklist

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Carbon implementation and Design System documentation are congruent

### Additional context

### Testing instructions
https://codesandbox.io/s/carbon-quickstart-forked-qhweu?file=/src/index.js