### PR TITLE
feat(message): describe Message component using design tokens

### DIFF
--- a/src/components/message/message.spec.js
+++ b/src/components/message/message.spec.js
@@ -9,7 +9,6 @@ import {
   testStyledSystemMargin,
 } from "../../__spec_helper__/test-utils";
 import I18nProvider from "../i18n-provider";
-import { baseTheme } from "../../style/themes";
 import IconButton from "../icon-button";
 
 const wrappingComponent = (props) => (
@@ -23,6 +22,13 @@ const wrappingComponent = (props) => (
     }}
   />
 );
+
+const messageVariants = {
+  error: "var(--colorsSemanticNegative500)",
+  info: "var(--colorsSemanticNeutral500)",
+  success: "var(--colorsSemanticPositive500)",
+  warning: "var(--colorsSemanticCaution500)",
+};
 
 function render(props) {
   return TestRenderer.create(<MessageStyle {...props}>Message</MessageStyle>);
@@ -94,7 +100,7 @@ describe("Message", () => {
       ["info", "error", "success", "warning"].forEach((messageType) => {
         assertStyleMatch(
           {
-            border: `1px solid ${baseTheme.colors[messageType]}`,
+            border: `1px solid ${messageVariants[messageType]}`,
           },
           mount(<Message variant={messageType}>Message</Message>)
         );

--- a/src/components/message/message.style.js
+++ b/src/components/message/message.style.js
@@ -4,13 +4,20 @@ import { margin } from "styled-system";
 import BaseTheme from "../../style/themes/base";
 import StyledIconButton from "../icon-button/icon-button.style";
 
+const messageVariants = {
+  error: "var(--colorsSemanticNegative500)",
+  info: "var(--colorsSemanticNeutral500)",
+  success: "var(--colorsSemanticPositive500)",
+  warning: "var(--colorsSemanticCaution500)",
+};
+
 const MessageStyle = styled.div`
   position: relative;
   display: flex;
   justify-content: flex-start;
   align-content: center;
-  border: 1px solid ${({ theme, variant }) => theme.colors[variant]};
-  background-color: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${({ variant }) => messageVariants[variant]};
+  background-color: var(--colorsUtilityYang100);
   min-height: 38px;
 
   ${({ transparent }) =>

--- a/src/components/message/type-icon/__snapshots__/type-icon.spec.js.snap
+++ b/src/components/message/type-icon/__snapshots__/type-icon.spec.js.snap
@@ -6,7 +6,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #C7384F;
+  background-color: var(--colorsSemanticNegative500);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -21,7 +21,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
 }
 
 .c0 span:before {
-  color: #FFFFFF;
+  color: var(--colorsUtilityYang100);
 }
 
 <div
@@ -35,7 +35,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #0073C2;
+  background-color: var(--colorsSemanticNeutral500);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -50,7 +50,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
 }
 
 .c0 span:before {
-  color: #FFFFFF;
+  color: var(--colorsUtilityYang100);
 }
 
 <div
@@ -64,7 +64,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #00B000;
+  background-color: var(--colorsSemanticPositive500);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -79,7 +79,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
 }
 
 .c0 span:before {
-  color: #FFFFFF;
+  color: var(--colorsUtilityYang100);
 }
 
 <div
@@ -93,7 +93,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #E96400;
+  background-color: var(--colorsSemanticCaution500);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -108,7 +108,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
 }
 
 .c0 span:before {
-  color: #FFFFFF;
+  color: var(--colorsUtilityYang100);
 }
 
 <div
@@ -122,7 +122,7 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #0073C2;
+  background-color: var(--colorsSemanticNeutral500);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -138,11 +138,11 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
 }
 
 .c0 span:before {
-  color: #FFFFFF;
+  color: var(--colorsUtilityYang100);
 }
 
 .c0 span:before {
-  color: #0073C2;
+  color: var(--colorsSemanticNeutral500);
 }
 
 <div
@@ -156,7 +156,7 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #C7384F;
+  background-color: var(--colorsSemanticNegative500);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -172,11 +172,11 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
 }
 
 .c0 span:before {
-  color: #FFFFFF;
+  color: var(--colorsUtilityYang100);
 }
 
 .c0 span:before {
-  color: #C7384F;
+  color: var(--colorsSemanticNegative500);
 }
 
 <div
@@ -190,7 +190,7 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #00B000;
+  background-color: var(--colorsSemanticPositive500);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -206,11 +206,11 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
 }
 
 .c0 span:before {
-  color: #FFFFFF;
+  color: var(--colorsUtilityYang100);
 }
 
 .c0 span:before {
-  color: #00B000;
+  color: var(--colorsSemanticPositive500);
 }
 
 <div
@@ -224,7 +224,7 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #E96400;
+  background-color: var(--colorsSemanticCaution500);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -240,11 +240,11 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
 }
 
 .c0 span:before {
-  color: #FFFFFF;
+  color: var(--colorsUtilityYang100);
 }
 
 .c0 span:before {
-  color: #E96400;
+  color: var(--colorsSemanticCaution500);
 }
 
 <div

--- a/src/components/message/type-icon/type-icon.style.js
+++ b/src/components/message/type-icon/type-icon.style.js
@@ -1,10 +1,16 @@
 import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
-import BaseTheme from "../../../style/themes/base";
+
+const messageVariants = {
+  error: "var(--colorsSemanticNegative500)",
+  info: "var(--colorsSemanticNeutral500)",
+  success: "var(--colorsSemanticPositive500)",
+  warning: "var(--colorsSemanticCaution500)",
+};
 
 const TypeIconStyle = styled.div`
   align-items: center;
-  background-color: ${({ theme, variant }) => theme.colors[variant]};
+  background-color: ${({ variant }) => messageVariants[variant]};
   display: flex;
   justify-content: center;
   line-height: 100%;
@@ -12,17 +18,17 @@ const TypeIconStyle = styled.div`
   text-align: center;
   span {
     &:before {
-      color: ${({ theme }) => theme.colors.white};
+      color: var(--colorsUtilityYang100);
     }
   }
 
-  ${({ theme, transparent, variant }) =>
+  ${({ transparent, variant }) =>
     transparent &&
     css`
       background-color: transparent;
       span {
         &:before {
-          color: ${theme.colors[variant]};
+          color: ${messageVariants[variant]};
         }
       }
     `}
@@ -30,7 +36,6 @@ const TypeIconStyle = styled.div`
 
 TypeIconStyle.defaultProps = {
   variant: "info",
-  theme: BaseTheme,
   transparent: false,
 };
 


### PR DESCRIPTION
### Proposed behaviour
Describes the message using design tokens. Removes all possible 'theme' in css files 
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour
The Message use the theme styled-component property.
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
