### PR TITLE
test(button-bar): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -56,6 +56,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("loader-bar") &&
       !prepareUrl[0].startsWith("link-preview") &&
       !prepareUrl[0].startsWith("verticaldivider") &&
+      !prepareUrl[0].startsWith("button-bar") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/button-bar/button-bar-test.stories.tsx
+++ b/src/components/button-bar/button-bar-test.stories.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-import { action } from "@storybook/addon-actions";
-
 import Button from "../button";
 import ButtonBar from ".";
 import IconButton from "../icon-button";
@@ -12,6 +10,7 @@ import {
 
 export default {
   title: "Button Bar/Test",
+  includeStories: ["Default", "Preview"],
   parameters: {
     info: { disable: true },
     chromatic: { disable: true },
@@ -36,7 +35,7 @@ const commonArgsButtonBar = {
 };
 
 export const Default = ({ ...args }) => (
-  <ButtonBar onClick={action("click")} {...args}>
+  <ButtonBar {...args}>
     <Button iconType="search">Example Button</Button>
     <Button iconType="pdf">Example Button</Button>
     <Button iconType="csv">Example Button</Button>
@@ -58,7 +57,7 @@ export const Preview = () => {
         </IconButton>
       </ButtonBar>
       {BUTTON_BAR_SIZES.map((size) => (
-        <ButtonBar key={size} size={size} ml={2} mt={2}>
+        <ButtonBar key={`${size}-key`} size={size} ml={2} mt={2}>
           <Button iconType="pdf" />
           <Button iconType="csv" />
           <Button iconType="search" />

--- a/src/components/button-bar/button-bar.config.ts
+++ b/src/components/button-bar/button-bar.config.ts
@@ -1,2 +1,2 @@
-export const BUTTON_BAR_SIZES = ["small", "medium", "large"];
-export const BUTTON_BAR_ICON_POSITIONS = ["before", "after"];
+export const BUTTON_BAR_SIZES = ["small", "medium", "large"] as const;
+export const BUTTON_BAR_ICON_POSITIONS = ["before", "after"] as const;

--- a/src/components/button-bar/button-bar.test.js
+++ b/src/components/button-bar/button-bar.test.js
@@ -1,6 +1,5 @@
 import React from "react";
-import ButtonBar from ".";
-import Button from "../button";
+import { Default as ButtonBarCustom } from "./button-bar-test.stories";
 import {
   BUTTON_BAR_SIZES,
   BUTTON_BAR_ICON_POSITIONS,
@@ -9,29 +8,8 @@ import {
 import { buttonDataComponent } from "../../../cypress/locators/button";
 
 import { icon } from "../../../cypress/locators";
-import { positionOfElement, keyCode } from "../../../cypress/support/helper";
 import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-helper/common-steps";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
-
-const ButtonBarCustom = ({ onClick, ...props }) => {
-  return (
-    <ButtonBar onClick={onClick} {...props} ml={2} mt={2}>
-      <Button>Button 1</Button>
-      <Button>Button 2</Button>
-      <Button>Button 3</Button>
-    </ButtonBar>
-  );
-};
-
-const ButtonBarIconPosition = ({ iconPositionProp, ...props }) => {
-  return (
-    <ButtonBar {...props} size={BUTTON_BAR_SIZES[0]} ml={2} mt={2}>
-      <Button iconType="csv">{iconPositionProp} Button</Button>
-      <Button iconType="pdf">{iconPositionProp} Button</Button>
-      <Button iconType="delete">{iconPositionProp} Button</Button>
-    </ButtonBar>
-  );
-};
 
 context("Test for Button-Bar component", () => {
   describe("check props for Button-Bar component", () => {
@@ -54,7 +32,7 @@ context("Test for Button-Bar component", () => {
       "should set position to %s for icon in a Button-Bar",
       (iconPosition, margin) => {
         CypressMountWithProviders(
-          <ButtonBarIconPosition iconPosition={iconPosition} />
+          <ButtonBarCustom iconPosition={iconPosition} />
         );
 
         icon().should("have.css", `margin-${margin}`, "8px");
@@ -70,63 +48,33 @@ context("Test for Button-Bar component", () => {
           useJQueryCssValueAndAssert($el, "width", 1366);
         });
     });
+  });
 
-    describe("check events for Button-Bar component", () => {
-      let callback;
+  describe("accessibility tests", () => {
+    it.each([BUTTON_BAR_SIZES[0], BUTTON_BAR_SIZES[1], BUTTON_BAR_SIZES[2]])(
+      "should check accessibility for %s size for a Button-Bar",
+      (size) => {
+        CypressMountWithProviders(<ButtonBarCustom size={size} />);
 
-      beforeEach(() => {
-        callback = cy.stub();
-      });
+        cy.checkAccessibility();
+      }
+    );
 
-      it("should call onClick callback when a click event is triggered", () => {
-        CypressMountWithProviders(<ButtonBarCustom onClick={callback} />);
+    it.each([BUTTON_BAR_ICON_POSITIONS[0], BUTTON_BAR_ICON_POSITIONS[1]])(
+      "should check accessibility for %s icon position in a Button-Bar",
+      (iconPosition) => {
+        CypressMountWithProviders(
+          <ButtonBarCustom iconPosition={iconPosition} />
+        );
 
-        buttonDataComponent()
-          .eq(positionOfElement("first"))
-          .click({ force: true })
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callback).to.have.been.calledOnce;
-          });
-      });
+        cy.checkAccessibility();
+      }
+    );
 
-      it("should call onBlur callback when a blur event is triggered", () => {
-        CypressMountWithProviders(<ButtonBarCustom onBlur={callback} />);
+    it("should check the accessibility of Button-Bar with full width", () => {
+      CypressMountWithProviders(<ButtonBarCustom fullWidth />);
 
-        buttonDataComponent()
-          .eq(positionOfElement("second"))
-          .focus()
-          .blur({ force: true })
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callback).to.have.been.calledOnce;
-          });
-      });
-
-      it("should call onKeyDown callback when a keydown event is triggered", () => {
-        CypressMountWithProviders(<ButtonBarCustom onKeyDown={callback} />);
-
-        buttonDataComponent()
-          .eq(positionOfElement("first"))
-          .trigger("keydown", { force: true }, keyCode("rightarrow"))
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callback).to.have.been.calledOnce;
-          });
-      });
-
-      it("should call onFocus callback when a focus event is triggered", () => {
-        CypressMountWithProviders(<ButtonBarCustom onFocus={callback} />);
-
-        buttonDataComponent()
-          .eq(positionOfElement("third"))
-          .focus()
-          .blur({ force: true })
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callback).to.have.been.calledOnce;
-          });
-      });
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Button-Bar` component to use the new cypress-component-react framework for testing.
- Refactor `button-test.stories.js` to the corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `button-bar.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `alert` tests are not running twice.