### PR TITLE
fix hover dropdown and action popover hover colours so they align with figma implementation

### DIFF
--- a/src/components/action-popover/action-popover.style.ts
+++ b/src/components/action-popover/action-popover.style.ts
@@ -65,7 +65,7 @@ const StyledMenuItem = styled.button<StyledMenuItemProps>`
     css`
       &:focus,
       &:hover {
-        background-color: var(--colorsUtilityMajor025);
+        background-color: var(--colorsUtilityMajor100);
       }
       && ${StyledIcon} {
         cursor: pointer;

--- a/src/components/action-popover/action-popover.test.js
+++ b/src/components/action-popover/action-popover.test.js
@@ -561,6 +561,18 @@ context("Test for ActionPopover component", () => {
         .should("have.attr", "data-popper-placement", "top-end")
         .and("be.visible");
     });
+
+    it.each([[0], [1]])(
+      "should have correct hover state of submenu item in ActionPopoverMenu",
+      (element) => {
+        CypressMountWithProviders(<ActionPopoverMenuWithProps />);
+
+        actionPopoverButton().eq(0).click();
+        actionPopoverInnerItem(element)
+          .realHover()
+          .should("have.css", "background-color", "rgb(204, 214, 219)");
+      }
+    );
   });
 
   describe("check props for ActionPopover component", () => {
@@ -645,6 +657,18 @@ context("Test for ActionPopover component", () => {
       actionPopoverButton().eq(0).click();
       actionPopover().eq(1).children().eq(0).should("not.be.focused");
     });
+
+    it.each([[0], [1]])(
+      "should have correct hover state of submenu item in ActionPopoverMenu",
+      (element) => {
+        CypressMountWithProviders(<ActionPopoverMenuWithProps />);
+
+        actionPopoverButton().eq(0).click();
+        actionPopoverInnerItem(element)
+          .realHover()
+          .should("have.css", "background-color", "rgb(204, 214, 219)");
+      }
+    );
   });
 
   describe("check events for ActionPopover component", () => {

--- a/src/components/select/filterable-select/filterable-select.test.js
+++ b/src/components/select/filterable-select/filterable-select.test.js
@@ -1242,6 +1242,17 @@ context("Tests for Filterable Select component", () => {
       filterableSelectAddNewButton().should("be.visible").click();
       getDataElementByValue("input").should("have.attr", "value", newOption);
     });
+
+    it("should have correct hover state of list option", () => {
+      CypressMountWithProviders(<FilterableSelectComponent />);
+
+      const optionValue = "Blue";
+
+      dropdownButton().click();
+      selectListText(optionValue)
+        .realHover()
+        .should("have.css", "background-color", "rgb(204, 214, 219)");
+    });
   });
 
   describe("check events for Filterable Select component", () => {

--- a/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
+++ b/src/components/select/list-action-button/__snapshots__/list-action-button.spec.js.snap
@@ -114,14 +114,8 @@ exports[`Option renders properly 1`] = `
   box-shadow: 0 0px 0 0 rgba(0,0,0,0),0 -8px 8px 0 rgba(0,0,0,0.03);
 }
 
-.c0 .c3 {
-  color: var(--colorsUtilityYin090);
-}
-
 .c0 .c1 {
-  background: transparent;
   border: none;
-  color: var(--colorsUtilityYin090);
   -webkit-box-pack: left;
   -webkit-justify-content: left;
   -ms-flex-pack: left;
@@ -129,14 +123,6 @@ exports[`Option renders properly 1`] = `
   padding-left: var(--spacing200);
   padding-right: var(--spacing200);
   width: 100%;
-}
-
-.c0 .c1:hover {
-  background-color: var(--colorsUtilityMajor025);
-}
-
-.c0 .c1:hover .c3 {
-  color: var(--colorsUtilityYin090);
 }
 
 <div

--- a/src/components/select/list-action-button/list-action-button.style.js
+++ b/src/components/select/list-action-button/list-action-button.style.js
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import StyledButton from "../../button/button.style";
-import StyledIcon from "../../icon/icon.style";
 
 const StyledListActionButtonWrapper = styled.div`
   padding-top: var(--spacing100);
@@ -8,25 +7,12 @@ const StyledListActionButtonWrapper = styled.div`
   border-top: 1px solid var(--colorsUtilityDisabled600);
   box-shadow: 0 0px 0 0 rgba(0, 0, 0, 0), 0 -8px 8px 0 rgba(0, 0, 0, 0.03);
 
-  ${StyledIcon} {
-    color: var(--colorsUtilityYin090);
-  }
-
   ${StyledButton} {
-    background: transparent;
     border: none;
-    color: var(--colorsUtilityYin090);
     justify-content: left;
     padding-left: var(--spacing200);
     padding-right: var(--spacing200);
     width: 100%;
-
-    :hover {
-      background-color: var(--colorsUtilityMajor025);
-      ${StyledIcon} {
-        color: var(--colorsUtilityYin090);
-      }
-    }
   }
 `;
 

--- a/src/components/select/multi-select/multi-select.test.js
+++ b/src/components/select/multi-select/multi-select.test.js
@@ -1174,6 +1174,15 @@ context("Tests for Multi Select component", () => {
       multiSelectPill().should("not.exist");
       selectList().should("be.visible");
     });
+
+    it("should have correct hover state of list option", () => {
+      CypressMountWithProviders(<MultiSelectComponent />);
+
+      dropdownButton().click();
+      selectListText(option1)
+        .realHover()
+        .should("have.css", "background-color", "rgb(204, 214, 219)");
+    });
   });
 
   describe("check events for Multi Select component", () => {

--- a/src/components/select/option-row/__snapshots__/option-row.spec.js.snap
+++ b/src/components/select/option-row/__snapshots__/option-row.spec.js.snap
@@ -7,7 +7,7 @@ exports[`OptionRow renders properly 1`] = `
 }
 
 .c0:hover {
-  background-color: var(--colorsUtilityMajor200);
+  background-color: var(--colorsUtilityMajor100);
 }
 
 .c0 td {

--- a/src/components/select/option-row/option-row.spec.js
+++ b/src/components/select/option-row/option-row.spec.js
@@ -31,7 +31,7 @@ describe("OptionRow", () => {
       const props = { value: "1", text: "foo" };
       expect(renderOptionRow(props, mount)).toHaveStyleRule(
         "background-color",
-        "var(--colorsUtilityMajor200)",
+        "var(--colorsUtilityMajor100)",
         { modifier: ":hover" }
       );
     });

--- a/src/components/select/option-row/option-row.style.js
+++ b/src/components/select/option-row/option-row.style.js
@@ -12,7 +12,7 @@ const StyledOptionRow = styled.tr`
     `}
 
   :hover {
-    background-color: var(--colorsUtilityMajor200);
+    background-color: var(--colorsUtilityMajor100);
   }
 
   td {

--- a/src/components/select/option/__snapshots__/option.spec.js.snap
+++ b/src/components/select/option/__snapshots__/option.spec.js.snap
@@ -15,7 +15,7 @@ exports[`Option renders properly 1`] = `
 }
 
 .c0:hover {
-  background-color: var(--colorsUtilityMajor200);
+  background-color: var(--colorsUtilityMajor100);
 }
 
 <li
@@ -44,7 +44,7 @@ exports[`Option when no children are provided renders with the text prop as chil
 }
 
 .c0:hover {
-  background-color: var(--colorsUtilityMajor200);
+  background-color: var(--colorsUtilityMajor100);
 }
 
 <li

