### PR TITLE
Sage/DSY-1757 Breadcrumbs Component (FE-5562)

### DIFF
--- a/cypress/locators/breadcrumbs/index.js
+++ b/cypress/locators/breadcrumbs/index.js
@@ -1,0 +1,6 @@
+import BREADCRUMBS from "./locators";
+
+// component preview locators
+export const breadcrumbsComponent = () => cy.get(BREADCRUMBS);
+export const crumb = (index) =>
+  breadcrumbsComponent().find("ol").find("li").eq(index);

--- a/cypress/locators/breadcrumbs/locators.js
+++ b/cypress/locators/breadcrumbs/locators.js
@@ -1,0 +1,4 @@
+// component preview locators
+const BREADCRUMBS = '[data-component="breadcrumbs"]';
+
+export default BREADCRUMBS;

--- a/src/components/breadcrumbs/breadcrumbs-test.stories.tsx
+++ b/src/components/breadcrumbs/breadcrumbs-test.stories.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Breadcrumbs } from ".";
+import { Crumb } from "./crumb";
+
+export default {
+  title: "Breadcrumbs/Test",
+  includeStories: "DefaultCrumb",
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+  argTypes: {
+    isCurrent: {
+      control: {
+        type: "boolean",
+      },
+    },
+    href: {
+      control: {
+        type: "text",
+      },
+    },
+  },
+};
+
+export const Default = ({ ...args }) => {
+  return (
+    <Breadcrumbs {...args}>
+      <Crumb href="#">Breadcrumb 1</Crumb>
+      <Crumb href="#">Breadcrumb 2</Crumb>
+      <Crumb href="#">Breadcrumb 3</Crumb>
+      <Crumb href="#" isCurrent>
+        Current Page
+      </Crumb>
+    </Breadcrumbs>
+  );
+};
+
+export const DefaultCrumb = ({ ...args }) => {
+  return (
+    <Breadcrumbs>
+      <Crumb href="#" {...args}>
+        Breadcrumb 1
+      </Crumb>
+    </Breadcrumbs>
+  );
+};
+
+Default.storyName = "default";
+DefaultCrumb.storyName = "default crumb";

--- a/src/components/breadcrumbs/breadcrumbs.component.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.component.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
+import StyledBreadcrumbs from "./breadcrumbs.style";
+import useLocale from "../../hooks/__internal__/useLocale";
+
+export interface BreadcrumbsProps extends TagProps {
+  /** Child crumbs to display */
+  children: React.ReactNode;
+}
+
+export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
+  ({ children, ...rest }: BreadcrumbsProps, ref) => {
+    const l = useLocale();
+    return (
+      <StyledBreadcrumbs
+        ref={ref}
+        role="navigation"
+        {...tagComponent("breadcrumbs", rest)}
+        aria-label={l.breadcrumbs.ariaLabel()}
+      >
+        <ol>{children}</ol>
+      </StyledBreadcrumbs>
+    );
+  }
+);
+
+Breadcrumbs.displayName = "Breadcrumbs";
+
+export default Breadcrumbs;

--- a/src/components/breadcrumbs/breadcrumbs.spec.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.spec.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { screen, render } from "@testing-library/react";
+import Breadcrumbs from "./breadcrumbs.component";
+import Crumb from "./crumb/crumb.component";
+
+test("renders all child crumbs correctly", () => {
+  render(
+    <Breadcrumbs>
+      <Crumb href="#">Breadcrumb</Crumb>
+      <Crumb href="#">Breadcrumb</Crumb>
+      <Crumb href="#">Breadcrumb</Crumb>
+      <Crumb href="#" isCurrent>
+        Breadcrumb
+      </Crumb>
+    </Breadcrumbs>
+  );
+
+  const crumbElement = screen.getAllByText("Breadcrumb");
+  expect(crumbElement.length).toBe(4);
+});

