### PR TITLE
test(badge): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -54,6 +54,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("action-popover") &&
       !prepareUrl[0].startsWith("loader-bar") &&
       !prepareUrl[0].startsWith("link-preview") &&
+      !prepareUrl[0].startsWith("badge") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/badge/badge-test.stories.tsx
+++ b/src/components/badge/badge-test.stories.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
-
 import specialCharacters from "../../__internal__/utils/argTypes/specialCharacters";
-import Badge from "./badge.component";
+import Badge from ".";
 import Button from "../button";
 
 export default {
   title: "Badge/Test",
+  includeStories: "Default",
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -50,4 +50,19 @@ DefaultStory.story = {
     counter: 1,
     counterSpecialCharacters: undefined,
   },
+};
+
+export const BadgeComponentTest = ({ ...args }: BadgeStoryProps) => {
+  const handleClick = () => {
+    action("click")();
+  };
+  return (
+    <div style={{ margin: "40px" }}>
+      <Badge onClick={handleClick} counter={8} {...args}>
+        <Button mr={0} buttonType="tertiary">
+          Filter
+        </Button>
+      </Badge>
+    </div>
+  );
 };

--- a/src/components/badge/badge.stories.mdx
+++ b/src/components/badge/badge.stories.mdx
@@ -1,7 +1,8 @@
+import { useState } from "react";
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import Badge from ".";
-import Button from "../button";
+import * as stories from "./badge.stories.tsx";
 
 <Meta title="Badge" parameters={{ info: { disable: true } }} />
 
@@ -28,15 +29,7 @@ import Badge from "carbon-react/lib/components/badge";
 ### Default Badge
 
 <Canvas>
-  <Story name="default">
-    <div style={{ margin: "40px" }}>
-      <Badge counter={9}>
-        <Button style={{ marginRight: 0 }} buttonType="tertiary">
-          Filter
-        </Button>
-      </Badge>
-    </div>
-  </Story>
+ <Story name="default" story={stories.DefaultStory} />
 </Canvas>
 
 ### Badge with counter > 99
@@ -44,15 +37,7 @@ import Badge from "carbon-react/lib/components/badge";
 Badge doesn't support more than 2 digits
 
 <Canvas>
-  <Story name="with 3 digits">
-    <div style={{ margin: "40px" }}>
-      <Badge counter={130}>
-        <Button style={{ marginRight: 0 }} buttonType="tertiary">
-          Filter
-        </Button>
-      </Badge>
-    </div>
-  </Story>
+  <Story name="with 3 digits" story={stories.BadgeCounterWithThreeDigits}/>
 </Canvas>
 
 ### Badge with counter 0
@@ -60,17 +45,11 @@ Badge doesn't support more than 2 digits
 If the counter is less than 1 badge will not show itself
 
 <Canvas>
-  <Story name="with counter 0">
-    <div style={{ margin: "40px" }}>
-      <Badge counter={0}>
-        <Button buttonType="tertiary">Filter</Button>
-      </Badge>
-    </div>
-  </Story>
+  <Story name="with counter 0" story={stories.BadgeCounterZero}/>
 </Canvas>
 
 ## Props
 
 ### Badge
 
-<ArgsTable of={Badge} />
+<StyledSystemProps margin of={Badge} />

--- a/src/components/badge/badge.stories.tsx
+++ b/src/components/badge/badge.stories.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { ComponentStory } from "@storybook/react";
+import Badge from ".";
+import Button from "../button";
+
+export const DefaultStory: ComponentStory<typeof Badge> = () => {
+  return (
+    <div style={{ margin: "40px" }}>
+      <Badge counter={9}>
+        <Button mr={0} buttonType="tertiary">
+          Filter
+        </Button>
+      </Badge>
+    </div>
+  );
+};
+
+export const BadgeCounterWithThreeDigits: ComponentStory<typeof Badge> = () => {
+  return (
+    <div style={{ margin: "40px" }}>
+      <Badge counter={130}>
+        <Button mr={0} buttonType="tertiary">
+          Filter
+        </Button>
+      </Badge>
+    </div>
+  );
+};
+
+export const BadgeCounterZero: ComponentStory<typeof Badge> = () => {
+  return (
+    <div style={{ margin: "40px" }}>
+      <Badge counter={0}>
+        <Button mr={0} buttonType="tertiary">
+          Filter
+        </Button>
+      </Badge>
+    </div>
+  );
+};

--- a/src/components/badge/badge.test.js
+++ b/src/components/badge/badge.test.js
@@ -1,6 +1,4 @@
 import React from "react";
-import Badge from "./badge.component";
-import Button from "../button/button.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import {
   badge,
@@ -8,21 +6,7 @@ import {
   badgeCrossIcon,
 } from "../../../cypress/locators/badge";
 import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
-
-const BadgeComponent = ({ ...props }) => {
-  return (
-    <Badge {...props}>
-      <Button
-        style={{
-          marginRight: 0,
-        }}
-        buttonType="tertiary"
-      >
-        Filter
-      </Button>
-    </Badge>
-  );
-};
+import { BadgeComponentTest as BadgeComponent } from "./badge-test.stories";
 
 context("Testing Badge component", () => {
   describe("should render Badge component", () => {
@@ -83,6 +67,17 @@ context("Testing Badge component", () => {
           // eslint-disable-next-line no-unused-expressions
           expect(callback).to.have.been.calledOnce;
         });
+    });
+  });
+  describe("Accessibility tests for Badge component", () => {
+    it("should pass accessibilty tests for Badge default story", () => {
+      CypressMountWithProviders(<BadgeComponent counter="9" />);
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for click event", () => {
+      CypressMountWithProviders(<BadgeComponent onClick={() => {}} />);
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
  - Add `accessibility` Cypress tests for the `badge` component to use the new cypress-component-react framework for testing.
  
### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added test.file
- [x] Check if the `badge.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `badge` tests are not running twice.