### PR TITLE
chore(flat-table-header): add displayName to component FE-5208

### DIFF
--- a/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.component.js
@@ -126,4 +126,6 @@ FlatTableCell.propTypes = {
   verticalBorderColor: PropTypes.string,
 };
 
+FlatTableCell.displayName = "FlatTableCell";
+
 export default FlatTableCell;

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.component.js
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.component.js
@@ -91,4 +91,6 @@ FlatTableCheckbox.propTypes = {
   reportCellWidth: PropTypes.func,
 };
 
+FlatTableCheckbox.displayName = "FlatTableCheckbox";
+
 export default FlatTableCheckbox;

--- a/src/components/flat-table/flat-table-header/flat-table-header.component.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.component.js
@@ -89,4 +89,6 @@ FlatTableHeader.defaultProps = {
   align: "left",
 };
 
+FlatTableHeader.displayName = "FlatTableHeader";
+
 export default FlatTableHeader;

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.js
@@ -90,4 +90,6 @@ FlatTableRowHeader.propTypes = {
   verticalBorderColor: PropTypes.string,
 };
 
+FlatTableRowHeader.displayName = "FlatTableRowHeader";
+
 export default FlatTableRowHeader;

--- a/src/components/flat-table/flat-table-row/flat-table-row.component.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.js
@@ -3,6 +3,7 @@ import React, {
   useContext,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -48,9 +49,15 @@ const FlatTableRow = React.forwardRef(
     const firstColumnExpandable = expandableArea === "firstColumn";
     const [stickyCellWidths, setStickyCellWidths] = useState([]);
     const [leftPositions, setLeftPositions] = useState([]);
-    const childrenArray = React.Children.toArray(children);
-    const rowHeaderIndex = childrenArray.findIndex(
-      (child) => child.type === FlatTableRowHeader
+    const childrenArray = useMemo(() => React.Children.toArray(children), [
+      children,
+    ]);
+    const rowHeaderIndex = useMemo(
+      () =>
+        childrenArray.findIndex(
+          (child) => child.type.displayName === FlatTableRowHeader.displayName
+        ),
+      [childrenArray]
     );
     const themeContext = useContext(FlatTableThemeContext);
 

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -1469,6 +1469,34 @@ describe("FlatTableRow", () => {
       );
     });
   });
+
+  describe("wrapping FlatTableRowHeader", () => {
+    it("calculates the rowHeaderIndex as expected", () => {
+      // eslint-disable-next-line react/prop-types
+      const FlatTableRowHeaderWrapper = ({ children }) => (
+        <FlatTableRowHeader>{children}</FlatTableRowHeader>
+      );
+      FlatTableRowHeaderWrapper.displayName = FlatTableRowHeader.displayName;
+      const rowHeaderIndex = mount(
+        <table>
+          <thead>
+            <FlatTableRow>
+              <FlatTableCell>Foo</FlatTableCell>
+              <FlatTableCell>Foo</FlatTableCell>
+              <FlatTableCell>Foo</FlatTableCell>
+              <FlatTableRowHeaderWrapper>Foo</FlatTableRowHeaderWrapper>
+              <FlatTableCell>Foo</FlatTableCell>
+              <FlatTableCell>Foo</FlatTableCell>
+            </FlatTableRow>
+          </thead>
+        </table>
+      )
+        .find(StyledFlatTableRow)
+        .prop("rowHeaderIndex");
+
+      expect(rowHeaderIndex).toEqual(3);
+    });
+  });
 });
 
 function renderFlatTableRow(props = {}, renderer = mount) {

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -2159,6 +2159,87 @@ of the button control.
   </Story>
 </Canvas>
 
+## Wrapping FlatTableRowHeaders
+
+The `FlatTableRow` relies on specific child composition to identify sticky columns. If you need to wrap the `FlatTableRowHeader` you will need to set the `displayName` of the wrapper to `FlatTableRowHeader.displayName`.
+
+<Canvas>
+  <Story
+    name="wrapping row headers"
+    parameters={{ chromatic: { disable: true } }}
+  >
+    {() => {
+      const FlatTableRowHeaderWrapper = ({ children, ...rest }) => (
+        <FlatTableRowHeader {...rest}>
+          {children}
+        </FlatTableRowHeader>
+      );
+      FlatTableRowHeaderWrapper.displayName = FlatTableRowHeader.displayName
+      return (
+        <FlatTable width="310px" overflowX="auto">
+          <FlatTableHead>
+            <FlatTableRow>
+              <FlatTableHeader>Name</FlatTableHeader>
+              <FlatTableRowHeaderWrapper>Location</FlatTableRowHeaderWrapper>
+              <FlatTableHeader>Relationship Status</FlatTableHeader>
+              <FlatTableHeader>Dependents</FlatTableHeader>
+            </FlatTableRow>
+          </FlatTableHead>
+          <FlatTableBody>
+            <FlatTableRow>
+              <FlatTableCell>John Doe</FlatTableCell>
+              <FlatTableRowHeaderWrapper>London</FlatTableRowHeaderWrapper>
+              <FlatTableCell>Single</FlatTableCell>
+              <FlatTableCell>
+                <ActionPopover>
+                  <ActionPopoverItem onClick={() => {}} icon="edit">
+                    Edit
+                  </ActionPopoverItem>
+                </ActionPopover>
+              </FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow>
+              <FlatTableCell>Jane Doe</FlatTableCell>
+              <FlatTableRowHeaderWrapper>York</FlatTableRowHeaderWrapper>
+              <FlatTableCell>Married</FlatTableCell>
+              <FlatTableCell>
+                <ActionPopover>
+                  <ActionPopoverItem onClick={() => {}} icon="edit">
+                    Edit
+                  </ActionPopoverItem>
+                </ActionPopover>
+              </FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow>
+              <FlatTableCell>John Smith</FlatTableCell>
+              <FlatTableRowHeaderWrapper>Edinburgh</FlatTableRowHeaderWrapper>
+              <FlatTableCell>Single</FlatTableCell>
+              <FlatTableCell>
+                <ActionPopover>
+                  <ActionPopoverItem onClick={() => {}} icon="edit">
+                    Edit
+                  </ActionPopoverItem>
+                </ActionPopover>
+              </FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow>
+              <FlatTableCell>Jane Smith</FlatTableCell>
+              <FlatTableRowHeaderWrapper>Newcastle</FlatTableRowHeaderWrapper>
+              <FlatTableCell>Married</FlatTableCell>
+              <FlatTableCell>
+                <ActionPopover>
+                  <ActionPopoverItem onClick={() => {}} icon="edit">
+                    Edit
+                  </ActionPopoverItem>
+                </ActionPopover>
+              </FlatTableCell>
+            </FlatTableRow>
+          </FlatTableBody>
+        </FlatTable>
+)}}
+  </Story>
+</Canvas>
+
 ## Props
 
 ### FlatTable


### PR DESCRIPTION
fix #5208

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Updates functionality to use `child.type.displayName` instead of `child.type`. This will allow
wrapping of the `FlatTableRowHeader` component as the wrapper component can set its `displayName` to
`FlatTableRowHeader.displayName` to ensure the required columns are sticky.

Adds `displayName` property to children of `FlatTableRow`.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Wrapping the `FlatTableRowHeader` prevents sticky column functioning correctly
Children of `FlatTableRow` have no `displayName` property

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
Use sandbox below, the one included in the linked issue will not work as there is no way to dynamically set the displayName on the wrapper. I have also added a story to demo how to implement this `flat-table--wrapping-row-headers`

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/carbon-quickstart-forked-y63erp?file=/src/index.js