### PR TITLE
test(tabs): update flaky test

### DIFF
--- a/src/components/tabs/tabs.test.js
+++ b/src/components/tabs/tabs.test.js
@@ -543,8 +543,11 @@ context("Testing Tabs component", () => {
       (id, validationMessage) => {
         CypressMountWithProviders(<TabsComponentValidations />);
 
-        tabById(id).realHover();
-        tooltipPreview().should("have.text", validationMessage);
+        tabById(id)
+          .trigger("mouseover")
+          .then(() => {
+            tooltipPreview().should("have.text", validationMessage);
+          });
       }
     );
 


### PR DESCRIPTION
### Proposed behaviour

- Change the `hover` way for `Tabs` component for cypress tests. 

### Current behaviour

- `Tabs` component test for `hover` is flaky.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

No functionality or visuals to test - ensure all cypress tests are passing, the tests are testing the behaviour they describe and no `flaky` tests marked on the Dashboard.