### PR TITLE
fix(date): ensure months and days are capitalised and formatted correctly for all locales FE-5197

### DIFF
--- a/src/components/date-range/date-range.spec.js
+++ b/src/components/date-range/date-range.spec.js
@@ -2,9 +2,9 @@ import React from "react";
 import { shallow, mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 
+import DayPicker from "react-day-picker";
 import DateRange from "./date-range.component";
 import DateInput from "../date";
-import DatePicker from "../date/__internal__/date-picker";
 import { rootTagTest } from "../../__internal__/utils/helpers/tags/tags-specs";
 import {
   assertStyleMatch,
@@ -476,13 +476,13 @@ describe("DateRange", () => {
     it("closes the other datepicker", () => {
       simulateFocusOnInput(wrapper.find(DateInput).last());
       expect(
-        wrapper.update().find(DateInput).last().find(DatePicker).exists()
+        wrapper.update().find(DateInput).last().find(DayPicker).exists()
       ).toBeTruthy();
 
       simulateFocusOnInput(wrapper.find(DateInput).first());
 
       expect(
-        wrapper.update().find(DateInput).last().find(DatePicker).exists()
+        wrapper.update().find(DateInput).last().find(DayPicker).exists()
       ).toBeFalsy();
     });
   });
@@ -491,12 +491,12 @@ describe("DateRange", () => {
     it("closes the other datepicker", () => {
       simulateFocusOnInput(wrapper.find(DateInput).first());
       expect(
-        wrapper.update().find(DateInput).first().find(DatePicker).exists()
+        wrapper.update().find(DateInput).first().find(DayPicker).exists()
       ).toBeTruthy();
 
       simulateFocusOnInput(wrapper.find(DateInput).last());
       expect(
-        wrapper.update().find(DateInput).first().find(DatePicker).exists()
+        wrapper.update().find(DateInput).first().find(DayPicker).exists()
       ).toBeFalsy();
     });
   });

--- a/src/components/date/__internal__/date-picker/date-picker.component.js
+++ b/src/components/date/__internal__/date-picker/date-picker.component.js
@@ -20,25 +20,45 @@ const DatePicker = React.forwardRef(
       onDayClick,
       pickerMouseDown,
       pickerProps,
+      open,
     },
     ref
   ) => {
     const l = useLocale();
     const { localize, options } = l.date.dateFnsLocale();
     const { weekStartsOn } = options;
-    const monthsLong = Array.from({ length: 12 }).map((_, i) =>
-      localize.month(i)
+    const monthsLong = useMemo(
+      () =>
+        Array.from({ length: 12 }).map((_, i) => {
+          const month = localize.month(i);
+          return month[0].toUpperCase() + month.slice(1);
+        }),
+      [localize]
     );
-    const monthsShort = Array.from({ length: 12 }).map((_, i) =>
-      localize.month(i, { width: "abbreviated" }).substring(0, 3)
+    const monthsShort = useMemo(
+      () =>
+        Array.from({ length: 12 }).map((_, i) =>
+          localize.month(i, { width: "abbreviated" }).substring(0, 3)
+        ),
+      [localize]
     );
-    const weekdaysLong = Array.from({ length: 7 }).map((_, i) =>
-      localize.day(i)
+    const weekdaysLong = useMemo(
+      () => Array.from({ length: 7 }).map((_, i) => localize.day(i)),
+      [localize]
     );
-    const weekdaysShort = Array.from({ length: 7 }).map((_, i) =>
-      localize
-        .day(i, l.locale() === "de" ? {} : { width: "abbreviated" })
-        .substring(0, 3)
+    const weekdaysShort = useMemo(
+      () =>
+        Array.from({ length: 7 }).map((_, i) =>
+          localize
+            .day(
+              i,
+              ["de", "pl"].filter((str) => l.locale().includes(str)).length
+                ? { width: "wide" }
+                : { width: "abbreviated" }
+            )
+            .substring(0, 3)
+        ),
+      [l, localize]
     );
 
     const popoverModifiers = useMemo(
@@ -69,6 +89,10 @@ const DatePicker = React.forwardRef(
       `${weekdaysShort[date.getDay()]} ${date.getDate()} ${
         monthsShort[date.getMonth()]
       } ${date.getFullYear()}`;
+
+    if (!open) {
+      return null;
+    }
 
     return (
       <Popover
@@ -127,6 +151,8 @@ DatePicker.propTypes = {
   pickerProps: PropTypes.object,
   /** Callback to handle mousedown event on picker */
   pickerMouseDown: PropTypes.func,
+  /** Sets whether the picker should be displayed */
+  open: PropTypes.bool,
 };
 
 export default DatePicker;

--- a/src/components/date/__internal__/date-picker/date-picker.d.ts
+++ b/src/components/date/__internal__/date-picker/date-picker.d.ts
@@ -16,6 +16,8 @@ export interface DatePickerProps extends Pick<DayPickerProps, "onDayClick"> {
   selectedDays?: Date;
   /** Callback to handle mousedown event on picker container */
   pickerMouseDown?: () => void;
+  /** Sets whether the picker should be displayed */
+  open?: boolean;
 }
 
 declare function DatePicker(

--- a/src/components/date/__internal__/date-picker/date-picker.spec.js
+++ b/src/components/date/__internal__/date-picker/date-picker.spec.js
@@ -174,7 +174,7 @@ describe("StyledDayPicker", () => {
     let wrapper;
     const translations = {
       "en-GB": enGBLocale,
-      de: deLocale,
+      "de-DE": deLocale,
       es: esLocale,
       "en-ZA": enZALocale,
       "fr-FR": frLocale,
@@ -210,9 +210,10 @@ describe("StyledDayPicker", () => {
     };
 
     const monthsArray = (l) =>
-      Array.from({ length: 12 }).map((_, i) =>
-        translations[l].localize.month(i)
-      );
+      Array.from({ length: 12 }).map((_, i) => {
+        const month = translations[l].localize.month(i);
+        return month[0].toUpperCase() + month.slice(1);
+      });
 
     beforeEach(() => {
       wrapper = renderI18n({
@@ -222,7 +223,7 @@ describe("StyledDayPicker", () => {
 
     describe.each([
       "en-GB",
-      "de",
+      "de-DE",
       "es",
       "en-ZA",
       "fr-FR",
@@ -256,7 +257,7 @@ describe("StyledDayPicker", () => {
 
           expect(title).toEqual(long[i]);
           expect(children).toEqual(
-            locale === "de" ? long[i].substring(0, 3) : short[i]
+            locale === "de-DE" ? long[i].substring(0, 3) : short[i]
           );
         });
       });
@@ -274,16 +275,23 @@ describe("StyledDayPicker", () => {
       });
     });
   });
+
+  it("does not render the picker if open prop is false", () => {
+    expect(render({ open: false }).find(StyledDayPicker).exists()).toBeFalsy();
+  });
 });
 
 function renderI18n({ locale, ...props }) {
   return mount(
     <I18nProvider locale={locale}>
-      <DatePicker inputElement={inputElement} {...props} />
+      <DatePicker inputElement={inputElement} open {...props} />
     </I18nProvider>
   );
 }
 
 function render(props, params) {
-  return mount(<DatePicker inputElement={inputElement} {...props} />, params);
+  return mount(
+    <DatePicker inputElement={inputElement} open {...props} />,
+    params
+  );
 }

--- a/src/components/date/date.component.js
+++ b/src/components/date/date.component.js
@@ -359,20 +359,19 @@ const DateInput = ({
         disabled={disabled}
         readOnly={readOnly}
       />
-      {open && (
-        <DatePicker
-          disablePortal={disablePortal}
-          inputElement={parentRef}
-          pickerProps={pickerProps}
-          selectedDays={selectedDays}
-          setSelectedDays={setSelectedDays}
-          onDayClick={handleDayClick}
-          minDate={minDate}
-          maxDate={maxDate}
-          ref={pickerRef}
-          pickerMouseDown={handlePickerMouseDown}
-        />
-      )}
+      <DatePicker
+        disablePortal={disablePortal}
+        inputElement={parentRef}
+        pickerProps={pickerProps}
+        selectedDays={selectedDays}
+        setSelectedDays={setSelectedDays}
+        onDayClick={handleDayClick}
+        minDate={minDate}
+        maxDate={maxDate}
+        ref={pickerRef}
+        pickerMouseDown={handlePickerMouseDown}
+        open={open}
+      />
     </StyledDateInput>
   );
 };

--- a/src/components/date/date.spec.js
+++ b/src/components/date/date.spec.js
@@ -146,7 +146,7 @@ describe("Date", () => {
       const focusedElement = document.activeElement;
 
       expect(input.getDOMNode()).toBe(focusedElement);
-      expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+      expect(wrapper.update().find(DayPicker).exists()).toBe(true);
     });
 
     it("the component's input should not be focused and picker should not exist when prop is falsy", () => {
@@ -155,7 +155,7 @@ describe("Date", () => {
       const focusedElement = document.activeElement;
 
       expect(input.getDOMNode()).not.toBe(focusedElement);
-      expect(wrapper.update().find(DatePicker).exists()).not.toBe(true);
+      expect(wrapper.update().find(DayPicker).exists()).not.toBe(true);
     });
   });
 
@@ -168,7 +168,7 @@ describe("Date", () => {
       wrapper = render({ onFocus: onFocusFn });
       simulateFocusOnInput(wrapper);
       expect(onFocusFn).toHaveBeenCalled();
-      expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+      expect(wrapper.update().find(DayPicker).exists()).toBe(true);
 
       simulateBlurOnInput(wrapper); // for coverage
     });
@@ -180,7 +180,7 @@ describe("Date", () => {
 
         simulateFocusOnInput(wrapper);
         expect(onFocusFn).not.toHaveBeenCalled();
-        expect(wrapper.update().find(DatePicker).exists()).not.toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).not.toBe(true);
       }
     );
   });
@@ -314,17 +314,17 @@ describe("Date", () => {
 
     describe('and with the "Tab" key', () => {
       it('then the "DatePicker" should be closed', () => {
-        expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(true);
         simulateOnKeyDown(wrapper, tabKeyCode);
-        expect(wrapper.update().find(DatePicker).exists()).toBe(false);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(false);
       });
     });
 
     describe('and with the key other that "Tab"', () => {
       it('then the "DatePicker" should not be closed', () => {
-        expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(true);
         simulateOnKeyDown(wrapper, enterKeyCode);
-        expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(true);
       });
     });
   });
@@ -351,9 +351,9 @@ describe("Date", () => {
       it("then the 'DatePicker' should open on first click and further clicks should not close the picker", () => {
         wrapper = render();
         simulateMouseDownOnInput(wrapper);
-        expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(true);
         simulateMouseDownOnInput(wrapper);
-        expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(true);
       });
 
       it.each(["disabled", "readOnly"])(
@@ -361,7 +361,7 @@ describe("Date", () => {
         (param) => {
           wrapper = render({ [param]: true });
           simulateMouseDownOnInput(wrapper);
-          expect(wrapper.update().find(DatePicker).exists()).toBe(false);
+          expect(wrapper.update().find(DayPicker).exists()).toBe(false);
         }
       );
 
@@ -371,7 +371,7 @@ describe("Date", () => {
           wrapper = render({ [param]: true, onClick: onClickFn });
           simulateClickOnInput(wrapper);
           expect(onClickFn).not.toHaveBeenCalled();
-          expect(wrapper.update().find(DatePicker).exists()).toBe(false);
+          expect(wrapper.update().find(DayPicker).exists()).toBe(false);
         }
       );
     });
@@ -395,11 +395,11 @@ describe("Date", () => {
       it("then the 'DatePicker' should toggle open or closed", () => {
         wrapper = render();
         simulateMouseDownOnInputIcon(wrapper);
-        expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(true);
         simulateMouseDownOnInputIcon(wrapper);
-        expect(wrapper.update().find(DatePicker).exists()).toBe(false);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(false);
         simulateMouseDownOnInputIcon(wrapper);
-        expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(true);
         simulateFocusOnInput(wrapper);
       });
 
@@ -409,7 +409,7 @@ describe("Date", () => {
           wrapper = render({ [param]: true, onClick: onClickFn });
           simulateClickOnInput(wrapper);
           expect(onClickFn).not.toHaveBeenCalled();
-          expect(wrapper.update().find(DatePicker).exists()).toBe(false);
+          expect(wrapper.update().find(DayPicker).exists()).toBe(false);
         }
       );
     });
@@ -418,7 +418,7 @@ describe("Date", () => {
       it("the 'DatePicker' should close if it is open", () => {
         wrapper = render();
         simulateFocusOnInput(wrapper);
-        expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(true);
 
         act(() => {
           document.dispatchEvent(
@@ -426,14 +426,14 @@ describe("Date", () => {
           );
         });
 
-        expect(wrapper.update().find(DatePicker).exists()).toBe(false);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(false);
         wrapper.unmount();
       });
 
       it("the 'DatePicker' should close if it is open", () => {
         wrapper = render();
         simulateFocusOnInput(wrapper);
-        expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(true);
 
         simulateMouseDownOnPicker(wrapper);
 
@@ -445,7 +445,7 @@ describe("Date", () => {
           );
         });
 
-        expect(wrapper.update().find(DatePicker).exists()).toBe(false);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(false);
         wrapper.unmount();
       });
     });
@@ -455,7 +455,7 @@ describe("Date", () => {
         const onBlurFn = jest.fn();
         wrapper = render({ onBlur: onBlurFn });
         simulateMouseDownOnInput(wrapper);
-        expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(true);
         simulateMouseDownOnPicker(wrapper);
         wrapper.update();
         simulateBlurOnInput(wrapper);
@@ -467,7 +467,7 @@ describe("Date", () => {
       it("the 'DatePicker' should remain open", () => {
         wrapper = render();
         simulateFocusOnInput(wrapper);
-        expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(true);
 
         act(() => {
           document.dispatchEvent(
@@ -481,7 +481,7 @@ describe("Date", () => {
           );
         });
 
-        expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(true);
       });
     });
   });
@@ -579,7 +579,7 @@ describe("Date", () => {
       });
 
       it("should return focus to the date input and close the DatePicker", () => {
-        expect(wrapper.update().find(DatePicker).exists()).toBe(false);
+        expect(wrapper.update().find(DayPicker).exists()).toBe(false);
         expect(onFocusFn).toHaveBeenCalled();
       });
 
@@ -608,7 +608,7 @@ describe("Date", () => {
         it("does not call onChange, focus the input or close the picker", () => {
           expect(onChangeFn).not.toHaveBeenCalled();
           expect(onFocusFn).not.toHaveBeenCalled();
-          expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+          expect(wrapper.update().find(DayPicker).exists()).toBe(true);
         });
       });
     });
@@ -837,7 +837,7 @@ describe("Date", () => {
         wrapper.find(InputIconToggle).props().onMouseDown({ target: {} });
       });
 
-      expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+      expect(wrapper.update().find(DayPicker).exists()).toBe(true);
     });
   });
 
@@ -848,7 +848,7 @@ describe("Date", () => {
         wrapper.find(InputIconToggle).props().onMouseDown({ target: {} });
       });
 
-      expect(wrapper.update().find(DatePicker).exists()).toBe(true);
+      expect(wrapper.update().find(DayPicker).exists()).toBe(true);
       expect(wrapper.find(DatePicker).props().inputElement.current).toBe(
         wrapper.find(StyledInputPresentation).getDOMNode()
       );


### PR DESCRIPTION
fix #5181

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Ensures that months are a capitalised for all locales and that day strings are all 3 characters long
in `DatePicker`. Introduces small optimisation by adding `useMemo` to arrays of days and months so
they only regenerate values when locale changes.

German days updated:
![image](https://user-images.githubusercontent.com/44157880/171385536-ab57429d-75f7-4b6c-ab00-f19697c3d11b.png)

Spanish months updated:
![image](https://user-images.githubusercontent.com/44157880/171385664-f0ea90e8-b074-4fce-a425-4efdffc4917c.png)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Incorrect formatting for month and days 
No memoization added

German days current:
![image](https://user-images.githubusercontent.com/44157880/171385761-1c504da0-454d-4e03-9723-535d4017ff57.png)


Spanish months current:
![image](https://user-images.githubusercontent.com/44157880/171385907-147a1b1f-524b-473c-8ab2-74d74178e59c.png)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/carbon-quickstart-forked-vwnj65?file=/src/index.js