### PR TITLE
fix(loader): give loader the correct role and aria-label prop - FE-4635

### DIFF
--- a/src/components/loader/loader.component.js
+++ b/src/components/loader/loader.component.js
@@ -10,9 +10,20 @@ const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
 );
 
-const Loader = ({ isInsideButton, isActive, size, ...rest }) => {
+const Loader = ({
+  "aria-label": ariaLabel,
+  isInsideButton,
+  isActive,
+  size,
+  ...rest
+}) => {
   return (
-    <StyledLoader {...rest} {...tagComponent("loader", rest)}>
+    <StyledLoader
+      aria-label={ariaLabel}
+      role="progressbar"
+      {...tagComponent("loader", rest)}
+      {...rest}
+    >
       <StyledLoaderSquare
         isInsideButton={isInsideButton}
         isActive={isActive}
@@ -36,10 +47,13 @@ Loader.defaultProps = {
   size: "medium",
   isInsideButton: false,
   isActive: true,
+  "aria-label": "loader",
 };
 
 Loader.propTypes = {
   ...marginPropTypes,
+  /** Specify an aria-label for the Loader component */
+  "aria-label": PropTypes.string,
   /** Size of the loader. */
   size: PropTypes.oneOf(["small", "medium", "large"]),
   /** Applies white color. */

--- a/src/components/loader/loader.d.ts
+++ b/src/components/loader/loader.d.ts
@@ -1,6 +1,8 @@
 import { MarginProps } from "styled-system";
 
 export interface LoaderProps extends MarginProps {
+  /** Specify an aria-label for the Loader component */
+  "aria-label"?: string;
   /** Size of the loader. */
   size?: "small" | "medium" | "large";
   /** Applies white color. */

--- a/src/components/loader/loader.stories.mdx
+++ b/src/components/loader/loader.stories.mdx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import Loader from ".";
-import Button from "../button";
+import Button from "../button/button.component";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 <Meta
@@ -70,7 +70,7 @@ please remember to pass the `isInsideButton` prop to the `Loader` component.
 
 <Canvas>
   <Story name="inside Buttons">
-    <Button buttonType="primary">
+    <Button buttonType="primary" aria-label="Loading">
       <Loader isInsideButton />
     </Button>
   </Story>


### PR DESCRIPTION
When a Loader component is nested in a button, axe throws an error to say that there is no
discernible text. Loader should have a role of progressbar and an aria-label to solve this issue.

fixes #4644

### Proposed behaviour

- Loader should have a role of `progressbar`
- aria-label prop has been made available for Loader to use
- When a Loader is nested inside of a Button component there are now no logged accessibility issues
![Screenshot 2021-12-22 at 15 39 00](https://user-images.githubusercontent.com/56251247/147117481-93fc2770-edba-41f9-b64c-3fed7bfe9935.png)

### Current behaviour

- Loader has no role
- aria-label is not available for Loader to use 
- When a Loader is nested inside of a Button component there is an accessibility issued logged by axe
![Screenshot 2021-12-22 at 15 39 40](https://user-images.githubusercontent.com/56251247/147117579-682dc8d9-6876-4c12-96bf-56d565a48715.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Visit `Loader -> inside buttons` example in storybook. There should not be accessibility errors on this example.
