### PR TITLE
feat(grid): add styled-system props (FE-4912)

### DIFF
--- a/src/components/grid/__snapshots__/grid.spec.js.snap
+++ b/src/components/grid/__snapshots__/grid.spec.js.snap
@@ -12,32 +12,29 @@ exports[`Grid GridItem builds the style rules for the GridItem with custom align
 
 .c1 {
   margin: 0;
-  justify-self: left;
   -webkit-align-self: start;
   -ms-flex-item-align: start;
   align-self: start;
-  grid-row: auto;
-  grid-column: 1 / 13;
+  justify-self: left;
+  grid-area: auto / 1 / auto / 13;
 }
 
 .c2 {
   margin: 0;
-  justify-self: center;
   -webkit-align-self: start;
   -ms-flex-item-align: start;
   align-self: start;
-  grid-row: auto;
-  grid-column: 1 / 13;
+  justify-self: center;
+  grid-area: auto / 1 / auto / 13;
 }
 
 .c3 {
   margin: 0;
-  justify-self: right;
   -webkit-align-self: start;
   -ms-flex-item-align: start;
   align-self: start;
-  grid-row: auto;
-  grid-column: 1 / 13;
+  justify-self: right;
+  grid-area: auto / 1 / auto / 13;
 }
 
 @media screen and (max-width:1920px) {
@@ -100,20 +97,17 @@ exports[`Grid GridItem builds the style rules for the GridItem with responsiveSe
 
 .c1 {
   margin: 0;
-  grid-row: auto;
-  grid-column: 1 / 13;
+  grid-area: auto / 1 / auto / 13;
 }
 
 .c2 {
   margin: 0;
-  grid-row: auto;
-  grid-column: 1 / 13;
+  grid-area: auto / 1 / auto / 13;
 }
 
 .c3 {
   margin: 0;
-  grid-row: auto;
-  grid-column: 1 / 13;
+  grid-area: auto / 1 / auto / 13;
 }
 
 @media screen and (max-width:1920px) {

--- a/src/components/grid/grid-container/grid-container.component.js
+++ b/src/components/grid/grid-container/grid-container.component.js
@@ -1,6 +1,5 @@
 import React from "react";
-import PropTypes from "prop-types";
-import propTypes from "@styled-system/prop-types";
+import styledSystemPropTypes from "@styled-system/prop-types";
 import GridContainerStyle from "./grid-container.style";
 import GridItem from "../grid-item";
 
@@ -33,7 +32,7 @@ GridContainer.propTypes = {
 
     return error;
   },
-  ...propTypes.space,
-  gridGap: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  ...styledSystemPropTypes.space,
+  ...styledSystemPropTypes.grid,
 };
 export default GridContainer;

--- a/src/components/grid/grid-container/grid-container.d.ts
+++ b/src/components/grid/grid-container/grid-container.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { SpaceProps } from "styled-system";
+import { SpaceProps, GridProps } from "styled-system";
 import { GridItemProps } from "../grid-item/grid-item";
 
 type GridContainerChild =
@@ -8,11 +8,9 @@ type GridContainerChild =
   | null
   | undefined;
 
-export interface GridContainerProps extends SpaceProps {
+export interface GridContainerProps extends SpaceProps, GridProps {
   /** Defines the Components to be rendered within the GridContainer. Requires GridItemProps */
   children?: GridContainerChild | GridContainerChild[];
-  /** Any valid CSS value to override default grid-gap */
-  gridGap?: string;
 }
 
 declare function GridContainer(props: GridContainerProps): JSX.Element;

--- a/src/components/grid/grid-container/grid-container.style.js
+++ b/src/components/grid/grid-container/grid-container.style.js
@@ -28,7 +28,8 @@ const GridContainerStyle = styled.div`
 
   @media screen {
     ${space}
-    ${({ gridGap }) => grid({ gridGap })}
+    ${grid}
+  }
 `;
 
 export default GridContainerStyle;

--- a/src/components/grid/grid-item/grid-item.component.js
+++ b/src/components/grid/grid-item/grid-item.component.js
@@ -23,6 +23,8 @@ GridItem.propTypes = {
   children: PropTypes.node,
   /** How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch */
   alignSelf: PropTypes.string,
+  /** Shorthand property for gridColumn and gridRow */
+  gridArea: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Starting and ending column position of the GridItem within the GridContainer separated by "/" */
   gridColumn: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Starting and ending row position of the GridItem within the GridContainer separated by "/" */
@@ -34,6 +36,8 @@ GridItem.propTypes = {
     PropTypes.shape({
       /** How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch */
       alignSelf: PropTypes.string,
+      /** Shorthand property for gridColumn and gridRow */
+      gridArea: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       /** Starting and ending column position of the GridItem within the GridContainer separated by "/" */
       gridColumn: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       /** Starting and ending row position of the GridItem within the GridContainer separated by "/" */

--- a/src/components/grid/grid-item/grid-item.d.ts
+++ b/src/components/grid/grid-item/grid-item.d.ts
@@ -1,5 +1,10 @@
 import * as React from "react";
-import { PaddingProps } from "styled-system";
+import {
+  PaddingProps,
+  GridAreaProps,
+  GridRowProps,
+  GridColumnProps,
+} from "styled-system";
 
 interface ResponsiveSettingsShape extends PaddingProps {
   /** How the grid item is aligned along the block (column) axis. Values: start, end, center, stretch */
@@ -8,10 +13,12 @@ interface ResponsiveSettingsShape extends PaddingProps {
   justifySelf?: string;
   /** Maximum width of the item */
   maxWidth?: string;
+  /** Shorthand property for gridColumn and gridRow */
+  gridArea?: GridAreaProps;
   /** Starting and ending column position of the GridItem within the GridContainer separated by "/" */
-  gridColumn?: string | number;
+  gridColumn?: GridColumnProps;
   /** Starting and ending row position of the GridItem within the GridContainer separated by "/" */
-  gridRow?: string | number;
+  gridRow?: GridRowProps;
 }
 
 export interface GridItemProps extends PaddingProps {
@@ -21,10 +28,12 @@ export interface GridItemProps extends PaddingProps {
   justifySelf?: string;
   /** Defines the Component(s) to be rendered within the GridItem */
   children?: React.ReactNode;
+  /** Shorthand property for gridColumn and gridRow */
+  gridArea?: GridAreaProps;
   /** Starting and ending column position of the GridItem within the GridContainer separated by "/" */
-  gridColumn?: string | number;
+  gridColumn?: GridColumnProps;
   /** Starting and ending row position of the GridItem within the GridContainer separated by "/" */
-  gridRow?: string | number;
+  gridRow?: GridRowProps;
   responsiveSettings?: ResponsiveSettingsShape[];
 }
 

--- a/src/components/grid/grid-item/grid-item.style.js
+++ b/src/components/grid/grid-item/grid-item.style.js
@@ -9,6 +9,7 @@ function responsiveGridItem(responsiveSettings) {
   return responsiveSettings.map((setting) => {
     const {
       alignSelf,
+      gridArea,
       gridColumn,
       gridRow,
       maxWidth,
@@ -23,6 +24,7 @@ function responsiveGridItem(responsiveSettings) {
       @media screen and (max-width: ${maxWidth}) {
         align-self: ${alignSelf || "stretch"};
         justify-self: ${justifySelf || "stretch"};
+        grid-area: ${gridArea};
         grid-column: ${gridColumn};
         grid-row: ${gridRow};
         padding: ${getSpacing(p)};
@@ -74,17 +76,24 @@ const paddingPropTypes = filterStyledSystemPaddingProps(
 
 const GridItemStyle = styled.div`
   margin: 0;
-
-  ${({ justifySelf }) => flexbox({ justifySelf })}
-  ${({ alignSelf }) => flexbox({ alignSelf })}
   ${padding}
-  ${({ gridRow }) => grid({ gridRow })}
-  ${({ gridColumn }) => grid({ gridColumn })}
-  ${({ responsiveSettings }) =>
-    responsiveSettings &&
+
+  ${({
+    alignSelf,
+    justifySelf,
+    gridArea,
+    gridColumn,
+    gridRow,
+    responsiveSettings,
+  }) => css`
+    ${flexbox({ alignSelf, justifySelf })}
+    ${grid({ gridArea, gridColumn, gridRow })};
+
+    ${responsiveSettings &&
     css`
       ${responsiveGridItem(responsiveSettings)};
     `}
+  `}
 `;
 
 GridItemStyle.propTypes = {
@@ -96,6 +105,7 @@ GridItemStyle.propTypes = {
   responsiveSettings: PropTypes.arrayOf(
     PropTypes.shape({
       alignSelf: PropTypes.string,
+      gridArea: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       gridColumn: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       gridRow: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       justifySelf: PropTypes.string,
@@ -106,8 +116,7 @@ GridItemStyle.propTypes = {
 };
 
 GridItemStyle.defaultProps = {
-  gridColumn: "1 / 13",
-  gridRow: "auto",
+  gridArea: "auto / 1 / auto / 13",
 };
 
 export default GridItemStyle;

--- a/src/components/grid/grid.spec.js
+++ b/src/components/grid/grid.spec.js
@@ -17,6 +17,24 @@ const paddingProps = [
   ["py", "paddingBottom"],
 ];
 
+const gridContainerProps = [
+  ["gridGap", "15px"],
+  ["gridRowGap", "15px"],
+  ["gridColumnGap", "15px"],
+  ["gridAutoFlow", "row dense"],
+  ["gridAutoRows", "1fr"],
+  ["gridAutoColumns", "1fr"],
+  ["gridTemplateRows", "100px 1fr"],
+  ["gridTemplateColumns", "100px 1fr"],
+  ["gridTemplateAreas", "foo bar"],
+];
+
+const gridItemProps = [
+  ["gridArea", "foo / bar"],
+  ["gridColumn", "1 / 3"],
+  ["gridRow", "1 / 3"],
+];
+
 const item1900 = {
   gridColumn: "1 / 9",
   gridRow: 2,
@@ -206,21 +224,26 @@ describe("Grid", () => {
       }
     );
 
-    describe('when a custom grid-gap is specified using the "gridGap" styled system prop', () => {
-      it("then that grid-gap should have been set on the GridContainer", () => {
-        const wrapper = enzymeMount(
-          <GridContainer id="testContainer" gridGap="15px">
-            <GridItem>1</GridItem>
-            <GridItem>2</GridItem>
-            <GridItem>3</GridItem>
-          </GridContainer>
-        );
+    describe.each(gridContainerProps)(
+      "when a custom %s is specified using that styled system prop",
+      (propName, propValue) => {
+        it(`then the ${propName} attribute should have been set on the GridContainer`, () => {
+          const wrapper = enzymeMount(
+            <GridContainer id="testContainer" {...{ [propName]: propValue }}>
+              <GridItem>1</GridItem>
+              <GridItem>2</GridItem>
+              <GridItem>3</GridItem>
+            </GridContainer>
+          );
 
-        expect(
-          assertStyleMatch({ gridGap: "15px" }, wrapper, { media: "screen" })
-        );
-      });
-    });
+          expect(
+            assertStyleMatch({ [propName]: propValue }, wrapper, {
+              media: "screen",
+            })
+          );
+        });
+      }
+    );
   });
 
   describe("GridItem", () => {
@@ -383,5 +406,27 @@ describe("Grid", () => {
         });
       });
     });
+
+    describe.each(gridItemProps)(
+      "when a custom %s is specified using that styled system prop",
+      (propName, propValue) => {
+        it(`then the ${propName} attribute should have been set on the GridItem`, () => {
+          const wrapper = enzymeMount(
+            <GridContainer id="testContainer">
+              <GridItem {...{ [propName]: propValue }}>1</GridItem>
+              <GridItem>2</GridItem>
+              <GridItem>3</GridItem>
+            </GridContainer>
+          );
+
+          expect(
+            assertStyleMatch(
+              { [propName]: propValue },
+              wrapper.find(GridItem).at(0)
+            )
+          );
+        });
+      }
+    );
   });
 });


### PR DESCRIPTION
### Proposed behaviour
Add styled-system grid props to GridContainer and GridItem

### Current behaviour
There is no possibility to customize the grid layout using the Carbon Grid component

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
