### PR TITLE
fix(design-tokens): improve values of tokens using theme.space, add color tokens contain opacity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3415,9 +3415,9 @@
       "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg=="
     },
     "@sage/design-tokens": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@sage/design-tokens/-/design-tokens-1.65.0.tgz",
-      "integrity": "sha512-N73JWW9I5jYqFkjCaJS1i1578QYzublFEkH3mg/j3QWRSTjaeiCGTZQZ15CDTLNUsBXsnoYY9q630Y8D8mn6GQ=="
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@sage/design-tokens/-/design-tokens-1.73.0.tgz",
+      "integrity": "sha512-y1cFdC3MtCWmnNPfUEk6mV7K2YCSeuRuiBI08Ltp0tKZY/zoNM/Sw4z+NJwO3vzeCvt1cU0s0Ak6vdewYdRlxg=="
     },
     "@semantic-release/changelog": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.9.0",
-    "@sage/design-tokens": "^1.65.0",
+    "@sage/design-tokens": "^1.73.0",
     "@styled-system/prop-types": "^5.1.5",
     "@tippyjs/react": "^4.2.5",
     "classnames": "~2.2.6",

--- a/src/style/design-tokens/theme-compatibility.util.js
+++ b/src/style/design-tokens/theme-compatibility.util.js
@@ -17,6 +17,10 @@ export default (theme) => ({
   metaName: "Base Theme",
   metaPublic: "true",
   colorsLogo: "#00D639",
+  colorsYin030: "rgba(0,0,0,0.3)",
+  colorsYin055: "rgba(0,0,0,0.55)",
+  colorsYin065: "rgba(0,0,0,0.65)",
+  colorsYin090: "rgba(0,0,0,0.9)",
   colorsComponentsNavigation500: "#008146",
   colorsComponentsNavigation600: "#006738",
   colorsComponentsNavigation700: "#004D2A",
@@ -120,22 +124,22 @@ export default (theme) => ({
   sizing050: "4px",
   sizing075: "6px",
   sizingLogowidth: "40px",
-  spacing000: theme.space[0], // 0px
+  spacing000: `${theme.space[0]}px`, // 0px
   spacing025: "2px",
   spacing050: "4px",
   spacing075: "6px",
-  spacing100: theme.space[1], // 8px
+  spacing100: `${theme.space[1]}px`, // 8px
   spacing125: "10px",
   spacing150: "12px",
-  spacing200: theme.space[2], // 16px
+  spacing200: `${theme.space[2]}px`, // 16px
   spacing250: "20px",
-  spacing300: theme.space[3], // 24px
-  spacing400: theme.space[4], // 32px
-  spacing500: theme.space[5], // 40px
-  spacing600: theme.space[6], // 48px
-  spacing700: theme.space[7], // 56px
-  spacing800: theme.space[8], // 64px
-  spacing900: theme.space[9], // 72px
+  spacing300: `${theme.space[3]}px`, // 24px
+  spacing400: `${theme.space[4]}px`, // 32px
+  spacing500: `${theme.space[5]}px`, // 40px
+  spacing600: `${theme.space[6]}px`, // 48px
+  spacing700: `${theme.space[7]}px`, // 56px
+  spacing800: `${theme.space[8]}px`, // 64px
+  spacing900: `${theme.space[9]}px`, // 72px
   borderWidth100: "1px",
   borderWidth200: "2px",
   borderWidth300: "3px",


### PR DESCRIPTION
### Proposed behaviour

Updates the package with design-tokens.
Adds new color tokens containing opacity to the theme-compatibility.util.js file.
Improves values for tokens that use 'theme.space'.

### Current behaviour

The current design-tokens package is: ^1.65.0
Currently there are no colour tokens that contain opacity

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

