### PR TITLE
fix(search): correct tabbing order when searchButton true and no search value - FE-4390

### DIFF
--- a/src/components/search/search.component.js
+++ b/src/components/search/search.component.js
@@ -191,7 +191,12 @@ const Search = ({
           {Boolean(
             isFocused || (!isControlled ? searchValue.length : value.length)
           ) && (
-            <Button size="medium" px="16px" {...buttonProps}>
+            <Button
+              tabIndex={iconTabIndex}
+              size="medium"
+              px="16px"
+              {...buttonProps}
+            >
               <StyledButtonIcon>
                 <Icon type="search" />
               </StyledButtonIcon>

--- a/src/components/search/search.spec.js
+++ b/src/components/search/search.spec.js
@@ -531,6 +531,40 @@ describe("Search", () => {
     });
   });
 
+  describe("tab index should be set on search button", () => {
+    it("when input field is not empty", () => {
+      wrapper = renderWrapper(
+        {
+          defaultValue: "Bar",
+          id: "Search",
+          name: "Search",
+          searchButton: true,
+        },
+        mount
+      );
+      const searchButton = wrapper.find(Button);
+      expect(searchButton.prop("tabIndex")).toEqual(0);
+    });
+  });
+
+  describe("tab index should not be set on search button", () => {
+    it("when input field has focus and is empty", () => {
+      wrapper = renderWrapper(
+        {
+          defaultValue: "",
+          id: "Search",
+          name: "Search",
+          searchButton: true,
+        },
+        mount
+      );
+      const input = wrapper.find("input");
+      input.simulate("focus");
+      const searchButton = wrapper.find(Button);
+      expect(searchButton.prop("tabIndex")).toEqual(-1);
+    });
+  });
+
   describe("when typing into the input", () => {
     const stopPropagationFn = jest.fn();
 


### PR DESCRIPTION
Fixes a bug when tabbing focus is lost to the search button when searchButton is true but search has
no value.

fixes #4480

### Proposed behaviour

![search_tabbing_fixed](https://user-images.githubusercontent.com/56251247/141089466-5f559169-4773-4441-ab5e-abd3f1bcfa84.gif)

### Current behaviour

![search_tabbing_borked](https://user-images.githubusercontent.com/56251247/141089511-356ee14b-4d1d-4133-9c3a-148856c43ce1.gif)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Please use the codesandbox built from the linked issue
