### PR TITLE
refactor(icon): use design tokens to describe icon component

### DIFF
--- a/src/components/batch-selection/__snapshots__/batch-selection.spec.js.snap
+++ b/src/components/batch-selection/__snapshots__/batch-selection.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`BatchSelection component should render correctly 1`] = `
 .c5 {
   position: relative;
-  color: rgba(0,0,0,0.65);
+  color: var(--colorsYin065);
   background-color: transparent;
   vertical-align: middle;
   -webkit-align-items: center;

--- a/src/components/carousel/carousel.spec.js
+++ b/src/components/carousel/carousel.spec.js
@@ -272,7 +272,7 @@ describe("CarouselStyledIcon", () => {
     const wrapper = mount(<CarouselStyledIcon type="home" theme={mintTheme} />);
     assertStyleMatch(
       {
-        color: "rgba(0,0,0,0.65)",
+        color: "var(--colorsYin065)",
       },
       wrapper
     );

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -292,7 +292,7 @@ describe("Icon component", () => {
       const wrapper = renderStyles({ disabled: true });
       assertStyleMatch(
         {
-          color: baseTheme.icon.disabled,
+          color: "var(--colorsYin030)",
         },
         wrapper.toJSON()
       );
@@ -305,7 +305,7 @@ describe("Icon component", () => {
         const wrapper = renderStyles({ disabled: true });
         assertStyleMatch(
           {
-            backgroundColor: baseTheme.icon.disabled,
+            backgroundColor: "var(--colorsYin030)",
           },
           wrapper.toJSON()
         );

--- a/src/components/icon/icon.style.js
+++ b/src/components/icon/icon.style.js
@@ -56,8 +56,8 @@ const StyledIcon = styled.span`
 
     try {
       if (disabled) {
-        finalColor = theme.icon.disabled;
-        finalHoverColor = theme.icon.disabled;
+        finalColor = "var(--colorsYin030)";
+        finalHoverColor = "var(--colorsYin030)";
       } else if (typeof color === "string" && color.startsWith("var")) {
         finalColor = color;
         finalHoverColor = shade(
@@ -69,8 +69,8 @@ const StyledIcon = styled.span`
         finalColor = renderedColor;
         finalHoverColor = shade(0.2, renderedColor);
       } else {
-        finalColor = theme.icon.default;
-        finalHoverColor = theme.icon.defaultHover;
+        finalColor = "var(--colorsYin065)";
+        finalHoverColor = "var(--colorsYin090)";
       }
 
       if (bg) {
@@ -78,8 +78,8 @@ const StyledIcon = styled.span`
         bgColor = backgroundColor;
         bgHoverColor = shade(0.2, backgroundColor);
       } else if (disabled) {
-        bgColor = theme.icon.disabled;
-        bgHoverColor = theme.icon.disabled;
+        bgColor = "var(--colorsYin030)";
+        bgHoverColor = "var(--colorsYin030)";
       } else {
         bgColor = "transparent";
         bgHoverColor = "transparent";
@@ -139,7 +139,7 @@ const StyledIcon = styled.span`
       ${hasTooltip &&
       `
         :focus {
-          outline: 2px solid ${theme.colors.focus};
+          outline: 2px solid var(--colorsSemanticFocus500);
         }
       `}
 

--- a/src/components/pod/__snapshots__/pod.spec.js.snap
+++ b/src/components/pod/__snapshots__/pod.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`ActionButtons StyledDeleteButton when isHovered prop is set should match expected styles 1`] = `
 .c3 {
   position: relative;
-  color: rgba(0,0,0,0.65);
+  color: var(--colorsYin065);
   background-color: transparent;
   vertical-align: middle;
   -webkit-align-items: center;
@@ -467,7 +467,7 @@ exports[`ActionButtons StyledEditAction when isHovered prop is set should match 
 exports[`ActionButtons StyledUndoButton when isHovered prop is set should match expected styles 1`] = `
 .c3 {
   position: relative;
-  color: rgba(0,0,0,0.65);
+  color: var(--colorsYin065);
   background-color: transparent;
   vertical-align: middle;
   -webkit-align-items: center;

--- a/src/components/portal/__snapshots__/portal.spec.js.snap
+++ b/src/components/portal/__snapshots__/portal.spec.js.snap
@@ -30,4 +30,4 @@ exports[`Portal when using default node to match snapshot  1`] = `
 </span>
 `;
 
-exports[`Portal when using default node when an element with id 'root' does not exist will mount on body 1`] = `"<div id=\\"root\\"><div class=\\"carbon-portal sage-design-tokens--guid-12345\\" data-portal-exit=\\"guid-12345\\"><span class=\\"sc-bwzfXH idgVWp\\" data-element=\\"tick\\" data-component=\\"icon\\" font-size=\\"small\\" type=\\"tick\\" tabindex=\\"0\\" role=\\"tooltip\\"></span></div></div>"`;
+exports[`Portal when using default node when an element with id 'root' does not exist will mount on body 1`] = `"<div id=\\"root\\"><div class=\\"carbon-portal sage-design-tokens--guid-12345\\" data-portal-exit=\\"guid-12345\\"><span class=\\"sc-bwzfXH gplFmG\\" data-element=\\"tick\\" data-component=\\"icon\\" font-size=\\"small\\" type=\\"tick\\" tabindex=\\"0\\" role=\\"tooltip\\"></span></div></div>"`;

--- a/src/components/search/search.spec.js
+++ b/src/components/search/search.spec.js
@@ -141,7 +141,7 @@ describe("Search", () => {
       wrapper.update();
       assertStyleMatch(
         {
-          color: "rgba(0,0,0,0.65)",
+          color: "var(--colorsYin065)",
         },
         icon
       );

--- a/src/components/select/option-group-header/__snapshots__/option-group-header.spec.js.snap
+++ b/src/components/select/option-group-header/__snapshots__/option-group-header.spec.js.snap
@@ -48,7 +48,7 @@ exports[`OptionGroupHeader renders properly 1`] = `
 exports[`OptionGroupHeader when icon prop is set then it should display the icon 1`] = `
 .c2 {
   position: relative;
-  color: rgba(0,0,0,0.65);
+  color: var(--colorsYin065);
   background-color: transparent;
   vertical-align: middle;
   -webkit-align-items: center;


### PR DESCRIPTION
### Proposed behaviour
Describes the icon using design tokens. Removes all possible 'theme' in css files (left theme where calling styledColor function).
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour
Icon styles use design tokens

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
