### PR TITLE
docs(storybook): add version switcher

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -4,35 +4,63 @@ on:
   push:
     # These are the branches that we expect to publish from
     # semantic-release also has a regex that validates we're running on a release branch
-    branches:    
+    branches:
       - master
-      - '[0-9]+.x'
-      - '[0-9]+.x.x'
-      - '[0-9]+.[0-9]+.x'
+      - "[0-9]+.x"
+      - "[0-9]+.x.x"
+      - "[0-9]+.[0-9]+.x"
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.versionNumber.outputs.version }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        persist-credentials: false
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '>=14.16.0 14'
-    - run: npm ci
-    - name: Import GPG key
-      uses: crazy-max/ghaction-import-gpg@v3.0.1
-      with:
-        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-        passphrase: ${{ secrets.GPG_PASSPHRASE }}
-        git-user-signingkey: true
-        git-commit-gpgsign: true
-    - run: npx semantic-release
-      env:
-        # A personal access token is required to publish from protected branches
-        GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        GIT_COMMITTER_NAME: Sage Carbon
-        GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }} 
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ">=14.16.0 14"
+      - run: npm ci
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v3.0.1
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git-user-signingkey: true
+          git-commit-gpgsign: true
+      - run: npx semantic-release
+        env:
+          # A personal access token is required to publish from protected branches
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_COMMITTER_NAME: Sage Carbon
+          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
+      - id: versionNumber
+        run: echo "::set-output name=version::$SEMVER_VERSION"
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: release
+    if: ${{ needs.release.outputs.version != null }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ">=14.16.0 14"
+      - run: npm ci
+      - name: Generate metadata file
+        run: npm run generate-metadata
+      - run: NODE_ENV=production npm run build-storybook
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+      - run: aws s3 sync ./storybook-static/ s3://carbon.sage.com/v/${{needs.release.outputs.version}}
+      - run: aws s3 sync ./metadata/ s3://carbon.sage.com/metadata

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -2,23 +2,22 @@ name: Storybook
 on:
   push:
     # These are the branches that we expect to publish from
-    branches:    
+    branches:
       - master
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '>=14.16.0 14'
-    - run: npm ci
-    - run: NODE_ENV=production IGNORE_TESTS=true STORYBOOK_VIEW_MODE=docs npm run build-storybook
-    - uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
-    - run: aws s3 sync ./storybook-static/ s3://carbon.sage.com --delete
-        
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ">=14.16.0 14"
+      - run: npm ci
+      - run: NODE_ENV=production IGNORE_TESTS=true STORYBOOK_VIEW_MODE=docs npm run build-storybook
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - run: aws s3 sync ./storybook-static/ s3://carbon.sage.com --delete --exclude "v/*" --exclude "metadata/*"

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,11 +1,22 @@
-import { addons } from "@storybook/addons";
+import { addons, types } from "@storybook/addons";
 import sageTheme from "./sageTheme";
+import { ADDON_ID, TOOL_ID } from "./version-picker/constants";
+import { VersionPicker } from "./version-picker";
 
 addons.setConfig({
   theme: sageTheme,
   panelPosition: "bottom",
   showNav: true,
   showPanel: true,
+});
+
+addons.register(ADDON_ID, () => {
+  addons.add(TOOL_ID, {
+    type: types.TOOL,
+    title: "Version picker",
+    match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
+    render: VersionPicker,
+  });
 });
 
 window.STORYBOOK_GA_ID = "UA-77028225-13";

--- a/.storybook/version-picker/constants.js
+++ b/.storybook/version-picker/constants.js
@@ -1,0 +1,2 @@
+export const ADDON_ID = "storybook/version-picker";
+export const TOOL_ID = `${ADDON_ID}/version-picker`;

--- a/.storybook/version-picker/fetch-data.js
+++ b/.storybook/version-picker/fetch-data.js
@@ -1,0 +1,11 @@
+const fetchData = async () => {
+  const response = await fetch(
+    "https://carbon.sage.com/metadata/metadata.json"
+  );
+
+  const versions = await response.json();
+
+  return versions;
+};
+
+export default fetchData;

--- a/.storybook/version-picker/index.js
+++ b/.storybook/version-picker/index.js
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from "react";
+import {
+  IconButton,
+  WithTooltip,
+  TooltipLinkList,
+} from "@storybook/components";
+
+import { TOOL_ID } from "./constants";
+import fetchData from "./fetch-data";
+
+const getDisplayedItems = (versions, onClick) => {
+  let formattedVersions = [];
+
+  for (const [key, value] of Object.entries(versions)) {
+    formattedVersions.push({
+      id: key,
+      title: key,
+      onClick,
+      active: false,
+      href: value,
+      target: "_blank",
+    });
+  }
+
+  formattedVersions[0].title = `${formattedVersions[0].title} (latest)`;
+
+  return formattedVersions;
+};
+
+export const VersionPicker = () => {
+  const [versions, setVersions] = useState();
+  const [currentVersion, setCurrentVersion] = useState("Latest");
+
+  useEffect(() => {
+    const url = window.location.href;
+    if (url.includes("/v/")) {
+      const startIndex = url.indexOf("/v/");
+      const endIndex = url.indexOf("/", startIndex + 4);
+
+      const urlVersion = url.substring(startIndex + 3, endIndex);
+      setCurrentVersion(`v${urlVersion}`);
+    }
+
+    const getData = async () => {
+      const data = await fetchData();
+      setVersions(data.versions);
+    };
+
+    getData();
+  }, []);
+
+  if (versions) {
+    return (
+      <WithTooltip
+        placement="top"
+        trigger="click"
+        closeOnClick
+        tooltip={({ onHide }) => {
+          return (
+            <TooltipLinkList links={getDisplayedItems(versions, onHide)} />
+          );
+        }}
+      >
+        <IconButton
+          key={TOOL_ID}
+          active={false}
+          title="Open docs for a different version"
+        >
+          {`${currentVersion}`}
+        </IconButton>
+      </WithTooltip>
+    );
+  }
+
+  return null;
+};

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const fs = jest.createMockFromModule("fs");
+
+module.exports = fs;

--- a/jest.conf.json
+++ b/jest.conf.json
@@ -1,6 +1,10 @@
 {
   "notify": false,
-  "setupFiles": ["raf/polyfill", "./src/__spec_helper__/index.js", "jest-canvas-mock"],
+  "setupFiles": [
+    "raf/polyfill",
+    "./src/__spec_helper__/index.js",
+    "jest-canvas-mock"
+  ],
   "setupFilesAfterEnv": ["./src/__spec_helper__/expect.js"],
   "snapshotSerializers": ["enzyme-to-json/serializer"],
   "testMatch": ["**/__spec__.js", "**/*.spec.js"],
@@ -17,13 +21,12 @@
       "statements": 100
     }
   },
