### PR TITLE
test(cypress): fix date input min and max date tests FE-4438

### DIFF
--- a/cypress/features/regression/dateInput.feature
+++ b/cypress/features/regression/dateInput.feature
@@ -31,15 +31,13 @@ Feature: Date Input component
   @positive
   Scenario: Change Date Input component minDate
     Given I open default "Date Input Test" component with "dateInput" json from "commonComponents" using "minDate" object name
-      And I set dateInput to today
-    When I choose date yesterday via DayPicker
+    When I set dateInput to minimum date
     Then the date before minDate is not available
 
   @positive
   Scenario: Change Date Input component maxDate
     Given I open default "Date Input Test" component with "dateInput" json from "commonComponents" using "maxDate" object name
-      And I set dateInput to today
-    When I choose date tomorrow via DayPicker
+    When I set dateInput to maximum date
     Then the date after maxDate is not available
 
   @positive

--- a/cypress/fixtures/commonComponents/dateInput.json
+++ b/cypress/fixtures/commonComponents/dateInput.json
@@ -33,13 +33,11 @@
   "large": {
     "mt": "400"
   },
-  "default": {
-    
-  },
+  "default": {},
   "minDate": {
-    "minDate": "2019-04-04"
+    "minDate": "2030-04-04"
   },
   "maxDate": {
-    "maxDate": "2019-04-04"
+    "maxDate": "2030-04-04"
   }
 }

--- a/cypress/support/helper.js
+++ b/cypress/support/helper.js
@@ -23,16 +23,12 @@ export function visitComponentUrlWithParameters(
   nameOfObject = ""
 ) {
   cy.fixture(`${path}/${json}`).then(($json) => {
-    const today = Cypress.dayjs().format("YYYY-MM-DD");
     const el = $json[nameOfObject];
     let url = "&args=";
     for (const prop in el) {
       if (prop === "theme") {
         url += `&theme=${encodeURIComponent(el[prop])}`;
       } else {
-        if (prop === "minDate" || prop === "maxDate") {
-          el[prop] = today;
-        }
         url += `${prop}:${encodeURIComponent(el[prop])};`;
       }
     }

--- a/cypress/support/step-definitions/date-input-steps.js
+++ b/cypress/support/step-definitions/date-input-steps.js
@@ -23,25 +23,36 @@ const NEXT_MONTH = Cypress.dayjs().add(1, "months").format("MMMM YYYY");
 const PREVIOUS_MONTH = Cypress.dayjs()
   .subtract(1, "months")
   .format("MMMM YYYY");
+const MIN_DATE = "04/04/2030";
+const DAY_BEFORE_MIN_DATE = "Wed 3 Apr 2030";
+const DAY_AFTER_MIN_DATE = "Fri 5 Apr 2030";
 
 When("I set dateInput to today", () => {
   dateInput().clear().type(TODAY_DATE_INPUT);
 });
 
+When("I set dateInput to minimum date", () => {
+  dateInput().clear().type(MIN_DATE);
+});
+
+When("I set dateInput to maximum date", () => {
+  dateInput().clear().type(MIN_DATE);
+});
+
 Then("the date before minDate is not available", () => {
-  dayPickerDay(YESTERDAY_CALENDAR)
+  dayPickerDay(DAY_BEFORE_MIN_DATE)
     .should("have.attr", "aria-disabled")
     .and("contains", "true");
-  dayPickerDay(YESTERDAY_CALENDAR)
+  dayPickerDay(DAY_BEFORE_MIN_DATE)
     .should("have.attr", "aria-selected")
     .and("contains", "false");
 });
 
 Then("the date after maxDate is not available", () => {
-  dayPickerDay(TOMORROW_CALENDAR)
+  dayPickerDay(DAY_AFTER_MIN_DATE)
     .should("have.attr", "aria-disabled")
     .and("contains", "true");
-  dayPickerDay(TOMORROW_CALENDAR)
+  dayPickerDay(DAY_AFTER_MIN_DATE)
     .should("have.attr", "aria-selected")
     .and("contains", "false");
 });


### PR DESCRIPTION
### Proposed behaviour

Fix the `Change Date Input component minDate` and `Change Date Input component maxDate` tests in Cypress. 

These now set a min/max date in the future to test against, rather than always testing against today's date, which can fail depending on the date/day.

### Current behaviour

Currently these tests are testing against today's date, so if the 1st of the month falls on a Monday, or the last day of the month falls on a Sunday these will fail.


### Checklist


- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context


### Testing instructions


http://localhost:9001/?path=/story/date-input-test--default-story