### PR TITLE
test(action-popover): refactor for accessibility

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -50,6 +50,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("contributing") &&
       !prepareUrl[0].startsWith("accordion") &&
       !prepareUrl[0].startsWith("alert") &&
+      !prepareUrl[0].startsWith("action-popover") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/action-popover/action-popover-test.stories.tsx
+++ b/src/components/action-popover/action-popover-test.stories.tsx
@@ -18,6 +18,7 @@ import {
 
 export default {
   title: "Action Popover/Test",
+  includeStories: "Default",
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -136,5 +137,180 @@ export const Default = () => {
         </FlatTableBody>
       </FlatTable>
     </div>
+  );
+};
+
+Default.storyName = "default";
+
+export const ActionPopoverCustom = ({ ...props }) => {
+  const submenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem data-element="submenu1" {...props}>
+        Sub Menu 1
+      </ActionPopoverItem>
+      <ActionPopoverItem {...props}>Sub Menu 2</ActionPopoverItem>
+      <ActionPopoverItem disabled>Sub Menu 3</ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+
+  const submenuWithIcons = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem icon="graph">Sub Menu 1</ActionPopoverItem>
+      <ActionPopoverItem icon="add">Sub Menu 2</ActionPopoverItem>
+      <ActionPopoverItem icon="print" disabled>
+        Sub Menu 3
+      </ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+
+  return (
+    <div
+      style={{
+        marginTop: "40px",
+        height: "275px",
+      }}
+    >
+      <FlatTable isZebra>
+        <FlatTableHead>
+          <FlatTableRow>
+            <FlatTableHeader>First Name</FlatTableHeader>
+            <FlatTableHeader>Last Name</FlatTableHeader>
+            <FlatTableHeader>&nbsp;</FlatTableHeader>
+          </FlatTableRow>
+        </FlatTableHead>
+        <FlatTableBody>
+          <FlatTableRow>
+            <FlatTableCell>John</FlatTableCell>
+            <FlatTableCell>Doe</FlatTableCell>
+            <FlatTableCell>
+              <ActionPopover>
+                <ActionPopoverItem
+                  disabled
+                  icon="graph"
+                  submenu={submenu}
+                  {...props}
+                >
+                  Business
+                </ActionPopoverItem>
+                <ActionPopoverItem icon="email" {...props}>
+                  Email Invoice
+                </ActionPopoverItem>
+                <ActionPopoverItem icon="print" {...props} submenu={submenu}>
+                  Print Invoice
+                </ActionPopoverItem>
+                <ActionPopoverItem icon="pdf" {...props} submenu={submenu}>
+                  Download PDF
+                </ActionPopoverItem>
+                <ActionPopoverItem icon="csv" {...props}>
+                  Download CSV
+                </ActionPopoverItem>
+                <ActionPopoverDivider />
+                <ActionPopoverItem icon="delete" {...props}>
+                  Delete
+                </ActionPopoverItem>
+              </ActionPopover>
+            </FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableCell>Jane</FlatTableCell>
+            <FlatTableCell>Smith</FlatTableCell>
+            <FlatTableCell>
+              <ActionPopover>
+                <ActionPopoverItem
+                  download
+                  {...props}
+                  icon="download"
+                  href="example-img.jpg"
+                >
+                  Download
+                </ActionPopoverItem>
+              </ActionPopover>
+            </FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow>
+            <FlatTableCell>Bob</FlatTableCell>
+            <FlatTableCell>Jones</FlatTableCell>
+            <FlatTableCell>
+              <ActionPopover>
+                <ActionPopoverItem
+                  icon="csv"
+                  {...props}
+                  submenu={submenuWithIcons}
+                >
+                  Download CSV
+                </ActionPopoverItem>
+              </ActionPopover>
+            </FlatTableCell>
+          </FlatTableRow>
+        </FlatTableBody>
+      </FlatTable>
+    </div>
+  );
+};
+
+export const ActionPopoverWithProps = ({ ...props }) => {
+  return (
+    <div
+      style={{
+        height: "250px",
+      }}
+    >
+      <FlatTable>
+        <FlatTableHead>
+          <FlatTableRow>
+            <FlatTableHeader>First Name</FlatTableHeader>
+            <FlatTableHeader>Last Name</FlatTableHeader>
+            <FlatTableHeader>&nbsp;</FlatTableHeader>
+          </FlatTableRow>
+        </FlatTableHead>
+        <FlatTableBody>
+          <FlatTableRow>
+            <FlatTableCell>John</FlatTableCell>
+            <FlatTableCell>Doe</FlatTableCell>
+            <FlatTableCell>
+              <ActionPopover {...props}>
+                <ActionPopoverItem icon="email" disabled onClick={() => {}}>
+                  Email Invoice
+                </ActionPopoverItem>
+                <ActionPopoverDivider />
+                <ActionPopoverItem onClick={() => {}} icon="delete">
+                  Delete
+                </ActionPopoverItem>
+              </ActionPopover>
+            </FlatTableCell>
+          </FlatTableRow>
+        </FlatTableBody>
+      </FlatTable>
+    </div>
+  );
+};
+
+export const ActionPopoverMenuWithProps = ({ ...props }) => {
+  return (
+    <ActionPopover>
+      <ActionPopoverItem
+        submenu={
+          <ActionPopoverMenu {...props}>
+            <ActionPopoverItem icon="graph">Sub Menu 1</ActionPopoverItem>
+            <ActionPopoverItem icon="add">Sub Menu 2</ActionPopoverItem>
+            <ActionPopoverItem icon="print" disabled>
+              Sub Menu 3
+            </ActionPopoverItem>
+          </ActionPopoverMenu>
+        }
+      >
+        Sub Menu 1
+      </ActionPopoverItem>
+      <ActionPopoverItem>Sub Menu 2</ActionPopoverItem>
+    </ActionPopover>
+  );
+};
+
+export const ActionPopoverProps = ({ ...props }) => {
+  return (
+    <ActionPopover {...props}>
+      <ActionPopoverItem>Sub Menu 1</ActionPopoverItem>
+      <ActionPopoverItem>Sub Menu 2</ActionPopoverItem>
+    </ActionPopover>
   );
 };

--- a/src/components/action-popover/action-popover.stories.mdx
+++ b/src/components/action-popover/action-popover.stories.mdx
@@ -1,30 +1,16 @@
 import { useState } from "react";
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
-import { Preview as MyPreview } from "@storybook/components";
 import LinkTo from "@storybook/addon-links/react";
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
-
 import {
   ActionPopover,
-  ActionPopoverDivider,
   ActionPopoverItem,
   ActionPopoverMenu,
-  ActionPopoverMenuButton,
 } from ".";
-import { Accordion } from "../accordion";
+
+import * as stories from "./action-popover.stories";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
-import DocsWrapper from "../../../.storybook/docs-helpers/components/iframe-wrapper";
-import Link from "../link";
-import {
-  FlatTable,
-  FlatTableHead,
-  FlatTableBody,
-  FlatTableRow,
-  FlatTableHeader,
-  FlatTableCell,
-} from "../flat-table";
-import Confirm from "../confirm";
 
 <Meta
   title="Action Popover"
@@ -88,124 +74,7 @@ import {
 Story showing most of the functionality of the action popover and what can be achieved by using it
 
 <Canvas>
-  <Story name="default">
-    {() => {
-      const submenu = (
-        <ActionPopoverMenu>
-          <ActionPopoverItem onClick={action("sub menu 1")}>
-            Sub Menu 1
-          </ActionPopoverItem>
-          <ActionPopoverItem onClick={action("sub menu 2")}>
-            Sub Menu 2
-          </ActionPopoverItem>
-          <ActionPopoverItem disabled onClick={action("sub menu 3")}>
-            Sub Menu 3
-          </ActionPopoverItem>
-        </ActionPopoverMenu>
-      );
-      const submenuWithIcons = (
-        <ActionPopoverMenu>
-          <ActionPopoverItem icon="graph" onClick={action("sub menu 1")}>
-            Sub Menu 1
-          </ActionPopoverItem>
-          <ActionPopoverItem icon="add" onClick={action("sub menu 2")}>
-            Sub Menu 2
-          </ActionPopoverItem>
-          <ActionPopoverItem
-            icon="print"
-            disabled
-            onClick={action("sub menu 3")}
-          >
-            Sub Menu 3
-          </ActionPopoverItem>
-        </ActionPopoverMenu>
-      );
-      return (
-        <div style={{ marginTop: "40px", height: "275px" }}>
-          <FlatTable isZebra>
-            <FlatTableHead>
-              <FlatTableRow>
-                <FlatTableHeader>First Name</FlatTableHeader>
-                <FlatTableHeader>Last Name</FlatTableHeader>
-                <FlatTableHeader>&nbsp;</FlatTableHeader>
-              </FlatTableRow>
-            </FlatTableHead>
-            <FlatTableBody>
-              <FlatTableRow>
-                <FlatTableCell>John</FlatTableCell>
-                <FlatTableCell>Doe</FlatTableCell>
-                <FlatTableCell>
-                  <ActionPopover
-                    onOpen={action("popover opened")}
-                    onClose={action("popover closed")}
-                  >
-                    <ActionPopoverItem
-                      disabled
-                      icon="graph"
-                      submenu={submenu}
-                      onClick={action("email")}
-                    >
-                      Business
-                    </ActionPopoverItem>
-                    <ActionPopoverItem icon="email" onClick={action("email")}>
-                      Email Invoice
-                    </ActionPopoverItem>
-                    <ActionPopoverItem
-                      icon="print"
-                      onClick={action("print")}
-                      submenu={submenu}
-                    >
-                      Print Invoice
-                    </ActionPopoverItem>
-                    <ActionPopoverItem
-                      icon="pdf"
-                      submenu={submenu}
-                      onClick={action("pdf")}
-                    >
-                      Download PDF
-                    </ActionPopoverItem>
-                    <ActionPopoverItem icon="csv" onClick={action("csv")}>
-                      Download CSV
-                    </ActionPopoverItem>
-                    <ActionPopoverDivider />
-                    <ActionPopoverItem icon="delete" onClick={action("delete")}>
-                      Delete
-                    </ActionPopoverItem>
-                  </ActionPopover>
-                </FlatTableCell>
-              </FlatTableRow>
-              <FlatTableRow>
-                <FlatTableCell>Jane</FlatTableCell>
-                <FlatTableCell>Smith</FlatTableCell>
-                <FlatTableCell>
-                  <ActionPopover>
-                    <ActionPopoverItem icon="csv" onClick={action("csv")}>
-                      Download CSV
-                    </ActionPopoverItem>
-                  </ActionPopover>
-                </FlatTableCell>
-              </FlatTableRow>
-              <FlatTableRow>
-                <FlatTableCell>Bob</FlatTableCell>
-                <FlatTableCell>Jones</FlatTableCell>
-                <FlatTableCell>
-                  <ActionPopover>
-                    <ActionPopoverItem
-                      icon="csv"
-                      submenu={submenuWithIcons}
-                      onClick={action("csv")}
-                    >
-                      Download CSV
-                    </ActionPopoverItem>
-                  </ActionPopover>
-                </FlatTableCell>
-              </FlatTableRow>
-            </FlatTableBody>
-          </FlatTable>
-        </div>
-      );
-    }}
-  </Story>
+  <Story name="default" story={stories.ActionPopoverComponent} />
 </Canvas>
 
 ### With icons
@@ -213,36 +82,7 @@ Story showing most of the functionality of the action popover and what can be ac
 Each item is clickable and represents an action to be taken on a given row.
 
 <Canvas>
-  <Story name="with icons">
-    <div style={{ height: "250px" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover>
-                <ActionPopoverItem icon="email" onClick={() => {}}>
-                  Email Invoice
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="with icons" story={stories.ActionPopoverComponentIcons} />
 </Canvas>
 
 ### With disabled item
@@ -250,36 +90,7 @@ Each item is clickable and represents an action to be taken on a given row.
 ActionPopoverItem&apos;s can be disabled and will not dispatch an action but can still be navigated with the keyboard.
 
 <Canvas>
-  <Story name="with disabled item">
-    <div style={{ height: "250px" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover>
-                <ActionPopoverItem icon="email" disabled onClick={() => {}}>
-                  Email Invoice
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="with disabled item" story={stories.ActionPopoverComponentDisabledItems} />
 </Canvas>
 
 ### With menu right aligned
@@ -287,69 +98,13 @@ ActionPopoverItem&apos;s can be disabled and will not dispatch an action but can
 It is possible to align the Menu to the right of the MenuButton by passing the &quot;rightAlignMenu&quot; to ActionPopover
 
 <Canvas>
-  <Story name="with menu right aligned">
-    <div style={{ height: "250px" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover rightAlignMenu>
-                <ActionPopoverItem icon="email" disabled onClick={() => {}}>
-                  Email Invoice
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="with menu right aligned" story={stories.ActionPopoverComponentMenuRightAligned} />
 </Canvas>
 
 ### With item content aligned to right
 
 <Canvas>
-  <Story name="with item content aligned to right">
-    <div style={{ height: "250px" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover horizontalAlignment="right">
-                <ActionPopoverItem icon="email">
-                  Email Invoice
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem icon="delete">Delete</ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="with item content aligned to right" story={stories.ActionPopoverComponentContentAlignedRight} />
 </Canvas>
 
 ### With no icons
@@ -357,34 +112,7 @@ It is possible to align the Menu to the right of the MenuButton by passing the &
 Menu items can also be displayed without icons.
 
 <Canvas>
-  <Story name="with no icons">
-    <div style={{ height: "250px" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover>
-                <ActionPopoverItem onClick={() => {}}>
-                  Email Invoice
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}}>Delete</ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="with no icons" story={stories.ActionPopoverComponentNoIcons} />
 </Canvas>
 
 ### With custom menu button
@@ -393,82 +121,7 @@ It is possible to use the `renderButton` prop to override the default button use
 ActionPopoverMenu. Expand the code example below for how to use this.
 
 <Canvas>
-  <Story name="with custom menu button">
-    <div style={{ height: "250px" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover
-                renderButton={({
-                  tabIndex,
-                  "data-element": dataElement,
-                  ariaAttributes,
-                }) => (
-                  <ActionPopoverMenuButton
-                    buttonType="tertiary"
-                    iconType="dropdown"
-                    iconPosition="after"
-                    size="small"
-                    tabIndex={tabIndex}
-                    data-element={dataElement}
-                    {...ariaAttributes}
-                  >
-                    More
-                  </ActionPopoverMenuButton>
-                )}
-              >
-                <ActionPopoverItem icon="email" onClick={() => {}}>
-                  Email Invoice
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover
-                renderButton={({
-                  "data-element": dataElement,
-                  ariaAttributes,
-                }) => (
-                  <Link
-                    onClick={() => {}}
-                    data-element={dataElement}
-                    {...ariaAttributes}
-                  >
-                    More
-                  </Link>
-                )}
-              >
-                <ActionPopoverItem icon="email" onClick={() => {}}>
-                  Email Invoice
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="with custom menu button" story={stories.ActionPopoverComponentCustomMenuButton} />
 </Canvas>
 
 ### With submenu
@@ -481,49 +134,7 @@ close it. No action is dispatched on click of the item and the sub-menu is opene
 leave.
 
 <Canvas>
-  <Story name="with submenu">
-    <div style={{ height: "250px" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover>
-                <ActionPopoverItem
-                  icon="print"
-                  onClick={() => {}}
-                  submenu={
-                    <ActionPopoverMenu>
-                      <ActionPopoverItem onClick={() => {}}>
-                        CSV
-                      </ActionPopoverItem>
-                      <ActionPopoverItem onClick={() => {}}>
-                        PDF
-                      </ActionPopoverItem>
-                    </ActionPopoverMenu>
-                  }
-                >
-                  Print
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="with submenu" story={stories.ActionPopoverComponentSubmenu} />
 </Canvas>
 
 ### With disabled submenu
@@ -531,158 +142,27 @@ leave.
 A sub-menu will not open if the item is in a disabled state.
 
 <Canvas>
-  <Story name="with disabled submenu">
-    <div style={{ height: "250px" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover>
-                <ActionPopoverItem
-                  disabled
-                  icon="print"
-                  onClick={() => {}}
-                  submenu={
-                    <ActionPopoverMenu>
-                      <ActionPopoverItem onClick={() => {}}>
-                        CSV
-                      </ActionPopoverItem>
-                      <ActionPopoverItem onClick={() => {}}>
-                        PDF
-                      </ActionPopoverItem>
-                    </ActionPopoverMenu>
-                  }
-                >
-                  Print
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="with disabled submenu" story={stories.ActionPopoverComponentDisabledSubmenu} />
 </Canvas>
 
 ### With submenu aligned right
 
 The sub-menu will open to the right side when there is no space to render the sub-menu to the left.
 
-<Story
-  name="with submenu aligned right"
-  parameters={{ docs: { disable: true } }}
->
-  <div style={{ height: "250px" }}>
-    <FlatTable>
-      <FlatTableHead>
-        <FlatTableRow>
-          <FlatTableHeader>&nbsp;</FlatTableHeader>
-          <FlatTableHeader>First Name</FlatTableHeader>
-          <FlatTableHeader>Last Name</FlatTableHeader>
-        </FlatTableRow>
-      </FlatTableHead>
-      <FlatTableBody>
-        <FlatTableRow>
-          <FlatTableCell>
-            <ActionPopover>
-              <ActionPopoverItem
-                icon="print"
-                onClick={() => {}}
-                submenu={
-                  <ActionPopoverMenu>
-                    <ActionPopoverItem icon="csv" onClick={() => {}}>
-                      CSV
-                    </ActionPopoverItem>
-                    <ActionPopoverItem icon="pdf" onClick={() => {}}>
-                      PDF
-                    </ActionPopoverItem>
-                  </ActionPopoverMenu>
-                }
-              >
-                Print
-              </ActionPopoverItem>
-              <ActionPopoverDivider />
-              <ActionPopoverItem onClick={() => {}} icon="delete">
-                Delete
-              </ActionPopoverItem>
-            </ActionPopover>
-          </FlatTableCell>
-          <FlatTableCell>John</FlatTableCell>
-          <FlatTableCell>Doe</FlatTableCell>
-        </FlatTableRow>
-      </FlatTableBody>
-    </FlatTable>
-  </div>
-</Story>
-
-<MyPreview>
-  <DocsWrapper
-    src="iframe.html?id=action-popover--with-submenu-aligned-right"
-    height="250px"
+<Canvas>
+  <Story
+    name="with submenu aligned right"
+    parameters={{ docs: { disable: true } }}
+    story={stories.ActionPopoverComponentSubmenuAlignedRight} 
   />
-</MyPreview>
+</Canvas>
 
 ### With menu opening above
 
 The menu can also be rendered above the button control by setting using `placement="top"`.
 
 <Canvas>
-  <Story name="with menu opening above">
-    <div style={{ paddingTop: "120px", height: "250px" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover placement="top">
-                <ActionPopoverItem
-                  icon="print"
-                  onClick={() => {}}
-                  submenu={
-                    <ActionPopoverMenu>
-                      <ActionPopoverItem onClick={() => {}}>
-                        CSV
-                      </ActionPopoverItem>
-                      <ActionPopoverItem onClick={() => {}}>
-                        PDF
-                      </ActionPopoverItem>
-                    </ActionPopoverMenu>
-                  }
-                >
-                  Print
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="with menu opening above" story={stories.ActionPopoverComponentMenuOpeningAbove} />
 </Canvas>
 
 ### Keyboard navigation
@@ -701,42 +181,7 @@ or "tab" key will close the menu with no action being triggered and focus the ne
 "shift + tab" will close the menu and focus the previously focused element.
 
 <Canvas>
-  <Story name="keyboard navigation">
-    <div style={{ height: "250px" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover>
-                <ActionPopoverItem icon="email" onClick={() => {}}>
-                  Email Invoice
-                </ActionPopoverItem>
-                <ActionPopoverItem disabled icon="csv" onClick={() => {}}>
-                  Download CSV
-                </ActionPopoverItem>
-                <ActionPopoverItem icon="pdf" onClick={() => {}}>
-                  Download PDF
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="keyboard navigation" story={stories.ActionPopoverComponentKeyboardNavigation} />
 </Canvas>
 
 ### Keyboard navigation left aligned submenu
@@ -747,65 +192,7 @@ the sub-menu. Pressing the "right" key will return focus back to the main menu a
 triggering an action.
 
 <Canvas>
-  <Story name="keyboard navigation left aligned submenu">
-    <div style={{ height: "250px" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover>
-                <ActionPopoverItem
-                  icon="csv"
-                  onClick={() => {}}
-                  submenu={
-                    <ActionPopoverMenu>
-                      <ActionPopoverItem icon="csv" onClick={() => {}}>
-                        CSV
-                      </ActionPopoverItem>
-                      <ActionPopoverItem icon="pdf" onClick={() => {}}>
-                        PDF
-                      </ActionPopoverItem>
-                    </ActionPopoverMenu>
-                  }
-                >
-                  Download
-                </ActionPopoverItem>
-                <ActionPopoverItem
-                  icon="pdf"
-                  onClick={() => {}}
-                  submenu={
-                    <ActionPopoverMenu>
-                      <ActionPopoverItem icon="csv" onClick={() => {}}>
-                        CSV
-                      </ActionPopoverItem>
-                      <ActionPopoverItem icon="pdf" onClick={() => {}}>
-                        PDF
-                      </ActionPopoverItem>
-                    </ActionPopoverMenu>
-                  }
-                >
-                  Print
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="keyboard navigation left aligned submenu" story={stories.ActionPopoverComponentKeyboardNaviationLeftAlignedSubmenu} />
 </Canvas>
 
 ### Keyboard navigation right aligned submenu
@@ -817,65 +204,8 @@ is on a item will open a sub-menu if it has one and pressing the "left" key will
   <Story
     name="keyboard navigation right aligned submenu"
     parameters={{ docs: { disable: true } }}
-  >
-    <div style={{ height: "250px" }}>
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>
-              <ActionPopover>
-                <ActionPopoverItem
-                  icon="csv"
-                  onClick={() => {}}
-                  submenu={
-                    <ActionPopoverMenu>
-                      <ActionPopoverItem icon="csv" onClick={() => {}}>
-                        CSV
-                      </ActionPopoverItem>
-                      <ActionPopoverItem icon="pdf" onClick={() => {}}>
-                        PDF
-                      </ActionPopoverItem>
-                    </ActionPopoverMenu>
-                  }
-                >
-                  Download
-                </ActionPopoverItem>
-                <ActionPopoverItem
-                  icon="pdf"
-                  onClick={() => {}}
-                  submenu={
-                    <ActionPopoverMenu>
-                      <ActionPopoverItem icon="csv" onClick={() => {}}>
-                        CSV
-                      </ActionPopoverItem>
-                      <ActionPopoverItem icon="pdf" onClick={() => {}}>
-                        PDF
-                      </ActionPopoverItem>
-                    </ActionPopoverMenu>
-                  }
-                >
-                  Print
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+    story={stories.ActionPopoverComponentKeyboardNaviationRightAlignedSubmenu} 
+  />
 </Canvas>
 
 ### With additional options
@@ -884,154 +214,19 @@ When a row has many actions you may choose to incldue the primary actions with a
 used actions, in this example "manage devices".
 
 <Canvas>
-  <Story name="with additional options">
-    <div style={{ marginTop: "40px", height: "275px", maxWidth: "800px" }}>
-      <FlatTable isZebra>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader colSpan="3">Devices</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>Mobile Phone</FlatTableCell>
-            <FlatTableCell>Online</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover rightAlignMenu>
-                <ActionPopoverItem onClick={() => {}}>
-                  Enroll Device
-                </ActionPopoverItem>
-                <ActionPopoverItem onClick={() => {}}>
-                  Assign Owner
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}}>
-                  Manage Devices
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="with additional options" story={stories.ActionPopoverComponentAdditionalOptions} />
 </Canvas>
 
 ## with download button
 
 <Canvas>
-  <Story name="with download button">
-    <div style={{ marginTop: "40px", height: "275px", maxWidth: "800px" }}>
-      <FlatTable isZebra>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader colSpan="3">Devices</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>Mobile Phone</FlatTableCell>
-            <FlatTableCell>Online</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover rightAlignMenu>
-                <ActionPopoverItem
-                  download
-                  icon="download"
-                  href={"example-img.jpg"}
-                >
-                  Download
-                </ActionPopoverItem>
-                <ActionPopoverItem icon="settings" onClick={() => {}}>
-                  Assign Owner
-                </ActionPopoverItem>
-                <ActionPopoverItem
-                  disabled
-                  icon="download"
-                  href={"example-img.jpg"}
-                >
-                  Download
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  </Story>
+  <Story name="with download button"story={stories.ActionPopoverComponentDownloadButton} />
 </Canvas>
 
 ## in overflow hidden container
 
 <Canvas>
-  <Story name="in overflow hidden container">
-    <div style={{ marginTop: "40px", height: "275px", maxWidth: "800px" }}>
-      <Accordion title="Heading">
-        <FlatTable isZebra>
-          <FlatTableHead>
-            <FlatTableRow>
-              <FlatTableHeader colSpan="3">Devices</FlatTableHeader>
-            </FlatTableRow>
-          </FlatTableHead>
-          <FlatTableBody>
-            <FlatTableRow>
-              <FlatTableCell>Mobile Phone</FlatTableCell>
-              <FlatTableCell>Online</FlatTableCell>
-              <FlatTableCell>
-                <ActionPopover>
-                  <ActionPopoverItem onClick={() => {}}>
-                    Enroll Device
-                  </ActionPopoverItem>
-                  <ActionPopoverItem onClick={() => {}}>
-                    Assign Owner
-                  </ActionPopoverItem>
-                  <ActionPopoverDivider />
-                  <ActionPopoverItem onClick={() => {}}>
-                    Manage Devices
-                  </ActionPopoverItem>
-                </ActionPopover>
-              </FlatTableCell>
-            </FlatTableRow>
-            <FlatTableRow>
-              <FlatTableCell>Tablet</FlatTableCell>
-              <FlatTableCell>Online</FlatTableCell>
-              <FlatTableCell>
-                <ActionPopover>
-                  <ActionPopoverItem onClick={() => {}}>
-                    Enroll Device
-                  </ActionPopoverItem>
-                  <ActionPopoverItem onClick={() => {}}>
-                    Assign Owner
-                  </ActionPopoverItem>
-                  <ActionPopoverDivider />
-                  <ActionPopoverItem onClick={() => {}}>
-                    Manage Devices
-                  </ActionPopoverItem>
-                </ActionPopover>
-              </FlatTableCell>
-            </FlatTableRow>
-            <FlatTableRow>
-              <FlatTableCell>Desktop</FlatTableCell>
-              <FlatTableCell>Online</FlatTableCell>
-              <FlatTableCell>
-                <ActionPopover>
-                  <ActionPopoverItem onClick={() => {}}>
-                    Enroll Device
-                  </ActionPopoverItem>
-                  <ActionPopoverItem onClick={() => {}}>
-                    Assign Owner
-                  </ActionPopoverItem>
-                  <ActionPopoverDivider />
-                  <ActionPopoverItem onClick={() => {}}>
-                    Manage Devices
-                  </ActionPopoverItem>
-                </ActionPopover>
-              </FlatTableCell>
-            </FlatTableRow>
-          </FlatTableBody>
-        </FlatTable>
-      </Accordion>
-    </div>
-  </Story>
+  <Story name="in overflow hidden container"story={stories.ActionPopoverComponentInOverflowHiddenContainer} />
 </Canvas>
 
 ## In FlatTable with highlightable rows
@@ -1039,163 +234,13 @@ used actions, in this example "manage devices".
 It is possible to utilise the selected and onClick props on the FlatTableRow to highlight single rows of data.
 
 <Canvas>
-  <Story name="in FlatTable" parameters={{ chromatic: { disable: true } }}>
-    {() => {
-      const [highlightedRow, setHighlightedRow] = useState("");
-      const handleHighlightRow = (id) => {
-        setHighlightedRow(id);
-      };
-      return (
-        <div style={{ paddingTop: "120px", height: "250px" }}>
-          <FlatTable>
-            <FlatTableHead>
-              <FlatTableRow>
-                <FlatTableHeader>Name</FlatTableHeader>
-                <FlatTableHeader>Location</FlatTableHeader>
-                <FlatTableHeader>Relationship Status</FlatTableHeader>
-                <FlatTableHeader>Dependents</FlatTableHeader>
-              </FlatTableRow>
-            </FlatTableHead>
-            <FlatTableBody>
-              <FlatTableRow
-                onClick={() => handleHighlightRow("one")}
-                highlighted={highlightedRow === "one"}
-              >
-                <FlatTableCell>John Doe</FlatTableCell>
-                <FlatTableCell>London</FlatTableCell>
-                <FlatTableCell>Single</FlatTableCell>
-                <FlatTableCell>
-                  <ActionPopover
-                    placement="top"
-                    onOpen={() => handleHighlightRow("one")}
-                  >
-                    <ActionPopoverItem
-                      icon="print"
-                      onClick={() => {}}
-                      submenu={
-                        <ActionPopoverMenu>
-                          <ActionPopoverItem onClick={() => {}}>
-                            CSV
-                          </ActionPopoverItem>
-                          <ActionPopoverItem onClick={() => {}}>
-                            PDF
-                          </ActionPopoverItem>
-                        </ActionPopoverMenu>
-                      }
-                    >
-                      Print
-                    </ActionPopoverItem>
-                    <ActionPopoverDivider />
-                    <ActionPopoverItem onClick={() => {}} icon="delete">
-                      Delete
-                    </ActionPopoverItem>
-                  </ActionPopover>
-                </FlatTableCell>
-              </FlatTableRow>
-              <FlatTableRow
-                onClick={() => handleHighlightRow("two")}
-                highlighted={highlightedRow === "two"}
-              >
-                <FlatTableCell>Jane Doe</FlatTableCell>
-                <FlatTableCell>York</FlatTableCell>
-                <FlatTableCell>Married</FlatTableCell>
-                <FlatTableCell>
-                  <ActionPopover
-                    placement="top"
-                    onOpen={() => handleHighlightRow("two")}
-                  >
-                    <ActionPopoverItem
-                      icon="print"
-                      onClick={() => {}}
-                      submenu={
-                        <ActionPopoverMenu>
-                          <ActionPopoverItem onClick={() => {}}>
-                            CSV
-                          </ActionPopoverItem>
-                          <ActionPopoverItem onClick={() => {}}>
-                            PDF
-                          </ActionPopoverItem>
-                        </ActionPopoverMenu>
-                      }
-                    >
-                      Print
-                    </ActionPopoverItem>
-                    <ActionPopoverDivider />
-                    <ActionPopoverItem onClick={() => {}} icon="delete">
-                      Delete
-                    </ActionPopoverItem>
-                  </ActionPopover>
-                </FlatTableCell>
-              </FlatTableRow>
-            </FlatTableBody>
-          </FlatTable>
-        </div>
-      );
-    }}
-  </Story>
+  <Story name="in FlatTable" parameters={{ chromatic: { disable: true } }} story={stories.ActionPopoverComponentInFlatTable} />
 </Canvas>
 
 ## Action opening a Modal
 
 <Canvas>
-  <Story name="opening a modal">
-    {() => {
-      const [isConfirmOpen, setIsConfirmOpen] = useState(false);
-      const [isOpen, setIsOpen] = useState(false);
-      return (
-        <>
-          <FlatTable colorTheme="transparent-white">
-            <FlatTableHead>
-              <FlatTableRow>
-                <FlatTableHeader>Devices</FlatTableHeader>
-                <FlatTableHeader>Status</FlatTableHeader>
-                <FlatTableHeader>Action Popover</FlatTableHeader>
-              </FlatTableRow>
-            </FlatTableHead>
-            <FlatTableBody>
-              <FlatTableRow>
-                <FlatTableCell>Mobile Phone</FlatTableCell>
-                <FlatTableCell>Online</FlatTableCell>
-                <FlatTableCell>
-                  <ActionPopover
-                    renderButton={(props) => (
-                      <ActionPopoverMenuButton isOpen={isOpen} {...props}>
-                        Open Actions
-                      </ActionPopoverMenuButton>
-                    )}
-                  >
-                    <ActionPopoverItem
-                      onClick={() => {
-                        setIsOpen(false);
-                        setIsConfirmOpen(true);
-                      }}
-                    >
-                      Open Confirm Dialog
-                    </ActionPopoverItem>
-                    <ActionPopoverItem icon="settings" onClick={() => {}}>
-                      Do Nothing
-                    </ActionPopoverItem>
-                  </ActionPopover>
-                </FlatTableCell>
-              </FlatTableRow>
-            </FlatTableBody>
-          </FlatTable>
-          <Confirm
-            title="Are you sure?"
-            subtitle="Subtitle"
-            confirmButtonDestructive
-            cancelButtonDestructive
-            disableConfirm
-            open={isConfirmOpen}
-            onConfirm={() => setIsConfirmOpen(false)}
-            onCancel={() => setIsConfirmOpen(false)}
-          >
-            Content
-          </Confirm>
-        </>
-      );
-    }}
-  </Story>
+  <Story name="opening a modal" story={stories.ActionPopoverComponentOpeningAModal} />
 </Canvas>
 
 ## Props

--- a/src/components/action-popover/action-popover.stories.tsx
+++ b/src/components/action-popover/action-popover.stories.tsx
@@ -1,0 +1,733 @@
+import React, { useState } from "react";
+import { ComponentStory } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import {
+  ActionPopover,
+  ActionPopoverDivider,
+  ActionPopoverItem,
+  ActionPopoverMenu,
+  ActionPopoverMenuButton,
+} from ".";
+import Link from "../link";
+import Box from "../box";
+import {
+  FlatTable,
+  FlatTableHead,
+  FlatTableBody,
+  FlatTableRow,
+  FlatTableHeader,
+  FlatTableCell,
+} from "../flat-table";
+import Confirm from "../confirm";
+import { Accordion } from "../accordion";
+
+export const ActionPopoverComponent: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  const submenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem onClick={action("sub menu 1")}>
+        Sub Menu 1
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={action("sub menu 2")}>
+        Sub Menu 2
+      </ActionPopoverItem>
+      <ActionPopoverItem disabled onClick={action("sub menu 3")}>
+        Sub Menu 3
+      </ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+  const submenuWithIcons = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem icon="graph" onClick={action("sub menu 1")}>
+        Sub Menu 1
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="add" onClick={action("sub menu 2")}>
+        Sub Menu 2
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="print" disabled onClick={action("sub menu 3")}>
+        Sub Menu 3
+      </ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+  return (
+    <div style={{ marginTop: "40px", height: "275px" }}>
+      <Box>
+        <ActionPopover
+          onOpen={action("popover opened")}
+          onClose={action("popover closed")}
+        >
+          <ActionPopoverItem
+            disabled
+            icon="graph"
+            submenu={submenu}
+            onClick={action("email")}
+          >
+            Business
+          </ActionPopoverItem>
+          <ActionPopoverItem icon="email" onClick={action("email")}>
+            Email Invoice
+          </ActionPopoverItem>
+          <ActionPopoverItem
+            icon="print"
+            onClick={action("print")}
+            submenu={submenu}
+          >
+            Print Invoice
+          </ActionPopoverItem>
+          <ActionPopoverItem
+            icon="pdf"
+            submenu={submenu}
+            onClick={action("pdf")}
+          >
+            Download PDF
+          </ActionPopoverItem>
+          <ActionPopoverItem icon="csv" onClick={action("csv")}>
+            Download CSV
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem icon="delete" onClick={action("delete")}>
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+        <ActionPopover>
+          <ActionPopoverItem icon="csv" onClick={action("csv")}>
+            Download CSV
+          </ActionPopoverItem>
+        </ActionPopover>
+        <ActionPopover>
+          <ActionPopoverItem
+            icon="csv"
+            submenu={submenuWithIcons}
+            onClick={action("csv")}
+          >
+            Download CSV
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentIcons: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ height: "250px" }}>
+      <Box>
+        <ActionPopover>
+          <ActionPopoverItem icon="email" onClick={() => {}}>
+            Email Invoice
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}} icon="delete">
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentDisabledItems: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ height: "250px" }}>
+      <Box>
+        <ActionPopover>
+          <ActionPopoverItem icon="email" disabled onClick={() => {}}>
+            Email Invoice
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}} icon="delete">
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentMenuRightAligned: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ height: "250px" }}>
+      <Box>
+        <ActionPopover rightAlignMenu>
+          <ActionPopoverItem icon="email" disabled onClick={() => {}}>
+            Email Invoice
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}} icon="delete">
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentContentAlignedRight: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ height: "250px" }}>
+      <Box>
+        <ActionPopover horizontalAlignment="right">
+          <ActionPopoverItem icon="email">Email Invoice</ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem icon="delete">Delete</ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentNoIcons: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ height: "250px" }}>
+      <Box>
+        <ActionPopover>
+          <ActionPopoverItem onClick={() => {}}>
+            Email Invoice
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}}>Delete</ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentCustomMenuButton: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ height: "250px" }}>
+      <Box>
+        <ActionPopover
+          renderButton={({
+            tabIndex,
+            "data-element": dataElement,
+            ariaAttributes,
+          }) => (
+            <ActionPopoverMenuButton
+              buttonType="tertiary"
+              iconType="dropdown"
+              iconPosition="after"
+              size="small"
+              tabIndex={tabIndex}
+              data-element={dataElement}
+              ariaAttributes={ariaAttributes}
+            >
+              More
+            </ActionPopoverMenuButton>
+          )}
+        >
+          <ActionPopoverItem icon="email" onClick={() => {}}>
+            Email Invoice
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}} icon="delete">
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+        <ActionPopover
+          renderButton={({ "data-element": dataElement }) => (
+            <Link onClick={() => {}} data-element={dataElement}>
+              More
+            </Link>
+          )}
+        >
+          <ActionPopoverItem icon="email" onClick={() => {}}>
+            Email Invoice
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}} icon="delete">
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentSubmenu: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ height: "250px" }}>
+      <Box>
+        <ActionPopover>
+          <ActionPopoverItem
+            icon="print"
+            onClick={() => {}}
+            submenu={
+              <ActionPopoverMenu>
+                <ActionPopoverItem onClick={() => {}}>CSV</ActionPopoverItem>
+                <ActionPopoverItem onClick={() => {}}>PDF</ActionPopoverItem>
+              </ActionPopoverMenu>
+            }
+          >
+            Print
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}} icon="delete">
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentDisabledSubmenu: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ height: "250px" }}>
+      <Box>
+        <ActionPopover>
+          <ActionPopoverItem
+            disabled
+            icon="print"
+            onClick={() => {}}
+            submenu={
+              <ActionPopoverMenu>
+                <ActionPopoverItem onClick={() => {}}>CSV</ActionPopoverItem>
+                <ActionPopoverItem onClick={() => {}}>PDF</ActionPopoverItem>
+              </ActionPopoverMenu>
+            }
+          >
+            Print
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}} icon="delete">
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentSubmenuAlignedRight: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ height: "250px" }}>
+      <Box>
+        <ActionPopover>
+          <ActionPopoverItem
+            icon="print"
+            onClick={() => {}}
+            submenu={
+              <ActionPopoverMenu>
+                <ActionPopoverItem icon="csv" onClick={() => {}}>
+                  CSV
+                </ActionPopoverItem>
+                <ActionPopoverItem icon="pdf" onClick={() => {}}>
+                  PDF
+                </ActionPopoverItem>
+              </ActionPopoverMenu>
+            }
+          >
+            Print
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}} icon="delete">
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentMenuOpeningAbove: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ paddingTop: "120px", height: "250px" }}>
+      <Box>
+        <ActionPopover placement="top">
+          <ActionPopoverItem
+            icon="print"
+            onClick={() => {}}
+            submenu={
+              <ActionPopoverMenu>
+                <ActionPopoverItem onClick={() => {}}>CSV</ActionPopoverItem>
+                <ActionPopoverItem onClick={() => {}}>PDF</ActionPopoverItem>
+              </ActionPopoverMenu>
+            }
+          >
+            Print
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}} icon="delete">
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentKeyboardNavigation: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ height: "250px" }}>
+      <Box>
+        <ActionPopover>
+          <ActionPopoverItem icon="email" onClick={() => {}}>
+            Email Invoice
+          </ActionPopoverItem>
+          <ActionPopoverItem disabled icon="csv" onClick={() => {}}>
+            Download CSV
+          </ActionPopoverItem>
+          <ActionPopoverItem icon="pdf" onClick={() => {}}>
+            Download PDF
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}} icon="delete">
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentKeyboardNaviationLeftAlignedSubmenu: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ height: "250px" }}>
+      <Box>
+        <ActionPopover>
+          <ActionPopoverItem
+            icon="csv"
+            onClick={() => {}}
+            submenu={
+              <ActionPopoverMenu>
+                <ActionPopoverItem icon="csv" onClick={() => {}}>
+                  CSV
+                </ActionPopoverItem>
+                <ActionPopoverItem icon="pdf" onClick={() => {}}>
+                  PDF
+                </ActionPopoverItem>
+              </ActionPopoverMenu>
+            }
+          >
+            Download
+          </ActionPopoverItem>
+          <ActionPopoverItem
+            icon="pdf"
+            onClick={() => {}}
+            submenu={
+              <ActionPopoverMenu>
+                <ActionPopoverItem icon="csv" onClick={() => {}}>
+                  CSV
+                </ActionPopoverItem>
+                <ActionPopoverItem icon="pdf" onClick={() => {}}>
+                  PDF
+                </ActionPopoverItem>
+              </ActionPopoverMenu>
+            }
+          >
+            Print
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}} icon="delete">
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentKeyboardNaviationRightAlignedSubmenu: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ height: "250px" }}>
+      <Box>
+        <ActionPopover>
+          <ActionPopoverItem
+            icon="csv"
+            onClick={() => {}}
+            submenu={
+              <ActionPopoverMenu>
+                <ActionPopoverItem icon="csv" onClick={() => {}}>
+                  CSV
+                </ActionPopoverItem>
+                <ActionPopoverItem icon="pdf" onClick={() => {}}>
+                  PDF
+                </ActionPopoverItem>
+              </ActionPopoverMenu>
+            }
+          >
+            Download
+          </ActionPopoverItem>
+          <ActionPopoverItem
+            icon="pdf"
+            onClick={() => {}}
+            submenu={
+              <ActionPopoverMenu>
+                <ActionPopoverItem icon="csv" onClick={() => {}}>
+                  CSV
+                </ActionPopoverItem>
+                <ActionPopoverItem icon="pdf" onClick={() => {}}>
+                  PDF
+                </ActionPopoverItem>
+              </ActionPopoverMenu>
+            }
+          >
+            Print
+          </ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}} icon="delete">
+            Delete
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentAdditionalOptions: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ marginTop: "40px", height: "275px", maxWidth: "800px" }}>
+      <Box>
+        <ActionPopover rightAlignMenu>
+          <ActionPopoverItem onClick={() => {}}>
+            Enroll Device
+          </ActionPopoverItem>
+          <ActionPopoverItem onClick={() => {}}>Assign Owner</ActionPopoverItem>
+          <ActionPopoverDivider />
+          <ActionPopoverItem onClick={() => {}}>
+            Manage Devices
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentDownloadButton: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ marginTop: "40px", height: "275px", maxWidth: "800px" }}>
+      <Box>
+        <ActionPopover rightAlignMenu>
+          <ActionPopoverItem download icon="download" href="example-img.jpg">
+            Download
+          </ActionPopoverItem>
+          <ActionPopoverItem icon="settings" onClick={() => {}}>
+            Assign Owner
+          </ActionPopoverItem>
+          <ActionPopoverItem disabled icon="download" href="example-img.jpg">
+            Download
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentInOverflowHiddenContainer: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  return (
+    <div style={{ marginTop: "40px", height: "275px", maxWidth: "800px" }}>
+      <Accordion title="Heading">
+        <Box>
+          <ActionPopover>
+            <ActionPopoverItem onClick={() => {}}>
+              Enroll Device
+            </ActionPopoverItem>
+            <ActionPopoverItem onClick={() => {}}>
+              Assign Owner
+            </ActionPopoverItem>
+            <ActionPopoverDivider />
+            <ActionPopoverItem onClick={() => {}}>
+              Manage Devices
+            </ActionPopoverItem>
+          </ActionPopover>
+          <ActionPopover>
+            <ActionPopoverItem onClick={() => {}}>
+              Enroll Device
+            </ActionPopoverItem>
+            <ActionPopoverItem onClick={() => {}}>
+              Assign Owner
+            </ActionPopoverItem>
+            <ActionPopoverDivider />
+            <ActionPopoverItem onClick={() => {}}>
+              Manage Devices
+            </ActionPopoverItem>
+          </ActionPopover>
+          <ActionPopover>
+            <ActionPopoverItem onClick={() => {}}>
+              Enroll Device
+            </ActionPopoverItem>
+            <ActionPopoverItem onClick={() => {}}>
+              Assign Owner
+            </ActionPopoverItem>
+            <ActionPopoverDivider />
+            <ActionPopoverItem onClick={() => {}}>
+              Manage Devices
+            </ActionPopoverItem>
+          </ActionPopover>
+        </Box>
+      </Accordion>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentInFlatTable: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  const [highlightedRow, setHighlightedRow] = useState("");
+  const handleHighlightRow = (id: string) => {
+    setHighlightedRow(id);
+  };
+  return (
+    <div style={{ paddingTop: "120px", height: "250px" }}>
+      <FlatTable>
+        <FlatTableHead>
+          <FlatTableRow>
+            <FlatTableHeader>Name</FlatTableHeader>
+            <FlatTableHeader>Location</FlatTableHeader>
+            <FlatTableHeader>Relationship Status</FlatTableHeader>
+            <FlatTableHeader>Dependents</FlatTableHeader>
+          </FlatTableRow>
+        </FlatTableHead>
+        <FlatTableBody>
+          <FlatTableRow
+            onClick={() => handleHighlightRow("one")}
+            highlighted={highlightedRow === "one"}
+          >
+            <FlatTableCell>John Doe</FlatTableCell>
+            <FlatTableCell>London</FlatTableCell>
+            <FlatTableCell>Single</FlatTableCell>
+            <FlatTableCell>
+              <ActionPopover
+                placement="top"
+                onOpen={() => handleHighlightRow("one")}
+              >
+                <ActionPopoverItem
+                  icon="print"
+                  onClick={() => {}}
+                  submenu={
+                    <ActionPopoverMenu>
+                      <ActionPopoverItem onClick={() => {}}>
+                        CSV
+                      </ActionPopoverItem>
+                      <ActionPopoverItem onClick={() => {}}>
+                        PDF
+                      </ActionPopoverItem>
+                    </ActionPopoverMenu>
+                  }
+                >
+                  Print
+                </ActionPopoverItem>
+                <ActionPopoverDivider />
+                <ActionPopoverItem onClick={() => {}} icon="delete">
+                  Delete
+                </ActionPopoverItem>
+              </ActionPopover>
+            </FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow
+            onClick={() => handleHighlightRow("two")}
+            highlighted={highlightedRow === "two"}
+          >
+            <FlatTableCell>Jane Doe</FlatTableCell>
+            <FlatTableCell>York</FlatTableCell>
+            <FlatTableCell>Married</FlatTableCell>
+            <FlatTableCell>
+              <ActionPopover
+                placement="top"
+                onOpen={() => handleHighlightRow("two")}
+              >
+                <ActionPopoverItem
+                  icon="print"
+                  onClick={() => {}}
+                  submenu={
+                    <ActionPopoverMenu>
+                      <ActionPopoverItem onClick={() => {}}>
+                        CSV
+                      </ActionPopoverItem>
+                      <ActionPopoverItem onClick={() => {}}>
+                        PDF
+                      </ActionPopoverItem>
+                    </ActionPopoverMenu>
+                  }
+                >
+                  Print
+                </ActionPopoverItem>
+                <ActionPopoverDivider />
+                <ActionPopoverItem onClick={() => {}} icon="delete">
+                  Delete
+                </ActionPopoverItem>
+              </ActionPopover>
+            </FlatTableCell>
+          </FlatTableRow>
+        </FlatTableBody>
+      </FlatTable>
+    </div>
+  );
+};
+
+export const ActionPopoverComponentOpeningAModal: ComponentStory<
+  typeof ActionPopover
+> = () => {
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <Box>
+        <ActionPopover
+          renderButton={({ ...props }) => (
+            <ActionPopoverMenuButton {...props}>
+              Open Actions
+            </ActionPopoverMenuButton>
+          )}
+        >
+          <ActionPopoverItem
+            onClick={() => {
+              setIsOpen(!isOpen);
+              setIsConfirmOpen(isConfirmOpen);
+            }}
+          >
+            Open Confirm Dialog
+          </ActionPopoverItem>
+          <ActionPopoverItem icon="settings" onClick={() => {}}>
+            Do Nothing
+          </ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+      <Confirm
+        title="Are you sure?"
+        subtitle="Subtitle"
+        confirmButtonDestructive
+        cancelButtonDestructive
+        disableConfirm
+        open={isConfirmOpen}
+        onConfirm={() => setIsConfirmOpen(!isConfirmOpen)}
+        onCancel={() => setIsConfirmOpen(!isConfirmOpen)}
+      >
+        Content
+      </Confirm>
+    </>
+  );
+};

