### PR TITLE
feat(progress-tracker): create new component  FE-4367

### DIFF
--- a/src/components/progress-tracker/index.d.ts
+++ b/src/components/progress-tracker/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from "./progress-tracker";

--- a/src/components/progress-tracker/index.js
+++ b/src/components/progress-tracker/index.js
@@ -1,0 +1,1 @@
+export { default } from "./progress-tracker.component";

--- a/src/components/progress-tracker/progress-tracker-test.stories.js
+++ b/src/components/progress-tracker/progress-tracker-test.stories.js
@@ -1,0 +1,72 @@
+import React from "react";
+import ProgressTracker from ".";
+import {
+  PROGRESS_TRACKER_SIZES,
+  PROGRESS_TRACKER_VARIANTS,
+} from "./progress-tracker.config";
+
+export default {
+  component: ProgressTracker,
+  title: "Progress Tracker/Test",
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disable: true,
+    },
+  },
+  argTypes: {
+    size: {
+      options: PROGRESS_TRACKER_SIZES,
+      control: {
+        type: "select",
+      },
+    },
+    progress: {
+      control: {
+        type: "number",
+      },
+    },
+    currentProgressLabel: {
+      options: ["", "$100", "100ml"],
+      control: {
+        type: "select",
+      },
+    },
+    maxProgressLabel: {
+      options: ["", "$200", "200ml"],
+      control: {
+        type: "select",
+      },
+    },
+    variant: {
+      options: PROGRESS_TRACKER_VARIANTS,
+      control: {
+        type: "select",
+      },
+    },
+    orientation: {
+      options: ["horizontal", "vertical"],
+      control: {
+        type: "select",
+      },
+    },
+    direction: {
+      options: ["up", "down"],
+      control: {
+        type: "select",
+      },
+    },
+    labelsPosition: {
+      options: ["top", "bottom", "left", "right"],
+      control: {
+        type: "select",
+      },
+    },
+  },
+};
+
+export const Default = ({ ...args }) => {
+  return <ProgressTracker {...args} />;
+};
+
+Default.storyName = "default";

--- a/src/components/progress-tracker/progress-tracker.component.js
+++ b/src/components/progress-tracker/progress-tracker.component.js
@@ -1,0 +1,126 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
+import tagComponent from "../../__internal__/utils/helpers/tags";
+import { filterStyledSystemMarginProps } from "../../style/utils";
+import {
+  StyledProgressBar,
+  InnerBar,
+  StyledValuesLabel,
+  StyledProgressTracker,
+  StyledValue,
+} from "./progress-tracker.style";
+
+const marginPropTypes = filterStyledSystemMarginProps(
+  styledSystemPropTypes.space
+);
+
+const ProgressTracker = ({
+  size = "medium",
+  progress = 0,
+  showDefaultLabels = false,
+  currentProgressLabel,
+  maxProgressLabel,
+  variant = "default",
+  orientation = "horizontal",
+  direction = "up",
+  labelsPosition,
+  ...rest
+}) => {
+  const isVertical = orientation === "vertical";
+  const prefixLabels =
+    (!isVertical && labelsPosition !== "bottom") ||
+    (isVertical && labelsPosition === "left");
+
+  const renderValueLabels = () => {
+    if (!showDefaultLabels && !currentProgressLabel && !maxProgressLabel) {
+      return null;
+    }
+
+    const label = (value, defaultValue) => {
+      if (value) {
+        return value;
+      }
+      return showDefaultLabels ? defaultValue : undefined;
+    };
+
+    return (
+      <StyledValuesLabel position={labelsPosition} isVertical={isVertical}>
+        {isVertical && direction === "up" && (
+          <>
+            <StyledValue isMaxValue>
+              {label(maxProgressLabel, "100%")}
+            </StyledValue>
+            <StyledValue>
+              {label(currentProgressLabel, `${progress}%`)}
+            </StyledValue>
+          </>
+        )}
+        {(direction === "down" || !isVertical) && (
+          <>
+            <StyledValue>
+              {label(currentProgressLabel, `${progress}%`)}
+            </StyledValue>
+            <StyledValue isMaxValue>
+              {label(maxProgressLabel, "100%")}
+            </StyledValue>
+          </>
+        )}
+      </StyledValuesLabel>
+    );
+  };
+
+  return (
+    <StyledProgressTracker
+      size={size}
+      isVertical={isVertical}
+      {...rest}
+      {...tagComponent("progress-bar", rest)}
+    >
+      {prefixLabels && renderValueLabels()}
+      <StyledProgressBar
+        direction={isVertical ? direction : undefined}
+        isVertical={isVertical}
+        size={size}
+      >
+        <InnerBar
+          isVertical={isVertical}
+          size={size}
+          progress={progress}
+          variant={variant}
+        />
+      </StyledProgressBar>
+      {!prefixLabels && renderValueLabels()}
+    </StyledProgressTracker>
+  );
+};
+
+ProgressTracker.propTypes = {
+  ...marginPropTypes,
+  /** Size of the progress bar. */
+  size: PropTypes.oneOf(["small", "medium", "large"]),
+  /** Current progress (percentage). */
+  progress: PropTypes.number,
+  /** Flag to control whether the default value labels (as percentages) should be rendered. */
+  showDefaultLabels: PropTypes.bool,
+  /** Value to display as current progress. */
+  currentProgressLabel: PropTypes.string,
+  /** Value to display as the maximum progress limit. */
+  maxProgressLabel: PropTypes.string,
+  /**
+   * Sets the colour of the bar that shows the current progress.
+   * The "traffic" variant changes the colour of status bar depending on current progress.
+   */
+  variant: PropTypes.oneOf(["default", "traffic"]),
+  /** The orientation of the component. */
+  orientation: PropTypes.oneOf(["horizontal", "vertical"]),
+  /** The direction the bar should move as progress increases, only applies in vertical orientation. */
+  direction: PropTypes.oneOf(["up", "down"]),
+  /**
+   * The position the value label are rendered in.
+   * Top/bottom apply to horizontal and left/right to vertical orientation.
+   */
+  labelsPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
+};
+
+export default ProgressTracker;

