### PR TITLE
fix(pager): correctly associate labels to input fields

### DIFF
--- a/src/components/pager/__internal__/pager-navigation.component.js
+++ b/src/components/pager/__internal__/pager-navigation.component.js
@@ -9,7 +9,6 @@ import NumberInput from "../../number";
 import Events from "../../../__internal__/utils/helpers/events";
 import createGuid from "../../../__internal__/utils/helpers/guid";
 import PagerNavigationLink from "./pager-navigation-link.component";
-import Label from "../../../__internal__/label";
 import useLocale from "../../../hooks/__internal__/useLocale";
 
 const PagerNavigation = ({
@@ -109,19 +108,19 @@ const PagerNavigation = ({
       {!hasOnePage && renderButtonsBeforeCount()}
       {showPageCount && (
         <StyledPagerNavInner>
-          <StyledPagerNoSelect>{l.pager.pageX()}</StyledPagerNoSelect>
-          <Label htmlFor={currentPageId}>
-            <NumberInput
-              value={currentPage.toString()}
-              data-element="current-page"
-              onChange={handleCurrentPageChange}
-              onBlur={handlePageInputChange}
-              id={currentPageId}
-              onKeyUp={(ev) =>
-                Events.isEnterKey(ev) ? handlePageInputChange(ev) : false
-              }
-            />
-          </Label>
+          <label htmlFor={currentPageId}>
+            <StyledPagerNoSelect>{l.pager.pageX()}</StyledPagerNoSelect>
+          </label>
+          <NumberInput
+            value={currentPage.toString()}
+            data-element="current-page"
+            onChange={handleCurrentPageChange}
+            onBlur={handlePageInputChange}
+            id={currentPageId}
+            onKeyUp={(ev) =>
+              Events.isEnterKey(ev) ? handlePageInputChange(ev) : false
+            }
+          />
           <StyledPagerNoSelect>{l.pager.ofY(pageCount)}</StyledPagerNoSelect>
         </StyledPagerNavInner>
       )}

--- a/src/components/pager/__internal__/pager-navigation.spec.js
+++ b/src/components/pager/__internal__/pager-navigation.spec.js
@@ -48,7 +48,7 @@ describe("Pager Navigation", () => {
     assertStyleMatch(
       {
         padding: "0",
-        margin: "8px 4px 0 4px",
+        margin: "4px",
         lineHeight: "26px",
         minHeight: "24px",
       },

--- a/src/components/pager/pager.component.js
+++ b/src/components/pager/pager.component.js
@@ -1,10 +1,11 @@
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 
 import { Select } from "../select";
 import PagerNavigation from "./__internal__/pager-navigation.component";
 import Option from "../select/option/option.component";
 import useLocale from "../../hooks/__internal__/useLocale";
+import createGuid from "../../__internal__/utils/helpers/guid";
 import {
   StyledPagerContainer,
   StyledPagerSizeOptions,
@@ -43,6 +44,9 @@ const Pager = ({
   const [page, setPage] = useState(currentPage);
   const [currentPageSize, setCurrentPageSize] = useState(pageSize);
   const [value, setValue] = useState(pageSize);
+
+  const guid = useRef(createGuid());
+  const pageSizeSelectId = `Pager_size_selector_${guid.current}`;
 
   const getPageCount = useCallback(() => {
     if (Number(totalRecords) < 0 || Number.isNaN(Number(totalRecords))) {
@@ -138,6 +142,7 @@ const Pager = ({
           onBlur={() => setValue(currentPageSize)}
           onKeyDown={handleKeyDown}
           data-element="page-select"
+          id={pageSizeSelectId}
         >
           {pageSizeSelectionOptions.map((sizeOption) => (
             <Option
@@ -156,7 +161,9 @@ const Pager = ({
     return (
       showPageSizeSelection && (
         <StyledPagerSizeOptionsInner>
-          {showPageSizeLabelBefore && <span>{l.pager.show()}</span>}
+          {showPageSizeLabelBefore && (
+            <label htmlFor={pageSizeSelectId}>{l.pager.show()}</label>
+          )}
           {sizeSelector()}
           {showPageSizeLabelAfter && (
             <div>{l.pager.records(currentPageSize, false)}</div>

--- a/src/components/pager/pager.spec.js
+++ b/src/components/pager/pager.spec.js
@@ -271,7 +271,7 @@ describe("Pager", () => {
         wrapper.find(StyledPagerSizeOptionsInner).getDOMNode().firstChild
           .textContent
       ).toEqual(
-        wrapper.find(StyledPagerSizeOptionsInner).find("span").first().text()
+        wrapper.find(StyledPagerSizeOptionsInner).find("label").first().text()
       );
       expect(wrapper.find(StyledPagerSizeOptionsInner).exists()).toBeTruthy();
       expect(
@@ -311,7 +311,7 @@ describe("Pager", () => {
         wrapper.find(StyledPagerSizeOptionsInner).getDOMNode().firstChild
           .textContent
       ).toEqual(
-        wrapper.find(StyledPagerSizeOptionsInner).find("span").first().text()
+        wrapper.find(StyledPagerSizeOptionsInner).find("label").first().text()
       );
       expect(
         wrapper.find(StyledPagerSizeOptionsInner).getDOMNode().lastChild

--- a/src/components/pager/pager.style.js
+++ b/src/components/pager/pager.style.js
@@ -79,7 +79,7 @@ const StyledPagerNavigation = styled.div`
 
   && ${StyledInputPresentation} {
     padding: 0;
-    margin: 8px 4px 0 4px;
+    margin: 4px;
     height: 26px;
     line-height: 26px;
     min-height: 24px;
@@ -96,6 +96,7 @@ const StyledPagerNavInner = styled.div`
   display: flex;
   align-items: center;
   padding: 0 12px;
+  margin: 4px 0;
 
   && ${StyledFormField} {
     margin-bottom: 0;
@@ -111,6 +112,7 @@ const StyledPagerLinkStyles = styled(Link)`
 const StyledPagerNoSelect = styled.div`
   user-select: none;
   white-space: nowrap;
+  font-weight: normal;
 `;
 
 const StyledPagerSummary = styled.div`


### PR DESCRIPTION
Neither the numeric input for page number nor the page size select had a label that was programatically associated to the input and contained descriptive text. This is now fixed.

fix #5284 and #5632

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

In the Pager component, both the numeric input showing the current page number, and the select for the page size (if present due to the `showPageSizeSelection` prop), should have a meaningful label which is correctly associated in HTML with the corresponding input.

This has the following benefits:
- screenreader users will get an indication of what the input is for when browsing the page (eg asking for a list of inputs, or navigating via the tab key)
- mouse users will be able to click on the label and have the input automatically focused

### Current behaviour

Both the select and the numeric input fail to associate labels properly with the input - although in different ways:
- the page size select has no label at all (the text "show" is a separate <span> element). This results in a "critical" error on Axe for "form inputs must have labels)
- the numeric input does have an associated <label> element (hence Axe doesn't complain here) but that label element has no text inside it. The word "page" is in its own div and not associated with the input at all.

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
