### PR TITLE
refactor(heading): convert to functional component

### DIFF
--- a/src/__internal__/checkable-input/hidden-checkable-input.component.js
+++ b/src/__internal__/checkable-input/hidden-checkable-input.component.js
@@ -13,9 +13,8 @@ const HiddenCheckableInput = ({
   autoFocus,
   ...props
 }) => {
-  const { onBlur, onFocus, onMouseEnter, onMouseLeave } = useContext(
-    InputContext
-  );
+  const { onBlur, onFocus, onMouseEnter, onMouseLeave } =
+    useContext(InputContext);
   const {
     onBlur: onBlurGroup,
     onFocus: onFocusGroup,

--- a/src/__internal__/input/input-presentation.component.js
+++ b/src/__internal__/input/input-presentation.component.js
@@ -18,14 +18,11 @@ const InputPresentation = ({
   warning,
   info,
 }) => {
-  const { hasFocus, onMouseDown, onMouseEnter, onMouseLeave } = useContext(
-    InputContext
-  );
+  const { hasFocus, onMouseDown, onMouseEnter, onMouseLeave } =
+    useContext(InputContext);
 
-  const {
-    onMouseEnter: onGroupMouseEnter,
-    onMouseLeave: onGroupMouseLeave,
-  } = useContext(InputGroupContext);
+  const { onMouseEnter: onGroupMouseEnter, onMouseLeave: onGroupMouseLeave } =
+    useContext(InputGroupContext);
 
   const handleMouseEnter = (e) => {
     if (onMouseEnter) onMouseEnter(e);

--- a/src/__internal__/label/label.component.js
+++ b/src/__internal__/label/label.component.js
@@ -39,10 +39,8 @@ const Label = ({
 }) => {
   const [isFocused, setFocus] = useState(false);
   const { onMouseEnter, onMouseLeave } = useContext(InputContext);
-  const {
-    onMouseEnter: onGroupMouseEnter,
-    onMouseLeave: onGroupMouseLeave,
-  } = useContext(InputGroupContext);
+  const { onMouseEnter: onGroupMouseEnter, onMouseLeave: onGroupMouseLeave } =
+    useContext(InputGroupContext);
 
   const handleMouseEnter = (ev) => {
     if (onMouseEnter) onMouseEnter(ev);

--- a/src/__internal__/radio-button-mapper/radio-button-mapper.component.js
+++ b/src/__internal__/radio-button-mapper/radio-button-mapper.component.js
@@ -10,9 +10,10 @@ const RadioButtonMapper = ({
   onKeyDown,
   value,
 }) => {
-  const filteredChildren = useMemo(() => React.Children.toArray(children), [
-    children,
-  ]);
+  const filteredChildren = useMemo(
+    () => React.Children.toArray(children),
+    [children]
+  );
   const anyChecked = useMemo(() => {
     let result = false;
     filteredChildren.forEach((child) => {

--- a/src/__internal__/radio-button-mapper/radio-button-mapper.spec.js
+++ b/src/__internal__/radio-button-mapper/radio-button-mapper.spec.js
@@ -7,8 +7,8 @@ import PropTypes from "prop-types";
 
 import mintTheme from "../../style/themes/mint";
 import RadioButtonMapper from "./radio-button-mapper.component";
-import { RadioButton } from ".";
-import Button from "../button";
+import { RadioButton } from "../../components/radio-button";
+import Button from "../../components/button";
 
 const buttonValues = ["test-1", "test-2"];
 const name = "test-group";

--- a/src/__internal__/validations/validation-icon.component.js
+++ b/src/__internal__/validations/validation-icon.component.js
@@ -35,10 +35,8 @@ const ValidationIcon = ({
   ...rest
 }) => {
   const { hasFocus, hasMouseOver } = useContext(InputContext);
-  const {
-    hasFocus: groupHasFocus,
-    hasMouseOver: groupHasMouseOver,
-  } = useContext(InputGroupContext);
+  const { hasFocus: groupHasFocus, hasMouseOver: groupHasMouseOver } =
+    useContext(InputGroupContext);
   const [triggeredByIcon, setTriggeredByIcon] = useState(false);
 
   const validationType = getValidationType({ error, warning, info });

--- a/src/__spec_helper__/test-utils.js
+++ b/src/__spec_helper__/test-utils.js
@@ -43,7 +43,10 @@ const keyMap = {
   1: "49",
 };
 
-const repeat = (action) => (n = 1) => makeArrayKeys(n).forEach(() => action());
+const repeat =
+  (action) =>
+  (n = 1) =>
+    makeArrayKeys(n).forEach(() => action());
 
 const keyboard = Object.keys(keyMap).reduce((acc, key) => {
   acc[`press${key}`] = () => repeat(dispatchKeyPress(keyMap[key]));
@@ -91,19 +94,20 @@ const selectedItemReducer = (method) => (wrapper) => (acc, i) => {
 const arraysEqual = (arr1, arr2) =>
   arr1.sort().join(",") === arr2.sort().join(",");
 
-const assertCorrectTraversal = (method) => (expect) => ({
-  num,
-  nonSelectables = [],
-}) => (wrapper) => {
-  const array = makeArrayKeys(num);
-  const validIndexes = array.filter(isSelectableGiven(nonSelectables));
+const assertCorrectTraversal =
+  (method) =>
+  (expect) =>
+  ({ num, nonSelectables = [] }) =>
+  (wrapper) => {
+    const array = makeArrayKeys(num);
+    const validIndexes = array.filter(isSelectableGiven(nonSelectables));
 
-  const selectedItem = selectedItemOf(wrapper);
-  const indexesThatWereSelected = array
-    .reduce(selectedItemReducer(method)(wrapper), [selectedItem])
-    .filter(isUnique);
-  expect(arraysEqual(validIndexes, indexesThatWereSelected)).toBeTruthy();
-};
+    const selectedItem = selectedItemOf(wrapper);
+    const indexesThatWereSelected = array
+      .reduce(selectedItemReducer(method)(wrapper), [selectedItem])
+      .filter(isUnique);
+    expect(arraysEqual(validIndexes, indexesThatWereSelected)).toBeTruthy();
+  };
 
 const assertKeyboardTraversal = assertCorrectTraversal(
   () => keyboard.pressDownArrow

--- a/src/components/accordion/accordion-group/accordion-group.component.js
+++ b/src/components/accordion/accordion-group/accordion-group.component.js
@@ -11,9 +11,10 @@ const marginProptypes = filterStyledSystemMarginProps(
 );
 
 const AccordionGroup = ({ children, ...rest }) => {
-  const filteredChildren = useMemo(() => React.Children.toArray(children), [
-    children,
-  ]);
+  const filteredChildren = useMemo(
+    () => React.Children.toArray(children),
+    [children]
+  );
 
   const refs = useMemo(
     () => filteredChildren.map((child) => child.ref || React.createRef()),

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.js
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.js
@@ -35,9 +35,8 @@ const MenuItem = ({
   ...rest
 }) => {
   const l = useLocale();
-  const { setOpenPopover, isOpenPopover, focusButton } = useContext(
-    ActionPopoverContext
-  );
+  const { setOpenPopover, isOpenPopover, focusButton } =
+    useContext(ActionPopoverContext);
 
   const isHref = !!href;
   const [containerPosition, setContainerPosition] = useState(null);

--- a/src/components/anchor-navigation/anchor-navigation.spec.js
+++ b/src/components/anchor-navigation/anchor-navigation.spec.js
@@ -352,8 +352,9 @@ describe("AnchorNavigation", () => {
   });
 
   it("renders selected navigation item with proper background when hovered", () => {
-    expect(
-      wrapper.find(StyledNavigationItem).at(0)
-    ).not.toHaveStyleRule("background-color", { modifier: "a:hover" });
+    expect(wrapper.find(StyledNavigationItem).at(0)).not.toHaveStyleRule(
+      "background-color",
+      { modifier: "a:hover" }
+    );
   });
 });

--- a/src/components/button-toggle-group/button-toggle-group.component.js
+++ b/src/components/button-toggle-group/button-toggle-group.component.js
@@ -5,7 +5,7 @@ import styledSystemPropTypes from "@styled-system/prop-types";
 import FormField from "../../__internal__/form-field";
 import ButtonToggleGroupStyle from "./button-toggle-group.style";
 import ButtonToggle from "../button-toggle";
-import RadioButtonMapper from "../radio-button/radio-button-mapper.component";
+import RadioButtonMapper from "../../__internal__/radio-button-mapper/radio-button-mapper.component";
 import ValidationIcon from "../../__internal__/validations/validation-icon.component";
 import { InputGroupBehaviour } from "../../__internal__/input-behaviour";
 import { filterStyledSystemMarginProps } from "../../style/utils";

--- a/src/components/date-range/date-range-test.stories.mdx
+++ b/src/components/date-range/date-range-test.stories.mdx
@@ -36,7 +36,7 @@ export const DateRangeStory = ({
       evt.target.value[1].formattedValue,
     ];
     setState(newValue);
-    action("change")(evt.target.value)
+    action("change")(evt.target.value);
   };
   return (
     <DateRange

--- a/src/components/date-range/date-range.component.js
+++ b/src/components/date-range/date-range.component.js
@@ -36,9 +36,10 @@ const DateRange = ({
 }) => {
   const l = useLocale();
   const { dateFnsLocale } = l.date;
-  const { format } = useMemo(() => getFormatData(dateFnsLocale()), [
-    dateFnsLocale,
-  ]);
+  const { format } = useMemo(
+    () => getFormatData(dateFnsLocale()),
+    [dateFnsLocale]
+  );
   const inlineLabelWidth = 40;
   const [lastChangedDate, setLastChangedDate] = useState("");
 

--- a/src/components/date-range/date-range.stories.mdx
+++ b/src/components/date-range/date-range.stories.mdx
@@ -5,12 +5,9 @@ import TranslationKeysTable from "../../../.storybook/utils/translation-keys-tab
 
 import DateRange from ".";
 import I18nProvider from "../i18n-provider";
-import { fr } from "../../locales/date-fns-locales"
+import { fr } from "../../locales/date-fns-locales";
 
-<Meta
-  title="Date Range"
-  parameters={{ info: { disable: true } }}
-/>
+<Meta title="Date Range" parameters={{ info: { disable: true } }} />
 
 # Date Range
 
@@ -38,7 +35,10 @@ import DateRange from "carbon-react/lib/components/date-range";
     {() => {
       const [state, setState] = useState(["01/10/2016", "30/10/2016"]);
       const handleChange = ({ target }) => {
-        const newValue = [target.value[0].formattedValue, target.value[1].formattedValue];
+        const newValue = [
+          target.value[0].formattedValue,
+          target.value[1].formattedValue,
+        ];
         setState(newValue);
       };
       return (
@@ -60,7 +60,10 @@ import DateRange from "carbon-react/lib/components/date-range";
     {() => {
       const [state, setState] = useState(["01/10/2016", "30/10/2016"]);
       const handleChange = ({ target }) => {
-        const newValue = [target.value[0].formattedValue, target.value[1].formattedValue];
+        const newValue = [
+          target.value[0].formattedValue,
+          target.value[1].formattedValue,
+        ];
         setState(newValue);
       };
       return (
@@ -93,26 +96,27 @@ For more information check our [Validations](?path=/docs/documentation-validatio
     {() => {
       const [state, setState] = useState(["01/10/2016", "30/10/2016"]);
       const handleChange = ({ target }) => {
-        const newValue = [target.value[0].formattedValue, target.value[1].formattedValue];
+        const newValue = [
+          target.value[0].formattedValue,
+          target.value[1].formattedValue,
+        ];
         setState(newValue);
       };
-      return (
-        [
-          { startError: "Start Error", endError: "End Error" },
-          { startWarning: "Start Warning", endWarning: "End Warning" },
-          { startInfo: "Start Info", endInfo: "End Info" },
-        ].map((validation) => (
-          <DateRange
-            key={`${Object.keys(validation)[0]}-string-component`}
-            startLabel="Start"
-            endLabel="End"
-            onChange={handleChange}
-            value={state}
-            {...validation}
-          />
-        ))
-      )}
-    }
+      return [
+        { startError: "Start Error", endError: "End Error" },
+        { startWarning: "Start Warning", endWarning: "End Warning" },
+        { startInfo: "Start Info", endInfo: "End Info" },
+      ].map((validation) => (
+        <DateRange
+          key={`${Object.keys(validation)[0]}-string-component`}
+          startLabel="Start"
+          endLabel="End"
+          onChange={handleChange}
+          value={state}
+          {...validation}
+        />
+      ));
+    }}
   </Story>
 </Canvas>
 
@@ -126,27 +130,28 @@ It is possible to use the `tooltipPosition` to override the default placement of
     {() => {
       const [state, setState] = useState(["01/10/2016", "30/10/2016"]);
       const handleChange = ({ target }) => {
-        const newValue = [target.value[0].formattedValue, target.value[1].formattedValue];
+        const newValue = [
+          target.value[0].formattedValue,
+          target.value[1].formattedValue,
+        ];
         setState(newValue);
       };
-      return (
-        [
-          { startError: "Start Error", endError: "End Error" },
-          { startWarning: "Start Warning", endWarning: "End Warning" },
-          { startInfo: "Start Info", endInfo: "End Info" },
-        ].map((validation) => (
-          <DateRange
-            key={`${Object.keys(validation)[0]}-string-component`}
-            startLabel="Start"
-            endLabel="End"
-            value={state}
-            onChange={handleChange}
-            {...validation}
-            tooltipPosition="top"
-          />
-        ))
-      )}
-    }
+      return [
+        { startError: "Start Error", endError: "End Error" },
+        { startWarning: "Start Warning", endWarning: "End Warning" },
+        { startInfo: "Start Info", endInfo: "End Info" },
+      ].map((validation) => (
+        <DateRange
+          key={`${Object.keys(validation)[0]}-string-component`}
+          startLabel="Start"
+          endLabel="End"
+          value={state}
+          onChange={handleChange}
+          {...validation}
+          tooltipPosition="top"
+        />
+      ));
+    }}
   </Story>
 </Canvas>
 
@@ -157,27 +162,28 @@ It is possible to use the `tooltipPosition` to override the default placement of
     {() => {
       const [state, setState] = useState(["01/10/2016", "30/10/2016"]);
       const handleChange = ({ target }) => {
-        const newValue = [target.value[0].formattedValue, target.value[1].formattedValue];
+        const newValue = [
+          target.value[0].formattedValue,
+          target.value[1].formattedValue,
+        ];
         setState(newValue);
       };
-      return (
-        [
-          { startError: "Start Error", endError: "End Error" },
-          { startWarning: "Start Warning", endWarning: "End Warning" },
-          { startInfo: "Start Info", endInfo: "End Info" },
-        ].map((validation) => (
-          <DateRange
-            key={`${Object.keys(validation)[0]}-string-label`}
-            startLabel="Start"
-            endLabel="End"
-            value={state}
-            onChange={handleChange}
-            validationOnLabel
-            {...validation}
-          />
-        ))
-      )}
-    }
+      return [
+        { startError: "Start Error", endError: "End Error" },
+        { startWarning: "Start Warning", endWarning: "End Warning" },
+        { startInfo: "Start Info", endInfo: "End Info" },
+      ].map((validation) => (
+        <DateRange
+          key={`${Object.keys(validation)[0]}-string-label`}
+          startLabel="Start"
+          endLabel="End"
+          value={state}
+          onChange={handleChange}
+          validationOnLabel
+          {...validation}
+        />
+      ));
+    }}
   </Story>
 </Canvas>
 
@@ -191,28 +197,29 @@ It is possible to use the `tooltipPosition` to override the default placement of
     {() => {
       const [state, setState] = useState(["01/10/2016", "30/10/2016"]);
       const handleChange = ({ target }) => {
-        const newValue = [target.value[0].formattedValue, target.value[1].formattedValue];
+        const newValue = [
+          target.value[0].formattedValue,
+          target.value[1].formattedValue,
+        ];
         setState(newValue);
       };
-      return (
-        [
-          { startError: "Start Error", endError: "End Error" },
-          { startWarning: "Start Warning", endWarning: "End Warning" },
-          { startInfo: "Start Info", endInfo: "End Info" },
-        ].map((validation) => (
-          <DateRange
-            key={`${Object.keys(validation)[0]}-string-label`}
-            startLabel="Start"
-            endLabel="End"
-            value={state}
-            onChange={handleChange}
-            validationOnLabel
-            {...validation}
-            tooltipPosition="top"
-          />
-        ))
-      )}
-    }
+      return [
+        { startError: "Start Error", endError: "End Error" },
+        { startWarning: "Start Warning", endWarning: "End Warning" },
+        { startInfo: "Start Info", endInfo: "End Info" },
+      ].map((validation) => (
+        <DateRange
+          key={`${Object.keys(validation)[0]}-string-label`}
+          startLabel="Start"
+          endLabel="End"
+          value={state}
+          onChange={handleChange}
+          validationOnLabel
+          {...validation}
+          tooltipPosition="top"
+        />
+      ));
+    }}
   </Story>
 </Canvas>
 
@@ -223,26 +230,27 @@ It is possible to use the `tooltipPosition` to override the default placement of
     {() => {
       const [state, setState] = useState(["01/10/2016", "30/10/2016"]);
       const handleChange = ({ target }) => {
-        const newValue = [target.value[0].formattedValue, target.value[1].formattedValue];
+        const newValue = [
+          target.value[0].formattedValue,
+          target.value[1].formattedValue,
+        ];
         setState(newValue);
       };
-      return (
-        [
-          { startError: true, endError: true },
-          { startWarning: true, endWarning: true },
-          { startInfo: true, endInfo: true },
-        ].map((validation) => (
-          <DateRange
-            key={`${Object.keys(validation)[0]}-boolean-component`}
-            startLabel="Start"
-            endLabel="End"
-            value={state}
-            onChange={handleChange}
-            {...validation}
-          />
-        ))
-      )}
-    }
+      return [
+        { startError: true, endError: true },
+        { startWarning: true, endWarning: true },
+        { startInfo: true, endInfo: true },
+      ].map((validation) => (
+        <DateRange
+          key={`${Object.keys(validation)[0]}-boolean-component`}
+          startLabel="Start"
+          endLabel="End"
+          value={state}
+          onChange={handleChange}
+          {...validation}
+        />
+      ));
+    }}
   </Story>
 </Canvas>
 
@@ -255,7 +263,10 @@ You can pass prop `allowEmptyValue` to start and end `DateInput` using `startDat
     {() => {
       const [state, setState] = useState(["", ""]);
       const handleChange = ({ target }) => {
-        const newValue = [target.value[0].formattedValue, target.value[1].formattedValue];
+        const newValue = [
+          target.value[0].formattedValue,
+          target.value[1].formattedValue,
+        ];
         setState(newValue);
       };
       return (
@@ -271,27 +282,38 @@ You can pass prop `allowEmptyValue` to start and end `DateInput` using `startDat
           }}
           onChange={handleChange}
         />
-      )}
-    }
+      );
+    }}
   </Story>
 </Canvas>
 
 ### Locale override
 
-The examples below illustrates how to override the locale passed into the DateRange component. In this example it has been set up for 
+The examples below illustrates how to override the locale passed into the DateRange component. In this example it has been set up for
 the French locale. Required locales can be imported like so `import { fr } from 'carbon-react/lib/locales/date-fns-locales';`
 
 <Canvas>
-  <Story name="locale override - example implementation" parameters={{ chromatic: { disable: true } }}>
+  <Story
+    name="locale override - example implementation"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
       const [state, setState] = useState(["01/10/2016", "30/10/2016"]);
       const handleChange = ({ target }) => {
-        const newValue = [target.value[0].formattedValue, target.value[1].formattedValue];
+        const newValue = [
+          target.value[0].formattedValue,
+          target.value[1].formattedValue,
+        ];
         setState(newValue);
       };
       return (
         <div>
-          <I18nProvider locale={{locale: () => "fr-FR", date: { dateFnsLocale: () => fr }}}>
+          <I18nProvider
+            locale={{
+              locale: () => "fr-FR",
+              date: { dateFnsLocale: () => fr },
+            }}
+          >
             <DateRange
               startLabel="Start"
               endLabel="End"
@@ -300,8 +322,8 @@ the French locale. Required locales can be imported like so `import { fr } from 
             />
           </I18nProvider>
         </div>
-      )}
-    }
+      );
+    }}
   </Story>
 </Canvas>
 

--- a/src/components/date/date-test.stories.mdx
+++ b/src/components/date/date-test.stories.mdx
@@ -31,7 +31,9 @@ export const DateStory = (args) => {
       name="dateinput"
       value={state}
       onChange={setValue}
-      onBlur={(ev) => {action("onBlur")(ev.target.value)}}
+      onBlur={(ev) => {
+        action("onBlur")(ev.target.value);
+      }}
       onKeyDown={(ev) => action("onKeyDown")(ev.target.value)}
       onClick={(ev) => action("onClick")(ev.target.value)}
       {...getCommonTextboxArgsWithSpecialCaracters(args)}

--- a/src/components/date/date.component.js
+++ b/src/components/date/date.component.js
@@ -62,9 +62,10 @@ const DateInput = ({
   const focusedViaPicker = useRef(false);
   const l = useLocale();
   const { dateFnsLocale } = l.date;
-  const { format, formats } = useMemo(() => getFormatData(dateFnsLocale()), [
-    dateFnsLocale,
-  ]);
+  const { format, formats } = useMemo(
+    () => getFormatData(dateFnsLocale()),
+    [dateFnsLocale]
+  );
   const { inputRefMap, setInputRefMap } = useContext(DateRangeContext);
   const inputName = dataElement?.split("-")[0];
   const [open, setOpen] = useState(false);

--- a/src/components/date/date.stories.mdx
+++ b/src/components/date/date.stories.mdx
@@ -8,12 +8,9 @@ import { OriginalTextbox } from "../textbox";
 import Button from "../button";
 import Box from "../box";
 import I18nProvider from "../i18n-provider";
-import { de } from "../../locales/date-fns-locales"
+import { de } from "../../locales/date-fns-locales";
 
-<Meta
-  title="Date Input"
-  parameters={{ info: { disable: true } }}
-/>
+<Meta title="Date Input" parameters={{ info: { disable: true } }} />
 
 # Date
 
@@ -38,9 +35,9 @@ import DateInput from "carbon-react/lib/components/date";
 
 ### Default
 
-The `value` and `onChange` props are required as this component must be controlled. The `onChange` will receive a event 
-with a target value containing a `formattedValue` and `rawValue`.  The `rawValue` should be used for storing the value 
-in the backend and for running validations: it will either return a valid ISO string or null. The `formattedValue` should 
+The `value` and `onChange` props are required as this component must be controlled. The `onChange` will receive a event
+with a target value containing a `formattedValue` and `rawValue`. The `rawValue` should be used for storing the value
+in the backend and for running validations: it will either return a valid ISO string or null. The `formattedValue` should
 be used to set the input value like in the example below, although the component can be initialised with an ISO formatted string.
 
 <Canvas>
@@ -71,36 +68,40 @@ be used to set the input value like in the example below, although the component
       const setValue = ({ target }) => {
         setState(target.value.formattedValue);
       };
-      return (
-        ["small", "medium", "large"].map((size) => (
-          <DateInput
-            key={`Date - ${size}`}
-            label={`Date - ${size}`}
-            value={state}
-            onChange={setValue}
-            size={size}
-            mb={2}
-          />
-        ))
-      )}
-    }
+      return ["small", "medium", "large"].map((size) => (
+        <DateInput
+          key={`Date - ${size}`}
+          label={`Date - ${size}`}
+          value={state}
+          onChange={setValue}
+          size={size}
+          mb={2}
+        />
+      ));
+    }}
   </Story>
 </Canvas>
 
 ### AutoFocus
 
 <Canvas>
-  <Story name="autoFocus" parameters={{themeSelector: {fourColumnLayout: true}, chromatic: {viewports: [1800]}}}>
+  <Story
+    name="autoFocus"
+    parameters={{
+      themeSelector: { fourColumnLayout: true },
+      chromatic: { viewports: [1800] },
+    }}
+  >
     {() => {
       const [state, setState] = useState("01/10/2016");
       const setValue = ({ target }) => {
         setState(target.value.formattedValue);
       };
       return (
-        <div style={{height: 450, width: 450}}>
+        <div style={{ height: 450, width: 450 }}>
           <DateInput label="Date" value={state} onChange={setValue} autoFocus />
         </div>
-      )
+      );
     }}
   </Story>
 </Canvas>
@@ -114,7 +115,9 @@ be used to set the input value like in the example below, although the component
       const setValue = ({ target }) => {
         setState(target.value.formattedValue);
       };
-      return  <DateInput label="Date" value={state} onChange={setValue} disabled />
+      return (
+        <DateInput label="Date" value={state} onChange={setValue} disabled />
+      );
     }}
   </Story>
 </Canvas>
@@ -128,7 +131,9 @@ be used to set the input value like in the example below, although the component
       const setValue = ({ target }) => {
         setState(target.value.formattedValue);
       };
-      return <DateInput label="Date" value={state} onChange={setValue} readOnly />
+      return (
+        <DateInput label="Date" value={state} onChange={setValue} readOnly />
+      );
     }}
   </Story>
 </Canvas>
@@ -172,7 +177,15 @@ be used to set the input value like in the example below, although the component
       const setValue = ({ target }) => {
         setState(target.value.formattedValue);
       };
-      return <DateInput label="Date" value={state} onChange={setValue} labelInline name="dateinput" />
+      return (
+        <DateInput
+          label="Date"
+          value={state}
+          onChange={setValue}
+          labelInline
+          name="dateinput"
+        />
+      );
     }}
   </Story>
 </Canvas>
@@ -186,7 +199,15 @@ be used to set the input value like in the example below, although the component
       const setValue = ({ target }) => {
         setState(target.value.formattedValue);
       };
-      return <DateInput label="Date" value={state} onChange={setValue} labelInline labelWidth={10} />
+      return (
+        <DateInput
+          label="Date"
+          value={state}
+          onChange={setValue}
+          labelInline
+          labelWidth={10}
+        />
+      );
     }}
   </Story>
 </Canvas>
@@ -208,7 +229,7 @@ be used to set the input value like in the example below, although the component
           fieldHelp="Help"
           name="dateinput"
         />
-      )
+      );
     }}
   </Story>
 </Canvas>
@@ -231,7 +252,7 @@ be used to set the input value like in the example below, although the component
           name="dateinput"
           helpAriaLabel="Help"
         />
-      )
+      );
     }}
   </Story>
 </Canvas>
@@ -248,7 +269,14 @@ be used to set the input value like in the example below, although the component
       const setValue = ({ target }) => {
         setState(target.value.formattedValue);
       };
-      return <DateInput label="Date" value={state} onChange={setValue} disablePortal />
+      return (
+        <DateInput
+          label="Date"
+          value={state}
+          onChange={setValue}
+          disablePortal
+        />
+      );
     }}
   </Story>
 </Canvas>
@@ -264,7 +292,9 @@ You can use the `required` prop to indicate if the field is mandatory.
       const setValue = ({ target }) => {
         setState(target.value.formattedValue);
       };
-      return <DateInput label="Date" value={state} onChange={setValue} required />
+      return (
+        <DateInput label="Date" value={state} onChange={setValue} required />
+      );
     }}
   </Story>
 </Canvas>
@@ -284,7 +314,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
 <Canvas>
   <Story name="validations - string - component">
     {() => {
-     const [state1, setState1] = useState("01/10/2016");
+      const [state1, setState1] = useState("01/10/2016");
       const setValue1 = ({ target }) => {
         setState1(target.value.formattedValue);
       };
@@ -292,28 +322,26 @@ For more information check our [Validations](?path=/docs/documentation-validatio
       const setValue2 = ({ target }) => {
         setState2(target.value.formattedValue);
       };
-      return (
-        ["error", "warning", "info"].map((validationType) => (
-          <div key={`${validationType}-string-component`}>
-            <DateInput
-              label="Date"
-              value={state1}
-              onChange={setValue1}
-              {...{ [validationType]: "Message" }}
-              mb={2}
-            />
-            <DateInput
-              label="Date - readOnly"
-              value={state2}
-              onChange={setValue2}
-              readOnly
-              {...{ [validationType]: "Message" }}
-              mb={2}
-            />
-          </div>
-        ))
-      )}
-    }
+      return ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-component`}>
+          <DateInput
+            label="Date"
+            value={state1}
+            onChange={setValue1}
+            {...{ [validationType]: "Message" }}
+            mb={2}
+          />
+          <DateInput
+            label="Date - readOnly"
+            value={state2}
+            onChange={setValue2}
+            readOnly
+            {...{ [validationType]: "Message" }}
+            mb={2}
+          />
+        </div>
+      ));
+    }}
   </Story>
 </Canvas>
 
@@ -329,21 +357,19 @@ It is possible to use the `tooltipPosition` to override the default placement of
       const setValue = ({ target }) => {
         setState(target.value.formattedValue);
       };
-      return (
-        ["error", "warning", "info"].map((validationType) => (
-          <div key={`${validationType}-string-component`}>
-            <DateInput
-              label="Date"
-              value={state}
-              onChange={setValue}
-              {...{ [validationType]: "Message" }}
-              mb={2}
-              tooltipPosition="top"
-            />
-          </div>
-        ))
-      )}
-    }
+      return ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-component`}>
+          <DateInput
+            label="Date"
+            value={state}
+            onChange={setValue}
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="top"
+          />
+        </div>
+      ));
+    }}
   </Story>
 </Canvas>
 
@@ -360,30 +386,28 @@ It is possible to use the `tooltipPosition` to override the default placement of
       const setValue2 = ({ target }) => {
         setState2(target.value.formattedValue);
       };
-      return (
-        ["error", "warning", "info"].map((validationType) => (
-          <div key={`${validationType}-string-label`}>
-            <DateInput
-              label="Date"
-              value={state1}
-              onChange={setValue1}
-              validationOnLabel
-              {...{ [validationType]: "Message" }}
-              mb={2}
-            />
-            <DateInput
-              label="Date"
-               value={state2}
-              onChange={setValue2}
-              validationOnLabel
-              readOnly
-              {...{ [validationType]: "Message" }}
-              mb={2}
-            />
-          </div>
-        ))
-      )}
-    }
+      return ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-label`}>
+          <DateInput
+            label="Date"
+            value={state1}
+            onChange={setValue1}
+            validationOnLabel
+            {...{ [validationType]: "Message" }}
+            mb={2}
+          />
+          <DateInput
+            label="Date"
+            value={state2}
+            onChange={setValue2}
+            validationOnLabel
+            readOnly
+            {...{ [validationType]: "Message" }}
+            mb={2}
+          />
+        </div>
+      ));
+    }}
   </Story>
 </Canvas>
 
