### PR TITLE
feat(textbox): describe Textbox component using design tokens - fe-4373

### DIFF
--- a/src/__internal__/input-icon-toggle/input-icon-toggle.spec.js
+++ b/src/__internal__/input-icon-toggle/input-icon-toggle.spec.js
@@ -154,9 +154,9 @@ describe("InputIconToggle", () => {
 
   describe("sizes", () => {
     [
-      ["small", "32px"],
-      ["medium", "40px"],
-      ["large", "48px"],
+      ["small", "var(--sizing400)"],
+      ["medium", "var(--sizing500)"],
+      ["large", "var(--sizing600)"],
     ].forEach((size) => {
       it(`updates the width for ${size[0]}`, () => {
         assertStyleMatch(

--- a/src/__internal__/input-icon-toggle/input-icon-toggle.style.js
+++ b/src/__internal__/input-icon-toggle/input-icon-toggle.style.js
@@ -19,8 +19,8 @@ const InputIconToggleStyle = styled.span.attrs(({ onClick }) => ({
   justify-content: center;
 
   ${({ size }) => css`
-    margin-right: -${sizes[size].horizontalPadding};
-    margin-left: -${sizes[size].horizontalPadding};
+    margin-right: calc(-1 * ${sizes[size].horizontalPadding});
+    margin-left: calc(-1 * ${sizes[size].horizontalPadding});
     width: ${sizes[size].height};
   `}
 

--- a/src/__internal__/input/__snapshots__/input-presentation.spec.js.snap
+++ b/src/__internal__/input/__snapshots__/input-presentation.spec.js.snap
@@ -18,7 +18,7 @@ exports[`InputPresentation renders presentational div and context provider for i
   -ms-flex-align: stretch;
   align-items: stretch;
   background: #fff;
-  border: 1px solid #668592;
+  border: 1px solid var(--colorsUtilityMajor300);
   box-sizing: border-box;
   cursor: text;
   display: -webkit-box;
@@ -30,9 +30,9 @@ exports[`InputPresentation renders presentational div and context provider for i
   flex-wrap: wrap;
   width: 100%;
   margin: 0;
-  min-height: 40px;
-  padding-left: 11px;
-  padding-right: 11px;
+  min-height: var(--sizing500);
+  padding-left: var(--spacing150);
+  padding-right: var(--spacing150);
 }
 
 .c1 input::-ms-clear {

--- a/src/__internal__/input/__snapshots__/input.spec.js.snap
+++ b/src/__internal__/input/__snapshots__/input.spec.js.snap
@@ -4,12 +4,12 @@ exports[`Input renders with an input 1`] = `
 .c0 {
   background: transparent;
   border: none;
-  color: rgba(0,0,0,0.9);
+  color: var(--colorsUtilityYin090);
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  font-size: 14px;
+  font-size: var(--fontSizes100);
   outline: none;
   padding: 0;
   margin: 0;
@@ -22,19 +22,19 @@ exports[`Input renders with an input 1`] = `
 }
 
 .c0::-webkit-input-placeholder {
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsUtilityYin030);
 }
 
 .c0::-moz-placeholder {
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsUtilityYin030);
 }
 
 .c0:-ms-input-placeholder {
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsUtilityYin030);
 }
 
 .c0::placeholder {
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsUtilityYin030);
 }
 
 <input

--- a/src/__internal__/input/input-presentation.spec.js
+++ b/src/__internal__/input/input-presentation.spec.js
@@ -5,7 +5,6 @@ import { InputPresentation } from ".";
 import InputPresentationStyle, {
   StyledInputPresentationContainer,
 } from "./input-presentation.style";
-import baseTheme from "../../style/themes/base";
 import sizes from "./input-sizes.style";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import { InputContext, InputGroupContext } from "../input-behaviour";
@@ -50,43 +49,41 @@ describe("InputPresentation", () => {
       });
     });
 
-    describe.each([["error"], ["warning"], ["info"]])(
-      "when %s prop is set to true",
-      (validation) => {
-        it("has the right style", () => {
-          const boxShadow =
-            `inset 1px 1px 0 ${baseTheme.colors[validation]},` +
-            `inset -1px -1px 0 ${baseTheme.colors[validation]}`;
+    describe.each([
+      ["error", "var(--colorsSemanticNegative500)"],
+      ["warning", "var(--colorsSemanticCaution500)"],
+      ["info", "var(--colorsSemanticInfo500)"],
+    ])("when %s prop is set to true", (state, token) => {
+      it("has the right style", () => {
+        const boxShadow = `inset 1px 1px 0 ${token},inset -1px -1px 0 ${token}`;
 
-          assertStyleMatch(
-            {
-              borderColor: `${baseTheme.colors[validation]} !important`,
-              boxShadow: validation === "error" ? boxShadow : undefined,
-            },
-            render({ [validation]: true }).find(InputPresentationStyle)
-          );
-        });
-      }
-    );
+        assertStyleMatch(
+          {
+            borderColor: `${token} !important`,
+            boxShadow: state === "error" ? boxShadow : undefined,
+          },
+          render({ [state]: true }).find(InputPresentationStyle)
+        );
+      });
+    });
 
-    describe.each([["error"], ["warning"], ["info"]])(
-      "when %s prop is a string",
-      (validation) => {
-        it("has the right style", () => {
-          const boxShadow =
-            `inset 1px 1px 0 ${baseTheme.colors[validation]},` +
-            `inset -1px -1px 0 ${baseTheme.colors[validation]}`;
+    describe.each([
+      ["error", "var(--colorsSemanticNegative500)"],
+      ["warning", "var(--colorsSemanticCaution500)"],
+      ["info", "var(--colorsSemanticInfo500)"],
+    ])("when %s prop is a string", (state, token) => {
+      it("has the right style", () => {
+        const boxShadow = `inset 1px 1px 0 ${token},inset -1px -1px 0 ${token}`;
 
-          assertStyleMatch(
-            {
-              borderColor: `${baseTheme.colors[validation]} !important`,
-              boxShadow: validation === "error" ? boxShadow : undefined,
-            },
-            render({ [validation]: "Message" }).find(InputPresentationStyle)
-          );
-        });
-      }
-    );
+        assertStyleMatch(
+          {
+            borderColor: `${token} !important`,
+            boxShadow: state === "error" ? boxShadow : undefined,
+          },
+          renderWithContext({ [state]: "Message" }).find(InputPresentationStyle)
+        );
+      });
+    });
 
     describe('when align prop is passed as "right"', () => {
       it("has the correct style rules", () => {
@@ -101,8 +98,8 @@ describe("InputPresentation", () => {
       it("has the correct style rules", () => {
         assertStyleMatch(
           {
-            background: baseTheme.disabled.input,
-            borderColor: baseTheme.disabled.border,
+            background: "var(--colorsUtilityDisabled400)",
+            borderColor: "var(--colorsUtilityDisabled600)",
             cursor: "not-allowed",
           },
           render({ disabled: true }).find(InputPresentationStyle)
@@ -114,8 +111,8 @@ describe("InputPresentation", () => {
       it("has the correct style rules", () => {
         assertStyleMatch(
           {
-            backgroundColor: baseTheme.readOnly.textboxBackground,
-            borderColor: baseTheme.readOnly.textboxBorder,
+            backgroundColor: "var(--colorsUtilityReadOnly400)",
+            borderColor: "var(--colorsUtilityReadOnly600)",
           },
           render({ readOnly: true }).find(InputPresentationStyle)
         );
@@ -126,9 +123,11 @@ describe("InputPresentation", () => {
       it("has the correct style rules", () => {
         assertStyleMatch(
           {
-            border: "1px solid #668592",
+            outline: "3px solid var(--colorsSemanticFocus500)",
           },
-          render({ readOnly: true }).find(InputPresentationStyle)
+          renderWithContext({}, {}, { hasFocus: true }).find(
+            InputPresentationStyle
+          )
         );
       });
     });

--- a/src/__internal__/input/input-presentation.style.js
+++ b/src/__internal__/input/input-presentation.style.js
@@ -1,6 +1,5 @@
 import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
-import baseTheme from "../../style/themes/base";
 import sizes from "./input-sizes.style";
 
 export const StyledInputPresentationContainer = styled.div`
@@ -12,7 +11,7 @@ export const StyledInputPresentationContainer = styled.div`
 const InputPresentationStyle = styled.div`
   align-items: stretch;
   background: #fff;
-  border: 1px solid ${({ theme }) => theme.colors.border};
+  border: 1px solid var(--colorsUtilityMajor300);
   box-sizing: border-box;
   cursor: text;
   display: flex;
@@ -23,31 +22,31 @@ const InputPresentationStyle = styled.div`
   padding-left: ${({ size }) => sizes[size].horizontalPadding};
   padding-right: ${({ size }) => sizes[size].horizontalPadding};
 
-  ${({ disabled, theme }) =>
+  ${({ disabled }) =>
     disabled &&
     css`
-      background: ${theme.disabled.input};
-      border-color: ${theme.disabled.border};
+      background: var(--colorsUtilityDisabled400);
+      border-color: var(--colorsUtilityDisabled600);
       cursor: not-allowed;
     `}
 
-  ${({ hasFocus, theme, disabled }) =>
+  ${({ hasFocus, disabled }) =>
     hasFocus &&
     !disabled &&
     css`
-      && {
-        outline: 3px solid ${theme.colors.focus};
+      & {
+        outline: 3px solid var(--colorsSemanticFocus500);
         z-index: 2;
       }
     `}
 
   ${stylingForValidations}
 
-  ${({ readOnly, theme }) =>
+  ${({ readOnly }) =>
     readOnly &&
     css`
-      background-color: ${theme.readOnly.textboxBackground};
-      border-color: ${theme.readOnly.textboxBorder};
+      background-color: var(--colorsUtilityReadOnly400);
+      border-color: var(--colorsUtilityReadOnly600);
     `}
 
   ${({ align }) => align === "right" && "flex-direction: row-reverse"}
@@ -60,7 +59,7 @@ const InputPresentationStyle = styled.div`
   }
 `;
 
-function stylingForValidations({ theme, error, warning, info, disabled }) {
+function stylingForValidations({ error, warning, info, disabled }) {
   let validationColor;
 
   if (disabled) {
@@ -68,11 +67,11 @@ function stylingForValidations({ theme, error, warning, info, disabled }) {
   }
 
   if (error) {
-    validationColor = theme.colors.error;
+    validationColor = "var(--colorsSemanticNegative500)";
   } else if (warning) {
-    validationColor = theme.colors.warning;
+    validationColor = "var(--colorsSemanticCaution500)";
   } else if (info) {
-    validationColor = theme.colors.info;
+    validationColor = "var(--colorsSemanticInfo500)";
   } else {
     return "";
   }
@@ -87,7 +86,6 @@ function stylingForValidations({ theme, error, warning, info, disabled }) {
 
 InputPresentationStyle.defaultProps = {
   size: "medium",
-  theme: baseTheme,
 };
 
 InputPresentationStyle.propTypes = {

--- a/src/__internal__/input/input-sizes.style.js
+++ b/src/__internal__/input/input-sizes.style.js
@@ -1,23 +1,14 @@
 export default {
   small: {
-    height: "32px",
-    verticalPadding: "7px",
-    horizontalPadding: "8px",
-    tooltipVerticalOffset: 3,
-    tooltipHorizontalOffset: 1,
+    height: "var(--sizing400)",
+    horizontalPadding: "var(--spacing100)",
   },
   medium: {
-    height: "40px",
-    verticalPadding: "12px",
-    horizontalPadding: "11px",
-    tooltipVerticalOffset: 6,
-    tooltipHorizontalOffset: 4,
+    height: "var(--sizing500)",
+    horizontalPadding: "var(--spacing150)",
   },
   large: {
-    height: "48px",
-    verticalPadding: "15px",
-    horizontalPadding: "13px",
-    tooltipVerticalOffset: 10,
-    tooltipHorizontalOffset: 6,
+    height: "var(--sizing600)",
+    horizontalPadding: "var(--spacing200)",
   },
 };

--- a/src/__internal__/input/input.spec.js
+++ b/src/__internal__/input/input.spec.js
@@ -7,7 +7,6 @@ import StyledInput from "./input.style";
 import { InputContext } from "../input-behaviour";
 
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
-import baseTheme from "../../style/themes/base";
 
 describe("Input", () => {
   let container;
@@ -61,7 +60,7 @@ describe("Input", () => {
 
     assertStyleMatch(
       {
-        color: baseTheme.readOnly.textboxText,
+        color: "var(--colorsActionMinorYin090)",
       },
       wrapper
     );

--- a/src/__internal__/input/input.style.js
+++ b/src/__internal__/input/input.style.js
@@ -1,13 +1,12 @@
 import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
-import baseTheme from "../../style/themes/base";
 
 const StyledInput = styled.input`
   background: transparent;
   border: none;
-  color: ${({ theme }) => theme.text.color};
+  color: var(--colorsUtilityYin090);
   flex-grow: 1;
-  font-size: ${({ theme }) => theme.text.size};
+  font-size: var(--fontSizes100);
   outline: none;
   padding: 0;
   margin: 0;
@@ -25,26 +24,22 @@ const StyledInput = styled.input`
     `}
 
   &::placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: var(--colorsUtilityYin030);
   }
 
-  ${({ disabled, theme }) =>
+  ${({ disabled }) =>
     disabled &&
     css`
-      color: ${theme.disabled.disabled};
+      color: var(--colorsUtilityYin030);
       cursor: not-allowed;
     `}
 
-  ${({ readOnly, theme }) =>
+  ${({ readOnly }) =>
     readOnly &&
     css`
-      color: ${theme.readOnly.textboxText};
+      color: var(--colorsActionMinorYin090);
     `}
 `;
-
-StyledInput.defaultProps = {
-  theme: baseTheme,
-};
 
 StyledInput.propTypes = {
   disabled: PropTypes.bool,

--- a/src/components/grouped-character/grouped-character.test.js
+++ b/src/components/grouped-character/grouped-character.test.js
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { mount } from "@cypress/react";
 import GroupedCharacter from "./grouped-character.component";
+import CarbonProvider from "../carbon-provider";
 
 import {
   fieldHelpPreview,
@@ -22,14 +23,16 @@ const GroupedCharacterComponent = ({ onChange, ...props }) => {
   };
 
   return (
-    <GroupedCharacter
-      label="GroupedCharacter"
-      value={state}
-      onChange={setValue}
-      groups={[2, 2, 3]}
-      separator="-"
-      {...props}
-    />
+    <CarbonProvider>
+      <GroupedCharacter
+        label="GroupedCharacter"
+        value={state}
+        onChange={setValue}
+        groups={[2, 2, 3]}
+        separator="-"
+        {...props}
+      />
+    </CarbonProvider>
   );
 };
 

--- a/src/components/select/multi-select/multi-select.spec.js
+++ b/src/components/select/multi-select/multi-select.spec.js
@@ -135,9 +135,9 @@ describe("MultiSelect", () => {
   });
 
   it.each([
-    ["small", "32px"],
-    ["medium", "40px"],
-    ["large", "48px"],
+    ["small", "var(--sizing400)"],
+    ["medium", "var(--sizing500)"],
+    ["large", "var(--sizing600)"],
   ])("the input toggle icon should have proper left margin", (a, expected) => {
     const wrapper = renderSelect({ size: a });
     assertStyleMatch(

--- a/src/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
+++ b/src/components/simple-color-picker/__snapshots__/simple-color-picker.spec.js.snap
@@ -159,12 +159,12 @@ exports[`SimpleColorPicker renders as expected 1`] = `
 .c6 {
   background: transparent;
   border: none;
-  color: rgba(0,0,0,0.9);
+  color: var(--colorsUtilityYin090);
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  font-size: 14px;
+  font-size: var(--fontSizes100);
   outline: none;
   padding: 0;
   margin: 0;
@@ -177,19 +177,19 @@ exports[`SimpleColorPicker renders as expected 1`] = `
 }
 
 .c6::-webkit-input-placeholder {
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsUtilityYin030);
 }
 
 .c6::-moz-placeholder {
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsUtilityYin030);
 }
 
 .c6:-ms-input-placeholder {
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsUtilityYin030);
 }
 
 .c6::placeholder {
-  color: rgba(0,0,0,0.55);
+  color: var(--colorsUtilityYin030);
 }
 
 .c7 {


### PR DESCRIPTION
### Proposed behaviour

Introduces design tokens into internal `Input` and `InputPresentation` components, that are consumed in `Textbox` component.
`Textbox` component itself doesn't include any theme properties that could be replaced with tokens.

Following elements are affected by this change:
- Search
- Date Range
- Date Input
- Inline Inputs
- Numeral Date
- Pager
- Multi select
- Select
- Textarea

PR includes test updates for code related with changes.

### Current behaviour

Currently `Input` and `InputPresentation` are described by styled-components theme feature.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

All styles in all themes should match. There should be no changes in mint or aegean theme.

<!-- Add CodeSandbox here -->
Code sandbox: https://codesandbox.io/s/carbon-quickstart-forked-jkw4x