### PR TITLE
fix(textarea): pass value down to input

### DIFF
--- a/src/components/textarea/textarea.component.js
+++ b/src/components/textarea/textarea.component.js
@@ -186,6 +186,7 @@ const Textarea = ({
                 aria-describedby={ariaDescribedBy}
                 autoFocus={autoFocus}
                 name={name}
+                value={value}
                 ref={inputRef}
                 maxLength={
                   enforceCharacterLimit && characterLimit

--- a/src/components/textarea/textarea.spec.js
+++ b/src/components/textarea/textarea.spec.js
@@ -53,6 +53,16 @@ describe("Textarea", () => {
 
   const validationTypes = ["error", "warning", "info"];
 
+  describe("when value prop set initially", () => {
+    it("should display the correct value", () => {
+      wrapper = renderTextarea({
+        value: "Initial content",
+      });
+
+      expect(wrapper.find(Input).text()).toEqual("Initial content");
+    });
+  });
+
   describe.each(validationTypes)(
     "when %s validation prop is string",
     (validationProp) => {


### PR DESCRIPTION
### Proposed behaviour

Pass the `value` prop down to the underlying input in `Textarea`. 

### Current behaviour

The `value` prop is no longer passed to the underlying input so the user cannot set the value.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