@@ -394,27 +418,25 @@ It is possible to use the `tooltipPosition` to override the default placement of
     name="validations - string - with tooltipPosition overriden - label"
     parameters={{ chromatic: { disable: true } }}
   >
-     {() => {
+    {() => {
       const [state, setState] = useState("01/10/2016");
       const setValue = ({ target }) => {
         setState(target.value.formattedValue);
       };
-      return (
-        ["error", "warning", "info"].map((validationType) => (
-          <div key={`${validationType}-string-component`}>
-            <DateInput
-              label="Date"
-              value={state}
-              onChange={setValue}
-              validationOnLabel
-              {...{ [validationType]: "Message" }}
-              mb={2}
-              tooltipPosition="top"
-            />
-          </div>
-        ))
-      )}
-    }
+      return ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-string-component`}>
+          <DateInput
+            label="Date"
+            value={state}
+            onChange={setValue}
+            validationOnLabel
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="top"
+          />
+        </div>
+      ));
+    }}
   </Story>
 </Canvas>
 
@@ -431,35 +453,36 @@ It is possible to use the `tooltipPosition` to override the default placement of
       const setValue2 = ({ target }) => {
         setState2(target.value.formattedValue);
       };
-      return (
-        ["error", "warning", "info"].map((validationType) => (
-          <div key={`${validationType}-boolean-component`}>
-            <DateInput
-              label="Date"
-              value={state1}
-              onChange={setValue1}
-              {...{ [validationType]: true }}
-            />
-            <DateInput
-              label="Date"
-              value={state2}
-              onChange={setValue2}
-              readOnly
-              {...{ [validationType]: true }}
-            />
-          </div>
-        ))
-      )}
-    }
+      return ["error", "warning", "info"].map((validationType) => (
+        <div key={`${validationType}-boolean-component`}>
+          <DateInput
+            label="Date"
+            value={state1}
+            onChange={setValue1}
+            {...{ [validationType]: true }}
+          />
+          <DateInput
+            label="Date"
+            value={state2}
+            onChange={setValue2}
+            readOnly
+            {...{ [validationType]: true }}
+          />
+        </div>
+      ));
+    }}
   </Story>
 </Canvas>
 
 #### Example implementation
 
-The example below will display an error if an invalid date or a date with a year value less than 2020 is passed to the input. 
+The example below will display an error if an invalid date or a date with a year value less than 2020 is passed to the input.
 
 <Canvas>
-  <Story name="validations - example implementation" parameters={{ chromatic: { disable: true } }}>
+  <Story
+    name="validations - example implementation"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
       const [state, setState] = useState("05/04/2022");
       const [validationState, setValidationState] = useState("");
@@ -468,7 +491,7 @@ The example below will display an error if an invalid date or a date with a year
       };
       const handleBlur = ({ target }) => {
         if (!target.value.rawValue) {
-          setValidationState("Error Invalid Date")
+          setValidationState("Error Invalid Date");
           return;
         }
         if (new Date(target.value.rawValue).getFullYear() <= 2020) {
@@ -483,22 +506,29 @@ The example below will display an error if an invalid date or a date with a year
             value={state}
             onChange={handleChange}
             onBlur={handleBlur}
-            error={validationState.includes("Error") ? validationState : undefined}
-            warning={validationState.includes("Warning") ? validationState : undefined}
+            error={
+              validationState.includes("Error") ? validationState : undefined
+            }
+            warning={
+              validationState.includes("Warning") ? validationState : undefined
+            }
           />
         </div>
-      )}
-    }
+      );
+    }}
   </Story>
 </Canvas>
 
 ### Locale override
 
-The examples below illustrates how to override the locale passed into the Date component. In this example it has been set up for 
+The examples below illustrates how to override the locale passed into the Date component. In this example it has been set up for
 the French locale. Required locales can be imported like so `import { fr } from 'carbon-react/lib/locales/date-fns-locales';`
 
 <Canvas>
-  <Story name="locale override - example implementation" parameters={{ chromatic: { disable: true } }}>
+  <Story
+    name="locale override - example implementation"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
       const [state, setState] = useState("05/04/2022");
       const handleChange = ({ target }) => {
@@ -506,16 +536,14 @@ the French locale. Required locales can be imported like so `import { fr } from 
       };
       return (
         <div>
-          <I18nProvider locale={{locale: () => "de", date: { dateFnsLocale: () => de }}}>
-            <DateInput
-              label="Date"
-              value={state}
-              onChange={handleChange}
-            />
+          <I18nProvider
+            locale={{ locale: () => "de", date: { dateFnsLocale: () => de } }}
+          >
+            <DateInput label="Date" value={state} onChange={handleChange} />
           </I18nProvider>
         </div>
-      )}
-    }
+      );
+    }}
   </Story>
 </Canvas>
 
