### PR TITLE
fix(loader): ensure correct colours are applied to loader when in a button - FE-5215

### DIFF
--- a/src/components/button/__snapshots__/button.spec.tsx.snap
+++ b/src/components/button/__snapshots__/button.spec.tsx.snap
@@ -1997,6 +1997,10 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   color: var(--colorsActionMajor500);
 }
 
+.c0 .c110 {
+  background-color: var(--colorsActionMajor500);
+}
+
 .c0:hover {
   background: var(--colorsActionMajor600);
   border-color: var(--colorsActionMajorTransparent);
@@ -2005,6 +2009,10 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 
 .c0:hover .c1 {
   color: var(--colorsActionMajorYang100);
+}
+
+.c0:hover .c110 {
+  background-color: var(--colorsActionMajorYang100);
 }
 
 .c0 .c1 {
@@ -2250,6 +2258,10 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   color: var(--colorsActionMajor500);
 }
 
+.c0 .c109 {
+  background-color: var(--colorsActionMajor500);
+}
+
 .c0:hover {
   background: var(--colorsActionMajor600);
   border-color: var(--colorsActionMajorTransparent);
@@ -2258,6 +2270,10 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
 
 .c0:hover .c1 {
   color: var(--colorsActionMajorYang100);
+}
+
+.c0:hover .c109 {
+  background-color: var(--colorsActionMajorYang100);
 }
 
 .c0 .c1 {

--- a/src/components/button/button-types.style.ts
+++ b/src/components/button/button-types.style.ts
@@ -1,10 +1,14 @@
 import StyledIcon from "../icon/icon.style";
+import StyledLoaderSquare from "../loader/loader-square.style";
 
 function makeColors(color: string) {
   return `
   color: ${color};
   ${StyledIcon} {
     color: ${color};
+  }
+  ${StyledLoaderSquare} {
+    background-color: ${color};
   }
   `;
 }

--- a/src/components/loader/loader.stories.mdx
+++ b/src/components/loader/loader.stories.mdx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import Loader from ".";
 import Button from "../button/button.component";
+import Box from "../box";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 <Meta
@@ -64,8 +65,7 @@ This is an example of the large Loader component. The larger size is only used w
 
 ### Inside Buttons
 
-This is an example of the Loader nested inside of a Button component. When used inside a primary button the colour of the squares will be white.
-To ensure that the correct styling is applied to the `Loader` component when it is nested inside of the `Button` component,
+These examples show a `Loader` nested inside of a `Button` component. To ensure that the correct styling is applied to the `Loader` component when it is nested inside of the `Button` component,
 please remember to pass the `isInsideButton` prop to the `Loader` component.
 
 <Canvas>
@@ -73,6 +73,26 @@ please remember to pass the `isInsideButton` prop to the `Loader` component.
     <Button buttonType="primary" aria-label="Loading">
       <Loader isInsideButton />
     </Button>
+    <Button ml={2} buttonType="primary" destructive aria-label="Loading">
+      <Loader isInsideButton />
+    </Button>
+    <Button ml={2} destructive aria-label="Loading">
+      <Loader isInsideButton />
+    </Button>
+    <Button ml={2} buttonType="tertiary" aria-label="Loading">
+      <Loader isInsideButton />
+    </Button>
+    <Button ml={2} buttonType="secondary" aria-label="Loading">
+      <Loader isInsideButton />
+    </Button>
+    <Button ml={2} buttonType="dashed" aria-label="Loading">
+      <Loader isInsideButton />
+    </Button>
+    <Box mt={2} height="72px" width="152px" bg="#000000">
+      <Button m={2} buttonType="darkBackground" aria-label="Loading">
+        <Loader isInsideButton />
+      </Button>
+    </Box>
   </Story>
 </Canvas>
 

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -81,7 +81,7 @@ context("Test for Loader component", () => {
     it("should render Loader with isActive prop set to false", () => {
       CypressMountWithProviders(<LoaderInsideButton isActive={false} />);
 
-      const color = "rgb(51, 91, 112)";
+      const color = "rgb(255, 255, 255)";
 
       loader(positionOfElement("first")).should(
         "have.css",

--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
@@ -78,6 +78,10 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
   color: var(--colorsActionMajor500);
 }
 
+.c2 .c15 {
+  background-color: var(--colorsActionMajor500);
+}
+
 .c2:hover {
   background: var(--colorsActionMajor600);
   border-color: var(--colorsActionMajorTransparent);
@@ -86,6 +90,10 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
 
 .c2:hover .c3 {
   color: var(--colorsActionMajorYang100);
+}
+
+.c2:hover .c15 {
+  background-color: var(--colorsActionMajorYang100);
 }
 
 .c2 .c3 {
@@ -345,7 +353,7 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
   color: var(--colorsActionMajorYang100);
 }
 
-.c14 .c1 + .c15 .c1 {
+.c14 .c1 + .c16 .c1 {
   margin-top: 3px;
 }
 

--- a/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
+++ b/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
@@ -78,6 +78,10 @@ exports[`Option renders properly 1`] = `
   color: var(--colorsActionMajor500);
 }
 
+.c2 .c5 {
+  background-color: var(--colorsActionMajor500);
+}
+
 .c2:hover {
   background: var(--colorsActionMajor600);
   border-color: var(--colorsActionMajorTransparent);
@@ -86,6 +90,10 @@ exports[`Option renders properly 1`] = `
 
 .c2:hover .c3 {
   color: var(--colorsActionMajorYang100);
+}
+
+.c2:hover .c5 {
+  background-color: var(--colorsActionMajorYang100);
 }
 
 .c2 .c3 {


### PR DESCRIPTION
Loader will now mimic the colours of icon when nested inside of a button.

fixes #5226

### Proposed behaviour

![Screenshot 2022-06-27 at 16 02 59](https://user-images.githubusercontent.com/56251247/175972321-782544e5-a43d-42f0-9676-12f579438582.png)


### Current behaviour
Any button other than primary renders like this with `Loader`

![Screenshot 2022-06-27 at 16 05 04](https://user-images.githubusercontent.com/56251247/175972723-ba72b0bf-eeb8-4072-8ecf-db4d62a50973.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Link to [codesandbox for testing](https://codesandbox.io/s/sweet-platform-4okwd3?file=/src/FilesT.js)