### PR TITLE
ci(chromatic): screenshot all themes - FE-4444

### DIFF
--- a/.storybook/theme-selector/register.js
+++ b/.storybook/theme-selector/register.js
@@ -48,6 +48,15 @@ export const ThemeSwitcher = memo(
     const [activeTheme, setTheme] = useState(getThemeName());
     const [expanded, setExpanded] = useState(false);
 
+    if (process.env.STORYBOOK_DEBUG_ALL_THEMES) {
+      modernThemes.all = {
+        colors: {
+          primary:
+            "linear-gradient(45deg, red, orange, yellow, green, blue, indigo, violet, red)",
+        },
+      };
+    }
+
     const themeList = Object.keys(modernThemes).map((themeName) => ({
       id: themeName,
       title: themeName,

--- a/docs/testing-styleguide.md
+++ b/docs/testing-styleguide.md
@@ -82,7 +82,7 @@ Where the stories in the main documentation directory do not cover all scenarios
 To clarify the purpose of each directory,
 
 | Directory     | Usage                                                                    |
-|---------------|--------------------------------------------------------------------------|
+| ------------- | ------------------------------------------------------------------------ |
 | Design System | User facing documentation, Cypress regression tests                      |
 | Test          | Additional stories for Cypress regression tests, visual regression tests |
 
@@ -92,6 +92,14 @@ All regression, accessibility and theme tests are written using the [Cypress.io]
 Where functionality is already tested in unit testing, this does not need to be repeated in assertions in Cypress tests, with the exception of events tests which should be repeated here in order to test actions in a manner more closely resembling that of a user in a browser.
 
 [Chromatic](https://www.chromatic.com/builds?appId=5ecf782fe724630022d27d7d) is used to test for visual regressions during each build by comparing snapshots of the storybook canvas with previous baseline snapshots. Chromatic automatically snapshots every story canvas. You should not need to run Chromatic locally.
+
+Chromatic is configured to display each theme side-by-side, you can do this locally by using `STORYBOOK_DEBUG_ALL_THEMES=true npm start`. It is possible to display the components in a column layout by passing `fourColumnLayout` param.
+
+```
+<Story name="Example Layout" parameters={{themeSelector: { fourColumnLayout: true }}
+  <Component />
+</Story>
+```
 
 ##### Cypress File Structure
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8978,6 +8978,12 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "dev": true
     },
+    "chromatic": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-6.0.5.tgz",
+      "integrity": "sha512-jYoU9WOLX8hx6oRWYgr2aH1O46BpWMdBIZvON7SgUTxh9fFpsQqQ9dp2tvowwpsw/d73DGYnpX0+h/St78+kXg==",
+      "dev": true
+    },
     "chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "babel": "cross-env NODE_ENV=production babel ./src --config-file ./babel.config.js --out-dir ./lib --ignore '**/*/__spec__.js','**/*.spec.js','**/__definition__.js' --quiet",
     "clean-lib": "rimraf ./lib",
     "copy-files": "cpy \"**/\" \"!**/(*.js|*.md|*.mdx|*.stories.*|*.snap)\" ../lib/ --cwd=src --parents",
-    "commit": "git-cz",
-    "chromatic": "chromatic"
+    "commit": "git-cz"
   },
   "repository": {
     "type": "git",
@@ -89,6 +88,7 @@
     "babel-jest": "^26.6.3",
     "browserslist": "^4.16.6",
     "chalk": "^4.1.1",
+    "chromatic": "^6.0.5",
     "commitizen": "^4.2.4",
     "conventional-changelog-conventionalcommits": "^4.5.0",
     "core-js": "^3.1.4",

--- a/src/components/button-toggle-group/button-toggle-group.stories.mdx
+++ b/src/components/button-toggle-group/button-toggle-group.stories.mdx
@@ -65,7 +65,7 @@ import ButtonToggleGroup from "carbon-react/lib/components/button-toggle-group";
 
 <Preview>
   <Story name="controlled" parameters={{ info: { disable: true } }}>
-    {() => {
+    {(args, {themeName}) => {
       const [value, setValue] = useState("bar");
       function onChangeHandler(event) {
         setValue(event.target.value);
@@ -73,8 +73,8 @@ import ButtonToggleGroup from "carbon-react/lib/components/button-toggle-group";
       }
       return (
         <ButtonToggleGroup
-          id="button-toggle-group-controlled-id"
-          name="button-toggle-group-controlled"
+          id={`button-toggle-group-controlled-id-${themeName}`}
+          name={`button-toggle-group-controlled-${themeName}`}
           label="Controlled example"
           labelHelp="help message"
           helpAriaLabel="Help"

--- a/src/components/button/button-test.stories.mdx
+++ b/src/components/button/button-test.stories.mdx
@@ -502,7 +502,7 @@ export const FullWidthButtonsStory = () => {
 ### Primary buttons icons before
 
 <Preview>
-  <Story name="primary buttons icons before">
+  <Story name="primary buttons icons before" parameters={{ themeSelector: { chromaticTheme : "sage"}}}>
     {generateButtons("primary", "before")}
   </Story>
 </Preview>
@@ -510,7 +510,7 @@ export const FullWidthButtonsStory = () => {
 ### Primary buttons icons after
 
 <Preview>
-  <Story name="primary buttons icons after">
+  <Story name="primary buttons icons after" parameters={{ themeSelector: { chromaticTheme : "sage"}}}>
     {generateButtons("primary", "after")}
   </Story>
 </Preview>
@@ -518,7 +518,7 @@ export const FullWidthButtonsStory = () => {
 ### Secondary buttons icons before
 
 <Preview>
-  <Story name="secondary buttons icons before">
+  <Story name="secondary buttons icons before" parameters={{ themeSelector: { chromaticTheme : "sage"}}}>
     {generateButtons("secondary", "before")}
   </Story>
 </Preview>
@@ -526,7 +526,7 @@ export const FullWidthButtonsStory = () => {
 ### Secondary buttons icons after
 
 <Preview>
-  <Story name="secondary buttons icons after">
+  <Story name="secondary buttons icons after" parameters={{ themeSelector: { chromaticTheme : "sage"}}}>
     {generateButtons("secondary", "after")}
   </Story>
 </Preview>
@@ -534,7 +534,7 @@ export const FullWidthButtonsStory = () => {
 ### Tertiary buttons icons before
 
 <Preview>
-  <Story name="tertiary buttons icons before">
+  <Story name="tertiary buttons icons before" parameters={{ themeSelector: { chromaticTheme : "sage"}}}>
     {generateButtons("tertiary", "before")}
   </Story>
 </Preview>
@@ -542,7 +542,7 @@ export const FullWidthButtonsStory = () => {
 ### Tertiary buttons icons after
 
 <Preview>
-  <Story name="tertiary buttons icons after">
+  <Story name="tertiary buttons icons after" parameters={{ themeSelector: { chromaticTheme : "sage"}}}>
     {generateButtons("tertiary", "after")}
   </Story>
 </Preview>
@@ -550,7 +550,7 @@ export const FullWidthButtonsStory = () => {
 ### Dashed buttons icons before
 
 <Preview>
-  <Story name="dashed buttons icons before">
+  <Story name="dashed buttons icons before" parameters={{ themeSelector: { chromaticTheme : "sage"}}}>
     {generateButtons("dashed", "before")}
   </Story>
 </Preview>
@@ -558,7 +558,7 @@ export const FullWidthButtonsStory = () => {
 ### Dashed buttons icons after
 
 <Preview>
-  <Story name="dashed buttons icons after">
+  <Story name="dashed buttons icons after" parameters={{ themeSelector: { chromaticTheme : "sage"}}}>
     {generateButtons("dashed", "after")}
   </Story>
 </Preview>
@@ -566,7 +566,7 @@ export const FullWidthButtonsStory = () => {
 ### Dark background buttons icons before
 
 <Preview>
-  <Story name="dark background buttons icons before">
+  <Story name="dark background buttons icons before" parameters={{ themeSelector: { chromaticTheme : "sage"}}}>
     {generateButtons("darkBackground", "before")}
   </Story>
 </Preview>
@@ -574,7 +574,7 @@ export const FullWidthButtonsStory = () => {
 ### Dark background buttons icons after
 
 <Preview>
-  <Story name="dark background buttons icons after">
+  <Story name="dark background buttons icons after" parameters={{ themeSelector: { chromaticTheme : "sage"}}}>
     {generateButtons("darkBackground", "after")}
   </Story>
 </Preview>
@@ -582,7 +582,9 @@ export const FullWidthButtonsStory = () => {
 ### Full width buttons
 
 <Preview>
-  <Story name="full width buttons">{FullWidthButtonsStory.bind({})}</Story>
+  <Story name="full width buttons" parameters={{ themeSelector: { chromaticTheme : "sage"}}}>
+    {FullWidthButtonsStory.bind({})}
+    </Story>
 </Preview>
 
 ### No wrap buttons

--- a/src/components/date/date.stories.mdx
+++ b/src/components/date/date.stories.mdx
@@ -76,8 +76,10 @@ import DateInput from "carbon-react/lib/components/date";
 ### AutoFocus
 
 <Preview>
-  <Story name="autoFocus">
-    <DateInput label="Date" value="2016-10-01" autoFocus />
+    <Story name="autoFocus" parameters={{themeSelector: {fourColumnLayout: true}, chromatic: {viewports: [1800]}}}>
+    <div style={{height: 450, width: 450}}>
+      <DateInput label="Date" value="2016-10-01" autoFocus />
+    </div>
   </Story>
 </Preview>
 

--- a/src/components/popover-container/popover-container.stories.mdx
+++ b/src/components/popover-container/popover-container.stories.mdx
@@ -59,7 +59,7 @@ of the screen.
 
 <Preview>
   <Story name="position" parameters={{ info: { disable: true } }}>
-    <div style={{ height: 100, float: "right" }}>
+    <div style={{ height: 150, float: "right", clear: "right" }}>
       <PopoverContainer title="Right Aligned" position="left" open={true}>
         Contents
       </PopoverContainer>

--- a/src/components/search/search.stories.mdx
+++ b/src/components/search/search.stories.mdx
@@ -145,9 +145,9 @@ In this example the `searchWidth` prop is 70%.
 
 In this example the `variant` prop is "dark" and `searchButton` is true.
 
-<Preview style={{ backgroundColor: "#003349" }}>
+<Preview>
   <Story name="with Alt Styling" parameters={{ info: { disable: true } }}>
-    <Box width="700px" height="75px" bg="#003349">
+    <Box width="700px" height="108px">
       <div style={{ padding: "32px", backgroundColor: "#003349" }}>
         <Search
           placeholder="Search..."
@@ -164,12 +164,12 @@ In this example the `variant` prop is "dark" and `searchButton` is true.
 
 In this example the `variant` prop is "dark" and no search button is present.
 
-<Preview style={{ backgroundColor: "#003349" }}>
+<Preview>
   <Story
     name="with Alt Styling and no button"
     parameters={{ info: { disable: true } }}
   >
-    <Box width="700px" height="75px" bg="#003349">
+    <Box width="700px" height="108px">
       <div style={{ padding: "32px", backgroundColor: "#003349" }}>
         <Search placeholder="Search..." defaultValue="" variant="dark" />
       </div>

--- a/src/components/vertical-divider/vertical-divider.stories.mdx
+++ b/src/components/vertical-divider/vertical-divider.stories.mdx
@@ -24,6 +24,7 @@ import {
   FlatTableCell,
 } from "../flat-table";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import styled from "styled-components";
 
 <Meta
   title="VerticalDivider"
@@ -54,26 +55,32 @@ import VerticalDivider from "carbon-react/lib/components/vertical-divider";
 
 By default the VerticalDivider has a height of `100%` and padding of `24px`.
 
+export const Square = styled.div`
+height: ${({size}) => size || '56px'};
+width: ${({size}) => size || '56px'};
+background-color: ${({theme}) => theme.colors.primary};
+`
+
 <Preview>
   <Story name="default">
     <div style={{ display: "inline-flex" }}>
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
       <VerticalDivider />
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
       <VerticalDivider />
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
       <VerticalDivider />
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
       <VerticalDivider />
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
       <VerticalDivider />
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
       <VerticalDivider />
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
       <VerticalDivider />
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
       <VerticalDivider />
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
     </div>
   </Story>
 </Preview>
@@ -163,45 +170,45 @@ theme spacing which is `8px`, or any valid CSS string. The default for the `p` p
   <Story name="with custom spacing and height">
     <div style={{ display: "inline-flex" }}>
       <div>
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
         <VerticalDivider h="100px" pt={1} pb={1} />
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
       </div>
       <VerticalDivider pl={1} pr={1} h={185} />
       <div>
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
         <VerticalDivider h="100px" pt={2} pb={2} />
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
       </div>
       <VerticalDivider pl={2} pr={2} h={200} />
       <div>
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
         <VerticalDivider h="100px" pt={3} pb={3} />
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
       </div>
       <VerticalDivider pl={3} pr={3} h={215} />
       <div>
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
         <VerticalDivider h="100px" pt={4} pb={4} />
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
       </div>
       <VerticalDivider pl={4} pr={4} h={230} />
       <div>
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
         <VerticalDivider h="100px" pt={5} pb={5} />
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
       </div>
       <VerticalDivider pl={5} pr={5} h={245} />
       <div>
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
         <VerticalDivider h="100px" pt={6} pb={6} />
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
       </div>
       <VerticalDivider pl={6} pr={6} h={260} />
       <div>
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
         <VerticalDivider h="100px" pt={7} pb={7} />
-        <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+        <Square />
       </div>
     </div>
   </Story>
@@ -215,15 +222,15 @@ applied to the slate.
 <Preview>
   <Story name="with custom tint">
     <div style={{ display: "inline-flex" }}>
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
       <VerticalDivider tint={20} />
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
       <VerticalDivider tint={75} />
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
       <VerticalDivider tint={80} />
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
       <VerticalDivider tint={90} />
-      <div style={{ height: 56, width: 56, backgroundColor: "#00815D" }} />
+      <Square />
     </div>
   </Story>
 </Preview>
@@ -239,33 +246,19 @@ applied to the slate.
           <Button onClick={() => setIsOpen(true)}>Click Me</Button>
           <Dialog title="Title" open={isOpen} onCancel={() => setIsOpen(false)}>
             <div style={{ display: "inline-flex" }}>
-              <div
-                style={{ height: 56, width: 56, backgroundColor: "#00815D" }}
-              />
+              <Square />
               <VerticalDivider />
-              <div
-                style={{ height: 56, width: 56, backgroundColor: "#00815D" }}
-              />
+              <Square />
               <VerticalDivider />
-              <div
-                style={{ height: 56, width: 56, backgroundColor: "#00815D" }}
-              />
+              <Square />
               <VerticalDivider />
-              <div
-                style={{ height: 56, width: 56, backgroundColor: "#00815D" }}
-              />
+              <Square />
               <VerticalDivider />
-              <div
-                style={{ height: 56, width: 56, backgroundColor: "#00815D" }}
-              />
+              <Square />
               <VerticalDivider />
-              <div
-                style={{ height: 56, width: 56, backgroundColor: "#00815D" }}
-              />
+              <Square />
               <VerticalDivider />
-              <div
-                style={{ height: 56, width: 56, backgroundColor: "#00815D" }}
-              />
+              <Square />
             </div>
           </Dialog>
         </>
@@ -281,23 +274,23 @@ applied to the slate.
     <Tile width={800} orientation="vertical">
       <Content title="Test Title One">Test Body One</Content>
       <div style={{ display: "inline-flex", height: 40 }}>
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
         <VerticalDivider pt={1} pb={1} pl={3} pr={3} />
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
         <VerticalDivider pt={1} pb={1} pl={3} pr={3} />
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
         <VerticalDivider pt={1} pb={1} pl={3} pr={3} />
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
         <VerticalDivider pt={1} pb={1} pl={3} pr={3} />
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
         <VerticalDivider pt={1} pb={1} pl={3} pr={3} />
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
         <VerticalDivider pt={1} pb={1} pl={3} pr={3} />
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
         <VerticalDivider pt={1} pb={1} pl={3} pr={3} />
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
         <VerticalDivider pt={1} pb={1} pl={3} pr={3} />
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
       </div>
     </Tile>
   </Story>
@@ -317,9 +310,9 @@ This example is best viewed in the Canvas tab using full-screen mode with device
         gridColumn="1 / 2"
         gridRow="1 / 2"
       >
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
         <VerticalDivider h={100} />
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
       </GridItem>
       <GridItem
         alignSelf="stretch"
@@ -335,9 +328,9 @@ This example is best viewed in the Canvas tab using full-screen mode with device
         gridColumn="5 / 6"
         gridRow="1 / 2"
       >
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
         <VerticalDivider h={100} />
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
       </GridItem>
       <GridItem
         alignSelf="stretch"
@@ -353,9 +346,9 @@ This example is best viewed in the Canvas tab using full-screen mode with device
         gridColumn="9 / 10"
         gridRow="1 / 2"
       >
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
         <VerticalDivider h={100} />
-        <div style={{ height: 40, width: 40, backgroundColor: "#00815D" }} />
+        <Square size="40px"/>
       </GridItem>
     </GridContainer>
   </Story>


### PR DESCRIPTION
### Proposed behaviour

Chromatic will snapshot all the themes by duplicating the story onto the same canvas.

### Current behaviour

Chromatic only snapshots the sage theme.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

FE-4444

### Testing instructions

Please review all the changes in Chromatic. There should be no differences but the content will be duplicated 4 times, one for each theme.
