### PR TITLE
docs: remove broken link vulnerable to hijacking

### DIFF
--- a/docs/using-draft-js.stories.mdx
+++ b/docs/using-draft-js.stories.mdx
@@ -117,5 +117,3 @@ converting html into `ContentState` using `convertFromHTML`.
 
 ### Useful Links
 * API reference documentaion - https://draftjs.org/docs/api-reference-editor-state.
-* A useful playground for getting to grips with `Draft.js` internal architecture and mechanisms 
-https://learn-draftjs.now.sh/.


### PR DESCRIPTION
Removes a broken link vulnerable to hijacking.

### Proposed behaviour

Removes the link used for https://learn-draftjs.now.sh

### Current behaviour

The link is embedded within our docs and it's assumed that this link is still active.

### Checklist

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This was reported through responsible disclosure at our bug bounty program. An external actor can host whatever content they'd like on the link, and potentially point developers towards phishing sites or malware.

### Testing instructions

Testing is not needed.
