### PR TITLE
feat(tooltip): describe tooltip using design tokens

### DIFF
--- a/cypress/integration/common/tooltip.feature
+++ b/cypress/integration/common/tooltip.feature
@@ -27,9 +27,9 @@ Feature: Tooltip component
     Then tooltip type is set to "<tooltipType>" and has color "<color>"
     Examples:
       | tooltipType | nameOfObject       | color            |
-      | info        | tooltipTypeInfo    | rgb(0, 0, 0)     |
-      | warning     | tooltipTypeWarning | rgb(0, 0, 0)     |
-      | error       | tooltipTypeError   | rgb(199, 56, 79) |
+      | info        | tooltipTypeInfo    | rgb(51, 91, 112) |
+      | warning     | tooltipTypeWarning | rgb(51, 91, 112) |
+      | error       | tooltipTypeError   | rgb(205, 56, 75) |
 
   @positive
   Scenario Outline: Set Tooltip size to <tooltipSize>

--- a/src/components/textbox/textbox.spec.js
+++ b/src/components/textbox/textbox.spec.js
@@ -19,9 +19,11 @@ import I18nProvider from "../i18n-provider";
 import baseTheme from "../../style/themes/base";
 import Tooltip from "../tooltip";
 import StyledHelp from "../help/help.style";
+import createGuid from "../../__internal__/utils/helpers/guid";
 
 const mockedGuid = "mocked-guid";
