### PR TITLE
fix(flat-table): make scrollable content accessible via keyboard

### DIFF
--- a/cypress/integration/common/flatTable.feature
+++ b/cypress/integration/common/flatTable.feature
@@ -166,19 +166,19 @@ Feature: FlatTable component
   @positive
   Scenario: There is the correct tab order through the expandable rows
     Given I open "Flat Table Expandable" component page "default story"
-    When I hit Tab key 3 times
+    When I hit Tab key 4 times
     Then The third content row has focus
 
   @positive
   Scenario: There is the correct tab order when the row is expandable by first column only
     Given I open "Flat Table Expandable" component page "expandable by first column only"
-    When I hit Tab key 3 times
+    When I hit Tab key 4 times
     Then The first cell in the third content row has focus
 
   @positive
   Scenario Outline: You can open the row using the <key> key
     Given I open "Flat Table Expandable" component page "default story"
-    When I hit Tab key 1 time
+    When I hit Tab key 2 times
       And I press keyboard "<key>" key times 1
     Then The subrows are visible
     Examples:
@@ -189,7 +189,7 @@ Feature: FlatTable component
   @positive
   Scenario Outline: You can open and close the row using the <key> key
     Given I open "Flat Table Expandable" component page "default story"
-    When I hit Tab key 1 time
+    When I hit Tab key 2 times
       And I press keyboard "<key>" key times 2
     Then The subrows are not visible
     Examples:
@@ -200,7 +200,7 @@ Feature: FlatTable component
   @positive
   Scenario Outline: You can open the row using the <key> key when the table is set to expandable by first column only
     Given I open "Flat Table Expandable" component page "expandable by first column only"
-    When I hit Tab key 1 time
+    When I hit Tab key 2 times
       And I press keyboard "<key>" key times 1
     Then The subrows are visible
     Examples:
@@ -211,7 +211,7 @@ Feature: FlatTable component
   @positive
   Scenario Outline: You can open and close the row using the <key> key when the table is set to expandable by first column only
     Given I open "Flat Table Expandable" component page "expandable by first column only"
-    When I hit Tab key 1 time
+    When I hit Tab key 2 times
       And I press keyboard "<key>" key times 2
     Then The subrows are not visible
     Examples:
@@ -222,7 +222,7 @@ Feature: FlatTable component
   @positive
   Scenario: There is the correct tab order when there are multiple tabbable elements in a row
     Given I open "Flat Table Expandable" component page "both parent and children selectable"
-    When I hit Tab key 8 times
+    When I hit Tab key 9 times
     Then The second content row has focus
 
   @positive
@@ -234,7 +234,7 @@ Feature: FlatTable component
   @positive
   Scenario Outline: You can not navigate through the rows using the <key> arrow key
     Given I open "Flat Table Expandable" component page "both parent and children selectable"
-    When I hit Tab key 5 times
+    When I hit Tab key 6 times
       And I press keyboard "<key>" key times 1
     Then The first content row has focus
     Examples:
@@ -247,7 +247,7 @@ Feature: FlatTable component
   @positive
   Scenario: You can enter the sub rows using the keyboard
     Given I open "Flat Table Expandable" component page "both parent and children selectable"
-    When I hit Tab key 5 times
+    When I hit Tab key 6 times
       And I press keyboard "Enter" key times 1
       And I continue to hit Tab key 4 times
     Then The first subrow action popover has focus
@@ -255,7 +255,7 @@ Feature: FlatTable component
   @positive
   Scenario: You leave the subrows when pressing tab at the end of the subrows tabbable content
     Given I open "Flat Table Expandable" component page "both parent and children selectable"
-    When I hit Tab key 5 times
+    When I hit Tab key 6 times
       And I press keyboard "Enter" key times 1
       And I continue to hit Tab key 7 times
     Then The fourth content row has focus