--- a/src/components/action-popover/action-popover.test.js
+++ b/src/components/action-popover/action-popover.test.js
@@ -2,21 +2,7 @@
 import React from "react";
 import path from "path";
 
-import {
-  ActionPopover,
-  ActionPopoverDivider,
-  ActionPopoverItem,
-  ActionPopoverMenu,
-  ActionPopoverMenuButton,
-} from ".";
-import {
-  FlatTable,
-  FlatTableHead,
-  FlatTableBody,
-  FlatTableRow,
-  FlatTableHeader,
-  FlatTableCell,
-} from "../flat-table";
+import { ActionPopoverMenuButton } from ".";
 import { Accordion } from "../accordion";
 
 import { accordionDefaultTitle } from "../../../cypress/locators/accordion";
@@ -36,198 +22,33 @@ import { buttonDataComponent } from "../../../cypress/locators/button";
 
 import { keyCode } from "../../../cypress/support/helper";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
-
-const ActionPopoverCustom = (props) => {
-  const submenu = (
-    <ActionPopoverMenu>
-      <ActionPopoverItem
-        data-element="submenu1"
-        onClick={() => props.onClick("sub menu item 1")}
-      >
-        Sub Menu 1
-      </ActionPopoverItem>
-      <ActionPopoverItem onClick={() => props.onClick("sub menu item 2")}>
-        Sub Menu 2
-      </ActionPopoverItem>
-      <ActionPopoverItem disabled>Sub Menu 3</ActionPopoverItem>
-    </ActionPopoverMenu>
-  );
-
-  const submenuWithIcons = (
-    <ActionPopoverMenu>
-      <ActionPopoverItem icon="graph">Sub Menu 1</ActionPopoverItem>
-      <ActionPopoverItem icon="add">Sub Menu 2</ActionPopoverItem>
-      <ActionPopoverItem icon="print" disabled>
-        Sub Menu 3
-      </ActionPopoverItem>
-    </ActionPopoverMenu>
-  );
-
-  return (
-    <div
-      style={{
-        marginTop: "40px",
-        height: "275px",
-      }}
-    >
-      <FlatTable isZebra>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover>
-                <ActionPopoverItem
-                  disabled
-                  icon="graph"
-                  submenu={submenu}
-                  onClick={() => props.onClick("Business")}
-                >
-                  Business
-                </ActionPopoverItem>
-                <ActionPopoverItem
-                  icon="email"
-                  onClick={() => props.onClick("Email Invoice")}
-                >
-                  Email Invoice
-                </ActionPopoverItem>
-                <ActionPopoverItem
-                  icon="print"
-                  onClick={() => props.onClick("Print Invoice")}
-                  submenu={submenu}
-                >
-                  Print Invoice
-                </ActionPopoverItem>
-                <ActionPopoverItem
-                  icon="pdf"
-                  onClick={() => props.onClick("Download PDF")}
-                  submenu={submenu}
-                >
-                  Download PDF
-                </ActionPopoverItem>
-                <ActionPopoverItem
-                  icon="csv"
-                  onClick={() => props.onClick("Download CSV")}
-                >
-                  Download CSV
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem icon="delete" {...props}>
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>Jane</FlatTableCell>
-            <FlatTableCell>Smith</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover>
-                <ActionPopoverItem
-                  download
-                  onClick={() => props.onClick("Download")}
-                  icon="download"
-                  href="example-img.jpg"
-                >
-                  Download
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-          <FlatTableRow>
-            <FlatTableCell>Bob</FlatTableCell>
-            <FlatTableCell>Jones</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover>
-                <ActionPopoverItem
-                  icon="csv"
-                  onClick={() => props.onClick("Download CSV")}
-                  submenu={submenuWithIcons}
-                >
-                  Download CSV
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  );
-};
-
-const ActionPopoverWithProps = ({ ...props }) => {
-  return (
-    <div
-      style={{
-        height: "250px",
-      }}
-    >
-      <FlatTable>
-        <FlatTableHead>
-          <FlatTableRow>
-            <FlatTableHeader>First Name</FlatTableHeader>
-            <FlatTableHeader>Last Name</FlatTableHeader>
-            <FlatTableHeader>&nbsp;</FlatTableHeader>
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>
-          <FlatTableRow>
-            <FlatTableCell>John</FlatTableCell>
-            <FlatTableCell>Doe</FlatTableCell>
-            <FlatTableCell>
-              <ActionPopover {...props}>
-                <ActionPopoverItem icon="email" disabled onClick={() => {}}>
-                  Email Invoice
-                </ActionPopoverItem>
-                <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
-                  Delete
-                </ActionPopoverItem>
-              </ActionPopover>
-            </FlatTableCell>
-          </FlatTableRow>
-        </FlatTableBody>
-      </FlatTable>
-    </div>
-  );
-};
-
-const ActionPopoverMenuWithProps = ({ ...props }) => {
-  return (
-    <ActionPopover>
-      <ActionPopoverItem
-        submenu={
-          <ActionPopoverMenu {...props}>
-            <ActionPopoverItem icon="graph">Sub Menu 1</ActionPopoverItem>
-            <ActionPopoverItem icon="add">Sub Menu 2</ActionPopoverItem>
-            <ActionPopoverItem icon="print" disabled>
-              Sub Menu 3
-            </ActionPopoverItem>
-          </ActionPopoverMenu>
-        }
-      >
-        Sub Menu 1
-      </ActionPopoverItem>
-      <ActionPopoverItem>Sub Menu 2</ActionPopoverItem>
-    </ActionPopover>
-  );
-};
-
-const ActionPopoverProps = ({ ...props }) => {
-  return (
-    <ActionPopover {...props}>
-      <ActionPopoverItem>Sub Menu 1</ActionPopoverItem>
-      <ActionPopoverItem>Sub Menu 2</ActionPopoverItem>
-    </ActionPopover>
-  );
-};
+import {
+  ActionPopoverCustom,
+  ActionPopoverWithProps,
+  ActionPopoverMenuWithProps,
+  ActionPopoverProps,
+} from "./action-popover-test.stories.tsx";
+import {
+  ActionPopoverComponent,
+  ActionPopoverComponentIcons,
+  ActionPopoverComponentDisabledItems,
+  ActionPopoverComponentMenuRightAligned,
+  ActionPopoverComponentContentAlignedRight,
+  ActionPopoverComponentNoIcons,
+  ActionPopoverComponentCustomMenuButton,
+  ActionPopoverComponentSubmenu,
+  ActionPopoverComponentDisabledSubmenu,
+  ActionPopoverComponentSubmenuAlignedRight,
+  ActionPopoverComponentMenuOpeningAbove,
+  ActionPopoverComponentKeyboardNavigation,
+  ActionPopoverComponentKeyboardNaviationLeftAlignedSubmenu,
+  ActionPopoverComponentKeyboardNaviationRightAlignedSubmenu,
+  ActionPopoverComponentAdditionalOptions,
+  ActionPopoverComponentDownloadButton,
+  ActionPopoverComponentInOverflowHiddenContainer,
+  ActionPopoverComponentInFlatTable,
+  ActionPopoverComponentOpeningAModal,
+} from "./action-popover.stories.tsx";
 
 context("Test for ActionPopover component", () => {
   describe("check functionality for ActionPopover component", () => {
@@ -748,6 +569,170 @@ context("Test for ActionPopover component", () => {
           // eslint-disable-next-line no-unused-expressions
           expect(callback).to.have.been.calledOnce;
         });
+    });
+  });
+
+  describe("Accessibility tests for ActionPopover", () => {
+    it("should pass accessibility tests for ActionPopover with custom button", () => {
+      CypressMountWithProviders(
+        <ActionPopoverWithProps
+          renderButton={() => (
+            <ActionPopoverMenuButton
+              buttonType="tertiary"
+              iconType="dropdown"
+              iconPosition="after"
+              size="small"
+            >
+              More
+            </ActionPopoverMenuButton>
+          )}
+        />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover default", () => {
+      CypressMountWithProviders(<ActionPopoverComponent />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with Icons", () => {
+      CypressMountWithProviders(<ActionPopoverComponentIcons />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with disabled items", () => {
+      CypressMountWithProviders(<ActionPopoverComponentDisabledItems />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with menu right aligned", () => {
+      CypressMountWithProviders(<ActionPopoverComponentMenuRightAligned />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with item content right aligned", () => {
+      CypressMountWithProviders(<ActionPopoverComponentContentAlignedRight />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with no icons", () => {
+      CypressMountWithProviders(<ActionPopoverComponentNoIcons />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with custom menu button", () => {
+      CypressMountWithProviders(<ActionPopoverComponentCustomMenuButton />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with submenu", () => {
+      CypressMountWithProviders(<ActionPopoverComponentSubmenu />);
+
+      actionPopoverButton().eq(0).click();
+      actionPopoverInnerItem(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with disabled submenu", () => {
+      CypressMountWithProviders(<ActionPopoverComponentDisabledSubmenu />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with submenu aligned right", () => {
+      CypressMountWithProviders(<ActionPopoverComponentSubmenuAlignedRight />);
+
+      actionPopoverButton().eq(0).click();
+      actionPopoverInnerItem(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with menu opening above", () => {
+      CypressMountWithProviders(<ActionPopoverComponentMenuOpeningAbove />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with keyboard navigation", () => {
+      CypressMountWithProviders(<ActionPopoverComponentKeyboardNavigation />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with keyboard navigation in left aligned submenu", () => {
+      CypressMountWithProviders(
+        <ActionPopoverComponentKeyboardNaviationLeftAlignedSubmenu />
+      );
+
+      actionPopoverButton().eq(0).click();
+      actionPopoverInnerItem(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with keyboard navigation in right aligned submenu", () => {
+      CypressMountWithProviders(
+        <ActionPopoverComponentKeyboardNaviationRightAlignedSubmenu />
+      );
+
+      actionPopoverButton().eq(0).click();
+      actionPopoverInnerItem(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with additional options", () => {
+      CypressMountWithProviders(<ActionPopoverComponentAdditionalOptions />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover with download button", () => {
+      CypressMountWithProviders(<ActionPopoverComponentDownloadButton />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover in overflow hidden container", () => {
+      CypressMountWithProviders(
+        <ActionPopoverComponentInOverflowHiddenContainer />
+      );
+
+      getDataElementByValue("accordion-icon").click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover in FlatTable", () => {
+      CypressMountWithProviders(<ActionPopoverComponentInFlatTable />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ActionPopover opening a modal", () => {
+      CypressMountWithProviders(<ActionPopoverComponentOpeningAModal />);
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Action-Popover` component to use the new cypress-component-react framework for testing.
- Refactor `action-popover.stories.mdx` and `action-popover.stories.test.mdx` to corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added test.file
- [x] Check if the `action-popover.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `action-popover` tests are not running twice.