### PR TITLE
fix(date-range): update styles so validation and label text wrap if they exceed input width

### DIFF
--- a/src/components/date-range/date-range.spec.js
+++ b/src/components/date-range/date-range.spec.js
@@ -13,9 +13,17 @@ import {
 import StyledDateRange from "./date-range.style";
 import StyledDateInput from "../date/date.style";
 import Tooltip from "../tooltip";
+import { FieldLineStyle } from "../../__internal__/form-field/form-field.style";
+import StyledValidationMessage from "../../__internal__/validation-message/validation-message.style";
+import StyledLabel from "../../__internal__/label/label.style";
 
 const initialValues = ["10/10/2016", "11/11/2016"];
 const updatedValues = ["12/12/2012", "13/12/2012"];
+const datePickerWidths = {
+  large: "140px",
+  medium: "135px",
+  small: "120px",
+};
 
 describe("DateRange", () => {
   let wrapper;
@@ -734,6 +742,36 @@ describe("StyledDateRange", () => {
 
       expect(position).toEqual("top");
     });
+  });
+
+  describe("validation layout", () => {
+    it.each(["small", "medium", "large"])(
+      "sets the maxWidth of the %s Date input wrappers to the expected value",
+      (size) => {
+        const maxWidth = datePickerWidths[size];
+
+        const dateInputs = mount(
+          <DateRange
+            value={["", ""]}
+            onChange={() => {}}
+            startDateProps={{ size }}
+            endDateProps={{ size }}
+          />
+        ).find(DateInput);
+
+        dateInputs.forEach((dateInput) => {
+          assertStyleMatch({ maxWidth }, dateInput, {
+            modifier: `${FieldLineStyle}`,
+          });
+          assertStyleMatch({ overflowWrap: "anywhere" }, dateInput, {
+            modifier: `${StyledValidationMessage}`,
+          });
+          assertStyleMatch({ overflowWrap: "anywhere" }, dateInput, {
+            modifier: `${StyledLabel}`,
+          });
+        });
+      }
+    );
   });
 });
 

--- a/src/components/date-range/date-range.stories.mdx
+++ b/src/components/date-range/date-range.stories.mdx
@@ -226,6 +226,10 @@ It is possible to use the `tooltipPosition` to override the default placement of
 
 #### New designs validation
 
