### PR TITLE
refactor(tooltip): make tooltips use floating-ui package - FE-5498

### DIFF
--- a/cypress/locators/radiobutton/locators.js
+++ b/cypress/locators/radiobutton/locators.js
@@ -2,3 +2,4 @@
 export const RADIOBUTTONGROUP = '[data-component="radiogroup"]';
 export const RADIOBUTTONCOMPONENT = '[data-component="radio-button"]';
 export const RADIOBUTTONROLE = '[role="radio"]';
+export const RADIOGROUP_ROLE = '[role="radiogroup"]';

--- a/cypress/locators/tooltip/index.js
+++ b/cypress/locators/tooltip/index.js
@@ -1,5 +1,12 @@
-import { TOOLTIP_PREVIEW, TOOLTIP_POINTER } from "./locators";
+import {
+  TOOLTIP_PREVIEW,
+  TOOLTIP_POINTER,
+  TOOLTIP_TRIGGER,
+  TOOLTIP_TRIGGER_TOGGLE,
+} from "./locators";
 
 // component preview locators
 export const tooltipPreview = () => cy.get(TOOLTIP_PREVIEW);
 export const tooltipPointer = () => cy.get(TOOLTIP_POINTER);
+export const tooltipTrigger = () => cy.get(TOOLTIP_TRIGGER);
+export const tooltipTriggerToggle = () => cy.get(TOOLTIP_TRIGGER_TOGGLE);

--- a/cypress/locators/tooltip/locators.js
+++ b/cypress/locators/tooltip/locators.js
@@ -1,3 +1,6 @@
 // component preview locators
 export const TOOLTIP_PREVIEW = '[data-element="tooltip"]';
 export const TOOLTIP_POINTER = `${TOOLTIP_PREVIEW} > div[data-element="tooltip-pointer"]`;
+export const TOOLTIP_TRIGGER = '[data-component="tooltip-trigger"]';
+export const TOOLTIP_TRIGGER_TOGGLE =
+  '[data-component="tooltip-trigger-toggle"]';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@floating-ui/dom": "^1.0.2",
+        "@floating-ui/dom": "^1.0.7",
+        "@floating-ui/react-dom": "^1.0.1",
         "@octokit/rest": "^18.12.0",
         "@styled-system/prop-types": "^5.1.5",
-        "@tippyjs/react": "^4.2.5",
         "@types/styled-system": "^5.1.11",
         "chalk": "^4.1.1",
         "ci-info": "^3.3.2",
@@ -3644,16 +3644,28 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.2.tgz",
+      "integrity": "sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg=="
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.2.tgz",
-      "integrity": "sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.7.tgz",
+      "integrity": "sha512-6RsqvCYe0AYWtsGvuWqCm7mZytnXAZCjWtsWu1Kg8dI3INvj/DbKlDsZO+mKSaQdPT12uxIW9W2dAWJkPx4Y5g==",
       "dependencies": {
-        "@floating-ui/core": "^1.0.1"
+        "@floating-ui/core": "^1.0.2"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.0.1.tgz",
+      "integrity": "sha512-UW0t1Gi8ikbDRr8cQPVcqIDMBwUEENe5V4wlHWdrJ5egFnRQFBV9JirauTBFI6S8sM1qFUC1i+qa3g87E6CLTw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -5540,6 +5552,7 @@
       "version": "2.11.5",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
       "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -9631,18 +9644,6 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@tippyjs/react": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.2.5.tgz",
-      "integrity": "sha512-YBLgy+1zznBNbx4JOoOdFXWMLXjBh9hLPwRtq3s8RRdrez2l3tPBRt2m2909wZd9S1KUeKjOOYYsnitccI9I3A==",
-      "dependencies": {
-        "tippy.js": "^6.3.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -28902,6 +28903,8 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -29365,6 +29368,8 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -35347,14 +35352,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/tippy.js": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.1.tgz",
-      "integrity": "sha512-JnFncCq+rF1dTURupoJ4yPie5Cof978inW6/4S6kmWV7LL9YOSEVMifED3KdrVPEG+Z/TFH2CDNJcQEfaeuQww==",
-      "dependencies": {
-        "@popperjs/core": "^2.8.3"
-      }
-    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -40292,16 +40289,24 @@
       }
     },
     "@floating-ui/core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.2.tgz",
+      "integrity": "sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg=="
     },
     "@floating-ui/dom": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.2.tgz",
-      "integrity": "sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.7.tgz",
+      "integrity": "sha512-6RsqvCYe0AYWtsGvuWqCm7mZytnXAZCjWtsWu1Kg8dI3INvj/DbKlDsZO+mKSaQdPT12uxIW9W2dAWJkPx4Y5g==",
       "requires": {
-        "@floating-ui/core": "^1.0.1"
+        "@floating-ui/core": "^1.0.2"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.0.1.tgz",
+      "integrity": "sha512-UW0t1Gi8ikbDRr8cQPVcqIDMBwUEENe5V4wlHWdrJ5egFnRQFBV9JirauTBFI6S8sM1qFUC1i+qa3g87E6CLTw==",
+      "requires": {
+        "@floating-ui/dom": "^1.0.5"
       }
     },
     "@gar/promisify": {
@@ -41789,7 +41794,8 @@
     "@popperjs/core": {
       "version": "2.11.5",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "dev": true
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -44842,14 +44848,6 @@
             "react-is": "^17.0.1"
           }
         }
