### PR TITLE
fix(tabs, tab-title): remove onFocus to stop firing callback twice and tabs activate onmouseup FE-4509

### DIFF
--- a/src/components/tabs/__internal__/tab-title/tab-title.style.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.style.js
@@ -339,18 +339,9 @@ const StyledTabTitle = styled.button`
       }
     `}
 
-  ${({
-    isTabSelected,
-    theme,
-    alternateStyling,
-    error,
-    warning,
-    info,
-    isInSidebar,
-  }) =>
+  ${({ isTabSelected, theme, alternateStyling, error, warning, info }) =>
     isTabSelected &&
     css`
-    ${!isInSidebar && "z-index: 1;"}
     color: ${theme.text.color};
     background-color: ${theme.colors.white};
 
@@ -376,7 +367,7 @@ const StyledTabTitle = styled.button`
   ${({ theme, isInSidebar }) => `
     &:focus {
       outline: ${isInSidebar ? "none;" : `2px solid ${theme.colors.focus};`}
-      z-index: 1;
+      z-index: 2;
     }
   `}
   
@@ -529,7 +520,7 @@ const StyledLayoutWrapper = styled.div`
 
 const StyledSelectedIndicator = styled.div`
   position: absolute;
-  z-index: 5;
+  z-index: 1;
 
   ${({ position, size, theme }) =>
     position === "top" &&

--- a/src/components/tabs/tabs.component.js
+++ b/src/components/tabs/tabs.component.js
@@ -258,14 +258,6 @@ const Tabs = ({
           customLayout={customLayout}
           isInSidebar={isInSidebar}
           align={align}
-          onFocus={() => {
-            if (!hasTabStop(tabId)) {
-              setTabStopId(tabId);
-            }
-            if (!isTabSelected(tabId)) {
-              updateVisibleTab(tabId);
-            }
-          }}
         />
       );
 

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -397,6 +397,7 @@ describe("Tabs", () => {
           });
       });
       wrapper.update();
+      expect(onTabChange).toHaveBeenCalledTimes(1);
       expect(onTabChange).toHaveBeenCalledWith("uniqueid2");
     });
 


### PR DESCRIPTION
fix #4640, fix #4611

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Removes `onFocus` handler to prevent `onTabChange` callback being triggered twice `onClick` and to
ensure that tabs become active on up click rather than down click

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Calls `onTabChange` twice when tabs are clicked
Tabs are active on mouse down

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