--- a/src/components/progress-tracker/progress-tracker.config.js
+++ b/src/components/progress-tracker/progress-tracker.config.js
@@ -1,0 +1,5 @@
+export const OUTER_TRACKER_LENGTH = "256px";
+
+export const PROGRESS_TRACKER_SIZES = ["small", "medium", "large"];
+
+export const PROGRESS_TRACKER_VARIANTS = ["default", "traffic"];

--- a/src/components/progress-tracker/progress-tracker.d.ts
+++ b/src/components/progress-tracker/progress-tracker.d.ts
@@ -1,0 +1,32 @@
+import { MarginProps } from "styled-system";
+
+export interface ProgressBarProps extends MarginProps {
+  /** Size of the progressBar. */
+  size?: "small" | "medium" | "large";
+  /** Current progress (percentage). */
+  progress?: number;
+  /** Flag to control whether the default value labels (as percentages) should be rendered. */
+  showDefaultLabels?: boolean;
+  /** Value to display as current progress. */
+  currentProgressLabel?: string;
+  /** Value to display as the maximum progress limit. */
+  maxProgressLabel?: string;
+  /**
+   * Sets the colour of the bar that shows the current progress.
+   * The "traffic" variant changes the colour of status bar depending on current progress.
+   * */
+  variant?: "default" | "traffic";
+  /** The orientation of the component. */
+  orientation?: "horizontal" | "vertical";
+  /** The direction the bar should move as progress increases, only applies in vertical orientation. */
+  direction?: "up" | "down";
+  /**
+   * The position the value label are rendered in.
+   * Top/bottom apply to horizontal and left/right to vertical orientation.
+   */
+  labelsPosition?: "top" | "bottom" | "left" | "right";
+}
+
+declare function ProgressBar(props: ProgressBarProps): JSX.Element;
+
+export default ProgressBar;

