### PR TITLE
fix(date): ensure correct output format and input formats are used for given locale FE-5035

### DIFF
--- a/src/components/date/__internal__/date-formats/date-formats.spec.js
+++ b/src/components/date/__internal__/date-formats/date-formats.spec.js
@@ -1,7 +1,18 @@
 import getFormatData from ".";
 
-const euLocales = ["en-GB", "en-ZA", "fr-FR", "es", "fr-CA", "de"];
+const euLocales = [
+  "en-GB",
+  "en-ZA",
+  "fr",
+  "es",
+  "fr-CA",
+  "de",
+  "pl",
+  "bg",
+  "zh-HK", // currently still using EU style formatting
+];
 const naLocales = ["en-US", "en-CA"];
+const cnLocales = ["zh", "zh-CN", "zh-TW", "hu"];
 
 const euFormats = [
   "d M yyyy",
@@ -181,36 +192,317 @@ const naFormats = [
   "MM:dd:yyyy",
 ];
 
-const formatMap = [...euLocales, ...naLocales].reduce((acc, code) => {
-  if (code === "de") {
+const cnFormats = [
+  "yyyy M",
+  "yyyyM",
+  "yyyy.M",
+  "yyyy,M",
+  "yyyy-M",
+  "yyyy/M",
+  "yyyy:M",
+  "yyyy M d",
+  "yyyyMd",
+  "yyyy.M.d",
+  "yyyy,M,d",
+  "yyyy-M-d",
+  "yyyy/M/d",
+  "yyyy:M:d",
+  "yyyy MM d",
+  "yyyyMMd",
+  "yyyy.MM.d",
+  "yyyy,MM,d",
+  "yyyy-MM-d",
+  "yyyy/MM/d",
+  "yyyy:MM:d",
+  "yyyy M dd",
+  "yyyyMdd",
+  "yyyy.M.dd",
+  "yyyy,M,dd",
+  "yyyy-M-dd",
+  "yyyy/M/dd",
+  "yyyy:M:dd",
+  "yyyy MM dd",
+  "yyyyMMdd",
+  "yyyy.MM.dd",
+  "yyyy,MM,dd",
+  "yyyy-MM-dd",
+  "yyyy/MM/dd",
+  "yyyy:MM:dd",
+  "yy M",
+  "yyM",
+  "yy.M",
+  "yy,M",
+  "yy-M",
+  "yy/M",
+  "yy:M",
+  "yy MM",
+  "yyMM",
+  "yy.MM",
+  "yy,MM",
+  "yy-MM",
+  "yy/MM",
+  "yy:MM",
+  "yy M d",
+  "yyMd",
+  "yy.M.d",
+  "yy,M,d",
+  "yy-M-d",
+  "yy/M/d",
+  "yy:M:d",
+  "yy MM d",
+  "yyMMd",
+  "yy.MM.d",
+  "yy,MM,d",
+  "yy-MM-d",
+  "yy/MM/d",
+  "yy:MM:d",
+  "yy M dd",
+  "yyMdd",
+  "yy.M.dd",
+  "yy,M,dd",
+  "yy-M-dd",
+  "yy/M/dd",
+  "yy:M:dd",
+  "yy MM dd",
+  "yyMMdd",
+  "yy.MM.dd",
+  "yy,MM,dd",
+  "yy-MM-dd",
+  "yy/MM/dd",
+  "yy:MM:dd",
+  "M",
+  "M d",
+  "Md",
+  "M.d",
+  "M,d",
+  "M-d",
+  "M/d",
+  "M:d",
+  "MM",
+  "M dd",
+  "Mdd",
+  "M.dd",
+  "M,dd",
+  "M-dd",
+  "M/dd",
+  "M:dd",
+  "MM d",
+  "MMd",
+  "MM.d",
+  "MM,d",
+  "MM-d",
+  "MM/d",
+  "MM:d",
+  "MM dd",
+  "MMdd",
+  "MM.dd",
+  "MM,dd",
+  "MM-dd",
+  "MM/dd",
+  "MM:dd",
+];
+
+const huFormats = [
+  "yyyy M",
+  "yyyyM",
+  "yyyy.M",
+  "yyyy,M",
+  "yyyy-M",
+  "yyyy/M",
+  "yyyy:M",
+  "yyyy. M.",
+  "yyyy. M",
+  "yyyy M d",
+  "yyyyMd",
+  "yyyy.M.d",
+  "yyyy,M,d",
+  "yyyy-M-d",
+  "yyyy/M/d",
+  "yyyy:M:d",
+  "yyyy. M. d.",
+  "yyyy. M. d",
+  "yyyy MM d",
+  "yyyyMMd",
+  "yyyy.MM.d",
+  "yyyy,MM,d",
+  "yyyy-MM-d",
+  "yyyy/MM/d",
+  "yyyy:MM:d",
+  "yyyy. MM. d.",
+  "yyyy. MM. d",
+  "yyyy M dd",
+  "yyyyMdd",
+  "yyyy.M.dd",
+  "yyyy,M,dd",
+  "yyyy-M-dd",
+  "yyyy/M/dd",
+  "yyyy:M:dd",
+  "yyyy. M. dd.",
+  "yyyy. M. dd",
+  "yyyy MM dd",
+  "yyyyMMdd",
+  "yyyy.MM.dd",
+  "yyyy,MM,dd",
+  "yyyy-MM-dd",
+  "yyyy/MM/dd",
+  "yyyy:MM:dd",
+  "yyyy. MM. dd.",
+  "yyyy. MM. dd",
+  "yy M",
+  "yyM",
+  "yy.M",
+  "yy,M",
+  "yy-M",
+  "yy/M",
+  "yy:M",
+  "yy. M.",
+  "yy. M",
+  "yy MM",
+  "yyMM",
+  "yy.MM",
+  "yy,MM",
+  "yy-MM",
+  "yy/MM",
+  "yy:MM",
+  "yy. MM.",
+  "yy. MM",
+  "yy M d",
+  "yyMd",
+  "yy.M.d",
+  "yy,M,d",
+  "yy-M-d",
+  "yy/M/d",
+  "yy:M:d",
+  "yy. M. d.",
+  "yy. M. d",
+  "yy MM d",
+  "yyMMd",
+  "yy.MM.d",
+  "yy,MM,d",
+  "yy-MM-d",
+  "yy/MM/d",
+  "yy:MM:d",
+  "yy. MM. d.",
+  "yy. MM. d",
+  "yy M dd",
+  "yyMdd",
+  "yy.M.dd",
+  "yy,M,dd",
+  "yy-M-dd",
+  "yy/M/dd",
+  "yy:M:dd",
+  "yy. M. dd.",
+  "yy. M. dd",
+  "yy MM dd",
+  "yyMMdd",
+  "yy.MM.dd",
+  "yy,MM,dd",
+  "yy-MM-dd",
+  "yy/MM/dd",
+  "yy:MM:dd",
+  "yy. MM. dd.",
+  "yy. MM. dd",
+  "M",
+  "M d",
+  "Md",
+  "M.d",
+  "M,d",
+  "M-d",
+  "M/d",
+  "M:d",
+  "M. d.",
+  "M. d",
+  "MM",
+  "M dd",
+  "Mdd",
+  "M.dd",
+  "M,dd",
+  "M-dd",
+  "M/dd",
+  "M:dd",
+  "M. dd.",
+  "M. dd",
+  "MM d",
+  "MMd",
+  "MM.d",
+  "MM,d",
+  "MM-d",
+  "MM/d",
+  "MM:d",
+  "MM. d.",
+  "MM. d",
+  "MM dd",
+  "MMdd",
+  "MM.dd",
+  "MM,dd",
+  "MM-dd",
+  "MM/dd",
+  "MM:dd",
+  "MM. dd.",
+  "MM. dd",
+];
+
+const formatMap = [...euLocales, ...naLocales, ...cnLocales].reduce(
+  (acc, code) => {
+    if (["de", "pl", "bg"].includes(code)) {
+      return {
+        ...acc,
+        [code]: "dd.MM.yyyy",
+      };
+    }
+
+    if (code === "hu") {
+      return {
+        ...acc,
+        [code]: "yyyy. MM. dd.",
+      };
+    }
+
+    if (naLocales.includes(code)) {
+      return {
+        ...acc,
+        [code]: "MM/dd/yyyy",
+      };
+    }
+
+    if (cnLocales.includes(code)) {
+      return {
+        ...acc,
+        [code]: "yyyy/MM/dd",
+      };
+    }
+
     return {
       ...acc,
-      [code]: "dd.MM.yyyy",
+      [code]: "dd/MM/yyyy",
     };
+  },
+  {}
+);
+
+const getExpectedFormatForLocale = (locale) => {
+  if (naLocales.includes(locale)) {
+    return naFormats;
   }
 
-  if (["en-CA", "en-US"].includes(code)) {
-    return {
-      ...acc,
-      [code]: "MM/dd/yyyy",
-    };
+  if (locale === "hu") {
+    return huFormats;
   }
 
-  return {
-    ...acc,
-    [code]: "dd/MM/yyyy",
-  };
-}, {});
+  if (cnLocales.includes(locale)) {
+    return cnFormats;
+  }
 
-describe.each([...euLocales, ...naLocales])(
+  return euFormats;
+};
+
+describe.each([...euLocales, ...naLocales, ...cnLocales])(
   "getFormatData for `%s` returns",
   (locale) => {
     const { formats, format } = getFormatData({ code: locale });
 
     it("the expected formats", () => {
-      const expectedFormats = naLocales.includes(locale)
-        ? naFormats
-        : euFormats;
+      const expectedFormats = getExpectedFormatForLocale(locale);
 
       expect(
         expectedFormats.every((formatStr) => formats.includes(formatStr)) &&

--- a/src/components/date/__internal__/utils.js
+++ b/src/components/date/__internal__/utils.js
@@ -38,19 +38,41 @@ function hasMatchedFormat(formatString, valueString, fullFormat, fullValue) {
   );
 }
 
+const THRESHOLD_FOR_ADDITIONAL_YEARS = 69;
+
 export function additionalYears(formatString, value) {
   if (formatString.split("y").length - 1 !== 2) {
     return [formatString, value];
   }
 
-  let year = value.substring(value.length - 2);
-  const dayAndMonth = value.substring(0, value.length - 2);
+  const formatStartWithYear = formatString.startsWith("yy");
+  const yearStringStartIndex = formatStartWithYear ? 0 : value.length - 2;
+  const yearStringEndIndex = formatStartWithYear ? 2 : value.length;
+  const dayAndMonthStringStartIndex = formatStartWithYear
+    ? yearStringEndIndex
+    : 0;
+  const dayAndMonthStringEndIndex = formatStartWithYear
+    ? value.length
+    : value.length - 2;
+
+  let year = value.substring(yearStringStartIndex, yearStringEndIndex);
+  const dayAndMonth = value.substring(
+    dayAndMonthStringStartIndex,
+    dayAndMonthStringEndIndex
+  );
   const yearAsNumber = Number(year);
 
-  if (yearAsNumber < 69) {
+  if (yearAsNumber < THRESHOLD_FOR_ADDITIONAL_YEARS) {
     year = String(2000 + yearAsNumber);
   } else {
     year = String(1900 + yearAsNumber);
+  }
+
+  if (formatStartWithYear) {
+    return [
+      `yyyy${formatString.substring(2, formatString.length)}`,
+      `${year}${dayAndMonth}`,
+    ];
   }
 
   return [

--- a/src/components/date/__internal__/utils.spec.js
+++ b/src/components/date/__internal__/utils.spec.js
@@ -262,6 +262,11 @@ describe("utils", () => {
         "dd/MM/yyyy",
         "01/01/2022",
       ]);
+
+      expect(additionalYears("yyyy/MM/dd", "2022/01/01")).toEqual([
+        "yyyy/MM/dd",
+        "2022/01/01",
+      ]);
     });
 
     describe.each(yearValuesLessThan69)("when year value is %s", (year) => {
@@ -284,6 +289,26 @@ describe("utils", () => {
         const output = result(format, `01-01-20${year}`);
         expect(additionalYears(format, input)).toEqual([`${format}yy`, output]);
       });
+
+      it.each([
+        "yy.M.d",
+        "yy,M,d",
+        "yy-M-d",
+        "yy/M/d",
+        "yy.M.dd",
+        "yy,M,dd",
+        "yy-M-dd-M",
+        "yy/M/dd/M",
+        "yyMdd",
+        "yy.MM.dd",
+        "yy,MM,dd",
+        "yy-MM-dd",
+        "yy/MM/dd",
+      ])("returns the expected when format is %s", (format) => {
+        const input = result(format, `${year}-01-01`);
+        const output = result(format, `20${year}-01-01`);
+        expect(additionalYears(format, input)).toEqual([`yy${format}`, output]);
+      });
     });
 
     describe.each(yearValuesGreaterThan69)("when year value is %s", (year) => {
@@ -305,6 +330,26 @@ describe("utils", () => {
         const input = result(format, `01-01-${year}`);
         const output = result(format, `01-01-19${year}`);
         expect(additionalYears(format, input)).toEqual([`${format}yy`, output]);
+      });
+
+      it.each([
+        "yy.M.d",
+        "yy,M,d",
+        "yy-M-d",
+        "yy/M/d",
+        "yy.M.dd",
+        "yy,M,dd",
+        "yy-M-dd-M",
+        "yy/M/dd/M",
+        "yyMdd",
+        "yy.MM.dd",
+        "yy,MM,dd",
+        "yy-MM-dd",
+        "yy/MM/dd",
+      ])("returns the expected when format is %s", (format) => {
+        const input = result(format, `${year}-01-01`);
+        const output = result(format, `19${year}-01-01`);
+        expect(additionalYears(format, input)).toEqual([`yy${format}`, output]);
       });
     });
   });

--- a/src/components/date/date.component.js
+++ b/src/components/date/date.component.js
@@ -212,7 +212,9 @@ const DateInput = ({
       return;
     }
 
-    isBlurBlocked.current = true;
+    if (setInputRefMap) {
+      isBlurBlocked.current = true;
+    }
 
     if (ev.target.type === "text" && !open) {
       setOpen(true);
@@ -220,6 +222,11 @@ const DateInput = ({
       alreadyFocused.current = true;
       setOpen((prev) => !prev);
     }
+  };
+
+  const handleIconMouseDown = (e) => {
+    isBlurBlocked.current = true;
+    handleMouseDown(e);
   };
 
   const handlePickerMouseDown = () => {
@@ -335,7 +342,7 @@ const DateInput = ({
         onKeyDown={handleKeyDown}
         iconOnClick={handleClick}
         onMouseDown={handleMouseDown}
-        iconOnMouseDown={handleMouseDown}
+        iconOnMouseDown={handleIconMouseDown}
         inputIcon="calendar"
         labelInline={labelInline}
         inputRef={assignInput}

--- a/src/components/date/date.component.js
+++ b/src/components/date/date.component.js
@@ -91,7 +91,7 @@ const DateInput = ({
         ? formattedValue(format, selectedDays)
         : ev.target.value;
     const rawValue = isDateValid(parseDate(matchedFormat, matchedValue))
-      ? formatToISO(matchedFormat, matchedValue)
+      ? formatToISO(...additionalYears(matchedFormat, matchedValue))
       : computeInvalidRawValue(ev.target.value);
 
     ev.target = {

--- a/src/components/date/date.component.js
+++ b/src/components/date/date.component.js
@@ -274,7 +274,7 @@ const DateInput = ({
       setSelectedDays(
         parseDate(...additionalYears(matchedFormat, matchedValue))
       );
-    } else if (checkISOFormatAndLength(value)) {
+    } else if (checkISOFormatAndLength(value) && isInitialValue.current) {
       setSelectedDays(parseISODate(value));
     } else {
       setSelectedDays(undefined);
@@ -282,7 +282,7 @@ const DateInput = ({
   }, [value, formats]);
 
   const computedValue = () => {
-    if (checkISOFormatAndLength(value)) {
+    if (checkISOFormatAndLength(value) && isInitialValue.current) {
       return formattedValue(format, parseISODate(value));
     }
 
@@ -299,6 +299,8 @@ const DateInput = ({
       valueSeparator !== formatSeparator &&
       isDateValid(parseDate(format, replaceSeparators()))
     ) {
+      isInitialValue.current = false;
+
       const [matchedFormat, matchedValue] = findMatchedFormatAndValue(
         replaceSeparators(),
         formats

--- a/src/components/date/date.spec.js
+++ b/src/components/date/date.spec.js
@@ -20,6 +20,7 @@ import StyledInputPresentation from "../../__internal__/input/input-presentation
 import Tooltip from "../tooltip";
 import StyledHelp from "../help/help.style";
 import ValidationIcon from "../../__internal__/validations";
+import DateRangeContext from "../date-range/date-range.context";
 import {
   // eslint-disable-next-line import/named
   de as deLocale,
@@ -234,6 +235,23 @@ describe("Date", () => {
         expect(onChangeFn).not.toHaveBeenCalled();
       }
     );
+
+    it("does not call onBlur when the input is click and DateRangeContext is detected", () => {
+      wrapper = mount(
+        <DateRangeContext.Provider
+          value={{ inputRefMap: {}, setInputRefMap: jest.fn() }}
+        >
+          <DateInput
+            value="2012-12-12"
+            onChange={onChangeFn}
+            onBlur={onBlurFn}
+          />
+        </DateRangeContext.Provider>
+      );
+      simulateMouseDownOnInput(wrapper);
+      simulateBlurOnInput(wrapper);
+      expect(onBlurFn).not.toHaveBeenCalled();
+    });
   });
 
   describe('when the "keyDown" event is triggered on the input', () => {

--- a/src/components/date/date.spec.js
+++ b/src/components/date/date.spec.js
@@ -89,11 +89,11 @@ describe("Date", () => {
   let onFocusFn;
 
   // eslint-disable-next-line react/prop-types
-  const MockComponent = ({ emptyValue, eventValues = () => {} }) => {
+  const MockComponent = ({ emptyValue, eventValues = () => {}, ...rest }) => {
     const [val, setVal] = useState(emptyValue ? "" : "02/02/2022");
     return (
       <DateInput
-        value={val}
+        value={rest.value || val}
         onChange={(ev) => {
           setVal(ev.target.value.formattedValue);
           eventValues(ev.target.value);
@@ -251,6 +251,32 @@ describe("Date", () => {
       simulateMouseDownOnInput(wrapper);
       simulateBlurOnInput(wrapper);
       expect(onBlurFn).not.toHaveBeenCalled();
+    });
+
+    describe("when year value is only two digits", () => {
+      it("emits rawValue as the expected ISO string when year is `69`", () => {
+        const eventValuesFn = jest.fn();
+        wrapper = mount(
+          <MockComponent eventValues={eventValuesFn} value="12.12.69" />
+        );
+        simulateBlurOnInput(wrapper);
+        expect(eventValuesFn).toBeCalledWith({
+          formattedValue: "12/12/1969",
+          rawValue: "1969-12-12",
+        });
+      });
+
+      it("emits rawValue as the expected ISO string when year is `20`", () => {
+        const eventValuesFn = jest.fn();
+        wrapper = mount(
+          <MockComponent eventValues={eventValuesFn} value="12.12.20" />
+        );
+        simulateBlurOnInput(wrapper);
+        expect(eventValuesFn).toBeCalledWith({
+          formattedValue: "12/12/2020",
+          rawValue: "2020-12-12",
+        });
+      });
     });
   });
 

--- a/src/components/date/date.stories.mdx
+++ b/src/components/date/date.stories.mdx
@@ -8,7 +8,7 @@ import Textbox from "../textbox";
 import Button from "../button";
 import Box from "../box";
 import I18nProvider from "../i18n-provider";
-import { de } from "../../locales/date-fns-locales";
+import { zhCN, de } from "../../locales/date-fns-locales";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 <Meta title="Date Input" parameters={{ info: { disable: true } }} />
@@ -571,8 +571,8 @@ The example below will display an error if an invalid date or a date with a year
 
 ### Locale override
 
-The examples below illustrates how to override the locale passed into the Date component. In this example it has been set up for
-the German locale. Required locales can be imported like so `import { de } from 'carbon-react/lib/locales/date-fns-locales';`
+The examples below illustrate how to override the locale passed into the Date component. The first example has been set up for
+the German (`de`) locale whilst the second is for a Chinese (`zh-CN`) locale. Required locales can be imported like so `import { de, zhCN } from 'carbon-react/lib/locales/date-fns-locales';`
 
 <Canvas>
   <Story
@@ -580,16 +580,25 @@ the German locale. Required locales can be imported like so `import { de } from 
     parameters={{ chromatic: { disable: true } }}
   >
     {() => {
-      const [state, setState] = useState("05/04/2022");
+      const [state, setState] = useState("2022-04-05");
       const handleChange = ({ target }) => {
         setState(target.value.formattedValue);
       };
+      const [state2, setState2] = useState("2022-04-05");
+      const handleChange2 = ({ target }) => {
+        setState2(target.value.formattedValue);
+      };
       return (
-        <div>
+        <div style={{ display: "flex", justifyContent: "space-around" }}>
           <I18nProvider
-            locale={{ locale: () => "de", date: { dateFnsLocale: () => de } }}
+            locale={{ locale: () => "de-DE", date: { dateFnsLocale: () => de } }}
           >
-            <DateInput label="Date" value={state} onChange={handleChange} />
+            <DateInput label="Date `DE` locale" value={state} onChange={handleChange} />
+          </I18nProvider>
+          <I18nProvider
+            locale={{ locale: () => "zh-CN", date: { dateFnsLocale: () => zhCN } }}
+          >
+            <DateInput label="Date `zh-CN` locale" value={state2} onChange={handleChange2} />
           </I18nProvider>
         </div>
       );


### PR DESCRIPTION
fix #4966
fix #5072
fix #5119

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Ensures that the correct formats are used for input and output strings. Fixes the output string and
valid inputs for Chinese (CN) locales for example by using the [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) util API to handle the format displayed
on blur of the text input

![image](https://user-images.githubusercontent.com/44157880/165328990-dbc3575e-657c-4ce8-8f66-cc093c66d293.png)

Ensures that the the callback passed to the `onBlur` prop is called when the text input is blurred.

Ensure that the rawValue matches formattedValue when a year string is only 2 digits long
![image](https://user-images.githubusercontent.com/44157880/166966903-4c14350f-dbee-4e1f-8e73-91261e7e1fdb.png)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
Two issue have sandbox repros that can be tested

QA should also test DateRange against current master to ensure the blur behaviour remains consistent

https://codesandbox.io/s/carbon-quickstart-forked-vwnj65?file=/src/index.js
