### PR TITLE
fix(select): fix openOnFocus behaviour when clicked

### DIFF
--- a/src/__internal__/popover/popover.component.js
+++ b/src/__internal__/popover/popover.component.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef } from "react";
+import React, { useContext, useEffect, useLayoutEffect, useRef } from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import { createPopper } from "@popperjs/core";
@@ -6,6 +6,7 @@ import { createPopper } from "@popperjs/core";
 import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
 import StyledBackdrop from "./popover.style";
 import CarbonScopedTokensProvider from "../../style/design-tokens/carbon-scoped-tokens-provider/carbon-scoped-tokens-provider.component";
+import { ModalContext } from "../../components/modal/modal.component";
 
 const Popover = ({
   children,
@@ -17,11 +18,17 @@ const Popover = ({
   disableBackgroundUI,
 }) => {
   const elementDOM = useRef();
+  const { isInModal } = useContext(ModalContext);
+  let mountNode = document.body;
+
+  if (isInModal && reference.current) {
+    mountNode = reference.current.closest("[role='dialog']");
+  }
 
   if (!elementDOM.current && !disablePortal) {
     elementDOM.current = document.createElement("div");
 
-    document.body.appendChild(elementDOM.current);
+    mountNode.appendChild(elementDOM.current);
   }
   const popperInstance = useRef();
   const popperRef = useRef();
@@ -75,10 +82,11 @@ const Popover = ({
   useEffect(() => {
     return () => {
       if (!disablePortal) {
-        document.body.removeChild(elementDOM.current);
+        mountNode.removeChild(elementDOM.current);
+        elementDOM.current = null;
       }
     };
-  }, [disablePortal]);
+  }, [disablePortal, mountNode]);
 
   if (disableBackgroundUI) {
     content = <StyledBackdrop>{content}</StyledBackdrop>;
@@ -126,7 +134,7 @@ Popover.propTypes = {
   // When true, children are not rendered in portal
   disablePortal: PropTypes.bool,
   // Reference element, children will be positioned in relation to this element - should be a ref
-  reference: PropTypes.shape({ current: PropTypes.any }),
+  reference: PropTypes.shape({ current: PropTypes.any }).isRequired,
 };
 
 export default Popover;

--- a/src/components/modal/modal.component.js
+++ b/src/components/modal/modal.component.js
@@ -175,6 +175,7 @@ const Modal = ({
                 value={{
                   isAnimationComplete,
                   triggerRefocusFlag,
+                  isInModal: true,
                 }}
               >
                 {content}

--- a/src/components/select/__internal__/select-text/select-text.component.js
+++ b/src/components/select/__internal__/select-text/select-text.component.js
@@ -1,38 +1,22 @@
-import React, { useContext } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import StyledSelectText from "./select-text.style";
-import { InputContext } from "../../../../__internal__/input-behaviour";
 
 const SelectText = ({
   disabled,
   formattedValue = "",
   onClick,
   onKeyDown,
-  onFocus,
-  onBlur,
   onMouseDown,
   placeholder,
   readOnly,
   textId,
   transparent,
 }) => {
-  const inputContext = useContext(InputContext);
   const hasPlaceholder = !disabled && !readOnly && !formattedValue;
 
-  function handleFocus(event) {
-    inputContext.onFocus(event);
-
-    if (onFocus) {
-      onFocus(event);
-    }
-  }
-
-  function handleBlur(event) {
-    inputContext.onBlur(event);
-
-    if (onBlur) {
-      onBlur(event);
-    }
+  function handleClick(event) {
+    onClick(event);
   }
 
   return (
@@ -42,9 +26,7 @@ const SelectText = ({
       disabled={disabled}
       hasPlaceholder={hasPlaceholder}
       id={textId}
-      onBlur={handleBlur}
-      onClick={onClick}
-      onFocus={handleFocus}
+      onClick={handleClick}
       onKeyDown={onKeyDown}
       onMouseDown={onMouseDown}
       readOnly={readOnly}
@@ -62,12 +44,8 @@ SelectText.propTypes = {
   disabled: PropTypes.bool,
   /** Value to be displayed */
   formattedValue: PropTypes.string,
-  /** Callback function for when the Select Textbox loses it's focus. */
-  onBlur: PropTypes.func,
   /** Callback function for when the component is clicked. */
   onClick: PropTypes.func,
-  /** Callback function for when the Select Textbox is focused. */
-  onFocus: PropTypes.func,
   /** Callback function for when the key is pressed when focused on Select Text. */
   onKeyDown: PropTypes.func,
   /** Callback function for when the left mouse key is pressed when focused on Select Text. */

--- a/src/components/select/__internal__/select-text/select-text.spec.js
+++ b/src/components/select/__internal__/select-text/select-text.spec.js
@@ -2,12 +2,6 @@ import { mount } from "enzyme";
 import React from "react";
 import { assertStyleMatch } from "../../../../__spec_helper__/test-utils";
 import SelectText from "./select-text.component";
-import { InputContext } from "../../../../__internal__/input-behaviour";
-
-const mockInputContextValue = {
-  onFocus: jest.fn(),
-  onBlur: jest.fn(),
-};
 
 describe("SelectText", () => {
   it("renders span that has a role of 'button' and is hidden from screen readers", () => {
@@ -73,58 +67,6 @@ describe("SelectText", () => {
       },
       wrapper
     );
-  });
-
-  describe("when the element is focused", () => {
-    it("then the onFocus method in the InputContext should have been called", () => {
-      const wrapper = mount(
-        <InputContext.Provider value={mockInputContextValue}>
-          <SelectText />
-        </InputContext.Provider>
-      );
-
-      wrapper.simulate("focus");
-
-      expect(mockInputContextValue.onFocus).toHaveBeenCalled();
-    });
-
-    it("then the onFocus method should have been called", () => {
-      const onFocusFn = jest.fn();
-      const wrapper = mount(
-        <InputContext.Provider value={mockInputContextValue}>
-          <SelectText onFocus={onFocusFn} />
-        </InputContext.Provider>
-      );
-      wrapper.simulate("focus");
-
-      expect(onFocusFn).toHaveBeenCalled();
-    });
-  });
-
-  describe("when the element is blurred", () => {
-    it("then the onFocus method in the InputContext should have been called", () => {
-      const wrapper = mount(
-        <InputContext.Provider value={mockInputContextValue}>
-          <SelectText />
-        </InputContext.Provider>
-      );
-
-      wrapper.simulate("blur");
-
-      expect(mockInputContextValue.onBlur).toHaveBeenCalled();
-    });
-
-    it("then the onFocus method should have been called", () => {
-      const onBlurFn = jest.fn();
-      const wrapper = mount(
-        <InputContext.Provider value={mockInputContextValue}>
-          <SelectText onBlur={onBlurFn} />
-        </InputContext.Provider>
-      );
-      wrapper.simulate("blur");
-
-      expect(onBlurFn).toHaveBeenCalled();
-    });
   });
 });
 

--- a/src/components/select/select-textbox/select-textbox.component.js
+++ b/src/components/select/select-textbox/select-textbox.component.js
@@ -164,7 +164,10 @@ const SelectTextbox = ({
         transparent={transparent}
         onKeyDown={handleSelectTextKeydown}
         placeholder={placeholder || l.select.placeholder()}
-        {...getTextboxProps()}
+        onClick={handleTextboxClick}
+        disabled={disabled}
+        readOnly={readOnly}
+        {...restProps}
       />
     );
   }

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -154,7 +154,7 @@ describe("SimpleSelect", () => {
       it("the SelectList should be rendered", () => {
         const wrapper = renderSelect({ openOnFocus: true });
 
-        simulateSelectTextEvent(wrapper, "focus");
+        simulateSelectTextboxEvent(wrapper, "focus");
         expect(wrapper.find(SelectList).exists()).toBe(true);
       });
 
@@ -165,7 +165,7 @@ describe("SimpleSelect", () => {
             const obj = { [prop]: true, openOnFocus: true };
             const wrapper = renderSelect(obj);
 
-            simulateSelectTextEvent(wrapper, "focus");
+            simulateSelectTextboxEvent(wrapper, "focus");
             expect(wrapper.find(SelectList).exists()).toBe(false);
           });
         }
@@ -179,7 +179,7 @@ describe("SimpleSelect", () => {
             openOnFocus: true,
           });
 
-          simulateSelectTextEvent(wrapper, "focus");
+          simulateSelectTextboxEvent(wrapper, "focus");
           expect(onFocusFn).toHaveBeenCalled();
         });
       });
@@ -194,17 +194,17 @@ describe("SimpleSelect", () => {
         });
 
         it("then that prop should be called", () => {
-          simulateSelectTextEvent(wrapper, "focus");
+          simulateSelectTextboxEvent(wrapper, "focus");
 
           expect(onOpenFn).toHaveBeenCalled();
         });
 
         describe("and the SelectList already open", () => {
           it("then that prop should not be called", () => {
-            simulateSelectTextEvent(wrapper, "click");
+            simulateSelectTextboxEvent(wrapper, "focus");
             onOpenFn.mockReset();
             expect(wrapper.find(SelectList).exists()).toBe(true);
-            simulateSelectTextEvent(wrapper, "focus");
+            simulateSelectTextboxEvent(wrapper, "focus");
             expect(onOpenFn).not.toHaveBeenCalled();
           });
         });
@@ -212,7 +212,7 @@ describe("SimpleSelect", () => {
         describe("and the focus triggered by mouseDown", () => {
           it("then that prop should not be called", () => {
             simulateSelectTextEvent(wrapper, "mousedown");
-            simulateSelectTextEvent(wrapper, "focus");
+            simulateSelectTextboxEvent(wrapper, "focus");
             expect(onOpenFn).not.toHaveBeenCalled();
           });
         });
@@ -230,7 +230,7 @@ describe("SimpleSelect", () => {
     });
 
     it("the SelectList should not be rendered", () => {
-      simulateSelectTextEvent(wrapper, "focus");
+      simulateSelectTextboxEvent(wrapper, "focus");
       expect(wrapper.find(SelectList).exists()).toBe(false);
     });
 
@@ -448,7 +448,7 @@ describe("SimpleSelect", () => {
       it("then an option with matching text should be selected", () => {
         const wrapper = renderSelect({ openOnFocus: true });
 
-        simulateSelectTextEvent(wrapper, "focus");
+        simulateSelectTextboxEvent(wrapper, "focus");
         simulateKeyDown(wrapper, "b");
         simulateKeyDown(wrapper, "l");
         simulateKeyDown(wrapper, "a");
@@ -464,7 +464,7 @@ describe("SimpleSelect", () => {
         const wrapper = renderSelect();
 
         act(() => {
-          simulateSelectTextEvent(wrapper, "focus");
+          simulateSelectTextboxEvent(wrapper, "focus");
           simulateKeyDown(wrapper, "b");
           simulateKeyDown(wrapper, "l");
           jest.runAllTimers();
@@ -490,7 +490,7 @@ describe("SimpleSelect", () => {
         const onChangeFn = jest.fn();
         const wrapper = renderSelect({ ...textboxProps, onChange: onChangeFn });
 
-        simulateSelectTextEvent(wrapper, "focus");
+        simulateSelectTextboxEvent(wrapper, "focus");
         simulateKeyDown(wrapper, "b");
         expect(onChangeFn).toHaveBeenCalledWith(mockEventObject);
       });
@@ -583,7 +583,7 @@ describe("SimpleSelect", () => {
         act(() => {
           wrapper.find(Option).first().simulate("click");
         });
-        simulateSelectTextEvent(wrapper, "focus");
+        simulateSelectTextboxEvent(wrapper, "focus");
         expect(wrapper.update().find(SelectList).exists()).toBe(false);
       });
     });
@@ -629,7 +629,7 @@ describe("SimpleSelect", () => {
       const onBlurFn = jest.fn();
       const wrapper = renderSelect({ onBlur: onBlurFn });
 
-      simulateSelectTextEvent(wrapper, "blur");
+      simulateSelectTextboxEvent(wrapper, "blur");
       expect(onBlurFn).toHaveBeenCalled();
     });
 
@@ -638,16 +638,16 @@ describe("SimpleSelect", () => {
         const onBlurFn = jest.fn();
         const wrapper = renderSelect({ onBlur: onBlurFn, openOnFocus: true });
 
-        simulateSelectTextEvent(wrapper, "focus");
+        simulateSelectTextboxEvent(wrapper, "focus");
         wrapper.find(Option).first().simulate("mousedown");
-        simulateSelectTextEvent(wrapper, "blur");
+        simulateSelectTextboxEvent(wrapper, "blur");
         expect(onBlurFn).not.toHaveBeenCalled();
       });
     });
 
     it("coverage filler for else path", () => {
       const wrapper = renderSelect();
-      simulateSelectTextEvent(wrapper, "blur");
+      simulateSelectTextboxEvent(wrapper, "blur");
     });
   });
 
@@ -778,6 +778,12 @@ function simulateKeyDown(container, key) {
 
 function simulateSelectTextEvent(container, eventType) {
   const selectText = container.find("[data-element='select-text']").first();
+
+  selectText.simulate(eventType);
+}
+
+function simulateSelectTextboxEvent(container, eventType) {
+  const selectText = container.find('input[type="text"]').first();
 
   selectText.simulate(eventType);
 }


### PR DESCRIPTION
Fixes: #4880

### Proposed behaviour

**First fix:** 

Fix the openOnFocus behaviour in SimpleSelect component by removing the unnecessary props passed down to `SelectText` from `SelectTextbox`. 

`SelectText` renders a span which is not focusable, therefore it doesn't need the focus or blur props that were currently being passed down. These were causing the `handleTextboxFocus` function in `SimpleSelect` to be called twice when clicking on the select input which was causing the broken behaviour as seen in Storybook.

**Second fix:**

Fixes the openOnFocus behaviour in every Select, FilterableSelect and MultiSelect when in a Dialog. This was caused by the portal generated by the Popover in the select list being in a different stacking context to the Dialog, so the scroll blocking background of the popover was always on top of the Select textbox input, even though Select puts a z-index of 9999 on the input.

The fix is to attach the portal created by the Popover to the root of the Dialog when it is open, rather than the document.body. This way it is in the same stacking context, and works the same as if the component wasn't in a Dialog.


### Current behaviour

**First fix:** 
See https://carbon.sage.com/?path=/docs/select--open-on-focus - opening the Select with a mouse click flickers the select list and doesn't open it.

**Second fix**
Same behaviour as the Select in the first fix, but for all select variants in a Dialog.
See issue #4880 for reproducible example.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

**First fix:** 

https://carbon.sage.com/?path=/docs/select--open-on-focus

**Second fix**

Use the sandbox from the linked issue.

