### PR TITLE
feat: dismissible buttons labels - FE-4154

### DIFF
--- a/src/components/dialog-full-screen/dialog-full-screen.component.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.js
@@ -10,6 +10,7 @@ import StyledContent from "./content.style";
 import FocusTrap from "../../__internal__/focus-trap";
 import IconButton from "../icon-button";
 import Icon from "../icon";
+import useLocale from "../../hooks/__internal__/useLocale";
 
 const DialogFullScreen = ({
   "aria-describedby": ariaDescribedBy,
@@ -32,6 +33,8 @@ const DialogFullScreen = ({
   role = "dialog",
   ...rest
 }) => {
+  const locale = useLocale();
+
   const dialogRef = useRef();
   const headingRef = useRef();
   const { current: titleId } = useRef(createGuid());
@@ -43,7 +46,7 @@ const DialogFullScreen = ({
     return (
       <IconButton
         data-element="close"
-        aria-label="Close button"
+        aria-label={locale.dialogFullScreen.ariaLabels.close()}
         onAction={onCancel}
       >
         <Icon type="close" />

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
@@ -17,6 +17,7 @@ import Icon from "../icon";
 import { ActionPopover, ActionPopoverItem } from "../action-popover";
 import Typography from "../typography";
 import { Dl, Dt, Dd } from "../definition-list";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 
 <Meta title="Dialog Full Screen" parameters={{ info: { disable: true } }} />
 
@@ -921,3 +922,19 @@ and setting the `autoFocus` on the element you wish to be focused instead (click
 ### DialogFullScreen
 
 <ArgsTable of={DialogFullScreen} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "dialogFullScreen.ariaLabels.close",
+      description: "The text for close button aria-label attribute",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/dialog/dialog.component.js
+++ b/src/components/dialog/dialog.component.js
@@ -17,6 +17,7 @@ import IconButton from "../icon-button";
 import Icon from "../icon";
 import Form from "../form";
 import { TOP_MARGIN } from "./dialog.config";
+import useLocale from "../../hooks/__internal__/useLocale";
 
 const Dialog = ({
   className,
@@ -37,6 +38,8 @@ const Dialog = ({
   role = "dialog",
   ...rest
 }) => {
+  const locale = useLocale();
+
   const dialogRef = useRef();
   const innerContentRef = useRef();
   const titleRef = useRef();
@@ -111,7 +114,7 @@ const Dialog = ({
     return (
       <IconButton
         data-element="close"
-        aria-label="Close button"
+        aria-label={locale.dialog.ariaLabels.close()}
         onAction={onCancel}
         disabled={disableClose}
       >

--- a/src/components/dialog/dialog.stories.mdx
+++ b/src/components/dialog/dialog.stories.mdx
@@ -10,6 +10,7 @@ import Textbox from "../textbox";
 import { RadioButton, RadioButtonGroup } from "../radio-button";
 import Fieldset from "../fieldset";
 import Loader from "../loader";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 
 <Meta title="Dialog" parameters={{ info: { disable: true } }} />
 
@@ -348,3 +349,19 @@ and setting the `autoFocus` on the element you wish to be focused instead (click
 ### Dialog
 
 <ArgsTable of={Dialog} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "dialog.ariaLabels.close",
+      description: "The text for close button aria-label attribute",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/sidebar/sidebar.component.js
+++ b/src/components/sidebar/sidebar.component.js
@@ -9,6 +9,7 @@ import FocusTrap from "../../__internal__/focus-trap";
 import SidebarHeader from "./__internal__/sidebar-header";
 import Box from "../box";
 import { SIDEBAR_SIZES, SIDEBAR_ALIGNMENTS } from "./sidebar.config";
+import useLocale from "../../hooks/__internal__/useLocale";
 
 export const SidebarContext = React.createContext({});
 
@@ -31,12 +32,18 @@ const Sidebar = React.forwardRef(
     },
     ref
   ) => {
+    const locale = useLocale();
+
     let sidebarRef = useRef();
     if (ref) sidebarRef = ref;
     const closeIcon = () => {
       if (!onCancel) return null;
       return (
-        <IconButton aria-label="close" onAction={onCancel} data-element="close">
+        <IconButton
+          aria-label={locale.sidebar.ariaLabels.close()}
+          onAction={onCancel}
+          data-element="close"
+        >
           <Icon type="close" />
         </IconButton>
       );

--- a/src/components/sidebar/sidebar.stories.mdx
+++ b/src/components/sidebar/sidebar.stories.mdx
@@ -5,6 +5,7 @@ import Sidebar from ".";
 import Button from "../button";
 import Typography from "../typography";
 import Form from "../form";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 
 <Meta title="Sidebar" parameters={{ info: { disable: true } }} />
 
@@ -56,7 +57,11 @@ with all the UI pass `enableBackgroundUI={ true }` to the component
       return (
         <>
           <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
-          <Sidebar aria-label="sidebar" open={isOpen} onCancel={() => setIsOpen(false)}>
+          <Sidebar
+            aria-label="sidebar"
+            open={isOpen}
+            onCancel={() => setIsOpen(false)}
+          >
             <div>
               <Button as="primary">Test</Button>
               <Button as="secondary" ml={2}>
@@ -229,3 +234,19 @@ If sidebar content does not fit the sidebar, scroll will appear. Default scroll 
 ### Sidebar
 
 <ArgsTable of={Sidebar} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "sidebar.ariaLabels.close",
+      description: "The text for close button aria-label attribute",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/toast/toast.component.js
+++ b/src/components/toast/toast.component.js
@@ -14,6 +14,7 @@ import {
 import IconButton from "../icon-button";
 import ModalManager from "../modal/__internal__/modal-manager";
 import Events from "../../__internal__/utils/helpers/events";
+import useLocale from "../../hooks/__internal__/useLocale";
 
 const Toast = ({
   as = "warning",
@@ -29,6 +30,8 @@ const Toast = ({
   variant,
   ...restProps
 }) => {
+  const locale = useLocale();
+
   const toastRef = useRef();
   const timer = useRef();
 
@@ -74,7 +77,11 @@ const Toast = ({
     if (!onDismiss) return null;
 
     return (
-      <IconButton data-element="close" onAction={onDismiss}>
+      <IconButton
+        aria-label={locale.toast.ariaLabels.close()}
+        data-element="close"
+        onAction={onDismiss}
+      >
         <Icon type="close" />
       </IconButton>
     );

--- a/src/components/toast/toast.stories.mdx
+++ b/src/components/toast/toast.stories.mdx
@@ -1,9 +1,11 @@
 import { Meta, ArgsTable, Canvas, Story } from "@storybook/addon-docs";
 import styled from "styled-components";
+
 import Toast from ".";
 import { useState } from "react";
 import { action } from "@storybook/addon-actions";
 import Button from "../button";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 
 <Meta
   title="Toast"
@@ -635,3 +637,19 @@ Please use `targetPortalId` prop to group multiple toasts so that they stack.
 ### Toast
 
 <ArgsTable of={Toast} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "toast.ariaLabels.close",
+      description: "The text for close button aria-label attribute",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/locales/en-gb.js
+++ b/src/locales/en-gb.js
@@ -22,6 +22,16 @@ export default {
   date: {
     dateFnsLocale: () => enGB,
   },
+  dialog: {
+    ariaLabels: {
+      close: () => "Close",
+    },
+  },
+  dialogFullScreen: {
+    ariaLabels: {
+      close: () => "Close",
+    },
+  },
   errors: {
     messages: {
       formSummary:
@@ -76,6 +86,11 @@ export default {
   link: {
     skipLinkLabel: () => "Skip to main content",
   },
+  sidebar: {
+    ariaLabels: {
+      close: () => "Close",
+    },
+  },
   switch: {
     on: () => "ON",
     off: () => "OFF",
@@ -96,6 +111,11 @@ export default {
   },
   tileSelect: {
     deselect: () => "Deselect",
+  },
+  toast: {
+    ariaLabels: {
+      close: () => "Close",
+    },
   },
   wizards: {
     multiStep: {

--- a/src/locales/locale.d.ts
+++ b/src/locales/locale.d.ts
@@ -19,6 +19,16 @@ interface Locale {
   date: {
     dateFnsLocale: () => DateFnsLocale;
   };
+  dialog: {
+    ariaLabels: {
+      close: () => string;
+    };
+  };
+  dialogFullScreen: {
+    ariaLabels: {
+      close: () => string;
+    };
+  };
   errors: {
     messages: {
       formSummary: (
@@ -53,6 +63,14 @@ interface Locale {
     placeholder: () => string;
     noResultsForTerm: (term: string) => string;
   };
+  link: {
+    skipLinkLabel: () => string;
+  };
+  sidebar: {
+    ariaLabels: {
+      close: () => string;
+    };
+  };
   switch: {
     on: () => string;
     off: () => string;
@@ -73,6 +91,11 @@ interface Locale {
   };
   tileSelect: {
     deselect: () => string;
+  };
+  toast: {
+    ariaLabels: {
+      close: () => string;
+    };
   };
   wizards: {
     multiStep: {

--- a/src/locales/pl-pl.js
+++ b/src/locales/pl-pl.js
@@ -22,6 +22,16 @@ export default {
   date: {
     dateFnsLocale: () => pl,
   },
+  dialog: {
+    ariaLabels: {
+      close: () => "Zamknij",
+    },
+  },
+  dialogFullScreen: {
+    ariaLabels: {
+      close: () => "Zamknij",
+    },
+  },
   errors: {
     messages: {
       formSummary:
@@ -76,6 +86,11 @@ export default {
   link: {
     skipLinkLabel: () => "Przejdź do treści",
   },
+  sidebar: {
+    ariaLabels: {
+      close: () => "Zamknij",
+    },
+  },
   switch: {
     on: () => "WŁ",
     off: () => "WYŁ",
@@ -96,6 +111,11 @@ export default {
   },
   tileSelect: {
     deselect: () => "Odznacz",
+  },
+  toast: {
+    ariaLabels: {
+      close: () => "Zamknij",
+    },
   },
   wizards: {
     multiStep: {


### PR DESCRIPTION
### Proposed behaviour

This PR fixes incorrect aria-labels in Toast, Sidebar, Dialog and DialogFullScreen and makes them translatable
Fixes #4142 
### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Check if aria-label on components listed above is correct, also check if changing the locale to polish changes these values as well
