### PR TITLE
docs(date): ensure with custom date format example has a code example - FE-4697

### DIFF
--- a/src/components/date/date.stories.mdx
+++ b/src/components/date/date.stories.mdx
@@ -334,7 +334,7 @@ It is possible to use the `tooltipPosition` to override the default placement of
 
 ### With custom date format
 
-<Preview>
+<Canvas>
   <Story name="with custom date format" parameters={{ chromatic: { disable: true } }}>
     {() => {
       const [state, setState] = useState("2019-04-04");
@@ -363,10 +363,10 @@ It is possible to use the `tooltipPosition` to override the default placement of
             onChange={setValue}
           />
         </I18nProvider>
-  );
+      );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ## Props
 


### PR DESCRIPTION
Currently `with custom date format` does not have a code example due to invalid JSX.

### Proposed behaviour

![Screenshot 2021-12-22 at 10 51 10](https://user-images.githubusercontent.com/56251247/147081402-eb4761da-e338-4d95-b538-3c1d00653a8d.png)

### Current behaviour

![Screenshot 2021-12-22 at 10 51 29](https://user-images.githubusercontent.com/56251247/147081436-a87f1085-86a4-4c59-9e49-52aff9ce3a9c.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Make sure that `Date Input -> with custom date format` example has a `show code` option and clicking this expands to show the code that makes this example.