-jest.mock("../../__internal__/utils/helpers/guid", () => () => mockedGuid);
+jest.mock("../../__internal__/utils/helpers/guid");
+createGuid.mockReturnValue(mockedGuid);
 
 describe("Textbox", () => {
   testStyledSystemMargin(

--- a/src/components/tooltip/tooltip-pointer.style.js
+++ b/src/components/tooltip/tooltip-pointer.style.js
@@ -5,7 +5,9 @@ import { toColor } from "../../style/utils/color";
 
 const pointerColor = (type, theme, bgColor) => {
   if (bgColor) return toColor(theme, bgColor);
-  return type === "error" ? theme.colors.error : theme.colors.black;
+  return type === "error"
+    ? "var(--colorsSemanticNegative500)"
+    : "var(--colorsSemanticNeutral500)";
 };
 const StyledTooltipPointer = styled.div`
   ${({ position, theme, type, bgColor }) => css`
@@ -18,7 +20,7 @@ const StyledTooltipPointer = styled.div`
       border-left: 8px solid transparent;
       border-right: 8px solid transparent;
       border-top: 8px solid ${pointerColor(type, theme, bgColor)};
-      bottom: -${theme.spacing}px;
+      bottom: calc(-1 * var(--spacing100));
       @-moz-document url-prefix() {
         bottom: -7px;
       }
@@ -29,7 +31,7 @@ const StyledTooltipPointer = styled.div`
       border-left: 8px solid transparent;
       border-right: 8px solid transparent;
       border-bottom: 8px solid ${pointerColor(type, theme, bgColor)};
-      top: -${theme.spacing}px;
+      top: calc(-1 * var(--spacing100));
       @-moz-document url-prefix() {
         top: -7px;
       }
@@ -40,7 +42,7 @@ const StyledTooltipPointer = styled.div`
       border-top: 8px solid transparent;
       border-bottom: 8px solid transparent;
       border-right: 8px solid ${pointerColor(type, theme, bgColor)};
-      left: -${theme.spacing}px;
+      left: calc(-1 * var(--spacing100));
       @-moz-document url-prefix() {
         left: -7px;
       }
@@ -51,7 +53,7 @@ const StyledTooltipPointer = styled.div`
       border-top: 8px solid transparent;
       border-bottom: 8px solid transparent;
       border-left: 8px solid ${pointerColor(type, theme, bgColor)};
-      right: -${theme.spacing}px;
+      right: calc(-1 * var(--spacing100));
       @-moz-document url-prefix() {
         right: -7px;
       }
@@ -68,6 +70,7 @@ StyledTooltipPointer.propTypes = {
   position: PropTypes.oneOf(["bottom", "left", "right", "top"]),
   theme: PropTypes.object,
   type: PropTypes.string,
+  bgColor: PropTypes.string,
 };
 
 export default StyledTooltipPointer;

--- a/src/components/tooltip/tooltip.component.js
+++ b/src/components/tooltip/tooltip.component.js
@@ -1,9 +1,12 @@
-import React, { useRef } from "react";
+import React, { useContext, useRef } from "react";
 import PropTypes from "prop-types";
 import Tippy from "@tippyjs/react/headless";
+import { ThemeContext } from "styled-components";
+
 import StyledTooltip from "./tooltip.style";
 import StyledPointer from "./tooltip-pointer.style";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import { tokensClassName } from "../../style/design-tokens/carbon-scoped-tokens-provider/carbon-scoped-tokens-provider.component";
 
 const TOOLTIP_DELAY = 100;
 
@@ -27,12 +30,13 @@ const Tooltip = React.forwardRef(
     ref
   ) => {
     const tooltipRef = useRef(ref || null);
-
+    const theme = useContext(ThemeContext);
     const tooltip = (attrs, content) => {
       const currentPosition = attrs["data-placement"] || position;
 
       return (
         <StyledTooltip
+          className={tokensClassName(theme?.name)}
           data-element="tooltip"
           role="tooltip"
           tabIndex="-1"

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -53,7 +53,7 @@ describe("Tooltip", () => {
               maxWidth: "300px",
               zIndex: "2000",
               textAlign: "left",
-              color: "#FFFFFF",
+              color: "var(--colorsSemanticNeutralYang100)",
               display: "inline-block",
               padding: "8px 12px",
               wordBreak: "break-word",
@@ -61,7 +61,7 @@ describe("Tooltip", () => {
               fontSize: "14px",
               lineHeight: "1.5rem",
               fontWeight: "400",
-              backgroundColor: "#000000",
+              backgroundColor: "var(--colorsSemanticNeutral500)",
             },
             render().find(StyledTooltipWrapper)
           );
@@ -76,7 +76,7 @@ describe("Tooltip", () => {
 
         it("applies the correct styles  type === 'error'", () => {
           assertStyleMatch(
-            { backgroundColor: "#C7384F" },
+            { backgroundColor: "var(--colorsSemanticNegative500)" },
             render({ type: "error" }).find(StyledTooltipWrapper)
           );
         });
@@ -165,8 +165,8 @@ describe("Tooltip", () => {
               height: "0",
               borderLeft: "8px solid transparent",
               borderRight: "8px solid transparent",
-              borderTop: "8px solid #000000",
-              bottom: "-8px",
+              borderTop: "8px solid var(--colorsSemanticNeutral500)",
+              bottom: "calc(-1 * var(--spacing100))",
             },
             render().find(StyledTooltipPointer)
           );
@@ -175,7 +175,7 @@ describe("Tooltip", () => {
 
       it("applies the correct styles when type === 'error'", () => {
         assertStyleMatch(
-          { borderTop: "8px solid #C7384F" },
+          { borderTop: "8px solid var(--colorsSemanticNegative500)" },
           render({ type: "error" }).find(StyledTooltipPointer)
         );
       });
@@ -186,8 +186,8 @@ describe("Tooltip", () => {
             {
               borderLeft: "8px solid transparent",
               borderRight: "8px solid transparent",
-              borderBottom: "8px solid #000000",
-              top: "-8px",
+              borderBottom: "8px solid var(--colorsSemanticNeutral500)",
+              top: "calc(-1 * var(--spacing100))",
             },
             render({ position: "bottom" }).find(StyledTooltipPointer)
           );
@@ -195,7 +195,7 @@ describe("Tooltip", () => {
 
         it("applies the correct styles when type === 'error'", () => {
           assertStyleMatch(
-            { borderBottom: "8px solid #C7384F" },
+            { borderBottom: "8px solid var(--colorsSemanticNegative500)" },
             render({ position: "bottom", type: "error" }).find(
               StyledTooltipPointer
             )
@@ -209,8 +209,8 @@ describe("Tooltip", () => {
             {
               borderTop: "8px solid transparent",
               borderBottom: "8px solid transparent",
-              borderLeft: "8px solid #000000",
-              right: "-8px",
+              borderLeft: "8px solid var(--colorsSemanticNeutral500)",
+              right: "calc(-1 * var(--spacing100))",
             },
             render({ position: "left" }).find(StyledTooltipPointer)
           );
@@ -218,7 +218,7 @@ describe("Tooltip", () => {
 
         it("applies the correct styles when type === 'error'", () => {
           assertStyleMatch(
-            { borderLeft: "8px solid #C7384F" },
+            { borderLeft: "8px solid var(--colorsSemanticNegative500)" },
             render({ position: "left", type: "error" }).find(
               StyledTooltipPointer
             )
@@ -232,8 +232,8 @@ describe("Tooltip", () => {
             {
               borderTop: "8px solid transparent",
               borderBottom: "8px solid transparent",
-              borderRight: "8px solid #000000",
-              left: "-8px",
+              borderRight: "8px solid var(--colorsSemanticNeutral500)",
+              left: "calc(-1 * var(--spacing100))",
             },
             render({ position: "right" }).find(StyledTooltipPointer)
           );
@@ -241,7 +241,7 @@ describe("Tooltip", () => {
 
         it("applies the correct styles when type === 'error'", () => {
           assertStyleMatch(
-            { borderRight: "8px solid #C7384F" },
+            { borderRight: "8px solid var(--colorsSemanticNegative500)" },
             render({ position: "right", type: "error" }).find(
               StyledTooltipPointer
             )

--- a/src/components/tooltip/tooltip.style.js
+++ b/src/components/tooltip/tooltip.style.js
@@ -15,7 +15,9 @@ const fadeIn = keyframes`
 
 const tooltipColor = (type, theme, bgColor) => {
   if (bgColor) return toColor(theme, bgColor);
-  return type === "error" ? theme.colors.error : theme.colors.black;
+  return type === "error"
+    ? "var(--colorsSemanticNegative500)"
+    : "var(--colorsSemanticNeutral500)";
 };
 
 const tooltipOffset = (position, inputSize, isPartOfInput) => {
@@ -64,9 +66,12 @@ const StyledTooltipWrapper = styled.div`
     max-width: 300px;
     position: relative;
     animation: ${fadeIn} 0.2s linear;
-    z-index: ${theme.zIndex.popover};
+    z-index: ${theme.zIndex
+      .popover}; // TODO (tokens): implement elevation tokens - FE-4437
     text-align: left;
-    color: ${fontColor ? toColor(theme, fontColor) : theme.colors.white};
+    color: ${fontColor
+      ? toColor(theme, fontColor)
+      : "var(--colorsSemanticNeutralYang100)"};
     display: inline-block;
     padding: 8px 12px;
     word-break: break-word;
@@ -80,8 +85,14 @@ const StyledTooltipWrapper = styled.div`
 `;
 
 StyledTooltipWrapper.propTypes = {
-  type: PropTypes.string,
+  position: PropTypes.oneOf(["top", "bottom", "left", "right"]),
   size: PropTypes.oneOf(["medium", "large"]),
+  theme: PropTypes.object,
+  type: PropTypes.string,
+  isPartOfInput: PropTypes.bool,
+  inputSize: PropTypes.oneOf(["small", "medium", "large"]),
+  bgColor: PropTypes.string,
+  fontColor: PropTypes.string,
 };
 
 StyledTooltipWrapper.defaultProps = {


### PR DESCRIPTION
### Proposed behaviour

Describes the tooltip with design tokens. 
Leaves a theme for z-index (layer order tokens will be created in the next step) and custom colors.
Changes the tooltip background color according to the design.
Adds missing props in tooltip.style.js and tooltip-pointer.style files.
Updates the tests after the above changes.

### Current behaviour

The Tooltip use the theme styled-component property.
The current background-color for `tooltip` is black color. 
The propTypes in the css files are missing used props.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

![tooltip](https://user-images.githubusercontent.com/44143630/139834894-410d0924-3425-4695-ab30-3e56f579c656.PNG)

### Testing instructions

The correct appearance can be checked in the component: `tooltip`.
For theme: mint and aegean there should be no differences.
Use devtools to check if tooltips use css variables.
