### PR TITLE
fix(action-popover): correct dom structure when rendering custom button

### DIFF
--- a/src/components/action-popover/action-popover.spec.js
+++ b/src/components/action-popover/action-popover.spec.js
@@ -23,6 +23,7 @@ import {
   MenuItemIcon,
   SubMenuItemIcon,
   StyledMenuItem,
+  StyledButtonIcon,
 } from "./action-popover.style";
 import Popover from "../../__internal__/popover";
 import { rootTagTest } from "../../utils/helpers/tags/tags-specs";
@@ -180,6 +181,7 @@ describe("ActionPopover", () => {
       return {
         items: cw.find(ActionPopoverItem),
         menubutton: cw.find(MenuButton),
+        buttonIcon: cw.find(StyledButtonIcon),
         menu: cw.find(Menu),
         divider: cw.find(ActionPopoverDivider),
       };
@@ -299,8 +301,8 @@ describe("ActionPopover", () => {
 
   it("has a default aria-label", () => {
     render();
-    const { menubutton } = getElements();
-    expect(menubutton.prop("aria-label")).toBe("actions");
+    const { buttonIcon } = getElements();
+    expect(buttonIcon.prop("aria-label")).toBe("actions");
   });
 
   it("renders with the menu closed by default", () => {
@@ -372,9 +374,9 @@ describe("ActionPopover", () => {
       });
 
       it(`${prefix} focuses the Menubutton`, () => {
-        const { menubutton } = getElements();
+        const { buttonIcon } = getElements();
 
-        expect(menubutton).toBeFocused();
+        expect(buttonIcon).toBeFocused();
       });
     });
 
@@ -587,13 +589,13 @@ describe("ActionPopover", () => {
 
       it("Pressing Escape focuses the MenuButton", () => {
         render();
-        const { menubutton } = getElements();
+        const { menubutton, buttonIcon } = getElements();
         simulate.keydown.pressDownArrow(menubutton);
         const { items } = getElements();
 
         simulate.keydown.pressEscape(items.first());
 
-        expect(menubutton).toBeFocused();
+        expect(buttonIcon).toBeFocused();
       });
 
       it.each([
@@ -1050,8 +1052,8 @@ describe("ActionPopover", () => {
           submenuItem
             .getDOMNode()
             .dispatchEvent(new MouseEvent("click", { bubbles: true }));
-          const { menubutton } = getElements();
-          expect(menubutton).toBeFocused();
+          const { buttonIcon } = getElements();
+          expect(buttonIcon).toBeFocused();
           jest.runAllTimers(); // needed to trigger coverage
         });
       });
@@ -1265,6 +1267,7 @@ describe("ActionPopover", () => {
       expect(item.find(ActionPopoverMenu).props().style.bottom).toEqual(-8);
     });
   });
+
   describe("Custom Menu Button", () => {
     it("supports being passed an override component to act as the menu button", () => {
       const popover = enzymeMount(
@@ -1289,7 +1292,7 @@ describe("ActionPopover", () => {
 
       const menuButton = popover.find(ActionPopoverMenuButton);
       expect(menuButton.exists()).toBeTruthy();
-      expect(menuButton.props().tabIndex).toEqual(-1);
+      expect(menuButton.props().tabIndex).toEqual("0");
       expect(menuButton.props()["data-element"]).toEqual(
         "action-popover-menu-button"
       );
@@ -1310,6 +1313,34 @@ describe("ActionPopover", () => {
         menuButton,
         { modifier: `${StyledButton}:focus ` }
       );
+    });
+
+    it("sets the tabIndex correctly when opened", () => {
+      wrapper = enzymeMount(
+        <ThemeProvider theme={mintTheme}>
+          <ActionPopover
+            renderButton={(props) => (
+              <ActionPopoverMenuButton
+                buttonType="tertiary"
+                iconType="dropdown"
+                iconPosition="after"
+                size="small"
+                {...props}
+              >
+                Foo
+              </ActionPopoverMenuButton>
+            )}
+          >
+            <ActionPopoverItem onClick={jest.fn()}>foo</ActionPopoverItem>
+          </ActionPopover>
+        </ThemeProvider>
+      );
+
+      openMenu();
+
+      const menuButton = wrapper.find(ActionPopoverMenuButton);
+      expect(menuButton.exists()).toBeTruthy();
+      expect(menuButton.props().tabIndex).toEqual("-1");
     });
   });
 

--- a/src/components/action-popover/action-popover.stories.mdx
+++ b/src/components/action-popover/action-popover.stories.mdx
@@ -295,12 +295,8 @@ ActionPopoverMenu. See the prop tables below for the properties surfaced to any 
           <TableCell>Doe</TableCell>
           <TableCell>
             <ActionPopover
-              renderButton={({ "data-element": dataElement }) => (
-                <Link
-                  onClick={() => {}}
-                  tabbable={false}
-                  data-element={dataElement}
-                >
+              renderButton={({ tabIndex, "data-element": dataElement }) => (
+                <Link onClick={() => {}} data-element={dataElement}>
                   More
                 </Link>
               )}
@@ -639,7 +635,7 @@ When sub-menus aligns to the right hand side, the key shortcuts are switiched: p
 is on a item will open a sub-menu if it has one and pressing the "left" key will close it.
 
 <Story
-  name="keyboard access right aligned submenu"
+  name="keyboard navigation right aligned submenu"
   parameters={{ docs: { disable: true } }}
 >
   <div style={{ height: "250px" }}>
@@ -993,18 +989,16 @@ It is possible to utilise the selected and onClick props on the FlatTableRow to 
 
 ## Translation keys
 
-The following keys are available to override the translations for this component by passing in a custom locale object 
+The following keys are available to override the translations for this component by passing in a custom locale object
 to the [i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
 
 <TranslationKeysTable
-  translationData={
-    [
-      {
-        name: "actionPopover.ariaLabel",
-        description: "The text for the aria-label attribute",
-        type: "func",
-        returnType: "string"
-      },
-    ]
-  }
+  translationData={[
+    {
+      name: "actionPopover.ariaLabel",
+      description: "The text for the aria-label attribute",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
 />

--- a/src/components/action-popover/action-popover.style.js
+++ b/src/components/action-popover/action-popover.style.js
@@ -85,12 +85,6 @@ const MenuButton = styled.div`
   margin: auto;
   ${margin}
   ${({ isOpen, theme }) => isOpen && `background-color: ${theme.colors.white}`}
-  &:hover, &:focus {
-    background-color: ${({ theme }) => theme.colors.white};
-  }
-  &:focus {
-    outline: 2px solid ${({ theme }) => theme.colors.focus};
-  }
 `;
 
 /**
@@ -116,6 +110,18 @@ const iconThemeProviderFactory = (Component, themeFn) =>
   });
 
 const ButtonIcon = iconThemeProviderFactory(Icon, (palette) => palette.slate);
+
+const StyledButtonIcon = styled.div`
+  &:hover,
+  &:focus {
+    background-color: ${({ theme }) => theme.colors.white};
+  }
+
+  &:focus {
+    outline: 2px solid ${({ theme }) => theme.colors.focus};
+  }
+`;
+
 const MenuItemIcon = styled(iconThemeProviderFactory(Icon, () => "inherit"))`
   ${({ theme, horizontalAlignment }) => css`
     ${horizontalAlignment === "right"
@@ -148,12 +154,17 @@ const SubMenuItemIcon = styled(ButtonIcon)`
 `;
 
 const MenuButtonOverrideWrapper = styled.div`
-  ${({ theme }) => `
+  ${({ theme }) => css`
     ${StyledButton} {
       padding: 0px ${theme.spacing}px;
       width: 100%;
       &:focus {
         outline-width: 2px;
+      }
+
+      &:hover,
+      &:focus {
+        background-color: ${theme.colors.white};
       }
     }
   `}
@@ -164,6 +175,7 @@ export {
   MenuItemFactory,
   MenuButton,
   ButtonIcon,
+  StyledButtonIcon,
   MenuItemIcon,
   MenuItemDivider,
   SubMenuItemIcon,


### PR DESCRIPTION
Fixes: #4401

### Proposed behaviour

Move the aria labels and tab-index onto the element that should actually be focused. This will prevent there being a button within a `div` with `role="button"` which is causing the accessibility error on the related issue.

### Current behaviour

`ActionPopover` currently sets `role="button"` and the aria attributes on it's wrapping `div` element, rather than the element we want to focus.

### Checklist

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs

### Additional context

### Testing instructions
<!-- How can a reviewer test this PR? -->
The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