@@ -547,7 +575,7 @@ Due to the `Textbox` component being used internally by the `Date` component the
     "warnOverLimit",
     "prefix",
     "inputIcon",
-    "iconTabIndex"
+    "iconTabIndex",
   ]}
 />
 

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
@@ -352,7 +352,10 @@ to have a possibility to manage active `Tabs` group
       );
       const ContentOne = (
         <div>
-          <Accordion borders="none" title={<Typography variant="h2">Example one details</Typography>}>
+          <Accordion
+            borders="none"
+            title={<Typography variant="h2">Example one details</Typography>}
+          >
             <Dl dtTextAlign="right" ddTextAlign="left">
               <Dt>Type</Dt>
               <Dd>Example Type Text</Dd>
@@ -388,7 +391,10 @@ to have a possibility to manage active `Tabs` group
               </Dd>
             </Dl>
           </Accordion>
-          <Accordion borders="none" title={<Typography variant="h2">Example one products</Typography>}>
+          <Accordion
+            borders="none"
+            title={<Typography variant="h2">Example one products</Typography>}
+          >
             <div>Example Product Content</div>
             <div>Example Product Content</div>
             <div>Example Product Content</div>
@@ -403,7 +409,10 @@ to have a possibility to manage active `Tabs` group
       );
       const ContentTwo = (
         <div>
-          <Accordion borders="none" title={<Typography variant="h2">Example two details</Typography>}>
+          <Accordion
+            borders="none"
+            title={<Typography variant="h2">Example two details</Typography>}
+          >
             <Dl dtTextAlign="right" ddTextAlign="left">
               <Dt>Type</Dt>
               <Dd>Example Type Text</Dd>
@@ -439,7 +448,10 @@ to have a possibility to manage active `Tabs` group
               </Dd>
             </Dl>
           </Accordion>
-          <Accordion borders="none" title={<Typography variant="h2">Example two products</Typography>}>
+          <Accordion
+            borders="none"
+            title={<Typography variant="h2">Example two products</Typography>}
+          >
             <div>Example Product Content</div>
             <div>Example Product Content</div>
             <div>Example Product Content</div>
@@ -454,7 +466,10 @@ to have a possibility to manage active `Tabs` group
       );
       const ContentThree = (
         <div>
-          <Accordion borders="none" title={<Typography variant="h2">Example three details</Typography>}>
+          <Accordion
+            borders="none"
+            title={<Typography variant="h2">Example three details</Typography>}
+          >
             <Dl dtTextAlign="right" ddTextAlign="left">
               <Dt>Type</Dt>
               <Dd>Example Type Text</Dd>
@@ -490,7 +505,10 @@ to have a possibility to manage active `Tabs` group
               </Dd>
             </Dl>
           </Accordion>
-          <Accordion borders="none" title={<Typography variant="h2">Example three products</Typography>}>
+          <Accordion
+            borders="none"
+            title={<Typography variant="h2">Example three products</Typography>}
+          >
             <div>Example Product Content</div>
             <div>Example Product Content</div>
             <div>Example Product Content</div>

--- a/src/components/dialog/dialog.component.js
+++ b/src/components/dialog/dialog.component.js
@@ -49,10 +49,8 @@ const Dialog = ({
   const { current: subtitleId } = useRef(createGuid());
 
   const centerDialog = useCallback(() => {
-    const {
-      width: dialogWidth,
-      height: dialogHeight,
-    } = dialogRef.current.getBoundingClientRect();
+    const { width: dialogWidth, height: dialogHeight } =
+      dialogRef.current.getBoundingClientRect();
 
     let midPointY = window.innerHeight / 2;
     let midPointX = window.innerWidth / 2;

--- a/src/components/dialog/dialog.stories.mdx
+++ b/src/components/dialog/dialog.stories.mdx
@@ -346,7 +346,7 @@ and setting the `autoFocus` on the element you wish to be focused instead (click
 
 ### Overriding the content padding
 
-Using the `contentPadding` prop will enable the padding of the `Dialog` content to be overriden, the example below has 
+Using the `contentPadding` prop will enable the padding of the `Dialog` content to be overriden, the example below has
 set the padding to 0. Please see the [table below](#props) for more iformation about the values accepted by this prop.
 
 <Canvas>
@@ -361,7 +361,7 @@ set the padding to 0. Please see the [table below](#props) for more iformation a
             onCancel={() => setIsOpen(false)}
             title="Title"
             subtitle="Subtitle"
-            contentPadding={{p: 0}}
+            contentPadding={{ p: 0 }}
           >
             <Form
               stickyFooter={true}
@@ -383,7 +383,8 @@ set the padding to 0. Please see the [table below](#props) for more iformation a
               <Textbox label="Surname" />
               <Textbox label="Birth Place" />
               <Textbox label="Favourite Colour" />
-              <Textbox label="Address" /><Textbox label="First Name" />
+              <Textbox label="Address" />
+              <Textbox label="First Name" />
               <Textbox label="Middle Name" />
               <Textbox label="Surname" />
               <Textbox label="Birth Place" />

--- a/src/components/dialog/dialog.style.js
+++ b/src/components/dialog/dialog.style.js
@@ -38,13 +38,8 @@ const calculateWidthValue = (props) => {
 };
 
 const calculateFormSpacingValues = (props, isFormContent) => {
-  const {
-    paddingTop,
-    paddingBottom,
-    paddingLeft,
-    paddingRight,
-    padding,
-  } = paddingFn(props);
+  const { paddingTop, paddingBottom, paddingLeft, paddingRight, padding } =
+    paddingFn(props);
 
   const spacingTopValue = paddingTop ?? padding ?? CONTENT_TOP_PADDING;
   const spacingRightValue = paddingRight ?? padding ?? HORIZONTAL_PADDING;

--- a/src/components/draggable/draggable.stories.mdx
+++ b/src/components/draggable/draggable.stories.mdx
@@ -120,11 +120,7 @@ import {
 
 ### DraggableItem
 
-<StyledSystemProps
-  noHeader
-  padding
-  defaults={{ py: "8px" }}
-/>
+<StyledSystemProps noHeader padding defaults={{ py: "8px" }} />
 
 <ArgsTable
   rows={[
@@ -132,14 +128,14 @@ import {
       name: "id",
       type: { summary: "string | number" },
       description:
-        'The id of the `DraggableItem`. Use this prop to make `Draggable` work. This prop is required.',
+        "The id of the `DraggableItem`. Use this prop to make `Draggable` work. This prop is required.",
       required: true,
     },
     {
       name: "children",
       type: { summary: "node" },
-      description:
-        'The content of the component. This prop is required.',
+      description: "The content of the component. This prop is required.",
       required: true,
     },
-  ]} />
+  ]}
+/>

--- a/src/components/drawer/drawer.stories.mdx
+++ b/src/components/drawer/drawer.stories.mdx
@@ -1017,7 +1017,7 @@ Use the `animationDuration` prop to alter the speed of the `Drawer` opening/clos
                         >
                           Filter
                         </Button>
-                      ); 
+                      );
                     }}
                     renderCloseComponent={() => {}}
                     open={isFilterOpen}

--- a/src/components/duelling-picklist/duelling-picklist.spec.js
+++ b/src/components/duelling-picklist/duelling-picklist.spec.js
@@ -175,9 +175,8 @@ describe("DuellingPicklist", () => {
   const MockComponent = ({ grouped }) => {
     const [notSelectedListItems, setNotSelectedItems] = useState([0, 1, 2]);
     const [selectedListItems, setSelectedItems] = useState([3, 4, 5]);
-    const [notSelectedListGroups, setNotSelectedGroups] = useState(
-      notSelectedGroups
-    );
+    const [notSelectedListGroups, setNotSelectedGroups] =
+      useState(notSelectedGroups);
     const [selectedListGroups, setSelectedGroups] = useState(selectedGroups);
 
     const addItem = (item) => {

--- a/src/components/duelling-picklist/picklist/picklist.component.js
+++ b/src/components/duelling-picklist/picklist/picklist.component.js
@@ -10,9 +10,10 @@ import PicklistGroup from "../picklist-group/picklist-group.component";
 export const Picklist = ({ disabled, children, placeholder, index }) => {
   const { elementToFocus, setElementToFocus } = useContext(FocusContext);
 
-  const isEmpty = useMemo(() => !React.Children.toArray(children).length, [
-    children,
-  ]);
+  const isEmpty = useMemo(
+    () => !React.Children.toArray(children).length,
+    [children]
+  );
 
   const filteredChildren = React.Children.toArray(children);
 

--- a/src/components/flat-table/flat-table-expandable.stories.mdx
+++ b/src/components/flat-table/flat-table-expandable.stories.mdx
@@ -87,7 +87,7 @@ export const FlatTableExpandableDefault = (args) => {
       </FlatTableBody>
     </FlatTable>
   );
-}
+};
 
 <Canvas>
   <Story
@@ -101,7 +101,7 @@ export const FlatTableExpandableDefault = (args) => {
     }}
     argTypes={{
       pl: {
-        options: [0,1,2,3,4,5,6,7,8,"25px","4em","69px","6em"],
+        options: [0, 1, 2, 3, 4, 5, 6, 7, 8, "25px", "4em", "69px", "6em"],
         control: {
           type: "select",
         },

--- a/src/components/flat-table/flat-table-test.stories.mdx
+++ b/src/components/flat-table/flat-table-test.stories.mdx
@@ -15,7 +15,7 @@ import {
 } from ".";
 import guid from "../../__internal__/utils/helpers/guid";
 import { FLAT_TABLE_SIZES, FLAT_TABLE_THEMES } from "./flat-table.config";
-import { FlatTableSortableStory } from "./flat-table.stories.mdx"
+import { FlatTableSortableStory } from "./flat-table.stories.mdx";
 
 <Meta
   title="Flat Table/Test"

--- a/src/components/form/form.stories.mdx
+++ b/src/components/form/form.stories.mdx
@@ -672,8 +672,8 @@ Please click on "Show code" below to see how to set these components up for alig
             inputWidth={30}
           />
         </Form>
-      )}
-    }
+      );
+    }}
   </Story>
 </Canvas>
 

--- a/src/components/heading/heading-test.stories.mdx
+++ b/src/components/heading/heading-test.stories.mdx
@@ -69,8 +69,8 @@ export const HeadingStory = ({
       helpLinkSpecialCharacters: undefined,
       backLink: "",
       backLinkSpecialCharacters: undefined,
-      divider: Heading.defaultProps.divider,
-      separator: Heading.defaultProps.separator,
+      divider: true,
+      separator: false,
     }}
   >
     {HeadingStory.bind({})}

--- a/src/components/heading/heading.component.js
+++ b/src/components/heading/heading.component.js
@@ -22,226 +22,146 @@ const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
 );
 
-class Heading extends React.Component {
-  /**
-   * Returns the help component.
-   *
-   * @method help
-   * @return {Object} JSX
-   */
-  get help() {
-    if (!this.props.help && !this.props.helpLink) {
-      return null;
-    }
-
+const Heading = ({
+  children,
+  backLink,
+  divider = true,
+  help,
+  helpAriaLabel,
+  helpLink,
+  pills,
+  separator = false,
+  subheader,
+  subtitleId,
+  title,
+  titleId,
+  ...rest
+}) => {
+  const getHelp = () => {
     return (
       <StyledHeaderHelp
         data-element="help"
         tooltipPosition="right"
-        href={this.props.helpLink}
-        ariaLabel={this.props.helpAriaLabel}
+        href={helpLink}
+        ariaLabel={helpAriaLabel}
       >
-        {this.props.help}
+        {help}
       </StyledHeaderHelp>
     );
-  }
+  };
 
-  /**
-   * Returns the back button.
-   *
-   * @method back
-   * @return {Object} JSX
-   */
-  get back() {
-    if (!this.props.backLink) {
-      return null;
-    }
-
-    let props;
-
-    if (typeof this.props.backLink === "string") {
-      props = { href: this.props.backLink };
-    } else {
-      props = { onClick: this.props.backLink };
-    }
+  const getBackButton = () => {
+    const backButtonProps =
+      typeof backLink === "string" ? { href: backLink } : { onClick: backLink };
 
     return (
       <StyledHeadingBackButton
         // this event allows an element to be focusable on click event on IE
         onMouseDown={(e) => e.currentTarget.focus()}
         data-element="back"
-        {...props}
+        {...backButtonProps}
       >
-        <StyledHeadingIcon type="chevron_left" divider={this.props.divider} />
+        <StyledHeadingIcon type="chevron_left" divider={divider} />
       </StyledHeadingBackButton>
     );
-  }
+  };
 
-  /**
-   * Returns the subheader.
-   *
-   * @method subheader
-   * @return {Object} JSX
-   */
-  get subheader() {
-    if (!this.props.subheader) {
-      return null;
-    }
-
+  const getSubheader = () => {
     return (
       <StyledSubHeader
         data-element="subtitle"
-        id={this.props.subtitleId}
-        hasBackLink={!!this.props.backLink}
-        hasSeparator={this.props.separator}
+        id={subtitleId}
+        hasBackLink={!!backLink}
+        hasSeparator={separator}
       >
-        {this.props.subheader}
+        {subheader}
       </StyledSubHeader>
     );
-  }
+  };
 
-  /**
-   * Returns the separator if enabled and needed.
-   *
-   * @method separator
-   * @return {Object} JSX
-   */
-  get separator() {
-    return this.props.separator ? <StyledSeparator /> : null;
-  }
-
-  /**
-   * Returns the separator if enabled and needed.
-   *
-   * @method divider
-   * @return {Object} JSX
-   */
-  get divider() {
-    return this.props.divider ? <StyledDivider data-element="divider" /> : null;
-  }
-
-  /**
-   * Returns pills if provided
-   *
-   * @method pills
-   * @return {Object} JSX
-   */
-  get pills() {
-    return this.props.pills ? (
-      <StyledHeadingPills data-element="pills">
-        {this.props.pills}
-      </StyledHeadingPills>
-    ) : null;
-  }
-
-  /**
-   * @method render
-   * @return {Object} JSX
-   */
-  render() {
-    if (!this.props.title) {
-      return null;
-    }
-
-    const marginProps = filterStyledSystemMarginProps(this.props);
-
+  const getPills = () => {
     return (
-      <StyledHeading {...tagComponent("heading", this.props)} {...marginProps}>
-        <StyledHeader
-          data-element="header-container"
-          divider={this.props.divider}
-          subheader={this.props.subheader}
-          hasBackLink={!!this.props.backLink}
-        >
-          {this.back}
-          <StyledHeaderContent>
-            <StyledHeadingTitle
-              withMargin={this.props.pills || this.props.help}
-              variant="h1"
-              data-element="title"
-              id={this.props.titleId}
-            >
-              {this.props.title}
-            </StyledHeadingTitle>
-            {this.help}
-            {this.pills}
-          </StyledHeaderContent>
-          {this.separator}
-          {this.subheader}
-        </StyledHeader>
-        {this.divider}
-        {this.props.children}
-      </StyledHeading>
+      <StyledHeadingPills data-element="pills">{pills}</StyledHeadingPills>
     );
-  }
-}
+  };
+
+  const marginProps = filterStyledSystemMarginProps(rest);
+  const dataAttributes = {
+    "data-element": rest["data-element"],
+    "data-role": rest["data-role"],
+  };
+
+  return title ? (
+    <StyledHeading
+      {...tagComponent("heading", dataAttributes)}
+      {...marginProps}
+    >
+      <StyledHeader
+        data-element="header-container"
+        divider={divider}
+        subheader={subheader}
+        hasBackLink={!!backLink}
+      >
+        {backLink && getBackButton()}
+        <StyledHeaderContent>
+          <StyledHeadingTitle
+            withMargin={pills || help}
+            variant="h1"
+            data-element="title"
+            id={titleId}
+          >
+            {title}
+          </StyledHeadingTitle>
+          {(help || helpLink) && getHelp()}
+          {pills && getPills()}
+        </StyledHeaderContent>
+        {separator && <StyledSeparator />}
+        {subheader && getSubheader()}
+      </StyledHeader>
+      {divider && <StyledDivider data-element="divider" />}
+      {children}
+    </StyledHeading>
+  ) : null;
+};
 
 Heading.propTypes = {
   ...marginPropTypes,
-  /**
-   * Children elements
-   */
+
+  /** Child elements */
   children: PropTypes.node,
 
-  /**
-   * Defines the title for the heading.
-   */
+  /** Defines the title for the heading. */
   title: PropTypes.node,
 
-  /**
-   * Defines the title id for the heading.
-   */
+  /** Defines the title id for the heading. */
   titleId: PropTypes.string,
 
-  /**
-   * Defines the subheader for the heading.
-   */
+  /** Defines the subheader for the heading. */
   subheader: PropTypes.node,
 
-  /**
-   * Defines the subtitle id for the heading.
-   */
+  /** Defines the subtitle id for the heading. */
   subtitleId: PropTypes.string,
 
-  /**
-   * Defines the help text for the heading.
-   */
+  /** Defines the help text for the heading. */
   help: PropTypes.string,
 
-  /**
-   * Defines the help link for the heading.
-   */
+  /** Defines the help link for the heading. */
   helpLink: PropTypes.string,
 
-  /**
-   * Defines the a href for the back link.
-   */
+  /** Defines the a href for the back link. */
   backLink: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 
-  /**
-   * Adds a divider below the heading and the content.
-   */
+  /** Adds a divider below the heading and the content. */
   divider: PropTypes.bool,
 
-  /**
-   * Adds a separator between the title and the subheader.
-   */
+  /** Adds a separator between the title and the subheader. */
   separator: PropTypes.bool,
 
-  /**
-   * Pills that will be added after the title.
-   */
+  /** Pills that will be added after the title. */
   pills: PropTypes.node,
 
-  /**
-   * Aria label for rendered help component
-   */
+  /** Aria label for rendered help component */
   helpAriaLabel: PropTypes.string,
-};
-
-Heading.defaultProps = {
-  divider: true,
-  separator: false,
 };
 
 export default Heading;

--- a/src/components/heading/heading.d.ts
+++ b/src/components/heading/heading.d.ts
@@ -2,8 +2,8 @@ import * as React from "react";
 import { MarginProps } from "styled-system";
 
 export interface HeadingProps extends MarginProps {
-  /** Custom className */
-  className?: string;
+  /** Child elements */
+  children?: React.ReactNode;
   /** Defines the title for the heading. */
   title?: React.ReactNode;
   /** Defines the title id for the heading. */
@@ -24,8 +24,10 @@ export interface HeadingProps extends MarginProps {
   separator?: boolean;
   /** Pills that will be added after the title. */
   pills?: React.ReactNode;
+  /** Aria label for rendered help component */
+  helpAriaLabel?: string;
 }
 
-declare class Heading extends React.Component<HeadingProps> {}
+declare function Heading(props: HeadingProps): JSX.Element | null;
 
 export default Heading;

--- a/src/components/help/help.stories.mdx
+++ b/src/components/help/help.stories.mdx
@@ -64,10 +64,7 @@ Hover over the help component to see the different positions.
     {() => {
       return ["right", "left", "top", "bottom"].map((position) => (
         <div style={{ margin: "64px 300px" }}>
-          <Help
-            tooltipPosition={position}
-            isFocused={true}
-          >
+          <Help tooltipPosition={position} isFocused={true}>
             {`This tooltip is positioned ${position}`}
           </Help>
         </div>
@@ -87,10 +84,7 @@ props accept and valid css color value.
     parameters={{ chromatic: { disable: true } }}
   >
     <div style={{ margin: "64px 300px" }}>
-      <Help
-        tooltipBgColor="lightblue"
-        tooltipFontColor="black"
-      >
+      <Help tooltipBgColor="lightblue" tooltipFontColor="black">
         The background and font color are overridden
       </Help>
     </div>
@@ -106,9 +100,7 @@ Using the `type` prop, different icons can be specified. In this example type ha
     {() => {
       return ["error", "add", "minus", "settings"].map((icon) => (
         <div style={{ margin: "64px" }}>
-          <Help
-            type={`${icon}`}
-          >
+          <Help type={`${icon}`}>
             {`This is the Help component with the ${icon} icon`}
           </Help>
         </div>
@@ -124,9 +116,7 @@ Using the `href` prop, a link can be specified.
 <Canvas>
   <Story name="with href" parameters={{ chromatic: { disable: true } }}>
     <div style={{ margin: "64px" }}>
-      <Help
-        href="https://carbon.sage.com"
-      >
+      <Help href="https://carbon.sage.com">
         This is the Help component with a href.
       </Help>
     </div>

--- a/src/components/modal/__internal__/modal-manager.js
+++ b/src/components/modal/__internal__/modal-manager.js
@@ -10,10 +10,8 @@ class ModalManagerInstance {
   }
 
   addModal = (modal, setTriggerRefocusFlag) => {
-    const {
-      modal: topModal,
-      setTriggerRefocusFlag: setTrapFlag,
-    } = this.#getTopModal();
+    const { modal: topModal, setTriggerRefocusFlag: setTrapFlag } =
+      this.#getTopModal();
 
     if (topModal && setTrapFlag) {
       setTrapFlag(false);

--- a/src/components/multi-action-button/multi-action-button.component.js
+++ b/src/components/multi-action-button/multi-action-button.component.js
@@ -34,9 +34,8 @@ const MultiActionButton = ({
   const listening = useRef(false);
   const isMainButtonFocused = useRef(false);
   const [showAdditionalButtons, setShowAdditionalButtons] = useState(false);
-  const [removeHandleClickOutside, setRemoveHandleClickOutside] = useState(
-    false
-  );
+  const [removeHandleClickOutside, setRemoveHandleClickOutside] =
+    useState(false);
   const [removeHandleKeyDown, setRemoveHandleKeyDown] = useState(false);
   const [minWidth, setMinWidth] = useState(0);
 

--- a/src/components/multi-step-wizard/step/__spec__.js
+++ b/src/components/multi-step-wizard/step/__spec__.js
@@ -50,7 +50,8 @@ describe("Step", () => {
     describe("when beforeSubmitValidation props is not null", () => {
       beforeEach(() => {
         spyBeforeSubmitValidation = jasmine.createSpy("beforeSubmitValidation");
-        instance.context.wizard.beforeSubmitValidation = spyBeforeSubmitValidation;
+        instance.context.wizard.beforeSubmitValidation =
+          spyBeforeSubmitValidation;
       });
 
       describe("when beforeSubmitValidation props does not returns true", () => {
@@ -89,7 +90,8 @@ describe("Step", () => {
     describe("when beforeSubmitValidation props is null", () => {
       beforeEach(() => {
         spyBeforeSubmitValidation = null;
-        instance.context.wizard.beforeSubmitValidation = spyBeforeSubmitValidation;
+        instance.context.wizard.beforeSubmitValidation =
+          spyBeforeSubmitValidation;
       });
 
       it("calls the parent wizard to complete", () => {

--- a/src/components/navigation-bar/navigation-bar.spec.tsx
+++ b/src/components/navigation-bar/navigation-bar.spec.tsx
@@ -198,22 +198,29 @@ describe("NavigationBar", () => {
     ["fixed", "bottom", undefined],
     ["sticky", "bottom", "10px"],
     ["fixed", "bottom", "10px"],
-  ])("should set correct position, orientation and offset", (position, orientation, offset) => {
-    wrapper = mount(
-      <NavigationBar position={position} orientation={orientation} offset={offset}>
-        <div>test content</div>
-      </NavigationBar>
-    );
-    assertStyleMatch(
-      {
-        position: `${position}`,
-        [orientation]: offset || "0",
-        ...(position === "fixed" && {
-          width: "100%",
-          boxSizing: "border-box",
-        })
-      },
-      wrapper
-    );
-  });
+  ])(
+    "should set correct position, orientation and offset",
+    (position, orientation, offset) => {
+      wrapper = mount(
+        <NavigationBar
+          position={position}
+          orientation={orientation}
+          offset={offset}
+        >
+          <div>test content</div>
+        </NavigationBar>
+      );
+      assertStyleMatch(
+        {
+          position: `${position}`,
+          [orientation]: offset || "0",
+          ...(position === "fixed" && {
+            width: "100%",
+            boxSizing: "border-box",
+          }),
+        },
+        wrapper
+      );
+    }
+  );
 });

--- a/src/components/navigation-bar/navigation-bar.stories.mdx
+++ b/src/components/navigation-bar/navigation-bar.stories.mdx
@@ -223,10 +223,16 @@ Then the `orientation` relative to the top/bottom can be offset using the `offse
 
 #### Fixed
 
-The `position` prop can be set to `fixed` to make the navigation bar fix to the viewport. Then the `orientation` relative to the 
+The `position` prop can be set to `fixed` to make the navigation bar fix to the viewport. Then the `orientation` relative to the
 top/bottom can be offset using the `offset` prop.
 
-<Story name="fixed" parameters={{ docs: { disable: true }, themeSelector: { chromaticTheme: "sage" } }}>
+<Story
+  name="fixed"
+  parameters={{
+    docs: { disable: true },
+    themeSelector: { chromaticTheme: "sage" },
+  }}
+>
   <div style={{ height: "calc(100% - 50px)" }}>
     <NavigationBar
       position="fixed"
@@ -306,10 +312,7 @@ top/bottom can be offset using the `offset` prop.
 </Story>
 
 <Canvas>
-  <DocsWrapper
-    src="iframe.html?id=navigation-bar--fixed"
-    height="400px"
-  />
+  <DocsWrapper src="iframe.html?id=navigation-bar--fixed" height="400px" />
 </Canvas>
 
 ## Props

--- a/src/components/navigation-bar/navigation-bar.style.ts
+++ b/src/components/navigation-bar/navigation-bar.style.ts
@@ -65,7 +65,8 @@ const StyledNavigationBar = styled.nav<StyledNavigationBarProps>`
     `}
 
   ${({ position, orientation, offset }) =>
-    position && orientation &&
+    position &&
+    orientation &&
     css`
       position: ${position};
       ${orientation}: ${offset};

--- a/src/components/pill/pill.style.js
+++ b/src/components/pill/pill.style.js
@@ -47,9 +47,8 @@ const PillStyle = styled.span`
           ? "var(--colorsUtilityYin090)"
           : "var(--colorsUtilityYang100)";
       } else {
-        const { varietyColor, buttonFocus, content } = styleConfig(theme)[
-          pillRole
-        ][variety];
+        const { varietyColor, buttonFocus, content } =
+          styleConfig(theme)[pillRole][variety];
         pillColor = varietyColor;
         buttonFocusColor = buttonFocus;
         contentColor = content;

--- a/src/components/progress-tracker/progress-tracker.spec.js
+++ b/src/components/progress-tracker/progress-tracker.spec.js
@@ -357,9 +357,8 @@ describe("ProgressBar", () => {
               display: "flex",
               justifyContent: "space-between",
               flexDirection: "column",
-              [labelsPosition === "left"
-                ? "paddingRight"
-                : "paddingLeft"]: "4px",
+              [labelsPosition === "left" ? "paddingRight" : "paddingLeft"]:
+                "4px",
             },
             wrapper.find(StyledValuesLabel)
           );

--- a/src/components/progress-tracker/progress-tracker.stories.mdx
+++ b/src/components/progress-tracker/progress-tracker.stories.mdx
@@ -404,19 +404,21 @@ It is possible to override the `labelsPosition` to `"left"` when in a `"vertical
 This component has `aria-valuemin`, `aria-valuemax`, `aria-valuenow` and `aria-valuetext` props that can be utilised to enhance the experience for a user that requires a screenreader.
 
 For more information on these props, please visit the W3 documentation on `role="progressbar"`. This can be accessed by clicking [here](https://www.w3.org/TR/wai-aria-1.1/#progressbar).
+
 ### Example
 
 <Canvas>
   <Story name="acessibility example">
     <div style={{ display: "flex", justifyContent: "space-around" }}>
-      <ProgressTracker 
+      <ProgressTracker
         currentProgressLabel="$100"
-        maxProgressLabel="$200" 
-        progress={50} 
-        aria-valuemin={0} 
-        aria-valuenow={50} 
-        aria-valuemax={100} 
-        aria-valuetext="$100"/>
+        maxProgressLabel="$200"
+        progress={50}
+        aria-valuemin={0}
+        aria-valuenow={50}
+        aria-valuemax={100}
+        aria-valuetext="$100"
+      />
     </div>
   </Story>
 </Canvas>

--- a/src/components/radio-button/radio-button-group.component.js
+++ b/src/components/radio-button/radio-button-group.component.js
@@ -4,7 +4,7 @@ import styledSystemPropTypes from "@styled-system/prop-types";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import Fieldset from "../../__internal__/fieldset";
 import RadioButtonGroupStyle from "./radio-button-group.style";
-import RadioButtonMapper from "./radio-button-mapper.component";
+import RadioButtonMapper from "../../__internal__/radio-button-mapper/radio-button-mapper.component";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";

--- a/src/components/select/select-list/select-list.spec.js
+++ b/src/components/select/select-list/select-list.spec.js
@@ -601,10 +601,8 @@ describe("SelectList", () => {
 
       it("then the focus function should have been called on the ListActionButton", () => {
         onFocusFn.mockClear();
-        wrapper
-          .find(ListActionButton)
-          .find("button")
-          .getDOMNode().focus = onFocusFn;
+        wrapper.find(ListActionButton).find("button").getDOMNode().focus =
+          onFocusFn;
         act(() => {
           testContainer.dispatchEvent(tabKeyDownEvent);
         });

--- a/src/components/select/select-list/update-list-scroll.js
+++ b/src/components/select/select-list/update-list-scroll.js
@@ -11,9 +11,8 @@ export default function updateListScrollTop(indexOfCurrent, list, options) {
 
   let newPosition = 0;
   const { offsetHeight: listHeight } = list;
-  const { offsetTop: itemTop, offsetHeight: currentItemHeight } = options[
-    indexOfCurrent
-  ].current;
+  const { offsetTop: itemTop, offsetHeight: currentItemHeight } =
+    options[indexOfCurrent].current;
 
   if (itemTop + currentItemHeight > listHeight) {
     newPosition = itemTop + currentItemHeight - listHeight;

--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -73,9 +73,10 @@ const SimpleSelect = React.forwardRef(
       value || defaultValue || ""
     );
 
-    const childOptions = useMemo(() => React.Children.toArray(children), [
-      children,
-    ]);
+    const childOptions = useMemo(
+      () => React.Children.toArray(children),
+      [children]
+    );
 
     const createCustomEvent = useCallback(
       (newValue) => {

--- a/src/components/simple-color-picker/simple-color-picker.component.js
+++ b/src/components/simple-color-picker/simple-color-picker.component.js
@@ -11,7 +11,7 @@ import Events from "../../__internal__/utils/helpers/events";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import Fieldset from "../../__internal__/fieldset";
 import SimpleColor from "./simple-color";
-import RadioButtonMapper from "../radio-button/radio-button-mapper.component";
+import RadioButtonMapper from "../../__internal__/radio-button-mapper/radio-button-mapper.component";
 import { StyledContent, StyledColorOptions } from "./simple-color-picker.style";
 import ValidationIcon from "../../__internal__/validations/validation-icon.component";
 import { InputGroupContext } from "../../__internal__/input-behaviour";
@@ -41,9 +41,10 @@ const SimpleColorPicker = (props) => {
     ...rest
   } = props;
 
-  const filteredChildren = useMemo(() => React.Children.toArray(children), [
-    children,
-  ]);
+  const filteredChildren = useMemo(
+    () => React.Children.toArray(children),
+    [children]
+  );
 
   const myRef = useRef(null);
   const [blurBlocked, setIsBlurBlocked] = useState(isBlurBlocked);

--- a/src/components/tabs/tabs.component.js
+++ b/src/components/tabs/tabs.component.js
@@ -109,9 +109,10 @@ const Tabs = ({
   );
 
   /** Returns true/false for if the given tab id is selected. */
-  const isTabSelected = useCallback((tabId) => tabId === selectedTabIdState, [
-    selectedTabIdState,
-  ]);
+  const isTabSelected = useCallback(
+    (tabId) => tabId === selectedTabIdState,
+    [selectedTabIdState]
+  );
 
   const hasTabStop = useCallback((tabId) => tabId === tabStopId, [tabStopId]);
 

--- a/src/components/tabs/tabs.stories.mdx
+++ b/src/components/tabs/tabs.stories.mdx
@@ -1479,12 +1479,19 @@ prop to the `Tab` component.
               title="Tab 1"
               key="tab-1"
               customLayout={
-                <Box width="calc(100% - 30px)" display="flex" flexDirection="column" padding="4px 4px 22px 14px">
+                <Box
+                  width="calc(100% - 30px)"
+                  display="flex"
+                  flexDirection="column"
+                  padding="4px 4px 22px 14px"
+                >
                   <Box display="flex" justifyContent="flex-end">
                     <Icon type="settings" color="primary" />
                     <Icon type="home" />
                   </Box>
-                  <Box display="flex" justifyContent="flex-start">Tab 1</Box>
+                  <Box display="flex" justifyContent="flex-start">
+                    Tab 1
+                  </Box>
                 </Box>
               }
             >
@@ -1502,12 +1509,19 @@ prop to the `Tab` component.
               title="Tab 2"
               key="tab-2"
               customLayout={
-                <Box width="calc(100% - 30px)" display="flex" flexDirection="column" padding="4px 4px 22px 14px">
+                <Box
+                  width="calc(100% - 30px)"
+                  display="flex"
+                  flexDirection="column"
+                  padding="4px 4px 22px 14px"
+                >
                   <Box display="flex" justifyContent="flex-end">
-                    <Icon type="settings" color="primary"/>
+                    <Icon type="settings" color="primary" />
                     <Icon type="home" />
                   </Box>
-                  <Box display="flex" justifyContent="flex-start">Tab 2</Box>
+                  <Box display="flex" justifyContent="flex-start">
+                    Tab 2
+                  </Box>
                 </Box>
               }
             >
@@ -1525,12 +1539,19 @@ prop to the `Tab` component.
               title="Tab 3"
               key="tab-3"
               customLayout={
-                <Box width="calc(100% - 30px)" display="flex" flexDirection="column" padding="4px 4px 22px 14px">
+                <Box
+                  width="calc(100% - 30px)"
+                  display="flex"
+                  flexDirection="column"
+                  padding="4px 4px 22px 14px"
+                >
                   <Box display="flex" justifyContent="flex-end">
                     <Icon type="settings" color="primary" />
                     <Icon type="home" />
                   </Box>
-                  <Box display="flex" justifyContent="flex-start">Tab 3</Box>
+                  <Box display="flex" justifyContent="flex-start">
+                    Tab 3
+                  </Box>
                 </Box>
               }
             >

--- a/src/components/text-editor/__internal__/utils/utils.js
+++ b/src/components/text-editor/__internal__/utils/utils.js
@@ -139,9 +139,8 @@ export const getSelectedLength = (value) => {
   let length = 0;
 
   if (!selection.isCollapsed()) {
-    const { startKey, endKey, startOffset, endOffset } = getSelectionInfo(
-      value
-    );
+    const { startKey, endKey, startOffset, endOffset } =
+      getSelectionInfo(value);
     const { content, blockLength } = getContentInfo(value);
     const startLength = blockLength - startOffset;
     const keyAfterEnd = content.getKeyAfter(endKey);

--- a/src/components/text-editor/text-editor.stories.mdx
+++ b/src/components/text-editor/text-editor.stories.mdx
@@ -319,8 +319,9 @@ icon. This example has mocked some functionality: previews will display for any 
       };
       const checkValidDomain = (url) => {
         const domainsWhitelist = [".com", ".co.uk", ".org", ".net"];
-        const result = domainsWhitelist.filter((domain) => url.endsWith(domain))
-          .length;
+        const result = domainsWhitelist.filter((domain) =>
+          url.endsWith(domain)
+        ).length;
         return !!result;
       };
       const addUrl = (reportedUrl) => {

--- a/src/components/tile-select/tile-select-group.component.js
+++ b/src/components/tile-select/tile-select-group.component.js
@@ -4,7 +4,7 @@ import styledSystemPropTypes from "@styled-system/prop-types";
 
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import TileSelect from "./tile-select.component";
-import RadioButtonMapper from "../radio-button/radio-button-mapper.component";
+import RadioButtonMapper from "../../__internal__/radio-button-mapper/radio-button-mapper.component";
 import {
   StyledTileSelectFieldset,
   StyledGroupDescription,

--- a/src/components/tile-select/tile-select.spec.js
+++ b/src/components/tile-select/tile-select.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { mount } from "enzyme";
-import RadioButtonMapper from "../radio-button/radio-button-mapper.component";
+import RadioButtonMapper from "../../__internal__/radio-button-mapper/radio-button-mapper.component";
 import { TileSelect, TileSelectGroup } from ".";
 
 import {

--- a/src/style/palette/index.js
+++ b/src/style/palette/index.js
@@ -1,14 +1,17 @@
 import tint from "../utils/tint";
 import shade from "../utils/shade";
 
-const cachedFunc = (cb) => (cache = {}) => (weight) => {
-  if (cache[weight]) {
-    return cache[weight];
-  }
-  const color = cb(weight);
-  cache[weight] = color;
-  return color;
-};
+const cachedFunc =
+  (cb) =>
+  (cache = {}) =>
+  (weight) => {
+    if (cache[weight]) {
+      return cache[weight];
+    }
+    const color = cb(weight);
+    cache[weight] = color;
+    return color;
+  };
 
 /**
  * Takes a config object of base colors and, for each base, generates functions


### PR DESCRIPTION
BREAKING CHANGE: `Heading` has been refactored from a class-based to a functional-based component - therefore cannot be extended anymore.

BREAKING CHANGE: `RadioButtonMapper` is now an internal component and can no longer be
imported by consuming apps.

### Proposed behaviour

- Rewrite `Heading` to a functional component.
- Move `RadioButtonMapper` to internal components directory

### Current behaviour

- `Heading` is currently class-based.
- `RadioButtonMapper` can be imported by consuming apps - even though it's only intended to be used internally.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~[ ] Related issues linked in commit messages if required~~
~~[ ] Screenshots are included in the PR if useful~~
~~[ ] All themes are supported if required~~
~~[ ] Unit tests added or updated if required~~
~~[ ] Cypress automation tests added or updated if required~~
- [x] Storybook added or updated if required
~~[ ] Translations added or updated (including creating or amending translation keys table in storybook) if required~~
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

Prettier has been run to fix some linting issues, but this has updated a lot of files. The only files relevant to this PR are:
- `src/__internal__/radio-button-mapper/`
- `src/components/heading/`

### Testing instructions

Double-check stories for any major regressions.
