### PR TITLE
fix(checkbox-group): remove incorrect margin in form (FE-4634)

### DIFF
--- a/src/components/checkbox/checkbox-group.spec.js
+++ b/src/components/checkbox/checkbox-group.spec.js
@@ -9,6 +9,7 @@ import {
 import CheckboxStyle, { StyledCheckboxGroup } from "./checkbox.style";
 import Fieldset from "../../__internal__/fieldset";
 import Tooltip from "../tooltip";
+import StyledFormField from "../../__internal__/form-field/form-field.style";
 
 const checkboxValues = ["required", "optional"];
 const groupName = "my-checkbox-group";
@@ -72,6 +73,18 @@ describe("CheckboxGroup", () => {
           .prop(expectedPropName || propName)
       ).toBe(propValue);
     });
+  });
+
+  it("should have a margin set to 0 on every Checkbox FormField", () => {
+    const wrapper = render({});
+
+    assertStyleMatch(
+      {
+        margin: "0",
+      },
+      wrapper.find(StyledCheckboxGroup),
+      { modifier: `&& ${StyledFormField}` }
+    );
   });
 
   it("should render correct styles if `legendInline` is provided", () => {

--- a/src/components/checkbox/checkbox.style.js
+++ b/src/components/checkbox/checkbox.style.js
@@ -212,6 +212,10 @@ const StyledCheckboxGroup = styled.div`
     font-size: 16px;
   }
 
+  && ${StyledFormField} {
+    margin: 0;
+  }
+
   & ${CheckboxStyle} {
     padding-top: 12px;
   }


### PR DESCRIPTION
Fixes #4641

### Proposed behaviour

Remove margin applied by the Form component to Checkboxes in a CheckboxGroup
![Screenshot 2021-12-23 at 14 23 28](https://user-images.githubusercontent.com/22885392/147246716-0397ee8d-9d15-454d-838a-f1ff75e03b69.png)

### Current behaviour

Incorrect margin of Checkboxes inside a CheckboxGroup when in Form
![image](https://user-images.githubusercontent.com/22885392/147246509-cd6d17ae-cf8f-4e1c-907e-33061bbcf8d6.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
