### PR TITLE
fix(form): apply margin correctly to textarea component in a form - FE-5146

### DIFF
--- a/src/components/form/form.spec.js
+++ b/src/components/form/form.spec.js
@@ -24,6 +24,8 @@ import Icon from "../icon";
 import Button from "../button";
 import { FieldsetStyle } from "../fieldset/fieldset.style";
 import StyledSearch from "../search/search.style";
+import Textarea from "../textarea";
+import StyledTextarea from "../textarea/textarea.style";
 
 jest.mock("lodash/debounce", () => jest.fn((fn) => fn));
 jest.mock("../../hooks/__internal__/useResizeObserver");
@@ -101,6 +103,22 @@ describe("Form", () => {
             ${FieldsetStyle}
           `,
         }
+      );
+    });
+
+    it("applies custom value to textarea with character count specified", () => {
+      wrapper = mount(
+        <StyledForm fieldSpacing={4}>
+          <Textarea label="Textarea with Character Limit" characterLimit={50} />
+        </StyledForm>
+      );
+      assertStyleMatch(
+        {
+          marginTop: "0",
+          marginBottom: "var(--spacing400)",
+        },
+        wrapper,
+        { modifier: `${StyledTextarea}` }
       );
     });
   });

--- a/src/components/form/form.stories.mdx
+++ b/src/components/form/form.stories.mdx
@@ -95,7 +95,7 @@ When `fieldSpacing` prop is given a value, the vertical spacing between the form
       <Textbox label="Textbox" />
       <Textbox label="Textbox" />
       <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
+      <Textarea label="Textarea with Character Limit" characterLimit={50} />
     </Form>
   </Story>
 </Canvas>

--- a/src/components/form/form.style.js
+++ b/src/components/form/form.style.js
@@ -11,6 +11,7 @@ import { FieldsetStyle } from "../fieldset/fieldset.style";
 import StyledInlineInputs from "../inline-inputs/inline-inputs.style";
 import { FORM_BUTTON_ALIGNMENTS } from "./form.config";
 import StyledSearch from "../search/search.style";
+import StyledTextarea from "../textarea/textarea.style";
 
 export const StyledFormContent = styled.div`
   ${({ stickyFooter }) => css`
@@ -75,12 +76,18 @@ export const StyledForm = styled.form`
   ${({ fieldSpacing }) =>
     css`
       &
+        ${StyledTextarea},
         ${StyledFormField},
         ${StyledFieldset},
         ${FieldsetStyle},
         > ${StyledButton} {
         margin-top: 0;
         margin-bottom: ${formBottomMargins(fieldSpacing)};
+      }
+
+      ${StyledTextarea}
+      ${StyledFormField} {
+        margin-bottom: 4px;
       }
 
       ${StyledInlineInputs} {


### PR DESCRIPTION
Margin should be applied to the div that wraps the textarea component and not just the form field of
textarea

fixes #5074

### Proposed behaviour

![Screenshot 2022-05-03 at 13 51 39](https://user-images.githubusercontent.com/56251247/166456152-5dd92dd5-4665-45b3-babe-6fc57c7dfec4.png)

### Current behaviour

![Screenshot 2022-05-03 at 13 51 10](https://user-images.githubusercontent.com/56251247/166456089-e768264e-d608-42a6-b95b-f9c9ca0a09fb.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

<!-- How can a reviewer test this PR? -->

You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]` or you can use https://codesandbox.io/s/serverless-violet-gsk4et