### PR TITLE
feat(dismissible-box, vertical-divider, content): describe components using design tokens, update tests

### DIFF
--- a/src/components/box/box.component.js
+++ b/src/components/box/box.component.js
@@ -5,6 +5,18 @@ import { space, layout, flexbox } from "styled-system";
 import BaseTheme from "../../style/themes/base";
 import color from "../../style/utils/color";
 
+export const boxColors = {
+  light: {
+    thumb: "var(--colorsUtilityMajor300)",
+    track: "var(--colorsUtilityMajor025)",
+  },
+
+  dark: {
+    thumb: "var(--colorsUtilityMajor200)",
+    track: "var(--colorsUtilityMajor400)",
+  },
+};
+
 const Box = styled.div`
   ${space}
   ${layout}
@@ -17,20 +29,20 @@ const Box = styled.div`
       overflow-wrap: ${overflowWrap};
     `}
 
-  ${({ scrollVariant, theme }) =>
+  ${({ scrollVariant }) =>
     scrollVariant &&
     css`
-      scrollbar-color: ${theme.scrollbar[scrollVariant].thumb}
-        ${theme.scrollbar[scrollVariant].track};
+      scrollbar-color: ${boxColors[scrollVariant].thumb}
+        ${boxColors[scrollVariant].track};
 
       &::-webkit-scrollbar {
         width: 8px;
       }
       &::-webkit-scrollbar-track {
-        background-color: ${theme.scrollbar[scrollVariant].track};
+        background-color: ${boxColors[scrollVariant].track};
       }
       &::-webkit-scrollbar-thumb {
-        background-color: ${theme.scrollbar[scrollVariant].thumb};
+        background-color: ${boxColors[scrollVariant].thumb};
       }
     `}
 `;

--- a/src/components/box/box.spec.js
+++ b/src/components/box/box.spec.js
@@ -7,8 +7,7 @@ import {
   testStyledSystemFlexBox,
   assertStyleMatch,
 } from "../../__spec_helper__/test-utils";
