### PR TITLE
docs(icon): add section listing all available icon types FE-4393

### DIFF
--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -5,6 +5,8 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import Icon from "./";
 import Box from "../box";
 
+import { ICONS } from "./icon-config";
+
 <Meta
   title="Icon"
   parameters={{ info: { disable: true }, chromatic: { disable: true } }}
@@ -12,7 +14,7 @@ import Box from "../box";
 
 # Icon
 
-Carbon comes with more than 100 standard icons to choose from. See the Icons page in the Style section.
+Carbon comes with more than 100 standard icons to choose from. See [list of icons](#list-of-icons) for full reference.
 
 A tooltip option is available within this component.
 
@@ -22,6 +24,7 @@ Many other components allow you to specify one of the standard Carbon icons to a
 
 - [Quick Start](#quick-start)
 - [Examples](#examples)
+- [List of icons](#list-of-icons)
 - [Props](#props)
 
 ## Quick Start
@@ -180,6 +183,29 @@ See <LinkTo kind="Documentation/Colors" name="page" story="page">Colors</LinkTo>
         <Icon type="add" color="white" bg="rgb(0, 123, 10)" />
       </Box>
     </>
+  </Story>
+</Preview>
+
+## List of icons
+
+Below is a comprehensive list of all the available icons in Carbon and their corresponding ``type``.
+It's **required** that the `type` prop is specified (even if it's `"none"`).
+
+<Preview>
+  <Story
+    name="list of icons"
+    parameters={{ info: { disable: true }, chromatic: { disable: true } }}
+  >
+    <Box m={2}>
+      {ICONS.sort().map(type => {
+        return (
+          <Box m={2} key={`icon-${type}`}>
+            <Icon m={2} type={type} fontSize="large"/>
+            {type}
+          </Box>
+        )
+      })}
+    </Box>
   </Story>
 </Preview>
 


### PR DESCRIPTION
resolves #4456 

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

Updated Storybook documentation for Icon component - including a new section which dynamically displays all the available icons next to their ``type``.

![Screenshot 2021-10-26 at 12 15 01](https://user-images.githubusercontent.com/18368713/138867043-229e153f-3fe7-4c37-8285-38fa801dfdcc.png)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

For documenting the Icon ``type`` prop, only a link to same Design System page above is provided in the prop table. This is not ideal, especially if there are discrepancies between Carbon and Design System now and in the future.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Storybook added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook