### PR TITLE
feat(duelling-picklist): describe duelling picklist component using d…

### DIFF
--- a/src/components/duelling-picklist/picklist-group/picklist-group.spec.js
+++ b/src/components/duelling-picklist/picklist-group/picklist-group.spec.js
@@ -176,7 +176,7 @@ describe("PicklistGroup component", () => {
 
           assertStyleMatch(
             {
-              background: "#006300",
+              background: "var(--colorsActionMajor600)",
             },
             wrapper,
             { modifier: `${StyledButton}` }
@@ -216,7 +216,7 @@ describe("PicklistGroup component", () => {
 
           assertStyleMatch(
             {
-              background: "#9F2D3F",
+              background: "var(--colorsSemanticNegative600)",
             },
             wrapper,
             { modifier: `${StyledButton}` }
@@ -258,7 +258,7 @@ describe("PicklistGroup component", () => {
 
           assertStyleMatch(
             {
-              background: "#006300",
+              background: "var(--colorsActionMajor600)",
             },
             wrapper,
             { modifier: `${StyledButton}` }
@@ -298,7 +298,7 @@ describe("PicklistGroup component", () => {
 
           assertStyleMatch(
             {
-              background: "#9F2D3F",
+              background: "var(--colorsSemanticNegative600)",
             },
             wrapper,
             { modifier: `${StyledButton}` }

--- a/src/components/duelling-picklist/picklist-group/picklist-group.style.js
+++ b/src/components/duelling-picklist/picklist-group/picklist-group.style.js
@@ -1,10 +1,9 @@
 import styled, { css } from "styled-components";
-import baseTheme from "../../../style/themes/base";
 import { ButtonWithForwardRef } from "../../button";
 import { StyledButton } from "../picklist-item/picklist-item.style";
 
 const StyledGroupWrapper = styled.li`
-  ${({ highlighted, type, theme }) => css`
+  ${({ highlighted, type }) => css`
     &:not(:first-of-type) {
       margin-top: 16px;
     }
@@ -12,10 +11,11 @@ const StyledGroupWrapper = styled.li`
     ${highlighted &&
     css`
       ${StyledButton} {
-        background: ${type === "add"
-          ? theme.colors.secondary
-          : theme.colors.destructive.hover};
-      }
+        background: ${
+          type === "add"
+            ? "var(--colorsActionMajor600)"
+            : "var(--colorsSemanticNegative600)"
+        }
     `}
   `}
 `;
@@ -32,7 +32,7 @@ const StyledPicklistGroup = styled.li`
 `;
 
 const StyledGroupButton = styled(ButtonWithForwardRef)`
-  ${({ iconType, theme }) => css`
+  ${({ iconType }) => css`
     padding: 0;
     margin-right: 0;
     margin-left: auto;
@@ -42,17 +42,15 @@ const StyledGroupButton = styled(ButtonWithForwardRef)`
 
     &:focus {
       > span {
-        color: ${theme.colors.white};
+        color: var(--colorsActionMajorYang100);
       }
-      background: ${iconType === "add"
-        ? theme.colors.secondary
-        : theme.colors.destructive.hover};
-    }
+      background: ${
+        iconType === "add"
+          ? "var(--colorsActionMajor600)"
+          : "var(--colorsSemanticNegative600)"
+      }
   `}
 `;
-
-StyledGroupWrapper.defaultProps = { theme: baseTheme };
-StyledGroupButton.defaultProps = { theme: baseTheme };
 
 export {
   StyledGroupWrapper,

--- a/src/components/duelling-picklist/picklist-item/picklist-item.style.js
+++ b/src/components/duelling-picklist/picklist-item/picklist-item.style.js
@@ -1,30 +1,30 @@
 import styled, { css } from "styled-components";
-import baseTheme from "../../../style/themes/base";
 import { ButtonWithForwardRef } from "../../button";
 import Icon from "../../icon";
 import StyledIcon from "../../icon/icon.style";
 
 const StyledPicklistItem = styled.li`
-  ${({ locked, theme }) => css`
+  ${({ locked }) => css`
     display: flex;
     align-items: center;
     width: 100%;
 
-    background-color: ${locked ? theme.picklist.locked : theme.colors.white};
+    background-color: ${locked
+      ? "var(--colorsUtilityMajor025)"
+      : "var(--colorsUtilityYang100)"};
 
     ${!locked &&
     css`
-      box-shadow: 0 2px 4px 0 rgba(0, 20, 29, 0.15),
-        0 3px 3px 0 rgba(0, 20, 29, 0.2);
+      box-shadow: var(--boxShadow050);
     `}
 
     ${locked &&
     css`
-      border: 1px solid ${theme.picklist.lockedContent};
-      color: ${theme.picklist.lockedText};
+      border: 1px solid var(--colorsUtilityMajor200);
+      color: var(--colorsUtilityYin065);
 
       ${StyledIcon} {
-        color: ${theme.picklist.lockedContent};
+        color: var(--colorsUtilityMajor200);
       }
     `}
 
@@ -35,7 +35,7 @@ const StyledPicklistItem = styled.li`
 `;
 
 const StyledButton = styled(ButtonWithForwardRef)`
-  ${({ iconType, theme }) => css`
+  ${({ iconType }) => css`
     padding: 0;
     margin-right: 0;
     margin-left: auto;
@@ -43,13 +43,11 @@ const StyledButton = styled(ButtonWithForwardRef)`
     min-width: 40px;
 
     &:focus {
-      > span {
-        color: ${theme.colors.white};
-      }
-      background: ${iconType === "add"
-        ? theme.colors.secondary
-        : theme.colors.destructive.hover};
-    }
+      background: ${
+        iconType === "add"
+          ? "var(--colorsActionMajor600)"
+          : "var(--colorsSemanticNegative600)"
+      };
   `}
 `;
 
@@ -58,8 +56,5 @@ const StyledLockIcon = styled(Icon)`
   height: 40px;
   min-width: 40px;
 `;
-
-StyledPicklistItem.defaultProps = { theme: baseTheme };
-StyledButton.defaultProps = { theme: baseTheme };
 
 export { StyledPicklistItem, StyledButton, StyledLockIcon };


### PR DESCRIPTION
…esign tokens

### Proposed behaviour
Describes the DeullingPicklist component using design tokens
Updates tests when the above changes are made.

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour
Component use the theme styled-component property.
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context
All necessary informations: https://jira.sage.com/browse/FE-4928
<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
