### PR TITLE
fix(tabs): enable validations when renderHiddenTabs set

### DIFF
--- a/src/components/tabs/tabs.component.js
+++ b/src/components/tabs/tabs.component.js
@@ -298,7 +298,15 @@ const Tabs = ({
 
     return tab
       ? cloneElement(tab, {
+          ...tab.props,
+          role: "tabpanel",
+          position,
           isTabSelected: isTabSelected(tab.props.tabId),
+          key: `${tab.props.tabId}-tab`,
+          ariaLabelledby: `${tab.props.tabId}-tab`,
+          updateErrors,
+          updateWarnings,
+          updateInfos,
         })
       : null;
   };

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -77,9 +77,13 @@ const MockWrapper = ({
   warnings = {},
   infos = {},
   validationStatusOverride = undefined,
+  renderHiddenTabs = true,
 }) => {
   return (
-    <Tabs validationStatusOverride={validationStatusOverride}>
+    <Tabs
+      validationStatusOverride={validationStatusOverride}
+      renderHiddenTabs={renderHiddenTabs}
+    >
       <Tab
         title="Tab Title 1"
         tabId="uniqueid1"
@@ -284,6 +288,21 @@ describe("Tabs", () => {
         expect(tab.props().title).toEqual("Tab Title 1");
         expect(tab.props().tabId).toEqual("uniqueid1");
       });
+
+      it.each(["error", "warning", "info"])(
+        "adds the correct %s state to the tab header",
+        (validation) => {
+          const validationProp = {
+            [`${validation}s`]: { one: true },
+          };
+          const tabTitle = mount(
+            <MockWrapper {...validationProp} renderHiddenTabs={false} />
+          ).find(TabTitle);
+
+          expect(tabTitle.at(0).props()[validation]).toEqual(true);
+          expect(tabTitle.at(1).props()[validation]).toEqual(false);
+        }
+      );
     });
 
     describe("is true", () => {


### PR DESCRIPTION
Fixes: #4501

### Proposed behaviour

Fix to allow validations to display correctly when `renderHiddentTabs={false}`.

![image](https://user-images.githubusercontent.com/14963680/139657634-87702963-a3f0-4736-b913-58bab6a62001.png)


### Current behaviour

When `renderHiddentTabs={false}`, validations do not display on the tab header.

![image](https://user-images.githubusercontent.com/14963680/139657604-ae6afdfa-e874-4f43-a0b2-7e9bf4581b0c.png)


### Checklist


- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context


### Testing instructions

<!-- How can a reviewer test this PR? -->

See codesandbox from the Github issue below

