### PR TITLE
feat: introduce new GlobalHeader component (FE-5148)

### DIFF
--- a/cypress/e2e/common/menu.feature
+++ b/cypress/e2e/common/menu.feature
@@ -143,3 +143,15 @@ Feature: Menu component
     Given I open "Menu Test" component page "menu-full-screen-story"
     When I continue to hit Tab key 8 times
     Then inner menu without active redirection is not focused
+
+  @positive
+  Scenario: If there is a Menu Item with a very long label inside a submenu, check that the width of the whole submenu is determined by this submenu item
+    Given I open "Menu Test" component page "long-labels-story"
+    When I hover over "first" expandable Menu component
+    Then width of submenu should equal the width of the "second" submenu item
+
+  @positive
+  Scenario: If there is a Menu Item with a submenu that has a very long label, check the width of the whole submenu is determined by this parent item
+    Given I open "Menu Test" component page "long-labels-story"
+    When I hover over "second" expandable Menu component
+    Then width of submenu should equal the width of "second" expandable Menu component

--- a/cypress/locators/global-header/index.js
+++ b/cypress/locators/global-header/index.js
@@ -1,0 +1,5 @@
+import { GLOBAL_HEADER, GLOBAL_HEADER_LOGO_WRAPPER } from "./locators";
+
+export const globalHeader = () => cy.get(GLOBAL_HEADER);
+export const globalHeaderLogo = () =>
+  cy.get(GLOBAL_HEADER_LOGO_WRAPPER).children().first();

--- a/cypress/locators/global-header/locators.js
+++ b/cypress/locators/global-header/locators.js
@@ -1,0 +1,4 @@
+// component preview locators
+export const GLOBAL_HEADER = "[data-component='global-header']";
+export const GLOBAL_HEADER_LOGO_WRAPPER =
+  "[data-element='global-header-logo-wrapper']";

--- a/cypress/locators/navigation-bar/index.js
+++ b/cypress/locators/navigation-bar/index.js
@@ -1,6 +1,6 @@
 import NAVIGATION_BAR from "./locators";
 
 // component preview locators
-const navigationBarChildren = () => cy.get(NAVIGATION_BAR);
+const navigationBar = () => cy.get(NAVIGATION_BAR);
 
-export default navigationBarChildren;
+export default navigationBar;

--- a/cypress/support/step-definitions/menu-steps.js
+++ b/cypress/support/step-definitions/menu-steps.js
@@ -209,3 +209,23 @@ Then("{string} inner menu element is focused", (position) => {
 Then("inner menu without active redirection is not focused", () => {
   menuItem().should("not.be.focused");
 });
+
+Then(
+  "width of submenu should equal the width of the {string} submenu item",
+  (position) => {
+    submenuItem(positionOfElement(position)).then(($item) => {
+      submenuBlock().should("have.css", "width", `${$item.width()}px`);
+    });
+  }
+);
+
+Then(
+  "width of submenu should equal the width of {string} expandable Menu component",
+  (position) => {
+    submenu()
+      .eq(positionOfElement(position))
+      .then(($menu) => {
+        submenuBlock().should("have.css", "width", `${$menu.width()}px`);
+      });
+  }
+);

--- a/cypress/support/step-definitions/navigation-bar-steps.js
+++ b/cypress/support/step-definitions/navigation-bar-steps.js
@@ -1,7 +1,6 @@
 import { Then } from "@badeball/cypress-cucumber-preprocessor";
-
-import navigationBarChildren from "../../locators/navigation-bar";
+import navigationBar from "../../locators/navigation-bar";
 
 Then("Navigation Bar children on preview is set to {word}", (text) => {
-  navigationBarChildren().should("have.text", text);
+  navigationBar().should("have.text", text);
 });

--- a/cypress/webpack.config.js
+++ b/cypress/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = {
         },
       },
       {
-        test: /\.(ttf|otf|eot|svg)(\?[\s\S]+)?$/,
+        test: /\.(ttf|otf|eot|svg|png)(\?[\s\S]+)?$/,
         loader: "file-loader",
         options: {
           esModule: false,

--- a/src/components/global-header/global-header-test.stories.tsx
+++ b/src/components/global-header/global-header-test.stories.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import GlobalHeader from "./global-header.component";
+import { Menu, MenuItem } from "../menu";
+import VerticalDivider from "../vertical-divider";
+
+import carbonLogo from "../../../logo/carbon-logo.png";
+
+export default {
+  title: "Global Header/Test",
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disable: true,
+    },
+    docs: {
+      inlineStories: false,
+      iframeHeight: 200,
+    },
+  },
+} as ComponentMeta<typeof GlobalHeader>;
+
+export const MenuWithIconOnlyButtonsStory: ComponentStory<
+  typeof GlobalHeader
+> = () => {
+  return (
+    <GlobalHeader logo={<img height={28} src={carbonLogo} alt="Carbon logo" />}>
+      <VerticalDivider h="100%" pt={1} pb={1} pr={0} pl={2} tint={100} />
+      <Menu menuType="black" display="flex" flex="1">
+        <MenuItem flex="1" submenu="Product Switcher">
+          <MenuItem href="#">Product A</MenuItem>
+        </MenuItem>
+        <MenuItem flex="0 0 auto" icon="person">
+          User name
+        </MenuItem>
+        <MenuItem flex="0 0 auto" submenu="Selected role">
+          <MenuItem>Administrator</MenuItem>
+        </MenuItem>
+        <MenuItem ariaLabel="search" icon="search" href="#" />
+        <MenuItem ariaLabel="alert" icon="alert" href="#" />
+        <MenuItem ariaLabel="settings" icon="settings" href="#" />
+        <MenuItem ariaLabel="logout" icon="logout" href="#" />
+      </Menu>
+    </GlobalHeader>
+  );
+};
+MenuWithIconOnlyButtonsStory.storyName = "menu with icon-only buttons";

--- a/src/components/global-header/global-header-test.stories.tsx
+++ b/src/components/global-header/global-header-test.stories.tsx
@@ -46,3 +46,11 @@ export const MenuWithIconOnlyButtonsStory: ComponentStory<
   );
 };
 MenuWithIconOnlyButtonsStory.storyName = "menu with icon-only buttons";
