### PR TITLE
feat(dialog): describe dialog and dialog full screen with design tokens

### DIFF
--- a/src/components/dialog-full-screen/dialog-full-screen.style.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.style.js
@@ -11,13 +11,15 @@ import {
 import { StyledForm } from "../form/form.style";
 
 const StyledDialogFullScreen = styled.div`
-  background-color: ${({ theme }) => theme.disabled.input};
+  background-color: var(--colorsUtilityMajor025);
   height: 100%;
   left: 0;
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: ${({ theme }) => theme.zIndex.fullScreenModal};
+  z-index: ${({ theme }) =>
+    theme.zIndex
+      .fullScreenModal}; // TODO (tokens): implement elevation tokens - FE-4437
   display: flex;
   flex-direction: column;
 

--- a/src/components/dialog/dialog.style.js
+++ b/src/components/dialog/dialog.style.js
@@ -1,6 +1,5 @@
 import styled, { css } from "styled-components";
 
-import baseTheme from "../../style/themes/base";
 import {
   StyledForm,
   StyledFormFooter,
@@ -28,8 +27,8 @@ const HORIZONTAL_PADDING = 35;
 const CONTENT_BOTTOM_PADDING = 30;
 
 const DialogStyle = styled.div`
-  background-color: #f2f5f6;
-  box-shadow: ${({ theme }) => theme.shadows.depth3};
+  background-color: var(--colorsUtilityMajor025);
+  box-shadow: var(--boxShadow300);
   display: flex;
   flex-direction: column;
   position: fixed;
@@ -107,7 +106,7 @@ const DialogTitleStyle = styled.div`
     margin-bottom: 20px;
 
     ${StyledHeadingTitle} {
-      color: ${({ theme }) => theme.text.color};
+      color: var(--colorsUtilityYin090);
       display: block;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -131,14 +130,6 @@ const DialogInnerContentStyle = styled.div`
   position: relative;
   flex: 1;
 `;
-
-DialogTitleStyle.defaultProps = {
-  theme: baseTheme,
-};
-
-DialogStyle.defaultProps = {
-  theme: baseTheme,
-};
 
 export {
   DialogStyle,


### PR DESCRIPTION
### Proposed behaviour
Describes the Dialog and DialogFullScreen with design tokens.

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour
The Dialog and DialogFullScreen use the theme styled-component property.

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
