### PR TITLE
feat(toast): add notice variant (FE-4402)

### DIFF
--- a/src/components/toast/toast-test.stories.mdx
+++ b/src/components/toast/toast-test.stories.mdx
@@ -5,6 +5,7 @@ import { action } from "@storybook/addon-actions";
 import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
 import Toast from ".";
 import Button from "../button";
+import Icon from "../icon";
 import { TOAST_COLORS } from "./toast.config";
 
 <Meta
@@ -191,6 +192,14 @@ export const ToastVisualStory = ({
         open={isOpen}
       >
         My Success
+      </Toast>
+      <Toast
+        onDismiss={onDismissClick}
+        open={isOpen}
+        targetPortalId="visual-notice"
+        variant="notice"
+      >
+        <Icon type="warning" color="--colorsSemanticNeutralYang100" /> Notice
       </Toast>
     </div>
   );

--- a/src/components/toast/toast.component.js
+++ b/src/components/toast/toast.component.js
@@ -34,6 +34,7 @@ const Toast = React.forwardRef(
     },
     ref
   ) => {
+    const isNotice = variant === "notice";
     const locale = useLocale();
 
     const toastRef = useRef();
@@ -119,20 +120,24 @@ const Toast = React.forwardRef(
       return (
         <CSSTransition
           enter
-          classNames="toast"
+          classNames={isNotice ? "toast-alternative" : "toast"}
           timeout={{ appear: 1600, enter: 1500, exit: 500 }}
           nodeRef={toastContentNodeRef}
         >
           <ToastStyle
+            isNotice={isNotice}
             className={componentClasses}
             {...tagComponent(restProps["data-component"] || "toast", restProps)}
             {...toastProps}
             ref={toastContentNodeRef}
           >
-            <TypeIcon variant={toastProps.variant}>
-              <Icon type={toastProps.variant} />
-            </TypeIcon>
+            {!isNotice && (
+              <TypeIcon variant={toastProps.variant}>
+                <Icon type={toastProps.variant} />
+              </TypeIcon>
+            )}
             <ToastContentStyle
+              isNotice={isNotice}
               variant={toastProps.variant}
               isDismiss={onDismiss}
             >
@@ -145,8 +150,8 @@ const Toast = React.forwardRef(
     }
 
     return (
-      <StyledPortal id={targetPortalId} isCenter={isCenter}>
-        <ToastWrapper isCenter={isCenter} ref={refToPass}>
+      <StyledPortal id={targetPortalId} isCenter={isCenter} isNotice={isNotice}>
+        <ToastWrapper isCenter={isCenter} ref={refToPass} isNotice={isNotice}>
           <TransitionGroup>{renderToastContent()}</TransitionGroup>
         </ToastWrapper>
       </StyledPortal>
@@ -156,7 +161,7 @@ const Toast = React.forwardRef(
 
 Toast.propTypes = {
   /** Customizes the appearance in the DLS theme */
-  variant: PropTypes.oneOf(["error", "info", "success", "warning"]),
+  variant: PropTypes.oneOf(["error", "info", "success", "warning", "notice"]),
   /** Custom className */
   className: PropTypes.string,
   /** Custom id  */

--- a/src/components/toast/toast.d.ts
+++ b/src/components/toast/toast.d.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-type ToastVariants = "error" | "info" | "success" | "warning";
+type ToastVariants = "error" | "info" | "success" | "warning" | "notice";
 
 export interface ToastPropTypes {
   /** The rendered children of the component. */

--- a/src/components/toast/toast.spec.js
+++ b/src/components/toast/toast.spec.js
@@ -2,7 +2,13 @@ import React from "react";
 import { shallow, mount } from "enzyme";
 import guid from "../../__internal__/utils/helpers/guid";
 import Toast from "./toast.component";
-import { ToastStyle, ToastContentStyle, ToastWrapper } from "./toast.style";
+import {
+  ToastStyle,
+  ToastContentStyle,
+  ToastWrapper,
+  StyledPortal,
+  TypeIcon,
+} from "./toast.style";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import IconButton from "../icon-button";
 import Button from "../button";
@@ -312,6 +318,39 @@ describe("Toast", () => {
     it("should render ToastStyle with correct maxWidth", () => {
       wrapper = mount(<Toast maxWidth="200px" />);
       assertStyleMatch({ maxWidth: "200px" }, wrapper.find(ToastStyle));
+    });
+  });
+
+  describe("when isNotice prop is set", () => {
+    const onDismissFn = jest.fn();
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = mount(
+        <Toast onDismiss={onDismissFn} open variant="notice">
+          foo
+        </Toast>
+      );
+    });
+
+    it("then the prop should be passed to ToastStyle", () => {
+      expect(wrapper.find(ToastStyle).props().isNotice).toBe(true);
+    });
+
+    it("then the prop should be passed to StyledPortal", () => {
+      expect(wrapper.find(StyledPortal).props().isNotice).toBe(true);
+    });
+
+    it("then the prop should be passed to ToastWrapper", () => {
+      expect(wrapper.find(ToastWrapper).props().isNotice).toBe(true);
+    });
+
+    it("then the prop should be passed to ToastContentStyle", () => {
+      expect(wrapper.find(ToastContentStyle).props().isNotice).toBe(true);
+    });
+
+    it("then the TypeIcon should not be rendered", () => {
+      expect(wrapper.find(TypeIcon).exists()).toBe(false);
     });
   });
 });

--- a/src/components/toast/toast.stories.mdx
+++ b/src/components/toast/toast.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, ArgsTable, Canvas, Story } from "@storybook/addon-docs";
 import styled from "styled-components";
 
 import Toast from ".";
+import Icon from "../icon";
 import { useState } from "react";
 import { action } from "@storybook/addon-actions";
 import Button from "../button";
@@ -222,6 +223,55 @@ Toast variant is `success` by default
           </StyledButton>
           <Toast variant="warning" id="toast-variant-warning" open={isOpen}>
             My Info
+          </Toast>
+        </div>
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Notice
+
+When the "notice" variant is set, the Toast component is rendered at the bottom of the screen with alternative styling and animation.
+The "isCenter" and "maxWidth" props will be ignored in this variant.
+
+<Canvas>
+  <Story name="notice" parameters={{ info: { disable: true } }}>
+    {() => {
+      const [isOpen, setIsOpen] = useState(false);
+      const onDismissClick = (evt) => {
+        if (!isOpen) {
+          window.scrollTo(0, 0);
+        }
+        setIsOpen(!isOpen);
+      };
+      const handleToggle = () => {
+        if (!isOpen) {
+          window.scrollTo(0, 0);
+        }
+        setIsOpen(!isOpen);
+        action("open")(!isOpen);
+      };
+      const StyledButton = styled(Button)`
+        position: absolute;
+        display: block;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        color: ${isOpen ? "green" : "blue"};
+        border: ${isOpen ? "2px solid green" : "2px solid blue"};
+      `;
+      return (
+        <div id="wrapper-alternative">
+          <StyledButton
+            id="button-alternative"
+            key="button"
+            onClick={handleToggle}
+          >
+            Toggle - Preview is: {isOpen ? "ON" : "OFF"}
+          </StyledButton>
+          <Toast id="toast-alternative" open={isOpen} onDismiss={onDismissClick} variant="notice">
+            <Icon type="warning" color="--colorsSemanticNeutralYang100" /> My Info
           </Toast>
         </div>
       );

--- a/src/components/toast/toast.style.js
+++ b/src/components/toast/toast.style.js
@@ -6,6 +6,7 @@ import TypeIcon from "../message/type-icon/type-icon.style";
 import StyledIconButton from "../icon-button/icon-button.style";
 import Portal from "../portal/portal";
 import baseTheme from "../../style/themes/base";
+import StyledIcon from "../icon/icon.style";
 
 const StyledPortal = styled(Portal)`
   ${({ theme }) => css`
@@ -20,6 +21,14 @@ const StyledPortal = styled(Portal)`
         margin-left: 50%;
         transform: translateX(-50%);
       `}
+
+    ${({ isNotice }) =>
+      isNotice &&
+      css`
+        bottom: 0;
+        top: auto;
+        width: 100%;
+      `}
   `}
 `;
 
@@ -28,6 +37,7 @@ StyledPortal.defaultProps = {
 };
 
 const animationName = ".toast";
+const alternativeAnimationName = ".toast-alternative";
 const ToastStyle = styled(MessageStyle)`
   ${({ maxWidth, isCenter }) => css`
     box-shadow: 0 10px 30px 0 rgba(0, 20, 29, 0.1),
@@ -38,23 +48,22 @@ const ToastStyle = styled(MessageStyle)`
     position: relative;
     margin-right: ${isCenter ? "auto" : "30px"};
   `}
- 
 
   &${animationName}-appear,
   &${animationName}-enter {
     opacity: 0;
-    transform: scale(0.5)};
+    transform: scale(0.5);
   }
 
-  &${animationName}-appear.toast-appear-active,
-  &${animationName}-enter.toast-enter-active {
+  &${animationName}-appear${animationName}-appear-active,
+    &${animationName}-enter${animationName}-enter-active {
     opacity: 1;
     transform: ${({ isCenter }) =>
       isCenter ? " scale(1) translateY(0)" : "scale(1)"};
-    transition: all 300ms cubic-bezier(0.250, 0.250, 0.000, 1.500);
+    transition: all 300ms cubic-bezier(0.25, 0.25, 0, 1.5);
   }
 
-  &${animationName}-exit.toast-exit-active {
+  &${animationName}-exit${animationName}-exit-active {
     opacity: 0;
     margin-top: -40px;
     transition: all 150ms ease-out;
@@ -66,15 +75,64 @@ const ToastStyle = styled(MessageStyle)`
     top: 50%;
     transform: translateY(-50%);
   }
+
+  ${({ isNotice }) =>
+    isNotice &&
+    css`
+      background-color: var(--colorsUtilityMajor400);
+      border: none;
+      color: var(--colorsSemanticNeutralYang100);
+      margin-right: 0;
+      max-width: 100%;
+
+      ${StyledIconButton} {
+        right: 55px;
+      }
+
+      ${StyledIconButton} ${StyledIcon} {
+        color: var(--colorsSemanticNeutralYang100);
+      }
+
+      &${alternativeAnimationName}-appear, &${alternativeAnimationName}-enter {
+        bottom: -40px;
+        opacity: 0;
+      }
+
+      &${alternativeAnimationName}-exit {
+        bottom: 0;
+        opacity: 1;
+      }
+
+      &${alternativeAnimationName}-appear${alternativeAnimationName}-appear-active,
+        &${alternativeAnimationName}-enter${alternativeAnimationName}-enter-active {
+        bottom: 0;
+        opacity: 1;
+        transition: all 400ms ease;
+      }
+
+      &${alternativeAnimationName}-exit${alternativeAnimationName}-exit-active {
+        bottom: -40px;
+        opacity: 0;
+        transition: all 200ms ease;
+      }
+    `}
 `;
 
 const ToastContentStyle = styled(MessageContentStyle)`
   padding: 8px 16px 8px 16px;
 
-  ${({ isDismiss }) =>
+  ${({ isNotice }) =>
+    isNotice &&
+    css`
+      display: flex;
+      align-items: center;
+      padding: 11px 40px;
+    `}
+
+  ${({ isDismiss, isNotice }) =>
     isDismiss &&
     css`
-      padding-right: 48px;
+      padding-right: ${isNotice ? "88px" : "48px"};
     `}
 `;
 
@@ -88,5 +146,12 @@ const ToastWrapper = styled.div`
       justify-content: center;
       display: flex;
     `}
+
+  ${({ isNotice }) =>
+    isNotice &&
+    css`
+      display: block;
+    `}
 `;
+
 export { ToastStyle, TypeIcon, ToastContentStyle, ToastWrapper, StyledPortal };

--- a/src/components/toast/toast.test.js
+++ b/src/components/toast/toast.test.js
@@ -157,6 +157,27 @@ context("Testing Toast component", () => {
 
       toastComponent().should("have.css", "maxWidth", "250px");
     });
+
+    it("should render Toast component with notice variant", () => {
+      CypressMountWithProviders(<ToastComponent variant="notice" open />);
+
+      toastComponent()
+        .then((toast) => {
+          expect(toast.css("background-color")).to.equals("rgb(51, 91, 112)");
+          expect(toast.css("box-shadow")).to.equals(
+            "rgba(0, 20, 29, 0.1) 0px 10px 30px 0px, rgba(0, 20, 29, 0.1) 0px 30px 60px 0px"
+          );
+        })
+        .and("be.visible");
+    });
+
+    it("should render Toast component with notice variant with focused close icon", () => {
+      CypressMountWithProviders(<ToastComponent variant="notice" open />);
+
+      closeIconButton().then(($el) => {
+        checkGoldenOutline($el);
+      });
+    });
   });
 
   describe("check events for Toast component", () => {


### PR DESCRIPTION
### Proposed behaviour

Toast component has the alternative style variant, which is always full width and rendered in the bottom of the screen.
Toast with that variant should animate from the bottom.
Alternative style can choose any content, icon/pill/text etc, default just text.
Alternative style can be dismissible or delay to animate out.

![image](https://user-images.githubusercontent.com/22885392/191698100-bc16bebc-6030-46fd-9fcb-e26575b95074.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Related issues linked in commit messages if required~~
- [x] Screenshots are included in the PR if useful
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
~~- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required~~
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
