### PR TITLE
docs: close modals by default - FE-5107

### DIFF
--- a/.storybook/theme-selector/index.js
+++ b/.storybook/theme-selector/index.js
@@ -71,12 +71,13 @@ export const withThemeSelector = makeDecorator({
   ) => {
     const channel = addons.getChannel();
     channel.emit(PARAMS_EVENT, parameters);
-    const themeName = parameters.chromaticTheme || getThemeName();
+
+    // We need to work out if this is a chromatic build so we can still use the theme selector on the hosted storybook
+    const isChromaticBuild =
+      isChromatic() && window.origin !== process.env.STORYBOOK_CHROMATIC_ORIGIN;
     if (
-      themeName === "all" ||
-      (isChromatic() &&
-        window.origin !== process.env.STORYBOOK_CHROMATIC_ORIGIN &&
-        !parameters.chromaticTheme)
+      (isChromaticBuild && !parameters.chromaticTheme) ||
+      getThemeName() === "all"
     ) {
       const Wrapper = parameters.fourColumnLayout
         ? FourColumnLayout
@@ -93,6 +94,11 @@ export const withThemeSelector = makeDecorator({
       );
     }
 
-    return render(Story, themeName);
+    return render(
+      Story,
+      isChromaticBuild && parameters.chromaticTheme
+        ? parameters.chromaticTheme
+        : getThemeName()
+    );
   },
 });

--- a/src/components/alert/alert.stories.mdx
+++ b/src/components/alert/alert.stories.mdx
@@ -5,8 +5,11 @@ import Alert from ".";
 import Modal from "../modal";
 import Dialog from "../dialog";
 import Button from "../button";
+import isChromatic from "chromatic/isChromatic";
 
-<Meta title="Alert" parameters={{ info: { disable: true } }} />
+export const isOpenForChromatic = isChromatic();
+
+<Meta title="Alert" parameters={{ info: { disable: true }, themeSelector: { chromaticTheme: "sage" }}} />
 
 # Alert
 