-  "moduleFileExtensions": ["ts", "tsx", "js", "jsx"],
+  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "mjs"],
   "transform": {
-    "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
+    "^.+\\.(js|mjs|jsx|ts|tsx)$": "babel-jest",
     "^.+\\.svg$": "<rootDir>/svgTransform.js"
   },
   "moduleNameMapper": {
     "\\.(png)$": "<rootDir>/__mocks__/imageMock.js"
   }
-
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4933,6 +4933,72 @@
       "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
       "dev": true
     },
+    "@semantic-release/exec": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.2.tgz",
+      "integrity": "sha512-ciaqJTHB1TFtU6C78xrgmoNI9UyfheR9+Bk6Ico7CJ7+ADOEAvUrPBKvz64UCfoWlg+SlKGTVGbFnA509wRUVw==",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^5.0.0"
+      },
+      "dependencies": {
+        "@semantic-release/error": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+          "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "execa": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+          "dev": true
+        },
+        "human-signals": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "@semantic-release/git": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-9.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17883,6 +17883,16 @@
         }
       }
     },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
@@ -22652,6 +22662,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
+    "promise-polyfill": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.1.tgz",
+      "integrity": "sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg==",
       "dev": true
     },
     "promise-retry": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "babel": "cross-env NODE_ENV=production babel ./src --config-file ./babel.config.js --out-dir ./lib --ignore '**/*/__spec__.js','**/*.spec.js','**/__definition__.js' --quiet",
     "clean-lib": "rimraf ./lib",
     "copy-files": "cpy \"**/\" \"!**/(*.js|*.md|*.mdx|*.stories.*|*.snap)\" ../lib/ --cwd=src --parents",