+MenuWithIconOnlyButtonsStory.parameters = {
+  docs: {
+    description: {
+      story:
+        "Disclaimer: use of Icon-only buttons is not recommended due to poor accessibility",
+    },
+  },
+};

--- a/src/components/global-header/global-header.component.tsx
+++ b/src/components/global-header/global-header.component.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import styled, { css } from "styled-components";
+import { PaddingProps, FlexboxProps } from "styled-system";
+import { ThemeObject } from "style/themes/base";
+import { baseTheme } from "../../style/themes";
+import StyledNavigationBar, {
+  StyledNavigationBarProps,
+} from "../navigation-bar/navigation-bar.style";
+import Box from "../box";
+
+export interface GlobalHeaderProps extends PaddingProps, FlexboxProps {
+  /** Child elements */
+  children?: React.ReactNode;
+  /** Logo to render */
+  logo?: React.ReactNode;
+}
+
+interface StyledGlobalHeaderProps extends StyledNavigationBarProps {
+  theme?: ThemeObject;
+}
+const StyledGlobalHeader = styled(StyledNavigationBar).attrs(({ theme }) => ({
+  theme: theme || /* istanbul ignore next */ baseTheme,
+}))<StyledGlobalHeaderProps>`
+  ${({ theme }) => css`
+    z-index: ${theme.zIndex.globalNav};
+  `}
+`;
+
+const StyledLogo = styled(Box)`
+  display: flex;
+  align-items: center;
+  margin-left: var(--spacing200);
+  margin-right: var(--spacing300);
+
+  & > * {
+    max-height: 100%;
+  }
+
+  @media (min-width: 600px) {
+    margin-left: var(--spacing300);
+  }
+  @media (min-width: 960px) {
+    margin-left: var(--spacing400);
+  }
+  @media (min-width: 1260px) {
+    margin-left: var(--spacing500);
+  }
+`;
+
+const GlobalHeader = ({ children, logo, ...rest }: GlobalHeaderProps) => {
+  return (
+    <StyledGlobalHeader
+      aria-label="Global Header"
+      data-component="global-header"
+      navigationType="black"
+      orientation="top"
+      offset="0px"
+      position="fixed"
+      {...rest}
+    >
+      {logo && (
+        <StyledLogo data-element="global-header-logo-wrapper">
+          {logo}
+        </StyledLogo>
+      )}
+      {children}
+    </StyledGlobalHeader>
+  );
+};
+
+GlobalHeader.displayName = "GlobalHeader";
+export default GlobalHeader;

--- a/src/components/global-header/global-header.spec.tsx
+++ b/src/components/global-header/global-header.spec.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import GlobalHeader, { GlobalHeaderProps } from "./global-header.component";
+
+function renderer(props?: GlobalHeaderProps) {
+  return render(<GlobalHeader {...props}>foobar</GlobalHeader>);
+}
+
+describe("Global Header", () => {
+  it("should be visible with correct accessible name", () => {
+    renderer();
+    expect(screen.getByRole("navigation")).toHaveAccessibleName(
+      "Global Header"
+    );
+  });
+
+  it("should be visible with correct styling", () => {
+    renderer();
+    expect(screen.getByRole("navigation")).toHaveStyle({
+      backgroundColor: "var(--colorsComponentsMenuWinterStandard500)",
+      color: "var(--colorsComponentsMenuYang100)",
+      position: "fixed",
+    });
+  });
+
+  it("should have correct z-index", () => {
+    renderer();
+    expect(screen.getByRole("navigation")).toHaveStyle("z-index: 2999");
+  });
+
+  describe("when logo prop is passed", () => {
+    it("and logo is an img element, logo is visible with correct alt text", () => {
+      const logo = <img src="foobar" alt="Carbon logo" />;
+      renderer({ logo });
+      expect(screen.getByAltText("Carbon logo")).toBeTruthy();
+    });
+
+    it("and logo is a svg element, logo is visible with correct accessible name", () => {
+      const logo = <svg aria-label="Carbon logo" data-testid="carbon-logo" />;
+      renderer({ logo });
+      expect(screen.getByTestId("carbon-logo")).toHaveAccessibleName(
+        "Carbon logo"
+      );
+    });
+  });
+});

