### PR TITLE
fix(flat-table-cell): ensure that pl prop is correctly applied to a sub row - FE-4306

### DIFF
--- a/cypress/fixtures/commonComponents/flatTable.json
+++ b/cypress/fixtures/commonComponents/flatTable.json
@@ -9,5 +9,17 @@
     "hasHeaderRow": true,
     "hasStickyHead": true,
     "hasClickableRows": true
+  },
+  "pl1": {
+    "pl": 1
+  },
+  "pl4": {
+    "pl": 4
+  },
+  "pl25px": {
+    "pl": "25px"
+  },
+  "pl6em": {
+    "pl": "6em"
   }
 }

--- a/cypress/integration/common/flatTable.feature
+++ b/cypress/integration/common/flatTable.feature
@@ -291,3 +291,15 @@ Feature: FlatTable component
       And I wait 100
     When I click "Expand All" button on preview
     Then The subrows are visible
+  
+  @positive
+  Scenario Outline: Correct padding left value of <nameOfObject> is applied to a sub row
+    Given I open default "Flat Table Expandable" component with "flatTable" json from "commonComponents" using "<nameOfObject>" object name
+    When I click on the first cell
+    Then The first table cell of "first" subrow should have <expectedPadding> padding left value
+    Examples:
+      | nameOfObject | expectedPadding  |
+      | pl1          | 8px              | 
+      | pl4          | 32px             |
+      | pl25px       | 25px             |
+      | pl6em        | 84px             |

--- a/cypress/locators/flat-table/index.js
+++ b/cypress/locators/flat-table/index.js
@@ -25,6 +25,9 @@ export const flatTableSubrows = () => cy.get(FLAT_TABLE_SUBROW);
 export const flatTableSubrowByPosition = (index) =>
   flatTableSubrows().eq(index);
 
+export const flatTableSubrowFirstCell = (index) =>
+  flatTableSubrows().eq(index).find("td div");
+
 export const flatTableCaption = () => flatTable().find("caption");
 
 export const flatTablePageSizeSelect = () =>

--- a/cypress/support/step-definitions/flat-table-steps.js
+++ b/cypress/support/step-definitions/flat-table-steps.js
@@ -12,6 +12,7 @@ import {
   flatTablePageSizeSelect,
   flatTablePageSelectListPosition,
   pageSelectDataComponent,
+  flatTableSubrowFirstCell,
 } from "../../locators/flat-table";
 
 import DEBUG_FLAG from "..";
