### PR TITLE
feat(icon-button): describe icon-button component using design tokens…

### DIFF
--- a/src/components/batch-selection/__snapshots__/batch-selection.spec.js.snap
+++ b/src/components/batch-selection/__snapshots__/batch-selection.spec.js.snap
@@ -42,9 +42,8 @@ exports[`BatchSelection component should render correctly 1`] = `
 }
 
 .c3:focus {
-  color: rgba(0,0,0,0.9);
   background-color: transparent;
-  outline: solid 3px #FFB500;
+  outline: solid 3px var(--colorsSemanticFocus500);
   z-index: 1;
 }
 

--- a/src/components/confirm/confirm.spec.js
+++ b/src/components/confirm/confirm.spec.js
@@ -138,7 +138,7 @@ describe("Confirm", () => {
 
         assertStyleMatch(
           {
-            color: baseTheme.icon.disabled,
+            color: "var(--colorsActionMinorYin030)",
           },
           wrapper.find(StyledIconButton),
           { modifier: `${StyledIcon}` }

--- a/src/components/icon-button/icon-button.spec.js
+++ b/src/components/icon-button/icon-button.spec.js
@@ -90,7 +90,7 @@ describe("IconButton component", () => {
       it("renders correct style for focused IconButton", () => {
         assertStyleMatch(
           {
-            outline: "solid 3px #FFB500",
+            outline: "solid 3px var(--colorsSemanticFocus500)",
           },
           wrapper.find(IconButton).first(),
           { modifier: ":focus" }

--- a/src/components/icon-button/icon-button.style.js
+++ b/src/components/icon-button/icon-button.style.js
@@ -4,16 +4,15 @@ import StyledIcon from "../icon/icon.style";
 import { baseTheme } from "../../style/themes";
 
 const StyledIconButton = styled.button.attrs({ type: "button" })`
-  ${({ theme, disabled }) => css`
+  ${({ disabled }) => css`
     ${margin}
     background: transparent;
     border: none;
     padding: 0;
 
     &:focus {
-      color: ${theme.text.color};
       background-color: transparent;
-      outline: solid 3px ${theme.colors.focus};
+      outline: solid 3px var(--colorsSemanticFocus500);
       z-index: 1;
     }
 
@@ -28,7 +27,7 @@ const StyledIconButton = styled.button.attrs({ type: "button" })`
     ${StyledIcon} {
       ${disabled &&
       css`
-        color: ${theme.icon.disabled};
+        color: var(--colorsActionMinorYin030);
         background-color: transparent;
       `};
       position: relative;

--- a/src/components/pod/__snapshots__/pod.spec.js.snap
+++ b/src/components/pod/__snapshots__/pod.spec.js.snap
@@ -58,9 +58,8 @@ exports[`ActionButtons StyledDeleteButton when isHovered prop is set should matc
 }
 
 .c0:focus {
-  color: rgba(0,0,0,0.9);
   background-color: transparent;
-  outline: solid 3px #FFB500;
+  outline: solid 3px var(--colorsSemanticFocus500);
   z-index: 1;
 }
 
@@ -522,9 +521,8 @@ exports[`ActionButtons StyledUndoButton when isHovered prop is set should match 
 }
 
 .c0:focus {
-  color: rgba(0,0,0,0.9);
   background-color: transparent;
-  outline: solid 3px #FFB500;
+  outline: solid 3px var(--colorsSemanticFocus500);
   z-index: 1;
 }
 


### PR DESCRIPTION
### Proposed behaviour
Describes IconButton components using design tokens. Removes all possible 'theme' in css files.
Updates tests after the above changes.


### Current behaviour
Component use the theme styled-component property.
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
