### PR TITLE
ci(cypress): use cypress-io gh action for component tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -168,7 +168,10 @@ jobs:
           npx cypress info
 
       - name: Cypress React tests
-        run: npm run cypress:ci:react 
+        uses: cypress-io/github-action@v2.10.2
+        with:
+          install: false
+          command: npx cypress run-ct --parallel --record --group 'ubuntu-cypress-react' --browser chrome
         env:
           COMMIT_INFO_BRANCH: ${{ fromJson(steps.get_pull.outputs.data).head.label }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -6,6 +6,8 @@
 
 [Running Tests](#running-tests)
 
+- [Run cypress react tests](#run-cypress-react-tests)
+
 [Continuous Integration (CI)](#continuous-integration-ci)
 
 - [Build Storybook (only accessibility tests)](#build-storybook-only-accessibility-tests)
@@ -43,6 +45,13 @@ Storybook must be running before Cypress tests can be run:
 4. To run specific Cypress tests at the command line (headless browser for continuous integration) use: `npx cypress run --spec 'cypress/integration/[tests-type]/[fileName](.feature|.test.js)'`. Test results can be seen in the console run summary.
 5. To run in the Chrome/Firefox browser add `--browser chrome` or `--browser firefox` to the above command.
 
+### Run cypress react tests
+
+We have implemented new approach for cypress tests, using cypress-react framework. There is no need to start storybook for this kind of integration tests.
+
+1. Run `npx cypress open-ct` to open `cypress` runner or
+   run `npx cypress run-ct` to run `tests` in `CI` mode.
+
 ## Continuous Integration (CI)
 
 Every commit/pull request in the repository initiates a Cypress test run using GitHub Actions.
@@ -64,6 +73,7 @@ Storybook must be running before cypress can run.
 ### GitHub Actions
 1. `cypress.yml`
 - `npx cypress run --browser chrome --parallel -–record --spec './cypress/integration/**/*.feature'` - runs the complete test suite (except `accessibility`).
+- `npx cypress run-ct --browser chrome --parallel -–record --spec './src/components/**/*.test.js' --group ubuntu-cypress-react` - runs the `cypress react` suite.
 - `npx cypress run --browser chrome --parallel -–record --spec './cypress/integration/accessibility/*.test.js'` - runs the `accessibility` test suite only.
 
 The build result can be seen in GitHub in the pull request/branch and the detailed results can be seen in the [Cypress.io dashboard](https://dashboard.cypress.io/projects/8458bb/runs) or in GitHub Actions, both linked from the pull request/branch checks.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "test-update": "jest --config=./jest.conf.json --updateSnapshot",
     "test:cypress": "cypress open",
     "cypress:react": "npx cypress open-ct",
-    "cypress:ci:react": "npx cypress run-ct --spec './src/components/**/*.test.js' --record --key --parallel --group 'ubuntu-cypress-react' --browser=chrome",
     "debug": "node --inspect ./node_modules/jest-cli/bin/jest --watch --config=./jest.conf.json",
     "format": "prettier --write './src'",
     "lint": "eslint ./src",


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
refactor for `cypress.yml` file to use `with` 
the [link](https://github.com/Sage/carbon/runs/4456795514?check_suite_focus=true) to report of passing tests

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Cypress doesn't allow us to use `custom command`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
