### PR TITLE
feat(sidebar-header): describe sidebar-header using design tokens, update tests - FE-5021

### DIFF
--- a/src/components/sidebar/__internal__/sidebar-header/sidebar-header.spec.js
+++ b/src/components/sidebar/__internal__/sidebar-header/sidebar-header.spec.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
+
 import SidebarHeader from "./sidebar-header.component";
 import SidebarHeaderStyle from "./sidebar-header.style";
 import Textbox from "../../../textbox";
-import baseTheme from "../../../../style/themes/base";
 import { assertStyleMatch } from "../../../../__spec_helper__/test-utils";
 
 describe("Sidebar Header", () => {
@@ -25,12 +25,12 @@ describe("SidebarHeaderStyle", () => {
     const wrapper = mount(<SidebarHeaderStyle />);
     assertStyleMatch(
       {
-        backgroundColor: baseTheme.colors.white,
-        boxShadow: `inset 0 -1px 0 0 ${baseTheme.disabled.border}`,
+        backgroundColor: "var(--colorsUtilityMajor025)",
+        boxShadow: "inset 0 -1px 0 0 var(--colorsUtilityMajor100)",
         boxSizing: "border-box",
         padding: "27px 32px 32px 32px",
         width: "100%",
-        color: baseTheme.text.color,
+        color: "var(--colorsActionMinorYin090)",
       },
       wrapper.find("div")
     );

--- a/src/components/sidebar/__internal__/sidebar-header/sidebar-header.style.js
+++ b/src/components/sidebar/__internal__/sidebar-header/sidebar-header.style.js
@@ -1,18 +1,13 @@
 import styled from "styled-components";
-import baseTheme from "../../../../style/themes/base";
 
 const SidebarHeaderStyle = styled.div`
-  background-color: ${({ theme }) => theme.colors.white};
-  box-shadow: inset 0 -1px 0 0 ${({ theme }) => theme.disabled.border};
+  background-color: var(--colorsUtilityMajor025);
+  box-shadow: inset 0 -1px 0 0 var(--colorsUtilityMajor100);
   box-sizing: border-box;
   width: 100%;
-  color: ${({ theme }) => theme.text.color};
+  color: var(--colorsActionMinorYin090);
   transition: all 0.2s ease;
   padding: 27px 32px 32px 32px;
 `;
-
-SidebarHeaderStyle.defaultProps = {
-  theme: baseTheme,
-};
 
 export default SidebarHeaderStyle;


### PR DESCRIPTION
### Proposed behaviour

Describes sidebar-header component using design tokens.
Changes background color: `--colorsUtilityMajor025`
Updates tests when the above changes are made.

### Current behaviour

Sidebar header component use theme styled-component property.
Currently the background color is `rgb(255, 255, 255)`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

![Zrzut ekranu 2022-03-4 o 14 42 43](https://user-images.githubusercontent.com/44143630/156773976-8e14a220-e2ee-4b3e-ab9e-94ccfce11c40.png)

### Testing instructions
The correct appearance can be checked in the component: `Sidebar`
Use devtools to check if component use css variables.
