### PR TITLE
fix(menu): change HTML to be more semantic and fix for screenreaders - FE-5009

### DIFF
--- a/src/components/link/link.component.tsx
+++ b/src/components/link/link.component.tsx
@@ -153,7 +153,7 @@ export const Link = React.forwardRef<
 
       return React.createElement(
         type,
-        { ...componentProps, ...(type === "button" && { role: "link" }) },
+        componentProps,
         <>
           {renderLinkIcon()}
 

--- a/src/components/link/link.spec.tsx
+++ b/src/components/link/link.spec.tsx
@@ -272,12 +272,6 @@ describe("Link", () => {
       wrapper = renderLink({ onClick: () => null });
       expect(wrapper.find("button")).toBeTruthy();
     });
-
-    it("should add a role of 'link' to the button", () => {
-      wrapper = renderLink({ onClick: () => null });
-      const anchor = wrapper.find("button").getDOMNode();
-      expect(anchor.getAttribute("role")).toEqual("link");
-    });
   });
 
   describe("aria props", () => {

--- a/src/components/link/link.stories.mdx
+++ b/src/components/link/link.stories.mdx
@@ -177,9 +177,13 @@ By rendering an icon and providing a string to the `tooltipMessage` prop, a tool
 
 A custom `onClick` function can be passed to the Link component to render it as a button instead of an anchor.
 
+**Please note**: this option is bad for accessibility, as the output looks like a link but behaves like an HTML button. If the `onClick` function performs navigation,
+instead use the `href` prop with an appropriate value. If an on-page action is performed, so you want a genuine button, please consider using
+the <LinkTo kind="Button" story="primary">Button component</LinkTo> instead so that styles match.
+
 <Canvas>
   <Story name="with onClick" parameters={{ chromatic: { disable: true } }}>
-    <Link onClick={() => {}}>This is a link</Link>
+    <Link onClick={() => {}}>This is actually a button but looks like a link</Link>
   </Story>
 </Canvas>
 

--- a/src/components/menu/__internal__/spec-helper/index.js
+++ b/src/components/menu/__internal__/spec-helper/index.js
@@ -10,7 +10,10 @@ const events = {
 };
 
 const openSubmenu = (wrapper) => {
-  const menuItem = wrapper.find('[data-component="submenu-wrapper"]').find("a");
+  const menuWrapper = wrapper.find('[data-component="submenu-wrapper"]');
+  const menuItem = menuWrapper.exists("a")
+    ? menuWrapper.find("a")
+    : menuWrapper.find("button");
 
   menuItem.getDOMNode().focus();
 

--- a/src/components/menu/__internal__/submenu/submenu.component.js
+++ b/src/components/menu/__internal__/submenu/submenu.component.js
@@ -36,6 +36,7 @@ const Submenu = React.forwardRef(
       asPassiveItem,
       onSubmenuOpen,
       onSubmenuClose,
+      onClick,
       ...rest
     },
     ref
@@ -235,6 +236,16 @@ const Submenu = React.forwardRef(
       [closeSubmenu]
     );
 
+    const handleClick = (event) => {
+      if (clickToOpen) {
+        openSubmenu();
+      }
+
+      if (onClick) {
+        onClick(event);
+      }
+    };
+
     useEffect(() => {
       if (characterString !== "") {
         const nextIndex = characterNavigation(
@@ -311,7 +322,6 @@ const Submenu = React.forwardRef(
         data-component="submenu-wrapper"
         onMouseOver={!clickToOpen ? () => openSubmenu() : undefined}
         onMouseLeave={() => closeSubmenu()}
-        onClick={clickToOpen ? () => openSubmenu() : undefined}
         ref={submenuRef}
         isSubmenuOpen={submenuOpen}
       >
@@ -328,9 +338,11 @@ const Submenu = React.forwardRef(
           hasSubmenu
           showDropdownArrow={showDropdownArrow}
           onKeyDown={handleKeyDown}
+          onClick={handleClick}
           clickToOpen={clickToOpen}
           href={href}
           maxWidth={maxWidth}
+          aria-expanded={submenuOpen}
         >
           {title}
         </StyledMenuItemWrapper>
@@ -399,6 +411,8 @@ Submenu.propTypes = {
   onSubmenuOpen: PropTypes.func,
   /** Callback triggered when submenu closes. Only valid with submenu prop */
   onSubmenuClose: PropTypes.func,
+  /** Callback triggered when the top-level menu item is clicked */
+  onClick: PropTypes.func,
 };
 
 export default Submenu;

--- a/src/components/menu/__internal__/submenu/submenu.component.js
+++ b/src/components/menu/__internal__/submenu/submenu.component.js
@@ -341,6 +341,7 @@ const Submenu = React.forwardRef(
             submenuDirection={submenuDirection}
             variant={variant}
             menuType={menuContext.menuType}
+            role="list"
           >
             {React.Children.map(children, (child, index) => (
               <SubmenuContext.Provider

--- a/src/components/menu/__internal__/submenu/submenu.spec.js
+++ b/src/components/menu/__internal__/submenu/submenu.spec.js
@@ -137,6 +137,12 @@ describe("Submenu component", () => {
     }
   });
 
+  it("should render the top-level menu item as a button, not a link", () => {
+    wrapper = render("light");
+    expect(wrapper.find("a").exists()).toEqual(false);
+    expect(wrapper.find("button").exists()).toEqual(true);
+  });
+
   describe("when closed", () => {
     it("should not render the submenu", () => {
       wrapper = render("light");
@@ -184,16 +190,32 @@ describe("Submenu component", () => {
     describe("when clicked", () => {
       it("should not open the submenu", () => {
         wrapper = render("light");
-        wrapper.find("a").getDOMNode().click();
+        wrapper.find("button").getDOMNode().click();
         wrapper.update();
 
         expect(wrapper.find(StyledSubmenu).exists()).toEqual(false);
       });
+
+      it("should execute the onClick callback", () => {
+        const mockCallback = jest.fn();
+        wrapper = render("light", { onClick: mockCallback });
+        wrapper.find("button").getDOMNode().click();
+        wrapper.update();
+
+        expect(mockCallback).toHaveBeenCalledTimes(1);
+      });
     });
 
     describe("when clickToOpen prop set", () => {
+      let mockCallback;
+
       beforeEach(() => {
-        wrapper = render("light", { clickToOpen: true });
+        mockCallback = jest.fn();
+        wrapper = render("light", { clickToOpen: true, onClick: mockCallback });
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
       });
 
       describe("on mouse over", () => {
@@ -209,10 +231,17 @@ describe("Submenu component", () => {
 
       describe("when clicked", () => {
         it("should open the submenu", () => {
-          wrapper.find("a").getDOMNode().click();
+          wrapper.find("button").getDOMNode().click();
           wrapper.update();
 
           expect(wrapper.find(StyledSubmenu).exists()).toEqual(true);
+        });
+
+        it("should execute the onClick callback", () => {
+          wrapper.find("button").getDOMNode().click();
+          wrapper.update();
+
+          expect(mockCallback).toHaveBeenCalledTimes(1);
         });
       });
     });
@@ -276,6 +305,11 @@ describe("Submenu component", () => {
         wrapper = render("light", { href: "/path" });
       });
 
+      it("should render the top-level menu item as a link instead of a button", () => {
+        expect(wrapper.find("button").exists()).toEqual(false);
+        expect(wrapper.find("a").exists()).toEqual(true);
+      });
+
       describe("when opening submenu with keyboard", () => {
         it("should leave the focus on the menu item", () => {
           openSubmenu(wrapper);
@@ -325,7 +359,10 @@ describe("Submenu component", () => {
           expect(wrapper.find(StyledSubmenu).exists()).toEqual(true);
 
           expect(document.activeElement).toMatchObject(
-            wrapper.find('[data-component="submenu-wrapper"]').find("a").at(1)
+            wrapper
+              .find('[data-component="submenu-wrapper"]')
+              .find("button")
+              .at(1)
           );
         });
 
@@ -355,7 +392,7 @@ describe("Submenu component", () => {
 
       submenuItem = wrapper
         .find('[data-component="submenu-wrapper"]')
-        .find("a");
+        .find("button");
 
       submenuItem.getDOMNode().focus();
       expect(submenuItem).toBeFocused();
@@ -449,7 +486,7 @@ describe("Submenu component", () => {
         wrapper = render("light");
         submenuItem = wrapper
           .find('[data-component="submenu-wrapper"]')
-          .find("a");
+          .find("button");
       });
 
       describe("when enter key pressed", () => {
@@ -659,7 +696,7 @@ describe("Submenu component", () => {
         wrapper = render("light", { onKeyDown: onKeyDownFn });
         submenuItem = wrapper
           .find('[data-component="submenu-wrapper"]')
-          .find("a");
+          .find("button");
         submenuItem.getDOMNode().focus();
 
         act(() => {
@@ -1032,7 +1069,7 @@ describe("Submenu component", () => {
         wrapper = render(menuType, { variant });
         submenuItem = wrapper
           .find('[data-component="submenu-wrapper"]')
-          .find("a");
+          .find("button");
         submenuItem.getDOMNode().focus();
 
         act(() => {

--- a/src/components/menu/menu.component.js
+++ b/src/components/menu/menu.component.js
@@ -45,6 +45,7 @@ const Menu = ({ menuType = "light", children, ...rest }) => {
       menuType={menuType}
       {...rest}
       ref={ref}
+      role="list"
     >
       {React.Children.map(children, (child, index) => {
         const isFocused = focusedItemIndex === index;

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -166,7 +166,7 @@ describe("Menu", () => {
         menuWrapper.update();
 
         expect(
-          menuWrapper.find(StyledMenuItemWrapper).at(2).find("a")
+          menuWrapper.find(StyledMenuItemWrapper).at(2).find("button")
         ).toBeFocused();
         wrapper.unmount();
       });

--- a/src/components/menu/scrollable-block/scrollable-block.component.js
+++ b/src/components/menu/scrollable-block/scrollable-block.component.js
@@ -28,6 +28,7 @@ const ScrollableBlock = ({
       data-component="submenu-scrollable-block"
       menuType={menuContext.menuType}
       variant={variant}
+      role="presentation"
       {...rest}
     >
       <Box
@@ -35,6 +36,7 @@ const ScrollableBlock = ({
         scrollVariant={scrollVariants[menuContext.menuType]}
         height={height}
         p={0}
+        role="presentation"
       >
         {React.Children.map(children, (child, index) => {
           let isFocused = false;


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Fixes for Menu behaviour with screenreaders:
- add role="list" to main menu and submenu ul's, so that Voiceover on Safari announces as a list (see https://www.tempertemper.net/blog/accessibility-issues-when-removing-list-markers)
- change menu items which open submenus from <a> tags with no href (which semantically are just spans) to <button>s
- remove role="link" from Link component when it renders as a button due to onClick prop
- fix Scrollable Block for screen readers so that in a scrollable submenu the correct number of menu items is announced
- update documentation to onChange story on Link component to explain why using this pattern is not accessible and suggest alternatives
- change link text in that story to make clear it's actually a button not a link

### Current behaviour
- Voiceover on Safari does not announce the menus as a list
- screenreaders do not indicate to an unsighted user that any action can be taken on the items which trigger submenus. Voiceover on Chrome even confusingly announces "empty group"
- Link component, when onClick is provided but no href, is announced as a link by screenreaders, which is confusing as it's actually an HTML button so doesn't have the expected behaviour of a link
- when using a scrollable submenu, screenreaders announce each submenu item incorrectly as "list 1 item"
- documentation of onClick on Link component does not mention the problems with this usage
- onClick story on Link has text "this is a link" although it's not correct rendered as a button, which is confusing with screenreaders

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Test with a various screenreader/browser combinations (particularly Voiceover on Safari) and ensure users are able to navigate to all menu items.

Also test for regressions on both Menu and Link components.

<!-- Add CodeSandbox here -->
