### PR TITLE
feat(tile): surface variant prop and add deprecation warning for as prop FE-5029

### DIFF
--- a/src/components/button/button.component.js
+++ b/src/components/button/button.component.js
@@ -97,7 +97,7 @@ const Button = ({
     deprecatedWarnTriggered = true;
     Logger.deprecate(
       // eslint-disable-next-line max-len
-      "The `as` prop is deprecated and will soon be removed. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop"
+      "The `as` prop is deprecated and will soon be removed from the `Button` component interface. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop"
     );
   }
 

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -773,7 +773,7 @@ describe("Button", () => {
   describe("when the `as` prop is used", () => {
     it("fires a prop deprecation warning to the console", () => {
       const message =
-        "[Deprecation] The `as` prop is deprecated and will soon be removed. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop";
+        "[Deprecation] The `as` prop is deprecated and will soon be removed from the `Button` component interface. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop";
       const assert = expectConsoleOutput(message, "warn");
 
       mount(<Button as="primary">foo</Button>);

--- a/src/components/multi-action-button/multi-action-button.component.js
+++ b/src/components/multi-action-button/multi-action-button.component.js
@@ -33,7 +33,7 @@ const MultiActionButton = ({
     deprecatedWarnTriggered = true;
     Logger.deprecate(
       // eslint-disable-next-line max-len
-      "The `as` prop is deprecated and will soon be removed. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop"
+      "The `as` prop is deprecated and will soon be removed from the `MultiActionButton` component interface. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop"
     );
   }
 

--- a/src/components/multi-action-button/multi-action-button.spec.js
+++ b/src/components/multi-action-button/multi-action-button.spec.js
@@ -435,7 +435,7 @@ describe("MultiActionButton", () => {
   describe("when the `as` prop is used", () => {
     it("fires a prop deprecation warning to the console", () => {
       const message =
-        "[Deprecation] The `as` prop is deprecated and will soon be removed. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop";
+        "[Deprecation] The `as` prop is deprecated and will soon be removed from the `MultiActionButton` component interface. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop";
       const assert = expectWarn(message, "warn");
 
       render({ as: "primary" }, mount);

--- a/src/components/split-button/split-button.component.js
+++ b/src/components/split-button/split-button.component.js
@@ -47,7 +47,7 @@ const SplitButton = ({
     deprecatedWarnTriggered = true;
     Logger.deprecate(
       // eslint-disable-next-line max-len
-      "The `as` prop is deprecated and will soon be removed. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop"
+      "The `as` prop is deprecated and will soon be removed from the `SplitButton` component interface. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop"
     );
   }
 

--- a/src/components/split-button/split-button.spec.js
+++ b/src/components/split-button/split-button.spec.js
@@ -669,7 +669,7 @@ describe("SplitButton", () => {
   describe("when the `as` prop is used", () => {
     it("fires a prop deprecation warning to the console", () => {
       const message =
-        "[Deprecation] The `as` prop is deprecated and will soon be removed. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop";
+        "[Deprecation] The `as` prop is deprecated and will soon be removed from the `SplitButton` component interface. You should use the `buttonType` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop";
       const assert = expectWarn(message, "warn");
 
       mount(
@@ -682,7 +682,6 @@ describe("SplitButton", () => {
           <Button key="testKey">Single Button</Button>
         </SplitButton>
       );
-      render({ as: "primary" }, undefined, mount);
       assert();
     });
   });

--- a/src/components/tile/tile.component.js
+++ b/src/components/tile/tile.component.js
@@ -2,15 +2,27 @@ import React from "react";
 import PropTypes from "prop-types";
 import propTypes from "@styled-system/prop-types";
 import { StyledTile, TileContent } from "./tile.style.js";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecatedWarnTriggered = false;
 
 const Tile = ({
-  as = "tile",
+  as,
+  variant = "tile",
   p = 3,
   children,
   orientation = "horizontal",
   width,
   ...props
 }) => {
+  if (!deprecatedWarnTriggered && as) {
+    deprecatedWarnTriggered = true;
+    Logger.deprecate(
+      // eslint-disable-next-line max-len
+      "The `as` prop is deprecated and will soon be removed from the `Tile` component interface. You should use the `variant` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop"
+    );
+  }
+
   const isHorizontal = () => orientation === "horizontal";
   const isVertical = () => orientation === "vertical";
   const wrappedChildren = React.Children.map(children, (child, index) => {
@@ -43,7 +55,7 @@ const Tile = ({
 
   return (
     <StyledTile
-      tileTheme={as}
+      tileTheme={as || variant}
       width={width}
       data-component="tile"
       isHorizontal={isHorizontal(orientation)}
@@ -60,6 +72,8 @@ Tile.propTypes = {
   ...propTypes.space,
   /** Sets the theme of the tile - either 'tile' or 'transparent' */
   as: PropTypes.oneOf(["tile", "transparent"]),
+  /** Sets the theme of the tile - either 'tile' or 'transparent' */
+  variant: PropTypes.oneOf(["tile", "transparent"]),
   /**
    * The content to render within the tile. Each child will be wrapped with
    * a TileContent wrapper, which allows any individual child component to take a

--- a/src/components/tile/tile.d.ts
+++ b/src/components/tile/tile.d.ts
@@ -4,6 +4,8 @@ import { SpaceProps } from "styled-system";
 export interface TileProps extends SpaceProps {
   /** Sets the theme of the tile - either 'tile' or 'transparent' */
   as?: "tile" | "transparent";
+  /** Sets the theme of the tile - either 'tile' or 'transparent' */
+  variant?: "tile" | "transparent";
   /**
    * The content to render within the tile. Each child will be wrapped with
    * a TileContent wrapper, which allows any individual child component to take a

--- a/src/components/tile/tile.spec.js
+++ b/src/components/tile/tile.spec.js
@@ -9,6 +9,7 @@ import {
   assertStyleMatch,
   testStyledSystemSpacing,
   testStyledSystemWidth,
+  expectConsoleOutput as expectWarn,
 } from "../../__spec_helper__/test-utils";
 
 function render(props, renderer = TestRenderer.create) {
@@ -70,9 +71,9 @@ describe("Tile", () => {
 
     testStyledSystemWidth((props) => <Tile {...props} />);
 
-    describe("as", () => {
+    describe("variant", () => {
       it('renders a white background when as === "tile"', () => {
-        const wrapper = render({ as: "tile" }).toJSON();
+        const wrapper = render({ variant: "tile" }).toJSON();
 
         assertStyleMatch(
           { backgroundColor: "var(--colorsUtilityYang100)" },
@@ -81,7 +82,7 @@ describe("Tile", () => {
       });
 
       it('renders a transparent background when as === "transparent"', () => {
-        const wrapper = render({ as: "transparent" }).toJSON();
+        const wrapper = render({ variant: "transparent" }).toJSON();
 
         assertStyleMatch({ backgroundColor: "transparent" }, wrapper);
       });
@@ -229,6 +230,22 @@ describe("Tile", () => {
           }
         );
       });
+    });
+  });
+
+  describe("when the `as` prop is used", () => {
+    it("fires a prop deprecation warning to the console", () => {
+      const message =
+        "[Deprecation] The `as` prop is deprecated and will soon be removed from the `Tile` component interface. You should use the `variant` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop";
+      const assert = expectWarn(message, "warn");
+
+      mount(
+        <Tile as="tile">
+          <Content key="one">Child 1</Content>
+          <Content>Child 2</Content>
+        </Tile>
+      );
+      assert();
     });
   });
 });

--- a/src/components/tile/tile.stories.mdx
+++ b/src/components/tile/tile.stories.mdx
@@ -174,7 +174,7 @@ Please note that it will not have any effect if the Tile orientation is set to `
 
 <Canvas>
   <Story name="custom Widths">
-    <Tile as="tile" orientation="horizontal" width="75%">
+    <Tile variant="tile" orientation="horizontal" width="75%">
       <Content
         align="left"
         variant="primary"
@@ -215,7 +215,7 @@ The Tile component can also have inline styling applied to the content.
 
 <Canvas>
   <Story name="with Inline">
-    <Tile as="tile" orientation="horizontal" width={0}>
+    <Tile variant="tile" orientation="horizontal" width={0}>
       <Content
         align="left"
         variant="primary"
@@ -255,22 +255,22 @@ The Tile component can also have inline styling applied to the content.
 <Canvas>
   <Story name="with different padding and margin">
     <>
-      <Tile p={0} m={0} as="tile" orientation="horizontal">
+      <Tile p={0} m={0} variant="tile" orientation="horizontal">
         <Content width="50%">Example content</Content>
       </Tile>
-      <Tile p={1} m={1} as="tile" orientation="horizontal">
+      <Tile p={1} m={1} variant="tile" orientation="horizontal">
         <Content width="50%">Example content</Content>
       </Tile>
-      <Tile p={2} m={2} as="tile" orientation="horizontal">
+      <Tile p={2} m={2} variant="tile" orientation="horizontal">
         <Content width="50%">Example content</Content>
       </Tile>
-      <Tile p={3} m={3} as="tile" orientation="horizontal">
+      <Tile p={3} m={3} variant="tile" orientation="horizontal">
         <Content width="50%">Example content</Content>
       </Tile>
-      <Tile p={4} m={4} as="tile" orientation="horizontal">
+      <Tile p={4} m={4} variant="tile" orientation="horizontal">
         <Content width="50%">Example content</Content>
       </Tile>
-      <Tile p={5} m={5} as="tile" orientation="horizontal">
+      <Tile p={5} m={5} variant="tile" orientation="horizontal">
         <Content width="50%">Example content</Content>
       </Tile>
     </>

--- a/src/components/toast/toast.component.js
+++ b/src/components/toast/toast.component.js
@@ -15,9 +15,12 @@ import IconButton from "../icon-button";
 import ModalManager from "../modal/__internal__/modal-manager";
 import Events from "../../__internal__/utils/helpers/events";
 import useLocale from "../../hooks/__internal__/useLocale";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecatedWarnTriggered = false;
 
 const Toast = ({
-  as = "success",
+  as,
   children,
   className,
   id,
@@ -30,6 +33,14 @@ const Toast = ({
   variant,
   ...restProps
 }) => {
+  if (!deprecatedWarnTriggered && as) {
+    deprecatedWarnTriggered = true;
+    Logger.deprecate(
+      // eslint-disable-next-line max-len
+      "The `as` prop is deprecated and will soon be removed from the `Toast` component interface. You should use the `variant` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop"
+    );
+  }
+
   const locale = useLocale();
 
   const toastRef = useRef();
@@ -92,7 +103,7 @@ const Toast = ({
 
     const toastProps = {
       isCenter,
-      variant: variant || as,
+      variant: variant || as || "success",
       id,
       maxWidth,
     };

--- a/src/components/toast/toast.spec.js
+++ b/src/components/toast/toast.spec.js
@@ -3,7 +3,10 @@ import { shallow, mount } from "enzyme";
 import guid from "../../__internal__/utils/helpers/guid";
 import Toast from "./toast.component";
 import { ToastStyle, ToastContentStyle, ToastWrapper } from "./toast.style";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import {
+  assertStyleMatch,
+  expectConsoleOutput as expectWarn,
+} from "../../__spec_helper__/test-utils";
 import IconButton from "../icon-button";
 import ModalManager from "../modal/__internal__/modal-manager";
 import {
@@ -45,7 +48,12 @@ describe("Toast", () => {
   describe("when toast is closed", () => {
     it("should exists anyway", () => {
       const wrapper = mount(
-        <Toast open={false} as="info" className="custom" onDismiss={() => {}}>
+        <Toast
+          open={false}
+          variant="info"
+          className="custom"
+          onDismiss={() => {}}
+        >
           foobar
         </Toast>
       );
@@ -72,7 +80,7 @@ describe("Toast", () => {
 
     it("does not render close icon", () => {
       const wrapper = mount(
-        <Toast open as="info" className="custom">
+        <Toast open variant="info" className="custom">
           foobar
         </Toast>
       );
@@ -228,6 +236,21 @@ describe("ToastStyle", () => {
         domNode.dispatchEvent(escapeKeyEvent);
         expect(onDismissFn).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe("when the `as` prop is used", () => {
+    it("fires a prop deprecation warning to the console", () => {
+      const message =
+        "[Deprecation] The `as` prop is deprecated and will soon be removed from the `Toast` component interface. You should use the `variant` prop to achieve the same styling. The following codemod is available to help with updating your code https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop";
+      const assert = expectWarn(message, "warn");
+
+      mount(
+        <Toast open={false} as="info" onDismiss={() => {}}>
+          foobar
+        </Toast>
+      );
+      assert();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
 Adds deprecation warning for `as` prop in Toast and Tile components
Updates warning for `Button`, `MultiActionButton` and `SplitButton` components to make it clearer which ones are triggering them

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No warning for `Toast` and `Tile`
 `Button`, `MultiActionButton` and `SplitButton` components have generic warning

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
Use sandbox based on linked one below
The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/carbon-quickstart-forked-lvotbt -- don't test this one test the one codesandbox builds using this