### PR TITLE
test(help): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -65,6 +65,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("advanced-color-picker") &&
       !prepareUrl[0].startsWith("preview") &&
       !prepareUrl[0].startsWith("detail") &&
+      !prepareUrl[0].startsWith("help") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/help/help.test.js
+++ b/src/components/help/help.test.js
@@ -111,13 +111,13 @@ context("Tests for Help component", () => {
       }
     );
 
-    it.each([
-      ["carbon", "https://carbon.sage.com"],
-      ["google", "https://www.google.com"],
-    ])("should check %s href for Help component", (name, link) => {
-      CypressMountWithProviders(<HelpComponent href={link} />);
-      getComponent("help").should("have.attr", "href", link);
-    });
+    it.each(["https://carbon.sage.com", "google", "https://www.google.com"])(
+      "should check %s href for Help component",
+      (link) => {
+        CypressMountWithProviders(<HelpComponent href={link} />);
+        getComponent("help").should("have.attr", "href", link);
+      }
+    );
 
     it.each([true, false])(
       "should check when isFocused is %s for Help component",
@@ -133,14 +133,9 @@ context("Tests for Help component", () => {
       }
     );
 
-    it.each([
-      ["orange", COLOR.ORANGE],
-      ["red", COLOR.RED],
-      ["black", COLOR.BLACK],
-      ["brown", COLOR.BROWN],
-    ])(
+    it.each([COLOR.ORANGE, COLOR.RED, COLOR.BLACK, COLOR.BROWN])(
       "should check tooltip background-color as %s for Help component",
-      (name, color) => {
+      (color) => {
         CypressMountWithProviders(
           <HelpComponent tooltipBgColor={color} isFocused>
             {tooltipText}
@@ -154,14 +149,9 @@ context("Tests for Help component", () => {
       }
     );
 
-    it.each([
-      ["orange", COLOR.ORANGE],
-      ["red", COLOR.RED],
-      ["black", COLOR.BLACK],
-      ["brown", COLOR.BROWN],
-    ])(
+    it.each([COLOR.ORANGE, COLOR.RED, COLOR.BLACK, COLOR.BROWN])(
       "should check tooltip font color as %s for Help component",
-      (name, color) => {
+      (color) => {
         CypressMountWithProviders(
           <HelpComponent tooltipFontColor={color} isFocused>
             {tooltipText}
@@ -196,7 +186,7 @@ context("Tests for Help component", () => {
       (id) => {
         CypressMountWithProviders(
           <HelpComponent tooltipId={id} isFocused>
-            {tooltipText}{" "}
+            {tooltipText}
           </HelpComponent>
         );
         getDataElementByValue("tooltip").should("have.id", id);
@@ -216,6 +206,139 @@ context("Tests for Help component", () => {
       (icon) => {
         CypressMountWithProviders(<HelpComponent isFocused type={icon} />);
         getComponent("icon").should("have.attr", "type", icon);
+      }
+    );
+  });
+
+  describe("Accessibility tests for Help component", () => {
+    it.each(testData)(
+      "should check %s as helpId for accessibility tests",
+      (id) => {
+        CypressMountWithProviders(<HelpComponent helpId={id} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check className as %s for accessibility tests",
+      (classname) => {
+        CypressMountWithProviders(<HelpComponent className={classname} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check %s as children for accessibility tests",
+      (children) => {
+        CypressMountWithProviders(<Help> {children} </Help>);
+        cy.checkAccessibility();
+      }
+    );
+
+    // FE-5625
+    describe.skip("check accessibility for tabIndex", () => {
+      it.each(["-1", "0", "1"])(
+        "should check tabIndex as %s for accessibility tests",
+        (tabIndex) => {
+          CypressMountWithProviders(<HelpComponent tabIndex={tabIndex} />);
+          cy.checkAccessibility();
+        }
+      );
+    });
+
+    it.each(["bottom", "left", "right", "top"])(
+      "should check tooltipPosition as %s for accessibility tests",
+      (position) => {
+        CypressMountWithProviders(
+          <HelpComponent tooltipPosition={position} isFocused>
+            {`This tooltip is positioned ${position}`}
+          </HelpComponent>
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["https://carbon.sage.com", "https://www.google.com"])(
+      "should check href as %s for accessibility tests",
+      (name, link) => {
+        CypressMountWithProviders(<HelpComponent href={link} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "should check isFocused as %s for accessibility tests",
+      (boolVal) => {
+        CypressMountWithProviders(
+          <HelpComponent isFocused={boolVal}>{tooltipText}</HelpComponent>
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([COLOR.ORANGE, COLOR.RED, COLOR.BLACK, COLOR.BROWN])(
+      "should check tooltipBgColor as %s for accessibility tests",
+      (color) => {
+        CypressMountWithProviders(
+          <HelpComponent tooltipBgColor={color} isFocused>
+            {tooltipText}
+          </HelpComponent>
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([COLOR.ORANGE, COLOR.RED, COLOR.BLACK, COLOR.BROWN])(
+      "should check tooltipFontColor as %s for accessibility tests",
+      (color) => {
+        CypressMountWithProviders(
+          <HelpComponent tooltipFontColor={color} isFocused>
+            {tooltipText}
+          </HelpComponent>
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["top", "bottom", "right", "left"])(
+      "should check tooltipFlipOverrides position as %s for accessibility tests",
+      (position) => {
+        CypressMountWithProviders(
+          <Box m="50px">
+            <HelpComponent isFocused tooltipFlipOverrides={[position]}>
+              {`This tooltip is positioned ${position}`}
+            </HelpComponent>
+          </Box>
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check tooltipId as %s for accessibility tests",
+      (id) => {
+        CypressMountWithProviders(
+          <HelpComponent tooltipId={id} isFocused>
+            {tooltipText}
+          </HelpComponent>
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check ariaLabel as %s for accessibility tests",
+      (label) => {
+        CypressMountWithProviders(<HelpComponent ariaLabel={label} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["error", "add", "minus", "settings"])(
+      "should check type as %s for accessibility tests",
+      (icon) => {
+        CypressMountWithProviders(<HelpComponent isFocused type={icon} />);
+        cy.checkAccessibility();
       }
     );
   });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Help` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `help.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `alert` tests are not running twice.