### PR TITLE
fix(select): render wrapped text correctly in SelectList - FE-4044

### DIFF
--- a/cypress/integration/common/simpleSelect.feature
+++ b/cypress/integration/common/simpleSelect.feature
@@ -63,6 +63,16 @@ Feature: Select component
       | uparrow   | eleventh | Yellow |
 
   @positive
+  Scenario: An Option that is more than one line is rendered correctly
+    Given I open "Select Test" component page "default"
+    When I click on dropdown button
+      And I scroll to the "bottom" of Select List
+    Then Select list "Like a lot of intelligent animals, most crows are quite social. For instance, American crows spend most of the year living in pairs or small family groups. During the winter months, they will congregate with hundreds or even thousands of their peers to sleep together at night" option is visible
+      And Select list "Pink" option is visible
+      And Select list "Red" option is visible
+      And Select list "Yellow" option is visible
+
+  @positive
   Scenario: Lazy loading is visible after open the Simple Select
     Given I open "Select" component page "with is loading prop"
     When I click on Select input with lazy loading

--- a/src/components/select/select-list/select-list.component.js
+++ b/src/components/select/select-list/select-list.component.js
@@ -309,7 +309,7 @@ const SelectList = React.forwardRef(
       }
 
       setListHeight(`${newHeight}px`);
-    }, [children]);
+    }, [children, listRef.current]);
 
     useEffect(() => {
       const keyboardEvent = "keydown";

--- a/src/components/select/select-list/select-list.spec.js
+++ b/src/components/select/select-list/select-list.spec.js
@@ -646,6 +646,34 @@ describe("SelectList", () => {
     });
   });
 
+  describe("When SelectList has an option with wrapped text", () => {
+    it("should correctly calculate the height of the SelectList", () => {
+      const testWrapper = document.createElement("div");
+      const wrapper = mount(getSelectList({}), { attachTo: testWrapper });
+      const listElement = wrapper.find(StyledSelectList).getDOMNode();
+      jest
+        .spyOn(listElement, "clientHeight", "get")
+        .mockImplementation(() => 60);
+
+      wrapper
+        .setProps({
+          children: [
+            <Option
+              value="opt1"
+              text="This is to mimic a long piece of text that could be used in the Select Component and the text could be wrapped
+            but this is a virtual DOM so that will not happen"
+            />,
+          ],
+        })
+        .update();
+
+      assertStyleMatch(
+        { height: "60px" },
+        wrapper.find(StyledSelectListContainer)
+      );
+    });
+  });
+
   describe("popover", () => {
     it("renders SelectList as a child of Popover with disablePortal=undefined by default", () => {
       const wrapper = renderSelectList();

--- a/src/components/select/simple-select/simple-select-test.stories.js
+++ b/src/components/select/simple-select/simple-select-test.stories.js
@@ -63,14 +63,17 @@ const Default = (args) => {
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
       <Option text="Blue" value="3" />
-      <Option text="Brown" value="4" />
+      <Option text="White" value="4" />
       <Option text="Green" value="5" />
-      <Option text="Orange" value="6" />
+      <Option
+        text="Like a lot of intelligent animals, most crows are quite social. 
+        For instance, American crows spend most of the year living in pairs or small family groups.
+        During the winter months, they will congregate with hundreds or even thousands of their peers to sleep together at night"
+        value="6"
+      />
       <Option text="Pink" value="7" />
-      <Option text="Purple" value="8" />
-      <Option text="Red" value="9" />
-      <Option text="White" value="10" />
-      <Option text="Yellow" value="11" />
+      <Option text="Red" value="8" />
+      <Option text="Yellow" value="9" />
     </Select>
   );
 };


### PR DESCRIPTION
Wrapped text should render at the correct height in the SelectList. Adding listRef.current to the
height calculation enables this to happen as expected.

fixes #4489

### Proposed behaviour
- Text in the SelectList should wrap correctly and apply the correct height the select option.

![Screenshot 2021-11-18 at 11 34 30](https://user-images.githubusercontent.com/56251247/142408014-9c382e04-b248-4fe1-bd07-01a3c21f575a.png)

### Current behaviour
- Select option height is not being calculated correctly.

![Screenshot 2021-11-18 at 11 31 00](https://user-images.githubusercontent.com/56251247/142407509-9707fe52-0f9f-48a3-9673-b409d9454686.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context
N/A

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

Use the codesandbox build from the Source `Issue #4489`
