### PR TITLE
feat: improve intellisense and autocompletion for props using typecript

### DIFF
--- a/src/__internal__/utils/helpers/types/expand.ts
+++ b/src/__internal__/utils/helpers/types/expand.ts
@@ -1,0 +1,23 @@
+// taken from answers to https://stackoverflow.com/questions/57683303/how-can-i-see-the-full-expanded-contract-of-a-typescript-type
+
+export type ExpandOnce<T> = T extends (...args: infer A) => infer R
+  ? (...args: ExpandOnce<A>) => ExpandOnce<R>
+  : T extends infer O
+  ? { [K in keyof O]: O[K] }
+  : never;
+
+// note: does not appear to fully recursively expand all styled-system types. But the alternatives
+// have all had worse problems.
+export type Expand<T> = T extends (...args: infer A) => infer R
+  ? (...args: Expand<A>) => Expand<R>
+  : T extends string // special case for strings added to definition to avoid issues with expanding complex types that include strings
+  ? T
+  : T extends number // same for number
+  ? T
+  : T extends object
+  ? T extends infer O
+    ? { [K in keyof O]: Expand<O[K]> }
+    : never
+  : T;
+
+export default Expand;

--- a/src/__internal__/utils/helpers/types/explicit-union.ts
+++ b/src/__internal__/utils/helpers/types/explicit-union.ts
@@ -1,0 +1,6 @@
+type WrapInObject<T> = T extends object ? T : { key: T };
+type ExtractFromObject<T> = T extends { key: unknown } ? T["key"] : T;
+
+type ExplicitUnion<T> = ExtractFromObject<WrapInObject<T>>;
+
+export default ExplicitUnion;

--- a/src/__internal__/utils/helpers/types/index.ts
+++ b/src/__internal__/utils/helpers/types/index.ts
@@ -1,0 +1,2 @@
+export type { default as Expand, ExpandOnce } from "./expand";
+export type { default as ExplicitUnion } from "./explicit-union";

--- a/src/components/accordion/accordion-group/accordion-group.component.tsx
+++ b/src/components/accordion/accordion-group/accordion-group.component.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useCallback } from "react";
 import { MarginProps } from "styled-system";
 import invariant from "invariant";
 
