### PR TITLE
fix(tabs): remove extra grey border on warning and info

### DIFF
--- a/src/components/tabs/__internal__/tab-title/tab-title.style.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.style.js
@@ -86,10 +86,7 @@ const StyledTitleContent = styled.div`
     css`
       font-size: 16px;
       padding: 22px 24px;
-      ${!isTabSelected &&
-      !alternateStyling &&
-      (error || warning || info) &&
-      `margin-right: -2px;`}
+      ${!isTabSelected && !alternateStyling && error && `margin-right: -2px;`}
     `}
 
     ${size === "default" &&
@@ -105,7 +102,7 @@ const StyledTitleContent = styled.div`
       ${position === "left" &&
       !isTabSelected &&
       !alternateStyling &&
-      (error || warning || info) &&
+      error &&
       `margin-right: -2px;`}
     `}
   `}
@@ -422,22 +419,24 @@ const StyledTabTitle = styled.li`
     error,
     warning,
     info,
+    isInSidebar,
   }) =>
     position === "left" &&
     css`
       background-color: transparent;
       border-bottom: 0px;
 
+      ${!isInSidebar &&
+      css`
+        border-right: ${alternateStyling ? "1px" : "2px"} solid
+          ${theme.tab.background};
+      `}
+
       ${!borders &&
       css`
         ${StyledTitleContent} {
           border-bottom: none;
         }
-      `}
-
-      ${!alternateStyling &&
-      css`
-        border-right: 2px solid ${theme.tab.background};
       `}
 
       display: block;
@@ -451,6 +450,11 @@ const StyledTabTitle = styled.li`
       &:hover {
         ${alternateStyling && `border-right-color: ${theme.tab.background};`}
       }
+
+      ${(warning || info) &&
+      css`
+        border-right: none;
+      `}
 
       ${({ isTabSelected }) =>
         isTabSelected &&

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.spec.js
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.spec.js
@@ -58,7 +58,7 @@ describe("TabsHeader", () => {
       assertStyleMatch(
         {
           flexDirection: "column",
-          boxShadow: `inset -2px 0px 0px 0px ${baseTheme.tab.background}`,
+          boxShadow: `none`,
         },
         wrapper.find(StyledTabsHeaderList)
       );
@@ -128,7 +128,7 @@ describe("TabsHeader", () => {
     it("applies proper styles when position left", () => {
       assertStyleMatch(
         {
-          boxShadow: `inset -1px 0px 0px 0px ${baseTheme.tab.background}`,
+          boxShadow: `none`,
         },
         renderStyles({ alternateStyling: true, position: "left" })
       );

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.style.js
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.style.js
@@ -52,11 +52,11 @@ const StyledTabsHeaderList = styled.ul`
       text-align: right;
     `}
 
-  ${({ position, noRightBorder, theme }) =>
+  ${({ position, noRightBorder }) =>
     position === "left" &&
     css`
       flex-direction: column;
-      box-shadow: inset ${computeLineWidth} 0px 0px 0px ${theme.tab.background};
+      box-shadow: none;
 
       ${noRightBorder &&
       css`


### PR DESCRIPTION
Fixes: #4254

### Proposed behaviour

Remove extra grey border on warning/info tabs. For position left, and for normal size and large size (I haven't added screenshots for the large size):

![image](https://user-images.githubusercontent.com/14963680/136047298-dbff84e1-5009-4a1d-b166-9b9c405802fb.png)


### Current behaviour
An extra grey border is visible on warning/info tabs, for position left: 


![image](https://user-images.githubusercontent.com/14963680/136047505-77ce51e1-419b-4bf2-ac8b-fa0f7dc4662a.png)


### Checklist

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs

### Additional context

### Testing instructions
Look at both tabs positioned left validations stories: 
https://carbon.sage.com/?path=/docs/tabs--with-validations-positioned-left
https://carbon.sage.com/?path=/docs/tabs--with-validations-sized-large-positioned-left

Chromatic will capture the visual changes as well for these.