+Longer validation strings that would exceed the input width will wrap to a new line. Inputs 
+should remain aligned but labels may no longer be when a string wraps. Label text that would 
+exceed the input widht will also wrap to a new line.
+
 <Canvas>
   <Story name="validations - string - new design">
     {() => {
@@ -240,8 +244,8 @@ It is possible to use the `tooltipPosition` to override the default placement of
       return (
         <CarbonProvider validationRedesignOptIn>
           {[
-            { startError: "Start Error", endError: "End Error" },
-            { startWarning: "Start Warning", endWarning: "End Warning" },
+            { startError: "Start error with long text string", endError: "End error" },
+            { startWarning: "Start warning", endWarning: "End warning with long text string" },
           ].map((validation) => (
             <DateRange
               key={`${Object.keys(validation)[0]}-string-component`}

--- a/src/components/date/date.component.js
+++ b/src/components/date/date.component.js
@@ -329,6 +329,7 @@ const DateInput = ({
       data-element={dataElement}
       data-role={dataRole}
       {...filterStyledSystemMarginProps(rest)}
+      applyDateRangeStyling={!!inputRefMap}
     >
       <Textbox
         {...filterOutStyledSystemSpacingProps(rest)}

--- a/src/components/date/date.style.js
+++ b/src/components/date/date.style.js
@@ -1,10 +1,13 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
 import { margin } from "styled-system";
 
 import baseTheme from "../../style/themes/base";
 import StyledInput from "../../__internal__/input/input.style";
 import StyledInputPresentation from "../../__internal__/input/input-presentation.style";
+import { FieldLineStyle } from "../../__internal__/form-field/form-field.style";
+import StyledValidationMessage from "../../__internal__/validation-message/validation-message.style";
+import StyledLabel from "../../__internal__/label/label.style";
 
 const datePickerWidth = {
   large: "140px",
@@ -23,6 +26,19 @@ const StyledDateInput = styled.div`
       margin-right: -8px;
     }
   }
+
+  ${({ applyDateRangeStyling, size, labelInline }) =>
+    applyDateRangeStyling &&
+    !labelInline &&
+    css`
+      ${FieldLineStyle} {
+        max-width: ${datePickerWidth[size]};
+      }
+
+      ${StyledValidationMessage}, ${StyledLabel} {
+        overflow-wrap: anywhere;
+      }
+    `}
 `;
 
 StyledDateInput.propTypes = {

--- a/src/components/textarea/textarea.component.tsx
+++ b/src/components/textarea/textarea.component.tsx
@@ -18,6 +18,7 @@ import useInputAccessibility from "../../hooks/__internal__/useInputAccessibilit
 import { NewValidationContext } from "../carbon-provider/carbon-provider.component";
 import { ErrorBorder, StyledHintText } from "../textbox/textbox.style";
 import ValidationMessage from "../../__internal__/validation-message";
+import Box from "../box";
 
 // TODO: Change characterLimit type to number - batch with other breaking changes
 export interface TextareaProps
@@ -226,6 +227,54 @@ export const Textarea = ({
     (validationIconId && !validationOnLabel)
   );
 
+  const input = (
+    <InputPresentation
+      size={size}
+      disabled={disabled}
+      readOnly={readOnly}
+      inputWidth={
+        typeof inputWidth === "number" ? inputWidth : 100 - labelWidth
+      }
+      error={error}
+      warning={warning}
+      info={info}
+    >
+      <Input
+        aria-invalid={!!error}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={validationRedesignOptIn ? undefined : ariaDescribedBy}
+        autoFocus={autoFocus}
+        name={name}
+        value={value}
+        ref={inputRef}
+        maxLength={maxLength}
+        onChange={onChange}
+        disabled={disabled}
+        readOnly={readOnly}
+        placeholder={disabled ? "" : placeholder}
+        rows={rows}
+        cols={cols}
+        id={id}
+        as="textarea"
+        {...props}
+      />
+      {children}
+      <InputIconToggle
+        disabled={disabled}
+        readOnly={readOnly}
+        inputIcon={inputIcon}
+        size={size}
+        error={error}
+        warning={warning}
+        info={info}
+        validationIconId={
+          validationRedesignOptIn ? undefined : validationIconId
+        }
+        useValidationIcon={!(validationRedesignOptIn || validationOnLabel)}
+      />
+    </InputPresentation>
+  );
+
   return (
     <TooltipProvider
       tooltipPosition={tooltipPosition}
@@ -263,61 +312,17 @@ export const Textarea = ({
             {validationRedesignOptIn && labelHelp && (
               <StyledHintText>{labelHelp}</StyledHintText>
             )}
-            {validationRedesignOptIn && (
-              <ValidationMessage error={error} warning={warning} />
+            {validationRedesignOptIn ? (
+              <Box position="relative">
+                <ValidationMessage error={error} warning={warning} />
+                {(error || warning) && (
+                  <ErrorBorder warning={!!(!error && warning)} />
+                )}
+                {input}
+              </Box>
+            ) : (
+              input
             )}
-            <InputPresentation
-              size={size}
-              disabled={disabled}
-              readOnly={readOnly}
-              inputWidth={
-                typeof inputWidth === "number" ? inputWidth : 100 - labelWidth
-              }
-              error={error}
-              warning={warning}
-              info={info}
-            >
-              {validationRedesignOptIn && (error || warning) && (
-                <ErrorBorder warning={!!(!error && warning)} />
-              )}
-              <Input
-                aria-invalid={!!error}
-                aria-labelledby={ariaLabelledBy}
-                aria-describedby={
-                  validationRedesignOptIn ? undefined : ariaDescribedBy
-                }
-                autoFocus={autoFocus}
-                name={name}
-                value={value}
-                ref={inputRef}
-                maxLength={maxLength}
-                onChange={onChange}
-                disabled={disabled}
-                readOnly={readOnly}
-                placeholder={disabled ? "" : placeholder}
-                rows={rows}
-                cols={cols}
-                id={id}
-                as="textarea"
-                {...props}
-              />
-              {children}
-              <InputIconToggle
-                disabled={disabled}
-                readOnly={readOnly}
-                inputIcon={inputIcon}
-                size={size}
-                error={error}
-                warning={warning}
-                info={info}
-                validationIconId={
-                  validationRedesignOptIn ? undefined : validationIconId
-                }
-                useValidationIcon={
-                  !(validationRedesignOptIn || validationOnLabel)
-                }
-              />
-            </InputPresentation>
           </FormField>
           {characterCount}
         </StyledTextarea>

--- a/src/components/textbox/textbox.component.tsx
+++ b/src/components/textbox/textbox.component.tsx
@@ -21,6 +21,7 @@ import { ErrorBorder, StyledHintText } from "./textbox.style";
 import ValidationMessage from "../../__internal__/validation-message";
 import { NewValidationContext } from "../carbon-provider/carbon-provider.component";
 import NumeralDateContext from "../numeral-date/numeral-date-context";
+import Box from "../box";
 
 export interface CommonTextboxProps
   extends ValidationProps,
@@ -209,6 +210,68 @@ export const Textbox = ({
     (validationIconId && !validationOnLabel)
   );
 
+  const input = (
+    <InputPresentation
+      align={align}
+      disabled={disabled}
+      readOnly={readOnly}
+      size={size}
+      error={error}
+      warning={warning}
+      info={info}
+      inputWidth={inputWidth || 100 - labelWidth}
+      positionedChildren={positionedChildren}
+      hasIcon={hasIconInside}
+    >
+      {leftChildren}
+      {prefix && (
+        <StyledPrefix data-element="textbox-prefix">{prefix}</StyledPrefix>
+      )}
+      <Input
+        {...(required && { required })}
+        align={align}
+        aria-invalid={!!error}
+        aria-labelledby={labelId}
+        aria-describedby={validationRedesignOptIn ? undefined : ariaDescribedBy}
+        autoFocus={autoFocus}
+        deferTimeout={deferTimeout}
+        disabled={disabled}
+        id={uniqueId}
+        inputRef={inputRef}
+        name={uniqueName}
+        onBlur={onBlur}
+        onChange={onChange}
+        onChangeDeferred={onChangeDeferred}
+        onClick={onClick}
+        onFocus={onFocus}
+        onMouseDown={onMouseDown}
+        placeholder={disabled || readOnly ? "" : placeholder}
+        readOnly={readOnly}
+        value={typeof formattedValue === "string" ? formattedValue : value}
+        maxLength={maxLength}
+        {...props}
+      />
+      {children}
+      <InputIconToggle
+        align={align}
+        disabled={disabled}
+        error={error}
+        iconTabIndex={iconTabIndex}
+        info={info}
+        inputIcon={inputIcon}
+        onClick={iconOnClick || onClick}
+        onMouseDown={iconOnMouseDown || onMouseDown}
+        readOnly={readOnly}
+        size={size}
+        useValidationIcon={!(validationRedesignOptIn || validationOnLabel)}
+        warning={warning}
+        validationIconId={
+          validationRedesignOptIn ? undefined : validationIconId
+        }
+      />
+    </InputPresentation>
+  );
+
   return (
     <TooltipProvider
       helpAriaLabel={helpAriaLabel}
@@ -247,81 +310,17 @@ export const Textbox = ({
           {validationRedesignOptIn && labelHelp && (
             <StyledHintText>{labelHelp}</StyledHintText>
           )}
-          {validationRedesignOptIn && (
-            <ValidationMessage error={error} warning={warning} />
-          )}
-          <InputPresentation
-            align={align}
-            disabled={disabled}
-            readOnly={readOnly}
-            size={size}
-            error={error}
-            warning={warning}
-            info={info}
-            inputWidth={inputWidth || 100 - labelWidth}
-            positionedChildren={positionedChildren}
-            hasIcon={hasIconInside}
-          >
-            {leftChildren}
-            {prefix && (
-              <StyledPrefix data-element="textbox-prefix">
-                {prefix}
-              </StyledPrefix>
-            )}
-            {validationRedesignOptIn &&
-              !disableErrorBorder &&
-              (error || warning) && (
+          {validationRedesignOptIn ? (
+            <Box position="relative">
+              <ValidationMessage error={error} warning={warning} />
+              {!disableErrorBorder && (error || warning) && (
                 <ErrorBorder warning={!!(!error && warning)} />
               )}
-            <Input
-              {...(required && { required })}
-              align={align}
-              aria-invalid={!!error}
-              aria-labelledby={labelId}
-              aria-describedby={
-                validationRedesignOptIn ? undefined : ariaDescribedBy
-              }
-              autoFocus={autoFocus}
-              deferTimeout={deferTimeout}
-              disabled={disabled}
-              id={uniqueId}
-              inputRef={inputRef}
-              name={uniqueName}
-              onBlur={onBlur}
-              onChange={onChange}
-              onChangeDeferred={onChangeDeferred}
-              onClick={onClick}
-              onFocus={onFocus}
-              onMouseDown={onMouseDown}
-              placeholder={disabled || readOnly ? "" : placeholder}
-              readOnly={readOnly}
-              value={
-                typeof formattedValue === "string" ? formattedValue : value
-              }
-              maxLength={maxLength}
-              {...props}
-            />
-            {children}
-            <InputIconToggle
-              align={align}
-              disabled={disabled}
-              error={error}
-              iconTabIndex={iconTabIndex}
-              info={info}
-              inputIcon={inputIcon}
-              onClick={iconOnClick || onClick}
-              onMouseDown={iconOnMouseDown || onMouseDown}
-              readOnly={readOnly}
-              size={size}
-              useValidationIcon={
-                !(validationRedesignOptIn || validationOnLabel)
-              }
-              warning={warning}
-              validationIconId={
-                validationRedesignOptIn ? undefined : validationIconId
-              }
-            />
-          </InputPresentation>
+              {input}
+            </Box>
+          ) : (
+            input
+          )}
         </FormField>
         {characterCount}
       </InputBehaviour>

--- a/src/components/textbox/textbox.style.ts
+++ b/src/components/textbox/textbox.style.ts
@@ -6,12 +6,12 @@ const ErrorBorder = styled.span`
       position: absolute;
       z-index: 6;
       width: 2px;
-      height: calc(100% + var(--spacing300));
       background-color: ${warning
         ? "var(--colorsSemanticCaution500)"
         : "var(--colorsSemanticNegative500)"};
       left: -12px;
       bottom: 0px;
+      top: 0px;
     `}
 `;
 


### PR DESCRIPTION
fix #5431

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
The text for the validation message and label will now wrap to a new line if they exceed the input width of the individual `Date` inputs within `DateRange`

![image](https://user-images.githubusercontent.com/44157880/203576526-95455e1b-fe03-484e-b87b-650c8f006071.png)


### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Label and validation text does not wrap

![image](https://user-images.githubusercontent.com/44157880/203575814-a39bb90a-a971-4960-acd0-efccd0d045e0.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.
See updated story and linked sandbox

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/strange-carson-v72mlk