### PR TITLE
Add new component to Carbon: Button Minor

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -55,6 +55,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("link-preview") &&
       !prepareUrl[0].startsWith("verticaldivider") &&
       !prepareUrl[0].startsWith("button-bar") &&
+      !prepareUrl[0].startsWith("button-minor") &&
       !prepareUrl[0].startsWith("batch-selection") &&
       !prepareUrl[0].startsWith("carousel") &&
       !prepareUrl[0].startsWith("badge") &&

--- a/src/components/button-minor/button-minor-test.stories.tsx
+++ b/src/components/button-minor/button-minor-test.stories.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import { ButtonProps } from "components/button/button.component";
+import ButtonMinor from "./button-minor.component";
+import { ICONS } from "../icon/icon-config";
+import {
+  BUTTON_SIZES,
+  BUTTON_VARIANTS,
+  BUTTON_ICON_POSITIONS,
+} from "../button/button.config";
+
+export default {
+  title: "Button Minor/Test",
+  includeStories: "DefaultStory",
+  parameters: {
+    info: { disable: true },
+    chromatic: { disable: true },
+  },
+};
+const commonArgTypesButtonMinor = {
+  size: {
+    options: BUTTON_SIZES,
+    control: { type: "select" },
+  },
+  buttonType: {
+    options: BUTTON_VARIANTS,
+    control: {
+      type: "select",
+    },
+  },
+  iconType: {
+    options: [...ICONS, ""],
+    control: {
+      type: "select",
+    },
+  },
+  iconPosition: {
+    options: BUTTON_ICON_POSITIONS,
+    control: { type: "select" },
+  },
+  href: {
+    control: {
+      type: "text",
+    },
+  },
+};
+const commonArgsButtonMinor = {
+  size: "medium",
+  subtext: "",
+  buttonType: "secondary",
+  fullWidth: false,
+  disabled: false,
+  destructive: false,
+  noWrap: false,
+  href: undefined,
+  iconPosition: "before",
+};
+export const DefaultStory = (args: ButtonProps) => (
+  <ButtonMinor onClick={action("click")} {...args}>
+    Example Button
+  </ButtonMinor>
+);
+export const Default = (args: ButtonProps) => <ButtonMinor {...args} />;
+export const ButtonMinorCustom = (props: ButtonProps) => (
+  <ButtonMinor {...props}>Example Button</ButtonMinor>
+);
+export const ButtonMinorDifferentTypes = (props: ButtonProps) => {
+  return (
+    <div>
+      <ButtonMinor buttonType="primary" {...props}>
+        Primary
+      </ButtonMinor>
+      <ButtonMinor buttonType="secondary" {...props}>
+        Secondary
+      </ButtonMinor>
+      <ButtonMinor buttonType="tertiary" {...props}>
+        Tertiary
+      </ButtonMinor>
+    </div>
+  );
+};
+DefaultStory.story = {
+  name: "default",
+  args: {
+    ...commonArgsButtonMinor,
+  },
+  argTypes: {
+    ...commonArgTypesButtonMinor,
+  },
+};

--- a/src/components/button-minor/button-minor.component.tsx
+++ b/src/components/button-minor/button-minor.component.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import StyledButtonMinor from "./button-minor.style";
+import { ButtonProps } from "../button";
+
+export const ButtonMinor = ({
+  buttonType = "secondary",
+  size = "medium",
+  ...rest
+}: ButtonProps) => (
+  <StyledButtonMinor size={size} buttonType={buttonType} {...rest} />
+);
+
+ButtonMinor.displayName = "ButtonMinor";
+
+export default ButtonMinor;

--- a/src/components/button-minor/button-minor.spec.tsx
+++ b/src/components/button-minor/button-minor.spec.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+import Icon from "../icon";
+import {
+  ButtonProps,
+  ButtonTypes,
+  SizeOptions,
+} from "../button/button.component";
+import ButtonMinor from "./button-minor.component";
+import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+
+const render = (props: ButtonProps, renderer: typeof shallow = shallow) => {
+  return renderer(<ButtonMinor {...props} />);
+};
+
+describe("when no props other than children are passed into the component", () => {
+  it("renders the default props and children", () => {
+    const wrapper = render({ children: "foo" });
+    expect(wrapper.contains(<Icon type="filter" />)).toBeFalsy();
+    expect(wrapper.props().buttonType).toEqual("secondary");
+  });
+});
+
+const minorSizesPadding: [SizeOptions, string][] = [
+  [
+    "small",
+    "var(--spacing000) var(--spacing100) var(--spacing000) var(--spacing100)",
+  ],
+  ["medium", "var(--spacing100)"],
+  ["large", "var(--spacing100)"],
+];
+
+interface VariantColorProperties {
+  background?: string;
+  borderColor?: string;
+  color?: string;
+}
+
+const minorColors: [ButtonTypes, VariantColorProperties][] = [
+  [
+    "primary",
+    {
+      background: "var(--colorsActionMinor500)",
+      borderColor: "var(--colorsActionMinorTransparent)",
+      color: "var(--colorsActionMinorYang100)",
+    },
+  ],
+  [
+    "secondary",
+    {
+      background: "transparent",
+      borderColor: "var(--colorsActionMinor500)",
+      color: "var(--colorsActionMinor500)",
+    },
+  ],
+  [
+    "tertiary",
+    {
+      background: "transparent",
+      borderColor: "transparent",
+      color: "var(--colorsActionMinor500)",
+    },
+  ],
+  [
+    "darkBackground",
+    {
+      borderColor: "transparent",
+    },
+  ],
+];
+
+describe("Button Minor", () => {
+  it.each(minorSizesPadding)(
+    "when size is %s the padding is %s",
+    (size, padding) => {
+      const wrapper = mount(<ButtonMinor size={size}>Foo</ButtonMinor>);
+      assertStyleMatch({ padding }, wrapper);
+    }
+  );
+
+  it.each(minorColors)(
+    "when buttonType is %s, renders with correct styling",
+    (buttonType, styles) => {
+      const wrapper = mount(
+        <ButtonMinor buttonType={buttonType}>Foo</ButtonMinor>
+      );
+      assertStyleMatch({ ...styles }, wrapper);
+    }
+  );
+
+  it("when destructive prop is passed, renders with destructive styling", () => {
+    const wrapper = mount(<ButtonMinor destructive>foo</ButtonMinor>);
+    assertStyleMatch(
+      {
+        background: "transparent",
+        color: "var(--colorsSemanticNegative500)",
+      },
+      wrapper
+    );
+  });
+  it("when disabled prop is passed, renders with disabled styling", () => {
+    const wrapper = mount(<ButtonMinor disabled>foo</ButtonMinor>);
+    assertStyleMatch(
+      {
+        background: "transparent",
+        color: "var(--colorsActionMajorYin030)",
+      },
+      wrapper
+    );
+  });
+});

