### PR TITLE
fix(search): fix onchange callback fired twice - FE-4899

### DIFF
--- a/src/components/search/search-test.stories.mdx
+++ b/src/components/search/search-test.stories.mdx
@@ -37,14 +37,22 @@ export const SearchStory = ({
   const handleBlur = (ev) => {
     action("blur")(ev);
   };
+  const handleFocus = (ev) => {
+    action("focus")(ev);
+  };
   const handleClick = (ev) => {
     action("click")(ev);
+  };
+  const handleKeyDown = (ev) => {
+    action("keydown")(ev);
   };
   return (
     <Search
       onChange={handleChange}
       onBlur={handleBlur}
       onClick={handleClick}
+      onFocus={handleFocus}
+      onKeyDown={handleKeyDown}
       value={value}
       placeholder={placeholder || placeholderSpecialCharacters}
       name="search_name"

--- a/src/components/search/search.component.js
+++ b/src/components/search/search.component.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import PropTypes from "prop-types";
 import styledSystemPropTypes from "@styled-system/prop-types";
 import invariant from "invariant";
@@ -48,6 +48,13 @@ const Search = ({
   const [searchIsActive, setSearchIsActive] = useState(
     initialValue.length >= threshold
   );
+  useEffect(() => {
+    setSearchIsActive(
+      !isControlled
+        ? searchValue.length >= threshold
+        : value.length >= threshold
+    );
+  }, [isControlled, searchValue, threshold, value]);
 
   const [iconType, iconTabIndex] = useMemo(() => {
     const isSearchValueEmpty = !isControlled
@@ -57,11 +64,6 @@ const Search = ({
       isFocused ||
       searchIsActive ||
       inputRef?.current === document.activeElement;
-    setSearchIsActive(
-      !isControlled
-        ? searchValue.length >= threshold
-        : value.length >= threshold
-    );
 
     if (!isSearchValueEmpty) {
       return ["cross", 0];
@@ -97,8 +99,11 @@ const Search = ({
     }
   };
 
-  const handleOnFocus = () => {
+  const handleFocus = (e) => {
     setIsFocused(true);
+    if (onFocus) {
+      onFocus(e);
+    }
   };
 
   let buttonProps = {};
@@ -133,13 +138,19 @@ const Search = ({
     ev.preventDefault();
   };
 
-  const handleBlur = () => {
+  const handleBlur = (e) => {
     setIsFocused(false);
+    if (onBlur) {
+      onBlur(e);
+    }
   };
 
   const handleKeyDown = (ev) => {
     if (Events.isAlphabetKey(ev) || Events.isNumberKey(ev)) {
       ev.stopPropagation();
+    }
+    if (onKeyDown) {
+      onKeyDown(ev);
     }
   };
 
@@ -165,11 +176,6 @@ const Search = ({
       {...filterStyledSystemMarginProps(rest)}
       {...tagComponent("search", rest)}
       id={id}
-      onFocus={handleOnFocus}
-      onClick={handleOnFocus}
-      onBlur={handleBlur}
-      onChange={handleChange}
-      onKeyDown={handleKeyDown}
       name={name}
       {...rest}
     >
@@ -181,10 +187,10 @@ const Search = ({
         iconOnClick={handleIconClick}
         iconOnMouseDown={handleMouseDown}
         aria-label={ariaLabel}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        onChange={onChange}
-        onKeyDown={onKeyDown}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
         inputRef={assignInput}
         tabIndex={tabIndex}
       />

--- a/src/components/search/search.spec.js
+++ b/src/components/search/search.spec.js
@@ -17,7 +17,12 @@ import TextBox from "../textbox";
 import { rootTagTest } from "../../__internal__/utils/helpers/tags/tags-specs";
 
 describe("Search", () => {
-  let wrapper, onBlur, onChange, onClick, onKeyDown;
+  let wrapper;
+  let onBlur;
+  let onFocus;
+  let onChange;
+  let onClick;
+  let onKeyDown;
 
   testStyledSystemMargin((props) => <Search value="" {...props} />);
 
@@ -283,6 +288,16 @@ describe("Search", () => {
         const input = wrapper.find("input");
         input.simulate("blur");
         expect(onBlur).toHaveBeenCalled();
+      });
+    });
+
+    describe("focusing the component", () => {
+      it("calls onFocus", () => {
+        onFocus = jest.fn();
+        wrapper = renderWrapper({ defaultValue: "Bar", onFocus }, mount);
+        const input = wrapper.find("input");
+        input.simulate("focus");
+        expect(onFocus).toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
### Proposed behaviour

Fixes #4768

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
