### PR TITLE
fix(navigation-bar): add z-index so NavigationBar stacks just below Modals

### DIFF
--- a/src/components/navigation-bar/navigation-bar.spec.tsx
+++ b/src/components/navigation-bar/navigation-bar.spec.tsx
@@ -90,6 +90,7 @@ describe("NavigationBar", () => {
         minHeight: "40px",
         backgroundColor: baseTheme.navigationBar.light.background,
         borderBottom: `1px solid ${baseTheme.navigationBar.light.borderBottom}`,
+        zIndex: "2999",
       },
       wrapper
     );
@@ -106,6 +107,7 @@ describe("NavigationBar", () => {
       {
         backgroundColor: baseTheme.navigationBar.dark.background,
         color: baseTheme.colors.white,
+        zIndex: "2999",
       },
       wrapper
     );
@@ -122,6 +124,7 @@ describe("NavigationBar", () => {
       {
         backgroundColor: baseTheme.colors.white,
         borderBottom: `1px solid ${baseTheme.navigationBar.white.borderBottom}`,
+        zIndex: "2999",
       },
       wrapper
     );
@@ -138,6 +141,7 @@ describe("NavigationBar", () => {
       {
         backgroundColor: baseTheme.navigationBar.black.background,
         color: baseTheme.colors.white,
+        zIndex: "2999",
       },
       wrapper
     );

--- a/src/components/navigation-bar/navigation-bar.style.ts
+++ b/src/components/navigation-bar/navigation-bar.style.ts
@@ -56,6 +56,7 @@ const StyledNavigationBar = styled.nav<StyledNavigationBarProps>`
 
   ${({ navigationType, theme }) => css`
     min-height: 40px;
+    z-index: ${theme.zIndex.nav};
 
     ${navigationType === "light" &&
     css`

--- a/src/components/portal/__snapshots__/portal.spec.js.snap
+++ b/src/components/portal/__snapshots__/portal.spec.js.snap
@@ -790,6 +790,7 @@ exports[`Portal when using default node to match snapshot  1`] = `
             "fullScreenModal": 5000,
             "header": 4000,
             "modal": 3000,
+            "nav": 2999,
             "notification": 6000,
             "overlay": 1000,
             "popover": 2000,

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -427,6 +427,7 @@ export default (palette) => {
       smallOverlay: 10,
       overlay: 1000,
       popover: 2000,
+      nav: 2999,
       modal: 3000,
       header: 4000,
       fullScreenModal: 5000,

--- a/src/style/themes/base/index.d.ts
+++ b/src/style/themes/base/index.d.ts
@@ -365,6 +365,7 @@ export interface ThemeObject {
     smallOverlay: number;
     overlay: number;
     popover: number;
+    nav: number;
     modal: number;
     header: number;
     fullScreenModal: number;


### PR DESCRIPTION
fix #4690

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Sets the z-index of NavigationBar to stack it just below Modals and displays over main UI components

![image](https://user-images.githubusercontent.com/44157880/150321765-ec9e09e2-c8a9-43a7-bbde-d91d41e9defe.png)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Has no z-index so does not stack over main UI components

![image](https://user-images.githubusercontent.com/44157880/150321889-97232664-f337-429c-9b22-321ed2a70779.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
