### PR TITLE
ci(chromatic): run workflow on push

### DIFF
--- a/.github/workflows/chromatic-push.yml
+++ b/.github/workflows/chromatic-push.yml
@@ -1,0 +1,28 @@
+name: Chromatic Push
+
+on:
+  push:
+    # We need these branches to update their baselines when they are merged into
+    branches:
+      - master
+      - "[0-9]+.x"
+      - "[0-9]+.x.x"
+      - "[0-9]+.[0-9]+.x"
+      - "major/**"
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ">=14.16.0 14"
+      - run: npm ci
+      - uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitOnceUploaded: true # We don't want it to fail CI, we'll be using the GitHub Check


### PR DESCRIPTION
### Proposed behaviour

Re-introduce running the chromatic workflow on push to master, major or tags

### Current behaviour

Chromatic is not running on push to any of these branches

### Checklist

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs

### Additional context

### Testing instructions

