### PR TITLE
test(badge): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -58,6 +58,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("verticaldivider") &&
       !prepareUrl[0].startsWith("button-bar") &&
       !prepareUrl[0].startsWith("batch-selection") &&
+      !prepareUrl[0].startsWith("badge") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/badge/badge.test.js
+++ b/src/components/badge/badge.test.js
@@ -85,4 +85,17 @@ context("Testing Badge component", () => {
         });
     });
   });
+
+  describe("Accessibility tests for Badge component", () => {
+    // FE-5596
+    it.skip("should pass accessibilty tests for Badge default story", () => {
+      CypressMountWithProviders(<BadgeComponent counter />);
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for click event", () => {
+      CypressMountWithProviders(<BadgeComponent onClick={() => {}} />);
+      cy.checkAccessibility();
+    });
+  });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Badge` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `badge.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `alert` tests are not running twice.