### PR TITLE
docs(dialog): add responsive examples

### DIFF
--- a/src/components/definition-list/dd.component.tsx
+++ b/src/components/definition-list/dd.component.tsx
@@ -16,4 +16,5 @@ const Dd = ({ children, ...rest }: DdProps) => {
   );
 };
 
+Dd.displayName = "Dd";
 export default Dd;

--- a/src/components/definition-list/definition-list.stories.mdx
+++ b/src/components/definition-list/definition-list.stories.mdx
@@ -6,6 +6,8 @@ import Box from "../box";
 import { ActionPopover, ActionPopoverItem } from "../action-popover";
 import Hr from "../hr";
 import Typography from "../typography";
+import useMediaQuery from "../../hooks/useMediaQuery";
+
 
 <Meta title="Definition List" parameters={{ info: { disable: true } }} />
 
@@ -215,6 +217,44 @@ such as `Typography` and `Hr`.
         <Hr ml={0} mt={1} />
       </Box>
     </Box>
+  </Story>
+</Canvas>
+
+### Responsive Example
+
+<Canvas>
+  <Story 
+    name="responsive" 
+    parameters={
+      { 
+        chromatic: { 
+          viewports: [1200, 500] 
+        } 
+      }
+    }
+  >
+    {() => {
+      const smallScreen = useMediaQuery("(max-width: 700px)");
+      return (
+        <Dl 
+          ddTextAlign={smallScreen === "right"} 
+          dtTextAlign={smallScreen ? "left" : "right"} 
+          asSingleColumn={smallScreen}
+        >
+          <Dt>First</Dt>
+          <Dd>Description</Dd>
+          <Dt>Second</Dt>
+          <Dd>
+            <Box display="inline-flex" alignItems="center">
+              <Box mr={1}>Details example</Box>
+              <Icon type="tick" />
+            </Box>
+          </Dd>
+          <Dt>Third</Dt>
+          <Dd>Description</Dd>
+        </Dl>
+      );
+    }}
   </Story>
 </Canvas>
 

--- a/src/components/definition-list/dl.component.tsx
+++ b/src/components/definition-list/dl.component.tsx
@@ -92,4 +92,5 @@ const Dl = ({
   );
 };
 
+Dl.displayName = "Dl";
 export default Dl;

--- a/src/components/definition-list/dt.component.tsx
+++ b/src/components/definition-list/dt.component.tsx
@@ -23,4 +23,5 @@ const Dt = ({ children, ...rest }: DtProps) => {
   );
 };
 
+Dt.displayName = "Dt";
 export default Dt;

--- a/src/components/dialog/dialog.stories.mdx
+++ b/src/components/dialog/dialog.stories.mdx
@@ -11,6 +11,7 @@ import { RadioButton, RadioButtonGroup } from "../radio-button";
 import Fieldset from "../fieldset";
 import Loader from "../loader";
 import Toast from "../toast";
+import useMediaQuery from "../../hooks/useMediaQuery";
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 import isChromatic from "../../../.storybook/isChromatic";
 
@@ -480,6 +481,75 @@ This may occasionally be useful with things like Toasts where they persist on th
           >
             Toast message 2
           </Toast>
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Responsive Example
+
+<Canvas>
+  <Story 
+    name="responsive" 
+    parameters={
+      { 
+        chromatic: { 
+          viewports: [1500, 900] 
+        } 
+      }
+    }
+  >
+    {() => {
+      const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+      const largeScreen = useMediaQuery("(min-width: 1260px)");
+      const mediumScreen = useMediaQuery("(min-width: 960px)");
+      const smallScreen = useMediaQuery("(min-width: 600px)");
+      const setCorrectScreenSize = () => {
+        if (largeScreen) {
+          return "large";
+        }
+        if (mediumScreen) {
+          return "medium";
+        }
+        if (smallScreen) {
+          return "small";
+        }
+        return "auto";
+      };
+      return (
+        <>
+          <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
+          <Dialog
+            size={setCorrectScreenSize()}
+            open={isOpen}
+            onCancel={() => setIsOpen(false)}
+            title="Title"
+            subtitle="Subtitle"
+          >
+            <Form
+              stickyFooter={true}
+              height="500px"
+              leftSideButtons={
+                <Button onClick={() => setIsOpen(false)}>Cancel</Button>
+              }
+              saveButton={
+                <Button buttonType="primary" type="submit">
+                  Save
+                </Button>
+              }
+            >
+              <Typography>
+                This is an example of a dialog with a Form as content
+              </Typography>
+              <Textbox label="First Name" />
+              <Textbox label="Middle Name" />
+              <Textbox label="Surname" />
+              <Textbox label="Birth Place" />
+              <Textbox label="Favourite Colour" />
+              <Textbox label="Address" />
+            </Form>
+          </Dialog>
         </>
       );
     }}