+import { ExpandOnce, Expand } from "../../../__internal__/utils/helpers/types";
 import Events from "../../../__internal__/utils/helpers/events";
 import Accordion, {
   AccordionInternalProps,
@@ -19,8 +20,8 @@ type AccordionGroupChild =
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface AccordionGroupChildArray extends Array<AccordionGroupChild> {}
 
-export interface AccordionGroupProps extends MarginProps {
-  children?: AccordionGroupChild;
+export interface AccordionGroupProps extends Expand<MarginProps> {
+  children?: ExpandOnce<AccordionGroupChild>;
 }
 
 export const AccordionGroup = ({ children, ...rest }: AccordionGroupProps) => {

--- a/src/components/accordion/accordion.component.tsx
+++ b/src/components/accordion/accordion.component.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from "react";
 import { SpaceProps } from "styled-system";
 
 import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import createGuid from "../../__internal__/utils/helpers/guid";
 import Events from "../../__internal__/utils/helpers/events";
 import {
@@ -19,7 +20,7 @@ import ValidationIcon from "../../__internal__/validations";
 
 export interface AccordionProps
   extends StyledAccordionContainerProps,
-    SpaceProps {
+    Expand<SpaceProps> {
   /** Width of the buttonHeading when it's set, defaults to 150px */
   buttonWidth?: number;
   children?: React.ReactNode;
@@ -32,7 +33,7 @@ export interface AccordionProps
   /** An error message to be displayed in the tooltip */
   error?: string;
   /** Styled system spacing props provided to Accordion Title */
-  headerSpacing?: SpaceProps;
+  headerSpacing?: Expand<SpaceProps>;
   id?: string;
   /** Sets icon type - accepted values: 'chevron_down' (default), 'dropdown' */
   iconType?: "chevron_down" | "dropdown";

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import invariant from "invariant";
 
+import { ExplicitUnion } from "../../../__internal__/utils/helpers/types";
 import {
   MenuItemIcon,
   SubMenuItemIcon,
@@ -30,7 +31,7 @@ export interface ActionPopoverItemProps {
   /** allows to provide href prop */
   href?: string;
   /** The name of the icon to display next to the label */
-  icon?: IconType;
+  icon?: ExplicitUnion<IconType>;
   /** Callback to run when item is clicked */
   onClick?: (
     ev:

--- a/src/components/action-popover/action-popover-menu-button/action-popover-menu-button.component.tsx
+++ b/src/components/action-popover/action-popover-menu-button/action-popover-menu-button.component.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 
+import {
+  ExplicitUnion,
+  Expand,
+} from "../../../__internal__/utils/helpers/types";
 import { MenuButtonOverrideWrapper } from "../action-popover.style";
 import Button from "../../button";
 import { ButtonTypes } from "../../button/button.component";
@@ -14,12 +18,12 @@ export type ActionPopoverMenuButtonAria = {
 
 export interface ActionPopoverMenuButtonProps {
   children?: string;
-  buttonType?: ButtonTypes;
-  iconType?: IconType;
+  buttonType?: ExplicitUnion<ButtonTypes>;
+  iconType?: ExplicitUnion<IconType>;
   iconPosition?: "after" | "before";
   size?: "small" | "medium" | "large";
   tabIndex: number;
-  ariaAttributes: ActionPopoverMenuButtonAria;
+  ariaAttributes: Expand<ActionPopoverMenuButtonAria>;
   "data-element": string;
 }
 

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -8,6 +8,7 @@ import React, {
 import { MarginProps } from "styled-system";
 import invariant from "invariant";
 
+import { Expand } from "../../__internal__/utils/helpers/types";
 import {
   MenuButton,
   ButtonIcon,
@@ -33,7 +34,7 @@ interface RenderButtonProps {
   };
 }
 
-export interface ActionPopoverProps extends MarginProps {
+export interface ActionPopoverProps extends Expand<MarginProps> {
   /** Children for popover component */
   children?: React.ReactNode;
   /** Horizontal alignment of menu items content */
@@ -47,7 +48,7 @@ export interface ActionPopoverProps extends MarginProps {
   /** Set whether the menu should open above or below the button */
   placement?: "bottom" | "top";
   /** Render a custom menu button to override default ellipsis icon */
-  renderButton?: (buttonProps: RenderButtonProps) => React.ReactNode;
+  renderButton?: (buttonProps: Expand<RenderButtonProps>) => React.ReactNode;
   /** Boolean to control whether menu should align to right */
   rightAlignMenu?: boolean;
 }

--- a/src/components/advanced-color-picker/advanced-color-picker.d.ts
+++ b/src/components/advanced-color-picker/advanced-color-picker.d.ts
@@ -1,12 +1,13 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 
 export interface AdvancedColor {
   label: string;
   value: string;
 }
 
-export interface AdvancedColorPickerPropTypes extends MarginProps {
+export interface AdvancedColorPickerPropTypes extends Expand<MarginProps> {
   /** Prop to specify the aria-describedby property of the component */
   "aria-describedby"?: string;
   /** Prop to specify the aria-label of the component */
@@ -14,7 +15,7 @@ export interface AdvancedColorPickerPropTypes extends MarginProps {
   /** Prop to specify the aria-labeledby property of the component */
   "aria-labelledby"?: string;
   /** Prop for `availableColors` containing array of objects of colors */
-  availableColors: AdvancedColor[];
+  availableColors: Expand<AdvancedColor>[];
   /** Prop for `defaultColor` containing the default color for `uncontrolled` use */
   defaultColor: string;
   /** Specifies the name prop to be applied to each color in the group */

--- a/src/components/box/box.component.tsx
+++ b/src/components/box/box.component.tsx
@@ -11,6 +11,7 @@ import {
   position,
   PositionProps,
 } from "styled-system";
+import { Expand, ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import BaseTheme from "../../style/themes/base";
 import styledColor from "../../style/utils/color";
 import boxConfig from "./box.config";
@@ -24,27 +25,27 @@ export type AllowedNumericalValues = typeof GAP_VALUES[number];
 export type Gap = AllowedNumericalValues | string;
 
 export interface BoxProps
-  extends SpaceProps,
-    LayoutProps,
-    FlexboxProps,
-    ColorProps,
-    Omit<PositionProps, "zIndex"> {
+  extends Expand<SpaceProps>,
+    Expand<LayoutProps>,
+    Expand<FlexboxProps>,
+    Expand<ColorProps>,
+    Expand<Omit<PositionProps, "zIndex">> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  as?: ExplicitUnion<keyof JSX.IntrinsicElements | React.ComponentType<any>>;
   /** String to set Box content break strategy. Note "anywhere" is not supported in Safari */
-  overflowWrap?: OverflowWrap;
+  overflowWrap?: ExplicitUnion<OverflowWrap>;
   /** scroll styling attribute */
-  scrollVariant?: ScrollVariant;
+  scrollVariant?: ExplicitUnion<ScrollVariant>;
   /** set the box-sizing attribute of the Box component */
-  boxSizing?: BoxSizing;
+  boxSizing?: ExplicitUnion<BoxSizing>;
   /** Allows a tabindex to be specified */
   tabIndex?: number | string;
   /** Gap, an integer multiplier of the base spacing constant (8px) or any valid CSS string." */
-  gap?: Gap;
+  gap?: ExplicitUnion<Gap>;
   /** Column gap, an integer multiplier of the base spacing constant (8px) or any valid CSS string." */
-  columnGap?: Gap;
+  columnGap?: ExplicitUnion<Gap>;
   /** Row gap an integer multiplier of the base spacing constant (8px) or any valid CSS string." */
-  rowGap?: Gap;
+  rowGap?: ExplicitUnion<Gap>;
 }
 
 const Box = styled.div<BoxProps>`

--- a/src/components/button-bar/button-bar.component.tsx
+++ b/src/components/button-bar/button-bar.component.tsx
@@ -2,11 +2,12 @@ import React, { useMemo } from "react";
 import invariant from "invariant";
 import { SpaceProps } from "styled-system";
 
+import { Expand } from "../../__internal__/utils/helpers/types";
 import StyledButtonBar from "./button-bar.style";
 import Button from "../button";
 import IconButton from "../icon-button";
 
-export interface ButtonBarProps extends SpaceProps {
+export interface ButtonBarProps extends Expand<SpaceProps> {
   children: React.ReactNode;
   /** Apply fullWidth style to the button bar */
   fullWidth?: boolean;

--- a/src/components/button-toggle-group/button-toggle-group.component.tsx
+++ b/src/components/button-toggle-group/button-toggle-group.component.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import invariant from "invariant";
 
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { ValidationProps } from "../../__internal__/validations";
 import { TagProps } from "../../__internal__/utils/helpers/tags";
 import FormField from "../../__internal__/form-field";
@@ -15,7 +16,7 @@ import { TooltipProvider } from "../../__internal__/tooltip-provider";
 
 export interface ButtonToggleGroupProps
   extends ValidationProps,
-    MarginProps,
+    Expand<MarginProps>,
     TagProps {
   /** Unique id for the root element of the component */
   id: string;

--- a/src/components/button-toggle/button-toggle.style.ts
+++ b/src/components/button-toggle/button-toggle.style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import { ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import { IconType } from "../icon";
 import StyledIcon from "../icon/icon.style";
 
@@ -44,9 +45,9 @@ const StyledButtonToggleContentWrapper = styled.div`
 
 export interface StyledButtonToggleLabelProps {
   /** The icon to be rendered inside of the button */
-  buttonIcon?: IconType;
+  buttonIcon?: ExplicitUnion<IconType>;
   /** Sets the size of the buttonIcon (eg. large) */
-  buttonIconSize?: ButtonToggleIconSizes;
+  buttonIconSize?: ExplicitUnion<ButtonToggleIconSizes>;
   /** Disable all user interaction. */
   disabled?: boolean;
   /** ButtonToggle size */

--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -4,6 +4,7 @@ import invariant from "invariant";
 
 import Icon, { IconType, IconProps } from "../icon";
 import StyledButton, { StyledButtonSubtext } from "./button.style";
+import { Expand, ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import Logger from "../../__internal__/utils/logger";
@@ -18,15 +19,14 @@ export type ButtonTypes =
 
 export type SizeOptions = "small" | "medium" | "large";
 export type ButtonIconPosition = "before" | "after";
-
-export interface ButtonProps extends SpaceProps {
+export interface ButtonProps extends Expand<SpaceProps> {
   /**
    * Prop to specify the aria-label attribute of the component
    * Defaults to the iconType, when the component has only an icon
    */
   "aria-label"?: string;
   /** Color variants for new business themes: "primary" | "secondary" | "tertiary" | "darkBackground" */
-  buttonType?: ButtonTypes;
+  buttonType?: ExplicitUnion<ButtonTypes>;
   /** The text the button displays */
   children?: React.ReactNode;
   /** Name attribute */
@@ -45,13 +45,13 @@ export interface ButtonProps extends SpaceProps {
   /** Used to transform button into anchor */
   href?: string;
   /** Defines an Icon position related to the children: "before" | "after" */
-  iconPosition?: ButtonIconPosition;
+  iconPosition?: ExplicitUnion<ButtonIconPosition>;
   /** Provides a tooltip message when the icon is hovered. */
   iconTooltipMessage?: string;
   /** Provides positioning when the tooltip is displayed. */
-  iconTooltipPosition?: TooltipPositions;
+  iconTooltipPosition?: ExplicitUnion<TooltipPositions>;
   /** Defines an Icon type within the button */
-  iconType?: IconType;
+  iconType?: ExplicitUnion<IconType>;
   /** id attribute */
   id?: string;
   /** If provided, the text inside a button will not wrap */
@@ -69,7 +69,7 @@ export interface ButtonProps extends SpaceProps {
     event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>
   ) => void;
   /** Assigns a size to the button: "small" | "medium" | "large" */
-  size?: SizeOptions;
+  size?: ExplicitUnion<SizeOptions>;
   /** Second text child, renders under main text, only when size is "large" */
   subtext?: string;
   /** HTML button type property */

--- a/src/components/carbon-provider/carbon-provider.component.tsx
+++ b/src/components/carbon-provider/carbon-provider.component.tsx
@@ -1,6 +1,7 @@
 import React, { createContext } from "react";
 import { ThemeProvider } from "styled-components";
 
+import { Expand } from "../../__internal__/utils/helpers/types";
 import mintTheme from "../../style/themes/mint";
 import CarbonScopedTokensProvider from "../../style/design-tokens/carbon-scoped-tokens-provider";
 
@@ -9,7 +10,7 @@ import { ThemeObject } from "../../style/themes/base";
 import { TopModalContextProvider } from "./top-modal-context";
 
 export interface CarbonProviderProps {
-  theme?: Partial<ThemeObject>;
+  theme?: Expand<Partial<ThemeObject>>;
   children: React.ReactNode;
   validationRedesignOptIn?: boolean;
 }

--- a/src/components/card/card-footer/card-footer.style.ts
+++ b/src/components/card/card-footer/card-footer.style.ts
@@ -1,5 +1,6 @@
 import styled, { css } from "styled-components";
 import { space, SpaceProps } from "styled-system";
+import { Expand } from "../../../__internal__/utils/helpers/types";
 import StyledCardColumn from "../card-column/card-column.style";
 import { CardSpacing } from "../card.config";
 
@@ -15,7 +16,7 @@ const paddingSizes = {
   large: "20px 48px",
 };
 
-export interface StyledCardFooterProps extends SpaceProps {
+export interface StyledCardFooterProps extends Expand<SpaceProps> {
   /** Predefined size of CardFooter for applying padding. For more granular control, this prop can be over-ridden by the spacing props from styled-system */
   spacing: CardSpacing;
   /** Specify styling variant to render */

--- a/src/components/card/card-row/card-row.style.ts
+++ b/src/components/card/card-row/card-row.style.ts
@@ -1,9 +1,10 @@
 import styled, { css } from "styled-components";
 import { padding, PaddingProps } from "styled-system";
+import { Expand } from "../../../__internal__/utils/helpers/types";
 import baseTheme from "../../../style/themes/base";
 import { CardSpacing } from "../card.config";
 
-export interface StyledCardRowProps extends PaddingProps {
+export interface StyledCardRowProps extends Expand<PaddingProps> {
   /**
    * Spacing prop is set in Card and defines the padding for the CardRow (the first CardRow has no padding by default).
    * For more granular control of CardRow padding these can be over-ridden by Padding props from styled-system.

--- a/src/components/card/card.component.tsx
+++ b/src/components/card/card.component.tsx
@@ -6,9 +6,10 @@ import StyledCard from "./card.style";
 import Icon from "../icon";
 import { CardRow, CardRowProps, CardFooter, CardFooterProps } from ".";
 import { CardSpacing } from "./card.config";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import Logger from "../../__internal__/utils/logger";
 
-export interface CardProps extends MarginProps {
+export interface CardProps extends Expand<MarginProps> {
   /** Identifier used for testing purposes, applied to the root element of the component. */
   "data-element"?: string;
   /** Identifier used for testing purposes, applied to the root element of the component. */

--- a/src/components/checkbox/checkbox-group.component.tsx
+++ b/src/components/checkbox/checkbox-group.component.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import StyledCheckboxGroup from "./checkbox-group.style";
 import Fieldset from "../../__internal__/fieldset";
@@ -7,7 +8,9 @@ import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import { ValidationProps } from "../../__internal__/validations";
 
-export interface CheckboxGroupProps extends ValidationProps, MarginProps {
+export interface CheckboxGroupProps
+  extends ValidationProps,
+    Expand<MarginProps> {
   /** The content for the CheckboxGroup Legend */
   legend?: string;
   /** When true, legend is placed inline with the checkboxes */

--- a/src/components/checkbox/checkbox.component.tsx
+++ b/src/components/checkbox/checkbox.component.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import { MarginProps } from "styled-system";
 import CheckboxStyle from "./checkbox.style";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import CheckableInput, {
   CommonCheckableInputProps,
 } from "../../__internal__/checkable-input/checkable-input.component";
@@ -10,7 +11,9 @@ import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import { CheckboxGroupContext } from "./checkbox-group.component";
 
-export interface CheckboxProps extends CommonCheckableInputProps, MarginProps {
+export interface CheckboxProps
+  extends CommonCheckableInputProps,
+    Expand<MarginProps> {
   /** Breakpoint for adaptive spacing (left margin changes to 0). Enables the adaptive behaviour when set */
   adaptiveSpacingBreakpoint?: number;
   /** Identifier used for testing purposes, applied to the root element of the component. */

--- a/src/components/confirm/confirm.d.ts
+++ b/src/components/confirm/confirm.d.ts
@@ -1,5 +1,6 @@
-import { IconType } from "components/icon/icon-type";
 import * as React from "react";
+import { IconType } from "../icon/icon-type";
+import { ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import { DialogProps } from "../dialog";
 
 export interface ConfirmProps extends DialogProps {
@@ -28,11 +29,11 @@ export interface ConfirmProps extends DialogProps {
   /** Defines a cancel button Icon position related to the children: "before" | "after" */
   cancelButtonIconPosition?: "before" | "after";
   /** Defines an Icon type within the cancel button (see Icon for options) */
-  cancelButtonIconType?: IconType;
+  cancelButtonIconType?: ExplicitUnion<IconType>;
   /** Defines a cancel button Icon position related to the children: "before" | "after" */
   confirmButtonIconPosition?: "before" | "after";
   /** Defines an Icon type within the confirm button (see Icon for options) */
-  confirmButtonIconType?: IconType;
+  confirmButtonIconType?: ExplicitUnion<IconType>;
   /** Makes cancel button disabled */
   disableCancel?: boolean;
   /** Makes confirm button disabled */

--- a/src/components/content/content.style.ts
+++ b/src/components/content/content.style.ts
@@ -1,14 +1,15 @@
 import styled, { css } from "styled-components";
 import { MarginProps, margin } from "styled-system";
 
+import { Expand, ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import { baseTheme } from "../../style/themes";
 
 export type AlignOptions = "left" | "center" | "right";
 export type VariantOptions = "primary" | "secondary";
 
-export interface StyledContentProps extends MarginProps {
+export interface StyledContentProps extends Expand<MarginProps> {
   /** Aligns the content (left, center or right) */
-  align?: AlignOptions;
+  align?: ExplicitUnion<AlignOptions>;
   /**
    * Over-rides the calculation of body width based on titleWidth.
    * Sometimes we need the body to be full width while keeping a title width similar to other widths
@@ -39,13 +40,13 @@ StyledContent.defaultProps = { theme: baseTheme };
 
 export interface StyledContentTitleProps {
   /** Aligns the content (left, center or right) */
-  align?: AlignOptions;
+  align?: ExplicitUnion<AlignOptions>;
   /** Displays the content inline with the title */
   inline?: boolean;
   /** Sets a custom width for the title element */
   titleWidth?: string;
   /** Applies a theme to the Content Value: primary, secondary */
-  variant?: VariantOptions;
+  variant?: ExplicitUnion<VariantOptions>;
 }
 
 const StyledContentTitle = styled.div<StyledContentTitleProps>`
@@ -74,7 +75,7 @@ const StyledContentTitle = styled.div<StyledContentTitleProps>`
 
 export interface StyledContentBodyProps {
   /** Aligns the content (left, center or right) */
-  align?: AlignOptions;
+  align?: ExplicitUnion<AlignOptions>;
   /**
    * Over-rides the calculation of body width based on titleWidth.
    * Sometimes we need the body to be full width while keeping a title width similar to other widths
@@ -85,7 +86,7 @@ export interface StyledContentBodyProps {
   /** Sets a custom width for the title element */
   titleWidth?: string;
   /** Applies a theme to the Content Value: primary, secondary */
-  variant?: VariantOptions;
+  variant?: ExplicitUnion<VariantOptions>;
 }
 
 const StyledContentBody = styled.div<StyledContentBodyProps>`

--- a/src/components/date-range/date-range.d.ts
+++ b/src/components/date-range/date-range.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { DateInputProps } from "../date/date";
 
 export interface DateRangeChangeEvent {
@@ -17,9 +18,9 @@ export interface DateRangeChangeEvent {
   };
 }
 
-export interface DateRangeProps extends MarginProps {
+export interface DateRangeProps extends Expand<MarginProps> {
   /** Props for the child end Date component */
-  endDateProps?: Partial<DateInputProps>;
+  endDateProps?: Expand<Partial<DateInputProps>>;
   /** Optional label for endDate field */
   endLabel?: string;
   /**
@@ -47,11 +48,11 @@ export interface DateRangeProps extends MarginProps {
   /** An optional string prop to provide a name to the component */
   name?: string;
   /** Specify a callback triggered on change */
-  onChange: (ev: DateRangeChangeEvent) => void;
+  onChange: (ev: Expand<DateRangeChangeEvent>) => void;
   /** Specify a callback triggered on blur */
   onBlur?: (ev: DateRangeChangeEvent) => void;
   /** Props for the child start Date component */
-  startDateProps?: Partial<DateInputProps>;
+  startDateProps?: Expand<Partial<DateInputProps>>;
   /** Optional label for startDate field */
   startLabel?: string;
   /**

--- a/src/components/date/date.d.ts
+++ b/src/components/date/date.d.ts
@@ -1,4 +1,5 @@
 import { DayPickerProps } from "react-day-picker";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { TextboxProps } from "../textbox";
 
 export interface DateChangeEvent {
@@ -39,11 +40,11 @@ export interface DateInputProps
   /** Maximum possible date YYYY-MM-DD */
   maxDate?: string;
   /** Specify a callback triggered on change */
-  onChange: (ev: DateChangeEvent) => void;
+  onChange: (ev: Expand<DateChangeEvent>) => void;
   /** The current date string */
   value: string;
   /** Pass any props that match the DayPickerProps interface to override default behaviors */
-  pickerProps?: DayPickerProps;
+  pickerProps?: Expand<DayPickerProps>;
 }
 
 declare function DateInput(props: DateInputProps): JSX.Element;

--- a/src/components/decimal/decimal.component.tsx
+++ b/src/components/decimal/decimal.component.tsx
@@ -8,6 +8,7 @@ import React, {
 import invariant from "invariant";
 
 import Textbox, { CommonTextboxProps } from "../textbox";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import LocaleContext from "../../__internal__/i18n-context";
 import usePrevious from "../../hooks/__internal__/usePrevious";
 
@@ -35,9 +36,9 @@ export interface DecimalProps
   /** The width of the input as a percentage */
   inputWidth?: number;
   /** Handler for change event if input is meant to be used as a controlled component */
-  onChange?: (ev: CustomEvent) => void;
+  onChange?: (ev: Expand<CustomEvent>) => void;
   /** Handler for blur event */
-  onBlur?: (ev: CustomEvent) => void;
+  onBlur?: (ev: Expand<CustomEvent>) => void;
   /** Handler for key press event */
   onKeyPress?: (ev: React.KeyboardEvent<HTMLInputElement>) => void;
   /** The input name */

--- a/src/components/definition-list/dd.component.tsx
+++ b/src/components/definition-list/dd.component.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { SpaceProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { StyledDd } from "./definition-list.style";
 
-export interface DdProps extends SpaceProps {
+export interface DdProps extends Expand<SpaceProps> {
   /** Prop for what will render in the `<Dd></Dd>` tags */
   children: React.ReactNode;
 }

--- a/src/components/definition-list/definition-list.style.ts
+++ b/src/components/definition-list/definition-list.style.ts
@@ -1,5 +1,6 @@
 import styled, { css } from "styled-components";
 import { space } from "styled-system";
+import { ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import StyledButton from "../button/button.style";
 import { baseTheme } from "../../style/themes";
 
@@ -41,7 +42,7 @@ StyledDl.defaultProps = {
 
 export interface StyledDtDivProps {
   /** This string will specify the text align styling of the `<dt></dt>`. */
-  dtTextAlign?: ElementAlignment;
+  dtTextAlign?: ExplicitUnion<ElementAlignment>;
 }
 
 export const StyledDtDiv = styled.div<StyledDtDivProps>`
@@ -57,7 +58,7 @@ StyledDtDiv.defaultProps = {
 
 export interface StyledDdDivProps {
   /** This string will specify the text align styling of the `<dd></dd>`. */
-  ddTextAlign?: ElementAlignment;
+  ddTextAlign?: ExplicitUnion<ElementAlignment>;
 }
 
 export const StyledDdDiv = styled.div<StyledDdDivProps>`

--- a/src/components/definition-list/dl.component.tsx
+++ b/src/components/definition-list/dl.component.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { SpaceProps } from "styled-system";
 import { isElement, isFragment } from "react-is";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import {
   StyledDl,
   StyledDtDiv,
@@ -14,7 +15,7 @@ import Dd from "./dd.component";
 import DlContext from "./__internal__/dl.context";
 
 export interface DlProps
-  extends SpaceProps,
+  extends Expand<SpaceProps>,
     StyledDlProps,
     StyledDtDivProps,
     StyledDdDivProps {

--- a/src/components/definition-list/dt.component.tsx
+++ b/src/components/definition-list/dt.component.tsx
@@ -1,9 +1,10 @@
 import React, { useContext } from "react";
 import { SpaceProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { StyledDt } from "./definition-list.style";
 import DlContext from "./__internal__/dl.context";
 
-export interface DtProps extends SpaceProps {
+export interface DtProps extends Expand<SpaceProps> {
   /** Prop for what will render in the `<Dd></Dd>` tags */
   children: React.ReactNode;
 }

--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -6,6 +6,11 @@ import React, {
   useContext,
 } from "react";
 
+import {
+  ExplicitUnion,
+  Expand,
+  ExpandOnce,
+} from "../../__internal__/utils/helpers/types";
 import createGuid from "../../__internal__/utils/helpers/guid";
 import Modal, { ModalProps } from "../modal";
 import Heading from "../heading";
@@ -35,9 +40,9 @@ type CustomRefObject<T> = {
 };
 
 export interface ContentPaddingInterface {
-  p?: PaddingValues;
-  py?: PaddingValues;
-  px?: PaddingValues;
+  p?: ExplicitUnion<PaddingValues>;
+  py?: ExplicitUnion<PaddingValues>;
+  px?: ExplicitUnion<PaddingValues>;
 }
 
 export interface DialogProps extends ModalProps, TagProps {
@@ -85,7 +90,7 @@ export interface DialogProps extends ModalProps, TagProps {
   /** Determines if the close icon is shown */
   showCloseIcon?: boolean;
   /** Size of dialog, default size is 750px */
-  size?: DialogSizes;
+  size?: ExplicitUnion<DialogSizes>;
   /** Subtitle displayed at top of dialog */
   subtitle?: string;
   /** Title displayed at top of dialog */
@@ -93,9 +98,9 @@ export interface DialogProps extends ModalProps, TagProps {
   /** The ARIA role to be applied to the Dialog container */
   role?: string;
   /** Padding to be set on the Dialog content */
-  contentPadding?: ContentPaddingInterface;
+  contentPadding?: Expand<ContentPaddingInterface>;
   /** an optional array of refs to containers whose content should also be reachable by tabbing from the dialog */
-  focusableContainers?: CustomRefObject<HTMLElement>[];
+  focusableContainers?: ExpandOnce<CustomRefObject<HTMLElement>>[];
 }
 
 export const Dialog = ({

--- a/src/components/dismissible-box/dismissible-box.component.tsx
+++ b/src/components/dismissible-box/dismissible-box.component.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { SpaceProps } from "styled-system";
 
+import { Expand } from "../../__internal__/utils/helpers/types";
 import {
   StyledDismissibleBox,
   StyledDismissibleBoxProps,
@@ -10,7 +11,7 @@ import Icon from "../icon";
 import { BoxProps } from "../box";
 
 export interface DismissibleBoxProps
-  extends SpaceProps,
+  extends Expand<SpaceProps>,
     StyledDismissibleBoxProps,
     Omit<BoxProps, "display" | "justifyContent"> {
   /** The content to render in the component */

--- a/src/components/draggable/draggable-container.d.ts
+++ b/src/components/draggable/draggable-container.d.ts
@@ -1,8 +1,9 @@
 import * as React from "react";
+import { Expand, ExpandOnce } from "../../__internal__/utils/helpers/types";
 import { DraggableItemProps } from "./draggable-item";
 
 type DraggableContainerChild =
-  | React.ReactElement<DraggableItemProps>
+  | React.ReactElement<Expand<DraggableItemProps>>
   | boolean
   | null
   | undefined;
@@ -15,7 +16,9 @@ export interface DraggableContainerProps {
    *
    * `<DraggableItem />` is required to make `Draggable` works
    */
-  children?: DraggableContainerChild | DraggableContainerChild[];
+  children?:
+    | ExpandOnce<DraggableContainerChild>
+    | ExpandOnce<DraggableContainerChild>[];
 }
 
 declare function DraggableContainer(

--- a/src/components/duelling-picklist/duelling-picklist.d.ts
+++ b/src/components/duelling-picklist/duelling-picklist.d.ts
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 
-export interface DuellingPicklistProps extends MarginProps {
+export interface DuellingPicklistProps extends Expand<MarginProps> {
   children?: React.ReactNode;
   /** Indicate if component is disabled */
   disabled?: boolean;

--- a/src/components/fieldset/fieldset.component.tsx
+++ b/src/components/fieldset/fieldset.component.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { MarginProps } from "styled-system";
 
+import { Expand } from "../../__internal__/utils/helpers/types";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import {
@@ -11,7 +12,9 @@ import {
 } from "./fieldset.style";
 import { NewValidationContext } from "../carbon-provider/carbon-provider.component";
 
-export interface FieldsetProps extends StyledFieldsetProps, MarginProps {
+export interface FieldsetProps
+  extends StyledFieldsetProps,
+    Expand<MarginProps> {
   /** Child elements */
   children?: React.ReactNode;
   /** The text for the fieldsets legend element. */

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.d.ts
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.d.ts
@@ -1,8 +1,12 @@
 import * as React from "react";
 import { PaddingProps } from "styled-system";
+import {
+  ExplicitUnion,
+  Expand,
+} from "../../../__internal__/utils/helpers/types";
 import { TableBorderSize } from "..";
 
-export interface FlatTableCellProps extends PaddingProps {
+export interface FlatTableCellProps extends Expand<PaddingProps> {
   /** Content alignment */
   align?: "left" | "center" | "right";
   children?: React.ReactNode | string;
@@ -17,7 +21,7 @@ export interface FlatTableCellProps extends PaddingProps {
   /** Title text to display if cell content truncates */
   title?: string;
   /** Sets a custom vertical right border */
-  verticalBorder?: TableBorderSize;
+  verticalBorder?: ExplicitUnion<TableBorderSize>;
   /** Sets the color of the right border */
   verticalBorderColor?: string;
 }

--- a/src/components/flat-table/flat-table-header/flat-table-header.d.ts
+++ b/src/components/flat-table/flat-table-header/flat-table-header.d.ts
@@ -1,9 +1,12 @@
 import * as React from "react";
 import { PaddingProps } from "styled-system";
-
+import {
+  Expand,
+  ExplicitUnion,
+} from "../../../__internal__/utils/helpers/types";
 import { TableBorderSize } from "..";
 
-export interface FlatTableHeaderProps extends PaddingProps {
+export interface FlatTableHeaderProps extends Expand<PaddingProps> {
   /** Content alignment */
   align?: "left" | "center" | "right";
   /** If true sets alternative background color */
@@ -14,7 +17,7 @@ export interface FlatTableHeaderProps extends PaddingProps {
   /** Number of rows that a header cell should span */
   rowspan?: number | string;
   /** Sets a custom vertical right border */
-  verticalBorder?: TableBorderSize;
+  verticalBorder?: ExplicitUnion<TableBorderSize>;
   /** Column width, pass a number to set a fixed width in pixels */
   width?: number;
 }

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.d.ts
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.d.ts
@@ -1,8 +1,12 @@
 import * as React from "react";
 import { PaddingProps } from "styled-system";
+import {
+  ExplicitUnion,
+  Expand,
+} from "../../../__internal__/utils/helpers/types";
 import { TableBorderSize } from "..";
 
-export interface FlatTableRowHeaderProps extends PaddingProps {
+export interface FlatTableRowHeaderProps extends Expand<PaddingProps> {
   /** Content alignment */
   align?: string;
   children?: React.ReactNode | string;
@@ -13,7 +17,7 @@ export interface FlatTableRowHeaderProps extends PaddingProps {
   /** Title text to display if cell content truncates */
   title?: string;
   /** Sets a custom vertical right border */
-  verticalBorder?: TableBorderSize;
+  verticalBorder?: ExplicitUnion<TableBorderSize>;
   /** Sets the color of the right border */
   verticalBorderColor?: string;
 }

--- a/src/components/flat-table/flat-table-row/flat-table-row.d.ts
+++ b/src/components/flat-table/flat-table-row/flat-table-row.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { ExplicitUnion } from "../../../__internal__/utils/helpers/types";
 import { TableBorderSize } from "..";
 
 export interface FlatTableRowProps {
@@ -15,7 +16,7 @@ export interface FlatTableRowProps {
   /** Sets the color of the bottom border in the row */
   horizontalBorderColor?: string;
   /** Sets the weight of the bottom border in the row */
-  horizontalBorderSize?: TableBorderSize;
+  horizontalBorderSize?: ExplicitUnion<TableBorderSize>;
   /** Function to handle click event. If provided the Component could be focused with tab key. */
   onClick?: (ev: React.MouseEvent<HTMLElement>) => void;
   /** Allows developers to manually control selected state for the row. */

--- a/src/components/flat-table/flat-table.d.ts
+++ b/src/components/flat-table/flat-table.d.ts
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 
-export interface FlatTableProps extends MarginProps {
+export interface FlatTableProps extends Expand<MarginProps> {
   /** The HTML id of the element that contains a description of this table. */
   ariaDescribedby?: string;
   /** A string to render as the table's caption */

--- a/src/components/form/form.component.tsx
+++ b/src/components/form/form.component.tsx
@@ -3,6 +3,7 @@ import { SpaceProps } from "styled-system";
 
 import { SidebarContext } from "../sidebar/sidebar.component";
 import { ModalContext } from "../modal/modal.component";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import FormSummary from "./__internal__/form-summary.component";
 import {
   StyledForm,
@@ -14,7 +15,7 @@ import {
 } from "./form.style";
 import { FormButtonAlignment } from "./form.config";
 
-export interface FormProps extends SpaceProps {
+export interface FormProps extends Expand<SpaceProps> {
   /** Alignment of buttons */
   buttonAlignment?: FormButtonAlignment;
   /** Child elements */

--- a/src/components/global-header/global-header.component.tsx
+++ b/src/components/global-header/global-header.component.tsx
@@ -2,13 +2,16 @@ import React from "react";
 import styled, { css } from "styled-components";
 import { PaddingProps, FlexboxProps } from "styled-system";
 import { ThemeObject } from "style/themes/base";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { baseTheme } from "../../style/themes";
 import StyledNavigationBar, {
   StyledNavigationBarProps,
 } from "../navigation-bar/navigation-bar.style";
 import Box from "../box";
 
-export interface GlobalHeaderProps extends PaddingProps, FlexboxProps {
+export interface GlobalHeaderProps
+  extends Expand<PaddingProps>,
+    Expand<FlexboxProps> {
   /** Child elements */
   children?: React.ReactNode;
   /** Logo to render */

--- a/src/components/grid/grid-container/grid-container.component.tsx
+++ b/src/components/grid/grid-container/grid-container.component.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { SpaceProps, GridProps } from "styled-system";
 
+import { Expand } from "../../../__internal__/utils/helpers/types";
 import StyledGridContainer from "./grid-container.style";
 
 export interface GridContainerProps
-  extends SpaceProps,
+  extends Expand<SpaceProps>,
     GridProps,
     React.HTMLAttributes<HTMLDivElement> {
   /** Defines the Components to be rendered within the GridContainer. Requires GridItemProps */

--- a/src/components/grid/grid-item/grid-item.style.ts
+++ b/src/components/grid/grid-item/grid-item.style.ts
@@ -8,6 +8,7 @@ import {
   GridColumnProps,
   GridRowProps,
 } from "styled-system";
+import { Expand, ExpandOnce } from "../../../__internal__/utils/helpers/types";
 
 export function getSpacing(prop?: PaddingProps[keyof PaddingProps]) {
   if (typeof prop === "number") {
@@ -42,7 +43,7 @@ export function getSpacing(prop?: PaddingProps[keyof PaddingProps]) {
   return String(prop);
 }
 
-interface GridProperties extends PaddingProps {
+interface GridProperties extends Expand<PaddingProps> {
   alignSelf?: string;
   justifySelf?: string;
   gridColumn?: GridColumnProps["gridColumn"];
@@ -54,8 +55,8 @@ interface ResponsiveSettings extends GridProperties {
   maxWidth?: string;
 }
 
-export interface StyledGridItemProps extends GridProperties {
-  responsiveSettings?: ResponsiveSettings[];
+export interface StyledGridItemProps extends Expand<GridProperties> {
+  responsiveSettings?: ExpandOnce<ResponsiveSettings>[];
 }
 
 function responsiveGridItem(responsiveSettings: ResponsiveSettings[]) {

--- a/src/components/heading/heading.component.tsx
+++ b/src/components/heading/heading.component.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { MarginProps } from "styled-system";
 
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import tagComponent, {
   TagProps,
 } from "../../__internal__/utils/helpers/tags/tags";
@@ -20,7 +21,7 @@ import {
 } from "./heading.style";
 import useLocale from "../../hooks/__internal__/useLocale";
 
-export interface HeadingProps extends MarginProps, TagProps {
+export interface HeadingProps extends Expand<MarginProps>, TagProps {
   /** Child elements */
   children?: React.ReactNode;
   /** Defines the title for the heading. */

--- a/src/components/help/help.component.tsx
+++ b/src/components/help/help.component.tsx
@@ -8,11 +8,12 @@ import Events from "../../__internal__/utils/helpers/events";
 import { TooltipContext } from "../../__internal__/tooltip-provider";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipPositions } from "../tooltip/tooltip.config";
+import { Expand, ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import guid from "../../__internal__/utils/helpers/guid";
 
-export interface HelpProps extends MarginProps {
+export interface HelpProps extends Expand<MarginProps> {
   /** Overrides the default 'as' attribute of the Help component */
-  as?: keyof JSX.IntrinsicElements;
+  as?: ExplicitUnion<keyof JSX.IntrinsicElements>;
   /** Aria label */
   ariaLabel?: string;
   /** The message to be displayed within the tooltip */
@@ -35,13 +36,13 @@ export interface HelpProps extends MarginProps {
    *  must be an array containing some or all of ["top", "bottom", "left", "right"]
    * (see https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements)
    */
-  tooltipFlipOverrides?: TooltipPositions[];
+  tooltipFlipOverrides?: ExplicitUnion<TooltipPositions>[];
   /** Id passed to the tooltip container, used for accessibility purposes */
   tooltipId?: string;
   /** Position of tooltip relative to target */
-  tooltipPosition?: TooltipPositions;
+  tooltipPosition?: ExplicitUnion<TooltipPositions>;
   /** Help Icon type */
-  type?: IconType;
+  type?: ExplicitUnion<IconType>;
   // any has been used here to allow rest props to be spread
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;

--- a/src/components/hr/hr.component.tsx
+++ b/src/components/hr/hr.component.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { MarginProps } from "styled-system";
 
+import { Expand } from "../../__internal__/utils/helpers/types";
 import StyledHr from "./hr.style";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 
-export interface HrProps extends MarginProps {
+export interface HrProps extends Expand<MarginProps> {
   /** Breakpoint for adaptive left and right margins (below the breakpoint they go to 0).
    * Enables the adaptive behaviour when set */
   adaptiveMxBreakpoint?: number;

--- a/src/components/i18n-provider/i18n-provider.component.tsx
+++ b/src/components/i18n-provider/i18n-provider.component.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import merge from "lodash/merge";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import Context from "../../__internal__/i18n-context";
 import enGB from "../../locales/en-gb";
 import Locale from "../../locales";
 
 export interface I18nProviderProps {
-  locale?: Partial<Locale>;
+  locale?: Expand<Partial<Locale>>;
   children: React.ReactNode;
 }
 

--- a/src/components/icon-button/icon-button.component.tsx
+++ b/src/components/icon-button/icon-button.component.tsx
@@ -1,13 +1,14 @@
 import React, { useState, useCallback } from "react";
 import { MarginProps } from "styled-system";
 
+import { Expand } from "../../__internal__/utils/helpers/types";
 import Events from "../../__internal__/utils/helpers/events";
 import StyledIconButton from "./icon-button.style";
 import { IconProps } from "../icon";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 
-export interface IconButtonProps extends MarginProps {
+export interface IconButtonProps extends Expand<MarginProps> {
   /** Prop to specify the aria-label of the icon-button component */
   "aria-label"?: string;
   /** Icon meant to be rendered, should be an Icon component */

--- a/src/components/icon/icon.component.tsx
+++ b/src/components/icon/icon.component.tsx
@@ -3,6 +3,7 @@ import { MarginProps } from "styled-system";
 import invariant from "invariant";
 import Tooltip from "../tooltip";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import { Expand, ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import { TooltipContext } from "../../__internal__/tooltip-provider";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import StyledIcon, { StyledIconProps } from "./icon.style";
@@ -19,7 +20,9 @@ export type LegacyIconTypes =
   | "success"
   | "messages";
 
-export interface IconProps extends Omit<StyledIconProps, "type">, MarginProps {
+export interface IconProps
+  extends Omit<StyledIconProps, "type">,
+    Expand<MarginProps> {
   /** Set whether icon should be recognised by assistive technologies */
   "aria-hidden"?: boolean;
   /** Aria label for accessibility purposes */
@@ -31,7 +34,7 @@ export interface IconProps extends Omit<StyledIconProps, "type">, MarginProps {
   /** The message to be displayed within the tooltip */
   tooltipMessage?: React.ReactNode;
   /** The position to display the tooltip */
-  tooltipPosition?: TooltipPositions;
+  tooltipPosition?: ExplicitUnion<TooltipPositions>;
   /** Control whether the tooltip is visible */
   tooltipVisible?: boolean;
   /** Override background color of the Tooltip, provide any color from palette or any valid css color value. */
@@ -39,7 +42,7 @@ export interface IconProps extends Omit<StyledIconProps, "type">, MarginProps {
   /** Override font color of the Tooltip, provide any color from palette or any valid css color value. */
   tooltipFontColor?: string;
   /** Overrides the default flip behaviour of the Tooltip */
-  tooltipFlipOverrides?: TooltipPositions[];
+  tooltipFlipOverrides?: ExplicitUnion<TooltipPositions>[];
   /** Id passed to the tooltip container, used for accessibility purposes */
   tooltipId?: string;
   /**
@@ -58,7 +61,7 @@ export interface IconProps extends Omit<StyledIconProps, "type">, MarginProps {
   tabIndex?: number;
 }
 
-const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
+const Icon = React.forwardRef<HTMLSpanElement, Expand<IconProps>>(
   (
     {
       "aria-hidden": ariaHidden,

--- a/src/components/icon/icon.style.ts
+++ b/src/components/icon/icon.style.ts
@@ -5,6 +5,7 @@ import { margin } from "styled-system";
 import iconUnicodes from "./icon-unicodes";
 import baseTheme, { ThemeObject } from "../../style/themes/base";
 import iconConfig from "./icon-config";
+import { ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import browserTypeCheck, {
   isSafari,
 } from "../../__internal__/utils/helpers/browser-type-check";
@@ -27,9 +28,9 @@ export interface StyledIconProps {
   /** Background colour, provide any color from palette or any valid css color value. */
   bg?: string;
   /** Background shape */
-  bgShape?: BackgroundShape;
+  bgShape?: ExplicitUnion<BackgroundShape>;
   /** Background size */
-  bgSize?: BgSize;
+  bgSize?: ExplicitUnion<BgSize>;
   /**
    * @private
    * @ignore
@@ -41,7 +42,7 @@ export interface StyledIconProps {
   /** Sets the icon in the disabled state */
   disabled?: boolean;
   /** Icon font size */
-  fontSize?: FontSize;
+  fontSize?: ExplicitUnion<FontSize>;
   /**
    * Icon type
    *

--- a/src/components/image/image.component.tsx
+++ b/src/components/image/image.component.tsx
@@ -1,8 +1,14 @@
 import React from "react";
 import invariant from "invariant";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { StyledImage, StyledImageProps } from "./image.style";
 
-export const Image = ({ alt, src, children, ...rest }: StyledImageProps) => {
+export const Image = ({
+  alt,
+  src,
+  children,
+  ...rest
+}: Expand<StyledImageProps>) => {
   invariant(
     !src || !children,
     "The 'Image' component renders as an 'img' element when the 'src' prop is used and therefore does not accept children."

--- a/src/components/image/image.style.ts
+++ b/src/components/image/image.style.ts
@@ -7,12 +7,13 @@ import {
   BackgroundProps,
   LayoutProps,
 } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { baseTheme } from "../../style/themes";
 
 export interface StyledImageProps
-  extends MarginProps,
-    BackgroundProps,
-    LayoutProps {
+  extends Expand<MarginProps>,
+    Expand<BackgroundProps>,
+    Expand<LayoutProps> {
   /** HTML alt property to display when an img fails to load */
   alt?: string;
   /** Any valid file path, passing this will render the component as an img element */

--- a/src/components/inline-inputs/inline-inputs.style.ts
+++ b/src/components/inline-inputs/inline-inputs.style.ts
@@ -1,6 +1,7 @@
 import styled, { css } from "styled-components";
 import InputPresentation from "../../__internal__/input/input-presentation.style";
 
+import { ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import { StyledLabelContainer } from "../../__internal__/label/label.style";
 import baseTheme from "../../style/themes/base";
 import { InlineInputsProps } from "./inline-inputs.component";
@@ -16,7 +17,7 @@ type GutterOptions =
   | "extra-large";
 interface StyledInlineInputProps {
   /** Gutter prop gets passed down to Row component if false gutter value is "none" */
-  gutter?: GutterOptions;
+  gutter?: ExplicitUnion<GutterOptions>;
 }
 
 export interface StyledContentContainerProps extends StyledInlineInputProps {

--- a/src/components/link-preview/link-preview.component.tsx
+++ b/src/components/link-preview/link-preview.component.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import {
   StyledLinkPreview,
   StyledPreviewWrapper,
@@ -26,7 +27,7 @@ export interface LinkPreviewProps {
   /** The description to be displayed */
   description?: string;
   /** The config for the image to be displayed */
-  image?: ImageShape;
+  image?: Expand<ImageShape>;
   /** Flag to trigger the loading animation */
   isLoading?: boolean;
   /** The callback to handle the deleting of a Preview, to hide the close button do not set this prop */

--- a/src/components/link/link.component.tsx
+++ b/src/components/link/link.component.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from "react";
-import { IconType } from "components/icon/icon-type";
+import { IconType } from "../icon/icon-type";
 
 import Icon from "../icon";
+import { ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import Event from "../../__internal__/utils/helpers/events";
 import { StyledLink, StyledContent, StyledLinkProps } from "./link.style";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
@@ -11,7 +12,7 @@ export interface LinkProps extends StyledLinkProps, React.AriaAttributes {
   /** An href for an anchor tag. */
   href?: string;
   /** An icon to display next to the link. */
-  icon?: IconType;
+  icon?: ExplicitUnion<IconType>;
   /** Function called when the mouse is clicked. */
   onClick?: (
     ev:

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import { ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import baseTheme from "../../style/themes/base";
 import StyledIcon from "../icon/icon.style";
 
@@ -13,7 +14,7 @@ export interface StyledLinkProps {
   /** Sets the colour styling when component is rendered on a dark background */
   isDarkBackground?: boolean;
   /** Allows link styling to be updated for light or dark backgrounds */
-  variant?: Variants;
+  variant?: ExplicitUnion<Variants>;
 }
 interface PrivateStyledLinkProps {
   hasContent: boolean;

--- a/src/components/loader-bar/loader-bar.component.tsx
+++ b/src/components/loader-bar/loader-bar.component.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import StyledLoaderBar, {
   InnerBar,
@@ -7,7 +8,9 @@ import StyledLoaderBar, {
   StyledLoaderBarProps,
 } from "./loader-bar.style";
 
-export interface LoaderBarProps extends StyledLoaderBarProps, MarginProps {}
+export interface LoaderBarProps
+  extends StyledLoaderBarProps,
+    Expand<MarginProps> {}
 
 export const LoaderBar = ({ size = "medium", ...rest }: LoaderBarProps) => {
   return (

--- a/src/components/loader/loader.component.tsx
+++ b/src/components/loader/loader.component.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import StyledLoader from "./loader.style";
 import StyledLoaderSquare, {
   StyledLoaderSquareProps,
 } from "./loader-square.style";
 
-export interface LoaderProps extends StyledLoaderSquareProps, MarginProps {
+export interface LoaderProps
+  extends StyledLoaderSquareProps,
+    Expand<MarginProps> {
   /** Specify an aria-label for the Loader component */
   "aria-label"?: string;
 }

--- a/src/components/menu/menu-item/menu-item.d.ts
+++ b/src/components/menu/menu-item/menu-item.d.ts
@@ -1,8 +1,14 @@
-import { IconType } from "components/icon/icon-type";
 import * as React from "react";
 import { FlexboxProps, LayoutProps } from "styled-system";
+import {
+  Expand,
+  ExplicitUnion,
+} from "../../../__internal__/utils/helpers/types";
+import { IconType } from "../icon/icon-type";
 
-export interface MenuItemBaseProps extends LayoutProps, FlexboxProps {
+export interface MenuItemBaseProps
+  extends Expand<LayoutProps>,
+    Expand<FlexboxProps> {
   /** Custom className */
   className?: string;
   /** onClick handler */
@@ -40,16 +46,21 @@ export interface MenuItemBaseProps extends LayoutProps, FlexboxProps {
 export interface MenuWithChildren extends MenuItemBaseProps {
   children: React.ReactNode;
   /** Either prop `icon` must be defined or this node must have children. */
-  icon?: IconType;
+  icon?: ExplicitUnion<IconType>;
 }
 
 export interface MenuWithIcon extends MenuItemBaseProps {
   /** Either prop `icon` must be defined or this node must have children. */
-  icon: IconType;
+  icon: ExplicitUnion<IconType>;
   children?: React.ReactNode;
 }
 
-export type MenuItemProps = MenuWithChildren | MenuWithIcon;
+type RawMenuItemProps = MenuWithChildren | MenuWithIcon;
+
+// need the below "trick" to get intellisense to work correctly with the individual props when hovering
+export type MenuItemProps = {
+  [K in keyof RawMenuItemProps]: RawMenuItemProps[K];
+};
 
 declare function MenuItem(props: MenuItemProps): JSX.Element;
 

--- a/src/components/menu/menu.d.ts
+++ b/src/components/menu/menu.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { LayoutProps, FlexboxProps } from "styled-system";
+import { Expand, ExplicitUnion } from "../../__internal__/utils/helpers/types";
 
 type menuType = "light" | "dark" | "white" | "black";
 interface MenuContextProps {
@@ -14,11 +15,11 @@ interface MenuContextProps {
   inMenu: boolean;
 }
 
-export interface MenuProps extends LayoutProps, FlexboxProps {
+export interface MenuProps extends Expand<LayoutProps>, Expand<FlexboxProps> {
   /** Children elements */
   children: React.ReactNode;
   /** Defines the color scheme of the component */
-  menuType?: menuType;
+  menuType?: ExplicitUnion<menuType>;
 }
 
 declare const MenuContext: React.Context<MenuContextProps>;

--- a/src/components/message/message.component.tsx
+++ b/src/components/message/message.component.tsx
@@ -4,6 +4,7 @@ import { MarginProps } from "styled-system";
 import MessageStyle from "./message.style";
 import TypeIcon from "./type-icon/type-icon.component";
 import MessageContent from "./message-content/message-content.component";
+import { Expand, ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import Icon from "../icon";
 import IconButton from "../icon-button";
@@ -12,7 +13,7 @@ import useLocale from "../../hooks/__internal__/useLocale";
 
 export type MessageVariant = "error" | "info" | "success" | "warning";
 
-export interface MessageProps extends MarginProps {
+export interface MessageProps extends Expand<MarginProps> {
   /** set content to component */
   children?: React.ReactNode;
   /** set custom class to component */
@@ -36,7 +37,7 @@ export interface MessageProps extends MarginProps {
   /** set background to be invisible */
   transparent?: boolean;
   /** set type of message based on new DLS standard */
-  variant?: MessageVariant;
+  variant?: ExplicitUnion<MessageVariant>;
 }
 
 export const Message = ({

--- a/src/components/navigation-bar/navigation-bar.component.tsx
+++ b/src/components/navigation-bar/navigation-bar.component.tsx
@@ -1,24 +1,27 @@
 import React from "react";
 import { PaddingProps, FlexboxProps } from "styled-system";
+import { Expand, ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import StyledNavigationBar from "./navigation-bar.style";
 
 export type Position = "sticky" | "fixed";
 export type Orientation = "top" | "bottom";
 export type NavigationType = "light" | "dark" | "white" | "black";
 
-export interface NavigationBarProps extends PaddingProps, FlexboxProps {
+export interface NavigationBarProps
+  extends Expand<PaddingProps>,
+    Expand<FlexboxProps> {
   children?: React.ReactNode;
   ariaLabel?: string;
   /** Color scheme of navigation component */
-  navigationType?: NavigationType;
+  navigationType?: ExplicitUnion<NavigationType>;
   /** If 'true' the children will not be visible */
   isLoading?: boolean;
   /** Defines whether the navigation bar should be positioned fixed or sticky */
-  position?: Position;
+  position?: ExplicitUnion<Position>;
   /** Defines the offset of navigation bar */
   offset?: string;
   /** Defines whether the navigation bar should be positioned top or bottom */
-  orientation?: Orientation;
+  orientation?: ExplicitUnion<Orientation>;
 }
 
 export const NavigationBar = ({

--- a/src/components/navigation-bar/navigation-bar.style.ts
+++ b/src/components/navigation-bar/navigation-bar.style.ts
@@ -1,5 +1,6 @@
 import styled, { css } from "styled-components";
 import { padding, flexbox, PaddingProps, FlexboxProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { baseTheme } from "../../style/themes";
 import {
   Position,
@@ -8,7 +9,7 @@ import {
 } from "./navigation-bar.component";
 
 export type StyledNavigationBarProps = PaddingProps &
-  FlexboxProps & {
+  Expand<FlexboxProps> & {
     /** Color scheme of navigation component */
     navigationType?: NavigationType;
     /** Defines whether the navigation bar should be positioned fixed or sticky */

--- a/src/components/note/note.d.ts
+++ b/src/components/note/note.d.ts
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 
-export interface NoteProps extends MarginProps {
+export interface NoteProps extends Expand<MarginProps> {
   /**  The rich text content to display in the Note */
   noteContent: Record<string, unknown>;
   /** Set a percentage-based width for the whole Note component, relative to its parent. */

--- a/src/components/numeral-date/numeral-date.d.ts
+++ b/src/components/numeral-date/numeral-date.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { ValidationProps } from "../../__internal__/validations";
 
 interface DayMonthDate {
@@ -24,7 +25,7 @@ interface NumeralDateEvent {
   };
 }
 
-export interface NumeralDateProps extends ValidationProps, MarginProps {
+export interface NumeralDateProps extends ValidationProps, Expand<MarginProps> {
   /** Identifier used for testing purposes, applied to the root element of the component. */
   "data-component"?: string;
   /** Identifier used for testing purposes, applied to the root element of the component. */
@@ -51,9 +52,9 @@ export interface NumeralDateProps extends ValidationProps, MarginProps {
     | ["mm", "dd"]
     | ["mm", "yyyy"];
   /** Default value for use in uncontrolled mode  */
-  defaultValue?: DayMonthDate | MonthYearDate | FullDate;
+  defaultValue?: Expand<DayMonthDate | MonthYearDate | FullDate>;
   /**  Value for use in controlled mode  */
-  value?: DayMonthDate | MonthYearDate | FullDate;
+  value?: Expand<DayMonthDate | MonthYearDate | FullDate>;
   /** When true, enables the internal errors to be displayed */
   enableInternalError?: boolean;
   /** When true, enables the internal warnings to be displayed */
@@ -77,9 +78,9 @@ export interface NumeralDateProps extends ValidationProps, MarginProps {
   /** Spacing between label and a field for inline label, given number will be multiplied by base spacing unit (8) */
   labelSpacing?: 1 | 2;
   /** Blur event handler */
-  onBlur?: (ev: NumeralDateEvent) => void;
+  onBlur?: (ev: Expand<NumeralDateEvent>) => void;
   /** Change event handler */
-  onChange?: (ev: NumeralDateEvent) => void;
+  onChange?: (ev: Expand<NumeralDateEvent>) => void;
   /** Flag to configure component as mandatory */
   required?: boolean;
   /** Size of an input */

--- a/src/components/pages/page/page.component.tsx
+++ b/src/components/pages/page/page.component.tsx
@@ -1,13 +1,14 @@
 import React, { useRef } from "react";
 import { CSSTransition } from "react-transition-group";
 import { PaddingProps } from "styled-system";
+import { Expand } from "../../../__internal__/utils/helpers/types";
 import tagComponent from "../../../__internal__/utils/helpers/tags/tags";
 import FullScreenHeading from "../../../__internal__/full-screen-heading";
 import Box from "../../box";
 import { StyledPage, StyledPageContent } from "./page.style";
 import { filterStyledSystemPaddingProps } from "../../../style/utils";
 
-export interface PageProps extends PaddingProps {
+export interface PageProps extends Expand<PaddingProps> {
   /** The title for the page, normally a Heading component. */
   title: React.ReactNode;
   /** This component supports children. */

--- a/src/components/pill/pill.style.ts
+++ b/src/components/pill/pill.style.ts
@@ -2,6 +2,7 @@ import styled, { css } from "styled-components";
 import { shade, meetsContrastGuidelines } from "polished";
 import { margin, MarginProps } from "styled-system";
 
+import { Expand } from "../../__internal__/utils/helpers/types";
 import styleConfig from "./pill.style.config";
 import { baseTheme } from "../../style/themes";
 import { ThemeObject } from "../../style/themes/base/base-theme.config";
@@ -9,7 +10,7 @@ import StyledIcon from "../icon/icon.style";
 import { toColor } from "../../style/utils/color";
 import getColorValue from "../../style/utils/get-color-value";
 
-export interface StyledPillProps extends MarginProps {
+export interface StyledPillProps extends Expand<MarginProps> {
   /** Override color variant, provide any color from palette or any valid css color value. */
   borderColor?: string;
   /** Sets the max-width of the pill. */

--- a/src/components/popover-container/popover-container.component.tsx
+++ b/src/components/popover-container/popover-container.component.tsx
@@ -12,6 +12,7 @@ import {
   PopoverContainerOpenIcon,
 } from "./popover-container.style";
 import Icon from "../icon";
+import { Expand, ExpandOnce } from "../../__internal__/utils/helpers/types";
 import Popover from "../../__internal__/popover";
 import createGuid from "../../__internal__/utils/helpers/guid";
 import { filterStyledSystemPaddingProps } from "../../style/utils";
@@ -83,19 +84,19 @@ export const renderClose = ({
   </PopoverContainerCloseIcon>
 );
 
-export interface PopoverContainerProps extends PaddingProps {
+export interface PopoverContainerProps extends Expand<PaddingProps> {
   /** A function that will render the open component
    *
    * `({tabIndex, isOpen, data-element, onClick, ref, aria-label}) => ()`
    *
    */
-  renderOpenComponent?: (args: RenderOpenProps) => JSX.Element;
+  renderOpenComponent?: (args: ExpandOnce<RenderOpenProps>) => JSX.Element;
   /** A function that will render the close component
    *
    * `({data-element, tabIndex, onClick, ref, aria-label}) => ()`
    *
    */
-  renderCloseComponent?: (args: RenderCloseProps) => JSX.Element;
+  renderCloseComponent?: (args: ExpandOnce<RenderCloseProps>) => JSX.Element;
   /** The content of the popover-container */
   children?: React.ReactNode;
   /** Sets rendering position of dialog */

--- a/src/components/portrait/portrait.component.tsx
+++ b/src/components/portrait/portrait.component.tsx
@@ -3,6 +3,7 @@ import { MarginProps } from "styled-system";
 
 import { IconType } from "../icon";
 import Tooltip from "../tooltip";
+import { Expand, ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import PortraitGravatar from "./portrait-gravatar.component";
 import PortraitInitials from "./portrait-initials.component";
@@ -18,15 +19,15 @@ export type PortraitShapes = "circle" | "square";
 
 export type PortraitSizes = "XS" | "S" | "M" | "ML" | "L" | "XL" | "XXL";
 
-export interface PortraitBaseProps extends MarginProps {
+export interface PortraitBaseProps extends Expand<MarginProps> {
   /** The size of the Portrait. */
-  size?: PortraitSizes;
+  size?: ExplicitUnion<PortraitSizes>;
   /** The `alt` HTML string. */
   alt?: string;
   /** The shape of the Portrait. */
-  shape?: PortraitShapes;
+  shape?: ExplicitUnion<PortraitShapes>;
   /** Icon to be rendered as a fallback. */
-  iconType?: IconType;
+  iconType?: ExplicitUnion<IconType>;
   /** The initials to render in the Portrait. */
   initials?: string;
   /** Use a dark background. */
@@ -63,7 +64,12 @@ export interface PortraitWithSrc extends PortraitBaseProps {
   gravatar?: never;
 }
 
-export type PortraitProps = PortraitWithGravatar | PortraitWithSrc;
+export type RawPortraitProps = PortraitWithGravatar | PortraitWithSrc;
+
+// need the below "trick" to get intellisense to work correctly with the individual props when hovering
+export type PortraitProps = {
+  [K in keyof RawPortraitProps]: RawPortraitProps[K];
+};
 
 export const Portrait = ({
   alt = "",

--- a/src/components/preview/preview.component.tsx
+++ b/src/components/preview/preview.component.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { MarginProps } from "styled-system";
 
+import { Expand } from "../../__internal__/utils/helpers/types";
 import PreviewPlaceholder, {
   PreviewPlaceholderProps,
 } from "./__internal__/preview-placeholder.component";
@@ -9,7 +10,7 @@ import { filterStyledSystemMarginProps } from "../../style/utils";
 
 export interface PreviewProps
   extends Partial<Omit<PreviewPlaceholderProps, "index">>,
-    MarginProps {
+    Expand<MarginProps> {
   /** Children content to render in the component. */
   children?: React.ReactNode;
   /* Provides more control over when in a loading state. */

--- a/src/components/progress-tracker/progress-tracker.d.ts
+++ b/src/components/progress-tracker/progress-tracker.d.ts
@@ -1,6 +1,7 @@
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 
-export interface ProgressTrackerProps extends MarginProps {
+export interface ProgressTrackerProps extends Expand<MarginProps> {
   /** Specifies an aria-label to the component */
   "aria-label"?: string;
   /** Specifies the aria-describedby for the component */

--- a/src/components/radio-button/radio-button-group.d.ts
+++ b/src/components/radio-button/radio-button-group.d.ts
@@ -1,8 +1,11 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { ValidationProps } from "../../__internal__/validations";
 
-export interface RadioButtonGroupProps extends ValidationProps, MarginProps {
+export interface RadioButtonGroupProps
+  extends ValidationProps,
+    Expand<MarginProps> {
   /** Breakpoint for adaptive legend (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLegendBreakpoint?: number;
   /** Breakpoint for adaptive spacing (left margin changes to 0). Enables the adaptive behaviour when set */

--- a/src/components/radio-button/radio-button.d.ts
+++ b/src/components/radio-button/radio-button.d.ts
@@ -1,9 +1,10 @@
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { CommonCheckableInputProps } from "../../__internal__/checkable-input";
 
 export interface RadioButtonProps
   extends CommonCheckableInputProps,
-    MarginProps {
+    Expand<MarginProps> {
   /** Identifier used for testing purposes, applied to the root element of the component. */
   "data-component"?: string;
   /** Identifier used for testing purposes, applied to the root element of the component. */

--- a/src/components/search/search.component.tsx
+++ b/src/components/search/search.component.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useEffect } from "react";
 import invariant from "invariant";
 import { MarginProps } from "styled-system";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import StyledSearch from "./search.style";
 import StyledSearchButton, { StyledButtonIcon } from "./search-button.style";
@@ -18,7 +19,7 @@ export interface SearchEvent {
   };
 }
 
-export interface SearchProps extends ValidationProps, MarginProps {
+export interface SearchProps extends ValidationProps, Expand<MarginProps> {
   /** Prop to specify the aria-label of the search component */
   "aria-label"?: string;
   /** Prop for `uncontrolled` use */
@@ -32,11 +33,11 @@ export interface SearchProps extends ValidationProps, MarginProps {
   /** Prop for `onBlur` events */
   onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
   /** Prop for `onChange` events */
-  onChange?: (ev: SearchEvent) => void;
+  onChange?: (ev: Expand<SearchEvent>) => void;
   /** Prop for `onClick` events.
    *  `onClick` events are triggered when the `searchButton` is clicked
    */
-  onClick?: (ev: SearchEvent) => void;
+  onClick?: (ev: Expand<SearchEvent>) => void;
   /** Prop for `onFocus` events */
   onFocus?: (ev: React.FocusEvent<HTMLInputElement>) => void;
   /** Prop for `onKeyDown` events */

--- a/src/components/select/filterable-select/filterable-select.d.ts
+++ b/src/components/select/filterable-select/filterable-select.d.ts
@@ -1,5 +1,9 @@
 import * as React from "react";
 import { Side } from "@floating-ui/dom";
+import {
+  Expand,
+  ExplicitUnion,
+} from "../../../__internal__/utils/helpers/types";
 import Button from "../../button";
 import { FormInputPropTypes } from "../select-textbox/select-textbox";
 
@@ -20,7 +24,7 @@ export interface FilterableSelectProps
   /** If true the loader animation is displayed in the option list */
   isLoading?: boolean;
   /** True for default text button or a Button Component to be rendered */
-  listActionButton?: boolean | typeof Button;
+  listActionButton?: boolean | Expand<typeof Button>;
   /** When true component will work in multi column mode.
    * Children should consist of OptionRow components in this mode
    */
@@ -48,7 +52,7 @@ export interface FilterableSelectProps
   /** Maximum list height - defaults to 180 */
   listMaxHeight?: number;
   /** Placement of the select list in relation to the input element */
-  listPlacement?: Side;
+  listPlacement?: ExplicitUnion<Side>;
   /** Use the opposite list placement if the set placement does not fit */
   flipEnabled?: boolean;
 }

--- a/src/components/select/multi-select/multi-select.d.ts
+++ b/src/components/select/multi-select/multi-select.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Side } from "@floating-ui/dom";
+import { ExplicitUnion } from "../../../__internal__/utils/helpers/types";
 import { FormInputPropTypes } from "../select-textbox/select-textbox";
 
 export interface MultiSelectProps
@@ -43,7 +44,7 @@ export interface MultiSelectProps
   /** Maximum list height - defaults to 180 */
   listMaxHeight?: number;
   /** Placement of the select list in relation to the input element */
-  listPlacement?: Side;
+  listPlacement?: ExplicitUnion<Side>;
   /** Use the opposite list placement if the set placement does not fit */
   flipEnabled?: boolean;
   /** Wraps the pill text when it would overflow the input width */

--- a/src/components/select/simple-select/simple-select.d.ts
+++ b/src/components/select/simple-select/simple-select.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Side } from "@floating-ui/dom";
+import { ExplicitUnion } from "../../../__internal__/utils/helpers/types";
 import { FormInputPropTypes } from "../select-textbox/select-textbox";
 
 export interface SimpleSelectProps
@@ -41,7 +42,7 @@ export interface SimpleSelectProps
   /** Maximum list height - defaults to 180 */
   listMaxHeight?: number;
   /** Placement of the select list in relation to the input element */
-  listPlacement?: Side;
+  listPlacement?: ExplicitUnion<Side>;
   /** Use the opposite list placement if the set placement does not fit */
   flipEnabled?: boolean;
 }

--- a/src/components/sidebar/sidebar.component.tsx
+++ b/src/components/sidebar/sidebar.component.tsx
@@ -5,6 +5,7 @@ import Modal from "../modal";
 import StyledSidebar from "./sidebar.style";
 import IconButton from "../icon-button";
 import Icon from "../icon";
+import { Expand, ExpandOnce } from "../../__internal__/utils/helpers/types";
 import FocusTrap from "../../__internal__/focus-trap";
 import SidebarHeader from "./__internal__/sidebar-header";
 import Box from "../box";
@@ -26,7 +27,7 @@ export interface SidebarContextProps {
 
 export const SidebarContext = React.createContext<SidebarContextProps>({});
 
-export interface SidebarProps extends PaddingProps, TagProps {
+export interface SidebarProps extends Expand<PaddingProps>, TagProps {
   /** Prop to specify the aria-describedby property of the component */
   "aria-describedby"?: string;
   /**
@@ -68,7 +69,7 @@ export interface SidebarProps extends PaddingProps, TagProps {
     | "large"
     | "extra-large";
   /** an optional array of refs to containers whose content should also be reachable by tabbing from the sidebar */
-  focusableContainers?: CustomRefObject<HTMLElement>[];
+  focusableContainers?: ExpandOnce<CustomRefObject<HTMLElement>>[];
   /** Optional selector to identify the focusable elements, if not provided a default selector is used */
   focusableSelectors?: string;
 }

--- a/src/components/simple-color-picker/simple-color-picker.d.ts
+++ b/src/components/simple-color-picker/simple-color-picker.d.ts
@@ -1,17 +1,22 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
+import { Expand, ExpandOnce } from "../../__internal__/utils/helpers/types";
 import { ValidationProps } from "../../__internal__/validations";
 import { SimpleColorProps } from "./simple-color/simple-color";
 
 type SimpleColorPickerChild =
-  | React.ReactElement<SimpleColorProps>
+  | React.ReactElement<ExpandOnce<SimpleColorProps>>
   | boolean
   | null
   | undefined;
 
-export interface SimpleColorPickerProps extends ValidationProps, MarginProps {
+export interface SimpleColorPickerProps
+  extends ValidationProps,
+    Expand<MarginProps> {
   /** The SimpleColor components to be rendered in the group */
-  children?: SimpleColorPickerChild | SimpleColorPickerChild[];
+  children?:
+    | ExpandOnce<SimpleColorPickerChild>
+    | ExpandOnce<SimpleColorPickerChild>[];
   /** prop that represents childWidth */
   childWidth?: string;
   /** Should the onBlur callback prop be initially blocked? */

--- a/src/components/split-button/split-button.component.tsx
+++ b/src/components/split-button/split-button.component.tsx
@@ -14,6 +14,7 @@ import Button from "../button";
 import StyledSplitButton from "./split-button.style";
 import StyledSplitButtonToggle from "./split-button-toggle.style";
 import StyledSplitButtonChildrenContainer from "./split-button-children.style";
+import { Expand, ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import Events from "../../__internal__/utils/helpers/events";
 import guid from "../../__internal__/utils/helpers/guid";
 import Popover from "../../__internal__/popover";
@@ -28,7 +29,7 @@ const CONTENT_WIDTH_RATIO = 0.75;
 
 export interface SplitButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    MarginProps {
+    Expand<MarginProps> {
   /** Set align of the rendered content */
   align?: "left" | "right";
   /** Button type: "primary" | "secondary" */
@@ -44,7 +45,7 @@ export interface SplitButtonProps
   /** Defines an Icon position within the button: "before" | "after" */
   iconPosition?: "before" | "after";
   /** Defines an Icon type within the button */
-  iconType?: IconType;
+  iconType?: ExplicitUnion<IconType>;
   /** The size of the buttons in the SplitButton. */
   size?: "small" | "medium" | "large";
   /** Second text child, renders under main text, only when size is "large" */

--- a/src/components/step-sequence/step-sequence.component.tsx
+++ b/src/components/step-sequence/step-sequence.component.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { MarginProps } from "styled-system";
 
+import { Expand } from "../../__internal__/utils/helpers/types";
 import StepSequenceStyle from "./step-sequence.style";
 
 export const StepSequenceContext = React.createContext<{
   orientation: "horizontal" | "vertical";
 }>({ orientation: "horizontal" });
 
-export interface StepSequenceProps extends MarginProps {
+export interface StepSequenceProps extends Expand<MarginProps> {
   /** Step sequence items to be rendered */
   children: React.ReactNode;
   /** The direction that step sequence items should be rendered */

--- a/src/components/switch/switch.d.ts
+++ b/src/components/switch/switch.d.ts
@@ -1,10 +1,13 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
+import { Expand, ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import { CommonCheckableInputProps } from "../../__internal__/checkable-input";
 
 export type LabelAlign = "left" | "right";
 
-export interface SwitchProps extends CommonCheckableInputProps, MarginProps {
+export interface SwitchProps
+  extends CommonCheckableInputProps,
+    Expand<MarginProps> {
   /** Identifier used for testing purposes, applied to the root element of the component. */
   "data-component"?: string;
   /** Identifier used for testing purposes, applied to the root element of the component. */
@@ -16,7 +19,7 @@ export interface SwitchProps extends CommonCheckableInputProps, MarginProps {
   /** Set the default value of the Switch if component is meant to be used as uncontrolled */
   defaultChecked?: boolean;
   /** Text alignment of the label */
-  labelAlign?: LabelAlign;
+  labelAlign?: ExplicitUnion<LabelAlign>;
   /** When true label is inline */
   labelInline?: boolean;
   /** Triggers loading animation */

--- a/src/components/tabs/tab/tab.d.ts
+++ b/src/components/tabs/tab/tab.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { PaddingProps } from "styled-system";
+import { Expand } from "../../../__internal__/utils/helpers/types";
 
 export interface TabContextProps {
   setError?: (childId: string, hasError: boolean) => void;
@@ -7,7 +8,7 @@ export interface TabContextProps {
   setInfo?: (childId: string, hasInfo: boolean) => void;
 }
 
-export interface TabProps extends PaddingProps {
+export interface TabProps extends Expand<PaddingProps> {
   title?: string;
   /** A unique ID to identify this specific tab. */
   tabId: string;

--- a/src/components/tabs/tabs.d.ts
+++ b/src/components/tabs/tabs.d.ts
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 import Tab from "./tab";
 
-export interface TabsProps extends MarginProps {
+export interface TabsProps extends Expand<MarginProps> {
   className?: string;
   /** Prevent rendering of hidden tabs, by default this is set to true and therefore all tabs will be rendered */
   renderHiddenTabs?: boolean;

--- a/src/components/text-editor/text-editor.d.ts
+++ b/src/components/text-editor/text-editor.d.ts
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
 import { Editor, EditorState, ContentState } from "draft-js";
+import { Expand } from "../../__internal__/utils/helpers/types";
 
-export interface TextEditorProps extends MarginProps {
+export interface TextEditorProps extends Expand<MarginProps> {
   /** The maximum characters that the input will accept */
   characterLimit?: number;
   /** The text for the editor's label */

--- a/src/components/textarea/textarea.d.ts
+++ b/src/components/textarea/textarea.d.ts
@@ -1,13 +1,14 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
 
+import { Expand } from "../../__internal__/utils/helpers/types";
 import { ValidationProps } from "../../__internal__/validations";
 import { CommonInputProps } from "../../__internal__/input";
 
 // TODO: Change characterLimit type to number - batch with other breaking changes
 export interface TextareaProps
   extends ValidationProps,
-    MarginProps,
+    Expand<MarginProps>,
     Omit<CommonInputProps, "size"> {
   /** Automatically focus the input on component mount */
   autoFocus?: boolean;

--- a/src/components/textbox/textbox.component.tsx
+++ b/src/components/textbox/textbox.component.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { MarginProps } from "styled-system";
 
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import { Expand, ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import {
   Input,
   InputPresentation,
@@ -24,7 +25,7 @@ import NumeralDateContext from "../numeral-date/numeral-date-context";
 
 export interface CommonTextboxProps
   extends ValidationProps,
-    MarginProps,
+    Expand<MarginProps>,
     Omit<CommonInputProps, "size"> {
   /** Identifier used for testing purposes, applied to the root element of the component. */
   "data-component"?: string;
@@ -46,7 +47,7 @@ export interface CommonTextboxProps
   /** Unique identifier for the input. Will use a randomly generated GUID if none is provided */
   id?: string;
   /** Type of the icon that will be rendered next to the input */
-  inputIcon?: IconType;
+  inputIcon?: ExplicitUnion<IconType>;
   /** Optional handler for click event on Textbox icon */
   iconOnClick?: (
     ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>

--- a/src/components/tile-select/tile-select-group.d.ts
+++ b/src/components/tile-select/tile-select-group.d.ts
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 
-export interface TileSelectGroupProps extends MarginProps {
+export interface TileSelectGroupProps extends Expand<MarginProps> {
   /** The TileSelect components to be rendered in the group */
   children: React.ReactNode;
   /** The content for the TileSelectGroup Legend */

--- a/src/components/tile-select/tile-select.d.ts
+++ b/src/components/tile-select/tile-select.d.ts
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { MarginProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 
-export interface TileSelectProps extends MarginProps {
+export interface TileSelectProps extends Expand<MarginProps> {
   /** title of the TileSelect */
   title?: string;
   /** adornment to be rendered next to the title */

--- a/src/components/tile/tile-footer/tile-footer.d.ts
+++ b/src/components/tile/tile-footer/tile-footer.d.ts
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { PaddingProps } from "styled-system";
+import { Expand } from "../../../__internal__/utils/helpers/types";
 
-export interface TileFooterProps extends PaddingProps {
+export interface TileFooterProps extends Expand<PaddingProps> {
   /** set which background color variant should be used */
   variant?: "default" | "transparent";
 }

--- a/src/components/tile/tile.d.ts
+++ b/src/components/tile/tile.d.ts
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { SpaceProps } from "styled-system";
+import { Expand } from "../../__internal__/utils/helpers/types";
 
-export interface TileProps extends SpaceProps {
+export interface TileProps extends Expand<SpaceProps> {
   /** Sets the theme of the tile - either 'tile', 'transparent' or 'active' */
   variant?: "tile" | "transparent" | "active";
   /**

--- a/src/components/toast/toast.d.ts
+++ b/src/components/toast/toast.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { ExplicitUnion } from "../../__internal__/utils/helpers/types";
 
 type ToastVariants = "error" | "info" | "success" | "warning" | "notice";
 
@@ -6,7 +7,7 @@ export interface ToastPropTypes {
   /** The rendered children of the component. */
   children: React.ReactNode;
   /** Customizes the appearance in the DLS theme */
-  variant?: ToastVariants;
+  variant?: ExplicitUnion<ToastVariants>;
   /** Custom className */
   className?: string;
   /** Custom id  */

--- a/src/components/tooltip/tooltip.component.tsx
+++ b/src/components/tooltip/tooltip.component.tsx
@@ -6,6 +6,7 @@ import invariant from "invariant";
 import StyledTooltip from "./tooltip.style";
 import StyledPointer from "./tooltip-pointer.style";
 import { TooltipPositions, TOOLTIP_POSITIONS } from "./tooltip.config";
+import { ExplicitUnion } from "../../__internal__/utils/helpers/types";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import CarbonScopedTokensProvider from "../../style/design-tokens/carbon-scoped-tokens-provider/carbon-scoped-tokens-provider.component";
 
@@ -28,7 +29,7 @@ export interface TooltipProps {
   /** Whether to to show the Tooltip */
   isVisible?: boolean;
   /** Sets position of the tooltip */
-  position?: TooltipPositions;
+  position?: ExplicitUnion<TooltipPositions>;
   /** Defines the message type */
   type?: string;
   /** Children elements */
@@ -44,7 +45,7 @@ export interface TooltipProps {
    * must be an array containing some or all of ["top", "bottom", "left", "right"]
    * (see https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements)
    */
-  flipOverrides?: TooltipPositions[];
+  flipOverrides?: ExplicitUnion<TooltipPositions>[];
   /** @ignore @private */
   target?: Element;
   /** @ignore @private */

--- a/src/components/typography/typography.component.tsx
+++ b/src/components/typography/typography.component.tsx
@@ -1,5 +1,6 @@
 import styled, { css } from "styled-components";
 import { ColorProps, space, SpaceProps } from "styled-system";
+import { ExplicitUnion, Expand } from "../../__internal__/utils/helpers/types";
 import styledColor from "../../style/utils/color";
 import baseTheme from "../../style/themes/base";
 
@@ -26,9 +27,11 @@ const VARIANT_TYPES = [
   "ol",
 ] as const;
 type VariantTypes = typeof VARIANT_TYPES[number];
-export interface TypographyProps extends SpaceProps, ColorProps {
+export interface TypographyProps
+  extends Expand<SpaceProps>,
+    Expand<ColorProps> {
   /** Override the variant component */
-  as?: React.ElementType;
+  as?: ExplicitUnion<React.ElementType>;
   /** The visual style to apply to the component */
   variant?: VariantTypes;
   /** Override the variant font-size */

--- a/src/components/vertical-divider/vertical-divider.component.tsx
+++ b/src/components/vertical-divider/vertical-divider.component.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import { SpaceProps } from "styled-system";
+import { ExplicitUnion, Expand } from "../../__internal__/utils/helpers/types";
 import { MenuContext } from "../menu/menu.component";
 import { StyledVerticalWrapper, StyledDivider } from "./vertical-divider.style";
 
@@ -105,12 +106,12 @@ type TintRange =
   | 99
   | 100;
 
-export interface VerticalDividerProps extends SpaceProps {
+export interface VerticalDividerProps extends Expand<SpaceProps> {
   h?: number | string;
   height?: number | string;
   displayInline?: boolean;
   /** the supported rage is 1-100  */
-  tint?: TintRange;
+  tint?: ExplicitUnion<TintRange>;
 }
 
 const VerticalDivider = ({


### PR DESCRIPTION
### Proposed behaviour

When using Carbon components in a TypeScript project, the auto-completion and intellisense on props should be helpful. In particular, when hovering over a prop name:
- if the prop is a union of strings or numbers, the options should be displayed, not just a type alias which is meaningful to the consumer
- if the prop is a relatively complex object or function, the type shown on hover should describe what properties it has and their types, rather than be something somewhat cryptic.

Note: this PR does not give a "ideal" representation of all props - firstly because what is best is often subjective, and secondly because particularly with some styled-system props it wasn't possible to do this completely to my satisfaction. But all props should at least display better than before, and any cases we are unhappy with can be left for future investigation.

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

Many types shown of props on hover do not live up to the above description and are confusing or even meaningless to consumers - see the linked codesandbox for examples.

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

Note that the following Codesandbox example does not even run, for reasons I do not fully understand but which I'm sure are unrelated to the TS issues fixed by this PR. Even if it did run, the output in the browser would be nonsensical, and it wouldn't matter anyway. The point of the sandbox instead is to highlight what consumers of Carbon see when using our components - in particular, what type is displayed when hovering over a prop. Only those props which have a problematic display are used (as well as some that are required by the component - these are highlighted in the comments). Each prop is commented with a brief description of what is wrong with it.

To test this PR, the best way - although unfortunately very time-consuming - is to compare every prop given in the sandbox both before and after the PR, and confirm that the version after the PR is more helpful to a developer consuming Carbon.

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.
https://codesandbox.io/s/bad-type-display-jvkjr2?file=/src/index.tsx:29249-29257

<!-- Add CodeSandbox here -->
