### PR TITLE
docs(number): remove invalid size control option

### DIFF
--- a/src/components/textbox/textbox-test.stories.mdx
+++ b/src/components/textbox/textbox-test.stories.mdx
@@ -7,9 +7,9 @@ import Textbox from ".";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import { ICONS } from "../icon/icon-config";
 
-export const commonTextboxArgTypes = (isNewValidation)  => ({
+export const commonTextboxArgTypes = (isNewValidation) => ({
   size: {
-    options: ["extra-small", "small", "medium", "large"],
+    options: ["small", "medium", "large"],
     control: {
       type: "select",
     },
@@ -162,7 +162,12 @@ export const NewValidationStory = (args) => {
   return (
     <div style={{ width: "296px" }}>
       <CarbonProvider validationRedesignOptIn>
-        <Textbox m={2} {...getCommonTextboxArgsWithSpecialCaracters(args)} value={state} onChange={setValue} />
+        <Textbox
+          m={2}
+          {...getCommonTextboxArgsWithSpecialCaracters(args)}
+          value={state}
+          onChange={setValue}
+        />
       </CarbonProvider>
     </div>
   );
@@ -173,7 +178,11 @@ export const NewValidationStory = (args) => {
 ### Default
 
 <Canvas>
-  <Story argTypes={commonTextboxArgTypes()} name="default" args={getCommonTextboxArgs()}>
+  <Story
+    argTypes={commonTextboxArgTypes()}
+    name="default"
+    args={getCommonTextboxArgs()}
+  >
     {TextboxStory.bind({})}
   </Story>
 </Canvas>
@@ -181,7 +190,11 @@ export const NewValidationStory = (args) => {
 ### Multiple
 
 <Canvas>
-  <Story argTypes={commonTextboxArgTypes()} name="multiple" args={getCommonTextboxArgs()}>
+  <Story
+    argTypes={commonTextboxArgTypes()}
+    name="multiple"
+    args={getCommonTextboxArgs()}
+  >
     {MultipleTextboxStory.bind({})}
   </Story>
 </Canvas>
@@ -189,7 +202,11 @@ export const NewValidationStory = (args) => {
 ### New Validation
 
 <Canvas>
-  <Story argTypes={commonTextboxArgTypes(true)} name="new validation" args={getCommonTextboxArgs(true)}>
+  <Story
+    argTypes={commonTextboxArgTypes(true)}
+    name="new validation"
+    args={getCommonTextboxArgs(true)}
+  >
     {NewValidationStory.bind({})}
   </Story>
 </Canvas>


### PR DESCRIPTION
Fixes: #5011

### Proposed behaviour

Remove invalid `size` option `extra-small` from the `Number` controls.

### Current behaviour

You can select `extra-small` on the control for `size` which causes the issue shown in #5011 

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
