### PR TITLE
fix(portrait): ensure background fills consistently when zoom is greater than 100% - FE-5102

### DIFF
--- a/src/components/portrait/portrait-initials.component.js
+++ b/src/components/portrait/portrait-initials.component.js
@@ -73,6 +73,7 @@ const PortraitInitials = ({
       data-element="initials"
       size={size}
       shape={shape}
+      initials={initials}
       {...rest}
     >
       <StyledPortraitInitialsImg src={generateDataUrl()} alt={alt} />

--- a/src/components/portrait/portrait.spec.js
+++ b/src/components/portrait/portrait.spec.js
@@ -15,6 +15,7 @@ import {
   StyledIcon,
   StyledCustomImg,
   StyledPortraitContainer,
+  StyledPortraitInitials,
 } from "./portrait.style";
 import PortraitInitials from "./portrait-initials.component";
 import PortraitGravatar from "./portrait-gravatar.component";
@@ -130,6 +131,59 @@ describe("PortraitComponent", () => {
     });
 
     /* eslint-enable no-console */
+  });
+
+  describe("Portrait styles", () => {
+    it("applies expected styles to Portrait with initials", () => {
+      const wrapper = mount(
+        <Portrait shape="circle" initials="AB" darkBackground={false} />
+      );
+
+      assertStyleMatch(
+        {
+          display: "inline-block",
+        },
+        wrapper.find(StyledPortraitContainer)
+      );
+
+      assertStyleMatch(
+        {
+          width: "inherit",
+          height: "inherit",
+          margin: "1px",
+          display: "inline-block",
+          verticalAlign: "middle",
+          boxSizing: "border-box",
+          outline: "1px solid var(--colorsUtilityMajor200)",
+        },
+        wrapper.find(StyledPortraitInitials)
+      );
+    });
+
+    // TODO: Currently due to this issue https://github.com/styled-components/jest-styled-components/pull/354 we are unable to test a media query with a `@supports` selector.
+    // Once this has been resolved we will need to write a test that covers the styles that target `@media not all and (min-resolution: 0.001dpcm)
+    // @supports (-webkit-appearance: none) and (stroke-color: transparent)`.
+
+    it("applies expected styling to Portrait with icon", () => {
+      const wrapper = mount(
+        <Portrait shape="square" darkBackground={false} iconType="image" />
+      );
+
+      assertStyleMatch(
+        {
+          display: "inline-block",
+        },
+        wrapper.find(StyledPortraitContainer)
+      );
+
+      assertStyleMatch(
+        {
+          height: "24px",
+          width: "24px",
+        },
+        wrapper.find(StyledIcon)
+      );
+    });
   });
 
   describe("render icon", () => {

--- a/src/components/portrait/portrait.style.js
+++ b/src/components/portrait/portrait.style.js
@@ -11,11 +11,18 @@ import {
   PORTRAIT_SIZE_PARAMS,
 } from "./portrait.config";
 
-function stylingForSize({ size }) {
+function stylingForSize({ size, initials }) {
   const params = PORTRAIT_SIZE_PARAMS[size];
-
   if (!params) {
     return css``;
+  }
+
+  if (initials) {
+    return css`
+      width: inherit;
+      height: inherit;
+      margin: 1px;
+    `;
   }
 
   return css`
@@ -73,7 +80,16 @@ export const StyledPortraitInitials = styled.div`
   box-sizing: border-box;
   ${stylingForSize}
   ${stylingForShape}
-  border: 1px solid var(--colorsUtilityMajor200);
+  outline: 1px solid var(--colorsUtilityMajor200);
+
+  /* Styling for safari. This ensures that there is no outline on the component but that a border is still present 
+     to achieve the same styling as Chrome and Firefox */
+  @media not all and (min-resolution: 0.001dpcm) {
+    @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+      border: 1px solid var(--colorsUtilityMajor200);
+      outline: none;
+    }
+  }
 `;
 
 StyledPortraitInitials.propTypes = {


### PR DESCRIPTION
The background of portrait should fill consistently when the component is zoomed to a value greater
than 100%

fixes #4939

### Proposed behaviour

![Screenshot 2022-05-06 at 10 43 35](https://user-images.githubusercontent.com/56251247/167111208-b1616a02-60fd-452a-85a8-9a404b5d7d81.png)

### Current behaviour

![Screenshot 2022-05-06 at 10 47 02](https://user-images.githubusercontent.com/56251247/167111260-eacfbd57-4011-4ee2-b3af-5b45b950950b.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

You can test in Storybook by using the stories for `Portrait`. Zoom in on the browser and background should correctly fill. You can also use this [codesandbox](https://codesandbox.io/s/vigilant-dust-j8pm1x?file=/src/index.js) and when zooming in, the background should fill the component consistently. 

Might also be good to regression test in Storybook to make sure that nothing else with Portrait has been effected by this change.