### PR TITLE
fix(search): fix incorrect tabindex behaviour - FE-4412

### DIFF
--- a/src/components/search/search.component.js
+++ b/src/components/search/search.component.js
@@ -34,6 +34,7 @@ const Search = ({
   variant = "default",
   "aria-label": ariaLabel = "search",
   inputRef,
+  tabIndex,
   ...rest
 }) => {
   const isControlled = value !== undefined;
@@ -185,6 +186,7 @@ const Search = ({
         onChange={onChange}
         onKeyDown={onKeyDown}
         inputRef={assignInput}
+        tabIndex={tabIndex}
       />
       {searchButton && (
         <StyledSearchButton>
@@ -259,6 +261,8 @@ Search.propTypes = {
    * A callback to retrieve the input reference
    */
   inputRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  /** Input tabindex */
+  tabIndex: PropTypes.number,
 };
 
 export default Search;

--- a/src/components/search/search.d.ts
+++ b/src/components/search/search.d.ts
@@ -40,6 +40,8 @@ export interface SearchProps extends MarginProps {
   variant?: string;
   /** A callback to retrieve the input reference */
   inputRef?: React.RefObject<HTMLInputElement>;
+  /** Input tabindex */
+  tabIndex?: number;
 }
 
 declare function Search(props: SearchProps): JSX.Element;


### PR DESCRIPTION
### Proposed behaviour

Incorrect tabindex behaviour on Search component caused the blue outline issue in DuellingPicklist. This PR fixes this issue.

### Current behaviour

![blue_focus_outline](https://user-images.githubusercontent.com/20651022/143921789-6c291ead-713a-4bb5-a7dc-ce228999ec14.png)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Check DuellingPicklist stories and confirm that the blue outline no longer occurs