### PR TITLE
docs(loader-bar): ensure prop table displays in docs - FE-5405

### DIFF
--- a/src/components/loader-bar/loader-bar.component.tsx
+++ b/src/components/loader-bar/loader-bar.component.tsx
@@ -9,7 +9,7 @@ import StyledLoaderBar, {
 
 export interface LoaderBarProps extends StyledLoaderBarProps, MarginProps {}
 
-const LoaderBar = ({ size = "medium", ...rest }: LoaderBarProps) => {
+export const LoaderBar = ({ size = "medium", ...rest }: LoaderBarProps) => {
   return (
     <StyledLoader {...rest} {...tagComponent("loader-bar", rest)}>
       <StyledLoaderBar size={size}>
@@ -19,4 +19,5 @@ const LoaderBar = ({ size = "medium", ...rest }: LoaderBarProps) => {
   );
 };
 
+LoaderBar.DisplayName = "Loader Bar";
 export default LoaderBar;


### PR DESCRIPTION
DisplayName and named export was missed when loader bar was refactored

### Proposed behaviour

<img width="1081" alt="Screenshot 2022-10-10 at 12 52 08" src="https://user-images.githubusercontent.com/56251247/194860190-d6d9be14-84f7-472c-825f-59c0ee5dca3b.png">


### Current behaviour

<img width="1099" alt="Screenshot 2022-10-10 at 12 52 00" src="https://user-images.githubusercontent.com/56251247/194860223-862778d3-15c3-4c7c-88a5-38d6f90d8f2a.png">

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Props table should appear in Storybook Docs
