### PR TITLE
fix(page): export page correctly from pages interface

### DIFF
--- a/src/components/pages/index.d.ts
+++ b/src/components/pages/index.d.ts
@@ -1,1 +1,2 @@
 export { default } from "./pages";
+export { default as Page } from "./page/page";

--- a/src/components/pages/index.js
+++ b/src/components/pages/index.js
@@ -1,1 +1,2 @@
 export { default } from "./pages.component";
+export { default as Page } from "./page/page.component";

--- a/src/components/pages/pages-test.stories.mdx
+++ b/src/components/pages/pages-test.stories.mdx
@@ -94,7 +94,9 @@ export const PagesStory = ({ initialPageIndex }) => {
                 divider={false}
               />
             }
-          />
+          >
+            Third Page
+          </Page>
         </Pages>
       </DialogFullScreen>
     </div>

--- a/src/components/pages/pages.stories.mdx
+++ b/src/components/pages/pages.stories.mdx
@@ -24,8 +24,7 @@ Allows to slide to different pages in a full screen dialog.
 ## Quick Start
 
 ```javascript
-import DefaultPages from "carbon-react/lib/components/pages";
-import Page from "carbon-react/lib/components/page/page";
+import Pages, { Page } from "carbon-react/lib/components/pages";
 ```
 
 ## Examples

--- a/src/components/pages/pages.stories.mdx
+++ b/src/components/pages/pages.stories.mdx
@@ -85,7 +85,9 @@ import Pages, { Page } from "carbon-react/lib/components/pages";
                 title={
                   <Heading title="My Third Page" backLink={handleBackClick} />
                 }
-              />
+              >
+                Third Page
+              </Page>
             </DefaultPages>
           </DialogFullScreen>
         </div>
@@ -159,7 +161,9 @@ import Pages, { Page } from "carbon-react/lib/components/pages";
                 title={
                   <Heading title="My Third Page" backLink={handleBackClick} />
                 }
-              />
+              >
+                Third Page
+              </Page>
             </DefaultPages>
           </DialogFullScreen>
         </div>
@@ -225,7 +229,9 @@ import Pages, { Page } from "carbon-react/lib/components/pages";
                 title={
                   <Heading title="My Third Page" backLink={handleBackClick} />
                 }
-              />
+              >
+                Third Page
+              </Page>
             </DefaultPages>
           </DialogFullScreen>
         </div>


### PR DESCRIPTION
Fixes: #4562

### Proposed behaviour

- Export `Page` from `Pages` index file (js and ts).
- Fix console errors in `Pages` stories by adding some content on the third page in each one.

### Current behaviour

`Page` is not exported from the `Pages` index file.

Every `Pages` story on Storybook has this console error: 

![image](https://user-images.githubusercontent.com/14963680/142461788-5c40dda5-cdc6-4482-8d9d-d7b0dbbe3593.png)


### Checklist


- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context


### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.



https://codesandbox.io/s/bitter-meadow-4bxzx?file=/src/index.js