### PR TITLE
chore(issue-template): add design tokens version field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -61,6 +61,16 @@ body:
       placeholder: 77.13.2
     validations:
       required: true
+  - type: input
+    id: design-tokens-version
+    attributes:
+      label: Design Tokens Version
+      description: >-
+        What version of [@sage/design-tokens](https://github.com/Sage/design-tokens) are you using?
+        Only applicable if using Carbon v106.0.0 or above.
+      placeholder: 1.0.0
+    validations:
+      required: false
   - type: dropdown
     id: browsers
     attributes:


### PR DESCRIPTION
### Proposed behaviour

Add a `@sage/design-tokens` version field to the bug report template. This is optional as it's not necessary if using a Carbon version lower than `106.0.0` (when `@sage/design-tokens` was introduced as a peer dependency).

### Current behaviour

.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
