### PR TITLE
fix(confirm): fix incorrect button margin - FE-4750

### DIFF
--- a/src/components/confirm/confirm.component.js
+++ b/src/components/confirm/confirm.component.js
@@ -69,7 +69,7 @@ const Confirm = ({
       buttonType={confirmButtonType}
       destructive={destructive || confirmButtonDestructive}
       disabled={isLoadingConfirm || disableConfirm}
-      ml={cancelButtonType === "tertiary" ? "3px" : 2}
+      ml={2}
       iconType={confirmButtonIconType}
       iconPosition={confirmButtonIconPosition}
     >

--- a/src/components/confirm/confirm.spec.js
+++ b/src/components/confirm/confirm.spec.js
@@ -149,21 +149,6 @@ describe("Confirm", () => {
       });
     });
 
-    describe("if `cancelButtonType` is tertiary", () => {
-      it("should render confirm button with left margin 3px", () => {
-        wrapper = mount(
-          <Confirm cancelButtonType="tertiary" onConfirm={() => {}} open />
-        );
-
-        assertStyleMatch(
-          {
-            marginLeft: "3px",
-          },
-          wrapper.find('[data-element="confirm"]')
-        );
-      });
-    });
-
     it("should not render IconButton if `disableCancel` is provided", () => {
       wrapper = mount(
         <Confirm


### PR DESCRIPTION
### Proposed behaviour

Fixes #4711

### Current behaviour

![149384344-8489010d-8add-4b8e-9ca4-c932632fcd27](https://user-images.githubusercontent.com/20651022/150496795-f764ccf3-8815-49bf-8bb5-58f29078835b.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
