### PR TITLE
chore: refactor asset loading for storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -28,6 +28,7 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-toolbars",
   ],
+  staticDirs: ["../.assets", "../logo"],
   webpackFinal: async (config, { configType }) => {
     config.resolve = {
       alias: {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "scripts/check_rfcs.js"
   ],
   "scripts": {
-    "start": "node ./scripts/check_node_version.js && start-storybook -p 9001 -s .assets -c .storybook",
+    "start": "node ./scripts/check_node_version.js && start-storybook -p 9001 -c .storybook",
     "start:debug-theme": "cross-env STORYBOOK_DEBUG_THEME=true npm run start",
     "test": "jest --config=./jest.conf.json",
     "test-update": "jest --config=./jest.conf.json --updateSnapshot",
@@ -29,8 +29,8 @@
     "prepublishOnly": "npm run precompile",
     "postinstall": "node ./scripts/check_carbon_version.js && node ./scripts/check_rfcs.js",
     "watch": "npm run clean-lib && npm run copy-files -- --watch & npm run babel -- --watch",
-    "build-storybook": "cross-env STORYBOOK_BUILD=true build-storybook -c .storybook -s .assets",
-    "start-storybook": "cross-env STORYBOOK_BUILD=true start-storybook -c .storybook -s .assets",
+    "build-storybook": "cross-env STORYBOOK_BUILD=true build-storybook -c .storybook",
+    "start-storybook": "cross-env STORYBOOK_BUILD=true start-storybook -c .storybook",
     "start:static": "npx http-server -p 9001 ./storybook-static",
     "babel": "cross-env NODE_ENV=production babel ./src --config-file ./babel.config.js --out-dir ./lib --ignore '**/*/__spec__.js','**/*.spec.js','**/*.spec.ts','**/*.spec.tsx','**/*.test.js','**/*.d.ts' --quiet --extensions '.js','.ts','.tsx'",
     "clean-lib": "rimraf ./lib && rimraf ./esm",


### PR DESCRIPTION
### Proposed behaviour

Update how assets are found by storybook. Use storybook configuration instead of the deprecated CLI option.

### Current behaviour

Storybook currently serves static assets using the `-s` CLI option, which is now deprecated: https://storybook.js.org/docs/react/configure/images-and-assets#%EF%B8%8F-deprecated-serving-static-files-via-storybook-cli

Our documentation around storybook use does not reference this CLI option so does not require updating.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required