### PR TITLE
test(vertical-divider): add cypress tests

### DIFF
--- a/cypress/locators/vertical-divider/index.js
+++ b/cypress/locators/vertical-divider/index.js
@@ -1,0 +1,6 @@
+import VERTICAL_DIVIDER_COMPONENT from "./locators";
+
+// component preview locators
+const verticalDividerComponent = () => cy.get(VERTICAL_DIVIDER_COMPONENT);
+
+export default verticalDividerComponent;

--- a/cypress/locators/vertical-divider/locators.js
+++ b/cypress/locators/vertical-divider/locators.js
@@ -1,0 +1,4 @@
+// component preview locators
+const VERTICAL_DIVIDER_COMPONENT = '[data-component="vertical-divider"]';
+
+export default VERTICAL_DIVIDER_COMPONENT;

--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -54,6 +54,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("action-popover") &&
       !prepareUrl[0].startsWith("loader-bar") &&
       !prepareUrl[0].startsWith("link-preview") &&
+      !prepareUrl[0].startsWith("verticaldivider") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/vertical-divider/vertical-divider-test.stories.tsx
+++ b/src/components/vertical-divider/vertical-divider-test.stories.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import VerticalDivider from "./vertical-divider.component";
+
+export default {
+  title: "VerticalDivider/Test",
+  includeStories: "Default",
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disable: true,
+    },
+  },
+  argTypes: {
+    h: {
+      control: {
+        type: "text",
+      },
+    },
+    height: {
+      control: {
+        type: "text",
+      },
+    },
+    tint: {
+      control: {
+        min: 0,
+        max: 100,
+        step: 1,
+        type: "range",
+      },
+    },
+    displayInline: {
+      control: {
+        type: "boolean",
+      },
+    },
+  },
+};
+
+type TintRange =
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 13
+  | 14
+  | 15
+  | 16
+  | 17
+  | 18
+  | 19
+  | 20
+  | 21
+  | 22
+  | 23
+  | 24
+  | 25
+  | 26
+  | 27
+  | 28
+  | 29
+  | 30
+  | 31
+  | 32
+  | 33
+  | 34
+  | 35
+  | 36
+  | 37
+  | 38
+  | 39
+  | 40
+  | 41
+  | 42
+  | 43
+  | 44
+  | 45
+  | 46
+  | 47
+  | 48
+  | 49
+  | 50
+  | 51
+  | 52
+  | 53
+  | 54
+  | 55
+  | 56
+  | 57
+  | 58
+  | 59
+  | 60
+  | 61
+  | 62
+  | 63
+  | 64
+  | 65
+  | 66
+  | 67
+  | 68
+  | 69
+  | 70
+  | 71
+  | 72
+  | 73
+  | 74
+  | 75
+  | 76
+  | 77
+  | 78
+  | 79
+  | 80
+  | 81
+  | 82
+  | 83
+  | 84
+  | 85
+  | 86
+  | 87
+  | 88
+  | 89
+  | 90
+  | 91
+  | 92
+  | 93
+  | 94
+  | 95
+  | 96
+  | 97
+  | 98
+  | 99
+  | 100;
+
+interface VerticalDividerArgs {
+  h: string | number;
+  height: string | number;
+  tint: TintRange;
+  displayInline: boolean;
+}
+
+export const Default = ({ ...args }: VerticalDividerArgs) => {
+  return <VerticalDivider {...args} />;
+};
+
+Default.storyName = "default";
+Default.args = {
+  height: "80px",
+  tint: 80,
+  displayInline: false,
+};
+
+export const VerticalDividerComponent = ({ ...props }) => {
+  return <VerticalDivider {...props} />;
+};

--- a/src/components/vertical-divider/vertical-divider.component.tsx
+++ b/src/components/vertical-divider/vertical-divider.component.tsx
@@ -113,7 +113,7 @@ export interface VerticalDividerProps extends SpaceProps {
   tint?: TintRange;
 }
 
-const VerticalDivider = ({
+export const VerticalDivider = ({
   h,
   height,
   displayInline = false,

--- a/src/components/vertical-divider/vertical-divider.test.js
+++ b/src/components/vertical-divider/vertical-divider.test.js
@@ -1,0 +1,72 @@
+import React from "react";
+import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
+import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-helper/common-steps";
+import { VerticalDividerComponent } from "./vertical-divider-test.stories";
+
+import verticalDividerComponent from "../../../cypress/locators/vertical-divider/index";
+
+context("Tests for VerticalDivider component", () => {
+  describe("should check VerticalDivider component properties", () => {
+    it.each([30, 50, "30px", "50px"])(
+      "should check h set to %s for VerticalDivider component",
+      (h) => {
+        CypressMountWithProviders(<VerticalDividerComponent h={h} />);
+        verticalDividerComponent()
+          .then(($el) => {
+            const val = Number.isNaN(h) ? h : parseInt(h);
+            useJQueryCssValueAndAssert($el, "height", val);
+          })
+          .should("have.attr", "height", h);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([30, 50, "30px", "50px"])(
+      "should check height set to %s for VerticalDivider component",
+      (height) => {
+        CypressMountWithProviders(<VerticalDividerComponent height={height} />);
+        verticalDividerComponent()
+          .then(($el) => {
+            const val = Number.isNaN(height) ? height : parseInt(height);
+            useJQueryCssValueAndAssert($el, "height", val);
+          })
+          .should("have.attr", "height", height);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      [3, "rgb(8, 57, 78)"],
+      [57, "rgb(145, 167, 177)"],
+      [71, "rgb(181, 196, 202)"],
+      [98, "rgb(250, 251, 251)"],
+    ])(
+      "should check tint set to %s for VerticalDivider component",
+      (tint, color) => {
+        CypressMountWithProviders(<VerticalDividerComponent tint={tint} />);
+        verticalDividerComponent()
+          .children()
+          .should("have.css", "border-left-color", color);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      [true, "have.css"],
+      [false, "not.have.css"],
+    ])(
+      "should check displayInline set to %s for VerticalDivider component",
+      (boolean, assertion) => {
+        CypressMountWithProviders(
+          <VerticalDividerComponent displayInline={boolean} />
+        );
+        verticalDividerComponent().should(assertion, "display", "inline");
+
+        cy.checkAccessibility();
+      }
+    );
+  });
+});


### PR DESCRIPTION
### Proposed behaviour
- Add `react` and `accessibility` Cypress tests for the `Vertical Divider` component to use the new cypress-component-react framework for testing.
- Refactor `vertical-divider-test.stories.tsx`

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added test.file
- [x] Check if the `vertical-divider.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `alert` tests are not running twice.