### PR TITLE
feat(anchor-navigation): modify font design tokens

### DIFF
--- a/src/components/anchor-navigation/anchor-navigation-item/anchor-navigation-item.style.js
+++ b/src/components/anchor-navigation/anchor-navigation-item/anchor-navigation-item.style.js
@@ -3,6 +3,7 @@ import styled, { css } from "styled-components";
 
 const StyledNavigationItem = styled.li`
   width: 100%;
+  min-height: var(--sizing500);
 
   a {
     cursor: pointer;
@@ -11,8 +12,8 @@ const StyledNavigationItem = styled.li`
     color: var(--colorsUtilityYin090);
     background-color: transparent;
     border-left: var(--sizing050) solid var(--colorsActionMinor100);
-    font-weight: 700;
-    padding: 12px 24px;
+    font: var(--typographyAnchorNavLabelM);
+    padding: 12px var(--spacing150);
 
     &:focus {
       outline: var(--borderWidth300) solid var(--colorsSemanticFocus500);

--- a/src/components/anchor-navigation/anchor-navigation-test.stories.mdx
+++ b/src/components/anchor-navigation/anchor-navigation-test.stories.mdx
@@ -11,7 +11,7 @@ import {
 } from ".";
 
 <Meta
-  title="Test/AnchorNavigation"
+  title="Anchor Navigation/Test"
   parameters={{
     info: { disable: true },
     chromatic: {

--- a/src/components/anchor-navigation/anchor-navigation.spec.js
+++ b/src/components/anchor-navigation/anchor-navigation.spec.js
@@ -341,6 +341,16 @@ describe("AnchorNavigation", () => {
     });
   });
 
+  it("renders navigation item with correct font styling", () => {
+    assertStyleMatch(
+      {
+        font: "var(--typographyAnchorNavLabelM)",
+      },
+      wrapper.find(StyledNavigationItem).at(0),
+      { modifier: "a" }
+    );
+  });
+
   it("renders not selected navigation item with proper background when hovered", () => {
     assertStyleMatch(
       {


### PR DESCRIPTION
### Proposed behaviour

- Define font styling using design token `--typographyAnchorNavigationM`.
- Amend padding and minimum height of each item using tokens to fit documented designs.
- Amend mistake in the name of `AnchorNavigation` test story  

![Screenshot 2022-04-13 at 13 28 09](https://user-images.githubusercontent.com/18368713/163179768-1d7052d4-1023-4448-9e0f-4080b040b4f6.png)

### Current behaviour

Font styling is hardcoded.

![Screenshot 2022-04-13 at 13 25 30](https://user-images.githubusercontent.com/18368713/163179806-91bbd38e-d748-4db4-ad81-af7b01d08a9a.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

_NOTE_: At the time of raising the PR, it's been noted the font weight is incorrect - with the text using `Sage UI` Regular instead of `Sage UI` Medium. @harpalsingh has flagged this as a separate issue and is working to address this.

### Testing instructions

Start storybook and use dev tools to check component uses token values (as css variables) correctly.
Check changes don't introduce regressions to official design in Design System docs.