### PR TITLE
test: remove hardcoded year from utils unit tests - FE-5594

### DIFF
--- a/src/components/date/__internal__/utils.spec.js
+++ b/src/components/date/__internal__/utils.spec.js
@@ -124,7 +124,7 @@ const yearValuesGreaterThan69 = Array.from({ length: 30 }).map(
 
 describe("utils", () => {
   beforeAll(() => {
-    MockDate.set("2022-01-01");
+    MockDate.set(`${currentYear}-01-01`);
   });
 
   afterAll(() => {


### PR DESCRIPTION
### Proposed behaviour

This PR fixes an internal issue where our unit tests are failing after the year has changed. This was caused by the fact, that we had hardcoded year `2022` in mocked Date.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

If the CI build has passed, there is no need for further QA