### PR TITLE
feat(navigation-bar): add position, offset and orientation props to enable fixed or sticky positions FE-4711

### DIFF
--- a/src/components/navigation-bar/navigation-bar.component.tsx
+++ b/src/components/navigation-bar/navigation-bar.component.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { PaddingProps, FlexboxProps } from "styled-system";
 import StyledNavigationBar from "./navigation-bar.style";
+import Logger from "../../__internal__/utils/logger";
 
 export type Position = "sticky" | "fixed";
 export type Orientation = "top" | "bottom";
@@ -28,6 +29,8 @@ export interface NavigationBarProps extends PaddingProps, FlexboxProps {
   orientation?: Orientation;
 }
 
+let deprecatedWarnTriggered = false;
+
 export const NavigationBar = ({
   navigationType = "light",
   isLoading = false,
@@ -40,6 +43,14 @@ export const NavigationBar = ({
   orientation,
   ...props
 }: NavigationBarProps): JSX.Element => {
+  if (!deprecatedWarnTriggered && stickyPosition) {
+    deprecatedWarnTriggered = true;
+    Logger.deprecate(
+      // eslint-disable-next-line max-len
+      "The `stickyPosition` and `stickyOffset` props are deprecated and will soon be removed. You should use the `position`, `offset` and `orientation` props to achieve the same layout. The following codemods are available to help with updating your code: https://github.com/Sage/carbon-codemod/tree/master/transforms/remove-prop and https://github.com/Sage/carbon-codemod/tree/master/transforms/add-prop"
+    );
+  }
+
   return (
     <StyledNavigationBar
       role="navigation"

--- a/src/components/navigation-bar/navigation-bar.component.tsx
+++ b/src/components/navigation-bar/navigation-bar.component.tsx
@@ -2,8 +2,12 @@ import React from "react";
 import { PaddingProps, FlexboxProps } from "styled-system";
 import StyledNavigationBar from "./navigation-bar.style";
 
-export type StickyPosition = "top" | "bottom";
+export type Position = "sticky" | "fixed";
+export type Orientation = "top" | "bottom";
 export type NavigationType = "light" | "dark" | "white" | "black";
+
+// remove this when `stickyPosition` and `stickyOffset` props are removed
+export type StickyPosition = "top" | "bottom";
 
 export interface NavigationBarProps extends PaddingProps, FlexboxProps {
   children?: React.ReactNode;
@@ -16,6 +20,12 @@ export interface NavigationBarProps extends PaddingProps, FlexboxProps {
   stickyPosition?: StickyPosition;
   /** Defines the offset of sticky navigation bar */
   stickyOffset?: string;
+  /** Defines whether the navigation bar should be positioned fixed or sticky */
+  position?: Position;
+  /** Defines the offset of navigation bar */
+  offset?: string;
+  /** Defines whether the navigation bar should be positioned top or bottom */
+  orientation?: Orientation;
 }
 
 export const NavigationBar = ({
@@ -25,6 +35,9 @@ export const NavigationBar = ({
   ariaLabel,
   stickyOffset = "0",
   stickyPosition,
+  position,
+  offset = "0",
+  orientation,
   ...props
 }: NavigationBarProps): JSX.Element => {
   return (
@@ -35,6 +48,9 @@ export const NavigationBar = ({
       data-component="navigation-bar"
       stickyOffset={stickyOffset}
       stickyPosition={stickyPosition}
+      position={position}
+      offset={offset}
+      orientation={orientation}
       {...props}
     >
       {!isLoading && children}

--- a/src/components/navigation-bar/navigation-bar.spec.tsx
+++ b/src/components/navigation-bar/navigation-bar.spec.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { shallow, mount } from "enzyme";
 import NavigationBar, {
   NavigationBarProps,
-  StickyPosition,
+  Orientation,
+  Position,
 } from "./navigation-bar.component";
 import {
   assertStyleMatch,
@@ -168,7 +169,7 @@ describe("NavigationBar", () => {
     );
   });
 
-  it.each<[StickyPosition, string | undefined]>([
+  it.each<[Orientation, string | undefined]>([
     ["top", undefined],
     ["top", "10px"],
     ["bottom", undefined],
@@ -183,6 +184,34 @@ describe("NavigationBar", () => {
       {
         position: "sticky",
         [position]: offset || "0",
+      },
+      wrapper
+    );
+  });
+
+  it.each<[Position, Orientation, string | undefined]>([
+    ["sticky", "top", undefined],
+    ["fixed", "top", undefined],
+    ["sticky", "top", "10px"],
+    ["fixed", "top", "10px"],
+    ["sticky", "bottom", undefined],
+    ["fixed", "bottom", undefined],
+    ["sticky", "bottom", "10px"],
+    ["fixed", "bottom", "10px"],
+  ])("should set correct position, orientation and offset", (position, orientation, offset) => {
+    wrapper = mount(
+      <NavigationBar position={position} orientation={orientation} offset={offset}>
+        <div>test content</div>
+      </NavigationBar>
+    );
+    assertStyleMatch(
+      {
+        position: `${position}`,
+        [orientation]: offset || "0",
+        ...(position === "fixed" && {
+          width: "100%",
+          boxSizing: "border-box",
+        })
       },
       wrapper
     );

--- a/src/components/navigation-bar/navigation-bar.stories.mdx
+++ b/src/components/navigation-bar/navigation-bar.stories.mdx
@@ -5,6 +5,7 @@ import Box from "../box";
 import VerticalDivider from "../vertical-divider";
 import { SageIcon } from "../../../.storybook/welcome-page/footer/footer.style.js";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import DocsWrapper from "../../../.storybook/docs-helpers/components/iframe-wrapper";
 
 <Meta title="Navigation Bar" parameters={{ info: { disable: true } }} />
 
@@ -125,9 +126,12 @@ valid CSS string.
   </Story>
 </Canvas>
 
-### Sticky
+### Position
 
-The `stickyPosition` prop can be used to make the navigation bar stick to the top or bottom of it's nearest scrolling ancestor. Then the position relative to the top/bottom can be offset using the `stickyOffset` prop.
+#### Sticky
+
+The `position` prop can be set to `sticky` to make the navigation bar stick to the top or bottom of its nearest scrolling ancestor.
+Then the `orientation` relative to the top/bottom can be offset using the `offset` prop.
 
 <Canvas>
   <Story name="sticky">
@@ -139,8 +143,9 @@ The `stickyPosition` prop can be used to make the navigation bar stick to the to
         }}
       >
         <NavigationBar
-          stickyPosition="top"
-          stickyOffset="25px"
+          position="sticky"
+          orientation="top"
+          offset="25px"
           aria-label="header"
         >
           <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
@@ -178,8 +183,9 @@ The `stickyPosition` prop can be used to make the navigation bar stick to the to
           }}
         />
         <NavigationBar
-          stickyPosition="bottom"
-          stickyOffset="25px"
+          position="sticky"
+          orientation="bottom"
+          offset="25px"
           aria-label="footer"
         >
           <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
@@ -213,6 +219,97 @@ The `stickyPosition` prop can be used to make the navigation bar stick to the to
       </div>
     </div>
   </Story>
+</Canvas>
+
+#### Fixed
+
+The `position` prop can be set to `fixed` to make the navigation bar fix to the viewport. Then the `orientation` relative to the 
+top/bottom can be offset using the `offset` prop.
+
+<Story name="fixed" parameters={{ docs: { disable: true }, themeSelector: { chromaticTheme: "sage" } }}>
+  <div style={{ height: "calc(100% - 50px)" }}>
+    <NavigationBar
+      position="fixed"
+      orientation="top"
+      offset="25px"
+      aria-label="header"
+    >
+      <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
+        <SageIcon style={{ alignSelf: "center" }} />
+        <Box>
+          <VerticalDivider displayInline pr={0} />
+        </Box>
+        <Menu display="flex" flex="1">
+          <MenuItem flex="1" onClick={() => {}}>
+            Menu Item One
+          </MenuItem>
+          <MenuItem flex="0 0 auto" href="#">
+            Menu Item Two
+          </MenuItem>
+          <MenuItem flex="0 0 auto" submenu="Menu Item Three">
+            <MenuItem href="#">Item Submenu One</MenuItem>
+            <MenuItem href="#">Item Submenu Two</MenuItem>
+            <MenuDivider />
+            <MenuItem icon="settings" href="#">
+              Item Submenu Three
+            </MenuItem>
+            <MenuItem href="#">Item Submenu Four</MenuItem>
+          </MenuItem>
+          <MenuItem flex="0 0 auto" submenu="Menu Item Four">
+            <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+            <MenuItem href="#">Item Submenu Two</MenuItem>
+          </MenuItem>
+        </Menu>
+      </Box>
+    </NavigationBar>
+    <div
+      style={{
+        height: "1000px",
+        background: "green",
+      }}
+    />
+    <NavigationBar
+      position="fixed"
+      orientation="bottom"
+      offset="25px"
+      aria-label="footer"
+    >
+      <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
+        <SageIcon style={{ alignSelf: "center" }} />
+        <Box>
+          <VerticalDivider displayInline pr={0} />
+        </Box>
+        <Menu display="flex" flex="1">
+          <MenuItem flex="1" onClick={() => {}}>
+            Menu Item One
+          </MenuItem>
+          <MenuItem flex="0 0 auto" href="#">
+            Menu Item Two
+          </MenuItem>
+          <MenuItem flex="0 0 auto" submenu="Menu Item Three">
+            <MenuItem href="#">Item Submenu One</MenuItem>
+            <MenuItem href="#">Item Submenu Two</MenuItem>
+            <MenuDivider />
+            <MenuItem icon="settings" href="#">
+              Item Submenu Three
+            </MenuItem>
+            <MenuItem href="#">Item Submenu Four</MenuItem>
+          </MenuItem>
+          <MenuItem flex="0 0 auto" submenu="Menu Item Four">
+            <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+            <MenuItem href="#">Item Submenu Two</MenuItem>
+          </MenuItem>
+        </Menu>
+      </Box>
+    </NavigationBar>
+  </div>
+</Story>
+
+<Canvas>
+  <DocsWrapper
+    src="iframe.html?id=navigation-bar--fixed"
+    height="400px"
+  />
 </Canvas>
 
 ## Props

--- a/src/components/navigation-bar/navigation-bar.style.ts
+++ b/src/components/navigation-bar/navigation-bar.style.ts
@@ -1,16 +1,26 @@
 import styled, { css } from "styled-components";
 import { padding, flexbox, PaddingProps, FlexboxProps } from "styled-system";
 import { baseTheme } from "../../style/themes";
-import { StickyPosition, NavigationType } from "./navigation-bar.component";
+import {
+  Position,
+  Orientation,
+  NavigationType,
+} from "./navigation-bar.component";
 
 type StyledNavigationBarProps = PaddingProps &
   FlexboxProps & {
     /** Color scheme of navigation component */
     navigationType?: NavigationType;
     /** Defines the position of sticky navigation bar */
-    stickyPosition?: StickyPosition;
+    stickyPosition?: Orientation;
     /** Defines the offset of sticky navigation bar */
     stickyOffset?: string;
+    /** Defines whether the navigation bar should be positioned fixed or sticky */
+    position?: Position;
+    /** Defines the offset of navigation bar */
+    offset?: string;
+    /** Defines whether the navigation bar should be positioned top or bottom */
+    orientation?: Orientation;
   };
 
 const StyledNavigationBar = styled.nav<StyledNavigationBarProps>`
@@ -51,8 +61,21 @@ const StyledNavigationBar = styled.nav<StyledNavigationBarProps>`
     stickyPosition &&
     css`
       position: sticky;
-      ${stickyPosition}: ${stickyOffset}
-    `};
+      ${stickyPosition}: ${stickyOffset};
+    `}
+
+  ${({ position, orientation, offset }) =>
+    position && orientation &&
+    css`
+      position: ${position};
+      ${orientation}: ${offset};
+
+      ${position === "fixed" &&
+      css`
+        box-sizing: border-box;
+        width: 100%;
+      `}
+    `}
 
   ${({ navigationType, theme }) => css`
     min-height: 40px;


### PR DESCRIPTION
fix #4691

### Proposed behaviour


Surfaces `position`, `offset` and `orientation` props to support setting the `NavigationBar` to be
either `sticky` or `fixed` positioned.

Adds deprecation warning for `stickyPosition` and `stickyOffset` props in favour of using `position`, `offset` and `orientation` props

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No support for setting position to `fixed`, `stickyOffset` and `stickyPosition` props have no deprecation warning

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
`navigation-bar--fixed` and `navigation-bar--sticky` stories should be tested

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/admiring-wilbur-uiwu52?file=/src/index.js
**--- No point in testing linked issue sandbox as interface has changed ---**