-      }
-    },
-    "@tippyjs/react": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.2.5.tgz",
-      "integrity": "sha512-YBLgy+1zznBNbx4JOoOdFXWMLXjBh9hLPwRtq3s8RRdrez2l3tPBRt2m2909wZd9S1KUeKjOOYYsnitccI9I3A==",
-      "requires": {
-        "tippy.js": "^6.3.1"
       }
     },
     "@tootallnate/once": {
@@ -59728,6 +59726,8 @@
             },
             "minimatch": {
               "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -60052,6 +60052,8 @@
             },
             "minimatch": {
               "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -64735,14 +64737,6 @@
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
-      }
-    },
-    "tippy.js": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.1.tgz",
-      "integrity": "sha512-JnFncCq+rF1dTURupoJ4yPie5Cof978inW6/4S6kmWV7LL9YOSEVMifED3KdrVPEG+Z/TFH2CDNJcQEfaeuQww==",
-      "requires": {
-        "@popperjs/core": "^2.8.3"
       }
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -164,10 +164,10 @@
     "webpack-dev-server": "^4.0.0"
   },
   "dependencies": {
-    "@floating-ui/dom": "^1.0.2",
+    "@floating-ui/dom": "^1.0.7",
+    "@floating-ui/react-dom": "^1.0.1",
     "@octokit/rest": "^18.12.0",
     "@styled-system/prop-types": "^5.1.5",
-    "@tippyjs/react": "^4.2.5",
     "@types/styled-system": "^5.1.11",
     "chalk": "^4.1.1",
     "ci-info": "^3.3.2",

--- a/src/__internal__/tooltip-provider/index.tsx
+++ b/src/__internal__/tooltip-provider/index.tsx
@@ -11,7 +11,7 @@ interface TooltipProviderProps {
   focusable?: boolean;
   tooltipVisible?: boolean;
   disabled?: boolean;
-  target?: Element;
+  target?: HTMLElement;
 }
 interface ToolbarContextProps extends Omit<TooltipProviderProps, "children"> {
   tooltipId?: {

--- a/src/components/button-toggle-group/button-toggle-group.test.js
+++ b/src/components/button-toggle-group/button-toggle-group.test.js
@@ -11,6 +11,8 @@ import {
   buttonToggleGroupHelp,
   buttonToggleGroupHelpIcon,
 } from "../../../cypress/locators/button-toggle-group";
+import { RADIOGROUP_ROLE } from "../../../cypress/locators/radiobutton/locators.js";
+import { ICON } from "../../../cypress/locators/locators.js";
 import { positionOfElement } from "../../../cypress/support/helper";
 import { getDataElementByValue, icon } from "../../../cypress/locators";
 import {
@@ -124,12 +126,8 @@ context("Testing Button-Toggle-Group component", () => {
         );
 
         buttonToggleGroup()
-          .children()
-          .children()
-          .eq(1)
-          .children()
-          .eq(3)
-          .children()
+          .find(RADIOGROUP_ROLE)
+          .find(ICON)
           .should("have.attr", "type", prop);
         icon().parent().should("have.attr", "data-component", "help");
         buttonTogglePreview()
@@ -144,13 +142,9 @@ context("Testing Button-Toggle-Group component", () => {
         <ButtonToggleGroupComponent info="Info Message" validationOnLabel />
       );
 
-      buttonToggleGroup()
-        .children()
-        .children()
-        .children()
-        .eq(1)
-        .children()
-        .children()
+      getDataElementByValue("label")
+        .parent()
+        .find(ICON)
         .should("have.attr", "data-element", "info");
     });
 

--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -94,7 +94,7 @@ interface RenderChildrenProps
     | "iconTooltipPosition"
   > {
   buttonType: ButtonTypes;
-  tooltipTarget?: Element;
+  tooltipTarget?: HTMLElement;
 }
 
 function renderChildren({

--- a/src/components/button/button.test.js
+++ b/src/components/button/button.test.js
@@ -6,7 +6,7 @@ import {
   buttonDataComponent,
 } from "../../../cypress/locators/button";
 
-import { icon, tooltipPreview } from "../../../cypress/locators";
+import { cyRoot, icon, tooltipPreview } from "../../../cypress/locators";
 import { positionOfElement, keyCode } from "../../../cypress/support/helper";
 import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
@@ -70,6 +70,7 @@ context("Test for Button component", () => {
 
         buttonDataComponent().children().last().realHover();
         tooltipPreview().should("have.text", tooltipMessage);
+        cyRoot().realHover({ position: "topLeft" });
       }
     );
 

--- a/src/components/decimal/decimal.test.js
+++ b/src/components/decimal/decimal.test.js
@@ -7,6 +7,7 @@ import {
   getDataElementByValue,
   tooltipPreview,
   commonDataElementInputPreview,
+  cyRoot,
 } from "../../../cypress/locators/index";
 
 import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
@@ -212,6 +213,7 @@ context("Tests for Decimal component", () => {
 
         getDataElementByValue("question").trigger("mouseover");
         tooltipPreview().should("have.text", specificValue);
+        cyRoot().realHover({ position: "topLeft" });
       }
     );
 

--- a/src/components/duelling-picklist/duelling-picklist.test.js
+++ b/src/components/duelling-picklist/duelling-picklist.test.js
@@ -30,6 +30,7 @@ import {
   tooltipPreview,
 } from "../../../cypress/locators";
 import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+import { ICON } from "../../../cypress/locators/locators";
 
 const specialCharacters = [
   CHARACTERS.STANDARD,
@@ -867,8 +868,7 @@ context("Testing Duelling-Picklist component", () => {
           backColor
         );
         unassignedPicklistItems()
-          .children()
-          .eq(1)
+          .find(ICON)
           .should(attribute, "data-element", state);
       }
     );

--- a/src/components/fieldset/fieldset.test.js
+++ b/src/components/fieldset/fieldset.test.js
@@ -12,6 +12,7 @@ import {
   CHARACTERS,
 } from "../../../cypress/support/component-helper/constants";
 import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-helper/common-steps";
+import { ICON } from "../../../cypress/locators/locators";
 
 const specialCharacters = [
   CHARACTERS.STANDARD,
@@ -121,11 +122,8 @@ context("Testing Fieldset component", () => {
         getDataElementByValue("input")
           .eq(positionOfElement("first"))
           .parent()
-          .children(1)
-          .children()
-          .children()
-          .should("have.attr", "data-component", "icon")
-          .and("have.attr", "data-element", type);
+          .find(ICON)
+          .should("have.attr", "data-element", type);
       }
     );
 
@@ -150,11 +148,8 @@ context("Testing Fieldset component", () => {
         getDataElementByValue("label")
           .eq(positionOfElement("first"))
           .parent()
-          .children(1)
-          .children()
-          .children()
-          .should("have.attr", "data-component", "icon")
-          .and("have.attr", "data-element", type);
+          .find(ICON)
+          .should("have.attr", "data-element", type);
       }
     );
 

--- a/src/components/help/help.spec.tsx
+++ b/src/components/help/help.spec.tsx
@@ -8,15 +8,6 @@ import StyledHelp from "./help.style";
 import Tooltip from "../tooltip";
 import { testStyledSystemMargin } from "../../__spec_helper__/test-utils";
 
-interface MockTippyContent {
-  children: typeof Icon;
-}
-
-jest.mock("@tippyjs/react/headless", () => ({
-  __esModule: true,
-  default: ({ children }: MockTippyContent) => children,
-}));
-
 function renderHelp(props: HelpProps = {}) {
   const { children } = props;
   return <Help {...props}>{children || "Helpful Content"}</Help>;

--- a/src/components/icon-button/icon-button.spec.tsx
+++ b/src/components/icon-button/icon-button.spec.tsx
@@ -13,11 +13,6 @@ import Icon from "../icon";
 import StyledIcon from "../icon/icon.style";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 
-jest.mock("@tippyjs/react/headless", () => ({
-  __esModule: true,
-  default: ({ children }: { children: React.ReactNode }) => children,
-}));
-
 describe("IconButton component", () => {
   let wrapper: ReactWrapper;
   let onDismiss: jest.Mock;

--- a/src/components/icon/icon.spec.tsx
+++ b/src/components/icon/icon.spec.tsx
@@ -31,15 +31,7 @@ interface MismatchedPairs {
   rendersAs: IconType;
 }
 
-interface MockTippyContent {
-  children: typeof Icon;
-}
-
 jest.mock("../../__internal__/utils/helpers/browser-type-check");
-jest.mock("@tippyjs/react/headless", () => ({
-  __esModule: true,
-  default: ({ children }: MockTippyContent) => children,
-}));
 
 const mockBrowserTypeCheck = (browserTypeCheck as unknown) as jest.MockedFunction<
   () => boolean

--- a/src/components/icon/icon.test.js
+++ b/src/components/icon/icon.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Icon from "./icon.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
-import { icon, getDataElementByValue } from "../../../cypress/locators";
+import { icon, getDataElementByValue, cyRoot } from "../../../cypress/locators";
 import {
   SIZE,
   COLOR,
@@ -137,6 +137,7 @@ context("Tests for Icon component", () => {
         getDataElementByValue("tooltip")
           .should("be.visible")
           .contains(tooltipMessage);
+        cyRoot().realHover({ position: "topLeft" });
       }
     );
 

--- a/src/components/link/link.test.js
+++ b/src/components/link/link.test.js
@@ -8,6 +8,7 @@ import {
   link,
   getDataElementByValue,
   body,
+  cyRoot,
 } from "../../../cypress/locators";
 import { skipLink } from "../../../cypress/locators/link/index";
 import { keyCode } from "../../../cypress/support/helper";
@@ -97,10 +98,17 @@ context("Test for Link component", () => {
           </Box>
         );
 
-        icon().realHover();
-        tooltipPreview()
-          .should("be.visible")
-          .and("have.attr", "data-placement", tooltipPosition);
+        icon()
+          .realHover()
+          .then(($el) => {
+            Cypress.dom.isVisible($el);
+            tooltipPreview().should(
+              "have.attr",
+              "data-placement",
+              tooltipPosition
+            );
+          });
+        cyRoot().realHover({ position: "topLeft" });
       }
     );
 

--- a/src/components/note/__internal__/status-icon/status.spec.tsx
+++ b/src/components/note/__internal__/status-icon/status.spec.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { mount } from "enzyme";
-import StatusIcon from "./status-icon.component";
+import StatusWithTooltip from "./status-icon.component";
+import StyledStatusIconWrapper from "./status-icon.style";
 import { assertStyleMatch } from "../../../../__spec_helper__/test-utils";
 
 const render = (props = {}) => {
@@ -8,9 +9,9 @@ const render = (props = {}) => {
     tooltipMessage: "foo",
   };
   return mount(
-    <StatusIcon {...defaultProps} {...props}>
+    <StatusWithTooltip {...defaultProps} {...props}>
       foo
-    </StatusIcon>
+    </StatusWithTooltip>
   );
 };
 
@@ -23,7 +24,7 @@ describe("ContentWithTooltip", () => {
           left: "-4px",
           position: "relative",
         },
-        wrapper
+        wrapper.find(StyledStatusIconWrapper)
       );
 
       assertStyleMatch(
@@ -31,7 +32,7 @@ describe("ContentWithTooltip", () => {
           content: '""',
           marginRight: "-6px",
         },
-        wrapper,
+        wrapper.find(StyledStatusIconWrapper),
         { modifier: ":before" }
       );
     });

--- a/src/components/note/note.test.js
+++ b/src/components/note/note.test.js
@@ -5,7 +5,7 @@ import Box from "../box";
 import LinkPreview from "../link-preview";
 import { ActionPopover, ActionPopoverItem } from "../action-popover";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
-import { tooltipPreview } from "../../../cypress/locators";
+import { cyRoot, tooltipPreview } from "../../../cypress/locators";
 import { linkPreview } from "../../../cypress/locators/link-preview/index";
 import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
@@ -139,6 +139,7 @@ context("Tests for Note component", () => {
 
         noteStatus().should("have.text", value).realHover();
         tooltipPreview().should("have.text", CHARACTERS.STANDARD);
+        cyRoot().realHover({ position: "topLeft" });
       }
     );
 

--- a/src/components/numeral-date/numeral-date.test.js
+++ b/src/components/numeral-date/numeral-date.test.js
@@ -26,6 +26,7 @@ import {
   SIZE,
   VALIDATION,
 } from "../../../cypress/support/component-helper/constants";
+import { ICON } from "../../../cypress/locators/locators";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
@@ -220,8 +221,7 @@ context("Tests for NumeralDate component", () => {
 
         numeralDateInputByPosition(2)
           .parent()
-          .find("span > span > span")
-          .should("have.attr", "data-component", "icon")
+          .find(ICON)
           .and("have.attr", "data-element", type);
       }
     );
@@ -240,10 +240,7 @@ context("Tests for NumeralDate component", () => {
 
         getDataElementByValue("label")
           .parent()
-          .children()
-          .eq(1)
-          .find("span > span")
-          .should("have.attr", "data-component", "icon")
+          .find(ICON)
           .and("have.attr", "data-element", type);
       }
     );
@@ -280,8 +277,7 @@ context("Tests for NumeralDate component", () => {
         numeralDateInputByPosition(inputIndex).type(errorInput).blur();
         numeralDateInputByPosition(2)
           .parent()
-          .find("span > span > span")
-          .should("have.attr", "data-component", "icon")
+          .find(ICON)
           .and("have.attr", "data-element", "error");
         errorIcon().realHover();
         tooltipPreview().should("contain.text", tooltipText);
@@ -304,8 +300,7 @@ context("Tests for NumeralDate component", () => {
         numeralDateInputByPosition(inputIndex).type(errorInput).blur();
         numeralDateInputByPosition(2)
           .parent()
-          .find("span > span > span")
-          .should("have.attr", "data-component", "icon")
+          .find(ICON)
           .and("have.attr", "data-element", "warning");
         warningIcon().realHover();
         tooltipPreview().should("contain.text", tooltipText);

--- a/src/components/switch/switch.test.js
+++ b/src/components/switch/switch.test.js
@@ -26,6 +26,7 @@ import {
   VALIDATION,
   SIZE,
 } from "../../../cypress/support/component-helper/constants";
+import { ICON } from "../../../cypress/locators/locators";
 
 const verifyBorderColor = (element, color) =>
   element.then(($els) => {
@@ -352,11 +353,7 @@ context("Testing Switch component", () => {
         switchLabel()
           .eq(position)
           .parent()
-          .children()
-          .eq(1)
-          .children()
-          .children()
-          .should("have.attr", "data-component", "icon")
+          .find(ICON)
           .and("have.attr", "data-element", validation);
       }
     );

--- a/src/components/tabs/tabs.test.js
+++ b/src/components/tabs/tabs.test.js
@@ -13,6 +13,7 @@ import { keyCode } from "../../../cypress/support/helper";
 import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-helper/common-steps";
+import { ICON } from "../../../cypress/locators/locators";
 import { DrawerSidebarContext } from "../drawer";
 
 const TabsComponent = ({ ...props }) => {
@@ -595,13 +596,7 @@ context("Testing Tabs component", () => {
       (id, validation) => {
         CypressMountWithProviders(<TabsComponentValidations />);
 
-        tabById(id)
-          .children()
-          .children(1)
-          .children()
-          .children()
-          .should("have.attr", "data-component", "icon")
-          .and("have.attr", "type", validation);
+        tabById(id).find(ICON).and("have.attr", "type", validation);
       }
     );
 

--- a/src/components/text-editor/__internal__/toolbar/toolbar.spec.js
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.spec.js
@@ -17,11 +17,6 @@ import ToolbarButton from "./toolbar-button/toolbar-button.component";
 import Tooltip from "../../../tooltip";
 import I18nProvider from "../../../i18n-provider";
 
-jest.mock("@tippyjs/react/headless", () => ({
-  __esModule: true,
-  default: ({ children }) => children,
-}));
-
 const setInlineStyle = jest.fn();
 const setBlockStyle = jest.fn();
 

--- a/src/components/textarea/textarea.test.js
+++ b/src/components/textarea/textarea.test.js
@@ -27,6 +27,7 @@ import {
 import { textarea, textareaChildren } from "../../../cypress/locators/textarea";
 
 import { keyCode } from "../../../cypress/support/helper";
+import { ICON } from "../../../cypress/locators/locators";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
@@ -300,12 +301,7 @@ context("Tests for Textarea component", () => {
           />
         );
 
-        textarea()
-          .children(1)
-          .children()
-          .children()
-          .should("have.attr", "data-component", "icon")
-          .and("have.attr", "data-element", type);
+        textarea().find(ICON).should("have.attr", "data-element", type);
       }
     );
 
@@ -323,11 +319,8 @@ context("Tests for Textarea component", () => {
 
         getDataElementByValue("label")
           .parent()
-          .children(1)
-          .children()
-          .children()
-          .should("have.attr", "data-component", "icon")
-          .and("have.attr", "data-element", type);
+          .find(ICON)
+          .should("have.attr", "data-element", type);
       }
     );
 

--- a/src/components/textbox/textbox.test.js
+++ b/src/components/textbox/textbox.test.js
@@ -32,6 +32,7 @@ import {
 
 import { keyCode } from "../../../cypress/support/helper";
 import Button from "../button/button.component";
+import { ICON } from "../../../cypress/locators/locators";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
@@ -340,12 +341,7 @@ context("Tests for Textbox component", () => {
           />
         );
 
-        textbox()
-          .children(1)
-          .children()
-          .children()
-          .should("have.attr", "data-component", "icon")
-          .and("have.attr", "data-element", type);
+        textbox().find(ICON).should("have.attr", "data-element", type);
       }
     );
 
@@ -363,11 +359,8 @@ context("Tests for Textbox component", () => {
 
         getDataElementByValue("label")
           .parent()
-          .children(1)
-          .children()
-          .children()
-          .should("have.attr", "data-component", "icon")
-          .and("have.attr", "data-element", type);
+          .find(ICON)
+          .should("have.attr", "data-element", type);
       }
     );
 

--- a/src/components/tooltip/__snapshots__/tooltip.spec.tsx.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.spec.tsx.snap
@@ -1,105 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tooltip controlled matches snapshot when isVisible is false 1`] = `
-<ForwardRef(TippyWrapper)
-  delay={100}
-  placement="top"
-  plugins={
-    Array [
-      Object {
-        "defaultValue": false,
-        "fn": [Function],
-        "name": "sticky",
-      },
-    ]
-  }
-  popperOptions={
-    Object {
-      "modifiers": Array [
-        Object {
-          "name": "computeStyles",
-          "options": Object {
-            "gpuAcceleration": false,
-          },
-        },
-      ],
-    }
-  }
-  render={[Function]}
-  sticky={true}
-  visible={false}
->
-  <div>
+<div>
+  <div
+    data-testid="tooltip-target"
+  >
     foo
   </div>
-</ForwardRef(TippyWrapper)>
+</div>
 `;
 
 exports[`Tooltip controlled matches snapshot when isVisible is true 1`] = `
-<ForwardRef(TippyWrapper)
-  delay={100}
-  placement="top"
-  plugins={
-    Array [
-      Object {
-        "defaultValue": false,
-        "fn": [Function],
-        "name": "sticky",
-      },
-    ]
-  }
-  popperOptions={
-    Object {
-      "modifiers": Array [
-        Object {
-          "name": "computeStyles",
-          "options": Object {
-            "gpuAcceleration": false,
-          },
-        },
-      ],
-    }
-  }
-  render={[Function]}
-  sticky={true}
-  visible={true}
->
-  <div>
+<div>
+  <div
+    data-testid="tooltip-target"
+  >
     foo
   </div>
-</ForwardRef(TippyWrapper)>
-`;
-
-exports[`Tooltip default props matches snapshot 1`] = `
-<ForwardRef(TippyWrapper)
-  delay={100}
-  placement="top"
-  plugins={
-    Array [
-      Object {
-        "defaultValue": false,
-        "fn": [Function],
-        "name": "sticky",
-      },
-    ]
-  }
-  popperOptions={
-    Object {
-      "modifiers": Array [
-        Object {
-          "name": "computeStyles",
-          "options": Object {
-            "gpuAcceleration": false,
-          },
-        },
-      ],
-    }
-  }
-  render={[Function]}
-  sticky={true}
->
-  <div>
-    foo
-  </div>
-</ForwardRef(TippyWrapper)>
+  <span
+    data-portal-entrance="guid-12345"
+  />
+</div>
 `;

--- a/src/components/tooltip/tooltip-pointer.style.ts
+++ b/src/components/tooltip/tooltip-pointer.style.ts
@@ -1,17 +1,8 @@
 import styled, { css } from "styled-components";
-import { Placement } from "tippy.js";
 
 import baseTheme, { ThemeObject } from "../../style/themes/base";
 import { toColor } from "../../style/utils/color";
-
-interface StyledTooltipPointer {
-  /** Sets position of the tooltip */
-  position?: Placement;
-  /** Defines the message type */
-  type?: string;
-  /** Override background color of the Tooltip, provide any color from palette or any valid css color value. */
-  bgColor?: string;
-}
+import { TooltipProps } from "./tooltip.component";
 
 const pointerColor = (theme: ThemeObject, bgColor?: string, type?: string) => {
   if (bgColor) return toColor(theme, bgColor);
@@ -19,61 +10,21 @@ const pointerColor = (theme: ThemeObject, bgColor?: string, type?: string) => {
     ? "var(--colorsSemanticNegative500)"
     : "var(--colorsSemanticNeutral500)";
 };
-const StyledTooltipPointer = styled.div<StyledTooltipPointer>`
-  ${({ position, theme, type, bgColor }) => css`
+
+const StyledTooltipPointer = styled.div<Pick<TooltipProps, "type" | "bgColor">>`
+  ${({ theme, type, bgColor }) => css`
+    z-index: ${theme.zIndex
+      .popover}; // TODO (tokens): implement elevation tokens - FE-4437
+    background: ${pointerColor(theme, bgColor, type)};
     position: absolute;
-    width: 0;
-    height: 0;
-
-    ${position === "top" &&
-    css`
-      border-left: 8px solid transparent;
-      border-right: 8px solid transparent;
-      border-top: 8px solid ${pointerColor(theme, bgColor, type)};
-      bottom: calc(-1 * var(--spacing100));
-      @-moz-document url-prefix() {
-        bottom: -7px;
-      }
-    `}
-
-    ${position === "bottom" &&
-    css`
-      border-left: 8px solid transparent;
-      border-right: 8px solid transparent;
-      border-bottom: 8px solid ${pointerColor(theme, bgColor, type)};
-      top: calc(-1 * var(--spacing100));
-      @-moz-document url-prefix() {
-        top: -7px;
-      }
-    `}
-
-    ${position === "right" &&
-    css`
-      border-top: 8px solid transparent;
-      border-bottom: 8px solid transparent;
-      border-right: 8px solid ${pointerColor(theme, bgColor, type)};
-      left: calc(-1 * var(--spacing100));
-      @-moz-document url-prefix() {
-        left: -7px;
-      }
-    `}
-
-    ${position === "left" &&
-    css`
-      border-top: 8px solid transparent;
-      border-bottom: 8px solid transparent;
-      border-left: 8px solid ${pointerColor(theme, bgColor, type)};
-      right: calc(-1 * var(--spacing100));
-      @-moz-document url-prefix() {
-        right: -7px;
-      }
-    `}
+    width: 12px;
+    height: 12px;
+    transform: rotate(45deg);
   `}
 `;
 
 StyledTooltipPointer.defaultProps = {
   theme: baseTheme,
-  position: "top",
 };
 
 export default StyledTooltipPointer;

--- a/src/components/tooltip/tooltip.component.tsx
+++ b/src/components/tooltip/tooltip.component.tsx
@@ -1,22 +1,42 @@
-import React from "react";
-import Tippy from "@tippyjs/react/headless";
-import { sticky, Placement } from "tippy.js";
+import React, {
+  useRef,
+  useMemo,
+  useCallback,
+  useState,
+  useEffect,
+} from "react";
 import invariant from "invariant";
+import {
+  Placement,
+  offset,
+  flip,
+  shift,
+  arrow,
+  limitShift,
+  autoUpdate,
+  useFloating,
+} from "@floating-ui/react-dom";
 
 import StyledTooltip from "./tooltip.style";
 import StyledPointer from "./tooltip-pointer.style";
 import { TooltipPositions, TOOLTIP_POSITIONS } from "./tooltip.config";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
-import CarbonScopedTokensProvider from "../../style/design-tokens/carbon-scoped-tokens-provider/carbon-scoped-tokens-provider.component";
+import Portal from "../portal";
+
+function preserveRef<ElementType>(
+  ref: React.ForwardedRef<ElementType | null>,
+  node: ElementType
+) {
+  if (!ref) return;
+  if (typeof ref === "function") {
+    ref(node);
+  }
+  if (typeof ref === "object" && "current" in ref) {
+    ref.current = node;
+  }
+}
 
 const TOOLTIP_DELAY = 100;
-const tippyPlugins = [sticky];
-
-type Attrs = {
-  "data-placement": Placement;
-  "data-reference-hidden"?: string;
-  "data-escaped"?: string;
-};
 
 export type InputSizes = "small" | "medium" | "large";
 
@@ -46,7 +66,7 @@ export interface TooltipProps {
    */
   flipOverrides?: TooltipPositions[];
   /** @ignore @private */
-  target?: Element;
+  target?: HTMLElement;
   /** @ignore @private */
   isPartOfInput?: boolean;
   /** @ignore @private */
@@ -63,7 +83,7 @@ export const Tooltip = React.forwardRef<HTMLDivElement | null, TooltipProps>(
       type,
       size = "medium",
       isPartOfInput,
-      inputSize,
+      inputSize = "medium",
       id,
       bgColor,
       fontColor,
@@ -73,6 +93,160 @@ export const Tooltip = React.forwardRef<HTMLDivElement | null, TooltipProps>(
     }: TooltipProps,
     ref
   ) => {
+    const targetInternalRef = useRef<HTMLElement | null>(null);
+
+    const isControlled = isVisible !== undefined;
+
+    const [isOpen, setIsOpen] = useState(false);
+
+    let showTooltip = isOpen;
+    if (isControlled) {
+      showTooltip = isVisible;
+    }
+
+    const showDelayedTimeout = useRef<number | undefined>(undefined);
+    const hideDelayedTimeout = useRef<number | undefined>(undefined);
+
+    useEffect(() => {
+      return () => {
+        clearTimeout(showDelayedTimeout.current);
+        clearTimeout(hideDelayedTimeout.current);
+      };
+    }, []);
+
+    const show = useCallback(() => setIsOpen(true), []);
+
+    const hide = useCallback(() => setIsOpen(false), []);
+
+    const showDelayed = useCallback(() => {
+      showDelayedTimeout.current = window.setTimeout(show, TOOLTIP_DELAY);
+    }, [show]);
+
+    const hideDelayed = useCallback(() => {
+      hideDelayedTimeout.current = window.setTimeout(hide, TOOLTIP_DELAY);
+    }, [hide]);
+
+    useEffect(() => {
+      const events = {
+        mouseenter: showDelayed,
+        mouseleave: hideDelayed,
+        focus: show,
+        blur: hide,
+      };
+
+      const targetElement = target || targetInternalRef.current;
+
+      if (!isControlled) {
+        Object.entries(events).forEach(([event, handler]) => {
+          targetElement?.addEventListener(event, handler);
+        });
+      }
+
+      return () => {
+        if (!isControlled) {
+          Object.entries(events).forEach(([event, handler]) => {
+            targetElement?.removeEventListener(event, handler);
+          });
+        }
+      };
+    }, [children, show, showDelayed, hide, hideDelayed, isControlled, target]);
+
+    const flipOverridesRef = useRef(flipOverrides);
+    flipOverridesRef.current = flipOverrides;
+
+    const arrowReference = useRef<HTMLDivElement | null>(null);
+
+    const calculateOffset = useCallback(
+      (placement) => {
+        let mainAxisOffset = 9;
+
+        if (isPartOfInput) {
+          const offsets = {
+            small: 5,
+            medium: ["top", "bottom"].includes(placement) ? 6 : 8,
+            large: ["top", "bottom"].includes(placement) ? 10 : 12,
+          };
+          mainAxisOffset = offsets[inputSize];
+        }
+        return mainAxisOffset;
+      },
+      [inputSize, isPartOfInput]
+    );
+
+    const defaultMiddleware = useMemo(
+      () => [
+        offset(({ placement }) => ({
+          mainAxis: calculateOffset(placement),
+        })),
+        flip({
+          fallbackPlacements: flipOverridesRef.current,
+        }),
+        shift({
+          padding: 5,
+          limiter: limitShift({
+            offset: ({ rects }) => ({
+              mainAxis: rects.reference.height,
+            }),
+          }),
+        }),
+        arrow({ element: arrowReference }),
+      ],
+      [calculateOffset, arrowReference]
+    );
+
+    const {
+      x,
+      y,
+      reference,
+      floating,
+      strategy,
+      placement: currentPlacement,
+      middlewareData,
+    } = useFloating({
+      placement: position,
+      middleware: defaultMiddleware,
+      whileElementsMounted: autoUpdate,
+    });
+    const tooltipStyle = {
+      position: strategy,
+      top: y ?? 0,
+      left: x ?? 0,
+    };
+
+    const handleTargetRef = useCallback(
+      (node: HTMLElement) => {
+        reference(target || node);
+        targetInternalRef.current = node;
+        preserveRef(
+          (children as any).ref as React.ForwardedRef<HTMLElement | null>,
+          node
+        );
+      },
+      [reference, children, target]
+    );
+
+    const handleFloatingRef = useCallback(
+      (node: HTMLDivElement) => {
+        floating(node);
+        preserveRef(ref, node);
+      },
+      [floating, ref]
+    );
+
+    const staticSide = {
+      top: "bottom",
+      right: "left",
+      bottom: "top",
+      left: "right",
+    }[currentPlacement.split("-")[0]];
+
+    const { x: arrowX, y: arrowY } = middlewareData.arrow || {};
+    const arrowStyle = {
+      left: arrowX,
+      top: arrowY,
+      [staticSide as Placement]: "-6px",
+    };
+
     const isFlipOverridesValid =
       !flipOverrides ||
       (Array.isArray(flipOverrides) &&
@@ -85,74 +259,40 @@ export const Tooltip = React.forwardRef<HTMLDivElement | null, TooltipProps>(
       `The flipOverrides prop supplied to Tooltip must be an array containing some or all of ["top", "bottom", "left", "right"].`
     );
 
-    const tooltip = (attrs: Attrs, content: React.ReactNode) => {
-      const currentPosition = attrs["data-placement"] || position;
-
-      return (
-        <CarbonScopedTokensProvider>
-          <StyledTooltip
-            data-element="tooltip"
-            role="tooltip"
-            tabIndex={-1}
-            type={type}
-            size={size}
-            id={id}
-            {...tagComponent("tooltip", rest)}
-            isPartOfInput={isPartOfInput}
-            inputSize={inputSize}
-            {...attrs}
-            position={currentPosition}
-            ref={ref}
-            bgColor={bgColor}
-            fontColor={fontColor}
-          >
-            <StyledPointer
-              key="pointer"
-              type={type}
-              {...attrs}
-              position={currentPosition}
-              data-popper-arrow=""
-              data-element="tooltip-pointer"
-              bgColor={bgColor}
-            />
-            {content}
-          </StyledTooltip>
-        </CarbonScopedTokensProvider>
-      );
-    };
-
     return (
-      <Tippy
-        placement={position}
-        delay={TOOLTIP_DELAY}
-        {...(isVisible !== undefined && { visible: isVisible })}
-        plugins={tippyPlugins}
-        sticky
-        render={(attrs) => tooltip(attrs, message)}
-        reference={target}
-        popperOptions={{
-          modifiers: [
-            ...(flipOverrides
-              ? [
-                  {
-                    name: "flip",
-                    options: {
-                      fallbackPlacements: flipOverrides,
-                    },
-                  },
-                ]
-              : []),
-            {
-              name: "computeStyles",
-              options: {
-                gpuAcceleration: false,
-              },
-            },
-          ],
-        }}
-      >
-        {children}
-      </Tippy>
+      <>
+        {React.cloneElement(children, {
+          ref: handleTargetRef,
+        })}
+
+        {showTooltip ? (
+          <Portal>
+            <StyledTooltip
+              data-element="tooltip"
+              role="tooltip"
+              tabIndex={-1}
+              type={type}
+              size={size}
+              id={id}
+              {...tagComponent("tooltip", rest)}
+              ref={handleFloatingRef}
+              bgColor={bgColor}
+              fontColor={fontColor}
+              style={tooltipStyle}
+              data-placement={currentPlacement}
+            >
+              <StyledPointer
+                type={type}
+                ref={arrowReference}
+                data-element="tooltip-pointer"
+                bgColor={bgColor}
+                style={arrowStyle}
+              />
+              {message}
+            </StyledTooltip>
+          </Portal>
+        ) : null}
+      </>
     );
   }
 );

--- a/src/components/tooltip/tooltip.spec.tsx
+++ b/src/components/tooltip/tooltip.spec.tsx
@@ -1,22 +1,29 @@
 import React from "react";
-import { mount, shallow } from "enzyme";
+import * as floatingUi from "@floating-ui/react-dom";
+
+import {
+  render as renderRTL,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 
 import Tooltip, { TooltipProps, InputSizes } from "./tooltip.component";
-import StyledTooltipWrapper from "./tooltip.style";
-import StyledTooltipPointer from "./tooltip-pointer.style";
 import { TooltipPositions } from "./tooltip.config";
+import guid from "../../__internal__/utils/helpers/guid";
 
-import { assertStyleMatch } from "../../__spec_helper__/test-utils";
-import CarbonScopedTokensProvider from "../../style/design-tokens/carbon-scoped-tokens-provider/carbon-scoped-tokens-provider.component";
+const mockedGuid = "guid-12345";
+jest.mock("../../__internal__/utils/helpers/guid");
+(guid as jest.MockedFunction<typeof guid>).mockImplementation(() => mockedGuid);
 
 const positions: TooltipPositions[] = ["top", "bottom", "left", "right"];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function render(props: Partial<TooltipProps> = {}, renderer: any = mount) {
-  const children = <div>foo</div>;
+function render(props: Partial<TooltipProps> = {}) {
+  const children = <div data-testid="tooltip-target">foo</div>;
   const message = "foo";
 
-  return renderer(
+  return renderRTL(
     <Tooltip {...props} message={message || props.message}>
       {props.children || children}
     </Tooltip>
@@ -24,25 +31,57 @@ function render(props: Partial<TooltipProps> = {}, renderer: any = mount) {
 }
 
 describe("Tooltip", () => {
-  describe("default props", () => {
-    it("matches snapshot", () => {
-      const wrapper = render({}, shallow);
-
-      expect(wrapper).toMatchSnapshot();
-    });
-  });
-
   describe("controlled", () => {
     it("matches snapshot when isVisible is true", () => {
-      const wrapper = render({ isVisible: true }, shallow);
+      const { container } = render({ isVisible: true });
 
-      expect(wrapper).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     it("matches snapshot when isVisible is false", () => {
-      const wrapper = render({ isVisible: false }, shallow);
+      const { container } = render({ isVisible: false });
 
-      expect(wrapper).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe("uncontrolled", () => {
+    it("shows tooltip with delay when tooltip target is hovered", async () => {
+      render();
+      const tooltipTarget = screen.getByTestId("tooltip-target");
+      fireEvent.mouseEnter(tooltipTarget);
+
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toBeInTheDocument();
+      });
+    });
+
+    it("hides tooltip after mouse leaves the tooltip target", async () => {
+      render();
+      const tooltipTarget = screen.getByTestId("tooltip-target");
+      fireEvent.mouseEnter(tooltipTarget);
+      fireEvent.mouseLeave(tooltipTarget);
+
+      await waitFor(() => {
+        expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+      });
+    });
+
+    it("shows tooltip when tooltip target is focused", () => {
+      render();
+      const tooltipTarget = screen.getByTestId("tooltip-target");
+      fireEvent.focus(tooltipTarget);
+
+      expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    });
+
+    it("hides tooltip when tooltip target is blurred", () => {
+      render();
+      const tooltipTarget = screen.getByTestId("tooltip-target");
+      fireEvent.focus(tooltipTarget);
+      fireEvent.blur(tooltipTarget);
+
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
     });
   });
 
@@ -50,87 +89,75 @@ describe("Tooltip", () => {
     describe("TooltipWrapper", () => {
       describe("default", () => {
         it("applies the default styles", () => {
-          assertStyleMatch(
-            {
-              bottom: "auto",
-              right: "auto",
-              position: "relative",
-              maxWidth: "300px",
-              zIndex: "6000",
-              textAlign: "left",
-              color: "var(--colorsSemanticNeutralYang100)",
-              display: "inline-block",
-              padding: "8px 12px",
-              wordBreak: "break-word",
-              whiteSpace: "pre-wrap",
-              fontSize: "14px",
-              lineHeight: "1.5rem",
-              fontWeight: "400",
-              backgroundColor: "var(--colorsSemanticNeutral500)",
-            },
-            render().find(StyledTooltipWrapper)
-          );
+          render({ isVisible: true });
+
+          expect(screen.getByRole("tooltip")).toHaveStyle({
+            bottom: "auto",
+            right: "auto",
+            position: "absolute",
+            maxWidth: "300px",
+            zIndex: "6000",
+            textAlign: "left",
+            color: "var(--colorsSemanticNeutralYang100)",
+            display: "inline-block",
+            padding: "8px 12px",
+            wordBreak: "break-word",
+            whiteSpace: "pre-wrap",
+            fontSize: "14px",
+            lineHeight: "1.5rem",
+            fontWeight: "400",
+            backgroundColor: "var(--colorsSemanticNeutral500)",
+          });
         });
 
         it("applies the correct styles when size is 'large'", () => {
-          assertStyleMatch(
-            { fontSize: "16px" },
-            render({ size: "large" }).find(StyledTooltipWrapper)
-          );
+          render({ isVisible: true, size: "large" });
+
+          expect(screen.getByRole("tooltip")).toHaveStyle({
+            fontSize: "16px",
+          });
         });
 
         it("applies the correct styles  type === 'error'", () => {
-          assertStyleMatch(
-            { backgroundColor: "var(--colorsSemanticNegative500)" },
-            render({ type: "error" }).find(StyledTooltipWrapper)
-          );
-        });
+          render({ isVisible: true, type: "error" });
 
-        it.each(positions)(
-          "applies the offset when position is %s",
-          (position) => {
-            assertStyleMatch(
-              { [position]: "1px" },
-              render({ position }).find(StyledTooltipWrapper)
-            );
-          }
-        );
+          expect(screen.getByRole("tooltip")).toHaveStyle({
+            backgroundColor: "var(--colorsSemanticNegative500)",
+          });
+        });
       });
 
       describe("color props", () => {
         it("overrides default background when a valid css string is passed via 'bgColor'", () => {
-          assertStyleMatch(
-            { backgroundColor: "pink" },
-            render({ bgColor: "pink" }).find(StyledTooltipWrapper)
-          );
+          render({ isVisible: true, bgColor: "pink" });
 
-          assertStyleMatch(
-            { borderTop: "8px solid pink" },
-            render({ bgColor: "pink" }).find(StyledTooltipPointer)
-          );
+          expect(screen.getByRole("tooltip")).toHaveStyle({
+            backgroundColor: "pink",
+          });
+
+          expect(screen.getByRole("tooltip").children[0]).toHaveStyle({
+            backgroundColor: "pink",
+          });
         });
 
         it("overrides the type prop if background color passed via 'bgColor'", () => {
-          assertStyleMatch(
-            { backgroundColor: "pink" },
-            render({ type: "error", bgColor: "pink" }).find(
-              StyledTooltipWrapper
-            )
-          );
+          render({ isVisible: true, type: "error", bgColor: "pink" });
 
-          assertStyleMatch(
-            { borderTop: "8px solid pink" },
-            render({ type: "error", bgColor: "pink" }).find(
-              StyledTooltipPointer
-            )
-          );
+          expect(screen.getByRole("tooltip")).toHaveStyle({
+            backgroundColor: "pink",
+          });
+
+          expect(screen.getByRole("tooltip").children[0]).toHaveStyle({
+            backgroundColor: "pink",
+          });
         });
 
         it("overrides default font color when a valid css string is passed via 'fontColor'", () => {
-          assertStyleMatch(
-            { color: "pink" },
-            render({ fontColor: "pink" }).find(StyledTooltipWrapper)
-          );
+          render({ isVisible: true, fontColor: "pink" });
+
+          expect(screen.getByRole("tooltip")).toHaveStyle({
+            color: "pink",
+          });
         });
       });
     });
@@ -140,121 +167,87 @@ describe("Tooltip", () => {
         ["top", "bottom"].includes(position);
       const offsets = (
         position: TooltipPositions
-      ): Record<InputSizes, string> => ({
-        small: "5px",
-        medium: isTopOrBottom(position) ? "4px" : "2px",
-        large: isTopOrBottom(position) ? "0px" : "-2px",
+      ): Record<InputSizes, number> => ({
+        small: 5,
+        medium: isTopOrBottom(position) ? 6 : 8,
+        large: isTopOrBottom(position) ? 10 : 12,
       });
 
       describe.each(positions)("and position is %s", (position) => {
         it.each<InputSizes>(["small", "medium", "large"])(
           "sets the offset as expected when size is %s",
           (size) => {
-            assertStyleMatch(
-              {
-                [position]: offsets(position)[size],
-              },
-              render({ position, isPartOfInput: true, inputSize: size }).find(
-                StyledTooltipWrapper
-              )
-            );
+            const useFloatingSpy = jest.spyOn(floatingUi, "useFloating");
+            render({
+              isVisible: true,
+              position,
+              isPartOfInput: true,
+              inputSize: size,
+            });
+
+            let middleware;
+            if (useFloatingSpy.mock.calls[0][0]?.middleware?.[0]) {
+              middleware = useFloatingSpy.mock.calls[0][0]?.middleware?.[0];
+            }
+
+            expect(
+              middleware?.options({
+                placement: position,
+              })
+            ).toMatchObject({
+              mainAxis: offsets(position)[size],
+            });
+            useFloatingSpy.mockRestore();
           }
         );
       });
     });
 
     describe("TooltipPointer", () => {
-      describe("when position === 'top' / default", () => {
-        it("applies the correct styles", () => {
-          assertStyleMatch(
-            {
-              position: "absolute",
-              width: "0",
-              height: "0",
-              borderLeft: "8px solid transparent",
-              borderRight: "8px solid transparent",
-              borderTop: "8px solid var(--colorsSemanticNeutral500)",
-              bottom: "calc(-1 * var(--spacing100))",
-            },
-            render().find(StyledTooltipPointer)
-          );
+      it("applies the correct styles", () => {
+        render({ isVisible: true });
+
+        expect(screen.getByRole("tooltip").children[0]).toHaveStyle({
+          zIndex: "6000",
+          position: "absolute",
+          width: "12px",
+          height: "12px",
+          transform: "rotate(45deg)",
         });
       });
 
       it("applies the correct styles when type === 'error'", () => {
-        assertStyleMatch(
-          { borderTop: "8px solid var(--colorsSemanticNegative500)" },
-          render({ type: "error" }).find(StyledTooltipPointer)
-        );
-      });
+        render({ isVisible: true, type: "error" });
 
-      describe('when position === "bottom"', () => {
-        it("applies the correct styles", () => {
-          assertStyleMatch(
-            {
-              borderLeft: "8px solid transparent",
-              borderRight: "8px solid transparent",
-              borderBottom: "8px solid var(--colorsSemanticNeutral500)",
-              top: "calc(-1 * var(--spacing100))",
-            },
-            render({ position: "bottom" }).find(StyledTooltipPointer)
-          );
-        });
-
-        it("applies the correct styles when type === 'error'", () => {
-          assertStyleMatch(
-            { borderBottom: "8px solid var(--colorsSemanticNegative500)" },
-            render({ position: "bottom", type: "error" }).find(
-              StyledTooltipPointer
-            )
-          );
+        expect(screen.getByRole("tooltip").children[0]).toHaveStyle({
+          background: "var(--colorsSemanticNegative500)",
         });
       });
 
-      describe('when position === "left"', () => {
-        it("applies the correct styles", () => {
-          assertStyleMatch(
-            {
-              borderTop: "8px solid transparent",
-              borderBottom: "8px solid transparent",
-              borderLeft: "8px solid var(--colorsSemanticNeutral500)",
-              right: "calc(-1 * var(--spacing100))",
-            },
-            render({ position: "left" }).find(StyledTooltipPointer)
-          );
+      it.each([
+        ["top", "bottom"],
+        ["right", "left"],
+        ["bottom", "top"],
+        ["left", "right"],
+      ])("applies correct position", (floatingUiPlacement, arrowPlacement) => {
+        const originalUseFloating = jest.requireActual("@floating-ui/react-dom")
+          .useFloating;
+        const useFloatingSpy = jest
+          .spyOn(floatingUi, "useFloating")
+          .mockImplementation((props) => {
+            return {
+              ...originalUseFloating(props),
+              placement: floatingUiPlacement,
+            };
+          });
+
+        render({ isVisible: true });
+
+        expect(screen.getByRole("tooltip").children[0]).toHaveStyle({
+          [arrowPlacement]: "-6px",
         });
 
-        it("applies the correct styles when type === 'error'", () => {
-          assertStyleMatch(
-            { borderLeft: "8px solid var(--colorsSemanticNegative500)" },
-            render({ position: "left", type: "error" }).find(
-              StyledTooltipPointer
-            )
-          );
-        });
-      });
-
-      describe('when position === "right"', () => {
-        it("applies the correct styles", () => {
-          assertStyleMatch(
-            {
-              borderTop: "8px solid transparent",
-              borderBottom: "8px solid transparent",
-              borderRight: "8px solid var(--colorsSemanticNeutral500)",
-              left: "calc(-1 * var(--spacing100))",
-            },
-            render({ position: "right" }).find(StyledTooltipPointer)
-          );
-        });
-
-        it("applies the correct styles when type === 'error'", () => {
-          assertStyleMatch(
-            { borderRight: "8px solid var(--colorsSemanticNegative500)" },
-            render({ position: "right", type: "error" }).find(
-              StyledTooltipPointer
-            )
-          );
-        });
+        useFloatingSpy.mockRestore();
       });
     });
   });
@@ -288,51 +281,27 @@ describe("Tooltip", () => {
     });
   });
 
-  describe("Design tokens", () => {
-    it("wraps content with CarbonScopedTokensProvider", () => {
-      const wrapper = render();
-
-      const carbonScopedTokensProvider = wrapper.find(
-        CarbonScopedTokensProvider
-      );
-
-      expect(
-        carbonScopedTokensProvider.find(StyledTooltipWrapper).exists()
-      ).toBe(true);
-    });
-  });
-
   describe("Ref forwarding", () => {
     it("should forward a ref object correctly", () => {
       const testRef = { current: null };
-
-      const wrapper = mount(
+      renderRTL(
         <Tooltip message="foo" isVisible ref={testRef}>
           <span>Test tooltip</span>
         </Tooltip>
       );
 
-      wrapper.update();
-
-      expect(testRef.current).toEqual(
-        wrapper.find(StyledTooltipWrapper).getDOMNode()
-      );
+      expect(testRef.current).toEqual(screen.getByRole("tooltip"));
     });
 
     it("should forward a callback ref correctly", () => {
       const testCallbackRef = jest.fn();
-
-      const wrapper = mount(
+      renderRTL(
         <Tooltip message="foo" isVisible ref={testCallbackRef}>
           <span>Test tooltip</span>
         </Tooltip>
       );
 
-      wrapper.update();
-
-      expect(testCallbackRef).toHaveBeenCalledWith(
-        wrapper.find(StyledTooltipWrapper).getDOMNode()
-      );
+      expect(testCallbackRef).toHaveBeenCalledWith(screen.getByRole("tooltip"));
     });
   });
 });

--- a/src/components/tooltip/tooltip.style.ts
+++ b/src/components/tooltip/tooltip.style.ts
@@ -1,9 +1,8 @@
 import styled, { css, keyframes } from "styled-components";
-import { Placement } from "tippy.js";
 
 import baseTheme, { ThemeObject } from "../../style/themes/base";
 import { toColor } from "../../style/utils/color";
-import { TooltipProps, InputSizes } from "./tooltip.component";
+import { TooltipProps } from "./tooltip.component";
 
 const fadeIn = keyframes`
   0% {
@@ -22,60 +21,15 @@ const tooltipColor = (theme: ThemeObject, bgColor?: string, type?: string) => {
     : "var(--colorsSemanticNeutral500)";
 };
 
-const tooltipOffset = (
-  position: Placement,
-  inputSize?: InputSizes,
-  isPartOfInput?: boolean
-) => {
-  if (!isPartOfInput) {
-    return { [position]: "1px" };
-  }
-
-  switch (inputSize) {
-    case "small":
-      return `
-        ${position}: 5px;
-        @-moz-document url-prefix() { 
-          ${position}: ${["top", "bottom"].includes(position) ? "7px" : "6px"};
-        }
-      `;
-    case "large":
-      return `
-        ${position}: ${["top", "bottom"].includes(position) ? "0px" : "-2px"};
-        @-moz-document url-prefix() { 
-          ${position}: -1px;
-        }
-      `;
-    default:
-      return `
-        ${position}: ${["top", "bottom"].includes(position) ? "4px" : "2px"};
-        @-moz-document url-prefix() { 
-          ${position}: 4px;
-        }
-      `;
-  }
-};
-
-interface StyledTooltipProps
-  extends Omit<TooltipProps, "children" | "message" | "position"> {
-  position: Placement;
-}
-
-const StyledTooltip = styled.div<StyledTooltipProps>`
-  ${({
-    position,
-    size,
-    theme,
-    type,
-    isPartOfInput,
-    inputSize = "medium",
-    bgColor,
-    fontColor,
-  }) => css`
+const StyledTooltip = styled.div<
+  Pick<TooltipProps, "size" | "type" | "bgColor" | "fontColor">
+>`
+  ${({ size, theme, type, bgColor, fontColor }) => css`
     bottom: auto;
     right: auto;
     max-width: 300px;
-    position: relative;
+    width: max-content;
+    position: absolute;
     animation: ${fadeIn} 0.2s linear;
     z-index: ${theme.zIndex
       .popover}; // TODO (tokens): implement elevation tokens - FE-4437
@@ -91,7 +45,6 @@ const StyledTooltip = styled.div<StyledTooltipProps>`
     line-height: 1.5rem;
     font-weight: 400;
     background-color: ${tooltipColor(theme, bgColor, type)};
-    ${tooltipOffset(position, inputSize, isPartOfInput)};
   `}
 `;
 

--- a/src/hooks/__internal__/useFloating/useFloating.ts
+++ b/src/hooks/__internal__/useFloating/useFloating.ts
@@ -10,8 +10,8 @@ import {
 
 export interface UseFloatingProps {
   isOpen?: boolean;
-  reference: React.RefObject<HTMLElement>;
-  floating: React.RefObject<HTMLElement>;
+  reference: React.RefObject<HTMLElement | null>;
+  floating: React.RefObject<HTMLElement | null>;
   strategy?: Strategy;
   middleware?: Middleware[];
   placement?: Placement;


### PR DESCRIPTION
BREAKING CHANGE: jest versions lower than 27 are no longer supported and might break unit tests

### Proposed behaviour

This PR removes @tippyjs/react package in favor of @floating-ui/react-dom-interactions to handle tooltips

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Testing instructions

Tooltip regression testing is suggested