--- a/src/components/select/option/option.spec.js
+++ b/src/components/select/option/option.spec.js
@@ -46,7 +46,7 @@ describe("Option", () => {
       const props = { value: "1", text: "foo" };
       expect(renderOption(props, mount)).toHaveStyleRule(
         "background-color",
-        "var(--colorsUtilityMajor200)",
+        "var(--colorsUtilityMajor100)",
         { modifier: ":hover" }
       );
     });

--- a/src/components/select/option/option.style.js
+++ b/src/components/select/option/option.style.js
@@ -18,7 +18,7 @@ const StyledOption = styled.li`
   ${({ hidden }) => hidden && "display: none;"}
 
   :hover {
-    background-color: var(--colorsUtilityMajor200);
+    background-color: var(--colorsUtilityMajor100);
   }
 `;
 

--- a/src/components/select/simple-select/simple-select.test.js
+++ b/src/components/select/simple-select/simple-select.test.js
@@ -990,6 +990,28 @@ context("Tests for Simple Select component", () => {
           .should("have.length", numberOfChildren);
       }
     );
+
+    it("should have correct hover state of list option", () => {
+      CypressMountWithProviders(<SimpleSelectComponent />);
+
+      const optionValue3 = "Blue";
+
+      selectText().click();
+      selectListText(optionValue3)
+        .realHover()
+        .should("have.css", "background-color", "rgb(204, 214, 219)");
+    });
+  });
+
+  describe("check height of Select list when opened", () => {
+    it("should not cut off any text with long option text", () => {
+      CypressMountWithProviders(<SimpleSelectWithLongWrappingTextComponent />);
+
+      selectText().click();
+      selectListWrapper()
+        .should("have.css", "height", "152px")
+        .and("be.visible");
+    });
   });
 
   describe("check events for Simple Select component", () => {
@@ -1075,16 +1097,5 @@ context("Tests for Simple Select component", () => {
           });
       }
     );
-  });
-
-  describe("check height of Select list when opened", () => {
-    it("should not cut off any text with long option text", () => {
-      CypressMountWithProviders(<SimpleSelectWithLongWrappingTextComponent />);
-
-      selectText().click();
-      selectListWrapper()
-        .should("have.css", "height", "152px")
-        .and("be.visible");
-    });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

- Change dropdown menu item hover colour and action popover menu item hover to use a light gray as opposed to dark. new colour token = 'colorsUtilityMajor100'
- Removed styling overrides for dropdown menu sticky footer button to align with figma implementation. 
![Screenshot 2022-08-30 at 16 32 05](https://user-images.githubusercontent.com/98600534/187496422-72851be6-d73b-484c-9763-5307d9c92bb5.png)

### Current behaviour
old colour tokenused  = 'colorsUtilityMajor200'
![Screenshot 2022-08-30 at 15 16 22](https://user-images.githubusercontent.com/98600534/187496457-9d6225f2-90f2-44c3-b62d-7dfa0c778601.png)



### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
