### PR TITLE
feat(tile-select): add support for rendering accordion footer FE-4283

### DIFF
--- a/src/components/tile-select/__internal__/accordion/accordion.component.js
+++ b/src/components/tile-select/__internal__/accordion/accordion.component.js
@@ -1,0 +1,45 @@
+import React, { useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+
+import { StyledContentContainer, StyledContent } from "./accordion.style";
+import useResizeObserver from "../../../../hooks/__internal__/useResizeObserver";
+
+const Accordion = ({ children, expanded, contentId, controlId }) => {
+  const [contentHeight, setContentHeight] = useState(0);
+  const contentRef = useRef(null);
+
+  useResizeObserver(contentRef, () => {
+    setContentHeight(contentRef.current.scrollHeight);
+  });
+
+  useEffect(() => {
+    setContentHeight(contentRef.current.scrollHeight);
+  }, [contentRef]);
+
+  return (
+    <StyledContentContainer
+      aria-expanded={expanded}
+      isExpanded={expanded}
+      maxHeight={contentHeight}
+    >
+      <StyledContent
+        role="region"
+        data-element="tile-select-accordion-content"
+        ref={contentRef}
+        id={contentId}
+        aria-labelledby={controlId}
+      >
+        {children}
+      </StyledContent>
+    </StyledContentContainer>
+  );
+};
+
+Accordion.propTypes = {
+  children: PropTypes.node.isRequired,
+  expanded: PropTypes.bool,
+  contentId: PropTypes.string,
+  controlId: PropTypes.string,
+};
+
+export default Accordion;

--- a/src/components/tile-select/__internal__/accordion/accordion.d.ts
+++ b/src/components/tile-select/__internal__/accordion/accordion.d.ts
@@ -1,0 +1,13 @@
+import * as React from "react";
+import { SpaceProps } from "styled-system";
+
+export interface AccordionProps extends SpaceProps {
+  children: React.ReactNode;
+  expanded?: boolean;
+  contentId?: string;
+  controlId?: string;
+}
+
+declare function Accordion(props: AccordionProps): JSX.Element;
+
+export default Accordion;

--- a/src/components/tile-select/__internal__/accordion/accordion.spec.js
+++ b/src/components/tile-select/__internal__/accordion/accordion.spec.js
@@ -1,0 +1,70 @@
+import React from "react";
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+
+import Accordion from "./accordion.component";
+import useResizeObserver from "../../../../hooks/__internal__/useResizeObserver";
+import { StyledContentContainer, StyledContent } from "./accordion.style";
+import baseTheme from "../../../../style/themes/base";
+import { assertStyleMatch } from "../../../../__spec_helper__/test-utils";
+
+jest.mock("../../../../hooks/__internal__/useResizeObserver");
+
+describe("Accordion", () => {
+  it("matches the expected styles", () => {
+    const wrapper = mount(<Accordion>Content</Accordion>);
+
+    assertStyleMatch(
+      {
+        backgroundColor: baseTheme.tileSelect.hoverBackground,
+      },
+      wrapper.find(StyledContentContainer)
+    );
+
+    assertStyleMatch(
+      {
+        padding: "24px",
+        position: "relative",
+        zIndex: "200",
+      },
+      wrapper.find(StyledContent)
+    );
+  });
+
+  describe("resize observer", () => {
+    it("recalculates the content height", () => {
+      const wrapper = mount(<Accordion expanded>Content</Accordion>);
+
+      act(() => {
+        jest
+          .spyOn(
+            wrapper.find(StyledContent).getDOMNode(),
+            "scrollHeight",
+            "get"
+          )
+          .mockImplementation(() => 200);
+      });
+
+      jest
+        .spyOn(wrapper.find(StyledContent).getDOMNode(), "scrollHeight", "get")
+        .mockImplementation(() => 400);
+
+      act(() => {
+        global.innerWidth = 500;
+        global.innerHeight = 500;
+
+        useResizeObserver.mock.calls[
+          useResizeObserver.mock.calls.length - 1
+        ][1]();
+      });
+      wrapper.update();
+
+      assertStyleMatch(
+        {
+          maxHeight: `400px`,
+        },
+        wrapper.find(StyledContentContainer)
+      );
+    });
+  });
+});

--- a/src/components/tile-select/__internal__/accordion/accordion.style.js
+++ b/src/components/tile-select/__internal__/accordion/accordion.style.js
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+import {
+  StyledAccordionContentContainer,
+  StyledAccordionContent,
+} from "../../../accordion/accordion.style";
+import baseTheme from "../../../../style/themes/base";
+
+const StyledContentContainer = styled(StyledAccordionContentContainer)`
+  background-color: ${({ theme }) => theme.tileSelect.hoverBackground};
+`;
+
+const StyledContent = styled(StyledAccordionContent)`
+  padding: 24px;
+  position: relative;
+  z-index: 200;
+`;
+
+StyledContentContainer.defaultProps = {
+  theme: baseTheme,
+};
+
+export { StyledContentContainer, StyledContent };

--- a/src/components/tile-select/__internal__/accordion/index.js
+++ b/src/components/tile-select/__internal__/accordion/index.js
@@ -1,0 +1,1 @@
+export { default } from "./accordion.component";

--- a/src/components/tile-select/tile-select.component.js
+++ b/src/components/tile-select/tile-select.component.js
@@ -1,11 +1,13 @@
+import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
-import React, { useState, useEffect } from "react";
 import styledSystemPropTypes from "@styled-system/prop-types";
 
 import tagComponent from "../../utils/helpers/tags/tags";
 import useLocale from "../../hooks/__internal__/useLocale";
+import createGuid from "../../utils/helpers/guid";
 import Button from "../button";
 import Box from "../box";
+import Accordion from "./__internal__/accordion";
 
 import {
   StyledTileSelectContainer,
@@ -19,6 +21,7 @@ import {
   StyledDeselectWrapper,
   StyledFooterWrapper,
   StyledFocusWrapper,
+  StyledAccordionFooterWrapper,
 } from "./tile-select.style";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 
@@ -48,6 +51,9 @@ const TileSelect = ({
   footer,
   prefixAdornment,
   additionalInformation,
+  accordionContent,
+  accordionControl,
+  accordionExpanded,
   ...rest
 }) => {
   const l = useLocale();
@@ -85,6 +91,10 @@ const TileSelect = ({
     }
   }, [disabled, hasFocus]);
 
+  const guid = useRef(createGuid());
+  const contentId = `AccordionContent_${guid.current}`;
+  const controlId = `AccordionControl_${guid.current}`;
+
   return (
     <StyledTileSelectContainer
       checked={checked}
@@ -116,8 +126,12 @@ const TileSelect = ({
           {...rest}
         />
         <StyledTileSelect disabled={disabled} checked={checked}>
-          <Box display="flex" justifyContent="space-between">
-            {prefixAdornment && <Box mr={3}>{prefixAdornment}</Box>}
+          <Box
+            display="flex"
+            justifyContent="space-between"
+            flexDirection="row-reverse"
+          >
+            {(customActionButton || checked) && renderActionButton()}
             <Box flexGrow="1">
               <StyledTitleContainer>
                 {title && (
@@ -145,10 +159,26 @@ const TileSelect = ({
                 {description}
               </StyledDescription>
               {footer && <StyledFooterWrapper>{footer}</StyledFooterWrapper>}
+              {accordionContent && accordionControl && (
+                <StyledAccordionFooterWrapper
+                  accordionExpanded={accordionExpanded}
+                >
+                  {accordionControl(controlId, contentId)}
+                </StyledAccordionFooterWrapper>
+              )}
             </Box>
-            {(customActionButton || checked) && renderActionButton()}
+            {prefixAdornment && <Box mr={3}>{prefixAdornment}</Box>}
           </Box>
         </StyledTileSelect>
+        {accordionContent && (
+          <Accordion
+            contentId={contentId}
+            controlId={controlId}
+            expanded={accordionExpanded}
+          >
+            {accordionContent}
+          </Accordion>
+        )}
       </StyledFocusWrapper>
     </StyledTileSelectContainer>
   );
@@ -199,6 +229,15 @@ TileSelect.propTypes = {
   prefixAdornment: PropTypes.node,
   /** Component to render additional information row between title and description */
   additionalInformation: PropTypes.node,
+  /** Components to render in the TileSelect Accordion */
+  accordionContent: PropTypes.node,
+  /**
+   * Render prop to support rendering the control to handle the expanded state of the TileSelect Accordion.
+   * `(controlId, contentId) => <Button id={controlId} aria-controls={contentId}>...</Button>`
+   */
+  accordionControl: PropTypes.func,
+  /** Flag to control the open state of TileSelect Accordion */
+  accordionExpanded: PropTypes.bool,
 };
 
 TileSelect.displayName = "TileSelect";

--- a/src/components/tile-select/tile-select.d.ts
+++ b/src/components/tile-select/tile-select.d.ts
@@ -38,6 +38,12 @@ export interface TileSelectProps extends MarginProps {
   prefixAdornment?: React.ReactNode;
   /** Component to render additional information row between title and description */
   additionalInformation?: React.ReactNode;
+  /** Components to render in the TileSelect Accordion */
+  accordionContent?: React.ReactNode;
+  /** Callback to toggle expanded state of TileSelect Accordion */
+  accordionControl?: (controlId: string, contentId: string) => JSX.Element;
+  /** Flag to control the open state of TileSelect Accordion */
+  accordionExpanded?: boolean;
 }
 
 declare function TileSelect(props: TileSelectProps): JSX.Element;

--- a/src/components/tile-select/tile-select.spec.js
+++ b/src/components/tile-select/tile-select.spec.js
@@ -18,6 +18,7 @@ import {
   StyledTitleContainer,
   StyledFocusWrapper,
   StyledFooterWrapper,
+  StyledAccordionFooterWrapper,
 } from "./tile-select.style";
 import Button from "../button";
 import Icon from "../icon";
@@ -388,6 +389,40 @@ describe("TileSelect", () => {
           marginBottom: "4px",
         },
         wrapper.find(StyledAdornment)
+      );
+    });
+  });
+
+  describe("Accordion footer", () => {
+    it("renders the node passed in via the accordionContent prop", () => {
+      const MyComp = () => <div>foo</div>;
+
+      render({
+        checked: true,
+        id: "id",
+        name: "name",
+        accordionContent: <MyComp />,
+        accordionControl: (props) => <Button {...props}>Foo</Button>,
+      });
+
+      expect(wrapper.find(MyComp).exists()).toBeTruthy();
+
+      assertStyleMatch(
+        {
+          width: "fit-content",
+          position: "relative",
+          zIndex: "200",
+          left: "-12px",
+        },
+        wrapper.find(StyledAccordionFooterWrapper)
+      );
+
+      assertStyleMatch(
+        {
+          transform: "rotate(-90deg)",
+        },
+        wrapper.find(StyledAccordionFooterWrapper),
+        { modifier: 'span[data-element="chevron_down"]' }
       );
     });
   });

--- a/src/components/tile-select/tile-select.stories.mdx
+++ b/src/components/tile-select/tile-select.stories.mdx
@@ -504,6 +504,67 @@ any node to the `additionalInformation` prop.
   </Story>
 </Preview>
 
+### With accordion footer
+
+It is possible to render an `Accordion` footer for the `TileSelect`. Pass a desired layout to the `accordionContent` prop 
+and a use the `accordionControl` render prop to supply the control for the expanded state of the accordion by toggling the
+`accordionExpanded` prop.
+
+<Preview>
+  <Story name="with accordion footer">
+    {() => {
+      const [isChecked, setIsChecked] = useState(false);
+      const [expanded, setExpanded] = useState(true);
+      const handleChange = (e) => {
+        const { value } = e.target;
+        setIsChecked(value === null ? false : true);
+      };
+      return (
+        <TileSelect
+          value="1"
+          id="single-1"
+          aria-label="single-1"
+          name="single"
+          title="Title"
+          subtitle="Subtitle"
+          description="Short and descriptive description"
+          checked={isChecked}
+          onChange={handleChange}
+          prefixAdornment={<Image height="40px" width="40px" backgroundImage={`url(${require("../../../.assets/flexible.svg")})`} />}
+          accordionContent={
+            <Box display="flex" flexWrap="wrap">
+              <Box flexGrow="1" pr={1}>
+               <Box width="100%" height="100px" bg="primary" display="inline-block"></Box>
+              </Box>
+              <Box flexGrow="1" pl={1}>
+               <Box width="100%" height="100px" bg="primary" display="inline-block"></Box>
+              </Box>
+            </Box>
+          }
+          accordionControl={
+            (controlId, contentId) => (
+              <Button
+                buttonType="tertiary"
+                iconPosition="before"
+                iconType="chevron_down"
+                data-element="accordion-button"
+                onClick={() => setExpanded((expandedState) => !expandedState)}
+                px={1}
+                mt={2}
+                aria-controls={contentId}
+                id={controlId}
+              >
+                {expanded ? "Close" : "Open"} accordion 
+              </Button>
+            )
+          }
+          accordionExpanded={expanded}
+          setAccordionExpanded={setExpanded}
+        />
+      );
+    }}
+  </Story>
+</Preview>
 
 ### With custom spacing
 

--- a/src/components/tile-select/tile-select.style.js
+++ b/src/components/tile-select/tile-select.style.js
@@ -101,6 +101,20 @@ const StyledFooterWrapper = styled.div`
   z-index: 200;
 `;
 
+const StyledAccordionFooterWrapper = styled.div`
+  width: fit-content;
+  position: relative;
+  z-index: 200;
+  left: -12px;
+
+  ${({ accordionExpanded }) => `
+      span[data-element="chevron_down"] {
+        transition: transform 0.3s;
+        ${!accordionExpanded && "transform: rotate(-90deg)"};
+      }
+  `}
+`;
+
 const StyledTileSelectInput = styled(Input)`
   position: absolute;
   top: 0;
@@ -215,4 +229,5 @@ export {
   StyledDeselectWrapper,
   StyledFooterWrapper,
   StyledFocusWrapper,
+  StyledAccordionFooterWrapper,
 };


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Adds support for rendering an `Accordion` as the footer of `TileSelect`. Pass a desired layout to the `accordionContent` prop and a use the `accordionControl` render prop to supply the control for the expanded state of the accordion, this is achieved by toggling the `accordionExpanded` prop.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No support for rendering an accordion footer

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in sandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs

### Additional context
![image](https://user-images.githubusercontent.com/44157880/133594365-241bab4c-e3cd-4ab3-b469-002db9b2bfbe.png)

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
`docs/design-system-tile-select--with-accordion-footer`

https://codesandbox.io/s/carbon-quickstart-forked-rm5j9?file=/src/index.js