### PR TITLE
fix(select): ensure select list appends to body if no element with role dialog exists FE-5163

### DIFF
--- a/src/__internal__/popover/popover.component.js
+++ b/src/__internal__/popover/popover.component.js
@@ -19,11 +19,8 @@ const Popover = ({
 }) => {
   const elementDOM = useRef();
   const { isInModal } = useContext(ModalContext);
-  let mountNode = document.body;
-
-  if (isInModal && reference.current) {
-    mountNode = reference.current.closest("[role='dialog']");
-  }
+  const candidateNode = reference.current?.closest("[role='dialog']");
+  const mountNode = isInModal && candidateNode ? candidateNode : document.body;
 
   if (!elementDOM.current && !disablePortal) {
     elementDOM.current = document.createElement("div");

--- a/src/__internal__/popover/popover.spec.js
+++ b/src/__internal__/popover/popover.spec.js
@@ -30,11 +30,11 @@ const Component = (props) => {
   );
 };
 
-const InDialog = (props) => {
+const InDialog = ({ dialogRole, ...props }) => {
   const ref = useRef();
 
   return (
-    <Dialog open>
+    <Dialog open role={dialogRole}>
       <div ref={ref} id="popover-container">
         {props.renderPopover && (
           <Popover placement="bottom-start" {...props} reference={ref}>
@@ -47,6 +47,7 @@ const InDialog = (props) => {
 };
 
 InDialog.propTypes = {
+  dialogRole: PropTypes.string,
   renderPopover: PropTypes.bool,
 };
 
@@ -186,6 +187,26 @@ describe("Popover", () => {
       });
 
       expect(appendChildSpy).toHaveBeenCalled();
+    });
+
+    it("should attach the portal to the document.body if no element with role of 'dialog' is found", () => {
+      const wrapper = mount(<InDialog dialogRole="alertdialog" />);
+      const dialog = wrapper.find("[role='alertdialog']");
+      const appendChildToDialogSpy = jest.spyOn(
+        dialog.at(2).getDOMNode(),
+        "appendChild"
+      );
+
+      const appendChildToBodySpy = jest.spyOn(document.body, "appendChild");
+
+      wrapper.setProps({ renderPopover: true });
+
+      act(() => {
+        wrapper.update();
+      });
+
+      expect(appendChildToDialogSpy).not.toHaveBeenCalled();
+      expect(appendChildToBodySpy).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/select/select.style.js
+++ b/src/components/select/select.style.js
@@ -13,7 +13,7 @@ const StyledSelect = styled.div`
     position: relative;
 
     ${StyledInput} {
-      cursor: "text";
+      cursor: text;
 
       ${disabled &&
       css`


### PR DESCRIPTION
fix #5135

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Ensures that the `Popover` the `SelectList` is rendered in appends to `document.body` if no parent
with `role="dialog"` is found

Updates select style to remove quotes around `cursor: "text"`

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
The `Popover` the `SelectList` is rendered tries to append to `document.body` with `role="dialog"` if `isInModal` context  flag is true

Select style has quotes around `cursor: "text"`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
See linked issue

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
