### PR TITLE
fix(page): ensure that children are constrained inside of component - FE-4505

### DIFF
--- a/src/components/pages/page/page.style.js
+++ b/src/components/pages/page/page.style.js
@@ -7,7 +7,7 @@ const StyledPage = styled.article`
 `;
 
 const StyledPageContent = styled.div`
-  box-sizing: content-box;
+  box-sizing: border-box;
   padding: 30px 40px;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Children inside of the page component should not exceed the width of the component.

fixes #4616

### Proposed behaviour

Children of the Page/Pages component should be constrained by the width of the component.

### Current behaviour

Children of the Page/Pages component are not constrained by the width of the component.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Codesandbox examples will be supplied.
