### PR TITLE
feat(tooltip): modify font design tokens

### DIFF
--- a/src/components/tooltip/tooltip.spec.tsx
+++ b/src/components/tooltip/tooltip.spec.tsx
@@ -58,14 +58,12 @@ describe("Tooltip", () => {
               maxWidth: "300px",
               zIndex: "6000",
               textAlign: "left",
+              font: "var(--typographyTooltipTextM)",
               color: "var(--colorsSemanticNeutralYang100)",
               display: "inline-block",
               padding: "8px 12px",
               wordBreak: "break-word",
               whiteSpace: "pre-wrap",
-              fontSize: "14px",
-              lineHeight: "1.5rem",
-              fontWeight: "400",
               backgroundColor: "var(--colorsSemanticNeutral500)",
             },
             render().find(StyledTooltipWrapper)
@@ -74,7 +72,7 @@ describe("Tooltip", () => {
 
         it("applies the correct styles when size is 'large'", () => {
           assertStyleMatch(
-            { fontSize: "16px" },
+            { font: "var(--typographyTooltipTextL)" },
             render({ size: "large" }).find(StyledTooltipWrapper)
           );
         });

--- a/src/components/tooltip/tooltip.style.ts
+++ b/src/components/tooltip/tooltip.style.ts
@@ -87,10 +87,11 @@ const StyledTooltip = styled.div<StyledTooltipProps>`
     padding: 8px 12px;
     word-break: break-word;
     white-space: pre-wrap;
-    font-size: ${size === "medium" ? "14px" : "16px"};
-    line-height: 1.5rem;
-    font-weight: 400;
+    font: ${size === "medium"
+      ? "var(--typographyTooltipTextM)"
+      : "var(--typographyTooltipTextL)"};
     background-color: ${tooltipColor(theme, bgColor, type)};
+
     ${tooltipOffset(position, inputSize, isPartOfInput)};
   `}
 `;


### PR DESCRIPTION
### Proposed behaviour

- Define font styles using design tokens.

Regular size:
![Medium sized tooltip proposed](https://user-images.githubusercontent.com/18368713/163166720-c8ddd10b-beee-48bb-abec-4b0e7a6f563b.png)

Large size:
![Large sized tooltip proposed](https://user-images.githubusercontent.com/18368713/163166552-0b8c8398-34e4-4284-822b-714429410623.png)


### Current behaviour

- Font styles are currently hardcoded.

Regular size:
![Medium sized tooltip](https://user-images.githubusercontent.com/18368713/163166194-774b670b-ea84-4ac5-a24d-a553c0347a23.png)

Large size:
![Large-sized tooltip](https://user-images.githubusercontent.com/18368713/163166349-0e2147dc-dd67-4d12-8dbd-5584d5272435.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Start storybook and use dev tools to check component uses token values (as css variables) correctly.
Check changes don't introduce regressions to official design in Design System docs.