--- a/src/components/button-minor/button-minor.stories.mdx
+++ b/src/components/button-minor/button-minor.stories.mdx
@@ -1,0 +1,241 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+
+import ButtonMinor from ".";
+import Button from "../button";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import * as stories from "./button-minor.stories";
+
+<Meta title="Button Minor" parameters={{ info: { disable: true } }} />
+
+# Button Minor
+
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/4121af-button-minor/b/03680d"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component - Button Minor Component
+</a>
+
+- A minor button is a user interface button rather than a primary action button.
+- It is less prominent than a major button.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quickstart
+
+```javascript
+import ButtonMinor from "carbon-react/lib/components/button-minor";
+```
+
+## Examples
+
+### Primary Buttons
+
+For the single most prominent call to action on the page (e.g. Save, Submit, Continue).
+
+<Canvas>
+  <Story 
+    name="primary" 
+    story={stories.PrimaryButton}
+  />
+</Canvas>
+
+Primary buttons can be destructive.
+
+<Canvas>
+  <Story
+    name="primary/destructive"
+    story={stories.PrimaryDestructiveButton}
+  />
+</Canvas>
+
+Primary buttons can be disabled.
+
+<Canvas>
+  <Story
+    name="primary/disabled"
+    story={stories.PrimaryDisabledButton}
+  />
+</Canvas>
+
+Primary buttons can have an icon positioned before or after the text.
+
+<Canvas>
+  <Story
+    name="primary/icon"
+    story={stories.PrimaryIconButton}
+  />
+</Canvas>
+
+Primary buttons can be `fullWidth`.
+
+<Canvas>
+  <Story
+    name="primary/full-width"
+    story={stories.PrimaryFullWidthButton}
+  />
+</Canvas>
+
+Primary buttons can be set into `noWrap` mode to prevent text wrapping.
+
+<Canvas>
+  <Story
+    name="primary/noWrap"
+    story={stories.PrimaryNoWrapButton}
+  />
+</Canvas>
+
+### Secondary Buttons
+
+Less prominent, there can be multiple secondary buttons on a page.
+Secondary buttons are transparent, rather than white.
+
+<Canvas>
+  <Story
+    name="secondary"
+    story={stories.SecondaryButton}
+  />
+</Canvas>
+
+Secondary buttons can be destructive.
+
+<Canvas>
+  <Story
+    name="secondary/destructive"
+    story={stories.SecondaryDestructiveButton}
+  />
+</Canvas>
+
+Secondary buttons can be disabled.
+
+<Canvas>
+  <Story
+    name="secondary/disabled"
+    story={stories.SecondaryDisabledButton}
+  />
+</Canvas>
+
+Secondary buttons can have an icon positioned before or after the text.
+
+<Canvas>
+  <Story
+    name="secondary/icon"
+    story={stories.SecondaryIconButton}
+  />
+</Canvas>
+
+Secondary buttons can be `fullWidth`.
+
+<Canvas>
+  <Story
+    name="secondary/full-width"
+    story={stories.SecondaryFullWidthButton}
+  />
+</Canvas>
+
+Secondary buttons can be set into `noWrap` mode to prevent text wrapping.
+
+<Canvas>
+  <Story
+    name="secondary/noWrap"
+    story={stories.SecondaryNoWrapButton}
+    parameters={{ chromatic: { disable: true } }}
+  />
+</Canvas>
+
+### Tertiary Buttons
+
+Tertiary Buttons or 'ghost' buttons are used for reversing actions, like 'Cancel' or 'Back'.
+
+<Canvas>
+  <Story
+    name="tertiary"
+    story={stories.TertiaryButton}
+  />
+</Canvas>
+
+Tertiary buttons can be destructive.
+
+<Canvas>
+  <Story
+    name="tertiary/destructive"
+    story={stories.TertiaryDestructiveButton}
+  />
+</Canvas>
+
+Tertiary buttons can be disabled.
+
+<Canvas>
+  <Story
+    name="tertiary/disabled"
+    story={stories.TertiaryDisabledButton}
+  />
+</Canvas>
+
+Tertiary buttons can have an icon positioned before or after the text.
+
+<Canvas>
+  <Story
+    name="tertiary/icon" 
+    story={stories.TertiaryIconButton} />
+</Canvas>
+
+Tertiary buttons can be `fullWidth`.
+
+<Canvas>
+  <Story
+    name="tertiary/full-width"
+    story={stories.TertiaryFullWidthButton}
+  />
+</Canvas>
+
+Tertiary buttons can be set to `noWrap` mode to prevent text wrapping.
+
+<Canvas>
+  <Story
+    name="tertiary/noWrap"
+    story={stories.TertiaryNoWrapButton}
+    parameters={{ chromatic: { disable: true } }}
+  />
+</Canvas>
+
+### Icon Only Button
+
+Buttons can be rendered with just an icon.
+
+<Canvas>
+  <Story
+    name="icon only button"
+    story={stories.IconOnlyButton}
+  />
+</Canvas>
+
+Icon only buttons can also display a tooltip message when the icon is hovered over. This can be acheived by passing a string to the `iconTooltipMessage` prop.
+
+<Canvas>
+  <Story
+    name="icon only button with tooltip"
+    story={stories.IconOnlyWithTooltipButton}
+    parameters={{ chromatic: { disable: true } }}
+  />
+</Canvas>
+
+
+## Props
+
+Options shared between all of the above types of buttons. When setting padding we recommend using either the `p`, `py`
+or `px` props to ensure the spacing within the button is applied evenly.
+
+### Button Minor
+
+<StyledSystemProps
+  of={Button}
+  spacing
+  defaults={{ pt: "1px", pb: "1px", px: "24px" }}
+  noHeader
+/>

