### PR TITLE
feat(card): add height prop (FE-5560)

### DIFF
--- a/src/components/card/card.component.tsx
+++ b/src/components/card/card.component.tsx
@@ -30,6 +30,8 @@ export interface CardProps extends MarginProps {
   children: React.ReactNode;
   /** Flag to indicate if card is draggable */
   draggable?: boolean;
+  /** Height of the component (any valid CSS value) */
+  height?: string;
   /** Flag to indicate if card is interactive */
   interactive?: boolean;
   /** Size of card for applying padding */
@@ -54,6 +56,7 @@ const Card = ({
   children,
   cardWidth = "500px",
   draggable,
+  height,
   interactive,
   spacing = "medium",
   boxShadow,
@@ -117,6 +120,7 @@ const Card = ({
       boxShadow={boxShadow}
       hoverBoxShadow={hoverBoxShadow}
       onClick={interactive && !draggable ? action : undefined}
+      height={height}
       {...(interactive && { tabIndex: 0, type: "button" })}
       {...filterStyledSystemMarginProps(rest)}
     >

--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -115,6 +115,12 @@ Click on the card to see the effect
   <Story name="with string as child" story={stories.WithStringAsChild} />
 </Canvas>
 
+## With custom height
+
+<Canvas>
+  <Story name="with custom height" story={stories.WithCustomHeight} />
+</Canvas>
+
 ## With draggable
 
 By using the `draggable` prop, Cards can be implemented to be draggable.

--- a/src/components/card/card.stories.tsx
+++ b/src/components/card/card.stories.tsx
@@ -55,6 +55,9 @@ LargeSpacing.args = { spacing: "large" };
 export const WithCardWidthProvided = DefaultStory.bind({});
 WithCardWidthProvided.args = { cardWidth: "500px" };
 
+export const WithCustomHeight = DefaultStory.bind({});
+WithCustomHeight.args = { height: "500px" };
+
 export const Interactive: StoryFn = () => {
   const [clickCounter, setClickCounter] = useState(0);
   return (

--- a/src/components/card/card.style.ts
+++ b/src/components/card/card.style.ts
@@ -17,6 +17,7 @@ export interface StyledCardProps extends MarginProps {
   cardWidth: string;
   interactive: boolean;
   draggable: boolean;
+  height?: string;
   spacing: CardSpacing;
   boxShadow?: BoxShadowsType;
   hoverBoxShadow?: BoxShadowsType;
@@ -26,6 +27,7 @@ const StyledCard = styled.div<StyledCardProps>`
     cardWidth,
     interactive,
     draggable,
+    height,
     spacing,
     boxShadow = "boxShadow050",
     hoverBoxShadow = "boxShadow100",
@@ -34,12 +36,16 @@ const StyledCard = styled.div<StyledCardProps>`
     border: none;
     box-shadow: var(--${boxShadow});
     color: var(--colorsUtilityYin090);
+    display: flex;
+    flex-direction: column;
+    height: ${height};
+    justify-content: space-between;
     margin: 25px;
+    outline: none;
     padding: ${paddingSizes[spacing]};
     transition: all 0.3s ease-in-out;
     vertical-align: top;
     width: ${cardWidth};
-    outline: none;
     ${margin}
 
     ${interactive &&

--- a/src/components/card/card.test.js
+++ b/src/components/card/card.test.js
@@ -328,6 +328,16 @@ context("Tests for Card component", () => {
       }
     );
 
+    it.each([375, 535, 777])(
+      "should check %s height for Card component",
+      (height) => {
+        CypressMountWithProviders(<CardComponent height={`${height}px`} />);
+        card().then(($el) => {
+          useJQueryCssValueAndAssert($el, "height", height);
+        });
+      }
+    );
+
     it("should call onClick callback when a click event is triggered", () => {
       const setClickCounter = cy.stub();
 


### PR DESCRIPTION
### Proposed behaviour

Add height prop and change the card display to flex, to allow content to match the card size

### Current behaviour

Component height could not be customised

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
~~- [ ] Related issues linked in commit messages if required~~
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
~~- [ ] Unit tests added or updated if required~~
~~- [ ] Cypress automation tests added or updated if required~~
- [x] Storybook added or updated if required
~~- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required~~
~~- [ ] Typescript `d.ts` file added or updated if required~~
~~- [ ] Related docs have been updated if required~~

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
