### PR TITLE
docs: storybook remove util references (FE-5315)

### DIFF
--- a/.storybook/utils/partial-action.js
+++ b/.storybook/utils/partial-action.js
@@ -1,9 +1,0 @@
-import { action } from "@storybook/addon-actions";
-
-function partialAction(actionName) {
-  return (eventObj, ...args) => {
-    action(actionName)({ ...eventObj, view: undefined }, ...args);
-  };
-}
-
-export default partialAction;

--- a/src/__internal__/utils/storybook/partial-action.ts
+++ b/src/__internal__/utils/storybook/partial-action.ts
@@ -1,0 +1,15 @@
+import { action } from "@storybook/addon-actions";
+import React from "react";
+
+function partialAction(actionName: string) {
+  return (eventObj?: React.SyntheticEvent | string, ...args: string[]) => {
+    action(actionName)(
+      typeof eventObj === "string"
+        ? { view: undefined }
+        : { ...eventObj, view: undefined },
+      ...args
+    );
+  };
+}
+
+export default partialAction;

--- a/src/components/action-popover/action-popover.stories.mdx
+++ b/src/components/action-popover/action-popover.stories.mdx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import { action } from "@storybook/addon-actions";
 import LinkTo from "@storybook/addon-links/react";
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 import {

--- a/src/components/action-popover/action-popover.stories.tsx
+++ b/src/components/action-popover/action-popover.stories.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { ComponentStory } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
 import {
   ActionPopover,
   ActionPopoverDivider,
@@ -26,26 +25,22 @@ export const ActionPopoverComponent: ComponentStory<
 > = () => {
   const submenu = (
     <ActionPopoverMenu>
-      <ActionPopoverItem onClick={action("sub menu 1")}>
-        Sub Menu 1
-      </ActionPopoverItem>
-      <ActionPopoverItem onClick={action("sub menu 2")}>
-        Sub Menu 2
-      </ActionPopoverItem>
-      <ActionPopoverItem disabled onClick={action("sub menu 3")}>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 1</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 2</ActionPopoverItem>
+      <ActionPopoverItem disabled onClick={() => {}}>
         Sub Menu 3
       </ActionPopoverItem>
     </ActionPopoverMenu>
   );
   const submenuWithIcons = (
     <ActionPopoverMenu>
-      <ActionPopoverItem icon="graph" onClick={action("sub menu 1")}>
+      <ActionPopoverItem icon="graph" onClick={() => {}}>
         Sub Menu 1
       </ActionPopoverItem>
-      <ActionPopoverItem icon="add" onClick={action("sub menu 2")}>
+      <ActionPopoverItem icon="add" onClick={() => {}}>
         Sub Menu 2
       </ActionPopoverItem>
-      <ActionPopoverItem icon="print" disabled onClick={action("sub menu 3")}>
+      <ActionPopoverItem icon="print" disabled onClick={() => {}}>
         Sub Menu 3
       </ActionPopoverItem>
     </ActionPopoverMenu>
@@ -53,45 +48,34 @@ export const ActionPopoverComponent: ComponentStory<
   return (
     <div style={{ marginTop: "40px", height: "275px" }}>
       <Box>
-        <ActionPopover
-          onOpen={action("popover opened")}
-          onClose={action("popover closed")}
-        >
+        <ActionPopover onOpen={() => {}} onClose={() => {}}>
           <ActionPopoverItem
             disabled
             icon="graph"
             submenu={submenu}
-            onClick={action("email")}
+            onClick={() => {}}
           >
             Business
           </ActionPopoverItem>
-          <ActionPopoverItem icon="email" onClick={action("email")}>
+          <ActionPopoverItem icon="email" onClick={() => {}}>
             Email Invoice
           </ActionPopoverItem>
-          <ActionPopoverItem
-            icon="print"
-            onClick={action("print")}
-            submenu={submenu}
-          >
+          <ActionPopoverItem icon="print" onClick={() => {}} submenu={submenu}>
             Print Invoice
           </ActionPopoverItem>
-          <ActionPopoverItem
-            icon="pdf"
-            submenu={submenu}
-            onClick={action("pdf")}
-          >
+          <ActionPopoverItem icon="pdf" submenu={submenu} onClick={() => {}}>
             Download PDF
           </ActionPopoverItem>
-          <ActionPopoverItem icon="csv" onClick={action("csv")}>
+          <ActionPopoverItem icon="csv" onClick={() => {}}>
             Download CSV
           </ActionPopoverItem>
           <ActionPopoverDivider />
-          <ActionPopoverItem icon="delete" onClick={action("delete")}>
+          <ActionPopoverItem icon="delete" onClick={() => {}}>
             Delete
           </ActionPopoverItem>
         </ActionPopover>
         <ActionPopover>
-          <ActionPopoverItem icon="csv" onClick={action("csv")}>
+          <ActionPopoverItem icon="csv" onClick={() => {}}>
             Download CSV
           </ActionPopoverItem>
         </ActionPopover>
@@ -99,7 +83,7 @@ export const ActionPopoverComponent: ComponentStory<
           <ActionPopoverItem
             icon="csv"
             submenu={submenuWithIcons}
-            onClick={action("csv")}
+            onClick={() => {}}
           >
             Download CSV
           </ActionPopoverItem>

--- a/src/components/alert/alert.stories.tsx
+++ b/src/components/alert/alert.stories.tsx
@@ -4,10 +4,10 @@ import Alert from ".";
 import Button from "../button";
 import isChromatic from "../../../.storybook/isChromatic";
 
-const isOpenForChromatic = isChromatic();
+const defaultOpenState = isChromatic();
 
 const AlertComponent: ComponentStory<typeof Alert> = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open Alert</Button>

--- a/src/components/button-toggle-group/button-toggle-group-test.stories.tsx
+++ b/src/components/button-toggle-group/button-toggle-group-test.stories.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import { action } from "@storybook/addon-actions";
+
+import ButtonToggle from "../button-toggle";
+import ButtonToggleGroup from ".";
+
+export default {
+  title: "Button Toggle Group/Test",
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disable: true,
+    },
+  },
+};
+
+export const DefaultStory = () => {
+  const [value, setValue] = useState("bar");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+    action("value set")(event.target.value);
+  }
+  return (
+    <ButtonToggleGroup
+      id="button-toggle-group"
+      name="button-toggle-group"
+      label="Button Toggle Group test"
+      labelHelp="help message"
+      helpAriaLabel="Help"
+      fieldHelp="field help mesage"
+      onChange={onChangeHandler}
+      value={value}
+    >
+      <ButtonToggle value="foo">Foo</ButtonToggle>
+      <ButtonToggle value="bar">Bar</ButtonToggle>
+      <ButtonToggle value="baz">Baz</ButtonToggle>
+    </ButtonToggleGroup>
+  );
+};
+
+DefaultStory.storyName = "default";

--- a/src/components/button-toggle-group/button-toggle-group.stories.mdx
+++ b/src/components/button-toggle-group/button-toggle-group.stories.mdx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Meta, Story, Canvas, Props } from "@storybook/addon-docs";
-import { action } from "@storybook/addon-actions";
 
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import ButtonToggle from "../button-toggle";
@@ -44,7 +43,6 @@ import ButtonToggleGroup from "carbon-react/lib/components/button-toggle-group";
       labelHelp="help message"
       helpAriaLabel="Help"
       fieldHelp="field help message"
-      onChange={action("onChange")}
     >
       <ButtonToggle value="foo">Foo</ButtonToggle>
       <ButtonToggle value="bar">Bar</ButtonToggle>
@@ -61,7 +59,6 @@ import ButtonToggleGroup from "carbon-react/lib/components/button-toggle-group";
       const [value, setValue] = useState("bar");
       function onChangeHandler(event) {
         setValue(event.target.value);
-        action("value set");
       }
       return (
         <ButtonToggleGroup

--- a/src/components/button-toggle/button-toggle.stories.mdx
+++ b/src/components/button-toggle/button-toggle.stories.mdx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import { action } from "@storybook/addon-actions";
 import ButtonToggle from ".";
 import ButtonToggleGroup from "../button-toggle-group";
 import LinkTo from "@storybook/addon-links/react";

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.tsx
@@ -20,7 +20,7 @@ import { Dl, Dt, Dd } from "../definition-list";
 import Toast from "../toast";
 import isChromatic from "../../../.storybook/isChromatic";
 
-const isOpenForChromatic = isChromatic();
+const defaultOpenState = isChromatic();
 
 export const Default = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -79,7 +79,7 @@ export const Default = () => {
 Default.parameters = { chromatic: { disable: true } };
 
 export const WithComplexExample = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   const [activeTab, setActiveTab] = useState("tab-1");
   const padding40 = useMediaQuery("(min-width: 1260px)");
   const padding32 = useMediaQuery("(min-width: 960px)");
@@ -564,7 +564,7 @@ export const WithDisableContentPadding = () => {
 WithDisableContentPadding.parameters = { chromatic: { disable: true } };
 
 export const WithHeaderChildren = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   const aboveBreakpoint = useMediaQuery("(min-width: 568px)");
   const verticalMargin = aboveBreakpoint ? "26px" : 0;
   const HeaderChildren = (
@@ -613,7 +613,7 @@ export const WithHeaderChildren = () => {
 WithDisableContentPadding.parameters = { viewports: [500, 1400] };
 
 export const WithHelp = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open DialogFullScreen</Button>

--- a/src/components/dialog/dialog.stories.tsx
+++ b/src/components/dialog/dialog.stories.tsx
@@ -14,10 +14,10 @@ import Loader from "../loader";
 import Toast from "../toast";
 import useMediaQuery from "../../hooks/useMediaQuery";
 
-const isOpenForChromatic = isChromatic();
+const defaultOpenState = isChromatic();
 
 export const DefaultStory: StoryFn = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
@@ -61,7 +61,7 @@ export const DefaultStory: StoryFn = () => {
 };
 
 export const Editable: StoryFn = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   const [isDisabled, setIsDisabled] = useState(true);
   const [radioValue, setRadioValue] = useState("1");
 
@@ -130,7 +130,7 @@ export const Editable: StoryFn = () => {
 Editable.parameters = { chromatic: { disable: true } };
 
 export const WithHelp: StoryFn = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
@@ -170,7 +170,7 @@ export const WithHelp: StoryFn = () => {
 
 export const DynamicContent: StoryFn = () => {
   const [isLoading, setIsLoading] = useState(false);
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
 
   const handleOpen = () => {
     setIsLoading(true);
@@ -268,7 +268,7 @@ FocusingADifferentFirstElement.parameters = {
 };
 
 export const OverridingContentPadding: StoryFn = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
@@ -383,7 +383,7 @@ OtherFocusableContainers.parameters = {
 };
 
 export const Responsive: StoryFn = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   const largeScreen = useMediaQuery("(min-width: 1260px)");
   const mediumScreen = useMediaQuery("(min-width: 960px)");
   const smallScreen = useMediaQuery("(min-width: 600px)");

--- a/src/components/dismissible-box/dismissible-box.stories.mdx
+++ b/src/components/dismissible-box/dismissible-box.stories.mdx
@@ -1,7 +1,6 @@
 import { useState, useRef } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import LinkTo from "@storybook/addon-links/react";
-import { action } from "@storybook/addon-actions";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 import DismissibleBox from ".";
@@ -36,7 +35,7 @@ import DismissibleBox from "carbon-react/lib/components/dismissible-box";
 <Canvas>
   <Story name="light variant">
     <Box p={2}>
-      <DismissibleBox onClose={(e) => action("onClose")(e)}>
+      <DismissibleBox onClose={() => {}}>
         <Box display="flex">
           <Typography mb={0}>
             Well, that's certainly good to know. Your head is not an artifact!
@@ -67,7 +66,7 @@ import DismissibleBox from "carbon-react/lib/components/dismissible-box";
 <Canvas>
   <Story name="dark variant">
     <Box p={2}>
-      <DismissibleBox variant="dark" onClose={(e) => action("onClose")(e)}>
+      <DismissibleBox variant="dark" onClose={() => {}}>
         <Box display="flex">
           <Typography mb={0}>
             Well, that's certainly good to know. Your head is not an artifact!
@@ -104,7 +103,7 @@ of this functionality.
       <DismissibleBox
         mb={2}
         hasBorderLeftHighlight={false}
-        onClose={(e) => action("onClose")(e)}
+        onClose={() => {}}
       >
         <Box display="flex">
           <Typography mb={0}>
@@ -138,7 +137,7 @@ It is also possible to override the `width` of the component: by default it will
 <Canvas>
   <Story name="width overridden">
     <Box p={2}>
-      <DismissibleBox width="650px" onClose={(e) => action("onClose")(e)}>
+      <DismissibleBox width="650px" onClose={() => {}}>
         <Box display="flex">
           <Typography mb={0}>
             Well, that's certainly good to know. Your head is not an artifact!

--- a/src/components/draggable/draggable.stories.mdx
+++ b/src/components/draggable/draggable.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
-import { action } from "@storybook/addon-actions";
 import { ArgsTable } from "@storybook/components";
 
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
@@ -89,11 +88,8 @@ import {
 <Canvas>
   <Story name="with getOrder callback">
     {() => {
-      const handleUpdate = (items) => {
-        action("onUpdate")(items);
-      };
       return (
-        <DraggableContainer getOrder={handleUpdate}>
+        <DraggableContainer getOrder={() => {}}>
           <DraggableItem key="1" id={1}>
             <Checkbox label="Draggable Label One" />
           </DraggableItem>

--- a/src/components/drawer/drawer.stories.mdx
+++ b/src/components/drawer/drawer.stories.mdx
@@ -1,6 +1,5 @@
 import { useMemo, useState, useCallback, useContext } from "react";
 import { Meta, ArgsTable, Canvas, Story } from "@storybook/addon-docs";
-import { action } from "@storybook/addon-actions";
 import styled from "styled-components";
 
 import { Checkbox } from "../checkbox";
@@ -734,7 +733,6 @@ Use the `expandedWidth` prop to alter the width of the open `Drawer`.
       const [isExpanded, setIsExpanded] = useState(false);
       const onChangeHandler = useCallback(() => {
         setIsExpanded(!isExpanded);
-        action("expansionToggled");
       }, [isExpanded]);
       return (
         <div>
@@ -778,7 +776,6 @@ Use the `animationDuration` prop to alter the speed of the `Drawer` opening/clos
       const [isExpanded, setIsExpanded] = useState(false);
       const onChangeHandler = useCallback(() => {
         setIsExpanded(!isExpanded);
-        action("expansionToggled");
       }, [isExpanded]);
       return (
         <div>
@@ -827,7 +824,6 @@ Use the `animationDuration` prop to alter the speed of the `Drawer` opening/clos
       const [isExpanded, setIsExpanded] = useState(false);
       const onChangeHandler = useCallback(() => {
         setIsExpanded(!isExpanded);
-        action("expansionToggled");
       }, [isExpanded]);
       return (
         <div>
@@ -918,7 +914,6 @@ Use the `animationDuration` prop to alter the speed of the `Drawer` opening/clos
       };
       const onChangeHandler = useCallback(() => {
         setIsExpanded(!isExpanded);
-        action("expansionToggled");
       }, [isExpanded]);
       const NavigationContainer = styled.div`
         display: flex;

--- a/src/components/pager/pager.stories.mdx
+++ b/src/components/pager/pager.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta, ArgsTable, Canvas, Story } from "@storybook/addon-docs";
 import { useState } from "react";
-import { action } from "@storybook/addon-actions";
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 
 import Pager from ".";

--- a/src/components/popover-container/popover-container.stories.mdx
+++ b/src/components/popover-container/popover-container.stories.mdx
@@ -16,7 +16,7 @@ import Badge from "../badge";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import isChromatic from "../../../.storybook/isChromatic";
 
-export const isOpenForChromatic = isChromatic();
+export const defaultOpenState = isChromatic();
 
 <Meta title="Popover Container" />
 
@@ -60,7 +60,7 @@ Use the `title` prop to set a title within the `PopoverContainer`.
 <Canvas>
   <Story name="title" parameters={{ info: { disable: true } }}>
     {() => {
-      const [open, setOpen] = useState(isOpenForChromatic);
+      const [open, setOpen] = useState(defaultOpenState);
       const onOpen = () => setOpen(true);
       const onClose = () => setOpen(false);
       return (
@@ -89,7 +89,7 @@ of the screen.
 <Canvas>
   <Story name="position" parameters={{ info: { disable: true } }}>
     {() => {
-      const [open, setOpen] = useState(isOpenForChromatic);
+      const [open, setOpen] = useState(defaultOpenState);
       const onOpen = () => setOpen(true);
       const onClose = () => setOpen(false);
       return (
@@ -118,7 +118,7 @@ Use the `shouldCoverButton` prop to hide the open button when the `PopoverContai
 <Canvas>
   <Story name="cover button" parameters={{ info: { disable: true } }}>
     {() => {
-      const [open, setOpen] = useState(isOpenForChromatic);
+      const [open, setOpen] = useState(defaultOpenState);
       const onOpen = () => setOpen(true);
       const onClose = () => setOpen(false);
       return (
@@ -249,7 +249,7 @@ You can easily use many different components to create your own composition.
 <Canvas>
   <Story name="complex" parameters={{ info: { disable: true } }}>
     {() => {
-      const [open, setOpen] = useState(isOpenForChromatic);
+      const [open, setOpen] = useState(defaultOpenState);
       const onOpen = () => setOpen(true);
       const onClose = () => setOpen(false);
       return (

--- a/src/components/select/filterable-select/filterable-select-test.stories.tsx
+++ b/src/components/select/filterable-select/filterable-select-test.stories.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import partialAction from "../../../__internal__/utils/storybook/partial-action";
+
+import { FilterableSelect, Option } from "..";
+
+export default {
+  component: FilterableSelect,
+  title: "Select/Filterable/Test",
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disable: true,
+    },
+  },
+};
+
+export const DefaultStory = () => (
+  <FilterableSelect
+    name="simple"
+    id="simple"
+    label="color"
+    labelInline
+    onOpen={partialAction("onOpen")}
+    onChange={partialAction("onChange")}
+    onClick={partialAction("onClick")}
+    onFilterChange={partialAction("onFilterChange")}
+    onFocus={partialAction("onFocus")}
+    onBlur={partialAction("onBlur")}
+    onKeyDown={partialAction("onKeyDown")}
+  >
+    <Option text="Amber" value="1" />
+    <Option text="Black" value="2" />
+    <Option text="Blue" value="3" />
+    <Option text="Brown" value="4" />
+    <Option text="Green" value="5" />
+    <Option text="Orange" value="6" />
+    <Option text="Pink" value="7" />
+    <Option text="Purple" value="8" />
+    <Option text="Red" value="9" />
+    <Option text="White" value="10" />
+    <Option text="Yellow" value="11" />
+  </FilterableSelect>
+);
+
+DefaultStory.storyName = "default";

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -2,7 +2,6 @@ import { Meta, ArgsTable, Canvas, Story } from "@storybook/addon-docs";
 import { useState, useRef } from "react";
 import StyledSystemProps from "../../../../.storybook/utils/styled-system-props";
 import TranslationKeysTable from "../../../../.storybook/utils/translation-keys-table";
-import partialAction from "../../../../.storybook/utils/partial-action";
 
 import Button from "../../button";
 import Dialog from "../../dialog";
@@ -49,13 +48,6 @@ you can filter through the existing options leaving only those that match the te
       id="simple"
       label="color"
       labelInline
-      onOpen={partialAction("onOpen")}
-      onChange={partialAction("onChange")}
-      onClick={partialAction("onClick")}
-      onFilterChange={partialAction("onFilterChange")}
-      onFocus={partialAction("onFocus")}
-      onBlur={partialAction("onBlur")}
-      onKeyDown={partialAction("onKeyDown")}
     >
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
@@ -135,7 +127,6 @@ You can use `listMaxHeight` prop to override default max height value of select 
       const [value, setValue] = useState("");
       function onChangeHandler(event) {
         setValue(event.target.value);
-        partialAction("value set")(event);
       }
       function clearValue() {
         setValue("");
@@ -625,13 +616,6 @@ In this example the `maxWidth` prop is 50%.
       id="simple"
       label="color"
       maxWidth="50%"
-      onOpen={partialAction("onOpen")}
-      onChange={partialAction("onChange")}
-      onClick={partialAction("onClick")}
-      onFilterChange={partialAction("onFilterChange")}
-      onFocus={partialAction("onFocus")}
-      onBlur={partialAction("onBlur")}
-      onKeyDown={partialAction("onKeyDown")}
     >
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
@@ -789,12 +773,6 @@ If there is no `id` prop specified on an object, then the exact objects will be 
               id={`${size} - ${validationType}`}
               label={`${size} - ${validationType}`}
               labelInline
-              onOpen={partialAction("onOpen")}
-              onChange={partialAction("onChange", { depth: 2 })}
-              onClick={partialAction("onClick", { depth: 2 })}
-              onFocus={partialAction("onFocus", { depth: 2 })}
-              onBlur={partialAction("onBlur", { depth: 2 })}
-              onKeyDown={partialAction("onKeyDown", { depth: 2 })}
               size={size}
               {...{ [validationType]: "Message" }}
               m={4}
@@ -816,12 +794,6 @@ If there is no `id` prop specified on an object, then the exact objects will be 
               id={`readOnly - ${size} - ${validationType}`}
               label={`readOnly - ${size} - ${validationType}`}
               labelInline
-              onOpen={partialAction("onOpen")}
-              onChange={partialAction("onChange", { depth: 2 })}
-              onClick={partialAction("onClick", { depth: 2 })}
-              onFocus={partialAction("onFocus", { depth: 2 })}
-              onBlur={partialAction("onBlur", { depth: 2 })}
-              onKeyDown={partialAction("onKeyDown", { depth: 2 })}
               size={size}
               {...{ [validationType]: "Message" }}
               readOnly

--- a/src/components/select/multi-select/multi-select-test.stories.tsx
+++ b/src/components/select/multi-select/multi-select-test.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { MultiSelect, Option } from "..";
+import partialAction from "../../../__internal__/utils/storybook/partial-action";
 
 export default {
   component: MultiSelect,
@@ -18,6 +19,7 @@ const Template = () => {
   const handleActivityChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.value.length <= MAX_SELECTIONS_ALLOWED) {
       setSelectedPills((event.target.value as unknown) as string[]);
+      partialAction("onChange");
     }
   };
   return (
@@ -25,6 +27,12 @@ const Template = () => {
       name="testing"
       value={selectedPills}
       onChange={handleActivityChange}
+      onOpen={partialAction("onOpen")}
+      onClick={partialAction("onClick")}
+      onFilterChange={partialAction("onFilterChange")}
+      onFocus={partialAction("onFocus")}
+      onBlur={partialAction("onBlur")}
+      onKeyDown={partialAction("onKeyDown")}
       disablePortal
       openOnFocus
       label="Test"

--- a/src/components/select/multi-select/multi-select.stories.mdx
+++ b/src/components/select/multi-select/multi-select.stories.mdx
@@ -3,7 +3,6 @@ import LinkTo from "@storybook/addon-links/react";
 import { useState, useRef } from "react";
 import StyledSystemProps from "../../../../.storybook/utils/styled-system-props";
 import TranslationKeysTable from "../../../../.storybook/utils/translation-keys-table";
-import partialAction from "../../../../.storybook/utils/partial-action";
 import Button from "../../button";
 import SelectTextbox from "../select-textbox/select-textbox.component";
 import { MultiSelect, Option, OptionRow } from "../";
@@ -47,13 +46,6 @@ you can filter through the existing options leaving only those that match the te
       id="simple"
       label="color"
       labelInline
-      onOpen={partialAction("onOpen")}
-      onChange={partialAction("onChange")}
-      onClick={partialAction("onClick")}
-      onFilterChange={partialAction("onFilterChange")}
-      onFocus={partialAction("onFocus")}
-      onBlur={partialAction("onBlur")}
-      onKeyDown={partialAction("onKeyDown")}
     >
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
@@ -560,13 +552,6 @@ In this example the `maxWidth` prop is 50%.
               id={`${size} - ${validationType}`}
               label={`${size} - ${validationType}`}
               labelInline
-              onOpen={partialAction("onOpen")}
-              onChange={partialAction("onChange")}
-              onClick={partialAction("onClick")}
-              onFilterChange={partialAction("onFilterChange")}
-              onFocus={partialAction("onFocus")}
-              onBlur={partialAction("onBlur")}
-              onKeyDown={partialAction("onKeyDown")}
               size={size}
               {...{ [validationType]: "Message" }}
               m={4}
@@ -588,13 +573,6 @@ In this example the `maxWidth` prop is 50%.
               id={`readOnly - ${size} - ${validationType}`}
               label={`readOnly - ${size} - ${validationType}`}
               labelInline
-              onOpen={partialAction("onOpen")}
-              onChange={partialAction("onChange")}
-              onClick={partialAction("onClick")}
-              onFilterChange={partialAction("onFilterChange")}
-              onFocus={partialAction("onFocus")}
-              onBlur={partialAction("onBlur")}
-              onKeyDown={partialAction("onKeyDown")}
               size={size}
               {...{ [validationType]: "Message" }}
               readOnly
@@ -631,13 +609,6 @@ setting the `wrapPillText` prop to false.
         name="long-pill-text-wrapped"
         id="long-pill-text-wrapped"
         label="long pill text wrapped"
-        onOpen={partialAction("onOpen")}
-        onChange={partialAction("onChange")}
-        onClick={partialAction("onClick")}
-        onFilterChange={partialAction("onFilterChange")}
-        onFocus={partialAction("onFocus")}
-        onBlur={partialAction("onBlur")}
-        onKeyDown={partialAction("onKeyDown")}
         wrapPillText
         defaultValue={["1"]}
       >

--- a/src/components/sidebar/sidebar.stories.tsx
+++ b/src/components/sidebar/sidebar.stories.tsx
@@ -10,10 +10,10 @@ import Textbox from "../textbox";
 
 import isChromatic from "../../../.storybook/isChromatic";
 
-const isOpenForChromatic = isChromatic();
+const defaultOpenState = isChromatic();
 
 export const DefaultStory: ComponentStory<typeof Sidebar> = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
@@ -37,7 +37,7 @@ export const DefaultStory: ComponentStory<typeof Sidebar> = () => {
 export const CustomPaddingAroundContent: ComponentStory<
   typeof Sidebar
 > = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
@@ -55,7 +55,7 @@ export const CustomPaddingAroundContent: ComponentStory<
 };
 
 export const WithHeader: ComponentStory<typeof Sidebar> = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
@@ -77,7 +77,7 @@ export const WithHeader: ComponentStory<typeof Sidebar> = () => {
 };
 
 export const WithScroll: ComponentStory<typeof Sidebar> = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
@@ -99,7 +99,7 @@ export const WithScroll: ComponentStory<typeof Sidebar> = () => {
 };
 
 export const WithTypography: ComponentStory<typeof Sidebar> = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
@@ -250,7 +250,7 @@ export const OtherFocusableContainers: ComponentStory<typeof Sidebar> = () => {
 OtherFocusableContainers.parameters = { chromatic: { disable: true } };
 
 export const CustomWidth: ComponentStory<typeof Sidebar> = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
@@ -275,7 +275,7 @@ export const CustomWidth: ComponentStory<typeof Sidebar> = () => {
 export const WithHeaderAndFooterPadding: ComponentStory<
   typeof Sidebar
 > = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>

--- a/src/components/tile/tile.stories.mdx
+++ b/src/components/tile/tile.stories.mdx
@@ -1,7 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import LinkTo from "@storybook/addon-links/react";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
-import { action } from "@storybook/addon-actions";
 
 import Tile from ".";
 

--- a/src/components/toast/toast-test.stories.tsx
+++ b/src/components/toast/toast-test.stories.tsx
@@ -43,6 +43,7 @@ export const Default = ({
   };
   const handleOpen = () => {
     setIsOpen(!isOpen);
+    action("open")(!isOpen);
   };
   if (scrollablePage) {
     return (

--- a/src/components/toast/toast.stories.tsx
+++ b/src/components/toast/toast.stories.tsx
@@ -6,7 +6,7 @@ import Button from "../button";
 import Icon from "../icon";
 import isChromatic from "../../../.storybook/isChromatic";
 
-const isOpenForChromatic = isChromatic();
+const defaultOpenState = isChromatic();
 
 const StyledButton = styled(Button)<{ isOpen: boolean }>`
   position: absolute;
@@ -312,7 +312,7 @@ export const DismissibleWithTimeout = () => {
 };
 
 export const DismissibleWithoutAutoFocus = () => {
-  const [isOpen, setIsOpen] = useState(isOpenForChromatic);
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
   const onDismissClick = () => {
     if (!isOpen) {
       window.scrollTo(0, 0);

--- a/src/components/toast/toast.stories.tsx
+++ b/src/components/toast/toast.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { action } from "@storybook/addon-actions";
 import styled from "styled-components";
 
 import Toast from ".";
@@ -26,7 +25,6 @@ export const Default = () => {
       window.scrollTo(0, 0);
     }
     setIsOpen(!isOpen);
-    action("open")(!isOpen);
   };
 
   return (
@@ -53,7 +51,6 @@ export const Info = () => {
       window.scrollTo(0, 0);
     }
     setIsOpen(!isOpen);
-    action("open")(!isOpen);
   };
 
   return (
@@ -80,7 +77,6 @@ export const Error = () => {
       window.scrollTo(0, 0);
     }
     setIsOpen(!isOpen);
-    action("open")(!isOpen);
   };
 
   return (
@@ -107,7 +103,6 @@ export const Warning = () => {
       window.scrollTo(0, 0);
     }
     setIsOpen(!isOpen);
-    action("open")(!isOpen);
   };
 
   return (
@@ -140,7 +135,6 @@ export const Notice = () => {
       window.scrollTo(0, 0);
     }
     setIsOpen(!isOpen);
-    action("open")(!isOpen);
   };
 
   return (
@@ -167,21 +161,14 @@ export const Notice = () => {
 
 export const LeftAligned = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const onDismissClick = (
-    ev?:
-      | KeyboardEvent
-      | React.KeyboardEvent<HTMLButtonElement>
-      | React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
+  const onDismissClick = () => {
     setIsOpen(!isOpen);
-    action("click")(ev);
   };
   const handleToggle = () => {
     if (!isOpen) {
       window.scrollTo(0, 0);
     }
     setIsOpen(!isOpen);
-    action("open")(!isOpen);
   };
 
   return (
@@ -209,21 +196,14 @@ export const LeftAligned = () => {
 
 export const CustomMaxWidth = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const onDismissClick = (
-    ev?:
-      | KeyboardEvent
-      | React.KeyboardEvent<HTMLButtonElement>
-      | React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
+  const onDismissClick = () => {
     setIsOpen(!isOpen);
-    action("click")(ev);
   };
   const handleToggle = () => {
     if (!isOpen) {
       window.scrollTo(0, 0);
     }
     setIsOpen(!isOpen);
-    action("open")(!isOpen);
   };
 
   return (
@@ -255,24 +235,17 @@ export const CustomMaxWidth = () => {
 
 export const Dismissible = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const onDismissClick = (
-    ev?:
-      | KeyboardEvent
-      | React.KeyboardEvent<HTMLButtonElement>
-      | React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
+  const onDismissClick = () => {
     if (!isOpen) {
       window.scrollTo(0, 0);
     }
     setIsOpen(!isOpen);
-    action("click")(ev);
   };
   const handleToggle = () => {
     if (!isOpen) {
       window.scrollTo(0, 0);
     }
     setIsOpen(!isOpen);
-    action("open")(!isOpen);
   };
 
   return (
@@ -301,24 +274,17 @@ export const Dismissible = () => {
 export const DismissibleWithTimeout = () => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const onDismissClick = (
-    ev?:
-      | KeyboardEvent
-      | React.KeyboardEvent<HTMLButtonElement>
-      | React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
+  const onDismissClick = () => {
     if (!isOpen) {
       window.scrollTo(0, 0);
     }
     setIsOpen(!isOpen);
-    action("click")(ev);
   };
   const handleToggle = () => {
     if (!isOpen) {
       window.scrollTo(0, 0);
     }
     setIsOpen(!isOpen);
-    action("open")(!isOpen);
   };
 
   return (
@@ -389,23 +355,11 @@ export const StackedDelayed = () => {
   const [isOpenB, setIsOpenB] = useState(false);
   const [buttonDisabled, setButtonDisabled] = useState(false);
 
-  const onDismissClickA = (
-    ev?:
-      | KeyboardEvent
-      | React.KeyboardEvent<HTMLButtonElement>
-      | React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
+  const onDismissClickA = () => {
     setIsOpenA(!isOpenA);
-    action("click")(ev);
   };
-  const onDismissClickB = (
-    ev?:
-      | KeyboardEvent
-      | React.KeyboardEvent<HTMLButtonElement>
-      | React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
+  const onDismissClickB = () => {
     setIsOpenB(!isOpenB);
-    action("click")(ev);
   };
 
   const handleToggle = () => {
@@ -419,7 +373,6 @@ export const StackedDelayed = () => {
         setIsOpenB(true);
         setButtonDisabled(false);
       }, 1000);
-      action("open")(true);
     } else {
       setButtonDisabled(true);
       setIsOpenA(false);
@@ -468,23 +421,11 @@ export const StackedDelayed = () => {
 export const Stacked = () => {
   const [isOpenA, setIsOpenA] = useState(false);
   const [isOpenB, setIsOpenB] = useState(false);
-  const onDismissClickA = (
-    ev?:
-      | KeyboardEvent
-      | React.KeyboardEvent<HTMLButtonElement>
-      | React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
+  const onDismissClickA = () => {
     setIsOpenA(!isOpenA);
-    action("click")(ev);
   };
-  const onDismissClickB = (
-    ev?:
-      | KeyboardEvent
-      | React.KeyboardEvent<HTMLButtonElement>
-      | React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
+  const onDismissClickB = () => {
     setIsOpenB(!isOpenB);
-    action("click")(ev);
   };
 
   const handleToggle = () => {
@@ -494,7 +435,6 @@ export const Stacked = () => {
     if (!isOpenA && !isOpenB) {
       setIsOpenA(true);
       setIsOpenB(true);
-      action("open")(true);
     } else {
       setIsOpenA(false);
       setIsOpenB(false);


### PR DESCRIPTION
### Proposed behaviour

Internal utils should not be used in code examples to not confuse Carbon users

### Current behaviour

internal utils like `partialAction` or storybook `action` are used in code examples

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Related issues linked in commit messages if required~~
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
~~- [ ] Unit tests added or updated if required~~
~~- [ ] Cypress automation tests added or updated if required~~
- [x] Storybook added or updated if required
~~- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required~~
~~- [ ] Typescript `d.ts` file added or updated if required~~

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