--- a/src/components/button-minor/button-minor.stories.tsx
+++ b/src/components/button-minor/button-minor.stories.tsx
@@ -1,0 +1,400 @@
+import React from "react";
+
+import ButtonMinor from ".";
+
+export const PrimaryButton = () => (
+  <>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="primary" size="small">
+      Small
+    </ButtonMinor>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="primary" size="medium">
+      Medium
+    </ButtonMinor>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="primary" size="large">
+      Large
+    </ButtonMinor>
+  </>
+);
+
+export const PrimaryDestructiveButton = () => (
+  <>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="primary"
+      destructive
+      size="small"
+    >
+      Small
+    </ButtonMinor>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="primary"
+      size="medium"
+      destructive
+    >
+      Medium
+    </ButtonMinor>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="primary"
+      destructive
+      size="large"
+    >
+      Large
+    </ButtonMinor>
+  </>
+);
+
+export const PrimaryDisabledButton = () => (
+  <>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="primary"
+      disabled
+      size="small"
+    >
+      Small
+    </ButtonMinor>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="primary"
+      size="medium"
+      disabled
+    >
+      Medium
+    </ButtonMinor>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="primary"
+      disabled
+      size="large"
+    >
+      Large
+    </ButtonMinor>
+  </>
+);
+
+export const PrimaryIconButton = () => (
+  <>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="primary" iconType="print">
+      Medium
+    </ButtonMinor>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="primary"
+      destructive
+      iconType="delete"
+      iconPosition="after"
+    >
+      Medium
+    </ButtonMinor>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="primary"
+      disabled
+      iconType="print"
+      iconPosition="after"
+    >
+      Medium
+    </ButtonMinor>
+  </>
+);
+
+export const PrimaryFullWidthButton = () => (
+  <>
+    <ButtonMinor mt={2} mb={2} buttonType="primary" fullWidth>
+      Full Width
+    </ButtonMinor>
+  </>
+);
+
+export const PrimaryNoWrapButton = () => (
+  <>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="primary" noWrap>
+      Long button text
+    </ButtonMinor>
+  </>
+);
+
+export const SecondaryButton = () => (
+  <>
+    <ButtonMinor mt={2} ml={2} mb={2} size="small">
+      Small
+    </ButtonMinor>
+    <ButtonMinor mt={2} ml={2} mb={2}>
+      Medium
+    </ButtonMinor>
+    <ButtonMinor mt={2} ml={2} mb={2} size="large">
+      Large
+    </ButtonMinor>
+  </>
+);
+
+export const SecondaryDestructiveButton = () => (
+  <>
+    <ButtonMinor mt={2} ml={2} mb={2} destructive size="small">
+      Small
+    </ButtonMinor>
+    <ButtonMinor mt={2} ml={2} mb={2} destructive>
+      Medium
+    </ButtonMinor>
+    <ButtonMinor mt={2} ml={2} mb={2} destructive size="large">
+      Large
+    </ButtonMinor>
+  </>
+);
+
+export const SecondaryDisabledButton = () => (
+  <>
+    <ButtonMinor mt={2} ml={2} mb={2} size="small" disabled>
+      Small
+    </ButtonMinor>
+    <ButtonMinor mt={2} ml={2} mb={2} disabled>
+      Medium
+    </ButtonMinor>
+    <ButtonMinor mt={2} ml={2} mb={2} size="large" disabled>
+      Large
+    </ButtonMinor>
+  </>
+);
+
+export const SecondaryIconButton = () => (
+  <>
+    <ButtonMinor mt={2} ml={2} mb={2} iconType="print">
+      Medium
+    </ButtonMinor>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      destructive
+      iconType="delete"
+      iconPosition="after"
+    >
+      Medium
+    </ButtonMinor>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      disabled
+      iconType="print"
+      iconPosition="after"
+    >
+      Medium
+    </ButtonMinor>
+  </>
+);
+
+export const SecondaryFullWidthButton = () => (
+  <>
+    <ButtonMinor mt={2} mb={2} buttonType="secondary" fullWidth>
+      Full Width
+    </ButtonMinor>
+  </>
+);
+
+export const SecondaryNoWrapButton = () => (
+  <>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="secondary" noWrap>
+      Long button text
+    </ButtonMinor>
+  </>
+);
+
+export const TertiaryButton = () => (
+  <>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="tertiary" size="small">
+      Small
+    </ButtonMinor>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="tertiary">
+      Medium
+    </ButtonMinor>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="tertiary" size="large">
+      Large
+    </ButtonMinor>
+  </>
+);
+
+export const TertiaryDestructiveButton = () => (
+  <>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="tertiary"
+      destructive
+      size="small"
+    >
+      Small
+    </ButtonMinor>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="tertiary" destructive>
+      Medium
+    </ButtonMinor>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="tertiary"
+      destructive
+      size="large"
+    >
+      Large
+    </ButtonMinor>
+  </>
+);
+
+export const TertiaryDisabledButton = () => (
+  <>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="tertiary"
+      disabled
+      size="small"
+    >
+      Small
+    </ButtonMinor>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="tertiary" disabled>
+      Medium
+    </ButtonMinor>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="tertiary"
+      disabled
+      size="large"
+    >
+      Large
+    </ButtonMinor>
+  </>
+);
+
+export const TertiaryIconButton = () => (
+  <>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="tertiary" iconType="print">
+      Medium
+    </ButtonMinor>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="tertiary"
+      destructive
+      iconType="delete"
+      iconPosition="after"
+    >
+      Medium
+    </ButtonMinor>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="tertiary"
+      disabled
+      iconType="print"
+      iconPosition="after"
+    >
+      Medium
+    </ButtonMinor>
+  </>
+);
+
+export const TertiaryFullWidthButton = () => (
+  <>
+    <ButtonMinor mt={2} mb={2} buttonType="tertiary" fullWidth>
+      Full Width
+    </ButtonMinor>
+  </>
+);
+
+export const TertiaryNoWrapButton = () => (
+  <>
+    <ButtonMinor mt={2} ml={2} mb={2} buttonType="tertiary" noWrap>
+      Long button text
+    </ButtonMinor>
+  </>
+);
+
+export const IconOnlyButton = () => (
+  <>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="primary"
+      size="small"
+      iconType="bin"
+      aria-label="Delete"
+    />
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      destructive
+      iconType="bin"
+      aria-label="Delete"
+    />
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      disabled
+      size="large"
+      iconType="bin"
+      aria-label="Delete"
+    />
+  </>
+);
+
+export const IconOnlyWithTooltipButton = () => (
+  <>
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      buttonType="primary"
+      size="small"
+      iconType="bin"
+      iconTooltipMessage="This is a tooltip"
+      aria-label="Delete"
+    />
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      destructive
+      iconType="bin"
+      iconTooltipMessage="This is a tooltip"
+      aria-label="Delete"
+    />
+    <ButtonMinor
+      mt={2}
+      ml={2}
+      mb={2}
+      disabled
+      size="large"
+      iconType="bin"
+      iconTooltipMessage="This is a tooltip"
+      aria-label="Delete"
+    />
+  </>
+);

