### PR TITLE
refactor(sticky-footer, slide, select-list): replace colorsComponentsNavigation tokens - FE-5002

### DIFF
--- a/src/__internal__/sticky-footer/sticky-footer.spec.js
+++ b/src/__internal__/sticky-footer/sticky-footer.spec.js
@@ -87,7 +87,7 @@ describe("StickyFooter component", () => {
             width: "100%",
             bottom: "0",
             left: "0",
-            backgroundColor: "var(--colorsComponentsNavigationYang100)",
+            backgroundColor: "var(--colorsActionMinorYang100)",
             boxShadow: "var(--boxShadow150)",
             zIndex: "1000",
           },

--- a/src/__internal__/sticky-footer/sticky-footer.style.js
+++ b/src/__internal__/sticky-footer/sticky-footer.style.js
@@ -16,7 +16,7 @@ const StyledStickyFooter = styled.div`
       position: sticky;
       bottom: 0;
       left: 0;
-      background-color: var(--colorsComponentsNavigationYang100);
+      background-color: var(--colorsActionMinorYang100);
       box-shadow: var(--boxShadow150);
       z-index: 1000;
     `}

--- a/src/components/carousel/slide/slide.style.js
+++ b/src/components/carousel/slide/slide.style.js
@@ -13,7 +13,7 @@ const SlideStyle = styled.div`
     opacity: 0.3;
     margin: 30px 0;
     box-shadow: var(--boxShadow200);
-    background-color: var(--colorsComponentsNavigationYang100);
+    background-color: var(--colorsUtilityYang100);
 
     ${id === selectedIndex &&
     css`

--- a/src/components/select/select-list/select-list.style.js
+++ b/src/components/select/select-list/select-list.style.js
@@ -93,7 +93,7 @@ const StyledSelectListTableHeader = styled.thead`
       bottom: -8px;
       left: 0px;
       background-image: linear-gradient(
-        var(--colorsComponentsNavigationYin100),
+        var(--colorsUtilityMajor800),
         var(--colorsUtilityYang100)
       );
       opacity: 0.03;


### PR DESCRIPTION
### Proposed behaviour
Replaces deprecated tokens from the design-tokens package: `colorsComponentsNavigation`
Up

### Current behaviour
Sticky-footer, slide and select-list use the `colorsComponentsNavigation` tokens

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Details of token substitution in the task FE-5002 - comments.
