### PR TITLE
feat(progress-tracker): add length prop

### DIFF
--- a/src/components/progress-tracker/progress-tracker.config.js
+++ b/src/components/progress-tracker/progress-tracker.config.js
@@ -1,3 +1,2 @@
-export const OUTER_TRACKER_LENGTH = "256px";
-
+/* eslint-disable import/prefer-default-export */
 export const PROGRESS_TRACKER_SIZES = ["small", "medium", "large"];

--- a/src/components/progress-tracker/progress-tracker.d.ts
+++ b/src/components/progress-tracker/progress-tracker.d.ts
@@ -1,6 +1,6 @@
 import { MarginProps } from "styled-system";
 
-export interface ProgressBarProps extends MarginProps {
+export interface ProgressTrackerProps extends MarginProps {
   /** Specifies an aria-label to the component */
   "aria-label"?: string;
   /** Specifies the aria-describedby for the component */
@@ -16,6 +16,8 @@ export interface ProgressBarProps extends MarginProps {
   "aria-valuetext"?: string;
   /** Size of the progressBar. */
   size?: "small" | "medium" | "large";
+  /** Length of the progress bar, any valid css string. */
+  length?: string;
   /** Current progress (percentage). */
   progress?: number;
   /** Flag to control whether the default value labels (as percentages) should be rendered. */
@@ -35,6 +37,6 @@ export interface ProgressBarProps extends MarginProps {
   labelsPosition?: "top" | "bottom" | "left" | "right";
 }
 
-declare function ProgressBar(props: ProgressBarProps): JSX.Element;
+declare function ProgressTracker(props: ProgressTrackerProps): JSX.Element;
 
-export default ProgressBar;
+export default ProgressTracker;

--- a/src/components/progress-tracker/progress-tracker.stories.mdx
+++ b/src/components/progress-tracker/progress-tracker.stories.mdx
@@ -63,6 +63,19 @@ This is an example of a large `ProgressTracker` component.
   </Story>
 </Canvas>
 
+### Custom bar length
+
+The length of the bar can be set to any valid css property. This sets the width of a horizontal bar or the height of a vertical bar. The default is "256px".
+
+<Canvas>
+  <Story name="custom bar length">
+    <div style={{ display: "flex", justifyContent: "space-evenly" }}>
+      <ProgressTracker progress={50} length="150px" />
+      <ProgressTracker orientation="vertical" progress={50} length="50px" />
+    </div>
+  </Story>
+</Canvas>
+
 ### Color variants
 
 This is an example of a `ProgressTracker` component with different colors depending on progress.
@@ -404,19 +417,21 @@ It is possible to override the `labelsPosition` to `"left"` when in a `"vertical
 This component has `aria-valuemin`, `aria-valuemax`, `aria-valuenow` and `aria-valuetext` props that can be utilised to enhance the experience for a user that requires a screenreader.
 
 For more information on these props, please visit the W3 documentation on `role="progressbar"`. This can be accessed by clicking [here](https://www.w3.org/TR/wai-aria-1.1/#progressbar).
+
 ### Example
 
 <Canvas>
   <Story name="acessibility example">
     <div style={{ display: "flex", justifyContent: "space-around" }}>
-      <ProgressTracker 
+      <ProgressTracker
         currentProgressLabel="$100"
-        maxProgressLabel="$200" 
-        progress={50} 
-        aria-valuemin={0} 
-        aria-valuenow={50} 
-        aria-valuemax={100} 
-        aria-valuetext="$100"/>
+        maxProgressLabel="$200"
+        progress={50}
+        aria-valuemin={0}
+        aria-valuenow={50}
+        aria-valuemax={100}
+        aria-valuetext="$100"
+      />
     </div>
   </Story>
 </Canvas>

--- a/src/components/progress-tracker/progress-tracker.style.js
+++ b/src/components/progress-tracker/progress-tracker.style.js
@@ -2,24 +2,21 @@ import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
 import { margin } from "styled-system";
 import baseTheme from "../../style/themes/base";
-import {
-  OUTER_TRACKER_LENGTH,
-  PROGRESS_TRACKER_SIZES,
-} from "./progress-tracker.config";
+import { PROGRESS_TRACKER_SIZES } from "./progress-tracker.config";
 
 const StyledProgressTracker = styled.div`
   ${margin}
   text-align: center;
   white-space: nowrap;
 
-  ${({ isVertical }) => css`
+  ${({ isVertical, length }) => css`
     ${!isVertical &&
     `
-      width: ${OUTER_TRACKER_LENGTH};
+      width: ${length};
     `}
     ${isVertical &&
     `
-      height: ${OUTER_TRACKER_LENGTH};
+      height: ${length};
       display: flex;
     `}
   `}
@@ -99,20 +96,20 @@ const StyledValuesLabel = styled.span`
 `;
 
 const InnerBar = styled.span`
-  ${({ isVertical, progress, size }) => css`
+  ${({ isVertical, progress, size, length }) => css`
     position: absolute;
     left: 0;
     background-color: ${getInnerBarColour(progress)};
 
     ${!isVertical &&
     css`
-      width: calc(${OUTER_TRACKER_LENGTH} * ${progress / 100});
+      width: calc(${length} * ${progress / 100});
       min-width: 2px;
       height: ${getHeight(size)};
     `}
     ${isVertical &&
     css`
-      height: calc(${OUTER_TRACKER_LENGTH} * ${progress / 100});
+      height: calc(${length} * ${progress / 100});
       min-height: 2px;
       width: ${getHeight(size)};
     `}


### PR DESCRIPTION
This can be used to set the width/height of the bar, for horizontal/vertical
orientations.

Fixes: #5106

### Proposed behaviour

Add `length` prop to `ProgressTracker`. 

This can be any valid CSS string and will set the width of horizontal bars, and height of vertical ones.

Also change the inner bar calculation to get the actual length of the outer bar from the DOM via a ref, and calculate a percentage of that, rather than a hardcoded `256px`.

### Current behaviour

There is currently no way for a user to change the length of the `ProgressTracker` component via props.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
