### PR TITLE
feat(textarea): modify padding to use design tokens

### DIFF
--- a/cypress/integration/common/textarea.feature
+++ b/cypress/integration/common/textarea.feature
@@ -40,7 +40,7 @@ Feature: Textarea component
       | 300  | rows300      |
 
   @positive
-  Scenario Outline: Set expandable and rows to <rows> 
+  Scenario Outline: Set expandable and rows to <rows>
     When I open default "Textarea Test" component with "textarea" json from "commonComponents" using "<nameOfObject>" object name
     Then rows is set to "<rows>"
       And Textarea height is "119px"
@@ -167,3 +167,11 @@ Feature: Textarea component
       | input                        |
       | mp150ú¿¡üßä                  |
       | !@#$%^*()_+-=~[];:.,?{}&"'<> |
+
+  @positive
+  Scenario: Verify padding of Textarea component with default props
+    When I open default "Textarea Test" component with "textarea" json from "commonComponents" using "expandableFalse" object name
+    Then Textarea padding "left" size is 16px
+      And Textarea padding "right" size is 16px
+      And Textarea padding "top" size is 12px
+      And Textarea padding "bottom" size is 12px

--- a/cypress/support/step-definitions/text-area-steps.js
+++ b/cypress/support/step-definitions/text-area-steps.js
@@ -16,6 +16,12 @@ Then("Textarea height is {string}", (height) => {
   textareaChildren().should("have.css", "height", height);
 });
 
+Then("Textarea padding {string} size is {int}px", (padding, pxValue) => {
+  textarea().should((el) => {
+    expect(el).to.have.css(`padding-${padding}`).to.equal(`${pxValue}px`);
+  });
+});
+
 Then("cols is set to {string}", (colsValue) => {
   textareaChildren().should("have.attr", "cols", colsValue);
 });

--- a/src/components/textarea/textarea-test.stories.js
+++ b/src/components/textarea/textarea-test.stories.js
@@ -104,7 +104,7 @@ export default {
     inputWidth: 100,
     warnOverLimit: false,
     enforceCharacterLimit: true,
-    label: "",
+    label: "Textarea",
     labelHelp: "",
     labelInline: false,
     labelWidth: 30,

--- a/src/components/textarea/textarea.style.js
+++ b/src/components/textarea/textarea.style.js
@@ -1,6 +1,7 @@
 import styled, { css } from "styled-components";
 import { margin } from "styled-system";
 
+import InputPresentationStyle from "../../__internal__/input/input-presentation.style";
 import StyledInput from "../../__internal__/input/input.style";
 import { StyledLabelContainer } from "../../__internal__/label/label.style";
 import InputIconToggleStyle from "../../__internal__/input-icon-toggle/input-icon-toggle.style";
@@ -14,8 +15,10 @@ const StyledTextarea = styled.div`
   ${StyledInput} {
     resize: none;
     min-height: ${MIN_HEIGHT}px;
-    margin-top: 5px;
-    margin-bottom: 5px;
+  }
+
+  ${InputPresentationStyle} {
+    padding: var(--spacing150) var(--spacing200);
   }
 
   ${({ labelInline }) =>


### PR DESCRIPTION
### Proposed behaviour

- Modify inner `InputPresentation` container to use design token for controlling its vertical padding.
- Add label to `Textarea` test story to fix accessibility violation 

![Screenshot 2022-05-04 at 09 41 34](https://user-images.githubusercontent.com/18368713/166648619-a5406deb-fde4-4e39-9371-93d125163f07.png)

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

- The vertical padding is not correct and doesn't use design tokens.

![Screenshot 2022-05-04 at 09 42 03](https://user-images.githubusercontent.com/18368713/166648689-f909a781-1773-4ba1-9165-ae76152c028d.png)

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

(For devs) Both `InputPresentation` and `Input` have css rules for their `min-height`. `Textarea` programmatically controls its height with its internal logic (using `MIN_HEIGHT` constant in `textarea.style.js` on line 10). Since `InputPresentation` controls its own min-height using design tokens, the logic in `Textarea` becomes partially redundant, however we cannot currently modify the `MIN_HEIGHT` constant to use the design token value since we can importing its value as a css custom property and not a js variable. This does not cause an issue but does introduce some complexity to the code related to inputs, so it may be worth having a quick discussion over whether we should refactor this or not. 

### Testing instructions

- Double check violation no longer exists for `Textarea` test story.
- Double check no regressions have been introduced.
