### PR TITLE
fix(multi-select): prevent component calling onChange on first render when uncontrolled FE-4884

### DIFF
--- a/src/components/select/multi-select/multi-select.component.js
+++ b/src/components/select/multi-select/multi-select.component.js
@@ -135,7 +135,7 @@ const MultiSelect = React.forwardRef(
           }
           const newValue = [...previousValue];
           newValue.splice(index, 1);
-          if (isControlled.current && onChange) {
+          if (onChange) {
             onChange(createCustomEvent(newValue));
             return newValue;
           }
@@ -300,12 +300,6 @@ const MultiSelect = React.forwardRef(
       }
     }, [filterText, onFilterChange]);
 
-    useEffect(() => {
-      if (!isControlled.current && onChange) {
-        onChange(createCustomEvent(selectedValue));
-      }
-    }, [createCustomEvent, onChange, selectedValue]);
-
     function handleTextboxClick(event) {
       isMouseDownReported.current = false;
 
@@ -427,6 +421,10 @@ const MultiSelect = React.forwardRef(
 
           if (isAlreadySelected) {
             return previousValue;
+          }
+
+          if (onChange) {
+            onChange(createCustomEvent([...previousValue, newValue]));
           }
 
           return [...previousValue, newValue];

--- a/src/components/select/multi-select/multi-select.spec.js
+++ b/src/components/select/multi-select/multi-select.spec.js
@@ -839,6 +839,41 @@ describe("MultiSelect", () => {
       expect(label.prop("isRequired")).toBe(true);
     });
   });
+
+  describe("uncontrolled", () => {
+    const onChangeFn = jest.fn();
+    const mockOptionObject = {
+      value: "opt1",
+      text: "red",
+    };
+    const textboxProps = {
+      name: "testName",
+      id: "testId",
+    };
+    const expectedEventObject = {
+      target: {
+        ...textboxProps,
+        value: ["opt1"],
+      },
+    };
+    const wrapper = renderSelect({
+      ...textboxProps,
+      onChange: onChangeFn,
+      openOnFocus: true,
+    });
+
+    it("does not call the onChange callback on first render", () => {
+      expect(onChangeFn).not.toHaveBeenCalled();
+    });
+
+    it("calls the onChange callback when an update occurs after first render", () => {
+      wrapper.find("input").simulate("focus");
+      act(() => {
+        wrapper.find(SelectList).prop("onSelect")(mockOptionObject);
+      });
+      expect(onChangeFn).toHaveBeenCalledWith(expectedEventObject);
+    });
+  });
 });
 
 describe("coverage filler for else path", () => {


### PR DESCRIPTION
fix #4727

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Removes `useEffect` and make `onChange` calls within `setSelectedValue`

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`onChange` is called on first render

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