--- a/src/components/preview/preview.stories.mdx
+++ b/src/components/preview/preview.stories.mdx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { ArgsTable } from "@storybook/components";
-import PreviewComponent from "./preview.component";
+import Preview from "./preview.component";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import Button from "../button";
 
@@ -29,7 +29,7 @@ import Preview from "carbon-react/lib/components/preview";
 
 <Canvas>
   <Story name="default">
-    <PreviewComponent loading />
+    <Preview loading />
   </Story>
 </Canvas>
 
@@ -37,7 +37,7 @@ import Preview from "carbon-react/lib/components/preview";
 
 <Canvas>
   <Story name="with Lines">
-    <PreviewComponent loading lines={6} />
+    <Preview loading lines={6} />
   </Story>
 </Canvas>
 
@@ -52,9 +52,9 @@ import Preview from "carbon-react/lib/components/preview";
       };
       return (
         <>
-          <PreviewComponent loading={isLoading} lines={3}>
+          <Preview loading={isLoading} lines={3}>
             This the where the children are rendered
-          </PreviewComponent>
+          </Preview>
           <Button mt={2} onClick={handleOnClick}>
             {isLoading ? "Click to preview children" : "Click to see loading state"}
           </Button>
@@ -68,7 +68,7 @@ import Preview from "carbon-react/lib/components/preview";
 
 <Canvas>
   <Story name="with Width">
-    <PreviewComponent loading width={"256px"} />
+    <Preview loading width={"256px"} />
   </Story>
 </Canvas>
 
@@ -76,7 +76,7 @@ import Preview from "carbon-react/lib/components/preview";
 
 <Canvas>
   <Story name="with Height">
-    <PreviewComponent loading height={"256px"} />
+    <Preview loading height={"256px"} />
   </Story>
 </Canvas>
 

--- a/src/components/preview/preview.stories.mdx
+++ b/src/components/preview/preview.stories.mdx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { ArgsTable } from "@storybook/components";
 import PreviewComponent from "./preview.component";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import Button from "../button";
 
 <Meta title="Preview" parameters={{ info: { disable: true } }} />
 
@@ -43,9 +45,22 @@ import Preview from "carbon-react/lib/components/preview";
 
 <Canvas>
   <Story name="with Children">
-    <PreviewComponent>
-      This the where the children are rendered
-    </PreviewComponent>
+    {() => {
+      const [isLoading, setIsLoading] = useState(true);
+      const handleOnClick = () => {
+        setIsLoading(!isLoading);
+      };
+      return (
+        <>
+          <PreviewComponent loading={isLoading} lines={3}>
+            This the where the children are rendered
+          </PreviewComponent>
+          <Button mt={2} onClick={handleOnClick}>
+            {isLoading ? "Click to preview children" : "Click to see loading state"}
+          </Button>
+        </>
+      );
+    }}
   </Story>
 </Canvas>
 

--- a/src/components/profile/profile.stories.mdx
+++ b/src/components/profile/profile.stories.mdx
@@ -2,6 +2,8 @@ import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 import Profile from ".";
+import useMediaQuery from "../../hooks/useMediaQuery";
+
 
 <Meta title="Profile" parameters={{ info: { disable: true } }} />
 
@@ -64,6 +66,49 @@ To use an image, simply pass any valid image URL as a `src` prop.
         />
       ))
     }