--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -160,6 +160,18 @@ exports[`FlatTable when rendered with proper table data should have expected str
   box-shadow: inset 0px 0px 0px 1px #CCD6DB;
 }
 
+.c0:focus {
+  outline: 2px solid #FFB500;
+}
+
+.c0:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.c0:focus:focus-visible {
+  outline: 2px solid #FFB500;
+}
+
 .c0 .c2 .c13,
 .c0 .c8,
 .c0 .c2 .c6 {
@@ -172,6 +184,8 @@ exports[`FlatTable when rendered with proper table data should have expected str
 <div
   className="c0"
   display="flex"
+  role="region"
+  tabIndex="0"
 >
   <table
     className="c1"

--- a/src/components/flat-table/flat-table.component.js
+++ b/src/components/flat-table/flat-table.component.js
@@ -28,6 +28,7 @@ const FlatTable = ({
   hasMaxHeight = false,
   ariaDescribedby,
   minHeight,
+  overflowX,
   ...rest
 }) => {
   const addDefaultHeight = !height && (hasStickyHead || hasStickyFooter);
@@ -48,7 +49,6 @@ const FlatTable = ({
           isInSidebar={isInSidebar}
           hasStickyHead={hasStickyHead}
           colorTheme={colorTheme}
-          {...rest}
           minHeight={minHeight}
           overflowY={
             !isInSidebar && (hasStickyHead || hasStickyFooter)
@@ -64,6 +64,8 @@ const FlatTable = ({
           }
           tabIndex="0"
           role="region"
+          overflowX={overflowX}
+          {...rest}
         >
           <StyledFlatTable data-component="flat-table" {...tableStylingProps}>
             {caption ? <caption>{caption}</caption> : null}
@@ -113,6 +115,8 @@ FlatTable.propTypes = {
   size: PropTypes.oneOf(["compact", "small", "medium", "large", "extraLarge"]),
   /** Applies max-height of 100% to FlatTable if true */
   hasMaxHeight: PropTypes.bool,
+  /** Set the overflow X of the table wrapper. Any valid CSS string */
+  overflowX: PropTypes.string,
 };
 
 FlatTable.defaultProps = {

--- a/src/components/flat-table/flat-table.component.js
+++ b/src/components/flat-table/flat-table.component.js
@@ -62,6 +62,8 @@ const FlatTable = ({
           justifyContent={
             hasStickyFooter || height ? "space-between" : undefined
           }
+          tabIndex="0"
+          role="region"
         >
           <StyledFlatTable data-component="flat-table" {...tableStylingProps}>
             {caption ? <caption>{caption}</caption> : null}

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -77,6 +77,48 @@ describe("FlatTable", () => {
     });
   });
 
+  describe("when the table wrapper is focused", () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = renderFlatTable({}, mount);
+    });
+
+    it("should add the correct focus styling", () => {
+      wrapper.find(StyledFlatTableWrapper).getDOMNode().focus();
+
+      assertStyleMatch(
+        {
+          outline: `2px solid ${baseTheme.colors.focus}`,
+        },
+        wrapper.find(StyledFlatTableWrapper),
+        {
+          modifier: ":focus",
+        }
+      );
+
+      assertStyleMatch(
+        {
+          outline: "none",
+        },
+        wrapper.find(StyledFlatTableWrapper),
+        {
+          modifier: ":focus:not(:focus-visible)",
+        }
+      );
+
+      assertStyleMatch(
+        {
+          outline: `2px solid ${baseTheme.colors.focus}`,
+        },
+        wrapper.find(StyledFlatTableWrapper),
+        {
+          modifier: ":focus:focus-visible",
+        }
+      );
+    });
+  });
+
   describe('when rendered with proper table data and "hasStickyHead" prop set to true', () => {
     let wrapper;
 

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -108,49 +108,99 @@ Any cells preceding the `FlatTableRowHeader`s will automatically also be made st
 
 <Preview>
   <Story name="with row header" parameters={{ chromatic: { disable: true } }}>
-    <div style={{ width: "380px", overflowX: "auto" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>ID Number</FlatTableHeader>
-            <FlatTableRowHeader>Name</FlatTableRowHeader>
-            <FlatTableHeader>Location</FlatTableHeader>
-            <FlatTableHeader>Relationship Status</FlatTableHeader>
-            <FlatTableHeader>Dependents</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>000001</FlatTableCell>
-            <FlatTableRowHeader>John Doe</FlatTableRowHeader>
-            <FlatTableCell>London</FlatTableCell>
-            <FlatTableCell>Single</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>000002</FlatTableCell>
-            <FlatTableRowHeader>Jane Doe</FlatTableRowHeader>
-            <FlatTableCell>York</FlatTableCell>
-            <FlatTableCell>Married</FlatTableCell>
-            <FlatTableCell>2</FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>000003</FlatTableCell>
-            <FlatTableRowHeader>John Smith</FlatTableRowHeader>
-            <FlatTableCell>Edinburgh</FlatTableCell>
-            <FlatTableCell>Single</FlatTableCell>
-            <FlatTableCell>1</FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>000004</FlatTableCell>
-            <FlatTableRowHeader>Jane Smith</FlatTableRowHeader>
-            <FlatTableCell>Newcastle</FlatTableCell>
-            <FlatTableCell>Married</FlatTableCell>
-            <FlatTableCell>5</FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
+    <FlatTable width="380px" overflowX="auto">
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader>ID Number</FlatTableHeader>
+          <FlatTableRowHeader>Name</FlatTableRowHeader>
+          <FlatTableHeader>Location</FlatTableHeader>
+          <FlatTableHeader>Relationship Status</FlatTableHeader>
+          <FlatTableHeader>Dependents</FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+      <FlatTableBody>
+        <FlatTableRow>
+          <FlatTableCell>000001</FlatTableCell>
+          <FlatTableRowHeader>John Doe</FlatTableRowHeader>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>000002</FlatTableCell>
+          <FlatTableRowHeader>Jane Doe</FlatTableRowHeader>
+          <FlatTableCell>York</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableCell>2</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>000003</FlatTableCell>
+          <FlatTableRowHeader>John Smith</FlatTableRowHeader>
+          <FlatTableCell>Edinburgh</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>1</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>000004</FlatTableCell>
+          <FlatTableRowHeader>Jane Smith</FlatTableRowHeader>
+          <FlatTableCell>Newcastle</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableCell>5</FlatTableCell>
+        </FlatTableRow>
+      </FlatTableBody>
+    </FlatTable>
+  </Story>
+</Preview>
+
+### Horizontal scrolling
+
+To allow horizontal scrolling, set the `width` and `overflowX` props as shown below. An `aria-label` should be added to give the table an accessible name.
+
+<Preview>
+  <Story
+    name="with horizontal scrolling"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    <FlatTable
+      width="380px"
+      overflowX="auto"
+      aria-label="Horizontal scroll table"
+    >
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader>Name</FlatTableHeader>
+          <FlatTableHeader>Location</FlatTableHeader>
+          <FlatTableHeader>Relationship Status</FlatTableHeader>
+          <FlatTableHeader>Dependents</FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+      <FlatTableBody>
+        <FlatTableRow>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>Jane Doe</FlatTableCell>
+          <FlatTableCell>York</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableCell>2</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>John Smith</FlatTableCell>
+          <FlatTableCell>Edinburgh</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>1</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>Jane Smith</FlatTableCell>
+          <FlatTableCell>Newcastle</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableCell>5</FlatTableCell>
+        </FlatTableRow>
+      </FlatTableBody>
+    </FlatTable>
   </Story>
 </Preview>
 
@@ -595,114 +645,106 @@ Is it possible to combine the `stickyHead` prop along with the `rowSpan` and `co
 
 <Preview>
   <Story name="with stickyHead rowSpan and colspan">
-    <div
-      style={{
-        height: "380px",
-        width: "310px",
-        overflowX: "auto",
-      }}
-    >
-      <FlatTable hasStickyHead>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader rowSpan={2}>Name</FlatTableHeader>
-            <FlatTableRowHeader rowSpan={2}>Code</FlatTableRowHeader>
-            <FlatTableHeader colspan={2}>Jun 21</FlatTableHeader>
-            <FlatTableHeader rowSpan={2}></FlatTableHeader>
-            <FlatTableHeader colspan={2}>YTD</FlatTableHeader>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableHeader>Debit</FlatTableHeader>
-            <FlatTableHeader>Credit</FlatTableHeader>
-            <FlatTableHeader>Debit</FlatTableHeader>
-            <FlatTableHeader>Credit</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John Doe</FlatTableCell>
-            <FlatTableRowHeader>000001</FlatTableRowHeader>
-            <FlatTableCell>London</FlatTableCell>
-            <FlatTableCell>Single</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>John Doe</FlatTableCell>
-            <FlatTableRowHeader>000001</FlatTableRowHeader>
-            <FlatTableCell>London</FlatTableCell>
-            <FlatTableCell>Single</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>John Doe</FlatTableCell>
-            <FlatTableRowHeader>000001</FlatTableRowHeader>
-            <FlatTableCell>London</FlatTableCell>
-            <FlatTableCell>Single</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>John Doe</FlatTableCell>
-            <FlatTableRowHeader>000001</FlatTableRowHeader>
-            <FlatTableCell>London</FlatTableCell>
-            <FlatTableCell>Single</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>John Doe</FlatTableCell>
-            <FlatTableRowHeader>000001</FlatTableRowHeader>
-            <FlatTableCell>London</FlatTableCell>
-            <FlatTableCell>Single</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>John Doe</FlatTableCell>
-            <FlatTableRowHeader>000001</FlatTableRowHeader>
-            <FlatTableCell>London</FlatTableCell>
-            <FlatTableCell>Single</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>John Doe</FlatTableCell>
-            <FlatTableRowHeader>000001</FlatTableRowHeader>
-            <FlatTableCell>London</FlatTableCell>
-            <FlatTableCell>Single</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>John Doe</FlatTableCell>
-            <FlatTableRowHeader>000001</FlatTableRowHeader>
-            <FlatTableCell>London</FlatTableCell>
-            <FlatTableCell>Single</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>John Doe</FlatTableCell>
-            <FlatTableRowHeader>000001</FlatTableRowHeader>
-            <FlatTableCell>London</FlatTableCell>
-            <FlatTableCell>Single</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-            <FlatTableCell>0</FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
+    <FlatTable hasStickyHead height="380px" width="310px" overflowX="auto">
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader rowSpan={2}>Name</FlatTableHeader>
+          <FlatTableRowHeader rowSpan={2}>Code</FlatTableRowHeader>
+          <FlatTableHeader colspan={2}>Jun 21</FlatTableHeader>
+          <FlatTableHeader rowSpan={2}></FlatTableHeader>
+          <FlatTableHeader colspan={2}>YTD</FlatTableHeader>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableHeader>Debit</FlatTableHeader>
+          <FlatTableHeader>Credit</FlatTableHeader>
+          <FlatTableHeader>Debit</FlatTableHeader>
+          <FlatTableHeader>Credit</FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+      <FlatTableBody>
+        <FlatTableRow>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableRowHeader>000001</FlatTableRowHeader>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableRowHeader>000001</FlatTableRowHeader>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableRowHeader>000001</FlatTableRowHeader>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableRowHeader>000001</FlatTableRowHeader>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableRowHeader>000001</FlatTableRowHeader>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableRowHeader>000001</FlatTableRowHeader>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableRowHeader>000001</FlatTableRowHeader>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableRowHeader>000001</FlatTableRowHeader>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableRowHeader>000001</FlatTableRowHeader>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+      </FlatTableBody>
+    </FlatTable>
   </Story>
 </Preview>
 
@@ -879,10 +921,7 @@ remains sticky.
 By using the `hasMaxHeight` prop you can automatically apply a max-height of 100% to the FlatTable.
 
 <Preview>
-  <Story
-    name="with hasMaxHeight"
-    parameters={{ chromatic: { disable: true } }}
-  >
+  <Story name="with hasMaxHeight" parameters={{ chromatic: { disable: true } }}>
     {() => {
       const rows = [
         <FlatTableRow key="0">
@@ -1140,7 +1179,7 @@ export const FlatTableSortableStory = (args) => {
 };
 
 <Preview>
-  <Story 
+  <Story
     name="with sorting headers"
     parameters={{
       docs: {
@@ -1276,7 +1315,9 @@ Where icons are used for batch actions, they have text labels too, or tooltips t
                 />
                 <FlatTableHeader id="ft-header-1">Name</FlatTableHeader>
                 <FlatTableHeader id="ft-header-2">Location</FlatTableHeader>
-                <FlatTableHeader id="ft-header-3">Relationship Status</FlatTableHeader>
+                <FlatTableHeader id="ft-header-3">
+                  Relationship Status
+                </FlatTableHeader>
                 <FlatTableHeader id="ft-header-4">Dependents</FlatTableHeader>
               </FlatTableRow>
             </FlatTableHead>
@@ -1479,7 +1520,9 @@ It is also possible to integrate selection of multiple rows and the highlighting
                 />
                 <FlatTableHeader id="ft-header-1">Name</FlatTableHeader>
                 <FlatTableHeader id="ft-header-2">Location</FlatTableHeader>
-                <FlatTableHeader id="ft-header-3">Relationship Status</FlatTableHeader>
+                <FlatTableHeader id="ft-header-3">
+                  Relationship Status
+                </FlatTableHeader>
                 <FlatTableHeader id="ft-header-4">Dependents</FlatTableHeader>
               </FlatTableRow>
             </FlatTableHead>
@@ -1521,7 +1564,7 @@ It is also possible to integrate selection of multiple rows and the highlighting
                 selected={selectedRows.three}
                 highlighted={highlightedRow === "three"}
               >
-               <FlatTableCheckbox
+                <FlatTableCheckbox
                   ariaLabelledBy="ft-row-3-cell-1 ft-row-3-cell-2 ft-row-3-cell-3"
                   onClick={(e) => e.stopPropagation()}
                   checked={selectedRows.three}
@@ -1917,7 +1960,9 @@ of the button control.
                   />
                   <FlatTableHeader id="ft-header-1">Name</FlatTableHeader>
                   <FlatTableHeader id="ft-header-2">Location</FlatTableHeader>
-                  <FlatTableHeader id="ft-header-3">Relationship Status</FlatTableHeader>
+                  <FlatTableHeader id="ft-header-3">
+                    Relationship Status
+                  </FlatTableHeader>
                   <FlatTableHeader id="ft-header-4">Dependents</FlatTableHeader>
                 </FlatTableRow>
               </FlatTableHead>
@@ -1959,7 +2004,7 @@ of the button control.
                   selected={selectedRows.three}
                   highlighted={highlightedRow === "three"}
                 >
-                <FlatTableCheckbox
+                  <FlatTableCheckbox
                     ariaLabelledBy="ft-row-3-cell-1 ft-row-3-cell-2 ft-row-3-cell-3"
                     onClick={(e) => e.stopPropagation()}
                     checked={selectedRows.three}
@@ -2002,7 +2047,7 @@ of the button control.
     <div>
       {["compact", "small", "medium", "large", "extraLarge"].map((size) => (
         <Box mb={3}>
-          <FlatTable size={size}>
+          <FlatTable size={size} aria-label={`flat-table-${size}`}>
             <FlatTableHead>
               <FlatTableRow>
                 <FlatTableHeader>Name</FlatTableHeader>

--- a/src/components/flat-table/flat-table.style.js
+++ b/src/components/flat-table/flat-table.style.js
@@ -78,6 +78,18 @@ const StyledFlatTableWrapper = styled(Box)`
     css`
       box-sizing: border-box;
 
+      :focus {
+        outline: 2px solid ${theme.colors.focus};
+
+        :not(:focus-visible) {
+          outline: none;
+        }
+
+        :focus-visible {
+          outline: 2px solid ${theme.colors.focus};
+        }
+      }
+
       ${isInSidebar
         ? "min-width: fit-content"
         : `box-shadow: inset 0px 0px 0px 1px ${theme.table.secondary}`};


### PR DESCRIPTION
Fixes: #4259 

### Proposed behaviour

Make `FlatTable` focusable by keyboard by giving the table wrapper div a `tabindex`. Give it the usual focus outline when it is focused and a `role` of `region`.

Note this focus border will **only** show when focus is given via keyboard, not via mouse. This allows keyboard users to scroll the table using the arrow keys, without impacting the existing mouse scroll functionality.

![image](https://user-images.githubusercontent.com/14963680/142631700-4b9d64f1-419b-47ef-924a-9039940d2f60.png)

Also add an `overflowX` prop to `FlatTable`. This allows the user to create a horizontally scrolled table without another wrapping div. It can be scrolled horizontally using the keyboard now as well. Add a new story for this.

![image](https://user-images.githubusercontent.com/14963680/142632109-ca3a1403-de75-4ef0-997e-061dc85db10c.png)


### Current behaviour

- Keyboard users cannot focus or scroll a `FlatTable`, either vertically or horizontally.
- Horizontal scrolling can only be set up by wrapping the table in an extra div with `overflow-x` set.

### Checklist


- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

Note that an `aria-label` can be added to any `FlatTable` to give it an accessible name already.

### Testing instructions

Vertical scrolling:
http://localhost:9001/?path=/docs/flat-table--with-sticky-head
http://localhost:9001/?path=/docs/flat-table--with-sticky-footer

Horizontal scrolling:
http://localhost:9001/?path=/docs/flat-table--with-horizontal-scrolling
http://localhost:9001/?path=/docs/flat-table--with-row-header