### PR TITLE
test(dialog-full-screen): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -67,6 +67,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("detail") &&
       !prepareUrl[0].startsWith("help") &&
       !prepareUrl[0].startsWith("toast") &&
+      !prepareUrl[0].startsWith("dialog-full-screen") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/dialog-full-screen/dialog-full-screen-test.stories.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen-test.stories.tsx
@@ -4,9 +4,14 @@ import DialogFullScreen, { DialogFullScreenProps } from ".";
 import Dialog from "../dialog";
 import Button from "../button";
 import Form from "../form";
+import Textbox from "../textbox";
+import Pill from "../pill";
+import Box from "../box";
+import CarbonProvider from "../carbon-provider";
 
 export default {
   title: "Dialog Full Screen/Test",
+  includeStories: "DefaultStory",
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -20,7 +25,7 @@ interface DefaultProps extends Partial<DialogFullScreenProps> {
   formHeight?: number;
 }
 
-export const Default = ({
+export const DefaultStory = ({
   stickyFooter,
   formHeight,
   children,
@@ -67,8 +72,8 @@ export const Default = ({
   );
 };
 
-Default.storyName = "default";
-Default.args = {
+DefaultStory.storyName = "default";
+DefaultStory.args = {
   title: "Example Dialog",
   subtitle: "Example Subtitle",
   children: "Text Content",
@@ -126,3 +131,155 @@ export const Nested = () => {
 };
 
 Nested.storyName = "nested";
+
+export const mainDialogTitle = "Main Dialog";
+export const nestedDialogTitle = "Nested Dialog";
+export const DialogFullScreenComponent = ({
+  // eslint-disable-next-line react/prop-types
+  children = "This is an example",
+  ...props
+}) => {
+  const [isOpen, setIsOpen] = useState(true);
+  const ref = React.useRef(null);
+  return (
+    <>
+      <DialogFullScreen
+        open={isOpen}
+        showCloseIcon
+        onCancel={() => setIsOpen(false)}
+        focusFirstElement={ref}
+        {...props}
+      >
+        <Button onClick={() => setIsOpen(false)}>Not focused</Button>
+        <Button forwardRef={ref} onClick={() => setIsOpen(false)}>
+          This should be focused first now
+        </Button>
+
+        <Textbox label="Textbox1" value="Textbox1" />
+        <Textbox label="Textbox2" value="Textbox2" />
+        <Textbox label="Textbox3" value="Textbox3" />
+        <Form>{children}</Form>
+      </DialogFullScreen>
+    </>
+  );
+};
+
+export const NestedDialog = () => {
+  const [mainDialogOpen, setMainDialogOpen] = React.useState(false);
+  const [nestedDialogOpen, setNestedDialogOpen] = React.useState(false);
+
+  const handleMainDialogOpen = () => {
+    setMainDialogOpen(true);
+  };
+
+  const handleMainDialogCancel = () => {
+    setMainDialogOpen(false);
+  };
+
+  const handleNestedDialogOpen = () => {
+    setNestedDialogOpen(true);
+  };
+
+  const handleNestedDialogCancel = () => {
+    setNestedDialogOpen(false);
+  };
+
+  return (
+    <>
+      <Button onClick={handleMainDialogOpen}>Open Main Dialog</Button>
+      <DialogFullScreen
+        open={mainDialogOpen}
+        onCancel={handleMainDialogCancel}
+        title={mainDialogTitle}
+      >
+        <Button onClick={handleNestedDialogOpen}>Open Nested Dialog</Button>
+        <Dialog
+          open={nestedDialogOpen}
+          onCancel={handleNestedDialogCancel}
+          title={nestedDialogTitle}
+        >
+          Nested Dialog Content
+        </Dialog>
+      </DialogFullScreen>
+    </>
+  );
+};
+
+export const MultipleDialogsInDifferentProviders = () => {
+  const [isModal1Open, setIsModal1Open] = React.useState(false);
+  const [isModal2Open, setIsModal2Open] = React.useState(false);
+  return (
+    <>
+      <CarbonProvider>
+        <Box>
+          <Button onClick={() => setIsModal1Open(true)}>Open Modal 1</Button>
+          <DialogFullScreen
+            title="Full Screen Dialog"
+            open={isModal1Open}
+            onCancel={() => setIsModal1Open(false)}
+          >
+            This is Modal 1
+            <Button onClick={() => setIsModal2Open(true)}>Open Modal 2</Button>
+          </DialogFullScreen>
+        </Box>
+      </CarbonProvider>
+      <CarbonProvider>
+        <Box>
+          <Dialog open={isModal2Open} onCancel={() => setIsModal2Open(false)}>
+            This is Modal 2
+          </Dialog>
+        </Box>
+      </CarbonProvider>
+    </>
+  );
+};
+
+export const DialogFullScreenWithHeaderChildren = () => {
+  const [isOpen, setIsOpen] = React.useState(true);
+  const HeaderChildren = (
+    <div
+      style={{
+        margin: `$min-width: 568px 0 26px`,
+      }}
+    >
+      <Pill fill>A pill</Pill>
+      <Pill fill ml={2} mr={1}>
+        Another pill
+      </Pill>
+    </div>
+  );
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open DialogFullScreen</Button>
+      <DialogFullScreen
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        title="An example of a long header"
+        subtitle="Subtitle"
+        headerChildren={HeaderChildren}
+      >
+        <Form
+          stickyFooter
+          leftSideButtons={
+            <Button onClick={() => setIsOpen(false)}>Cancel</Button>
+          }
+          saveButton={
+            <Button buttonType="primary" type="submit">
+              Save
+            </Button>
+          }
+        >
+          <div>
+            This is an example of a full screen Dialog with a Form as content
+          </div>
+          <Textbox label="First Name" />
+          <Textbox label="Middle Name" />
+          <Textbox label="Surname" />
+          <Textbox label="Birth Place" />
+          <Textbox label="Favourite Colour" />
+          <Textbox label="Address" />
+        </Form>
+      </DialogFullScreen>
+    </>
+  );
+};

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.tsx
@@ -78,7 +78,7 @@ export const Default = () => {
 };
 Default.parameters = { chromatic: { disable: true } };
 
-export const WithComplexExample = () => {
+export const WithComplexExample = ({ ...props }) => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
   const [activeTab, setActiveTab] = useState("tab-1");
   const padding40 = useMediaQuery("(min-width: 1260px)");
@@ -514,6 +514,7 @@ export const WithComplexExample = () => {
         disableEscKey={false}
         showCloseIcon
         disableContentPadding
+        {...props}
       >
         <Drawer sidebar={SidebarContent}>
           <Box p={5}>{showCorrectContent()}</Box>
@@ -523,7 +524,7 @@ export const WithComplexExample = () => {
   );
 };
 
-export const WithDisableContentPadding = () => {
+export const WithDisableContentPadding = ({ ...props }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -535,6 +536,7 @@ export const WithDisableContentPadding = () => {
         title="Title"
         subtitle="Subtitle"
         disableContentPadding
+        {...props}
       >
         <Form
           stickyFooter
@@ -563,7 +565,7 @@ export const WithDisableContentPadding = () => {
 };
 WithDisableContentPadding.parameters = { chromatic: { disable: true } };
 
-export const WithHeaderChildren = () => {
+export const WithHeaderChildren = ({ ...props }) => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
   const aboveBreakpoint = useMediaQuery("(min-width: 568px)");
   const verticalMargin = aboveBreakpoint ? "26px" : 0;
@@ -584,6 +586,7 @@ export const WithHeaderChildren = () => {
         title="An example of a long header"
         subtitle="Subtitle"
         headerChildren={HeaderChildren}
+        {...props}
       >
         <Form
           stickyFooter
@@ -612,7 +615,7 @@ export const WithHeaderChildren = () => {
 };
 WithDisableContentPadding.parameters = { viewports: [500, 1400] };
 
-export const WithHelp = () => {
+export const WithHelp = ({ ...props }) => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
@@ -623,6 +626,7 @@ export const WithHelp = () => {
         title="An example of a long header"
         subtitle="Subtitle"
         help="Some help text"
+        {...props}
       >
         <Form
           stickyFooter
@@ -650,7 +654,7 @@ export const WithHelp = () => {
   );
 };
 
-export const WithHideableHeaderChildren = () => {
+export const WithHideableHeaderChildren = ({ ...props }) => {
   const [isOpen, setIsOpen] = useState(false);
   const aboveBreakpoint = useMediaQuery("(min-width: 568px)");
   const verticalMargin = aboveBreakpoint ? "26px" : 0;
@@ -694,6 +698,7 @@ export const WithHideableHeaderChildren = () => {
             ? HeaderChildrenAboveBreakpoint
             : HeaderChildrenBelowBreakpoint
         }
+        {...props}
       >
         <Form
           stickyFooter
@@ -722,7 +727,7 @@ export const WithHideableHeaderChildren = () => {
 };
 WithHideableHeaderChildren.parameters = { chromatic: { disable: true } };
 
-export const WithBox = () => {
+export const WithBox = ({ ...props }) => {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <>
@@ -732,6 +737,7 @@ export const WithBox = () => {
         onCancel={() => setIsOpen(false)}
         title="Title"
         subtitle="Subtitle"
+        {...props}
       >
         <Box p="0px 40px">
           <Form
@@ -762,7 +768,7 @@ export const WithBox = () => {
 };
 WithBox.parameters = { chromatic: { disable: true } };
 
-export const FocusingADifferentFirstElement = () => {
+export const FocusingADifferentFirstElement = ({ ...props }) => {
   const [isOpenOne, setIsOpenOne] = useState(false);
   const [isOpenTwo, setIsOpenTwo] = useState(false);
   const ref = useRef<HTMLButtonElement | null>(null);
@@ -777,6 +783,7 @@ export const FocusingADifferentFirstElement = () => {
         onCancel={() => setIsOpenOne(false)}
         title="Title"
         subtitle="Subtitle"
+        {...props}
       >
         <p>Focus an element that doesnt support autofocus</p>
         <div
@@ -823,7 +830,7 @@ export const FocusingADifferentFirstElement = () => {
 };
 FocusingADifferentFirstElement.parameters = { chromatic: { disable: true } };
 
-export const OtherFocusableContainers = () => {
+export const OtherFocusableContainers = ({ ...props }) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isToast1Open, setIsToast1Open] = useState(false);
   const [isToast2Open, setIsToast2Open] = useState(false);
@@ -840,6 +847,7 @@ export const OtherFocusableContainers = () => {
         title="Title"
         subtitle="Subtitle"
         focusableContainers={[toast1Ref, toast2Ref]}
+        {...props}
       >
         <Form
           stickyFooter

--- a/src/components/dialog-full-screen/dialog-full-screen.test.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.test.js
@@ -1,13 +1,23 @@
 import React from "react";
 import PropTypes from "prop-types";
-import DialogFullScreen from "./dialog-full-screen.component";
-import Dialog from "../dialog/dialog.component";
-import Button from "../button";
-import Textbox from "../textbox";
-import Pill from "../pill";
-import Form from "../form";
-import Box from "../box";
-import CarbonProvider from "../carbon-provider";
+import {
+  DialogFullScreenComponent,
+  NestedDialog,
+  MultipleDialogsInDifferentProviders,
+  DialogFullScreenWithHeaderChildren,
+  mainDialogTitle,
+  nestedDialogTitle,
+} from "./dialog-full-screen-test.stories";
+import {
+  WithComplexExample,
+  WithDisableContentPadding,
+  WithHeaderChildren,
+  WithHelp,
+  WithHideableHeaderChildren,
+  WithBox,
+  FocusingADifferentFirstElement,
+  OtherFocusableContainers,
+} from "./dialog-full-screen.stories.tsx";
 import {
   dialogTitle,
   dialogSubtitle,
@@ -33,155 +43,6 @@ import { CHARACTERS } from "../../../cypress/support/component-helper/constants"
 
 const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testAria = "cypress_aria";
-const mainDialogTitle = "Main Dialog";
-const nestedDialogTitle = "Nested Dialog";
-const DialogFullScreenComponent = ({ children, ...props }) => {
-  const [isOpen, setIsOpen] = React.useState(true);
-  const ref = React.useRef();
-  return (
-    <>
-      <DialogFullScreen
-        open={isOpen}
-        showCloseIcon
-        onCancel={() => setIsOpen(false)}
-        focusFirstElement={ref}
-        {...props}
-      >
-        <Button onClick={() => setIsOpen(false)}>Not focused</Button>
-        <Button forwardRef={ref} onClick={() => setIsOpen(false)}>
-          This should be focused first now
-        </Button>
-
-        <Textbox label="Textbox1" value="Textbox1" />
-        <Textbox label="Textbox2" value="Textbox2" />
-        <Textbox label="Textbox3" value="Textbox3" />
-        <Form>{children}</Form>
-      </DialogFullScreen>
-    </>
-  );
-};
-
-const NestedDialog = () => {
-  const [mainDialogOpen, setMainDialogOpen] = React.useState(false);
-  const [nestedDialogOpen, setNestedDialogOpen] = React.useState(false);
-
-  const handleMainDialogOpen = () => {
-    setMainDialogOpen(true);
-  };
-
-  const handleMainDialogCancel = () => {
-    setMainDialogOpen(false);
-  };
-
-  const handleNestedDialogOpen = () => {
-    setNestedDialogOpen(true);
-  };
-
-  const handleNestedDialogCancel = () => {
-    setNestedDialogOpen(false);
-  };
-
-  return (
-    <>
-      <Button onClick={handleMainDialogOpen}>Open Main Dialog</Button>
-      <DialogFullScreen
-        open={mainDialogOpen}
-        onCancel={handleMainDialogCancel}
-        title={mainDialogTitle}
-      >
-        <Button onClick={handleNestedDialogOpen}>Open Nested Dialog</Button>
-        <Dialog
-          open={nestedDialogOpen}
-          onCancel={handleNestedDialogCancel}
-          title={nestedDialogTitle}
-        >
-          Nested Dialog Content
-        </Dialog>
-      </DialogFullScreen>
-    </>
-  );
-};
-
-const MultipleDialogsInDifferentProviders = () => {
-  const [isModal1Open, setIsModal1Open] = React.useState(false);
-  const [isModal2Open, setIsModal2Open] = React.useState(false);
-  return (
-    <>
-      <CarbonProvider>
-        <Box>
-          <Button onClick={() => setIsModal1Open(true)}>Open Modal 1</Button>
-          <DialogFullScreen
-            title="Full Screen Dialog"
-            open={isModal1Open}
-            onCancel={() => setIsModal1Open(false)}
-          >
-            This is Modal 1
-            <Button onClick={() => setIsModal2Open(true)}>Open Modal 2</Button>
-          </DialogFullScreen>
-        </Box>
-      </CarbonProvider>
-      <CarbonProvider>
-        <Box>
-          <Dialog open={isModal2Open} onCancel={() => setIsModal2Open(false)}>
-            This is Modal 2
-          </Dialog>
-        </Box>
-      </CarbonProvider>
-    </>
-  );
-};
-
-const DialogFullScreenWithHeaderChildren = () => {
-  const [isOpen, setIsOpen] = React.useState(true);
-  const HeaderChildren = (
-    <div
-      style={{
-        margin: `$min-width: 568px 0 26px`,
-      }}
-    >
-      <Pill as="help" fill>
-        A pill
-      </Pill>
-      <Pill as="info" fill ml={2} mr={1}>
-        Another pill
-      </Pill>
-    </div>
-  );
-  return (
-    <>
-      <Button onClick={() => setIsOpen(true)}>Open DialogFullScreen</Button>
-      <DialogFullScreen
-        open={isOpen}
-        onCancel={() => setIsOpen(false)}
-        title="An example of a long header"
-        subtitle="Subtitle"
-        headerChildren={HeaderChildren}
-      >
-        <Form
-          stickyFooter
-          leftSideButtons={
-            <Button onClick={() => setIsOpen(false)}>Cancel</Button>
-          }
-          saveButton={
-            <Button buttonType="primary" type="submit">
-              Save
-            </Button>
-          }
-        >
-          <div>
-            This is an example of a full screen Dialog with a Form as content
-          </div>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
-        </Form>
-      </DialogFullScreen>
-    </>
-  );
-};
 
 DialogFullScreenComponent.propTypes = {
   children: PropTypes.node.isRequired,
@@ -412,6 +273,62 @@ context("Testing DialogFullScreen component", () => {
       contentElement()
         .should("have.css", "padding-right", "0px")
         .should("have.css", "padding-bottom", "0px");
+    });
+  });
+
+  describe("should check accessibility for Dialog Full Screen", () => {
+    it("should check accessibility for default Dialog Full Screen component", () => {
+      CypressMountWithProviders(<DialogFullScreenComponent open />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for default Dialog Full Screen with complex example", () => {
+      CypressMountWithProviders(<WithComplexExample open />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for default Dialog Full Screen with disabled content padding", () => {
+      CypressMountWithProviders(<WithDisableContentPadding open />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for default Dialog Full Screen component with header children", () => {
+      CypressMountWithProviders(<WithHeaderChildren open />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for default Dialog Full Screen component with help", () => {
+      CypressMountWithProviders(<WithHelp open />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for default Dialog Full Screen component with hideable header children", () => {
+      CypressMountWithProviders(<WithHideableHeaderChildren open />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for default Dialog Full Screen component with box", () => {
+      CypressMountWithProviders(<WithBox open />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for default Dialog Full Screen component using autoFocus", () => {
+      CypressMountWithProviders(<FocusingADifferentFirstElement open />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for default Dialog Full Screen component with other focusable containers", () => {
+      CypressMountWithProviders(<OtherFocusableContainers open />);
+
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Dialog-Full-Screen` component to use the new cypress-component-react framework for testing.
- Refactor `dialog-full-screen.stories.mdx` and `dialog-full-screen.stories.test.mdx` to corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there is newly added test.file
- [ ] Check if the `dialog-full-screen.test.js` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `action-popover` tests are not running twice.