### PR TITLE
feat(typography): change strong font weight to 700

### DIFF
--- a/src/components/typography/typography.component.js
+++ b/src/components/typography/typography.component.js
@@ -91,7 +91,6 @@ const getWeight = (variant) => {
     case "h1":
     case "segment-header":
     case "segment-header-small":
-    case "strong":
       return "900";
     case "h2":
     case "h3":
@@ -99,6 +98,7 @@ const getWeight = (variant) => {
     case "segment-subheader-alt":
     case "b":
     case "em":
+    case "strong":
       return "700";
     case "h4":
     case "h5":

--- a/src/components/typography/typography.spec.js
+++ b/src/components/typography/typography.spec.js
@@ -316,7 +316,7 @@ describe("Typography", () => {
           fontSize: "14px",
           as: "strong",
           lineHeight: "21px",
-          fontWeight: "900",
+          fontWeight: "700",
           textTransform: "none",
           textDecoration: "none",
           verticalAlign: undefined,


### PR DESCRIPTION
Strong font weight have been changed from 900 to 700 to reduce the bold visual impact of the new
sage ui font

fixes FE-5142

### Proposed behaviour

![Screenshot 2022-05-03 at 15 37 12](https://user-images.githubusercontent.com/56251247/166474591-9ad01526-6205-4127-8455-2ab3d06b9063.png)

### Current behaviour

![Screenshot 2022-05-03 at 15 37 31](https://user-images.githubusercontent.com/56251247/166474641-39bcaa32-6f05-40bc-bd47-fa2717fc2863.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Visit the `Typography` story generated by Chromatic 
- Navigate to `variants`
- Look for the strong variant. It has the text `Only when the text is more important should you use the strong variant.`
- Inspect the text and it should have a `font-weight: 700`