@@ -280,3 +281,14 @@ Then("I type {int} in pagination input", (value) => {
 Then("Pagination input should have {int} value", (value) => {
   pageSelectDataComponent().find("input").should("have.value", value);
 });
+
+Then(
+  "The first table cell of {string} subrow should have {word} padding left value",
+  (position, value) => {
+    flatTableSubrowFirstCell(positionOfElement(position)).should(
+      "have.css",
+      "padding-left",
+      value
+    );
+  }
+);

--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -36,7 +36,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
   padding: 0;
 }
 
-.c11.c11.c11 > div {
+.c11.c11.c11.c11 > div {
   box-sizing: border-box;
 }
 
@@ -57,7 +57,7 @@ exports[`FlatTable when rendered with proper table data should have expected str
   padding: 0;
 }
 
-.c12.c12.c12 > div {
+.c12.c12.c12.c12 > div {
   box-sizing: border-box;
 }
 

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.spec.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.spec.js
@@ -31,7 +31,7 @@ describe("FlatTableRowCell", () => {
         width: "40px",
       },
       wrapper.find(StyledFlatTableCell),
-      { modifier: "&&& > div" }
+      { modifier: "&&&& > div" }
     );
   });
 
@@ -57,7 +57,7 @@ describe("FlatTableRowCell", () => {
           whiteSpace: "nowrap",
         },
         wrapper.find(StyledFlatTableCell),
-        { modifier: "&&& > div" }
+        { modifier: "&&&& > div" }
       );
     });
 
@@ -99,7 +99,7 @@ describe("FlatTableRowCell", () => {
             borderRight: expectedValue,
           },
           wrapper,
-          { modifier: "&&&" }
+          { modifier: "&&&&" }
         );
       });
     }
@@ -122,7 +122,7 @@ describe("FlatTableRowCell", () => {
             borderRightColor: expectedValue,
           },
           wrapper,
-          { modifier: "&&&" }
+          { modifier: "&&&&" }
         );
       });
     }
@@ -141,7 +141,7 @@ describe("FlatTableRowCell", () => {
       ),
       {},
       null,
-      { modifier: "&&& > div" }
+      { modifier: "&&&& > div" }
     );
   });
 });

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.style.js
@@ -35,7 +35,7 @@ const StyledFlatTableCell = styled.td`
       width: ${colWidth}px;
     `}
 
-    &&& {
+    &&&& {
       > div {
         box-sizing: border-box;
 

--- a/src/components/flat-table/flat-table-expandable.stories.mdx
+++ b/src/components/flat-table/flat-table-expandable.stories.mdx
@@ -34,62 +34,81 @@ import {
 
 Flat table rows can be made expandable, with any number of sub rows.
 
-<Canvas>
-  <Story name="default">
-    {() => {
-      const SubRows = [
+export const FlatTableExpandableDefault = (args) => {
+  const SubRows = [
+    <FlatTableRow>
+      <FlatTableCell {...args}>Child one</FlatTableCell>
+      <FlatTableCell>York</FlatTableCell>
+      <FlatTableCell>Single</FlatTableCell>
+      <FlatTableCell>2</FlatTableCell>
+    </FlatTableRow>,
+    <FlatTableRow>
+      <FlatTableCell {...args}>Child two</FlatTableCell>
+      <FlatTableCell>Edinburgh</FlatTableCell>
+      <FlatTableCell>Single</FlatTableCell>
+      <FlatTableCell>1</FlatTableCell>
+    </FlatTableRow>,
+  ];
+  return (
+    <FlatTable>
+      <FlatTableHead>
         <FlatTableRow>
-          <FlatTableCell>Child one</FlatTableCell>
-          <FlatTableCell>York</FlatTableCell>
+          <FlatTableHeader>Name</FlatTableHeader>
+          <FlatTableHeader>Location</FlatTableHeader>
+          <FlatTableHeader>Relationship Status</FlatTableHeader>
+          <FlatTableHeader>Dependents</FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+      <FlatTableBody>
+        <FlatTableRow expandable subRows={SubRows}>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableCell>London</FlatTableCell>
           <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow expandable subRows={SubRows}>
+          <FlatTableCell>Jane Doe</FlatTableCell>
+          <FlatTableCell>York</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
           <FlatTableCell>2</FlatTableCell>
-        </FlatTableRow>,
-        <FlatTableRow>
-          <FlatTableCell>Child two</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow expandable subRows={SubRows}>
+          <FlatTableCell>John Smith</FlatTableCell>
           <FlatTableCell>Edinburgh</FlatTableCell>
           <FlatTableCell>Single</FlatTableCell>
           <FlatTableCell>1</FlatTableCell>
-        </FlatTableRow>,
-      ];
-      return (
-        <FlatTable>
-          <FlatTableHead>
-            <FlatTableRow>
-              <FlatTableHeader>Name</FlatTableHeader>
-              <FlatTableHeader>Location</FlatTableHeader>
-              <FlatTableHeader>Relationship Status</FlatTableHeader>
-              <FlatTableHeader>Dependents</FlatTableHeader>
-            </FlatTableRow>
-          </FlatTableHead>
-          <FlatTableBody>
-            <FlatTableRow expandable subRows={SubRows}>
-              <FlatTableCell>John Doe</FlatTableCell>
-              <FlatTableCell>London</FlatTableCell>
-              <FlatTableCell>Single</FlatTableCell>
-              <FlatTableCell>0</FlatTableCell>
-            </FlatTableRow>
-            <FlatTableRow expandable subRows={SubRows}>
-              <FlatTableCell>Jane Doe</FlatTableCell>
-              <FlatTableCell>York</FlatTableCell>
-              <FlatTableCell>Married</FlatTableCell>
-              <FlatTableCell>2</FlatTableCell>
-            </FlatTableRow>
-            <FlatTableRow expandable subRows={SubRows}>
-              <FlatTableCell>John Smith</FlatTableCell>
-              <FlatTableCell>Edinburgh</FlatTableCell>
-              <FlatTableCell>Single</FlatTableCell>
-              <FlatTableCell>1</FlatTableCell>
-            </FlatTableRow>
-            <FlatTableRow expandable subRows={SubRows}>
-              <FlatTableCell>Jane Smith</FlatTableCell>
-              <FlatTableCell>Newcastle</FlatTableCell>
-              <FlatTableCell>Married</FlatTableCell>
-              <FlatTableCell>5</FlatTableCell>
-            </FlatTableRow>
-          </FlatTableBody>
-        </FlatTable>
-      );
+        </FlatTableRow>
+        <FlatTableRow expandable subRows={SubRows}>
+          <FlatTableCell>Jane Smith</FlatTableCell>
+          <FlatTableCell>Newcastle</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableCell>5</FlatTableCell>
+        </FlatTableRow>
+      </FlatTableBody>
+    </FlatTable>
+  );
+}
+
+<Canvas>
+  <Story
+    name="default"
+    parameters={{
+      docs: {
+        source: {
+          type: "code",
+        },
+      },
     }}
+    argTypes={{
+      pl: {
+        options: [0,1,2,3,4,5,6,7,8,"25px","4em","69px","6em"],
+        control: {
+          type: "select",
+        },
+      },
+    }}
+  >
+    {FlatTableExpandableDefault.bind({})}
   </Story>
 </Canvas>
 

--- a/src/components/flat-table/flat-table-row/__snapshots__/flat-table-row.spec.js.snap
+++ b/src/components/flat-table/flat-table-row/__snapshots__/flat-table-row.spec.js.snap
@@ -10,7 +10,7 @@ exports[`FlatTableRow should have expected styles 1`] = `
   padding: 0;
 }
 
-.c1.c1.c1 > div {
+.c1.c1.c1.c1 > div {
   box-sizing: border-box;
 }
 

--- a/src/components/flat-table/flat-table-test.stories.mdx
+++ b/src/components/flat-table/flat-table-test.stories.mdx
@@ -15,7 +15,7 @@ import {
 } from ".";
 import guid from "../../__internal__/utils/helpers/guid";
 import { FLAT_TABLE_SIZES, FLAT_TABLE_THEMES } from "./flat-table.config";
-import { FlatTableSortableStory } from "./flat-table.stories.mdx";
+import { FlatTableSortableStory } from "./flat-table.stories.mdx"
 
 <Meta
   title="Flat Table/Test"


### PR DESCRIPTION
Increase specificity of padding props so that the pl prop is correctly applied to a flat table cell
when it is a sub row.

fixes #4348

### Proposed behaviour

pl prop should apply the desired padding-left to a flat table cell when it is nested in a sub row.

### Current behaviour

pl prop is not being applied to a flat table cell when it is nested in a sub row.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Please use the codesandboxes provided [here](https://github.com/Sage/carbon/pull/4617#issuecomment-984547871)