--- a/src/components/breadcrumbs/breadcrumbs.stories.mdx
+++ b/src/components/breadcrumbs/breadcrumbs.stories.mdx
@@ -1,0 +1,68 @@
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Breadcrumbs, Crumb } from "./index";
+import * as stories from "./breadcrumbs.stories.tsx";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+
+<Meta title="Breadcrumbs" parameters={{ info: { disable: true } }} />
+
+# Breadcrumbs
+
+  <a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/32c1b6-breadcrumbs/b/87b2c7"
+  style={{ color: "#007E45", fontWeight: "bold", textDecoration: "underline" }}
+  >
+    Product Design System component
+  </a>
+
+Breadcrumbs are a secondary navigation aid that helps users easily understand their location.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+To use Breadcrumbs component you need to import `Breadcrumbs` and pass an array of `Crumb`s.
+
+```javascript
+import { Breadcrumbs, Crumb } from "carbon-react/lib/components/breadcrumbs";
+```
+
+## Examples
+
+### Breadcrumbs
+
+<Canvas>
+  <Story name="default" story={stories.DefaultBreadcrumbs} />
+</Canvas>
+
+## Props
+
+### Breadcrumbs
+
+<ArgsTable
+   of={Breadcrumbs}
+ />
+
+### Crumb
+
+<ArgsTable of={Crumb} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "breadcrumbs.ariaLabel",
+      description: "The text for the aria-label attribute",
+      type: "func",
+      returnType: "string",
+    },
+]}
+/>

--- a/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { ComponentStory } from "@storybook/react";
+
+import { Breadcrumbs } from ".";
+import { Crumb } from "./crumb";
+
+// eslint-disable-next-line import/prefer-default-export
+export const DefaultBreadcrumbs: ComponentStory<typeof Breadcrumbs> = () => {
+  return (
+    <Breadcrumbs>
+      <Crumb href="#">Breadcrumb 1</Crumb>
+      <Crumb href="#">Breadcrumb 2</Crumb>
+      <Crumb href="#">Breadcrumb 3</Crumb>
+      <Crumb href="#" isCurrent>
+        Current Page
+      </Crumb>
+    </Breadcrumbs>
+  );
+};

--- a/src/components/breadcrumbs/breadcrumbs.style.ts
+++ b/src/components/breadcrumbs/breadcrumbs.style.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+const StyledBreadcrumbs = styled.nav`
+  ol {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+  }
+`;
+
+export default StyledBreadcrumbs;

--- a/src/components/breadcrumbs/breadcrumbs.test.js
+++ b/src/components/breadcrumbs/breadcrumbs.test.js
@@ -1,0 +1,96 @@
+import React from "react";
+import * as testStories from "./breadcrumbs-test.stories";
+import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
+import {
+  breadcrumbsComponent,
+  crumb,
+} from "../../../cypress/locators/breadcrumbs";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+
+context("Testing Breadcrumbs component", () => {
+  describe("should render Breadcrumbs component", () => {
+    it("should check Breadcrumbs children is set visible", () => {
+      CypressMountWithProviders(<testStories.Default />);
+
+      breadcrumbsComponent()
+        .find("ol")
+        .children()
+        .should("have.length", 4)
+        .and("be.visible");
+    });
+
+    it("should check Breadcrumbs on hover color", () => {
+      CypressMountWithProviders(<testStories.Default />);
+
+      crumb(1)
+        .realHover()
+        .find("a")
+        .should("have.css", "color", "rgb(0, 103, 56)");
+    });
+
+    it("should check Breadcrumbs on focus", () => {
+      CypressMountWithProviders(<testStories.Default />);
+
+      cy.get("body").tab();
+      crumb(0).find("a").should("be.focused");
+      cy.focused().tab().tab();
+      crumb(2).find("a").should("be.focused");
+    });
+
+    it.each([
+      [true, "aria-current", "page"],
+      [false, "href", "#"],
+    ])(
+      "should check Crumb with isCurrent prop is %s",
+      (boolean, attr, value) => {
+        CypressMountWithProviders(
+          <testStories.DefaultCrumb isCurrent={boolean} />
+        );
+
+        crumb(0).find("a").should("have.attr", attr, value);
+      }
+    );
+
+    it("should check Crumb with href prop set to default val", () => {
+      CypressMountWithProviders(
+        <testStories.DefaultCrumb href={CHARACTERS.STANDARD} />
+      );
+
+      crumb(0).find("a").should("have.attr", "href", CHARACTERS.STANDARD);
+    });
+  });
+
+  describe("should check Crumb props", () => {
+    it.each([
+      ["not.exist", true],
+      ["be.visible", false],
+    ])("should check Crumb divider is %s", (assertion, boolean) => {
+      CypressMountWithProviders(
+        <testStories.DefaultCrumb isCurrent={boolean} />
+      );
+
+      crumb(0).children().eq(1).should(assertion);
+      if (!boolean) {
+        crumb(0)
+          .children()
+          .eq(1)
+          .then(($el) => {
+            expect($el).to.have.text("/");
+            expect($el).to.have.css("color", "rgba(0, 0, 0, 0.55)");
+          });
+      }
+    });
+  });
+
+  describe("Accessibility tests for Breadcrumbs component", () => {
+    it("should pass accessibilty tests for Breadcrumbs default story", () => {
+      CypressMountWithProviders(<testStories.Default />);
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for Crumb default story", () => {
+      CypressMountWithProviders(<testStories.DefaultCrumb />);
+      cy.checkAccessibility();
+    });
+  });
+});

