### PR TITLE
docs(hooks): add useMediaQuery docs

### DIFF
--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -742,10 +742,10 @@ at the different breakpoints.
     parameters={{ chromatic: { disable: true } }}
   >
     {() => {
-      const isBelowBreakpoint1 = useMediaQuery("(max-width: 1600px)");
-      const isBelowBreakpoint2 = useMediaQuery("(max-width: 1300px)");
-      const isBelowBreakpoint3 = useMediaQuery("(max-width: 1000px)");
-      const isBelowBreakpoint4 = useMediaQuery("(max-width: 850px)");
+      const isBelowBreakpoint1 = useMediaQuery("(max-width: 1200px)");
+      const isBelowBreakpoint2 = useMediaQuery("(max-width: 1000px)");
+      const isBelowBreakpoint3 = useMediaQuery("(max-width: 800px)");
+      const isBelowBreakpoint4 = useMediaQuery("(max-width: 600px)");
       const responsiveMenuItems = () => {
         if (isBelowBreakpoint4) {
           return [

--- a/src/hooks/useMediaQuery/use-media-query.stories.mdx
+++ b/src/hooks/useMediaQuery/use-media-query.stories.mdx
@@ -1,0 +1,56 @@
+import { ArgsTable } from "@storybook/components";
+import LinkTo from "@storybook/addon-links/react";
+import useMediaQuery from ".";
+
+<Meta
+  title="Documentation/Hooks/useMediaQuery"
+  parameters={{ info: { disable: true } }}
+/>
+
+# useMediaQuery
+
+`useMediaQuery` is a custom React hook and a JavaScript implementation of a CSS media query. Pass in a valid CSS media query as a string, and it returns a boolean depending on the outcome of the query.
+
+This is particularly useful for setting responsive breakpoints on a component by component basis for particular properties, for example padding or margin.
+
+## Contents
+
+- [Import path](#import-path)
+- [Examples](#examples)
+- [Parameters](#parameters)
+
+## Import path
+
+```javascript
+import useMediaQuery from "carbon-react/lib/hooks/useMediaQuery";
+```
+
+## Examples
+
+### Basic usage
+
+```javascript
+const isWideScreen = useMediaQuery("(min-width: 1000px)");
+
+// Returns "true" if the current window width is greater than (or equal to) 1000px
+// Returns "false" if not.
+```
+
+### Setting multiple breakpoints
+
+See this `Menu` <LinkTo kind="Menu" story="responsive composition">example</LinkTo> for an example of using `useMediaQuery` to set responsive breakpoints to determine what content to render.
+
+This `Image` <LinkTo kind="Image" story="custom responsive behaviour">example</LinkTo> changes the image displayed based on the window width.
+
+## Parameters
+
+<ArgsTable
+  rows={[
+    {
+      name: "query",
+      type: { summary: "string" },
+      description: "Any valid CSS media query.",
+      required: true,
+    },
+  ]}
+/>


### PR DESCRIPTION
### Proposed behaviour

Add some documentation for our `useMediaQuery` hook, within a "Hooks" folder on Storybook.

http://localhost:9001/?path=/docs/hooks-usemediaquery--page

### Current behaviour

We have no documentation at all for this hook.

### Checklist

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context


### Testing instructions

http://localhost:9001/?path=/docs/documentation-hooks-usemediaquery--page
