### PR TITLE
chore(code-owners): ensure ts spec files are owned by carbon-qa

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,20 +1,20 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-*     @Sage/carbon
+*                  @Sage/carbon
 
 # The Carbon Dev team are responsible for reviewing Pull Requests
-# that contain any change modifying JS or TS files
-*.js    @Sage/carbon-dev
-*.ts    @Sage/carbon-dev
+# that contain any change modifying JS, JSX, TS or TSX files
+*.js               @Sage/carbon-dev
+*.ts               @Sage/carbon-dev
 
 # The Carbon QA team are responsible for reviewing Pull Requests
-# that contain any change modifying only spec.js and test.js files 
+# that contain any change modifying spec and test.js files 
 # or anything in the cypress directory
-*.spec.js    @Sage/carbon-qa
-/cypress/    @Sage/carbon-qa
-cypress.json @Sage/carbon-qa
-cypress.env.json @Sage/carbon-qa
-*.test.js    @Sage/carbon-qa
+*.spec.*           @Sage/carbon-qa
+*.test.*           @Sage/carbon-qa
+/cypress/          @Sage/carbon-qa
+cypress.json       @Sage/carbon-qa
+cypress.env.json   @Sage/carbon-qa
 
 # Codeowners file changes must be approved by a Carbon Admin.
 .github/CODEOWNERS @Sage/carbon-admin


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Updates `CODEOWNERS` to include all spec files as we now have some that are `ts` and `tsx` that aren't being assigned to the correct owner group

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
The `ts` and `tsx` spec files aren't being assigned to the correct `carbon-qa` owners

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
