### PR TITLE
ci(forked): use input number instead of pr

### DIFF
--- a/.github/workflows/forked-ci.yml
+++ b/.github/workflows/forked-ci.yml
@@ -17,7 +17,7 @@ jobs:
           repo: ${{ github.event.repository.name }}
           workflow_id: "chromatic.yml"
           ref: "master"
-          inputs: '{"number": "${{ github.event.pull_request.number }}"}'
+          inputs: '{"number": "${{ github.event.inputs.number }}"}'
         env:
           GITHUB_TOKEN: ${{ secrets.CYPRESS_WORKFLOW_TOKEN }}
 


### PR DESCRIPTION
### Proposed behaviour

Use the number input by the user to pass to the Chromatic workflow.

### Current behaviour
The incorrect number is being passed, the pull request number will be undefined.

### Checklist

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs

### Additional context

### Testing instructions

