### PR TITLE
fix(tile select): apply opacity to prefixAdornment when component is disabled - FE-4489

### DIFF
--- a/src/components/tile-select/tile-select.component.js
+++ b/src/components/tile-select/tile-select.component.js
@@ -167,7 +167,15 @@ const TileSelect = ({
                 </StyledAccordionFooterWrapper>
               )}
             </Box>
-            {prefixAdornment && <Box mr={3}>{prefixAdornment}</Box>}
+            {prefixAdornment && (
+              <Box
+                data-element="prefix-adornment"
+                mr={3}
+                opacity={disabled ? "0.3" : undefined}
+              >
+                {prefixAdornment}
+              </Box>
+            )}
           </Box>
         </StyledTileSelect>
         {accordionContent && (

--- a/src/components/tile-select/tile-select.spec.js
+++ b/src/components/tile-select/tile-select.spec.js
@@ -189,7 +189,8 @@ describe("TileSelect", () => {
     });
 
     it("renders component with proper background and proper text color when disabled", () => {
-      render({ disabled: true });
+      const MyComp = () => <div />;
+      render({ disabled: true, prefixAdornment: <MyComp /> });
       assertStyleMatch(
         {
           background: baseTheme.tileSelect.disabledBackground,
@@ -215,6 +216,14 @@ describe("TileSelect", () => {
         },
         wrapper.find(StyledTileSelect),
         { modifier: ` ${StyledAdornment} *` }
+      );
+
+      assertStyleMatch(
+        {
+          opacity: "0.3",
+        },
+        wrapper.find(`[data-element="prefix-adornment"]`),
+        {}
       );
     });
 


### PR DESCRIPTION
Opacity of 0.3 is now applied to the prefixAdornment when disabled is true for TileSelect component

fixes #4606

### Proposed behaviour

Opacity of 0.3 applied to the prefixAdornment when disabled is true on TileSelect Component.

![Screenshot 2021-12-02 at 16 41 57](https://user-images.githubusercontent.com/56251247/144464967-fb6acec5-30ce-4537-86ad-5c6de189602f.png)

### Current behaviour

Opacity is not applied to the prefixAdornment when disabled is true on TileSelect Component.

![Screenshot 2021-12-02 at 16 44 16](https://user-images.githubusercontent.com/56251247/144465437-5099847b-8ccd-4505-b67c-ebb2523c4e62.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

[Codesandbox link](https://codesandbox.io/s/vigorous-bash-v54eq?file=/src/index.js)
