### PR TITLE
feat(link): describe link component using design tokens

### DIFF
--- a/src/components/card/__snapshots__/card.spec.js.snap
+++ b/src/components/card/__snapshots__/card.spec.js.snap
@@ -96,7 +96,7 @@ exports[`Card CardFooter styling should match the expected styling when it has n
   font-size: 14px;
   -webkit-text-decoration: underline;
   text-decoration: underline;
-  color: #008200;
+  color: var(--colorsActionMajor500);
   display: inline-block;
 }
 
@@ -105,19 +105,19 @@ exports[`Card CardFooter styling should match the expected styling when it has n
   display: inline-block;
   position: relative;
   vertical-align: middle;
-  margin-right: 5px;
+  margin-right: var(--spacing100);
 }
 
 .c1 a:hover,
 .c1 button:hover {
   cursor: pointer;
-  color: #006300;
+  color: var(--colorsActionMajor600);
 }
 
 .c1 a:focus,
 .c1 button:focus {
-  color: rgba(0,0,0,0.9);
-  background-color: #FFDA80;
+  color: var(--colorsYin090);
+  background-color: var(--colorsSemanticFocus250);
   outline: none;
 }
 

--- a/src/components/link/link.spec.js
+++ b/src/components/link/link.spec.js
@@ -46,10 +46,10 @@ describe("Link", () => {
           lineHeight: "36px",
           fontSize: "16px",
           left: "-999em",
-          textColor: baseTheme.colors.text,
+          color: "var(--colorsYin090)",
           zIndex: `${baseTheme.zIndex.aboveAll}`,
-          boxShadow: `inset 0 0 0 2px ${baseTheme.colors.primary}`,
-          border: `2px solid ${baseTheme.colors.white}`,
+          boxShadow: `inset 0 0 0 2px var(--colorsActionMajor500)`,
+          border: `2px solid var(--colorsYang100)`,
         },
         skipLinkWrapper,
         { modifier: "a" }
@@ -59,7 +59,7 @@ describe("Link", () => {
         {
           top: "8px",
           left: "8px",
-          textColors: baseTheme.colors.text,
+          color: "var(--colorsYin090)",
         },
         skipLinkWrapper,
         { modifier: "a:focus" }
@@ -144,7 +144,7 @@ describe("Link", () => {
     it("should render an `Icon` on the left side of the component by default", () => {
       assertStyleMatch(
         {
-          marginRight: "5px",
+          marginRight: "var(--spacing100)",
           position: "relative",
         },
         wrapper.find(StyledLink),
@@ -157,7 +157,7 @@ describe("Link", () => {
       assertStyleMatch(
         {
           marginRight: "0",
-          marginLeft: "5px",
+          marginLeft: "var(--spacing100)",
           position: "relative",
         },
         wrapper.find(StyledLink),

--- a/src/components/link/link.stories.mdx
+++ b/src/components/link/link.stories.mdx
@@ -99,7 +99,7 @@ To show how it works, press the TAB key and you will be able to see how `Skip Li
         laboris dolor ut. Lorem ullamco adipisicing duis aute non minim.
         Adipisicing consequat labore non aliquip anim.
       </Typography>
-      <Link href="www.carbon.sage.com">Carbon Page</Link>
+      <Link href="https://carbon.sage.com">Carbon Page</Link>
     </Box>
   </Story>
 </Canvas>

--- a/src/components/link/link.style.js
+++ b/src/components/link/link.style.js
@@ -16,8 +16,8 @@ const StyledLink = styled.span`
         line-height: 36px;
         left: -999em;
         z-index: ${theme.zIndex.aboveAll};
-        box-shadow: inset 0 0 0 2px ${theme.colors.primary};
-        border: 2px solid ${theme.colors.white};
+        box-shadow: inset 0 0 0 2px var(--colorsActionMajor500);
+        border: 2px solid var(--colorsYang100);
       }
 
       a:focus {
@@ -30,7 +30,9 @@ const StyledLink = styled.span`
   button {
       font-size: ${isSkipLink ? "16px" : "14px"};
       text-decoration: underline;
-      color: ${isSkipLink ? theme.text.color : theme.colors.primary};
+      color: ${isSkipLink
+        ? "var(--colorsYin090)"
+        : "var(--colorsActionMajor500)"};
       display: inline-block;
       ${StyledIcon} {
         display: inline-block;
@@ -38,35 +40,37 @@ const StyledLink = styled.span`
         vertical-align: middle;
         ${iconAlign === "left" &&
         css`
-          margin-right: ${hasContent ? "5px" : 0};
+          margin-right: ${hasContent ? "var(--spacing100)" : 0};
         `}
         ${iconAlign === "right" &&
         css`
           margin-right: 0;
-          margin-left: ${hasContent ? "5px" : 0};
+          margin-left: ${hasContent ? "var(--spacing100)" : 0};
         `}
       }
 
       &:hover {
         cursor: pointer;
-        color: ${isSkipLink ? theme.text.color : theme.colors.secondary};
+        color: ${isSkipLink
+          ? "var(--colorsYin090)"
+          : "var(--colorsActionMajor600)"};
       }
 
       &:focus {
-        color: ${theme.text.color};
+        color: var(--colorsYin090);
         background-color: ${isSkipLink
-          ? theme.colors.white
-          : theme.colors.focusedLinkBackground};
+          ? "var(--colorsYang100)"
+          : "var(--colorsSemanticFocus250)"};
         outline: none;
       }
 
       ${disabled &&
       css`
-        color: ${theme.disabled.text};
+        color: var(--colorsYin065);
         &:hover,
         &:focus {
           cursor: not-allowed;
-          color: ${theme.disabled.text};
+          color: var(--colorsYin065);
         }
       `}
     }

--- a/src/components/pod/__snapshots__/pod.spec.js.snap
+++ b/src/components/pod/__snapshots__/pod.spec.js.snap
@@ -40,7 +40,7 @@ exports[`ActionButtons StyledDeleteButton when isHovered prop is set should matc
   display: inline-block;
   position: relative;
   vertical-align: middle;
-  margin-right: 5px;
+  margin-right: var(--spacing100);
 }
 
 .c5 a .c2,
@@ -344,7 +344,7 @@ exports[`ActionButtons StyledEditAction when isHovered prop is set should match 
   font-size: 14px;
   -webkit-text-decoration: underline;
   text-decoration: underline;
-  color: #008200;
+  color: var(--colorsActionMajor500);
   display: inline-block;
 }
 
@@ -359,13 +359,13 @@ exports[`ActionButtons StyledEditAction when isHovered prop is set should match 
 .c0 a:hover,
 .c0 button:hover {
   cursor: pointer;
-  color: #006300;
+  color: var(--colorsActionMajor600);
 }
 
 .c0 a:focus,
 .c0 button:focus {
-  color: rgba(0,0,0,0.9);
-  background-color: #FFDA80;
+  color: var(--colorsYin090);
+  background-color: var(--colorsSemanticFocus250);
   outline: none;
 }
 
@@ -500,7 +500,7 @@ exports[`ActionButtons StyledUndoButton when isHovered prop is set should match 
   display: inline-block;
   position: relative;
   vertical-align: middle;
-  margin-right: 5px;
+  margin-right: var(--spacing100);
 }
 
 .c5 a .c2,


### PR DESCRIPTION
### Proposed behaviour
Describes the link using design tokens. Removes all possible 'theme' in css files (left theme where using elevation property - lack of tokens for elevations). 
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour
The Link use the theme styled-component property.
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
