### PR TITLE
ci(cypress-image): update to latest

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -44,7 +44,7 @@ jobs:
             19,
             20,
           ]
-    container: cypress/browsers:node14.17.0-chrome91-ff89
+    container: cypress/browsers:node14.17.6-chrome100-ff98
     steps:
       - id: get_pull
         uses: octokit/request-action@v2.x
@@ -122,7 +122,7 @@ jobs:
           [
             1
           ]
-    container: cypress/browsers:node14.17.0-chrome91-ff89
+    container: cypress/browsers:node14.17.6-chrome100-ff98
     steps:
       - id: get_pull
         uses: octokit/request-action@v2.x
@@ -198,7 +198,7 @@ jobs:
             5,
             6
           ]
-    container: cypress/browsers:node14.17.0-chrome91-ff89
+    container: cypress/browsers:node14.17.6-chrome100-ff98
     steps:
       - id: get_pull
         uses: octokit/request-action@v2.x


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Update cypress docker image with `node14` to the latest version to use `chrome` with `v.100`

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Currently we are using an old image with `chrome v.91`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions
All CI tests should be marked as pass - :heavy_check_mark: