### PR TITLE
fix(icon): add missing sage_coin to type definition

### DIFF
--- a/src/components/icon/icon.component.js
+++ b/src/components/icon/icon.component.js
@@ -131,7 +131,11 @@ Icon.propTypes = {
    * Add classes to this component
    * */
   className: PropTypes.string,
-  /** Icon type */
+  /**
+   * Icon type.
+   *
+   * The full list of types can be seen [here](https://github.com/Sage/carbon/blob/master/src/components/icon/icon-config.js).
+   * */
   type: PropTypes.string.isRequired,
   /** Background size */
   bgSize: PropTypes.oneOf([
@@ -179,7 +183,10 @@ Icon.propTypes = {
   tooltipBgColor: PropTypes.string,
   /** Override font color of the Tooltip, provide any color from palette or any valid css color value. */
   tooltipFontColor: PropTypes.string,
-  /** Overrides the default flip behaviour of the Tooltip, must be an array containing some or all of ["top", "bottom", "left", "right"] (see https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements) */
+  /** Overrides the default flip behaviour of the Tooltip, must be an array containing some or all of ["top", "bottom", "left", "right"].
+   *
+   *  See the Popper [documentation](https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements) for more information
+   * */
   tooltipFlipOverrides: (props, propName) => {
     const prop = props[propName];
     const isValid =

--- a/src/components/icon/icon.d.ts
+++ b/src/components/icon/icon.d.ts
@@ -180,6 +180,7 @@ export type IconType =
   | "refresh"
   | "refresh_clock"
   | "remove"
+  | "sage_coin"
   | "save"
   | "scan"
   | "search"


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Add missing `sage_coin` to `type` defintion in `icon.d.ts`
Tidies up the prop table documentation

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`sage_coin` missing in `type` definition in `icon.d.ts`
### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs

### Additional context
<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/135635128-74120108-d588-46dd-98f7-ecfca0c98e18.png)

![image](https://user-images.githubusercontent.com/44157880/135635180-4fa1fa40-9ce8-4c08-a643-bdfad1cb907b.png)

### Testing instructions
<!-- How can a reviewer test this PR? -->
The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
