### PR TITLE
ci(codesandbox): add typescript template for pr generation

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,7 @@
 {
-  "sandboxes": ["carbon-quickstart-xi5jc"],
+  "sandboxes": [
+    "carbon-quickstart-xi5jc",
+    "carbon-quickstart-typescript-2gt5y"
+  ],
   "buildCommand": "precompile"
 }


### PR DESCRIPTION
### Proposed behaviour

- Add our TypeScript codesandbox template to the codesandbox ci config so it's built in every PR, like the carbon-quickstart one is

### Current behaviour

- Only a JavaScript codesandbox is built automatically in our PRs

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
