### PR TITLE
chore: prevent chromatic from being indexed

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,6 +3,7 @@ const glob = require("glob");
 
 const projectRoot = path.resolve(__dirname, "../");
 const ignoreTests = process.env.IGNORE_TESTS === "true";
+const isChromatic = !ignoreTests;
 const getStories = () =>
   glob.sync(`${projectRoot}/src/**/*.stories.@(js|mdx)`, {
     ...(ignoreTests && {
@@ -43,4 +44,14 @@ module.exports = {
 
     return config;
   },
+  ...(isChromatic && {
+    previewHead: (head) => `
+      ${head}
+      <meta name="robots" content="noindex">
+  `,
+    managerHead: (head) => `
+      ${head}
+      <meta name="robots" content="noindex">
+  `,
+  }),
 };


### PR DESCRIPTION
### Proposed behaviour

Prevent chromatic/test stories from being indexed.

### Current behaviour

Chromatic/text stories could be indexed.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Run the storybook with `NODE_ENV=production IGNORE_TESTS=true npm run start` and check that the `meta` tag is on the page in both the sidebar and the iframe.
