### PR TITLE
fix(menu-full-screen): pass onClick to menu item

### DIFF
--- a/src/components/menu/__internal__/submenu/submenu.component.js
+++ b/src/components/menu/__internal__/submenu/submenu.component.js
@@ -266,6 +266,7 @@ const Submenu = React.forwardRef(
         >
           <StyledMenuItemWrapper
             {...rest}
+            onClick={onClick}
             className={className}
             menuType={menuContext.menuType}
             ref={ref}

--- a/src/components/menu/menu-full-screen/menu-full-screen.spec.js
+++ b/src/components/menu/menu-full-screen/menu-full-screen.spec.js
@@ -21,6 +21,7 @@ import { StyledMenuItem } from "../menu.style";
 import menuConfigVariants from "../menu.config";
 
 const onClose = jest.fn();
+const onClick = jest.fn();
 
 // eslint-disable-next-line react/prop-types
 const TestMenu = ({ startPosition, isOpen }) => (
@@ -32,7 +33,7 @@ const TestMenu = ({ startPosition, isOpen }) => (
     <MenuItem maxWidth="200px" href="#">
       Menu Item One
     </MenuItem>
-    <MenuItem maxWidth="200px" onClick={() => {}} submenu="Menu Item Two">
+    <MenuItem maxWidth="200px" onClick={onClick} submenu="Menu Item Two">
       <MenuItem maxWidth="200px" href="#">
         Submenu Item One
       </MenuItem>
@@ -211,6 +212,17 @@ describe("MenuFullscreen", () => {
         render({ isOpen: true }).find(StyledMenuFullscreen)
       );
       expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe("onClick", () => {
+    it("calls the onClick callback when menu item is clicked", () => {
+      const menuItem = render({ isOpen: true })
+        .find(MenuItem)
+        .at(1)
+        .find("button");
+      menuItem.simulate("click");
+      expect(onClick).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
When onClick is passed to a top-level MenuItem of a MenuFullScreen, ensure it is passed down to the
underlying component

fix #5313

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

an onClick handler passed to a top-level MenuItem (with submenu prop) inside a MenuFullScreen should be called when the corresponding menu item is clicked

### Current behaviour

the onClick handler is not called in this situation (broken since version 106.6.4)

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.
https://codesandbox.io/s/menu-items-v54s7l


<!-- Add CodeSandbox here -->