--- a/src/components/button-minor/button-minor.style.ts
+++ b/src/components/button-minor/button-minor.style.ts
@@ -1,0 +1,80 @@
+import styled, { css } from "styled-components";
+import Button from "../button";
+
+import StyledIcon from "../icon/icon.style";
+import StyledLoaderSquare from "../loader/loader-square.style";
+
+function makeColors(color: string) {
+  return `
+  color: ${color};
+  ${StyledIcon} {
+    color: ${color};
+  }
+  ${StyledLoaderSquare} {
+    background-color: ${color};
+  }
+  `;
+}
+
+const StyledButtonMinor = styled(Button)`
+  ${({ buttonType, destructive, disabled }) =>
+    !destructive &&
+    !disabled &&
+    css`
+      ${buttonType === "primary" &&
+      `
+      background: var(--colorsActionMinor500);
+      border-color: var(--colorsActionMinorTransparent);
+      ${makeColors("var(--colorsActionMinorYang100)")}
+      &:hover {
+        background: var(--colorsActionMinor600);
+      }
+    `}
+
+      ${buttonType === "secondary" &&
+      `
+      background: transparent;
+      padding: var(--spacing100);
+      border-color: var(--colorsActionMinor500);
+      ${makeColors("var(--colorsActionMinor500)")}
+      &:hover {
+        color: var(--colorsActionMinorYang100);
+        background: var(--colorsActionMinor600);
+      }
+    `}
+
+      ${buttonType === "tertiary" &&
+      `
+      background: transparent;
+      padding: var(--spacing100);
+      ${makeColors("var(--colorsActionMinor500)")}
+      &:hover {
+        color: var(--colorsActionMinorYang100);
+        background: var(--colorsActionMinor600);
+      }
+    `}
+    `}
+
+  ${({ size }) => css`
+    ${size === "small" &&
+    `
+        min-height: 32px;
+        padding: var(--spacing000) var(--spacing100) var(--spacing000)
+          var(--spacing100);
+      `}
+
+    ${size === "medium" &&
+    `
+        padding-left: var(--spacing150);
+        padding-right: var(--spacing150);
+      `}
+
+    ${size === "large" &&
+    `
+        padding-left: var(--spacing200);
+        padding-right: var(--spacing200);
+      `}
+  `}
+`;
+
+export default StyledButtonMinor;

