### PR TITLE
fix(textbox): prevent axe issue when the validation string is empty (FE-4982)

### DIFF
--- a/src/hooks/__internal__/useInputAccessibility/useInputAccessibility.js
+++ b/src/hooks/__internal__/useInputAccessibility/useInputAccessibility.js
@@ -8,9 +8,9 @@ export default function useInputAccessibility({
 }) {
   const labelId = label ? `${id}-label` : undefined;
 
-  const validationIconId = [error, warning, info].filter(
-    (validation) => typeof validation === "string"
-  ).length
+  const validationIconId = [error, warning, info].filter((validation) => {
+    return validation && typeof validation === "string";
+  }).length
     ? `${id}-validation-icon`
     : undefined;
 


### PR DESCRIPTION
### Proposed behaviour

check for empty string when creating the validation icon id

### Current behaviour

when the validation string is empty, aria-describedby is filled with non existent id

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

fixes #4839

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
