### PR TITLE
chore(deps): upgrade core-js to latest and update version in babel co…

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,7 +8,7 @@ module.exports = {
           browsers:
             "last 2 Chrome versions, last 2 Firefox versions, last 2 Edge versions, last 2 Safari versions",
         },
-        corejs: "3.1",
+        corejs: "3.20",
       },
     ],
     "@babel/preset-react",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11545,9 +11545,9 @@
       }
     },
     "core-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
-      "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
+      "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "chromatic": "^6.0.5",
     "commitizen": "^4.2.4",
     "conventional-changelog-conventionalcommits": "^4.5.0",
-    "core-js": "^3.1.4",
+    "core-js": "^3.20.3",
     "cpy-cli": "^3.1.1",
     "cross-env": "^5.2.0",
     "cypress": "^9.2.0",


### PR DESCRIPTION
…nfig

### Proposed behaviour

Update `core-js` version to latest, and use the new version in our babel config.

### Current behaviour

The version we currently use `3.1.4` is not recommended for usage by the maintainers of `core-js`: 
![image](https://user-images.githubusercontent.com/14963680/151534908-d3a1d8e4-09d3-4d73-8eab-9a8027c88b22.png)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