-    "commit": "git-cz"
+    "commit": "git-cz",
+    "generate-metadata": "node ./scripts/generate_metadata/index.mjs"
   },
   "repository": {
     "type": "git",
@@ -120,6 +121,7 @@
     "husky": "^4.3.6",
     "jest": "^26.6.3",
     "jest-canvas-mock": "^2.3.1",
+    "jest-fetch-mock": "^3.0.3",
     "jest-styled-components": "^6.3.1",
     "lint-staged": "^10.5.3",
     "mockdate": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@semantic-release/changelog": "^5.0.1",
+    "@semantic-release/exec": "^6.0.2",
     "@semantic-release/git": "^9.0.0",
     "@storybook/addon-a11y": "^6.3.6",
     "@storybook/addon-actions": "^6.3.6",
@@ -203,6 +204,12 @@
         "@semantic-release/git",
         {
           "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+        }
+      ],
+      [
+        "@semantic-release/exec",
+        {
+          "successCmd": "echo \"SEMVER_VERSION=${nextRelease.version}\" >> $GITHUB_ENV"
         }
       ],
       "@semantic-release/github"

--- a/scripts/generate_metadata/generate_metadata.mjs
+++ b/scripts/generate_metadata/generate_metadata.mjs
@@ -1,0 +1,65 @@
+/* eslint-disable no-console */
+import fs from "fs";
+import fetch from "node-fetch";
+
+const MIN_VERSION = "100.2.1";
+
+const fetchVersions = async () => {
+  const response = await fetch("https://registry.npmjs.com/carbon-react");
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch from npm with HTTP error code ${response.status}`
+    );
+  }
+
+  const json = await response.json();
+
+  return Object.keys(json.versions);
+};
+
+const formatVersions = (versions) => {
+  const filteredVersions = versions
+    .slice(versions.indexOf(MIN_VERSION))
+    .reverse();
+  const versionsJson = {
+    versions: {},
+  };
+
+  filteredVersions.forEach((item) => {
+    versionsJson.versions[
+      `v${item}`
+    ] = `https://carbon.sage.com/v/${item}/index.html`;
+  });
+
+  return JSON.stringify(versionsJson);
+};
+
+export const writeFile = (jsonString) => {
+  fs.mkdirSync("metadata", {}, (err) => {
+    if (err) throw err;
+  });
+
+  fs.writeFileSync("metadata/metadata.json", jsonString, (err) => {
+    if (err) {
+      throw err;
+    } else {
+      console.log("Successfully created metadata.json file.");
+    }
+  });
+};
+
+export const generateMetadata = async () => {
+  let versions;
+
+  try {
+    versions = await fetchVersions();
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+
+  const formattedVersions = formatVersions(versions);
+
+  writeFile(formattedVersions);
+};

--- a/scripts/generate_metadata/generate_metadata.spec.js
+++ b/scripts/generate_metadata/generate_metadata.spec.js
@@ -1,0 +1,117 @@
+import { generateMetadata, writeFile } from "./generate_metadata";
+
+const fs = require("fs");
+
+jest.mock("fs");
+
+const mockNpmVersions = {
+  versions: {
+    "98.0.0": {},
+    "99.0.0": {},
+    "100.2.1": {},
+    "101.0.0": {},
+    "102.0.0": {},
+  },
+};
+
+const mockMetadata = {
+  versions: {
+    "v102.0.0": "https://carbon.sage.com/v/102.0.0/index.html",
+    "v101.0.0": "https://carbon.sage.com/v/101.0.0/index.html",
+    "v100.2.1": "https://carbon.sage.com/v/100.2.1/index.html",
+  },
+};
+
+describe("generateMetadata script", () => {
+  let consoleErrorMock;
+
+  beforeAll(() => {
+    jest.spyOn(global.console, "log").mockImplementation(() => {});
+    consoleErrorMock = jest
+      .spyOn(global.console, "error")
+      .mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    fetch.resetMocks();
+    fetch.mockResponse(JSON.stringify(mockNpmVersions));
+    fs.mkdirSync = jest.fn((path, options, callback) => {
+      callback();
+    });
+    fs.writeFileSync = jest.fn((path, json, callback) => {
+      callback();
+    });
+  });
+
+  afterAll(() => {
+    global.console.log.mockReset();
+    global.console.error.mockReset();
+  });
+
+  it("should create a metadata.json file in a metadata directory", async () => {
+    await generateMetadata();
+
+    expect(fs.mkdirSync).toHaveBeenCalledWith(
+      "metadata",
+      {},
+      expect.any(Function)
+    );
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      "metadata/metadata.json",
+      JSON.stringify(mockMetadata),
+      expect.any(Function)
+    );
+  });
+
+  describe("when there is an error creating the metadata directory", () => {
+    it("should throw an error", () => {
+      fs.mkdirSync = jest.fn((path, options, callback) => {
+        callback(new Error("An error occurred."));
+      });
+
+      expect(() => {
+        writeFile();
+      }).toThrowError("An error occurred.");
+    });
+  });
+
+  describe("when there is an error creating the metadata.json file", () => {
+    it("should throw an error", () => {
+      fs.writeFileSync = jest.fn((path, json, callback) => {
+        callback(new Error("An error occurred."));
+      });
+
+      expect(() => {
+        writeFile();
+      }).toThrowError("An error occurred.");
+    });
+  });
+
+  describe("when there is an error fetching the carbon data from npm", () => {
+    const mockExit = jest
+      .spyOn(process, "exit")
+      .mockImplementation((number) => {
+        throw new Error(`process.exit: ${number}`);
+      });
+
+    afterAll(() => {
+      mockExit.mockRestore();
+    });
+
+    it("should throw an error with exit code 1", async () => {
+      fetch.mockResponse(JSON.stringify(mockNpmVersions), {
+        status: 500,
+        ok: false,
+      });
+
+      await expect(async () => {
+        await generateMetadata();
+      }).rejects.toThrowError("process.exit: 1");
+      expect(consoleErrorMock).toHaveBeenCalledWith(
+        new Error("Failed to fetch from npm with HTTP error code 500")
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/scripts/generate_metadata/index.mjs
+++ b/scripts/generate_metadata/index.mjs
@@ -1,0 +1,3 @@
+import { generateMetadata } from "./generate_metadata.mjs";
+
+generateMetadata();

--- a/src/__spec_helper__/index.js
+++ b/src/__spec_helper__/index.js
@@ -3,6 +3,8 @@ import Adapter from "enzyme-adapter-react-16";
 import { setup } from "./mock-match-media";
 import setupResizeObserverMock from "./mock-resize-observer";
 
+require("jest-fetch-mock").enableMocks();
+
 setupResizeObserverMock();
 setup();
 Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
### Proposed behaviour

Add versioned docs for the Carbon Storybook. As of this PR every new version of Carbon going forward will have archived docs available at `https://carbon.sage.com/v/X.X.X/index.html`.

The process for generating these is this: 

- When a commit generating a new version of Carbon is pushed to master, the `storybook.yml` workflow will push the new version to `carbon.sage.com` as usual.
- The semantic-release workflow will:
  - Release the new version to npm as usual.
  - Run the new `generate_metadata` script to generate a metadata json file with the archived versions and the corresponding urls for their storybooks.
  - Push the archived storybook to the s3 bucket.
  - Push the `metadata.json` to the s3 bucket, overwriting the existing one (after the first run).

This PR then introduces a custom addon for the Storybook toolbar to switch between these archived versions (screenshot is an example from my test repo): 

![image](https://user-images.githubusercontent.com/14963680/141499030-c5d1130b-af5f-4acc-9510-44f98b75119c.png)

This addon fetches the `metadata.json` file from the s3 bucket and uses it to work out what versions to display, and what URLs to link them to.

Clicking on a version in the dropdown will open the archived storybook in a new tab.

### Current behaviour

No versioned docs in Carbon.

### Checklist


- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

**Note this will not work on this branch as until this is merged, we have no archived storybooks in the s3 bucket.**

### Testing instructions

I have a test repo to test the version switcher addon. You can test the functionality of that here: https://carbon-versioned.s3.eu-west-1.amazonaws.com/index.html?path=/story/example-button--primary 

The primary button colour will change between the versions.

Unfortunately we can't test this whole pipeline until we have versioned storybooks in the s3 bucket, which will only happen once this PR is merged.