--- a/src/components/button-minor/button-minor.test.js
+++ b/src/components/button-minor/button-minor.test.js
@@ -1,0 +1,416 @@
+import React from "react";
+
+import {
+  Default as ButtonMinor,
+  ButtonMinorCustom,
+  ButtonMinorDifferentTypes,
+} from "./button-minor-test.stories";
+
+import * as stories from "./button-minor.stories.tsx";
+
+import { BUTTON_SIZES, BUTTON_ICON_POSITIONS } from "../button/button.config";
+
+import {
+  buttonSubtextPreview,
+  buttonDataComponent,
+} from "../../../cypress/locators/button";
+
+import { cyRoot, icon, tooltipPreview } from "../../../cypress/locators";
+import { positionOfElement } from "../../../cypress/support/helper";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
+import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-helper/common-steps";
+
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+
+const destructive = "rgb(203, 55, 74)";
+const transparent = "rgba(0, 0, 0, 0)";
+
+context("Test for Button Minor component", () => {
+  describe("Check props for Button Minor component", () => {
+    it("should render Button Minor with aria-label prop", () => {
+      CypressMountWithProviders(
+        <ButtonMinorCustom aria-label="cypress-aria" />
+      );
+
+      buttonDataComponent().should("have.attr", "aria-label", "cypress-aria");
+    });
+
+    it.each(testData)(
+      "should render Button Minor label using %s special characters",
+      (label) => {
+        CypressMountWithProviders(<ButtonMinor>{label}</ButtonMinor>);
+
+        buttonDataComponent().should("have.text", label);
+      }
+    );
+
+    it.each(testData)(
+      "should render Button Minor subtext with %s special characters",
+      (subtext) => {
+        CypressMountWithProviders(
+          <ButtonMinorCustom size="large" subtext={subtext} />
+        );
+
+        buttonSubtextPreview().should("have.text", subtext);
+      }
+    );
+
+    it.each(testData)(
+      "should render Button Minor name using %s special characters",
+      (name) => {
+        CypressMountWithProviders(<ButtonMinorCustom name={name} />);
+
+        buttonDataComponent().should("have.attr", "name", name);
+      }
+    );
+
+    it.each(testData)(
+      "should render Button Minor id using %s special characters",
+      (id) => {
+        CypressMountWithProviders(<ButtonMinorCustom id={id} />);
+
+        buttonDataComponent().should("have.attr", "id", id);
+      }
+    );
+
+    it.each(testData)(
+      "should render tooltip message with %s special characters",
+      (tooltipMessage) => {
+        CypressMountWithProviders(
+          <ButtonMinor
+            iconType="bin"
+            iconTooltipMessage={tooltipMessage}
+            m="100px"
+          />
+        );
+
+        buttonDataComponent().children().last().realHover();
+        tooltipPreview().should("have.text", tooltipMessage);
+        cyRoot().realHover({ position: "topLeft" });
+      }
+    );
+
+    it.each([
+      [BUTTON_SIZES[0], 32],
+      [BUTTON_SIZES[1], 40],
+      [BUTTON_SIZES[2], 48],
+    ])("should render Button Minor in %s size", (size, minHeight) => {
+      CypressMountWithProviders(<ButtonMinor size={size}>{size}</ButtonMinor>);
+
+      buttonDataComponent().should("have.css", "min-height", `${minHeight}px`);
+    });
+
+    it.each([
+      [BUTTON_ICON_POSITIONS[0], "right"],
+      [BUTTON_ICON_POSITIONS[1], "left"],
+    ])(
+      "should set position to %s for icon in a button",
+      (iconPosition, margin) => {
+        CypressMountWithProviders(
+          <ButtonMinorCustom iconType="add" iconPosition={iconPosition} />
+        );
+
+        icon().should("have.css", `margin-${margin}`, "8px");
+      }
+    );
+
+    it("should render Button Minor with full width", () => {
+      CypressMountWithProviders(<ButtonMinorCustom fullWidth />);
+
+      buttonDataComponent().then(($el) => {
+        useJQueryCssValueAndAssert($el, "width", 1365);
+      });
+    });
+
+    it("should render Button Minor with href", () => {
+      CypressMountWithProviders(
+        <ButtonMinorCustom href="https://carbon.sage.com/" />
+      );
+
+      buttonDataComponent().should(
+        "have.attr",
+        "href",
+        "https://carbon.sage.com/"
+      );
+    });
+
+    it.each([
+      [true, "white-space"],
+      [false, "flex-wrap"],
+    ])(
+      "should render the Button Minor text with noWrap prop set to %s",
+      (booleanState, cssValue) => {
+        const assertion = booleanState ? "nowrap" : "wrap";
+
+        CypressMountWithProviders(
+          <ButtonMinor noWrap={booleanState}>
+            {" "}
+            Long long long long long text{" "}
+          </ButtonMinor>
+        );
+
+        buttonDataComponent().should("have.css", cssValue, assertion);
+      }
+    );
+
+    it("should check Button Minor is disabled", () => {
+      CypressMountWithProviders(<ButtonMinorDifferentTypes disabled />);
+
+      for (let i = 0; i < 3; i++) {
+        buttonDataComponent()
+          .eq(i)
+          .should("be.disabled")
+          .and("have.attr", "disabled");
+      }
+    });
+
+    it("should check Button Minor is enabled", () => {
+      CypressMountWithProviders(<ButtonMinorDifferentTypes />);
+
+      for (let i = 0; i < 3; i++) {
+        buttonDataComponent().eq(i).should("be.enabled");
+      }
+    });
+
+    it("should check Button Minor is destructive", () => {
+      CypressMountWithProviders(<ButtonMinorDifferentTypes destructive />);
+
+      cyRoot().realHover({ position: "topRight" });
+
+      buttonDataComponent()
+        .eq(positionOfElement("first"))
+        .should(
+          "have.css",
+          "background",
+          `${destructive} none repeat scroll 0% 0% / auto padding-box border-box`
+        )
+        .and("have.css", "border-color", transparent)
+        .and("have.css", "color", "rgb(255, 255, 255)");
+      buttonDataComponent()
+        .eq(positionOfElement("second"))
+        .should(
+          "have.css",
+          "background",
+          `${transparent} none repeat scroll 0% 0% / auto padding-box border-box`
+        )
+        .and("have.css", "border-color", destructive)
+        .and("have.css", "color", destructive);
+      buttonDataComponent()
+        .eq(positionOfElement("third"))
+        .should(
+          "have.css",
+          "background",
+          "rgba(0, 0, 0, 0) none repeat scroll 0% 0% / auto padding-box border-box"
+        )
+        .and("have.css", "border-color", transparent)
+        .and("have.css", "color", destructive);
+    });
+
+    it.each(["noopener", "noreferrer", "opener"])(
+      "should render Button Minor with rel prop set to %s",
+      (rel) => {
+        CypressMountWithProviders(<ButtonMinorCustom rel={rel} />);
+
+        buttonDataComponent().should("have.attr", "rel", rel);
+      }
+    );
+
+    it.each(["_blank", "_self", "_parent", "_top"])(
+      "should render Button Minor with target prop set to %s",
+      (target) => {
+        CypressMountWithProviders(<ButtonMinorCustom target={target} />);
+
+        buttonDataComponent().should("have.attr", "target", target);
+      }
+    );
+
+    it.each(["add", "share", "tick"])(
+      "should render Button Minor with type prop set to %s",
+      (type) => {
+        CypressMountWithProviders(<ButtonMinorCustom type={type} />);
+
+        buttonDataComponent().should("have.attr", "type", type);
+      }
+    );
+  });
+
+  describe("check events for Button Minor component", () => {
+    let callback;
+
+    beforeEach(() => {
+      callback = cy.stub();
+    });
+
+    it("should call onClick callback when a click event is triggered", () => {
+      CypressMountWithProviders(<ButtonMinorCustom onClick={callback} />);
+
+      buttonDataComponent()
+        .click()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          expect(callback).to.have.been.calledOnce;
+        });
+    });
+
+    it("should call onBlur callback when a blur event is triggered", () => {
+      CypressMountWithProviders(<ButtonMinorCustom onBlur={callback} />);
+
+      buttonDataComponent()
+        .focus()
+        .blur()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          expect(callback).to.have.been.calledOnce;
+        });
+    });
+
+    it.each(["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Enter"])(
+      "should call onKeyDown callback when a keydown event is triggered",
+      (key) => {
+        CypressMountWithProviders(<ButtonMinorCustom onKeyDown={callback} />);
+
+        buttonDataComponent()
+          .focus()
+          .realPress(key)
+          .then(() => {
+            // eslint-disable-next-line no-unused-expressions
+            expect(callback).to.have.been.calledOnce;
+          });
+      }
+    );
+
+    it("should call onFocus callback when a focus event is triggered", () => {
+      CypressMountWithProviders(<ButtonMinorCustom onFocus={callback} />);
+
+      buttonDataComponent()
+        .focus()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          expect(callback).to.have.been.calledOnce;
+        });
+    });
+  });
+
+  describe("accessibility tests", () => {
+    it("should check accessibility for primary Button Minor", () => {
+      CypressMountWithProviders(<stories.PrimaryButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for primary destructive Button Minor", () => {
+      CypressMountWithProviders(<stories.PrimaryDestructiveButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for primary disabled Button Minor", () => {
+      CypressMountWithProviders(<stories.PrimaryDisabledButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for primary icon before and after Button Minor", () => {
+      CypressMountWithProviders(<stories.PrimaryIconButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for primary full width Button Minor", () => {
+      CypressMountWithProviders(<stories.PrimaryFullWidthButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for primary no wrap Button Minor", () => {
+      CypressMountWithProviders(<stories.PrimaryNoWrapButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for secondary Button Minor", () => {
+      CypressMountWithProviders(<stories.SecondaryButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for secondary destrictive Button Minor", () => {
+      CypressMountWithProviders(<stories.SecondaryDestructiveButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for secondary disabled Button Minor", () => {
+      CypressMountWithProviders(<stories.SecondaryDisabledButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for secondary icon before and after Button Minor", () => {
+      CypressMountWithProviders(<stories.SecondaryIconButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for secondary full width Button Minor", () => {
+      CypressMountWithProviders(<stories.SecondaryFullWidthButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for secondary no wrap Button Minor", () => {
+      CypressMountWithProviders(<stories.SecondaryNoWrapButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for tertiary Button Minor", () => {
+      CypressMountWithProviders(<stories.TertiaryButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for tertiary destructive Button Minor", () => {
+      CypressMountWithProviders(<stories.TertiaryDestructiveButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for tertiary disabled Button Minor", () => {
+      CypressMountWithProviders(<stories.TertiaryDisabledButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for tertiary icon before and after Button Minor", () => {
+      CypressMountWithProviders(<stories.TertiaryIconButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for tertiary full width Button Minor", () => {
+      CypressMountWithProviders(<stories.TertiaryFullWidthButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for tertiary no wrap Button Minor", () => {
+      CypressMountWithProviders(<stories.TertiaryNoWrapButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for icon only Button Minor", () => {
+      CypressMountWithProviders(<stories.IconOnlyButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for icon only with tooltip Button Minor", () => {
+      CypressMountWithProviders(<stories.IconOnlyWithTooltipButton />);
+
+      cy.checkAccessibility();
+    });
+  });
+});

--- a/src/components/button-minor/index.ts
+++ b/src/components/button-minor/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./button-minor.component";
+export type { ButtonProps as ButtonMinorProps } from "../button";

--- a/src/components/button/button-types.style.ts
+++ b/src/components/button/button-types.style.ts
@@ -79,7 +79,7 @@ export default (isDisabled?: boolean, destructive?: boolean) => ({
       `
           : ""
       }
-
+      
       ${
         isDisabled
           ? `
@@ -163,7 +163,7 @@ export default (isDisabled?: boolean, destructive?: boolean) => ({
       background: var(--colorsActionMajor600);
       ${makeColors("var(--colorsActionMajorYang100)")}
     }
-
+    
     ${
       isDisabled
         ? `

--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -136,14 +136,16 @@ RenderChildrenProps) {
       {iconType && iconPosition === "before" && children && (
         <Icon type={iconType} {...iconProps} />
       )}
-      <span>
-        <span data-element="main-text">{children}</span>
-        {size === "large" && (
-          <StyledButtonSubtext data-element="subtext">
-            {subtext}
-          </StyledButtonSubtext>
-        )}
-      </span>
+      {children && (
+        <span>
+          <span data-element="main-text">{children}</span>
+          {size === "large" && (
+            <StyledButtonSubtext data-element="subtext">
+              {subtext}
+            </StyledButtonSubtext>
+          )}
+        </span>
+      )}
       {iconType && !children && (
         <TooltipProvider
           disabled={disabled}

--- a/src/components/button/button.spec.tsx
+++ b/src/components/button/button.spec.tsx
@@ -33,6 +33,7 @@ const sizesPadding: [SizeOptions, string][] = [
   ["medium", "24px"],
   ["large", "32px"],
 ];
+
 const sizesHeights: [SizeOptions, string][] = [
   ["small", "32px"],
   ["medium", "40px"],
@@ -509,7 +510,10 @@ describe("Button", () => {
                   variant === "dashed"
                     ? "var(--colorsActionMinorYin030)"
                     : "var(--colorsActionMajorYin030)",
-                fontSize: size === "large" ? "16px" : "var(--fontSizes100)",
+                fontSize:
+                  size === "large"
+                    ? "var(--fontSizes200)"
+                    : "var(--fontSizes100)",
                 minHeight: height,
               },
               wrapper
@@ -544,7 +548,10 @@ describe("Button", () => {
                   variant === "dashed"
                     ? "var(--colorsActionMinorYin030)"
                     : "var(--colorsActionMajorYin030)",
-                fontSize: size === "large" ? "16px" : "var(--fontSizes100)",
+                fontSize:
+                  size === "large"
+                    ? "var(--fontSizes200)"
+                    : "var(--fontSizes100)",
                 minHeight: height,
               },
               wrapper

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -13,14 +13,6 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 >
   Product Design System component - Button Major Component
 </a>
-<br/>
-<a
-  target="_blank"
-  href="https://zeroheight.com/2ccf2b601/p/4121af-button-minor/b/03680d"
-  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
->
-  Product Design System component - Button Minor Component
-</a>
 
 A Button triggers a single action or event.
 Use it to submit a form (Save), to advance to the next step in a process (Next), or to create a new item (New).
@@ -46,7 +38,7 @@ For the single most prominent call to action on the page (e.g. Save, Submit, Con
 <Canvas>
   <Story name="primary">
     <>
-      <Button mt={2} buttonType="primary" size="small">
+      <Button mt={2} buttonType="primary" size="small" ml={2}>
         Small
       </Button>
       <Button mt={2} buttonType="primary" ml={2}>
@@ -64,7 +56,7 @@ Primary buttons can be destructive.
 <Canvas>
   <Story name="primary/destructive">
     <>
-      <Button mt={2} buttonType="primary" destructive size="small">
+      <Button mt={2} buttonType="primary" destructive size="small" ml={2}>
         Small
       </Button>
       <Button mt={2} buttonType="primary" destructive ml={2}>
@@ -82,7 +74,7 @@ Primary buttons can be disabled.
 <Canvas>
   <Story name="primary/disabled">
     <>
-      <Button mt={2} buttonType="primary" disabled size="small">
+      <Button mt={2} buttonType="primary" disabled size="small" ml={2}>
         Small
       </Button>
       <Button mt={2} buttonType="primary" disabled ml={2}>
@@ -100,7 +92,7 @@ Primary buttons can have an icon positioned before or after the text.
 <Canvas>
   <Story name="primary/icon">
     <>
-      <Button mt={2} buttonType="primary" iconType="print">
+      <Button ml={2} mt={2} buttonType="primary" iconType="print">
         Medium
       </Button>
       <Button
@@ -123,7 +115,7 @@ Primary buttons can have an icon positioned before or after the text.
       >
         Medium
       </Button>
-    </>
+      </>
   </Story>
 </Canvas>
 
@@ -143,7 +135,7 @@ Primary buttons can be set into `noWrap` mode to prevent text wrapping.
 
 <Canvas>
   <Story name="primary/noWrap">
-    <Button mt={2} buttonType="primary" noWrap>
+    <Button ml={2} mt={2} buttonType="primary" noWrap>
       Long button text
     </Button>
   </Story>
@@ -157,7 +149,7 @@ Secondary buttons are transparent, rather than white.
 <Canvas>
   <Story name="secondary">
     <>
-      <Button mt={2} size="small">
+      <Button mt={2} size="small" ml={2}>
         Small
       </Button>
       <Button mt={2} ml={2}>
@@ -175,7 +167,7 @@ Secondary buttons can be destructive.
 <Canvas>
   <Story name="secondary/destructive">
     <>
-      <Button mt={2} destructive size="small">
+      <Button mt={2} destructive size="small" ml={2}>
         Small
       </Button>
       <Button mt={2} destructive ml={2}>
@@ -193,7 +185,7 @@ Secondary buttons can be disabled.
 <Canvas>
   <Story name="secondary/disabled">
     <>
-      <Button mt={2} size="small" disabled>
+      <Button mt={2} size="small" disabled ml={2}>
         Small
       </Button>
       <Button mt={2} disabled ml={2}>
@@ -211,7 +203,7 @@ Secondary buttons can have an icon positioned before or after the text.
 <Canvas>
   <Story name="secondary/icon">
     <>
-      <Button mt={2} iconType="print">
+      <Button mt={2} iconType="print" ml={2}>
         Medium
       </Button>
       <Button mt={2} destructive iconType="delete" iconPosition="after" ml={2}>
@@ -240,7 +232,7 @@ Secondary buttons can be set into `noWrap` mode to prevent text wrapping.
 
 <Canvas>
   <Story name="secondary/noWrap" parameters={{ chromatic: { disable: true } }}>
-    <Button mt={2} buttonType="secondary" noWrap>
+    <Button ml={2} mt={2} buttonType="secondary" noWrap>
       Long button text
     </Button>
   </Story>
@@ -253,7 +245,7 @@ Tertiary or ‘ghost’ buttons are used for reversing actions, like ‘Cancel�
 <Canvas>
   <Story name="tertiary">
     <>
-      <Button mt={2} buttonType="tertiary" size="small">
+      <Button mt={2} buttonType="tertiary" size="small" ml={2}>
         Small
       </Button>
       <Button mt={2} buttonType="tertiary" ml={2}>
@@ -271,7 +263,7 @@ Tertiary buttons can be destructive.
 <Canvas>
   <Story name="tertiary/destructive">
     <>
-      <Button mt={2} buttonType="tertiary" destructive size="small">
+      <Button mt={2} buttonType="tertiary" destructive size="small" ml={2}>
         Small
       </Button>
       <Button mt={2} buttonType="tertiary" destructive ml={2}>
@@ -289,7 +281,7 @@ Tertiary buttons can be disabled.
 <Canvas>
   <Story name="tertiary/disabled">
     <>
-      <Button mt={2} buttonType="tertiary" disabled size="small">
+      <Button mt={2} buttonType="tertiary" disabled size="small" ml={2}>
         Small
       </Button>
       <Button mt={2} buttonType="tertiary" disabled ml={2}>
@@ -307,7 +299,7 @@ Tertiary buttons can have an icon positioned before or after the text.
 <Canvas>
   <Story name="tertiary/icon">
     <>
-      <Button mt={2} buttonType="tertiary" iconType="print">
+      <Button mt={2} buttonType="tertiary" iconType="print" ml={2}>
         Medium
       </Button>
       <Button
@@ -350,7 +342,7 @@ Tertiary buttons can be set to `noWrap` mode to prevent text wrapping.
 
 <Canvas>
   <Story name="tertiary/noWrap" parameters={{ chromatic: { disable: true } }}>
-    <Button mt={2} buttonType="tertiary" noWrap>
+    <Button ml={2} mt={2} buttonType="tertiary" noWrap>
       Long button text
     </Button>
   </Story>
@@ -461,7 +453,7 @@ Passing in the `href` prop will render an anchor with `role="button"` and the Bu
 
 <Canvas>
   <Story name="as a link">
-    <Button mt={2} buttonType="primary" href="/">
+    <Button ml={2} mt={2} buttonType="primary" href="/">
       I'm a link
     </Button>
     <Button
@@ -486,6 +478,7 @@ Buttons can be rendered with just an icon.
     <>
       <Button
         mt={2}
+        ml={2}
         buttonType="primary"
         size="small"
         iconType="bin"
@@ -494,7 +487,7 @@ Buttons can be rendered with just an icon.
       <Button mt={2} destructive ml={2} iconType="bin" aria-label="Delete" />
       <Button
         mt={2}
-        buttonType="dashed"
+        disabled
         size="large"
         ml={2}
         iconType="bin"
@@ -514,6 +507,7 @@ Icon only buttons can also display a tooltip message when the icon is hovered ov
     <>
       <Button
         mt={2}
+        ml={2}
         buttonType="primary"
         size="small"
         iconType="bin"
@@ -523,15 +517,16 @@ Icon only buttons can also display a tooltip message when the icon is hovered ov
       <Button
         destructive
         ml={2}
+        mt={2}
         iconType="bin"
         iconTooltipMessage="This is a tooltip"
         aria-label="Delete"
       />
       <Button
         mt={2}
-        buttonType="dashed"
-        size="large"
         ml={2}
+        disabled
+        size="large"
         iconType="bin"
         iconTooltipMessage="This is a tooltip"
         aria-label="Delete"

--- a/src/components/button/button.style.ts
+++ b/src/components/button/button.style.ts
@@ -64,9 +64,10 @@ function stylingForType({
     
     ${size === "large" &&
     css`
-      font-size: 16px;
+      font-size: var(--fontSizes200);
       min-height: 48px;
     `}
+
     ${iconOnly && stylingForIconOnly(size)}
   `;
 }
@@ -95,7 +96,7 @@ const StyledButton = styled.button<StyledButtonProps>`
     css`
       width: 100%;
     `}
-
+    
   ${({ iconOnly, iconPosition, iconType }) => css`
     ${StyledIcon} {
       margin-left: ${!iconOnly && iconPosition === "after"


### PR DESCRIPTION
### Proposed behaviour
<img width="167" alt="Screenshot 2022-11-23 at 14 12 13" src="https://user-images.githubusercontent.com/48626342/203568968-4b2bd2b2-15aa-4555-b594-43af4b385878.png">
<img width="945" alt="Screenshot 2022-11-23 at 14 13 39" src="https://user-images.githubusercontent.com/48626342/203568990-90a81175-ed2f-4c04-a546-10b17d974ea4.png">
<img width="956" alt="Screenshot 2022-11-23 at 14 14 02" src="https://user-images.githubusercontent.com/48626342/203569004-5bc50d90-31e3-4358-8c70-e89932d37bb1.png">
<img width="941" alt="Screenshot 2022-11-23 at 14 14 27" src="https://user-images.githubusercontent.com/48626342/203569025-023b42dc-c130-45a6-ab9f-b4294d9ec870.png">
<img width="949" alt="Screenshot 2022-11-23 at 14 14 45" src="https://user-images.githubusercontent.com/48626342/203569044-dd65c868-fc41-4654-be48-0b975c993e77.png">
<img width="949" alt="Screenshot 2022-11-23 at 14 15 01" src="https://user-images.githubusercontent.com/48626342/203569062-07556729-22d2-49d7-bae9-6265ceee44d2.png">
<img width="941" alt="Screenshot 2022-11-23 at 14 15 16" src="https://user-images.githubusercontent.com/48626342/203569085-8b0187d4-5f21-4a62-aede-c559e13b9d19.png">
<img width="936" alt="Screenshot 2022-11-23 at 14 15 32" src="https://user-images.githubusercontent.com/48626342/203569110-de5b6c2f-fc01-48ea-8de2-ae714269334f.png">


<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour
The Button Minor is a new component. The boolean prop isMinor is added to render a Button Minor variant. Storybook stories has been updated to reflect the differences between Minor and Major varinats.
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
