### PR TITLE
feat(pill): describe pill component using design tokens - FE-4454

### DIFF
--- a/cypress/integration/common/pill.feature
+++ b/cypress/integration/common/pill.feature
@@ -15,7 +15,7 @@ Feature: Pill component
     Given I open default "Pill Test" component with "pill" json from "commonComponents" using "onDelete" object name
     When I focus Pill close icon
     Then Pill close icon has golden border outline
-      And Pill close icon has "rgb(0, 96, 70)" backgroundColor
+      And Pill close icon has "rgb(0, 103, 56)" backgroundColor
 
   @positive
   Scenario: Enable onDelete checkbox and check the delete event

--- a/src/components/pill/pill.spec.js
+++ b/src/components/pill/pill.spec.js
@@ -170,8 +170,8 @@ describe("Pill", () => {
     });
 
     describe("content color", () => {
-      const darkColor = baseTheme.text.color;
-      const lightColor = baseTheme.colors.white;
+      const darkColor = "var(--colorsUtilityYin090)";
+      const lightColor = "var(--colorsUtilityYang100)";
 
       it.each([
         ["black", lightColor],
@@ -341,7 +341,7 @@ describe("Pill", () => {
                     assertStyleMatch(
                       {
                         backgroundColor: styleSet[style].varietyColor,
-                        color: theme.colors.white,
+                        color: styleSet[style].content,
                       },
                       fillWrapper
                     );
@@ -363,7 +363,7 @@ describe("Pill", () => {
                     assertStyleMatch(
                       {
                         backgroundColor: styleSet[style].varietyColor,
-                        color: theme.text.color,
+                        color: styleSet[style].content,
                       },
                       fillWrapper
                     );

--- a/src/components/pill/pill.style.config.js
+++ b/src/components/pill/pill.style.config.js
@@ -1,31 +1,32 @@
-import baseTheme from "../../style/themes/base";
-
-const { colors, pill } = baseTheme;
-
-export default (theme) => {
+export default () => {
   return {
     status: {
       neutral: {
-        varietyColor: pill.neutral,
-        buttonFocus: pill.neutralBackgroundFocus,
+        varietyColor: "var(--colorsSemanticNeutral500)",
+        buttonFocus: "var(--colorsSemanticNeutral600)",
+        content: "var(--colorsSemanticNeutralYang100)",
       },
       negative: {
-        varietyColor: colors.error,
-        buttonFocus: pill.errorButtonFocus,
+        varietyColor: "var(--colorsSemanticNegative500)",
+        buttonFocus: "var(--colorsSemanticNegative600)",
+        content: "var(--colorsSemanticNegativeYang100)",
       },
       warning: {
-        varietyColor: pill.warning,
-        buttonFocus: pill.warningButtonFocus,
+        varietyColor: "var(--colorsSemanticCaution400)",
+        buttonFocus: "var(--colorsSemanticCaution600)",
+        content: "var(--colorsSemanticCautionYin090)",
       },
       positive: {
-        varietyColor: colors.secondary,
-        buttonFocus: colors.tertiary,
+        varietyColor: "var(--colorsSemanticPositive500)",
+        buttonFocus: "var(--colorsSemanticPositive600)",
+        content: "var(--colorsSemanticPositiveYang100)",
       },
     },
     tag: {
       primary: {
-        varietyColor: theme.colors.primary,
-        buttonFocus: theme.colors.secondary,
+        varietyColor: "var(--colorsActionMajor500)",
+        buttonFocus: "var(--colorsActionMajor600)",
+        content: "var(--colorsActionMajorYang100)",
       },
     },
   };

--- a/src/components/pill/pill.style.js
+++ b/src/components/pill/pill.style.js
@@ -30,7 +30,6 @@ const PillStyle = styled.span`
     size,
   }) => {
     const isStatus = pillRole === "status";
-    const { colors, text } = baseTheme;
     const variety = isStatus ? colorVariant : "primary";
     let pillColor;
     let buttonFocusColor;
@@ -40,17 +39,20 @@ const PillStyle = styled.span`
       if (borderColor) {
         pillColor = toColor(theme, borderColor);
         buttonFocusColor = shade(0.2, pillColor);
+        contentColor = meetsContrastGuidelines(
+          pillColor,
+          theme.compatibility.colorsUtilityYin090
+        ).AAA
+          ? "var(--colorsUtilityYin090)"
+          : "var(--colorsUtilityYang100)";
       } else {
-        const { varietyColor, buttonFocus } = styleConfig(theme)[pillRole][
-          variety
-        ];
+        const { varietyColor, buttonFocus, content } = styleConfig(theme)[
+          pillRole
+        ][variety];
         pillColor = varietyColor;
         buttonFocusColor = buttonFocus;
+        contentColor = content;
       }
-
-      contentColor = meetsContrastGuidelines(pillColor, text.color).AAA
-        ? text.color
-        : colors.white;
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(e);
@@ -69,11 +71,16 @@ const PillStyle = styled.span`
       border: 2px solid ${pillColor};
       height: auto;
       white-space: nowrap;
+      color: ${contentColor};
 
       ${inFill &&
       css`
         background-color: ${pillColor};
-        color: ${contentColor};
+      `}
+
+      ${!inFill &&
+      css`
+        color: var(--colorsUtilityYin090);
       `}
 
       ${size === "S" &&
@@ -119,23 +126,9 @@ const PillStyle = styled.span`
           margin: 0;
           line-height: 16px;
 
-          ${inFill &&
-          css`
-            color: ${contentColor};
-            ${StyledIcon} {
-              color: ${contentColor};
-            }
-          `}
-
-          ${!inFill &&
-          css`
-            background-color: transparent;
-            color: ${text.color};
-          `}
-
           &:focus {
             outline: none;
-            box-shadow: 0 0 0 3px ${colors.focus};
+            box-shadow: 0 0 0 3px var(--colorsSemanticFocus500);
             background-color: ${buttonFocusColor};
             & {
               color: ${contentColor};
@@ -162,12 +155,20 @@ const PillStyle = styled.span`
             padding: 0 4px;
             height: unset;
             width: unset;
+            color: ${contentColor};
 
             &:hover,
             &:focus {
               color: ${contentColor};
             }
           }
+
+          ${!inFill &&
+          css`
+            ${StyledIcon} {
+              color: var(--colorsUtilityYin090);
+            }
+          `}
         }
 
         ${size === "S" &&
@@ -292,6 +293,9 @@ PillStyle.propTypes = {
   colorVariant: PropTypes.oneOf(["neutral", "negative", "positive", "warning"]),
   isDeletable: PropTypes.func,
   size: PropTypes.oneOf(["S", "M", "L", "XL"]),
+  pillRole: PropTypes.oneOf(["tag", "status"]),
+  borderColor: PropTypes.string,
+  theme: PropTypes.object,
 };
 
 export default PillStyle;

--- a/src/style/design-tokens/carbon-scoped-tokens-provider/__snapshots__/carbon-scoped-tokens-provider.component.spec.js.snap
+++ b/src/style/design-tokens/carbon-scoped-tokens-provider/__snapshots__/carbon-scoped-tokens-provider.component.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`CarbonScopedTokensProvider should render css variables for all themes 1`] = `
 Array [
   CSSStyleRule {
-    "__ends": 10567,
+    "__ends": 10569,
     "__starts": 45,
     "parentRule": null,
     "parentStyleSheet": CSSStyleSheet {
@@ -112,7 +112,7 @@ Array [
       "--colorsSemanticNeutralYin055": "#0000008c",
       "--colorsSemanticNeutralYin065": "#000000a6",
       "--colorsSemanticNeutralYin090": "#000000e6",
-      "--colorsSemanticPositive500": "#00B000",
+      "--colorsSemanticPositive500": "#008a21ff",
       "--colorsSemanticPositive600": "#006e1aff",
       "--colorsSemanticPositiveTransparent": "#00000000",
       "--colorsSemanticPositiveYang100": "#ffffffff",
@@ -905,8 +905,8 @@ Array [
     },
   },
   CSSStyleRule {
-    "__ends": 21088,
-    "__starts": 10568,
+    "__ends": 21092,
+    "__starts": 10570,
     "parentRule": null,
     "parentStyleSheet": CSSStyleSheet {
       "cssRules": [Circular],
@@ -1014,7 +1014,7 @@ Array [
       "--colorsSemanticNeutralYin055": "#0000008c",
       "--colorsSemanticNeutralYin065": "#000000a6",
       "--colorsSemanticNeutralYin090": "#000000e6",
-      "--colorsSemanticPositive500": "#00B000",
+      "--colorsSemanticPositive500": "#008a21ff",
       "--colorsSemanticPositive600": "#006e1aff",
       "--colorsSemanticPositiveTransparent": "#00000000",
       "--colorsSemanticPositiveYang100": "#ffffffff",
@@ -1504,7 +1504,7 @@ Array [
       "97": "--colorsSemanticPositiveYin055",
       "98": "--colorsSemanticPositiveYin065",
       "99": "--colorsSemanticPositiveYin090",
-      "__starts": 10597,
+      "__starts": 10599,
       "_importants": Object {
         "--borderRadiusCircle": "",
         "--borderWidth000": "",
@@ -1807,8 +1807,8 @@ Array [
     },
   },
   CSSStyleRule {
-    "__ends": 31609,
-    "__starts": 21089,
+    "__ends": 31615,
+    "__starts": 21093,
     "parentRule": null,
     "parentStyleSheet": CSSStyleSheet {
       "cssRules": [Circular],
@@ -1916,7 +1916,7 @@ Array [
       "--colorsSemanticNeutralYin055": "#0000008c",
       "--colorsSemanticNeutralYin065": "#000000a6",
       "--colorsSemanticNeutralYin090": "#000000e6",
-      "--colorsSemanticPositive500": "#00B000",
+      "--colorsSemanticPositive500": "#008a21ff",
       "--colorsSemanticPositive600": "#006e1aff",
       "--colorsSemanticPositiveTransparent": "#00000000",
       "--colorsSemanticPositiveYang100": "#ffffffff",
@@ -2406,7 +2406,7 @@ Array [
       "97": "--colorsSemanticPositiveYin055",
       "98": "--colorsSemanticPositiveYin065",
       "99": "--colorsSemanticPositiveYin090",
-      "__starts": 21118,
+      "__starts": 21122,
       "_importants": Object {
         "--borderRadiusCircle": "",
         "--borderWidth000": "",
@@ -2709,8 +2709,8 @@ Array [
     },
   },
   CSSStyleRule {
-    "__ends": 42161,
-    "__starts": 31610,
+    "__ends": 42167,
+    "__starts": 31616,
     "parentRule": null,
     "parentStyleSheet": CSSStyleSheet {
       "cssRules": [Circular],
@@ -3308,7 +3308,7 @@ Array [
       "97": "--colorsSemanticPositiveYin055",
       "98": "--colorsSemanticPositiveYin065",
       "99": "--colorsSemanticPositiveYin090",
-      "__starts": 31652,
+      "__starts": 31658,
       "_importants": Object {
         "--borderRadiusCircle": "",
         "--borderWidth000": "",
@@ -3611,8 +3611,8 @@ Array [
     },
   },
   CSSStyleRule {
-    "__ends": 42249,
-    "__starts": 42195,
+    "__ends": 42255,
+    "__starts": 42201,
     "parentRule": null,
     "parentStyleSheet": CSSStyleSheet {
       "cssRules": [Circular],
@@ -3624,7 +3624,7 @@ Array [
       "1": "padding",
       "2": "width",
       "3": "display",
-      "__starts": 42202,
+      "__starts": 42208,
       "_importants": Object {
         "display": "",
         "margin": "",

--- a/src/style/themes/aegean/__snapshots__/aegean-theme.spec.js.snap
+++ b/src/style/themes/aegean/__snapshots__/aegean-theme.spec.js.snap
@@ -102,7 +102,7 @@ Object {
   "colorsSemanticNeutralYin055": "#0000008c",
   "colorsSemanticNeutralYin065": "#000000a6",
   "colorsSemanticNeutralYin090": "#000000e6",
-  "colorsSemanticPositive500": "#00B000",
+  "colorsSemanticPositive500": "#008a21ff",
   "colorsSemanticPositive600": "#006e1aff",
   "colorsSemanticPositiveTransparent": "#00000000",
   "colorsSemanticPositiveYang100": "#ffffffff",

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -446,8 +446,6 @@ export default (palette) => {
 
         colorsSemanticFocus500: this.colors.focus,
 
-        colorsSemanticPositive500: this.colors.success,
-
         colorsSemanticNegative500: this.colors.error,
         colorsSemanticNegative600: this.colors.destructive.hover,
 

--- a/src/style/themes/mint/__snapshots__/mint-theme.spec.js.snap
+++ b/src/style/themes/mint/__snapshots__/mint-theme.spec.js.snap
@@ -102,7 +102,7 @@ Object {
   "colorsSemanticNeutralYin055": "#0000008c",
   "colorsSemanticNeutralYin065": "#000000a6",
   "colorsSemanticNeutralYin090": "#000000e6",
-  "colorsSemanticPositive500": "#00B000",
+  "colorsSemanticPositive500": "#008a21ff",
   "colorsSemanticPositive600": "#006e1aff",
   "colorsSemanticPositiveTransparent": "#00000000",
   "colorsSemanticPositiveYang100": "#ffffffff",

--- a/src/style/themes/none/__snapshots__/none.spec.js.snap
+++ b/src/style/themes/none/__snapshots__/none.spec.js.snap
@@ -102,7 +102,7 @@ Object {
   "colorsSemanticNeutralYin055": "#0000008c",
   "colorsSemanticNeutralYin065": "#000000a6",
   "colorsSemanticNeutralYin090": "#000000e6",
-  "colorsSemanticPositive500": "#00B000",
+  "colorsSemanticPositive500": "#008a21ff",
   "colorsSemanticPositive600": "#006e1aff",
   "colorsSemanticPositiveTransparent": "#00000000",
   "colorsSemanticPositiveYang100": "#ffffffff",


### PR DESCRIPTION
### Proposed behaviour

Describes the pill component using design tokens.
Changes the backgroundColor for the ` positive`  color - token colorsSemanticPositive500  used. 
_(Both the Pill and Messages components use the same colorsSemanticPositive500 token. In the `mint` and `aegean` theme the colors are changed and are identical to those in sage(experimental). The color change for positive is required because of the contrast between background and text - accessibility contrast tests.  The changes made also change the color for the `message` component for the `success` state - same for all theme. )_
Changes the backgroundColor for the ` neutral`  color - token colorsSemanticNeutral500 used.
Changes the backgroundColor for the ` warning`  color - token colorsSemanticCaution400 used.
Adds missing props in the pill.style.js file.
Updates tests that are related to the changes made.

### Current behaviour

The pill component uses the theme styled-component property.
Currently for the `warning` color,  backgroundColor has color: # ED8333.
Currently for the `positive`  color, backgroundColor has color: # 006300.
Currently for the `neutral`  color, backgroundColor has color: # 4D7080,
The propTypes in the css files are missing the props used.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context
Warning color: 
![image](https://user-images.githubusercontent.com/44143630/148901930-fe6c88fa-652a-4091-9557-9d409b03e076.png)

Neutral background:
![image](https://user-images.githubusercontent.com/44143630/144581589-eb0c06ee-03be-4569-9909-54f09fb41ccb.png)

Positive backgound:
![image](https://user-images.githubusercontent.com/44143630/144581287-0123ac91-785c-4a2b-858b-3027a465f3f5.png)


### Testing instructions

The correct appearance can be checked in the component: Pill.
In the `mint` and `aegean` theme the colors of `positive` status are identical to those in `sage(experimental)`.
Use devtools to check if pill use css variables.