### PR TITLE
test(anchor-navigation): refactor for accessibility

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -52,6 +52,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("content") &&
       !prepareUrl[0].startsWith("alert") &&
       !prepareUrl[0].startsWith("action-popover") &&
+      !prepareUrl[0].startsWith("anchor-navigation") &&
       !prepareUrl[0].startsWith("loader-bar") &&
       !prepareUrl[0].startsWith("link-preview") &&
       !prepareUrl[0].endsWith("test")

--- a/src/components/anchor-navigation/anchor-navigation-test.stories.tsx
+++ b/src/components/anchor-navigation/anchor-navigation-test.stories.tsx
@@ -141,3 +141,46 @@ export const InFullScreenDialogStory: ComponentStory<
   );
 };
 InFullScreenDialogStory.storyName = "in full screen dialog";
+
+export const AnchorNavigationComponent = () => {
+  const ref1 = useRef<HTMLDivElement>(null);
+  const ref2 = useRef<HTMLDivElement>(null);
+  const ref3 = useRef<HTMLDivElement>(null);
+  const ref4 = useRef<HTMLDivElement>(null);
+  const ref5 = useRef<HTMLDivElement>(null);
+  return (
+    <AnchorNavigation
+      stickyNavigation={
+        <>
+          <AnchorNavigationItem target={ref1}>First</AnchorNavigationItem>
+          <AnchorNavigationItem target={ref2}>Second</AnchorNavigationItem>
+          <AnchorNavigationItem target={ref3}>Third</AnchorNavigationItem>
+          <AnchorNavigationItem target={ref4}>
+            Navigation item with very long label
+          </AnchorNavigationItem>
+          <AnchorNavigationItem target={ref5}>Fifth</AnchorNavigationItem>
+        </>
+      }
+    >
+      <div ref={ref1}>
+        <Content title="First section" />
+      </div>
+      <AnchorSectionDivider />
+      <div ref={ref2}>
+        <Content title="Second section" />
+      </div>
+      <AnchorSectionDivider />
+      <div ref={ref3}>
+        <Content noTextbox title="Third section" />
+      </div>
+      <AnchorSectionDivider />
+      <div ref={ref4}>
+        <Content title="Fourth section" />
+      </div>
+      <AnchorSectionDivider />
+      <div ref={ref5}>
+        <Content title="Fifth section" />
+      </div>
+    </AnchorNavigation>
+  );
+};

--- a/src/components/anchor-navigation/anchor-navigation.test.js
+++ b/src/components/anchor-navigation/anchor-navigation.test.js
@@ -1,74 +1,15 @@
 import React from "react";
 import {
-  AnchorNavigation,
-  AnchorNavigationItem,
-  AnchorSectionDivider,
-} from ".";
-import Textbox from "../textbox";
+  AnchorNavigationComponent,
+  InFullScreenDialogStory,
+} from "./anchor-navigation-test.stories";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
 import {
   anchorNavigationStickyNavigation,
   anchorNavigationStickyMainPage,
 } from "../../../cypress/locators/anchor-navigation";
-
-const Content = ({ title, noTextbox }) => (
-  <>
-    <div>
-      <h2>{title}</h2>
-      {!noTextbox && <Textbox label={title} />}
-      <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
-      <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
-      <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
-      <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
-      <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
-      <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
-    </div>
-  </>
-);
-
-const AnchorNavigationComponent = () => {
-  const ref1 = React.useRef();
-  const ref2 = React.useRef();
-  const ref3 = React.useRef();
-  const ref4 = React.useRef();
-  const ref5 = React.useRef();
-  return (
-    <AnchorNavigation
-      stickyNavigation={
-        <>
-          <AnchorNavigationItem target={ref1}>First</AnchorNavigationItem>
-          <AnchorNavigationItem target={ref2}>Second</AnchorNavigationItem>
-          <AnchorNavigationItem target={ref3}>Third</AnchorNavigationItem>
-          <AnchorNavigationItem target={ref4}>
-            Navigation item with very long label
-          </AnchorNavigationItem>
-          <AnchorNavigationItem target={ref5}>Fifth</AnchorNavigationItem>
-        </>
-      }
-    >
-      <div ref={ref1}>
-        <Content title="First section" />
-      </div>
-      <AnchorSectionDivider />
-      <div ref={ref2}>
-        <Content title="Second section" />
-      </div>
-      <AnchorSectionDivider />
-      <div ref={ref3}>
-        <Content noTextbox title="Third section" />
-      </div>
-      <AnchorSectionDivider />
-      <div ref={ref4}>
-        <Content title="Fourth section" />
-      </div>
-      <AnchorSectionDivider />
-      <div ref={ref5}>
-        <Content title="Fifth section" />
-      </div>
-    </AnchorNavigation>
-  );
-};
+import { getDataElementByValue } from "../../../cypress/locators";
 
 context("Testing AnchorNavigation component", () => {
   describe("should render AnchorNavigation component", () => {
@@ -101,5 +42,23 @@ context("Testing AnchorNavigation component", () => {
         anchorNavigationStickyMainPage(sectionName).should("be.visible");
       }
     );
+  });
+
+  describe("Accessibility tests for Anchor Navigation component", () => {
+    it("should pass accessibility tests for Anchor Navigation default story", () => {
+      CypressMountWithProviders(<AnchorNavigationComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Anchor Navigation in full screen dialog", () => {
+      CypressMountWithProviders(<InFullScreenDialogStory />);
+
+      getDataElementByValue("main-text")
+        .click()
+        .then(() => {
+          cy.checkAccessibility();
+        });
+    });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Anchor-Navigation` component to use the new cypress-component-react framework for testing.
- Refactor `anchor-navigation.stories.mdx` and `anchor-navigation.stories.test.mdx` to corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added test.file
- [x] Check if the `anchor-navigation.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `action-popover` tests are not running twice.