### PR TITLE
fix(flat-table-header): alternative color not changing according theme

### DIFF
--- a/src/components/flat-table/flat-table-header/flat-table-header-utils.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header-utils.js
@@ -1,0 +1,18 @@
+const getAlternativeBackgroundColor = (colorTheme) => {
+  switch (colorTheme) {
+    case "light":
+      return "var(--colorsActionMinor100)";
+
+    case "transparent-base":
+      return "var(--colorsUtilityMajor025)";
+
+    case "transparent-white":
+      return "var(--colorsUtilityYang100)";
+
+    // default theme is "dark"
+    default:
+      return "var(--colorsActionMinor550)";
+  }
+};
+
+export default getAlternativeBackgroundColor;

--- a/src/components/flat-table/flat-table-header/flat-table-header.component.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.component.js
@@ -1,9 +1,10 @@
-import React, { useLayoutEffect, useRef } from "react";
+import React, { useLayoutEffect, useRef, useContext } from "react";
 import PropTypes from "prop-types";
 import styledSystemPropTypes from "@styled-system/prop-types";
 
 import StyledFlatTableHeader from "./flat-table-header.style";
 import { filterStyledSystemPaddingProps } from "../../../style/utils";
+import { FlatTableThemeContext } from "../flat-table.component";
 
 const paddingPropTypes = filterStyledSystemPaddingProps(
   styledSystemPropTypes.space
@@ -23,6 +24,7 @@ const FlatTableHeader = ({
   ...rest
 }) => {
   const ref = useRef(null);
+  const { colorTheme } = useContext(FlatTableThemeContext);
 
   useLayoutEffect(() => {
     if (ref.current && reportCellWidth) {
@@ -36,6 +38,7 @@ const FlatTableHeader = ({
       leftPosition={leftPosition || 0}
       makeCellSticky={!!reportCellWidth}
       align={align}
+      colorTheme={colorTheme}
       data-element="flat-table-header"
       colSpan={colspan}
       rowSpan={rowspan}

--- a/src/components/flat-table/flat-table-header/flat-table-header.spec.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.spec.js
@@ -3,6 +3,8 @@ import { mount } from "enzyme";
 import FlatTableHeader from "./flat-table-header.component";
 import StyledFlatTableHeader from "./flat-table-header.style";
 import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
+import { FlatTableThemeContext } from "../flat-table.component";
+import getAlternativeBackgroundColor from "./flat-table-header-utils";
 
 describe("FlatTableHeader", () => {
   it("renders with proper width style rule when width prop is passed", () => {
@@ -49,25 +51,30 @@ describe("FlatTableHeader", () => {
   });
 
   describe('with the "alternativeBgColor" prop set', () => {
-    it('it overrides the header "background-color"', () => {
-      const wrapper = mount(
-        <table>
-          <thead>
-            <tr>
-              <FlatTableHeader alternativeBgColor />
-            </tr>
-          </thead>
-        </table>
-      );
+    it.each(["dark", "light", "transparent-white", "transparent-base"])(
+      'it overrides the header "background-color" with correspond color for %s themeColor"',
+      (colorTheme) => {
+        const wrapper = mount(
+          <FlatTableThemeContext.Provider value={{ colorTheme }}>
+            <table>
+              <thead>
+                <tr>
+                  <FlatTableHeader alternativeBgColor>test 1</FlatTableHeader>
+                </tr>
+              </thead>
+            </table>
+          </FlatTableThemeContext.Provider>
+        );
 
-      assertStyleMatch(
-        {
-          backgroundColor: "var(--colorsActionMinor550)",
-        },
-        wrapper.find(StyledFlatTableHeader),
-        { modifier: "&&&" }
-      );
-    });
+        assertStyleMatch(
+          {
+            backgroundColor: getAlternativeBackgroundColor(colorTheme),
+          },
+          wrapper.find(StyledFlatTableHeader),
+          { modifier: "&&&" }
+        );
+      }
+    );
   });
 
   describe.each([

--- a/src/components/flat-table/flat-table-header/flat-table-header.style.js
+++ b/src/components/flat-table/flat-table-header/flat-table-header.style.js
@@ -1,5 +1,6 @@
 import styled, { css } from "styled-components";
 import { padding } from "styled-system";
+import getAlternativeBackgroundColor from "./flat-table-header-utils";
 
 const verticalBorderSizes = {
   small: "1px",
@@ -15,6 +16,7 @@ const StyledFlatTableHeader = styled.th`
     leftPosition,
     makeCellSticky,
     verticalBorder,
+    colorTheme,
   }) => css`
     background-color: transparent;
     border-width: 0;
@@ -57,11 +59,11 @@ const StyledFlatTableHeader = styled.th`
     ${
       alternativeBgColor &&
       css`
-        &&&:first-child {
-          border-left: 1px solid var(--colorsActionMinor550);
-        }
         &&& {
-          background-color: var(--colorsActionMinor550);
+          background-color: ${getAlternativeBackgroundColor(colorTheme)};
+        }
+        &&&:first-child {
+          border-left: unset;
         }
       `
     };


### PR DESCRIPTION
Closes: FE-5319

### Proposed behaviour

Fix for the "Light" theme of the Flat Table header alternative background color then attribute trigger alternativeBgColor is used: https://github.com/Sage/carbon/issues/5136 

The theme "dark" is already using correct colors, themes "transparent-base" and "transparent-white" don't has alternative background colors, so they are using the same Flat Table header colors.

<img width="511" alt="image" src="https://user-images.githubusercontent.com/2675648/185583240-6eb3554a-f487-46ca-8772-72710417d44a.png">

Sandbox with bug: https://codesandbox.io/s/modest-shaw-n4hxlv

### Current behaviour

Flat Table header with alternative background color is showing wrong colors, used in "dark" theme.
<img width="609" alt="image" src="https://user-images.githubusercontent.com/2675648/185369926-5197b6c4-b77f-4f3a-93fe-9a5a590275f3.png">

### Checklist

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

### Testing instructions

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

Sandbox with bug: https://codesandbox.io/s/modest-shaw-n4hxlv
