### PR TITLE
fix(accessibility): fix incorrect aria-describedby on input  (FE-4713)

### DIFF
--- a/src/__internal__/checkable-input/checkable-input.component.js
+++ b/src/__internal__/checkable-input/checkable-input.component.js
@@ -46,8 +46,8 @@ const CheckableInput = ({
 
   const {
     labelId,
-    tooltipId,
     fieldHelpId,
+    validationIconId,
     ariaDescribedBy,
     ariaLabelledBy,
   } = useInputAccessibility({
@@ -56,7 +56,6 @@ const CheckableInput = ({
     warning,
     info,
     label,
-    labelHelp,
     fieldHelp,
   });
 
@@ -67,7 +66,6 @@ const CheckableInput = ({
     error,
     fieldHelp,
     fieldHelpInline,
-    tooltipId,
     fieldHelpId,
     id,
     info,
@@ -81,6 +79,7 @@ const CheckableInput = ({
     name: id,
     reverse,
     warning,
+    validationIconId,
     // We don't want an asterisk on each radio control, only the legend
     // However, we still want the input element to receive the required prop
     isRequired: isRadio ? undefined : required,

--- a/src/__internal__/checkable-input/checkable-input.spec.js
+++ b/src/__internal__/checkable-input/checkable-input.spec.js
@@ -106,7 +106,7 @@ describe("CheckableInput", () => {
           });
         });
 
-        describe.each(["info", "warning", "error", "labelHelp"])(
+        describe.each(["info", "warning", "error"])(
           "and %s are present",
           (validationType) => {
             const wrapper = mountInput({
@@ -117,12 +117,12 @@ describe("CheckableInput", () => {
             it('should render a valid "aria-describedby"', () => {
               expect(
                 wrapper.find(HiddenCheckableInputStyle).prop("aria-describedby")
-              ).toBe(`${id}-tooltip`);
+              ).toBe(`${id}-validation-icon`);
             });
 
-            it("should pass tooltipId prop to FormField", () => {
-              expect(wrapper.find(FormField).prop("tooltipId")).toBe(
-                `${id}-tooltip`
+            it("should pass validationIconId prop to FormField", () => {
+              expect(wrapper.find(FormField).prop("validationIconId")).toBe(
+                `${id}-validation-icon`
               );
             });
           }
@@ -164,7 +164,7 @@ describe("CheckableInput", () => {
                 hiddenCheckableInputStyle
                   .find(HiddenCheckableInputStyle)
                   .prop("aria-describedby")
-              ).toBe(`${id}-field-help ${id}-tooltip`);
+              ).toBe(`${id}-field-help ${id}-validation-icon`);
             }
           );
         });

--- a/src/__internal__/form-field/form-field.component.js
+++ b/src/__internal__/form-field/form-field.component.js
@@ -39,6 +39,7 @@ const FormField = ({
   useValidationIcon,
   adaptiveLabelBreakpoint,
   isRequired,
+  validationIconId,
   ...rest
 }) => {
   const context = useContext(TabContext);
@@ -96,6 +97,7 @@ const FormField = ({
             pr={!reverse ? labelSpacing : undefined}
             pl={reverse ? labelSpacing : undefined}
             isRequired={isRequired}
+            validationIconId={validationIconId}
           >
             {label}
           </Label>
@@ -160,6 +162,8 @@ FormField.propTypes = {
   adaptiveLabelBreakpoint: PropTypes.number,
   /** Flag to configure component as mandatory */
   isRequired: PropTypes.bool,
+  /** Id of the validation icon */
+  validationIconId: PropTypes.string,
 };
 
 export default FormField;

--- a/src/__internal__/form-field/form-field.d.ts
+++ b/src/__internal__/form-field/form-field.d.ts
@@ -33,6 +33,8 @@ export interface CommonFormFieldPropTypes
   labelWidth?: number;
   /** If true the label switches position with the input */
   reverse?: boolean;
+  /** Id of the validation icon */
+  validationIconId?: string;
 }
 
 export interface FormFieldPropTypes extends CommonFormFieldPropTypes {

--- a/src/__internal__/input-icon-toggle/input-icon-toggle.component.js
+++ b/src/__internal__/input-icon-toggle/input-icon-toggle.component.js
@@ -24,7 +24,7 @@ const InputIconToggle = ({
   useValidationIcon,
   align,
   iconTabIndex,
-  tooltipId,
+  validationIconId,
 }) => {
   if (
     useValidationIcon &&
@@ -43,7 +43,7 @@ const InputIconToggle = ({
           onBlur={onBlur}
           isPartOfInput
           tabIndex={iconTabIndex}
-          tooltipId={tooltipId}
+          iconId={validationIconId}
           tooltipPosition={align === "right" ? "left" : "right"}
         />
       </InputIconToggleStyle>
@@ -60,7 +60,7 @@ const InputIconToggle = ({
         onMouseDown={onMouseDown}
         tabIndex={iconTabIndex}
       >
-        <Icon type={type} tooltipId={tooltipId} />
+        <Icon type={type} />
       </InputIconToggleStyle>
     );
   }
@@ -82,7 +82,8 @@ InputIconToggle.propTypes = {
   align: PropTypes.oneOf(["left", "right"]),
   useValidationIcon: PropTypes.bool,
   iconTabIndex: PropTypes.number,
-  tooltipId: PropTypes.string,
+  /** Id of the validation icon */
+  validationIconId: PropTypes.string,
 };
 
 export default InputIconToggle;

--- a/src/__internal__/input-icon-toggle/input-icon-toggle.d.ts
+++ b/src/__internal__/input-icon-toggle/input-icon-toggle.d.ts
@@ -16,6 +16,8 @@ export interface InputIconToggleProps {
   useValidationIcon?: boolean;
   iconTabIndex?: number;
   tooltipId?: string;
+  /** Id of the validation icon */
+  validationIconId?: string;
 }
 declare function InputIconToggle(props: InputIconToggleProps): JSX.Element;
 

--- a/src/__internal__/input-icon-toggle/input-icon-toggle.spec.js
+++ b/src/__internal__/input-icon-toggle/input-icon-toggle.spec.js
@@ -251,22 +251,17 @@ describe("InputIconToggle", () => {
       });
     });
 
-    describe("tooltipId", () => {
-      it("passes tooltipId to Icon", () => {
-        const tooltipId = "tooltip-id";
-        const wrapper = render({ inputIcon: "dropdown", tooltipId }, mount);
-
-        expect(wrapper.find(Icon).props().tooltipId).toBe(tooltipId);
-      });
-
-      it("passes tooltipId to ValidationIcon", () => {
-        const tooltipId = "tooltip-id";
+    describe("validationIconId", () => {
+      it("passes iconId to ValidationIcon", () => {
+        const validationIconId = "validation-id";
         const wrapper = render(
-          { error: "Error", tooltipId, useValidationIcon: true },
+          { error: "Error", validationIconId, useValidationIcon: true },
           mount
         );
 
-        expect(wrapper.find(ValidationIcon).props().tooltipId).toBe(tooltipId);
+        expect(wrapper.find(ValidationIcon).props().iconId).toBe(
+          validationIconId
+        );
       });
     });
   });

--- a/src/__internal__/label/label.component.js
+++ b/src/__internal__/label/label.component.js
@@ -35,6 +35,7 @@ const Label = ({
   pr,
   pl,
   isRequired,
+  validationIconId,
 }) => {
   const [isFocused, setFocus] = useState(false);
   const { onMouseEnter, onMouseLeave } = useContext(InputContext);
@@ -77,6 +78,7 @@ const Label = ({
       return (
         <IconWrapperStyle>
           <ValidationIcon
+            iconId={validationIconId}
             tooltipId={tooltipId}
             error={error}
             warning={warning}
@@ -168,6 +170,8 @@ Label.propTypes = {
   pl: PropTypes.oneOf([1, 2]),
   /** Flag to configure component as mandatory */
   isRequired: PropTypes.bool,
+  /** Id of the validation icon */
+  validationIconId: PropTypes.string,
 };
 
 export default React.memo(Label);

--- a/src/__internal__/label/label.component.js
+++ b/src/__internal__/label/label.component.js
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useState, useContext } from "react";
 import PropTypes from "prop-types";
 import Help from "../../components/help";
 import StyledLabel, { StyledLabelContainer } from "./label.style";
@@ -36,9 +36,8 @@ const Label = ({
   pl,
   isRequired,
 }) => {
-  const { hasFocus, hasMouseOver, onMouseEnter, onMouseLeave } = useContext(
-    InputContext
-  );
+  const [isFocused, setFocus] = useState(false);
+  const { onMouseEnter, onMouseLeave } = useContext(InputContext);
   const {
     onMouseEnter: onGroupMouseEnter,
     onMouseLeave: onGroupMouseLeave,
@@ -55,6 +54,11 @@ const Label = ({
   };
 
   const icon = () => {
+    const wrapperProps = {
+      onFocus: () => setFocus(true),
+      onBlur: () => setFocus(false),
+    };
+
     if (
       useValidationIcon &&
       shouldDisplayValidationIcon({
@@ -86,12 +90,12 @@ const Label = ({
 
     return (
       help && (
-        <IconWrapperStyle>
+        <IconWrapperStyle {...wrapperProps}>
           <Help
             tooltipId={tooltipId}
             tabIndex={helpTabIndex}
             type={helpIcon}
-            isFocused={hasFocus || hasMouseOver}
+            isFocused={isFocused}
           >
             {help}
           </Help>

--- a/src/__internal__/label/label.d.ts
+++ b/src/__internal__/label/label.d.ts
@@ -34,6 +34,8 @@ export interface LabelPropTypes extends ValidationPropTypes {
   pr?: 1 | 2;
   /** Padding left, integer multiplied by base spacing constant (8) */
   pl?: 1 | 2;
+  /** Id of the validation icon */
+  validationIconId?: string;
 }
 
 declare function Label(props: LabelPropTypes): JSX.Element;

--- a/src/__internal__/label/label.spec.js
+++ b/src/__internal__/label/label.spec.js
@@ -1,8 +1,8 @@
 import React from "react";
+import { act } from "react-dom/test-utils";
 import { shallow, mount } from "enzyme";
 
 import Help from "../../components/help";
-import Tooltip from "../../components/tooltip/tooltip.component";
 import Label from ".";
 import StyledLabel, { StyledLabelContainer } from "./label.style";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
@@ -216,6 +216,44 @@ describe("Label", () => {
     });
   });
 
+  describe("when attached to child of form", () => {
+    describe("when IconWrapperStyle", () => {
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = render(
+          {
+            help: "Message",
+          },
+          mount
+        );
+      });
+
+      describe("will run `onFocus` event", () => {
+        it("should change `isFocused` to be true", () => {
+          act(() => {
+            wrapper.find(IconWrapperStyle).simulate("focus");
+          });
+          wrapper.update();
+
+          expect(wrapper.find(Help).props().isFocused).toBe(true);
+        });
+      });
+
+      describe("will run `onBlur` event", () => {
+        it("should change `isFocused` to be false", () => {
+          act(() => {
+            wrapper.find(IconWrapperStyle).simulate("blur");
+          });
+
+          wrapper.update();
+
+          expect(wrapper.find(Help).props().isFocused).toBe(false);
+        });
+      });
+    });
+  });
+
   describe.each(validationTypes)(
     "when %s prop is passed as string",
     (vType) => {
@@ -282,46 +320,6 @@ describe("Label", () => {
       });
     }
   );
-
-  describe("when help prop is passed", () => {
-    const help = "help me!";
-
-    it("consumed focus flag controls visibility prop of Tooltip", () => {
-      const hasFocus = true;
-      const wrapper = renderWithContext(
-        { help },
-        {},
-        {
-          hasFocus,
-        }
-      );
-
-      const tooltipProps = wrapper.find(Tooltip).props();
-      const desiredTooltipProps = {
-        message: help,
-        isVisible: hasFocus,
-      };
-      expect(tooltipProps).toMatchObject(desiredTooltipProps);
-    });
-
-    it("consumed mouse over flag controls visibility prop of Tooltip", () => {
-      const hasMouseOver = true;
-      const wrapper = renderWithContext(
-        { help },
-        {},
-        {
-          hasMouseOver,
-        }
-      );
-
-      const tooltipProps = wrapper.find(Tooltip).props();
-      const desiredTooltipProps = {
-        message: help,
-        isVisible: hasMouseOver,
-      };
-      expect(tooltipProps).toMatchObject(desiredTooltipProps);
-    });
-  });
 });
 
 function render(props, renderer = mount) {

--- a/src/__internal__/tooltip-provider/index.js
+++ b/src/__internal__/tooltip-provider/index.js
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useRef } from "react";
 import PropTypes from "prop-types";
+import guid from "../utils/helpers/guid/guid";
 
 export const TooltipContext = React.createContext({});
 
@@ -9,22 +10,27 @@ export const TooltipProvider = ({
   helpAriaLabel,
   focusable = true,
   tooltipVisible,
-  disabled = false,
+  disabled,
   target,
-}) => (
-  <TooltipContext.Provider
-    value={{
-      tooltipPosition,
-      helpAriaLabel,
-      focusable,
-      tooltipVisible,
-      disabled,
-      target,
-    }}
-  >
-    {children}
-  </TooltipContext.Provider>
-);
+}) => {
+  const tooltipId = useRef(guid());
+
+  return (
+    <TooltipContext.Provider
+      value={{
+        tooltipPosition,
+        helpAriaLabel,
+        focusable,
+        tooltipVisible,
+        disabled,
+        tooltipId,
+        target,
+      }}
+    >
+      {children}
+    </TooltipContext.Provider>
+  );
+};
 
 TooltipProvider.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/components/help/help.component.js
+++ b/src/components/help/help.component.js
@@ -122,7 +122,7 @@ Help.propTypes = {
   tooltipPosition: PropTypes.oneOf(["bottom", "left", "right", "top"]),
   /** A path for the anchor */
   href: PropTypes.string,
-  /** Overrides the visibility of the Tooltip if true */
+  /** A boolean received from IconWrapper */
   isFocused: PropTypes.bool,
   /** <a href="https://brand.sage.com/d/NdbrveWvNheA/foundations#/icons/icons" target="_blank">List of supported icons</a>
    *

--- a/src/components/help/help.d.ts
+++ b/src/components/help/help.d.ts
@@ -13,7 +13,7 @@ export interface HelpProps extends MarginProps {
   helpId?: string;
   /** A path for the anchor */
   href?: string;
-  /** Overrides the visibility of the Tooltip if true */
+  /** A boolean received from IconWrapper */
   isFocused?: boolean;
   /** Overrides the default tabindex of the component */
   tabIndex?: number | string;

--- a/src/components/textarea/textarea.component.js
+++ b/src/components/textarea/textarea.component.js
@@ -84,7 +84,7 @@ const Textarea = ({
 
   const {
     labelId,
-    tooltipId,
+    validationIconId,
     fieldHelpId,
     ariaDescribedBy,
     ariaLabelledBy,
@@ -94,7 +94,6 @@ const Textarea = ({
     warning,
     info,
     label,
-    labelHelp,
     fieldHelp,
   });
 
@@ -164,7 +163,6 @@ const Textarea = ({
             labelWidth={labelWidth}
             labelHelp={labelHelp}
             labelSpacing={labelSpacing}
-            tooltipId={tooltipId}
             isRequired={props.required}
             useValidationIcon={validationOnLabel}
             adaptiveLabelBreakpoint={adaptiveLabelBreakpoint}
@@ -213,6 +211,7 @@ const Textarea = ({
                 error={error}
                 warning={warning}
                 info={info}
+                validationIconId={validationIconId}
                 useValidationIcon={!validationOnLabel}
               />
             </InputPresentation>

--- a/src/components/textarea/textarea.spec.js
+++ b/src/components/textarea/textarea.spec.js
@@ -176,7 +176,7 @@ describe("Textarea", () => {
           });
         });
 
-        describe.each(["info", "warning", "error", "labelHelp"])(
+        describe.each(["info", "warning", "error"])(
           "and %s are present",
           (validationType) => {
             const textarea = mount(
@@ -185,13 +185,7 @@ describe("Textarea", () => {
 
             it('should render a valid "aria-describedby"', () => {
               expect(textarea.find(Input).prop("aria-describedby")).toBe(
-                `${id}-tooltip`
-              );
-            });
-
-            it("should pass tooltipId to FormField", () => {
-              expect(textarea.find(FormField).prop("tooltipId")).toBe(
-                `${id}-tooltip`
+                `${id}-validation-icon`
               );
             });
           }
@@ -229,7 +223,7 @@ describe("Textarea", () => {
               );
 
               expect(textarea.find(Input).prop("aria-describedby")).toBe(
-                `${id}-field-help ${id}-tooltip`
+                `${id}-field-help ${id}-validation-icon`
               );
             }
           );

--- a/src/components/textbox/textbox.component.js
+++ b/src/components/textbox/textbox.component.js
@@ -80,7 +80,7 @@ const Textbox = ({
 
   const {
     labelId: internalLabelId,
-    tooltipId,
+    validationIconId,
     fieldHelpId,
     ariaDescribedBy,
   } = useInputAccessibility({
@@ -102,7 +102,6 @@ const Textbox = ({
     >
       <InputBehaviour>
         <FormField
-          tooltipId={tooltipId}
           disabled={disabled}
           fieldHelp={fieldHelp}
           fieldHelpId={fieldHelpId}
@@ -125,6 +124,7 @@ const Textbox = ({
           data-component={dataComponent}
           data-role={dataRole}
           data-element={dataElement}
+          validationIconId={validationIconId}
           {...filterStyledSystemMarginProps(props)}
         >
           <InputPresentation
@@ -182,7 +182,7 @@ const Textbox = ({
               size={size}
               useValidationIcon={!validationOnLabel}
               warning={warning}
-              tooltipId={tooltipId}
+              validationIconId={validationIconId}
             />
           </InputPresentation>
         </FormField>

--- a/src/components/textbox/textbox.spec.js
+++ b/src/components/textbox/textbox.spec.js
@@ -266,7 +266,7 @@ describe("Textbox", () => {
           });
         });
 
-        describe.each(["info", "warning", "error", "labelHelp"])(
+        describe.each(["info", "warning", "error"])(
           "and %s are present",
           (validationType) => {
             const wrapper = mount(
@@ -274,13 +274,7 @@ describe("Textbox", () => {
             );
             it('should render a valid "aria-describedby"', () => {
               expect(wrapper.find(Input).prop("aria-describedby")).toBe(
-                `${id}-tooltip`
-              );
-            });
-
-            it("should pass tooltipId to FormField", () => {
-              expect(wrapper.find(FormField).prop("tooltipId")).toBe(
-                `${id}-tooltip`
+                `${id}-validation-icon`
               );
             });
           }
@@ -313,7 +307,7 @@ describe("Textbox", () => {
               );
 
               expect(wrapper.find(Input).prop("aria-describedby")).toBe(
-                `${id}-field-help ${id}-tooltip`
+                `${id}-field-help ${id}-validation-icon`
               );
             }
           );

--- a/src/hooks/__internal__/useInputAccessibility/index.spec.js
+++ b/src/hooks/__internal__/useInputAccessibility/index.spec.js
@@ -3,52 +3,39 @@ import useInputAccessibility from ".";
 describe("useInputAccessibility", () => {
   const id = "test-id";
   const label = "label";
-  const labelHelp = "labelHelp";
   const fieldHelp = "fieldHelp";
   const error = "error";
   const warning = "warning";
   const info = "info";
 
   it("returns all aria related props when all arguments are passed", () => {
-    expect(
-      useInputAccessibility({ id, label, labelHelp, fieldHelp })
-    ).toMatchObject({
-      labelId: `${id}-label`,
-      tooltipId: `${id}-tooltip`,
-      fieldHelpId: `${id}-field-help`,
-      ariaDescribedBy: `${id}-field-help ${id}-tooltip`,
-      ariaLabelledBy: `${id}-label`,
-    });
-  });
-
-  it("returns aria props without labelId and ariaAlbelledBy when label is not provided", () => {
-    expect(useInputAccessibility({ id, labelHelp, fieldHelp })).toMatchObject({
-      labelId: undefined,
-      tooltipId: `${id}-tooltip`,
-      fieldHelpId: `${id}-field-help`,
-      ariaDescribedBy: `${id}-field-help ${id}-tooltip`,
-      ariaLabelledBy: undefined,
-    });
-  });
-
-  it("returns aria props without tooltipId fieldHelp/error/warning/info are not provided", () => {
     expect(useInputAccessibility({ id, label, fieldHelp })).toMatchObject({
       labelId: `${id}-label`,
-      tooltipId: undefined,
+      validationIconId: undefined,
       fieldHelpId: `${id}-field-help`,
       ariaDescribedBy: `${id}-field-help`,
       ariaLabelledBy: `${id}-label`,
     });
   });
 
-  it.each([labelHelp, error, info, warning])(
-    "returns proper tooltipId when %s is provided",
+  it("returns aria props without labelId and ariaAlbelledBy when label is not provided", () => {
+    expect(useInputAccessibility({ id, fieldHelp })).toMatchObject({
+      labelId: undefined,
+      validationIconId: undefined,
+      fieldHelpId: `${id}-field-help`,
+      ariaDescribedBy: `${id}-field-help`,
+      ariaLabelledBy: undefined,
+    });
+  });
+
+  it.each([error, info, warning])(
+    "returns proper validationIconId when %s is provided",
     (key) => {
       expect(useInputAccessibility({ id, [key]: key })).toMatchObject({
         labelId: undefined,
-        tooltipId: `${id}-tooltip`,
+        validationIconId: `${id}-validation-icon`,
         fieldHelpId: undefined,
-        ariaDescribedBy: `${id}-tooltip`,
+        ariaDescribedBy: `${id}-validation-icon`,
         ariaLabelledBy: undefined,
       });
     }

--- a/src/hooks/__internal__/useInputAccessibility/useInputAccessibility.js
+++ b/src/hooks/__internal__/useInputAccessibility/useInputAccessibility.js
@@ -4,26 +4,27 @@ export default function useInputAccessibility({
   warning,
   info,
   label,
-  labelHelp,
   fieldHelp,
 }) {
   const labelId = label ? `${id}-label` : undefined;
 
-  const tooltipId = [error, warning, info, labelHelp].filter(
+  const validationIconId = [error, warning, info].filter(
     (validation) => typeof validation === "string"
   ).length
-    ? `${id}-tooltip`
+    ? `${id}-validation-icon`
     : undefined;
 
   const fieldHelpId = fieldHelp ? `${id}-field-help` : undefined;
 
-  const ariaDescribedBy = [fieldHelpId, tooltipId].filter(Boolean).join(" ");
+  const ariaDescribedBy = [fieldHelpId, validationIconId]
+    .filter(Boolean)
+    .join(" ");
 
   const ariaLabelledBy = labelId;
 
   return {
     labelId,
-    tooltipId,
+    validationIconId,
     fieldHelpId,
     ariaDescribedBy,
     ariaLabelledBy,


### PR DESCRIPTION
fix #4725

### Proposed behaviour

aria-describedby should point to icons instead of their tooltips, as these icons already have aria-label attribute

### Current behaviour

aria-describedby in the input points to tooltips which are not yet displayed

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
