### PR TITLE
feat(form): describe form using design tokens, update tests

### DIFF
--- a/src/components/form/__internal__/form-summary.style.js
+++ b/src/components/form/__internal__/form-summary.style.js
@@ -1,6 +1,5 @@
 import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
-import baseTheme from "../../../style/themes/base";
 import StyledIcon from "../../icon/icon.style";
 import StyledButton from "../../button/button.style";
 
@@ -13,10 +12,10 @@ export const StyledFormSummary = styled.div`
   padding: 8px;
   white-space: nowrap;
 
-  ${({ showSummary, theme }) =>
+  ${({ showSummary }) =>
     showSummary &&
     css`
-      background-color: ${theme.form.invalid};
+      background-color: var(--colorsUtilityMajor025);
     `}
 
   ${StyledButton} {
@@ -38,44 +37,36 @@ export const StyledInternalSummary = styled.div`
   &:last-of-type {
     margin-right: 16px;
   }
-  ${({ type, theme }) =>
+  ${({ type }) =>
     type === "warnings" &&
     css`
-      color: ${theme.colors.warning};
+      color: var(--colorsSemanticCaution650);
     `}
-  ${({ type, theme }) =>
+  ${({ type }) =>
     type === "errors" &&
     css`
-      color: ${theme.colors.error};
+      color: var(--colorsSemanticNegative600);
     `}
 
   ${StyledIcon} {
     margin-right: 4px;
-    ${({ type, theme }) =>
+    ${({ type }) =>
       type === "warnings" &&
       css`
-        color: ${theme.colors.warning};
+        color: var(--colorsSemanticCaution650);
       `}
-    ${({ type, theme }) =>
+    ${({ type }) =>
       type === "errors" &&
       css`
-        color: ${theme.colors.error};
+        color: var(--colorsSemanticNegative600);
       `}
   }
 `;
 
 StyledFormSummary.propTypes = {
-  theme: PropTypes.object,
   showSummary: PropTypes.bool,
-};
-StyledFormSummary.defaultProps = {
-  theme: baseTheme,
 };
 
 StyledInternalSummary.propTypes = {
-  theme: PropTypes.object,
   type: PropTypes.oneOf(["errors", "warnings"]),
-};
-StyledInternalSummary.defaultProps = {
-  theme: baseTheme,
 };

--- a/src/components/form/form.spec.js
+++ b/src/components/form/form.spec.js
@@ -1,7 +1,6 @@
 import React, { useRef } from "react";
 import { mount, shallow } from "enzyme";
 
-import baseTheme from "../../style/themes/base";
 import {
   assertStyleMatch,
   testStyledSystemSpacing,
@@ -78,7 +77,7 @@ describe("Form", () => {
       assertStyleMatch(
         {
           marginTop: "0",
-          marginBottom: "24px",
+          marginBottom: "var(--spacing300)",
         },
         wrapper,
         {
@@ -94,7 +93,7 @@ describe("Form", () => {
       assertStyleMatch(
         {
           marginTop: "0",
-          marginBottom: "16px",
+          marginBottom: "var(--spacing200)",
         },
         wrapper,
         {
@@ -113,7 +112,7 @@ describe("Form", () => {
 
       assertStyleMatch(
         {
-          backgroundColor: baseTheme.colors.white,
+          backgroundColor: "var(--colorsUtilityYang100)",
           boxShadow: "0 -4px 12px 0 rgba(0,0,0,0.05)",
           boxSizing: "border-box",
           padding: "16px 32px",
@@ -180,11 +179,11 @@ describe("Form", () => {
 
         assertStyleMatch(
           {
-            paddingRight: "32px",
-            paddingLeft: "32px",
+            paddingRight: "var(--spacing400)",
+            paddingLeft: "var(--spacing400)",
             paddingTop: "27px",
-            marginRight: "-32px",
-            marginLeft: "-32px",
+            marginRight: "calc(-1 * var(--spacing400))",
+            marginLeft: "calc(-1 * var(--spacing400))",
             marginTop: "-27px",
           },
           wrapper,
@@ -193,11 +192,11 @@ describe("Form", () => {
 
         assertStyleMatch(
           {
-            marginLeft: "-32px",
-            marginBottom: "-32px",
-            width: "calc(100% + 64px)",
-            paddingLeft: "32px",
-            paddingRight: "32px",
+            marginLeft: "calc(-1 * var(--spacing400))",
+            marginBottom: "calc(-1 * var(--spacing400))",
+            width: "calc(100% + var(--spacing800))",
+            paddingLeft: "var(--spacing400)",
+            paddingRight: "var(--spacing400)",
           },
           wrapper,
           { modifier: `${StyledFormFooter}.sticky` }
@@ -300,14 +299,14 @@ describe("Form", () => {
       wrapper.setProps({ warningCount: 1 });
       assertStyleMatch(
         {
-          backgroundColor: baseTheme.form.invalid,
+          backgroundColor: "var(--colorsUtilityMajor025)",
         },
         wrapper.find(StyledFormSummary)
       );
       wrapper.setProps({ errorCount: 1 });
       assertStyleMatch(
         {
-          backgroundColor: baseTheme.form.invalid,
+          backgroundColor: "var(--colorsUtilityMajor025)",
         },
         wrapper.find(StyledFormSummary)
       );
@@ -334,7 +333,7 @@ describe("Form", () => {
 
         assertStyleMatch(
           {
-            color: baseTheme.colors.error,
+            color: "var(--colorsSemanticNegative600)",
           },
           errorSummary
         );
@@ -351,7 +350,7 @@ describe("Form", () => {
 
         assertStyleMatch(
           {
-            color: baseTheme.colors.warning,
+            color: "var(--colorsSemanticCaution650)",
           },
           warningSummary
         );
@@ -366,7 +365,7 @@ describe("Form", () => {
 
         assertStyleMatch(
           {
-            color: baseTheme.colors.error,
+            color: "var(--colorsSemanticNegative600)",
           },
           errorSummary
         );
@@ -379,7 +378,7 @@ describe("Form", () => {
 
         assertStyleMatch(
           {
-            color: baseTheme.colors.warning,
+            color: "var(--colorsSemanticCaution650)",
           },
           warningSummary
         );

--- a/src/components/form/form.style.js
+++ b/src/components/form/form.style.js
@@ -32,7 +32,7 @@ export const StyledFormFooter = styled.div`
       justify-content: flex-end;
     `}
 
-  ${({ stickyFooter, theme }) => css`
+  ${({ stickyFooter }) => css`
     ${!stickyFooter &&
     css`
       margin-top: 48px;
@@ -40,7 +40,7 @@ export const StyledFormFooter = styled.div`
 
     ${stickyFooter &&
     css`
-      background-color: ${theme.colors.white};
+      background-color: var(--colorsUtilityYang100);
       box-shadow: 0 -4px 12px 0 rgba(0, 0, 0, 0.05);
       box-sizing: border-box;
       padding: 16px 32px;
@@ -52,6 +52,17 @@ export const StyledFormFooter = styled.div`
   `}
 `;
 
+const formBottomMargins = (fieldSpacing) =>
+  ({
+    0: "var(--spacing000)",
+    1: "var(--spacing100)",
+    2: "var(--spacing200)",
+    3: "var(--spacing300)",
+    4: "var(--spacing400)",
+    5: "var(--spacing500)",
+    7: "var(--spacing700)",
+  }[fieldSpacing]);
+
 export const StyledForm = styled.form`
   ${space}
 
@@ -61,26 +72,31 @@ export const StyledForm = styled.form`
       height: ${height};
     `}
 
-  & ${StyledFormField}, ${StyledFieldset}, ${FieldsetStyle}, > ${StyledButton} {
-    margin-top: 0;
-    margin-bottom: ${({ fieldSpacing, theme }) =>
-      theme.spacing * fieldSpacing}px;
-  }
+  ${({ fieldSpacing }) =>
+    css`
+      &
+        ${StyledFormField},
+        ${StyledFieldset},
+        ${FieldsetStyle},
+        > ${StyledButton} {
+        margin-top: 0;
+        margin-bottom: ${formBottomMargins(fieldSpacing)};
+      }
 
-  ${StyledInlineInputs} {
-    ${StyledFormField} {
-      margin-bottom: 0;
-    }
+      ${StyledInlineInputs} {
+        ${StyledFormField} {
+          margin-bottom: 0;
+        }
 
-    margin-bottom: ${({ fieldSpacing, theme }) =>
-      theme.spacing * fieldSpacing}px;
-  }
+        margin-bottom: ${formBottomMargins(fieldSpacing)};
+      }
+    `}  
 
   ${StyledSearch} ${StyledFormField} {
     margin-bottom: 0px;
   }
 
-  ${({ stickyFooter, isInSidebar, theme }) =>
+  ${({ stickyFooter, isInSidebar }) =>
     stickyFooter &&
     css`
       display: flex;
@@ -91,20 +107,20 @@ export const StyledForm = styled.form`
       css`
         min-height: 100%;
         ${StyledFormContent}.sticky {
-          padding-right: ${theme.space[4]}px;
-          padding-left: ${theme.space[4]}px;
+          padding-right: var(--spacing400);
+          padding-left: var(--spacing400);
           padding-top: 27px;
-          margin-right: -${theme.space[4]}px;
-          margin-left: -${theme.space[4]}px;
+          margin-right: calc(-1 * var(--spacing400));
+          margin-left: calc(-1 * var(--spacing400));
           margin-top: -27px;
         }
 
         ${StyledFormFooter}.sticky {
-          margin-left: -${theme.space[4]}px;
-          margin-bottom: -${theme.space[4]}px;
-          width: calc(100% + ${2 * theme.space[4]}px);
-          padding-left: ${theme.space[4]}px;
-          padding-right: ${theme.space[4]}px;
+          margin-left: calc(-1 * var(--spacing400));
+          margin-bottom: calc(-1 * var(--spacing400));
+          width: calc(100% + var(--spacing800));
+          padding-left: var(--spacing400);
+          padding-right: var(--spacing400);
           bottom: -32px;
         }
       `}
@@ -151,11 +167,6 @@ StyledRightButtons.propTypes = {
 };
 
 StyledFormFooter.propTypes = {
-  theme: PropTypes.object,
   buttonAlignment: PropTypes.oneOf(FORM_BUTTON_ALIGNMENTS),
   stickyFooter: PropTypes.bool,
-};
-
-StyledFormFooter.defaultProps = {
-  theme: baseTheme,
 };

--- a/src/components/portal/__snapshots__/portal.spec.js.snap
+++ b/src/components/portal/__snapshots__/portal.spec.js.snap
@@ -524,9 +524,6 @@ exports[`Portal when using default node to match snapshot  1`] = `
               "headerBackground": "#fff",
             },
           },
-          "form": Object {
-            "invalid": "#F2F5F6",
-          },
           "help": Object {
             "color": "rgba(0,0,0,0.65)",
             "hover": "rgba(0,0,0,0.9)",

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -151,10 +151,6 @@ export default (palette) => {
       },
     },
 
-    form: {
-      invalid: palette.slateTint(95),
-    },
-
     card: {
       footerBackground: palette.slateTint(95),
       footerBorder: palette.slateTint(80),


### PR DESCRIPTION
### Proposed behaviour
Describes Form component using design tokens. Removes all possible 'theme' in css files.
Removes the redundant form's object from base-theme.config.js.
Updates tests after the above changes.
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour
Component use the theme styled-component property.
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
