### PR TITLE
feat(select): describe select component using design tokens

### DIFF
--- a/cypress/support/step-definitions/select-steps.js
+++ b/cypress/support/step-definitions/select-steps.js
@@ -72,14 +72,14 @@ When("I click on default Select input", () => {
 When("{string} option on the list is hovered over", (position) => {
   selectOption(positionOfElement(position))
     .should("have.attr", "aria-selected", "true")
-    .and("have.css", "background-color", "rgb(242, 245, 246)");
+    .and("have.css", "background-color", "rgb(153, 173, 183)");
 });
 
 When("{string} option on the list is highlighted", (position) => {
   selectOption(positionOfElement(position)).should(
     "have.css",
     "background-color",
-    "rgb(242, 245, 246)"
+    "rgb(153, 173, 183)"
   );
 });
 

--- a/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
+++ b/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
@@ -103,35 +103,35 @@ exports[`Option renders properly 1`] = `
 }
 
 .c0 {
-  padding-top: 8px;
-  padding-bottom: 8px;
-  border-top: 1px solid #CCD6DB;
+  padding-top: var(--spacing100);
+  padding-bottom: var(--spacing100);
+  border-top: 1px solid var(--colorsUtilityDisabled600);
   box-shadow: 0 0px 0 0 rgba(0,0,0,0),0 -8px 8px 0 rgba(0,0,0,0.03);
 }
 
 .c0 .c3 {
-  color: rgba(0,0,0,0.9);
+  color: var(--colorsUtilityYin090);
 }
 
 .c0 .c1 {
   background: transparent;
   border: none;
-  color: rgba(0,0,0,0.9);
+  color: var(--colorsUtilityYin090);
   -webkit-box-pack: left;
   -webkit-justify-content: left;
   -ms-flex-pack: left;
   justify-content: left;
-  padding-left: 16px;
-  padding-right: 16px;
+  padding-left: var(--spacing200);
+  padding-right: var(--spacing200);
   width: 100%;
 }
 
 .c0 .c1:hover {
-  background-color: #F2F5F6;
+  background-color: var(--colorsUtilityMajor025);
 }
 
 .c0 .c1:hover .c3 {
-  color: rgba(0,0,0,0.9);
+  color: var(--colorsUtilityYin090);
 }
 
 <div

--- a/src/components/select/list-action-button/list-action-button.style.js
+++ b/src/components/select/list-action-button/list-action-button.style.js
@@ -1,41 +1,33 @@
-import styled, { css } from "styled-components";
-import { baseTheme } from "../../../style/themes";
+import styled from "styled-components";
 import StyledButton from "../../button/button.style";
 import StyledIcon from "../../icon/icon.style";
 
 const StyledListActionButtonWrapper = styled.div`
-  ${({ theme }) => css`
-    padding-top: ${theme.space[1]}px;
-    padding-bottom: ${theme.space[1]}px;
-    border-top: 1px solid ${theme.disabled.border};
-    box-shadow: 0 0px 0 0 rgba(0, 0, 0, 0), 0 -8px 8px 0 rgba(0, 0, 0, 0.03);
+  padding-top: var(--spacing100);
+  padding-bottom: var(--spacing100);
+  border-top: 1px solid var(--colorsUtilityDisabled600);
+  box-shadow: 0 0px 0 0 rgba(0, 0, 0, 0), 0 -8px 8px 0 rgba(0, 0, 0, 0.03);
 
-    ${StyledIcon} {
-      color: ${theme.text.color};
-    }
+  ${StyledIcon} {
+    color: var(--colorsUtilityYin090);
+  }
 
-    ${StyledButton} {
-      background: transparent;
-      border: none;
-      color: ${theme.text.color};
-      justify-content: left;
-      padding-left: ${theme.space[2]}px;
-      padding-right: ${theme.space[2]}px;
-      width: 100%;
+  ${StyledButton} {
+    background: transparent;
+    border: none;
+    color: var(--colorsUtilityYin090);
+    justify-content: left;
+    padding-left: var(--spacing200);
+    padding-right: var(--spacing200);
+    width: 100%;
 
-      :hover {
-        background-color: ${theme.select.selected};
-
-        ${StyledIcon} {
-          color: ${theme.text.color};
-        }
+    :hover {
+      background-color: var(--colorsUtilityMajor025);
+      ${StyledIcon} {
+        color: var(--colorsUtilityYin090);
       }
     }
-  `}
+  }
 `;
-
-StyledListActionButtonWrapper.defaultProps = {
-  theme: baseTheme,
-};
 
 export default StyledListActionButtonWrapper;

--- a/src/components/select/option-group-header/__snapshots__/option-group-header.spec.js.snap
+++ b/src/components/select/option-group-header/__snapshots__/option-group-header.spec.js.snap
@@ -23,17 +23,17 @@ exports[`OptionGroupHeader renders properly 1`] = `
   line-height: 18px;
   text-align: left;
   margin: 0;
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsYin055);
 }
 
 .c0 .c1 {
   margin-right: 4px;
   margin-left: -5px;
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsYin055);
 }
 
 .c0 .c1:hover {
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsYin055);
 }
 
 <div
