### PR TITLE
fix(accordion): fix group documentation example - FE-4386

### DIFF
--- a/src/components/accordion/accordion.stories.mdx
+++ b/src/components/accordion/accordion.stories.mdx
@@ -409,7 +409,27 @@ To achieve proper keyboard accessibility as described in `W3` sources it is requ
 `AccordionGroup`.
 
 <Preview>
-  <Story id="accordion-test--grouped" name="grouped"></Story>
+  <Story name="grouped">
+    <AccordionGroup>
+    <Accordion title="First Accordion">
+      <Box p={2}>
+        <Textbox label="Textbox in an Accordion" />
+      </Box>
+    </Accordion>
+    <Accordion title="Second Accordion">
+      <Box p={2}>
+        <Textbox label="Textbox in an Accordion" />
+      </Box>
+    </Accordion>
+    <Accordion title="Third Accordion">
+      <Box p={2}>
+        <div>Content</div>
+        <div>Content</div>
+        <div>Content</div>
+      </Box>
+    </Accordion>
+  </AccordionGroup>
+  </Story>
 </Preview>
 
 ### With validation icon


### PR DESCRIPTION
### Proposed behaviour

![Screenshot 2021-10-06 at 13 23 24](https://user-images.githubusercontent.com/56251247/136205069-dac204c7-b1d7-4ff5-9c29-c177946892ed.png)

![Screenshot 2021-10-06 at 13 23 16](https://user-images.githubusercontent.com/56251247/136205099-52b2d962-55ad-410b-9aef-85610f48d14a.png)

### Current behaviour
![Screenshot 2021-10-06 at 13 23 02](https://user-images.githubusercontent.com/56251247/136205135-0c0c6a6b-0983-4781-8faf-4e8b737a9565.png)

![Screenshot 2021-10-06 at 13 22 38](https://user-images.githubusercontent.com/56251247/136205169-56a6075f-e425-425d-8739-0f25f815470f.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!-- How can a reviewer test this PR? -->
The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
