### PR TITLE
fix(icon): add support for keyboard focus, gold outline, role and ariaLabel when has tooltip FE-4364

### DIFF
--- a/src/__internal__/validations/validation-icon.component.js
+++ b/src/__internal__/validations/validation-icon.component.js
@@ -87,6 +87,7 @@ const ValidationIcon = ({
         }
         isPartOfInput={isPartOfInput}
         inputSize={size}
+        blockFocusBehaviour
       />
     </ValidationIconStyle>
   );

--- a/src/components/help/help.component.js
+++ b/src/components/help/help.component.js
@@ -26,6 +26,7 @@ const Help = ({
   tooltipBgColor,
   tooltipFontColor,
   tooltipFlipOverrides,
+  ariaLabel,
   ...rest
 }) => {
   const helpElement = useRef(null);
@@ -56,7 +57,6 @@ const Help = ({
 
   return (
     <StyledHelp
-      role="tooltip"
       className={className}
       as={tagType}
       href={href}
@@ -84,6 +84,8 @@ const Help = ({
         tooltipBgColor={tooltipBgColor}
         tooltipFontColor={tooltipFontColor}
         tooltipFlipOverrides={tooltipFlipOverrides}
+        ariaLabel={ariaLabel || type}
+        role="tooltip"
         blockFocusBehaviour
       />
     </StyledHelp>
@@ -134,6 +136,8 @@ Help.propTypes = {
       `The \`${propName}\` prop supplied to \`${componentName}\` must be an array containing some or all of ["top", "bottom", "left", "right"].`
     );
   },
+  /** Aria label for accessibility purposes */
+  ariaLabel: PropTypes.string,
 };
 
 Help.defaultProps = {

--- a/src/components/help/help.component.js
+++ b/src/components/help/help.component.js
@@ -84,6 +84,7 @@ const Help = ({
         tooltipBgColor={tooltipBgColor}
         tooltipFontColor={tooltipFontColor}
         tooltipFlipOverrides={tooltipFlipOverrides}
+        blockFocusBehaviour
       />
     </StyledHelp>
   );

--- a/src/components/help/help.d.ts
+++ b/src/components/help/help.d.ts
@@ -30,6 +30,8 @@ export interface HelpProps extends MarginProps {
   tooltipPosition?: "top" | "bottom" | "left" | "right";
   /** Help Icon type */
   type?: IconType;
+  /** Aria label for accessibility purposes */
+  ariaLabel?: string;
 }
 
 declare function Help(props: HelpProps): JSX.Element;

--- a/src/components/icon/icon.component.js
+++ b/src/components/icon/icon.component.js
@@ -37,6 +37,9 @@ const Icon = React.forwardRef(
       tabIndex,
       isPartOfInput,
       inputSize,
+      role,
+      ariaLabel,
+      blockFocusBehaviour,
       ...rest
     },
     ref
@@ -79,10 +82,11 @@ const Icon = React.forwardRef(
       fontSize,
       isInteractive,
       iconColor,
-      tabIndex,
       type: iconType(),
       ...filterStyledSystemMarginProps(rest),
     };
+
+    const hasTooltip = tooltipMessage && !blockFocusBehaviour;
 
     const icon = (
       <StyledIcon
@@ -92,6 +96,10 @@ const Icon = React.forwardRef(
         data-element={iconType()}
         {...tagComponent("icon", rest)}
         {...styleProps}
+        hasTooltip={hasTooltip}
+        tabIndex={tabIndex || hasTooltip ? 0 : undefined}
+        aria-label={ariaLabel || hasTooltip ? type : undefined}
+        role={role || hasTooltip ? "tooltip" : undefined}
       />
     );
 
@@ -200,7 +208,9 @@ Icon.propTypes = {
   /** @ignore @private */
   inputSize: PropTypes.oneOf(["small", "medium", "large"]),
   /** @ignore @private */
-  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.number]),
+  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /** @ignore @private */
+  blockFocusBehaviour: PropTypes.bool,
 };
 
 Icon.defaultProps = {

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -591,6 +591,20 @@ describe("Icon component", () => {
       expect(wrapper.find(Tooltip).props().isVisible).toEqual(false);
     });
 
+    it("sets the tabIndex, ariaLabel and role", () => {
+      const wrapper = mount(
+        <Icon type="home" tooltipMessage="foo" tooltipVisible disabled />
+      );
+
+      expect(wrapper.find(StyledIcon).props()).toEqual(
+        expect.objectContaining({
+          "aria-label": "home",
+          role: "tooltip",
+          tabIndex: 0,
+        })
+      );
+    });
+
     describe("tooltipFlipOverrides", () => {
       it("does not throw an error if a valid array is passed", () => {
         global.console.error.mockReset();

--- a/src/components/icon/icon.style.js
+++ b/src/components/icon/icon.style.js
@@ -105,6 +105,7 @@ const StyledIcon = styled.span`
     type,
     fontSize,
     disabled,
+    hasTooltip,
   }) => {
     let finalColor;
     let finalHoverColor;
@@ -192,6 +193,13 @@ const StyledIcon = styled.span`
         
         display: block;
       }
+
+      ${hasTooltip &&
+      `
+        :focus {
+          outline: 2px solid ${theme.colors.focus};
+        }
+      `}
 
       ${margin}
     `;

--- a/src/components/portal/__snapshots__/portal.spec.js.snap
+++ b/src/components/portal/__snapshots__/portal.spec.js.snap
@@ -30,4 +30,4 @@ exports[`Portal when using default node to match snapshot  1`] = `
 </span>
 `;
 
-exports[`Portal when using default node when an element with id 'root' does not exist will mount on body 1`] = `"<div id=\\"root\\"><div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><span class=\\"sc-bdVaJa bwQgrC\\" data-element=\\"tick\\" data-component=\\"icon\\" font-size=\\"small\\" type=\\"tick\\" tabindex=\\"0\\" aria-label=\\"tick\\" role=\\"tooltip\\"></span></div></div>"`;
+exports[`Portal when using default node when an element with id 'root' does not exist will mount on body 1`] = `"<div id=\\"root\\"><div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><span class=\\"sc-bdVaJa dbSdba\\" data-element=\\"tick\\" data-component=\\"icon\\" font-size=\\"small\\" type=\\"tick\\" tabindex=\\"0\\" aria-label=\\"tick\\" role=\\"tooltip\\"></span></div></div>"`;

--- a/src/components/portal/__snapshots__/portal.spec.js.snap
+++ b/src/components/portal/__snapshots__/portal.spec.js.snap
@@ -30,4 +30,4 @@ exports[`Portal when using default node to match snapshot  1`] = `
 </span>
 `;
 
-exports[`Portal when using default node when an element with id 'root' does not exist will mount on body 1`] = `"<div id=\\"root\\"><div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><span class=\\"sc-bdVaJa tTFaT\\" data-element=\\"tick\\" data-component=\\"icon\\" font-size=\\"small\\" type=\\"tick\\"></span></div></div>"`;
+exports[`Portal when using default node when an element with id 'root' does not exist will mount on body 1`] = `"<div id=\\"root\\"><div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><span class=\\"sc-bdVaJa bwQgrC\\" data-element=\\"tick\\" data-component=\\"icon\\" font-size=\\"small\\" type=\\"tick\\" tabindex=\\"0\\" aria-label=\\"tick\\" role=\\"tooltip\\"></span></div></div>"`;


### PR DESCRIPTION
fix #4428
fix #4404

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Ensures `tabIndex` is set to 0 if has `tooltipMessage` and no prop passed. Sets `role` to "tooltip"
if none passed and `Icon` is not composed as part of `ValidationIcon` or `Help`. Sets `ariaLabel` to
`type` if none passed and not composed as part of `ValidationIcon` or `Help`.

Moves the `role` prop and surfaces `ariaLabel` so they can be passed to `Icon` to fix axe warning.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No `ariaLabel`, `tabIndex` or `role` set on `Icon` when it has `tooltipMessage`, no gold outline when focused.

Axe warning on all `labelHelp` and `Help` stories.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
Check `labelHelp` stories and `Help`
Check `icon--with-tooltip` ensure added props present and can tab to `Icon` etc
Check `ValidationIcon` html is unchanged

will add sandbox if needed

