### PR TITLE
docs: disable version switcher in dev mode

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -56,7 +56,7 @@ jobs:
       - run: npm ci
       - name: Generate metadata file
         run: npm run generate-metadata
-      - run: NODE_ENV=production npm run build-storybook
+      - run: NODE_ENV=production IGNORE_TESTS=true STORYBOOK_VIEW_MODE=docs npm run build-storybook
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -10,13 +10,15 @@ addons.setConfig({
   showPanel: true,
 });
 
-addons.register(ADDON_ID, () => {
-  addons.add(TOOL_ID, {
-    type: types.TOOL,
-    title: "Version picker",
-    match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
-    render: VersionPicker,
+if (process.env.NODE_ENV === "production") {
+  addons.register(ADDON_ID, () => {
+    addons.add(TOOL_ID, {
+      type: types.TOOL,
+      title: "Version picker",
+      match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
+      render: VersionPicker,
+    });
   });
-});
+}
 
 window.STORYBOOK_GA_ID = "UA-77028225-13";


### PR DESCRIPTION
### Proposed behaviour

- Disable the Storybook version switcher in development mode (it doesn't work anyway).
- Hide the test stories and set the view mode to docs on the versioned Storybook docs.

### Current behaviour

- The version switcher tries to fetch the metadata in dev mode and fails due to CORS errors (and rightfully so). This give us some console errors.
- The versioned docs contain the test stories and default to canvas view.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
