### PR TITLE
fix(date): prevent calling onChange when input is blurred and value has not changed FE-5161

### DIFF
--- a/src/components/date/__internal__/utils.js
+++ b/src/components/date/__internal__/utils.js
@@ -103,7 +103,7 @@ function findMatchWithNoSeparators(valueString, formatString) {
   const valueArray = makeSeparatedValues(indexArray, valueString);
 
   if (checkForCompleteMatch(formatArray, valueArray)) {
-    return [formatArray.join("."), valueArray.join(".")];
+    return [formatArray.join(" "), valueArray.join(" ")];
   }
 
   return null;

--- a/src/components/date/__internal__/utils.spec.js
+++ b/src/components/date/__internal__/utils.spec.js
@@ -355,18 +355,18 @@ describe("utils", () => {
   });
 
   describe("findMatchedFormatAndValue", () => {
-    // when no separator is used it will return "." separated format and value due to bug in date-fns
+    // when no separator is used it will return whitespace separated format and value due to bug in date-fns
     it.each([
-      ["ddMMyyyy", "01012022", "dd.MM.yyyy", "01.01.2022"],
-      ["ddMMyy", "010122", "dd.MM.yy", "01.01.22"],
-      ["dMMyy", "10122", "d.MM.yy", "1.01.22"],
-      ["ddMyy", "01122", "dd.M.yy", "01.1.22"],
-      ["ddMyyyy", "0112022", "dd.M.yyyy", "01.1.2022"],
-      ["dMyyyy", "112022", "d.M.yyyy", "1.1.2022"],
-      ["dMMyyyy", "1012022", "d.MM.yyyy", "1.01.2022"],
-      ["ddMMyyyy", "31012022", "dd.MM.yyyy", "31.01.2022"],
-      ["ddMMyy", "300122", "dd.MM.yy", "30.01.22"],
-      ["ddMyy", "28222", "dd.M.yy", "28.2.22"],
+      ["ddMMyyyy", "01012022", "dd MM yyyy", "01 01 2022"],
+      ["ddMMyy", "010122", "dd MM yy", "01 01 22"],
+      ["dMMyy", "10122", "d MM yy", "1 01 22"],
+      ["ddMyy", "01122", "dd M yy", "01 1 22"],
+      ["ddMyyyy", "0112022", "dd M yyyy", "01 1 2022"],
+      ["dMyyyy", "112022", "d M yyyy", "1 1 2022"],
+      ["dMMyyyy", "1012022", "d MM yyyy", "1 01 2022"],
+      ["ddMMyyyy", "31012022", "dd MM yyyy", "31 01 2022"],
+      ["ddMMyy", "300122", "dd MM yy", "30 01 22"],
+      ["ddMyy", "28222", "dd M yy", "28 2 22"],
     ])(
       "should match the un-separated %s format and %s value and return the expected [%s, %s]",
       (format, value, formatResult, valueResult) => {

--- a/src/components/date/date.component.js
+++ b/src/components/date/date.component.js
@@ -141,7 +141,12 @@ const DateInput = ({
     if (isDateValid(selectedDays)) {
       event = buildCustomEvent(ev);
 
-      if (formattedValue(format, selectedDays) !== value) {
+      const currentValue = checkISOFormatAndLength(value)
+        ? formattedValue(format, parseISODate(value))
+        : value;
+      const [, matchedValue] = findMatchedFormatAndValue(currentValue, formats);
+
+      if (formattedValue(format, selectedDays) !== matchedValue) {
         onChange(event);
       }
     } else {

--- a/src/components/date/date.spec.js
+++ b/src/components/date/date.spec.js
@@ -222,6 +222,20 @@ describe("Date", () => {
       });
     });
 
+    describe("and the component's initial value has not been updated", () => {
+      it("then onBlur should have been called but onChange should not have been called", () => {
+        wrapper = render({
+          onChange: onChangeFn,
+          onBlur: onBlurFn,
+          value: "2012-12-12",
+        });
+        simulateBlurOnInput(wrapper);
+
+        expect(onBlurFn).toHaveBeenCalled();
+        expect(onChangeFn).not.toHaveBeenCalled();
+      });
+    });
+
     it.each(["disabled", "readOnly"])(
       "the onBlur and onChange props should not have been called if the %s prop is true",
       (param) => {


### PR DESCRIPTION
fix #5120

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Prevents `onChange` from being called when input is blurred and the value has not updated

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
When the initial value is different from the given locale's format it will call onChange when the input is blurred

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
Compare the the story in linked issue with local version

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
