### PR TITLE
docs(select): stop stories from crashing when opening select

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -11,9 +11,11 @@ import "cypress-storybook/react";
 // Temporary fix for issue mentioned in FE-2565 ticket
 // Should be solved by the storybook team in foreseeable future
 // https://github.com/storybookjs/storybook/issues/9948
+// This usage is legacy (https://github.com/storybookjs/storybook/blob/master/addons/actions/ADVANCED.md)
+// and will be removed in Storybook v7
 configureActions({
   // Maximum depth of serialization for large objects
-  depth: 4,
+  depth: 6,
   // Limit the number of items logged into the actions panel
   limit: 20,
 });
@@ -78,7 +80,7 @@ export const parameters = {
   },
   chromatic: { disable: false },
   viewport: { viewports: customViewports },
-  actions: { argTypesRegex: "^on.*" },
+  actions: { argTypesRegex: "^on[A-Z].*" },
   viewMode: process.env.STORYBOOK_VIEW_MODE,
 };
 

--- a/cypress/integration/common/simpleSelect.feature
+++ b/cypress/integration/common/simpleSelect.feature
@@ -109,7 +109,7 @@ Feature: Select component
 
   @positive
   Scenario: Check the onOpen, onClick, onFocus after clicking on the Select Textbox
-    Given I open "Select" component page "default story"
+    Given I open "Select Test" component page "default"
     When I click on Select text
     Then onOpen action was called in Actions Tab
       And onFocus action was called in Actions Tab
@@ -117,14 +117,14 @@ Feature: Select component
 
   @positive
   Scenario: Check the onChange event by clicking mouse on the select list option
-    Given I open "Select" component page "default story"
+    Given I open "Select Test" component page "default"      
       And I click on Select text
     When I click on "first" option on Select list
     Then onChange action was called in Actions Tab
 
   @positive
   Scenario: Check the onKeyDown event after pressing the downarrow key
-    Given I open "Select" component page "default story"
+    Given I open "Select Test" component page "default"
       And I click on Select text
     When I press the "downarrow" key, when focused on the input
       And I wait 500
@@ -133,7 +133,7 @@ Feature: Select component
 
   @positive
   Scenario Outline: Check the onKeyDown event after press <key>
-    Given I open "Select" component page "default story"
+    Given I open "Select Test" component page "default"
       And I click on Select text
     When I press the "<key>" key, when focused on the input
       And I wait 500
@@ -147,7 +147,7 @@ Feature: Select component
 
   @positive
   Scenario: Check the onBlur event
-    Given I open "Select" component page "default story"
+    Given I open "Select Test" component page "default"
       And I click on Select text
     When I click on Select label
     Then onBlur action was called in Actions Tab

--- a/src/components/select/simple-select/simple-select-test.stories.js
+++ b/src/components/select/simple-select/simple-select-test.stories.js
@@ -1,7 +1,4 @@
-// it's not mdx file because of https://github.com/storybookjs/storybook/issues/11542
-
 import React from "react";
-import { action } from "@storybook/addon-actions";
 
 import { Select, Option } from "..";
 
@@ -15,11 +12,20 @@ export default {
     },
   },
   argTypes: {
-    value: {
-      table: {
-        disabled: true,
-      },
-    },
+    value: { table: { disable: true }, control: false },
+    disablePortal: { table: { disable: true }, control: false },
+    defaultValue: { table: { disable: true }, control: false },
+    children: { table: { disable: true }, control: false },
+    openOnFocus: { table: { disable: true }, control: false },
+    transparent: { table: { disable: true }, control: false },
+    tableHeader: { table: { disable: true }, control: false },
+    multiColumn: { table: { disable: true }, control: false },
+    isLoading: { table: { disable: true }, control: false },
+    onListScrollBottom: { table: { disable: true }, control: false },
+    tooltipPosition: { table: { disable: true }, control: false },
+    "data-component": { table: { disable: true }, control: false },
+    "data-element": { table: { disable: true }, control: false },
+    "data-role": { table: { disable: true }, control: false },
     listPlacement: {
       options: [
         "auto",
@@ -42,24 +48,42 @@ export default {
         type: "select",
       },
     },
+    onOpen: {
+      action: "onOpen",
+      table: { disable: true },
+      control: false,
+    },
+    onChange: {
+      action: "onChange",
+      table: { disable: true },
+      control: false,
+    },
+    onClick: {
+      action: "onClick",
+      table: { disable: true },
+      control: false,
+    },
+    onFocus: {
+      action: "onFocus",
+      table: { disable: true },
+      control: false,
+    },
+    onBlur: {
+      action: "onBlur",
+      table: { disable: true },
+      control: false,
+    },
+    onKeyDown: {
+      action: "onKeyDown",
+      table: { disable: true },
+      control: false,
+    },
   },
 };
 
