### PR TITLE
test(icon-button): add cypress tests

### DIFF
--- a/src/components/icon-button/icon-button.test.js
+++ b/src/components/icon-button/icon-button.test.js
@@ -1,0 +1,132 @@
+import React from "react";
+import IconButton from ".";
+import Icon from "../icon";
+import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
+import { icon } from "../../../cypress/locators";
+
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+import { keyCode } from "../../../cypress/support/helper";
+
+const IconButtonComponent = ({ ...props }) => {
+  return (
+    <IconButton aria-label="icon-button" onAction={() => {}} {...props}>
+      <Icon type="home" />
+    </IconButton>
+  );
+};
+
+context("Tests for IconButton component", () => {
+  describe("check props for IconButton component", () => {
+    it("should render IconButton with aria-label prop", () => {
+      CypressMountWithProviders(
+        <IconButtonComponent aria-label={CHARACTERS.STANDARD} />
+      );
+
+      icon()
+        .parent()
+        .should("have.attr", "aria-label", CHARACTERS.STANDARD)
+        .and("be.visible");
+    });
+
+    it("should render IconButton with children prop", () => {
+      CypressMountWithProviders(<IconButtonComponent />);
+
+      icon().should("be.visible");
+    });
+
+    it("should render IconButton with disabled prop", () => {
+      CypressMountWithProviders(<IconButtonComponent disabled />);
+
+      icon().parent().should("be.disabled").and("have.attr", "disabled");
+    });
+  });
+
+  describe("check events for IconButton component", () => {
+    let callback;
+
+    beforeEach(() => {
+      callback = cy.stub();
+    });
+
+    it("should call onBlur callback when a blur event is triggered", () => {
+      CypressMountWithProviders(<IconButtonComponent onBlur={callback} />);
+
+      icon()
+        .parent()
+        .focus()
+        .blur()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          expect(callback).to.have.been.calledOnce;
+        });
+    });
+
+    it("should call onFocus callback when a focus event is triggered", () => {
+      CypressMountWithProviders(<IconButtonComponent onFocus={callback} />);
+
+      icon()
+        .parent()
+        .focus()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          expect(callback).to.have.been.calledOnce;
+        });
+    });
+
+    it("should call onMouseEnter callback when a mouseover event is triggered", () => {
+      CypressMountWithProviders(
+        <IconButtonComponent onMouseEnter={callback} />
+      );
+
+      icon()
+        .parent()
+        .trigger("mouseover")
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          expect(callback).to.have.been.calledOnce;
+        });
+    });
+
+    it("should call onMouseLeave callback when a mouseout event is triggered", () => {
+      CypressMountWithProviders(
+        <IconButtonComponent onMouseLeave={callback} />
+      );
+
+      icon()
+        .parent()
+        .trigger("mouseover")
+        .trigger("mouseout")
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          expect(callback).to.have.been.calledOnce;
+        });
+    });
+
+    it("should call onAction callback when a click event is triggered", () => {
+      CypressMountWithProviders(<IconButtonComponent onAction={callback} />);
+
+      icon()
+        .parent()
+        .click()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          expect(callback).to.have.been.calledOnce;
+        });
+    });
+
+    it.each(["Space", "Enter"])(
+      "should call onAction callback when a keydown event is triggered with %s",
+      (key) => {
+        CypressMountWithProviders(<IconButtonComponent onAction={callback} />);
+
+        icon()
+          .parent()
+          .trigger("keydown", keyCode(key))
+          .then(() => {
+            // eslint-disable-next-line no-unused-expressions
+            expect(callback).to.have.been.calledOnce;
+          });
+      }
+    );
+  });
+});


### PR DESCRIPTION
### Proposed behaviour
- Add Cypress tests for the `Icon-Button` component to use new cypress-component-react framework for testing.
- Add `icon-button.test.js`. 

### Current behaviour
No tests for `Icon-Button` component

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added test.file
- [x] Check if the `icon-button.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed