### PR TITLE
fix: fix missing type declarations - FE-5204

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -21,6 +21,8 @@ async function run(bundle) {
     "**/*.spec.js",
     "**/*.spec.ts",
     "**/*.spec.tsx",
+    "**/*.stories.js",
+    "**/*.stories.tsx",
     "**/*.d.ts",
   ];
 

--- a/src/__internal__/utils/argTypes/specialCharacters.ts
+++ b/src/__internal__/utils/argTypes/specialCharacters.ts
@@ -41,6 +41,7 @@ export const number = {
 export default {
   options: ["undefined", "otherLanguage", "specialCharacters"],
   mapping: {
+    // eslint-disable-next-line object-shorthand
     undefined: undefined,
     otherLanguage: "mp150ú¿¡üßä",
     specialCharacters: "!@#$%^*()_+-=~[];:.,?{}&\"'<>",

--- a/src/components/alert/alert-test.stories.mdx
+++ b/src/components/alert/alert-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Alert from ".";
 import Modal from "../modal";
 import Dialog from "../dialog";

--- a/src/components/app-wrapper/app-wrapper-test.stories.mdx
+++ b/src/components/app-wrapper/app-wrapper-test.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import AppWrapper from "./app-wrapper.component";
 
 <Meta

--- a/src/components/badge/badge-test.stories.mdx
+++ b/src/components/badge/badge-test.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Badge from "./badge.component";
 import Button from "../button";
 

--- a/src/components/button-toggle/button-toggle-test.stories.mdx
+++ b/src/components/button-toggle/button-toggle-test.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import ButtonToggle from ".";
 
 <Meta

--- a/src/components/button/button-test.stories.mdx
+++ b/src/components/button/button-test.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Button from ".";
 import { ICONS } from "../icon/icon-config";
 import {

--- a/src/components/checkbox/checkbox-test.stories.mdx
+++ b/src/components/checkbox/checkbox-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import { Checkbox } from ".";
 
 <Meta

--- a/src/components/confirm/confirm-test.stories.mdx
+++ b/src/components/confirm/confirm-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Button from "../button";
 import Confirm from ".";
 import { CONFIRM_SIZES } from "./confirm.config";

--- a/src/components/content/content-test.stories.mdx
+++ b/src/components/content/content-test.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Content from "./content.component.js";
 
 <Meta

--- a/src/components/date-range/date-range-test.stories.mdx
+++ b/src/components/date-range/date-range-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import DateRange from "./date-range.component";
 
 <Meta
@@ -36,7 +36,7 @@ export const DateRangeStory = ({
       evt.target.value[1].formattedValue,
     ];
     setState(newValue);
-    action("change")(evt.target.value)
+    action("change")(evt.target.value);
   };
   return (
     <DateRange

--- a/src/components/detail/detail-test.stories.mdx
+++ b/src/components/detail/detail-test.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import { ICONS } from "../icon/icon-config";
 import Detail from "./detail.component";
 

--- a/src/components/dialog-full-screen/dialog-full-screen-test.stories.mdx
+++ b/src/components/dialog-full-screen/dialog-full-screen-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import DialogFullScreen from ".";
 import Dialog from "../dialog";
 import Button from "../button";

--- a/src/components/dialog/dialog-test.stories.mdx
+++ b/src/components/dialog/dialog-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Dialog from "./dialog.component";
 import Form from "../form";
 import Textbox from "../textbox";

--- a/src/components/fieldset/fieldset-test.stories.mdx
+++ b/src/components/fieldset/fieldset-test.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Fieldset from "./fieldset.component";
 import Textbox from "../textbox";
 import { Checkbox } from "../checkbox";

--- a/src/components/flat-table/flat-table-test.stories.mdx
+++ b/src/components/flat-table/flat-table-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import {
   FlatTable,
   FlatTableHead,
@@ -15,7 +15,7 @@ import {
 } from ".";
 import guid from "../../__internal__/utils/helpers/guid";
 import { FLAT_TABLE_SIZES, FLAT_TABLE_THEMES } from "./flat-table.config";
-import { FlatTableSortableStory } from "./flat-table.stories.mdx"
+import { FlatTableSortableStory } from "./flat-table.stories.mdx";
 
 <Meta
   title="Flat Table/Test"

--- a/src/components/grouped-character/grouped-character-test.stories.mdx
+++ b/src/components/grouped-character/grouped-character-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import { singleSpecialCharacters } from "../../../.storybook/utils/argTypes/specialCharacters";
+import { singleSpecialCharacters } from "../../__internal__/utils/argTypes/specialCharacters";
 import {
   commonTextboxArgTypes,
   getCommonTextboxArgs,

--- a/src/components/heading/heading-test.stories.mdx
+++ b/src/components/heading/heading-test.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Heading from "./heading.component";
 
 <Meta

--- a/src/components/help/help-test.stories.mdx
+++ b/src/components/help/help-test.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import { HELP_POSITIONS } from "./help.config";
 import { ICONS } from "../icon/icon-config";
 import Help from "./help.component";

--- a/src/components/inline-inputs/inline-inputs.stories.mdx
+++ b/src/components/inline-inputs/inline-inputs.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, ArgsTable, Canvas, Story } from "@storybook/addon-docs";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import InlineInputs from ".";
 import Textbox from "../textbox";
 import Decimal from "../decimal";

--- a/src/components/link/link-test.stories.mdx
+++ b/src/components/link/link-test.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import { ICONS } from "../icon/icon-config";
 import { LINK_ALIGNMENTS, LINK_POSITIONS } from "./link.config";
 import Link from "./link.component";

--- a/src/components/message/message-test.stories.mdx
+++ b/src/components/message/message-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Button from "../button";
 import Message from "./message.component";
 

--- a/src/components/multi-action-button/multi-action-button-test.stories.tsx
+++ b/src/components/multi-action-button/multi-action-button-test.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
+
 import MultiActionButton, {
   MultiActionButtonProps,
 } from "./multi-action-button.component";

--- a/src/components/navigation-bar/navigation-bar-test.stories.mdx
+++ b/src/components/navigation-bar/navigation-bar-test.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import NavigationBar from "./navigation-bar.component";
 
 <Meta

--- a/src/components/pager/pager-test.stories.mdx
+++ b/src/components/pager/pager-test.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Pager from ".";
 
 <Meta

--- a/src/components/pill/pill-test.stories.mdx
+++ b/src/components/pill/pill-test.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Pill from "./pill.component";
 
 <Meta

--- a/src/components/pod/pod-test.stories.mdx
+++ b/src/components/pod/pod-test.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Pod from "./pod.component";
 import { POD_ALIGNMENTS, POD_SIZES, POD_THEMES } from "./pod.config";
 

--- a/src/components/popover-container/popover-container-test.stories.mdx
+++ b/src/components/popover-container/popover-container-test.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import PopoverContainer from "./popover-container.component";
 
 <Meta

--- a/src/components/portrait/portrait-test.stories.mdx
+++ b/src/components/portrait/portrait-test.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import { ICONS } from "../icon/icon-config";
 import { PORTRAIT_SHAPES, PORTRAIT_SIZES } from "./portrait.config";
 import Portrait from "./portrait.component";

--- a/src/components/preview/preview-test.stories.mdx
+++ b/src/components/preview/preview-test.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Preview from "./preview.component";
 
 <Meta

--- a/src/components/profile/profile-test.stories.js
+++ b/src/components/profile/profile-test.stories.js
@@ -3,7 +3,7 @@ import React from "react";
 
 import specialCharacters, {
   email as testEmail,
-} from "../../../.storybook/utils/argTypes/specialCharacters";
+} from "../../__internal__/utils/argTypes/specialCharacters";
 import Profile from "./profile.component";
 import { PROFILE_SIZES } from "./profile.config";
 

--- a/src/components/search/search-test.stories.mdx
+++ b/src/components/search/search-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Search from ".";
 
 <Meta

--- a/src/components/settings-row/settings-row-test.stories.mdx
+++ b/src/components/settings-row/settings-row-test.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import SettingsRow from ".";
 
 <Meta

--- a/src/components/show-edit-pod/show-edit-pod-test.stories.js
+++ b/src/components/show-edit-pod/show-edit-pod-test.stories.js
@@ -4,7 +4,7 @@ import { action } from "@storybook/addon-actions";
 import ShowEditPod from "./show-edit-pod.component";
 import Content from "../content";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Textbox from "../textbox";
 import Fieldset from "../fieldset";
 import {

--- a/src/components/simple-color-picker/simple-color-picker-test.stories.mdx
+++ b/src/components/simple-color-picker/simple-color-picker-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import { SimpleColorPicker, SimpleColor } from ".";
 
 <Meta

--- a/src/components/split-button/split-button-test.stories.mdx
+++ b/src/components/split-button/split-button-test.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Button from "../button";
 import Box from "../box";
 import { ICONS } from "../icon/icon-config";

--- a/src/components/step-sequence/step-sequence-test.stories.mdx
+++ b/src/components/step-sequence/step-sequence-test.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import StepSequence from "./step-sequence.component";
 import StepSequenceItem from "./step-sequence-item/step-sequence-item.component";
 import {

--- a/src/components/switch/switch-test.stories.mdx
+++ b/src/components/switch/switch-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Switch, { BaseSwitch } from "./switch.component";
 
 <Meta

--- a/src/components/textarea/textarea-test.stories.js
+++ b/src/components/textarea/textarea-test.stories.js
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 
 import specialCharacters, {
   number,
-} from "../../../.storybook/utils/argTypes/specialCharacters";
+} from "../../__internal__/utils/argTypes/specialCharacters";
 import Textarea from ".";
 
 export default {

--- a/src/components/textbox/textbox-test.stories.mdx
+++ b/src/components/textbox/textbox-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Textbox from ".";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import { ICONS } from "../icon/icon-config";

--- a/src/components/toast/toast-test.stories.mdx
+++ b/src/components/toast/toast-test.stories.mdx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Toast from ".";
 import Button from "../button";
 import { TOAST_COLORS } from "./toast.config";

--- a/src/components/tooltip/tooltip-test.stories.mdx
+++ b/src/components/tooltip/tooltip-test.stories.mdx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
-import specialCharacters from "../../../.storybook/utils/argTypes/specialCharacters";
+import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Tooltip from ".";
 import { TOOLTIP_POSITIONS } from "./tooltip.config";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "outDir": "./lib/",
-    "rootDir": "./",
+    "rootDir": "./src",
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
### Proposed behaviour

Fixes #5206

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

It's best to test it locally in a clean repo, you can use create-react-app for that:
`npx create-react-app test-repo --template typescript`

Then in this repo
`npm install carbon-react`
 and import components mentioned in the issue #5206 to see that they give this error:
`error TS7016: Could not find a declaration file for module ...'`
Then install latest carbon-react build from codesandbox:
`npm i https://pkg.csb.dev/Sage/carbon/commit/6fa87a65/carbon-react` 
and see if this issue still exists
