### PR TITLE
fix(menu): ensure submenu closes when enter key is pressed - FE-4919

### DIFF
--- a/src/components/menu/__internal__/submenu/submenu.component.js
+++ b/src/components/menu/__internal__/submenu/submenu.component.js
@@ -195,6 +195,12 @@ const Submenu = React.forwardRef(
             setCharacterString("");
           }
 
+          if (Events.isEnterKey(event)) {
+            /* timeout enforces that the "closeSubmenu" method will be run after 
+              the browser navigates to the specified href of the menu-item. */
+            setTimeout(() => closeSubmenu());
+          }
+
           if (href && index === undefined) {
             if (
               Events.isEnterKey(event) ||

--- a/src/components/menu/__internal__/submenu/submenu.spec.js
+++ b/src/components/menu/__internal__/submenu/submenu.spec.js
@@ -1036,6 +1036,40 @@ describe("Submenu component", () => {
           ).toBeFocused();
         });
       });
+
+      describe("when enter key pressed", () => {
+        it("it should navigate to href and close submenu", () => {
+          jest.useFakeTimers();
+          document.dispatchEvent(tabKey);
+          wrapper.update();
+
+          expect(document.activeElement).toMatchObject(
+            wrapper
+              .find(StyledSubmenu)
+              .find(StyledMenuItemWrapper)
+              .at(1)
+              .find("a")
+          );
+
+          act(() => {
+            wrapper
+              .find(StyledMenuItemWrapper)
+              .at(1)
+              .props()
+              .onKeyDown(events.enter);
+          });
+
+          wrapper.update();
+
+          act(() => {
+            jest.runAllTimers();
+          });
+
+          wrapper.update();
+
+          expect(wrapper.find(StyledSubmenu).exists()).toEqual(false);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This fix ensures that when a menuitem with a href has a key press of enter, that the broswer navigates to the href and closes the submenu

fixes #4792

### Proposed behaviour

MenuItem should close after `enter` key is pressed.

### Current behaviour

MenuItem currently stays open when `enter` key is pressed.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

<!-- How can a reviewer test this PR? -->

Open storybook and navigate to the menu stories. Default story will do. 
Navigate to a menuitem with a href and press enter. 
Menu should close and browser should navigate to the specified href destination. 