--- a/src/components/global-header/global-header.stories.mdx
+++ b/src/components/global-header/global-header.stories.mdx
@@ -1,0 +1,225 @@
+import { useState } from "react";
+import { Meta, Canvas, Story } from "@storybook/addon-docs";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import NavigationBar from "../navigation-bar";
+import Box from "../box";
+import VerticalDivider from "../vertical-divider";
+import { Menu, MenuFullscreen, MenuItem, MenuSegmentTitle } from "../menu";
+import GlobalHeader from "./global-header.component";
+import useMediaQuery from "../../hooks/useMediaQuery";
+import LinkTo from "@storybook/addon-links/react";
+import carbonLogo from "../../../logo/carbon-logo.png";
+
+<Meta
+  title="Global Header"
+  parameters={{
+    info: { disable: true },
+    chromatic: { disable: true },
+    docs: {
+      inlineStories: false,
+      iframeHeight: 200,
+    },
+  }}
+/>
+
+# Global Header
+
+`GlobalHeader` is a wrapper component designed for creating site-wide navigation layouts.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import GlobalHeader from "carbon-react/lib/components/global-header";
+```
+
+## Examples
+
+### Default
+
+`GlobalHeader` shares similarities with the <LinkTo kind="Navigation Bar" story="default">NavigationBar component</LinkTo>, but is permanently fixed to the top of the viewport and has a greater z-index than `NavigationBar`.
+
+<Canvas>
+  <Story name="default">
+    <GlobalHeader>Example content</GlobalHeader>
+  </Story>
+</Canvas>
+
+### With logo
+
+A custom logo in the form of an HTML element or a React component can be rendered by passing it via the `logo` prop. The logo is wrapped in a container that applies style rules for margins and child element height. It is possible to set a custom height for the logo element, but any value that exceeds the height of the `GlobalHeader` component will be constrained to 40px.
+
+<Canvas>
+  <Story name="with logo">
+    {() => {
+      const Logo = () => <img height={28} src={carbonLogo} alt="Carbon logo" />;
+      return <GlobalHeader logo={<Logo />}>Example content</GlobalHeader>;
+    }}
+  </Story>
+</Canvas>
+
+### Basic menu
+
+In conjunction with the <LinkTo kind="Menu" story="default">Menu component</LinkTo>, `GlobalHeader` can be used to create global navigation layouts.
+
+<Canvas>
+  <Story name="basic menu">
+    {() => {
+      const Logo = () => <img height={28} src={carbonLogo} alt="Carbon logo" />;
+      return (
+        <GlobalHeader logo={<Logo />}>
+          <Menu menuType="black" display="flex" flex="1">
+            <MenuItem flex="1" submenu="Product Switcher">
+              <MenuItem>Product A</MenuItem>
+            </MenuItem>
+            <MenuItem flex="0 0 auto" submenu="Parent Menu 1">
+              <MenuItem href="#">Child Item 1</MenuItem>
+              <MenuSegmentTitle>Segment title</MenuSegmentTitle>
+              <MenuItem href="#">Child Item 2</MenuItem>
+              <MenuItem href="#">Child Item 3</MenuItem>
+            </MenuItem>
+            <MenuItem flex="0 0 auto" submenu="Parent Menu 2">
+              <MenuItem>Child Item</MenuItem>
+            </MenuItem>
+          </Menu>
+        </GlobalHeader>
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Responsive menu
+
+This story is best viewed in the `canvas` view and by adjusting the size of the window. The fullscreen behaviour will trigger when the screen size is smaller than `600px`.
+
+<Canvas>
+  <Story name="responsive menu">
+    {() => {
+      const Logo = () => <img height={28} src={carbonLogo} alt="Carbon logo" />;
+      const fullscreenViewBreakPoint = useMediaQuery("(max-width: 599px)");
+      const [isListViewOpen, setIsListViewOpen] = useState(false);
+      const menuItems = [
+        <MenuItem
+          key="product-switcher"
+          minWidth="160px"
+          flex="1"
+          submenu="Product Switcher"
+        >
+          <MenuItem>Product A</MenuItem>
+        </MenuItem>,
+        <MenuItem
+          key="parent-menu-1"
+          minWidth="145px"
+          flex="0 0 auto"
+          submenu="Parent Menu 1"
+        >
+          <MenuItem href="#">Child Item 1</MenuItem>
+          <MenuSegmentTitle>Segment title</MenuSegmentTitle>
+          <MenuItem href="#">Child Item 2</MenuItem>
+          <MenuItem href="#">Child Item 3</MenuItem>
+        </MenuItem>,
+        <MenuItem
+          key="parent-menu-2"
+          minWidth="145px"
+          flex="0 0 auto"
+          submenu="Parent Menu 2"
+        >
+          <MenuItem>Child Item</MenuItem>
+        </MenuItem>,
+      ];
+      return (
+        <GlobalHeader logo={<Logo />}>
+          <Menu menuType="black" display="flex" flex="1">
+            {fullscreenViewBreakPoint ? (
+              <>
+                <MenuItem
+                  onClick={(ev) => {
+                    ev.preventDefault();
+                    setIsListViewOpen(true);
+                  }}
+                >
+                  Admin
+                </MenuItem>
+                <MenuFullscreen
+                  menuType="black"
+                  isOpen={isListViewOpen}
+                  onClose={() => setIsListViewOpen(false)}
+                >
+                  {menuItems}
+                </MenuFullscreen>
+              </>
+            ) : (
+              menuItems
+            )}
+          </Menu>
+        </GlobalHeader>
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Global and local navigation bar layout
+
+The component can be used alongside the <LinkTo kind='Navigation Bar' story="default">NavigationBar component</LinkTo> to create a two navigation bar layout, with the former being for site-wide navigation and the latter being for local navigation. Since `GlobalHeader` is fixed to top of the viewport, the `NavigationBar` must also have its `position` fixed, with a top `orientation` and `offset` of 40px.
+
+<Canvas>
+  <Story
+    name="global and local navigation bar layout"
+    parameters={{ docs: { inlineStories: false, iframeHeight: 250 } }}
+  >
+    {() => {
+      const Logo = () => <img height={28} src={carbonLogo} alt="Carbon logo" />;
+      return (
+        <>
+          <GlobalHeader logo={<Logo />}>
+            <Menu menuType="black" display="flex" flex="1">
+              <MenuItem flex="1" submenu="Product Switcher">
+                <MenuItem href="#">Product A</MenuItem>
+              </MenuItem>
+              <MenuItem flex="0 0 auto" submenu="Parent Menu 1">
+                <MenuItem href="#">Child Item 1</MenuItem>
+                <MenuItem href="#">Child Item 2</MenuItem>
+                <MenuItem href="#">Child Item 3</MenuItem>
+              </MenuItem>
+              <MenuItem flex="0 0 auto" submenu="Parent Menu 2">
+                <MenuItem>Child Item</MenuItem>
+              </MenuItem>
+            </Menu>
+          </GlobalHeader>
+          <NavigationBar position="fixed" orientation="top" offset="40px">
+            <Menu display="flex" flex="1">
+              <MenuItem flex="1">Menu Item One</MenuItem>
+              <MenuItem flex="0 0 auto" href="#">
+                Menu Item Two
+              </MenuItem>
+              <MenuItem flex="0 0 auto" submenu="Menu Item Three">
+                <MenuItem href="#">Item Submenu One</MenuItem>
+                <MenuItem href="#">Item Submenu Two</MenuItem>
+                <MenuDivider />
+                <MenuItem icon="settings" href="#">
+                  Item Submenu Three
+                </MenuItem>
+                <MenuItem href="#">Item Submenu Four</MenuItem>
+              </MenuItem>
+              <MenuItem flex="0 0 auto" submenu="Menu Item Four">
+                <MenuItem href="#">Item Submenu One</MenuItem>
+                <MenuItem href="#">Item Submenu Two</MenuItem>
+              </MenuItem>
+            </Menu>
+          </NavigationBar>
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Props
+
+### Global Header
+
+<StyledSystemProps of={GlobalHeader} noHeader padding flexBox />

--- a/src/components/global-header/global-header.stories.mdx
+++ b/src/components/global-header/global-header.stories.mdx
@@ -4,7 +4,13 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import NavigationBar from "../navigation-bar";
 import Box from "../box";
 import VerticalDivider from "../vertical-divider";
-import { Menu, MenuFullscreen, MenuItem, MenuSegmentTitle } from "../menu";
+import {
+  Menu,
+  MenuFullscreen,
+  MenuItem,
+  MenuSegmentTitle,
+  MenuDivider,
+} from "../menu";
 import GlobalHeader from "./global-header.component";
 import useMediaQuery from "../../hooks/useMediaQuery";
 import LinkTo from "@storybook/addon-links/react";
@@ -143,7 +149,7 @@ This story is best viewed in the `canvas` view and by adjusting the size of the 
                     setIsListViewOpen(true);
                   }}
                 >
-                  Admin
+                  Menu
                 </MenuItem>
                 <MenuFullscreen
                   menuType="black"

--- a/src/components/global-header/global-header.test.js
+++ b/src/components/global-header/global-header.test.js
@@ -1,0 +1,89 @@
+import React from "react";
+import { Menu, MenuItem, MenuDivider } from "../menu";
+import NavigationBar from "../navigation-bar";
+import GlobalHeader from "./global-header.component";
+
+import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
+
+import carbonLogo from "../../../logo/carbon-logo.png";
+import navigationBar from "../../../cypress/locators/navigation-bar";
+import {
+  globalHeader,
+  globalHeaderLogo,
+} from "../../../cypress/locators/global-header";
+
+const FullMenuExample = () => (
+  <>
+    <GlobalHeader>
+      <Menu menuType="black" display="flex" flex="1">
+        <MenuItem flex="1" submenu="Product Switcher">
+          <MenuItem href="#">Product A</MenuItem>
+        </MenuItem>
+        <MenuItem flex="0 0 auto" submenu="Parent Menu 1">
+          <MenuItem href="#">Child Item 1</MenuItem>
+          <MenuItem href="#">Child Item 2</MenuItem>
+          <MenuItem href="#">Child Item 3</MenuItem>
+        </MenuItem>
+        <MenuItem flex="0 0 auto" submenu="Parent Menu 2">
+          <MenuItem>Child Item</MenuItem>
+        </MenuItem>
+      </Menu>
+    </GlobalHeader>
+    <NavigationBar position="fixed" orientation="top" offset="40px">
+      <Menu display="flex" flex="1">
+        <MenuItem flex="1">Menu Item One</MenuItem>
+        <MenuItem flex="0 0 auto" href="#">
+          Menu Item Two
+        </MenuItem>
+        <MenuItem flex="0 0 auto" submenu="Menu Item Three">
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+          <MenuDivider />
+          <MenuItem icon="settings" href="#">
+            Item Submenu Three
+          </MenuItem>
+          <MenuItem href="#">Item Submenu Four</MenuItem>
+        </MenuItem>
+        <MenuItem flex="0 0 auto" submenu="Menu Item Four">
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+        </MenuItem>
+      </Menu>
+    </NavigationBar>
+  </>
+);
+
+context("Global Header", () => {
+  it("z-index of component is greater than that of NavigationBar", () => {
+    CypressMountWithProviders(<FullMenuExample />);
+
+    globalHeader()
+      .invoke("css", "z-index")
+      .then(parseInt)
+      .then(($globalHeaderZIndex) => {
+        navigationBar()
+          .invoke("css", "z-index")
+          .then(parseInt)
+          .should(($navigationBarZIndex) => {
+            expect($globalHeaderZIndex).to.be.greaterThan($navigationBarZIndex);
+          });
+      });
+  });
+
+  it("when logo prop is passed, the height of the logo element never exceeds the maximum height of the component", () => {
+    const logoHeight = 41;
+    const expectedHeight = 40;
+
+    const logo = (
+      <img
+        data-element="logo"
+        height={logoHeight}
+        src={carbonLogo}
+        alt="Carbon logo"
+      />
+    );
+    CypressMountWithProviders(<GlobalHeader logo={logo}>Example</GlobalHeader>);
+
+    globalHeaderLogo().should("have.css", "height", `${expectedHeight}px`);
+  });
+});

--- a/src/components/global-header/global-header.test.js
+++ b/src/components/global-header/global-header.test.js
@@ -53,8 +53,8 @@ const FullMenuExample = () => (
   </>
 );
 
-context("Global Header", () => {
-  it("z-index of component is greater than that of NavigationBar", () => {
+context("Testing Global Header component", () => {
+  it("should check that z-index of component is greater than that of NavigationBar", () => {
     CypressMountWithProviders(<FullMenuExample />);
 
     globalHeader()
@@ -70,7 +70,7 @@ context("Global Header", () => {
       });
   });
 
-  it("when logo prop is passed, the height of the logo element never exceeds the maximum height of the component", () => {
+  it("should check when logo prop is passed, the height of the logo element never exceeds the maximum height of the component", () => {
     const logoHeight = 41;
     const expectedHeight = 40;
 

--- a/src/components/global-header/index.ts
+++ b/src/components/global-header/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./global-header.component";
+export type { GlobalHeaderProps } from "./global-header.component";

--- a/src/components/menu/menu-test.stories.js
+++ b/src/components/menu/menu-test.stories.js
@@ -15,32 +15,6 @@ export default {
       disable: false,
     },
   },
-  argTypes: {
-    menuType: {
-      options: ["light", "dark"],
-      control: {
-        type: "select",
-      },
-    },
-    startPosition: {
-      options: ["left", "right"],
-      control: {
-        type: "select",
-      },
-    },
-    searchVariant: {
-      options: ["default", "dark"],
-      control: {
-        type: "select",
-      },
-    },
-    searchButton: {
-      options: [true, false],
-      control: {
-        type: "boolean",
-      },
-    },
-  },
 };
 
 export const MenuFullScreenStory = ({
@@ -94,12 +68,57 @@ export const MenuFullScreenStory = ({
   );
 };
 
+MenuFullScreenStory.storyName = "fullscreen menu";
 MenuFullScreenStory.story = {
-  name: "fullscreen menu",
   args: {
     menuType: "light",
     startPosition: "left",
     searchVariant: "default",
     searchButton: true,
   },
+  argTypes: {
+    menuType: {
+      options: ["light", "dark"],
+      control: {
+        type: "select",
+      },
+    },
+    startPosition: {
+      options: ["left", "right"],
+      control: {
+        type: "select",
+      },
+    },
+    searchVariant: {
+      options: ["default", "dark"],
+      control: {
+        type: "select",
+      },
+    },
+    searchButton: {
+      options: [true, false],
+      control: {
+        type: "boolean",
+      },
+    },
+  },
 };
+
+export const LongLabelsStory = () => {
+  return (
+    <Menu>
+      <MenuItem submenu="Parent Menu A">
+        <MenuItem>Child A</MenuItem>
+        <MenuItem>Child B with very long label</MenuItem>
+        <MenuItem>Child C</MenuItem>
+      </MenuItem>
+      <MenuItem submenu="Parent Menu B with very long label">
+        <MenuItem>Child A</MenuItem>
+        <MenuItem>Child B</MenuItem>
+        <MenuItem>Child C</MenuItem>
+      </MenuItem>
+    </Menu>
+  );
+};
+
+LongLabelsStory.storyName = "submenus with long item labels";

--- a/src/components/menu/menu.d.ts
+++ b/src/components/menu/menu.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { LayoutProps, FlexBoxProps } from "../../utils/helpers/options-helper";
+import { LayoutProps, FlexboxProps } from "styled-system";
 
 type menuType = "light" | "dark" | "white" | "black";
 interface MenuContextProps {
@@ -11,7 +11,7 @@ interface MenuContextProps {
   inMenu: boolean;
 }
 
-export interface MenuProps extends LayoutProps, FlexBoxProps {
+export interface MenuProps extends LayoutProps, FlexboxProps {
   /** Children elements */
   children: React.ReactNode;
   /** Defines the color scheme of the component */

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -12,7 +12,6 @@ import {
 import Box from "../box";
 import NavigationBar from "../navigation-bar";
 import VerticalDivider from "../vertical-divider";
-import { SageIcon } from "../../../.storybook/welcome-page/footer/footer.style.js";
 import useMediaQuery from "../../hooks/useMediaQuery";
 import Search from "../search";
 import Icon from "../icon";
@@ -33,7 +32,14 @@ Provides navigation for an app, which can be used via mouse or keyboard.
 ## Quick Start
 
 ```javascript
