### PR TITLE
fix(link): apply correct hover colour to icon - FE-5143

### DIFF
--- a/src/components/card/__snapshots__/card.spec.js.snap
+++ b/src/components/card/__snapshots__/card.spec.js.snap
@@ -114,6 +114,11 @@ exports[`Card CardFooter styling should match the expected styling when it has n
   color: var(--colorsActionMajor600);
 }
 
+.c1 a:hover .c2,
+.c1 button:hover .c2 {
+  color: var(--colorsActionMajor600);
+}
+
 .c1 a:focus,
 .c1 button:focus {
   color: var(--colorsActionMajorYin090);

--- a/src/components/link/link.spec.tsx
+++ b/src/components/link/link.spec.tsx
@@ -180,6 +180,19 @@ describe("Link", () => {
       );
     });
 
+    it("should apply correct colour to icon on hover", () => {
+      wrapper = mount(
+        <Link iconAlign="right" icon="home" href="www.sage.com" />
+      );
+      assertStyleMatch(
+        {
+          color: "var(--colorsActionMajor600)",
+        },
+        wrapper.find(StyledLink),
+        { modifier: `a:hover ${StyledIcon}` }
+      );
+    });
+
     it("should render a `Tooltip` if tooltipMessage is passed", () => {
       wrapper = mount(
         <Link

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -59,6 +59,10 @@ const StyledLink = styled.span<StyledLinkProps>`
         color: ${isSkipLink
           ? "var(--colorsUtilityYin090)"
           : "var(--colorsActionMajor600)"};
+
+        ${StyledIcon} {
+          color: var(--colorsActionMajor600);
+        }
       }
 
       &:focus {

--- a/src/components/pod/__snapshots__/pod.spec.js.snap
+++ b/src/components/pod/__snapshots__/pod.spec.js.snap
@@ -43,12 +43,22 @@ exports[`ActionButtons StyledDeleteButton when isHovered prop is set should matc
   margin-right: var(--spacing100);
 }
 
+.c4 a:hover .c2,
+.c4 button:hover .c2 {
+  color: var(--colorsActionMajor600);
+}
+
 .c5 a .c2,
 .c5 button .c2 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
   margin-right: 0;
+}
+
+.c5 a:hover .c2,
+.c5 button:hover .c2 {
+  color: var(--colorsActionMajor600);
 }
 
 .c0 {
@@ -365,6 +375,11 @@ exports[`ActionButtons StyledEditAction when isHovered prop is set should match 
   color: var(--colorsActionMajor600);
 }
 
+.c0 a:hover .c9,
+.c0 button:hover .c9 {
+  color: var(--colorsActionMajor600);
+}
+
 .c0 a:focus,
 .c0 button:focus {
   color: var(--colorsActionMajorYin090);
@@ -506,12 +521,22 @@ exports[`ActionButtons StyledUndoButton when isHovered prop is set should match 
   margin-right: var(--spacing100);
 }
 
+.c4 a:hover .c2,
+.c4 button:hover .c2 {
+  color: var(--colorsActionMajor600);
+}
+
 .c5 a .c2,
 .c5 button .c2 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
   margin-right: 0;
+}
+
+.c5 a:hover .c2,
+.c5 button:hover .c2 {
+  color: var(--colorsActionMajor600);
 }
 
 .c0 {


### PR DESCRIPTION
fixes https://github.com/Sage/carbon/issues/5088

### Proposed behaviour

![Screenshot 2022-04-28 at 09 40 30](https://user-images.githubusercontent.com/56251247/165713292-f7a1339d-32b9-4f07-b445-125868d4e928.png)
![Screenshot 2022-04-28 at 09 40 44](https://user-images.githubusercontent.com/56251247/165713345-b6f4ad37-7b92-4b0d-b620-3ff0b6ce2589.png)

### Current behaviour

![Screenshot 2022-04-28 at 09 41 16](https://user-images.githubusercontent.com/56251247/165713429-aeb023e2-d404-444d-a464-442d0d9a8068.png)
![Screenshot 2022-04-28 at 09 41 30](https://user-images.githubusercontent.com/56251247/165713462-3b636b32-4822-4ae3-abd8-55cb19a93b18.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- Navigate to `Link` stories and select `with icon`
- hover over the link and the colour of the icon should match that of the link
