### PR TITLE
fix(split-button): apply type of button to split button toggle - FE-4969

### DIFF
--- a/src/components/split-button/__snapshots__/split-button.spec.js.snap
+++ b/src/components/split-button/__snapshots__/split-button.spec.js.snap
@@ -427,6 +427,7 @@ exports[`SplitButton for business themes renders styles correctly 1`] = `
     onMouseEnter={[Function]}
     onTouchStart={[Function]}
     size="medium"
+    type="button"
   >
     <span
       className="c4 c5"

--- a/src/components/split-button/split-button-test.stories.mdx
+++ b/src/components/split-button/split-button-test.stories.mdx
@@ -96,7 +96,7 @@ export const SplitButtonStory = ({
   );
 };
 
-# Alert
+# Split Button
 
 ### Default
 

--- a/src/components/split-button/split-button.component.js
+++ b/src/components/split-button/split-button.component.js
@@ -185,6 +185,7 @@ const SplitButton = ({
         aria-label="Show more"
         data-element="toggle-button"
         key="toggle-button"
+        type="button"
         {...toggleButtonProps()}
       >
         <Icon

--- a/src/components/split-button/split-button.spec.js
+++ b/src/components/split-button/split-button.spec.js
@@ -106,7 +106,7 @@ const renderWithNoChildren = (mainProps = {}, renderer = shallow) => {
 
 const buildSizeConfig = (name, size) => {
   const sizeObj = {};
-  sizeObj.fontSizze = size === "large" ? "16px" : "14px";
+  sizeObj.fontSize = size === "large" ? "16px" : "14px";
   if (size === "small") {
     sizeObj.height = "32px";
     sizeObj.padding = "16px";
@@ -177,7 +177,7 @@ describe("SplitButton", () => {
   });
 
   describe("when children are not Button Components", () => {
-    it("then child elements should be redered as they are", () => {
+    it("then child elements should be rendered as they are", () => {
       const spanElement = <span className="span-element" />;
       wrapper = render({}, spanElement, mount);
       simulateFocusOnToggle(wrapper);
@@ -570,7 +570,7 @@ describe("SplitButton", () => {
     });
 
     describe('when "up" key is pressed', () => {
-      it("the additonal buttons should be stepped through in sequence", () => {
+      it("the additional buttons should be stepped through in sequence", () => {
         const additionalButtons = wrapper
           .find(additionalButtonsSelector)
           .find(ButtonWithForwardRef);
@@ -591,7 +591,7 @@ describe("SplitButton", () => {
     });
 
     describe('when "down" key is pressed', () => {
-      it("the additonal buttons should be stepped through in sequence", () => {
+      it("the additional buttons should be stepped through in sequence", () => {
         const additionalButtons = wrapper
           .find(additionalButtonsSelector)
           .find(ButtonWithForwardRef);
@@ -623,7 +623,7 @@ describe("SplitButton", () => {
         expect(timeoutSpy).toHaveBeenCalled();
       });
 
-      it("it does not pass focus to the first additonal button", () => {
+      it("it does not pass focus to the first additional button", () => {
         toggle.simulate("keydown", { which: 9 });
         const firstButton = wrapper
           .find(additionalButtonsSelector)


### PR DESCRIPTION
Ensures that a type of button is specified on the split button toggle. This is to make sure that
when split button is used inside of a HTML form, the split toggle button does not automatically
submit the form when clicked.

fixes #4651

### Proposed behaviour

- `Split Button Toggle` has a type of `button`.

### Current behaviour

- `Split Button Toggle` does not a type specified so when `Split Button` is used in a Form, the toggle button acts as a submit button by default.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Codesandbox built using the example in Github issue can be found [here](https://github.com/Sage/carbon/pull/4678#issuecomment-1005928848).
