### PR TITLE
ci(pr-template): remove 123 from template comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Please DO NOT share screenshots or the source code of your project.
 You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2
 
 If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
-If you have a commit that includes fixes #123 and issue #123 has a CodeSandbox link in the body, the bot will fork
+If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
 it with the new built version of carbon.
 -->
 


### PR DESCRIPTION
### Proposed behaviour

Remove the 123 from our PR template comment, whenever this gets left in and the PR is merged, `@semantic-release/github` thinks the PR is linked to [this issue](https://github.com/Sage/carbon/pull/123) and comments on it 😅 

### Current behaviour


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
