### PR TITLE
test(advanced-color-picked): refactor for accessibility test

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -61,6 +61,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("batch-selection") &&
       !prepareUrl[0].startsWith("carousel") &&
       !prepareUrl[0].startsWith("badge") &&
+      !prepareUrl[0].startsWith("advanced-color-picker") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/advanced-color-picker/advanced-color-picker.test.js
+++ b/src/components/advanced-color-picker/advanced-color-picker.test.js
@@ -1,18 +1,14 @@
 import React from "react";
-import AdvancedColorPicker from ".";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
-
+import AdvancedColorPicker from "./advanced-color-picker.component";
 import {
   simpleColorPicker,
   advancedColorPickerCell,
   advancedColorPicker,
   simpleColorPickerInput,
 } from "../../../cypress/locators/advanced-color-picker";
-
 import { alertDialogPreview as advancedColorPickerParent } from "../../../cypress/locators/dialog";
-
 import { closeIconButton } from "../../../cypress/locators";
-
 import { keyCode } from "../../../cypress/support/helper";
 import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
@@ -293,6 +289,15 @@ context("Testing AdvancedColorPicker component", () => {
           // eslint-disable-next-line no-unused-expressions
           expect(callback).to.have.been.calledOnce;
         });
+    });
+  });
+
+  describe("Accessibility tests for AdvancedColorPicker component", () => {
+    // Test skipped because of issue FE-5591
+    it.skip("should pass accessibility tests for AdvancedColorPicker default", () => {
+      CypressMountWithProviders(<AdvancedColorPickerCustom />);
+
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Advanced-Color-Picker` component to use the new cypress-component-react framework for testing.
- Refactor `advanced-color-picker.stories.mdx` and `advanced-color-picker.stories.test.mdx` to corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added test.file
- [x] Check if the `advanced-color-picker.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `action-popover` tests are not running twice.