### PR TITLE
fix(modal): remove propTypes from component - FE-5309

### DIFF
--- a/src/components/modal/modal.component.tsx
+++ b/src/components/modal/modal.component.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useCallback, useState } from "react";
-import PropTypes from "prop-types";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 
 import useScrollBlock from "../../hooks/__internal__/useScrollBlock";
@@ -148,23 +147,6 @@ const Modal = ({
       </StyledModal>
     </Portal>
   );
-};
-
-Modal.propTypes = {
-  /** Modal content */
-  children: PropTypes.node,
-  /** A custom close event handler */
-  onCancel: PropTypes.func,
-  /** Controls the open state of the modal */
-  open: PropTypes.bool.isRequired,
-  /** Determines if the background is disabled when the modal is open */
-  enableBackgroundUI: PropTypes.bool,
-  /** Determines if the Esc Key closes the modal */
-  disableEscKey: PropTypes.bool,
-  /** Determines if the Dialog can be closed */
-  disableClose: PropTypes.bool,
-  /** Transition time */
-  timeout: PropTypes.number,
 };
 
 export default Modal;


### PR DESCRIPTION
The propTypes import and declaration object for Modal were left in the component after the refactor
to TS.

fixes #5376

### Proposed behaviour

Remove propType import and object from `modal` component

### Current behaviour

`modal` component still has the propTypes import and declaration. This is causing an error when carbon is built.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Export the follow [codesandbox](https://codesandbox.io/s/carbon-quickstart-typescript-forked-3zjh85)
- Open it locally in VSCode
- run `npm install`
- run `npm run build`
- There should be no errors relating to Modal having two propType declarations
