### PR TITLE
feat(inline-inputs): add adaptiveLabelBreakpoint prop to component - FE-5187

### DIFF
--- a/src/components/inline-inputs/inline-inputs.component.tsx
+++ b/src/components/inline-inputs/inline-inputs.component.tsx
@@ -3,8 +3,12 @@ import Label from "../../__internal__/label";
 import StyledInlineInputs, {
   StyledContentContainer,
   StyledInlineInput,
+  StyledContentContainerProps,
+  StyledInlineInputsProps,
 } from "./inline-inputs.style";
+
 import createGuid from "../../__internal__/utils/helpers/guid";
+import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 
 interface InlineInputsContextProps {
   ariaLabelledBy?: string;
@@ -20,21 +24,19 @@ type GutterOptions =
   | "large"
   | "extra-large";
 
-export interface InlineInputsProps {
+export interface InlineInputsProps
+  extends StyledContentContainerProps,
+    StyledInlineInputsProps {
+  /** Breakpoint for adaptive label (inline label change to top aligned). Enables the adaptive behaviour when set */
+  adaptiveLabelBreakpoint?: number;
   /** Children elements */
   children?: React.ReactNode;
   /** [Legacy prop] A custom class name for the component. */
   className?: string;
-  /** Gutter prop gets passed down to Row component if false gutter value is "none" */
-  gutter?: GutterOptions;
   /** The id of the corresponding input control for the label */
   htmlFor?: string;
-  /** Width of the inline inputs container in percentage */
-  inputWidth?: number;
   /** Defines the label text for the heading. */
   label?: string;
-  /** Width of a label in percentage */
-  labelWidth?: number;
 }
 
 export const InlineInputsContext: React.Context<InlineInputsContextProps> = React.createContext(
@@ -58,21 +60,28 @@ const columnWrapper = (
 };
 
 const InlineInputs = ({
+  adaptiveLabelBreakpoint,
   label,
   htmlFor,
   children = null,
   className = "",
   gutter = "none",
   inputWidth,
+  labelInline = true,
   labelWidth,
 }: InlineInputsProps) => {
   const labelId = useRef(createGuid());
+  const largeScreen = useIsAboveBreakpoint(adaptiveLabelBreakpoint);
+  let inlineLabel: boolean | undefined = labelInline;
+  if (adaptiveLabelBreakpoint) {
+    inlineLabel = largeScreen;
+  }
 
   function renderLabel() {
     if (!label) return null;
 
     return (
-      <Label labelId={labelId.current} inline htmlFor={htmlFor}>
+      <Label labelId={labelId.current} inline={inlineLabel} htmlFor={htmlFor}>
         {label}
       </Label>
     );
@@ -84,6 +93,7 @@ const InlineInputs = ({
       data-component="inline-inputs"
       className={className}
       labelWidth={labelWidth}
+      labelInline={inlineLabel}
     >
       {renderLabel()}
       <StyledContentContainer

--- a/src/components/inline-inputs/inline-inputs.spec.tsx
+++ b/src/components/inline-inputs/inline-inputs.spec.tsx
@@ -4,9 +4,12 @@ import Label from "../../__internal__/label";
 import Textbox from "../textbox";
 import { Checkbox } from "../checkbox";
 import InlineInputs, { InlineInputsProps } from "./inline-inputs.component";
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
-import { StyledLabelContainer } from "../../__internal__/label/label.style";
 import {
+  assertStyleMatch,
+  mockMatchMedia,
+} from "../../__spec_helper__/test-utils";
+import { StyledLabelContainer } from "../../__internal__/label/label.style";
+import StyledInlineInputs, {
   StyledContentContainer,
   StyledInlineInput,
 } from "./inline-inputs.style";
@@ -199,6 +202,58 @@ describe("Inline Inputs", () => {
           .find(StyledContentContainer)
           .prop("children")
       ).toBe(null);
+    });
+  });
+
+  describe("when adaptiveLabelBreakpoint is set", () => {
+    describe("when screen is smaller than breakpoint", () => {
+      beforeEach(() => {
+        mockMatchMedia(false);
+      });
+
+      it("labelInline prop should be false", () => {
+        wrapper = mount(
+          <InlineInputs
+            label="inline label"
+            labelWidth={30}
+            adaptiveLabelBreakpoint={500}
+          >
+            <Textbox />
+            <Textbox />
+            <Checkbox />
+          </InlineInputs>
+        );
+
+        expect(wrapper.find(StyledInlineInputs).props().labelInline).toEqual(
+          false
+        );
+        expect(wrapper.find(Label).props().inline).toEqual(false);
+      });
+    });
+
+    describe("when screen is larger than breakpoint", () => {
+      beforeEach(() => {
+        mockMatchMedia(true);
+      });
+
+      it("labelInline prop should be true", () => {
+        wrapper = mount(
+          <InlineInputs
+            label="inline label"
+            labelWidth={30}
+            adaptiveLabelBreakpoint={500}
+          >
+            <Textbox />
+            <Textbox />
+            <Checkbox />
+          </InlineInputs>
+        );
+
+        expect(wrapper.find(StyledInlineInputs).props().labelInline).toEqual(
+          true
+        );
+        expect(wrapper.find(Label).props().inline).toEqual(true);
+      });
     });
   });
 });

--- a/src/components/inline-inputs/inline-inputs.stories.mdx
+++ b/src/components/inline-inputs/inline-inputs.stories.mdx
@@ -7,6 +7,7 @@ import Decimal from "../decimal";
 import { Select, Option } from "../select";
 import { useState } from "react";
 import { INLINE_INPUTS_SIZES } from "./inline-inputs.config";
+import Box from "../box";
 
 <Meta
   title="Inline Inputs"
@@ -88,6 +89,36 @@ import InlineInputs from "carbon-react/lib/components/inline-inputs";
         </InlineInputs>
       );
     }}
