### PR TITLE
fix(character count): allow screen reader to read character count - FE-4338

### DIFF
--- a/src/__internal__/character-count/character-count.component.js
+++ b/src/__internal__/character-count/character-count.component.js
@@ -5,8 +5,8 @@ import baseTheme from "../../style/themes/base";
 import StyledCharacterCount from "./character-count.style";
 
 const CharacterCount = ({ value, limit, theme, ...props }) => (
-  <StyledCharacterCount theme={theme} {...props}>
-    {value}/{limit}
+  <StyledCharacterCount theme={theme} aria-live="polite" {...props}>
+    {`${value}/${limit}`}
   </StyledCharacterCount>
 );
 


### PR DESCRIPTION
Fixes an issue where the character count in Textarea would not be read out when a user uses a screen
reader. Aria-live has been set to polite.

fixes FE-4338

### Proposed behaviour

Screen reader should read out the character count when a user uses Textarea with a character limit.

### Current behaviour

When a user uses Textarea with a character limit, a screen reader does not read out the character limit.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

The character count will be read out twice. This is an issue relating to `aria-live`. This also happens on the [GOV.UK](https://design-system.service.gov.uk/components/character-count/) examples of Textarea with character count.

I am also speaking with DS about changing the content from `0/50` to something similar to the GOV.UK example.

### Testing instructions

This can be tested using Voiceover along with the existing Textarea -> with character limit story in Storybook.
