### PR TITLE
fix(multi-select): prevent re-renders from setting selectedValue to undefined FE-4396

### DIFF
--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -64,7 +64,9 @@ const FilterableSelect = React.forwardRef(
     const [textboxRef, setTextboxRef] = useState();
     const [isOpen, setOpen] = useState(false);
     const [textValue, setTextValue] = useState("");
-    const [selectedValue, setSelectedValue] = useState("");
+    const [selectedValue, setSelectedValue] = useState(
+      value || defaultValue || ""
+    );
     const [highlightedValue, setHighlightedValue] = useState("");
     const [filterText, setFilterText] = useState("");
 
@@ -226,7 +228,6 @@ const FilterableSelect = React.forwardRef(
     );
 
     useEffect(() => {
-      const newValue = value || defaultValue;
       const modeSwitchedMessage =
         "Input elements should not switch from uncontrolled to controlled (or vice versa). " +
         "Decide between using a controlled or uncontrolled input element for the lifetime of the component";
@@ -241,19 +242,27 @@ const FilterableSelect = React.forwardRef(
         !isControlled.current || (isControlled.current && onChange),
         onChangeMissingMessage
       );
+      if (isControlled.current) {
+        setSelectedValue((prevValue) => {
+          if (value && prevValue !== value) {
+            setMatchingText(value);
+          }
 
-      setSelectedValue((prevValue) => {
-        if (value && isControlled.current && prevValue !== newValue) {
-          setMatchingText(newValue);
+          return value;
+        });
+        setHighlightedValue(value);
+      } else {
+        if (textValue !== selectedValue) {
+          setMatchingText(selectedValue);
         }
-
-        return newValue;
-      });
-
-      setHighlightedValue(newValue);
+        if (highlightedValue !== selectedValue) {
+          setHighlightedValue(selectedValue);
+        }
+      }
       // prevent value update on filter change
+      // selectedValue and highlightedValue omitted from deps, only want uncontrolled change if onChange/children update
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [value, defaultValue, onChange, children]);
+    }, [value, onChange, children]);
 
     useEffect(() => {
       if (!isOpen) {
@@ -275,7 +284,9 @@ const FilterableSelect = React.forwardRef(
     }, [listActionButton, onListAction]);
 
     useEffect(() => {
-      setMatchingText(value || defaultValue);
+      if (isControlled.current) {
+        setMatchingText(value);
+      }
       // update text value only when children are changing
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [value, children]);

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -633,7 +633,7 @@ describe("FilterableSelect", () => {
     });
 
     describe("and onListAction has been called in the SelectList", () => {
-      it("then the onlistAction prop should have been called", () => {
+      it("then the onListAction prop should have been called", () => {
         onListActionFn.mockClear();
         act(() => {
           wrapper.find(SelectList).props().onListAction();
@@ -732,9 +732,7 @@ describe("FilterableSelect", () => {
           it("then the textbox value should be cleared", () => {
             expect(wrapper.find(Textbox).props().value).toBe("opt1");
             wrapper.setProps({ value: "" });
-            expect(wrapper.update().find(Textbox).props().value).toBe(
-              undefined
-            );
+            expect(wrapper.update().find(Textbox).props().value).toBe("");
           });
         });
       });
@@ -762,6 +760,34 @@ describe("FilterableSelect", () => {
           });
         });
       });
+    });
+  });
+
+  describe("when parent re-renders", () => {
+    const WrapperComponent = (props) => {
+      const mockRef = useRef();
+
+      return (
+        <span change={props.change}>
+          <FilterableSelect name="testSelect" id="testSelect" ref={mockRef}>
+            <Option value="opt1" text="red" />
+            <Option value="opt2" text="green" />
+            <Option value="opt3" text="blue" />
+            <Option value="opt4" text="black" />
+          </FilterableSelect>
+        </span>
+      );
+    };
+
+    it("should persist the input value", () => {
+      const wrapper = mount(<WrapperComponent change="foo" />);
+      wrapper.find(Textbox).find('[type="dropdown"]').first().simulate("click");
+      act(() => {
+        wrapper.find(Option).first().simulate("click");
+      });
+      expect(wrapper.update().find(Textbox).props().formattedValue).toBe("red");
+      wrapper.setProps({ change: "bar" });
+      expect(wrapper.update().find(Textbox).props().formattedValue).toBe("red");
     });
   });
 

--- a/src/components/select/multi-select/multi-select.component.js
+++ b/src/components/select/multi-select/multi-select.component.js
@@ -69,7 +69,9 @@ const MultiSelect = React.forwardRef(
     const [textboxRef, setTextboxRef] = useState();
     const [isOpen, setOpenState] = useState(false);
     const [textValue, setTextValue] = useState("");
-    const [selectedValue, setSelectedValue] = useState([]);
+    const [selectedValue, setSelectedValue] = useState(
+      value || defaultValue || []
+    );
     const [highlightedValue, setHighlightedValue] = useState("");
     const [filterText, setFilterText] = useState("");
     const [placeholderOverride, setPlaceholderOverride] = useState();
@@ -119,7 +121,7 @@ const MultiSelect = React.forwardRef(
       (index) => {
         setSelectedValue((previousValue) => {
           isClickTriggeredBySelect.current = true;
-          if (previousValue.length === 0) {
+          if (!previousValue.length) {
             return previousValue;
           }
           const newValue = [...previousValue];
@@ -189,7 +191,7 @@ const MultiSelect = React.forwardRef(
     const mapValuesToPills = useCallback(() => {
       const canDelete = !disabled && !readOnly;
 
-      if (selectedValue.length === 0) {
+      if (!selectedValue.length) {
         return "";
       }
 
@@ -209,9 +211,10 @@ const MultiSelect = React.forwardRef(
         }
 
         const { title } = pillProps;
+        const key = title + (matchingOption?.props.value || index);
 
         return (
-          <StyledSelectPillContainer key={title}>
+          <StyledSelectPillContainer key={key}>
             <Pill
               onDelete={
                 canDelete ? () => removeSelectedValue(index) : undefined
@@ -227,11 +230,10 @@ const MultiSelect = React.forwardRef(
     }, [children, disabled, readOnly, selectedValue]);
 
     useEffect(() => {
-      const newValue = value || defaultValue;
       const modeSwitchedMessage =
         "Input elements should not switch from uncontrolled to controlled (or vice versa). " +
         "Decide between using a controlled or uncontrolled input element for the lifetime of the component";
-      const onChageMissingMessage =
+      const onChangeMissingMessage =
         "onChange prop required when using a controlled input element";
 
       invariant(
@@ -240,21 +242,17 @@ const MultiSelect = React.forwardRef(
       );
       invariant(
         !isControlled.current || (isControlled.current && onChange),
-        onChageMissingMessage
+        onChangeMissingMessage
       );
-      setSelectedValue((previousValue) => {
-        if (!newValue && previousValue.length === 0) {
-          return previousValue;
-        }
-
-        return newValue;
-      });
-    }, [value, defaultValue, onChange]);
+      if (isControlled.current) {
+        setSelectedValue(value);
+      }
+    }, [value, onChange]);
 
     // removes placeholder when a value is present
     useEffect(() => {
-      const hasValue = value && value.length > 0;
-      const hasSelectedValue = selectedValue && selectedValue.length > 0;
+      const hasValue = value?.length;
+      const hasSelectedValue = selectedValue?.length;
 
       if (hasValue || hasSelectedValue) {
         setPlaceholderOverride(" ");

--- a/src/components/select/multi-select/multi-select.spec.js
+++ b/src/components/select/multi-select/multi-select.spec.js
@@ -780,6 +780,39 @@ describe("MultiSelect", () => {
     );
   });
 
+  describe("when parent re-renders", () => {
+    const WrapperComponent = (props) => {
+      const mockRef = useRef();
+
+      return (
+        <span change={props.change}>
+          <MultiSelect
+            openOnFocus
+            name="testSelect"
+            id="testSelect"
+            ref={mockRef}
+          >
+            <Option value="opt1" text="red" />
+            <Option value="opt2" text="green" />
+            <Option value="opt3" text="blue" />
+            <Option value="opt4" text="black" />
+          </MultiSelect>
+        </span>
+      );
+    };
+
+    it("should persist the input value", () => {
+      const wrapper = mount(<WrapperComponent change="foo" />);
+      wrapper.find("input").simulate("focus");
+      act(() => {
+        wrapper.find(Option).first().simulate("click");
+      });
+      expect(wrapper.update().find(Textbox).props().value).toEqual(["opt1"]);
+      wrapper.setProps({ change: "bar" });
+      expect(wrapper.update().find(Textbox).props().value).toEqual(["opt1"]);
+    });
+  });
+
   describe("required", () => {
     let wrapper;
 

--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -68,7 +68,9 @@ const SimpleSelect = React.forwardRef(
     const [textboxRef, setTextboxRef] = useState();
     const [isOpen, setOpenState] = useState(false);
     const [textValue, setTextValue] = useState("");
-    const [selectedValue, setSelectedValue] = useState("");
+    const [selectedValue, setSelectedValue] = useState(
+      value || defaultValue || ""
+    );
 
     const childOptions = useMemo(() => React.Children.toArray(children), [
       children,
@@ -200,7 +202,6 @@ const SimpleSelect = React.forwardRef(
     }, []);
 
     useEffect(() => {
-      const newValue = value || defaultValue;
       const modeSwitchedMessage =
         "Input elements should not switch from uncontrolled to controlled (or vice versa). " +
         "Decide between using a controlled or uncontrolled input element for the lifetime of the component";
@@ -216,8 +217,10 @@ const SimpleSelect = React.forwardRef(
         onChangeMissingMessage
       );
 
-      setSelectedValue(newValue);
-    }, [value, defaultValue, onChange]);
+      if (isControlled.current) {
+        setSelectedValue(value);
+      }
+    }, [value, onChange]);
 
     useEffect(() => {
       const matchingOption = childOptions.find((child) =>

--- a/src/components/select/simple-select/simple-select.d.ts
+++ b/src/components/select/simple-select/simple-select.d.ts
@@ -55,7 +55,7 @@ export interface SimpleSelectProps
     | "left-start"
     | "left-end";
   /** Use the opposite list placement if the set placement does not fit */
-  flipEnabled?: bool;
+  flipEnabled?: boolean;
 }
 
 declare function SimpleSelect(

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -790,7 +790,39 @@ describe("SimpleSelect", () => {
       it("then the textbox value should be cleared", () => {
         expect(wrapper.find(Textbox).props().value).toBe("opt1");
         wrapper.setProps({ value: "" });
-        expect(wrapper.update().find(Textbox).props().value).toBe(undefined);
+        expect(wrapper.update().find(Textbox).props().value).toBe("");
+      });
+    });
+
+    describe("when parent re-renders", () => {
+      const WrapperComponent = (props) => {
+        const mockRef = useRef();
+
+        return (
+          <span change={props.change}>
+            <SimpleSelect name="testSelect" id="testSelect" ref={mockRef}>
+              <Option value="opt1" text="red" />
+              <Option value="opt2" text="green" />
+              <Option value="opt3" text="blue" />
+              <Option value="opt4" text="black" />
+            </SimpleSelect>
+          </span>
+        );
+      };
+
+      it("should persist the input value", () => {
+        wrapper = mount(<WrapperComponent />);
+        wrapper.find("input").simulate("click");
+        act(() => {
+          wrapper.find(Option).first().simulate("click");
+        });
+        expect(wrapper.update().find(Textbox).props().formattedValue).toBe(
+          "red"
+        );
+        wrapper.setProps({ change: "bar" });
+        expect(wrapper.update().find(Textbox).props().formattedValue).toBe(
+          "red"
+        );
       });
     });
   });

--- a/src/components/select/utils/is-expected-option.js
+++ b/src/components/select/utils/is-expected-option.js
@@ -11,5 +11,14 @@ export default function isExpectedOption(element, expectedValue) {
     return false;
   }
 
+  const { length } =
+    typeof expectedValue === "string"
+      ? expectedValue
+      : Object.keys(expectedValue);
+
+  if (!length) {
+    return false;
+  }
+
   return isExpectedValue(element.props.value, expectedValue);
 }

--- a/src/components/select/utils/is-expected-option.spec.js
+++ b/src/components/select/utils/is-expected-option.spec.js
@@ -57,4 +57,17 @@ describe("isExpectedOption", () => {
       });
     });
   });
+
+  describe.each([
+    ["`null`", null],
+    ["`undefined`", undefined],
+    ["`empty string`", ""],
+    ["`empty object`", {}],
+  ])("when expectedValue is %s", (_, expectedValue) => {
+    it("then it should return false", () => {
+      const element = <Option text="bar" value={{ id: "foo", value: "foo" }} />;
+
+      expect(isExpectedOption(element, expectedValue)).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
fix #4482

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Select components no longer set the selectedValue to `defaultValue` on re-renders: this was causing issues
as in some demos no `value` or `defaultValue` is passed so when the theme changes and the component
re-renders the new `selectedValue` is `undefined`. Also updates the `isExpectedOption` function to
handle for empty strings and objects.
 
### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

Behaviour in master:

![multi-select-broken](https://user-images.githubusercontent.com/44157880/139440491-925f9fab-ca5a-4799-86d0-f8eaa4857f31.gif)

![simple-select-broken](https://user-images.githubusercontent.com/44157880/139440527-38c0722a-2c0e-4095-b3f0-9a48ade6c9b2.gif)

![simple-select-broken](https://user-images.githubusercontent.com/44157880/139440570-099d4981-ead3-4b40-aec0-6ef24d922861.gif)


Behaviour in PR:

![simple-fixed](https://user-images.githubusercontent.com/44157880/139441379-62ec7529-b02c-4647-9994-57acdbc5579c.gif)

![filterable-fixed](https://user-images.githubusercontent.com/44157880/139441422-ba2e56d7-dcad-40c6-959f-abfc19b31b72.gif)

![multi-fixed](https://user-images.githubusercontent.com/44157880/139441536-d4be9a29-e305-410f-8140-f8c2c3f3ac8a.gif)

### Testing instructions

<!-- How can a reviewer test this PR? -->
Behaviour is testable by following the steps included in the linked issue for all Select components
All stories should have brush test to ensure no functionality has broken following change
 
The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
Open selects, pick `red` then click the button

https://codesandbox.io/s/competent-diffie-slf6r?file=/src/index.js