### PR TITLE
fix(pager): fix bottom margin of number input when inside a form

### DIFF
--- a/cypress/locators/pager/index.js
+++ b/cypress/locators/pager/index.js
@@ -9,6 +9,7 @@ import {
   PAGER_LAST_ARROW,
   SHOW_LABEL_BEFORE,
   PAGE_SIZE_LABEL_AFTER,
+  CURRENT_PAGE,
 } from "./locators";
 import { COMMMON_DATA_ELEMENT_INPUT } from "../locators";
 import { getDataElementByValue } from "..";
@@ -19,6 +20,7 @@ export const pageSelect = () =>
   cy.get(PAGE_SELECT).find(COMMMON_DATA_ELEMENT_INPUT);
 export const pageSelectElement = () => cy.get(PAGE_SELECT);
 export const maxPages = () => cy.get(MAX_PAGES);
+export const currentPageWrapper = () => cy.get(CURRENT_PAGE);
 export const currentPageInput = () => cy.get(PAGER_SUMMARY).find("input");
 export const previousArrow = () =>
   getDataElementByValue(`${COMMON_PART_OF_PAGER_LINK}${PAGER_PREVIOUS_ARROW}`);

--- a/cypress/locators/pager/locators.js
+++ b/cypress/locators/pager/locators.js
@@ -10,3 +10,4 @@ export const PAGER_LAST_ARROW = "last";
 export const COMMON_PART_OF_PAGER_LINK = "pager-link-";
 export const SHOW_LABEL_BEFORE = "Show";
 export const PAGE_SIZE_LABEL_AFTER = "items";
+export const CURRENT_PAGE = '[data-element="current-page"]';

--- a/src/components/pager/pager.spec.js
+++ b/src/components/pager/pager.spec.js
@@ -572,7 +572,7 @@ describe("Pager", () => {
       assertStyleMatch(
         { marginBottom: "0" },
         wrapper.find(StyledPagerNavInner),
-        { modifier: `${StyledFormField}` }
+        { modifier: `&& ${StyledFormField}` }
       );
     });
   });

--- a/src/components/pager/pager.style.js
+++ b/src/components/pager/pager.style.js
@@ -97,7 +97,7 @@ const StyledPagerNavInner = styled.div`
   align-items: center;
   padding: 0 12px;
 
-  & ${StyledFormField} {
+  && ${StyledFormField} {
     margin-bottom: 0;
   }
 `;

--- a/src/components/pager/pager.test.js
+++ b/src/components/pager/pager.test.js
@@ -8,6 +8,7 @@ import {
   nextArrow,
   firstArrow,
   lastArrow,
+  currentPageWrapper,
   currentPageInput,
   pagerSummary,
   pageSelectElement,
@@ -22,6 +23,7 @@ import { keyCode } from "../../../cypress/support/helper";
 import useMediaQuery from "../../hooks/useMediaQuery";
 import { checkGoldenOutline } from "../../../cypress/support/component-helper/common-steps";
 import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+import Form from "../form";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const records = [
@@ -136,6 +138,14 @@ const PagerComponentResponsive = () => {
       {...responsiveProps()}
       pageSizeSelectionOptions={records}
     />
+  );
+};
+
+const PagerInForm = () => {
+  return (
+    <Form>
+      <PagerComponent />
+    </Form>
   );
 };
 
@@ -531,5 +541,13 @@ context("Test for Pager component", () => {
           });
       }
     );
+  });
+
+  describe("when inside a form component", () => {
+    it("should have no bottom margin", () => {
+      CypressMountWithProviders(<PagerInForm />);
+
+      currentPageWrapper().should("have.css", "margin-bottom", "0px");
+    });
   });
 });


### PR DESCRIPTION
Ensure the "current page" input field of Pager always has margin-bottom 0, even when inside a form.

Note - this is a fix for the change already merged from [this PR](https://github.com/Sage/carbon/pull/5660), which doesn't always work due to CSS rules having the same specificity. This PR increases the specificity of the `margin-bottom: 0` in Pager and adds a Cypress test to ensure the correct CSS is applies in the browser.

fix #5650 (properly this time!)

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
