### PR TITLE
chore(storybook): use docs mode in published version only

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         node-version: '>=14.16.0 14'
     - run: npm ci
-    - run: NODE_ENV=production IGNORE_TESTS=true npm run build-storybook
+    - run: NODE_ENV=production IGNORE_TESTS=true STORYBOOK_VIEW_MODE=docs npm run build-storybook
     - uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -79,7 +79,7 @@ export const parameters = {
   chromatic: { disable: false },
   viewport: { viewports: customViewports },
   actions: { argTypesRegex: "^on.*" },
-  viewMode: "docs",
+  viewMode: process.env.STORYBOOK_VIEW_MODE,
 };
 
 export const globalTypes = {


### PR DESCRIPTION
### Proposed behaviour

Use docs mode in published version only. The local version will use `canvas`.

### Current behaviour

Docs mode is used locally, when viewing icons test story it can cause the browser to freeze.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

https://github.com/Sage/carbon/pull/4439

### Testing instructions

Start storybook locally and see that the view mode you select is persisted when navigating stories. The version on `carbon.sage.com` should switch to `docs` when you change story.
