### PR TITLE
fix(duelling-picklist): correct dom structure of picklist groups

### DIFF
--- a/src/components/duelling-picklist/duelling-picklist.stories.mdx
+++ b/src/components/duelling-picklist/duelling-picklist.stories.mdx
@@ -6,6 +6,11 @@ import PicklistDivider from "./picklist-divider/picklist-divider.component";
 import PicklistPlaceholder from "./picklist-placeholder/picklist-placeholder.component";
 import DuellingPicklist from "./duelling-picklist.component";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import {
+  DuelingPicklistStory,
+  DuelingPicklistGroupedStory,
+  DuelingPicklistInDialogStory,
+} from "./duelling-picklist-test.stories.mdx";
 
 <Meta
   title="DuellingPicklist"
@@ -61,7 +66,7 @@ It invokes passed `onChange` method with passed `item` prop as an argument when 
 Example of composed Duelling Picklist components with order preservation and search implemented.
 
 <Preview>
-  <Story id="duellingpicklist--default" name="Default" />
+  <Story name="default">{DuelingPicklistStory.bind({})}</Story>
 </Preview>
 
 ### Grouped
@@ -69,7 +74,7 @@ Example of composed Duelling Picklist components with order preservation and sea
 Picklist items can be organised into selectable groups. Whole groups can be moved from one list to another at once, or group items can be moved individually.
 
 <Preview>
-  <Story id="duellingpicklist--grouped" name="Grouped" />
+  <Story name="Grouped">{DuelingPicklistGroupedStory.bind({})}</Story>
 </Preview>
 
 ### In Dialog
@@ -77,7 +82,7 @@ Picklist items can be organised into selectable groups. Whole groups can be move
 Same as above but as a children of `Dialog` component.
 
 <Preview>
-  <Story id="duellingpicklist--in-dialog" name="InDialog" />
+  <Story name="InDialog">{DuelingPicklistInDialogStory.bind({})}</Story>
 </Preview>
 
 ## PicklistItem Examples

--- a/src/components/duelling-picklist/picklist-group/picklist-group.component.js
+++ b/src/components/duelling-picklist/picklist-group/picklist-group.component.js
@@ -96,24 +96,26 @@ const PicklistGroup = React.forwardRef(
         {...(type === "add" ? { enter: false } : {})}
       >
         <StyledGroupWrapper highlighted={highlighted} type={type}>
-          <StyledPicklistGroup
-            onKeyDown={handleKeydown}
-            data-element="picklist-group"
-          >
-            {title}
-            <StyledGroupButton
-              buttonType="secondary"
-              destructive={type === "remove"}
-              iconType={type}
-              onClick={handleClick}
-              onMouseEnter={() => setHighlighted(true)}
-              onMouseLeave={() => setHighlighted(false)}
-              onFocus={() => setHighlighted(true)}
-              onBlur={() => setHighlighted(false)}
-              ref={ref}
-            />
-          </StyledPicklistGroup>
-          <TransitionGroup component={null}>{content}</TransitionGroup>
+          <ul>
+            <StyledPicklistGroup
+              onKeyDown={handleKeydown}
+              data-element="picklist-group"
+            >
+              {title}
+              <StyledGroupButton
+                buttonType="secondary"
+                destructive={type === "remove"}
+                iconType={type}
+                onClick={handleClick}
+                onMouseEnter={() => setHighlighted(true)}
+                onMouseLeave={() => setHighlighted(false)}
+                onFocus={() => setHighlighted(true)}
+                onBlur={() => setHighlighted(false)}
+                ref={ref}
+              />
+            </StyledPicklistGroup>
+            <TransitionGroup component={null}>{content}</TransitionGroup>
+          </ul>
         </StyledGroupWrapper>
       </CSSTransition>
     );

--- a/src/components/duelling-picklist/picklist-group/picklist-group.style.js
+++ b/src/components/duelling-picklist/picklist-group/picklist-group.style.js
@@ -3,7 +3,7 @@ import baseTheme from "../../../style/themes/base";
 import { ButtonWithForwardRef } from "../../button";
 import { StyledButton } from "../picklist-item/picklist-item.style";
 
-const StyledGroupWrapper = styled.div`
+const StyledGroupWrapper = styled.li`
   ${({ highlighted, type, theme }) => css`
     &:not(:first-of-type) {
       margin-top: 16px;


### PR DESCRIPTION
### Proposed behaviour

Fix the broken `DuellingPicklist` stories.

Change `PicklistGroup` to render a `li` with a `ul` as a direct child (it's children are `li`'s).

### Current behaviour

Accessibility violations on the `DuellingPicklist` grouped story as it currently has a `div` as a direct child of a `ul`,  and `li`'s as children of the `div`

### Checklist

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs

### Additional context

### Testing instructions
Look at the `DuellingPicklist` grouped story on Storybook. 

Note this won't show up in carbon.sage.com as it's currently in a Test story only. I've moved them to normal stories as well in this task.
