### PR TITLE
docs(tabs): update headerWidth story to use unique id for each tab child  FE-4440

### DIFF
--- a/cypress/support/step-definitions/tabs-steps.js
+++ b/cypress/support/step-definitions/tabs-steps.js
@@ -14,7 +14,6 @@ Then("Tab {int} content is visible", (id) => {
 
 Then("Second Tab has a link property", () => {
   tabById(2)
-    .find("a")
     .should("have.attr", "href", "https://carbon.sage.com/")
     .and("have.attr", "target", "_blank");
 });

--- a/src/components/tabs/__internal__/tab-title/index.d.ts
+++ b/src/components/tabs/__internal__/tab-title/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from "./tab-title";

--- a/src/components/tabs/__internal__/tab-title/tab-title.component.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.component.js
@@ -37,6 +37,7 @@ const TabTitle = React.forwardRef(
       isInSidebar,
       href,
       onKeyDown,
+      align,
       ...tabTitleProps
     },
     ref
@@ -72,6 +73,9 @@ const TabTitle = React.forwardRef(
         onClick(customEvent);
         return window.open(href, "_blank");
       }
+
+      // safari does not focus buttons by default
+      ref.current?.focus();
 
       return onClick(customEvent);
     };
@@ -121,17 +125,16 @@ const TabTitle = React.forwardRef(
         error={error}
         warning={warning}
         info={info}
-        size={size}
         noRightBorder={noRightBorder}
         alternateStyling={alternateStyling || isInSidebar}
         borders={borders}
         isInSidebar={isInSidebar}
         {...tabTitleProps}
+        {...(isHref && { href, target: "_blank", as: "a" })}
         {...tagComponent("tab-header", tabTitleProps)}
         onKeyDown={handleKeyDown}
       >
         <StyledTitleContent
-          {...(isHref && { href, target: "_blank", as: "a" })}
           error={error}
           warning={warning}
           info={info}
@@ -145,35 +148,45 @@ const TabTitle = React.forwardRef(
           isTabSelected={isTabSelected}
           hasCustomLayout={!!customLayout}
           alternateStyling={hasAlternateStyling}
+          align={align}
+          hasHref={!!href}
         >
           {renderContent()}
           {isHref && <Icon type="link" />}
 
-          <StyledLayoutWrapper hasCustomSibling={!!customLayout}>
-            {error && (
-              <ValidationIcon
-                onClick={handleClick}
-                tooltipPosition="top"
-                error={errorMessage}
-              />
-            )}
+          {hasFailedValidation && (
+            <StyledLayoutWrapper
+              position={position}
+              hasCustomSibling={!!customLayout}
+            >
+              {error && (
+                <ValidationIcon
+                  onClick={handleClick}
+                  tooltipPosition="top"
+                  error={errorMessage}
+                  tabIndex={null}
+                />
+              )}
 
-            {!error && warning && (
-              <ValidationIcon
-                onClick={handleClick}
-                tooltipPosition="top"
-                warning={warningMessage}
-              />
-            )}
+              {!error && warning && (
+                <ValidationIcon
+                  onClick={handleClick}
+                  tooltipPosition="top"
+                  warning={warningMessage}
+                  tabIndex={null}
+                />
+              )}
 
-            {!warning && !error && info && (
-              <ValidationIcon
-                onClick={handleClick}
-                tooltipPosition="top"
-                info={infoMessage}
-              />
-            )}
-          </StyledLayoutWrapper>
+              {!warning && !error && info && (
+                <ValidationIcon
+                  onClick={handleClick}
+                  tooltipPosition="top"
+                  info={infoMessage}
+                  tabIndex={null}
+                />
+              )}
+            </StyledLayoutWrapper>
+          )}
         </StyledTitleContent>
         {!(hasFailedValidation || hasAlternateStyling) && isTabSelected && (
           <StyledSelectedIndicator
@@ -213,6 +226,7 @@ TabTitle.propTypes = {
   customLayout: PropTypes.node,
   isInSidebar: PropTypes.bool,
   href: PropTypes.string,
+  align: PropTypes.oneOf(["left", "right"]),
 };
 
 export default TabTitle;

--- a/src/components/tabs/__internal__/tab-title/tab-title.d.ts
+++ b/src/components/tabs/__internal__/tab-title/tab-title.d.ts
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+export interface TabTitleProps {
+  title: string;
+  id?: string;
+  dataTabId?: string;
+  className?: string;
+  children?: React.ReactNode;
+  isTabSelected?: boolean;
+  position?: "top" | "left";
+  errorMessage?: string;
+  warningMessage?: string;
+  infoMessage?: string;
+  errors?: boolean;
+  warning?: boolean;
+  info?: boolean;
+  borders?: boolean;
+  noLeftBorder?: boolean;
+  noRightBorder?: boolean;
+  alternateStyling?: boolean;
+  isInSidebar?: boolean;
+  siblings?: React.ReactNode[];
+  titlePosition?: "before" | "after";
+  href?: string;
+  tabIndex?: string;
+  size?: "default" | "large";
+  align?: "left" | "right";
+  customLayout?: React.ReactNode;
+  onClick?: (
+    ev: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
+  ) => void;
+  onKeyDown?: (
+    ev: React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>
+  ) => void;
+}
+
+declare function TabTitle(props: TabTitleProps): JSX.Element;
+
+export default TabTitle;

--- a/src/components/tabs/__internal__/tab-title/tab-title.spec.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.spec.js
@@ -28,7 +28,7 @@ describe("TabTitle", () => {
         backgroundColor: "transparent",
         display: "inline-block",
         fontWeight: "bold",
-        height: "100%",
+        height: "40px",
       },
       render({}, mount).find(StyledTabTitle)
     );
@@ -131,7 +131,7 @@ describe("TabTitle", () => {
             marginLeft: "-1px",
           },
           wrapper.find(StyledTabTitle),
-          { modifier: ":not(:first-of-type)" }
+          { modifier: ":nth-of-type(n + 1)" }
         );
       });
 
@@ -148,7 +148,7 @@ describe("TabTitle", () => {
         );
 
         assertStyleMatch(
-          { paddingBottom: "6px" },
+          { paddingBottom: "9px" },
           wrapper.find(StyledTitleContent)
         );
 
@@ -203,7 +203,7 @@ describe("TabTitle", () => {
           backgroundColor: "transparent",
           borderBottom: "0px",
           borderRight: `2px solid ${baseTheme.tab.background}`,
-          display: "block",
+          display: "flex",
           height: "auto",
           marginLeft: "0px",
         },
@@ -224,6 +224,24 @@ describe("TabTitle", () => {
         },
         wrapper.find(StyledTabTitle),
         { modifier: ":first-child" }
+      );
+    });
+
+    it("renders as expected when `align='left'`", () => {
+      assertStyleMatch(
+        { justifyContent: "flex-start", textAlign: "left" },
+        render({ position: "left", align: "left" }, mount).find(
+          StyledTitleContent
+        )
+      );
+    });
+
+    it("renders as expected when `align='right'`", () => {
+      assertStyleMatch(
+        { justifyContent: "flex-end", textAlign: "right" },
+        render({ align: "right", position: "left" }, mount).find(
+          StyledTitleContent
+        )
       );
     });
 
@@ -261,7 +279,7 @@ describe("TabTitle", () => {
               marginTop: "-1px",
             },
             wrapper.find(StyledTabTitle),
-            { modifier: ":not(:first-of-type)" }
+            { modifier: ":nth-of-type(n + 1)" }
           );
 
           assertStyleMatch(
@@ -305,15 +323,6 @@ describe("TabTitle", () => {
         },
         wrapper.find(StyledTabTitle),
         { modifier: ":hover" }
-      );
-    });
-
-    it("applies proper styling when size is large", () => {
-      wrapper = render({ isTabSelected: true, size: "large" }, mount);
-
-      assertStyleMatch(
-        { paddingBottom: "6px" },
-        wrapper.find(StyledTitleContent)
       );
     });
 
@@ -420,29 +429,6 @@ describe("TabTitle", () => {
           paddingTop: "10px",
           paddingBottom: "10px",
         },
-        wrapper.find(StyledTitleContent)
-      );
-    });
-
-    it('adjusts padding when isTabSelected is true and position is "top"', () => {
-      wrapper = render(
-        {
-          title: "Tab 1",
-          siblings: [<span>foo</span>, <span>bar</span>],
-          titlePosition: "before",
-          isTabSelected: true,
-        },
-        mount
-      );
-
-      expect(wrapper.find(StyledTitleContent).props().hasSiblings).toEqual(
-        true
-      );
-      expect(
-        wrapper.find(StyledTitleContent).props().children[0][0].props.children
-      ).toEqual("Tab 1");
-      assertStyleMatch(
-        { paddingBottom: "8px" },
         wrapper.find(StyledTitleContent)
       );
     });
