### PR TITLE
test(anchor-nav): increase timeout

### DIFF
--- a/cypress/features/regression/anchorNavigation.feature
+++ b/cypress/features/regression/anchorNavigation.feature
@@ -6,9 +6,9 @@ Feature: Anchor Navigation component
       And I open component preview
 
   @positive
-  Scenario Outline: Press on <tab> tab and scroll to the the <index> anchor navigation
+  Scenario Outline: Press on <tab> tab and scroll to the <index> anchor navigation
     When I click onto "<tab>" tab
-      And I wait 750
+      And I wait 1000
     Then "<index>" anchor navigation section is visible
     Examples:
       | tab                                  | index          |


### PR DESCRIPTION
### Proposed behaviour

A timeout error occurred in the AchorNavigation.feature file, it is caused by the wait isn’t quite long enough and the h2 it’s trying to select isn’t on the screen yet. So just changed the wait time from 750 to 1000. And also a small typo found from the feature file. 


### Current behaviour

Should be no failing in AnchorNavigation cypress

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Verify the changes in the feature file work



