### PR TITLE
fix(pager): resolve typing for pageSizeSelectionOptions to be an array of objects

### DIFF
--- a/src/components/pager/pager.d.ts
+++ b/src/components/pager/pager.d.ts
@@ -20,7 +20,7 @@ export interface PagerPropTypes {
   /** Should the page size selection dropdown be shown */
   showPageSizeSelection?: boolean;
   /** Set of page size options */
-  pageSizeSelectionOptions?: Record<string, unknown>;
+  pageSizeSelectionOptions?: Record<string, unknown>[];
   /** Should the label before the page size selection dropdown be shown */
   showPageSizeLabelBefore?: boolean;
   /** Should the label after the page size selection dropdown be shown */


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

When consuming the latest version of Carbon in our application, we found the type for pageSizeSelectionOptions was causing errors in our linter.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

The type is: `Record<string, unknown>` when this should be `Record<string, unknown>[]`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