+  </Story>
+</Canvas>
+
+## with adaptiveLabelBreakpoint
+
+<Canvas>
+  <Story 
+    name="with adaptiveLabelBreakpoint"
+    args={{
+      gutter: "none",
+      label: "My Inline Inputs",
+      labelSpecialCharacters: undefined,
+    }}>
+    {({ label, labelSpecialCharacters, ...args }) => {
+      return (
+        <Box p={4} >
+          <InlineInputs
+            label={label || labelSpecialCharacters}
+            adaptiveLabelBreakpoint={768}
+            labelWidth={30}
+            {...args}
+          >
+            <Textbox />
+            <Textbox />
+          </InlineInputs>
+          <Textbox label="My Textbox" adaptiveLabelBreakpoint={768} />
+        </Box>
+      );
+    }
+  }
   </Story>
 </Canvas>
 

--- a/src/components/inline-inputs/inline-inputs.style.ts
+++ b/src/components/inline-inputs/inline-inputs.style.ts
@@ -5,6 +5,32 @@ import { StyledLabelContainer } from "../../__internal__/label/label.style";
 import baseTheme from "../../style/themes/base";
 import { InlineInputsProps } from "./inline-inputs.component";
 
+type GutterOptions =
+  | "none"
+  | "extra-small"
+  | "small"
+  | "medium-small"
+  | "medium"
+  | "medium-large"
+  | "large"
+  | "extra-large";
+interface StyledInlineInputProps {
+  /** Gutter prop gets passed down to Row component if false gutter value is "none" */
+  gutter?: GutterOptions;
+}
+
+export interface StyledContentContainerProps extends StyledInlineInputProps {
+  /** Width of the inline inputs container in percentage */
+  inputWidth?: number;
+}
+
+export interface StyledInlineInputsProps extends StyledInlineInputProps {
+  /** Width of a label in percentage */
+  labelWidth?: number;
+  /** @ignore @private */
+  labelInline?: boolean;
+}
+
 const spacings = {
   none: 0,
   "extra-small": 8,
@@ -16,7 +42,7 @@ const spacings = {
   "extra-large": 40,
 };
 
-const StyledInlineInput = styled.div<Pick<InlineInputsProps, "gutter">>`
+const StyledInlineInput = styled.div<InlineInputsProps>`
   flex: 1;
 
   ${({ gutter }) =>
@@ -27,9 +53,7 @@ const StyledInlineInput = styled.div<Pick<InlineInputsProps, "gutter">>`
     `}
 `;
 
-const StyledContentContainer = styled.div<
-  Pick<InlineInputsProps, "gutter" | "inputWidth">
->`
+const StyledContentContainer = styled.div<InlineInputsProps>`
   display: flex;
   flex: ${({ inputWidth }) => (inputWidth ? `0 0 ${inputWidth}%` : 1)};
 
@@ -48,15 +72,13 @@ const StyledContentContainer = styled.div<
     `}
 `;
 
-const StyledInlineInputs = styled.div<
-  Pick<InlineInputsProps, "gutter" | "labelWidth">
->`
-  display: flex;
+const StyledInlineInputs = styled.div<InlineInputsProps>`
+  display: ${({ labelInline }) => (labelInline ? `flex` : `block`)};
   align-items: center;
 
   ${StyledLabelContainer} {
     width: auto;
-    margin-bottom: 0;
+    margin-bottom: ${({ labelInline }) => (labelInline ? `0px` : `8px`)};
     padding-right: 16px;
     flex: 0 0 ${({ labelWidth }) => (labelWidth ? `${labelWidth}%` : "auto")};
   }


### PR DESCRIPTION
currently it is not possible to add a breakpoint where the label will be displayed above the
component if displayed on a small screen. this change will make this component behave the same way
as the `Form Field` components.

fixes #5099

### Proposed behaviour

![Screenshot 2022-06-16 at 14 27 11](https://user-images.githubusercontent.com/56251247/174080299-522319f7-f675-4eac-812b-de9520825481.png)

![Screenshot 2022-06-16 at 14 27 55](https://user-images.githubusercontent.com/56251247/174080449-130f2b8b-88fe-4c2f-afeb-7a3e01c386a9.png)

### Current behaviour

![Screenshot 2022-06-16 at 14 28 44](https://user-images.githubusercontent.com/56251247/174080625-e913160f-cc84-412d-be89-d81c13eed194.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

This can be tested against the codesandbox from the issue. https://codesandbox.io/s/flamboyant-breeze-yq5pde?file=/src/index.js

Resize the window and you should be able to see the label move from above to inline. 