--- a/src/components/breadcrumbs/crumb/crumb.component.tsx
+++ b/src/components/breadcrumbs/crumb/crumb.component.tsx
@@ -1,0 +1,53 @@
+import { LinkProps } from "components/link/link.component";
+import React from "react";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags";
+import { StyledCrumb, Divider } from "./crumb.style";
+
+export interface CrumbProps
+  extends Omit<
+      LinkProps,
+      | "tooltipMessage"
+      | "tooltipPosition"
+      | "iconType"
+      | "iconAlign"
+      | "isSkipLink"
+      | "isDarkBackground"
+      | "ariaLabel"
+      | "className"
+      | "variant"
+      | "target"
+      | "rel"
+      | "icon"
+      | "disabled"
+    >,
+    TagProps {
+  /** This sets the Crumb to current, does not render Link */
+  isCurrent?: boolean;
+  /** The href string for Crumb Link */
+  href: string;
+}
+
+const Crumb = React.forwardRef<HTMLLinkElement, CrumbProps>(
+  ({ href, isCurrent, children, ...rest }: CrumbProps, ref) => (
+    <li>
+      <StyledCrumb
+        ref={ref}
+        isCurrent={isCurrent}
+        aria-current={isCurrent ? "page" : undefined}
+        {...tagComponent("crumb", rest)}
+        {...(!isCurrent && {
+          href,
+        })}
+      >
+        {children}
+      </StyledCrumb>
+      {!isCurrent && <Divider />}
+    </li>
+  )
+);
+
+Crumb.displayName = "Crumb";
+
+export default Crumb;

--- a/src/components/breadcrumbs/crumb/crumb.spec.tsx
+++ b/src/components/breadcrumbs/crumb/crumb.spec.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Crumb from "./crumb.component";
+
+const LINK_TEXT = "Link text";
+
+describe("Crumb", () => {
+  it("passes href to the anchor element isCurrent is false", () => {
+    render(<Crumb href="foo">{LINK_TEXT}</Crumb>);
+
+    const link = screen.getByText(LINK_TEXT);
+    expect(link).toBeInTheDocument();
+    expect(link.closest("a")).toHaveAttribute("href", "foo");
+  });
+
+  it("does not pass href to the anchor element when isCurrent is true", () => {
+    render(
+      <Crumb href="foo" isCurrent>
+        {LINK_TEXT}
+      </Crumb>
+    );
+
+    const anchor = screen.getByText(LINK_TEXT).closest("a");
+    expect(anchor).not.toHaveAttribute("href", "foo");
+
+    expect(anchor).toHaveStyle({
+      color: "var(--colorsYin055)",
+      textDecoration: "none",
+      cursor: "text",
+    });
+  });
+
+  it("calls the handleClick callback if one is passed and isCurrent is false", async () => {
+    const handleClickFn = jest.fn();
+
+    render(
+      <Crumb href="#" onClick={handleClickFn}>
+        {LINK_TEXT}
+      </Crumb>
+    );
+
+    const link = screen.getByText(LINK_TEXT);
+    await userEvent.click(link);
+
+    expect(handleClickFn).toHaveBeenCalledTimes(0);
+  });
+
+  it("does not call the handleClick callback if one is passed and isCurrent is true", async () => {
+    const handleClickFn = jest.fn();
+
+    render(
+      <Crumb href="#" onClick={handleClickFn}>
+        {LINK_TEXT}
+      </Crumb>
+    );
+    const link = screen.getByText(LINK_TEXT);
+    await userEvent.click(link);
+
+    expect(handleClickFn).not.toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/breadcrumbs/crumb/crumb.style.ts
+++ b/src/components/breadcrumbs/crumb/crumb.style.ts
@@ -1,0 +1,37 @@
+import styled, { css } from "styled-components";
+import Link, { LinkProps } from "../../link";
+
+interface StyleCrumbProps extends LinkProps {
+  isCurrent?: boolean;
+}
+
+export const StyledCrumb = styled(Link)<StyleCrumbProps>`
+  font: var(--typographyLinkTextM);
+  ${({ isCurrent }) =>
+    isCurrent &&
+    css`
+      a {
+        color: var(--colorsUtilityYin090);
+        text-decoration: none;
+        font: var(--typographyBreadcrumbCurrentPageM);
+        cursor: text;
+        :hover {
+          color: var(--colorsUtilityYin090);
+          text-decoration: none;
+          cursor: text;
+        }
+      }
+    `}
+`;
+
+export const Divider = styled.span.attrs({
+  children: "/",
+  "aria-hidden": "true",
+})`
+  margin: 0px var(--spacing050) 0px var(--spacing100);
+  line-height: 16px;
+  font: var(--typographyBreadcrumbSeparatorM);
+  color: var(--colorsUtilityYin055);
+`;
+
+export default { StyledCrumb, Divider };

--- a/src/components/breadcrumbs/crumb/index.ts
+++ b/src/components/breadcrumbs/crumb/index.ts
@@ -1,0 +1,2 @@
+export { default as Crumb } from "./crumb.component";
+export type { CrumbProps } from "./crumb.component";

--- a/src/components/breadcrumbs/index.ts
+++ b/src/components/breadcrumbs/index.ts
@@ -1,0 +1,4 @@
+export { default as Breadcrumbs } from "./breadcrumbs.component";
+export { Crumb } from "./crumb";
+export type { BreadcrumbsProps } from "./breadcrumbs.component";
+export type { CrumbProps } from "./crumb";

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -16,6 +16,9 @@ const enGB: Locale = {
   batchSelection: {
     selected: (count) => `${count} selected`,
   },
+  breadcrumbs: {
+    ariaLabel: () => "breadcrumbs",
+  },
   confirm: {
     no: () => "No",
     yes: () => "Yes",

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -12,6 +12,9 @@ interface Locale {
   batchSelection: {
     selected: (count: number | string) => string;
   };
+  breadcrumbs: {
+    ariaLabel: () => string;
+  };
   characterCount: {
     hintString: () => string;
     tooManyCharacters: (count: number, formattedCount: string) => string;

--- a/src/locales/pl-pl.ts
+++ b/src/locales/pl-pl.ts
@@ -35,6 +35,9 @@ const plPL: Locale = {
   batchSelection: {
     selected: (count) => `${count} wybrano`,
   },
+  breadcrumbs: {
+    ariaLabel: () => "okruszki",
+  },
   confirm: {
     no: () => "Nie",
     yes: () => "Tak",


### PR DESCRIPTION
### Proposed behaviour

<img width="396" alt="Screenshot 2023-02-07 at 14 24 58" src="https://user-images.githubusercontent.com/48626342/217271539-5372c433-824a-44ee-8c27-1c9c15e95d92.png">


<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour
This is a new component.
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
