### PR TITLE
feat(action popover): describe action popover using design tokens, update tests - FE-4725

### DIFF
--- a/cypress/support/step-definitions/action-popover-steps.js
+++ b/cypress/support/step-definitions/action-popover-steps.js
@@ -29,11 +29,7 @@ When(
 );
 
 Then("Action Popover element has golden border on focus", () => {
-  cy.focused().should(
-    "have.css",
-    "box-shadow",
-    "rgb(255, 181, 0) 0px 0px 0px 2px inset"
-  );
+  cy.focused().should("have.css", "outline", "rgb(255, 181, 0) solid 3px");
 });
 
 When("I click {int} actionPopoverInnerItem", (element) => {

--- a/cypress/support/step-definitions/flat-table-steps.js
+++ b/cypress/support/step-definitions/flat-table-steps.js
@@ -249,7 +249,7 @@ Then("The {word} subrow action popover has focus", (position) => {
   flatTableSubrowByPosition(positionOfElement(position))
     .find('[data-component="action-popover-button"]')
     .should("have.focus")
-    .and("have.css", "outline", `${gold} solid 2px`);
+    .and("have.css", "outline", `${gold} solid 3px`);
 });
 
 When("I have a large viewport", () => {

--- a/src/components/action-popover/action-popover.spec.js
+++ b/src/components/action-popover/action-popover.spec.js
@@ -759,23 +759,6 @@ describe("ActionPopover", () => {
     });
   });
 
-  describe("styles", () => {
-    it("renders the button with a white background when the menu is open", () => {
-      render();
-
-      const { menubutton } = getElements();
-
-      expect(menubutton).not.toHaveStyleRule("background-color");
-
-      simulate.keydown.pressDownArrow(menubutton);
-
-      expect(getElements().menubutton).toHaveStyleRule(
-        "background-color",
-        mintTheme.colors.white
-      );
-    });
-  });
-
   it("validates the children prop", () => {
     jest.spyOn(global.console, "error").mockImplementation(() => {});
     const tempWrapper = enzymeMount(
@@ -807,7 +790,7 @@ describe("ActionPopover", () => {
         const submenuIcon = item.find(SubMenuItemIcon);
         assertStyleMatch(
           {
-            left: "0px",
+            left: "-2px",
           },
           submenuIcon
         );
@@ -1144,7 +1127,7 @@ describe("ActionPopover", () => {
         const submenuIcon = item.find(SubMenuItemIcon);
         assertStyleMatch(
           {
-            right: "0px",
+            right: "-5px",
           },
           submenuIcon
         );
@@ -1299,19 +1282,11 @@ describe("ActionPopover", () => {
 
       assertStyleMatch(
         {
-          padding: "0px 8px",
+          padding: "0px var(--sizing100)",
           width: "100%",
         },
         menuButton,
         { modifier: `${StyledButton}` }
-      );
-
-      assertStyleMatch(
-        {
-          outlineWidth: "2px",
-        },
-        menuButton,
-        { modifier: `${StyledButton}:focus ` }
       );
     });
 
@@ -1371,7 +1346,7 @@ describe("ActionPopover", () => {
       openMenu();
       assertStyleMatch(
         {
-          paddingLeft: "8px",
+          padding: "var(--spacing100)",
         },
         wrapper.find(MenuItemIcon)
       );

--- a/src/components/action-popover/action-popover.style.js
+++ b/src/components/action-popover/action-popover.style.js
@@ -1,5 +1,4 @@
-import React from "react";
-import styled, { ThemeProvider, css, withTheme } from "styled-components";
+import styled, { css } from "styled-components";
 import { margin } from "styled-system";
 
 import Icon from "../icon";
@@ -10,11 +9,12 @@ import { isSafari } from "../../__internal__/utils/helpers/browser-type-check";
 const Menu = styled.div`
   ${({ isOpen }) => (isOpen ? "display: block;" : "visibility: hidden;")}
   margin: 0;
-  padding: ${({ theme }) => `${theme.spacing}px 0`};
-  box-shadow: ${({ theme }) => theme.shadows.depth1};
+  padding: var(--spacing100) 0;
+  box-shadow: var(--boxShadow100);
   position: absolute;
-  background-color: ${({ theme }) => theme.colors.white};
-  z-index: ${({ theme }) => `${theme.zIndex.popover}`};
+  background-color: var(--colorsUtilityYang100);
+  z-index: ${({ theme }) =>
+    `${theme.zIndex.popover}`}; // TODO (tokens): implement elevation tokens - FE-4437
 `;
 
 const StyledMenuItem = styled.div`
@@ -24,7 +24,7 @@ const StyledMenuItem = styled.div`
 const MenuItemFactory = (button) => styled(button)`
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
   box-sizing: border-box;
-  ${({ theme }) => `padding: 0 ${theme.spacing * 3}px;`}
+  padding: 0 var(--spacing150);
   position: relative;
   line-height: 40px;
   white-space: nowrap;
@@ -33,8 +33,8 @@ const MenuItemFactory = (button) => styled(button)`
   align-items: center;
   border: none;
   width: 100%;
-  color: ${({ disabled, theme }) =>
-    disabled ? theme.menu.itemColorDisabled : theme.menu.itemColor};
+  color: ${({ disabled }) =>
+    disabled ? "var(--colorsUtilityYin030)" : "var(--colorsUtilityYin090)"};
   font-size: 14px;
   font-weight: 700;
   justify-content: ${({ horizontalAlignment }) =>
@@ -44,12 +44,12 @@ const MenuItemFactory = (button) => styled(button)`
     ${({ disabled }) =>
       !disabled &&
       css`
-        background-color: ${({ theme }) => theme.menu.focus};
+        background-color: var(--colorsUtilityMajor025);
       `}
   }
   &:focus {
-    outline: none;
-    box-shadow: inset 0px 0px 0px 2px ${({ theme }) => theme.colors.focus};
+    outline: var(--borderWidth300) solid var(--colorsSemanticFocus500);
+    z-index: 1;
   }
   ${({ disabled }) =>
     !disabled &&
@@ -63,7 +63,7 @@ const MenuItemFactory = (button) => styled(button)`
     css`
       && ${StyledIcon} {
         cursor: not-allowed;
-        color: inherit;
+        color: var(--colorsUtilityYin030);
       }
     `}
 `;
@@ -71,9 +71,9 @@ const MenuItemFactory = (button) => styled(button)`
 const MenuItemDivider = styled.div.attrs({
   "data-element": "action-popover-divider",
 })`
-  background-color: ${({ theme }) => theme.menu.divider};
-  height: 1px;
-  margin: 9px;
+  background-color: var(--colorsUtilityMajor050);
+  height: var(--borderWidth100);
+  margin: var(--spacing100) var(--spacing150);
 `;
 
 const MenuButton = styled.div`
@@ -84,90 +84,61 @@ const MenuButton = styled.div`
   width: fit-content;
   margin: auto;
   ${margin}
-  ${({ isOpen, theme }) => isOpen && `background-color: ${theme.colors.white}`}
 `;
 
-/**
- * Creates a factory that returns a styled component with a custom
- * theme provider wrapped around it
- * @param {*} themeFn
- */
-const iconThemeProviderFactory = (Component, themeFn) =>
-  withTheme(({ theme, ...props }) => {
-    const color = themeFn(theme.palette);
-    const customTheme = {
-      ...theme,
-      icon: {
-        default: color,
-        defaultHover: color,
-      },
-    };
-    return (
-      <ThemeProvider theme={customTheme}>
-        <Component {...props} />
-      </ThemeProvider>
-    );
-  });
+const ButtonIcon = styled(Icon)`
+  color: var(--colorsActionMinor500);
 
-const ButtonIcon = iconThemeProviderFactory(Icon, (palette) => palette.slate);
+  :hover {
+    color: var(--colorsActionMinor600);
+  }
+`;
 
 const StyledButtonIcon = styled.div`
-  &:hover,
   &:focus {
-    background-color: ${({ theme }) => theme.colors.white};
-  }
-
-  &:focus {
-    outline: 2px solid ${({ theme }) => theme.colors.focus};
+    outline: var(--borderWidth300) solid var(--colorsSemanticFocus500);
   }
 `;
 
-const MenuItemIcon = styled(iconThemeProviderFactory(Icon, () => "inherit"))`
-  ${({ theme, horizontalAlignment }) => css`
-    ${horizontalAlignment === "right"
-      ? "padding-left"
-      : "padding-right"}: ${theme.spacing}px;
-  `}
+const MenuItemIcon = styled(Icon)`
+  padding: var(--spacing100);
+  color: var(--colorsUtilityYin065);
 `;
 
 const SubMenuItemIcon = styled(ButtonIcon)`
-  ${({ theme, type }) => css`
+  ${({ type }) => css`
     position: absolute;
-    &,
-    :hover {
-      color: ${theme.colors.border};
-    }
     ${type === "chevron_left" &&
     css`
-      left: 0px;
+      left: -2px;
     `}
 
     ${type === "chevron_right" &&
     css`
-      right: 0px;
+      right: -5px;
       ${isSafari(navigator) &&
       css`
-        top: ${theme.spacing}px;
+        top: var(--sizing100);
       `}
     `}
   `}
 `;
 
 const MenuButtonOverrideWrapper = styled.div`
-  ${({ theme }) => css`
-    ${StyledButton} {
-      padding: 0px ${theme.spacing}px;
-      width: 100%;
-      &:focus {
-        outline-width: 2px;
-      }
+  ${StyledButton} {
+    padding: 0px var(--sizing100);
+    width: 100%;
 
-      &:hover,
-      &:focus {
-        background-color: ${theme.colors.white};
+    &:hover,
+    &:focus {
+      background-color: var(--colorsActionMajorTransparent);
+      color: var(--colorsActionMajor600);
+
+      span[color] {
+        color: var(--colorsActionMajor600);
       }
     }
-  `}
+  }
 `;
 
 export {


### PR DESCRIPTION
### Proposed behaviour

Describes a action popover element using the tokens of the design.
Changes the left and right padding of menu items to - `--spacing150` (12px).
Removes white background from MenuButton when menu is open. 
Changes the color of the ButtonIcon to:  
 - default color: `--colorsActionMinor500`
 - hover color: `--colorsActionMinor600`

Changes the outline border thickness for focus - 3px.

Changes the color of the custom menu button on hover: 
 - background: `--colorsActionMajorTransparent`
 - color: `--colorsActionMajor600`
   
Updates tests when the above changes are made.

### Current behaviour

Action popover component use the theme styled-component property.
Current the left and right padding of menu items: 24px.
MenuButton has white background when menu is open.

Current outline border thickness for focus - 2px.

Current colors for custom menu button on hover: white.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

![image](https://user-images.githubusercontent.com/44143630/149962541-5c3773b4-4569-419b-897a-84d01c91bcc1.png)
![image](https://user-images.githubusercontent.com/44143630/149962599-4007a0e5-184b-4a47-9228-1cdcf3c98d21.png)


### Testing instructions

The correct appearance can be checked in the component: Action popover.
For theme: mint and aegean there should be no differences.
Use devtools to check if action popover use css variables.
