### PR TITLE
refactor(step-sequence): move demo stories to tsx file FE-5501 

### DIFF
--- a/src/components/step-sequence/__snapshots__/step-sequence.spec.tsx.snap
+++ b/src/components/step-sequence/__snapshots__/step-sequence.spec.tsx.snap
@@ -7,8 +7,8 @@ exports[`StepSequence renders correctly 1`] = `
   display: -ms-flexbox;
   display: flex;
   margin: 0;
-  padding: 18px;
   font-weight: bold;
+  padding: var(--spacing000);
 }
 
 .c1 {
@@ -121,12 +121,11 @@ exports[`StepSequence renders correctly with vertical orientation 1`] = `
   display: -ms-flexbox;
   display: flex;
   margin: 0;
-  padding: 18px;
   font-weight: bold;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  padding: 0;
+  padding: var(--spacing000);
 }
 
 .c1 {

--- a/src/components/step-sequence/__snapshots__/step-sequence.spec.tsx.snap
+++ b/src/components/step-sequence/__snapshots__/step-sequence.spec.tsx.snap
@@ -125,6 +125,7 @@ exports[`StepSequence renders correctly with vertical orientation 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 100%;
   padding: var(--spacing000);
 }
 
@@ -202,7 +203,8 @@ exports[`StepSequence renders correctly with vertical orientation 1`] = `
   -ms-flex-positive: 0;
   flex-grow: 0;
   width: var(--sizing025);
-  height: var(--sizing300);
+  height: 100%;
+  min-height: var(--sizing300);
   margin: 12px 8px;
 }
 

--- a/src/components/step-sequence/__snapshots__/step-sequence.spec.tsx.snap
+++ b/src/components/step-sequence/__snapshots__/step-sequence.spec.tsx.snap
@@ -36,9 +36,8 @@ exports[`StepSequence renders correctly 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   display: block;
-  height: var(--sizing025);
   margin: 0 16px;
-  background-color: var(--colorsUtilityYin055);
+  border-top: var(--sizing025) dashed var(--colorsUtilityYin055);
 }
 
 .c1 span {
@@ -161,9 +160,8 @@ exports[`StepSequence renders correctly with vertical orientation 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   display: block;
-  height: var(--sizing025);
   margin: 0 16px;
-  background-color: var(--colorsUtilityYin055);
+  border-left: var(--sizing025) dashed var(--colorsUtilityYin055);
 }
 
 .c1 span {
@@ -202,7 +200,7 @@ exports[`StepSequence renders correctly with vertical orientation 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  width: var(--sizing025);
+  border-left-width: var(--sizing025);
   height: 100%;
   min-height: var(--sizing300);
   margin: 12px 8px;

--- a/src/components/step-sequence/step-sequence-item/step-sequence-item.component.tsx
+++ b/src/components/step-sequence/step-sequence-item/step-sequence-item.component.tsx
@@ -1,9 +1,9 @@
 import React, { useContext } from "react";
 import {
-  StepSequenceItemStyle,
-  StepSequenceItemContentStyle,
-  StepSequenceItemIndicatorStyle,
-  StepSequenceItemHiddenLabelStyle,
+  StyledStepSequenceItem,
+  StyledStepSequenceItemContent,
+  StyledStepSequenceItemIndicator,
+  StyledStepSequenceItemHiddenLabel,
 } from "./step-sequence-item.style";
 import Icon from "../../icon";
 import { StepSequenceContext } from "../step-sequence.component";
@@ -39,9 +39,9 @@ export const StepSequenceItem = ({
 
   const indicatorText = () => {
     return !hideIndicator ? (
-      <StepSequenceItemIndicatorStyle>
+      <StyledStepSequenceItemIndicator>
         {indicator}
-      </StepSequenceItemIndicatorStyle>
+      </StyledStepSequenceItemIndicator>
     ) : null;
   };
 
@@ -51,23 +51,23 @@ export const StepSequenceItem = ({
   const hiddenLabel = () => {
     if (hiddenCompleteLabel && status === "complete") {
       return (
-        <StepSequenceItemHiddenLabelStyle>
+        <StyledStepSequenceItemHiddenLabel>
           {hiddenCompleteLabel}
-        </StepSequenceItemHiddenLabelStyle>
+        </StyledStepSequenceItemHiddenLabel>
       );
     }
     if (hiddenCurrentLabel && status === "current") {
       return (
-        <StepSequenceItemHiddenLabelStyle>
+        <StyledStepSequenceItemHiddenLabel>
           {hiddenCurrentLabel}
-        </StepSequenceItemHiddenLabelStyle>
+        </StyledStepSequenceItemHiddenLabel>
       );
     }
     return null;
   };
 
   return (
-    <StepSequenceItemStyle
+    <StyledStepSequenceItem
       data-component="step-sequence-item"
       orientation={orientation}
       status={status}
@@ -76,11 +76,11 @@ export const StepSequenceItem = ({
       {...rest}
     >
       {hiddenLabel()}
-      <StepSequenceItemContentStyle>
+      <StyledStepSequenceItemContent>
         {icon()}
         <span>{children}</span>
-      </StepSequenceItemContentStyle>
-    </StepSequenceItemStyle>
+      </StyledStepSequenceItemContent>
+    </StyledStepSequenceItem>
   );
 };
 

--- a/src/components/step-sequence/step-sequence-item/step-sequence-item.spec.tsx
+++ b/src/components/step-sequence/step-sequence-item/step-sequence-item.spec.tsx
@@ -10,9 +10,15 @@ import {
   StyledStepSequenceItemHiddenLabel,
   StyledStepSequenceItemIndicator,
 } from "./step-sequence-item.style";
+import { StepSequenceProps } from "../step-sequence.component";
+
+const orientations = ["horizontal", "vertical"] as const;
 
 describe("StepSequenceItem", () => {
-  const render = (props: Partial<StepSequenceItemProps>, renderer = mount) =>
+  const render = (
+    props: Partial<StepSequenceItemProps & StepSequenceProps>,
+    renderer = mount
+  ) =>
     renderer(
       <StepSequenceItem indicator="1" {...props}>
         Item
@@ -26,7 +32,61 @@ describe("StepSequenceItem", () => {
     hiddenCurrentLabel: "HiddenCurrent",
   };
 
-  describe("when complete", () => {
+  describe("when status is incomplete", () => {
+    it.each(orientations)(
+      "renders the correct styling when orientation is %s",
+      (orientation) => {
+        const wrapper = render({
+          ...defaultProps,
+          status: "incomplete",
+          orientation,
+        });
+        const side = orientation === "vertical" ? "Left" : "Top";
+        const border = `border${side}`;
+
+        assertStyleMatch(
+          {
+            [border]: "var(--sizing025) dashed var(--colorsUtilityYin055)",
+          },
+          wrapper,
+          { modifier: "::before" }
+        );
+      }
+    );
+  });
+
+  describe("when status is complete", () => {
+    it.each(orientations)(
+      "renders the correct styling when orientation is %s",
+      (orientation) => {
+        const wrapper = render({
+          ...defaultProps,
+          status: "complete",
+          orientation,
+        });
+        const side = orientation === "vertical" ? "Left" : "Top";
+        const borderColor = `border${side}Color`;
+        const borderStyle = `border${side}Style`;
+
+        assertStyleMatch(
+          {
+            color: "var(--colorsBaseTheme,var(--colorsSemanticPositive500))",
+          },
+          wrapper
+        );
+
+        assertStyleMatch(
+          {
+            [borderColor]:
+              "var( --colorsBaseTheme, var(--colorsSemanticPositive500) )",
+            [borderStyle]: "solid",
+          },
+          wrapper,
+          { modifier: "::before" }
+        );
+      }
+    );
+
     it("renders the tick item", () => {
       const wrapper = render({
         ...defaultProps,
@@ -49,19 +109,36 @@ describe("StepSequenceItem", () => {
     });
   });
 
-  describe("when current", () => {
-    it("renders the correct styling", () => {
-      const wrapper = render({
-        ...defaultProps,
-        status: "current",
-      });
-      assertStyleMatch(
-        {
-          color: "var(--colorsUtilityYin090)",
-        },
-        wrapper
-      );
-    });
+  describe("when status is current", () => {
+    it.each(orientations)(
+      "renders the correct styling when orientation is %s",
+      (orientation) => {
+        const wrapper = render({
+          ...defaultProps,
+          status: "current",
+          orientation,
+        });
+        const side = orientation === "vertical" ? "Left" : "Top";
+        const borderColor = `border${side}Color`;
+        const borderStyle = `border${side}Style`;
+
+        assertStyleMatch(
+          {
+            color: "var(--colorsUtilityYin090)",
+          },
+          wrapper
+        );
+
+        assertStyleMatch(
+          {
+            [borderColor]: "var(--colorsUtilityYin090)",
+            [borderStyle]: "solid",
+          },
+          wrapper,
+          { modifier: "::before" }
+        );
+      }
+    );
 
     it("renders the hidden label", () => {
       const wrapper = render({

--- a/src/components/step-sequence/step-sequence-item/step-sequence-item.spec.tsx
+++ b/src/components/step-sequence/step-sequence-item/step-sequence-item.spec.tsx
@@ -7,8 +7,8 @@ import StepSequenceItem, {
 } from "./step-sequence-item.component";
 import Icon from "../../icon";
 import {
-  StepSequenceItemHiddenLabelStyle,
-  StepSequenceItemIndicatorStyle,
+  StyledStepSequenceItemHiddenLabel,
+  StyledStepSequenceItemIndicator,
 } from "./step-sequence-item.style";
 
 describe("StepSequenceItem", () => {
@@ -40,10 +40,10 @@ describe("StepSequenceItem", () => {
         ...defaultProps,
         status: "complete",
       });
-      expect(wrapper.find(StepSequenceItemHiddenLabelStyle).exists()).toBe(
+      expect(wrapper.find(StyledStepSequenceItemHiddenLabel).exists()).toBe(
         true
       );
-      expect(wrapper.find(StepSequenceItemHiddenLabelStyle).text()).toEqual(
+      expect(wrapper.find(StyledStepSequenceItemHiddenLabel).text()).toEqual(
         "HiddenComplete"
       );
     });
@@ -68,10 +68,10 @@ describe("StepSequenceItem", () => {
         ...defaultProps,
         status: "current",
       });
-      expect(wrapper.find(StepSequenceItemHiddenLabelStyle).exists()).toBe(
+      expect(wrapper.find(StyledStepSequenceItemHiddenLabel).exists()).toBe(
         true
       );
-      expect(wrapper.find(StepSequenceItemHiddenLabelStyle).text()).toEqual(
+      expect(wrapper.find(StyledStepSequenceItemHiddenLabel).text()).toEqual(
         "HiddenCurrent"
       );
     });
@@ -82,7 +82,7 @@ describe("StepSequenceItem", () => {
           ...defaultProps,
           hideIndicator: true,
         });
-        expect(wrapper.find(StepSequenceItemIndicatorStyle).exists()).toBe(
+        expect(wrapper.find(StyledStepSequenceItemIndicator).exists()).toBe(
           false
         );
       });

--- a/src/components/step-sequence/step-sequence-item/step-sequence-item.style.ts
+++ b/src/components/step-sequence/step-sequence-item/step-sequence-item.style.ts
@@ -1,12 +1,12 @@
 import styled, { css } from "styled-components";
 import StyledIcon from "../../icon/icon.style";
 
-type StepSequenceItemStyle = {
+type StyledStepSequenceItem = {
   status: "complete" | "current" | "incomplete";
   orientation: "horizontal" | "vertical";
 };
 
-export const StepSequenceItemStyle = styled.li<StepSequenceItemStyle>`
+export const StyledStepSequenceItem = styled.li<StyledStepSequenceItem>`
   display: flex;
   align-items: center;
   flex-grow: 1;
@@ -74,17 +74,18 @@ export const StepSequenceItemStyle = styled.li<StepSequenceItemStyle>`
       &::before {
         flex-grow: 0;
         width: var(--sizing025);
-        height: var(--sizing300);
+        height: 100%;
+        min-height: var(--sizing300);
         margin: 12px 8px;
       }
     `}
 `;
 
-export const StepSequenceItemContentStyle = styled.span`
+export const StyledStepSequenceItemContent = styled.span`
   display: flex;
 `;
 
-export const StepSequenceItemHiddenLabelStyle = styled.span`
+export const StyledStepSequenceItemHiddenLabel = styled.span`
   position: absolute !important;
   height: 1px;
   width: 1px;
@@ -92,7 +93,7 @@ export const StepSequenceItemHiddenLabelStyle = styled.span`
   clip: rect(1px, 1px, 1px, 1px);
 `;
 
-export const StepSequenceItemIndicatorStyle = styled.span`
+export const StyledStepSequenceItemIndicator = styled.span`
   display: block;
   min-width: 16px;
   height: 16px;

--- a/src/components/step-sequence/step-sequence-item/step-sequence-item.style.ts
+++ b/src/components/step-sequence/step-sequence-item/step-sequence-item.style.ts
@@ -1,12 +1,11 @@
 import styled, { css } from "styled-components";
+import { StepSequenceProps } from "../step-sequence.component";
+import { StepSequenceItemProps } from "./step-sequence-item.component";
 import StyledIcon from "../../icon/icon.style";
 
-type StyledStepSequenceItem = {
-  status: "complete" | "current" | "incomplete";
-  orientation: "horizontal" | "vertical";
-};
-
-export const StyledStepSequenceItem = styled.li<StyledStepSequenceItem>`
+export const StyledStepSequenceItem = styled.li<
+  Pick<StepSequenceItemProps, "status"> & Pick<StepSequenceProps, "orientation">
+>`
   display: flex;
   align-items: center;
   flex-grow: 1;
@@ -14,71 +13,81 @@ export const StyledStepSequenceItem = styled.li<StyledStepSequenceItem>`
   list-style-type: none;
   color: var(--colorsUtilityYin055);
 
-  &::before {
-    content: "";
-    flex-grow: 1;
-    display: block;
-    height: var(--sizing025);
-    margin: 0 16px;
-    background-color: var(--colorsUtilityYin055);
-  }
+  ${({ orientation, status }) => {
+    const side: string = orientation === "vertical" ? "left" : "top";
 
-  & span {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  ${StyledIcon} {
-    margin-right: 8px;
-    color: var(--colorsBaseTheme, var(--colorsSemanticPositive500));
-  }
-
-  &:first-child {
-    flex-grow: 0;
-
-    &::before {
-      display: none;
-    }
-  }
-
-  ${({ status }) =>
-    status === "current" &&
-    css`
-      color: var(--colorsUtilityYin090);
-
+    return css`
       &::before {
-        background-color: var(--colorsUtilityYin090);
+        content: "";
+        flex-grow: 1;
+        display: block;
+        margin: 0 16px;
+        border-${side}: var(--sizing025) dashed var(--colorsUtilityYin055);
       }
-    `}
 
-  ${({ status }) =>
-    status === "complete" &&
-    css`
-      color: var(--colorsBaseTheme, var(--colorsSemanticPositive500));
-
-      &::before {
-        background-color: var(
-          --colorsBaseTheme,
-          var(--colorsSemanticPositive500)
-        );
+      & span {
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
-    `}
 
-  ${({ orientation }) =>
-    orientation === "vertical" &&
-    css`
-      flex-direction: column;
-      align-items: flex-start;
+      ${StyledIcon} {
+        margin-right: 8px;
+        color: var(--colorsBaseTheme, var(--colorsSemanticPositive500));
+      }
 
-      &::before {
+      &:first-child {
         flex-grow: 0;
-        width: var(--sizing025);
-        height: 100%;
-        min-height: var(--sizing300);
-        margin: 12px 8px;
+
+        &::before {
+          display: none;
+        }
       }
-    `}
+
+      ${
+        status === "current" &&
+        css`
+          color: var(--colorsUtilityYin090);
+
+          &::before {
+            border-${side}-color: var(--colorsUtilityYin090);
+            border-${side}-style: solid;
+          }
+        `
+      }
+
+      ${
+        status === "complete" &&
+        css`
+          color: var(--colorsBaseTheme, var(--colorsSemanticPositive500));
+
+          &::before {
+            border-${side}-color: var(
+              --colorsBaseTheme,
+              var(--colorsSemanticPositive500)
+            );
+            border-${side}-style: solid;
+          }
+        `
+      }
+
+      ${
+        orientation === "vertical" &&
+        css`
+          flex-direction: column;
+          align-items: flex-start;
+
+          &::before {
+            flex-grow: 0;
+            border-left-width: var(--sizing025);
+            height: 100%;
+            min-height: var(--sizing300);
+            margin: 12px 8px;
+          }
+        `
+      }
+    `;
+  }}
 `;
 
 export const StyledStepSequenceItemContent = styled.span`

--- a/src/components/step-sequence/step-sequence.component.tsx
+++ b/src/components/step-sequence/step-sequence.component.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MarginProps } from "styled-system";
+import { SpaceProps } from "styled-system";
 
 import StyledStepSequence from "./step-sequence.style";
 
@@ -7,7 +7,7 @@ export const StepSequenceContext = React.createContext<{
   orientation: "horizontal" | "vertical";
 }>({ orientation: "horizontal" });
 
-export interface StepSequenceProps extends MarginProps {
+export interface StepSequenceProps extends SpaceProps {
   /** Step sequence items to be rendered */
   children: React.ReactNode;
   /** The direction that step sequence items should be rendered */

--- a/src/components/step-sequence/step-sequence.component.tsx
+++ b/src/components/step-sequence/step-sequence.component.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { MarginProps } from "styled-system";
 
-import StepSequenceStyle from "./step-sequence.style";
+import StyledStepSequence from "./step-sequence.style";
 
 export const StepSequenceContext = React.createContext<{
   orientation: "horizontal" | "vertical";
@@ -20,15 +20,16 @@ export const StepSequence = ({
   ...props
 }: StepSequenceProps) => {
   return (
-    <StepSequenceStyle
+    <StyledStepSequence
       data-component="step-sequence"
       orientation={orientation}
+      p={0}
       {...props}
     >
       <StepSequenceContext.Provider value={{ orientation }}>
         {children}
       </StepSequenceContext.Provider>
-    </StepSequenceStyle>
+    </StyledStepSequence>
   );
 };
 

--- a/src/components/step-sequence/step-sequence.spec.tsx
+++ b/src/components/step-sequence/step-sequence.spec.tsx
@@ -3,7 +3,7 @@ import TestRenderer from "react-test-renderer";
 
 import StepSequence, { StepSequenceProps } from "./step-sequence.component";
 import StepSequenceItem from "./step-sequence-item/step-sequence-item.component";
-import { testStyledSystemMargin } from "../../__spec_helper__/test-utils";
+import { testStyledSystemSpacing } from "../../__spec_helper__/test-utils";
 
 describe("StepSequence", () => {
   const wrapper = (props?: Partial<StepSequenceProps>) =>
@@ -29,7 +29,7 @@ describe("StepSequence", () => {
   });
 
   describe("styled system", () => {
-    testStyledSystemMargin((props) => (
+    testStyledSystemSpacing((props) => (
       <StepSequence {...props}>
         <div>test</div>
       </StepSequence>

--- a/src/components/step-sequence/step-sequence.stories.mdx
+++ b/src/components/step-sequence/step-sequence.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import { StepSequence, StepSequenceItem } from "./";
-import useMediaQuery from "../../hooks/useMediaQuery";
+import { StepSequence, StepSequenceItem } from ".";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import * as stories from "./step-sequence.stories.tsx";
 
 <Meta title="Step Sequence" parameters={{ info: { disable: true } }} />
 
@@ -35,234 +35,25 @@ import {
 ### Default
 
 <Canvas>
-  <Story name="default">
-    <StepSequence>
-      <StepSequenceItem
-        aria-label="Step 1 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="1"
-        status="complete"
-      >
-        Name
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 2 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="2"
-        status="complete"
-      >
-        Delivery Address
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 3 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="3"
-        status="current"
-      >
-        Delivery Details
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 4 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="4"
-        status="incomplete"
-      >
-        Payment
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 5 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="5"
-        status="incomplete"
-      >
-        Confirm
-      </StepSequenceItem>
-    </StepSequence>
-  </Story>
+  <Story name="default" story={stories.DefaultStory} />
 </Canvas>
 
 ### Vertical
 
 <Canvas>
-  <Story name="vertical">
-    <StepSequence orientation="vertical">
-      <StepSequenceItem
-        aria-label="Step 1 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="1"
-        status="complete"
-      >
-        Name
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 2 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="2"
-        status="complete"
-      >
-        Delivery Address
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 3 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="3"
-        status="current"
-      >
-        Delivery Details
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 4 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="4"
-        status="incomplete"
-      >
-        Payment
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 5 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="5"
-        status="incomplete"
-      >
-        Confirm
-      </StepSequenceItem>
-    </StepSequence>
-  </Story>
+  <Story name="vertical" story={stories.Vertical} />
 </Canvas>
 
 ### With hidden indicators
 
 <Canvas>
-  <Story name="with hidden indicators">
-    <StepSequence>
-      <StepSequenceItem
-        aria-label="Step 1 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="1"
-        status="complete"
-      >
-        Name
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 2 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="2"
-        status="complete"
-      >
-        Delivery Address
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 3 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="3"
-        hideIndicator={true}
-        status="current"
-      >
-        Delivery Details
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 4 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="4"
-        hideIndicator={true}
-        status="incomplete"
-      >
-        Payment
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 5 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="5"
-        hideIndicator={true}
-        status="incomplete"
-      >
-        Confirm
-      </StepSequenceItem>
-    </StepSequence>
-  </Story>
+  <Story name="with hidden indicators" story={stories.WithHiddenIndicators} />
 </Canvas>
 
 ### Responsive Example
 
 <Canvas>
-  <Story 
-    name="responsive"
-    parameters={
-      { 
-        chromatic: { 
-          viewports: [700] 
-        } 
-      }
-    }
-  >
-    {() => {
-      const displayVertical = useMediaQuery("(max-width: 760px)");
-      return (
-        <StepSequence orientation={displayVertical ? "vertical" : "horizontal"}>
-          <StepSequenceItem
-            aria-label="Step 1 of 5"
-            hiddenCompleteLabel="Complete"
-            hiddenCurrentLabel="Current"
-            indicator="1"
-            status="complete"
-          >
-            Name
-          </StepSequenceItem>
-          <StepSequenceItem
-            aria-label="Step 2 of 5"
-            hiddenCompleteLabel="Complete"
-            hiddenCurrentLabel="Current"
-            indicator="2"
-            status="complete"
-          >
-            Delivery Address
-          </StepSequenceItem>
-          <StepSequenceItem
-            aria-label="Step 3 of 5"
-            hiddenCompleteLabel="Complete"
-            hiddenCurrentLabel="Current"
-            indicator="3"
-            status="current"
-          >
-            Delivery Details
-          </StepSequenceItem>
-          <StepSequenceItem
-            aria-label="Step 4 of 5"
-            hiddenCompleteLabel="Complete"
-            hiddenCurrentLabel="Current"
-            indicator="4"
-            status="incomplete"
-          >
-            Payment
-          </StepSequenceItem>
-          <StepSequenceItem
-            aria-label="Step 5 of 5"
-            hiddenCompleteLabel="Complete"
-            hiddenCurrentLabel="Current"
-            indicator="5"
-            status="incomplete"
-          >
-            Confirm
-          </StepSequenceItem>
-        </StepSequence>
-      );
-    }}
-  </Story>
+  <Story name="responsive" story={stories.ResponsiveExample} />
 </Canvas>
 
 

--- a/src/components/step-sequence/step-sequence.stories.mdx
+++ b/src/components/step-sequence/step-sequence.stories.mdx
@@ -61,7 +61,7 @@ import {
 
 ### StepSequence
 
-<StyledSystemProps of={StepSequence} margin noHeader />
+<StyledSystemProps of={StepSequence} spacing noHeader />
 
 ### StepSequenceItem
 

--- a/src/components/step-sequence/step-sequence.stories.tsx
+++ b/src/components/step-sequence/step-sequence.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ComponentStory } from "@storybook/react";
 
 import { StepSequence, StepSequenceItem } from ".";
+import Box from "../box";
 import useMediaQuery from "../../hooks/useMediaQuery";
 
 export const DefaultStory: ComponentStory<typeof StepSequence> = () => (
@@ -55,53 +56,55 @@ export const DefaultStory: ComponentStory<typeof StepSequence> = () => (
 );
 
 export const Vertical: ComponentStory<typeof StepSequence> = () => (
-  <StepSequence orientation="vertical">
-    <StepSequenceItem
-      aria-label="Step 1 of 5"
-      hiddenCompleteLabel="Complete"
-      hiddenCurrentLabel="Current"
-      indicator="1"
-      status="complete"
-    >
-      Name
-    </StepSequenceItem>
-    <StepSequenceItem
-      aria-label="Step 2 of 5"
-      hiddenCompleteLabel="Complete"
-      hiddenCurrentLabel="Current"
-      indicator="2"
-      status="complete"
-    >
-      Delivery Address
-    </StepSequenceItem>
-    <StepSequenceItem
-      aria-label="Step 3 of 5"
-      hiddenCompleteLabel="Complete"
-      hiddenCurrentLabel="Current"
-      indicator="3"
-      status="current"
-    >
-      Delivery Details
-    </StepSequenceItem>
-    <StepSequenceItem
-      aria-label="Step 4 of 5"
-      hiddenCompleteLabel="Complete"
-      hiddenCurrentLabel="Current"
-      indicator="4"
-      status="incomplete"
-    >
-      Payment
-    </StepSequenceItem>
-    <StepSequenceItem
-      aria-label="Step 5 of 5"
-      hiddenCompleteLabel="Complete"
-      hiddenCurrentLabel="Current"
-      indicator="5"
-      status="incomplete"
-    >
-      Confirm
-    </StepSequenceItem>
-  </StepSequence>
+  <Box height="600px">
+    <StepSequence orientation="vertical">
+      <StepSequenceItem
+        aria-label="Step 1 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="1"
+        status="complete"
+      >
+        Name
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 2 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="2"
+        status="complete"
+      >
+        Delivery Address
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 3 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="3"
+        status="current"
+      >
+        Delivery Details
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 4 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="4"
+        status="incomplete"
+      >
+        Payment
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 5 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="5"
+        status="incomplete"
+      >
+        Confirm
+      </StepSequenceItem>
+    </StepSequence>
+  </Box>
 );
 
 export const WithHiddenIndicators: ComponentStory<typeof StepSequence> = () => (

--- a/src/components/step-sequence/step-sequence.stories.tsx
+++ b/src/components/step-sequence/step-sequence.stories.tsx
@@ -1,0 +1,213 @@
+import React from "react";
+import { ComponentStory } from "@storybook/react";
+
+import { StepSequence, StepSequenceItem } from ".";
+import useMediaQuery from "../../hooks/useMediaQuery";
+
+export const DefaultStory: ComponentStory<typeof StepSequence> = () => (
+  <StepSequence>
+    <StepSequenceItem
+      aria-label="Step 1 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="1"
+      status="complete"
+    >
+      Name
+    </StepSequenceItem>
+    <StepSequenceItem
+      aria-label="Step 2 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="2"
+      status="complete"
+    >
+      Delivery Address
+    </StepSequenceItem>
+    <StepSequenceItem
+      aria-label="Step 3 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="3"
+      status="current"
+    >
+      Delivery Details
+    </StepSequenceItem>
+    <StepSequenceItem
+      aria-label="Step 4 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="4"
+      status="incomplete"
+    >
+      Payment
+    </StepSequenceItem>
+    <StepSequenceItem
+      aria-label="Step 5 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="5"
+      status="incomplete"
+    >
+      Confirm
+    </StepSequenceItem>
+  </StepSequence>
+);
+
+export const Vertical: ComponentStory<typeof StepSequence> = () => (
+  <StepSequence orientation="vertical">
+    <StepSequenceItem
+      aria-label="Step 1 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="1"
+      status="complete"
+    >
+      Name
+    </StepSequenceItem>
+    <StepSequenceItem
+      aria-label="Step 2 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="2"
+      status="complete"
+    >
+      Delivery Address
+    </StepSequenceItem>
+    <StepSequenceItem
+      aria-label="Step 3 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="3"
+      status="current"
+    >
+      Delivery Details
+    </StepSequenceItem>
+    <StepSequenceItem
+      aria-label="Step 4 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="4"
+      status="incomplete"
+    >
+      Payment
+    </StepSequenceItem>
+    <StepSequenceItem
+      aria-label="Step 5 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="5"
+      status="incomplete"
+    >
+      Confirm
+    </StepSequenceItem>
+  </StepSequence>
+);
+
+export const WithHiddenIndicators: ComponentStory<typeof StepSequence> = () => (
+  <StepSequence>
+    <StepSequenceItem
+      aria-label="Step 1 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="1"
+      status="complete"
+    >
+      Name
+    </StepSequenceItem>
+    <StepSequenceItem
+      aria-label="Step 2 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="2"
+      status="complete"
+    >
+      Delivery Address
+    </StepSequenceItem>
+    <StepSequenceItem
+      aria-label="Step 3 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="3"
+      hideIndicator
+      status="current"
+    >
+      Delivery Details
+    </StepSequenceItem>
+    <StepSequenceItem
+      aria-label="Step 4 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="4"
+      hideIndicator
+      status="incomplete"
+    >
+      Payment
+    </StepSequenceItem>
+    <StepSequenceItem
+      aria-label="Step 5 of 5"
+      hiddenCompleteLabel="Complete"
+      hiddenCurrentLabel="Current"
+      indicator="5"
+      hideIndicator
+      status="incomplete"
+    >
+      Confirm
+    </StepSequenceItem>
+  </StepSequence>
+);
+
+export const ResponsiveExample: ComponentStory<typeof StepSequence> = () => {
+  const displayVertical = useMediaQuery("(max-width: 760px)");
+  return (
+    <StepSequence orientation={displayVertical ? "vertical" : "horizontal"}>
+      <StepSequenceItem
+        aria-label="Step 1 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="1"
+        status="complete"
+      >
+        Name
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 2 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="2"
+        status="complete"
+      >
+        Delivery Address
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 3 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="3"
+        status="current"
+      >
+        Delivery Details
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 4 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="4"
+        status="incomplete"
+      >
+        Payment
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 5 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="5"
+        status="incomplete"
+      >
+        Confirm
+      </StepSequenceItem>
+    </StepSequence>
+  );
+};
+
+ResponsiveExample.parameters = { chromatic: { viewports: [700] } };

--- a/src/components/step-sequence/step-sequence.style.ts
+++ b/src/components/step-sequence/step-sequence.style.ts
@@ -1,25 +1,26 @@
 import styled, { css } from "styled-components";
-import { margin } from "styled-system";
+import { space, SpaceProps } from "styled-system";
 import { baseTheme } from "../../style/themes";
+import { StepSequenceProps } from "./step-sequence.component";
 
-const StepSequenceStyle = styled.ol<{ orientation: "horizontal" | "vertical" }>`
+const StyledStepSequence = styled.ol<
+  Pick<StepSequenceProps, "orientation"> & SpaceProps
+>`
   display: flex;
   margin: 0;
-  padding: 18px;
   font-weight: bold;
 
   ${({ orientation }) =>
     orientation === "vertical" &&
     css`
       flex-direction: column;
-      padding: 0;
     `}
 
-  ${margin}
+  ${space}
 `;
 
-StepSequenceStyle.defaultProps = {
+StyledStepSequence.defaultProps = {
   theme: baseTheme,
 };
 
-export default StepSequenceStyle;
+export default StyledStepSequence;

--- a/src/components/step-sequence/step-sequence.style.ts
+++ b/src/components/step-sequence/step-sequence.style.ts
@@ -14,6 +14,7 @@ const StyledStepSequence = styled.ol<
     orientation === "vertical" &&
     css`
       flex-direction: column;
+      height: 100%;
     `}
 
   ${space}

--- a/src/components/step-sequence/step-sequence.test.js
+++ b/src/components/step-sequence/step-sequence.test.js
@@ -87,8 +87,11 @@ context("Testing StepSequence component", () => {
           <StepSequenceComponent orientation={orientation} />
         );
 
-        stepSequenceDataComponent()
-          .should("have.attr", "orientation", orientation);
+        stepSequenceDataComponent().should(
+          "have.attr",
+          "orientation",
+          orientation
+        );
 
         if (orientation === "vertical") {
           stepSequenceDataComponent().should(

--- a/src/components/step-sequence/step-sequence.test.js
+++ b/src/components/step-sequence/step-sequence.test.js
@@ -80,19 +80,15 @@ const StepSequenceItemCustom = ({ ...props }) => {
 
 context("Testing StepSequence component", () => {
   describe("should render StepSequence component", () => {
-    it.each([
-      ["horizontal", 18],
-      ["vertical", 0],
-    ])(
+    it.each(["horizontal", "vertical"])(
       "should render StepSequence with orientation set to %s",
-      (orientation, padding) => {
+      (orientation) => {
         CypressMountWithProviders(
           <StepSequenceComponent orientation={orientation} />
         );
 
         stepSequenceDataComponent()
-          .should("have.attr", "orientation", orientation)
-          .and("have.css", "padding-top", `${padding}px`);
+          .should("have.attr", "orientation", orientation);
 
         if (orientation === "vertical") {
           stepSequenceDataComponent().should(


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Refactor stories, moved to tsx file
Removes the hardcoded padding styling and surfaces the padding interface with a default value of 0
Ensures height flexes to container when in `vertical` `orientation`
Update styling for `incomplete` steps to include dashed line
### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Hardcoded padding styling
Height does not flex to container when in `vertical` `orientation`
Styling for `incomplete` steps to has solid line

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

![image](https://user-images.githubusercontent.com/44157880/201896503-4959b7b9-acda-46e3-88b5-bd2825bb38c2.png)

![image](https://user-images.githubusercontent.com/44157880/201896570-7ec9bbd9-66fd-4e7c-b0a7-35554594ce03.png)

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/sad-field-nu72jj?file=/src/index.js