-import { Menu, MenuItem, MenuDivider } from "carbon-react/lib/components/menu";
+import {
+  Menu,
+  MenuItem,
+  MenuDivider,
+  MenuSegmentTitle,
+  ScrollableBlock,
+  MenuFullscreen,
+} from "carbon-react/lib/components/menu";
 ```
 
 ## Examples
@@ -320,81 +326,6 @@ is rendered.
         </MenuItem>
       </Menu>
     </div>
-  </Story>
-</Canvas>
-
-### Full navbar alignment example
-
-<Canvas>
-  <Story name="full navbar alignment example">
-    {() => {
-      const isBelowBreakpoint = (value) =>
-        useMediaQuery(`(max-width: ${value})`);
-      return (
-        <Box mb={150}>
-          {["white", "light", "dark", "black"].map((menuType) => (
-            <div key={menuType}>
-              <Typography variant="h4" textTransform="capitalize" my={2}>
-                {menuType}
-              </Typography>
-              <NavigationBar
-                navigationType={menuType}
-                aria-label={`Navbar ${menuType}`}
-              >
-                <SageIcon style={{ alignSelf: "center" }} />
-                <Box>
-                  <VerticalDivider displayInline pr={0} />
-                </Box>
-                <Menu display="flex" flex="1" menuType={menuType}>
-                  <MenuItem
-                    flex="1"
-                    onClick={() => {}}
-                    maxWidth={isBelowBreakpoint("850px") ? "130px" : undefined}
-                    submenu="Menu Item One"
-                  >
-                    <MenuItem href="#">Item Submenu One</MenuItem>
-                    <MenuItem href="#">Item Submenu Two</MenuItem>
-                    <MenuDivider />
-                    <MenuItem icon="settings" href="#">
-                      Item Submenu Three
-                    </MenuItem>
-                    <MenuItem href="#">Item Submenu Four</MenuItem>
-                  </MenuItem>
-                  <MenuItem
-                    flex="0 0 auto"
-                    href="#"
-                    maxWidth={isBelowBreakpoint("800px") ? "120px" : undefined}
-                  >
-                    Menu Item Two
-                  </MenuItem>
-                  <MenuItem
-                    flex="0 0 auto"
-                    maxWidth={isBelowBreakpoint("770px") ? "130px" : undefined}
-                    submenu="Menu Item Three"
-                  >
-                    <MenuItem href="#">Item Submenu One</MenuItem>
-                    <MenuItem href="#">Item Submenu Two</MenuItem>
-                    <MenuDivider />
-                    <MenuItem icon="settings" href="#">
-                      Item Submenu Three
-                    </MenuItem>
-                    <MenuItem href="#">Item Submenu Four</MenuItem>
-                  </MenuItem>
-                  <MenuItem
-                    flex="0 0 auto"
-                    maxWidth={isBelowBreakpoint("750px") ? "130px" : undefined}
-                    submenu="Menu Item Four"
-                  >
-                    <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
-                    <MenuItem href="#">Item Submenu Two</MenuItem>
-                  </MenuItem>
-                </Menu>
-              </NavigationBar>
-            </div>
-          ))}
-        </Box>
-      );
-    }}
   </Story>
 </Canvas>
 

--- a/src/components/navigation-bar/navigation-bar.spec.tsx
+++ b/src/components/navigation-bar/navigation-bar.spec.tsx
@@ -88,7 +88,7 @@ describe("NavigationBar", () => {
         backgroundColor: "var(--colorsComponentsMenuSpringStandard500)",
         borderBottom:
           "var(--borderWidth100) solid var(--colorsComponentsMenuSpringChildAlt500)",
-        zIndex: "2999",
+        zIndex: "2998",
       },
       wrapper
     );
@@ -105,7 +105,7 @@ describe("NavigationBar", () => {
       {
         backgroundColor: "var(--colorsComponentsMenuAutumnStandard500)",
         color: "var(--colorsComponentsMenuYang100)",
-        zIndex: "2999",
+        zIndex: "2998",
       },
       wrapper
     );
@@ -123,7 +123,7 @@ describe("NavigationBar", () => {
         backgroundColor: "var(--colorsComponentsMenuSummerStandard500)",
         borderBottom:
           "var(--borderWidth100) solid var(--colorsComponentsMenuSummerChildAlt500)",
-        zIndex: "2999",
+        zIndex: "2998",
       },
       wrapper
     );
@@ -140,7 +140,7 @@ describe("NavigationBar", () => {
       {
         backgroundColor: "var(--colorsComponentsMenuWinterStandard500)",
         color: "var(--colorsComponentsMenuYang100)",
-        zIndex: "2999",
+        zIndex: "2998",
       },
       wrapper
     );

--- a/src/components/navigation-bar/navigation-bar.stories.mdx
+++ b/src/components/navigation-bar/navigation-bar.stories.mdx
@@ -2,10 +2,7 @@ import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import NavigationBar from "./navigation-bar.component";
 import { Menu, MenuItem } from "../menu";
 import Box from "../box";
-import VerticalDivider from "../vertical-divider";
-import { SageIcon } from "../../../.storybook/welcome-page/footer/footer.style.js";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
-import DocsWrapper from "../../../.storybook/docs-helpers/components/iframe-wrapper";
 
 <Meta title="Navigation Bar" parameters={{ info: { disable: true } }} />
 
@@ -59,6 +56,19 @@ import NavigationBar from "carbon-react/lib/components/navigation-bar";
   </Story>
 </Canvas>
 
+### Example with menu
+
+<Canvas>
+  <Story name="example with menu">
+    <NavigationBar>
+      <Menu>
+        <MenuItem>Menu Item One</MenuItem>
+        <MenuItem>Menu Item Two</MenuItem>
+      </Menu>
+    </NavigationBar>
+  </Story>
+</Canvas>
+
 ### Loading State
 
 If `isLoading={true}` the children will not be visible
@@ -67,8 +77,8 @@ If `isLoading={true}` the children will not be visible
   <Story name="isLoading">
     <NavigationBar isLoading>
       <Menu>
-        <MenuItem>menu item one</MenuItem>
-        <MenuItem>menu item two</MenuItem>
+        <MenuItem>Menu Item One</MenuItem>
+        <MenuItem>Menu Item Two</MenuItem>
       </Menu>
     </NavigationBar>
   </Story>
@@ -93,13 +103,18 @@ valid CSS string.
 ### Set content max width using Box
 
 <Canvas>
-  <Story name="content max width using Box">
+  <Story
+    name="content max width using Box"
+    decorators={[
+      (Story) => (
+        <div style={{ height: 200 }}>
+          <Story />
+        </div>
+      ),
+    ]}
+  >
     <NavigationBar>
       <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
-        <SageIcon style={{ alignSelf: "center" }} />
-        <Box>
-          <VerticalDivider displayInline pr={0} />
-        </Box>
         <Menu display="flex" flex="1">
           <MenuItem flex="1" onClick={() => {}}>
             Menu Item One
@@ -134,133 +149,114 @@ The `position` prop can be set to `sticky` to make the navigation bar stick to t
 Then the `orientation` relative to the top/bottom can be offset using the `offset` prop.
 
 <Canvas>
-  <Story name="sticky">
-    <div style={{ overflow: "scroll" }}>
+  <Story
+    name="sticky"
+    parameters={{ docs: { inlineStories: false, iframeHeight: 250 } }}
+  >
+    <div id="sticky-container" style={{ height: "250px" }}>
+      <NavigationBar
+        position="sticky"
+        orientation="top"
+        offset="25px"
+        aria-label="header"
+      >
+        <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
+          <Menu display="flex" flex="1">
+            <MenuItem flex="1" onClick={() => {}}>
+              Menu Item One
+            </MenuItem>
+            <MenuItem flex="0 0 auto" href="#">
+              Menu Item Two
+            </MenuItem>
+            <MenuItem flex="0 0 auto" submenu="Menu Item Three">
+              <MenuItem href="#">Item Submenu One</MenuItem>
+              <MenuItem href="#">Item Submenu Two</MenuItem>
+              <MenuDivider />
+              <MenuItem icon="settings" href="#">
+                Item Submenu Three
+              </MenuItem>
+              <MenuItem href="#">Item Submenu Four</MenuItem>
+            </MenuItem>
+            <MenuItem flex="0 0 auto" submenu="Menu Item Four">
+              <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+              <MenuItem href="#">Item Submenu Two</MenuItem>
+            </MenuItem>
+          </Menu>
+        </Box>
+      </NavigationBar>
       <div
         style={{
-          margin: "50px",
-          height: "250px",
+          height: "1000px",
+          background: "green",
         }}
+      />
+      <NavigationBar
+        position="sticky"
+        orientation="bottom"
+        offset="25px"
+        aria-label="footer"
       >
-        <NavigationBar
-          position="sticky"
-          orientation="top"
-          offset="25px"
-          aria-label="header"
-        >
-          <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
-            <SageIcon style={{ alignSelf: "center" }} />
-            <Box>
-              <VerticalDivider displayInline pr={0} />
-            </Box>
-            <Menu display="flex" flex="1">
-              <MenuItem flex="1" onClick={() => {}}>
-                Menu Item One
-              </MenuItem>
-              <MenuItem flex="0 0 auto" href="#">
-                Menu Item Two
-              </MenuItem>
-              <MenuItem flex="0 0 auto" submenu="Menu Item Three">
-                <MenuItem href="#">Item Submenu One</MenuItem>
-                <MenuItem href="#">Item Submenu Two</MenuItem>
-                <MenuDivider />
-                <MenuItem icon="settings" href="#">
-                  Item Submenu Three
-                </MenuItem>
-                <MenuItem href="#">Item Submenu Four</MenuItem>
-              </MenuItem>
-              <MenuItem flex="0 0 auto" submenu="Menu Item Four">
-                <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
-                <MenuItem href="#">Item Submenu Two</MenuItem>
-              </MenuItem>
-            </Menu>
-          </Box>
-        </NavigationBar>
-        <div
-          style={{
-            height: "1000px",
-            background: "green",
-          }}
-        />
-        <NavigationBar
-          position="sticky"
-          orientation="bottom"
-          offset="25px"
-          aria-label="footer"
-        >
-          <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
-            <SageIcon style={{ alignSelf: "center" }} />
-            <Box>
-              <VerticalDivider displayInline pr={0} />
-            </Box>
-            <Menu display="flex" flex="1">
-              <MenuItem flex="1" onClick={() => {}}>
-                Menu Item One
-              </MenuItem>
-              <MenuItem flex="0 0 auto" href="#">
-                Menu Item Two
-              </MenuItem>
-              <MenuItem flex="0 0 auto" submenu="Menu Item Three">
-                <MenuItem href="#">Item Submenu One</MenuItem>
-                <MenuItem href="#">Item Submenu Two</MenuItem>
-                <MenuDivider />
-                <MenuItem icon="settings" href="#">
-                  Item Submenu Three
-                </MenuItem>
-                <MenuItem href="#">Item Submenu Four</MenuItem>
-              </MenuItem>
-              <MenuItem flex="0 0 auto" submenu="Menu Item Four">
-                <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
-                <MenuItem href="#">Item Submenu Two</MenuItem>
-              </MenuItem>
-            </Menu>
-          </Box>
-        </NavigationBar>
-      </div>
+        <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
+          <Menu display="flex" flex="1">
+            <MenuItem flex="1" onClick={() => {}}>
+              Menu Item One
+            </MenuItem>
+            <MenuItem flex="0 0 auto" href="#">
+              Menu Item Two
+            </MenuItem>
+            <MenuItem flex="0 0 auto" href="#">
+              Menu Item Three
+            </MenuItem>
+            <MenuItem flex="0 0 auto" href="#">
+              Menu Item Four
+            </MenuItem>
+          </Menu>
+        </Box>
+      </NavigationBar>
     </div>
   </Story>
 </Canvas>
 
 #### Fixed
 
-The `position` prop can be set to `fixed` to make the navigation bar fix to the viewport. Then the `orientation` relative to the 
+The `position` prop can be set to `fixed` to make the navigation bar fix to the viewport. Then the `orientation` relative to the
 top/bottom can be offset using the `offset` prop.
 
-<Story name="fixed" parameters={{ docs: { disable: true }, themeProvider: { chromatic: { theme: "sage" } } }}>
-  <div style={{ height: "calc(100% - 50px)" }}>
+<Canvas>
+  <Story
+    name="fixed"
+    parameters={{
+      docs: { inlineStories: false, iframeHeight: 200 },
+      themeProvider: { chromatic: { theme: "sage" } },
+    }}
+  >
     <NavigationBar
       position="fixed"
       orientation="top"
       offset="25px"
       aria-label="header"
     >
-      <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
-        <SageIcon style={{ alignSelf: "center" }} />
-        <Box>
-          <VerticalDivider displayInline pr={0} />
-        </Box>
-        <Menu display="flex" flex="1">
-          <MenuItem flex="1" onClick={() => {}}>
-            Menu Item One
+      <Menu display="flex" flex="1">
+        <MenuItem flex="1" onClick={() => {}}>
+          Menu Item One
+        </MenuItem>
+        <MenuItem flex="0 0 auto" href="#">
+          Menu Item Two
+        </MenuItem>
+        <MenuItem flex="0 0 auto" submenu="Menu Item Three">
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+          <MenuDivider />
+          <MenuItem icon="settings" href="#">
+            Item Submenu Three
           </MenuItem>
-          <MenuItem flex="0 0 auto" href="#">
-            Menu Item Two
-          </MenuItem>
-          <MenuItem flex="0 0 auto" submenu="Menu Item Three">
-            <MenuItem href="#">Item Submenu One</MenuItem>
-            <MenuItem href="#">Item Submenu Two</MenuItem>
-            <MenuDivider />
-            <MenuItem icon="settings" href="#">
-              Item Submenu Three
-            </MenuItem>
-            <MenuItem href="#">Item Submenu Four</MenuItem>
-          </MenuItem>
-          <MenuItem flex="0 0 auto" submenu="Menu Item Four">
-            <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
-            <MenuItem href="#">Item Submenu Two</MenuItem>
-          </MenuItem>
-        </Menu>
-      </Box>
+          <MenuItem href="#">Item Submenu Four</MenuItem>
+        </MenuItem>
+        <MenuItem flex="0 0 auto" submenu="Menu Item Four">
+          <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+        </MenuItem>
+      </Menu>
     </NavigationBar>
     <div
       style={{
@@ -274,42 +270,22 @@ top/bottom can be offset using the `offset` prop.
       offset="25px"
       aria-label="footer"
     >
-      <Box display="flex" flex="1" maxWidth="1000px" margin="0 auto">
-        <SageIcon style={{ alignSelf: "center" }} />
-        <Box>
-          <VerticalDivider displayInline pr={0} />
-        </Box>
-        <Menu display="flex" flex="1">
-          <MenuItem flex="1" onClick={() => {}}>
-            Menu Item One
-          </MenuItem>
-          <MenuItem flex="0 0 auto" href="#">
-            Menu Item Two
-          </MenuItem>
-          <MenuItem flex="0 0 auto" submenu="Menu Item Three">
-            <MenuItem href="#">Item Submenu One</MenuItem>
-            <MenuItem href="#">Item Submenu Two</MenuItem>
-            <MenuDivider />
-            <MenuItem icon="settings" href="#">
-              Item Submenu Three
-            </MenuItem>
-            <MenuItem href="#">Item Submenu Four</MenuItem>
-          </MenuItem>
-          <MenuItem flex="0 0 auto" submenu="Menu Item Four">
-            <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
-            <MenuItem href="#">Item Submenu Two</MenuItem>
-          </MenuItem>
-        </Menu>
-      </Box>
+      <Menu display="flex" flex="1">
+        <MenuItem flex="1" onClick={() => {}}>
+          Menu Item One
+        </MenuItem>
+        <MenuItem flex="0 0 auto" href="#">
+          Menu Item Two
+        </MenuItem>
+        <MenuItem flex="0 0 auto" href="#">
+          Menu Item Three
+        </MenuItem>
+        <MenuItem flex="0 0 auto" href="#">
+          Menu Item Four
+        </MenuItem>
+      </Menu>
     </NavigationBar>
-  </div>
-</Story>
-
-<Canvas>
-  <DocsWrapper
-    src="iframe.html?id=navigation-bar--fixed"
-    height="400px"
-  />
+  </Story>
 </Canvas>
 
 ## Props

--- a/src/components/navigation-bar/navigation-bar.style.ts
+++ b/src/components/navigation-bar/navigation-bar.style.ts
@@ -7,7 +7,7 @@ import {
   NavigationType,
 } from "./navigation-bar.component";
 
-type StyledNavigationBarProps = PaddingProps &
+export type StyledNavigationBarProps = PaddingProps &
   FlexboxProps & {
     /** Color scheme of navigation component */
     navigationType?: NavigationType;

--- a/src/components/portal/__snapshots__/portal.spec.js.snap
+++ b/src/components/portal/__snapshots__/portal.spec.js.snap
@@ -544,9 +544,10 @@ exports[`Portal when using default node to match snapshot  1`] = `
           "zIndex": Object {
             "aboveAll": 9999,
             "fullScreenModal": 5000,
+            "globalNav": 2999,
             "header": 4000,
             "modal": 3000,
-            "nav": 2999,
+            "nav": 2998,
             "notification": 7000,
             "overlay": 1000,
             "popover": 6000,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,2 @@
 declare module "@styled-system/prop-types";
+declare module "*.png";

--- a/src/style/themes/base/base-theme.config.ts
+++ b/src/style/themes/base/base-theme.config.ts
@@ -46,6 +46,7 @@ export interface ThemeObject extends Record<string, unknown> {
     overlay: number;
     popover: number;
     nav: number;
+    globalNav: number;
     modal: number;
     header: number;
     fullScreenModal: number;
@@ -109,7 +110,8 @@ export default (palette: BasePalette): ThemeObject => {
     zIndex: {
       smallOverlay: 10,
       overlay: 1000,
-      nav: 2999,
+      nav: 2998,
+      globalNav: 2999,
       modal: 3000,
       header: 4000,
       fullScreenModal: 5000,


### PR DESCRIPTION
Addresses #5045

# Proposed behaviour
![Screenshot 2022-07-13 at 15 45 42](https://user-images.githubusercontent.com/18368713/178762659-c03e4e1b-3813-43aa-936d-7228bacb1266.png)

![Screenshot 2022-07-15 at 11 54 36](https://user-images.githubusercontent.com/18368713/179209890-a5da92ad-9980-48ea-9735-fa2a64dfdff3.png)

Add a new `GlobalHeader` component to match the component of the same name in Design System. This should also fix the linked issue where it is not possible to have two navigation bars side by side vertically.

Amend old stories in `Menu` and `NavigationBar` which show how to create a navigation bar with the Sage logo

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

# Current behaviour

![Screenshot 2022-06-29 at 17 06 19](https://user-images.githubusercontent.com/18368713/176484155-4b4cbc7d-dd09-4898-a712-811c3f1ea8f9.png)

If two `NavigationBar`s are used side by side vertically both have the same z-index, so when a submenu is opened from the top bar, its content is shown beneath the bottom bar, which consequently means it's not possible hover over the contents. 

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

# Why create a new component?

To fix the referenced issue, a separate component has been created instead of surfacing a `z-index` prop in `NavigationBar`. This is so Carbon is aligned with Design System (where Global Header and Navigation Bar are separate components) and because surfacing the `z-index` property would make product support difficult in the long-term.

# Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

# QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required


# Testing instructions

## Verify the referenced issue is fixed
To observe the broken behaviour please use this [codesandbox](https://codesandbox.io/s/mutable-hill-fyqgns?file=/src/index.js). For the fixed behaviour a new story has been created showing an example two navigation bar layout. To view it please do the following:
1. `git pr 5269`
2. `npm start`
3. Go to `localhost:9001/?path=/docs/global-header--global-and-local-navigation-bar-layout`

## Check design meets requirements
Start storybook locally (see above) and compare the Global Header stories with the Design System documentation. 

## Check for introduced regressions
In Storybook, double check for any regressions or console errors for following components' stories and docs:
- `GlobalHeader`
-  `NavigationBar`
- `Menu`