### PR TITLE
fix(menu-full-screen): fix heights and widths and remove horizontal s…

### DIFF
--- a/cypress/integration/common/menu.feature
+++ b/cypress/integration/common/menu.feature
@@ -110,36 +110,36 @@ Feature: Menu component
 
   @positive
   Scenario: Check that the fullscreen menu is rendered properly
-    When I open "Menu Test" component page "fullscreen-menu"
+    When I open "Menu Test" component page "menu-full-screen-story"
     Then Menu is in fullscreen mode
 
   @positive
   Scenario: Check that the fullscreen menu is closed
-    Given I open "Menu Test" component page "fullscreen-menu"
+    Given I open "Menu Test" component page "menu-full-screen-story"
     When I click closeIcon
     Then Menu is in fullscreen mode is not visible
 
   @positive
   Scenario: Check that close icon is focused in Fullscreen Menu
-    Given I open "Menu Test" component page "fullscreen-menu"
+    Given I open "Menu Test" component page "menu-full-screen-story"
     When I hit Tab key 1 times
     Then closeIcon has the border outline color "rgb(255, 181, 0)" and width "3px"
 
   @positive
   Scenario: Check that inner Menu is available with tabbing in Fullscreen Menu
-    Given I open "Menu Test" component page "fullscreen-menu"
+    Given I open "Menu Test" component page "menu-full-screen-story"
     When I hit Tab key 5 times
     Then "fourth" inner menu element is focused
 
   @positive
   Scenario: Check that previous inner Menu is available with shift tabbing in Fullscreen Menu
-    Given I open "Menu Test" component page "fullscreen-menu"
+    Given I open "Menu Test" component page "menu-full-screen-story"
       And I hit Tab key 6 times
     When I press Shift Tab on focused element
     Then "fourth" inner menu element is focused
 
   @positive
   Scenario: Check that inner Menu without link is NOT available with tabbing in Fullscreen Menu
-    Given I open "Menu Test" component page "fullscreen-menu"
+    Given I open "Menu Test" component page "menu-full-screen-story"
     When I hit Tab key 8 times
     Then inner menu without active redirection is not focused

--- a/cypress/integration/common/menu.feature
+++ b/cypress/integration/common/menu.feature
@@ -110,36 +110,36 @@ Feature: Menu component
 
   @positive
   Scenario: Check that the fullscreen menu is rendered properly
-    When I open "Menu Test" component page "default"
+    When I open "Menu Test" component page "fullscreen-menu"
     Then Menu is in fullscreen mode
 
   @positive
   Scenario: Check that the fullscreen menu is closed
-    Given I open "Menu Test" component page "default"
+    Given I open "Menu Test" component page "fullscreen-menu"
     When I click closeIcon
     Then Menu is in fullscreen mode is not visible
 
   @positive
   Scenario: Check that close icon is focused in Fullscreen Menu
-    Given I open "Menu Test" component page "default"
+    Given I open "Menu Test" component page "fullscreen-menu"
     When I hit Tab key 1 times
     Then closeIcon has the border outline color "rgb(255, 181, 0)" and width "3px"
 
   @positive
   Scenario: Check that inner Menu is available with tabbing in Fullscreen Menu
-    Given I open "Menu Test" component page "default"
+    Given I open "Menu Test" component page "fullscreen-menu"
     When I hit Tab key 5 times
     Then "fourth" inner menu element is focused
 
   @positive
   Scenario: Check that previous inner Menu is available with shift tabbing in Fullscreen Menu
-    Given I open "Menu Test" component page "default"
+    Given I open "Menu Test" component page "fullscreen-menu"
       And I hit Tab key 6 times
     When I press Shift Tab on focused element
     Then "fourth" inner menu element is focused
 
   @positive
   Scenario: Check that inner Menu without link is NOT available with tabbing in Fullscreen Menu
-    Given I open "Menu Test" component page "default"
+    Given I open "Menu Test" component page "fullscreen-menu"
     When I hit Tab key 8 times
     Then inner menu without active redirection is not focused

