### PR TITLE
feat(step-sequence-item): support hiding indicator

### DIFF
--- a/cypress/fixtures/commonComponents/stepSequence.json
+++ b/cypress/fixtures/commonComponents/stepSequence.json
@@ -1,4 +1,4 @@
-{ 
+{
   "indicator-100": {
     "indicator": -100
   },
@@ -15,6 +15,14 @@
   "indicatorSpecialCharacter": {
     "indicator": "",
     "indicatorSpecialCharacters": "specialCharacters"
+  },
+  "showIndicator": {
+    "indicator": 999,
+    "hideIndicator": false
+  },
+  "hideIndicator": {
+    "indicator": 999,
+    "hideIndicator": true
   },
   "hiddenCompleteLabelOtherLanguage": {
     "status": "complete",

--- a/cypress/integration/common/stepSequenceItem.feature
+++ b/cypress/integration/common/stepSequenceItem.feature
@@ -14,6 +14,16 @@ Feature: Step Sequence Item component
       | !@#$%^*()_+-=~[];:.,?{}&"'<> | indicatorSpecialCharacter |
 
   @positive
+  Scenario: Show indicator
+    When I open step-sequence-item "Step Sequence Test" component with "stepSequence" json from "commonComponents" using "showIndicator" object name
+    Then indicator 999 is shown
+
+  @positive
+  Scenario: Hide indicator
+    When I open step-sequence-item "Step Sequence Test" component with "stepSequence" json from "commonComponents" using "hideIndicator" object name
+    Then indicator 999 is not shown
+
+  @positive
   Scenario: I set hiddenCompleteLabel to mp150ú¿¡üßä
     When I open step-sequence-item "Step Sequence Test" component with "stepSequence" json from "commonComponents" using "hiddenCompleteLabelOtherLanguage" object name
     Then hidden label is set to mp150ú¿¡üßä

--- a/cypress/support/step-definitions/step-sequence-steps.js
+++ b/cypress/support/step-definitions/step-sequence-steps.js
@@ -9,6 +9,14 @@ Then("indicator is set to {word}", (indicator) => {
   stepSequenceItemIndicator().should("have.text", indicator);
 });
 
+Then("indicator {word} is shown", (indicator) => {
+  stepSequenceItemIndicator().should("have.text", indicator);
+});
+
+Then("indicator {word} is not shown", (indicator) => {
+  stepSequenceItemIndicator().should("not.have.text", indicator);
+});
+
 Then("hidden label is set to {word}", (hiddenLabel) => {
   stepSequenceDataComponent().children().should("have.text", hiddenLabel);
 });

--- a/src/components/step-sequence/step-sequence-item/step-sequence-item.component.js
+++ b/src/components/step-sequence/step-sequence-item/step-sequence-item.component.js
@@ -7,11 +7,13 @@ import StepSequenceItemHiddenLabelStyle from "./step-sequence-item-hidden-label.
 import Icon from "../../icon";
 
 const StepSequenceItem = (props) => {
-  const indicatorText = () => (
-    <StepSequenceItemIndicatorStyle>
-      {props.indicator}
-    </StepSequenceItemIndicatorStyle>
-  );
+  const indicatorText = () => {
+    return !props.hideIndicator ? (
+      <StepSequenceItemIndicatorStyle>
+        {props.indicator}
+      </StepSequenceItemIndicatorStyle>
+    ) : null;
+  };
 
   const icon = () =>
     props.status === "complete" ? <Icon type="tick" /> : indicatorText();
@@ -56,6 +58,8 @@ StepSequenceItem.propTypes = {
   children: PropTypes.node.isRequired,
   /** Value to be displayed before text for uncompleted steps */
   indicator: PropTypes.string.isRequired,
+  /** Flag to hide the indicator for uncompleted steps */
+  hideIndicator: PropTypes.bool,
   /** Aria label */
   ariaLabel: PropTypes.string,
   /** Status for the step */
@@ -68,6 +72,7 @@ StepSequenceItem.propTypes = {
 
 StepSequenceItem.defaultProps = {
   status: "incomplete",
+  hideIndicator: false,
 };
 
 export default StepSequenceItem;

--- a/src/components/step-sequence/step-sequence-item/step-sequence-item.d.ts
+++ b/src/components/step-sequence/step-sequence-item/step-sequence-item.d.ts
@@ -9,6 +9,8 @@ export interface StepSequenceItemProps {
   hiddenCurrentLabel?: string;
   /** Value to be displayed before text for uncomplete steps */
   indicator: string;
+  /** Flag to hide the indicator for uncomplete steps */
+  hideIndicator?: boolean;
   /** Status for the step */
   status?: "complete" | "current" | "incomplete";
 }

--- a/src/components/step-sequence/step-sequence-item/step-sequence-item.spec.js
+++ b/src/components/step-sequence/step-sequence-item/step-sequence-item.spec.js
@@ -6,6 +6,7 @@ import StepSequenceItem from "./step-sequence-item.component";
 import mintTheme from "../../../style/themes/mint";
 import Icon from "../../icon";
 import StepSequenceItemHiddenLabelStyle from "./step-sequence-item-hidden-label.style";
+import StepSequenceItemIndicatorStyle from "./step-sequence-item-indicator.style";
 
 describe("StepSequenceItem", () => {
   const render = (props, renderer = mount) =>
@@ -76,6 +77,18 @@ describe("StepSequenceItem", () => {
       expect(wrapper.find(StepSequenceItemHiddenLabelStyle).text()).toEqual(
         "HiddenCurrent"
       );
+    });
+
+    describe("when hideIndicator is set to true", () => {
+      it("doesn't render the indicator", () => {
+        const wrapper = render({
+          ...defaultProps,
+          hideIndicator: true,
+        });
+        expect(wrapper.find(StepSequenceItemIndicatorStyle).exists()).toBe(
+          false
+        );
+      });
     });
   });
 });

--- a/src/components/step-sequence/step-sequence-test.stories.mdx
+++ b/src/components/step-sequence/step-sequence-test.stories.mdx
@@ -85,6 +85,7 @@ export const StepSequenceStory = (args) => (
 export const StepSequenceItemStory = ({
   indicatorSpecialCharacters,
   indicator,
+  hideIndicator,
   hiddenCompleteLabelSpecialCharacters,
   hiddenCompleteLabel,
   hiddenCurrentLabelSpecialCharacters,
@@ -97,6 +98,7 @@ export const StepSequenceItemStory = ({
 }) => (
   <StepSequenceItem
     indicator={indicator || indicatorSpecialCharacters}
+    hideIndicator={hideIndicator}
     hiddenCompleteLabel={
       hiddenCompleteLabel || hiddenCompleteLabelSpecialCharacters
     }
@@ -141,6 +143,7 @@ export const StepSequenceItemStory = ({
     }}
     args={{
       indicator: "1",
+      hideIndicator: false,
       indicatorSpecialCharacters: undefined,
       status: StepSequenceItem.defaultProps.status,
       hiddenCompleteLabel: "",

--- a/src/components/step-sequence/step-sequence.stories.mdx
+++ b/src/components/step-sequence/step-sequence.stories.mdx
@@ -139,6 +139,63 @@ import {
   </Story>
 </Canvas>
 
+### With hidden indicators
+
+<Canvas>
+  <Story name="with hidden indicators">
+    <StepSequence>
+      <StepSequenceItem
+        aria-label="Step 1 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="1"
+        status="complete"
+      >
+        Name
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 2 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="2"
+        status="complete"
+      >
+        Delivery Address
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 3 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="3"
+        hideIndicator={true}
+        status="current"
+      >
+        Delivery Details
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 4 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="4"
+        hideIndicator={true}
+        status="incomplete"
+      >
+        Payment
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 5 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="5"
+        hideIndicator={true}
+        status="incomplete"
+      >
+        Confirm
+      </StepSequenceItem>
+    </StepSequence>
+  </Story>
+</Canvas>
+
 ## Props
 
 ### StepSequence


### PR DESCRIPTION
### Proposed behaviour

There is now a new flag called `hideIndicator` for the `StepSequenceItem` which, when set to true, hides the sequence indicator on non-completed steps. The gap on either side of the `StepSequenceItem` is now the same distance if there is the desire for no `indicator` to be shown. Example: 

![image](https://user-images.githubusercontent.com/28150291/152526393-2c1f3a5f-b163-4613-96aa-8d3844c2650a.png)

### Current behaviour

If there is no indicator supplied, then there is a bigger gap on the left side of the `StepSequenceItem` text than on the right. 

![image](https://user-images.githubusercontent.com/28150291/152526566-a276f2b1-c2a6-4dc6-9922-d48ce6f18e1a.png)


### Checklist

<!-- Each PR should include the following -->

- [ ✓ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ✓ ] Screenshots are included in the PR if useful
- [ ✓ ] All themes are supported if required
- [ ✓ ] Unit tests added or updated if required
- [ ✓ ] Cypress automation tests added or updated if required
- [ ✓ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ✓ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

<!-- How can a reviewer test this PR? -->

This can be tested by locally running the Storybook
The following CodeSandbox is an example of the current behaviour.


[codesandbox](https://codesandbox.io/s/mystifying-bouman-kr9dl)
