### PR TITLE
feat(flat-table): add width prop

### DIFF
--- a/cypress/locators/flat-table/index.js
+++ b/cypress/locators/flat-table/index.js
@@ -5,10 +5,12 @@ import {
   FLAT_TABLE_PAGE_SIZE_SELECT,
   FLAT_TABLE_PAGE_SELECT_LIST,
   PAGE_SELECT_INPUT,
+  FLAT_TABLE_WRAPPER,
 } from "./locators";
 
 // component preview locators
 export const flatTable = () => cy.get(FLAT_TABLE_COMPONENT);
+export const flatTableWrapper = () => cy.get(FLAT_TABLE_WRAPPER);
 export const flatTableHeader = () => flatTable().find("thead tr");
 export const flatTableHeaderCells = () => flatTableHeader().find("th");
 export const flatTableBodyRowByPosition = (index) =>

--- a/cypress/locators/flat-table/locators.js
+++ b/cypress/locators/flat-table/locators.js
@@ -1,5 +1,6 @@
 // component preview locators
 export const FLAT_TABLE_COMPONENT = '[data-component="flat-table"]';
+export const FLAT_TABLE_WRAPPER = '[data-component="flat-table-wrapper"]';
 export const FLAT_TABLE_STICKY_ROW = '[data-element="flat-table-row-header"]';
 export const FLAT_TABLE_CELL = '[data-element="flat-table-cell"]';
 export const FLAT_TABLE_SUBROW = '[data-element="flat-table-sub-row"]';

