### PR TITLE
Design tokens/fe 4876 button

### DIFF
--- a/cypress/fixtures/themes/themes.json
+++ b/cypress/fixtures/themes/themes.json
@@ -1,8 +1,8 @@
 {
     "button-toggle": {
-        "mint": "rgb(230, 246, 241)",
-        "aegean": "rgb(230, 241, 250)",
-        "none": "rgb(230, 245, 230)"
+        "mint": "rgb(153, 173, 183)",
+        "aegean": "rgb(153, 173, 183)",
+        "none": "rgb(153, 173, 183)"
     },
     "common": {
         "mint": "rgb(0, 125, 90)",

--- a/src/components/button-toggle-group/__snapshots__/button-toggle-group.spec.js.snap
+++ b/src/components/button-toggle-group/__snapshots__/button-toggle-group.spec.js.snap
@@ -25,35 +25,34 @@ exports[`ButtonToggleGroup Modern theme renders correctly with default settings 
   height: 40px;
   padding: 0 24px;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-  border: 1px solid #668592;
-  background-color: #FFFFFF;
+  border: 1px solid var(--colorsActionMinor500);
 }
 
 .c6 .c8 {
-  color: #000000;
+  color: var(--colorsActionMinor500);
 }
 
 input:checked ~ .c6.c6 {
-  background-color: #E6F6F1;
-  border-color: #006046;
+  background-color: var(--colorsActionMinor300);
+  color: var(--colorsActionMinor600);
   cursor: auto;
 }
 
 input:focus ~ .c6 {
-  outline: 3px solid #FFB500;
+  outline: 3px solid var(--colorsSemanticFocus500);
   z-index: 100;
 }
 
 input:not(:checked):not(:disabled) ~ .c6:hover {
-  background-color: #006046;
-  border-color: #006046;
-  color: #FFFFFF;
+  background-color: var(--colorsWhiteMixTheme,var(--colorsActionMinor200));
+  border-color: var(--colorsActionMinor500);
+  color: var(--colorsActionMinor500);
 }
 
 input:not(:checked):not(:disabled) ~ .c6:hover .c8 {
-  color: #FFFFFF;
+  color: var(--colorsActionMinor500);
 }
 
 .c4 {

--- a/src/components/button-toggle-group/button-toggle-group.spec.js
+++ b/src/components/button-toggle-group/button-toggle-group.spec.js
@@ -31,6 +31,12 @@ const formFieldProps = [
   ["labelAlign", "right"],
 ];
 
+const buttonToggleGroupVariants = {
+  error: "var(--colorsSemanticNegative500)",
+  warning: "var(--colorsSemanticCaution500)",
+  info: "var(--colorsActionMinor500)",
+};
+
 describe("ButtonToggleGroup", () => {
   it("wraps ButtonToggle components in a FormField", () => {
     const wrapper = renderWithTheme({ theme: baseTheme }, mount);
@@ -158,7 +164,7 @@ describe("ButtonToggleGroup", () => {
           // eslint-disable-next-line max-len
           const boxShadow =
             type === "error"
-              ? `inset 1px 1px 0 ${baseTheme.colors.error}, inset -1px -1px 0 ${baseTheme.colors.error}`
+              ? `inset 1px 1px 0 var(--colorsSemanticNegative500), inset -1px -1px 0 var(--colorsSemanticNegative500)`
               : undefined;
           const wrapper = renderWithTheme(
             { theme: baseTheme, [type]: "Message" },
@@ -167,7 +173,7 @@ describe("ButtonToggleGroup", () => {
           assertStyleMatch(
             {
               boxShadow,
-              borderColor: baseTheme.colors[type],
+              borderColor: buttonToggleGroupVariants[type],
             },
             wrapper.find(ButtonToggleGroupStyle),
             { modifier: `${StyledButtonToggleLabel}` }
@@ -215,7 +221,7 @@ describe("ButtonToggleGroup", () => {
           // eslint-disable-next-line max-len
           const boxShadow =
             type === "error"
-              ? `inset 1px 1px 0 ${baseTheme.colors.error}, inset -1px -1px 0 ${baseTheme.colors.error}`
+              ? `inset 1px 1px 0 var(--colorsSemanticNegative500), inset -1px -1px 0 var(--colorsSemanticNegative500)`
               : undefined;
           const wrapper = renderWithTheme(
             { theme: baseTheme, [type]: true },
@@ -224,7 +230,7 @@ describe("ButtonToggleGroup", () => {
           assertStyleMatch(
             {
               boxShadow,
-              borderColor: baseTheme.colors[type],
+              borderColor: buttonToggleGroupVariants[type],
             },
             wrapper.find(ButtonToggleGroupStyle),
             { modifier: `${StyledButtonToggleLabel}` }

--- a/src/components/button-toggle-group/button-toggle-group.style.js
+++ b/src/components/button-toggle-group/button-toggle-group.style.js
@@ -1,7 +1,6 @@
 import styled, { css } from "styled-components";
 import { StyledButtonToggleLabel } from "../button-toggle/button-toggle.style";
 import ValidationIconStyle from "../../__internal__/validations/validation-icon.style";
-import baseTheme from "../../style/themes/base";
 
 const ButtonToggleGroupStyle = styled.div`
   display: flex;
@@ -13,22 +12,22 @@ const ButtonToggleGroupStyle = styled.div`
     `};
 
   ${StyledButtonToggleLabel} {
-    ${({ theme, info }) =>
+    ${({ info }) =>
       info &&
       css`
-        border-color: ${theme.colors.info};
+        border-color: var(--colorsActionMinor500);
       `};
-    ${({ theme, warning }) =>
+    ${({ warning }) =>
       warning &&
       css`
-        border-color: ${theme.colors.warning};
+        border-color: var(--colorsSemanticCaution500);
       `}
-    ${({ theme, error }) =>
+    ${({ error }) =>
       error &&
       css`
-        box-shadow: inset 1px 1px 0 ${theme.colors.error},
-          inset -1px -1px 0 ${theme.colors.error};
-        border-color: ${theme.colors.error};
+        box-shadow: inset 1px 1px 0 var(--colorsSemanticNegative500),
+          inset -1px -1px 0 var(--colorsSemanticNegative500);
+        border-color: var(--colorsSemanticNegative500);
       `}
   }
 
@@ -36,9 +35,5 @@ const ButtonToggleGroupStyle = styled.div`
     margin-left: 4px;
   }
 `;
-
-ButtonToggleGroupStyle.defaultProps = {
-  theme: baseTheme,
-};
 
 export default ButtonToggleGroupStyle;

--- a/src/components/button-toggle/__snapshots__/button-toggle.spec.js.snap
+++ b/src/components/button-toggle/__snapshots__/button-toggle.spec.js.snap
@@ -25,35 +25,34 @@ exports[`ButtonToggle General styling renders correctly when grouped 1`] = `
   height: 40px;
   padding: 0 24px;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-  border: 1px solid #668592;
-  background-color: #FFFFFF;
+  border: 1px solid var(--colorsActionMinor500);
 }
 
 .c2 .c8 {
-  color: #000000;
+  color: var(--colorsActionMinor500);
 }
 
 input:checked ~ .c2.c2 {
-  background-color: #E6F5E6;
-  border-color: #006300;
+  background-color: var(--colorsActionMinor300);
+  color: var(--colorsActionMinor600);
   cursor: auto;
 }
 
 input:focus ~ .c2 {
-  outline: 3px solid #FFB500;
+  outline: 3px solid var(--colorsSemanticFocus500);
   z-index: 100;
 }
 
 input:not(:checked):not(:disabled) ~ .c2:hover {
-  background-color: #006300;
-  border-color: #006300;
-  color: #FFFFFF;
+  background-color: var(--colorsWhiteMixTheme,var(--colorsActionMinor200));
+  border-color: var(--colorsActionMinor500);
+  color: var(--colorsActionMinor500);
 }
 
 input:not(:checked):not(:disabled) ~ .c2:hover .c8 {
-  color: #FFFFFF;
+  color: var(--colorsActionMinor500);
 }
 
 .c5 .c3 {
@@ -173,35 +172,34 @@ exports[`ButtonToggle when the aegean theme is set renders correct styles 1`] = 
   height: 40px;
   padding: 0 24px;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-  border: 1px solid #668592;
-  background-color: #FFFFFF;
+  border: 1px solid var(--colorsActionMinor500);
 }
 
 .c2 .c4 {
-  color: #000000;
+  color: var(--colorsActionMinor500);
 }
 
 input:checked ~ .c2.c2 {
-  background-color: #E6F1FA;
-  border-color: #005C9A;
+  background-color: var(--colorsActionMinor300);
+  color: var(--colorsActionMinor600);
   cursor: auto;
 }
 
 input:focus ~ .c2 {
-  outline: 3px solid #FFB500;
+  outline: 3px solid var(--colorsSemanticFocus500);
   z-index: 100;
 }
 
 input:not(:checked):not(:disabled) ~ .c2:hover {
-  background-color: #005C9A;
-  border-color: #005C9A;
-  color: #FFFFFF;
+  background-color: var(--colorsWhiteMixTheme,var(--colorsActionMinor200));
+  border-color: var(--colorsActionMinor500);
+  color: var(--colorsActionMinor500);
 }
 
 input:not(:checked):not(:disabled) ~ .c2:hover .c4 {
-  color: #FFFFFF;
+  color: var(--colorsActionMinor500);
 }
 
 .c0 {
@@ -272,35 +270,34 @@ exports[`ButtonToggle when the mint theme is set renders correct styles 1`] = `
   height: 40px;
   padding: 0 24px;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-  border: 1px solid #668592;
-  background-color: #FFFFFF;
+  border: 1px solid var(--colorsActionMinor500);
 }
 
 .c2 .c4 {
-  color: #000000;
+  color: var(--colorsActionMinor500);
 }
 
 input:checked ~ .c2.c2 {
-  background-color: #E6F6F1;
-  border-color: #006046;
+  background-color: var(--colorsActionMinor300);
+  color: var(--colorsActionMinor600);
   cursor: auto;
 }
 
 input:focus ~ .c2 {
-  outline: 3px solid #FFB500;
+  outline: 3px solid var(--colorsSemanticFocus500);
   z-index: 100;
 }
 
 input:not(:checked):not(:disabled) ~ .c2:hover {
-  background-color: #006046;
-  border-color: #006046;
-  color: #FFFFFF;
+  background-color: var(--colorsWhiteMixTheme,var(--colorsActionMinor200));
+  border-color: var(--colorsActionMinor500);
+  color: var(--colorsActionMinor500);
 }
 
 input:not(:checked):not(:disabled) ~ .c2:hover .c4 {
-  color: #FFFFFF;
+  color: var(--colorsActionMinor500);
 }
 
 .c0 {
@@ -371,35 +368,34 @@ exports[`ButtonToggle when the sage (experimental) theme is set renders correct 
   height: 40px;
   padding: 0 24px;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-  border: 1px solid #668592;
-  background-color: #FFFFFF;
+  border: 1px solid var(--colorsActionMinor500);
 }
 
 .c2 .c4 {
-  color: #000000;
+  color: var(--colorsActionMinor500);
 }
 
 input:checked ~ .c2.c2 {
-  background-color: #E6F6F1;
-  border-color: #006046;
+  background-color: var(--colorsActionMinor300);
+  color: var(--colorsActionMinor600);
   cursor: auto;
 }
 
 input:focus ~ .c2 {
-  outline: 3px solid #FFB500;
+  outline: 3px solid var(--colorsSemanticFocus500);
   z-index: 100;
 }
 
 input:not(:checked):not(:disabled) ~ .c2:hover {
-  background-color: #006046;
-  border-color: #006046;
-  color: #FFFFFF;
+  background-color: var(--colorsWhiteMixTheme,var(--colorsActionMinor200));
+  border-color: var(--colorsActionMinor500);
+  color: var(--colorsActionMinor500);
 }
 
 input:not(:checked):not(:disabled) ~ .c2:hover .c4 {
-  color: #FFFFFF;
+  color: var(--colorsActionMinor500);
 }
 
 .c0 {

--- a/src/components/button-toggle/button-toggle.spec.js
+++ b/src/components/button-toggle/button-toggle.spec.js
@@ -242,9 +242,8 @@ describe("ButtonToggle", () => {
       });
       assertStyleMatch(
         {
-          backgroundColor: "#E6EBED",
-          borderColor: "#E6EBED",
-          color: "rgba(0,0,0,.2)",
+          borderColor: "var(--colorsActionDisabled500)",
+          color: "var(--colorsActionMinorYin030)",
         },
         wrapper.find("label"),
         { modifier: "&" }

--- a/src/components/button-toggle/button-toggle.style.js
+++ b/src/components/button-toggle/button-toggle.style.js
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
-import baseTheme from "../../style/themes/base";
 import StyledIcon from "../icon/icon.style";
 
 const heightConfig = {
@@ -50,39 +49,35 @@ const StyledButtonToggleLabel = styled.label`
     padding: 0 ${paddingConfig[size]}px;
     font-size: ${fontSizeConfig[size]}px;
   `}
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
 
-  ${({ theme }) => css`
-    border: 1px solid ${theme.colors.border};
-    background-color: ${theme.colors.white};
+  border: 1px solid var(--colorsActionMinor500);
+
+  ${StyledIcon} {
+    color: var(--colorsActionMinor500);
+  }
+
+  input:checked ~ && {
+    background-color: var(--colorsActionMinor300);
+    color: var(--colorsActionMinor600);
+    cursor: auto;
+  }
+
+  input:focus ~ & {
+    outline: 3px solid var(--colorsSemanticFocus500);
+    z-index: 100;
+  }
+
+  input:not(:checked):not(:disabled) ~ &:hover {
+    background-color: var(--colorsWhiteMixTheme, var(--colorsActionMinor200));
+    border-color: var(--colorsActionMinor500);
+    color: var(--colorsActionMinor500);
 
     ${StyledIcon} {
-      color: ${theme.colors.black};
+      color: var(--colorsActionMinor500);
     }
-
-    input:checked ~ && {
-      background-color: ${theme.colors.whiteMix};
-      border-color: ${theme.colors.secondary};
-      color: ${theme.colors.text};
-      cursor: auto;
-    }
-
-    input:focus ~ & {
-      outline: 3px solid ${theme.colors.focus};
-      z-index: 100;
-    }
-
-    input:not(:checked):not(:disabled) ~ &:hover {
-      background-color: ${theme.colors.secondary};
-      border-color: ${theme.colors.secondary};
-      color: ${theme.colors.white};
-
-      ${StyledIcon} {
-        color: ${theme.colors.white};
-      }
-    }
-  `};
+  }
 
   ${({ buttonIcon, buttonIconSize, size }) =>
     buttonIcon &&
@@ -96,16 +91,15 @@ const StyledButtonToggleLabel = styled.label`
       }
     `}
 
-  ${({ disabled, theme }) =>
+  ${({ disabled }) =>
     disabled &&
     css`
       & {
-        background-color: ${theme.disabled.button};
-        border-color: ${theme.disabled.button};
-        color: ${theme.disabled.buttonText};
+        border-color: var(--colorsActionDisabled500);
+        color: var(--colorsActionMinorYin030);
 
         ${StyledIcon} {
-          color: ${theme.disabled.buttonText};
+          color: var(--colorsActionMinorYin030);
         }
       }
       cursor: not-allowed;
@@ -173,14 +167,6 @@ const StyledButtonToggleInput = styled.input`
 
 StyledButtonToggleIcon.propTypes = {
   buttonIconSize: PropTypes.string,
-};
-
-StyledButtonToggleLabel.defaultProps = {
-  theme: baseTheme,
-};
-
-StyledButtonToggleLabel.defaultProps = {
-  theme: baseTheme,
 };
 
 export {

--- a/src/components/button/button-types.style.js
+++ b/src/components/button/button-types.style.js
@@ -22,7 +22,7 @@ export default (isDisabled, destructive) => ({
       isDisabled
         ? `
     background: var(--colorsActionDisabled500);
-    ${makeColors("var(--colorsYin030)")};
+    ${makeColors("var(--colorsActionMajorYin030)")};
     &:hover {
       background: var(--colorsActionDisabled500);
     }
@@ -42,7 +42,7 @@ export default (isDisabled, destructive) => ({
       isDisabled
         ? `
       background: var(--colorsActionDisabled500);
-      ${makeColors("var(--colorsYin030)")};
+      ${makeColors("var(--colorsActionMajorYin030)")};
       &:hover {
         background: var(--colorsActionDisabled500);
       }
@@ -80,11 +80,11 @@ export default (isDisabled, destructive) => ({
         isDisabled
           ? `
         border-color: var(--colorsActionDisabled500);
-        ${makeColors("var(--colorsYin030)")};
+        ${makeColors("var(--colorsActionMajorYin030)")};
         &:hover {
           background: transparent;
           border-color: var(--colorsActionDisabled500);
-          ${makeColors("var(--colorsYin030)")};
+          ${makeColors("var(--colorsActionMajorYin030)")};
         }
     `
           : ""
@@ -114,10 +114,10 @@ export default (isDisabled, destructive) => ({
     ${
       isDisabled
         ? `
-      ${makeColors("var(--colorsYin030)")};
+      ${makeColors("var(--colorsActionMajorYin030)")};
       &:hover {
         background: var(--colorsActionMajorTransparent);
-        ${makeColors("var(--colorsYin030)")};
+        ${makeColors("var(--colorsActionMajorYin030)")};
       }
     `
         : ""
@@ -143,7 +143,7 @@ export default (isDisabled, destructive) => ({
       isDisabled
         ? `
       border-color: var(--colorsActionDisabled500);
-      ${makeColors("var(--colorsYin030)")};
+      ${makeColors("var(--colorsActionMinorYin030)")};
       &:hover {
         background-color: transparent;
       }
@@ -164,10 +164,10 @@ export default (isDisabled, destructive) => ({
       isDisabled
         ? `
       background: var(--colorsActionDisabled500);
-      ${makeColors("var(--colorsYin030)")};
+      ${makeColors("var(--colorsActionMajorYin030)")};
       &:hover {
         background: var(--colorsActionDisabled500);
-        ${makeColors("var(--colorsYin030)")};
+        ${makeColors("var(--colorsActionMajorYin030)")};
       }
     `
         : ""

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -204,7 +204,10 @@ describe("Button", () => {
               variant === "secondary" || variant === "dashed"
                 ? "var(--colorsActionDisabled500)"
                 : "transparent",
-            color: "var(--colorsYin030)",
+            color:
+              variant === "dashed"
+                ? "var(--colorsActionMinorYin030)"
+                : "var(--colorsActionMajorYin030)",
           },
           wrapper
         );
@@ -348,7 +351,7 @@ describe("Button", () => {
         {
           background: "transparent",
           borderColor: "var(--colorsActionDisabled500)",
-          color: "var(--colorsYin030)",
+          color: "var(--colorsActionMajorYin030)",
           fontSize: "var(--fontSizes100)",
           minHeight: sizesHeights.medium,
         },
@@ -383,7 +386,10 @@ describe("Button", () => {
                   variant === "secondary" || variant === "dashed"
                     ? "var(--colorsActionDisabled500)"
                     : "transparent",
-                color: "var(--colorsYin030)",
+                color:
+                  variant === "dashed"
+                    ? "var(--colorsActionMinorYin030)"
+                    : "var(--colorsActionMajorYin030)",
                 fontSize: size === "large" ? "16px" : "var(--fontSizes100)",
                 minHeight: height,
               },
@@ -415,7 +421,10 @@ describe("Button", () => {
                   variant === "secondary" || variant === "dashed"
                     ? "var(--colorsActionDisabled500)"
                     : "transparent",
-                color: "var(--colorsYin030)",
+                color:
+                  variant === "dashed"
+                    ? "var(--colorsActionMinorYin030)"
+                    : "var(--colorsActionMajorYin030)",
                 fontSize: size === "large" ? "16px" : "var(--fontSizes100)",
                 minHeight: height,
               },

--- a/src/components/split-button/split-button.spec.js
+++ b/src/components/split-button/split-button.spec.js
@@ -329,7 +329,7 @@ describe("SplitButton", () => {
         assertStyleMatch(
           {
             background: "transparent",
-            color: "var(--colorsYin030)",
+            color: "var(--colorsActionMajorYin030)",
           },
           toggle
         );

--- a/src/style/design-tokens/carbon-scoped-tokens-provider/__snapshots__/carbon-scoped-tokens-provider.component.spec.js.snap
+++ b/src/style/design-tokens/carbon-scoped-tokens-provider/__snapshots__/carbon-scoped-tokens-provider.component.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`CarbonScopedTokensProvider should render css variables for all themes 1`] = `
 Array [
   CSSStyleRule {
-    "__ends": 10569,
+    "__ends": 10599,
     "__starts": 45,
     "parentRule": null,
     "parentStyleSheet": CSSStyleSheet {
@@ -143,6 +143,7 @@ Array [
       "--colorsUtilityYin055": "#0000008c",
       "--colorsUtilityYin065": "#000000a6",
       "--colorsUtilityYin090": "#000000e6",
+      "--colorsWhiteMixTheme": "#E6F1FA",
       "--colorsYang100": "#ffffffff",
       "--colorsYin030": "#0000004d",
       "--colorsYin055": "#0000008c",
@@ -525,6 +526,7 @@ Array [
       "292": "--typographyTooltipTextL",
       "293": "--opacity300",
       "294": "--opacity600",
+      "295": "--colorsWhiteMixTheme",
       "3": "--colorsTransparent",
       "30": "--colorsUtilityMajor500",
       "31": "--colorsUtilityMajor800",
@@ -735,6 +737,7 @@ Array [
         "--colorsUtilityYin055": "",
         "--colorsUtilityYin065": "",
         "--colorsUtilityYin090": "",
+        "--colorsWhiteMixTheme": "",
         "--colorsYang100": "",
         "--colorsYin030": "",
         "--colorsYin055": "",
@@ -900,13 +903,13 @@ Array [
         "--typographyTooltipTextL": "",
         "--typographyTooltipTextM": "",
       },
-      "length": 295,
+      "length": 296,
       "parentRule": [Circular],
     },
   },
   CSSStyleRule {
-    "__ends": 21092,
-    "__starts": 10570,
+    "__ends": 21152,
+    "__starts": 10600,
     "parentRule": null,
     "parentStyleSheet": CSSStyleSheet {
       "cssRules": [Circular],
@@ -1045,6 +1048,7 @@ Array [
       "--colorsUtilityYin055": "#0000008c",
       "--colorsUtilityYin065": "#000000a6",
       "--colorsUtilityYin090": "#000000e6",
+      "--colorsWhiteMixTheme": "#E6F6F1",
       "--colorsYang100": "#ffffffff",
       "--colorsYin030": "#0000004d",
       "--colorsYin055": "#0000008c",
@@ -1427,6 +1431,7 @@ Array [
       "292": "--typographyTooltipTextL",
       "293": "--opacity300",
       "294": "--opacity600",
+      "295": "--colorsWhiteMixTheme",
       "3": "--colorsTransparent",
       "30": "--colorsUtilityMajor500",
       "31": "--colorsUtilityMajor800",
@@ -1504,7 +1509,7 @@ Array [
       "97": "--colorsSemanticPositiveYin055",
       "98": "--colorsSemanticPositiveYin065",
       "99": "--colorsSemanticPositiveYin090",
-      "__starts": 10599,
+      "__starts": 10629,
       "_importants": Object {
         "--borderRadiusCircle": "",
         "--borderWidth000": "",
@@ -1637,6 +1642,7 @@ Array [
         "--colorsUtilityYin055": "",
         "--colorsUtilityYin065": "",
         "--colorsUtilityYin090": "",
+        "--colorsWhiteMixTheme": "",
         "--colorsYang100": "",
         "--colorsYin030": "",
         "--colorsYin055": "",
@@ -1802,13 +1808,13 @@ Array [
         "--typographyTooltipTextL": "",
         "--typographyTooltipTextM": "",
       },
-      "length": 295,
+      "length": 296,
       "parentRule": [Circular],
     },
   },
   CSSStyleRule {
-    "__ends": 31615,
-    "__starts": 21093,
+    "__ends": 31675,
+    "__starts": 21153,
     "parentRule": null,
     "parentStyleSheet": CSSStyleSheet {
       "cssRules": [Circular],
@@ -2406,7 +2412,7 @@ Array [
       "97": "--colorsSemanticPositiveYin055",
       "98": "--colorsSemanticPositiveYin065",
       "99": "--colorsSemanticPositiveYin090",
-      "__starts": 21122,
+      "__starts": 21182,
       "_importants": Object {
         "--borderRadiusCircle": "",
         "--borderWidth000": "",
@@ -2709,8 +2715,8 @@ Array [
     },
   },
   CSSStyleRule {
-    "__ends": 42167,
-    "__starts": 31616,
+    "__ends": 42227,
+    "__starts": 31676,
     "parentRule": null,
     "parentStyleSheet": CSSStyleSheet {
       "cssRules": [Circular],
@@ -3308,7 +3314,7 @@ Array [
       "97": "--colorsSemanticPositiveYin055",
       "98": "--colorsSemanticPositiveYin065",
       "99": "--colorsSemanticPositiveYin090",
-      "__starts": 31658,
+      "__starts": 31718,
       "_importants": Object {
         "--borderRadiusCircle": "",
         "--borderWidth000": "",
@@ -3611,8 +3617,8 @@ Array [
     },
   },
   CSSStyleRule {
-    "__ends": 42255,
-    "__starts": 42201,
+    "__ends": 42315,
+    "__starts": 42261,
     "parentRule": null,
     "parentStyleSheet": CSSStyleSheet {
       "cssRules": [Circular],
@@ -3624,7 +3630,7 @@ Array [
       "1": "padding",
       "2": "width",
       "3": "display",
-      "__starts": 42208,
+      "__starts": 42268,
       "_importants": Object {
         "display": "",
         "margin": "",

--- a/src/style/themes/aegean/__snapshots__/aegean-theme.spec.js.snap
+++ b/src/style/themes/aegean/__snapshots__/aegean-theme.spec.js.snap
@@ -133,6 +133,7 @@ Object {
   "colorsUtilityYin055": "#0000008c",
   "colorsUtilityYin065": "#000000a6",
   "colorsUtilityYin090": "#000000e6",
+  "colorsWhiteMixTheme": "#E6F1FA",
   "colorsYang100": "#ffffffff",
   "colorsYin030": "#0000004d",
   "colorsYin055": "#0000008c",

--- a/src/style/themes/aegean/aegean-theme.config.js
+++ b/src/style/themes/aegean/aegean-theme.config.js
@@ -27,6 +27,7 @@ export default (palette) => {
         colorsActionMajor500: this.colors.primary,
         colorsActionMajor600: this.colors.secondary,
         colorsActionMajor150: this.colors.loadingBarBackground,
+        colorsWhiteMixTheme: this.colors.whiteMix,
       };
     },
   };

--- a/src/style/themes/mint/__snapshots__/mint-theme.spec.js.snap
+++ b/src/style/themes/mint/__snapshots__/mint-theme.spec.js.snap
@@ -133,6 +133,7 @@ Object {
   "colorsUtilityYin055": "#0000008c",
   "colorsUtilityYin065": "#000000a6",
   "colorsUtilityYin090": "#000000e6",
+  "colorsWhiteMixTheme": "#E6F6F1",
   "colorsYang100": "#ffffffff",
   "colorsYin030": "#0000004d",
   "colorsYin055": "#0000008c",

--- a/src/style/themes/mint/mint-theme.config.js
+++ b/src/style/themes/mint/mint-theme.config.js
@@ -22,6 +22,7 @@ export default (palette) => {
         colorsActionMajor500: this.colors.primary,
         colorsActionMajor600: this.colors.secondary,
         colorsActionMajor150: this.colors.loadingBarBackground,
+        colorsWhiteMixTheme: this.colors.whiteMix,
       };
     },
   };


### PR DESCRIPTION
### Proposed behaviour
Replace token colorsYin with proper token based on category:
- for buttons from primary to tertiary with colorsActionMajorYin030
- for button:dashed with colorsActionMinorYin030

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
