### PR TITLE
docs: change 'Storybook' to 'Carbon' in <title>

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -2,6 +2,7 @@ import { addons, types } from "@storybook/addons";
 import sageTheme from "./sageTheme";
 import { ADDON_ID, TOOL_ID } from "./version-picker/constants";
 import { VersionPicker } from "./version-picker";
+import "./titleAddon";
 
 addons.setConfig({
   theme: sageTheme,

--- a/.storybook/titleAddon.js
+++ b/.storybook/titleAddon.js
@@ -1,0 +1,28 @@
+import addons from "@storybook/addons";
+import { STORY_RENDERED } from "@storybook/core-events";
+
+addons.register("TitleAddon", (api) => {
+  const customTitle = "Carbon";
+  let interval = null;
+  const setTitle = () => {
+    clearTimeout(interval);
+    let storyData = null;
+    try {
+      storyData = api.getCurrentStoryData();
+    } catch (e) {}
+    let title;
+    if (!storyData) {
+      title = customTitle;
+    } else {
+      title = `${storyData.kind} - ${storyData.name} ⋅ ${customTitle}`;
+    }
+    if (document.title !== title) {
+      document.title = title;
+    }
+    interval = setTimeout(setTitle, 100);
+  };
+  setTitle();
+  api.on(STORY_RENDERED, (story) => {
+    setTitle();
+  });
+});


### PR DESCRIPTION
### Proposed behaviour

Change the HTML title rendered in the browser to display "Carbon" instead of "Storybook".

Also, change the label on the app icon when you add the Carbon site to a mobile device's Home screen to read "Carbon" instead of "Storybook".

See FE-5630

### Current behaviour

The title is displayed in the current format:

`${storyData.kind} - ${storyData.name} ⋅ Storybook`
 
For example "Welcome - Welcome Page - Storybook".

![storybook-tab](https://user-images.githubusercontent.com/83212011/214269209-e9072399-f856-4973-88d5-8d9595423aba.png)

Also, when you view the Carbon website on a mobile device and select **Add to Home screen**, the label added to the Home screen appears as "Storybook".

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

1. From this branch run `npm start`.
2. In your browser, go to http://localhost:9001
3. The title in the browser tab should initially display "Carbon" and then "Welcome - Welcome page - Carbon"
4. On a mobile device browser go to http://192.168.86.28:9001
5. Select **Add to Home screen**.
6. The icon added to the Home screen should be labelled "Carbon"
