### PR TITLE
test(toast): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -66,6 +66,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("preview") &&
       !prepareUrl[0].startsWith("detail") &&
       !prepareUrl[0].startsWith("help") &&
+      !prepareUrl[0].startsWith("toast") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/toast/toast-test.stories.tsx
+++ b/src/components/toast/toast-test.stories.tsx
@@ -7,6 +7,7 @@ import { TOAST_COLORS } from "./toast.config";
 
 export default {
   title: "Toast/Test",
+  includeStories: ["Default", "Visual"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -231,4 +232,25 @@ Visual.parameters = {
     disable: false,
   },
   themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const ToastComponent = ({
+  children = "Toast",
+  ...props
+}: Partial<ToastProps>) => {
+  const [isOpen, setIsOpen] = React.useState(true);
+
+  return (
+    <>
+      <Toast
+        variant="info"
+        id="toast-cypress"
+        open={isOpen}
+        onDismiss={() => setIsOpen(!isOpen)}
+        {...props}
+      >
+        {children}
+      </Toast>
+    </>
+  );
 };

--- a/src/components/toast/toast.test.js
+++ b/src/components/toast/toast.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Toast from ".";
+import { ToastComponent } from "./toast-test.stories";
 import { TOAST_COLORS } from "./toast.config";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { checkGoldenOutline } from "../../../cypress/support/component-helper/common-steps";
@@ -16,25 +16,6 @@ const colorTypes = [
   ["rgb(0, 138, 33)"],
   ["rgb(239, 103, 0)"],
 ];
-
-// eslint-disable-next-line react/prop-types
-const ToastComponent = ({ children, ...props }) => {
-  const [isOpen, setIsOpen] = React.useState(true);
-
-  return (
-    <>
-      <Toast
-        variant="info"
-        id="toast-cypress"
-        open={isOpen}
-        onDismiss={() => setIsOpen(!isOpen)}
-        {...props}
-      >
-        {children}
-      </Toast>
-    </>
-  );
-};
 
 context("Testing Toast component", () => {
   describe("should render Toast component", () => {
@@ -205,6 +186,34 @@ context("Testing Toast component", () => {
         // eslint-disable-next-line no-unused-expressions
         expect(callback).to.have.been.calledOnce;
       });
+    });
+  });
+
+  describe("should render Toast component and check accessibility issues", () => {
+    it.each([
+      TOAST_COLORS[0],
+      TOAST_COLORS[1],
+      TOAST_COLORS[2],
+      TOAST_COLORS[3],
+    ])(
+      "should render Toast component with %s variant and check accessibility",
+      (variant) => {
+        CypressMountWithProviders(<ToastComponent variant={variant} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should render Toast component with notice variant and check accessibility", () => {
+      CypressMountWithProviders(<ToastComponent variant="notice" open />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should render Toast component with maxWidth prop and check accessibility", () => {
+      CypressMountWithProviders(<ToastComponent maxWidth="250px" />);
+
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Toast` component to use the new cypress-component-react framework for testing.
- Refactor `toast-test.stories.js` to the corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `toast.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `alert` tests are not running twice.