@@ -1077,7 +1063,10 @@ describe("TabTitle", () => {
         stopPropagation,
         target: { dataset: { tabid: "uniqueid1" } },
       };
-      wrapper = render({ onClick }, mount);
+      wrapper = render(
+        { onClick, ref: { current: { focus: jest.fn() } } },
+        mount
+      );
 
       wrapper
         .find(StyledTitleContent)

--- a/src/components/tabs/__internal__/tab-title/tab-title.style.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.style.js
@@ -4,8 +4,9 @@ import BaseTheme from "../../../../style/themes/base";
 import StyledIcon from "../../../icon/icon.style";
 import StyledValidationIcon from "../../../../__internal__/validations/validation-icon.style";
 
-const StyledTitleContent = styled.div`
+const StyledTitleContent = styled.span`
   outline: none;
+  display: inline-block;
 
   ${({
     theme,
@@ -15,17 +16,23 @@ const StyledTitleContent = styled.div`
     noLeftBorder,
     noRightBorder,
     isTabSelected,
-    hasSiblings,
-    href,
+    hasHref,
     error,
-    warning,
-    info,
     alternateStyling,
+    align,
   }) => css`
     line-height: 20px;
     margin: 0;
+    text-align: ${align};
 
-    ${href &&
+    ${position === "left" &&
+    css`
+      display: flex;
+      width: 100%;
+      justify-content: ${align === "right" ? "flex-end" : "flex-start"};
+    `}
+
+    ${hasHref &&
     css`
       color: ${theme.text.color};
       display: block;
@@ -72,13 +79,8 @@ const StyledTitleContent = styled.div`
     position === "top" &&
     css`
       padding: 10px 24px;
+      ${borders && `padding-bottom: 9px;`}
       font-size: 16px;
-      ${isTabSelected &&
-      !hasSiblings &&
-      !(error || warning || info) &&
-      css`
-        padding-bottom: 6px;
-      `}
     `}
 
     ${size === "large" &&
@@ -92,18 +94,16 @@ const StyledTitleContent = styled.div`
     ${size === "default" &&
     css`
       padding: 10px 16px;
-      ${isTabSelected &&
-      !(error || warning || info) &&
-      position === "top" &&
-      css`
-        padding-bottom: 8px;
-      `}
+
+      ${borders && `padding-bottom: 9px;`}
 
       ${position === "left" &&
       !isTabSelected &&
       !alternateStyling &&
       error &&
-      `margin-right: -2px;`}
+      `
+        margin-right: -2px;
+      `}
     `}
   `}
 
@@ -135,7 +135,7 @@ const StyledTitleContent = styled.div`
         padding-right: ${size === "large" ? "26px;" : "18px;"};
       `}
       
-    &:hover {
+      &:hover {
         outline: 1px solid;
         outline-offset: -1px;
 
@@ -182,10 +182,10 @@ const StyledTitleContent = styled.div`
       ${position === "left" &&
       css`
         border-right-color: transparent;
-        padding-right: ${size === "large" ? "26px;" : "18px;"};
+        padding-right: ${size === "large" ? "26px" : "18px"};
       `}
     
-    &:hover {
+      &:hover {
         outline: 2px solid ${theme.colors.error};
         outline-offset: -2px;
         ${position === "top" &&
@@ -201,7 +201,7 @@ const StyledTitleContent = styled.div`
         ${position === "left" &&
         css`
           border-right-color: transparent;
-          padding-right: ${size === "large" ? "26px;" : "18px;"};
+          padding-right: ${size === "large" ? "26px" : "18px"};
         `}
       }
     `}
@@ -221,29 +221,14 @@ const StyledTitleContent = styled.div`
     position === "top" &&
     css`
       height: 20px;
-
-      ${size === "default" &&
-      css`
-        padding-top: 10px;
-        padding-bottom: 10px;
-
-        ${!(error || warning || info) &&
-        isTabSelected &&
-        css`
-          padding-bottom: 8px;
-        `}
-      `}
+      padding-top: 10px;
+      padding-bottom: 10px;
 
       ${size === "large" &&
+      !(error || warning || info) &&
+      isTabSelected &&
       css`
-        padding-top: 10px;
-        padding-bottom: 10px;
-
-        ${!(error || warning || info) &&
-        isTabSelected &&
-        css`
-          padding-bottom: 6px;
-        `}
+        padding-bottom: 6px;
       `}
     `}
 
@@ -262,15 +247,15 @@ const StyledTitleContent = styled.div`
 
       ${position === "left" &&
       css`
-        padding: ${size === "large" ? "2px;" : "0px;"}
-          ${isTabSelected &&
-          css`
-            padding-right: 0px;
-          `}
-          ${(error || warning || info) &&
-          css`
-            padding-right: ${size === "large" ? "26px" : "18px"};
-          `};
+        padding: ${size === "large" ? "2px" : "0px"};
+        ${isTabSelected &&
+        css`
+          padding-right: 0px;
+        `}
+        ${(error || warning || info) &&
+        css`
+          padding-right: ${size === "large" ? "26px" : "18px"};
+        `}
       `}
 
       ${position === "top" &&
@@ -282,53 +267,63 @@ const StyledTitleContent = styled.div`
           `}
           ${(error || warning || info) &&
           css`
-        padding-bottom: ${size === "large" ? "4px;" : "2px;"}
-        padding-right: ${size === "large" ? "18px;" : "14px;"}
-
-        &:hover {
           padding-bottom: ${size === "large" ? "4px;" : "2px;"}
-        }
-      `};
+          padding-right: ${size === "large" ? "18px;" : "14px;"}
+
+          &:hover {
+            padding-bottom: ${size === "large" ? "4px;" : "2px;"}
+          }
+        `};
       `}
     `}
 `;
 
-const StyledTabTitle = styled.li`
+const StyledTabTitle = styled.button`
   background-color: transparent;
   display: inline-block;
   font-weight: bold;
-  height: 100%;
   position: relative;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0px;
+  text-decoration: none;
+  outline-offset: 0px;
+  margin: 0;
 
-  ${({ position, borders, noRightBorder, noLeftBorder }) => `
-      ${
-        position === "top" &&
-        css`
-          ${borders &&
-          !(noRightBorder || noLeftBorder) &&
-          css`
-            &:not(:first-of-type) {
-              margin-left: -1px;
-            }
-          `}
-        `
-      }
-      ${
-        position === "left" &&
-        css`
-          ${borders &&
-          css`
-            &:not(:first-of-type) {
-              margin-top: -1px;
-            }
-          `}
-        `
-      }
-    `}
-
-  &:first-child {
-    margin-left: 0;
+  a:visited {
+    color: inherit;
   }
+
+  ${({ position, borders, noRightBorder, noLeftBorder }) => css`
+    ${position === "top" &&
+    css`
+      height: 40px;
+
+      ${borders &&
+      !(noRightBorder || noLeftBorder) &&
+      css`
+        &:nth-of-type(n + 1) {
+          margin-left: -1px;
+        }
+        &:first-child {
+          margin-left: 0;
+        }
+      `}
+    `}
+    ${position === "left" &&
+    css`
+      ${borders &&
+      css`
+        &:nth-of-type(n + 1) {
+          margin-top: -1px;
+        }
+        &:first-child {
+          margin-top: 0;
+        }
+      `}
+    `}
+  `}
 
   ${({ isTabSelected, theme }) =>
     !isTabSelected &&
@@ -351,9 +346,7 @@ const StyledTabTitle = styled.li`
     error,
     warning,
     info,
-    size,
     isInSidebar,
-    position,
   }) =>
     isTabSelected &&
     css`
@@ -361,29 +354,6 @@ const StyledTabTitle = styled.li`
     color: ${theme.text.color};
     background-color: ${theme.colors.white};
 
