### PR TITLE
test(note): add cypress tests

### DIFF
--- a/cypress/locators/note/index.js
+++ b/cypress/locators/note/index.js
@@ -1,0 +1,12 @@
+import { DATA_CONTENTS, NOTE_COMPONENT, NOTE_STATUS } from "./locators";
+
+// component preview locators
+export const noteComponent = () => cy.get(NOTE_COMPONENT);
+export const noteHeader = () => noteComponent().find("header");
+export const noteContent = () => cy.get(DATA_CONTENTS);
+export const noteFooter = () => noteComponent().children().eq(2);
+export const noteFooterCreatedBy = () =>
+  noteFooter().find("div").children().eq(0);
+export const noteFooterChangeTime = () =>
+  noteFooter().find("div").children().eq(1);
+export const noteStatus = () => cy.get(NOTE_STATUS);

--- a/cypress/locators/note/locators.js
+++ b/cypress/locators/note/locators.js
@@ -1,0 +1,4 @@
+// component preview locators
+export const NOTE_COMPONENT = '[data-component="note"]';
+export const NOTE_STATUS = '[data-component="note-status"]';
+export const DATA_CONTENTS = '[data-contents="true"]';

--- a/src/components/note/note.test.js
+++ b/src/components/note/note.test.js
@@ -1,0 +1,178 @@
+import React from "react";
+import { EditorState, ContentState, convertFromHTML } from "draft-js";
+import Note from "./note.component";
+import Box from "../box";
+import LinkPreview from "../link-preview";
+import { ActionPopover, ActionPopoverItem } from "../action-popover";
+import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
+import { tooltipPreview } from "../../../cypress/locators";
+import { linkPreview } from "../../../cypress/locators/link-preview/index";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+
+import {
+  noteComponent,
+  noteHeader,
+  noteFooterCreatedBy,
+  noteFooterChangeTime,
+  noteStatus,
+  noteContent,
+} from "../../../cypress/locators/note";
+import { actionPopoverWrapper } from "../../../cypress/locators/action-popover";
+
+const NoteComponent = ({ text, ...props }) => {
+  const initialValue = text
+    ? EditorState.createWithContent(ContentState.createFromText(text))
+    : EditorState.createEmpty();
+
+  return (
+    <Note
+      title="Here is a Title"
+      name="Lauren Smith"
+      noteContent={initialValue}
+      createdDate="23 May 2020, 12:08 PM"
+      {...props}
+    />
+  );
+};
+
+const NoteComponentWithInlineControl = () => {
+  const html = `<p>Lorem ipsum <b>dolor</b> sit amet. Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>
+      <p>Lorem ipsum <b>dolor</b> sit amet, <i>consectetuer adipiscing elit.</i></p>
+      <p>Aenean commodo ligula eget dolor. <b><i>Aenean massa.</i></b></p>`;
+  const blocksFromHTML = convertFromHTML(html);
+  const content = ContentState.createFromBlockArray(
+    blocksFromHTML.contentBlocks,
+    blocksFromHTML.entityMap
+  );
+  const noteContentVal = EditorState.createWithContent(content);
+  const inlineControl = (
+    <ActionPopover>
+      <ActionPopoverItem onClick={() => {}}>Edit</ActionPopoverItem>
+    </ActionPopover>
+  );
+  return (
+    <Note
+      title="Here is a Title"
+      inlineControl={inlineControl}
+      noteContent={noteContentVal}
+      name="Lauren Smith"
+      createdDate="23 May 2020, 12:08 PM"
+    />
+  );
+};
+
+context("Tests for Note component", () => {
+  describe("check props for Note component", () => {
+    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+      "should render Note with noteContent prop",
+      (text) => {
+        CypressMountWithProviders(<NoteComponent text={text} />);
+
+        noteContent().should("have.text", text);
+      }
+    );
+
+    it.each([
+      [30, 75],
+      [75, 187],
+    ])(
+      "should render Note with width prop is set to %s",
+      (width, widthInPx) => {
+        CypressMountWithProviders(
+          <Box width="250px">
+            <NoteComponent width={width} />
+          </Box>
+        );
+
+        noteComponent()
+          .should("have.attr", "width", width)
+          .then(($el) => {
+            const value = $el.css("width");
+            // console.log(value);
+            expect(parseInt(value)).to.be.within(widthInPx - 1, widthInPx + 1);
+          });
+      }
+    );
+
+    it("should render Note with inlineControl prop", () => {
+      CypressMountWithProviders(<NoteComponentWithInlineControl />);
+
+      actionPopoverWrapper().should("be.visible");
+    });
+
+    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+      "should render Note with title prop set to %s",
+      (title) => {
+        CypressMountWithProviders(<NoteComponent title={title} />);
+
+        noteHeader().should("have.text", title);
+      }
+    );
+
+    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+      "should render Note with name prop set to %s",
+      (name) => {
+        CypressMountWithProviders(<NoteComponent name={name} />);
+
+        noteFooterCreatedBy().should("have.text", name);
+      }
+    );
+
+    it("should render Note with createdDate prop", () => {
+      const createdDate = "25 June 2022, 11:57 AM";
+
+      CypressMountWithProviders(<NoteComponent createdDate={createdDate} />);
+
+      noteFooterChangeTime().should("have.text", createdDate);
+    });
+
+    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+      "should render Note with status prop set to %s",
+      (value) => {
+        CypressMountWithProviders(
+          <NoteComponent
+            status={{
+              text: value,
+              timeStamp: `${CHARACTERS.STANDARD}`,
+            }}
+          />
+        );
+
+        noteStatus().should("have.text", value).realHover();
+        tooltipPreview().should("have.text", CHARACTERS.STANDARD);
+      }
+    );
+
+    it("should render Note with previews prop", () => {
+      const previews = [
+        <LinkPreview
+          title="This is an example of a title"
+          url="https://www.bbc.co.uk"
+          description="Captain, why are we out here chasing comets?"
+        />,
+        <LinkPreview
+          title="This is an example of a title"
+          url="https://www.sage.com"
+          description="Captain, why are we out here chasing comets?"
+        />,
+      ];
+
+      CypressMountWithProviders(<NoteComponent previews={previews} />);
+
+      linkPreview().should("have.length", 2).and("be.visible");
+    });
+
+    it("should call onLinkAdded callback when a valid url is detected by Note component", () => {
+      const callback = cy.stub();
+
+      CypressMountWithProviders(
+        <NoteComponent onLinkAdded={callback} text="https://carbon.s" />
+      );
+
+      noteComponent().then(() => {
+        // eslint-disable-next-line no-unused-expressions
+        expect(callback).to.have.been.calledOnce;
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Proposed behaviour

Add Cypress tests for the `Note` component to use new cypress-component-react framework for testing.
Add `note.test.js`. 
Add locators as well.

### Current behaviour

No tests for `Note` component

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added test.file
- [x] Check if the `note.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed