### PR TITLE
test: refactor cypress tests to use constants

### DIFF
--- a/cypress/support/component-helper/constants.js
+++ b/cypress/support/component-helper/constants.js
@@ -1,7 +1,11 @@
 export const SIZE = {
+  EXTRASMALL: "extra-small",
   SMALL: "small",
+  MEDIUMSMALL: "medium-small",
   MEDIUM: "medium",
+  MEDIUMLARGE: "medium-large",
   LARGE: "large",
+  EXTRALARGE: "extra-large",
 };
 
 export const VALIDATION = {
@@ -12,6 +16,9 @@ export const VALIDATION = {
 
 export const COLOR = {
   BLACK: "rgb(0, 0, 0)",
+  RED: "rgb(205, 56, 75)",
+  ORANGE: "rgb(255, 156, 75)",
+  BROWN: "rgb(105, 61, 57)",
 };
 
 export const CHARACTERS = {

--- a/src/components/accordion/accordion.test.js
+++ b/src/components/accordion/accordion.test.js
@@ -15,7 +15,10 @@ import {
   ACCORDION_REMOVE_CONTENT,
 } from "../../../cypress/locators/accordion/locators";
 import { checkGoldenOutline } from "../../../cypress/support/component-helper/common-steps";
-import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
 import {
   AccordionComponent,
@@ -33,10 +36,7 @@ import {
   AccordionWithDefinitionList,
 } from "./accordion.stories.tsx";
 
-const sizes = [
-  ["small", "24px"],
-  ["large", "46px"],
-];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const accWidths = [["700px"], ["900px"], ["1100px"], ["1300px"]];
 
 context("Testing Accordion component", () => {
@@ -181,7 +181,7 @@ context("Testing Accordion component", () => {
       }
     );
 
-    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+    it.each(testData)(
       "should render Accordion component with %s as a title",
       (titleValue) => {
         CypressMountWithProviders(<AccordionComponent title={titleValue} />);
@@ -190,7 +190,7 @@ context("Testing Accordion component", () => {
       }
     );
 
-    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+    it.each(testData)(
       "should render Accordion component with %s as a subtitle",
       (titleValue) => {
         CypressMountWithProviders(<AccordionComponent subTitle={titleValue} />);
@@ -199,7 +199,10 @@ context("Testing Accordion component", () => {
       }
     );
 
-    it.each(sizes)(
+    it.each([
+      [SIZE.SMALL, "24px"],
+      [SIZE.LARGE, "46px"],
+    ])(
       "should render Accordion component with %s as a size and has height property set to %s",
       (size, height) => {
         CypressMountWithProviders(<AccordionComponent size={size} />);

--- a/src/components/advanced-color-picker/advanced-color-picker.test.js
+++ b/src/components/advanced-color-picker/advanced-color-picker.test.js
@@ -14,6 +14,7 @@ import { alertDialogPreview as advancedColorPickerParent } from "../../../cypres
 import { closeIconButton } from "../../../cypress/locators";
 
 import { keyCode } from "../../../cypress/support/helper";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
 const AdvancedColorPickerCustom = ({ onChange, ...props }) => {
   const [open, setOpen] = React.useState(true);
@@ -114,7 +115,7 @@ context("Testing AdvancedColorPicker component", () => {
   });
 
   describe("should render AdvancedColorPicker component and check props", () => {
-    const testPropValue = "cypress_test";
+    const testPropValue = CHARACTERS.STANDARD;
     const colors = [
       { value: "#111222", label: "superBlack" },
       { value: "#333555", label: "black" },

--- a/src/components/alert/alert.test.js
+++ b/src/components/alert/alert.test.js
@@ -13,17 +13,12 @@ import {
   pressESCKeyOntoFocusedElement,
   closeIconButton,
 } from "../../../cypress/locators/index";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
-const sizes = [
-  ["extra-small", 300],
-  ["small", 380],
-  ["medium-small", 540],
-  ["medium", 750],
-  ["medium-large", 850],
-  ["large", 960],
-  ["extra-large", 1080],
-];
+const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 context("Testing Alert component", () => {
   describe("should render Alert component", () => {
@@ -108,7 +103,15 @@ context("Testing Alert component", () => {
       }
     );
 
-    it.each(sizes)(
+    it.each([
+      [SIZE.EXTRASMALL, 300],
+      [SIZE.SMALL, 380],
+      [SIZE.MEDIUMSMALL, 540],
+      [SIZE.MEDIUM, 750],
+      [SIZE.MEDIUMLARGE, 850],
+      [SIZE.LARGE, 960],
+      [SIZE.EXTRALARGE, 1080],
+    ])(
       "should render Alert component with %s as a size and has width property set to %s",
       (size, width) => {
         CypressMountWithProviders(

--- a/src/components/badge/badge.test.js
+++ b/src/components/badge/badge.test.js
@@ -7,6 +7,7 @@ import {
   badgeCounter,
   badgeCrossIcon,
 } from "../../../cypress/locators/badge";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
 const BadgeComponent = ({ ...props }) => {
   return (
@@ -48,7 +49,7 @@ context("Testing Badge component", () => {
       }
     );
 
-    it.each([[0], [-12], ["test"], ["!@#$%^*()_+-=~[];:.,?{}&\"'<>"]])(
+    it.each([[0], [-12], ["test"], [CHARACTERS.SPECIALCHARACTERS]])(
       "should check Badge counter is not visible when using %s param",
       (incorectValue) => {
         CypressMountWithProviders(<BadgeComponent counter={incorectValue} />);

--- a/src/components/button-toggle-group/button-toggle-group.test.js
+++ b/src/components/button-toggle-group/button-toggle-group.test.js
@@ -12,14 +12,13 @@ import {
 } from "../../../cypress/locators/button-toggle-group";
 import { positionOfElement } from "../../../cypress/support/helper";
 import { getDataElementByValue, icon } from "../../../cypress/locators";
+import {
+  VALIDATION,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
-const specialCharacters = [
-  "label",
-  "mp150ú¿¡üßä",
-  "!@#$%^*()_+-=~[];:.,?{}&\"'<>",
-];
-const testPropValue = "cypress_test";
+const testPropValue = CHARACTERS.STANDARD;
 
 const ButtonToggleGroupComponent = ({ ...props }) => {
   return (
@@ -71,7 +70,7 @@ const ButtonToggleGroupDefaultChecked = () => {
 
 context("Testing Button-Toggle-Group component", () => {
   describe("should render Button-Toggle-Group component", () => {
-    it("should render Button-Toggle-Group with data-component prop set to Cypress-Test", () => {
+    it("should render Button-Toggle-Group with data-component prop set to cypress_data", () => {
       CypressMountWithProviders(
         <ButtonToggleGroupComponent data-component={testPropValue} />
       );
@@ -81,7 +80,7 @@ context("Testing Button-Toggle-Group component", () => {
         .should("have.attr", "data-component", testPropValue);
     });
 
-    it("should render Button-Toggle-Group with data-element prop set to Cypress-Test", () => {
+    it("should render Button-Toggle-Group with data-element prop set to cypress_data", () => {
       CypressMountWithProviders(
         <ButtonToggleGroupComponent data-element={testPropValue} />
       );
@@ -89,7 +88,7 @@ context("Testing Button-Toggle-Group component", () => {
       buttonToggleGroup().should("have.attr", "data-element", testPropValue);
     });
 
-    it("should render Button-Toggle-Group with data-role prop set to Cypress-Test", () => {
+    it("should render Button-Toggle-Group with data-role prop set to cypress_data", () => {
       CypressMountWithProviders(
         <ButtonToggleGroupComponent data-role={testPropValue} />
       );
@@ -97,7 +96,7 @@ context("Testing Button-Toggle-Group component", () => {
       buttonToggleGroup().should("have.attr", "data-role", testPropValue);
     });
 
-    it("should render Button-Toggle-Group with all button toggle input name props set to Cypress-Test", () => {
+    it("should render Button-Toggle-Group with all button toggle input name props set to cypress_data", () => {
       CypressMountWithProviders(
         <ButtonToggleGroupComponent name={testPropValue} />
       );
@@ -108,9 +107,9 @@ context("Testing Button-Toggle-Group component", () => {
     });
 
     it.each([
-      ["error", "Error Message", "", "", "rgb(203, 55, 74)"],
-      ["warning", "", "Warning Message", "", "rgb(239, 103, 0)"],
-      ["info", "", "", "Info Message", "rgb(0, 96, 167)"],
+      ["error", "Error Message", "", "", VALIDATION.ERROR],
+      ["warning", "", "Warning Message", "", VALIDATION.WARNING],
+      ["info", "", "", "Info Message", VALIDATION.INFO],
     ])(
       "should render Button-Toggle-Group with %s icon",
       (prop, errorMessage, warningMessage, infoMessage, bottomColor) => {
@@ -153,18 +152,19 @@ context("Testing Button-Toggle-Group component", () => {
         .should("have.attr", "data-element", "info");
     });
 
-    it.each(specialCharacters)(
-      "should render Button-Toggle-Group with %s as label",
-      (labelText) => {
-        CypressMountWithProviders(
-          <ButtonToggleGroupComponent label={labelText} />
-        );
+    it.each([
+      CHARACTERS.STANDARD,
+      CHARACTERS.DIACRITICS,
+      CHARACTERS.SPECIALCHARACTERS,
+    ])("should render Button-Toggle-Group with %s as label", (labelText) => {
+      CypressMountWithProviders(
+        <ButtonToggleGroupComponent label={labelText} />
+      );
 
-        buttonToggleGroup().should("contain.text", labelText);
-      }
-    );
+      buttonToggleGroup().should("contain.text", labelText);
+    });
 
-    it("should render Button-Toggle-Group with tooltip set to Cypress-Test", () => {
+    it("should render Button-Toggle-Group with tooltip set to cypress_data", () => {
       CypressMountWithProviders(
         <ButtonToggleGroupComponent labelHelp={testPropValue} />
       );
@@ -175,7 +175,11 @@ context("Testing Button-Toggle-Group component", () => {
         .and("has.text", testPropValue);
     });
 
-    it.each(specialCharacters)(
+    it.each([
+      CHARACTERS.STANDARD,
+      CHARACTERS.DIACRITICS,
+      CHARACTERS.SPECIALCHARACTERS,
+    ])(
       "should render Button-Toggle-Group with %s as field help text",
       (fieldHelpText) => {
         CypressMountWithProviders(

--- a/src/components/button-toggle/button-toggle.test.js
+++ b/src/components/button-toggle/button-toggle.test.js
@@ -8,18 +8,10 @@ import {
 import { icon } from "../../../cypress/locators";
 import { positionOfElement } from "../../../cypress/support/helper";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
-
-const specialCharacters = [
-  "label",
-  "mp150ú¿¡üßä",
-  "!@#$%^*()_+-=~[];:.,?{}&\"'<>",
-];
-const sizes = [
-  ["small", 32],
-  ["medium", 40],
-  ["large", 48],
-];
-const testPropValue = "cypress_test";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
 const ButtonToggleComponent = ({ children, ...props }) => {
   return (
@@ -68,10 +60,14 @@ context("Testing Button-Toggle component", () => {
 
     it("should render Button-Toggle with aria-labelledby prop", () => {
       CypressMountWithProviders(
-        <ButtonToggleComponent aria-labelledby={testPropValue} />
+        <ButtonToggleComponent aria-labelledby={CHARACTERS.STANDARD} />
       );
 
-      buttonToggleInput().should("have.attr", "aria-labelledby", testPropValue);
+      buttonToggleInput().should(
+        "have.attr",
+        "aria-labelledby",
+        CHARACTERS.STANDARD
+      );
     });
 
     it.each([
@@ -86,43 +82,49 @@ context("Testing Button-Toggle component", () => {
       }
     );
 
-    it("should render Button-Toggle with data-component prop set to Cypress-Test", () => {
+    it("should render Button-Toggle with data-component prop set to cypress_data", () => {
       CypressMountWithProviders(
-        <ButtonToggleComponent data-component={testPropValue} />
+        <ButtonToggleComponent data-component={CHARACTERS.STANDARD} />
       );
 
       buttonToggleInput()
         .parent()
-        .should("have.attr", "data-component", testPropValue);
+        .should("have.attr", "data-component", CHARACTERS.STANDARD);
     });
 
-    it("should render Button-Toggle with data-element prop set to Cypress-Test", () => {
+    it("should render Button-Toggle with data-element prop set to cypress_data", () => {
       CypressMountWithProviders(
-        <ButtonToggleComponent data-element={testPropValue} />
+        <ButtonToggleComponent data-element={CHARACTERS.STANDARD} />
       );
 
       buttonToggleInput()
         .parent()
-        .should("have.attr", "data-element", testPropValue);
+        .should("have.attr", "data-element", CHARACTERS.STANDARD);
     });
 
-    it("should render Button-Toggle with data-role prop set to Cypress-Test", () => {
+    it("should render Button-Toggle with data-role prop set to cypress_data", () => {
       CypressMountWithProviders(
-        <ButtonToggleComponent data-role={testPropValue} />
+        <ButtonToggleComponent data-role={CHARACTERS.STANDARD} />
       );
 
       buttonToggleInput()
         .parent()
-        .should("have.attr", "data-role", testPropValue);
+        .should("have.attr", "data-role", CHARACTERS.STANDARD);
     });
 
-    it("should render Button-Toggle with name prop set to Cypress-Test", () => {
-      CypressMountWithProviders(<ButtonToggleComponent name={testPropValue} />);
+    it("should render Button-Toggle with name prop set to cypress_data", () => {
+      CypressMountWithProviders(
+        <ButtonToggleComponent name={CHARACTERS.STANDARD} />
+      );
 
-      buttonToggleInput().should("have.attr", "name", testPropValue);
+      buttonToggleInput().should("have.attr", "name", CHARACTERS.STANDARD);
     });
 
-    it.each(sizes)(
+    it.each([
+      [SIZE.SMALL, 32],
+      [SIZE.MEDIUM, 40],
+      [SIZE.LARGE, 48],
+    ])(
       "should check when prop is %s that Button-Toggle height is %s",
       (size, height) => {
         CypressMountWithProviders(
@@ -147,7 +149,7 @@ context("Testing Button-Toggle component", () => {
       }
     );
 
-    it.each(["small", "medium", "large"])(
+    it.each([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE])(
       "should check that Button-Toggle icon size is %s",
       (iconSize) => {
         CypressMountWithProviders(
@@ -177,7 +179,11 @@ context("Testing Button-Toggle component", () => {
       }
     );
 
-    it.each(specialCharacters)(
+    it.each([
+      CHARACTERS.STANDARD,
+      CHARACTERS.DIACRITICS,
+      CHARACTERS.SPECIALCHARACTERS,
+    ])(
       "should check Button-Toggle text is %s when Children prop is set to %s",
       (labelText) => {
         CypressMountWithProviders(<ButtonToggle>{labelText}</ButtonToggle>);
@@ -189,12 +195,12 @@ context("Testing Button-Toggle component", () => {
       }
     );
 
-    it("should render Button-Toggle with Value set to Cypress-Test", () => {
+    it("should render Button-Toggle with Value set to cypress_data", () => {
       CypressMountWithProviders(
-        <ButtonToggleComponent value={testPropValue} />
+        <ButtonToggleComponent value={CHARACTERS.STANDARD} />
       );
 
-      buttonToggleInput().should("have.attr", "value", testPropValue);
+      buttonToggleInput().should("have.attr", "value", CHARACTERS.STANDARD);
     });
   });
 

--- a/src/components/button/button.test.js
+++ b/src/components/button/button.test.js
@@ -8,9 +8,10 @@ import {
 
 import { icon, tooltipPreview } from "../../../cypress/locators";
 import { positionOfElement, keyCode } from "../../../cypress/support/helper";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const ButtonDifferentTypes = ({ ...props }) => {
   return (

--- a/src/components/card/card.test.js
+++ b/src/components/card/card.test.js
@@ -17,8 +17,12 @@ import {
   draggableContainer,
   columnCard,
 } from "../../../cypress/locators/card/index";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const textAlignment = ["center", "left", "right"];
 
 const CardComponent = ({ ...props }) => {
@@ -216,9 +220,9 @@ const CardTextAlignment = ({ ...props }) => {
 context("Tests for Card component", () => {
   describe("should check Card component properties", () => {
     it.each([
-      ["small", 24],
-      ["medium", 32],
-      ["large", 48],
+      [SIZE.SMALL, 24],
+      [SIZE.MEDIUM, 32],
+      [SIZE.LARGE, 48],
     ])(
       "should check %s spacing and padding for Card component ",
       (spacing, paddings) => {

--- a/src/components/checkbox/checkbox.test.js
+++ b/src/components/checkbox/checkbox.test.js
@@ -24,10 +24,14 @@ import {
   verifyRequiredAsteriskForLegend,
   verifyRequiredAsteriskForLabel,
 } from "../../../cypress/support/component-helper/common-steps";
+import {
+  SIZE,
+  VALIDATION,
+  COLOR,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
-const testData = "cypress_data";
-
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const CheckboxComponent = ({ ...props }) => {
   const [setIsChecked] = React.useState(false);
   return (
@@ -90,19 +94,31 @@ context("Testing Checkbox component", () => {
   describe("should render Checkbox component", () => {
     it("should render Checkbox component with data-component", () => {
       CypressMountWithProviders(
-        <CheckboxComponent data-component={testData} />
+        <CheckboxComponent data-component={CHARACTERS.STANDARD} />
       );
-      getComponent(testData).should("have.attr", "data-component", testData);
+      getComponent(CHARACTERS.STANDARD).should(
+        "have.attr",
+        "data-component",
+        CHARACTERS.STANDARD
+      );
     });
 
     it("should render Checkbox component with data-element", () => {
-      CypressMountWithProviders(<CheckboxComponent data-element={testData} />);
-      checkboxComponent().should("have.attr", "data-element", testData);
+      CypressMountWithProviders(
+        <CheckboxComponent data-element={CHARACTERS.STANDARD} />
+      );
+      checkboxComponent().should(
+        "have.attr",
+        "data-element",
+        CHARACTERS.STANDARD
+      );
     });
 
     it("should render Checkbox component with data-role", () => {
-      CypressMountWithProviders(<CheckboxComponent data-role={testData} />);
-      checkboxComponent().should("have.attr", "data-role", testData);
+      CypressMountWithProviders(
+        <CheckboxComponent data-role={CHARACTERS.STANDARD} />
+      );
+      checkboxComponent().should("have.attr", "data-role", CHARACTERS.STANDARD);
     });
 
     it.each([
@@ -117,7 +133,7 @@ context("Testing Checkbox component", () => {
     );
   });
 
-  it.each(specialCharacters)(
+  it.each(testData)(
     "should render Checkbox component with %s as a label",
     (label) => {
       CypressMountWithProviders(<CheckboxComponent label={label} />);
@@ -126,7 +142,7 @@ context("Testing Checkbox component", () => {
     }
   );
 
-  it.each(specialCharacters)(
+  it.each(testData)(
     "should render Checkbox component with %s as fieldHelp",
     (fieldHelp) => {
       CypressMountWithProviders(<CheckboxComponent fieldHelp={fieldHelp} />);
@@ -172,8 +188,8 @@ context("Testing Checkbox component", () => {
   );
 
   it("should render Checkbox component with id", () => {
-    CypressMountWithProviders(<CheckboxComponent id={testData} />);
-    checkboxRole().should("have.id", testData);
+    CypressMountWithProviders(<CheckboxComponent id={CHARACTERS.STANDARD} />);
+    checkboxRole().should("have.id", CHARACTERS.STANDARD);
   });
 
   it("should render Checkbox component with name", () => {
@@ -187,8 +203,8 @@ context("Testing Checkbox component", () => {
   });
 
   it.each([
-    ["small", "16"],
-    ["large", "24"],
+    [SIZE.SMALL, "16"],
+    [SIZE.LARGE, "24"],
   ])("should render Checkbox component with size set to %s", (size, width) => {
     CypressMountWithProviders(<CheckboxComponent size={size} />);
     checkboxRole().should("have.css", "height", `${width}px`);
@@ -242,19 +258,19 @@ context("Testing Checkbox component", () => {
   it("should render Checkbox component with error", () => {
     CypressMountWithProviders(<CheckboxComponent error />);
 
-    checkboxSvg().should("have.css", "border-bottom-color", "rgb(203, 55, 74)");
+    checkboxSvg().should("have.css", "border-bottom-color", VALIDATION.ERROR);
   });
 
   it("should render Checkbox component with warning", () => {
     CypressMountWithProviders(<CheckboxComponent warning />);
 
-    checkboxSvg().should("have.css", "border-bottom-color", "rgb(239, 103, 0)");
+    checkboxSvg().should("have.css", "border-bottom-color", VALIDATION.WARNING);
   });
 
   it("should render Checkbox component with info", () => {
     CypressMountWithProviders(<CheckboxComponent info />);
 
-    checkboxSvg().should("have.css", "border-bottom-color", "rgb(0, 96, 167)");
+    checkboxSvg().should("have.css", "border-bottom-color", VALIDATION.INFO);
   });
 
   it("should render Checkbox component with error message", () => {
@@ -321,7 +337,7 @@ context("Testing Checkbox component", () => {
     CypressMountWithProviders(<CheckboxComponent checked />);
     checkboxRole()
       .should("be.checked")
-      .should("have.css", "color", "rgb(0, 0, 0)");
+      .should("have.css", "color", COLOR.BLACK);
   });
 
   describe("should render CheckBox component and check events", () => {
@@ -390,7 +406,7 @@ context("Testing Checkbox component", () => {
     });
 
     describe("Testing CheckboxGroup component", () => {
-      it.each(specialCharacters)(
+      it.each(testData)(
         "should render CheckboxGroup component with %s as legend",
         (legendValue) => {
           CypressMountWithProviders(
@@ -406,7 +422,7 @@ context("Testing Checkbox component", () => {
         checkboxSvg().should(
           "have.css",
           "border-bottom-color",
-          "rgb(203, 55, 74)"
+          VALIDATION.ERROR
         );
       });
 
@@ -416,7 +432,7 @@ context("Testing Checkbox component", () => {
         checkboxSvg().should(
           "have.css",
           "border-bottom-color",
-          "rgb(239, 103, 0)"
+          VALIDATION.WARNING
         );
       });
 
@@ -426,7 +442,7 @@ context("Testing Checkbox component", () => {
         checkboxSvg().should(
           "have.css",
           "border-bottom-color",
-          "rgb(0, 96, 167)"
+          VALIDATION.INFO
         );
       });
 

--- a/src/components/confirm/confirm.test.js
+++ b/src/components/confirm/confirm.test.js
@@ -10,23 +10,18 @@ import {
 } from "../../../cypress/locators/confirm";
 import { getDataElementByValue, icon } from "../../../cypress/locators/index";
 import { positionOfElement, keyCode } from "../../../cypress/support/helper";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
-const testPropValue = "cypress_test";
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+
 const heights = [
   [0, "0"],
   [10, "10"],
   [999, "999"],
   [1500, "1500"],
-];
-const sizes = [
-  ["extra-small", 300],
-  ["small", 380],
-  ["medium-small", 540],
-  ["medium", 750],
-  ["medium-large", 850],
-  ["large", 960],
-  ["extra-large", 1080],
 ];
 const confirmButtonTypes = [
   ["primary", "rgb(255, 255, 255)", "rgba(0, 0, 0, 0)"],
@@ -78,7 +73,7 @@ context("Testing Confirm component", () => {
       callback = cy.stub();
     });
 
-    it.each(specialCharacters)(
+    it.each(testData)(
       "should check confirm button text is %s",
       (confirmButtonText) => {
         CypressMountWithProviders(
@@ -89,7 +84,7 @@ context("Testing Confirm component", () => {
       }
     );
 
-    it.each(specialCharacters)(
+    it.each(testData)(
       "should check cancel button text is %s",
       (cancelButtonText) => {
         CypressMountWithProviders(
@@ -100,20 +95,17 @@ context("Testing Confirm component", () => {
       }
     );
 
-    it.each(specialCharacters)("should check title text is %s", (titleText) => {
+    it.each(testData)("should check title text is %s", (titleText) => {
       CypressMountWithProviders(<ConfirmComponent title={titleText} />);
 
       getDataElementByValue("title").should("have.text", titleText);
     });
 
-    it.each(specialCharacters)(
-      "should check subtitle text is %s",
-      (subTitleText) => {
-        CypressMountWithProviders(<ConfirmComponent subtitle={subTitleText} />);
+    it.each(testData)("should check subtitle text is %s", (subTitleText) => {
+      CypressMountWithProviders(<ConfirmComponent subtitle={subTitleText} />);
 
-        dialogSubtitle().should("have.text", subTitleText);
-      }
-    );
+      dialogSubtitle().should("have.text", subTitleText);
+    });
 
     it.each(heights)(
       "should check confirm height is %spx",
@@ -133,7 +125,15 @@ context("Testing Confirm component", () => {
       }
     );
 
-    it.each(sizes)(
+    it.each([
+      [SIZE.EXTRASMALL, 300],
+      [SIZE.SMALL, 380],
+      [SIZE.MEDIUMSMALL, 540],
+      [SIZE.MEDIUM, 750],
+      [SIZE.MEDIUMLARGE, 850],
+      [SIZE.LARGE, 960],
+      [SIZE.EXTRALARGE, 1080],
+    ])(
       "should check confirm size is %s with width of %spx",
       (sizeName, size) => {
         CypressMountWithProviders(<ConfirmComponent size={sizeName} />);
@@ -327,18 +327,26 @@ context("Testing Confirm component", () => {
 
     it("should render Confirm with aria-labelledby prop", () => {
       CypressMountWithProviders(
-        <Confirm open aria-labelledby={testPropValue} />
+        <Confirm open aria-labelledby={CHARACTERS.STANDARD} />
       );
 
-      dialogPreview().should("have.attr", "aria-labelledby", testPropValue);
+      dialogPreview().should(
+        "have.attr",
+        "aria-labelledby",
+        CHARACTERS.STANDARD
+      );
     });
 
     it("should render Confirm with aria-describedby prop", () => {
       CypressMountWithProviders(
-        <Confirm open aria-describedby={testPropValue} />
+        <Confirm open aria-describedby={CHARACTERS.STANDARD} />
       );
 
-      dialogPreview().should("have.attr", "aria-describedby", testPropValue);
+      dialogPreview().should(
+        "have.attr",
+        "aria-describedby",
+        CHARACTERS.STANDARD
+      );
     });
 
     it("should focus override first element", () => {

--- a/src/components/content/content.test.js
+++ b/src/components/content/content.test.js
@@ -6,9 +6,13 @@ import {
   contentTitle,
   contentBody,
 } from "../../../cypress/locators/content/index";
+import {
+  COLOR,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const totalWidth = 1350;
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
 
 const ContentComponent = ({ ...props }) => {
   return (
@@ -21,7 +25,7 @@ const ContentComponent = ({ ...props }) => {
 context("Tests for Content component", () => {
   describe("should check Content component properties", () => {
     it.each([
-      ["primary", "rgb(0, 0, 0)"],
+      ["primary", COLOR.BLACK],
       ["secondary", "rgba(0, 0, 0, 0.55)"],
     ])(
       "should check %s as variant for Content component",

--- a/src/components/date-range/date-range.test.js
+++ b/src/components/date-range/date-range.test.js
@@ -15,6 +15,10 @@ import {
   INFO_ICON,
   WARNING_ICON,
 } from "../../../cypress/locators/locators";
+import {
+  VALIDATION,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
 const testCypressText = "test_cypress";
 
@@ -54,12 +58,9 @@ const DateRangeCustom = ({ onChange, onBlur, ...props }) => {
   );
 };
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const START_DATE_RANGE_INDEX = 0;
 const END_DATE_RANGE_INDEX = 1;
-const ERROR_COLOUR = "rgb(203, 55, 74)";
-const WARN_COLOUR = "rgb(239, 103, 0)";
-const INFO_COLOUR = "rgb(0, 96, 167)";
 
 const checkInputColor = (index, color) => {
   dateRangeComponentInput(index)
@@ -103,7 +104,7 @@ context("Test for DateRange component", () => {
           .find(ICON)
           .realHover();
         getDataElementByValue("tooltip").should("have.text", startError);
-        checkInputColor(START_DATE_RANGE_INDEX, ERROR_COLOUR);
+        checkInputColor(START_DATE_RANGE_INDEX, VALIDATION.ERROR);
       }
     );
 
@@ -117,7 +118,7 @@ context("Test for DateRange component", () => {
           .find(ICON)
           .realHover();
         getDataElementByValue("tooltip").should("have.text", endError);
-        checkInputColor(END_DATE_RANGE_INDEX, ERROR_COLOUR);
+        checkInputColor(END_DATE_RANGE_INDEX, VALIDATION.ERROR);
       }
     );
 
@@ -133,7 +134,7 @@ context("Test for DateRange component", () => {
           .find(ICON)
           .realHover();
         getDataElementByValue("tooltip").should("have.text", startWarning);
-        checkInputColor(START_DATE_RANGE_INDEX, WARN_COLOUR);
+        checkInputColor(START_DATE_RANGE_INDEX, VALIDATION.WARNING);
       }
     );
 
@@ -147,7 +148,7 @@ context("Test for DateRange component", () => {
           .find(ICON)
           .realHover();
         getDataElementByValue("tooltip").should("have.text", endWarning);
-        checkInputColor(END_DATE_RANGE_INDEX, WARN_COLOUR);
+        checkInputColor(END_DATE_RANGE_INDEX, VALIDATION.WARNING);
       }
     );
 
@@ -161,7 +162,7 @@ context("Test for DateRange component", () => {
           .find(ICON)
           .realHover();
         getDataElementByValue("tooltip").should("have.text", startInfo);
-        checkInputColor(START_DATE_RANGE_INDEX, INFO_COLOUR);
+        checkInputColor(START_DATE_RANGE_INDEX, VALIDATION.INFO);
       }
     );
 
@@ -175,44 +176,44 @@ context("Test for DateRange component", () => {
           .find(ICON)
           .realHover();
         getDataElementByValue("tooltip").should("have.text", endInfo);
-        checkInputColor(END_DATE_RANGE_INDEX, INFO_COLOUR);
+        checkInputColor(END_DATE_RANGE_INDEX, VALIDATION.INFO);
       }
     );
 
     it("should check the startError as boolean", () => {
       CypressMountWithProviders(<DateRangeCustom startError />);
 
-      checkInputColor(START_DATE_RANGE_INDEX, ERROR_COLOUR);
+      checkInputColor(START_DATE_RANGE_INDEX, VALIDATION.ERROR);
     });
 
     it("should check the endError as boolean", () => {
       CypressMountWithProviders(<DateRangeCustom endError />);
 
-      checkInputColor(END_DATE_RANGE_INDEX, ERROR_COLOUR);
+      checkInputColor(END_DATE_RANGE_INDEX, VALIDATION.ERROR);
     });
 
     it("should check the startWarning as boolean", () => {
       CypressMountWithProviders(<DateRangeCustom startWarning />);
 
-      checkInputColor(START_DATE_RANGE_INDEX, WARN_COLOUR);
+      checkInputColor(START_DATE_RANGE_INDEX, VALIDATION.WARNING);
     });
 
     it("should check the endWarning as boolean", () => {
       CypressMountWithProviders(<DateRangeCustom endWarning />);
 
-      checkInputColor(END_DATE_RANGE_INDEX, WARN_COLOUR);
+      checkInputColor(END_DATE_RANGE_INDEX, VALIDATION.WARNING);
     });
 
     it("should check the startInfo as boolean", () => {
       CypressMountWithProviders(<DateRangeCustom startInfo />);
 
-      checkInputColor(START_DATE_RANGE_INDEX, INFO_COLOUR);
+      checkInputColor(START_DATE_RANGE_INDEX, VALIDATION.INFO);
     });
 
     it("should check the endInfo as boolean", () => {
       CypressMountWithProviders(<DateRangeCustom endInfo />);
 
-      checkInputColor(END_DATE_RANGE_INDEX, INFO_COLOUR);
+      checkInputColor(END_DATE_RANGE_INDEX, VALIDATION.INFO);
     });
 
     it.each(testData)(

--- a/src/components/date/date.test.js
+++ b/src/components/date/date.test.js
@@ -43,7 +43,12 @@ import {
 import { keyCode } from "../../../cypress/support/helper";
 import { verifyRequiredAsteriskForLabel } from "../../../cypress/support/component-helper/common-steps";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const DAY_PICKER_PREFIX = "DayPicker-Day--";
 const TODAY = Cypress.dayjs().format("ddd D MMM YYYY");
 const DATE_INPUT = Cypress.dayjs("2022-05-01").format("DD/MM/YYYY");
@@ -94,8 +99,6 @@ const DateInputCustom = ({ onChange, onBlur, ...props }) => {
     />
   );
 };
-
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
 
 context("Test for DateInput component", () => {
   describe("check functionality for DateInput component", () => {
@@ -266,9 +269,9 @@ context("Test for DateInput component", () => {
     );
 
     it.each([
-      ["small", 29, 30.5],
-      ["medium", 37, 38.5],
-      ["large", 45, 46.5],
+      [SIZE.SMALL, 29, 30.5],
+      [SIZE.MEDIUM, 37, 38.5],
+      [SIZE.LARGE, 45, 46.5],
     ])("should check the %s of the DateInput", (size, minValue, maxValue) => {
       CypressMountWithProviders(<DateInputCustom size={size} />);
 

--- a/src/components/decimal/decimal.test.js
+++ b/src/components/decimal/decimal.test.js
@@ -9,6 +9,8 @@ import {
   commonDataElementInputPreview,
 } from "../../../cypress/locators/index";
 
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+
 context("Tests for Decimal component", () => {
   describe("check props for Decimal component", () => {
     const input = [
@@ -160,7 +162,7 @@ context("Tests for Decimal component", () => {
   });
 
   describe("check Decimal input", () => {
-    const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+    const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
     it.each(testData)(
       "check label renders properly with %s as specific value",

--- a/src/components/definition-list/definition-list.test.js
+++ b/src/components/definition-list/definition-list.test.js
@@ -8,11 +8,12 @@ import Hr from "../hr/hr.component";
 import Typography from "../typography/typography.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { getDataElementByValue } from "../../../cypress/locators/index";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
 const specialCharacters = [
-  "text",
-  "mp150ú¿¡üßä",
-  "!@#$%^*()_+-=~[];:.,?{}&\"'<>",
+  CHARACTERS.STANDARD,
+  CHARACTERS.DIACRITICS,
+  CHARACTERS.SPECIALCHARACTERS,
 ];
 const widths = [
   [135, 1215, 10, 90],

--- a/src/components/detail/detail.test.js
+++ b/src/components/detail/detail.test.js
@@ -9,7 +9,9 @@ import {
 
 import { icon } from "../../../cypress/locators";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 context("Tests for Detail component", () => {
   describe("check Detail component text input", () => {

--- a/src/components/dialog-full-screen/dialog-full-screen.test.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.test.js
@@ -29,8 +29,9 @@ import {
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { contentElement } from "../../../cypress/locators/content/index";
 import { keyCode } from "../../../cypress/support/helper";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testAria = "cypress_aria";
 const mainDialogTitle = "Main Dialog";
 const nestedDialogTitle = "Nested Dialog";

--- a/src/components/dialog/dialog.test.js
+++ b/src/components/dialog/dialog.test.js
@@ -19,8 +19,12 @@ import {
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import Toast from "../toast";
 import toastComponent from "../../../cypress/locators/toast";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const getInput = (index) => cy.get('[data-element="input"]').eq(index);
 
@@ -110,13 +114,13 @@ context("Testing Dialog component", () => {
     );
 
     it.each([
-      ["extra-small", 300],
-      ["small", 380],
-      ["medium-small", 540],
-      ["medium", 750],
-      ["medium-large", 850],
-      ["large", 960],
-      ["extra-large", 1080],
+      [SIZE.EXTRASMALL, 300],
+      [SIZE.SMALL, 380],
+      [SIZE.MEDIUMSMALL, 540],
+      [SIZE.MEDIUM, 750],
+      [SIZE.MEDIUMLARGE, 850],
+      [SIZE.LARGE, 960],
+      [SIZE.EXTRALARGE, 1080],
     ])(
       "should render Dialog component with %s as a size and has width property set to %s",
       (size, width) => {

--- a/src/components/dismissible-box/dismissible-box.test.js
+++ b/src/components/dismissible-box/dismissible-box.test.js
@@ -8,7 +8,7 @@ import point from "../../../.assets/point.svg";
 import dismissibleBoxDataComponent from "../../../cypress/locators/dismissible-box";
 import { icon } from "../../../cypress/locators/index.js";
 import { keyCode } from "../../../cypress/support/helper";
-
+import { COLOR } from "../../../cypress/support/component-helper/constants";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
 const DismissibleBoxCustomComponent = ({ ...props }) => {
@@ -28,7 +28,7 @@ const DismissibleBoxCustomComponent = ({ ...props }) => {
 context("Test for DismissibleBox component", () => {
   describe("check props for DismissibleBox component", () => {
     it.each([
-      [true, "rgb(0, 0, 0)"],
+      [true, COLOR.BLACK],
       [false, "rgb(204, 214, 219)"],
     ])(
       "should render DismissibleBox with hasBorderLeftHighlight prop set to %s",

--- a/src/components/duelling-picklist/duelling-picklist.test.js
+++ b/src/components/duelling-picklist/duelling-picklist.test.js
@@ -29,11 +29,12 @@ import {
   getDataElementByValue,
   tooltipPreview,
 } from "../../../cypress/locators";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
 const specialCharacters = [
-  "legend",
-  "mp150ú¿¡üßä",
-  "!@#$%^*()_+-=~[];:.,?{}&\"'<>",
+  CHARACTERS.STANDARD,
+  CHARACTERS.DIACRITICS,
+  CHARACTERS.SPECIALCHARACTERS,
 ];
 
 const DuellingPicklistComponent = ({ ...props }) => {

--- a/src/components/fieldset/fieldset.test.js
+++ b/src/components/fieldset/fieldset.test.js
@@ -7,11 +7,15 @@ import Form from "../form/form.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { getDataElementByValue } from "../../../cypress/locators/index";
 import { positionOfElement } from "../../../cypress/support/helper";
+import {
+  VALIDATION,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
 const specialCharacters = [
-  "legend",
-  "mp150ú¿¡üßä",
-  "!@#$%^*()_+-=~[];:.,?{}&\"'<>",
+  CHARACTERS.STANDARD,
+  CHARACTERS.DIACRITICS,
+  CHARACTERS.SPECIALCHARACTERS,
 ];
 
 const verifyCssProps = (element, cssProp, lessValue, greaterValue) => {
@@ -160,9 +164,9 @@ context("Testing Fieldset component", () => {
     );
 
     it.each([
-      ["rgb(203, 55, 74)", "error", true],
-      ["rgb(239, 103, 0)", "warning", true],
-      ["rgb(0, 96, 167)", "info", true],
+      [VALIDATION.ERROR, "error", true],
+      [VALIDATION.WARNING, "warning", true],
+      [VALIDATION.INFO, "info", true],
       ["rgb(102, 132, 148)", "error", false],
       ["rgb(102, 132, 148)", "warning", false],
       ["rgb(102, 132, 148)", "info", false],

--- a/src/components/grouped-character/grouped-character.test.js
+++ b/src/components/grouped-character/grouped-character.test.js
@@ -1,17 +1,19 @@
 import * as React from "react";
 import GroupedCharacter from "./grouped-character.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
-
 import {
   fieldHelpPreview,
   getDataElementByValue,
   tooltipPreview,
   commonDataElementInputPreview,
 } from "../../../cypress/locators/index";
-
 import { verifyRequiredAsteriskForLabel } from "../../../cypress/support/component-helper/common-steps";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const GroupedCharacterComponent = ({ onChange, ...props }) => {
   const [state, setState] = React.useState("");
@@ -38,9 +40,9 @@ const GroupedCharacterComponent = ({ onChange, ...props }) => {
 context("Tests for GroupedCharacter component", () => {
   describe("check props for GroupedCharacter component", () => {
     it.each([
-      ["small", "32px"],
-      ["medium", "40px"],
-      ["large", "48px"],
+      [SIZE.SMALL, "32px"],
+      [SIZE.MEDIUM, "40px"],
+      [SIZE.LARGE, "48px"],
     ])(
       "should use %s as size and render it with %s as height",
       (size, height) => {

--- a/src/components/heading/heading.test.js
+++ b/src/components/heading/heading.test.js
@@ -15,7 +15,9 @@ import { pillPreview } from "../../../cypress/locators/pill";
 
 import { getDataElementByValue, getComponent } from "../../../cypress/locators";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+
+const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testData = ["https://carbon.sage.com/"];
 
 const HeadingComponent = ({ ...props }) => {

--- a/src/components/help/help.test.js
+++ b/src/components/help/help.test.js
@@ -6,8 +6,12 @@ import CypressMountWithProviders from "../../../cypress/support/component-helper
 import { getDataElementByValue, getComponent } from "../../../cypress/locators";
 
 import { keyCode } from "../../../cypress/support/helper";
+import {
+  COLOR,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const tooltipText = "Some helpful text goes here";
 const errorMsg = (msg, param) => sprintf(msg, param, "");
 
@@ -129,10 +133,10 @@ context("Tests for Help component", () => {
     );
 
     it.each([
-      ["orange", "rgb(255, 156, 75)"],
-      ["red", "rgb(205, 56, 75)"],
-      ["black", "rgb(0, 0, 0)"],
-      ["brown", "rgb(105, 61, 57)"],
+      ["orange", COLOR.ORANGE],
+      ["red", COLOR.RED],
+      ["black", COLOR.BLACK],
+      ["brown", COLOR.BROWN],
     ])(
       "should check tooltip background-color as %s for Help component",
       (name, color) => {
@@ -150,10 +154,10 @@ context("Tests for Help component", () => {
     );
 
     it.each([
-      ["orange", "rgb(255, 156, 75)"],
-      ["red", "rgb(205, 56, 75)"],
-      ["black", "rgb(0, 0, 0)"],
-      ["brown", "rgb(105, 61, 57)"],
+      ["orange", COLOR.ORANGE],
+      ["red", COLOR.RED],
+      ["black", COLOR.BLACK],
+      ["brown", COLOR.BROWN],
     ])(
       "should check tooltip font color as %s for Help component",
       (name, color) => {

--- a/src/components/icon/icon.test.js
+++ b/src/components/icon/icon.test.js
@@ -2,14 +2,14 @@ import * as React from "react";
 import Icon from "./icon.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { icon, getDataElementByValue } from "../../../cypress/locators";
+import {
+  SIZE,
+  COLOR,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
-const colorData = [
-  "rgb(255, 156, 75)",
-  "rgb(205, 56, 75)",
-  "rgb(0, 0, 0)",
-  "rgb(105, 61, 57)",
-];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+const colorData = [COLOR.ORANGE, COLOR.RED, COLOR.BLACK, COLOR.BROWN];
 
 const IconComponent = ({ ...props }) => {
   return <Icon type="add" tooltipVisible {...props} />;
@@ -47,11 +47,11 @@ context("Tests for Icon component", () => {
     );
 
     it.each([
-      ["extra-small", 16],
-      ["small", 24],
-      ["medium", 32],
-      ["large", 40],
-      ["extra-large", 56],
+      [SIZE.EXTRASMALL, 16],
+      [SIZE.SMALL, 24],
+      [SIZE.MEDIUM, 32],
+      [SIZE.LARGE, 40],
+      [SIZE.EXTRALARGE, 56],
     ])("should check %s bgSize for Icon component", (size, pixelSize) => {
       CypressMountWithProviders(<IconComponent bgSize={size} />);
       icon()
@@ -73,10 +73,10 @@ context("Tests for Icon component", () => {
     });
 
     it.each([
-      ["small", 24],
-      ["medium", 32],
-      ["large", 40],
-      ["extra-large", 56],
+      [SIZE.SMALL, 24],
+      [SIZE.MEDIUM, 32],
+      [SIZE.LARGE, 40],
+      [SIZE.EXTRALARGE, 56],
     ])("should check %s fontSize for Icon component", (fontSize, pixelSize) => {
       CypressMountWithProviders(<IconComponent fontSize={fontSize} />);
       icon()

--- a/src/components/inline-inputs/inline-inputs.test.js
+++ b/src/components/inline-inputs/inline-inputs.test.js
@@ -5,7 +5,6 @@ import SimpleSelect from "../select/simple-select/simple-select.component";
 import Option from "../select/option/option.component";
 import InlineInputs from "./inline-inputs.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
-
 import {
   inlineInputContainer,
   inlineInputsPreview,
@@ -13,8 +12,12 @@ import {
   inlinelabelWidth,
   inlineChildren,
 } from "../../../cypress/locators/inline-inputs/index";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const InlineInputComponent = ({ ...props }) => {
   return (
@@ -39,13 +42,13 @@ context("Tests for InlineInputs component", () => {
   describe("should check InlineInputs component properties", () => {
     it.each([
       ["none", 0],
-      ["extra-small", -8],
-      ["small", -16],
-      ["medium-small", -20],
-      ["medium", -24],
-      ["medium-large", -28],
-      ["large", -32],
-      ["extra-large", -40],
+      [SIZE.EXTRASMALL, -8],
+      [SIZE.SMALL, -16],
+      [SIZE.MEDIUMSMALL, -20],
+      [SIZE.MEDIUM, -24],
+      [SIZE.MEDIUMLARGE, -28],
+      [SIZE.LARGE, -32],
+      [SIZE.EXTRALARGE, -40],
     ])(
       "should check when gutter size is %s for InlineInputs component",
       (size, gutterMargin) => {

--- a/src/components/link-preview/link-preview.test.js
+++ b/src/components/link-preview/link-preview.test.js
@@ -10,9 +10,10 @@ import {
 } from "../../../cypress/locators/link-preview/index";
 import { keyCode } from "../../../cypress/support/helper";
 import { checkGoldenOutline } from "../../../cypress/support/component-helper/common-steps";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testCypress = "test-cypress";
 const urlProp = "./carbon-by-sage-logo.png";
 

--- a/src/components/link/link.test.js
+++ b/src/components/link/link.test.js
@@ -10,9 +10,10 @@ import {
 } from "../../../cypress/locators";
 import { skipLink } from "../../../cypress/locators/link/index";
 import { keyCode } from "../../../cypress/support/helper";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testCypress = "test-cypress";
 
 const LinkComponent = ({ ...props }) => {

--- a/src/components/loader-bar/loader-bar.test.js
+++ b/src/components/loader-bar/loader-bar.test.js
@@ -2,13 +2,14 @@ import * as React from "react";
 import LoaderBar from "./loader-bar.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import loaderBar from "../../../cypress/locators/loader-bar/index";
+import { SIZE } from "../../../cypress/support/component-helper/constants";
 
 context("Tests for LoaderBar component", () => {
   describe("should check LoaderBar component properties", () => {
     it.each([
-      ["small", 4],
-      ["medium", 8],
-      ["large", 16],
+      [SIZE.SMALL, 4],
+      [SIZE.MEDIUM, 8],
+      [SIZE.LARGE, 16],
     ])("should check %s size for LoaderBar component", (size, height) => {
       CypressMountWithProviders(<LoaderBar size={size} mt={2} />);
 

--- a/src/components/menu/menu.test.js
+++ b/src/components/menu/menu.test.js
@@ -34,7 +34,10 @@ import {
   pressTABKey,
   continuePressingTABKey,
 } from "../../../cypress/support/helper";
-import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+import {
+  CHARACTERS,
+  COLOR,
+} from "../../../cypress/support/component-helper/constants";
 import { checkGoldenOutline } from "../../../cypress/support/component-helper/common-steps";
 import useMediaQuery from "../../hooks/useMediaQuery";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
@@ -321,7 +324,7 @@ context("Testing Menu component", () => {
       ["white", "first", "rgb(255, 255, 255)"],
       ["light", "fifth", "rgb(230, 235, 237)"],
       ["dark", "ninth", "rgb(0, 50, 76)"],
-      ["black", "thirteenth", "rgb(0, 0, 0)"],
+      ["black", "thirteenth", COLOR.BLACK],
     ])("should verify Menu is %s menuType", (menuType, menuNumber, color) => {
       CypressMountWithProviders(<MenuComponent />);
 
@@ -891,7 +894,7 @@ context("Testing Menu component", () => {
       submenu().eq(0).children().should("have.css", "background-color", color);
     });
 
-    it("should verify Menu Item ariaLabel is set to cypress-data", () => {
+    it("should verify Menu Item ariaLabel is set to cypress_data", () => {
       CypressMountWithProviders(
         <MenuComponentItems ariaLabel={CHARACTERS.STANDARD} />
       );

--- a/src/components/message/message.test.js
+++ b/src/components/message/message.test.js
@@ -14,8 +14,12 @@ import {
   messageDismissIcon,
   variantPreview,
 } from "../../../cypress/locators/message/index";
+import {
+  VALIDATION,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const MessageComponent = ({ ...props }) => {
   const [isOpen, setIsOpen] = useState(true);
@@ -33,9 +37,9 @@ context("Tests for Message component", () => {
   describe("should check Message component properties", () => {
     it.each([
       ["info", "rgb(51, 91, 112)"],
-      ["error", "rgb(203, 55, 74)"],
+      ["error", VALIDATION.ERROR],
       ["success", "rgb(0, 138, 33)"],
-      ["warning", "rgb(239, 103, 0)"],
+      ["warning", VALIDATION.WARNING],
     ])(
       "should check %s variant for Message component",
       (variant, backgroundColor) => {

--- a/src/components/multi-action-button/multi-action-button.test.js
+++ b/src/components/multi-action-button/multi-action-button.test.js
@@ -2,10 +2,8 @@ import * as React from "react";
 import MultiActionButton from "./multi-action-button.component";
 import Button from "../button";
 import { Accordion } from "../accordion";
-
 import { buttonSubtextPreview } from "../../../cypress/locators/button";
 import { pressTABKey, keyCode } from "../../../cypress/support/helper";
-
 import {
   multiActionButtonList,
   multiActionButtonListContainer,
@@ -14,10 +12,13 @@ import {
   multiActionButtonComponent,
 } from "../../../cypress/locators/multi-action-button";
 import { accordionDefaultTitle } from "../../../cypress/locators/accordion";
-
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const MultiActionButtonList = ({ ...props }) => {
   return (
     <div>
@@ -77,9 +78,9 @@ context("Tests for MultiActionButton component", () => {
     );
 
     it.each([
-      ["small", "32px"],
-      ["medium", "40px"],
-      ["large", "48px"],
+      [SIZE.SMALL, "32px"],
+      [SIZE.MEDIUM, "40px"],
+      [SIZE.LARGE, "48px"],
     ])("should render Multi Action Button with %s size", (size, height) => {
       CypressMountWithProviders(<MultiActionButtonList size={size} />);
 

--- a/src/components/navigation-bar/navigation-bar.test.js
+++ b/src/components/navigation-bar/navigation-bar.test.js
@@ -5,11 +5,15 @@ import { Menu, MenuItem } from "../menu";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
 import navigationBar from "../../../cypress/locators/navigation-bar";
+import {
+  COLOR,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
-const testData = "cypressData";
+const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+const testData = CHARACTERS.STANDARD;
 const variants = [
-  ["black", "rgb(0, 0, 0)"],
+  ["black", COLOR.BLACK],
   ["light", "rgb(230, 235, 237)"],
   ["white", "rgb(255, 255, 255)"],
   ["dark", "rgb(0, 50, 76)"],

--- a/src/components/note/note.test.js
+++ b/src/components/note/note.test.js
@@ -19,6 +19,8 @@ import {
 } from "../../../cypress/locators/note";
 import { actionPopoverWrapper } from "../../../cypress/locators/action-popover";
 
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+
 const NoteComponent = ({ text, ...props }) => {
   const initialValue = text
     ? EditorState.createWithContent(ContentState.createFromText(text))
@@ -100,7 +102,7 @@ context("Tests for Note component", () => {
       actionPopoverWrapper().should("be.visible");
     });
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render Note with title prop set to %s",
       (title) => {
         CypressMountWithProviders(<NoteComponent title={title} />);
@@ -109,14 +111,11 @@ context("Tests for Note component", () => {
       }
     );
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
-      "should render Note with name prop set to %s",
-      (name) => {
-        CypressMountWithProviders(<NoteComponent name={name} />);
+    it.each(testData)("should render Note with name prop set to %s", (name) => {
+      CypressMountWithProviders(<NoteComponent name={name} />);
 
-        noteFooterCreatedBy().should("have.text", name);
-      }
-    );
+      noteFooterCreatedBy().should("have.text", name);
+    });
 
     it("should render Note with createdDate prop", () => {
       const createdDate = "25 June 2022, 11:57 AM";
@@ -126,7 +125,7 @@ context("Tests for Note component", () => {
       noteFooterChangeTime().should("have.text", createdDate);
     });
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render Note with status prop set to %s",
       (value) => {
         CypressMountWithProviders(

--- a/src/components/number/number.test.js
+++ b/src/components/number/number.test.js
@@ -1,7 +1,6 @@
 import * as React from "react";
 import Number from "./number.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
-
 import {
   getDataElementByValue,
   getElement,
@@ -12,10 +11,13 @@ import {
   commonInputPrefix,
   commonInputCharacterLimit,
 } from "../../../cypress/locators";
-
 import { verifyRequiredAsteriskForLabel } from "../../../cypress/support/component-helper/common-steps";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const NumberInputComponent = ({ onChange, ...props }) => {
   const [state, setState] = React.useState("");
@@ -165,9 +167,9 @@ context("Tests for Number component", () => {
     });
 
     it.each([
-      ["small", "32px"],
-      ["medium", "40px"],
-      ["large", "48px"],
+      [SIZE.SMALL, "32px"],
+      [SIZE.MEDIUM, "40px"],
+      [SIZE.LARGE, "48px"],
     ])(
       "should use %s as size and render Number with %s as height",
       (size, height) => {

--- a/src/components/numeral-date/numeral-date.test.js
+++ b/src/components/numeral-date/numeral-date.test.js
@@ -18,7 +18,13 @@ import {
   numeralDateInputByPosition,
 } from "../../../cypress/locators/numeralDate";
 
-import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+import {
+  CHARACTERS,
+  SIZE,
+  VALIDATION,
+} from "../../../cypress/support/component-helper/constants";
+
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const NumeralDateComponent = ({ ...props }) => {
   const [value, setValue] = React.useState({
@@ -88,7 +94,7 @@ context("Tests for NumeralDate component", () => {
       );
     });
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render NumeralDate with label prop set to %s",
       (label) => {
         CypressMountWithProviders(<NumeralDateComponent label={label} />);
@@ -123,7 +129,7 @@ context("Tests for NumeralDate component", () => {
       }
     );
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render NumeralDate with labelHelp prop set to %s",
       (labelHelp) => {
         CypressMountWithProviders(
@@ -333,9 +339,9 @@ context("Tests for NumeralDate component", () => {
     );
 
     it.each([
-      ["rgb(203, 55, 74)", "error", true],
-      ["rgb(239, 103, 0)", "warning", true],
-      ["rgb(0, 96, 167)", "info", true],
+      [VALIDATION.ERROR, "error", true],
+      [VALIDATION.WARNING, "warning", true],
+      [VALIDATION.INFO, "info", true],
       ["rgb(102, 132, 148)", "error", false],
       ["rgb(102, 132, 148)", "warning", false],
       ["rgb(102, 132, 148)", "info", false],
@@ -366,9 +372,9 @@ context("Tests for NumeralDate component", () => {
     );
 
     it.each([
-      ["small", "30px"],
-      ["medium", "38px"],
-      ["large", "46px"],
+      [SIZE.SMALL, "30px"],
+      [SIZE.MEDIUM, "38px"],
+      [SIZE.LARGE, "46px"],
     ])(
       "should use %s as size and render NumeralDate with %s as height",
       (size, height) => {
@@ -398,7 +404,7 @@ context("Tests for NumeralDate component", () => {
       }
     );
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render NumeralDate with fieldHelp prop set to %s",
       (fieldHelp) => {
         CypressMountWithProviders(

--- a/src/components/pager/pager.test.js
+++ b/src/components/pager/pager.test.js
@@ -21,8 +21,9 @@ import CypressMountWithProviders from "../../../cypress/support/component-helper
 import { keyCode } from "../../../cypress/support/helper";
 import useMediaQuery from "../../hooks/useMediaQuery";
 import { checkGoldenOutline } from "../../../cypress/support/component-helper/common-steps";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const records = [
   {
     id: "1",

--- a/src/components/pill/pill.test.js
+++ b/src/components/pill/pill.test.js
@@ -3,9 +3,10 @@ import Pill from "./pill.component";
 import { pillPreview } from "../../../cypress/locators/pill/index";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { closeIconButton } from "../../../cypress/locators/index";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
-const testData = "cypress_data";
+const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+const testData = CHARACTERS.STANDARD;
 const warning = "rgb(242, 133, 51)";
 const neutral = "rgb(51, 91, 112)";
 const negative = "rgb(203, 55, 74)";

--- a/src/components/pod/pod.test.js
+++ b/src/components/pod/pod.test.js
@@ -18,8 +18,12 @@ import {
 } from "../../../cypress/locators/pod";
 
 import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-helper/common-steps";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const PodComponent = ({ ...props }) => {
   return (
@@ -91,11 +95,11 @@ context("Testing Pod component", () => {
 
     it.each([
       ["none", 88, 45],
-      ["extra-small", 120, 61],
-      ["small", 120, 61],
-      ["medium", 136, 77],
-      ["large", 184, 93],
-      ["extra-large", 216, 125],
+      [SIZE.EXTRASMALL, 120, 61],
+      [SIZE.SMALL, 120, 61],
+      [SIZE.MEDIUM, 136, 77],
+      [SIZE.LARGE, 184, 93],
+      [SIZE.EXTRALARGE, 216, 125],
     ])(
       "should check %s size for Pod component when height is %s and width is %s",
       (size, height, width) => {

--- a/src/components/popover-container/popover-container.test.js
+++ b/src/components/popover-container/popover-container.test.js
@@ -18,8 +18,9 @@ import {
 } from "../../../cypress/locators/select/index";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { keyCode } from "../../../cypress/support/helper";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testCypress = "test-cypress";
 
 const PopoverContainerComponent = ({ ...props }) => {

--- a/src/components/portrait/portrait.test.js
+++ b/src/components/portrait/portrait.test.js
@@ -10,14 +10,20 @@ import {
   portraitInitials,
   portraitImage,
 } from "../../../cypress/locators/portrait";
+import {
+  SIZE,
+  VALIDATION,
+  COLOR,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const colors = [
-  ["orange", "rgb(255, 156, 75)"],
-  ["red", "rgb(205, 56, 75)"],
-  ["black", "rgb(0, 0, 0)"],
-  ["brown", "rgb(105, 61, 57)"],
+  ["orange", COLOR.ORANGE],
+  ["red", COLOR.RED],
+  ["black", COLOR.BLACK],
+  ["brown", COLOR.BROWN],
 ];
 
 const testImage =
@@ -188,13 +194,13 @@ context("Tests for Portrait component", () => {
       getDataElementByValue("tooltip").and(
         "have.css",
         "background-color",
-        "rgb(203, 55, 74)"
+        VALIDATION.ERROR
       );
     });
 
     it.each([
-      ["medium", "14px"],
-      ["large", "16px"],
+      [SIZE.MEDIUM, "14px"],
+      [SIZE.LARGE, "16px"],
     ])(
       "should render Portrait with the tooltip in the %s size",
       (tooltipSize, fontSize) => {

--- a/src/components/preview/preview.test.js
+++ b/src/components/preview/preview.test.js
@@ -6,8 +6,9 @@ import {
   previewComponent,
   lineComponent,
 } from "../../../cypress/locators/preview/index";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const pixelsData = [256, 275, 300];
 
 const PreviewComponent = ({ ...props }) => {

--- a/src/components/profile/profile.test.js
+++ b/src/components/profile/profile.test.js
@@ -12,6 +12,8 @@ import {
   initialPreview,
 } from "../../../cypress/locators/profile/index";
 
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+
 context("Tests for Profile component", () => {
   describe("should check Profile component properties", () => {
     it("should set className for Profile component", () => {
@@ -21,7 +23,7 @@ context("Tests for Profile component", () => {
       profilePreview().should("have.class", "profile-cypress-classname");
     });
 
-    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+    it.each(testData)(
       "should set email out of scope to %s for Profile component",
       (email) => {
         CypressMountWithProviders(
@@ -35,19 +37,16 @@ context("Tests for Profile component", () => {
       }
     );
 
-    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
-      "should set name to %s for Profile component",
-      (name) => {
-        CypressMountWithProviders(
-          <Profile
-            email="johnsmith@sage.com"
-            name={name}
-            src="https://www.gravatar.com/avatar/05c1c705ee45d7ae88b80b3a8866ddaa?s=24&d=404"
-          />
-        );
-        namePreview().should("have.text", name);
-      }
-    );
+    it.each(testData)("should set name to %s for Profile component", (name) => {
+      CypressMountWithProviders(
+        <Profile
+          email="johnsmith@sage.com"
+          name={name}
+          src="https://www.gravatar.com/avatar/05c1c705ee45d7ae88b80b3a8866ddaa?s=24&d=404"
+        />
+      );
+      namePreview().should("have.text", name);
+    });
 
     it.each([
       [

--- a/src/components/radio-button/radiobutton.test.js
+++ b/src/components/radio-button/radiobutton.test.js
@@ -29,6 +29,7 @@ import {
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { verifyRequiredAsteriskForLegend } from "../../../cypress/support/component-helper/common-steps";
 
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const radioContainerWidth = 400;
 const radioInputWidth = 16;
 const labelContainerWidth = 40;
@@ -129,7 +130,7 @@ context("Testing RadioButton component", () => {
     );
   });
 
-  it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+  it.each(testData)(
     "should render Radiobutton component with %s as a label",
     (label) => {
       CypressMountWithProviders(<RadiobuttonComponent label={label} />);
@@ -138,7 +139,7 @@ context("Testing RadioButton component", () => {
     }
   );
 
-  it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+  it.each(testData)(
     "should render Radiobutton component with %s as fieldHelp",
     (fieldHelp) => {
       CypressMountWithProviders(<RadiobuttonComponent fieldHelp={fieldHelp} />);
@@ -428,7 +429,7 @@ context("Testing RadioButton component", () => {
     });
 
     describe("Testing RadiobuttonGroup component", () => {
-      it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+      it.each(testData)(
         "should render RadiobuttonGroup component with %s as legend",
         (legendValue) => {
           CypressMountWithProviders(

--- a/src/components/search/search.test.js
+++ b/src/components/search/search.test.js
@@ -21,13 +21,17 @@ import {
 } from "../../../cypress/support/component-helper/common-steps";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { keyCode } from "../../../cypress/support/helper";
+import {
+  VALIDATION,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
-const testCypress = "test-cypress";
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+const testCypress = CHARACTERS.STANDARD;
 const validationTypes = [
-  ["error", "rgb(203, 55, 74)"],
-  ["warning", "rgb(239, 103, 0)"],
-  ["info", "rgb(0, 96, 167)"],
+  ["error", VALIDATION.ERROR],
+  ["warning", VALIDATION.WARNING],
+  ["info", VALIDATION.INFO],
 ];
 
 const SearchComponent = ({ ...props }) => {

--- a/src/components/select/filterable-select/filterable-select.test.js
+++ b/src/components/select/filterable-select/filterable-select.test.js
@@ -43,6 +43,11 @@ import { keyCode, positionOfElement } from "../../../../cypress/support/helper";
 
 import { alertDialogPreview } from "../../../../cypress/locators/dialog";
 
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../../cypress/support/component-helper/constants";
+
 const FilterableSelectComponent = ({ ...props }) => {
   const [value, setValue] = React.useState("");
 
@@ -566,8 +571,8 @@ const FilterableSelectListActionEventComponent = ({ ...props }) => {
   );
 };
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
-const testPropValue = "cypress_test";
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+const testPropValue = CHARACTERS.STANDARD;
 const addElementText = "Add a New Element";
 const columns = 3;
 const icon = "add";
@@ -704,9 +709,9 @@ context("Tests for Filterable Select component", () => {
     });
 
     it.each([
-      ["small", "32px"],
-      ["medium", "40px"],
-      ["large", "48px"],
+      [SIZE.SMALL, "32px"],
+      [SIZE.MEDIUM, "40px"],
+      [SIZE.LARGE, "48px"],
     ])(
       "should use %s as size and render Filterable Select with %s as height",
       (size, height) => {

--- a/src/components/select/multi-select/multi-select.test.js
+++ b/src/components/select/multi-select/multi-select.test.js
@@ -41,6 +41,10 @@ import { loader } from "../../../../cypress/locators/loader";
 import { verifyRequiredAsteriskForLabel } from "../../../../cypress/support/component-helper/common-steps";
 
 import { keyCode, positionOfElement } from "../../../../cypress/support/helper";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../../cypress/support/component-helper/constants";
 
 const MultiSelectComponent = ({ ...props }) => {
   const [value, setValue] = React.useState([]);
@@ -463,8 +467,8 @@ const MultiSelectCustomColorComponent = ({ ...props }) => {
   );
 };
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
-const testPropValue = "cypress_test";
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+const testPropValue = CHARACTERS.STANDARD;
 const columns = 3;
 const option1 = "Green";
 const option2 = "Purple";
@@ -597,9 +601,9 @@ context("Tests for Multi Select component", () => {
     });
 
     it.each([
-      ["small", "32px"],
-      ["medium", "40px"],
-      ["large", "48px"],
+      [SIZE.SMALL, "32px"],
+      [SIZE.MEDIUM, "40px"],
+      [SIZE.LARGE, "48px"],
     ])(
       "should use %s as size and render Multi Select with %s as height",
       (size, height) => {

--- a/src/components/select/simple-select/simple-select.test.js
+++ b/src/components/select/simple-select/simple-select.test.js
@@ -39,8 +39,13 @@ import { loader } from "../../../../cypress/locators/loader";
 import { verifyRequiredAsteriskForLabel } from "../../../../cypress/support/component-helper/common-steps";
 
 import { keyCode, positionOfElement } from "../../../../cypress/support/helper";
+import {
+  SIZE,
+  CHARACTERS,
+} from "../../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+const testPropValue = CHARACTERS.STANDARD;
 
 const SimpleSelectComponent = ({ ...props }) => {
   const [value, setValue] = React.useState("");
@@ -469,8 +474,6 @@ const SimpleSelectWithLongWrappingTextComponent = () => (
   </Box>
 );
 
-const testPropValue = "cypress_test";
-
 context("Tests for Simple Select component", () => {
   describe("check props for Simple Select component", () => {
     it.each(testData)(
@@ -505,7 +508,7 @@ context("Tests for Simple Select component", () => {
       }
     );
 
-    it("should render Simple Select with data-component prop set to Cypress-Test", () => {
+    it("should render Simple Select with data-component prop set to cypress_data", () => {
       CypressMountWithProviders(
         <SimpleSelectComponent data-component={testPropValue} />
       );
@@ -516,7 +519,7 @@ context("Tests for Simple Select component", () => {
         .should("have.attr", "data-component", testPropValue);
     });
 
-    it("should render Simple Select with data-element prop set to Cypress-Test", () => {
+    it("should render Simple Select with data-element prop set to cypress_data", () => {
       CypressMountWithProviders(
         <SimpleSelectComponent data-element={testPropValue} />
       );
@@ -527,7 +530,7 @@ context("Tests for Simple Select component", () => {
         .should("have.attr", "data-element", testPropValue);
     });
 
-    it("should render Simple Select with data-role prop set to Cypress-Test", () => {
+    it("should render Simple Select with data-role prop set to cypress_data", () => {
       CypressMountWithProviders(
         <SimpleSelectComponent data-role={testPropValue} />
       );
@@ -592,9 +595,9 @@ context("Tests for Simple Select component", () => {
     });
 
     it.each([
-      ["small", "32px"],
-      ["medium", "40px"],
-      ["large", "48px"],
+      [SIZE.SMALL, "32px"],
+      [SIZE.MEDIUM, "40px"],
+      [SIZE.LARGE, "48px"],
     ])(
       "should use %s as size and render Simple Select with %s as height",
       (size, height) => {

--- a/src/components/settings-row/settings-row.test.js
+++ b/src/components/settings-row/settings-row.test.js
@@ -8,8 +8,9 @@ import {
   settingsRowChildren,
   settingsRowDescription,
 } from "../../../cypress/locators/settings-row/index";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const SettingsRowComponent = ({ ...props }) => {
   return <SettingsRow title="title" description="description" {...props} />;

--- a/src/components/show-edit-pod/show-edit-pod.test.js
+++ b/src/components/show-edit-pod/show-edit-pod.test.js
@@ -22,8 +22,9 @@ import {
 import { contentPreview } from "../../../cypress/locators/content";
 
 import { getDataElementByValue } from "../../../cypress/locators/index";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const ShowEditPodComponent = ({ ...props }) => {
   return (

--- a/src/components/sidebar/sidebar.test.js
+++ b/src/components/sidebar/sidebar.test.js
@@ -117,7 +117,7 @@ context("Testing Sidebar component", () => {
         .and("have.css", "right", `${right}px`);
     });
 
-    it("verify Sidebar has aria-describedby cypress-data", () => {
+    it("verify Sidebar has aria-describedby cypress_data", () => {
       CypressMountWithProviders(
         <SidebarComponent aria-describedby={CHARACTERS.STANDARD} />
       );
@@ -129,7 +129,7 @@ context("Testing Sidebar component", () => {
       );
     });
 
-    it("verify Sidebar has aria-label cypress-data", () => {
+    it("verify Sidebar has aria-label cypress_data", () => {
       CypressMountWithProviders(
         <SidebarComponent aria-label={CHARACTERS.STANDARD} />
       );
@@ -137,7 +137,7 @@ context("Testing Sidebar component", () => {
       sidebarPreview().should("have.attr", "aria-label", CHARACTERS.STANDARD);
     });
 
-    it("verify Sidebar has aria-labelledby cypress-data", () => {
+    it("verify Sidebar has aria-labelledby cypress_data", () => {
       CypressMountWithProviders(
         <SidebarComponent aria-labelledby={CHARACTERS.STANDARD} />
       );
@@ -180,7 +180,7 @@ context("Testing Sidebar component", () => {
         .and("have.text", "Sidebar Header");
     });
 
-    it("verify Sidebar has role cypress-data", () => {
+    it("verify Sidebar has role cypress_data", () => {
       CypressMountWithProviders(
         <SidebarComponent role={CHARACTERS.STANDARD} />
       );
@@ -188,7 +188,7 @@ context("Testing Sidebar component", () => {
       sidebarPreview().should("have.attr", "role", CHARACTERS.STANDARD);
     });
 
-    it("verify Sidebar has data-element cypress-data", () => {
+    it("verify Sidebar has data-element cypress_data", () => {
       CypressMountWithProviders(
         <SidebarComponent data-element={CHARACTERS.STANDARD} />
       );
@@ -201,7 +201,7 @@ context("Testing Sidebar component", () => {
         .should("have.attr", "data-element", CHARACTERS.STANDARD);
     });
 
-    it("verify Sidebar has data-role cypress-data", () => {
+    it("verify Sidebar has data-role cypress_data", () => {
       CypressMountWithProviders(
         <SidebarComponent data-role={CHARACTERS.STANDARD} />
       );

--- a/src/components/simple-color-picker/simple-color-picker.test.js
+++ b/src/components/simple-color-picker/simple-color-picker.test.js
@@ -20,6 +20,11 @@ import {
 
 import { keyCode } from "../../../cypress/support/helper";
 
+import {
+  VALIDATION,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
+
 const verifyBeforeColor = (element, color) =>
   getDataElementByValue(element).then(($els) => {
     // get Window reference from element
@@ -32,8 +37,8 @@ const verifyBeforeColor = (element, color) =>
     expect(colorVal).to.eq(color);
   });
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
-const testPropValue = "cypress_test";
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+const testPropValue = CHARACTERS.STANDARD;
 const colors = [
   {
     color: "#FFFFFF",
@@ -75,12 +80,6 @@ const colors = [
     color: "#00DC00",
     label: "light blue",
   },
-];
-
-const validationTypes = [
-  ["error", "rgb(203, 55, 74)"],
-  ["warning", "rgb(239, 103, 0)"],
-  ["info", "rgb(0, 96, 167)"],
 ];
 
 const indexes = Array.from({ length: colors.length }).map((_, index) => index);
@@ -262,7 +261,11 @@ context("Testing SimpleColorPicker component", () => {
       verifyRequiredAsteriskForLegend();
     });
 
-    it.each(validationTypes)(
+    it.each([
+      ["error", VALIDATION.ERROR],
+      ["warning", VALIDATION.WARNING],
+      ["info", VALIDATION.INFO],
+    ])(
       "should render SimpleColorPicker and set type to %s and set as string",
       (type, color) => {
         CypressMountWithProviders(
@@ -282,7 +285,11 @@ context("Testing SimpleColorPicker component", () => {
       }
     );
 
-    it.each(validationTypes)(
+    it.each([
+      ["error", VALIDATION.ERROR],
+      ["warning", VALIDATION.WARNING],
+      ["info", VALIDATION.INFO],
+    ])(
       "should render SimpleColorPicker and set type to %s as string and have validationOnLegend prop",
       (type, color) => {
         CypressMountWithProviders(
@@ -305,7 +312,11 @@ context("Testing SimpleColorPicker component", () => {
       }
     );
 
-    it.each(validationTypes)(
+    it.each([
+      ["error", VALIDATION.ERROR],
+      ["warning", VALIDATION.WARNING],
+      ["info", VALIDATION.INFO],
+    ])(
       "should render SimpleColorPicker and set type to %s as boolean",
       (type, color) => {
         CypressMountWithProviders(

--- a/src/components/split-button/split-button.test.js
+++ b/src/components/split-button/split-button.test.js
@@ -16,10 +16,10 @@ import {
   splitMainButton,
 } from "../../../cypress/locators/split-button";
 import { accordionDefaultTitle } from "../../../cypress/locators/accordion";
-
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const SplitButtonList = ({ ...props }) => {
   return (

--- a/src/components/step-sequence/step-sequence.test.js
+++ b/src/components/step-sequence/step-sequence.test.js
@@ -8,8 +8,9 @@ import {
   stepSequenceDataComponentItem,
 } from "../../../cypress/locators/step-sequence";
 import { ICON } from "../../../cypress/locators/locators";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const StepSequenceComponent = ({ ...props }) => {
   return (

--- a/src/components/switch/switch.test.js
+++ b/src/components/switch/switch.test.js
@@ -20,6 +20,7 @@ import { verifyRequiredAsteriskForLabel } from "../../../cypress/support/compone
 import {
   CHARACTERS,
   VALIDATION,
+  SIZE,
 } from "../../../cypress/support/component-helper/constants";
 
 const verifyBorderColor = (element, color) =>
@@ -378,8 +379,8 @@ context("Testing Switch component", () => {
     );
 
     it.each([
-      ["small", 60, 24],
-      ["large", 78, 40],
+      [SIZE.SMALL, 60, 24],
+      [SIZE.LARGE, 78, 40],
     ])("verify Switch component with size set to %s", (size, width, height) => {
       CypressMountWithProviders(<SwitchComponent size={size} />);
 

--- a/src/components/text-editor/text-editor.test.js
+++ b/src/components/text-editor/text-editor.test.js
@@ -17,6 +17,10 @@ import {
 import { getDataElementByValue } from "../../../cypress/locators";
 import { positionOfElement, keyCode } from "../../../cypress/support/helper";
 import { verifyRequiredAsteriskForLabel } from "../../../cypress/support/component-helper/common-steps";
+import {
+  VALIDATION,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
 const TextEditorCustom = ({ text, onChange, onLinkAdded, ...props }) => {
@@ -89,7 +93,7 @@ const longText =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 const longTextAssert =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore ";
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 context("Test for TextEditor component", () => {
   describe("check functionality for TextEditor component", () => {
@@ -277,9 +281,9 @@ context("Test for TextEditor component", () => {
       });
 
       it.each([
-        ["error", 0, "rgb(203, 55, 74)"],
-        ["warning", 5, "rgb(239, 103, 0)"],
-        ["info", 10, "rgb(0, 96, 167)"],
+        ["error", 0, VALIDATION.ERROR],
+        ["warning", 5, VALIDATION.WARNING],
+        ["info", 10, VALIDATION.INFO],
       ])("should show %s validation state", (state, times, color) => {
         CypressMountWithProviders(<TextEditorCustomValidation />);
 

--- a/src/components/textarea/textarea.test.js
+++ b/src/components/textarea/textarea.test.js
@@ -18,11 +18,17 @@ import {
   fieldHelpPreview,
   getElement,
 } from "../../../cypress/locators";
-import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+import {
+  CHARACTERS,
+  SIZE,
+  VALIDATION,
+} from "../../../cypress/support/component-helper/constants";
 
 import { textarea, textareaChildren } from "../../../cypress/locators/textarea";
 
 import { keyCode } from "../../../cypress/support/helper";
+
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const TextareaComponent = ({ ...props }) => {
   const [state, setState] = React.useState("");
@@ -73,7 +79,7 @@ context("Tests for Textarea component", () => {
       textareaChildren().should("have.attr", "id", CHARACTERS.STANDARD);
     });
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render Textarea with label prop set to %s",
       (label) => {
         CypressMountWithProviders(<TextareaComponent label={label} />);
@@ -108,7 +114,7 @@ context("Tests for Textarea component", () => {
       }
     );
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render Textarea with labelHelp prop set to %s",
       (labelHelp) => {
         CypressMountWithProviders(
@@ -230,7 +236,7 @@ context("Tests for Textarea component", () => {
       textareaChildren().should("be.disabled").and("have.attr", "disabled");
     });
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render Textarea with placeholder prop set to %s",
       (placeholder) => {
         CypressMountWithProviders(
@@ -301,9 +307,9 @@ context("Tests for Textarea component", () => {
     );
 
     it.each([
-      ["rgb(203, 55, 74)", "error", true],
-      ["rgb(239, 103, 0)", "warning", true],
-      ["rgb(0, 96, 167)", "info", true],
+      [VALIDATION.ERROR, "error", true],
+      [VALIDATION.WARNING, "warning", true],
+      [VALIDATION.INFO, "info", true],
       ["rgb(102, 132, 148)", "error", false],
       ["rgb(102, 132, 148)", "warning", false],
       ["rgb(102, 132, 148)", "info", false],
@@ -323,9 +329,9 @@ context("Tests for Textarea component", () => {
     );
 
     it.each([
-      ["small", "32px"],
-      ["medium", "40px"],
-      ["large", "48px"],
+      [SIZE.SMALL, "32px"],
+      [SIZE.MEDIUM, "40px"],
+      [SIZE.LARGE, "48px"],
     ])(
       "should use %s as size and render Textarea with %s as height",
       (size, height) => {
@@ -355,7 +361,7 @@ context("Tests for Textarea component", () => {
       }
     );
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render Textarea with fieldHelp prop set to %s",
       (fieldHelp) => {
         CypressMountWithProviders(<TextareaComponent fieldHelp={fieldHelp} />);
@@ -415,7 +421,7 @@ context("Tests for Textarea component", () => {
       }
     );
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should input into Textarea and verify the value",
       (input) => {
         CypressMountWithProviders(<TextareaComponent />);
@@ -424,7 +430,7 @@ context("Tests for Textarea component", () => {
       }
     );
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render Textarea with value prop set to %s",
       (value) => {
         CypressMountWithProviders(<TextareaComponent value={value} />);

--- a/src/components/textbox/textbox.test.js
+++ b/src/components/textbox/textbox.test.js
@@ -17,7 +17,11 @@ import {
   fieldHelpPreview,
   getElement,
 } from "../../../cypress/locators";
-import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+import {
+  CHARACTERS,
+  SIZE,
+  VALIDATION,
+} from "../../../cypress/support/component-helper/constants";
 
 import {
   textbox,
@@ -27,6 +31,8 @@ import {
 
 import { keyCode } from "../../../cypress/support/helper";
 import Button from "../button/button.component";
+
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 const verifyOptional = (element) =>
   element.then(($els) => {
@@ -116,7 +122,7 @@ context("Tests for Textbox component", () => {
       textboxInput().should("have.attr", "id", CHARACTERS.STANDARD);
     });
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render Textbox with label prop set to %s",
       (label) => {
         CypressMountWithProviders(<TextboxComponent label={label} />);
@@ -151,7 +157,7 @@ context("Tests for Textbox component", () => {
       }
     );
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render Textbox with labelHelp prop",
       (labelHelp) => {
         CypressMountWithProviders(
@@ -269,7 +275,7 @@ context("Tests for Textbox component", () => {
       textboxInput().should("be.disabled").and("have.attr", "disabled");
     });
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render Textbox with placeholder prop set to %s",
       (placeholder) => {
         CypressMountWithProviders(
@@ -340,9 +346,9 @@ context("Tests for Textbox component", () => {
     );
 
     it.each([
-      ["rgb(203, 55, 74)", "error", true],
-      ["rgb(239, 103, 0)", "warning", true],
-      ["rgb(0, 96, 167)", "info", true],
+      [VALIDATION.ERROR, "error", true],
+      [VALIDATION.WARNING, "warning", true],
+      [VALIDATION.INFO, "info", true],
       ["rgb(102, 132, 148)", "error", false],
       ["rgb(102, 132, 148)", "warning", false],
       ["rgb(102, 132, 148)", "info", false],
@@ -372,7 +378,7 @@ context("Tests for Textbox component", () => {
         .and("be.visible");
     });
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render Textbox with prefix prop set to %s",
       (prefix) => {
         CypressMountWithProviders(<TextboxComponent prefix={prefix} />);
@@ -409,9 +415,9 @@ context("Tests for Textbox component", () => {
     );
 
     it.each([
-      ["small", "32px"],
-      ["medium", "40px"],
-      ["large", "48px"],
+      [SIZE.SMALL, "32px"],
+      [SIZE.MEDIUM, "40px"],
+      [SIZE.LARGE, "48px"],
     ])(
       "should use %s as size and render Textbox with %s as height",
       (size, height) => {
@@ -466,7 +472,7 @@ context("Tests for Textbox component", () => {
         .and("have.attr", "for", `${CHARACTERS.STANDARD}_cy`);
     });
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should render Textbox with fieldHelp prop set to %s",
       (fieldHelp) => {
         CypressMountWithProviders(<TextboxComponent fieldHelp={fieldHelp} />);
@@ -549,7 +555,7 @@ context("Tests for Textbox component", () => {
       textboxInput().should("be.focused");
     });
 
-    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+    it.each(testData)(
       "should input into Textbox and verify the value",
       (input) => {
         CypressMountWithProviders(<TextboxComponent />);

--- a/src/components/tile-select/tile-select.test.js
+++ b/src/components/tile-select/tile-select.test.js
@@ -19,6 +19,8 @@ import {
 
 import { getComponent, getElement } from "../../../cypress/locators/index";
 
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+
 const TileSelectComponent = ({ multiSelect, ...props }) => {
   const [value, setValue] = React.useState(null);
   return (
@@ -266,7 +268,7 @@ const TileSelectGroupComponent = ({ ...props }) => {
 
 context("Tests for TileSelect component", () => {
   describe("check props for TileSelect component", () => {
-    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+    it.each(testData)(
       "should check title as %s for TileSelect component",
       (title) => {
         CypressMountWithProviders(<TileSelectComponent title={title} />);
@@ -286,7 +288,7 @@ context("Tests for TileSelect component", () => {
       }
     );
 
-    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+    it.each(testData)(
       "should check subtitle as %s for TileSelect component",
       (subtitle) => {
         CypressMountWithProviders(<TileSelectComponent subtitle={subtitle} />);
@@ -294,7 +296,7 @@ context("Tests for TileSelect component", () => {
       }
     );
 
-    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+    it.each(testData)(
       "should check description as %s for TileSelect component",
       (description) => {
         CypressMountWithProviders(
@@ -323,7 +325,7 @@ context("Tests for TileSelect component", () => {
       }
     );
 
-    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+    it.each(testData)(
       "should check id as %s for TileSelect component",
       (id) => {
         CypressMountWithProviders(<TileSelectComponent id={id} />);
@@ -331,7 +333,7 @@ context("Tests for TileSelect component", () => {
       }
     );
 
-    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+    it.each(testData)(
       "should check name as %s for TileSelect component",
       (name) => {
         CypressMountWithProviders(<TileSelect name={name} />);
@@ -351,7 +353,7 @@ context("Tests for TileSelect component", () => {
       inputElement().should("have.attr", "aria-checked", "false");
     });
 
-    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+    it.each(testData)(
       "should check className as %s for TileSelect component",
       (className) => {
         CypressMountWithProviders(
@@ -381,7 +383,7 @@ context("Tests for TileSelect component", () => {
         .and("have.text", "Footer Button");
     });
 
-    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+    it.each(testData)(
       "should check prefixAdornment as %s for TileSelect component",
       (PrefixAdornment) => {
         CypressMountWithProviders(
@@ -455,7 +457,7 @@ context("Tests for TileSelect component", () => {
     }
   );
 
-  it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+  it.each(testData)(
     "should check accordionContent as %s for TileSelect component",
     (accordionContent) => {
       CypressMountWithProviders(
@@ -504,7 +506,7 @@ describe("check props for ActionButtonAdornment", () => {
 });
 
 describe("check props for TileSelectGroup component", () => {
-  it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+  it.each(testData)(
     "should check name as %s for TileSelect component",
     (name) => {
       CypressMountWithProviders(<TileSelectGroupComponent name={name} />);
@@ -512,7 +514,7 @@ describe("check props for TileSelectGroup component", () => {
     }
   );
 
-  it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+  it.each(testData)(
     "should check legend as %s for TileSelectGroup component",
     (legend) => {
       CypressMountWithProviders(<TileSelectGroupComponent legend={legend} />);
@@ -520,7 +522,7 @@ describe("check props for TileSelectGroup component", () => {
     }
   );
 
-  it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+  it.each(testData)(
     "should check description as %s for TileSelectGroup component",
     (description) => {
       CypressMountWithProviders(
@@ -535,7 +537,7 @@ describe("check props for TileSelectGroup component", () => {
     inputElement().should("have.attr", "value", "1");
   });
 
-  it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+  it.each(testData)(
     "should check children as %s for TileSelectGroup component",
     (characters) => {
       CypressMountWithProviders(

--- a/src/components/toast/toast.test.js
+++ b/src/components/toast/toast.test.js
@@ -1,16 +1,15 @@
-import * as React from "react";
+import React from "react";
 import Toast from ".";
 import { TOAST_COLORS } from "./toast.config";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { checkGoldenOutline } from "../../../cypress/support/component-helper/common-steps";
-
 import toastComponent from "../../../cypress/locators/toast";
-import { closeIconButton, getComponent } from "../../../cypress/locators/index";
-
 import { pressESCKey, pressTABKey } from "../../../cypress/support/helper";
+import { closeIconButton, getComponent } from "../../../cypress/locators/index";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
-const specialCharacters = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
-const testData = "cypressData";
+const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+const testData = CHARACTERS.STANDARD;
 const colorTypes = [
   ["rgb(203, 55, 74)"],
   ["rgb(51, 91, 112)"],

--- a/src/components/tooltip/tooltip.test.js
+++ b/src/components/tooltip/tooltip.test.js
@@ -6,14 +6,14 @@ import Tooltip from "./tooltip.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
 import { tooltipPreview } from "../../../cypress/locators/tooltip/index";
+import {
+  SIZE,
+  COLOR,
+  CHARACTERS,
+} from "../../../cypress/support/component-helper/constants";
 
-const testData = ["mp150ú¿¡üßä", "!@#$%^*()_+-=~[];:.,?{}&\"'<>"];
-const backgroundColors = [
-  "rgb(255, 156, 75)",
-  "rgb(205, 56, 75)",
-  "rgb(0, 0, 0)",
-  "rgb(105, 61, 57)",
-];
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+const backgroundColors = [COLOR.ORANGE, COLOR.RED, COLOR.BLACK, COLOR.BROWN];
 
 const TooltipComponent = ({ ...props }) => {
   const Component = forwardRef(({ children }, ref) => (
@@ -117,8 +117,8 @@ context("Tests for Tooltip component", () => {
     );
 
     it.each([
-      ["medium", 14],
-      ["large", 16],
+      [SIZE.MEDIUM, 14],
+      [SIZE.LARGE, 16],
     ])("should check %s size for Tooltip component", (size, fontSize) => {
       CypressMountWithProviders(<TooltipComponent size={size} />);
       tooltipPreview().should("have.css", "font-size", `${fontSize}px`);
@@ -156,9 +156,18 @@ context("Tests for Tooltip component", () => {
       "when tooltip has %s position and",
       (position) => {
         it.each([
-          ["small", { top: "5px", bottom: "5px", left: "5px", right: "5px" }],
-          ["medium", { top: "4px", bottom: "4px", left: "2px", right: "2px" }],
-          ["large", { top: "0px", bottom: "0px", left: "-2px", right: "-2px" }],
+          [
+            SIZE.SMALL,
+            { top: "5px", bottom: "5px", left: "5px", right: "5px" },
+          ],
+          [
+            SIZE.MEDIUM,
+            { top: "4px", bottom: "4px", left: "2px", right: "2px" },
+          ],
+          [
+            SIZE.LARGE,
+            { top: "0px", bottom: "0px", left: "-2px", right: "-2px" },
+          ],
         ])(
           "when inputSize is %s should have correct styles applied",
           (inputSize, offset) => {


### PR DESCRIPTION
### Proposed behaviour
- Refactor all Cypress tests to use component-helper/constants.
- Update constants.js.

### Current behaviour
Colours, special characters, validation colours & sizes are all declared individually in test files.

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Check if all `.test.js` files passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `alert` tests are not running twice.