### PR TITLE
test(detail): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -63,6 +63,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("badge") &&
       !prepareUrl[0].startsWith("advanced-color-picker") &&
       !prepareUrl[0].startsWith("preview") &&
+      !prepareUrl[0].startsWith("detail") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/detail/detail.test.js
+++ b/src/components/detail/detail.test.js
@@ -41,4 +41,24 @@ context("Tests for Detail component", () => {
       icon().should("have.attr", "type", "chevron_up").and("be.visible");
     });
   });
+
+  describe("Accessibility tests for Detail component", () => {
+    it("should pass accessibility tests for Detail default story", () => {
+      CypressMountWithProviders(<Detail />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Detail component with footnote", () => {
+      CypressMountWithProviders(<Detail footnote="footnote"> "detail"</Detail>);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Detail component with icon on preview set to chevron_up", () => {
+      CypressMountWithProviders(<Detail icon="chevron_up" />);
+
+      cy.checkAccessibility();
+    });
+  });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Detail` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [] Run `npx cypress open --component` to check if there is newly added test.file
- [] Check if the `detail.test.js` file passed
- [] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `action-popover` tests are not running twice.