### PR TITLE
test(check_rfcs): ensure NODE_ENV is set correctly for test checking that API call is not made

### DIFF
--- a/scripts/check_rfcs/check_rfcs.spec.js
+++ b/scripts/check_rfcs/check_rfcs.spec.js
@@ -84,8 +84,12 @@ describe("checkRfcs script", () => {
 
   it("should not run the script when being run in CI", async () => {
     ci.isCI = true;
+    const OLD_ENV = process.env.NODE_ENV;
+    process.env.NODE_ENV = "NOT-TEST";
     await checkRfcs();
 
     expect(consoleLogMock).not.toHaveBeenCalled();
+
+    process.env.NODE_ENV = OLD_ENV;
   });
 });


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Overrides the `process.env.NODE_ENV` (so it is not `test` ) in test asserting `Octokit` API is not called.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
The `process.env.NODE_ENV` is `test` meaning the guard does not catch

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
