### PR TITLE
fix(date-range): prevent both fields becoming populated when one value passed (FE-4506)

### DIFF
--- a/src/components/date-range/date-range-test.stories.mdx
+++ b/src/components/date-range/date-range-test.stories.mdx
@@ -20,6 +20,7 @@ import DateRange from "./date-range.component";
 />
 
 export const DateRangeStory = ({
+  initialDates,
   allowEmptyValueOnStartDate,
   allowEmptyValueOnEndDate,
   startLabel,
@@ -28,7 +29,7 @@ export const DateRangeStory = ({
   endLabelSpecialCharacters,
   ...args
 }) => {
-  const [state, setState] = useState(["2016-10-01", "2016-10-30"]);
+  const [state, setState] = useState(initialDates);
   const handleChange = (evt) => {
     const newValue = [
       evt.target.value[0].rawValue,
@@ -39,7 +40,7 @@ export const DateRangeStory = ({
   };
   return (
     <DateRange
-      onChange={handleChange}
+      onChange={(evt) => handleChange(evt)}
       value={state}
       onBlur={action("blur")}
       startDateProps={{
@@ -63,8 +64,27 @@ export const DateRangeStory = ({
   <Story
     name="default"
     args={{
+      initialDates: ["2016-10-01", "2016-10-30"],
       startLabel: "",
       endLabel: "",
+      allowEmptyValueOnStartDate: undefined,
+      allowEmptyValueOnEndDate: undefined,
+      labelsInline: false,
+      startLabelSpecialCharacters: undefined,
+      endLabelSpecialCharacters: undefined,
+    }}
+  >
+    {DateRangeStory.bind({})}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="is controlled with dates initially empty"
+    args={{
+      initialDates: ["", ""],
+      startLabel: "Start",
+      endLabel: "End",
       allowEmptyValueOnStartDate: true,
       allowEmptyValueOnEndDate: true,
       labelsInline: false,

--- a/src/components/date-range/date-range.component.js
+++ b/src/components/date-range/date-range.component.js
@@ -70,7 +70,7 @@ const DateRange = ({
       ...localeData,
     }),
     rawValue: DateHelper.formatValue({
-      value: getStartDate() || (!isControlled ? today : ""),
+      value: getStartDate() || (startDateProps.allowEmptyValue ? "" : today),
       ...localeData,
     }),
   });
@@ -81,7 +81,7 @@ const DateRange = ({
       ...localeData,
     }),
     rawValue: DateHelper.formatValue({
-      value: getEndDate() || (!isControlled ? today : ""),
+      value: getEndDate() || (endDateProps.allowEmptyValue ? "" : today),
       ...localeData,
     }),
   });
@@ -93,7 +93,7 @@ const DateRange = ({
         ...localeData,
       }),
       rawValue: DateHelper.formatValue({
-        value: getStartDate() || today,
+        value: getStartDate() || (startDateProps.allowEmptyValue ? "" : today),
         ...localeData,
       }),
     });
@@ -104,11 +104,18 @@ const DateRange = ({
         ...localeData,
       }),
       rawValue: DateHelper.formatValue({
-        value: getEndDate() || today,
+        value: getEndDate() || (endDateProps.allowEmptyValue ? "" : today),
         ...localeData,
       }),
     });
-  }, [getEndDate, getStartDate, localeData, today]);
+  }, [
+    getEndDate,
+    getStartDate,
+    endDateProps,
+    startDateProps,
+    localeData,
+    today,
+  ]);
 
   function usePrevious(arg) {
     const ref = useRef();

--- a/src/components/date-range/date-range.spec.js
+++ b/src/components/date-range/date-range.spec.js
@@ -305,29 +305,61 @@ describe("DateRange", () => {
         },
         mount
       );
-      wrapper.setProps({ value: ["2016-10-10", "2016-11-11"] });
+      wrapper.setProps({ value: ["2021-12-12", "2021-12-12"] });
       wrapper.update();
+
       startInput = wrapper.find(BaseDateInput).at(0);
       endInput = wrapper.find(BaseDateInput).at(1);
-      expect(startInput.props().value).toEqual("2016-10-10");
-      expect(endInput.props().value).toEqual("2016-11-11");
+
+      expect(startInput.props().value).toEqual("2021-12-12");
+      expect(endInput.props().value).toEqual("2021-12-12");
     });
 
-    it("supports value update dynamically at runtime and defaults to today if new value is undefined", () => {
-      MockDate.set("2020-01-21");
+    it.each([
+      { updatedValue: ["2021-12-12", ""] },
+      { updatedValue: ["", "2021-12-12"] },
+    ])(
+      "when allowEmptyValue is true for both date props, updating one value dynamically doesn't change other",
+      ({ updatedValue }) => {
+        wrapper = renderDateRange(
+          {
+            onChange: customOnChange,
+            value: ["", ""],
+            startDateProps: { allowEmptyValue: true },
+            endDateProps: { allowEmptyValue: true },
+          },
+          mount
+        );
+
+        wrapper.setProps({ value: updatedValue });
+        wrapper.update();
+
+        startInput = wrapper.find(BaseDateInput).at(0);
+        endInput = wrapper.find(BaseDateInput).at(1);
+        expect(startInput.props().value).toEqual(updatedValue[0]);
+        expect(endInput.props().value).toEqual(updatedValue[1]);
+      }
+    );
+
+    it("when allowEmptyValue is false for both date props, empty values default to today's date", () => {
+      MockDate.set("2021-12-12");
       wrapper = renderDateRange(
         {
           onChange: customOnChange,
-          value: ["2012-12-12", "2012-12-13"],
+          value: ["1999-01-01", "1999-01-01"],
+          startDateProps: { allowEmptyValue: false },
+          endDateProps: { allowEmptyValue: false },
         },
         mount
       );
-      wrapper.setProps({ value: [] });
+
+      wrapper.setProps({ value: ["", ""] });
       wrapper.update();
+
       startInput = wrapper.find(BaseDateInput).at(0);
       endInput = wrapper.find(BaseDateInput).at(1);
-      expect(startInput.props().value).toEqual("2020-01-21");
-      expect(endInput.props().value).toEqual("2020-01-21");
+      expect(startInput.props().value).toEqual("2021-12-12");
+      expect(endInput.props().value).toEqual("2021-12-12");
     });
 
     it("class names can be added to dates by passing startDateProps and endDateProps to DateRange", () => {


### PR DESCRIPTION
closes #4615

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

When `DateRange` allows for empty values and both stored dates are empty, updating one of the dates via `onChange` should only update that date and not its sibling.

### Current behaviour
When `allowEmptyValue` is set to true for the start/end date props and `value = ["",""]`, updating one of the date values via `onChange` also causes the other value to update to the current date.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

A test which verifies that current behaviour occurs actually exists in the codebase, so this has been removed and updated with a new test that verifies if the proposed behaviour occurs.

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour:
https://codesandbox.io/s/thirsty-gagarin-wc56o?file=/src/index.js

You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
