### PR TITLE
fix(search): update icon colour and hover colour in default variant FE-5157

### DIFF
--- a/src/components/search/search.spec.js
+++ b/src/components/search/search.spec.js
@@ -11,7 +11,7 @@ import {
 } from "../../__spec_helper__/test-utils";
 import StyledTextInput from "../../__internal__/input/input-presentation.style";
 import StyledInputIconToggle from "../../__internal__/input-icon-toggle/input-icon-toggle.style";
-
+import StyledIcon from "../icon/icon.style";
 import Icon from "../icon";
 import TextBox from "../textbox";
 import { rootTagTest } from "../../__internal__/utils/helpers/tags/tags-specs";
@@ -164,6 +164,82 @@ describe("Search", () => {
         },
         wrapper,
         { modifier: `${StyledInputIconToggle}` }
+      );
+
+      assertStyleMatch(
+        {
+          color: "var(--colorsActionMinor500)",
+        },
+        wrapper,
+        { modifier: `${StyledIcon}` }
+      );
+
+      assertStyleMatch(
+        {
+          color: "var(--colorsActionMinor600)",
+        },
+        wrapper,
+        { modifier: `${StyledIcon}:hover` }
+      );
+    });
+
+    it("applies the expected styling to the close icon when dark variant", () => {
+      wrapper = renderWrapper({ value: "FooBar", variant: "dark" }, mount);
+      assertStyleMatch(
+        {
+          marginBottom: "-1px",
+        },
+        wrapper,
+        { modifier: `${StyledInputIconToggle}` }
+      );
+
+      assertStyleMatch(
+        {
+          color: "var(--colorsUtilityMajor200)",
+        },
+        wrapper,
+        { modifier: `${StyledIcon}` }
+      );
+
+      assertStyleMatch(
+        {
+          color: "var(--colorsUtilityMajor100)",
+        },
+        wrapper,
+        { modifier: `${StyledIcon}:hover` }
+      );
+    });
+
+    it("applies the expected styling to the close icon when dark variant and input is focused", () => {
+      wrapper = renderWrapper({ value: "FooBar", variant: "dark" }, mount);
+      act(() => {
+        const input = wrapper.find(Input);
+        input.simulate("focus");
+      });
+      wrapper.update();
+
+      assertStyleMatch(
+        {
+          marginBottom: "-1px",
+        },
+        wrapper,
+        { modifier: `${StyledInputIconToggle}` }
+      );
+
+      assertStyleMatch(
+        {
+          color: "var(--colorsUtilityMajor400)",
+        },
+        wrapper,
+        { modifier: `${StyledIcon}` }
+      );
+
+      assertStyleMatch(
+        {
+          color: "var(--colorsUtilityMajor500)",
+        },
+        wrapper,
+        { modifier: `${StyledIcon}:hover` }
       );
     });
   });

--- a/src/components/search/search.style.js
+++ b/src/components/search/search.style.js
@@ -129,26 +129,38 @@ const StyledSearch = styled.div`
         z-index: ${theme.zIndex.smallOverlay};
       }
       ${StyledIcon} {
-        color: ${iconColor
-          ? "var(--colorsUtilityMajor400)"
-          : "var(--colorsUtilityMajor200)"};
+        ${darkVariant &&
+        css`
+          ${iconColor &&
+          css`
+            color: var(--colorsUtilityMajor400);
+
+            :hover {
+              color: var(--colorsUtilityMajor500);
+            }
+          `}
+          ${!iconColor &&
+          css`
+            color: var(--colorsUtilityMajor200);
+
+            :hover {
+              color: var(--colorsUtilityMajor100);
+            }
+          `}
+        `}
+
         ${!darkVariant &&
         css`
-          color: var(--colorsUtilityMajor400);
+          color: var(--colorsActionMinor500);
+
+          :hover {
+            color: var(--colorsActionMinor600);
+          }
         `}
 
         width: 20px;
         height: 20px;
         cursor: pointer;
-        :hover {
-          color: ${iconColor
-            ? "var(--colorsUtilityMajor500)"
-            : "var(--colorsUtilityMajor100)"};
-          ${!darkVariant &&
-          css`
-            color: var(--colorsUtilityMajor500);
-          `}
-        }
       }
 
       ${StyledInputIconToggle} {


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Update the Icon colour styles when `variant="default"` to use `actionMinor500` and `actionMinor600` (hovered) tokens.

![image](https://user-images.githubusercontent.com/44157880/177803466-ec6a3ceb-3dd7-44ae-9340-34ea100aab94.png)

![image](https://user-images.githubusercontent.com/44157880/177803531-f6666ea8-3b3e-48e9-92a1-fb8f3b10274b.png)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Icon colour styles when `variant="default"` use  `utilityMajor400` and `utilityMajor500`(hovered) tokens

![image](https://user-images.githubusercontent.com/44157880/177803227-7e367a91-c4a8-4097-a60b-207a6573e346.png)

![image](https://user-images.githubusercontent.com/44157880/177803315-b733e252-8572-49c6-b4a3-eeff21396715.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
Existing stories for `Search` component can be used

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
