### PR TITLE
fix(icon-button): fix background color when component is disabled

### DIFF
--- a/src/components/icon-button/icon-button.spec.js
+++ b/src/components/icon-button/icon-button.spec.js
@@ -233,6 +233,16 @@ describe("IconButton component", () => {
         );
       });
 
+      it("should have the correct background color applied to the icon button", () => {
+        assertStyleMatch(
+          {
+            backgroundColor: "transparent",
+          },
+          wrapper,
+          { modifier: `${StyledIcon}` }
+        );
+      });
+
       it("should not set the onFocus prop and not show the tooltip on focus of the button", () => {
         expect(wrapper.find(StyledIconButton).prop("onFocus")).toEqual(
           undefined

--- a/src/components/icon-button/icon-button.stories.mdx
+++ b/src/components/icon-button/icon-button.stories.mdx
@@ -30,6 +30,16 @@ import IconButton from "carbon-react/lib/components/icon-button";
   </Story>
 </Preview>
 
+### Disabled
+
+<Canvas>
+  <Story name="disabled">
+    <IconButton disabled aria-label="icon-button" onAction={() => {}}>
+      <Icon type="home" />
+    </IconButton>
+  </Story>
+</Canvas>
+
 ## Props
 
 ### Icon Button

--- a/src/components/icon-button/icon-button.style.js
+++ b/src/components/icon-button/icon-button.style.js
@@ -26,7 +26,11 @@ const StyledIconButton = styled.button.attrs({ type: "button" })`
     }
 
     ${StyledIcon} {
-      ${disabled && `color: ${theme.icon.disabled}`};
+      ${disabled &&
+      css`
+        color: ${theme.icon.disabled};
+        background-color: transparent;
+      `};
       position: relative;
 
       &:focus {


### PR DESCRIPTION
A bug was introduced in v101.2.0 where the background color of a disabled icon-button was made to
be grey. The correct colour should be transparent.

This patches #4790 to 101.2.x.

### Proposed behaviour

![Screenshot 2022-02-04 at 13 42 48](https://user-images.githubusercontent.com/56251247/152538888-7ec317f7-ec67-453b-a5cd-de90eabb592a.png)

![Screenshot 2022-02-04 at 13 43 27](https://user-images.githubusercontent.com/56251247/152538969-f6e7aa4f-53be-4229-bfd4-9779d5ad6531.png)

### Current behaviour

![Screenshot 2022-02-04 at 13 44 12](https://user-images.githubusercontent.com/56251247/152539102-bcd994d6-5ae2-41f8-8a23-71f265bb3803.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

### Testing instructions

<!-- How can a reviewer test this PR? -->

- Check `Confirm -> disableCancel` story to make sure that the `X` has the correct styling.
- New story for `icon-button` has been created called `disabled` so that Chromatic can catch any visual changes in future.