### PR TITLE
chore: amend withThemeProvider to load three SageUI variants

### DIFF
--- a/.storybook/withThemeProvider.js
+++ b/.storybook/withThemeProvider.js
@@ -64,7 +64,7 @@ const withThemeProvider = makeDecorator({
     useEffect(() => {
       WebFont.load({
         custom: {
-          families: ["CarbonIcons", "Sage UI"],
+          families: ["CarbonIcons", "Sage UI:n4,n7,n9"],
         },
         classes: false,
         active: () => setLoading(false),


### PR DESCRIPTION
### Proposed behaviour

Specify the three variants of `Sage UI` font to wait for when loading storybook.

### Current behaviour

Storybook waits until all fonts are loaded before rendering storybooks, but the specific variants of `Sage UI` font haven't been specified.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
