### PR TITLE
fix(split-button): ensure prop type definition is exported from index.d.ts file

### DIFF
--- a/src/components/split-button/index.d.ts
+++ b/src/components/split-button/index.d.ts
@@ -1,1 +1,2 @@
 export { default } from "./split-button";
+export type { SplitButtonProps } from "./split-button";


### PR DESCRIPTION
fix #5049

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Exports the prop type definition from the index file as well as the functional component

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
`MultiActionButton` is not correctly extending the `SplitButton` prop type as they are not exported from the index file

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

Export the built TS sandbox and test it locally that the component now supports `children` without throwing TS errors

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
I will help QA test this in a local TS project as the error isn't showing up in a codesanbox
https://codesandbox.io/s/determined-marco-9zqno9?file=/src/index.tsx