### PR TITLE
fix(definition-list): ensure links are styled correctly - FE-5293

### DIFF
--- a/src/components/definition-list/definition-list.style.ts
+++ b/src/components/definition-list/definition-list.style.ts
@@ -1,7 +1,6 @@
 import styled, { css } from "styled-components";
 import { space } from "styled-system";
 import StyledButton from "../button/button.style";
-import { StyledLink } from "../link/link.style";
 import { baseTheme } from "../../style/themes";
 
 export interface StyledDlProps {
@@ -87,14 +86,6 @@ export const StyledDd = styled.dd`
   ${StyledButton} {
     padding: 0;
     border: none;
-  }
-
-  ${StyledLink} {
-    a,
-    button {
-      font-weight: 700px;
-      text-decoration: none;
-    }
   }
   ${space}
 `;


### PR DESCRIPTION
During the introduction of design tokens, text-decoration of none was added to links when they are
used in a definition-list. Links are underlined by default in the browser and we should honour this.

fixes #5240

### Proposed behaviour

![Screenshot 2022-08-10 at 15 09 31](https://user-images.githubusercontent.com/56251247/183927589-2d21128a-2cc7-4259-bc85-0bc1b6e4e182.png)

### Current behaviour

![Screenshot 2022-08-10 at 15 09 22](https://user-images.githubusercontent.com/56251247/183927604-a399fd90-c60f-4d04-b11a-9380da07596c.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

This change can be seen in the story `Tile -> with Definition List Default`. Link Text should be underlined.

<!-- Add CodeSandbox here -->
