### PR TITLE
fix(help): icon tooltip voice reader issue (FE-979)

### DIFF
--- a/cypress/support/step-definitions/tooltip-steps.js
+++ b/cypress/support/step-definitions/tooltip-steps.js
@@ -9,7 +9,7 @@ Then("tooltipPosition is set to {string}", (tooltipPosition) => {
 });
 
 Then("tooltip text is set to {word}", (text) => {
-  tooltipPreview().children().should("have.text", text);
+  tooltipPreview().should("have.text", text);
 });
 
 Then(

--- a/src/__internal__/tooltip-provider/index.js
+++ b/src/__internal__/tooltip-provider/index.js
@@ -8,7 +8,7 @@ export const TooltipProvider = ({
   children,
   tooltipPosition,
   helpAriaLabel,
-  focusable = true,
+  focusable,
   tooltipVisible,
   disabled,
   target,

--- a/src/components/help/help.component.js
+++ b/src/components/help/help.component.js
@@ -9,6 +9,7 @@ import Events from "../../__internal__/utils/helpers/events";
 import { TooltipContext } from "../../__internal__/tooltip-provider";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { HELP_POSITIONS } from "./help.config";
+import guid from "../../__internal__/utils/helpers/guid";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
@@ -28,9 +29,10 @@ const Help = ({
   tooltipBgColor,
   tooltipFontColor,
   tooltipFlipOverrides,
-  ariaLabel,
+  ariaLabel = "help",
   ...rest
 }) => {
+  const defaultTooltipId = useRef(guid());
   const helpElement = useRef(null);
   const [isTooltipVisible, updateTooltipVisible] = useState(false);
   const { helpAriaLabel } = useContext(TooltipContext);
@@ -60,6 +62,11 @@ const Help = ({
 
   return (
     <StyledHelp
+      aria-describedby={
+        isFocused || isTooltipVisible
+          ? tooltipId || defaultTooltipId.current
+          : undefined
+      }
       className={className}
       as={tagType}
       href={href}
@@ -80,13 +87,14 @@ const Help = ({
             rel: "noopener noreferrer",
           }
         : {
-            role: "tooltip",
-            "aria-label": ariaLabel || helpAriaLabel,
+            role: "button",
+            "aria-label": helpAriaLabel || ariaLabel,
           })}
       {...filterStyledSystemMarginProps(rest)}
       {...rest}
     >
       <Icon
+        aria-hidden
         type={type}
         tooltipMessage={children}
         tooltipPosition={tooltipPosition}
@@ -95,12 +103,7 @@ const Help = ({
         tooltipFontColor={tooltipFontColor}
         tooltipFlipOverrides={tooltipFlipOverrides}
         focusable={false}
-        tooltipId={tooltipId}
-        aria-hidden="true"
-        {...(href && {
-          role: "tooltip",
-          ariaLabel: ariaLabel || helpAriaLabel,
-        })}
+        tooltipId={tooltipId || defaultTooltipId.current}
       />
     </StyledHelp>
   );

--- a/src/components/help/help.spec.js
+++ b/src/components/help/help.spec.js
@@ -89,8 +89,6 @@ describe("Help", () => {
       );
       expect(wrapper.find(StyledHelp).prop("role")).toEqual(undefined);
       expect(wrapper.find(StyledHelp).prop("aria-label")).toEqual(undefined);
-      expect(wrapper.find(Icon).prop("role")).toEqual("tooltip");
-      expect(wrapper.find(Icon).prop("ariaLabel")).toEqual("foo");
       wrapper.unmount();
     });
 

--- a/src/components/help/help.stories.mdx
+++ b/src/components/help/help.stories.mdx
@@ -32,9 +32,7 @@ import Help from "carbon-react/lib/components/help";
 <Canvas>
   <Story name="default" parameters={{ chromatic: { disable: true } }}>
     <div style={{ margin: "64px" }}>
-      <Help ariaLabel="Some helpful text goes here">
-        Some helpful text goes here
-      </Help>
+      <Help>Some helpful text goes here</Help>
     </div>
   </Story>
 </Canvas>
@@ -47,7 +45,7 @@ import Help from "carbon-react/lib/components/help";
     parameters={{ chromatic: { disable: true } }}
   >
     <div style={{ margin: "64px" }}>
-      <Help ariaLabel="Some helpful text goes here">
+      <Help>
         <Icon type="add" color="red" />
         <Icon type="add" color="green" />
         <Icon type="add" color="blue" /> Some <em>helpful</em> text goes here
@@ -69,7 +67,6 @@ Hover over the help component to see the different positions.
           <Help
             tooltipPosition={position}
             isFocused={true}
-            ariaLabel={`This tooltip is positioned ${position}`}
           >
             {`This tooltip is positioned ${position}`}
           </Help>
@@ -93,7 +90,6 @@ props accept and valid css color value.
       <Help
         tooltipBgColor="lightblue"
         tooltipFontColor="black"
-        ariaLabel="The background and font color are overridden"
       >
         The background and font color are overridden
       </Help>
@@ -112,7 +108,6 @@ Using the `type` prop, different icons can be specified. In this example type ha
         <div style={{ margin: "64px" }}>
           <Help
             type={`${icon}`}
-            ariaLabel={`This is the Help component with the ${icon} icon`}
           >
             {`This is the Help component with the ${icon} icon`}
           </Help>
@@ -131,7 +126,6 @@ Using the `href` prop, a link can be specified.
     <div style={{ margin: "64px" }}>
       <Help
         href="https://carbon.sage.com"
-        ariaLabel="This is the Help component with a href."
       >
         This is the Help component with a href.
       </Help>

--- a/src/components/icon/icon.component.js
+++ b/src/components/icon/icon.component.js
@@ -15,6 +15,7 @@ const marginPropTypes = filterStyledSystemMarginProps(
 const Icon = React.forwardRef(
   (
     {
+      "aria-hidden": ariaHidden,
       bg,
       bgShape,
       bgSize,
@@ -35,7 +36,6 @@ const Icon = React.forwardRef(
       inputSize,
       role,
       ariaLabel,
-      "aria-hidden": ariaHidden,
       focusable = true,
       ...rest
     },
@@ -90,6 +90,7 @@ const Icon = React.forwardRef(
 
     const icon = (
       <StyledIcon
+        aria-hidden={ariaHidden}
         ref={ref}
         key="icon"
         className={className || null}
@@ -98,8 +99,7 @@ const Icon = React.forwardRef(
         {...styleProps}
         hasTooltip={hasTooltip}
         aria-label={ariaLabel}
-        aria-hidden={ariaHidden}
-        role={hasTooltip && role === undefined ? "tooltip" : role}
+        role={role}
       />
     );
 

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -426,7 +426,7 @@ describe("Icon component", () => {
       expect(wrapper.find(Tooltip).props().isVisible).toEqual(undefined);
     });
 
-    it("sets the tabIndex, ariaLabel and role", () => {
+    it("sets the tabIndex and ariaLabel", () => {
       const wrapper = mount(
         <Icon
           type="home"
@@ -439,20 +439,18 @@ describe("Icon component", () => {
       expect(wrapper.find(StyledIcon).props()).toEqual(
         expect.objectContaining({
           "aria-label": "home",
-          role: "tooltip",
           tabIndex: 0,
         })
       );
     });
 
-    it("does not set the tabIndex and role when the disabled prop is set", () => {
+    it("does not set the tabIndex when the disabled prop is set", () => {
       const wrapper = mount(
         <Icon type="home" tooltipMessage="foo" tooltipVisible disabled />
       );
 
       expect(wrapper.find(StyledIcon).props()).toEqual(
         expect.objectContaining({
-          role: undefined,
           tabIndex: undefined,
         })
       );

--- a/src/components/numeral-date/numeral-date.stories.mdx
+++ b/src/components/numeral-date/numeral-date.stories.mdx
@@ -263,7 +263,7 @@ The inline label can change to be top aligned at a breakpoint. Enable this by pa
       dateFormat={["dd", "mm", "yyyy"]}
       label="With label help"
       labelHelp="Label help"
-      helpAriaLabel="Help"
+      helpAriaLabel="Label help"
     />
   </Story>
 </Canvas>

--- a/src/components/portal/__snapshots__/portal.spec.js.snap
+++ b/src/components/portal/__snapshots__/portal.spec.js.snap
@@ -794,4 +794,4 @@ exports[`Portal when using default node to match snapshot  1`] = `
 </span>
 `;
 
-exports[`Portal when using default node when an element with id 'root' does not exist will mount on body 1`] = `"<div id=\\"root\\"><div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><div class=\\"sc-bdVaJa gxcojr\\"><span class=\\"sc-bwzfXH gplFmG\\" data-element=\\"tick\\" data-component=\\"icon\\" font-size=\\"small\\" type=\\"tick\\" tabindex=\\"0\\" role=\\"tooltip\\"></span></div></div></div>"`;
+exports[`Portal when using default node when an element with id 'root' does not exist will mount on body 1`] = `"<div id=\\"root\\"><div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><div class=\\"sc-bdVaJa gxcojr\\"><span class=\\"sc-bwzfXH gplFmG\\" data-element=\\"tick\\" data-component=\\"icon\\" font-size=\\"small\\" type=\\"tick\\" tabindex=\\"0\\"></span></div></div></div>"`;

--- a/src/components/radio-button/radio-button.stories.mdx
+++ b/src/components/radio-button/radio-button.stories.mdx
@@ -58,16 +58,19 @@ A legend can be set for the group, and each radio button can have a label.
         id="legend-and-labels-radio-1"
         value="radio1"
         label="Radio Option 1"
+        labelHelp="first option"
       />
       <RadioButton
         id="legend-and-labels-radio-2"
         value="radio2"
         label="Radio Option 2"
+        labelHelp="second option"
       />
       <RadioButton
         id="legend-and-labels-radio-3"
         value="radio3"
         label="Radio Option 3"
+        labelHelp="third option"
       />
     </RadioButtonGroup>
   </Story>

--- a/src/components/switch/switch-test.stories.mdx
+++ b/src/components/switch/switch-test.stories.mdx
@@ -91,7 +91,7 @@ export const SwitchStory = ({
       fieldHelpInline: false,
       label: "Switch on this component?",
       labelHelp: "Switch off and on this component.",
-      helpAriaLabel: "Help",
+      helpAriaLabel: "Switch off and on this component.",
       labelInline: false,
       loading: false,
       inputWidth: 0,

--- a/src/components/switch/switch.stories.mdx
+++ b/src/components/switch/switch.stories.mdx
@@ -216,7 +216,7 @@ You can use the `required` prop to indicate if the field is mandatory.
           label="With labelHelp"
           labelHelp="This text provides more information for the label."
           onChange={(e) => setIsChecked((state) => !state)}
-          helpAriaLabel="Help"
+          helpAriaLabel="This text provides more information for the label."
         />
       );
     }}

--- a/src/components/tooltip/tooltip.component.js
+++ b/src/components/tooltip/tooltip.component.js
@@ -60,7 +60,7 @@ const Tooltip = React.forwardRef(
               data-element="tooltip-pointer"
               bgColor={bgColor}
             />
-            <div>{content}</div>
+            {content}
           </StyledTooltip>
         </CarbonScopedTokensProvider>
       );


### PR DESCRIPTION
### Proposed behaviour
Resolve ARIA issues so the component is read correctly in voice readers:
- allow to pass aria-hidden attribute to the Icon HTML
- remove tooltip role from Help and Icon, that role should be set only on the tooltip itself
- add button role to Help
- add aria-describedby attribute to Help so it could reference the tooltip

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

fixes #4676
fixes #4634
fixes #4734
<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