@@ -102,17 +102,17 @@ exports[`OptionGroupHeader when icon prop is set then it should display the icon
   line-height: 18px;
   text-align: left;
   margin: 0;
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsYin055);
 }
 
 .c0 .c1 {
   margin-right: 4px;
   margin-left: -5px;
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsYin055);
 }
 
 .c0 .c1:hover {
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsYin055);
 }
 
 <div

--- a/src/components/select/option-group-header/option-group-header.style.js
+++ b/src/components/select/option-group-header/option-group-header.style.js
@@ -1,7 +1,5 @@
 import styled from "styled-components";
-import propTypes from "prop-types";
 import StyledIcon from "../../icon/icon.style";
-import baseTheme from "../../../style/themes/base";
 
 const StyledOptionGroupHeader = styled.div`
   box-sizing: border-box;
@@ -18,26 +16,18 @@ const StyledOptionGroupHeader = styled.div`
     line-height: 18px;
     text-align: left;
     margin: 0;
-    color: ${({ theme }) => theme.select.optionHeader};
+    color: var(--colorsYin055);
   }
 
   ${StyledIcon} {
     margin-right: 4px;
     margin-left: -5px;
-    color: ${({ theme }) => theme.select.optionHeader};
+    color: var(--colorsYin055);
 
     &:hover {
-      color: ${({ theme }) => theme.select.optionHeader};
+      color: var(--colorsYin055);
     }
   }
 `;
-
-StyledOptionGroupHeader.propTypes = {
-  theme: propTypes.object,
-};
-
-StyledOptionGroupHeader.defaultProps = {
-  theme: baseTheme,
-};
 
 export default StyledOptionGroupHeader;

--- a/src/components/select/option-row/__snapshots__/option-row.spec.js.snap
+++ b/src/components/select/option-row/__snapshots__/option-row.spec.js.snap
@@ -6,7 +6,7 @@ exports[`OptionRow renders properly 1`] = `
 }
 
 .c0:hover {
-  background-color: #F2F5F6;
+  background-color: var(--colorsUtilityMajor200);
 }
 
 .c0 td {

--- a/src/components/select/option-row/option-row.spec.js
+++ b/src/components/select/option-row/option-row.spec.js
@@ -2,7 +2,6 @@ import React from "react";
 import TestRenderer from "react-test-renderer";
 import { shallow, mount } from "enzyme";
 import OptionRow from "./option-row.component";
-import { baseTheme } from "../../../style/themes";
 
 describe("OptionRow", () => {
   it("renders properly", () => {
@@ -15,7 +14,7 @@ describe("OptionRow", () => {
       const props = { value: "1", text: "foo", isHighlighted: true };
       expect(renderOptionRow(props, mount)).toHaveStyleRule(
         "background-color",
-        baseTheme.select.selected
+        "var(--colorsUtilityMajor200)"
       );
     });
   });
@@ -32,7 +31,7 @@ describe("OptionRow", () => {
       const props = { value: "1", text: "foo" };
       expect(renderOptionRow(props, mount)).toHaveStyleRule(
         "background-color",
-        baseTheme.select.selected,
+        "var(--colorsUtilityMajor200)",
         { modifier: ":hover" }
       );
     });

--- a/src/components/select/option-row/option-row.style.js
+++ b/src/components/select/option-row/option-row.style.js
@@ -1,19 +1,18 @@
 import styled, { css } from "styled-components";
-import baseTheme from "../../../style/themes/base";
 
 const StyledOptionRow = styled.tr`
   cursor: pointer;
 
   ${({ hidden }) => hidden && "display: none;"}
 
-  ${({ isHighlighted, theme }) =>
+  ${({ isHighlighted }) =>
     isHighlighted &&
     css`
-      background-color: ${theme.select.selected};
+      background-color: var(--colorsUtilityMajor200);
     `}
 
   :hover {
-    background-color: ${({ theme }) => theme.select.selected};
+    background-color: var(--colorsUtilityMajor200);
   }
 
   td {
@@ -25,9 +24,5 @@ const StyledOptionRow = styled.tr`
     }
   }
 `;
-
-StyledOptionRow.defaultProps = {
-  theme: baseTheme,
-};
 
 export default StyledOptionRow;

--- a/src/components/select/option/__snapshots__/option.spec.js.snap
+++ b/src/components/select/option/__snapshots__/option.spec.js.snap
@@ -14,7 +14,7 @@ exports[`Option renders properly 1`] = `
 }
 
 .c0:hover {
-  background-color: #F2F5F6;
+  background-color: var(--colorsUtilityMajor200);
 }
 
 <li
@@ -41,7 +41,7 @@ exports[`Option when no children are provided renders with the text prop as chil
 }
 
 .c0:hover {
-  background-color: #F2F5F6;
+  background-color: var(--colorsUtilityMajor200);
 }
 
 <li

--- a/src/components/select/option/option.spec.js
+++ b/src/components/select/option/option.spec.js
@@ -2,7 +2,6 @@ import React from "react";
 import TestRenderer from "react-test-renderer";
 import { shallow, mount } from "enzyme";
 import Option from "./option.component";
-import { baseTheme } from "../../../style/themes";
 
 describe("Option", () => {
   it("renders properly", () => {
@@ -22,7 +21,7 @@ describe("Option", () => {
       const props = { value: "1", text: "foo", isHighlighted: true };
       expect(renderOption(props, mount)).toHaveStyleRule(
         "background-color",
-        baseTheme.select.selected
+        "var(--colorsUtilityMajor200)"
       );
     });
   });
@@ -39,7 +38,7 @@ describe("Option", () => {
       const props = { value: "1", text: "foo" };
       expect(renderOption(props, mount)).toHaveStyleRule(
         "background-color",
-        baseTheme.select.selected,
+        "var(--colorsUtilityMajor200)",
         { modifier: ":hover" }
       );
     });

--- a/src/components/select/option/option.style.js
+++ b/src/components/select/option/option.style.js
@@ -1,6 +1,5 @@
 import styled, { css } from "styled-components";
 import propTypes from "prop-types";
-import baseTheme from "../../../style/themes/base";
 
 const StyledOption = styled.li`
   cursor: pointer;
@@ -10,30 +9,22 @@ const StyledOption = styled.li`
   width: 100%;
   user-select: none;
 
-  ${({ isHighlighted, theme }) =>
+  ${({ isHighlighted }) =>
     isHighlighted &&
     css`
-      background-color: ${theme.select.selected};
+      background-color: var(--colorsUtilityMajor200);
     `}
 
   ${({ hidden }) => hidden && "display: none;"}
 
   :hover {
-    ${({ theme }) =>
-      css`
-        background-color: ${theme.select.selected};
-      `}
+    background-color: var(--colorsUtilityMajor200);
   }
 `;
 
 StyledOption.propTypes = {
   id: propTypes.any,
   isHighlighted: propTypes.bool,
-  theme: propTypes.object,
-};
-
-StyledOption.defaultProps = {
-  theme: baseTheme,
 };
 
 export default StyledOption;

--- a/src/components/select/select-list/select-list.spec.js
+++ b/src/components/select/select-list/select-list.spec.js
@@ -4,7 +4,6 @@ import { mount } from "enzyme";
 
 import SelectList from "./select-list.component";
 import { StyledSelectList, StyledPopoverContainer } from "./select-list.style";
-import { baseTheme } from "../../../style/themes";
 import Option from "../option/option.component";
 import OptionRow from "../option-row/option-row.component";
 import OptionGroupHeader from "../option-group-header/option-group-header.component";
@@ -263,7 +262,7 @@ describe("SelectList", () => {
 
       expect(wrapper.find(optionType).at(1)).toHaveStyleRule(
         "background-color",
-        baseTheme.select.selected
+        "var(--colorsUtilityMajor200)"
       );
     });
 

--- a/src/components/select/select-list/select-list.style.js
+++ b/src/components/select/select-list/select-list.style.js
@@ -3,6 +3,7 @@ import { baseTheme } from "../../../style/themes";
 
 const overhang = 4;
 
+// TODO (design-tokens): no elovation/zindex tokens yet
 const StyledPopoverContainer = styled.div`
   position: absolute;
   z-index: ${({ theme }) => theme.zIndex.popover};
@@ -56,7 +57,7 @@ const StyledSelectLoaderContainer = styled.li`
 `;
 
 const StyledSelectListTable = styled.table`
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: var(--colorsUtilityYang100);
   border-collapse: collapse;
   border-radius: 0px;
   border-spacing: 0;
@@ -72,22 +73,19 @@ const StyledSelectListTable = styled.table`
   }
 `;
 
-StyledSelectListTable.defaultProps = {
-  theme: baseTheme,
-};
-
+// TODO (design-tokens): to match current style for border bottom colorsUtilityMajor100
 const StyledSelectListTableHeader = styled.thead`
   th {
     position: sticky;
     top: 0;
-    padding: ${({ theme }) => 2 * theme.spacing}px;
-    border-bottom: 1px solid ${({ theme }) => theme.select.tableHeaderBorder};
+    padding: var(--spacing200);
+    border-bottom: 1px solid var(--colorsUtilityMajor050);
     background-color: white;
     text-align: left;
     font-weight: 900;
     font-size: 12px;
     text-transform: uppercase;
-    color: ${({ theme }) => theme.tileSelect.descriptionColor};
+    color: var(--colorsYin055);
     :after {
       content: "";
       display: block;
@@ -95,8 +93,8 @@ const StyledSelectListTableHeader = styled.thead`
       bottom: -8px;
       left: 0px;
       background-image: linear-gradient(
-        ${({ theme }) => theme.colors.black},
-        ${({ theme }) => theme.colors.white}
+        var(--colorsComponentsNavigationYin100),
+        var(--colorsYang100)
       );
       opacity: 0.03;
       height: 8px;
@@ -112,10 +110,6 @@ const StyledSelectListTableBody = styled.tbody`
   table-layout: fixed;
   max-height: 132px;
 `;
-
-StyledSelectListTableHeader.defaultProps = {
-  theme: baseTheme,
-};
 
 export {
   StyledPopoverContainer,

--- a/src/components/select/select.style.js
+++ b/src/components/select/select.style.js
@@ -7,7 +7,7 @@ import InputIconToggleStyle from "../../__internal__/input-icon-toggle/input-ico
 import { baseTheme } from "../../style/themes";
 
 const StyledSelect = styled.div`
-  ${({ hasTextCursor, disabled, theme, readOnly, transparent }) => css`
+  ${({ hasTextCursor, disabled, readOnly, transparent }) => css`
     ${margin}
 
     position: relative;
@@ -18,14 +18,14 @@ const StyledSelect = styled.div`
       ${disabled &&
       css`
         cursor: not-allowed;
-        color: ${theme.disabled.disabled};
+        color: var(--colorsUtilityYin030);
         text-shadow: none;
       `}
 
       ${readOnly &&
       css`
         cursor: ${hasTextCursor ? "text" : "default"};
-        color: ${theme.readOnly.textboxText};
+        color: var(--colorsYin065);
         text-shadow: none;
       `}
     }

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -14,7 +14,6 @@ import SelectTextbox from "../select-textbox/select-textbox.component";
 import InputIconToggleStyle from "../../../__internal__/input-icon-toggle/input-icon-toggle.style";
 import StyledInput from "../../../__internal__/input/input.style";
 import InputPresentationStyle from "../../../__internal__/input/input-presentation.style";
-import { baseTheme } from "../../../style/themes";
 import Label from "../../../__internal__/label";
 
 describe("SimpleSelect", () => {
@@ -143,7 +142,7 @@ describe("SimpleSelect", () => {
     assertStyleMatch(
       {
         cursor: "not-allowed",
-        color: baseTheme.disabled.disabled,
+        color: "var(--colorsUtilityYin030)",
         textShadow: "none",
       },
       wrapper,
@@ -157,7 +156,7 @@ describe("SimpleSelect", () => {
     assertStyleMatch(
       {
         cursor: "default",
-        color: baseTheme.readOnly.textboxText,
+        color: "var(--colorsYin065)",
         textShadow: "none",
       },
       wrapper,


### PR DESCRIPTION
### Proposed behaviour
Describes the select using design tokens. Removes all possible 'theme' in css files

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

The select use the theme styled-component property.

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