-const Default = (args) => {
+const Template = (args) => {
   return (
-    <Select
-      name="simple"
-      id="simple"
-      label="label"
-      labelInline
-      onOpen={action("onOpen")}
-      onChange={action("onChange", { depth: 2 })}
-      onClick={action("onClick", { depth: 2 })}
-      onFocus={action("onFocus", { depth: 2 })}
-      onBlur={action("onBlur", { depth: 2 })}
-      onKeyDown={action("onKeyDown", { depth: 2 })}
-      {...args}
-    >
+    <Select name="simple" id="simple" label="label" labelInline {...args}>
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
       <Option text="Blue" value="3" />
@@ -78,28 +102,10 @@ const Default = (args) => {
   );
 };
 
-Default.storyName = "default";
-Default.argTypes = {
-  value: { table: { disable: true }, control: false },
-  disablePortal: { table: { disable: true }, control: false },
-  defaultValue: { table: { disable: true }, control: false },
-  children: { table: { disable: true }, control: false },
-  openOnFocus: { table: { disable: true }, control: false },
-  transparent: { table: { disable: true }, control: false },
-  tableHeader: { table: { disable: true }, control: false },
-  multiColumn: { table: { disable: true }, control: false },
-  onOpen: { table: { disable: true }, control: false },
-  isLoading: { table: { disable: true }, control: false },
-  onListScrollBottom: { table: { disable: true }, control: false },
-  tooltipPosition: { table: { disable: true }, control: false },
-  "data-component": { table: { disable: true }, control: false },
-  "data-element": { table: { disable: true }, control: false },
-  "data-role": { table: { disable: true }, control: false },
-};
+export const Default = Template.bind({});
+
 Default.args = {
   mt: 0,
   listPlacement: undefined,
   flipEnabled: true,
 };
-
-export { Default };

--- a/src/components/select/simple-select/simple-select.stories.mdx
+++ b/src/components/select/simple-select/simple-select.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, ArgsTable, Canvas, Story } from "@storybook/addon-docs";
-import { action } from "@storybook/addon-actions";
 import StyledSystemProps from "../../../../.storybook/utils/styled-system-props";
 import TranslationKeysTable from "../../../../.storybook/utils/translation-keys-table";
 
@@ -41,18 +40,7 @@ Always insert `Option` Components inside the `Select`, analogous to the original
 
 <Canvas>
   <Story name="default">
-    <Select
-      name="simple"
-      id="simple"
-      label="color"
-      labelInline
-      onOpen={action("onOpen")}
-      onChange={action("onChange", { depth: 2 })}
-      onClick={action("onClick", { depth: 2 })}
-      onFocus={action("onFocus", { depth: 2 })}
-      onBlur={action("onBlur", { depth: 2 })}
-      onKeyDown={action("onKeyDown", { depth: 2 })}
-    >
+    <Select name="simple" id="simple" label="color" labelInline>
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
       <Option text="Blue" value="3" />
@@ -106,12 +94,6 @@ You can use `listPlacement` prop to set the position of the select list relative
       id="simple"
       label="color"
       labelInline
-      onOpen={action("onOpen")}
-      onChange={action("onChange", { depth: 2 })}
-      onClick={action("onClick", { depth: 2 })}
-      onFocus={action("onFocus", { depth: 2 })}
-      onBlur={action("onBlur", { depth: 2 })}
-      onKeyDown={action("onKeyDown", { depth: 2 })}
       listPlacement="top-start"
     >
       <Option text="Amber" value="1" />
@@ -137,7 +119,6 @@ You can use `listPlacement` prop to set the position of the select list relative
       const [value, setValue] = useState("");
       function onChangeHandler(event) {
         setValue(event.target.value);
-        action("value set");
       }
       function clearValue() {
         setValue("");


### PR DESCRIPTION
### Proposed behaviour

- Change the maximum depth for action objects to 6, as it's broken for anything less than 5. 6 allows us to see the option selected on the onChange action for Select.
- Remove actions completely from Select docs, we only need them in the test stories. 
- Update implementation of actions in the test stories
- Change Cypress to run the actions tests over the test stories

![image](https://user-images.githubusercontent.com/14963680/157417282-50583982-ee9f-4bd8-8987-96086cec8cd6.png)

 

### Current behaviour

As per #4878, whenever you try to open Select (via keyboard or mouse) in Storybook, it crashes the page.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

You can test the new actions implementation here: http://localhost:9001/?path=/story/select-test--default