-import Box from "./box.component";
-import BaseTheme from "../../style/themes/base";
+import Box, { boxColors } from "./box.component";
 
 describe("Box", () => {
   testStyledSystemSpacing((props) => <Box {...props} />);
@@ -45,7 +44,7 @@ describe("Box", () => {
 
       assertStyleMatch(
         {
-          backgroundColor: BaseTheme.scrollbar[scrollVariant].track,
+          backgroundColor: boxColors[scrollVariant].track,
         },
         wrapper,
         { modifier: "::-webkit-scrollbar-track" }
@@ -53,7 +52,7 @@ describe("Box", () => {
 
       assertStyleMatch(
         {
-          backgroundColor: BaseTheme.scrollbar[scrollVariant].thumb,
+          backgroundColor: boxColors[scrollVariant].thumb,
         },
         wrapper,
         { modifier: "::-webkit-scrollbar-thumb" }

--- a/src/components/content/content.spec.js
+++ b/src/components/content/content.spec.js
@@ -12,7 +12,6 @@ import {
   assertStyleMatch,
   testStyledSystemMargin,
 } from "../../__spec_helper__/test-utils";
-import { baseTheme } from "../../style/themes";
 import { rootTagTest } from "../../__internal__/utils/helpers/tags/tags-specs";
 
 describe("Content", () => {
@@ -103,7 +102,7 @@ describe("Content", () => {
           {
             display: "block",
             fontWeight: "bold",
-            color: baseTheme.text.colors,
+            color: "var(--colorsUtilityYin090)",
           },
           wrapper.find(StyledContentTitle)
         );
@@ -133,7 +132,7 @@ describe("Content", () => {
         wrapper = renderWrapper({ variant: "secondary" });
         assertStyleMatch(
           {
-            color: baseTheme.content.secondaryColor,
+            color: "var(--colorsUtilityMajor300)",
             fontWeight: "normal",
           },
           wrapper.find(StyledContentTitle)

--- a/src/components/content/content.style.js
+++ b/src/components/content/content.style.js
@@ -25,11 +25,11 @@ const StyledContent = styled.div`
 StyledContent.defaultProps = { theme: baseTheme };
 
 const StyledContentTitle = styled.div`
-  ${({ theme, titleWidth, inline, variant, align }) => {
+  ${({ titleWidth, inline, variant, align }) => {
     return css`
       display: ${inline ? "inline-block" : "block"};
       font-weight: bold;
-      color: ${theme.text.colors};
+      color: var(--colorsUtilityYin090);
       width: ${titleWidth && `calc(${titleWidth}% - 30px)`};
       text-align: ${!inline && align};
 
@@ -42,7 +42,7 @@ const StyledContentTitle = styled.div`
 
       ${variant === "secondary" &&
       css`
-        color: ${theme.content.secondaryColor};
+        color: var(--colorsUtilityMajor300);
         font-weight: normal;
       `}
     `;
@@ -88,7 +88,5 @@ const StyledContentBody = styled.div`
     `;
   }};
 `;
-
-StyledContentTitle.defaultProps = { theme: baseTheme };
 
 export { StyledContent, StyledContentTitle, StyledContentBody };

--- a/src/components/dismissible-box/dismissible-box.component.js
+++ b/src/components/dismissible-box/dismissible-box.component.js
@@ -11,7 +11,7 @@ const variantStyles = {
     backgroundColor: "#FFFFFF",
   },
   dark: {
-    backgroundColor: "slateTint90",
+    backgroundColor: "var(--colorsUtilityMajor050)",
   },
 };
 
@@ -33,7 +33,7 @@ const DismissibleBox = ({
     {children}
     <span>
       <IconButton onAction={onClose} aria-label="close-button" ml={3}>
-        <Icon type="close" color="slateTint20" />
+        <Icon type="close" color="var(--colorsActionMinor500)" />
       </IconButton>
     </span>
   </StyledDismissibleBox>

--- a/src/components/dismissible-box/dismissible-box.spec.js
+++ b/src/components/dismissible-box/dismissible-box.spec.js
@@ -2,7 +2,6 @@ import React from "react";
 import { mount } from "enzyme";
 import DismissibleBox from "./dismissible-box.component";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
-import { baseTheme } from "../../style/themes";
 import StyledIcon from "../icon/icon.style";
 import IconButton from "../icon-button";
 
@@ -22,10 +21,10 @@ describe("DismissibleBox", () => {
 
       assertStyleMatch(
         {
-          border: `1px solid ${baseTheme.palette.slateTint(80)}`,
+          border: "1px solid var(--colorsUtilityMajor100)",
           borderLeft: "none",
           wordBreak: "break-word",
-          boxShadow: `-4px 0 0 0 ${baseTheme.palette.slateTint(20)}`,
+          boxShadow: "-4px 0 0 0 var(--colorsUtilityMajor400)",
           padding: "20px 24px 20px 20px",
           display: "flex",
           justifyContent: "space-between",
@@ -36,7 +35,7 @@ describe("DismissibleBox", () => {
 
       assertStyleMatch(
         {
-          color: baseTheme.palette.slate,
+          color: "var(--colorsActionMinor600)",
         },
         wrapper,
         { modifier: `${StyledIcon}:hover` }
@@ -48,14 +47,14 @@ describe("DismissibleBox", () => {
 
       assertStyleMatch(
         {
-          border: `1px solid ${baseTheme.palette.slateTint(80)}`,
+          border: "1px solid var(--colorsUtilityMajor100)",
           borderLeft: "none",
           wordBreak: "break-word",
-          boxShadow: `-4px 0 0 0 ${baseTheme.palette.slateTint(20)}`,
+          boxShadow: "-4px 0 0 0 var(--colorsUtilityMajor400)",
           padding: "20px 24px 20px 20px",
           display: "flex",
           justifyContent: "space-between",
-          backgroundColor: baseTheme.palette.slateTint(90),
+          backgroundColor: "var(--colorsUtilityMajor050)",
         },
         wrapper
       );
@@ -75,7 +74,7 @@ describe("DismissibleBox", () => {
 
       assertStyleMatch(
         {
-          border: `1px solid ${baseTheme.palette.slateTint(80)}`,
+          border: "1px solid var(--colorsUtilityMajor100)",
           boxShadow: undefined,
         },
         wrapper

--- a/src/components/dismissible-box/dismissible-box.style.js
+++ b/src/components/dismissible-box/dismissible-box.style.js
@@ -1,22 +1,21 @@
 import styled, { css } from "styled-components";
 import Box from "../box";
-import { toColor } from "../../style/utils/color";
 import StyledIcon from "../icon/icon.style";
 
 export default styled(Box)`
-  ${({ hasBorderLeftHighlight, theme }) => css`
+  ${({ hasBorderLeftHighlight }) => css`
     word-break: break-word;
 
-    border: 1px solid ${toColor(theme, "slateTint80")};
+    border: 1px solid var(--colorsUtilityMajor100);
 
     ${hasBorderLeftHighlight &&
     `
       border-left: none;
-      box-shadow: -4px 0 0 0 ${toColor(theme, "slateTint20")};
+      box-shadow: -4px 0 0 0 var(--colorsUtilityMajor400);
     `}
 
     ${StyledIcon}:hover {
-      color: ${theme.palette.slate};
+      color: var(--colorsActionMinor600);
     }
   `}
 `;

--- a/src/components/portal/__snapshots__/portal.spec.js.snap
+++ b/src/components/portal/__snapshots__/portal.spec.js.snap
@@ -696,16 +696,6 @@ exports[`Portal when using default node to match snapshot  1`] = `
             "textboxBorder": "#CCD6DB",
             "textboxText": "rgba(0,0,0,0.74)",
           },
-          "scrollbar": Object {
-            "dark": Object {
-              "thumb": "#99ADB6",
-              "track": "#335C6D",
-            },
-            "light": Object {
-              "thumb": "#668592",
-              "track": "#F2F5F6",
-            },
-          },
           "search": Object {
             "active": "#FFB500",
             "button": "#255BC7",

--- a/src/components/tile/__snapshots__/tile.spec.js.snap
+++ b/src/components/tile/__snapshots__/tile.spec.js.snap
@@ -68,6 +68,7 @@ exports[`Tile renders base styles 1`] = `
 .c5 {
   display: block;
   font-weight: bold;
+  color: var(--colorsUtilityYin090);
   text-align: left;
 }
 

--- a/src/style/themes/base/base-theme.config.js
+++ b/src/style/themes/base/base-theme.config.js
@@ -340,18 +340,6 @@ export default (palette) => {
       errorButtonFocus: palette.errorRedShade(20),
     },
 
-    scrollbar: {
-      light: {
-        thumb: palette.slateTint(40),
-        track: palette.slateTint(95),
-      },
-
-      dark: {
-        thumb: palette.slateTint(60),
-        track: palette.slateTint(20),
-      },
-    },
-
     search: {
       active: palette.gold,
       button: "#255BC7",

--- a/src/style/themes/base/index.d.ts
+++ b/src/style/themes/base/index.d.ts
@@ -300,18 +300,6 @@ export interface ThemeObject {
     errorButtonFocus: string;
   };
 
-  scrollbar: {
-    light: {
-      thumb: string;
-      track: string;
-    };
-
-    dark: {
-      thumb: string;
-      track: string;
-    };
-  };
-
   search: {
     active: string;
     button: string;


### PR DESCRIPTION
### Proposed behaviour
Describes PopoverContainer and Draggable components using design tokens. Removes all possible 'theme' in css files.
Removed redundant base-theme property.
Updates tests after the above changes.
<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour
Component use the theme styled-component property.
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
