### PR TITLE
style(pod): modify colours to fix poor colour contrast ratios (FE-5246)

### DIFF
--- a/cypress/locators/pod/index.js
+++ b/cypress/locators/pod/index.js
@@ -1,5 +1,6 @@
 import {
   POD_DATA_COMPONENT,
+  POD_BLOCK,
   POD_EDIT_ICON,
   POD_FOOTER,
   POD_CONTENT,
@@ -8,6 +9,7 @@ import {
 
 // component preview locators
 export const podComponent = () => cy.get(POD_DATA_COMPONENT);
+export const podBlock = () => cy.get(POD_BLOCK);
 export const podPreview = () => cy.get(POD_DATA_COMPONENT).children();
 export const podFooter = () => podComponent().find(POD_FOOTER);
 export const podContent = () => podComponent().find(POD_CONTENT);

--- a/cypress/locators/pod/locators.js
+++ b/cypress/locators/pod/locators.js
@@ -1,5 +1,6 @@
 // component preview locators
 export const POD_DATA_COMPONENT = '[data-component="pod"]';
+export const POD_BLOCK = "[data-element='block']";
 export const POD_FOOTER = '[data-element="footer"]';
 export const POD_EDIT_ICON = '[data-element="edit"]';
 export const POD_CONTENT = '[data-element="content"]';

--- a/src/components/content/content.spec.js
+++ b/src/components/content/content.spec.js
@@ -102,7 +102,6 @@ describe("Content", () => {
           {
             display: "block",
             fontWeight: "bold",
-            color: "var(--colorsUtilityYin090)",
           },
           wrapper.find(StyledContentTitle)
         );

--- a/src/components/content/content.style.js
+++ b/src/components/content/content.style.js
@@ -29,7 +29,6 @@ const StyledContentTitle = styled.div`
     return css`
       display: ${inline ? "inline-block" : "block"};
       font-weight: bold;
-      color: var(--colorsUtilityYin090);
       width: ${titleWidth && `calc(${titleWidth}% - 30px)`};
       text-align: ${!inline && align};
 

--- a/src/components/content/content.test.js
+++ b/src/components/content/content.test.js
@@ -21,7 +21,7 @@ const ContentComponent = ({ ...props }) => {
 context("Tests for Content component", () => {
   describe("should check Content component properties", () => {
     it.each([
-      ["primary", "rgba(0, 0, 0, 0.9)"],
+      ["primary", "rgb(0, 0, 0)"],
       ["secondary", "rgba(0, 0, 0, 0.55)"],
     ])(
       "should check %s as variant for Content component",

--- a/src/components/pod/pod.component.js
+++ b/src/components/pod/pod.component.js
@@ -238,6 +238,7 @@ const Pod = forwardRef(
         ref={ref}
       >
         <StyledBlock
+          data-element="block"
           contentTriggersEdit={shouldContentHaveEditEvents()}
           hasButtons={onEdit || onDelete || onUndo}
           fullWidth={editContentFullWidth}

--- a/src/components/pod/pod.spec.js
+++ b/src/components/pod/pod.spec.js
@@ -286,7 +286,7 @@ describe("Pod", () => {
               editContainer.simulate(nextEventType);
               assertStyleMatch(
                 {
-                  backgroundColor: "var(--colorsUtilityMajor050)",
+                  backgroundColor: "var(--colorsUtilityMajor040)",
                 },
                 wrapper.find(StyledBlock)
               );
@@ -642,7 +642,7 @@ describe("StyledBlock", () => {
   describe.each([
     ["primary", "var(--colorsUtilityYang100)"],
     ["secondary", "var(--colorsUtilityMajor025)"],
-    ["tertiary", "var(--colorsUtilityMajor050)"],
+    ["tertiary", "var(--colorsUtilityMajor040)"],
     ["transparent", "var(--colorsUtilityMajorTransparent)"],
     ["tile", "var(--colorsUtilityYang100)"],
   ])("when the variant prop is set to %s", (variant, expectedValue) => {
@@ -713,8 +713,8 @@ describe("StyledBlock", () => {
       wrapper = renderStyledBlock({ softDelete: true });
       assertStyleMatch(
         {
-          color: "var(--colorsUtilityYin030)",
-          backgroundColor: "var(--colorsUtilityMajor050)",
+          color: "var(--colorsUtilityYin065)",
+          backgroundColor: "var(--colorsActionDisabled500)",
         },
         wrapper
       );
@@ -835,7 +835,7 @@ describe("StyledFooter", () => {
       wrapper = renderStyledFooter({ softDelete: true });
       assertStyleMatch(
         {
-          color: "var(--colorsUtilityYin030)",
+          color: "var(--colorsUtilityYin055)",
         },
         wrapper
       );

--- a/src/components/pod/pod.spec.js
+++ b/src/components/pod/pod.spec.js
@@ -709,14 +709,14 @@ describe("StyledBlock", () => {
   });
 
   describe("when softDelete prop is set", () => {
-    it("should not render the border", () => {
+    it("should render block with no border", () => {
       wrapper = renderStyledBlock({ softDelete: true });
+
       assertStyleMatch(
         {
-          color: "var(--colorsUtilityYin065)",
-          backgroundColor: "var(--colorsActionDisabled500)",
+          border: "none",
         },
-        wrapper
+        wrapper.find(StyledBlock)
       );
     });
   });

--- a/src/components/pod/pod.stories.mdx
+++ b/src/components/pod/pod.stories.mdx
@@ -195,7 +195,7 @@ and then set `height` prop to `100%` on each `Pod` so that it fills the entire h
       onUndo={() => {}}
       softDelete
     >
-      <Typography color="blackOpacity30">Soft delete state</Typography>
+      Soft delete state
     </Pod>
   </Story>
 </Canvas>
@@ -329,23 +329,18 @@ and then set `height` prop to `100%` on each `Pod` so that it fills the entire h
 <Canvas>
   <Story name="address example">
     <Pod internalEditButton variant="tertiary">
-      <h5 style={{ margin: 0 }}>Unit 1</h5>
-      <div>South Nelson Industrial Estate</div>
-      <div>Cramlington</div>
-      <div>NE23 1WF</div>
-      <div>United Kingdom</div>
-      <div
-        style={{
-          fontWeight: 900,
-          borderTop: "1px solid #ccd6db",
-          marginTop: "15px",
-          paddingTop: "5px",
-        }}
-      >
-        <Button buttonType="tertiary" size="small" px={0}>
-          Select a different address
-        </Button>
-      </div>
+      <Box>
+        <Typography variant="h5" fontWeight="700">
+          Unit 1
+        </Typography>
+        <Typography m={0}>South Nelson Industrial Estate</Typography>
+        <Typography m={0}>Cramlington</Typography>
+        <Typography m={0}>NE23 1WF</Typography>
+        <Typography m={0}>United Kingdom</Typography>
+      </Box>
+      <Button buttonType="tertiary" size="small" mt={1} px={0}>
+        Select a different address
+      </Button>
       <div style={{ position: "absolute", right: "8px", top: "8px" }}>
         <Button
           buttonType="tertiary"

--- a/src/components/pod/pod.style.js
+++ b/src/components/pod/pod.style.js
@@ -25,7 +25,7 @@ const blockBackgrounds = (variant) =>
   ({
     primary: "var(--colorsUtilityYang100)",
     secondary: "var(--colorsUtilityMajor025)",
-    tertiary: "var(--colorsUtilityMajor050)",
+    tertiary: "var(--colorsUtilityMajor040)",
     transparent: "var(--colorsUtilityMajorTransparent)",
     tile: "var(--colorsUtilityYang100)",
   }[variant]);
@@ -93,8 +93,8 @@ const StyledBlock = styled.div`
 
       ${softDelete &&
       css`
-        color: var(--colorsUtilityYin030);
-        background-color: var(--colorsUtilityMajor050);
+        color: var(--colorsUtilityYin065);
+        background-color: var(--colorsActionDisabled500);
       `};
     `}
 `;
@@ -130,7 +130,7 @@ const StyledFooter = styled.div`
 
     ${softDelete &&
     css`
-      color: var(--colorsUtilityYin030);
+      color: var(--colorsUtilityYin055);
     `}
 
     ${variant === "tile" &&

--- a/src/components/pod/pod.style.js
+++ b/src/components/pod/pod.style.js
@@ -93,8 +93,12 @@ const StyledBlock = styled.div`
 
       ${softDelete &&
       css`
-        color: var(--colorsUtilityYin065);
+        border: none;
         background-color: var(--colorsActionDisabled500);
+
+        & > * {
+          color: var(--colorsUtilityYin065);
+        }
       `};
     `}
 `;

--- a/src/components/pod/pod.test.js
+++ b/src/components/pod/pod.test.js
@@ -1,0 +1,34 @@
+import React from "react";
+import Pod from "./pod.component";
+import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
+import Content from "../content";
+
+import { podBlock } from "../../../cypress/locators/pod";
+
+const PodWithSoftDelete = () => (
+  <Pod softDelete onUndo={() => {}}>
+    Content
+    <Content>More content</Content>
+  </Pod>
+);
+
+context("Testing Pod component", () => {
+  describe("When softDelete is true", () => {
+    it("renders block with correct background colour", () => {
+      const blockBackgroundColor = "rgb(230, 235, 237)";
+
+      CypressMountWithProviders(<PodWithSoftDelete />);
+
+      podBlock().should("have.css", "background-color", blockBackgroundColor);
+    });
+
+    it("renders text of children with correct colours", () => {
+      const childrenColor = "rgba(0, 0, 0, 0.65)";
+
+      CypressMountWithProviders(<PodWithSoftDelete />);
+
+      cy.contains("Content").should("have.css", "color", childrenColor);
+      cy.contains("More content").should("have.css", "color", childrenColor);
+    });
+  });
+});

--- a/src/components/show-edit-pod/show-edit-pod.spec.js
+++ b/src/components/show-edit-pod/show-edit-pod.spec.js
@@ -3,7 +3,6 @@ import { mount } from "enzyme";
 
 import { act } from "react-dom/test-utils";
 import ShowEditPod from "./show-edit-pod.component";
-import { StyledContent } from "../pod/pod.style.js";
 import Form from "../form";
 import Pod from "../pod";
 import Button from "../button";
@@ -11,10 +10,7 @@ import {
   elementsTagTest,
   rootTagTest,
 } from "../../__internal__/utils/helpers/tags/tags-specs";
-import {
-  testStyledSystemMargin,
-  assertStyleMatch,
-} from "../../__spec_helper__/test-utils";
+import { testStyledSystemMargin } from "../../__spec_helper__/test-utils";
 
 describe("ShowEditPod", () => {
   testStyledSystemMargin((props) => <ShowEditPod {...props} />);
@@ -368,21 +364,6 @@ describe("ShowEditPod", () => {
 
         expect(wrapper.find(Pod).find('[data-element="delete"]').exists()).toBe(
           false
-        );
-      });
-    });
-    describe("when softDelete prop set", () => {
-      it("content title has correct color", () => {
-        wrapper = renderShowEditPod({
-          onDelete,
-          softDelete: true,
-        });
-        assertStyleMatch(
-          {
-            color: "var(--colorsUtilityYin030)",
-          },
-          wrapper.find(Pod),
-          { modifier: `${StyledContent} [data-element="content-title"]` }
         );
       });
     });

--- a/src/components/show-edit-pod/show-edit-pod.style.js
+++ b/src/components/show-edit-pod/show-edit-pod.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import { StyledFormFooter } from "../form/form.style.js";
 import { StyledContent } from "../pod/pod.style.js";
 import Pod from "../pod";
@@ -10,13 +10,6 @@ const StyledPod = styled(Pod)`
 
   ${StyledContent} {
     padding: 16px;
-    ${({ softDelete }) =>
-      softDelete &&
-      css`
-        [data-element="content-title"] {
-          color: var(--colorsUtilityYin030);
-        }
-      `}
   }
 
   .common-input__prefix {

--- a/src/components/show-edit-pod/show-edit-pod.test.js
+++ b/src/components/show-edit-pod/show-edit-pod.test.js
@@ -51,7 +51,7 @@ context("Testing ShowEditPod component", () => {
     it.each([
       ["primary", "rgb(255, 255, 255)", "none"],
       ["secondary", "rgb(242, 245, 246)", "none"],
-      ["tertiary", "rgb(230, 235, 237)", "none"],
+      ["tertiary", "rgb(237, 241, 242)", "none"],
       ["tile", "rgb(255, 255, 255)", "rgba(2, 18, 36, 0.2) 0px 2px 3px 0px"],
       ["transparent", "rgba(0, 0, 0, 0)", "none"],
     ])(

--- a/src/components/tile/__snapshots__/tile.spec.js.snap
+++ b/src/components/tile/__snapshots__/tile.spec.js.snap
@@ -68,7 +68,6 @@ exports[`Tile renders base styles 1`] = `
 .c5 {
   display: block;
   font-weight: bold;
-  color: var(--colorsUtilityYin090);
   text-align: left;
 }
 


### PR DESCRIPTION
fixes #5301

### Proposed behaviour

- Update `color` css for text within a `Pod` in a soft delete state to improve colour contrast with `Pod` background
- Update `background-color` for tertiary variant `Pod` to improve colour contrast when used with secondary or tertiary buttons
- Refactored markup in `address example` and `soft delete state` stories for `Pod` 
- Fix `Pod` styling so no border is rendered when in soft delete state
![Screenshot 2022-08-19 at 11 57 52](https://user-images.githubusercontent.com/18368713/185604283-99135b8c-02e8-45c2-a923-38a500340bef.png)
- Update `Content` component so when `title` prop is passed and `variant='primary'` - it uses body css rule for `color`


### Current behaviour

- Having a secondary or tertiary `Button` within a tertiary variant `Pod` causes a colour contrast warning in AXE
- Any text within a `Pod` in a soft delete state causes a colour contrast warning in AXE

![Screenshot 2022-08-05 at 13 37 09](https://user-images.githubusercontent.com/18368713/183078955-3ac9c4a8-dc90-4cc2-9876-fbcc87c6162e.png)
![Screenshot 2022-08-05 at 13 53 42](https://user-images.githubusercontent.com/18368713/183081399-77eb9994-9aba-40dd-87cb-30b70f2a76f3.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### For UX review

`Pod` does not exist within Design System. Check visual changes such as colours are consistent with other components. 

### Testing instructions

<!-- How can a reviewer test this PR? -->

Double check AXE colour contrast ratio violations have been resolved.

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/pod-colour-contrast-y9tecn
