### PR TITLE
fix(multi-action-button): fix styling bug when a href is passed to a button - FE-5375

### DIFF
--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
@@ -340,7 +340,14 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
 .c14 .c1 {
   border: 1px solid var(--colorsActionMajorTransparent);
   color: var(--colorsActionMajor500);
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: left;
+  -webkit-justify-content: left;
+  -ms-flex-pack: left;
+  justify-content: left;
   margin-left: 0;
   min-width: 100%;
   text-align: left;

--- a/src/components/multi-action-button/multi-action-button.component.tsx
+++ b/src/components/multi-action-button/multi-action-button.component.tsx
@@ -164,7 +164,7 @@ export const MultiActionButton = ({
         data-element="toggle-button"
         key="toggle-button"
         {...mainButtonProps}
-        forwardRef={buttonRef}
+        ref={buttonRef}
         iconPosition="after"
         iconType="dropdown"
       >

--- a/src/components/multi-action-button/multi-action-button.style.ts
+++ b/src/components/multi-action-button/multi-action-button.style.ts
@@ -74,11 +74,19 @@ const StyledButtonChildrenContainer = styled.div<StyledButtonChildrenContainerPr
     ${StyledButton} {
       border: 1px solid var(--colorsActionMajorTransparent);
       color: var(--colorsActionMajor500);
-      display: block;
+      display: flex;
+      justify-content: ${align};
       margin-left: 0;
       min-width: 100%;
       text-align: ${align};
       z-index: ${theme.zIndex.overlay};
+
+      /* Styling for Safari. Display flex is not supported on buttons in Safari. */
+      @media not all and (min-resolution: 0.001dpcm) {
+        @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+          display: -webkit-box;
+        }
+      }
 
       &:focus,
       &:hover {


### PR DESCRIPTION
Fixes a styling bug that would appear when a href is passed to a children button

fixes #5483

### Proposed behaviour

<img width="281" alt="Screenshot 2022-10-11 at 16 58 17" src="https://user-images.githubusercontent.com/56251247/195141527-15f7195d-da2a-4f56-a96b-a0b88aa6900e.png">

### Current behaviour

<img width="317" alt="Screenshot 2022-10-10 at 10 45 47" src="https://user-images.githubusercontent.com/56251247/194839136-bd64aca8-5389-46e2-8576-ee18378bddbf.png">

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Use [pensive-jerry-yl0tz4](https://codesandbox.io/s/pensive-jerry-yl0tz4) to test this PR