--- a/cypress/support/step-definitions/flat-table-steps.js
+++ b/cypress/support/step-definitions/flat-table-steps.js
@@ -1,5 +1,5 @@
 import {
-  flatTable,
+  flatTableWrapper,
   flatTableHeaderCells,
   flatTableBodyRowByPosition,
   flatTableCell,
@@ -65,7 +65,7 @@ Then("First/Last {int} header cells {word} visible", (count, state) => {
 
 When("I scroll table content to bottom right", () => {
   cy.viewport(625, 450);
-  flatTable().parent().scrollTo("100%", "100%");
+  flatTableWrapper().scrollTo("100%", "100%");
 });
 
 Then("First/Last {int} FlatTable rows {word} visible", (count, state) => {

--- a/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
+++ b/src/components/flat-table/__snapshots__/flat-table.spec.js.snap
@@ -187,138 +187,143 @@ exports[`FlatTable when rendered with proper table data should have expected str
 
 <div
   className="c0"
+  data-component="flat-table-wrapper"
   display="flex"
   role="region"
   tabIndex="0"
 >
-  <table
-    className="c1"
-    data-component="flat-table"
-    size="medium"
+  <div
+    className=""
   >
-    <thead
-      className="c2 c3"
+    <table
+      className="c1"
+      data-component="flat-table"
+      size="medium"
     >
-      <tr
-        className="c4 c5"
-        data-element="flat-table-row"
-        onClick={[Function]}
-        size="medium"
+      <thead
+        className="c2 c3"
       >
-        <th
-          className="c6 c7"
-          data-element="flat-table-row-header"
+        <tr
+          className="c4 c5"
+          data-element="flat-table-row"
+          onClick={[Function]}
+          size="medium"
         >
-          <div
-            className=""
+          <th
+            className="c6 c7"
+            data-element="flat-table-row-header"
           >
-            row header
-          </div>
-        </th>
-        <th
-          className="c8 c9"
-          data-element="flat-table-header"
-        >
-          <div>
-            header1
-          </div>
-        </th>
-        <th
-          className="c8 c9"
-          data-element="flat-table-header"
-        >
-          <div>
-            header2
-          </div>
-        </th>
-        <th
-          className="c8 c9"
-          data-element="flat-table-header"
-        >
-          <div>
-            header3
-          </div>
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr
-        className="c4 c5"
-        data-element="flat-table-row"
-        onClick={[Function]}
-        size="medium"
-      >
-        <th
-          className="c6 c7"
-          data-element="flat-table-row-header"
-        >
-          <div
-            className=""
+            <div
+              className=""
+            >
+              row header
+            </div>
+          </th>
+          <th
+            className="c8 c9"
+            data-element="flat-table-header"
           >
-            row header
-          </div>
-        </th>
-        <td
-          className="c10 c11"
-          data-element="flat-table-cell"
-        >
-          <div
-            className=""
+            <div>
+              header1
+            </div>
+          </th>
+          <th
+            className="c8 c9"
+            data-element="flat-table-header"
           >
-            cell1
-          </div>
-        </td>
-        <td
-          className="c10 c11"
-          data-element="flat-table-cell"
-        >
-          <div
-            className=""
+            <div>
+              header2
+            </div>
+          </th>
+          <th
+            className="c8 c9"
+            data-element="flat-table-header"
           >
-            cell2
-          </div>
-        </td>
-        <td
-          className="c10 c12"
-          data-element="flat-table-cell"
-          rowSpan="2"
+            <div>
+              header3
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          className="c4 c5"
+          data-element="flat-table-row"
+          onClick={[Function]}
+          size="medium"
         >
-          <div
-            className=""
+          <th
+            className="c6 c7"
+            data-element="flat-table-row-header"
           >
-            cell3
-          </div>
-        </td>
-      </tr>
-      <tr
-        className="c4 c5"
-        data-element="flat-table-row"
-        onClick={[Function]}
-        size="medium"
-      >
-        <th
-          className="c6 c7"
-          data-element="flat-table-row-header"
+            <div
+              className=""
+            >
+              row header
+            </div>
+          </th>
+          <td
+            className="c10 c11"
+            data-element="flat-table-cell"
+          >
+            <div
+              className=""
+            >
+              cell1
+            </div>
+          </td>
+          <td
+            className="c10 c11"
+            data-element="flat-table-cell"
+          >
+            <div
+              className=""
+            >
+              cell2
+            </div>
+          </td>
+          <td
+            className="c10 c12"
+            data-element="flat-table-cell"
+            rowSpan="2"
+          >
+            <div
+              className=""
+            >
+              cell3
+            </div>
+          </td>
+        </tr>
+        <tr
+          className="c4 c5"
+          data-element="flat-table-row"
+          onClick={[Function]}
+          size="medium"
         >
-          <div
-            className=""
+          <th
+            className="c6 c7"
+            data-element="flat-table-row-header"
           >
-            row header
-          </div>
-        </th>
-        <td
-          className="c10 c11"
-          colSpan="2"
-          data-element="flat-table-cell"
-        >
-          <div
-            className=""
+            <div
+              className=""
+            >
+              row header
+            </div>
+          </th>
+          <td
+            className="c10 c11"
+            colSpan="2"
+            data-element="flat-table-cell"
           >
-            cell1
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+            <div
+              className=""
+            >
+              cell1
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>
 `;

--- a/src/components/flat-table/flat-table.component.js
+++ b/src/components/flat-table/flat-table.component.js
@@ -5,6 +5,7 @@ import {
   StyledFlatTableWrapper,
   StyledFlatTable,
   StyledFlatTableFooter,
+  StyledTableContainer,
 } from "./flat-table.style";
 import { DrawerSidebarContext } from "../drawer";
 import { filterStyledSystemMarginProps } from "../../style/utils";
@@ -29,6 +30,7 @@ const FlatTable = ({
   ariaDescribedby,
   minHeight,
   overflowX,
+  width,
   ...rest
 }) => {
   const addDefaultHeight = !height && (hasStickyHead || hasStickyFooter);
@@ -46,6 +48,7 @@ const FlatTable = ({
     <DrawerSidebarContext.Consumer>
       {({ isInSidebar }) => (
         <StyledFlatTableWrapper
+          data-component="flat-table-wrapper"
           isInSidebar={isInSidebar}
           hasStickyHead={hasStickyHead}
           colorTheme={colorTheme}
@@ -64,15 +67,19 @@ const FlatTable = ({
           }
           tabIndex="0"
           role="region"
-          overflowX={overflowX}
+          overflowX={width ? "hidden" : undefined}
+          width={width}
           {...rest}
         >
-          <StyledFlatTable data-component="flat-table" {...tableStylingProps}>
-            {caption ? <caption>{caption}</caption> : null}
-            <FlatTableThemeContext.Provider value={{ colorTheme, size }}>
-              {children}
-            </FlatTableThemeContext.Provider>
-          </StyledFlatTable>
+          <StyledTableContainer overflowX={overflowX} width={width}>
+            <StyledFlatTable data-component="flat-table" {...tableStylingProps}>
+              {caption ? <caption>{caption}</caption> : null}
+              <FlatTableThemeContext.Provider value={{ colorTheme, size }}>
+                {children}
+              </FlatTableThemeContext.Provider>
+            </StyledFlatTable>
+          </StyledTableContainer>
+
           {footer && (
             <StyledFlatTableFooter hasStickyFooter={hasStickyFooter}>
               {footer}
@@ -117,6 +124,8 @@ FlatTable.propTypes = {
   hasMaxHeight: PropTypes.bool,
   /** Set the overflow X of the table wrapper. Any valid CSS string */
   overflowX: PropTypes.string,
+  /** Width of the table. Any valid CSS string */
+  width: PropTypes.string,
 };
 
 FlatTable.defaultProps = {

--- a/src/components/flat-table/flat-table.d.ts
+++ b/src/components/flat-table/flat-table.d.ts
@@ -26,6 +26,10 @@ export interface FlatTableProps extends MarginProps {
   size?: "compact" | "small" | "medium" | "large" | "extraLarge";
   /** Applies max-height of 100% to FlatTable if true */
   hasMaxHeight?: boolean;
+  /** Set the overflow X of the table wrapper. Any valid CSS string */
+  overflowX?: string;
+  /** Width of the table. Any valid CSS string */
+  width?: string;
 }
 
 declare function FlatTable(props: FlatTableProps): JSX.Element;

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -22,6 +22,7 @@ import {
   StyledFlatTable,
   StyledFlatTableWrapper,
   StyledFlatTableFooter,
+  StyledTableContainer,
 } from "./flat-table.style";
 import { DrawerSidebarContext } from "../drawer";
 import { StyledFlatTableCell } from "./flat-table-cell/flat-table-cell.style";
@@ -575,6 +576,49 @@ describe("FlatTable", () => {
 
   describe("styled system", () => {
     testStyledSystemMargin(RenderComponent);
+  });
+
+  describe("when width prop is set", () => {
+    it("should apply the correct styles to StyledFlatTableWrapper and StyledTableContainer", () => {
+      const wrapper = renderFlatTable({ width: "300px" }, mount);
+
+      assertStyleMatch(
+        {
+          width: "300px",
+        },
+        wrapper.find(StyledFlatTableWrapper)
+      );
+
+      assertStyleMatch(
+        {
+          width: "300px",
+        },
+        wrapper.find(StyledTableContainer)
+      );
+    });
+
+    describe("when overflowX prop is also set", () => {
+      it("should apply the correct styles to StyledFlatTableWrapper and StyledTableContainer", () => {
+        const wrapper = renderFlatTable(
+          { width: "300px", overflowX: "auto" },
+          mount
+        );
+
+        assertStyleMatch(
+          {
+            overflowX: "hidden",
+          },
+          wrapper.find(StyledFlatTableWrapper)
+        );
+
+        assertStyleMatch(
+          {
+            overflowX: "auto",
+          },
+          wrapper.find(StyledTableContainer)
+        );
+      });
+    });
   });
 });
 

--- a/src/components/flat-table/flat-table.style.js
+++ b/src/components/flat-table/flat-table.style.js
@@ -9,6 +9,16 @@ import { StyledFlatTableCell } from "./flat-table-cell/flat-table-cell.style";
 import cellSizes from "./cell-sizes.style";
 import Box from "../box";
 
+const StyledTableContainer = styled.div`
+  ${({ width, overflowX }) =>
+    width &&
+    css`
+      width: ${width};
+
+      ${overflowX && `overflow-x: ${overflowX}`}
+    `}
+`;
+
 const StyledFlatTable = styled.table`
   border-collapse: separate;
   border-radius: 0px;
@@ -185,4 +195,9 @@ const StyledFlatTableFooter = styled.div`
     `}
 `;
 
-export { StyledFlatTableWrapper, StyledFlatTable, StyledFlatTableFooter };
+export {
+  StyledFlatTableWrapper,
+  StyledFlatTable,
+  StyledFlatTableFooter,
+  StyledTableContainer,
+};


### PR DESCRIPTION
Fixes: #4822
Fixes: #4821

Note we will not be adding the `overflowY` prop for issue #4821 


### Proposed behaviour

Add a `width` prop to `FlatTable`.

Add a wrapper around the table element in `FlatTable` to handle the horizontal scrolling so it does not horizontally scroll the table footer. This means only the table content (including headings) can be scrolled horizontally, and not a `Pager` when it is in the footer. The `Pager` should be 100% of the width of the table. It is down to the user to use the responsive props on `Pager` to ensure that it fits within the table width.

The `width` and `overflowX` props cannot just be added to the `StyledFlatTable` as they don't work as expected on a `table` element.

### Current behaviour

When using the `width` and `overflowX` props on `FlatTable` with a `Pager` in the footer, scrolling horizontally incorrectly scrolls the `Pager` as well as the table content.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Use the following sandbox: 
(https://codesandbox.io/s/condescending-sky-i5pnku?file=/src/index.js)

You can modify the width of the table using the textbox, and it shows an example of how the Pager content should be modified by the user at different widths. We do not support widths of less than 300px.

The Pager can no longer be horizontally scrolled with this fix but the table content can be.

**DO NOT USE THE SANDBOX FROM THE ISSUE.** This does not have the responsive props on Pager set correctly.