### PR TITLE
feat(drawer): add typography tokens to component - FE-5051

### DIFF
--- a/src/components/drawer/drawer.spec.js
+++ b/src/components/drawer/drawer.spec.js
@@ -176,6 +176,11 @@ describe("Drawer", () => {
           {
             flex: "1",
             overflow: "auto",
+            color: "var(--colorsUtilityYin090)",
+            fontFamily: "var(--fontFamiliesDefault)",
+            fontWeight: "var(--fontWeights400)",
+            fontSize: "var(--fontSizes100)",
+            lineHeight: "var(--lineHeights500)",
           },
           children
         );
@@ -245,6 +250,7 @@ describe("Drawer", () => {
         assertStyleMatch(
           {
             padding: "var(--spacing300) var(--spacing500)",
+            font: "var(--typographyDrawerTitleM)",
           },
           title
         );

--- a/src/components/drawer/drawer.style.js
+++ b/src/components/drawer/drawer.style.js
@@ -5,6 +5,14 @@ import StyledStickyFooter from "../../__internal__/sticky-footer/sticky-footer.s
 
 const defaultExpandedWidth = "var(--sizing500)";
 
+const drawerFont = `
+  color: var(--colorsUtilityYin090);
+  font-family: var(--fontFamiliesDefault);
+  font-weight: var(--fontWeights400);
+  font-size: var(--fontSizes100);
+  line-height: var(--lineHeights500);
+`;
+
 const StyledSidebarHeader = styled.div`
   ${({ isExpanded }) => css`
     position: sticky;
@@ -20,12 +28,15 @@ const StyledSidebarHeader = styled.div`
 const StyledSidebarTitle = styled.div`
   white-space: nowrap;
   padding: var(--spacing300) var(--spacing500);
+  font: var(--typographyDrawerTitleM);
 `;
 
 const StyledDrawerChildren = styled.div`
   flex: 1;
   margin-left: 1px;
   overflow: auto;
+
+  ${drawerFont}
 `;
 
 const StyledDrawerSidebar = styled(Box)`
@@ -59,6 +70,8 @@ const StyledDrawerSidebar = styled(Box)`
   &::-webkit-scrollbar {
     width: 12px;
   }
+
+  ${drawerFont}
 `;
 
 const sidebarVisible = () => keyframes`


### PR DESCRIPTION
### Proposed behaviour

![Screenshot 2022-04-26 at 16 57 05](https://user-images.githubusercontent.com/56251247/165342416-46a9abcf-6b90-4866-b837-ec72afbdca9d.png)

### Current behaviour

![Screenshot 2022-04-26 at 16 57 22](https://user-images.githubusercontent.com/56251247/165342476-962cb36a-1768-4431-bcb6-4bd8c766e1f0.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Check that the tokens in the console match those specified on the designs for `Drawer`
