### PR TITLE
fix(menu): incorrect menu aria role (FE-4327)

### DIFF
--- a/src/components/menu/__internal__/submenu/submenu.component.js
+++ b/src/components/menu/__internal__/submenu/submenu.component.js
@@ -262,7 +262,6 @@ const Submenu = React.forwardRef(
       return (
         <StyledSubmenuWrapper
           data-component="submenu-wrapper"
-          role="menuitem"
           ref={submenuRef}
           inFullscreenView={inFullscreenView}
           menuType={menuContext.menuType}
@@ -310,7 +309,6 @@ const Submenu = React.forwardRef(
     return (
       <StyledSubmenuWrapper
         data-component="submenu-wrapper"
-        role="menuitem"
         onMouseOver={!clickToOpen ? () => openSubmenu() : undefined}
         onMouseLeave={() => closeSubmenu()}
         onClick={clickToOpen ? () => openSubmenu() : undefined}

--- a/src/components/menu/__internal__/submenu/submenu.component.js
+++ b/src/components/menu/__internal__/submenu/submenu.component.js
@@ -269,7 +269,6 @@ const Submenu = React.forwardRef(
         >
           <StyledMenuItemWrapper
             {...rest}
-            data-component="menu-item"
             className={className}
             menuType={menuContext.menuType}
             ref={ref}
@@ -283,6 +282,7 @@ const Submenu = React.forwardRef(
             {title}
           </StyledMenuItemWrapper>
           <StyledSubmenu
+            data-component="submenu"
             variant={variant}
             menuType={menuContext.menuType}
             inFullscreenView={inFullscreenView}
@@ -317,7 +317,6 @@ const Submenu = React.forwardRef(
       >
         <StyledMenuItemWrapper
           {...rest}
-          data-component="menu-item"
           className={className}
           menuType={menuContext.menuType}
           ref={ref}
@@ -338,6 +337,7 @@ const Submenu = React.forwardRef(
 
         {submenuOpen && (
           <StyledSubmenu
+            data-component="submenu"
             submenuDirection={submenuDirection}
             variant={variant}
             menuType={menuContext.menuType}

--- a/src/components/menu/menu-divider/menu-divider.component.js
+++ b/src/components/menu/menu-divider/menu-divider.component.js
@@ -8,7 +8,7 @@ const MenuDivider = React.forwardRef(({ size = "default" }, ref) => {
   const menuContext = useContext(MenuContext);
 
   return (
-    <StyledMenuItem role="presentation" inSubmenu>
+    <StyledMenuItem inSubmenu>
       <StyledDivider
         size={size}
         data-component="menu-divider"

--- a/src/components/menu/menu-item/menu-item.component.js
+++ b/src/components/menu/menu-item/menu-item.component.js
@@ -140,7 +140,6 @@ const MenuItem = ({
 
     return (
       <StyledMenuItem
-        role="presentation"
         menuType={menuContext.menuType}
         display="inline-block"
         title={getTitle(submenu)}
@@ -170,7 +169,6 @@ const MenuItem = ({
 
   return (
     <StyledMenuItem
-      role="presentation"
       menuType={menuContext.menuType}
       inSubmenu={submenuContext.handleKeyDown !== undefined}
       display="inline-block"
@@ -186,7 +184,6 @@ const MenuItem = ({
         isSearch={isChildSearch.current}
         menuType={menuContext.menuType}
         {...elementProps}
-        role="menuitem"
         ariaLabel={ariaLabel}
         maxWidth={maxWidth}
         inFullscreenView={inFullscreenView}

--- a/src/components/menu/menu-item/menu-item.component.js
+++ b/src/components/menu/menu-item/menu-item.component.js
@@ -140,6 +140,7 @@ const MenuItem = ({
 
     return (
       <StyledMenuItem
+        data-component="menu-item"
         menuType={menuContext.menuType}
         display="inline-block"
         title={getTitle(submenu)}
@@ -169,6 +170,7 @@ const MenuItem = ({
 
   return (
     <StyledMenuItem
+      data-component="menu-item"
       menuType={menuContext.menuType}
       inSubmenu={submenuContext.handleKeyDown !== undefined}
       display="inline-block"
@@ -180,7 +182,6 @@ const MenuItem = ({
     >
       <StyledMenuItemWrapper
         as={isChildSearch.current ? "div" : Link}
-        data-component="menu-item"
         isSearch={isChildSearch.current}
         menuType={menuContext.menuType}
         {...elementProps}

--- a/src/components/menu/menu.component.js
+++ b/src/components/menu/menu.component.js
@@ -42,7 +42,6 @@ const Menu = ({ menuType = "light", children, ...rest }) => {
   return (
     <StyledMenuWrapper
       data-component="menu"
-      role="menubar"
       menuType={menuType}
       {...rest}
       ref={ref}


### PR DESCRIPTION
### Proposed behaviour

Remove incorrect menubar ARIA role in the Menu component and unused menuitem role in MenuItem Component.

Move `data-component="menu-item"` attribute to the menu item 'li' wrapper as it is overwritten by the Link component attribute.

### Current behaviour

Axe test failing in Navbar component, caused by incorrect use of menubar role in Menu Component

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
~~- [ ] Unit tests added or updated if required~~
~~- [ ] Cypress automation tests added or updated if required~~
~~- [ ] Storybook added or updated if required~~
~~- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required~~
~~- [ ] Typescript `d.ts` file added or updated if required~~

#### QA

- [ ] Tested in sandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
