### PR TITLE
fix(date-picker): correct css disabled states

### DIFF
--- a/src/components/date/__internal__/date-picker/__snapshots__/date-picker.spec.js.snap
+++ b/src/components/date/__internal__/date-picker/__snapshots__/date-picker.spec.js.snap
@@ -293,9 +293,14 @@ exports[`StyledDayPicker renders presentational div and context provider for its
 
 .c0 .DayPicker-Day--disabled,
 .c0 .DayPicker-Day--disabled:hover {
-  color: var(colorsActionMajorYin030);
+  color: var(--colorsActionMajorYin030);
   background-color: var(--colorsUtilityYang100);
   cursor: default;
+}
+
+.c0 .DayPicker-Day--disabled.DayPicker-Day--today,
+.c0 .DayPicker-Day--disabled:hover.DayPicker-Day--today {
+  background-color: var(--colorsActionMinor200);
 }
 
 .c0 .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {

--- a/src/components/date/__internal__/date-picker/day-picker.style.js
+++ b/src/components/date/__internal__/date-picker/day-picker.style.js
@@ -284,9 +284,13 @@ const StyledDayPicker = styled.div`
 
   .DayPicker-Day--disabled,
   .DayPicker-Day--disabled:hover {
-    color: var(colorsActionMajorYin030);
+    color: var(--colorsActionMajorYin030);
     background-color: var(--colorsUtilityYang100);
     cursor: default;
+
+    &.DayPicker-Day--today {
+      background-color: var(--colorsActionMinor200);
+    }
   }
 
   .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {


### PR DESCRIPTION
### Proposed behaviour

Current date active styling:
<img width="357" alt="Screenshot 2022-10-26 at 14 49 21" src="https://user-images.githubusercontent.com/112480511/198047496-95ba1c38-ed04-4749-96d6-28a897a524a4.png">

Current date disabled styling:
<img width="354" alt="Screenshot 2022-10-26 at 14 56 59" src="https://user-images.githubusercontent.com/112480511/198047711-af66e371-baaf-4591-bdbe-90d4136d1433.png">

Fixes: #5332 

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

The styling was incorrect for the current date and appeared like it was selectable even if disabled.
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

An updated codesandbox link can be found here: https://codesandbox.io/s/nervous-lucy-z5rssd?file=/src/index.js

It describes both test cases (disabled and active 'current date')
