### PR TITLE
test(test-utils): refactor expectError to catch console warn and rename to expectConsoleOutput FE-5023

### DIFF
--- a/src/__spec_helper__/test-utils.js
+++ b/src/__spec_helper__/test-utils.js
@@ -457,37 +457,38 @@ const testStyledSystemBackground = (component, styleContainer) => {
   );
 };
 
-const expectError = (errorMessage) => {
-  if (!errorMessage) {
-    throw new Error("no error message provided");
+// this util will catch that a console output occurred without polluting the output when running the unit tests
+const expectConsoleOutput = (message, type = "error") => {
+  if (!message) {
+    throw new Error(`no ${type} message provided`);
   }
 
   expect.assertions(1);
 
-  const { error } = global.console;
-  let errorArgs;
+  const consoleType = global.console[type];
+  let consoleArgs;
 
-  jest.spyOn(global.console, "error").mockImplementation((...args) => {
+  jest.spyOn(global.console, type).mockImplementation((...args) => {
     if (!args.length) return;
 
     const msg = args.join(" ");
     const params = args.slice(1, args.length);
 
-    if (sprintf(msg, ...params).includes(errorMessage)) {
-      errorArgs = args;
+    if (sprintf(msg, ...params).includes(message)) {
+      consoleArgs = args;
       return;
     }
 
-    error(...args);
+    consoleType(...args);
   });
 
   return () => {
-    if (errorArgs) {
+    if (consoleArgs) {
       // eslint-disable-next-line no-console
-      expect(console.error).toHaveBeenCalledWith(...errorArgs);
+      expect(console[type]).toHaveBeenCalledWith(...consoleArgs);
     }
 
-    global.console.error = error;
+    global.console[type] = consoleType;
   };
 };
 
@@ -514,5 +515,5 @@ export {
   testStyledSystemLayout,
   testStyledSystemFlexBox,
   testStyledSystemBackground,
-  expectError,
+  expectConsoleOutput,
 };

--- a/src/components/button-bar/button-bar.spec.js
+++ b/src/components/button-bar/button-bar.spec.js
@@ -6,7 +6,7 @@ import Button from "../button/button.component";
 import ButtonBar from "./button-bar.component";
 import {
   assertStyleMatch,
-  expectError,
+  expectConsoleOutput as expectError,
 } from "../../__spec_helper__/test-utils";
 import IconButton from "../icon-button/icon-button.component";
 

--- a/src/components/button/button.component.js
+++ b/src/components/button/button.component.js
@@ -5,6 +5,7 @@ import Icon from "../icon";
 import StyledButton, { StyledButtonSubtext } from "./button.style";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
+import Logger from "../../__internal__/utils/logger";
 
 function renderChildren({
   /* eslint-disable react/prop-types */
@@ -69,6 +70,8 @@ function renderChildren({
   );
 }
 
+let deprecatedWarnTriggered = false;
+
 const Button = ({
   size,
   subtext,
@@ -90,9 +93,17 @@ const Button = ({
   iconTooltipPosition,
   ...rest
 }) => {
+  if (!deprecatedWarnTriggered && as) {
+    deprecatedWarnTriggered = true;
+    Logger.deprecate(
+      // eslint-disable-next-line max-len
+      "The `as` prop is deprecated and will soon be removed. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop"
+    );
+  }
+
   const [internalRef, setInternalRef] = useState(null);
 
-  const buttonType = buttonTypeProp || as;
+  const buttonType = as || buttonTypeProp;
 
   if (subtext.length > 0 && size !== "large") {
     throw new Error("subtext prop has no effect unless the button is large");
@@ -247,7 +258,7 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
-  as: "secondary",
+  buttonType: "secondary",
   size: "medium",
   fullWidth: false,
   disabled: false,

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -10,7 +10,7 @@ import StyledButton from "./button.style";
 import {
   assertStyleMatch,
   testStyledSystemSpacing,
-  expectConsoleOutput as expectError,
+  expectConsoleOutput,
 } from "../../__spec_helper__/test-utils";
 import { rootTagTest } from "../../__internal__/utils/helpers/tags/tags-specs";
 import StyledIcon from "../icon/icon.style";
@@ -225,7 +225,7 @@ describe("Button", () => {
     it("throws an error", () => {
       const errorMessage =
         "Warning: Failed prop type: Either prop `iconType` must be defined or this node must have children.";
-      const assert = expectError(errorMessage);
+      const assert = expectConsoleOutput(errorMessage);
 
       render({}, mount);
       assert();
@@ -504,7 +504,7 @@ describe("Button", () => {
   describe("A primary button", () => {
     const primary = render({
       name: "Primary Button",
-      as: "primary",
+      buttonType: "primary",
       onClick: jest.fn(),
       children: "Primary",
     }).dive();
@@ -768,5 +768,16 @@ describe("Button", () => {
         );
       }
     );
+  });
+
+  describe("when the `as` prop is used", () => {
+    it("fires a prop deprecation warning to the console", () => {
+      const message =
+        "[Deprecation] The `as` prop is deprecated and will soon be removed. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop";
+      const assert = expectConsoleOutput(message, "warn");
+
+      mount(<Button as="primary">foo</Button>);
+      assert();
+    });
   });
 });

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -10,7 +10,7 @@ import StyledButton from "./button.style";
 import {
   assertStyleMatch,
   testStyledSystemSpacing,
-  expectError,
+  expectConsoleOutput as expectError,
 } from "../../__spec_helper__/test-utils";
 import { rootTagTest } from "../../__internal__/utils/helpers/tags/tags-specs";
 import StyledIcon from "../icon/icon.style";

--- a/src/components/multi-action-button/multi-action-button.component.js
+++ b/src/components/multi-action-button/multi-action-button.component.js
@@ -10,10 +10,13 @@ import Events from "../../__internal__/utils/helpers/events";
 import Popover from "../../__internal__/popover";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { defaultFocusableSelectors } from "../../__internal__/focus-trap/focus-trap-utils";
+import Logger from "../../__internal__/utils/logger";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
 );
+
+let deprecatedWarnTriggered = false;
 
 const MultiActionButton = ({
   align = "left",
@@ -26,6 +29,14 @@ const MultiActionButton = ({
   subtext,
   ...rest
 }) => {
+  if (!deprecatedWarnTriggered && as) {
+    deprecatedWarnTriggered = true;
+    Logger.deprecate(
+      // eslint-disable-next-line max-len
+      "The `as` prop is deprecated and will soon be removed. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop"
+    );
+  }
+
   const ref = useRef();
   const buttonRef = useRef();
   const buttonContainer = useRef();

--- a/src/components/multi-action-button/multi-action-button.spec.js
+++ b/src/components/multi-action-button/multi-action-button.spec.js
@@ -13,6 +13,7 @@ import {
   assertStyleMatch,
   keyboard,
   testStyledSystemMargin,
+  expectConsoleOutput as expectWarn,
 } from "../../__spec_helper__/test-utils";
 import StyledButton from "../button/button.style";
 import StyledIcon from "../icon/icon.style";
@@ -428,6 +429,17 @@ describe("MultiActionButton", () => {
           true
         );
       });
+    });
+  });
+
+  describe("when the `as` prop is used", () => {
+    it("fires a prop deprecation warning to the console", () => {
+      const message =
+        "[Deprecation] The `as` prop is deprecated and will soon be removed. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop";
+      const assert = expectWarn(message, "warn");
+
+      render({ as: "primary" }, mount);
+      assert();
     });
   });
 });

--- a/src/components/pill/pill.spec.js
+++ b/src/components/pill/pill.spec.js
@@ -10,7 +10,7 @@ import {
   assertStyleMatch,
   carbonThemesJestTable,
   testStyledSystemMargin,
-  expectError,
+  expectConsoleOutput as expectError,
 } from "../../__spec_helper__/test-utils";
 import IconButton from "../icon-button";
 import { baseTheme } from "../../style/themes";

--- a/src/components/simple-color-picker/color-sample-box/color-sample-box.spec.js
+++ b/src/components/simple-color-picker/color-sample-box/color-sample-box.spec.js
@@ -5,7 +5,7 @@ import ColorSampleBox from ".";
 import StyledColorSampleBox from "./color-sample-box.style";
 import {
   assertStyleMatch,
-  expectError,
+  expectConsoleOutput as expectError,
 } from "../../../__spec_helper__/test-utils";
 import StyledTickIcon from "../tick-icon/tick-icon.style";
 

--- a/src/components/simple-color-picker/simple-color-picker.spec.js
+++ b/src/components/simple-color-picker/simple-color-picker.spec.js
@@ -8,7 +8,7 @@ import { StyledLegend } from "../../__internal__/fieldset/fieldset.style";
 import {
   assertStyleMatch,
   testStyledSystemMargin,
-  expectError,
+  expectConsoleOutput as expectError,
 } from "../../__spec_helper__/test-utils";
 import StyledValidationIcon from "../../__internal__/validations/validation-icon.style";
 import Fieldset from "../../__internal__/fieldset";

--- a/src/components/split-button/split-button.component.js
+++ b/src/components/split-button/split-button.component.js
@@ -19,6 +19,7 @@ import Popover from "../../__internal__/popover";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { baseTheme } from "../../style/themes";
 import { defaultFocusableSelectors } from "../../__internal__/focus-trap/focus-trap-utils";
+import Logger from "../../__internal__/utils/logger";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
@@ -26,10 +27,12 @@ const marginPropTypes = filterStyledSystemMarginProps(
 
 const CONTENT_WIDTH_RATIO = 0.75;
 
+let deprecatedWarnTriggered = false;
+
 const SplitButton = ({
   align = "left",
-  as = "secondary",
-  buttonType,
+  as,
+  buttonType = "secondary",
   children,
   disabled = false,
   iconPosition = "before",
@@ -40,6 +43,14 @@ const SplitButton = ({
   text,
   ...rest
 }) => {
+  if (!deprecatedWarnTriggered && as) {
+    deprecatedWarnTriggered = true;
+    Logger.deprecate(
+      // eslint-disable-next-line max-len
+      "The `as` prop is deprecated and will soon be removed. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop"
+    );
+  }
+
   const theme = useContext(ThemeContext) || baseTheme;
   const isToggleButtonFocused = useRef(false);
   const buttonLabelId = useRef(guid());
@@ -145,7 +156,7 @@ const SplitButton = ({
         isToggleButtonFocused.current = false;
       },
       onKeyDown: handleToggleButtonKeyDown,
-      buttonType: buttonType || as,
+      buttonType: as || buttonType,
       size,
     };
 
@@ -174,7 +185,7 @@ const SplitButton = ({
       primary: theme.colors.white,
       secondary: theme.colors.primary,
     };
-    return colorsMap[buttonType || as];
+    return colorsMap[as || buttonType];
   }
 
   function renderMainButton() {

--- a/src/components/split-button/split-button.spec.js
+++ b/src/components/split-button/split-button.spec.js
@@ -17,6 +17,7 @@ import {
   assertStyleMatch,
   keyboard,
   testStyledSystemMargin,
+  expectConsoleOutput as expectWarn,
 } from "../../__spec_helper__/test-utils";
 import guid from "../../__internal__/utils/helpers/guid";
 
@@ -663,6 +664,27 @@ describe("SplitButton", () => {
     jest.clearAllMocks();
 
     wrapper.unmount();
+  });
+
+  describe("when the `as` prop is used", () => {
+    it("fires a prop deprecation warning to the console", () => {
+      const message =
+        "[Deprecation] The `as` prop is deprecated and will soon be removed. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop";
+      const assert = expectWarn(message, "warn");
+
+      mount(
+        <SplitButton
+          as="primary"
+          text="Split button"
+          data-element="bar"
+          data-role="baz"
+        >
+          <Button key="testKey">Single Button</Button>
+        </SplitButton>
+      );
+      render({ as: "primary" }, undefined, mount);
+      assert();
+    });
   });
 });
 

--- a/src/components/text-editor/text-editor.spec.js
+++ b/src/components/text-editor/text-editor.spec.js
@@ -5,7 +5,7 @@ import { shallow, mount } from "enzyme";
 import {
   assertStyleMatch,
   testStyledSystemMargin,
-  expectError,
+  expectConsoleOutput as expectError,
 } from "../../__spec_helper__/test-utils";
 import TextEditor, {
   TextEditorContentState,


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Updates `expectError` util to support other console functions such as `warn` and renames the
function to `expectConsoleOutput`.
Adds deprecation warnings to `Button`, `SplitButton` and `MultiActionButton` when `as` prop used

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Util only supports `console.error` and no deprecation warnings exist

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
Run unit tests for  `Button`, `SplitButton` and `MultiActionButton`, there should be no console output and all test should pass.

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/bold-dust-vr0lx1 -- check that console outputs deprecation warnings for the components
