### PR TITLE
feat(tile-select): modify font design tokens

### DIFF
--- a/src/components/tile-select/tile-select.spec.js
+++ b/src/components/tile-select/tile-select.spec.js
@@ -115,10 +115,16 @@ describe("TileSelect", () => {
     expect(mockCb).toHaveBeenCalled();
   });
 
-  it("renders title element as h3 when title prop is passed as string", () => {
+  it("renders title element as h3 with correct font when title prop is passed as string", () => {
     render({ title: "Title" });
     expect(wrapper.find(StyledTitleContainer).find("h3").exists()).toBeTruthy();
     expect(wrapper.find(StyledTitle).prop("children")).toBe("Title");
+    assertStyleMatch(
+      {
+        font: "var(--typographyCardSelectTitleM)",
+      },
+      wrapper.find("div[data-component='tile-select']").find("h3")
+    );
   });
 
   it("renders title element as a div when title prop is passed as node", () => {
@@ -130,10 +136,16 @@ describe("TileSelect", () => {
     );
   });
 
-  it("renders subtitle element as h4 when subtitle prop is passed as string", () => {
+  it("renders subtitle element as h4 with correct font when subtitle prop is passed as string", () => {
     render({ subtitle: "Subtitle" });
     expect(wrapper.find(StyledTitleContainer).find("h4").exists()).toBeTruthy();
     expect(wrapper.find(StyledSubtitle).prop("children")).toBe("Subtitle");
+    assertStyleMatch(
+      {
+        font: "var(--typographyCardSelectSubtitleM)",
+      },
+      wrapper.find("div[data-component='tile-select']").find("h4")
+    );
   });
 
   it("renders subtitle element as a div when subtitle prop is passed as node", () => {
@@ -151,11 +163,17 @@ describe("TileSelect", () => {
     expect(wrapper.find(StyledAdornment).find(MyComp).exists()).toBe(true);
   });
 
-  it("renders description element as p when description prop is passed as string", () => {
+  it("renders description element as p with correct font when description prop is passed as string", () => {
     render({ description: "description" });
     expect(wrapper.find(StyledDescription).prop("as")).toBe(undefined);
     expect(wrapper.find(StyledDescription).prop("children")).toBe(
       "description"
+    );
+    assertStyleMatch(
+      {
+        font: "var(--typographyCardSelectParagraphM)",
+      },
+      wrapper.find("div[data-component='tile-select']").find("p")
     );
   });
 

--- a/src/components/tile-select/tile-select.style.js
+++ b/src/components/tile-select/tile-select.style.js
@@ -7,8 +7,7 @@ import StyledIcon from "../icon/icon.style";
 import { baseTheme } from "../../style/themes";
 
 const StyledTitle = styled.h3`
-  font-size: 16px;
-  font-weight: 900;
+  font: var(--typographyCardSelectTitleM);
   margin: 0;
   margin-right: 16px;
   margin-bottom: 8px;
@@ -16,8 +15,7 @@ const StyledTitle = styled.h3`
 `;
 
 const StyledSubtitle = styled.h4`
-  font-size: 14px;
-  font-weight: 700;
+  font: var(--typographyCardSelectSubtitleM);
   margin: 0;
   margin-right: 16px;
   margin-bottom: 8px;
@@ -32,7 +30,7 @@ const StyledAdornment = styled.div`
 
 const StyledDescription = styled.p`
   color: var(--colorsActionMinorYin055);
-  font-size: 14px;
+  font: var(--typographyCardSelectParagraphM);
   margin: 0;
 `;
 


### PR DESCRIPTION
### Proposed behaviour

- Define font styles using design tokens.

![Screenshot 2022-04-13 at 14 54 29](https://user-images.githubusercontent.com/18368713/163196331-a1842209-0457-478a-bb4f-723b027a14c6.png)

### Current behaviour

- Font styles are hardcoded.

![Screenshot 2022-04-13 at 14 54 56](https://user-images.githubusercontent.com/18368713/163196436-b9f46316-457c-4f08-aafa-69c1b3bdff04.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Start storybook and use dev tools to check component uses token values (as css variables) correctly.
Check changes don't introduce regressions to official design in Design System docs.