--- a/src/components/progress-tracker/progress-tracker.spec.js
+++ b/src/components/progress-tracker/progress-tracker.spec.js
@@ -1,0 +1,431 @@
+import React from "react";
+import { mount } from "enzyme";
+import {
+  StyledProgressBar,
+  InnerBar,
+  StyledValuesLabel,
+  StyledValue,
+} from "./progress-tracker.style";
+import {
+  assertStyleMatch,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/test-utils";
+import baseTheme from "../../style/themes/base";
+import ProgressBar from "./progress-tracker.component";
+
+describe("ProgressBar", () => {
+  let wrapper;
+
+  testStyledSystemMargin((props) => <ProgressBar {...props} />);
+
+  it("renders component as expected", () => {
+    wrapper = mount(<ProgressBar />);
+    const innerBar = wrapper.find(InnerBar);
+    expect(innerBar).toBeTruthy();
+  });
+
+  describe("when size is not specified", () => {
+    beforeEach(() => {
+      wrapper = mount(<ProgressBar progress={50} />);
+    });
+
+    it("renders outer bar as expected", () => {
+      assertStyleMatch(
+        {
+          textAlign: "center",
+          whiteSpace: "nowrap",
+          width: "256px",
+        },
+        wrapper.find(ProgressBar)
+      );
+    });
+
+    it("renders inner bar as expected", () => {
+      assertStyleMatch(
+        {
+          backgroundColor: baseTheme.progressTracker.innerBackground,
+          width: "calc(256px * 0.5)",
+          height: "8px",
+        },
+        wrapper.find(InnerBar)
+      );
+    });
+
+    describe("and orientation is vertical", () => {
+      beforeEach(() => {
+        wrapper = mount(<ProgressBar orientation="vertical" progress={50} />);
+      });
+
+      it("renders outer bar as expected", () => {
+        assertStyleMatch(
+          {
+            textAlign: "center",
+            whiteSpace: "nowrap",
+            height: "256px",
+          },
+          wrapper.find(ProgressBar)
+        );
+      });
+
+      it("renders inner bar as expected", () => {
+        assertStyleMatch(
+          {
+            backgroundColor: baseTheme.progressTracker.innerBackground,
+            height: "calc(256px * 0.5)",
+            width: "8px",
+          },
+          wrapper.find(InnerBar)
+        );
+      });
+    });
+  });
+
+  describe("when size is set to small", () => {
+    beforeEach(() => {
+      wrapper = mount(<ProgressBar size="small" progress={50} />);
+    });
+
+    it("applies proper width and height to outer bar", () => {
+      assertStyleMatch({ width: "256px" }, wrapper.find(ProgressBar));
+    });
+
+    it("applies proper width and height to inner bar", () => {
+      assertStyleMatch(
+        {
+          width: "calc(256px * 0.5)",
+          height: "4px",
+        },
+        wrapper.find(InnerBar)
+      );
+    });
+
+    describe("and orientation is vertical", () => {
+      beforeEach(() => {
+        wrapper = mount(
+          <ProgressBar orientation="vertical" size="small" progress={50} />
+        );
+      });
+
+      it("renders outer bar as expected", () => {
+        assertStyleMatch(
+          {
+            height: "256px",
+          },
+          wrapper.find(ProgressBar)
+        );
+      });
+
+      it("renders inner bar as expected", () => {
+        assertStyleMatch(
+          {
+            backgroundColor: baseTheme.progressTracker.innerBackground,
+            height: "calc(256px * 0.5)",
+            width: "4px",
+          },
+          wrapper.find(InnerBar)
+        );
+      });
+    });
+  });
+
+  describe("when size is set to large", () => {
+    beforeEach(() => {
+      wrapper = mount(<ProgressBar size="large" progress={50} />);
+    });
+
+    it("applies proper width and height to outer bar", () => {
+      assertStyleMatch(
+        {
+          width: "100%",
+          height: "16px",
+        },
+        wrapper.find(StyledProgressBar)
+      );
+    });
+
+    it("applies proper width and height to inner bar", () => {
+      assertStyleMatch(
+        {
+          width: "calc(256px * 0.5)",
+          height: "16px",
+        },
+        wrapper.find(InnerBar)
+      );
+    });
+
+    describe("and orientation is vertical", () => {
+      beforeEach(() => {
+        wrapper = mount(
+          <ProgressBar orientation="vertical" size="large" progress={50} />
+        );
+      });
+
+      it("renders outer bar as expected", () => {
+        assertStyleMatch(
+          {
+            height: "256px",
+          },
+          wrapper.find(ProgressBar)
+        );
+      });
+
+      it("renders inner bar as expected", () => {
+        assertStyleMatch(
+          {
+            backgroundColor: baseTheme.progressTracker.innerBackground,
+            height: "calc(256px * 0.5)",
+            width: "16px",
+          },
+          wrapper.find(InnerBar)
+        );
+      });
+    });
+  });
+
+  describe.each(["top", "bottom"])(
+    "default labels and labelsPosition is %s",
+    (labelsPosition) => {
+      beforeEach(() => {
+        wrapper = mount(
+          <ProgressBar
+            labelsPosition={labelsPosition}
+            size="large"
+            progress={50}
+            showDefaultLabels
+          />
+        );
+      });
+
+      it("shows current progress correctly", () => {
+        expect(wrapper.text().includes("50%")).toBeTruthy();
+      });
+
+      it("shows maximum progress limit correctly", () => {
+        expect(wrapper.text().includes("100%")).toBeTruthy();
+      });
+
+      it("renders the current progress labels as expected", () => {
+        assertStyleMatch(
+          {
+            textAlign: "start",
+            display: "flex",
+            justifyContent: "space-between",
+            [labelsPosition === "top" ? "paddingBottom" : "paddingTop"]: "4px",
+          },
+          wrapper.find(StyledValuesLabel)
+        );
+      });
+
+      describe.each(["up", "down"])(
+        "and orientation is vertical adn direction is %s",
+        (direction) => {
+          beforeEach(() => {
+            wrapper = mount(
+              <ProgressBar
+                direction={direction}
+                orientation="vertical"
+                showDefaultLabels
+                progress={50}
+              />
+            );
+          });
+
+          it("shows current progress correctly", () => {
+            expect(wrapper.text().includes("50%")).toBeTruthy();
+          });
+
+          it("shows maximum progress limit correctly", () => {
+            expect(wrapper.text().includes("100%")).toBeTruthy();
+          });
+
+          it("applies expected styles to the wrapper", () => {
+            assertStyleMatch(
+              {
+                overflowY: "hidden",
+                width: "8px",
+                height: "100%",
+                alignItems: direction === "up" ? "flex-end" : undefined,
+              },
+              wrapper.find(StyledProgressBar)
+            );
+          });
+
+          it("renders the current progress labels as expected", () => {
+            assertStyleMatch(
+              {
+                textAlign: "start",
+                display: "flex",
+                justifyContent: "space-between",
+                flexDirection: "column",
+                paddingLeft: "4px",
+              },
+              wrapper.find(StyledValuesLabel)
+            );
+          });
+        }
+      );
+    }
+  );
+
+  describe("custom labels", () => {
+    beforeEach(() => {
+      wrapper = mount(
+        <ProgressBar
+          progress={50}
+          currentProgressLabel="foo"
+          maxProgressLabel="bar"
+        />
+      );
+    });
+
+    it("shows currentProgressLabel correctly", () => {
+      expect(
+        wrapper.find(StyledValuesLabel).find(StyledValue).first().text()
+      ).toEqual("foo");
+    });
+
+    it("shows maxProgressLabel correctly", () => {
+      expect(
+        wrapper.find(StyledValuesLabel).find(StyledValue).last().text()
+      ).toEqual("bar");
+    });
+
+    describe("when showDefaultLabels is not set", () => {
+      it("only shows the currentProgressLabel that has a value", () => {
+        wrapper = mount(
+          <ProgressBar progress={50} currentProgressLabel="foo" />
+        );
+
+        expect(
+          wrapper.find(StyledValuesLabel).find(StyledValue).first().text()
+        ).toEqual("foo");
+
+        expect(
+          wrapper.find(StyledValuesLabel).find(StyledValue).last().text()
+        ).toEqual("");
+      });
+
+      it("only shows the maxProgressLabel that has a value", () => {
+        wrapper = mount(<ProgressBar progress={50} maxProgressLabel="bar" />);
+
+        expect(
+          wrapper.find(StyledValuesLabel).find(StyledValue).first().text()
+        ).toEqual("");
+
+        expect(
+          wrapper.find(StyledValuesLabel).find(StyledValue).last().text()
+        ).toEqual("bar");
+      });
+    });
+
+    describe.each([
+      ["up", "left"],
+      ["up", "right"],
+      ["down", "left"],
+      ["down", "right"],
+    ])(
+      "and orientation is vertical, direction is %s and labelsPosition is %s",
+      (direction, labelsPosition) => {
+        beforeEach(() => {
+          wrapper = mount(
+            <ProgressBar
+              orientation="vertical"
+              currentProgressLabel="foo"
+              maxProgressLabel="bar"
+              progress={50}
+              direction={direction}
+              labelsPosition={labelsPosition}
+            />
+          );
+        });
+
+        it("shows currentProgressLabel correctly", () => {
+          expect(
+            wrapper.find(StyledValuesLabel).find(StyledValue).first().text()
+          ).toEqual(direction === "up" ? "bar" : "foo");
+        });
+
+        it("shows maxProgressLabel correctly", () => {
+          expect(
+            wrapper.find(StyledValuesLabel).find(StyledValue).last().text()
+          ).toEqual(direction === "up" ? "foo" : "bar");
+        });
+
+        it("renders the currentProgressLabel labels as expected", () => {
+          assertStyleMatch(
+            {
+              textAlign: "start",
+              display: "flex",
+              justifyContent: "space-between",
+              flexDirection: "column",
+              [labelsPosition === "left"
+                ? "paddingRight"
+                : "paddingLeft"]: "4px",
+            },
+            wrapper.find(StyledValuesLabel)
+          );
+
+          if (labelsPosition === "left") {
+            assertStyleMatch(
+              {
+                textAlign: "right",
+              },
+              wrapper.find(StyledValuesLabel),
+              { modifier: `${StyledValue}` }
+            );
+          }
+        });
+      }
+    );
+  });
+
+  describe.each(["horizontal", "vertical"])("variant prop", (orientation) => {
+    it("applies proper background color when progress < 20 when orientation is %s", () => {
+      wrapper = mount(
+        <ProgressBar
+          orientation={orientation}
+          progress={10}
+          variant="traffic"
+        />
+      );
+      assertStyleMatch(
+        {
+          backgroundColor: baseTheme.colors.error,
+        },
+        wrapper.find(InnerBar)
+      );
+    });
+
+    it("applies proper background color when 20 < progress < 100", () => {
+      wrapper = mount(
+        <ProgressBar
+          orientation={orientation}
+          progress={50}
+          variant="traffic"
+        />
+      );
+      assertStyleMatch(
+        {
+          backgroundColor: baseTheme.progressTracker.trafficNeutral,
+        },
+        wrapper.find(InnerBar)
+      );
+    });
+
+    it("applies proper background color when 20 < progress < 100", () => {
+      wrapper = mount(
+        <ProgressBar
+          orientation={orientation}
+          progress={100}
+          variant="traffic"
+        />
+      );
+      assertStyleMatch(
+        {
+          backgroundColor: baseTheme.colors.success,
+        },
+        wrapper.find(InnerBar)
+      );
+    });
+  });
+});

--- a/src/components/progress-tracker/progress-tracker.stories.mdx
+++ b/src/components/progress-tracker/progress-tracker.stories.mdx
@@ -1,0 +1,240 @@
+import { useState } from "react";
+import { Meta, Story, Preview } from "@storybook/addon-docs";
+import ProgressTracker from ".";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+
+<Meta
+  title="Progress Tracker"
+  parameters={{ info: { disable: true } }}
+/>
+
+# ProgressTracker
+
+Use the `ProgressTracker` component to let users know a task or loading data is still in progress.
+Showing a `ProgressTracker` helps the user to understand that they should wait, rather than reload the page or abandon a process.
+In general, place a `ProgressTracker` in the centre and middle of the page or container it relates to.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import ProgressTracker from "carbon-react/lib/components/progress-tracker";
+```
+
+## Examples
+
+### Default
+
+This example of the `ProgressTracker` component demonstrates how it will appear as default. Please note by default the 
+`progress` is set to `0`, but for the purpose of the demo it has been set to `50`.
+
+<Preview>
+  <Story name="default">
+    <div style={{ display: "flex", justifyContent: "space-around" }}>
+      <ProgressTracker progress={50} />
+    </div>
+  </Story>
+</Preview>
+
+### Small bar size
+
+This is an example of a small `ProgressTracker` component.
+
+<Preview>
+  <Story name="size - small">
+    <div style={{ display: "flex", justifyContent: "space-around" }}>
+      <ProgressTracker size="small" progress={50} />
+    </div>
+  </Story>
+</Preview>
+
+### Large bar size
+
+This is an example of a large `ProgressTracker` component.
+
+<Preview>
+  <Story name="size - large">
+    <div style={{ display: "flex", justifyContent: "space-around" }}>
+      <ProgressTracker size="large" progress={50} />
+    </div>
+  </Story>
+</Preview>
+
+### Variants
+
+This is an example of a `ProgressTracker` component with the `"default"` `variant`.
+
+<Preview>
+  <Story name="variant - default">
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <ProgressTracker size="large" progress={15} variant="default" />
+      <ProgressTracker size="large" mt={2} progress={50} variant="default" />
+      <ProgressTracker size="large" mt={2} progress={100} variant="default" />
+    </div>
+  </Story>
+</Preview>
+
+This is an example of a `ProgressTracker` component with the `"traffic"` `variant`.
+
+<Preview>
+  <Story name="variant - traffic">
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <ProgressTracker size="large" progress={15} variant="traffic" />
+      <ProgressTracker size="large" mt={2} progress={50} variant="traffic" />
+      <ProgressTracker size="large" mt={2} progress={100} variant="traffic" />
+    </div>
+  </Story>
+</Preview>
+
+### Default label values
+
+This is an example of a `ProgressTracker` component with `showDefaultLabels` set to `true`, which will render the labels as 
+percentages.
+
+<Preview>
+  <Story name="default label value">
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <ProgressTracker progress={15} showDefaultLabels />
+      <ProgressTracker mt={2} progress={50} showDefaultLabels />
+      <ProgressTracker mt={2} progress={100} showDefaultLabels />
+    </div>
+  </Story>
+</Preview>
+
+It is possible to override the default `labelsPosition` to `"bottom"` when in a `"horizontal"` `orientation`
+
+<Preview>
+  <Story name="default label value - labelsPosition bottom">
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <ProgressTracker labelsPosition="bottom" progress={15} showDefaultLabels />
+      <ProgressTracker mt={2} labelsPosition="bottom" progress={50} showDefaultLabels />
+      <ProgressTracker mt={2} labelsPosition="bottom" progress={100} showDefaultLabels />
+    </div>
+  </Story>
+</Preview>
+
+### Custom label values
+
+This is an example of a `ProgressTracker` component with `currentProgressLabel` and `maxProgressLabel` props.
+
+<Preview>
+  <Story name="custom label values">
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <ProgressTracker
+        progress={15}
+        currentProgressLabel="$50"
+        maxProgressLabel="$200"
+      />
+      <ProgressTracker
+        mt={2}
+        progress={50}
+        currentProgressLabel="$100"
+        maxProgressLabel="$200"
+      />
+      <ProgressTracker
+        mt={2}
+        progress={100}
+        currentProgressLabel="$200"
+        maxProgressLabel="$200"
+      />
+    </div>
+  </Story>
+</Preview>
+
+It also possible to render the component with a mix of default and custom labels by only setting one of the `currentProgressLabel` 
+and `maxProgressLabel` props and optionally setting the `showDefaultLabels` prop.
+
+<Preview>
+  <Story name="default and custom label values">
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <ProgressTracker
+        progress={15}
+        currentProgressLabel="$50"
+      />
+      <ProgressTracker
+        mt={2}
+        progress={50}
+        maxProgressLabel="$200"
+      />
+       <ProgressTracker
+        mt={2}
+        progress={15}
+        showDefaultLabels
+        currentProgressLabel="$50"
+      />
+      <ProgressTracker
+        mt={2}
+        progress={50}
+        showDefaultLabels
+        maxProgressLabel="$200"
+      />
+    </div>
+  </Story>
+</Preview>
+
+### Orientation
+
+This is an example of a `ProgressTracker` component with the `"vertical"` `orientation`.
+
+<Preview>
+  <Story name="orientation vertical">
+    <div style={{ display: "flex", justifyContent: "space-between" }}>
+      <ProgressTracker orientation="vertical" size="small" progress={15} showDefaultLabels />
+      <ProgressTracker orientation="vertical" size="small" progress={50} showDefaultLabels />
+      <ProgressTracker orientation="vertical" size="small" progress={100} showDefaultLabels />
+      <ProgressTracker orientation="vertical" size="medium" progress={15} showDefaultLabels />
+      <ProgressTracker orientation="vertical" size="medium" progress={50} showDefaultLabels />
+      <ProgressTracker orientation="vertical" size="medium" progress={100} showDefaultLabels />
+      <ProgressTracker orientation="vertical" size="large" progress={15} showDefaultLabels />
+      <ProgressTracker orientation="vertical" size="large" progress={50} showDefaultLabels />
+      <ProgressTracker orientation="vertical" size="large" progress={100} showDefaultLabels />
+    </div>
+  </Story>
+</Preview>
+
+It is possible to override the `direction` the inner progress bar moves to `"down"`.
+
+<Preview>
+  <Story name="orientation vertical - direction down">
+    <div style={{ display: "flex", justifyContent: "space-between" }}>
+      <ProgressTracker direction="down" orientation="vertical" size="small" progress={15} showDefaultLabels />
+      <ProgressTracker direction="down" orientation="vertical" size="small" progress={50} showDefaultLabels />
+      <ProgressTracker direction="down" orientation="vertical" size="small" progress={100} showDefaultLabels />
+      <ProgressTracker direction="down" orientation="vertical" size="medium" progress={15} showDefaultLabels />
+      <ProgressTracker direction="down" orientation="vertical" size="medium" progress={50} showDefaultLabels />
+      <ProgressTracker direction="down" orientation="vertical" size="medium" progress={100} showDefaultLabels />
+      <ProgressTracker direction="down" orientation="vertical" size="large" progress={15} showDefaultLabels />
+      <ProgressTracker direction="down" orientation="vertical" size="large" progress={50} showDefaultLabels />
+      <ProgressTracker direction="down" orientation="vertical" size="large" progress={100} showDefaultLabels />
+    </div>
+  </Story>
+</Preview>
+
+It is possible to override the `labelsPosition` to `"left"` when in a `"vertical"` `orientation`.
+
+<Preview>
+  <Story name="orientation vertical - labelsPosition left">
+    <div style={{ display: "flex", justifyContent: "space-between" }}>
+      <ProgressTracker labelsPosition="left" orientation="vertical" size="small" progress={15} showDefaultLabels />
+      <ProgressTracker labelsPosition="left" orientation="vertical" size="small" progress={50} showDefaultLabels />
+      <ProgressTracker labelsPosition="left" orientation="vertical" size="small" progress={100} showDefaultLabels />
+      <ProgressTracker labelsPosition="left" orientation="vertical" size="medium" progress={15} showDefaultLabels />
+      <ProgressTracker labelsPosition="left" orientation="vertical" size="medium" progress={50} showDefaultLabels />
+      <ProgressTracker labelsPosition="left" orientation="vertical" size="medium" progress={100} showDefaultLabels />
+      <ProgressTracker labelsPosition="left" orientation="vertical" size="large" progress={15} showDefaultLabels />
+      <ProgressTracker labelsPosition="left" orientation="vertical" size="large" progress={50} showDefaultLabels />
+      <ProgressTracker labelsPosition="left" orientation="vertical" size="large" progress={100} showDefaultLabels />
+    </div>
+  </Story>
+</Preview>
+
+## Props
+
+### ProgressTracker
+
+<StyledSystemProps of={ProgressTracker} noHeader margin />

--- a/src/components/progress-tracker/progress-tracker.style.js
+++ b/src/components/progress-tracker/progress-tracker.style.js
@@ -1,0 +1,182 @@
+import styled, { css } from "styled-components";
+import PropTypes from "prop-types";
+import { margin } from "styled-system";
+import baseTheme from "../../style/themes/base";
+import {
+  OUTER_TRACKER_LENGTH,
+  PROGRESS_TRACKER_SIZES,
+  PROGRESS_TRACKER_VARIANTS,
+} from "./progress-tracker.config";
+
+const StyledProgressTracker = styled.div`
+  ${margin}
+  text-align: center;
+  white-space: nowrap;
+
+  ${({ isVertical }) => css`
+    ${!isVertical &&
+    `
+      width: ${OUTER_TRACKER_LENGTH};
+    `}
+    ${isVertical &&
+    `
+      height: ${OUTER_TRACKER_LENGTH};
+      display: flex;
+    `}
+  `}
+`;
+
+const StyledProgressBar = styled.span`
+  ${({ direction, isVertical, size, theme }) => css`
+    display: flex;
+    position: relative;
+    background-color: ${theme.progressTracker.background};
+
+    ${!isVertical &&
+    css`
+      overflow-x: hidden;
+      height: ${getHeight(size)};
+      width: 100%;
+    `}
+    ${isVertical &&
+    css`
+      overflow-y: hidden;
+      width: ${getHeight(size)};
+      height: 100%;
+
+      ${direction === "up" &&
+      `
+        align-items: flex-end;
+      `}
+    `}
+  `}
+`;
+
+const StyledValue = styled.span`
+  ${({ isMaxValue, theme }) => css`
+    ${isMaxValue &&
+    `
+      color: ${theme.text.placeholder};
+    `}
+    ${!isMaxValue &&
+    `
+      font-weight: bold;
+    `}
+  `}
+`;
+
+const StyledValuesLabel = styled.span`
+  text-align: start;
+  display: flex;
+  justify-content: space-between;
+  ${({ isVertical, position }) => css`
+    ${isVertical &&
+    css`
+      flex-direction: column;
+
+      ${position !== "left" &&
+      css`
+        padding-left: 4px;
+      `}
+
+      ${position === "left" &&
+      css`
+        padding-right: 4px;
+
+        ${StyledValue} {
+          text-align: right;
+        }
+      `}
+    `}
+
+    ${!isVertical &&
+    css`
+      ${position !== "bottom" &&
+      css`
+        padding-bottom: 4px;
+      `}
+
+      ${position === "bottom" &&
+      css`
+        padding-top: 4px;
+      `}
+    `}
+  `}
+`;
+
+const InnerBar = styled.span`
+  ${({ isVertical, progress, size, theme, variant }) => css`
+    position: absolute;
+    left: 0;
+    background-color: ${getInnerBarColour(variant, progress, theme)};
+
+    ${!isVertical &&
+    css`
+      width: calc(${OUTER_TRACKER_LENGTH} * ${progress / 100});
+      min-width: 2px;
+      height: ${getHeight(size)};
+    `}
+    ${isVertical &&
+    css`
+      height: calc(${OUTER_TRACKER_LENGTH} * ${progress / 100});
+      min-height: 2px;
+      width: ${getHeight(size)};
+    `}
+  `}
+`;
+
+function getHeight(size) {
+  switch (size) {
+    case "small":
+      return "4px";
+    case "large":
+      return "16px";
+    default:
+      return "8px";
+  }
+}
+
+function getInnerBarColour(variant, progress, theme) {
+  if (progress >= 100) return theme.colors.success;
+  if (variant === "default") return theme.progressTracker.innerBackground;
+  if (progress < 20) return theme.colors.error;
+  return theme.progressTracker.trafficNeutral;
+}
+
+StyledProgressTracker.defaultProps = {
+  theme: baseTheme,
+};
+
+StyledProgressBar.defaultProps = {
+  theme: baseTheme,
+  size: "medium",
+};
+
+InnerBar.propTypes = {
+  size: PropTypes.oneOf(PROGRESS_TRACKER_SIZES),
+  progress: PropTypes.number,
+  variant: PropTypes.oneOf(PROGRESS_TRACKER_VARIANTS),
+};
+
+InnerBar.defaultProps = {
+  progress: 0,
+  theme: baseTheme,
+  size: "medium",
+  variant: "default",
+};
+
+StyledValue.defaultProps = {
+  theme: baseTheme,
+};
+
+StyledProgressBar.propTypes = {
+  size: PropTypes.oneOf(PROGRESS_TRACKER_SIZES),
+};
+
+export {
+  StyledProgressBar,
+  InnerBar,
+  StyledProgressTracker,
+  StyledValuesLabel,
+  StyledValue,
+};

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -51,6 +51,12 @@ export default (palette) => {
       asterisk: palette.errorRed,
     },
 
+    progressTracker: {
+      background: palette.slateTint(90),
+      innerBackground: palette.slateTint(40),
+      trafficNeutral: palette.productBlueShade(3),
+    },
+
     anchorNavigation: {
       divider: palette.slateTint(80),
       navItemHoverBackground: palette.slateTint(90),


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Creates the `ProgressTracker` component. It currently supports two colour `variant`s ("default" and
"traffic"), either "horizontal" or "vertical" `orientation`, various `size`s ("small", "medium",
"large"), a current `progress`,  supports rendering custom strings through the `currentProgressLabel` and `maxProgressLabel` props or the option to render default percentages by setting `showDefaultLabels` (the `labelPosition` can also be set depending on the orientation). The component also supports changing the `direction` the bar travels when in vertical orientation. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
New component
### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->
![image](https://user-images.githubusercontent.com/44157880/138733171-9c231344-1059-4ce9-8be7-3eca82295d55.png)

![image](https://user-images.githubusercontent.com/44157880/138733233-4c1c4462-b88a-4d1b-9cbf-a96c82a37b25.png)

![image](https://user-images.githubusercontent.com/44157880/138733769-e6e861c1-907e-4d3b-8a0b-92116e6d2d34.png)

### Testing instructions

<!-- How can a reviewer test this PR? -->
`progress-bar` stories have been added

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