+  </Story>
+</Canvas>
+
+### Responsive Example
+
+<Canvas>
+  <Story 
+    name="responsive"
+    parameters={
+      { 
+        chromatic: { 
+          viewports: [1300, 900] 
+        } 
+      }
+    }
+  >
+    {() => {
+      const largeScreen = useMediaQuery("(min-width: 1260px)");
+      const mediumScreen = useMediaQuery("(min-width: 960px)");
+      const smallScreen = useMediaQuery("(max-width: 600px)");
+      const setCorrectScreenSize = () => {
+        if (largeScreen) {
+          return "XL";
+        }
+        if (mediumScreen) {
+          return "ML";
+        }
+        if (smallScreen) {
+          return "S";
+        }
+        return "M";
+      };
+      return (
+        <div>
+          <Profile
+            email="email@email.com"
+            initials="JD"
+            name="John Doe"
+            size={setCorrectScreenSize()}
+          />
+        </div>
+      );
+    }}
   </Story>
 </Canvas>
 

--- a/src/components/step-sequence/step-sequence.stories.mdx
+++ b/src/components/step-sequence/step-sequence.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import { StepSequence, StepSequenceItem } from "./";
+import useMediaQuery from "../../hooks/useMediaQuery";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 <Meta title="Step Sequence" parameters={{ info: { disable: true } }} />
@@ -195,6 +196,75 @@ import {
     </StepSequence>
   </Story>
 </Canvas>
+
+### Responsive Example
+
+<Canvas>
+  <Story 
+    name="responsive"
+    parameters={
+      { 
+        chromatic: { 
+          viewports: [700] 
+        } 
+      }
+    }
+  >
+    {() => {
+      const displayVertical = useMediaQuery("(max-width: 760px)");
+      return (
+        <StepSequence orientation={displayVertical ? "vertical" : "horizontal"}>
+          <StepSequenceItem
+            aria-label="Step 1 of 5"
+            hiddenCompleteLabel="Complete"
+            hiddenCurrentLabel="Current"
+            indicator="1"
+            status="complete"
+          >
+            Name
+          </StepSequenceItem>
+          <StepSequenceItem
+            aria-label="Step 2 of 5"
+            hiddenCompleteLabel="Complete"
+            hiddenCurrentLabel="Current"
+            indicator="2"
+            status="complete"
+          >
+            Delivery Address
+          </StepSequenceItem>
+          <StepSequenceItem
+            aria-label="Step 3 of 5"
+            hiddenCompleteLabel="Complete"
+            hiddenCurrentLabel="Current"
+            indicator="3"
+            status="current"
+          >
+            Delivery Details
+          </StepSequenceItem>
+          <StepSequenceItem
+            aria-label="Step 4 of 5"
+            hiddenCompleteLabel="Complete"
+            hiddenCurrentLabel="Current"
+            indicator="4"
+            status="incomplete"
+          >
+            Payment
+          </StepSequenceItem>
+          <StepSequenceItem
+            aria-label="Step 5 of 5"
+            hiddenCompleteLabel="Complete"
+            hiddenCurrentLabel="Current"
+            indicator="5"
+            status="incomplete"
+          >
+            Confirm
+          </StepSequenceItem>
+        </StepSequence>
+      );
+    }}
+  </Story>
+</Canvas>
+
 
 ## Props
 


### PR DESCRIPTION
### Proposed behaviour

Adds responsive examples for: 
- Dialog
- Profile
- Step Sequence
- Definition List

Also improve upon an existing story in `Preview`

### Current behaviour

No responsive examples for dialog, step sequence, profile and definition list
The with children example of preview could be better.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Visit the new stories in Storybook and make sure they work as expected.
New stories are:
`dialog -> responsive`
`definition list -> responsive`
`profile -> responsive`
`step sequence -> responsive`
and also ensure sure that `Preview -> with children` example works as expected.
