### PR TITLE
test(accordion): refactor for accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -1,5 +1,4 @@
 import { commonButtonPreviewRoot, getDataElementByValue } from "../../locators";
-import { accordionDefaultTitle } from "../../locators/accordion";
 import {
   actionPopoverButton,
   actionPopoverWrapper,
@@ -48,6 +47,7 @@ export default (from, end) => {
     if (
       !prepareUrl[0].startsWith("welcome") &&
       !prepareUrl[0].startsWith("documentation") &&
+      !prepareUrl[0].startsWith("accordion") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);
@@ -63,10 +63,6 @@ export default (from, end) => {
         "should render %s component with %s story and have no accessibility violations",
         (componentName, storyName) => {
           visitComponentUrl(componentName, storyName);
-          // open the accordion component
-          if (componentName.startsWith("accordion")) {
-            accordionDefaultTitle().click({ multiple: true });
-          }
 
           // open the action-popover component
           if (

--- a/cypress/support/component.js
+++ b/cypress/support/component.js
@@ -3,6 +3,7 @@ import "cypress-each";
 import "cypress-real-events/support";
 import { mount } from "cypress/react";
 import DEBUG_FLAG from "./e2e";
+import { CY_ROOT } from "../locators/locators";
 
 require("cypress-plugin-tab");
 
@@ -21,3 +22,46 @@ Cypress.Commands.add("mount", mount);
 const dayjs = require("dayjs");
 
 Cypress.dayjs = dayjs;
+
+Cypress.Commands.add("checkAccessibility", () => {
+  const A11YOptions = {
+    runOnly: {
+      type: "tag",
+      values: [
+        "wcag2a", // WCAG 2.0 & WCAG 2.1 Level A
+        "wcag2aa", // WCAG 2.0 & WCAG 2.1 Level AA
+        "wcag21a", // WCAG 2.1 Level A
+        "wcag21aa", // WCAG 2.1 Level AA
+        "best-practice", // Best practices endorsed by Deque
+      ],
+    },
+  };
+
+  const terminalLog = (violations) => {
+    cy.task(
+      "log",
+      `${violations.length} accessibility violation${
+        violations.length === 1 ? "" : "s"
+      } ${violations.length === 1 ? "was" : "were"} detected`
+    );
+    // pluck specific keys to keep the table readable
+    const violationData = violations.map(
+      ({ id, impact, description, nodes }) => ({
+        id,
+        impact,
+        description,
+        nodes: nodes.length,
+      })
+    );
+
+    cy.task("table", violationData);
+  };
+
+  cy.get(CY_ROOT).then((root) => {
+    root.addClass("cypress_axe_class");
+  });
+
+  return cy.injectAxe().then(() => {
+    cy.checkA11y(".cypress_axe_class", A11YOptions, terminalLog);
+  });
+});

--- a/src/components/accordion/accordion.stories.tsx
+++ b/src/components/accordion/accordion.stories.tsx
@@ -1,0 +1,553 @@
+import React from "react";
+import Accordion from "./accordion.component";
+import AccordionGroup from "./accordion-group/accordion-group.component";
+import Box from "../box/box.component";
+import Button from "../button/button.component";
+import { Checkbox } from "../checkbox";
+import { Dl, Dt, Dd } from "../definition-list";
+import Link from "../link/link.component";
+import Textbox from "../textbox/textbox.component";
+
+const errorVal = "error";
+const warningVal = "warning";
+const infoVal = "info";
+
+interface ValidationObject {
+  one: string;
+  two: string;
+  three: string;
+}
+
+type Validations = keyof ValidationObject;
+
+// stories for component testing
+export const AccordionComponent = ({ ...props }) => {
+  return (
+    <Accordion
+      onChange={() => {}}
+      subTitle="Sub Title"
+      title="Title"
+      width="100%"
+      {...props}
+    >
+      <div>Content</div>
+      <div>Content</div>
+      <div>Content</div>
+    </Accordion>
+  );
+};
+
+export const AccordionWithIcon = () => {
+  const [errors] = React.useState({
+    one: errorVal,
+  });
+  const [warnings] = React.useState({
+    one: warningVal,
+  });
+
+  const [expanded, setExpanded] = React.useState({
+    one: false,
+  });
+
+  return (
+    <AccordionGroup>
+      <Accordion
+        title="Heading"
+        expanded={expanded.one}
+        onChange={() =>
+          setExpanded((previousState) => ({
+            ...previousState,
+            one: !previousState.one,
+          }))
+        }
+        error={errors.one}
+        warning={warnings.one}
+      >
+        <Checkbox label="Add error" />
+      </Accordion>
+    </AccordionGroup>
+  );
+};
+
+export const AccordionGroupWithError = () => {
+  const [errors] = React.useState({
+    one: errorVal,
+    two: errorVal,
+    three: errorVal,
+  });
+
+  return (
+    <div
+      style={{
+        marginTop: "16px",
+      }}
+    >
+      <AccordionGroup>
+        <Accordion title="Heading" error={errors.one}>
+          <div style={{ padding: "8px" }}>
+            <Checkbox label="Add error" error={!!errors.one} />
+          </div>
+        </Accordion>
+      </AccordionGroup>
+    </div>
+  );
+};
+
+export const AccordionGroupWithWarning = () => {
+  const [warnings] = React.useState({
+    one: warningVal,
+  });
+
+  return (
+    <div
+      style={{
+        marginTop: "16px",
+      }}
+    >
+      <AccordionGroup>
+        <Accordion title="Heading" warning={warnings.one}>
+          <div style={{ padding: "8px" }}>
+            <Checkbox label="Add warning" warning={!!warnings.one} />
+          </div>
+        </Accordion>
+      </AccordionGroup>
+    </div>
+  );
+};
+
+export const AccordionGroupWithInfo = () => {
+  const [infos] = React.useState({
+    one: infoVal,
+  });
+
+  return (
+    <div
+      style={{
+        marginTop: "16px",
+      }}
+    >
+      <AccordionGroup>
+        <Accordion title="Heading" info={infos.one}>
+          <div style={{ padding: "8px" }}>
+            <Checkbox label="Add info" info={!!infos.one} />
+          </div>
+        </Accordion>
+      </AccordionGroup>
+    </div>
+  );
+};
+
+export const AccordionGroupComponent = () => {
+  return (
+    <AccordionGroup>
+      <Accordion title="First Accordion" onChange={() => {}} width="100%">
+        <Box p={2}>
+          <Textbox label="Textbox in an Accordion" />
+        </Box>
+      </Accordion>
+      <Accordion title="Second Accordion" onChange={() => {}} width="100%">
+        <Box p={2}>
+          <Box height="100px" bg="primary" />
+        </Box>
+      </Accordion>
+      <Accordion title="Third Accordion" onChange={() => {}} width="100%">
+        <div>Content</div>
+      </Accordion>
+    </AccordionGroup>
+  );
+};
+
+export const DynamicContent = () => {
+  const [contentCount, setContentCount] = React.useState(3);
+  const modifyContentCount = (modifier: number) => {
+    if (modifier === 1) {
+      setContentCount(contentCount + 1);
+    }
+    if (modifier === -1 && contentCount > 0) {
+      setContentCount(contentCount - 1);
+    }
+  };
+  return (
+    <>
+      <Button data-element="add-content" onClick={() => modifyContentCount(1)}>
+        Add content
+      </Button>
+      <Button
+        data-element="remove-content"
+        onClick={() => modifyContentCount(-1)}
+        ml={2}
+      >
+        Remove content
+      </Button>
+      <Accordion title="Title" defaultExpanded>
+        {Array.from(Array(contentCount).keys()).map((value) => (
+          <div key={value}>Content</div>
+        ))}
+      </Accordion>
+    </>
+  );
+};
+
+// stories from storybook to import
+export const AccordionDefault = ({ ...props }) => {
+  return (
+    <Accordion title="Heading" {...props}>
+      <div>Content</div>
+      <div>Content</div>
+      <div>Content</div>
+    </Accordion>
+  );
+};
+
+export const AccordionWithBoxAndDifferentPaddings = () => {
+  return (
+    <Box>
+      <Accordion
+        expanded
+        disableContentPadding
+        headerSpacing={{
+          p: 2,
+        }}
+        title="Accordion controlled"
+      >
+        <Box p={2} pr="21px">
+          <Box bg="gray">
+            This is example content inside of the Box component with gray
+            background
+          </Box>
+          <div>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in
+            ornare neque. Maecenas pellentesque et erat tincidunt mollis. Etiam
+            diam nisi, elementum efficitur ipsum et, imperdiet iaculis ligula.
+            Cras eget lorem aliquam lorem mollis fringilla a sit amet nisl.
+            Donec semper odio elit, tempus ultrices est molestie id. Ut sit amet
+            sollicitudin ipsum, eu tristique ligula. Praesent velit velit,
+            finibus ut odio sit amet, fringilla iaculis lacus. Aliquam facilisis
+            libero nec ipsum tincidunt imperdiet. Ut commodo mi ac odio blandit,
+            ac molestie ante dapibus. Ut molestie auctor turpis, quis ultrices
+            ante aliquet eu. Aenean et condimentum arcu, non malesuada elit.
+            Cras a magna vestibulum, semper tortor id, molestie eros.
+          </div>
+        </Box>
+      </Accordion>
+      <Accordion
+        disableContentPadding
+        headerSpacing={{
+          p: 3,
+        }}
+        title="Accordion with a very long title Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in ornare neque. Maecenas pellentesque et erat tincidunt mollis. 
+                Etiam diam nisi, elementum efficitur ipsum et, imperdiet iaculis ligula. "
+      >
+        <Box p={3} pr="29px">
+          <Box bg="gray">
+            This is example content inside of the Box component with gray
+            background
+          </Box>
+          <div>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in
+            ornare neque. Maecenas pellentesque et erat tincidunt mollis. Etiam
+            diam nisi, elementum efficitur ipsum et, imperdiet iaculis ligula.
+            Cras eget lorem aliquam lorem mollis fringilla a sit amet nisl.
+            Donec semper odio elit, tempus ultrices est molestie id. Ut sit amet
+            sollicitudin ipsum, eu tristique ligula. Praesent velit velit,
+            finibus ut odio sit amet, fringilla iaculis lacus. Aliquam facilisis
+            libero nec ipsum tincidunt imperdiet. Ut commodo mi ac odio blandit,
+            ac molestie ante dapibus. Ut molestie auctor turpis, quis ultrices
+            ante aliquet eu. Aenean et condimentum arcu, non malesuada elit.
+            Cras a magna vestibulum, semper tortor id, molestie eros.
+          </div>
+        </Box>
+      </Accordion>
+    </Box>
+  );
+};
+
+export const AccordionOpeningButton = () => {
+  return (
+    <div
+      style={{
+        margin: "8px",
+      }}
+    >
+      <Accordion
+        title="More info"
+        openTitle="Less info"
+        scheme="transparent"
+        borders="none"
+        iconAlign="left"
+        buttonHeading
+        buttonWidth={200}
+        error="hello"
+      >
+        <div>Content</div>
+        <div>Content</div>
+        <div>Content</div>
+      </Accordion>
+      <br />
+      <Accordion
+        title="More info"
+        openTitle="Less info"
+        scheme="transparent"
+        borders="none"
+        iconAlign="right"
+        buttonHeading
+        buttonWidth={200}
+      >
+        <div>Content</div>
+        <div>Content</div>
+        <div>Content</div>
+      </Accordion>
+      <br />
+      <Accordion
+        scheme="transparent"
+        borders="none"
+        title="More info"
+        openTitle="Less info"
+        buttonHeading
+        headerSpacing={{
+          px: 0,
+        }}
+        buttonWidth={96}
+      >
+        <div>Content</div>
+        <div>Content</div>
+        <div>Content</div>
+      </Accordion>
+      <br />
+      <Accordion
+        scheme="transparent"
+        borders="none"
+        title="More info"
+        openTitle="Less info"
+        iconAlign="left"
+        buttonHeading
+        buttonWidth={120}
+        headerSpacing={{
+          px: 1,
+        }}
+      >
+        <div>Content</div>
+        <div>Content</div>
+        <div>Content</div>
+      </Accordion>
+    </div>
+  );
+};
+
+export const AccordionGroupDefault = () => {
+  return (
+    <AccordionGroup>
+      <Accordion title="First Accordion">
+        <Box p={2}>
+          <Textbox label="Textbox in an Accordion" />
+        </Box>
+      </Accordion>
+      <Accordion title="Second Accordion">
+        <Box p={2}>
+          <Textbox label="Textbox in an Accordion" />
+        </Box>
+      </Accordion>
+      <Accordion title="Third Accordion">
+        <Box p={2}>
+          <div>Content</div>
+          <div>Content</div>
+          <div>Content</div>
+        </Box>
+      </Accordion>
+    </AccordionGroup>
+  );
+};
+
+export const AccordionGroupValidation = () => {
+  const [errors, setErrors] = React.useState({
+    one: errorVal,
+    two: errorVal,
+    three: errorVal,
+  });
+  const [warnings, setWarnings] = React.useState({
+    one: warningVal,
+    two: warningVal,
+    three: warningVal,
+  });
+  const [infos, setInfos] = React.useState({
+    one: infoVal,
+    two: infoVal,
+    three: infoVal,
+  });
+  const [expanded, setExpanded] = React.useState({
+    one: false,
+    two: false,
+    three: true,
+  });
+
+  const handleChange = (
+    id: Validations,
+    type: ValidationObject,
+    setter: React.Dispatch<React.SetStateAction<ValidationObject>>,
+    msg: string
+  ) => {
+    const update = type[id] ? undefined : msg;
+    setter((previous: ValidationObject) => ({ ...previous, [id]: update }));
+  };
+
+  return (
+    <Box>
+      <AccordionGroup>
+        <Accordion
+          title="Heading"
+          expanded={expanded.one}
+          onChange={() =>
+            setExpanded((previousState) => ({
+              ...previousState,
+              one: !previousState.one,
+            }))
+          }
+          error={errors.one}
+          warning={warnings.one}
+          info={infos.one}
+        >
+          <div
+            style={{
+              padding: "8px",
+            }}
+          >
+            <Checkbox
+              label="Add error"
+              error={!!errors.one}
+              onChange={() => handleChange("one", errors, setErrors, "error")}
+              checked={!!errors.one}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={!!warnings.one}
+              onChange={() =>
+                handleChange("one", warnings, setWarnings, "warning")
+              }
+            />
+            <Checkbox
+              label="Add info"
+              info={!!infos.one}
+              onChange={() => handleChange("one", infos, setInfos, "info")}
+            />
+          </div>
+        </Accordion>
+        <Accordion
+          title="Heading"
+          expanded={expanded.two}
+          onChange={() =>
+            setExpanded((previousState) => ({
+              ...previousState,
+              two: !previousState.two,
+            }))
+          }
+          subTitle="Sub title"
+          error={errors.two}
+          warning={warnings.two}
+          info={infos.two}
+        >
+          <div
+            style={{
+              padding: "8px",
+            }}
+          >
+            <Checkbox
+              label="Add error"
+              error={!!errors.two}
+              onChange={() => handleChange("two", errors, setErrors, "error")}
+              checked={!!errors.two}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={!!warnings.two}
+              onChange={() =>
+                handleChange("two", warnings, setWarnings, "warning")
+              }
+            />
+            <Checkbox
+              label="Add info"
+              info={!!infos.two}
+              onChange={() => handleChange("two", infos, setInfos, "info")}
+            />
+          </div>
+        </Accordion>
+        <Accordion
+          title="Heading"
+          expanded={expanded.three}
+          onChange={() =>
+            setExpanded((previousState) => ({
+              ...previousState,
+              three: !previousState.three,
+            }))
+          }
+          subTitle="This is a longer sub title"
+          error={errors.three}
+          warning={warnings.three}
+          info={infos.three}
+        >
+          <div
+            style={{
+              padding: "8px",
+            }}
+          >
+            <Checkbox
+              label="Add error"
+              error={!!errors.three}
+              onChange={() => handleChange("three", errors, setErrors, "error")}
+              checked={!!errors.three}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={!!warnings.three}
+              onChange={() =>
+                handleChange("three", warnings, setWarnings, "warning")
+              }
+            />
+            <Checkbox
+              label="Add info"
+              info={!!infos.three}
+              onChange={() => handleChange("three", infos, setInfos, "info")}
+            />
+          </div>
+        </Accordion>
+      </AccordionGroup>
+    </Box>
+  );
+};
+
+export const AccordionWithDefinitionList = () => {
+  return (
+    <Accordion title="Heading" expanded>
+      <Dl>
+        <Dt>Drink</Dt>
+        <Dd>Coffee</Dd>
+        <Dt>Brew Method</Dt>
+        <Dd>Stove Top Moka Pot</Dd>
+        <Dt>Brand of Coffee</Dt>
+        <Dd>Magic Coffee Beans</Dd>
+        <Dt>Website</Dt>
+        <Dd>
+          <Link href="www.sage.com">Magic Coffee Beans Website</Link>
+        </Dd>
+        <Dt>Email</Dt>
+        <Dd>
+          <Link href="magic@coffeebeans.com">magic@coffeebeans.com</Link>
+        </Dd>
+        <Dt>Main and Registered Address</Dt>
+        <Dd mb="4px">Magic Coffee Beans,</Dd>
+        <Dd mb="4px">In The Middle of Our Street,</Dd>
+        <Dd mb="4px">Madness,</Dd>
+        <Dd mb="4px">CO4 3VE</Dd>
+        <Dd>
+          <Button
+            buttonType="tertiary"
+            iconType="link"
+            iconPosition="after"
+            href="https://goo.gl/maps/GMReLoBpbn9mdZVZ7"
+          >
+            View in Google Maps
+          </Button>
+        </Dd>
+      </Dl>
+    </Accordion>
+  );
+};

--- a/src/components/accordion/accordion.test.js
+++ b/src/components/accordion/accordion.test.js
@@ -1,10 +1,4 @@
 import * as React from "react";
-import Accordion from "./accordion.component";
-import AccordionGroup from "./accordion-group/accordion-group.component";
-import Checkbox from "../checkbox/checkbox.component";
-import Box from "../box/box.component";
-import Button from "../button";
-import Textbox from "../textbox/textbox.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import {
   accordion,
@@ -21,196 +15,29 @@ import {
   ACCORDION_REMOVE_CONTENT,
 } from "../../../cypress/locators/accordion/locators";
 import { checkGoldenOutline } from "../../../cypress/support/component-helper/common-steps";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+import {
+  AccordionComponent,
+  AccordionWithIcon,
+  AccordionGroupWithError,
+  AccordionGroupWithWarning,
+  AccordionGroupWithInfo,
+  AccordionGroupComponent,
+  DynamicContent,
+  AccordionDefault,
+  AccordionWithBoxAndDifferentPaddings,
+  AccordionOpeningButton,
+  AccordionGroupDefault,
+  AccordionGroupValidation,
+  AccordionWithDefinitionList,
+} from "./accordion.stories.tsx";
+
 const sizes = [
   ["small", "24px"],
   ["large", "46px"],
 ];
 const accWidths = [["700px"], ["900px"], ["1100px"], ["1300px"]];
-
-const AccordionComponent = ({ ...props }) => {
-  return (
-    <Accordion
-      customPadding={0}
-      onChange={() => {}}
-      subTitle="Sub Title"
-      title="Title"
-      width="100%"
-      {...props}
-    >
-      <div>Content</div>
-      <div>Content</div>
-      <div>Content</div>
-    </Accordion>
-  );
-};
-
-const AccordionWithIcon = () => {
-  const [errors] = React.useState({
-    one: "error",
-  });
-  const [warnings] = React.useState({
-    one: "warning",
-  });
-
-  const [expanded, setExpanded] = React.useState({
-    one: false,
-  });
-
-  return (
-    <AccordionGroup>
-      <Accordion
-        title="Heading"
-        expanded={expanded.one}
-        onChange={() =>
-          setExpanded((previousState) => ({
-            ...previousState,
-            one: !previousState.one,
-          }))
-        }
-        error={errors.one}
-        warning={warnings.one}
-      >
-        <Checkbox label="Add error" />
-      </Accordion>
-    </AccordionGroup>
-  );
-};
-
-const AccordionGroupWithError = () => {
-  const [errors] = React.useState({
-    one: "error",
-    two: "error",
-    three: "error",
-  });
-
-  return (
-    <div
-      style={{
-        marginTop: "16px",
-      }}
-    >
-      <AccordionGroup>
-        <Accordion title="Heading" error={errors.one}>
-          <div style={{ padding: "8px" }}>
-            <Checkbox label="Add error" error={!!errors.one} />
-          </div>
-        </Accordion>
-      </AccordionGroup>
-    </div>
-  );
-};
-
-const AccordionGroupWithWarning = () => {
-  const [warnings] = React.useState({
-    one: "warning",
-  });
-
-  return (
-    <div
-      style={{
-        marginTop: "16px",
-      }}
-    >
-      <AccordionGroup>
-        <Accordion title="Heading" warning={warnings.one}>
-          <div style={{ padding: "8px" }}>
-            <Checkbox label="Add warning" warning={!!warnings.one} />
-          </div>
-        </Accordion>
-      </AccordionGroup>
-    </div>
-  );
-};
-
-const AccordionGroupWithInfo = () => {
-  const [infos] = React.useState({
-    one: "info",
-  });
-
-  return (
-    <div
-      style={{
-        marginTop: "16px",
-      }}
-    >
-      <AccordionGroup>
-        <Accordion title="Heading" info={infos.one}>
-          <div style={{ padding: "8px" }}>
-            <Checkbox label="Add info" info={!!infos.one} />
-          </div>
-        </Accordion>
-      </AccordionGroup>
-    </div>
-  );
-};
-
-const AccordionGroupComponent = () => {
-  return (
-    <AccordionGroup>
-      <Accordion
-        title="First Accordion"
-        customPadding={0}
-        onChange={() => {}}
-        width="100%"
-      >
-        <Box p={2}>
-          <Textbox label="Textbox in an Accordion" />
-        </Box>
-      </Accordion>
-      <Accordion
-        title="Second Accordion"
-        customPadding={0}
-        onChange={() => {}}
-        width="100%"
-      >
-        <Box p={2}>
-          <Box height="100px" bg="primary" />
-        </Box>
-      </Accordion>
-      <Accordion
-        title="Third Accordion"
-        customPadding={0}
-        onChange={() => {}}
-        width="100%"
-      >
-        <div>Content</div>
-      </Accordion>
-    </AccordionGroup>
-  );
-};
-
-const DynamicContent = () => {
-  const [contentCount, setContentCount] = React.useState(3);
-  const modifyContentCount = (modifier) => {
-    if (modifier === 1) {
-      setContentCount(contentCount + 1);
-    }
-    if (modifier === -1 && contentCount > 0) {
-      setContentCount(contentCount - 1);
-    }
-  };
-  return (
-    <>
-      <Button data-element="add-content" onClick={() => modifyContentCount(1)}>
-        Add content
-      </Button>
-      <Button
-        data-element="remove-content"
-        onClick={() => modifyContentCount(-1)}
-        ml={2}
-      >
-        Remove content
-      </Button>
-      <Accordion title="Title" defaultExpanded>
-        {Array.from({ length: contentCount }).map((_, index) => (
-          <div key={index}>Content</div>
-        ))}
-      </Accordion>
-    </>
-  );
-};
 
 context("Testing Accordion component", () => {
   describe("should render Accordion component", () => {
@@ -354,7 +181,7 @@ context("Testing Accordion component", () => {
       }
     );
 
-    it.each(specialCharacters)(
+    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
       "should render Accordion component with %s as a title",
       (titleValue) => {
         CypressMountWithProviders(<AccordionComponent title={titleValue} />);
@@ -363,7 +190,7 @@ context("Testing Accordion component", () => {
       }
     );
 
-    it.each(specialCharacters)(
+    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
       "should render Accordion component with %s as a subtitle",
       (titleValue) => {
         CypressMountWithProviders(<AccordionComponent subTitle={titleValue} />);
@@ -568,6 +395,130 @@ context("Testing Accordion component", () => {
       accordionContent().parent().should("have.css", "height", "96px");
       getDataElementByValue(ACCORDION_REMOVE_CONTENT).click();
       accordionContent().parent().should("have.css", "height", "78px");
+    });
+  });
+
+  describe("Accessibility tests for Accordion", () => {
+    it("should pass accessibility tests for AccordionDefault", () => {
+      CypressMountWithProviders(<AccordionDefault />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for AccordionDefault expanded", () => {
+      CypressMountWithProviders(<AccordionDefault expanded />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Accordion with disableContentPadding ", () => {
+      CypressMountWithProviders(<AccordionDefault disableContentPadding />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Accordion transparent", () => {
+      CypressMountWithProviders(<AccordionDefault scheme="transparent" />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Accordion size small", () => {
+      CypressMountWithProviders(<AccordionDefault size="small" />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Accordion with subTitle", () => {
+      CypressMountWithProviders(<AccordionDefault subTitle="Sub title" />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Accordion with full borders", () => {
+      CypressMountWithProviders(<AccordionDefault borders="full" />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Accordion with full borders expanded", () => {
+      CypressMountWithProviders(<AccordionDefault borders="full" expanded />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Accordion with left aligned icon", () => {
+      CypressMountWithProviders(<AccordionDefault iconAlign="left" />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Accordion with 500px width", () => {
+      CypressMountWithProviders(<AccordionDefault width="500px" />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each([
+      [0, 0],
+      [1, 1],
+      [2, 2],
+      [3, 3],
+      [4, 4],
+      [5, 5],
+      [6, 6],
+    ])(
+      "should pass accessibility tests for Accordion with margin set to %s and padding set to %s",
+      (margin, padding) => {
+        CypressMountWithProviders(<AccordionDefault m={margin} p={padding} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([[0], [1], [2], [3], [4], [5], [6]])(
+      "should pass accessibility tests for Accordion with title padding set to %s",
+      (padding) => {
+        CypressMountWithProviders(
+          <AccordionDefault
+            headerSpacing={{
+              p: padding,
+            }}
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibility tests for Accordion with Box and different paddings", () => {
+      CypressMountWithProviders(<AccordionWithBoxAndDifferentPaddings />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Accordion with opening buttons", () => {
+      CypressMountWithProviders(<AccordionOpeningButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for AccordionGroup", () => {
+      CypressMountWithProviders(<AccordionGroupDefault />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for AccordionGroupValidation", () => {
+      CypressMountWithProviders(<AccordionGroupValidation />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for AccordionWithDefinitionList", () => {
+      CypressMountWithProviders(<AccordionWithDefinitionList />);
+
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

POC of the possible refactor for the `accessibility` Cypress tests for the `Accordion` component to use new cypress-component-react framework for testing.

Introduced new `custom` command for `a11y` check.

### Current behaviour

Current process is based on building the `json` story for the all list of `component` -> `story`.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` and check if there are newly added tests for `accessibility`
- [x] Check if the `accordion.test.js` file passed
- [x] Check if the proper condition was added to the `cypress/support/accessibility/a11y-utils.js` to ignore re-added tests
- [x] Check are the tests ignored 
- [x] Check if the `accordion.examples.jsx` file was added
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed