### PR TITLE
chore(date): add DateChangeEvent interface and export from index file FE-5195

### DIFF
--- a/src/components/date-range/date-range.d.ts
+++ b/src/components/date-range/date-range.d.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import { MarginProps } from "styled-system";
 import { DateInputProps } from "../date/date";
 
-interface DateRangeChangeEvent {
+export interface DateRangeChangeEvent {
   target: {
     value: [
       {
@@ -19,7 +19,7 @@ interface DateRangeChangeEvent {
 
 export interface DateRangeProps extends MarginProps {
   /** Props for the child end Date component */
-  endDateProps?: DateInputProps;
+  endDateProps?: Partial<DateInputProps>;
   /** Optional label for endDate field */
   endLabel?: string;
   /**
@@ -51,7 +51,7 @@ export interface DateRangeProps extends MarginProps {
   /** Specify a callback triggered on blur */
   onBlur?: (ev: DateRangeChangeEvent) => void;
   /** Props for the child start Date component */
-  startDateProps?: DateInputProps;
+  startDateProps?: Partial<DateInputProps>;
   /** Optional label for startDate field */
   startLabel?: string;
   /**

--- a/src/components/date-range/index.d.ts
+++ b/src/components/date-range/index.d.ts
@@ -1,2 +1,3 @@
 export { default } from "./date-range";
 export { default as DateRangeContext } from "./date-range-context";
+export type { DateRangeChangeEvent } from "./date-range";

--- a/src/components/date/date.d.ts
+++ b/src/components/date/date.d.ts
@@ -2,6 +2,15 @@ import * as React from "react";
 import { DayPickerProps } from "react-day-picker";
 import { TextboxProps } from "../textbox/textbox";
 
+export interface DateChangeEvent {
+  target: {
+    value: {
+      formattedValue: string;
+      rawValue: string;
+    };
+  };
+}
+
 export interface DateInputProps
   extends Omit<
     TextboxProps,
@@ -31,7 +40,7 @@ export interface DateInputProps
   /** Maximum possible date YYYY-MM-DD */
   maxDate?: string;
   /** Specify a callback triggered on change */
-  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (ev: DateChangeEvent) => void;
   /** The current date string */
   value: string;
   /** Pass any props that match the DayPickerProps interface to override default behaviors */

--- a/src/components/date/index.d.ts
+++ b/src/components/date/index.d.ts
@@ -1,1 +1,2 @@
 export { default } from "./date";
+export type { DateChangeEvent } from "./date";


### PR DESCRIPTION
fix #5185

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Sets the type for `startDateProps` and `endDateProps` are `Partial` implementations of the
`DateInputProps` interface. Also exports the `DateRangeChangeEvent` interface

exports `DateChangeEvent` from `Date` component

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
- Export the sandbox locally 
- run `npm i`
- confirm no type warnings in `startDateProps` and `endDateProps` for `value` and `onChange`
- compare to master where there will be warnings

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/carbon-quickstart-typescript-forked-vhtwgu
