### PR TITLE
fix(docs): sort versions by semver in picker

### DIFF
--- a/.storybook/version-picker/index.js
+++ b/.storybook/version-picker/index.js
@@ -4,9 +4,12 @@ import {
   WithTooltip,
   TooltipLinkList,
 } from "@storybook/components";
+import compareBuild from "semver/functions/compare-build";
 
 import { TOOL_ID } from "./constants";
 import fetchData from "./fetch-data";
+
+const semverSort = (list) => list.sort((a, b) => compareBuild(b.id, a.id));
 
 const getDisplayedItems = (versions, onClick) => {
   let formattedVersions = [];
@@ -22,6 +25,7 @@ const getDisplayedItems = (versions, onClick) => {
     });
   }
 
+  semverSort(formattedVersions);
   formattedVersions[0].title = `${formattedVersions[0].title} (latest)`;
 
   return formattedVersions;


### PR DESCRIPTION
### Proposed behaviour

Correctly sort versions in Storybook version picker by semantic version: 

![image](https://user-images.githubusercontent.com/14963680/153440775-cc48068d-bcd4-42d6-a08b-bc67050fd0ed.png)


### Current behaviour

The versions are currently sorted in chronological order of when each version was realised. So when we patch versions, they will be displayed in the incorrect order like this:

![image](https://user-images.githubusercontent.com/14963680/153441081-c4817873-3573-405f-8824-b3fbcc0565bb.png)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
