### PR TITLE
ci: replace semantic app with GH action to lint commit messages FE-5151

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,0 @@
-allowMergeCommits: true
-titleAndCommits: true
-anyCommit: true

--- a/.github/workflows/semantic-commit-lint.yml
+++ b/.github/workflows/semantic-commit-lint.yml
@@ -1,0 +1,18 @@
+name: Lint Commit Messages
+
+on: pull_request
+
+jobs:
+  commitlint:
+    # this will only run on non-forked PRs
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: checkout_pr
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - id: lint_commits
+        uses: wagoid/commitlint-github-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Semantic App has gone down https://github.com/zeke/semantic-pull-requests/issues/183
Adds a workflow to handle checking commit messages are semantically valid according
to conventional commits spec https://www.conventionalcommits.org/en/v1.0.0/

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No commit linting runs on PRs

