### PR TITLE
feat(date): modify font design tokens

### DIFF
--- a/src/components/date/__internal__/date-picker/__snapshots__/date-picker.spec.js.snap
+++ b/src/components/date/__internal__/date-picker/__snapshots__/date-picker.spec.js.snap
@@ -239,15 +239,29 @@ exports[`StyledDayPicker renders presentational div and context provider for its
 
 .c0 .DayPicker-Caption {
   color: var(--colorsActionMajorYin090);
-  line-height: var(--sizing500);
   height: var(--sizing500);
-  font-size: 16px;
-  font-weight: 800;
+  font: var(--typographyDatePickerCalendarMonthM);
 }
 
 .c0 .DayPicker-Caption > div {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   margin: 0 auto;
+  height: 100%;
   width: 80%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c0 .DayPicker-Day {
@@ -257,9 +271,7 @@ exports[`StyledDayPicker renders presentational div and context provider for its
   background-color: var(--colorsUtilityYang100);
   cursor: pointer;
   border: none;
-  font-weight: var(--fontWeights700);
-  font-size: var(--fontSizes100);
-  line-height: var(--lineHeights500);
+  font: var(--typographyDatePickerCalendarDateM);
 }
 
 .c0 .DayPicker-Day:hover {

--- a/src/components/date/__internal__/date-picker/day-picker.style.js
+++ b/src/components/date/__internal__/date-picker/day-picker.style.js
@@ -228,15 +228,16 @@ const StyledDayPicker = styled.div`
 
   .DayPicker-Caption {
     color: var(--colorsActionMajorYin090);
-    line-height: var(--sizing500);
     height: var(--sizing500);
-    //font: var(--typographyDatePickerCalendarMonthM); font assets to be updated part of FE-4975
-    font-size: 16px;
-    font-weight: 800;
-
+    font: var(--typographyDatePickerCalendarMonthM);
     > div {
+      display: flex;
+      flex-direction: row;
       margin: 0 auto;
+      height: 100%;
       width: 80%;
+      justify-content: center;
+      align-items: center;
     }
   }
 
@@ -247,11 +248,7 @@ const StyledDayPicker = styled.div`
     background-color: var(--colorsUtilityYang100);
     cursor: pointer;
     border: none;
-    //font-family: var(--fontFamiliesDefault); font assets to be updated part of FE-4975
-    //font: var(--typographyDatePickerCalendarDateM); font assets to be updated part of FE-4975
-    font-weight: var(--fontWeights700);
-    font-size: var(--fontSizes100);
-    line-height: var(--lineHeights500);
+    font: var(--typographyDatePickerCalendarDateM);
 
     &:hover {
       background-color: var(--colorsActionMinor050);

--- a/src/components/date/__internal__/weekday/__snapshots__/weekday.spec.js.snap
+++ b/src/components/date/__internal__/weekday/__snapshots__/weekday.spec.js.snap
@@ -6,10 +6,9 @@ exports[`Weekday renders presentational div and context provider for its childre
   border: none;
   height: var(--sizing500);
   min-width: var(--sizing500);
-  font-weight: 800;
   color: var(--colorsActionMinor400);
   text-transform: uppercase;
-  font-size: 12px;
+  font: var(--typographyDatePickerCalendarDayM);
   text-align: center;
   padding: 20px 0 5px;
   box-sizing: border-box;

--- a/src/components/date/__internal__/weekday/weekday.style.js
+++ b/src/components/date/__internal__/weekday/weekday.style.js
@@ -6,11 +6,9 @@ const StyledWeekday = styled.div`
     border: none;
     height: var(--sizing500);
     min-width: var(--sizing500);
-    font-weight: 800;
     color: var(--colorsActionMinor400);
     text-transform: uppercase;
-    font-size: 12px;
-    //font: var(--typographyDatePickerCalendarDayM) font assets to be updated part of FE-4975
+    font: var(--typographyDatePickerCalendarDayM);
     text-align: center;
     padding: 20px 0 5px;
     box-sizing: border-box;


### PR DESCRIPTION
### Proposed behaviour

Define font styling using design tokens.

Date Picker open:
![Screenshot 2022-04-13 at 15 04 56](https://user-images.githubusercontent.com/18368713/163198570-39cf1818-bd0a-4d4b-8b1a-2d92fa84710a.png)

Sizes of Date Input:
![Screenshot 2022-04-13 at 15 06 02](https://user-images.githubusercontent.com/18368713/163198767-7c18b829-c839-4d79-8119-3b3df6191f05.png)

### Current behaviour

Font styles are hardcoded.

Date Picker open:
![Screenshot 2022-04-13 at 15 07 34](https://user-images.githubusercontent.com/18368713/163199178-22296fda-d963-4b36-86ef-36be32c02d16.png)

Sizes of Date Input:
![Screenshot 2022-04-13 at 15 06 48](https://user-images.githubusercontent.com/18368713/163198918-22546f2c-198e-4fa6-8a24-53a4b0fd3137.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions
Start storybook and use dev tools to check component uses token values (as css variables) correctly.
Check changes don't introduce regressions to official design in Design System docs.
