### PR TITLE
docs(chromatic): remove webfontloader

### DIFF
--- a/.storybook/withThemeProvider.js
+++ b/.storybook/withThemeProvider.js
@@ -11,7 +11,6 @@ import {
   sageTheme,
 } from "../src/style/themes";
 import { config } from "react-transition-group";
-import WebFont from "webfontloader";
 
 const themes = [mintTheme, aegeanTheme, noTheme, sageTheme].reduce(
   (themesObject, theme) => {
@@ -59,22 +58,35 @@ const withThemeProvider = makeDecorator({
     // Disable transitions
     config.disabled = isChromaticBuild;
 
-    // Only render the story once the fonts are loaded
-    const [loading, setLoading] = useState(true);
-    useEffect(() => {
-      WebFont.load({
-        custom: {
-          families: ["CarbonIcons", "Sage UI:n4,n7,n9"],
-        },
-        classes: false,
-        active: () => setLoading(false),
-        inactive: () => setLoading(new Error("Unable to load font files.")),
-      });
-    }, []);
+    const shouldLoadFonts = isChromatic() && document.fonts;
+    const [loading, setLoading] = useState(shouldLoadFonts);
 
-    if (loading instanceof Error) {
-      throw loading;
-    }
+    useEffect(() => {
+      if (!shouldLoadFonts) {
+        return null;
+      }
+
+      const fonts = [
+        "400 1em Sage UI",
+        "700 1em Sage UI",
+        "900 1em Sage UI",
+        "1em CarbonIcons",
+      ];
+
+      // These fonts are pre-loaded but we want to wait until they're finished loading
+      Promise.all(fonts.map((fontName) => document.fonts.load(fontName))).then(
+        (results) => {
+          const firstError = results.findIndex((r) => r.length === 0);
+          if (firstError >= 0) {
+            setLoading(() => {
+              throw new Error(`Font "${fonts[firstError]}" failed to load.`);
+            });
+          } else {
+            setLoading(false);
+          }
+        }
+      );
+    }, []);
 
     if (loading) {
       return null;

--- a/docs/getting-started.stories.mdx
+++ b/docs/getting-started.stories.mdx
@@ -107,18 +107,6 @@ The `Sage UI` font files themselves are loaded via a public CDN under [license](
 </head>
 ```
 
-##### Webfont Loader
-
-While not required, we also recommend using [`webfontloader`](https://github.com/typekit/webfontloader#custom). This allows you to know when the fonts have finished loading. Once loaded you can render without risking a flash of unstyled text.
-
-```js
-WebFont.load({
-  custom: {
-    families: ["CarbonIcons", "Sage UI"],
-  },
-});
-```
-
 #### React and React DOM
 
 React and React DOM are imported from the [React library](https://reactjs.org/), which forms the basis for Carbon's components.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30105,12 +30105,6 @@
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
       "dev": true
     },
-    "webfontloader": {
-      "version": "1.6.28",
-      "resolved": "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.28.tgz",
-      "integrity": "sha1-23hhKSU8tujq5UwvsF+HCvZnW64=",
-      "dev": true
-    },
     "webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
     "typescript": "^4.6.2",
     "typescript-to-proptypes": "^2.2.1",
     "uuid": "^8.3.2",
-    "webfontloader": "^1.6.28",
     "webpack-dev-server": "^4.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
### Proposed behaviour

Remove webfontloader, it's unsupported and isn't solving our loading issue on chromatic.

### Current behaviour

We recommend and use webfontloader to check if the font has finished loading.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

N/A

### Additional context

N/A

### Testing instructions

Ensure there are no chromatic differences.
