### PR TITLE
docs: update storybook quickstart and create new codesandbox template (FE-4718)

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,6 @@
 {
   "sandboxes": [
-    "carbon-quickstart-xi5jc",
+    "carbon-quickstart-j5pb2",
     "carbon-quickstart-typescript-2gt5y"
   ],
   "buildCommand": "precompile"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       value: |
         ### ⚠️ This bug report is public
-        Please create a reproducible example using this [CodeSandbox template](https://codesandbox.io/s/carbon-quickstart-xi5jc). 
+        Please create a reproducible example using this [CodeSandbox template](https://codesandbox.io/s/carbon-quickstart-j5pb2). 
         Please do not include any confidential or commercially sensitive information.
 
         ---
@@ -33,17 +33,17 @@ body:
     id: url
     attributes:
       label: CodeSandbox or Storybook URL
-      description: >- 
-        Please fork [this template](https://codesandbox.io/s/carbon-quickstart-xi5jc), and ensure you save your changes.
+      description: >-
+        Please fork [this template](https://codesandbox.io/s/carbon-quickstart-j5pb2), and ensure you save your changes.
         Alternatively, if your issue relates to [Storybook](https://carbon.sage.com) please link to the story.
-      placeholder: https://codesandbox.io/s/carbon-quickstart-xi5jc
+      placeholder: https://codesandbox.io/s/carbon-quickstart-j5pb2
     validations:
       required: true
   - type: input
     id: jira-id
     attributes:
       label: JIRA Ticket (Sage Only)
-      description: >- 
+      description: >-
         Please include any related JIRA ticket numbers. If we accept this report, we'll create another JIRA ticket and add a `relates to` link to your tickets.
         Do not include any URL's.
       placeholder: FE-123, SBS-456

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -17,7 +17,7 @@ body:
       label: Desired behaviour
       description: |
         Please give a clear and concise description of the desired behaviour.
-        If applicable, add screenshots or screen recording of a [CodeSandbox](https://codesandbox.io/s/carbon-quickstart-xi5jc) to help explain the request. You can paste these directly into GitHub.
+        If applicable, add screenshots or screen recording of a [CodeSandbox](https://codesandbox.io/s/carbon-quickstart-j5pb2) to help explain the request. You can paste these directly into GitHub.
     validations:
       required: true
   - type: textarea
@@ -38,10 +38,10 @@ body:
     id: url
     attributes:
       label: CodeSandbox or Storybook URL
-      description: >- 
-        Please fork [this template](https://codesandbox.io/s/carbon-quickstart-xi5jc), and ensure you save your changes.
+      description: >-
+        Please fork [this template](https://codesandbox.io/s/carbon-quickstart-j5pb2), and ensure you save your changes.
         Alternatively, if your issue relates to [Storybook](https://carbon.sage.com) please link to the story.
-      placeholder: https://codesandbox.io/s/carbon-quickstart-xi5jc
+      placeholder: https://codesandbox.io/s/carbon-quickstart-j5pb2
     validations:
       required: false
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ If applicable, add screenshots of a codesandbox to help explain your request. Yo
 
 Please DO NOT share screenshots or the source code of your project.
 
-You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-xi5jc
+You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2
 
 If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
 If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork

--- a/docs/development-roadmap.stories.mdx
+++ b/docs/development-roadmap.stories.mdx
@@ -8,10 +8,6 @@
 
 Listed below is the activity we have on our backlog.
 
-### Move experimental folder
-
-Move the experimental components into the main components folder and remove the experimental folder.
-
 ### Internationalisation
 
 Implement the proposal in the [i18n RFC](https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md).
@@ -40,5 +36,6 @@ Review our Design System documentation and ensure our components are congruent w
 
 Deprecation of components that are no longer actively maintained.
 
-1. Multi Step Wizard
-1. Row and Column
+1. AppWrapper
+2. Row and Column
+3. Multi Step Wizard

--- a/docs/getting-started.stories.mdx
+++ b/docs/getting-started.stories.mdx
@@ -15,7 +15,6 @@ import LinkTo from "@storybook/addon-links/react";
 - [Fonts](#fonts)
 - [React and React DOM](#react-and-react-dom)
 - [Theming and Design Tokens](#theming-and-design-tokens)
-- [AppWrapper](#appwrapper)
 - [Quickstart](#quickstart)
 
 ### Installation
@@ -58,6 +57,7 @@ then the `GlobalStyle` component could be placed next to the content of the app:
     .
   </App>
 ```
+
 #### Fonts
 
 ##### CDN
@@ -173,12 +173,12 @@ import React from "react";
 import ReactDOM from "react-dom";
 ```
 
-
 ### Theming and Design Tokens
 
 Currently we are implementing Design Tokens into our components. Implementing Design Tokens implies migration from ThemeProvider to CSS Variables. Because of this we temporary support two theming systems.
 
 There are multiple theming systems available in Carbon, different themes use different systems:
+
 - sage - uses Design Tokens applied with css-variables. This theme fallbacks to the mint theme.
 - mint, aegean and none - uses old theme properties consumed by ThemeProvider.
 - sage-debug - available in theme debug mode (accessible by running `npm run start:debug-theme` locally). This theme uses Design Tokens mixed with old theme properties mapped to bright colours. This theme allows you to spot non-migrated properties more easily.
@@ -186,37 +186,38 @@ There are multiple theming systems available in Carbon, different themes use dif
 #### Design Tokens providers
 
 During the time of Design Tokens implementation, using Design Tokens themes require providing Design Tokens Providers. Please note, that for compatibility reasons it still requires `ThemeProvider`. There are two Design Token providers:
+
 - **<LinkTo kind="Carbon Global Tokens Provider" story="default">Global Tokens Provider</LinkTo>** -
-Provides Design Tokens in form of CSS variables definitions globally.
+  Provides Design Tokens in form of CSS variables definitions globally.
+
 ```js
 import CarbonProvider from "carbon-react/lib/components/carbon-provider";
-import CarbonGlobalTokensProvider from 'carbon-react/lib/style/design-tokens/carbon-global-tokens-provider/';
+import CarbonGlobalTokensProvider from "carbon-react/lib/style/design-tokens/carbon-global-tokens-provider/";
 ```
 
 ```jsx
 <CarbonProvider theme={theme}>
-    <CarbonGlobalTokensProvider />
-    [...]
+  <CarbonGlobalTokensProvider />
+  [...]
 </CarbonProvider>
 ```
 
 - **<LinkTo kind="Carbon Scoped Tokens Provider" story="default">Scoped Tokens Provider</LinkTo>**
-Provides Design Tokens for given scope, for example to use with micro-frontends.
+  Provides Design Tokens for given scope, for example to use with micro-frontends.
 
 ```js
 import CarbonProvider from "carbon-react/lib/components/carbon-provider";
-import CarbonScopedTokensProvider from 'carbon-react/lib/style/design-tokens/carbon-scoped-tokens-provider/';
+import CarbonScopedTokensProvider from "carbon-react/lib/style/design-tokens/carbon-scoped-tokens-provider/";
 ```
 
 ```jsx
 <CarbonProvider theme={theme}>
-    <CarbonScopedTokensProvider>
-        [...]
-    </CarbonScopedTokensProvider>
+  <CarbonScopedTokensProvider>[...]</CarbonScopedTokensProvider>
 </CarbonProvider>
 ```
 
 #### Old theme providers
+
 Carbon provides the <LinkTo kind="Carbon Provider" story="default">Carbon Provider</LinkTo> component that uses the `ThemeProvider` from the [styled-components library](https://styled-components.com/docs/advanced#theming) to supply theme styles to your components. Themes are define within the Carbon library. `mintTheme` is provided by default.
 
 ```js
@@ -236,16 +237,6 @@ Provided `aegeanTheme`:
 <CarbonProvider theme={aegeanTheme}>Children</CarbonProvider>
 ```
 
-#### AppWrapper
-
-This component wraps all components within the width constrains of your application.
-
-```jsx
-<AppWrapper>Children</AppWrapper>
-```
-
-You should refer to our [Storybook documentation](https://carbon.sage.com/?path=/docs/app-wrapper--default) for details.
-
 #### Quickstart
 
 A basic project `index.js` file would resemble this example.
@@ -253,24 +244,24 @@ A basic project `index.js` file would resemble this example.
 ```jsx
 import React from "react";
 import ReactDOM from "react-dom";
-import { ThemeProvider } from "styled-components";
-import mintTheme from "carbon-react/lib/style/themes/mint";
-import "carbon-react/lib/utils/css";
-import AppWrapper from "carbon-react/lib/components/app-wrapper";
+import CarbonProvider from "carbon-react/lib/components/carbon-provider";
+import GlobalStyle from "carbon-react/lib/style/global-style";
+import Box from "carbon-react/lib/components/box";
 import Button from "carbon-react/lib/components/button";
 
 const App = (props) => {
   return (
-    <ThemeProvider theme={mintTheme}>
-      <AppWrapper>
+    <CarbonProvider>
+      <GlobalStyle />
+      <Box margin="0 25px">
         <Button>Hello Carbon</Button>
         <p>Please remember to select the appropriate version of Carbon.</p>
-      </AppWrapper>
-    </ThemeProvider>
+      </Box>
+    </CarbonProvider>
   );
 };
 
 ReactDOM.render(<App />, document.getElementById("app"));
 ```
 
-This can also be found in our [Codesandbox template](https://codesandbox.io/s/carbon-quickstart-xi5jc).
+This can also be found in our [Codesandbox template](https://codesandbox.io/s/carbon-quickstart-j5pb2).


### PR DESCRIPTION
closes #4679

### Proposed behaviour


Update storybook to have:

- Updated quickstart code snippet
- Section detailing the deprecation of `AppWrapper`
- Links to a new starting template - which uses `Box` instead of `AppWrapper`. [View template here](https://codesandbox.io/s/carbon-quickstart-j5pb2?file=/src/index.js).

Also update all files (such as CI files, github PR templates, etc) to have a reference to the new starting template. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

Storybook quickstart guide is out of date - `AppWrapper` is to be deprecated and not recommended for future use and old imports need to be removed.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

### Testing instructions

Sanity check that links are working, descriptions and examples used are sufficient and clear.