@@ -47,12 +50,12 @@ import Alert from "carbon-react/lib/components/alert";
 <Canvas>
   <Story name="default">
     {() => {
-      const [isOpen, setIsOpen] = useState(true);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Alert</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Alert</Button>
           <Alert
-            onCancel={() => setIsOpen(!isOpen)}
+            onCancel={() => setIsOpen(false)}
             title="Title"
             subtitle="Subtitle"
             open={isOpen}

--- a/src/components/confirm/confirm.stories.mdx
+++ b/src/components/confirm/confirm.stories.mdx
@@ -3,11 +3,11 @@ import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 
 import Confirm from ".";
 import Button from "../button";
+import isChromatic from "chromatic/isChromatic";
 
-<Meta
-  title="Confirm"
-  parameters={{ info: { disable: true }, chromatic: { disable: true } }}
-/>
+export const isOpenForChromatic = isChromatic();
+
+<Meta title="Confirm" parameters={{ info: { disable: true }, themeSelector: { chromaticTheme: "sage" }}} />
 
 # Confirm
 
@@ -53,10 +53,10 @@ A good example could be confirming deletion of a large number of records.
 <Canvas>
   <Story name="default">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Confirm</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Confirm</Button>
           <Confirm
             cancelButtonDestructive
             title="Are you sure?"
@@ -78,10 +78,10 @@ A good example could be confirming deletion of a large number of records.
 <Canvas>
   <Story name="single action">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Confirm</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Confirm</Button>
           <Confirm
             title="Are you sure?"
             subtitle="Subtitle"
@@ -101,10 +101,10 @@ A good example could be confirming deletion of a large number of records.
 <Canvas>
   <Story name="destructive">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Confirm</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Confirm</Button>
           <Confirm
             title="Are you sure?"
             subtitle="Subtitle"
@@ -127,10 +127,10 @@ A good example could be confirming deletion of a large number of records.
 <Canvas>
   <Story name="cancelButtonDestructive">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Confirm</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Confirm</Button>
           <Confirm
             title="Are you sure?"
             subtitle="Subtitle"
@@ -152,10 +152,10 @@ A good example could be confirming deletion of a large number of records.
 <Canvas>
   <Story name="confirmButtonDestructive">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Confirm</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Confirm</Button>
           <Confirm
             title="Are you sure?"
             subtitle="Subtitle"
@@ -177,10 +177,10 @@ A good example could be confirming deletion of a large number of records.
 <Canvas>
   <Story name="disableConfirm">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Confirm</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Confirm</Button>
           <Confirm
             title="Are you sure?"
             subtitle="Subtitle"
@@ -204,10 +204,10 @@ A good example could be confirming deletion of a large number of records.
 <Canvas>
   <Story name="disableCancel">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Confirm</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Confirm</Button>
           <Confirm
             title="Are you sure?"
             subtitle="Subtitle"
@@ -232,10 +232,10 @@ Allows to set variant which is supported in `<Button />` and it will be applied 
 <Canvas>
   <Story name="cancelButtonType">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Confirm</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Confirm</Button>
           <Confirm
             title="Are you sure?"
             subtitle="Subtitle"
@@ -259,10 +259,10 @@ Allows to set variant which is supported in `<Button />` and it will be applied 
 <Canvas>
   <Story name="confirmButtonType">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Confirm</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Confirm</Button>
           <Confirm
             title="Are you sure?"
             subtitle="Subtitle"
@@ -284,10 +284,10 @@ Allows to set variant which is supported in `<Button />` and it will be applied 
 <Canvas>
   <Story name="buttonsIcons">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Confirm</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Confirm</Button>
           <Confirm
             title="Are you sure?"
             subtitle="Subtitle"
@@ -311,10 +311,10 @@ Allows to set variant which is supported in `<Button />` and it will be applied 
 <Canvas>
   <Story name="isLoadingConfirm">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Confirm</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Confirm</Button>
           <Confirm
             title="Are you sure?"
             subtitle="Subtitle"

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
@@ -18,8 +18,11 @@ import { ActionPopover, ActionPopoverItem } from "../action-popover";
 import Typography from "../typography";
 import { Dl, Dt, Dd } from "../definition-list";
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+import isChromatic from "chromatic/isChromatic";
 
-<Meta title="Dialog Full Screen" parameters={{ info: { disable: true } }} />
+export const isOpenForChromatic = isChromatic();
+
+<Meta title="Dialog Full Screen" parameters={{ info: { disable: true }, themeSelector: { chromaticTheme: "sage" }}} />
 
 # DialogFullScreen
 
@@ -62,7 +65,7 @@ A good example could be importing a large volume of data, and checking for error
       const [isOpen, setIsOpen] = useState(false);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>
+          <Button onClick={() => setIsOpen(true)}>
             Open DialogFullScreen
           </Button>
           <DialogFullScreen
@@ -108,7 +111,7 @@ to have a possibility to manage active `Tabs` group
 <Canvas>
   <Story name="with complex example">
     {() => {
-      const [isOpen, setIsOpen] = useState(true);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       const [activeTab, setActiveTab] = useState("tab-1");
       const padding40 = useMediaQuery("(min-width: 1260px)");
       const padding32 = useMediaQuery("(min-width: 960px)");
@@ -562,7 +565,7 @@ to have a possibility to manage active `Tabs` group
       const [isOpen, setIsOpen] = useState(false);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>
+          <Button onClick={() => setIsOpen(true)}>
             Open DialogFullScreen
           </Button>
           <DialogFullScreen
@@ -606,7 +609,7 @@ to have a possibility to manage active `Tabs` group
 <Canvas>
   <Story name="with header children" parameters={{ viewports: [500, 1400] }}>
     {() => {
-      const [isOpen, setIsOpen] = useState(true);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       const aboveBreakpoint = useMediaQuery("(min-width: 568px)");
       const verticalMargin = aboveBreakpoint ? "26px" : 0;
       const HeaderChildren = (
@@ -621,7 +624,7 @@ to have a possibility to manage active `Tabs` group
       );
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>
+          <Button onClick={() => setIsOpen(true)}>
             Open DialogFullScreen
           </Button>
           <DialogFullScreen
@@ -665,10 +668,10 @@ to have a possibility to manage active `Tabs` group
 <Canvas>
   <Story name="with help">
     {() => {
-      const [isOpen, setIsOpen] = useState(true);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>
+          <Button onClick={() => setIsOpen(true)}>
             Open DialogFullScreen
           </Button>
           <DialogFullScreen
@@ -751,7 +754,7 @@ to have a possibility to manage active `Tabs` group
       );
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>
+          <Button onClick={() => setIsOpen(true)}>
             Open DialogFullScreen
           </Button>
           <DialogFullScreen
@@ -802,7 +805,7 @@ to have a possibility to manage active `Tabs` group
       const [isOpen, setIsOpen] = useState(false);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>
+          <Button onClick={() => setIsOpen(true)}>
             Open DialogFullScreen
           </Button>
           <DialogFullScreen

--- a/src/components/dialog/dialog.stories.mdx
+++ b/src/components/dialog/dialog.stories.mdx
@@ -11,8 +11,11 @@ import { RadioButton, RadioButtonGroup } from "../radio-button";
 import Fieldset from "../fieldset";
 import Loader from "../loader";
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+import isChromatic from "chromatic/isChromatic";
 
-<Meta title="Dialog" parameters={{ info: { disable: true } }} />
+export const isOpenForChromatic = isChromatic();
+
+<Meta title="Dialog" parameters={{ info: { disable: true }, themeSelector: { chromaticTheme: "sage" }}} />
 
 # Dialog
 
@@ -54,10 +57,10 @@ A configuration shows a close icon at the top right of the Dialog. Sometimes use
 <Canvas>
   <Story name="default">
     {() => {
-      const [isOpen, setIsOpen] = useState(true);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Dialog</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
           <Dialog
             open={isOpen}
             onCancel={() => setIsOpen(false)}
@@ -100,12 +103,12 @@ When mixing editable and non-editable content, you can use the <LinkTo kind="Box
 <Canvas>
   <Story name="editable" parameters={{ chromatic: { disable: true } }}>
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       const [isDisabled, setIsDisabled] = useState(true);
       const [radioValue, setRadioValue] = useState("1");
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Dialog</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
           <Dialog
             open={isOpen}
             onCancel={() => setIsOpen(false)}
@@ -173,10 +176,10 @@ When mixing editable and non-editable content, you can use the <LinkTo kind="Box
 <Canvas>
   <Story name="with help">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Dialog</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
           <Dialog
             open={isOpen}
             onCancel={() => setIsOpen(false)}
@@ -219,7 +222,7 @@ When mixing editable and non-editable content, you can use the <LinkTo kind="Box
   <Story name="dynamic content" parameters={{ chromatic: { disable: true } }}>
     {() => {
       const [isLoading, setIsLoading] = useState(false);
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       const [addContent, setAddContent] = useState(false);
       const handleOpen = () => {
         setIsLoading(true);
@@ -352,10 +355,10 @@ set the padding to 0. Please see the [table below](#props) for more iformation a
 <Canvas>
   <Story name="overriding content padding">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
-          <Button onClick={() => setIsOpen(!isOpen)}>Open Dialog</Button>
+          <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
           <Dialog
             open={isOpen}
             onCancel={() => setIsOpen(false)}

--- a/src/components/sidebar/sidebar.stories.mdx
+++ b/src/components/sidebar/sidebar.stories.mdx
@@ -7,7 +7,11 @@ import Typography from "../typography";
 import Form from "../form";
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 
-<Meta title="Sidebar" parameters={{ info: { disable: true } }} />
+import isChromatic from "chromatic/isChromatic";
+
+export const isOpenForChromatic = isChromatic();
+
+<Meta title="Sidebar" parameters={{ info: { disable: true }, themeSelector: { chromaticTheme: "sage" }}} />
 
 # Sidebar
 
@@ -53,7 +57,7 @@ with all the UI pass `enableBackgroundUI={ true }` to the component
 <Canvas>
   <Story name="default">
     {() => {
-      const [isOpen, setIsOpen] = useState(true);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
           <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
@@ -79,9 +83,9 @@ with all the UI pass `enableBackgroundUI={ true }` to the component
 ### With header
 
 <Canvas>
-  <Story name="with header" parameters={{ chromatic: { disable: true } }}>
+  <Story name="with header">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
           <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
@@ -109,9 +113,9 @@ with all the UI pass `enableBackgroundUI={ true }` to the component
 If sidebar content does not fit the sidebar, scroll will appear. Default scroll theme is "light".
 
 <Canvas>
-  <Story name="with scroll" parameters={{ chromatic: { disable: true } }}>
+  <Story name="with scroll">
     {() => {
-      const [isOpen, setIsOpen] = useState(false);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
           <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
@@ -139,7 +143,7 @@ If sidebar content does not fit the sidebar, scroll will appear. Default scroll 
 <Canvas>
   <Story name="with typography">
     {() => {
-      const [isOpen, setIsOpen] = useState(true);
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
       return (
         <>
           <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>


### PR DESCRIPTION
### Proposed behaviour

- Modal based components in storybook are closed by default, unless it's taking a chromatic screenshot.

- Fixed the theme selector so you can use it if we have set `chromaticTheme`. Note that the `all` theme does not work at the moment. I've removed this broken code and will re-introduce it at a later date. It's also not possible to link to a theme.

### Current behaviour

When you visit the a modal based stories the component is open by default. Readers must close them to see the documentation.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

FE-5107

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
