### PR TITLE
test(loader): refactor for accessibility test

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -54,6 +54,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("alert") &&
       !prepareUrl[0].startsWith("action-popover") &&
       !prepareUrl[0].startsWith("anchor-navigation") &&
+      !prepareUrl[0].startsWith("loader") &&
       !prepareUrl[0].startsWith("loader-bar") &&
       !prepareUrl[0].startsWith("link-preview") &&
       !prepareUrl[0].startsWith("verticaldivider") &&

--- a/src/components/loader/loader-test.stories.tsx
+++ b/src/components/loader/loader-test.stories.tsx
@@ -58,3 +58,11 @@ Default.storyName = "default";
 Default.args = {
   size: "medium",
 };
+
+export const LoaderInsideButtonTest = ({ ...props }) => {
+  return (
+    <Button buttonType="primary" aria-label="Loading">
+      <Loader isInsideButton {...props} />
+    </Button>
+  );
+};

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Loader from "./loader.component";
-import Button from "../button/button.component";
+
+import { LoaderInsideButtonTest as LoaderInsideButton } from "./loader-test.stories";
 import { LOADER_SIZES } from "./loader.config";
 
 import { loader, loaderInsideButton } from "../../../cypress/locators/loader";
@@ -11,14 +12,6 @@ import {
   checkGoldenOutline,
   useJQueryCssValueAndAssert,
 } from "../../../cypress/support/component-helper/common-steps";
-
-const LoaderInsideButton = ({ ...props }) => {
-  return (
-    <Button buttonType="primary" aria-label="Loading">
-      <Loader isInsideButton {...props} />
-    </Button>
-  );
-};
 
 context("Test for Loader component", () => {
   describe("check props for Loader component", () => {
@@ -119,6 +112,19 @@ context("Test for Loader component", () => {
         .then(($el) => {
           checkGoldenOutline($el);
         });
+    });
+  });
+
+  describe("Accessibility tests for Loader component", () => {
+    it("should pass accessibilty tests for Loader default story", () => {
+      CypressMountWithProviders(<Loader />);
+
+      cy.checkAccessibility();
+    });
+    it("should pass accessibility tests for loading state", () => {
+      CypressMountWithProviders(<LoaderInsideButton />);
+
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Loader` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `loader.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `loader` tests are not running twice.