### PR TITLE
chore(deps): update design tokens package to the last version 1.87.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5053,9 +5053,9 @@
       "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg=="
     },
     "@sage/design-tokens": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@sage/design-tokens/-/design-tokens-1.80.0.tgz",
-      "integrity": "sha512-3kfVE5pJKN9ZVNIKUXAcVraXXcjXPbfBFRbn+F0MiVCeDp6JZw3Fp1TqObAkUTOP0DOLwBxZubE93+VY5mIb4w=="
+      "version": "1.87.0",
+      "resolved": "https://registry.npmjs.org/@sage/design-tokens/-/design-tokens-1.87.0.tgz",
+      "integrity": "sha512-C0YBxyMzStxDExUNwkkUXfoBKT8Si9sdsp6VdXDWg02p9g2/fJi7us0fumUSSVt2hCKtOFw0ddDMPY3EpIekkQ=="
     },
     "@semantic-release/changelog": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   "dependencies": {
     "@octokit/rest": "^18.12.0",
     "@popperjs/core": "^2.9.0",
-    "@sage/design-tokens": "^1.80.0",
+    "@sage/design-tokens": "^1.87.0",
     "@styled-system/prop-types": "^5.1.5",
     "@tippyjs/react": "^4.2.5",
     "classnames": "~2.2.6",


### PR DESCRIPTION
### Proposed behaviour

New version of packege includes a new boxShadow support. New version: 1.87.0

### Current behaviour

The latest version of the package is: ^1.80.0

