### PR TITLE
chore(tab): make isTabSelected prop private and ignore in prop table docs

### DIFF
--- a/src/components/tabs/tab/tab.component.js
+++ b/src/components/tabs/tab/tab.component.js
@@ -103,7 +103,7 @@ Tab.propTypes = {
   children: PropTypes.node,
   /** Overrides Title default layout with a one defined in this prop */
   customLayout: PropTypes.node,
-  /** Boolean indicating selected state of Tab. */
+  /** @ignore @private Boolean indicating selected state of Tab. */
   isTabSelected: PropTypes.bool,
   /** The position of the Tab. */
   position: PropTypes.oneOf(["top", "left"]),

--- a/src/components/tabs/tab/tab.d.ts
+++ b/src/components/tabs/tab/tab.d.ts
@@ -14,7 +14,7 @@ export interface TabProps extends PaddingProps {
   className?: string;
   /** The child elements of Tab component. */
   children?: React.ReactNode;
-  /** Boolean indicating selected state of Tab. */
+  /** @ignore @private Boolean indicating selected state of Tab. */
   isTabSelected?: boolean;
   /** The position of the Tab. */
   position?: "top" | "left";


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Adds `private` and `ignore` annotations to the `isTabSelected` prop as it is an internal prop that cannot be used by passing a value to it.
![image](https://user-images.githubusercontent.com/44157880/195645323-0aed1b1f-729e-4ff1-b197-e40d1ec2fb5c.png)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
 `isTabSelected` prop is exposed in the `Tab` prop table
![image](https://user-images.githubusercontent.com/44157880/195645276-e5b9efd8-9dcf-4ff8-8315-cfeb55cd8b14.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
