### PR TITLE
fix(decimal): fix precision console error firing when no precision pr…

### DIFF
--- a/src/components/decimal/decimal.component.js
+++ b/src/components/decimal/decimal.component.js
@@ -17,9 +17,9 @@ const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
 );
 const Decimal = ({
-  align = "right",
+  align,
   defaultValue,
-  precision = 2,
+  precision,
   inputWidth,
   readOnly,
   onChange,
@@ -27,7 +27,7 @@ const Decimal = ({
   onKeyPress,
   id,
   name,
-  allowEmptyValue = false,
+  allowEmptyValue,
   required,
   locale,
   value,
@@ -342,6 +342,12 @@ Decimal.propTypes = {
   locale: PropTypes.string,
   /** Aria label for rendered help component */
   helpAriaLabel: PropTypes.string,
+};
+
+Decimal.defaultProps = {
+  precision: 2,
+  allowEmptyValue: false,
+  align: "right",
 };
 
 export default Decimal;

--- a/src/components/decimal/decimal.spec.js
+++ b/src/components/decimal/decimal.spec.js
@@ -33,7 +33,7 @@ function render(props = {}, renderer = mount) {
     ...props,
   };
 
-  renderer(<Decimal precision={2} {...defaultProps} />);
+  renderer(<Decimal {...defaultProps} />);
 }
 
 describe("Decimal", () => {
@@ -131,7 +131,7 @@ describe("Decimal", () => {
   });
 
   testStyledSystemMargin(
-    (props) => <Decimal precision={2} {...props} />,
+    (props) => <Decimal {...props} />,
     undefined,
     (component) => component.find(FormFieldStyle),
     { modifier: "&&&" }
@@ -246,16 +246,6 @@ describe("Decimal", () => {
         render({ defaultValue: "12345.654", precision: 3 });
         expect(value()).toBe("12,345.654");
         expect(hiddenValue()).toBe("12345.654");
-      });
-
-      it("triggers an error message if the precision value is greater than 15", () => {
-        jest.spyOn(global.console, "error").mockImplementation(() => {});
-        mount(<Decimal defaultValue="12345.654" precision={16} />);
-        // eslint-disable-next-line no-console
-        expect(console.error).toHaveBeenCalledWith(
-          "Warning: Failed prop type: Precision prop must be a number greater than 0 or equal to or less than 15.\n    in Decimal"
-        );
-        global.console.error.mockReset();
       });
 
       it.each([
@@ -810,6 +800,7 @@ describe("Decimal", () => {
           expect(value()).toBe("-1.234,56");
           expect(hiddenValue()).toBe("-1234.56");
         });
+
         describe("precision", () => {
           it("fires a console error when precision is changed once component is loaded.", () => {
             jest.spyOn(global.console, "error").mockImplementation(() => {});
@@ -818,6 +809,7 @@ describe("Decimal", () => {
             expect(console.error).toHaveBeenCalledWith(
               "Decimal `precision` prop has changed value. Changing the Decimal `precision` prop has no effect."
             );
+            global.console.error.mockReset();
           });
 
           it("supports a precision of 0", () => {
@@ -1386,6 +1378,30 @@ describe("Decimal", () => {
         expect(value()).toBe("0.00");
       });
     });
+  });
+});
+
+describe("Precision prop console errors", () => {
+  beforeEach(() => {
+    jest.spyOn(global.console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    global.console.error.mockReset();
+  });
+
+  it("does not trigger an error message if the precision value is not specified", () => {
+    mount(<Decimal defaultValue="12345.654" />);
+    // eslint-disable-next-line no-console
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("triggers an error message if the precision value is greater than 15", () => {
+    mount(<Decimal defaultValue="12345.654" precision={16} />);
+    // eslint-disable-next-line no-console
+    expect(console.error).toHaveBeenCalledWith(
+      "Warning: Failed prop type: Precision prop must be a number greater than 0 or equal to or less than 15.\n    in Decimal"
+    );
   });
 });
 


### PR DESCRIPTION
### Proposed behaviour

Patching https://github.com/Sage/carbon/pull/4832 to 103.2.x

### Current behaviour

Bug occurs in 103.2.x

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context
https://github.com/Sage/carbon/issues/4826

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

https://codesandbox.io/s/decimal-precision-5s6l0
