### PR TITLE
feat(accordion): modify font design tokens

### DIFF
--- a/src/components/accordion/accordion.spec.js
+++ b/src/components/accordion/accordion.spec.js
@@ -87,6 +87,16 @@ describe("Accordion", () => {
     render();
   });
 
+  it("renders content with correct font", () => {
+    render();
+    assertStyleMatch(
+      {
+        font: "var(--typographyAccordionParagraphM)",
+      },
+      wrapper.find("div[data-element='accordion-content']")
+    );
+  });
+
   it("renders content without paddings if `disableCustomPadding` is applied", () => {
     render({ disableContentPadding: true });
 
@@ -95,6 +105,26 @@ describe("Accordion", () => {
         padding: "0",
       },
       wrapper.find(StyledAccordionContent)
+    );
+  });
+
+  it("when title prop is a string, renders title with correct font", () => {
+    render();
+    assertStyleMatch(
+      {
+        font: "var(--typographyAccordionTitleM)",
+      },
+      wrapper.find("h3[data-element='accordion-title']")
+    );
+  });
+
+  it("when title prop is a string and size is small, override title font to be smaller", () => {
+    render({ size: "small" });
+    assertStyleMatch(
+      {
+        fontSize: "14px",
+      },
+      wrapper.find("h3[data-element='accordion-title']")
     );
   });
 
@@ -376,6 +406,7 @@ describe("Accordion", () => {
       assertStyleMatch(
         {
           marginTop: "8px",
+          font: "var(--typographyAccordionSubtitleM)",
         },
         subTitle
       );
@@ -478,11 +509,10 @@ describe("Accordion", () => {
       assertStyleMatch(
         {
           boxSizing: "border-box",
-          fontWeight: "600",
           textDecoration: "none",
-          fontSize: "var(--fontSizes100)",
           minHeight: "var(--spacing500)",
           color: "var(--colorsActionMajor500)",
+          font: "var(--typographyButtonLabelM)",
           width: "150px",
         },
         wrapper

--- a/src/components/accordion/accordion.style.js
+++ b/src/components/accordion/accordion.style.js
@@ -44,14 +44,18 @@ const StyledAccordionContainer = styled.div`
 `;
 
 const StyledAccordionTitle = styled.h3`
-  font-size: ${({ size }) => (size === "small" ? "14" : "20")}px;
-  font-weight: ${({ size }) => (size === "small" ? 700 : 900)};
-  line-height: 1;
+  font: var(--typographyAccordionTitleM);
+  ${({ size }) =>
+    size === "small" &&
+    css`
+      font-size: 14px;
+    `}
   user-select: none;
   margin: 0;
 `;
 
 const StyledAccordionSubTitle = styled.span`
+  font: var(--typographyAccordionSubtitleM);
   margin-top: 8px;
 `;
 
@@ -128,11 +132,9 @@ const StyledAccordionTitleContainer = styled.div`
     ${buttonHeading &&
     css`
       box-sizing: border-box;
-      font-weight: 600;
       text-decoration: none;
-      font-size: var(--fontSizes100);
       min-height: var(--spacing500);
-
+      font: var(--typographyButtonLabelM);
       color: var(--colorsActionMajor500);
 
       ${!hasButtonProps &&
@@ -183,6 +185,7 @@ const StyledAccordionContentContainer = styled.div`
 `;
 
 const StyledAccordionContent = styled.div`
+  font: var(--typographyAccordionParagraphM);
   padding: var(--spacing300);
   padding-top: 0;
   overflow: hidden;

--- a/src/components/accordion/accordion.test.js
+++ b/src/components/accordion/accordion.test.js
@@ -18,7 +18,7 @@ import { positionOfElement, keyCode } from "../../../cypress/support/helper";
 const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
 const sizes = [
   ["small", "24px"],
-  ["large", "46px"],
+  ["large", "54px"],
 ];
 const accWidths = [["700px"], ["900px"], ["1100px"], ["1300px"]];
 


### PR DESCRIPTION
### Proposed behaviour

- Define font styling using `--typography*` design tokens
   - Add tokens for accordion title, subtitle and paragraphs
   - Override default token styling for when size is small - since this variant is not supported by Design System.
   - Amend opening button variant to use same font styling as tertiary button.
   
![Screenshot 2022-04-14 at 13 09 01](https://user-images.githubusercontent.com/18368713/163387666-6727a552-c1e8-4f39-b844-c0539d55ad1c.png)
![Screenshot 2022-04-14 at 13 09 39](https://user-images.githubusercontent.com/18368713/163387766-1fc86c03-1f65-4dd8-ac84-8fd65f0d26ee.png)


### Current behaviour
- Font styling is hardcoded.

![Screenshot 2022-04-14 at 13 09 16](https://user-images.githubusercontent.com/18368713/163387693-09e86eb2-94f9-4768-a683-bcc9d13504d3.png)
![Screenshot 2022-04-14 at 13 11 31](https://user-images.githubusercontent.com/18368713/163388048-e521887e-71d6-4b43-8ab8-72e277b919d4.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required


### Testing instructions

Start storybook and use dev tools to check component uses token values (as css variables) correctly.
Check changes don't introduce regressions to official design in Design System docs.