### PR TITLE
fix: support for Polish and Chinese date formats #4966

### DIFF
--- a/src/components/date/__internal__/date-formats/date-formats.spec.js
+++ b/src/components/date/__internal__/date-formats/date-formats.spec.js
@@ -1,7 +1,110 @@
 import getFormatData from ".";
 
-const euLocales = ["en-GB", "en-ZA", "fr-FR", "es", "fr-CA", "de"];
+const euLocales = [
+  "en-GB",
+  "en-ZA",
+  "fr-FR",
+  "es",
+  "fr-CA",
+  "de",
+  "pl",
+  "de-AT",
+  "it-IT",
+  "it-CH",
+  "de-CH",
+];
 const naLocales = ["en-US", "en-CA"];
+
+const cnFormats = [
+  "M",
+  "M d",
+  "Md",
+  "M.d",
+  "M,d",
+  "M-d",
+  "M/d",
+  "M:d",
+  "MM",
+  "M dd",
+  "Mdd",
+  "M.dd",
+  "M,dd",
+  "M-dd",
+  "M/dd",
+  "M:dd",
+  "MM d",
+  "MMd",
+  "MM.d",
+  "MM,d",
+  "MM-d",
+  "MM/d",
+  "MM:d",
+  "MM dd",
+  "MMdd",
+  "MM.dd",
+  "MM,dd",
+  "MM-dd",
+  "MM/dd",
+  "MM:dd",
+  "yy d M",
+  "yydM",
+  "yy.d.M",
+  "yy,d,M",
+  "yy-d-M",
+  "yy/d/M",
+  "yy:d:M",
+  "yy d MM",
+  "yydMM",
+  "yy.d.MM",
+  "yy,d,MM",
+  "yy-d-MM",
+  "yy/d/MM",
+  "yy:d:MM",
+  "yy dd M",
+  "yyddM",
+  "yy.dd.M",
+  "yy,dd,M",
+  "yy-dd-M",
+  "yy/dd/M",
+  "yy:dd:M",
+  "yy dd MM",
+  "yyddMM",
+  "yy.dd.MM",
+  "yy,dd,MM",
+  "yy-dd-MM",
+  "yy/dd/MM",
+  "yy:dd:MM",
+  "yyyy d M",
+  "yyyydM",
+  "yyyy.d.M",
+  "yyyy,d,M",
+  "yyyy-d-M",
+  "yyyy/d/M",
+  "yyyy:d:M",
+  "yyyy d MM",
+  "yyyydMM",
+  "yyyy.d.MM",
+  "yyyy,d,MM",
+  "yyyy-d-MM",
+  "yyyy/d/MM",
+  "yyyy:d:MM",
+  "yyyy dd M",
+  "yyyyddM",
+  "yyyy.dd.M",
+  "yyyy,dd,M",
+  "yyyy-dd-M",
+  "yyyy/dd/M",
+  "yyyy:dd:M",
+  "yyyy dd MM",
+  "yyyyddMM",
+  "yyyy.dd.MM",
+  "yyyy,dd,MM",
+  "yyyy-dd-MM",
+  "yyyy/dd/MM",
+  "yyyy:dd:MM",
+];
+
+const cnLocales = ["zh", "zh-CN", "zh-HK", "zh-TW"];
 
 const euFormats = [
   "d M yyyy",
@@ -181,37 +284,56 @@ const naFormats = [
   "MM:dd:yyyy",
 ];
 
-const formatMap = [...euLocales, ...naLocales].reduce((acc, code) => {
-  if (code === "de") {
+const formatMap = [...euLocales, ...naLocales, ...cnLocales].reduce(
+  (acc, code) => {
+    if (code.startsWith("de") || code.startsWith("pl")) {
+      return {
+        ...acc,
+        [code]: "dd.MM.yyyy",
+      };
+    }
+
+    if (["en-CA", "en-US"].includes(code)) {
+      return {
+        ...acc,
+        [code]: "MM/dd/yyyy",
+      };
+    }
+
+    if (code.startsWith("zh")) {
+      return {
+        ...acc,
+        [code]: "yyyy-MM-dd",
+      };
+    }
+
     return {
       ...acc,
-      [code]: "dd.MM.yyyy",
+      [code]: "dd/MM/yyyy",
     };
+  },
+  {}
+);
+
+const getExpectedFormatForLocale = (locale) => {
+  if (naLocales.includes(locale)) {
+    return naFormats;
   }
 
-  if (["en-CA", "en-US"].includes(code)) {
-    return {
-      ...acc,
-      [code]: "MM/dd/yyyy",
-    };
+  if (cnLocales.includes(locale)) {
+    return cnFormats;
   }
 
-  return {
-    ...acc,
-    [code]: "dd/MM/yyyy",
-  };
-}, {});
+  return euFormats;
+};
 
-describe.each([...euLocales, ...naLocales])(
+describe.each([...euLocales, ...naLocales, ...cnLocales])(
   "getFormatData for `%s` returns",
   (locale) => {
     const { formats, format } = getFormatData({ code: locale });
 
     it("the expected formats", () => {
-      const expectedFormats = naLocales.includes(locale)
-        ? naFormats
-        : euFormats;
-
+      const expectedFormats = getExpectedFormatForLocale(locale);
       expect(
         expectedFormats.every((formatStr) => formats.includes(formatStr)) &&
           formats.length === expectedFormats.length

--- a/src/components/date/__internal__/date-formats/index.js
+++ b/src/components/date/__internal__/date-formats/index.js
@@ -34,6 +34,24 @@ const NA_FORMATS = [
   "MM dd yyyy",
 ];
 
+// The order of this array is important
+const CN_FORMATS = [
+  "M",
+  "M d",
+  "MM",
+  "M dd",
+  "MM d",
+  "MM dd",
+  "yy d M",
+  "yy d MM",
+  "yy dd M",
+  "yy dd MM",
+  "yyyy d M",
+  "yyyy d MM",
+  "yyyy dd M",
+  "yyyy dd MM",
+];
+
 const SEPARATORS = ["", ".", ",", "-", "/", ":"];
 
 const generateFormats = (formatArray) =>
@@ -55,10 +73,19 @@ const getFormatData = ({ code }) => {
     };
   }
 
-  if (code === "de") {
+  if (
+    ["de", "de-DE", "de-DE", "de-CH", "de-AT", "pl", "pl-PL"].includes(code)
+  ) {
     return {
       format: "dd.MM.yyyy",
       formats: generateFormats(EU_FORMATS),
+    };
+  }
+
+  if (["zh", "zh-CN", "zh-HK", "zh-TW"].includes(code)) {
+    return {
+      format: "yyyy-MM-dd",
+      formats: generateFormats(CN_FORMATS),
     };
   }
 


### PR DESCRIPTION
### Proposed behaviour

Certain European and Chinese locales are not supported and the code falls back to the most common European format 
Please see the issue linked to the ticket

### Current behaviour

Chinese and Polish date formats can be used with the date input.

### Checklist


- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

I extended the list of supported European locales, added support for Polish date format and various Chinese date formats.

### Testing instructions

The following CodeSandbox is an example of the broken behaviour:
https://codesandbox.io/s/funny-hofstadter-rf2y4l

You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

https://codesandbox.io/s/funny-hofstadter-rf2y4l
