### PR TITLE
fix(tab): ensure that validation failures are no longer reported when children unmount FE-5527

### DIFF
--- a/src/__internal__/form-field/form-field.component.tsx
+++ b/src/__internal__/form-field/form-field.component.tsx
@@ -143,9 +143,9 @@ const FormField = ({
   }, []);
 
   useEffect(() => {
-    if (setError) setError(id, !!error);
-    if (setWarning) setWarning(id, !!warning);
-    if (setInfo) setInfo(id, !!info);
+    if (setError) setError(id, error);
+    if (setWarning) setWarning(id, warning);
+    if (setInfo) setInfo(id, info);
 
     return () => {
       if (!isMounted.current) {

--- a/src/__internal__/form-field/form-field.component.tsx
+++ b/src/__internal__/form-field/form-field.component.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useEffect, useMemo } from "react";
+import React, {
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
 
 import { ValidationProps } from "__internal__/validations";
 import { MarginProps } from "styled-system";
@@ -126,10 +132,28 @@ const FormField = ({
     TabContext
   );
 
+  const isMounted = useRef(false);
+
+  useLayoutEffect(() => {
+    isMounted.current = true;
+
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
   useEffect(() => {
     if (setError) setError(id, !!error);
     if (setWarning) setWarning(id, !!warning);
     if (setInfo) setInfo(id, !!info);
+
+    return () => {
+      if (!isMounted.current) {
+        if (setError && error) setError(id, false);
+        if (setWarning && warning) setWarning(id, false);
+        if (setInfo && info) setInfo(id, false);
+      }
+    };
   }, [id, setError, setWarning, setInfo, error, warning, info]);
 
   const marginProps = filterStyledSystemMarginProps(rest);

--- a/src/components/tabs/tab/tab.component.js
+++ b/src/components/tabs/tab/tab.component.js
@@ -31,27 +31,27 @@ const Tab = ({
   const [tabInfos, setTabInfos] = useState({});
 
   const setError = useCallback(
-    (childId, hasError) => {
-      if (tabErrors[childId] !== hasError) {
-        setTabErrors({ ...tabErrors, [childId]: hasError });
+    (childId, error) => {
+      if (tabErrors[childId] !== error) {
+        setTabErrors({ ...tabErrors, [childId]: error });
       }
     },
     [tabErrors]
   );
 
   const setWarning = useCallback(
-    (childId, hasWarning) => {
-      if (tabWarnings[childId] !== hasWarning) {
-        setTabWarnings({ ...tabWarnings, [childId]: hasWarning });
+    (childId, warning) => {
+      if (tabWarnings[childId] !== warning) {
+        setTabWarnings({ ...tabWarnings, [childId]: warning });
       }
     },
     [tabWarnings]
   );
 
   const setInfo = useCallback(
-    (childId, hasInfo) => {
-      if (tabInfos[childId] !== hasInfo) {
-        setTabInfos({ ...tabInfos, [childId]: hasInfo });
+    (childId, info) => {
+      if (tabInfos[childId] !== info) {
+        setTabInfos({ ...tabInfos, [childId]: info });
       }
     },
     [tabInfos]

--- a/src/components/tabs/tab/tab.d.ts
+++ b/src/components/tabs/tab/tab.d.ts
@@ -2,9 +2,9 @@ import * as React from "react";
 import { PaddingProps } from "styled-system";
 
 export interface TabContextProps {
-  setError?: (childId: string, hasError: boolean) => void;
-  setWarning?: (childId: string, hasWarning: boolean) => void;
-  setInfo?: (childId: string, hasInfo: boolean) => void;
+  setError?: (childId: string, error?: boolean | string) => void;
+  setWarning?: (childId: string, warning?: boolean | string) => void;
+  setInfo?: (childId: string, info?: boolean | string) => void;
 }
 
 export interface TabProps extends PaddingProps {

--- a/src/components/tabs/tabs.component.js
+++ b/src/components/tabs/tabs.component.js
@@ -38,6 +38,7 @@ const Tabs = ({
   variant = "default",
   validationStatusOverride,
   headerWidth,
+  showValidationsSummary,
   ...rest
 }) => {
   /** The children nodes converted into an Array */
@@ -70,27 +71,27 @@ const Tabs = ({
   const [tabsInfos, setTabsInfos] = useState({});
 
   const updateErrors = useCallback(
-    (id, hasError) => {
-      if (tabsErrors[id] !== hasError) {
-        setTabsErrors({ ...tabsErrors, [id]: hasError });
+    (id, error) => {
+      if (tabsErrors[id] !== error) {
+        setTabsErrors({ ...tabsErrors, [id]: error });
       }
     },
     [tabsErrors]
   );
 
   const updateWarnings = useCallback(
-    (id, hasWarning) => {
-      if (tabsWarnings[id] !== hasWarning) {
-        setTabsWarnings({ ...tabsWarnings, [id]: hasWarning });
+    (id, warning) => {
+      if (tabsWarnings[id] !== warning) {
+        setTabsWarnings({ ...tabsWarnings, [id]: warning });
       }
     },
     [tabsWarnings]
   );
 
   const updateInfos = useCallback(
-    (id, hasInfo) => {
-      if (tabsInfos[id] !== hasInfo) {
-        setTabsInfos({ ...tabsInfos, [id]: hasInfo });
+    (id, info) => {
+      if (tabsInfos[id] !== info) {
+        setTabsInfos({ ...tabsInfos, [id]: info });
       }
     },
     [tabsInfos]
@@ -206,19 +207,16 @@ const Tabs = ({
         customLayout,
       } = child.props;
       const refId = `${tabId}-tab`;
+      const errors = tabsErrors[tabId];
+      const warnings = tabsWarnings[tabId];
+      const infos = tabsInfos[tabId];
 
-      const errors = tabsErrors[tabId]
-        ? Object.entries(tabsErrors[tabId]).filter((tab) => tab[1] === true)
-            .length
-        : 0;
-      const warnings = tabsWarnings[tabId]
-        ? Object.entries(tabsWarnings[tabId]).filter((tab) => tab[1] === true)
-            .length
-        : 0;
-      const infos = tabsInfos[tabId]
-        ? Object.entries(tabsInfos[tabId]).filter((tab) => tab[1] === true)
-            .length
-        : 0;
+      const errorsCount =
+        errors && Object.entries(errors).filter((tab) => tab[1]).length;
+      const warningsCount =
+        warnings && Object.entries(warnings).filter((tab) => tab[1]).length;
+      const infosCount =
+        infos && Object.entries(infos).filter((tab) => tab[1]).length;
 
       const hasOverride =
         validationStatusOverride && validationStatusOverride[tabId];
@@ -228,15 +226,31 @@ const Tabs = ({
         hasOverride && validationStatusOverride[tabId].warning;
       const infoOverride = hasOverride && validationStatusOverride[tabId].info;
       const tabHasError =
-        errorOverride !== undefined ? errorOverride : errors > 0;
+        errorOverride !== undefined ? errorOverride : !!errorsCount;
       const tabHasWarning =
         warningOverride !== undefined
           ? warningOverride
-          : warnings > 0 && !tabHasError;
+          : !!warningsCount && !tabHasError;
       const tabHasInfo =
         infoOverride !== undefined
           ? infoOverride
-          : infos > 0 && !tabHasError && !tabHasWarning;
+          : !!infosCount && !tabHasError && !tabHasWarning;
+
+      const getValidationMessage = (message, validations = {}) => {
+        const summaryOfMessages = Object.values(validations).filter(
+          (value) => value && typeof value === "string"
+        );
+
+        if (!showValidationsSummary || !summaryOfMessages.length) {
+          return message;
+        }
+
+        if (summaryOfMessages.length === 1) {
+          return summaryOfMessages[0];
+        }
+
+        return summaryOfMessages.map((value) => `• ${value}`).join("\n");
+      };
 
       const tabTitle = (
         <TabTitle
@@ -259,9 +273,9 @@ const Tabs = ({
           borders={borders !== "off"}
           siblings={siblings}
           titlePosition={titlePosition}
-          errorMessage={errorMessage}
-          warningMessage={warningMessage}
-          infoMessage={infoMessage}
+          errorMessage={getValidationMessage(errorMessage, errors)}
+          warningMessage={getValidationMessage(warningMessage, warnings)}
+          infoMessage={getValidationMessage(infoMessage, infos)}
           alternateStyling={variant === "alternate"}
           noLeftBorder={["no left side", "no sides"].includes(borders)}
           noRightBorder={["no right side", "no sides"].includes(borders)}
@@ -408,6 +422,10 @@ Tabs.propTypes = {
       info: PropTypes.bool,
     }),
   }),
+  /** When this prop is set any string validation failures in the children of each Tab
+   * will be summaraised in the Tooltip next to the Tab title
+   */
+  showValidationsSummary: PropTypes.bool,
 };
 
 export { Tabs, Tab };

--- a/src/components/tabs/tabs.d.ts
+++ b/src/components/tabs/tabs.d.ts
@@ -40,6 +40,10 @@ export interface TabsProps extends MarginProps {
       info?: boolean;
     };
   };
+  /** When this prop is set any string validation failures in the children of each Tab
+   * will be summaraised in the Tooltip next to the Tab title
+   */
+  showValidationsSummary?: boolean;
 }
 
 declare function Tabs(props: TabsProps): JSX.Element;

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -17,6 +17,8 @@ import {
 } from "../../__spec_helper__/test-utils";
 import { StyledTabsHeaderWrapper } from "./__internal__/tabs-header/tabs-header.style";
 import { DrawerSidebarContext } from "../drawer";
+import Textbox from "../textbox";
+import ValidationIcon from "../../__internal__/validations";
 
 function render(props, mountOptions) {
   return mount(
@@ -930,5 +932,43 @@ describe("Tabs", () => {
         rootTagTest(wrapper, "tabs", "bar", "baz");
       });
     });
+  });
+
+  describe("when children of Tab have validation failures", () => {
+    const MockComponent = ({ show = true, error, warning, info }) => (
+      <Tabs data-element="bar" data-role="baz">
+        <Tab
+          tabId="1"
+          title="Test"
+          errorMessage=""
+          warningMessage=""
+          infoMessage=""
+        >
+          {show && (
+            <Textbox
+              value="foo"
+              onChange={() => {}}
+              error={error}
+              warning={warning}
+              info={info}
+            />
+          )}
+        </Tab>
+      </Tabs>
+    );
+
+    it.each(["error", "warning", "info"])(
+      "any %s failure in a child component is correctly reported in the TabTitle",
+      (validation) => {
+        const validationProp = { [validation]: true };
+        const wrapper = mount(<MockComponent {...validationProp} />);
+
+        expect(wrapper.find(ValidationIcon).exists()).toBe(true);
+
+        wrapper.setProps({ show: false });
+        wrapper.update();
+        expect(wrapper.update().find(ValidationIcon).exists()).toBe(false);
+      }
+    );
   });
 });

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -971,4 +971,117 @@ describe("Tabs", () => {
       }
     );
   });
+
+  describe.each(["error", "warning", "info"])(
+    "showValidationsSummary",
+    (validation) => {
+      it(`passes the ${validation} validation failures from the child inputs to the Tab's title when they are strings`, () => {
+        const message = mount(
+          <Tabs data-element="bar" data-role="baz" showValidationsSummary>
+            <Tab tabId="1" title="Test">
+              <Textbox
+                value="foo"
+                onChange={() => {}}
+                {...{ [validation]: validation }}
+              />
+              <Textbox
+                value="foo"
+                onChange={() => {}}
+                {...{ [validation]: validation }}
+              />
+              <Textbox
+                value="foo"
+                onChange={() => {}}
+                {...{ [validation]: validation }}
+              />
+            </Tab>
+          </Tabs>
+        )
+          .find(TabTitle)
+          .prop(`${validation}Message`);
+
+        expect(message).toEqual(
+          `• ${validation}\n• ${validation}\n• ${validation}`
+        );
+      });
+
+      it(`does not pass the ${validation} validation failures from the child inputs to the Tab's title when they are not strings`, () => {
+        const message = mount(
+          <Tabs data-element="bar" data-role="baz" showValidationsSummary>
+            <Tab tabId="1" title="Test">
+              <Textbox
+                value="foo"
+                onChange={() => {}}
+                {...{ [validation]: validation }}
+              />
+              <Textbox
+                value="foo"
+                onChange={() => {}}
+                {...{ [validation]: validation }}
+              />
+              <Textbox
+                value="foo"
+                onChange={() => {}}
+                {...{ [validation]: true }}
+              />
+            </Tab>
+          </Tabs>
+        )
+          .find(TabTitle)
+          .prop(`${validation}Message`);
+
+        expect(message).toEqual(`• ${validation}\n• ${validation}`);
+      });
+
+      it(`does not add a "•" when there is only one string ${validation} validation failure`, () => {
+        const message = mount(
+          <Tabs data-element="bar" data-role="baz" showValidationsSummary>
+            <Tab tabId="1" title="Test">
+              <Textbox
+                value="foo"
+                onChange={() => {}}
+                {...{ [validation]: validation }}
+              />
+            </Tab>
+          </Tabs>
+        )
+          .find(TabTitle)
+          .prop(`${validation}Message`);
+
+        expect(message).toEqual(validation);
+      });
+
+      it(`passes the ${validation}Message if there is only boolean ${validation} validation failures`, () => {
+        const message = mount(
+          <Tabs data-element="bar" data-role="baz" showValidationsSummary>
+            <Tab
+              tabId="1"
+              title="Test"
+              {...{ [`${validation}Message`]: `${validation} message` }}
+            >
+              <Textbox
+                value="foo"
+                onChange={() => {}}
+                {...{ [validation]: true }}
+              />
+              <Textbox
+                value="foo"
+                onChange={() => {}}
+                {...{ [validation]: true }}
+              />
+              <Textbox
+                value="foo"
+                onChange={() => {}}
+                {...{ [validation]: true }}
+              />
+            </Tab>
+          </Tabs>
+        )
+          .find(TabTitle)
+          .prop(`${validation}Message`);
+
+        expect(message).toEqual(`${validation} message`);
+      });
+    }
+  );
 });

--- a/src/components/tabs/tabs.stories.mdx
+++ b/src/components/tabs/tabs.stories.mdx
@@ -1761,6 +1761,92 @@ CSS string.
   </Story>
 </Canvas>
 
+### With string validations summarised
+
+By default the strings passed to `errorMessage`, `warningMessage` and `infoMessage` props are what is 
+used in the validation tooltip. However, setting the `showValidationsSumary` prop allows for the 
+summarising of validation messages from the children of a given `Tab`. You can see an example of this 
+by hovering your mouse pointer over the `ValidationIcon`s in the example below.
+
+<Canvas>
+  <Story name="with string validations summarised" parameters={{ chromatic: { disable: true } }}>
+    {() => {
+      const [errors, setErrors] = useState({
+        one: 'This is an error',
+        two: 'Here is another error'
+      });
+      const [warnings, setWarnings] = useState({
+        one: 'This is a warning',
+        two: 'Here is another warning'
+      });
+      const [infos, setInfos] = useState({ 
+        one: 'This is an info', 
+        two: 'Here is another info'
+      });
+      return (
+        <div style={{ padding: "4px" }}>
+          <Tabs align="left" position="top" showValidationsSummary>
+            <Tab
+              tabId="tab-1"
+              title="Tab 1"
+              key="tab-1"
+            >
+              <Checkbox
+                label="Error 1"
+                error={errors.one}
+                onChange={e => e.target.checked ? setErrors({ ...errors, one: 'This is an error' }) : setErrors({ ...errors, one: '' })}
+                checked={errors.one}
+              />
+              <Checkbox
+                label="Error 2"
+                error={errors.two}
+                onChange={e => e.target.checked ? setErrors({ ...errors, two: 'Here is another error' }) : setErrors({ ...errors, two: '' })}
+                checked={errors.two}
+              />
+            </Tab>
+            <Tab
+              tabId="tab-2"
+              title="Tab 2"
+              key="tab-2"
+            >
+              <Checkbox
+                label="Warning 1"
+                warning={warnings.one}
+                onChange={e => e.target.checked ? setWarnings({ ...warnings, one: 'This is a warning' }) : setWarnings({ ...warnings, one: '' })}
+                checked={warnings.one}
+              />
+              <Checkbox
+                label="Warning 2"
+                warning={warnings.two}
+                onChange={e => e.target.checked ? setWarnings({ ...warnings, two: 'Here is another warning' }) : setWarnings({ ...warnings, two: '' })}
+                checked={warnings.two}
+              />
+            </Tab>
+            <Tab
+              tabId="tab-3"
+              title="Tab 3"
+              key="tab-3"
+            >
+              <Checkbox
+                label="Info 1"
+                info={infos.one}
+                onChange={e => e.target.checked ? setInfos({ ...infos, one: true }) : setInfos({ ...infos, one: '' })}
+                checked={infos.one}
+              />
+              <Checkbox
+                label="Info 2"
+                info={infos.two}
+                onChange={e => e.target.checked ? setInfos({ ...infos, two: 'This is a warning' }) : setInfos({ ...infos, two: '' })}
+                checked={infos.two}
+              />
+            </Tab>
+          </Tabs>
+        </div>
+      );
+    }}
+  </Story>
+</Canvas>
+
 ### Integrating with an external history
 
 It is possible to integrate the `Tabs` component with an external `history` to manipulate the location when a given `Tab`

--- a/src/components/tabs/tabs.test.js
+++ b/src/components/tabs/tabs.test.js
@@ -187,6 +187,32 @@ const TabsComponentValidations = ({ ...props }) => {
 };
 
 // eslint-disable-next-line react/prop-types
+const TabsComponentWithValidationsSummary = ({ validation }) => {
+  return (
+    <div
+      style={{
+        padding: "4px",
+      }}
+    >
+      <Tabs align="left" position="top" showValidationsSummary>
+        <Tab
+          errorMessage="error"
+          warningMessage="warning"
+          infoMessage="info"
+          tabId="tab-1"
+          title="Tab 1"
+          key="tab-1"
+        >
+          <Checkbox label="foo" {...validation} />
+          <Checkbox label="foo" {...validation} />
+          <Checkbox label="foo" {...validation} />
+        </Tab>
+      </Tabs>
+    </div>
+  );
+};
+
+// eslint-disable-next-line react/prop-types
 const TabsComponentValidationsUnregistering = ({ validation }) => {
   const [show, setShow] = React.useState(true);
 
@@ -591,6 +617,26 @@ context("Testing Tabs component", () => {
           .trigger("mouseover")
           .then(() => {
             tooltipPreview().should("have.text", validationMessage);
+          });
+      }
+    );
+
+    it.each(["error", "warning", "info"])(
+      "should verify when the ValidationIcon is hovered over that a summary of the %s messages is displayed",
+      (validationMessage) => {
+        const validation = { [validationMessage]: validationMessage };
+
+        CypressMountWithProviders(
+          <TabsComponentWithValidationsSummary validation={validation} />
+        );
+
+        tabById(1)
+          .trigger("mouseover")
+          .then(() => {
+            tooltipPreview().should(
+              "have.text",
+              `• ${validationMessage}\n• ${validationMessage}\n• ${validationMessage}`
+            );
           });
       }
     );

--- a/src/components/tabs/tabs.test.js
+++ b/src/components/tabs/tabs.test.js
@@ -186,6 +186,46 @@ const TabsComponentValidations = ({ ...props }) => {
   );
 };
 
+// eslint-disable-next-line react/prop-types
+const TabsComponentValidationsUnregistering = ({ validation }) => {
+  const [show, setShow] = React.useState(true);
+
+  return (
+    <div
+      style={{
+        padding: "4px",
+      }}
+    >
+      <button
+        data-element="foo-button"
+        type="button"
+        onClick={() => setShow(false)}
+      >
+        Hide Tab Child
+      </button>
+      <Tabs align="left" position="top">
+        <Tab
+          errorMessage="error"
+          warningMessage="warning"
+          infoMessage="info"
+          tabId="tab-1"
+          title="Tab 1"
+          key="tab-1"
+        >
+          {show && (
+            <Checkbox
+              label="Add error"
+              onChange={() => {}}
+              checked
+              {...validation}
+            />
+          )}
+        </Tab>
+      </Tabs>
+    </div>
+  );
+};
+
 const TabsValidationOverride = () => {
   const [validation, setValidation] = React.useState({
     error: true,
@@ -552,6 +592,21 @@ context("Testing Tabs component", () => {
           .then(() => {
             tooltipPreview().should("have.text", validationMessage);
           });
+      }
+    );
+
+    it.each(["error", "warning", "info"])(
+      "should no longer report the any validation failures of children no longer mounted",
+      (type) => {
+        const validation = { [type]: true };
+
+        CypressMountWithProviders(
+          <TabsComponentValidationsUnregistering validation={validation} />
+        );
+
+        getDataElementByValue("foo-button").click();
+
+        tabById(1).children().children().should("not.exist");
       }
     );
 


### PR DESCRIPTION
fix #5591
fix #5618

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Ensures that any validation failures reported to parent Tab components are removed when the
associated child unmounts.

![tabs validation fix](https://user-images.githubusercontent.com/44157880/205977195-ca3f1b84-a995-4681-992f-9a1c5f7f4f1e.gif)

Adds `showValidationsSummary` prop to `Tabs` to support the option of rendering a summary of any
validation string failures in the `ValidationIcon` `Tooltip`.

![image](https://user-images.githubusercontent.com/44157880/205975600-ecc647e7-da8f-4e09-a456-f571086eb471.png)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Validation failures are not removed when an input within a `Tab` unmounts
No support for rendering a summary of all validation string failures in the `ValidationIcon` `Tooltip`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
Use linked sandbox below for testing validation summary (linked issue has different implementation) and sandbox included in #5591

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/nostalgic-dawn-ubkcu0?file=/src/index.js