### PR TITLE
feat(link): make skip link possible to be translated

### DIFF
--- a/src/components/link/link.component.js
+++ b/src/components/link/link.component.js
@@ -1,11 +1,13 @@
 import React, { useContext, useMemo } from "react";
 import { ThemeContext } from "styled-components";
 import PropTypes from "prop-types";
+
 import Icon from "../icon";
 import Event from "../../__internal__/utils/helpers/events";
 import { StyledLink, StyledContent } from "./link.style";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import { baseTheme } from "../../style/themes";
+import useLocale from "../../hooks/__internal__/useLocale";
 
 const Link = React.forwardRef(
   (
@@ -30,6 +32,7 @@ const Link = React.forwardRef(
     },
     ref
   ) => {
+    const l = useLocale();
     const theme = useContext(ThemeContext) || baseTheme;
     const tabIndex = tabbable && !disabled ? "0" : "-1";
     const handleOnKeyDown = (ev) => {
@@ -101,7 +104,7 @@ const Link = React.forwardRef(
           {renderLinkIcon()}
 
           <StyledContent>
-            {isSkipLink ? "Skip to main content" : children}
+            {isSkipLink ? l.link.skipLinkLabel() : children}
           </StyledContent>
 
           {renderLinkIcon("right")}

--- a/src/components/link/link.stories.mdx
+++ b/src/components/link/link.stories.mdx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs";
 import LinkTo from "@storybook/addon-links/react";
+
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 import Link from "./link.component";
 import Box from "../box";
 import { Menu, MenuItem } from "../menu";
@@ -198,3 +200,19 @@ Use the `target` prop to modify the behaviour when the Link component is clicked
 ### Link
 
 <Props of={Link} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object
+to the [i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "link.skipLinkLabel",
+      description: "The text to be displayed in skip link",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/locales/en-gb.js
+++ b/src/locales/en-gb.js
@@ -136,6 +136,9 @@ export default {
     placeholder: () => "Please Select...",
     noResultsForTerm: (term) => `No results for "${term}"`,
   },
+  link: {
+    skipLinkLabel: () => "Skip to main content",
+  },
   switch: {
     on: () => "ON",
     off: () => "OFF",

--- a/src/locales/pl-pl.js
+++ b/src/locales/pl-pl.js
@@ -68,6 +68,9 @@ export default {
     placeholder: () => "Proszę wybierz...",
     noResultsForTerm: (term) => `Brak wyników dla "${term}"`,
   },
+  link: {
+    skipLinkLabel: () => "Przejdź do treści",
+  },
   switch: {
     on: () => "WŁ",
     off: () => "WYŁ",


### PR DESCRIPTION
### Proposed behaviour

Fixes #4581 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

<!-- How can a reviewer test this PR? -->

After opening the sandbox, focus the browser and press tab to display Skip Link and check that the text is equal to "Different text"

https://codesandbox.io/s/confident-shockley-hzmjr?file=/src/index.js