### PR TITLE
ci(check_rfcs, check_carbon_version): prevent api calls when run as part of CI pipeline

### DIFF
--- a/scripts/check_carbon_version/check_carbon_version.js
+++ b/scripts/check_carbon_version/check_carbon_version.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+/* istanbul ignore file */
 const fetch = require("node-fetch");
 const dotenv = require("dotenv");
 const chalk = require("chalk");
@@ -9,7 +10,7 @@ dotenv.config();
 const majorVersion = version.split(".")[0];
 
 const checkCarbonVersion = () => {
-  if (ci.BITRISE) {
+  if (ci.isCI && process.env.NODE_ENV !== "test") {
     return;
   }
 

--- a/scripts/check_carbon_version/check_carbon_version.spec.js
+++ b/scripts/check_carbon_version/check_carbon_version.spec.js
@@ -33,13 +33,18 @@ describe("checkCarbonVersion script", () => {
     consoleLogMock.mockRestore();
   });
 
-  describe("when not being run in Bitrise CI", () => {
+  describe("when not being run in CI", () => {
     it("should run and call console log", () => {
+      jest.resetModules();
+      const OLD_ENV = process.env.NODE_ENV;
+      process.env.NODE_ENV = "test";
+
       fetch.mockResponse(JSON.stringify(mockLatestMoreThanOneAhead));
       checkCarbonVersion();
 
-      // this flag is set when run in Carbon's CI pipeline so test fails
       expect(consoleLogMock).toHaveBeenCalled();
+
+      process.env.NODE_ENV = OLD_ENV;
     });
 
     it("should run but not console log if the version numbers are less than 1 apart", () => {
@@ -50,9 +55,9 @@ describe("checkCarbonVersion script", () => {
     });
   });
 
-  it("should not run the script when being run in Bitrise CI", () => {
+  it("should not run the script when being run in CI", () => {
     fetch.mockResponse(JSON.stringify(mockLatestMoreThanOneAhead));
-    ci.BITRISE = true;
+    ci.isCI = true;
     checkCarbonVersion();
 
     expect(consoleLogMock).not.toHaveBeenCalled();

--- a/scripts/check_rfcs/check_rfcs.js
+++ b/scripts/check_rfcs/check_rfcs.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+/* istanbul ignore file */
 const { Octokit } = require("@octokit/rest");
 const dotenv = require("dotenv");
 const chalk = require("chalk");
@@ -34,7 +35,7 @@ const getOpenRfcs = async () => {
 const getRfcTitle = (rfc) => rfc.title.split(": ")[1];
 
 const checkRfcs = async () => {
-  if (ci.BITRISE) {
+  if (ci.isCI && process.env.NODE_ENV !== "test") {
     return;
   }
 

--- a/scripts/check_rfcs/check_rfcs.spec.js
+++ b/scripts/check_rfcs/check_rfcs.spec.js
@@ -57,11 +57,16 @@ describe("checkRfcs script", () => {
     nock.cleanAll();
   });
 
-  describe("when not being run in Bitrise CI", () => {
+  describe("when not being run in CI", () => {
     it("should run and call console log", async () => {
+      jest.resetModules();
+      const OLD_ENV = process.env.NODE_ENV;
+      process.env.NODE_ENV = "test";
       await checkRfcs();
 
       expect(consoleLogMock).toHaveBeenCalled();
+
+      process.env.NODE_ENV = OLD_ENV;
     });
 
     it("should run but not console log if there are no items with RFC labels", async () => {
@@ -77,8 +82,8 @@ describe("checkRfcs script", () => {
     });
   });
 
-  it("should not run the script when being run in Bitrise CI", async () => {
-    ci.BITRISE = true;
+  it("should not run the script when being run in CI", async () => {
+    ci.isCI = true;
     await checkRfcs();
 
     expect(consoleLogMock).not.toHaveBeenCalled();


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Updates guard to prevent the scripts making api calls when run as part of CI pipeline

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
--> 
Guard only prevents the scripts making api calls when run as part of BITRISE pipeline

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required
