### PR TITLE
fix(toast): make toast position fixed to top of viewport

### DIFF
--- a/cypress/fixtures/commonComponents/toast.json
+++ b/cypress/fixtures/commonComponents/toast.json
@@ -1,4 +1,4 @@
-{ 
+{
   "childrenOtherLanguage": {
     "children": "",
     "childrenSpecialCharacters": "otherLanguage"
@@ -6,5 +6,8 @@
   "childrenSpecialCharacter": {
     "children": "",
     "childrenSpecialCharacters": "specialCharacters"
+  },
+  "scrollablePage": {
+    "scrollablePage": true
   }
 }

--- a/cypress/integration/common/toast.feature
+++ b/cypress/integration/common/toast.feature
@@ -40,3 +40,12 @@ Feature: Toast component
     Given I open "Toast" component page "default story"
     When I click on "button-default" Toggle Preview
     Then Toast is centred
+
+  @positive
+  Scenario Outline: Confirm Toast stays visible when page is scrolled down
+    Given I open default "Toast Test" component with "toast" json from "commonComponents" using "<nameOfObject>" object name
+    When I scroll down the page
+    Then Toast is still visible
+    Examples:
+      | nameOfObject   |
+      | scrollablePage |

--- a/cypress/support/step-definitions/toast-steps.js
+++ b/cypress/support/step-definitions/toast-steps.js
@@ -20,3 +20,11 @@ Then("Toast is centred", () => {
 Then("Toast is not centred", () => {
   toastComponent().should("have.css", "margin-right", "30px");
 });
+
+When("I scroll down the page", () => {
+  cy.scrollTo("0", "500");
+});
+
+Then("Toast is still visible", () => {
+  toastComponent().should("be.visible");
+});

--- a/src/components/toast/toast-test.stories.mdx
+++ b/src/components/toast/toast-test.stories.mdx
@@ -237,6 +237,7 @@ export const ToastVisualStory = ({
       chromatic: {
         disable: false,
       },
+      themeSelector: { chromaticTheme: "sage" },
     }}
   >
     {ToastVisualStory.bind({})}

--- a/src/components/toast/toast-test.stories.mdx
+++ b/src/components/toast/toast-test.stories.mdx
@@ -23,6 +23,7 @@ import { TOAST_COLORS } from "./toast.config";
 export const ToastStory = ({
   children,
   childrenSpecialCharacters,
+  scrollablePage,
   ...args
 }) => {
   const [isOpen, setIsOpen] = useState(true);
@@ -33,6 +34,20 @@ export const ToastStory = ({
   const handleOpen = () => {
     setIsOpen(!isOpen);
   };
+  if (scrollablePage) {
+    return (
+      <div style={{ height: "150vh", overflow: "auto" }}>
+        <Button onClick={handleOpen}>Open Toast</Button>
+        <Toast
+          id="toast-dismissible"
+          open={isOpen}
+          onDismiss={onDismissClick}
+          children={children || childrenSpecialCharacters}
+          {...args}
+        />
+      </div>
+    );
+  }
   return (
     <>
       <Button onClick={handleOpen}>Open Toast</Button>
@@ -194,6 +209,7 @@ export const ToastVisualStory = ({
       timeout: 0,
       variant: "warning",
       isCenter: true,
+      scrollablePage: false,
     }}
     argTypes={{
       variant: {

--- a/src/components/toast/toast.style.js
+++ b/src/components/toast/toast.style.js
@@ -9,7 +9,7 @@ import baseTheme from "../../style/themes/base";
 
 const StyledPortal = styled(Portal)`
   ${({ theme }) => css`
-    position: absolute;
+    position: fixed;
     top: 0;
 
     z-index: ${theme.zIndex.notification};


### PR DESCRIPTION
Fixes: #4730 

### Proposed behaviour

Change `Toast` position to fixed, so it stays at the top of the viewport when it is scrolled down.

Add a Cypress test which scrolls the page down to test `Toast` is still visible.

### Current behaviour

`Toast` currently has a position absolute set, which means it can be scrolled off the top of the page.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

See issue PR below and use the http://localhost:9001/?path=/story/toast-test--default-story story with the `scrollablePage` control set to true to test.
