### PR TITLE
fix(note): fix text overlapping inlineControl button (FE-5611)

### DIFF
--- a/src/components/note/note.component.tsx
+++ b/src/components/note/note.component.tsx
@@ -88,13 +88,15 @@ export const Note = ({
   return (
     <EditorContext.Provider value={{ onLinkAdded, editMode: false }}>
       <StyledNote width={width} {...rest} data-component="note">
-        {title && <StyledTitle>{title}</StyledTitle>}
+        {title && (
+          <StyledTitle hasInlineControl={!!inlineControl}>{title}</StyledTitle>
+        )}
 
         {inlineControl && (
           <StyledInlineControl>{inlineControl}</StyledInlineControl>
         )}
 
-        <StyledNoteContent>
+        <StyledNoteContent hasInlineControl={!!inlineControl}>
           <Editor
             readOnly
             editorState={getDecoratedValue(noteContent)}
@@ -111,7 +113,10 @@ export const Note = ({
             : preview
         )}
         {createdDate && (
-          <StyledNoteContent hasPreview={!!React.Children.count(previews)}>
+          <StyledNoteContent
+            hasPreview={!!React.Children.count(previews)}
+            hasInlineControl={!!inlineControl}
+          >
             <StyledFooter>
               {name && (
                 <StyledFooterContent hasName={!!name}>

--- a/src/components/note/note.spec.tsx
+++ b/src/components/note/note.spec.tsx
@@ -301,6 +301,30 @@ describe("Note", () => {
     });
   });
 
+  describe("when the inlineControl prop is set", () => {
+    const inlineControl = (
+      <ActionPopover>
+        <ActionPopoverItem onClick={() => {}}>Edit</ActionPopoverItem>
+      </ActionPopover>
+    );
+    const wrapper = renderNote({ inlineControl, title: "foo" });
+
+    it.each([
+      ["Note Title", StyledTitle],
+      ["Note Content", StyledNoteContent],
+    ])(
+      "should add margin-left in %s to make space for inlineControl button",
+      (name, element) => {
+        assertStyleMatch(
+          {
+            marginRight: "24px",
+          },
+          wrapper.find(element)
+        );
+      }
+    );
+  });
+
   describe("Link Previews", () => {
     it("renders any LinkPreviews passed in via the `previews` prop passed as an array", () => {
       const previews = [

--- a/src/components/note/note.style.ts
+++ b/src/components/note/note.style.ts
@@ -3,7 +3,10 @@ import { margin } from "styled-system";
 import baseTheme from "../../style/themes/base";
 import { StyledLinkPreview } from "../link-preview/link-preview.style";
 
-const StyledNoteContent = styled.div<{ hasPreview?: boolean }>`
+const StyledNoteContent = styled.div<{
+  hasInlineControl: boolean;
+  hasPreview?: boolean;
+}>`
   position: relative;
   width: 100%;
 
@@ -34,6 +37,8 @@ const StyledNoteContent = styled.div<{ hasPreview?: boolean }>`
       margin-top: var(--spacing200);
     `}
   `}
+
+  ${({ hasInlineControl }) => hasInlineControl && "margin-right: 24px;"}
 `;
 
 const StyledInlineControl = styled.div`
@@ -43,11 +48,13 @@ const StyledInlineControl = styled.div`
   z-index: 100;
 `;
 
-const StyledTitle = styled.header`
+const StyledTitle = styled.header<{ hasInlineControl: boolean }>`
   font-weight: 900;
   font-size: 16px;
   line-height: 21px;
   padding-bottom: 16px;
+
+  ${({ hasInlineControl }) => hasInlineControl && "margin-right: 24px;"}
 `;
 
 const StyledFooterContent = styled.div<{ hasName: boolean }>`


### PR DESCRIPTION
### Proposed behaviour
![image](https://user-images.githubusercontent.com/22885392/212732387-1d9d9907-7fdc-410e-ab85-aa87222633eb.png)

Add margin to Note tile and Note content to avoid these elements be overlapped by the inlineControl button.

### Current behaviour
![image](https://user-images.githubusercontent.com/22885392/212732125-0395ab99-e693-433d-b32e-4d171654a1e8.png)

When inlineControl is defined, it is rendered over the Note title or content.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
~~- [ ] Storybook added or updated if required~~
~~- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required~~
~~- [ ] Typescript `d.ts` file added or updated if required~~
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

fixes #5734

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