--- a/cypress/support/step-definitions/menu-steps.js
+++ b/cypress/support/step-definitions/menu-steps.js
@@ -171,7 +171,7 @@ Then("Menu is in fullscreen mode", () => {
     .should("be.visible");
   fullscreenMenu(positionOfElement("second"))
     .find("ul > li")
-    .should("have.length", 15);
+    .should("have.length", 17);
 });
 
 Then("Menu is in fullscreen mode is not visible", () => {

--- a/src/components/menu/__internal__/submenu/submenu.spec.js
+++ b/src/components/menu/__internal__/submenu/submenu.spec.js
@@ -1177,7 +1177,7 @@ describe("Submenu component", () => {
           wrapper.find(StyledSubmenu),
           {
             modifier: css`
-              ${StyledMenuItemWrapper} ${StyledSearch} [data-component="icon"]
+              ${StyledMenuItemWrapper} ${StyledSearch} span > [data-component="icon"]
             `,
           }
         );
@@ -1188,7 +1188,7 @@ describe("Submenu component", () => {
           wrapper.find(StyledSubmenu),
           {
             modifier: css`
-              ${StyledMenuItemWrapper} ${StyledSearch} [data-component="icon"]:hover
+              ${StyledMenuItemWrapper} ${StyledSearch} span > [data-component="icon"]:hover
             `,
           }
         );

--- a/src/components/menu/__internal__/submenu/submenu.style.js
+++ b/src/components/menu/__internal__/submenu/submenu.style.js
@@ -106,7 +106,7 @@ const StyledSubmenu = styled.ul`
         margin-right: 5px;
       }
 
-      ${StyledSearch} [data-component="icon"] {
+      ${StyledSearch} span > [data-component="icon"] {
         color: ${theme.menu[menuType].searchIcon};
 
         &:hover {

--- a/src/components/menu/__internal__/submenu/submenu.style.js
+++ b/src/components/menu/__internal__/submenu/submenu.style.js
@@ -20,12 +20,16 @@ const StyledSubmenuWrapper = styled.div`
 
   ${({ inFullscreenView, menuType, asPassiveItem, theme }) =>
     inFullscreenView &&
-    asPassiveItem &&
     css`
-      ${StyledMenuItemWrapper} {
-        outline: none;
-        color: ${theme.menu[menuType].title};
-      }
+      width: 100%;
+
+      ${asPassiveItem &&
+      css`
+        ${StyledMenuItemWrapper} {
+          outline: none;
+          color: ${theme.menu[menuType].title};
+        }
+      `}
     `}
 `;
 
@@ -50,7 +54,7 @@ const StyledSubmenu = styled.ul`
     ${inFullscreenView &&
     css`
       ${StyledMenuItem} {
-        width: 100vw;
+        width: 100%;
       }
     `}
 

--- a/src/components/menu/menu-full-screen/menu-full-screen.component.js
+++ b/src/components/menu/menu-full-screen/menu-full-screen.component.js
@@ -88,10 +88,10 @@ const MenuFullscreen = ({
               </IconButton>
             </StyledMenuFullscreenHeader>
             <Box
-              overflow="auto"
+              overflowY="auto"
               scrollVariant={scrollVariants[menuType]}
-              width="100vw"
-              height="100vh"
+              width="100%"
+              height="calc(100% - 40px)"
             >
               <StyledMenuWrapper
                 data-component="menu"

--- a/src/components/menu/menu-full-screen/menu-full-screen.spec.js
+++ b/src/components/menu/menu-full-screen/menu-full-screen.spec.js
@@ -74,7 +74,7 @@ describe("MenuFullscreen", () => {
           backgroundColor: baseTheme.menu.light.background,
           zIndex: `${baseTheme.zIndex.fullScreenModal}`,
           visibility: "hidden",
-          left: "-100vw",
+          left: "-100%",
           transition: "all 0.3s ease",
         },
         wrapper.find(StyledMenuFullscreen)

--- a/src/components/menu/menu-full-screen/menu-full-screen.style.js
+++ b/src/components/menu/menu-full-screen/menu-full-screen.style.js
@@ -7,6 +7,8 @@ const StyledMenuFullscreen = styled.div`
   position: fixed;
   top: 0;
   bottom: 0;
+  height: 100vh;
+  width: 100%;
 
   a,
   button,
@@ -28,7 +30,7 @@ const StyledMenuFullscreen = styled.div`
     ${!isOpen &&
     css`
       visibility: hidden;
-      ${startPosition}: -100vw;
+      ${startPosition}: -100%;
       transition: all 0.3s ease;
     `}
   `}

--- a/src/components/menu/menu-full-screen/menu-full-screen.style.js
+++ b/src/components/menu/menu-full-screen/menu-full-screen.style.js
@@ -2,6 +2,9 @@ import styled, { css } from "styled-components";
 import { baseTheme } from "../../../style/themes";
 import StyledIconButton from "../../icon-button/icon-button.style";
 import Box from "../../box";
+import StyledSearch from "../../search/search.style";
+import StyledIcon from "../../icon/icon.style";
+import StyledButton from "../../button/button.style";
 
 const StyledMenuFullscreen = styled.div`
   position: fixed;
@@ -19,6 +22,47 @@ const StyledMenuFullscreen = styled.div`
   ${({ isOpen, menuType, startPosition, theme }) => css`
     background-color: ${theme.menu[menuType].background};
     z-index: ${theme.zIndex.fullScreenModal};
+
+    ${menuType === "dark" &&
+    css`
+      ${StyledSearch} span > [data-component="icon"] {
+        color: ${theme.menu.dark.searchIcon};
+
+        &:hover {
+          color: ${theme.menu.dark.searchIconHover};
+        }
+      }
+    `}
+
+    ${menuType === "light" &&
+    css`
+      ${StyledSearch} span > [data-component="icon"] {
+        color: ${theme.search.icon};
+
+        &:hover {
+          color: ${theme.search.iconHover};
+        }
+      }
+    `}
+
+    ${StyledSearch} {
+      ${StyledIcon} {
+        display: inline-flex;
+        margin-right: 0;
+        bottom: auto;
+      }
+
+      ${StyledButton} {
+        display: flex;
+        line-height: normal;
+        padding-bottom: 0;
+
+        &:focus {
+          outline: solid 3px var(--colorsSemanticFocus500);
+          box-shadow: none;
+        }
+      }
+    }
 
     ${isOpen &&
     css`

--- a/src/components/menu/menu-item/menu-item.style.js
+++ b/src/components/menu/menu-item/menu-item.style.js
@@ -215,7 +215,6 @@ const StyledMenuItemWrapper = styled.a`
     css`
       ${as === "div" &&
       css`
-        width: 100vw;
         cursor: default;
         padding: 0 16px;
 
@@ -223,14 +222,6 @@ const StyledMenuItemWrapper = styled.a`
           background: transparent;
         }
       `}
-
-      a,
-      ${StyledLink} a,
-      button,
-      ${StyledLink} button {
-        width: 100vw;
-        box-sizing: border-box;
-      }
     `}
   `}
 `;

--- a/src/components/menu/menu-test.stories.js
+++ b/src/components/menu/menu-test.stories.js
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Meta, Story, Canvas } from "@storybook/addon-docs";
+/* eslint-disable react/prop-types */
+import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
 
 import { Menu } from ".";
@@ -7,15 +7,15 @@ import MenuItem from "./menu-item";
 import MenuFullscreen from "./menu-full-screen";
 import Search from "../search";
 
-<Meta
-  title="Menu/Test"
-  parameters={{
+export default {
+  title: "Menu/Test",
+  parameters: {
     info: { disable: true },
     chromatic: {
       disable: false,
     },
-  }}
-  argTypes={{
+  },
+  argTypes: {
     menuType: {
       options: ["light", "dark"],
       control: {
@@ -28,13 +28,26 @@ import Search from "../search";
         type: "select",
       },
     },
-  }}
-/>
+    searchVariant: {
+      options: ["default", "dark"],
+      control: {
+        type: "select",
+      },
+    },
+    searchButton: {
+      options: [true, false],
+      control: {
+        type: "boolean",
+      },
+    },
+  },
+};
 
 export const MenuFullScreenStory = ({
   menuType,
   startPosition,
   searchVariant,
+  searchButton,
 }) => {
   const [isOpen, setIsOpen] = useState(true);
   const onClose = (evt) => {
@@ -66,6 +79,7 @@ export const MenuFullScreenStory = ({
             placeholder="Search..."
             variant={searchVariant}
             defaultValue=""
+            searchButton={searchButton}
           />
         </MenuItem>
         <MenuItem href="#">Menu Item Three</MenuItem>
@@ -80,34 +94,12 @@ export const MenuFullScreenStory = ({
   );
 };
 
-# Menu
-
-### Full screen light menu
-
-<Canvas>
-  <Story
-    name="light fullscreen menu"
-    args={{
-      menuType: "light",
-      startPosition: "left",
-      searchVariant: "default",
-    }}
-  >
-    {MenuFullScreenStory.bind({})}
-  </Story>
-</Canvas>
-
-### Full screen dark menu
-
-<Canvas>
-  <Story
-    name="dark fullscreen menu"
-    args={{
-      menuType: "dark",
-      startPosition: "left",
-      searchVariant: "dark",
-    }}
-  >
-    {MenuFullScreenStory.bind({})}
-  </Story>
-</Canvas>
+MenuFullScreenStory.story = {
+  name: "fullscreen menu",
+  args: {
+    menuType: "light",
+    startPosition: "left",
+    searchVariant: "default",
+    searchButton: true,
+  },
+};

--- a/src/components/menu/menu-test.stories.mdx
+++ b/src/components/menu/menu-test.stories.mdx
@@ -5,6 +5,7 @@ import { action } from "@storybook/addon-actions";
 import { Menu } from ".";
 import MenuItem from "./menu-item";
 import MenuFullscreen from "./menu-full-screen";
+import Search from "../search";
 
 <Meta
   title="Menu/Test"
@@ -30,7 +31,11 @@ import MenuFullscreen from "./menu-full-screen";
   }}
 />
 
-export const MenuStory = ({ menuType, startPosition }) => {
+export const MenuFullScreenStory = ({
+  menuType,
+  startPosition,
+  searchVariant,
+}) => {
   const [isOpen, setIsOpen] = useState(true);
   const onClose = (evt) => {
     setIsOpen(false);
@@ -56,6 +61,13 @@ export const MenuStory = ({ menuType, startPosition }) => {
           <MenuItem href="#">Submenu Item One</MenuItem>
           <MenuItem href="#">Submenu Item Two</MenuItem>
         </MenuItem>
+        <MenuItem variant="alternate">
+          <Search
+            placeholder="Search..."
+            variant={searchVariant}
+            defaultValue=""
+          />
+        </MenuItem>
         <MenuItem href="#">Menu Item Three</MenuItem>
         <MenuItem href="#">Menu Item Four</MenuItem>
         <MenuItem submenu="Menu Item Five">
@@ -70,16 +82,32 @@ export const MenuStory = ({ menuType, startPosition }) => {
 
 # Menu
 
-### Default
+### Full screen light menu
 
 <Canvas>
   <Story
-    name="default"
+    name="light fullscreen menu"
     args={{
       menuType: "light",
       startPosition: "left",
+      searchVariant: "default",
     }}
   >
-    {MenuStory.bind({})}
+    {MenuFullScreenStory.bind({})}
+  </Story>
+</Canvas>
+
+### Full screen dark menu
+
+<Canvas>
+  <Story
+    name="dark fullscreen menu"
+    args={{
+      menuType: "dark",
+      startPosition: "left",
+      searchVariant: "dark",
+    }}
+  >
+    {MenuFullScreenStory.bind({})}
   </Story>
 </Canvas>

--- a/src/components/menu/menu.style.js
+++ b/src/components/menu/menu.style.js
@@ -6,6 +6,7 @@ import {
   StyledDivider,
 } from "../vertical-divider/vertical-divider.style";
 import { baseTheme } from "../../style/themes";
+import { StyledLink } from "../link/link.style";
 
 const StyledMenuWrapper = styled.ul`
   line-height: 40px;
@@ -34,12 +35,6 @@ const StyledMenuWrapper = styled.ul`
       top: -1px;
     }
   }
-
-  ${({ inFullscreenView }) =>
-    inFullscreenView &&
-    css`
-      padding-bottom: 24px;
-    `}
 `;
 
 const StyledMenuItem = styled.li`
@@ -58,6 +53,15 @@ const StyledMenuItem = styled.li`
     css`
       padding-top: 16px;
       padding-bottom: 16px;
+
+      a,
+      ${StyledLink} a,
+      button,
+      ${StyledLink} button,
+      span {
+        width: 100%;
+        box-sizing: border-box;
+      }
     `}
 `;
 

--- a/src/components/menu/menu.style.js
+++ b/src/components/menu/menu.style.js
@@ -58,7 +58,9 @@ const StyledMenuItem = styled.li`
       ${StyledLink} a,
       button,
       ${StyledLink} button,
-      span {
+      > span,
+      > div,
+      [data-component="submenu-wrapper"] > ${StyledLink} {
         width: 100%;
         box-sizing: border-box;
       }


### PR DESCRIPTION
…croll bar

Fixes: #4473
Fixes: #4674
Fixes: #4675 

### Proposed behaviour

Fix the heights and widths of elements within `MenuFullScreen` so that you can no longer scroll horizontally on the menu when none of the content is wider than the viewport.

Fixing the height means that tabbing through the menu items, scrolls them fully onto the viewport if they are half out of it:

![image](https://user-images.githubusercontent.com/14963680/148413658-46a1dd47-e739-42bf-9c3f-3b9ad4eb5c4d.png)

Fixing the styling of a Search within a MenuFullScreen in light and dark variants:

![image](https://user-images.githubusercontent.com/14963680/148573776-ea46c5d5-39e7-40d3-a57b-88dbaae0058d.png)

![image](https://user-images.githubusercontent.com/14963680/148573817-bec0da28-f498-41f3-9d0d-64595e327614.png)



### Current behaviour

You can currently scroll horizontally on `MenuFullScreen` when you should not be able to: 
![image](https://user-images.githubusercontent.com/14963680/148413997-5704ef77-fe0a-405f-b1ba-bca2f5264e4b.png)

Using the keyboard to tab through menu items, if you tab onto one that is half out of the viewport, it does not scroll into view: 

![image](https://user-images.githubusercontent.com/14963680/148414443-3a90e478-cb0a-43b1-a4f3-e1edf069e0ed.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Use this story: http://localhost:9001/?path=/story/menu-test--menu-full-screen-story to test the fixes.

You can change the `menuType`, `searchVariant` and `searchButton` controls to test the different variations of a `Search` component within a full screen menu.
