### PR TITLE
refactor(page): remove AppWrapper from component - FE-4574

### DIFF
--- a/src/components/pages/page/page.component.js
+++ b/src/components/pages/page/page.component.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { CSSTransition } from "react-transition-group";
 import tagComponent from "../../../__internal__/utils/helpers/tags/tags";
 import FullScreenHeading from "../../../__internal__/full-screen-heading";
-import AppWrapper from "../../app-wrapper";
+import Box from "../../box";
 import { StyledPage, StyledPageContent } from "./page.style";
 
 const Page = ({ title, children, ...props }) => {
@@ -22,7 +22,15 @@ const Page = ({ title, children, ...props }) => {
       <StyledPage {...tagComponent("page", props)}>
         <FullScreenHeading hasContent={title}>{title}</FullScreenHeading>
         <StyledPageContent data-element="carbon-page-content">
-          <AppWrapper>{children}</AppWrapper>
+          <Box
+            boxSizing="border-box"
+            maxWidth="100%"
+            minWidth="auto"
+            margin="0 auto"
+            padding="4px 0px"
+          >
+            {children}
+          </Box>
         </StyledPageContent>
       </StyledPage>
     </CSSTransition>

--- a/src/components/pages/page/page.spec.js
+++ b/src/components/pages/page/page.spec.js
@@ -5,22 +5,23 @@ import Page from "./page.component";
 import FullScreenHeading from "../../../__internal__/full-screen-heading";
 
 describe("Pages", () => {
+  const wrapper = shallow(
+    <Page
+      transitionName={() => {}}
+      title="My Title"
+      data-element="carbon-page-content"
+    >
+      My Content
+    </Page>
+  );
+
   it("renders a page with a full screen heading", () => {
-    const wrapper = shallow(
-      <Page
-        transitionName={() => {}}
-        title="My Title"
-        data-element="carbon-page-content"
-      >
-        My Content
-      </Page>
-    );
-    const fullScrenHeading = wrapper.find(FullScreenHeading);
+    const fullScreenHeading = wrapper.find(FullScreenHeading);
     expect(wrapper.find(StyledPage).props()["data-element"]).toEqual(
       "carbon-page-content"
     );
     expect(wrapper.find(StyledPage).props()["data-component"]).toEqual("page");
-    expect(fullScrenHeading.props().children).toEqual("My Title");
+    expect(fullScreenHeading.props().children).toEqual("My Title");
     expect(
       wrapper.find(StyledPage).props().children[1].props.children.props.children
     ).toEqual("My Content");

--- a/src/components/pages/pages.style.js
+++ b/src/components/pages/pages.style.js
@@ -6,12 +6,6 @@ import { StyledDivider, StyledHeading } from "../heading/heading.style";
 const PagesContent = styled.div`
   border: none;
 
-  .carbon-app-wrapper {
-    min-width: auto;
-    max-width: 100%;
-    padding: 4px 0 0 0;
-  }
-
   ${StyledHeading} {
     padding-left: 45px;
     margin-bottom: 34px;


### PR DESCRIPTION
AppWrapper is due to be deprecated but before this can happen, we must remove it from the Page
component. AppWrapper has been removed in favour of Box in the Page component.

fixes FE-4574

### Proposed behaviour

Replace `AppWrapper` with `Box` component.

### Current behaviour

Page component uses `AppWrapper` but `AppWrapper` is due to be deprecated.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

There should be no differences in appearance or functionality between Pages on `master` and Pages on this PR. 
A codesandbox can be prepared if a test case arises.
