### PR TITLE
chore: add lint rule to prevent prop-type imports in typescript files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -151,7 +151,11 @@
         "no-use-before-define": "off",
         "@typescript-eslint/no-use-before-define": ["error"],
         "@typescript-eslint/no-empty-function": ["error", {"allow": ["arrowFunctions"]}],
-        "jest-dom/prefer-to-have-attribute": "off"
+        "jest-dom/prefer-to-have-attribute": "off",
+        "no-restricted-imports": ["error", {
+          "name": "prop-types",
+          "message": "Please do not import `prop-types` in TypeScript files."
+      }]
       }
     }
   ]


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Adds eslint plugin `no-restricted-imports` and configures to prevent `prop-types` being imported in `ts/x` files

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
No linting exists to prevent `prop-types` from being imported in `ts/x` files

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
Add `import PropTypes from "prop-types"` to a `ts/x` file and run the linter

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
