### PR TITLE
Sage/DSY-1748 Remove Designer Notes

### DIFF
--- a/src/components/accordion/accordion.stories.mdx
+++ b/src/components/accordion/accordion.stories.mdx
@@ -26,12 +26,19 @@ import {
 
 # Accordion
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/028f94-accordion/b/3614a6"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Accordions are a good progressive disclosure technique - initially showing only top-level information, but allowing the user quick access to more on request. But, they can confuse users sometimes, so use them sparingly.
 
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -45,17 +52,6 @@ import {
   AccordionGroup,
 } from "carbon-react/lib/components/accordion";
 ```
-
-## Designer Notes
-
-- Don’t put accordions within accordions.
-- Don’t hide important controls within accordions - for example, primary actions should always be outside them.
-- Accordions expand and collapse vertically. If there are lots, or content is extensive, be careful that the user doesn’t become confused, lose their place, or have problems with discoverability. Use them sparingly for these reasons.
-- Accordions should remain open or closed until a user interacts with them. Consider whether multiple, or only one accordion section can be open at a time.
-- An arrow icon pointing down indicates that the accordion is closed.
-- An arrow icon pointing up indicates that the accordion is open.
-- The icon can animate when a transition is made.
-- The user can click the icon directly, the text label, or the text label’s background to action the accordion.
 
 It can be used as a controlled component where the expansion state is controlled externally,
 in that case both `onChange` and `expanded` props are required.

--- a/src/components/action-popover/action-popover.stories.mdx
+++ b/src/components/action-popover/action-popover.stories.mdx
@@ -19,13 +19,20 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 # ActionPopover
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/5722a7-action-popover/b/48b79b"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 ActionPopovers present a handy list of actions the user can perform on a whole table, a specific row within a table, or a tile.
 Click the ellipsis icon to show actions the user can take on a specific table row, for example, emailing the invoice.
 
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
@@ -45,17 +52,6 @@ import {
   ActionPopoverMenuButton,
 } from "carbon-react/lib/components/action-popover";
 ```
-
-## Designer Notes
-
-- Action Popovers only perform commands - they aren’t used to collect data, or choose between data items as in a form.
-- Place the most common and useful actions within them. Although designs for separator rows and sub-menus are provided,
-  these add complexity, so use them sparingly.
-- Clicking the table row or tile links the user to that item. Only clicking the Action Popover's icon displays its items.
-- Action popovers appear in front of all other UI elements.
-- If they are in a position to be cut off by the browser or screen’s edge, the Action Popover can instead appear to the
-  left, right, or above the element that generates it.
-- Content in the popover is usually left aligned.
 
 ## Related Components
 

--- a/src/components/alert/alert.stories.mdx
+++ b/src/components/alert/alert.stories.mdx
@@ -18,7 +18,6 @@ An important message that interrupts user activity, but can be dismissed.
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
@@ -28,13 +27,6 @@ An important message that interrupts user activity, but can be dismissed.
 ```javascript
 import Alert from "carbon-react/lib/components/alert";
 ```
-
-## Designer Notes
-
-- Useful if a message is so important you’d like to prevent any other activity until the user resolves it.
-- If the message isn’t so important, or you want to avoid disrupting the user’s activity, consider showing a static Message component in the underlying screen.
-- Include a Message component within the Alert component, use plain text, or apply a standard Carbon Error or Warning icon.
-- This component has the same options and properties as the Dialog component.
 
 ## Related Components
 

--- a/src/components/anchor-navigation/anchor-navigation.stories.mdx
+++ b/src/components/anchor-navigation/anchor-navigation.stories.mdx
@@ -23,12 +23,19 @@ import {
 
 # Anchor Navigation
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/496ff6-anchor-navigation/b/285c84"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Easily navigate through long scrollable content.
 
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -44,18 +51,16 @@ import {
 } from "carbon-react/lib/components/anchor-navigation";
 ```
 
-## Designer Notes
+- Create `refs` which will be used internally in `AnchorNavigation` to measure positions of the elements.
 
-Create `refs` which will be used internally in `AnchorNavigation` to measure positions of the elements.
+- Pass proper structure of `AnchorNavigationItem`'s with assigned `refs` to `stickyNavigation` prop.
 
-Pass proper structure of `AnchorNavigationItem`'s with assigned `refs` to `stickyNavigation` prop.
+- Pass children where elements which are meant to serve as sections have `refs` assigned.
+- Keep in mind that to assign a `ref` to a component it either has to be a `Class` component or it has to be wrapped in `React.forwardRef()` in case of a function component.
 
-Pass children where elements which are meant to serve as sections have `refs` assigned.
-Keep in mind that to assign a `ref` to a component it either has to be a `Class` component or it has to be wrapped in `React.forwardRef()` in case of a function component.
+- **It is necessary to maintain the same order of navigation items and children when assigning the `refs`**
 
-**It is necessary to maintain the same order of navigation items and children when assigning the `refs`**
-
-**It is necessary to maintain `stickyNavigation` prop structure as shown below**
+- **It is necessary to maintain `stickyNavigation` prop structure as shown below**
 
 ```javascript
 const MyComponent = () => (

--- a/src/components/badge/badge.stories.mdx
+++ b/src/components/badge/badge.stories.mdx
@@ -7,6 +7,14 @@ import Button from "../button";
 
 # Badge
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/112938-badge/b/97debf"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Compact visual indicators that help things in common stand out.
 
 ## Contents

--- a/src/components/button-toggle-group/button-toggle-group.stories.mdx
+++ b/src/components/button-toggle-group/button-toggle-group.stories.mdx
@@ -14,7 +14,6 @@ Press one of the buttons to make selection. ButtonToggleGroup component should b
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -24,8 +23,6 @@ Press one of the buttons to make selection. ButtonToggleGroup component should b
 import ButtonToggle from "carbon-react/lib/components/button-toggle";
 import ButtonToggleGroup from "carbon-react/lib/components/button-toggle-group";
 ```
-
-## Designer Notes
 
 - Only pass `ButtonToggle` components as children of `ButtonToggleGroup`, passing anything else will result in an error.
 - An icon could be added to make the meaning of an option clearer.

--- a/src/components/button-toggle/button-toggle.stories.mdx
+++ b/src/components/button-toggle/button-toggle.stories.mdx
@@ -2,18 +2,24 @@ import { useState } from "react";
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import ButtonToggle from ".";
 import ButtonToggleGroup from "../button-toggle-group";
-import LinkTo from "@storybook/addon-links/react";
 
 <Meta title="Button Toggle" parameters={{ info: { disable: true } }} />
 
 # Button Toggle
+
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/996a28-button-toggle/b/7384f9"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component
+</a>
 
 Press one of the buttons to make selection. This component should be used when user has to make a choice between a small number of options.
 
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -23,8 +29,6 @@ Press one of the buttons to make selection. This component should be used when u
 import ButtonToggle from "carbon-react/lib/components/button-toggle";
 import ButtonToggleGroup from "carbon-react/lib/components/button-toggle-group";
 ```
-
-## Designer Notes
 
 - You should use the <LinkTo kind="Button Toggle Group" story="default">ButtonToggleGroup component</LinkTo> if you need to wrap multiple `ButtonToggle` components together.
 - An icon could be added to make the meaning of an option clearer.

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -6,6 +6,22 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 # Button
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/10358e-button-major/b/66a1c8"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component - Button Major Component
+</a>
+<br/>
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/4121af-button-minor/b/03680d"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component - Button Minor Component
+</a>
+
 A Button triggers a single action or event.
 Use it to submit a form (Save), to advance to the next step in a process (Next), or to create a new item (New).
 

--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
-
 import { Card, CardRow, CardFooter, CardColumn } from ".";
 
 import * as stories from "./card.stories.tsx";
@@ -12,12 +11,19 @@ import * as stories from "./card.stories.tsx";
 
 # Card
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/54feb0-card/b/712f18"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 A container for interactive content and controls related to a single subject.
 
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -31,15 +37,6 @@ import {
   CardColumn,
 } from "carbon-react/lib/components/card";
 ```
-
-## Designer Notes
-
-- Cards contain interactive content or controls.
-- Cards can be made entirely draggable between designated locations (see [with draggable](#with-draggable) story below).
-- Cards may have hover and dragging states, whereas tiles not.
-- Neither cards nor tiles scroll.
-- The primary action area of a card is typically the card itself. Often cards are one large touch target to a detail screen on a subject.
-- When an array of cards or tiles are shown together, they may wrap into a grid depending on the available width and height of their container.
 
 ## Examples
 

--- a/src/components/carousel/carousel.stories.mdx
+++ b/src/components/carousel/carousel.stories.mdx
@@ -9,6 +9,14 @@ import { Carousel, Slide } from ".";
 
 # Carousel
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/0701e2-carousel-whats-new/b/248536"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 - Presents a series of images which the user can step through one-by-one, or quickly jump to a particular step.
 - Useful for showcasing a set of new features, for example.
 

--- a/src/components/checkbox/checkbox-validations.stories.mdx
+++ b/src/components/checkbox/checkbox-validations.stories.mdx
@@ -5,6 +5,16 @@ import { Checkbox, CheckboxGroup } from ".";
 
 <Meta title="Checkbox/Test" parameters={{ info: { disable: true } }} />
 
+# Checkbox
+
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/5937c7-checkbox/b/317d8f"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 ## Validations
 
 Validation status can be set by passing `error`, `warning` or `info` prop to the component

--- a/src/components/checkbox/checkbox.stories.mdx
+++ b/src/components/checkbox/checkbox.stories.mdx
@@ -8,6 +8,14 @@ import { Checkbox, CheckboxGroup } from ".";
 
 # Checkbox
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/5937c7-checkbox/b/317d8f"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 - Checkbox provides a way to efficiently select more than one item from a list.
 
 ## Contents

--- a/src/components/confirm/confirm.stories.mdx
+++ b/src/components/confirm/confirm.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-
 import Confirm from ".";
 import * as stories from "./confirm.stories";
 
@@ -18,7 +17,6 @@ Confirms or cancels an action.
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
@@ -28,18 +26,6 @@ Confirms or cancels an action.
 ```javascript
 import Confirm from "carbon-react/lib/components/confirm";
 ```
-
-## Designer Notes
-
-Shows a static message in a dialog which asks the user to confirm or cancel an action they’ve initiated.
-
-Useful to confirm actions which may be difficult to undo, or potentially harmful.
-
-Include a Message component within the Alert component (a warning Message component may be particularly useful for a potentially harmful choice), use plain text, or apply a standard Carbon Error or Warning icon.
-
-This component has the same options and properties as the Dialog component.
-
-A good example could be confirming deletion of a large number of records.
 
 ## Related Components
 

--- a/src/components/date-range/date-range-test.stories.mdx
+++ b/src/components/date-range/date-range-test.stories.mdx
@@ -50,6 +50,14 @@ export const DateRangeStory = ({
 
 # Date Range
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/4122f0-date-range"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 ### Default
 
 <Canvas>

--- a/src/components/date-range/date-range.stories.mdx
+++ b/src/components/date-range/date-range.stories.mdx
@@ -12,6 +12,14 @@ import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 # Date Range
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/4122f0-date-range"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Captures a start and end date.
 
 Used to filter a Table of data according to a start and end date, or to set two dates which are related to each other, for example, a hotel booking.

--- a/src/components/date/date.stories.mdx
+++ b/src/components/date/date.stories.mdx
@@ -15,6 +15,14 @@ import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 # Date
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/11ef00-date-picker"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 - If the date is likely to be close to today (e.g. an invoice due date), then a datepicker may be useful. If the date is likely to be far in the past (e.g. a date of birth), then it may be better to use separate inputs for day, month, and year or use a NumeralDate component.
 - Field focus automatically opens the datepicker, but a user can key in dates too, which many users find more convenient, especially in financial applications.
 - Carbon handles a range of formats, like dd/mm/yyyy, dd/mm/yy, dd/mm, or dd. Configuration can be regional, and copes with space, slash, full stop, comma and colon as separators, as well as no separator at all.

--- a/src/components/decimal/decimal.stories.mdx
+++ b/src/components/decimal/decimal.stories.mdx
@@ -16,7 +16,6 @@ Captures a number with a decimal point, or a currency value.
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -25,14 +24,6 @@ Captures a number with a decimal point, or a currency value.
 ```javascript
 import Decimal from "carbon-react/lib/components/decimal";
 ```
-
-## Designer Notes
-
-- For currency values, show currency symbols outside the field rather than inserting one for the user dynamically.
-- Carbon offers a Precision configuration, so you can choose how many decimal places to show.
-- Decimals are usually right-aligned, so that the decimal places of numbers presented in rows line up for easy comparison by the user.
-- Even if the user just enters a string of numbers, consider presenting them into a format with the separators which apply in the user’s country (e.g. £12,345.67 for the UK, and €12 345,67 for France).
-- Where it’s clear a field only accepts numerals, you could disable entry of other characters - but remember to cater for a minus sign if necessary.
 
 ## Examples
 

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.mdx
@@ -20,7 +20,6 @@ A full-width and full-height dialog overlaid on top of any page.
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
@@ -30,14 +29,6 @@ A full-width and full-height dialog overlaid on top of any page.
 ```javascript
 import DialogFullScreen from "carbon-react/lib/components/dialog-full-screen";
 ```
-
-## Designer Notes
-
-Useful to perform an action in context without navigating the user to a separate page.
-
-Whilst a standard Dialog component’s width might constrain what you can do, the full screen dialog uses the full width and height available.
-
-A good example could be importing a large volume of data, and checking for errors, in the context of an underlying table of data.
 
 ## Related Components
 

--- a/src/components/dialog/dialog.stories.mdx
+++ b/src/components/dialog/dialog.stories.mdx
@@ -17,12 +17,19 @@ import * as stories from "./dialog.stories.tsx";
 
 # Dialog
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/497e21-dialog/b/310ef2"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 A dialog box overlaid on top of any page.
 
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
@@ -32,16 +39,6 @@ A dialog box overlaid on top of any page.
 ```javascript
 import Dialog from "carbon-react/lib/components/dialog";
 ```
-
-## Designer Notes
-
-Useful to perform an action in context without navigating the user to a separate page.
-
-Several pre-set widths are available - the height of the dialog will flex to fit the content. It’s best to avoid dialogs that are taller than the user’s viewport height. Typical user viewport heights can be as little as 650 pixels.
-
-Choose whether a dark tint is applied behind the dialog which helps to focus the user on the dialog.
-
-A configuration shows a close icon at the top right of the Dialog. Sometimes users are more likely to click this than a traditional ‘Cancel’ button.
 
 ## Related Components
 

--- a/src/components/draggable/draggable.stories.mdx
+++ b/src/components/draggable/draggable.stories.mdx
@@ -15,7 +15,6 @@ with possibility to change their order with drag and drop mechanics
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -29,8 +28,6 @@ import {
   DraggableItem,
 } from "carbon-react/lib/components/draggable";
 ```
-
-## Designer Notes
 
 - Always use `DraggableItem` inside of the `DraggableContainer`
 - `DraggableItem` doesn't work without `DraggableContainer`

--- a/src/components/drawer/drawer.stories.mdx
+++ b/src/components/drawer/drawer.stories.mdx
@@ -31,6 +31,14 @@ import Pager from "../pager";
 
 # Drawer
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/77fb82-drawer/b/665a20"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Drawer is a two column layout container.
 It is designed to have left hand side container expand and collapse to respectively reveal and hide the content of that container.
 Drawer component is designed to fill the space of the element that it is put inside.

--- a/src/components/duelling-picklist/duelling-picklist.stories.mdx
+++ b/src/components/duelling-picklist/duelling-picklist.stories.mdx
@@ -6,6 +6,7 @@ import PicklistDivider from "./picklist-divider/picklist-divider.component";
 import PicklistPlaceholder from "./picklist-placeholder/picklist-placeholder.component";
 import DuellingPicklist from "./duelling-picklist.component";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+
 import {
   Default,
   AlternativeSearch,
@@ -25,7 +26,6 @@ Select a subset of relatively short list.
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -43,22 +43,22 @@ import {
 } from "carbon-react/lib/components/duelling-picklist";
 ```
 
-## Designer Notes
+- `DuellingPicklist` is meant to be a container composed of two `Picklist` children and a `PicklistDivider` between them.
 
-`DuellingPicklist` is meant to be a container composed of two `Picklist` children and a `PicklistDivider` between them.
-It also accepts `leftLabel` and `rightLabel` props of type string which will be rendered above the corresponding `PickList`s.
-Similarly to labels, `leftControls` and `rightControls` props accept a node to be rendered between the labels and the `Picklist`.
+- It also accepts `leftLabel` and `rightLabel` props of type string which will be rendered above the corresponding `PickList`.
+
+- Similarly to labels, `leftControls` and `rightControls` props accept a node to be rendered between the labels and the `Picklist`.
 This is a suitable place for components like `Search` or `Filter` used to manipulate displayed data.
 To display an overlay over whole `DuellingPicklist` content pass a `disabled` prop set to true.
 
-`Picklist` wraps a list of `PicklistItem`'s, applies enter transition animations and provides an extended keyboard navigation (up/down/home/end keys).
+- `Picklist` wraps a list of `PicklistItem`, applies enter transition animations and provides an extended keyboard navigation (up/down/home/end keys).
 
-`PicklistDivider` as name states is a component meant to visually divide two `PickList`'s. It is optional, the spacing between the two picklists will be equal with or without it.
+- `PicklistDivider` as name states is a component meant to visually divide two `PickList`. It is optional, the spacing between the two picklists will be equal with or without it.
 
-`PicklistItem` is a component meant to visually represent one of the iterable entities. It can be of a type `add` or `remove`.
+- `PicklistItem` is a component meant to visually represent one of the iterable entities. It can be of a type `add` or `remove`.
 It invokes passed `onChange` method with passed `item` prop as an argument when either `add` or `remove` icon is clicked or `space` or `enter` pressed when whole `PicklistItem` is focused.
 
-`PicklistPlaceholder` can be used to display the content of its `text` prop. It is meant to be passed as a `placeholder` prop in `Picklist` component.
+- `PicklistPlaceholder` can be used to display the content of its `text` prop. It is meant to be passed as a `placeholder` prop in `Picklist` component.
 
 ## Examples
 

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -31,6 +31,14 @@ import Button from "../button";
 
 # Flat Table
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/56c2ee-table/b/28fa8b"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Logically structure content in a grid for the user to enter, view, or work with.
 
 ## Contents

--- a/src/components/global-header/global-header.stories.mdx
+++ b/src/components/global-header/global-header.stories.mdx
@@ -30,6 +30,14 @@ import carbonLogo from "../../../logo/carbon-logo.png";
 
 # Global Header
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/901fb3-global-header/b/7937f5"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 `GlobalHeader` is a wrapper component designed for creating site-wide navigation layouts.
 
 ## Contents

--- a/src/components/grid/grid.stories.mdx
+++ b/src/components/grid/grid.stories.mdx
@@ -5,12 +5,19 @@ import Pod from "../pod";
 import { GridContainer, GridItem } from ".";
 import { Dl, Dt, Dd } from "../definition-list";
 import Button from "../button";
-import Link from "../link";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 <Meta title="Grid" parameters={{ chromatic: { disable: true } }} />
 
 # Grid
+
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/58ef5d-grid-system"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
 
 The Carbon responsive grid system is a layout component that provides guidance on how components should be positioned within a user interface, adapting to screen size and orientation.
 The Grid system is designed to provide:

--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -1,7 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import LinkTo from "@storybook/addon-links/react";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
-
 import Icon from "./";
 import Box from "../box";
 
@@ -10,6 +9,14 @@ import { ICONS } from "./icon-config";
 <Meta title="Icon" parameters={{ info: { disable: true } }} />
 
 # Icon
+
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/53fdcc-product-ui-icons"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
 
 Carbon comes with more than 100 standard icons to choose from. See [list of icons](#list-of-icons) for full reference.
 

--- a/src/components/link/link.stories.mdx
+++ b/src/components/link/link.stories.mdx
@@ -2,19 +2,25 @@ import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import LinkTo from "@storybook/addon-links/react";
 
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
-import Link from ".";
 import * as stories from "./link.stories";
 
 <Meta title="Link" component={Link} parameters={{ info: { disable: true }, controls: { disable: true } }} />
 
 # Link
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/16ff08-link"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Navigates the user to another location.
 
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -25,16 +31,9 @@ Import `Link` into the project.
 ```javascript
 import Link from "carbon-react/lib/components/link";
 ```
-
-## Designer Notes
-
-To use `Link` with a routing library see our documentation on this here: <LinkTo kind="Documentation/Usage with routing" story="page">Usage with routing</LinkTo>
-
-Avoid using links for commands (performing an action like saving a form) - use them for navigating the user to a new location.
-If you’re navigating the user away from your site, consider using an icon after the link, and open the link in a new window, so the user doesn’t lose their place.
-To make the meaning of a link clearer, you can add an icon before it. Just name one of the Carbon icons.
-Make your link names meaningful - for example, instead of ‘Click here’, try ‘Download Invoice 001’.
-WCAG guidelines recommend that Color is not used as the only visual means of conveying information, indicating an action. Carbon applies bold weight, but you could also use text decoration.
+To use Link with a routing library see our documentation on this here: <Link href="https://carbon.sage.com/?path=/docs/documentation-usage-with-routing--page"
+    target="_blank"
+    rel="noreferrer noopener">Usage with routing</Link>
 
 ## Examples
 

--- a/src/components/loader-bar/loader-bar.stories.mdx
+++ b/src/components/loader-bar/loader-bar.stories.mdx
@@ -1,8 +1,7 @@
 import { useState } from "react";
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
-
 import LoaderBar from ".";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 import * as stories from "./loader-bar.stories.tsx";
 
@@ -12,6 +11,15 @@ import * as stories from "./loader-bar.stories.tsx";
 />
 
 # LoaderBar
+
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/74be25-loader/b/81df60"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 
 Use the LoaderBar component to let users know a task or loading data is still in progress.
 Showing a LoaderBar helps the user to understand that they should wait, rather than reload the page or abandon a process.

--- a/src/components/loader/loader.stories.mdx
+++ b/src/components/loader/loader.stories.mdx
@@ -12,6 +12,14 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 # Loader
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/74be25-loader"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Use the Loader component to let users know a task or loading data is still in progress.
 Showing a Loader helps the user to understand that they should wait, rather than reload the page or abandon a process.
 In general, place a Loader in the centre and middle of the page or container it relates to.

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -21,6 +21,14 @@ import Typography from "../typography";
 
 # Menu
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/59e0bd-menu"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Provides navigation for an app, which can be used via mouse or keyboard.
 
 ## Contents

--- a/src/components/multi-action-button/multi-action-button.stories.mdx
+++ b/src/components/multi-action-button/multi-action-button.stories.mdx
@@ -11,10 +11,17 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 # Multi Action Button
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/7428b1-button-multi-action/b/18aaff"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -23,15 +30,6 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 ```javascript
 import MultiActionButton from "carbon-react/lib/components/multi-action-button";
 ```
-
-## Designer Notes
-
-- Offers related actions to the user, but without taking up valuable space by showing them separately.
-- But, users may not always discover them, and could miss out.
-- Useful to show about 5 options or less.
-- Only use this component for commands that are related (e.g. Export PDF, Export CSV).
-- Don’t use this component if one option is more generic or important than the others.
-- Carbon has a Transparent configuration, with subtle visual style, which could be useful to present less important or infrequently used options to the user, without calling attention to them.
 
 ## Examples
 

--- a/src/components/navigation-bar/navigation-bar.stories.mdx
+++ b/src/components/navigation-bar/navigation-bar.stories.mdx
@@ -8,6 +8,14 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 # Navigation Bar
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/36c339-navigation-bar"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 This component is used as a wrapper for the Menu component when used as a navigation layout.
 
 ## Contents

--- a/src/components/note/note.stories.mdx
+++ b/src/components/note/note.stories.mdx
@@ -26,7 +26,6 @@ consuming projects to install `draft-js` as a peer-dependency to enable it to wo
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -36,9 +35,6 @@ consuming projects to install `draft-js` as a peer-dependency to enable it to wo
 import Note from "carbon-react/lib/components/note";
 import { EditorState, ContentState, convertFromHTML } from "draft-js";
 ```
-
-## Designer Notes
-
 To use `Note`, use the import path above and pass the content via the `noteContent` prop by utilising the static
 methods provided by the `draft-js` (see the import above) framework https://draftjs.org/docs/api-reference-content-state#static-methods.
 

--- a/src/components/pager/pager.stories.mdx
+++ b/src/components/pager/pager.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta, ArgsTable, Canvas, Story } from "@storybook/addon-docs";
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
-
 import Pager from ".";
 import * as stories from "./pager.stories.tsx";
 

--- a/src/components/pill/pill.stories.mdx
+++ b/src/components/pill/pill.stories.mdx
@@ -8,6 +8,14 @@ import Box from "../box";
 
 # Pill
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/89f1fa-pill"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Compact visual indicators that help things in common stand out.
 
 ## Contents

--- a/src/components/pod/pod.stories.mdx
+++ b/src/components/pod/pod.stories.mdx
@@ -17,7 +17,6 @@ Presents content grouped visually together. This can be text, or other component
 
 - [Quick Start](#quick-start)
 - [Related Components](#related-components)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -27,19 +26,20 @@ Presents content grouped visually together. This can be text, or other component
 import Pod from "carbon-react/lib/components/pod";
 ```
 
-## Designer Notes
+## Designer's Notes
 
-Configure Pod and Fieldset components to work together, or choose the pre-configured Show/Edit Pod component:
+- Configure Pod and Fieldset components to work together, or choose the pre-configured Show/Edit Pod component: 
 
-The ShowEditPod component automatically presents content as a read-only Pod, until the user clicks an edit icon, which shows the same information in an editable Fieldset.
+- The ShowEditPod component automatically presents content as a read-only Pod, until the user clicks an edit icon, which shows the same information in an editable Fieldset. 
 
-However, configuring Pod and Fieldset components manually will give you more customization options, like the following:
+- However, configuring Pod and Fieldset components manually will give you more customization options, like the following: 
 
-The onEdit property shows a standard edit icon, which can be used to show a fieldset. You can choose whether this icon appears inside or outside the pod, and whether it appears only on hover. You can also choose whether clicking only the icon triggers the onEdit property, or clicking anywhere on the pod.
+- The onEdit property shows a standard edit icon, which can be used to show a fieldset. You can choose whether this icon appears inside or outside the pod, and whether it appears only on hover. You can also choose whether clicking only the icon triggers the onEdit property, or clicking anywhere on the pod. 
 
-Choose from various visual options, including padding, borders, and primary, secondary, or tertiary appearance.
+- Choose from various visual options, including padding, borders, and primary, secondary, or tertiary appearance. 
 
-Set the pod to flex to the width of its content, or take up the full width of its container.
+- Set the pod to flex to the width of its content, or take up the full width of its container. 
+
 
 ## Related Components
 

--- a/src/components/portrait/portrait.stories.mdx
+++ b/src/components/portrait/portrait.stories.mdx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
-
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 import Box from "../box";
@@ -9,6 +8,14 @@ import Portrait from ".";
 <Meta title="Portrait" parameters={{ info: { disable: true } }} />
 
 # Portrait
+
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/56e693-portrait"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
 
 - Useful to represent a person, user, or organisation.
 - Use initials rather than an avatar if you prefer.

--- a/src/components/profile/profile.stories.mdx
+++ b/src/components/profile/profile.stories.mdx
@@ -4,10 +4,17 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import Profile from ".";
 import useMediaQuery from "../../hooks/useMediaQuery";
 
-
 <Meta title="Profile" parameters={{ info: { disable: true } }} />
 
 # Profile
+
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/16fc08-profile"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
 
 - Display information alongside a [Portrait](/components/portrait) component.
 - Useful to represent a person, user, or organisation.

--- a/src/components/progress-tracker/progress-tracker.stories.mdx
+++ b/src/components/progress-tracker/progress-tracker.stories.mdx
@@ -9,6 +9,14 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 # ProgressTracker
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/00f4d0-progress-tracker"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Use the `ProgressTracker` component to let users know a task or loading data is still in progress.
 Showing a `ProgressTracker` helps the user to understand that they should wait, rather than reload the page or abandon a process.
 In general, place a `ProgressTracker` in the centre and middle of the page or container it relates to.

--- a/src/components/radio-button/radio-button.stories.mdx
+++ b/src/components/radio-button/radio-button.stories.mdx
@@ -9,12 +9,19 @@ import * as stories from "./radio-button.stories";
 
 # RadioButton/RadioButtonGroup
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/647e16-radio-button"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Used to provide a group of selectable radio buttons.
 
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
@@ -29,12 +36,6 @@ import {
   RadioButtonGroup,
 } from "carbon-react/lib/components/radio-button";
 ```
-
-## Designer Notes
-
-Consider ‘smart default’ selections, based on what your user is likely to choose. But, users may well leave the defaults in place, so make sure any consequences are easy to undo, and not harmful.
-Useful to show less than about 10 options.
-Disabled or read-only radio buttons might be difficult for a user to distinguish visually, so try to avoid this.
 
 ## Related Components
 
@@ -112,6 +113,8 @@ The radio buttons and labels can be flipped around using the `reverse` prop on e
 ### Disable radio buttons
 
 The radio buttons and labels can be disabled using the `disabled` prop on each radio button.
+
+**Please Note**: Even though Carbon does support disabled radio buttons, their use is not generally recommended by Design System.
 
 <Canvas>
   <Story name="disable radio buttons" story={stories.DisableRadioButtons} />

--- a/src/components/search/search.stories.mdx
+++ b/src/components/search/search.stories.mdx
@@ -9,6 +9,14 @@ import Box from "../box";
 
 # Search
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/64709e-search"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 This search component should be used if you require the user to conduct a search.
 
 ## Contents

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -19,7 +19,6 @@ Filterable Select is a Carbon styled implementation of WAI-ARIA Combobox with In
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 - [Translation keys](#translation-keys)
@@ -29,13 +28,9 @@ Filterable Select is a Carbon styled implementation of WAI-ARIA Combobox with In
 ```javascript
 import { FilterableSelect, Option } from "carbon-react/lib/components/select";
 ```
-
-## Designer Notes
-
 Always insert `Option` Components inside the `FilterableSelect`, analogous to the `<select>` and `<option>` HTML Elements.
 
-If you type printable characters in the Textbox,
-you can filter through the existing options leaving only those that match the text you typed.
+If you type printable characters in the Textbox, you can filter through the existing options leaving only those that match the text you typed.
 
 ## Examples
 

--- a/src/components/select/multi-select/multi-select.stories.mdx
+++ b/src/components/select/multi-select/multi-select.stories.mdx
@@ -17,7 +17,6 @@ Select multiple options from the drop-down menu. MultiSelect is a component that
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 - [Translation keys](#translation-keys)
@@ -28,12 +27,9 @@ Select multiple options from the drop-down menu. MultiSelect is a component that
 import { MultiSelect, Option } from "carbon-react/lib/components/select";
 ```
 
-## Designer Notes
-
 Always insert `Option` Components inside the `MultiSelect`, analogous to the `<select>` and `<option>` HTML Elements.
 
-If you type printable characters in the Textbox,
-you can filter through the existing options leaving only those that match the text you typed.
+If you type printable characters in the Textbox, you can filter through the existing options leaving only those that match the text you typed.
 
 ## Examples
 

--- a/src/components/select/simple-select/simple-select.stories.mdx
+++ b/src/components/select/simple-select/simple-select.stories.mdx
@@ -13,12 +13,19 @@ import CarbonProvider from "../../carbon-provider/carbon-provider.component";
 
 # Simple Select
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/464d11-dropdown-select/b/51c4c7"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Select one of available options from the drop-down menu. Simple Select is a Carbon styled equivalent of HTML Select Element.
 
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 - [Translation keys](#translation-keys)
@@ -31,8 +38,6 @@ from `carbon-react/lib/components/select`.
 ```javascript
 import { Select, Option } from "carbon-react/lib/components/select";
 ```
-
-## Designer Notes
 
 Always insert `Option` Components inside the `Select`, analogous to the original `<select>` and `<option>` HTML Elements.
 

--- a/src/components/show-edit-pod/show-edit-pod.stories.mdx
+++ b/src/components/show-edit-pod/show-edit-pod.stories.mdx
@@ -16,7 +16,6 @@ import Textbox from "../textbox";
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
@@ -28,29 +27,27 @@ import Textbox from "../textbox";
 import ShowEditPod from "carbon-react/lib/components/show-edit-pod";
 ```
 
-## Designer Notes
+- Nest any Carbon input into this component.
 
-Nest any Carbon input into this component.
+- Configure Pod and Fieldset components to work together, or choose this pre-configured Show/Edit Pod component.
 
-Configure Pod and Fieldset components to work together, or choose this pre-configured Show/Edit Pod component.
+- The Show/Edit Pod Component automatically presents content as a read-only Pod, until the user clicks an edit icon, which shows the same information in an editable Fieldset.
 
-The Show/Edit Pod Component automatically presents content as a read-only Pod, until the user clicks an edit icon, which shows the same information in an editable Fieldset.
+- However, configuring Pod and Fieldset components manually will give you more customization options.
 
-However, configuring Pod and Fieldset components manually will give you more customization options.
+- Choose whether the editable state has a disabled or enabled Save button, a Cancel button, or a Delete button, and their alignment.
 
-Choose whether the editable state has a disabled or enabled Save button, a Cancel button, or a Delete button, and their alignment.
+- Choose from various visual options, including borders, and primary, secondary, or tertiary appearance.
 
-Choose from various visual options, including borders, and primary, secondary, or tertiary appearance.
+- Set the pod to flex to the width of its content, or take up the full width of its container.
 
-Set the pod to flex to the width of its content, or take up the full width of its container.
+- Top-aligned labels (Carbon default) or inline right-aligned labels are usually fastest for users.
 
-Top-aligned labels (Carbon default) or inline right-aligned labels are usually fastest for users.
+- Create a single path to completion with your inputs, and between your inputs and the primary action Button.
 
-Create a single path to completion with your inputs, and between your inputs and the primary action Button.
+- Indicate mandatory, or optional fields, whichever is the minority. Think carefully before collecting optional data - don’t collect information you don’t need! Try suffixing ‘(optional)’ after your field label.
 
-Indicate mandatory, or optional fields, whichever is the minority. Think carefully before collecting optional data - don’t collect information you don’t need! Try suffixing ‘(optional)’ after your field label.
-
-More guidance is available for each of the individual inputs you might place inside this component.
+- More guidance is available for each of the individual inputs you might place inside this component.
 
 ## Related Components
 

--- a/src/components/sidebar/sidebar.stories.mdx
+++ b/src/components/sidebar/sidebar.stories.mdx
@@ -15,10 +15,17 @@ import * as stories from "./sidebar.stories.tsx";
 
 # Sidebar
 
-## Contents
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/925533-sidebar"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
+# <h2>Contents</h2>
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
@@ -29,21 +36,9 @@ import * as stories from "./sidebar.stories.tsx";
 import Sidebar from "carbon-react/lib/components/sidebar";
 ```
 
-## Designer Notes
+- Sidebar is positioned on the right hand screen of the window by default. To position the sidebar on the left hand side pass `position='left'` to the component.
 
-Useful to perform an action in context without navigating the user to a separate page.
-
-Useful if the user might need to refer back to the page behind the sidebar. For example, the user could select from a list of clients on the page, with detailed information on the client loading in the sidebar.
-
-Several pre-set widths are available, and the height of the sidebar is always 100%. It’s best to avoid sidebars that are taller than the user’s viewport height, as a scroll would hide some information. Typical user viewport heights can be as little as 650 pixels.
-
-Choose whether a dark tint is applied behind the dialog which helps to focus the user on the sidebar, but don’t select this option if the user needs to refer back to the underlying page.
-
-Sidebar is positioned on the right hand screen of the window by default.
-To position the sidebar on the left hand side pass `position='left'` to the component.
-
-The background behind the sidebar is disabled by default. To allow the user to interact
-with all the UI pass `enableBackgroundUI={ true }` to the component
+- The background behind the sidebar is disabled by default. To allow the user to interact with all the UI pass `enableBackgroundUI={ true }` to the component
 
 ## Related Components
 
@@ -55,7 +50,7 @@ with all the UI pass `enableBackgroundUI={ true }` to the component
 ### Default
 
 <Canvas>
-  <Story name="default" story={stories.DefaultStory} />
+  <Story name="default" story={stories.DefaultStory}/>
 </Canvas>
 
 ### Custom padding around content

--- a/src/components/simple-color-picker/simple-color-picker.stories.mdx
+++ b/src/components/simple-color-picker/simple-color-picker.stories.mdx
@@ -9,6 +9,14 @@ import Box from "../box";
 
 # Simple Color Picker
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/83c4f8-color-picker"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 - Choose from a small palette of pre-set colours, with indication of a currently selected colour.
 
 ## Contents

--- a/src/components/split-button/split-button.stories.mdx
+++ b/src/components/split-button/split-button.stories.mdx
@@ -10,10 +10,17 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 # Split Button
 
-## Contents
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/861289-button-split"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
+# <h2>Contents</h2>
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
@@ -23,14 +30,6 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 ```javascript
 import SplitButton from "carbon-react/lib/components/split-button";
 ```
-
-## Designer Notes
-
-- Offers one more important action to the user, with some related actions also quickly accessible, but without taking up valuable space by showing them all separately.
-- But, users may not always discover the related items, and could miss out.
-- Useful to show about 5 options or less.
-- Only use this component for buttons that are very closely related (e.g. Save, Save and Email, Save and Print, Save and New).
-- Only use this component if one option is more generic or important than the others.
 
 ## Examples
 

--- a/src/components/step-sequence/step-sequence.stories.mdx
+++ b/src/components/step-sequence/step-sequence.stories.mdx
@@ -7,6 +7,14 @@ import * as stories from "./step-sequence.stories.tsx";
 
 # StepSequence
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/405a47-step-flow"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Indicate the progress of a step flow.
 
 Progress indicators always directly mirror the number of pages, not general categories.

--- a/src/components/switch/switch.stories.mdx
+++ b/src/components/switch/switch.stories.mdx
@@ -10,6 +10,14 @@ import * as stories from "./switch.stories.tsx";
 
 # Switch
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/36a24a-switch"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Switches provide a way to efficiently toggle between two states. They are often used on settings pages to switch on and off individual features.
 
 Disabled or read-only Switches might be difficult for a user to distinguish visually, so try to avoid this.

--- a/src/components/tabs/tabs.stories.mdx
+++ b/src/components/tabs/tabs.stories.mdx
@@ -12,12 +12,19 @@ import Box from "../box";
 
 # Tabs
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/54468c-tab"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Switch between content panes or filtered views of tables.
 
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
@@ -28,7 +35,8 @@ Switch between content panes or filtered views of tables.
 import { Tabs, Tab } from "carbon-react/lib/components/tabs";
 ```
 
-## Designer Notes
+- Navigating the hierarchy of the app? [Try Menu](https://carbon.sage.com/?path=/docs/menu)
+- Positioning your primary navigation? [Try Navigation Bar](https://carbon.sage.com/?path=/docs/navigation-bar)
 
 - Switch between variants of a page or different tables (e.g. separate tables showing unread and read emails).
 - There are two `position` options:
@@ -40,11 +48,6 @@ import { Tabs, Tab } from "carbon-react/lib/components/tabs";
 - Only use tabs if there’s more than one, and show the content of one tab by default. Avoid multiple rows of tabs,
   nested tabs, or using vertical and horizontal tabs at the same time.
 - To use `Tabs` with a routing library see our documentation on this here: <LinkTo kind="Documentation/Usage with routing" story="page">Usage with routing</LinkTo>
-
-## Related Components
-
-- Navigating the hierarchy of the app? [Try Menu](https://carbon.sage.com/?path=/docs/menu)
-- Positioning your primary navigation? [Try Navigation Bar](https://carbon.sage.com/?path=/docs/navigation-bar)
 
 ## Examples
 

--- a/src/components/text-editor/text-editor.stories.mdx
+++ b/src/components/text-editor/text-editor.stories.mdx
@@ -20,7 +20,6 @@ peer-dependency to enable it to work.
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 - [Translation keys](#translation-keys)
@@ -33,8 +32,6 @@ import TextEditor, {
   ContentState,
 } from "carbon-react/lib/components/text-editor";
 ```
-
-## Designer Notes
 
 To use the text editor , import the `TextEditor` and pass the content as as an immutable `EditorState` object.
 

--- a/src/components/textarea/textarea.stories.mdx
+++ b/src/components/textarea/textarea.stories.mdx
@@ -13,6 +13,14 @@ import * as stories from "./textarea.stories";
 
 # Textarea
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/20f5ea-text-area"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 - Useful for collecting a significant amount of text (e.g. notes about clients, or a short email message).
 - If content in a textarea is read-only, remove the field border so it appears as static text.
 - Use placeholder text to give the user context or examples of what to write.

--- a/src/components/textbox/textbox.stories.mdx
+++ b/src/components/textbox/textbox.stories.mdx
@@ -10,12 +10,19 @@ import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 # Textbox
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/60f854-text-input/b/007c6c"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Captures a single line of text.
 
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 

--- a/src/components/toast/toast.stories.mdx
+++ b/src/components/toast/toast.stories.mdx
@@ -12,13 +12,20 @@ import * as stories from "./toast.stories";
 
 # Toast
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/31d5ea-toast/b/227fa0"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 Toast is part of Carbon's Flashes components.
 Its purpose is to present quick confirmation of success or failure, relating to the task the user has just performed. Alternatively, use Toast messages for a longer, timely message that the user must dismiss.
 
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Designer Notes](#designer-notes)
 - [Examples](#examples)
 - [Props](#props)
 
@@ -29,11 +36,6 @@ To use toast, import the `Toast` and pass the content as children.
 ```javascript
 import Toast from "carbon-react/lib/components/toast";
 ```
-
-## Designer Notes
-
-It can be used as a controlled component where the open state is controlled externally,
-in that case both `onDismiss` and `open` props are required.
 
 ### Controlled
 

--- a/src/components/tooltip/tooltip.stories.mdx
+++ b/src/components/tooltip/tooltip.stories.mdx
@@ -11,6 +11,14 @@ import Button from "../button";
 
 # Tooltip
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/93ac95-tooltip"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component 
+</a>
+
 The `Tooltip` component is built using `tippyjs` to support features such as dynamic positioning where the tooltip will
 flip if there is no space in its default placement; and the arrow and tooltip will track the target element when a user scrolls
 or the window resizes.


### PR DESCRIPTION
The purpose of this PR is to include links instead of Designer's Notes section, which would direct to the Product Design Hub with more extensive Designer's Guidelines. Some notes are being left as they are as they give a useful guidelines on how to work with certain components. 

### Proposed behaviour
<img width="328" alt="Screenshot 2023-01-10 at 16 58 53" src="https://user-images.githubusercontent.com/48626342/211614924-97be0235-bdde-4df9-9f06-09bd0ddded78.png">
<img width="252" alt="Screenshot 2023-01-10 at 16 59 18" src="https://user-images.githubusercontent.com/48626342/211614953-592eba0b-71f9-44c0-8e2c-0d8e11bc4818.png">

<img width="276" alt="Screenshot 2023-01-10 at 16 59 36" src="https://user-images.githubusercontent.com/48626342/211614898-ff1c373d-e38e-48ac-b6f1-b41d0649381c.png">

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour
<img width="1005" alt="Screenshot 2022-11-29 at 09 55 25" src="https://user-images.githubusercontent.com/48626342/204497750-6ee66fb3-5542-402a-9119-619290b6d052.png">
<img width="1029" alt="Screenshot 2022-11-29 at 09 53 40" src="https://user-images.githubusercontent.com/48626342/204497761-e06a14d4-553b-4142-851c-7f90f047743d.png">
<img width="1070" alt="example" src="https://user-images.githubusercontent.com/48626342/204497801-4560be61-caf3-4042-ac30-7b4652857d04.png">

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
