### PR TITLE
refactor(split-button): rewrite class component to functional

### DIFF
--- a/src/components/split-button/split-button-test.stories.mdx
+++ b/src/components/split-button/split-button-test.stories.mdx
@@ -105,16 +105,16 @@ export const SplitButtonStory = ({
     name="default"
     args={{
       iconType: "",
-      iconPosition: Button.defaultProps.iconPosition,
-      buttonType: Button.defaultProps.as,
+      iconPosition: "before",
+      buttonType: "secondary",
       dataElement: "data-element",
       dataRole: "",
-      disabled: Button.defaultProps.disabled,
-      size: Button.defaultProps.size,
-      align: SplitButton.defaultProps.align,
+      disabled: false,
+      size: "medium",
+      align: "left",
       text: "Example Split Button",
       textSpecialCharacters: undefined,
-      subtext: Button.defaultProps.subtext,
+      subtext: "",
       subtextSpecialCharacters: undefined,
     }}
   >


### PR DESCRIPTION
Rewrite SplitButton class component to functional

BREAKING CHANGE: SplitButton is now a functional component and cannot be extended

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Related issues linked in commit messages if required~~
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
~~- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required~~
~~- [ ] Typescript `d.ts` file added or updated if required~~

#### QA

- [ ] Tested in sandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