-    ${
-      alternateStyling &&
-      css`
-        border-bottom: 2px solid ${theme.tab.background};
-      `
-    }
-
-    ${
-      !alternateStyling &&
-      css`
-        padding-bottom: 2px;
-      `
-    }
-
-    ${
-      size === "large" &&
-      css`
-        ${position === "top" &&
-        `
-          padding-bottom: ${alternateStyling ? "3px" : "4px"};
-          `}
-      `
-    }
     ${
       (error || warning || info) &&
       css`
@@ -412,7 +382,6 @@ const StyledTabTitle = styled.li`
   
   ${({
     position,
-    size,
     borders,
     theme,
     alternateStyling,
@@ -439,7 +408,7 @@ const StyledTabTitle = styled.li`
         }
       `}
 
-      display: block;
+      display: flex;
       height: auto;
       margin-left: 0px;
 
@@ -476,13 +445,6 @@ const StyledTabTitle = styled.li`
           `}
     
           background-color: ${theme.colors.white};
-
-          ${size === "large" &&
-          css`
-            & ${StyledTitleContent} {
-              padding-right: 22px;
-            }
-          `}
 
           &:hover {
             ${alternateStyling &&
@@ -529,7 +491,7 @@ const StyledLayoutWrapper = styled.div`
       min-width: 100px;
     `}
 
-  ${({ hasCustomLayout, titlePosition, hasCustomSibling }) =>
+  ${({ hasCustomLayout, titlePosition, hasCustomSibling, position }) =>
     !hasCustomLayout &&
     css`
       display: inline-flex;
@@ -559,7 +521,7 @@ const StyledLayoutWrapper = styled.div`
         ${StyledIcon} {
           height: 16px;
           left: -2px;
-          top: 3px;
+          top: ${position === "left" ? "1px" : "3px"};
         }
       }
     `}

--- a/src/components/tabs/__internal__/tabs-header/index.d.ts
+++ b/src/components/tabs/__internal__/tabs-header/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from "./tab-header";

--- a/src/components/tabs/__internal__/tabs-header/tab-header.d.ts
+++ b/src/components/tabs/__internal__/tabs-header/tab-header.d.ts
@@ -1,0 +1,16 @@
+import * as React from "react";
+
+export interface TabHeaderProps {
+  role?: string;
+  position?: "top" | "left";
+  extendedLine?: boolean;
+  noRightBorder?: boolean;
+  alternateStyling?: boolean;
+  isInSidebar?: boolean;
+  children: React.ReactNode;
+  align?: "left" | "right";
+}
+
+declare function TabHeader(props: TabHeaderProps): JSX.Element;
+
+export default TabHeader;

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.style.js
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.style.js
@@ -31,7 +31,7 @@ const StyledTabsHeaderWrapper = styled.div`
     `}
 `;
 
-const StyledTabsHeaderList = styled.ul`
+const StyledTabsHeaderList = styled.div`
   display: flex;
   box-shadow: inset 0px ${computeLineWidth} 0px 0px
     ${({ theme }) => theme.tab.background};

--- a/src/components/tabs/tabs.component.js
+++ b/src/components/tabs/tabs.component.js
@@ -257,6 +257,7 @@ const Tabs = ({
           noRightBorder={["no right side", "no sides"].includes(borders)}
           customLayout={customLayout}
           isInSidebar={isInSidebar}
+          align={align}
           onFocus={() => {
             if (!hasTabStop(tabId)) {
               setTabStopId(tabId);

--- a/src/components/tabs/tabs.stories.mdx
+++ b/src/components/tabs/tabs.stories.mdx
@@ -5,7 +5,6 @@ import { Tabs, Tab } from "./tabs.component";
 import { Checkbox } from "../checkbox";
 import Icon from "../icon";
 import Pill from "../pill";
-import { ActionPopover, ActionPopoverItem } from "../action-popover";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 <Meta title="Tabs" parameters={{ info: { disable: true } }} />
@@ -1484,11 +1483,7 @@ prop to the `Tab` component.
                     <Icon type="settings" />
                   </div>
                   <div style={{ gridColumn: "11 / 13" }}>
-                    <ActionPopover>
-                      <ActionPopoverItem onClick={() => {}}>
-                        Edit
-                      </ActionPopoverItem>
-                    </ActionPopover>
+                    <Icon type="home" />
                   </div>
                   <div style={{ gridColumn: "1 / 6" }}>Tab 1</div>
                 </div>
@@ -1513,11 +1508,7 @@ prop to the `Tab` component.
                     <Icon type="settings" />
                   </div>
                   <div style={{ gridColumn: "11 / 13" }}>
-                    <ActionPopover>
-                      <ActionPopoverItem onClick={() => {}}>
-                        Edit
-                      </ActionPopoverItem>
-                    </ActionPopover>
+                    <Icon type="home" />
                   </div>
                   <div style={{ gridColumn: "1 / 6" }}>Tab 2</div>
                 </div>
@@ -1542,11 +1533,7 @@ prop to the `Tab` component.
                     <Icon type="settings" />
                   </div>
                   <div style={{ gridColumn: "11 / 13" }}>
-                    <ActionPopover>
-                      <ActionPopoverItem onClick={() => {}}>
-                        Edit
-                      </ActionPopoverItem>
-                    </ActionPopover>
+                    <Icon type="home" />
                   </div>
                   <div style={{ gridColumn: "1 / 6" }}>Tab 3</div>
                 </div>

--- a/src/components/tabs/tabs.stories.mdx
+++ b/src/components/tabs/tabs.stories.mdx
@@ -1643,9 +1643,9 @@ The `headerWidth` prop works only if prop `position` is set to `left`.
               errorMessage="error"
               warningMessage="warning"
               infoMessage="info"
-              tabId="tab-1"
+              tabId="tabs-1-tab-1"
               title="Very long title for Tab 1 without with prop it would be not well aligned with the second Tabs group"
-              key="tab-1"
+              key="tabs-1-tab-1"
             >
               Content for tab 1
             </Tab>
@@ -1653,9 +1653,9 @@ The `headerWidth` prop works only if prop `position` is set to `left`.
               errorMessage="error"
               warningMessage="warning"
               infoMessage="info"
-              tabId="tab-2"
+              tabId="tabs-1-tab-2"
               title="Tab 2"
-              key="tab-2"
+              key="tabs-1-tab-2"
             >
               Content for tab 2
             </Tab>
@@ -1665,9 +1665,9 @@ The `headerWidth` prop works only if prop `position` is set to `left`.
               errorMessage="error"
               warningMessage="warning"
               infoMessage="info"
-              tabId="tab-1"
+              tabId="tabs-2-tab-1"
               title="Tab 1"
-              key="tab-1"
+              key="tabs-2-tab-1"
             >
               Content for tab 1
             </Tab>
@@ -1675,9 +1675,9 @@ The `headerWidth` prop works only if prop `position` is set to `left`.
               errorMessage="error"
               warningMessage="warning"
               infoMessage="info"
-              tabId="tab-2"
+              tabId="tabs-2-tab-2"
               title="Tab 2"
-              key="tab-2"
+              key="tabs-2-tab-2"
             >
               Content for tab 2
             </Tab>


### PR DESCRIPTION
fix #4517
fix #4524

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
The `headerWidth` story has multiple `Tab` components with the same `tabId` which causes axe warnings to be generated

`TabHeader` now renders a `div` container and `TabTitle` renders either a `button` or `a` element. This fixes accessibility issues raised against the old implementation relating to focusable children  not being read out by screen readers: `tabIndex` for `ValidationIcon` is now null and `customLayout` story has been updated to remove `ActionPopover`.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Renders `ul` and `li` elements, has multiple accessibility errors on stories
No `d.ts` files for `TabTitle` and `TabHeader`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
Test all Tabs stories for accessibility errors and to confirm no regressions after refactor away from `ul` `li`

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
