### PR TITLE
docs(typography,box): add deprecation message regarding removal of undocumented props

### DIFF
--- a/src/components/box/box.component.tsx
+++ b/src/components/box/box.component.tsx
@@ -12,6 +12,7 @@ import {
   PositionProps,
 } from "styled-system";
 import * as DesignTokens from "@sage/design-tokens/js/base/common";
+import Logger from "../../__internal__/utils/logger";
 import BaseTheme from "../../style/themes/base";
 import styledColor from "../../style/utils/color";
 import boxConfig from "./box.config";
@@ -53,7 +54,19 @@ export interface BoxProps
   boxShadow?: BoxShadowsType;
 }
 
+let isDeprecationWarningTriggered = false;
+
 export const Box = styled.div<BoxProps>`
+  ${() => {
+    if (!isDeprecationWarningTriggered) {
+      isDeprecationWarningTriggered = true;
+      Logger.deprecate(
+        "Previous props that could be spread to the `Box` component are being removed. Only props documented in the intefaces will be supported."
+      );
+    }
+    return css``;
+  }}
+
   ${space}
   ${layout}
   ${flexbox}

--- a/src/components/typography/typography.component.tsx
+++ b/src/components/typography/typography.component.tsx
@@ -2,6 +2,7 @@ import styled, { css } from "styled-components";
 import { ColorProps, space, SpaceProps } from "styled-system";
 import styledColor from "../../style/utils/color";
 import baseTheme from "../../style/themes/base";
+import Logger from "../../__internal__/utils/logger";
 
 const VARIANT_TYPES = [
   "h1-large",
@@ -176,6 +177,8 @@ const getDecoration = (variant?: VariantTypes) => {
   return "none";
 };
 
+let isDeprecationWarningTriggered = false;
+
 const Typography = styled.span.attrs(
   ({
     variant,
@@ -197,6 +200,15 @@ const Typography = styled.span.attrs(
     };
   }
 )<TypographyProps>`
+  ${() => {
+    if (!isDeprecationWarningTriggered) {
+      isDeprecationWarningTriggered = true;
+      Logger.deprecate(
+        "Previous props that could be spread to the `Typography` component are being removed. Only props documented in the intefaces will be supported."
+      );
+    }
+    return css``;
+  }}
   ${({
     size,
     weight,


### PR DESCRIPTION
### Proposed behaviour

Add a deprecation warning to the console explaining immediate plans to remove undocumented props being allowed on Box and Typography components.

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->


### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

Can see the deprecation comment when you navigate to the Typography or Box stories and check your Browser's console.

<!-- Add any other context or links about the pull request here. -->
