### PR TITLE
chore(deps): update design tokens package to the last version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3302,9 +3302,9 @@
       "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg=="
     },
     "@sage/design-tokens": {
-      "version": "1.73.0",
-      "resolved": "https://registry.npmjs.org/@sage/design-tokens/-/design-tokens-1.73.0.tgz",
-      "integrity": "sha512-y1cFdC3MtCWmnNPfUEk6mV7K2YCSeuRuiBI08Ltp0tKZY/zoNM/Sw4z+NJwO3vzeCvt1cU0s0Ak6vdewYdRlxg=="
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@sage/design-tokens/-/design-tokens-1.80.0.tgz",
+      "integrity": "sha512-3kfVE5pJKN9ZVNIKUXAcVraXXcjXPbfBFRbn+F0MiVCeDp6JZw3Fp1TqObAkUTOP0DOLwBxZubE93+VY5mIb4w=="
     },
     "@semantic-release/changelog": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
   "dependencies": {
     "@octokit/rest": "^18.12.0",
     "@popperjs/core": "^2.9.0",
-    "@sage/design-tokens": "^1.73.0",
+    "@sage/design-tokens": "^1.80.0",
     "@styled-system/prop-types": "^5.1.5",
     "@tippyjs/react": "^4.2.5",
     "classnames": "~2.2.6",


### PR DESCRIPTION
### Proposed behaviour

New version of packege includes a new types of tokens with yang. New version: 1.80.0

### Current behaviour

The latest version of the package is: ^1.73.0

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

<!-- Add CodeSandbox here -->
