### PR TITLE
test(sidebar): refactor for accessibility test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [114.6.0](https://github.com/Sage/carbon/compare/v114.5.1...v114.6.0) (2023-01-26)
+
+
+### Features
+
+* add new VerticalMenu component ([819d65d](https://github.com/Sage/carbon/commit/819d65d077b4c28d216cf96f753b1fcc6ee96b61))
+
 ### [114.5.1](https://github.com/Sage/carbon/compare/v114.5.0...v114.5.1) (2023-01-26)
 
 

--- a/cypress/locators/vertical-menu/index.js
+++ b/cypress/locators/vertical-menu/index.js
@@ -1,0 +1,12 @@
+import {
+  VERTICAL_MENU_TRIGGER,
+  VERTICAL_MENU_COMPONENT,
+  VERTICAL_MENU_ITEM,
+  VERTICAL_MENU_FULL_SCREEN,
+} from "./locators";
+
+// component preview locators
+export const verticalMenuComponent = () => cy.get(VERTICAL_MENU_COMPONENT);
+export const verticalMenuItem = () => cy.get(VERTICAL_MENU_ITEM);
+export const verticalMenuTrigger = () => cy.get(VERTICAL_MENU_TRIGGER);
+export const verticalMenuFullScreen = () => cy.get(VERTICAL_MENU_FULL_SCREEN);

--- a/cypress/locators/vertical-menu/locators.js
+++ b/cypress/locators/vertical-menu/locators.js
@@ -1,0 +1,6 @@
+// component preview locators
+export const VERTICAL_MENU_COMPONENT = '[data-component="vertical-menu"]';
+export const VERTICAL_MENU_ITEM = '[data-component="vertical-menu-item"]';
+export const VERTICAL_MENU_TRIGGER = '[data-component="vertical-menu-trigger"]';
+export const VERTICAL_MENU_FULL_SCREEN =
+  '[data-component="vertical-menu-full-screen"]';

--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -67,6 +67,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("detail") &&
       !prepareUrl[0].startsWith("help") &&
       !prepareUrl[0].startsWith("toast") &&
+      !prepareUrl[0].startsWith("sidebar") &&
       !prepareUrl[0].startsWith("dialog-full-screen") &&
       !prepareUrl[0].startsWith("verticalmenu") &&
       !prepareUrl[0].endsWith("test")

--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -68,6 +68,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("help") &&
       !prepareUrl[0].startsWith("toast") &&
       !prepareUrl[0].startsWith("dialog-full-screen") &&
+      !prepareUrl[0].startsWith("verticalmenu") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "carbon-react",
-  "version": "114.5.1",
+  "version": "114.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "carbon-react",
-      "version": "114.5.1",
+      "version": "114.6.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-react",
-  "version": "114.5.1",
+  "version": "114.6.0",
   "description": "A library of reusable React components for easily building user interfaces.",
   "files": [
     "lib",

--- a/src/components/sidebar/sidebar-test.stories.tsx
+++ b/src/components/sidebar/sidebar-test.stories.tsx
@@ -92,3 +92,31 @@ Default.args = {
   enableBackgroundUI: false,
   disableEscKey: false,
 };
+
+export const SidebarComponent = ({ ...props }) => {
+  return (
+    <>
+      <Sidebar
+        aria-label="sidebar"
+        open
+        position="right"
+        size="medium"
+        {...props}
+      >
+        <div>
+          <Button buttonType="primary">Test</Button>
+          <Button buttonType="secondary" ml={2}>
+            Last
+          </Button>
+        </div>
+        <div
+          style={{
+            marginBottom: 3000,
+          }}
+        >
+          Main content
+        </div>
+      </Sidebar>
+    </>
+  );
+};

--- a/src/components/sidebar/sidebar.test.js
+++ b/src/components/sidebar/sidebar.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Sidebar from "./sidebar.component";
 import { sidebarPreview } from "../../../cypress/locators/sidebar";
+import { SidebarComponent } from "./sidebar-test.stories";
 import {
   backgroundUILocator,
   closeIconButton,
@@ -18,35 +19,6 @@ import CypressMountWithProviders from "../../../cypress/support/component-helper
 import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-helper/common-steps";
 
 const CUSTOM_SELECTOR = "button, .focusable-container input";
-
-const SidebarComponent = ({ ...props }) => {
-  return (
-    <>
-      <Sidebar
-        aria-label="sidebar"
-        onCancel={function noRefCheck() {}}
-        open
-        position="right"
-        size="medium"
-        {...props}
-      >
-        <div>
-          <Button buttonType="primary">Test</Button>
-          <Button buttonType="secondary" ml={2}>
-            Last
-          </Button>
-        </div>
-        <div
-          style={{
-            marginBottom: 3000,
-          }}
-        >
-          Main content
-        </div>
-      </Sidebar>
-    </>
-  );
-};
 
 const SidebarComponentFocusable = ({ ...props }) => {
   const [setIsDialogOpen] = React.useState(false);
@@ -269,6 +241,47 @@ context("Testing Sidebar component", () => {
           // eslint-disable-next-line no-unused-expressions
           expect(callback).to.have.been.calledOnce;
         });
+    });
+  });
+
+  describe("should render Sidebar component and check accessibility issues", () => {
+    it("should check sidebar accessibility", () => {
+      CypressMountWithProviders(<SidebarComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each(["left", "right"])(
+      "should check accessibility when sidebar position is %s",
+      (boolVal) => {
+        CypressMountWithProviders(<SidebarComponent position={boolVal} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check accessibility when sidebar has header", () => {
+      CypressMountWithProviders(
+        <SidebarComponent
+          header={<Typography variant="h3">Sidebar Header</Typography>}
+        />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it.each([
+      SIDEBAR_SIZES[0],
+      SIDEBAR_SIZES[1],
+      SIDEBAR_SIZES[2],
+      SIDEBAR_SIZES[3],
+      SIDEBAR_SIZES[4],
+      SIDEBAR_SIZES[5],
+      SIDEBAR_SIZES[6],
+    ])("should check accessibility when sidebar size is %s", (size) => {
+      CypressMountWithProviders(<SidebarComponent size={size} />);
+
+      cy.checkAccessibility();
     });
   });
 });

--- a/src/components/vertical-menu/index.ts
+++ b/src/components/vertical-menu/index.ts
@@ -1,0 +1,11 @@
+export { default as VerticalMenu } from "./vertical-menu.component";
+export type { VerticalMenuProps } from "./vertical-menu.component";
+
+export { default as VerticalMenuItem } from "./vertical-menu-item.component";
+export type { VerticalMenuItemProps } from "./vertical-menu-item.component";
+
+export { default as VerticalMenuFullScreen } from "./vertical-menu-full-screen.component";
+export type { VerticalMenuFullScreenProps } from "./vertical-menu-full-screen.component";
+
+export { default as VerticalMenuTrigger } from "./vertical-menu-trigger.component";
+export type { VerticalMenuTriggerProps } from "./vertical-menu-trigger.component";

--- a/src/components/vertical-menu/vertical-menu-full-screen.component.tsx
+++ b/src/components/vertical-menu/vertical-menu-full-screen.component.tsx
@@ -1,0 +1,104 @@
+import React, { useCallback, useRef } from "react";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
+
+import useLocale from "../../hooks/__internal__/useLocale";
+import Portal from "../portal";
+import FocusTrap from "../../__internal__/focus-trap/focus-trap.component";
+import IconButton from "../icon-button";
+import Icon from "../icon";
+import Box from "../box";
+import {
+  StyledList,
+  StyledVerticalMenuFullScreen,
+} from "./vertical-menu.style";
+import VerticalMenuFullScreenContext from "./vertical-menu-full-screen.context";
+import Events from "../../__internal__/utils/helpers/events/events";
+
+export interface VerticalMenuFullScreenProps extends TagProps {
+  /** An aria-label attribute for the menu */
+  "aria-label"?: string;
+  /** An aria-labelledby attribute for the menu */
+  "aria-labelledby"?: string;
+  /**  Content of the menu - VerticalMenuItem */
+  children: React.ReactNode;
+  /** Whether the menu is open or not */
+  isOpen: boolean;
+  /** A callback to be called when the close icon is clicked or enter is pressed when focused */
+  onClose: (
+    ev:
+      | React.KeyboardEvent<HTMLButtonElement>
+      | React.MouseEvent<HTMLButtonElement>
+  ) => void;
+}
+
+export const VerticalMenuFullScreen = ({
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
+  children,
+  isOpen,
+  onClose,
+  ...rest
+}: VerticalMenuFullScreenProps) => {
+  const l = useLocale();
+
+  const menuWrapperRef = useRef<HTMLDivElement | null>(null);
+
+  const handleKeyDown = useCallback(
+    (ev) => {
+      // istanbul ignore else
+      if (Events.isEscKey(ev)) {
+        onClose(ev);
+      }
+    },
+    [onClose]
+  );
+
+  // TODO remove this as part of FE-5650
+  if (!isOpen) return null;
+
+  return (
+    <Portal>
+      <FocusTrap isOpen={isOpen} wrapperRef={menuWrapperRef}>
+        <StyledVerticalMenuFullScreen
+          ref={menuWrapperRef}
+          scrollVariant="light"
+          as="nav"
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
+          onKeyDown={handleKeyDown}
+          {...tagComponent("vertical-menu-full-screen", rest)}
+        >
+          <Box
+            display="flex"
+            justifyContent="flex-end"
+            height="60px"
+            alignItems="flex-start"
+            px="20px"
+            pt="20px"
+            boxSizing="border-box"
+          >
+            <IconButton
+              aria-label={l.verticalMenuFullScreen.ariaLabels.close()}
+              onAction={onClose}
+              data-element="close"
+            >
+              <Icon
+                type="close"
+                color="var(--colorsComponentsLeftnavWinterStandardContent)"
+                bgSize="small"
+                fontSize="medium"
+              />
+            </IconButton>
+          </Box>
+          <VerticalMenuFullScreenContext.Provider
+            value={{ isFullScreen: true }}
+          >
+            <StyledList>{children}</StyledList>
+          </VerticalMenuFullScreenContext.Provider>
+        </StyledVerticalMenuFullScreen>
+      </FocusTrap>
+    </Portal>
+  );
+};
+
+export default VerticalMenuFullScreen;

--- a/src/components/vertical-menu/vertical-menu-full-screen.context.ts
+++ b/src/components/vertical-menu/vertical-menu-full-screen.context.ts
@@ -1,0 +1,7 @@
+import React from "react";
+
+const VerticalMenuFullScreenContext = React.createContext({
+  isFullScreen: false,
+});
+
+export default VerticalMenuFullScreenContext;

--- a/src/components/vertical-menu/vertical-menu-full-screen.spec.tsx
+++ b/src/components/vertical-menu/vertical-menu-full-screen.spec.tsx
@@ -1,0 +1,185 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import Portal from "../portal";
+import FocusTrap from "../../__internal__/focus-trap/focus-trap.component";
+import { VerticalMenuFullScreen, VerticalMenuItem } from ".";
+
+jest.mock("../portal", () => jest.fn(({ children }) => <div>{children}</div>));
+
+jest.mock("../../__internal__/focus-trap/focus-trap.component", () =>
+  jest.fn(({ children }) => <div>{children}</div>)
+);
+
+describe("VerticalMenuFullScreen", () => {
+  it("should accepts aria-label prop", () => {
+    render(
+      <VerticalMenuFullScreen isOpen onClose={() => {}} aria-label="test">
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenuFullScreen>
+    );
+
+    expect(screen.getByRole("navigation")).toHaveAttribute(
+      "aria-label",
+      "test"
+    );
+  });
+
+  it("should accepts aria-labelledby prop", () => {
+    render(
+      <VerticalMenuFullScreen isOpen onClose={() => {}} aria-labelledby="test">
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenuFullScreen>
+    );
+
+    expect(screen.getByRole("navigation")).toHaveAttribute(
+      "aria-labelledby",
+      "test"
+    );
+  });
+
+  it("should render in a Portal", () => {
+    render(
+      <VerticalMenuFullScreen isOpen onClose={() => {}}>
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenuFullScreen>
+    );
+
+    expect(Portal).toHaveBeenCalled();
+  });
+
+  it("should render a FocusTrap", () => {
+    render(
+      <VerticalMenuFullScreen isOpen onClose={() => {}}>
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenuFullScreen>
+    );
+
+    expect(FocusTrap).toHaveBeenCalled();
+  });
+
+  // TODO remove skip as part of FE-5650
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should render hidden when "isOpen" prop is false', () => {
+    render(
+      <VerticalMenuFullScreen isOpen={false} onClose={() => {}}>
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenuFullScreen>
+    );
+
+    expect(screen.getByRole("navigation", { hidden: true })).toHaveStyle({
+      visibility: "hidden",
+      transform: "translateX(-100%)",
+    });
+  });
+
+  // TODO remove skip as part of FE-5650
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should render visible when "isOpen" prop is true', () => {
+    render(
+      <VerticalMenuFullScreen isOpen onClose={() => {}}>
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenuFullScreen>
+    );
+
+    expect(screen.getByRole("navigation")).toHaveStyle({
+      visibility: "visible",
+      transform: "translateX(0)",
+    });
+  });
+
+  // TODO remove this as part of FE-5650
+  it("should not render the menu if isOpen is false", () => {
+    render(
+      <VerticalMenuFullScreen isOpen={false} onClose={() => {}}>
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenuFullScreen>
+    );
+
+    const menu = screen.queryByRole("navigation");
+
+    expect(menu).toBeNull();
+  });
+
+  it("should override the scrollbar styling", () => {
+    render(
+      <VerticalMenuFullScreen isOpen onClose={() => {}}>
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenuFullScreen>
+    );
+
+    expect(screen.getByRole("navigation")).toHaveStyleRule(
+      "background-color",
+      "#cccccc",
+      {
+        modifier: "::-webkit-scrollbar-track",
+      }
+    );
+
+    expect(screen.getByRole("navigation")).toHaveStyleRule(
+      "background-color",
+      "#808080",
+      {
+        modifier: "::-webkit-scrollbar-thumb",
+      }
+    );
+
+    expect(screen.getByRole("navigation")).toHaveStyleRule("width", "12px", {
+      modifier: "::-webkit-scrollbar",
+    });
+  });
+
+  it("should invoke onClose callback when close Icon is clicked", async () => {
+    const user = userEvent.setup();
+
+    const onClose = jest.fn();
+    render(
+      <VerticalMenuFullScreen isOpen onClose={onClose}>
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenuFullScreen>
+    );
+
+    await user.click(screen.getByRole("button"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("should invoke onClose callback escape key pressed", () => {
+    const onClose = jest.fn();
+    render(
+      <VerticalMenuFullScreen isOpen onClose={onClose}>
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenuFullScreen>
+    );
+
+    fireEvent.keyDown(screen.getByRole("navigation"), {
+      key: "Escape",
+      code: "Escape",
+      keyCode: 27,
+      charCode: 27,
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("should have the expected data attributes", () => {
+    render(
+      <VerticalMenuFullScreen
+        isOpen
+        data-element="foo"
+        data-role="bar"
+        onClose={() => {}}
+      >
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenuFullScreen>
+    );
+
+    const menu = screen.getByRole("navigation");
+
+    expect(menu.getAttribute("data-component")).toEqual(
+      "vertical-menu-full-screen"
+    );
+    expect(menu.getAttribute("data-element")).toEqual("foo");
+    expect(menu.getAttribute("data-role")).toEqual("bar");
+  });
+});

--- a/src/components/vertical-menu/vertical-menu-item.component.tsx
+++ b/src/components/vertical-menu/vertical-menu-item.component.tsx
@@ -1,0 +1,138 @@
+import React, { useState, useContext } from "react";
+import { PaddingProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
+
+import { filterStyledSystemPaddingProps } from "../../style/utils";
+import { IconType } from "../icon";
+import VerticalMenuFullScreenContext from "./vertical-menu-full-screen.context";
+import {
+  StyledVerticalMenuItem,
+  StyledTitle,
+  StyledAdornment,
+  StyledList,
+  StyledChevronIcon,
+  StyledTitleIcon,
+} from "./vertical-menu.style";
+
+const MenuItemContext = React.createContext({
+  level: 0,
+});
+
+export interface VerticalMenuItemProps<T = React.ElementType>
+  extends PaddingProps,
+    TagProps {
+  /** Children of the menu item - another level of VerticalMenuItems */
+  children?: React.ReactNode;
+  /** Title of the menu item */
+  title: string;
+  /** Adornment of the menu item meant to be rendered on the right side */
+  adornment?: React.ReactNode | ((isOpen: boolean) => React.ReactNode);
+  /** Icon meant to be rendered on the left side */
+  iconType?: IconType;
+  /** Whether the menu item is active or not */
+  active?: boolean | ((isOpen: boolean) => boolean);
+  /** Height of the menu item */
+  height?: string;
+  /**  Href, when passed the menu item will be rendered as an anchor tag */
+  href?: string;
+  /** Optional component to render instead of the default div, useful for rendering router link components */
+  component?: T;
+}
+
+type InferredComponentProps<T extends React.ElementType> = Omit<
+  React.ComponentProps<T>,
+  keyof VerticalMenuItemProps<T>
+>;
+
+export const VerticalMenuItem = <T,>({
+  title,
+  iconType,
+  adornment,
+  children,
+  component,
+  active,
+  height = "56px",
+  href,
+  ...rest
+}: T extends React.ElementType
+  ? InferredComponentProps<T> & VerticalMenuItemProps<T>
+  : VerticalMenuItemProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOnClick = () => {
+    setIsOpen((state) => !state);
+  };
+
+  const { level } = useContext(MenuItemContext);
+
+  const { isFullScreen } = useContext(VerticalMenuFullScreenContext);
+
+  const renderAdornment = () =>
+    typeof adornment === "function" ? adornment(isOpen) : adornment;
+
+  const shouldDisplayActiveState =
+    typeof active === "function" ? active(isOpen) : active;
+
+  let itemProps = {};
+
+  if (href) {
+    itemProps = {
+      as: "a",
+      href,
+    };
+  }
+
+  if (component) {
+    itemProps = {
+      as: component,
+      href,
+      tabIndex: 0,
+      ...rest,
+    };
+  }
+
+  if (children) {
+    itemProps = {
+      as: "button",
+      type: "button",
+      "aria-expanded": isOpen,
+      onClick: handleOnClick,
+    };
+  }
+
+  const paddingX = `calc(var(--spacing500) + (${level} * var(--spacing400)))`;
+
+  return (
+    <li>
+      <StyledVerticalMenuItem
+        height={height}
+        px={paddingX}
+        py={2}
+        active={shouldDisplayActiveState}
+        {...itemProps}
+        {...filterStyledSystemPaddingProps(rest)}
+        {...tagComponent("vertical-menu-item", rest)}
+      >
+        {iconType && <StyledTitleIcon type={iconType} />}
+
+        <StyledTitle>{title}</StyledTitle>
+
+        {adornment && <StyledAdornment>{renderAdornment()}</StyledAdornment>}
+
+        {children && !isFullScreen && (
+          <StyledChevronIcon
+            type={isOpen ? "chevron_up_thick" : "chevron_down_thick"}
+          />
+        )}
+      </StyledVerticalMenuItem>
+
+      {(isOpen || isFullScreen) && (
+        <MenuItemContext.Provider value={{ level: level + 1 }}>
+          <StyledList>{children}</StyledList>
+        </MenuItemContext.Provider>
+      )}
+    </li>
+  );
+};
+
+export default VerticalMenuItem;

--- a/src/components/vertical-menu/vertical-menu-item.spec.tsx
+++ b/src/components/vertical-menu/vertical-menu-item.spec.tsx
@@ -1,0 +1,300 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "styled-components";
+
+import mintTheme from "../../style/themes/mint";
+import { testStyledSystemPadding } from "../../__spec_helper__/test-utils";
+import Icon from "../icon";
+import { StyledVerticalMenuItem } from "./vertical-menu.style";
+import { VerticalMenuItem, VerticalMenuFullScreen } from ".";
+
+jest.mock("../icon", () => {
+  return jest.fn(() => null);
+});
+
+describe("VerticalMenuItem", () => {
+  testStyledSystemPadding(
+    (props) => (
+      <ThemeProvider theme={mintTheme}>
+        <VerticalMenuItem title="Item1" {...props} />
+      </ThemeProvider>
+    ),
+    undefined,
+    (component) => component.find(StyledVerticalMenuItem)
+  );
+
+  describe("when is rendered without children", () => {
+    it("should render with a custom height", () => {
+      render(<VerticalMenuItem title="Item1" height="100px" />);
+
+      expect(screen.getByRole("listitem").firstChild).toHaveStyle({
+        minHeight: "100px",
+      });
+    });
+
+    it("should render passed title", () => {
+      render(<VerticalMenuItem title="Item1" />);
+      expect(screen.getByText("Item1")).toBeTruthy();
+    });
+
+    it("should render adornment passed as a node", () => {
+      render(
+        <VerticalMenuItem title="Item1" adornment={<div>Adornment</div>} />
+      );
+      expect(screen.getByText("Adornment")).toBeTruthy();
+    });
+
+    it("should render passed active state as boolean", () => {
+      render(<VerticalMenuItem title="Item1" active />);
+      expect(screen.getByRole("listitem").firstChild).toHaveStyleRule(
+        "background",
+        "var(--colorsComponentsLeftnavWinterStandardSelected)",
+        {
+          modifier: ":before",
+        }
+      );
+    });
+
+    it("should override active state when mouseover detected", () => {
+      render(<VerticalMenuItem title="Item1" active />);
+
+      userEvent.hover(screen.getByRole("listitem"));
+
+      expect(screen.getByRole("listitem").firstChild).toHaveStyleRule(
+        "background",
+        "var(--colorsComponentsLeftnavWinterStandardHover)",
+        {
+          modifier: ":hover:before",
+        }
+      );
+    });
+
+    it("should render proper Icon when iconType prop is passed", () => {
+      render(<VerticalMenuItem title="Item1" iconType="add" />);
+      expect(Icon).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "add" }),
+        {}
+      );
+
+      jest.clearAllMocks();
+    });
+
+    it('should render as an anchor when "href" prop is passed', () => {
+      render(<VerticalMenuItem title="Item1" href="http://www.sage.com" />);
+      expect(screen.getByRole("link")).toBeTruthy();
+    });
+
+    it("should render custom component when passed as a prop", () => {
+      interface CustomComponentProps {
+        customComponentTitle: string;
+        children?: React.ReactNode;
+      }
+
+      const CustomComponent = ({
+        customComponentTitle,
+        children,
+      }: CustomComponentProps) => (
+        <>
+          <div>{customComponentTitle}</div>
+          <div>{children}</div>;
+        </>
+      );
+
+      render(
+        <VerticalMenuItem
+          title="Item1"
+          component={CustomComponent}
+          customComponentTitle="Custom component"
+        />
+      );
+      expect(screen.getByText("Custom component")).toBeTruthy();
+    });
+  });
+
+  describe("when is rendered with children", () => {
+    it("should render as a button", () => {
+      render(
+        <VerticalMenuItem title="Item1">
+          <VerticalMenuItem title="ChildItem1" />
+        </VerticalMenuItem>
+      );
+      expect(screen.getByRole("button")).toBeTruthy();
+    });
+
+    it("should not render children by default", () => {
+      render(
+        <VerticalMenuItem title="Item1">
+          <VerticalMenuItem title="ChildItem1" />
+        </VerticalMenuItem>
+      );
+      expect(screen.queryByText("ChildItem1")).toBeNull();
+    });
+
+    it("should render children after item has been clicked on", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <VerticalMenuItem title="Item1">
+          <VerticalMenuItem title="ChildItem1" />
+        </VerticalMenuItem>
+      );
+      expect(screen.queryByText("ChildItem1")).toBeNull();
+      await user.click(screen.getByText("Item1"));
+      expect(screen.getByText("ChildItem1")).toBeTruthy();
+    });
+
+    it.each([
+      ["enter", "enter"],
+      ["space", " "],
+    ])(
+      "should render children after focused item has been pressed on with %s",
+      async (keyName, key) => {
+        const user = userEvent.setup();
+
+        render(
+          <VerticalMenuItem title="Item1">
+            <VerticalMenuItem title="ChildItem1" />
+          </VerticalMenuItem>
+        );
+
+        expect(screen.queryByText("ChildItem1")).toBeNull();
+        await user.tab();
+        await user.keyboard(`{${key}}`);
+        expect(screen.getByText("ChildItem1")).toBeTruthy();
+      }
+    );
+
+    it("should render chevron icon", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <VerticalMenuItem title="Item1">
+          <VerticalMenuItem title="ChildItem1" />
+        </VerticalMenuItem>
+      );
+
+      expect(Icon).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "chevron_down_thick" }),
+        {}
+      );
+
+      jest.clearAllMocks();
+      await user.click(screen.getByText("Item1"));
+      expect(Icon).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "chevron_up_thick" }),
+        {}
+      );
+    });
+
+    it("should increase padding for each level of nested children", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <VerticalMenuItem title="Item1">
+          <VerticalMenuItem title="ChildItem1">
+            <VerticalMenuItem title="GrandChildItem1" />
+          </VerticalMenuItem>
+        </VerticalMenuItem>
+      );
+
+      expect(screen.getByRole("listitem").firstChild).toHaveStyle({
+        paddingLeft: "calc(40px + 0px)",
+        paddingRight: "calc(40px + 0px)",
+      });
+
+      await user.click(screen.getByText("Item1"));
+      expect(screen.getAllByRole("listitem")[1].firstChild).toHaveStyle({
+        paddingLeft: "calc(40px + 32px)",
+        paddingRight: "calc(40px + 32px)",
+      });
+
+      await user.click(screen.getByText("ChildItem1"));
+      expect(screen.getAllByRole("listitem")[2].firstChild).toHaveStyle({
+        paddingLeft: "calc(40px + 64px)",
+        paddingRight: "calc(40px + 64px)",
+      });
+    });
+
+    it("should render adornment passed as a render function", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <VerticalMenuItem
+          title="Item1"
+          adornment={(isOpen) => !isOpen && <div>Adornment</div>}
+        >
+          <VerticalMenuItem title="ChildItem1" />
+        </VerticalMenuItem>
+      );
+
+      expect(screen.getByText("Adornment")).toBeTruthy();
+      await user.click(screen.getByText("Item1"));
+      expect(screen.queryByText("Adornment")).toBeNull();
+    });
+
+    it("should render passed active state as render function", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <VerticalMenuItem title="Item1" active={(isOpen) => !isOpen}>
+          <VerticalMenuItem title="ChildItem1" />
+        </VerticalMenuItem>
+      );
+
+      expect(screen.getByRole("listitem").firstChild).toHaveStyleRule(
+        "background",
+        "var(--colorsComponentsLeftnavWinterStandardSelected)",
+        {
+          modifier: ":before",
+        }
+      );
+
+      await user.click(screen.getByText("Item1"));
+      expect(screen.getAllByRole("listitem")[0].firstChild).not.toHaveStyleRule(
+        "background",
+        "var(--colorsComponentsLeftnavWinterStandardSelected)",
+        {
+          modifier: ":before",
+        }
+      );
+    });
+  });
+
+  describe("when rendered inside of VerticalMenuFullScreen", () => {
+    it("always render VerticalMenuItems open on all levels", () => {
+      render(
+        <VerticalMenuFullScreen isOpen onClose={() => {}}>
+          <VerticalMenuItem title="Item1">
+            <VerticalMenuItem title="ChildItem1">
+              <VerticalMenuItem title="GrandChildItem1" />
+            </VerticalMenuItem>
+          </VerticalMenuItem>
+        </VerticalMenuFullScreen>
+      );
+
+      expect(screen.getByText("Item1")).toBeTruthy();
+      expect(screen.getByText("ChildItem1")).toBeTruthy();
+      expect(screen.getByText("GrandChildItem1")).toBeTruthy();
+    });
+  });
+
+  it("should have the expected data attributes", () => {
+    render(
+      <VerticalMenuItem
+        title="Item1"
+        data-element="foo"
+        data-role="bar"
+        href="foo"
+      />
+    );
+
+    const listItem = screen.getByRole("listitem").querySelector("a");
+
+    expect(listItem?.getAttribute("data-component")).toEqual(
+      "vertical-menu-item"
+    );
+    expect(listItem?.getAttribute("data-element")).toEqual("foo");
+    expect(listItem?.getAttribute("data-role")).toEqual("bar");
+  });
+});

--- a/src/components/vertical-menu/vertical-menu-test.stories.tsx
+++ b/src/components/vertical-menu/vertical-menu-test.stories.tsx
@@ -1,0 +1,297 @@
+import React, { useState } from "react";
+import { ComponentStory } from "@storybook/react";
+import useMediaQuery from "../../hooks/useMediaQuery";
+
+import {
+  VerticalMenu,
+  VerticalMenuItem,
+  VerticalMenuTrigger,
+  VerticalMenuTriggerProps,
+  VerticalMenuFullScreen,
+  VerticalMenuFullScreenProps,
+} from ".";
+import Box from "../box";
+import Pill from "../pill";
+
+export default {
+  title: "VerticalMenu/Test",
+  includeStories: ["Default"],
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disable: true,
+    },
+  },
+  argTypes: {
+    "aria-label": {
+      control: {
+        type: "text",
+      },
+    },
+    "aria-labelledby": {
+      control: {
+        type: "text",
+      },
+    },
+    width: {
+      control: {
+        type: "text",
+      },
+    },
+    height: {
+      control: {
+        type: "text",
+      },
+    },
+  },
+};
+
+export const Default: ComponentStory<typeof VerticalMenu> = ({ ...args }) => {
+  return (
+    <Box height="100vh">
+      <VerticalMenu {...args}>
+        <VerticalMenuItem
+          iconType="analysis"
+          adornment={(isOpen) =>
+            !isOpen && (
+              <Pill borderColor="#fff" fill size="S">
+                10
+              </Pill>
+            )
+          }
+          title="Item 1"
+        >
+          <VerticalMenuItem
+            title="ChildItem 1"
+            href="/child-item-1"
+            adornment={
+              <Pill borderColor="#fff" fill size="S">
+                10
+              </Pill>
+            }
+          />
+          <VerticalMenuItem href="/child-item-2" title="ChildItem 2" />
+        </VerticalMenuItem>
+
+        <VerticalMenuItem iconType="admin" href="/item1" title="Item 2" />
+
+        <VerticalMenuItem
+          iconType="home"
+          title="Item 3"
+          active={(isOpen) => !isOpen}
+          adornment={(isOpen) =>
+            !isOpen && (
+              <Pill borderColor="#fff" fill size="S">
+                129
+              </Pill>
+            )
+          }
+        >
+          <VerticalMenuItem
+            title="Very long text that will be wrapped"
+            href="/very-long-text-that-will-be-wrapped"
+            adornment={
+              <Pill borderColor="#fff" fill size="S">
+                100
+              </Pill>
+            }
+          />
+          <VerticalMenuItem
+            title="Active item"
+            href="/active-item"
+            active
+            adornment={
+              <Pill borderColor="#fff" fill size="S">
+                29
+              </Pill>
+            }
+          />
+        </VerticalMenuItem>
+
+        <VerticalMenuItem iconType="alert" title="Item 4" href="/item-4" />
+
+        <VerticalMenuItem iconType="bank" title="Item 5">
+          <VerticalMenuItem title="ChildItem 1" href="/child-item-1" />
+          <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+        </VerticalMenuItem>
+
+        <VerticalMenuItem iconType="basket" title="Item 6" href="/item-6" />
+
+        <VerticalMenuItem
+          iconType="calendar"
+          title="Item 7 - More text to wrap the whole title. More text to wrap the whole title. More text to wrap the whole title."
+        >
+          <VerticalMenuItem title="ChildItem 1" href="/child-item-1" />
+          <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+        </VerticalMenuItem>
+      </VerticalMenu>
+    </Box>
+  );
+};
+
+Default.storyName = "default";
+
+export const VerticalMenuItemCustom: ComponentStory<
+  typeof VerticalMenuItem
+> = ({ ...args }) => {
+  return (
+    <Box height="100vh">
+      <VerticalMenu>
+        <VerticalMenuItem
+          iconType="analysis"
+          adornment={(isOpen) =>
+            !isOpen && (
+              <Pill borderColor="#fff" fill size="S">
+                10
+              </Pill>
+            )
+          }
+          title="Item 1"
+          {...args}
+        >
+          <VerticalMenuItem
+            title="ChildItem 1"
+            href="/child-item-1"
+            adornment={
+              <Pill borderColor="#fff" fill size="S">
+                10
+              </Pill>
+            }
+          />
+          <VerticalMenuItem href="/child-item-2" title="ChildItem 2" />
+        </VerticalMenuItem>
+      </VerticalMenu>
+    </Box>
+  );
+};
+
+export const VerticalMenuItemCustomHref: ComponentStory<
+  typeof VerticalMenuItem
+> = ({ ...args }) => {
+  return (
+    <Box height="100vh">
+      <VerticalMenu>
+        <VerticalMenuItem
+          iconType="analysis"
+          adornment={(isOpen) =>
+            !isOpen && (
+              <Pill borderColor="#fff" fill size="S">
+                100
+              </Pill>
+            )
+          }
+          title="Item 1"
+        >
+          <VerticalMenuItem
+            title="ChildItem 1"
+            adornment={
+              <Pill borderColor="#fff" fill size="S">
+                10
+              </Pill>
+            }
+            {...args}
+          />
+          <VerticalMenuItem href="/child-item-2" title="ChildItem 2" />
+        </VerticalMenuItem>
+      </VerticalMenu>
+    </Box>
+  );
+};
+
+export const VerticalMenuTriggerCustom: ComponentStory<
+  typeof VerticalMenuTrigger
+> = ({ ...args }: Partial<VerticalMenuTriggerProps>) => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  return (
+    <Box height="100vh">
+      <VerticalMenuTrigger onClick={() => setIsMenuOpen(!isMenuOpen)} {...args}>
+        Menu
+      </VerticalMenuTrigger>
+    </Box>
+  );
+};
+
+export const VerticalMenuFullScreenCustom: ComponentStory<
+  typeof VerticalMenuFullScreen
+> = ({ ...args }: Partial<VerticalMenuFullScreenProps>) => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const fullscreenViewBreakPoint = useMediaQuery("(max-width: 1200px)");
+
+  const menuItems = (
+    <>
+      <VerticalMenuItem iconType="analysis" title="Item 1">
+        <VerticalMenuItem
+          title="ChildItem 1"
+          href="/child-item-1"
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              10
+            </Pill>
+          }
+        />
+        <VerticalMenuItem href="/child-item-2" title="ChildItem 2" />
+      </VerticalMenuItem>
+
+      <VerticalMenuItem iconType="admin" href="/item1" title="Item 2" />
+
+      <VerticalMenuItem iconType="home" title="Item 3">
+        <VerticalMenuItem
+          title="Very long text that will be wrapped"
+          href="/very-long-text-that-will-be-wrapped"
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              100
+            </Pill>
+          }
+        />
+        <VerticalMenuItem
+          title="Active item"
+          href="/active-item"
+          active
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              29
+            </Pill>
+          }
+        />
+      </VerticalMenuItem>
+
+      <VerticalMenuItem iconType="alert" title="Item 4" href="/item-4" />
+
+      <VerticalMenuItem iconType="bank" title="Item 5">
+        <VerticalMenuItem title="ChildItem 1" href="/child-item-1" />
+        <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+      </VerticalMenuItem>
+
+      <VerticalMenuItem iconType="basket" title="Item 6" href="/item-6" />
+
+      <VerticalMenuItem
+        iconType="calendar"
+        title="Item 7 - More text to wrap the whole title. More text to wrap the whole title. More text to wrap the whole title. More text to wrap the whole title. "
+      >
+        <VerticalMenuItem title="ChildItem 1" href="/child-item-1" />
+        <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+      </VerticalMenuItem>
+    </>
+  );
+
+  if (fullscreenViewBreakPoint) {
+    return (
+      <>
+        <VerticalMenuTrigger onClick={() => setIsMenuOpen(!isMenuOpen)}>
+          Menu
+        </VerticalMenuTrigger>
+        <VerticalMenuFullScreen
+          isOpen={isMenuOpen}
+          onClose={() => setIsMenuOpen(false)}
+          {...args}
+        >
+          {menuItems}
+        </VerticalMenuFullScreen>
+      </>
+    );
+  }
+  return <VerticalMenu>{menuItems}</VerticalMenu>;
+};

--- a/src/components/vertical-menu/vertical-menu-trigger.component.tsx
+++ b/src/components/vertical-menu/vertical-menu-trigger.component.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { PaddingProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
+
+import { filterStyledSystemPaddingProps } from "../../style/utils";
+import { StyledVerticalMenuItem, StyledTitle } from "./vertical-menu.style";
+
+export interface VerticalMenuTriggerProps extends PaddingProps, TagProps {
+  /** Height of the menu trigger */
+  height?: string;
+  /** Title of the menu trigger */
+  children: string;
+  /** Callback passed to the menu trigger */
+  onClick: (ev: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export const VerticalMenuTrigger = ({
+  height = "40px",
+  p = 2,
+  onClick,
+  children,
+  ...rest
+}: VerticalMenuTriggerProps) => {
+  const paddingProps = filterStyledSystemPaddingProps(rest);
+
+  return (
+    <StyledVerticalMenuItem
+      onClick={onClick as (ev: React.MouseEvent<HTMLButtonElement>) => void}
+      as="button"
+      height={height}
+      p={p}
+      tabIndex={0}
+      {...paddingProps}
+      {...tagComponent("vertical-menu-trigger", rest)}
+    >
+      <StyledTitle>{children}</StyledTitle>
+    </StyledVerticalMenuItem>
+  );
+};
+
+export default VerticalMenuTrigger;

--- a/src/components/vertical-menu/vertical-menu-trigger.spec.tsx
+++ b/src/components/vertical-menu/vertical-menu-trigger.spec.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "styled-components";
+
+import mintTheme from "../../style/themes/mint";
+import { VerticalMenuTrigger } from ".";
+import { testStyledSystemPadding } from "../../__spec_helper__/test-utils";
+import { StyledVerticalMenuItem } from "./vertical-menu.style";
+
+describe("VerticalMenuTrigger", () => {
+  testStyledSystemPadding(
+    (props) => (
+      <ThemeProvider theme={mintTheme}>
+        <VerticalMenuTrigger {...props} onClick={() => {}}>
+          Open menu
+        </VerticalMenuTrigger>
+      </ThemeProvider>
+    ),
+    undefined,
+    (component) => component.find(StyledVerticalMenuItem)
+  );
+
+  it("should render proper height when height prop is passed", () => {
+    render(
+      <VerticalMenuTrigger height="100px" onClick={() => {}}>
+        Open menu
+      </VerticalMenuTrigger>
+    );
+    expect(screen.getByRole("button")).toHaveStyle({
+      minHeight: "100px",
+    });
+  });
+
+  it("should invoke onClick callback when clicked", async () => {
+    const user = userEvent.setup();
+    const onClick = jest.fn();
+    render(
+      <VerticalMenuTrigger onClick={onClick}>Open menu</VerticalMenuTrigger>
+    );
+
+    await user.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("should have the expected data attributes", () => {
+    render(
+      <VerticalMenuTrigger
+        data-element="foo"
+        data-role="bar"
+        onClick={() => {}}
+      >
+        Open Menu
+      </VerticalMenuTrigger>
+    );
+
+    const trigger = screen.getByRole("button");
+
+    expect(trigger.getAttribute("data-component")).toEqual(
+      "vertical-menu-trigger"
+    );
+    expect(trigger.getAttribute("data-element")).toEqual("foo");
+    expect(trigger.getAttribute("data-role")).toEqual("bar");
+  });
+});

--- a/src/components/vertical-menu/vertical-menu.component.tsx
+++ b/src/components/vertical-menu/vertical-menu.component.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
+
+import { StyledVerticalMenu, StyledList } from "./vertical-menu.style";
+
+export interface VerticalMenuProps extends TagProps {
+  /** An aria-label attribute for the menu */
+  "aria-label"?: string;
+  /** An aria-labelledby attribute for the menu */
+  "aria-labelledby"?: string;
+  /** Width of the menu */
+  width?: string;
+  /** Content of the menu - VerticalMenuItem */
+  children: React.ReactNode;
+  /** Height of the menu */
+  height?: string;
+}
+
+export const VerticalMenu = ({
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
+  width = "322px",
+  children,
+  height = "100%",
+  ...rest
+}: VerticalMenuProps) => {
+  return (
+    <StyledVerticalMenu
+      boxSizing="border-box"
+      scrollVariant="light"
+      backgroundColor="var(--colorsComponentsLeftnavWinterStandardBackground)"
+      width={width}
+      height={height}
+      py={1}
+      as="nav"
+      overflow="auto"
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      {...tagComponent("vertical-menu", rest)}
+    >
+      <StyledList>{children}</StyledList>
+    </StyledVerticalMenu>
+  );
+};
+
+export default VerticalMenu;

--- a/src/components/vertical-menu/vertical-menu.spec.tsx
+++ b/src/components/vertical-menu/vertical-menu.spec.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { VerticalMenu, VerticalMenuItem } from ".";
+
+describe("VerticalMenu", () => {
+  it("should accept aria-label prop", () => {
+    render(
+      <VerticalMenu aria-label="test">
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenu>
+    );
+
+    expect(screen.getByRole("navigation")).toHaveAttribute(
+      "aria-label",
+      "test"
+    );
+  });
+
+  it("should accept aria-labelledby prop", () => {
+    render(
+      <VerticalMenu aria-labelledby="test">
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenu>
+    );
+
+    expect(screen.getByRole("navigation")).toHaveAttribute(
+      "aria-labelledby",
+      "test"
+    );
+  });
+
+  it("should render with a custom width", () => {
+    render(
+      <VerticalMenu width="100px">
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenu>
+    );
+
+    expect(screen.getByRole("navigation")).toHaveStyle({
+      width: "100px",
+    });
+  });
+
+  it("should render with a custom height", () => {
+    render(
+      <VerticalMenu height="100px">
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenu>
+    );
+
+    expect(screen.getByRole("navigation")).toHaveStyle({
+      height: "100px",
+    });
+  });
+
+  it("should override the scrollbar styling", () => {
+    render(
+      <VerticalMenu height="100px">
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenu>
+    );
+
+    expect(screen.getByRole("navigation")).toHaveStyleRule(
+      "background-color",
+      "#cccccc",
+      {
+        modifier: "::-webkit-scrollbar-track",
+      }
+    );
+
+    expect(screen.getByRole("navigation")).toHaveStyleRule(
+      "background-color",
+      "#808080",
+      {
+        modifier: "::-webkit-scrollbar-thumb",
+      }
+    );
+
+    expect(screen.getByRole("navigation")).toHaveStyleRule("width", "12px", {
+      modifier: "::-webkit-scrollbar",
+    });
+  });
+
+  it("should have the expected data attributes", () => {
+    render(
+      <VerticalMenu data-element="foo" data-role="bar">
+        <VerticalMenuItem title="Item1" />
+      </VerticalMenu>
+    );
+
+    const menu = screen.getByRole("navigation");
+
+    expect(menu.getAttribute("data-component")).toEqual("vertical-menu");
+    expect(menu.getAttribute("data-element")).toEqual("foo");
+    expect(menu.getAttribute("data-role")).toEqual("bar");
+  });
+});

--- a/src/components/vertical-menu/vertical-menu.stories.mdx
+++ b/src/components/vertical-menu/vertical-menu.stories.mdx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import {
+  VerticalMenu,
+  VerticalMenuItem,
+  VerticalMenuFullScreen,
+  VerticalMenuTrigger,
+} from ".";
+import * as stories from "./vertical-menu.stories";
+
+<Meta
+  title="VerticalMenu"
+  parameters={{
+    info: { disable: true },
+    themeProvider: { chromatic: { theme: "sage" } },
+  }} 
+/>
+
+# VerticalMenu
+
+Provides a vertical navigation for an app, which can be used via mouse or keyboard.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import {
+  VerticalMenu,
+  VerticalMenuItem,
+  VerticalMenuFullScreen,
+  VerticalMenuTrigger,
+} from "carbon-react/lib/components/vertical-menu";
+```
+
+## Examples
+
+### Default
+
+<Canvas>
+  <Story name="default" story={stories.Default} />
+</Canvas>
+
+### With custom width and height
+
+<Canvas>
+  <Story name="custom width and height" story={stories.CustomWidthAndHeight} />
+</Canvas>
+
+### Adornment
+
+The `adornment` prop of `VerticalMenuItem` component can be used to pass a component that will be rendered on the right hand side of the title.
+This prop also accepts a render function which accepts `isOpen` as a parameter. This can be used to conditionally render an icon based on the open state of the menu.
+
+<Canvas>
+  <Story name="adornment" story={stories.Adornment} />
+</Canvas>
+
+### Active
+
+Same as `adornment`, the `active` prop of `VerticalMenuItem` component can be used to pass a boolean value to indicate if the menu item is active or not.
+This prop also accepts a render function which accepts `isOpen` as a parameter.
+
+<Canvas>
+  <Story name="active" story={stories.Active} />
+</Canvas>
+
+### Custom item padding
+
+<Canvas>
+  <Story name="custom item padding" story={stories.CustomItemPadding} />
+</Canvas>
+
+### Custom item height
+
+<Canvas>
+  <Story name="custom item height" story={stories.CustomItemHeight} />
+</Canvas>
+
+### With custom component
+
+The `component` prop of `VerticalMenuItem` component can be used to pass a custom component.
+It can be used to render the item as a `Link` component from a router library like `react-router`.
+
+<Canvas>
+  <Story name="custom component" story={stories.CustomComponent} />
+</Canvas>
+
+### Full Screen
+
+This story is best viewed in the `canvas` view and by adjusting the size of the window. The fullscreen menu behaviour will
+trigger when the screen size is smaller than `1200px`. Also take note that in full screen mode the `VerticalMenuItems` are always open.
+The `VerticalMenuTrigger` component is intended to be used to trigger opening the `VerticalMenuFullScreen`.
+
+<Canvas>
+  <Story name="full screen" story={stories.FullScreen} />
+</Canvas>
+
+## Props
+
+### VerticalMenu
+
+<ArgsTable of={VerticalMenu} />
+
+### VerticalMenuItem
+
+<StyledSystemProps of={VerticalMenuItem} padding noHeader />
+
+### VerticalMenuFullScreen
+
+<ArgsTable of={VerticalMenuFullScreen} />
+
+### VerticalMenuTrigger
+
+<StyledSystemProps of={VerticalMenuTrigger} padding noHeader />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object
+to the [i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "verticalMenuFullScreen.ariaLabels.close",
+      description: "The text for the close Icon aria-label attribute",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/vertical-menu/vertical-menu.stories.tsx
+++ b/src/components/vertical-menu/vertical-menu.stories.tsx
@@ -1,0 +1,290 @@
+import React, { useState } from "react";
+
+import {
+  VerticalMenu,
+  VerticalMenuItem,
+  VerticalMenuFullScreen,
+  VerticalMenuTrigger,
+} from ".";
+import Box from "../box";
+import Pill from "../pill";
+import useMediaQuery from "../../hooks/useMediaQuery";
+
+interface LinkProps {
+  to: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+const Link = ({ to, children, className }: LinkProps) => {
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    window.history.pushState({}, "", to);
+  };
+  return (
+    <a href={to} className={className} onClick={handleClick}>
+      {children}
+    </a>
+  );
+};
+
+export const Default = () => {
+  return (
+    <Box height="100vh">
+      <VerticalMenu>
+        <VerticalMenuItem
+          iconType="analysis"
+          adornment={(isOpen) =>
+            !isOpen && (
+              <Pill borderColor="#fff" fill size="S">
+                10
+              </Pill>
+            )
+          }
+          title="Item 1"
+        >
+          <VerticalMenuItem
+            title="ChildItem 1"
+            href="/child-item-1"
+            adornment={
+              <Pill borderColor="#fff" fill size="S">
+                10
+              </Pill>
+            }
+          />
+          <VerticalMenuItem href="/child-item-2" title="ChildItem 2" />
+        </VerticalMenuItem>
+
+        <VerticalMenuItem iconType="admin" href="/item1" title="Item 2" />
+
+        <VerticalMenuItem
+          iconType="home"
+          title="Item 3"
+          active={(isOpen) => !isOpen}
+          adornment={(isOpen) =>
+            !isOpen && (
+              <Pill borderColor="#fff" fill size="S">
+                129
+              </Pill>
+            )
+          }
+        >
+          <VerticalMenuItem
+            title="Very long text that will be wrapped"
+            href="/very-long-text-that-will-be-wrapped"
+            adornment={
+              <Pill borderColor="#fff" fill size="S">
+                100
+              </Pill>
+            }
+          />
+          <VerticalMenuItem
+            title="Active item"
+            href="/active-item"
+            active
+            adornment={
+              <Pill borderColor="#fff" fill size="S">
+                29
+              </Pill>
+            }
+          />
+        </VerticalMenuItem>
+
+        <VerticalMenuItem iconType="alert" title="Item 4" href="/item-4" />
+
+        <VerticalMenuItem iconType="bank" title="Item 5">
+          <VerticalMenuItem title="ChildItem 1" href="/child-item-1" />
+          <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+        </VerticalMenuItem>
+
+        <VerticalMenuItem iconType="basket" title="Item 6" href="/item-6" />
+
+        <VerticalMenuItem
+          iconType="calendar"
+          title="Item 7 - More text to wrap the whole title. More text to wrap the whole title. More text to wrap the whole title."
+        >
+          <VerticalMenuItem title="ChildItem 1" href="/child-item-1" />
+          <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+        </VerticalMenuItem>
+      </VerticalMenu>
+    </Box>
+  );
+};
+
+export const CustomWidthAndHeight = () => {
+  return (
+    <VerticalMenu width="500px" height="100vh">
+      <VerticalMenuItem
+        iconType="analysis"
+        adornment={
+          <Pill borderColor="#fff" fill size="S">
+            10
+          </Pill>
+        }
+        title="Item 1"
+        href="/item-1"
+      />
+      <VerticalMenuItem iconType="cart" active title="Item 2" href="/item-2" />
+      <VerticalMenuItem iconType="bank" title="Item 3" href="/item-3" />
+    </VerticalMenu>
+  );
+};
+
+export const Adornment = () => {
+  return (
+    <VerticalMenu>
+      <VerticalMenuItem
+        iconType="analysis"
+        adornment={(isOpen) =>
+          !isOpen && (
+            <Pill borderColor="#fff" fill size="S">
+              10
+            </Pill>
+          )
+        }
+        title="Item 1"
+      >
+        <VerticalMenuItem
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              10
+            </Pill>
+          }
+          title="ChildItem 1"
+          href="/child-item-1"
+        />
+        <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+      </VerticalMenuItem>
+    </VerticalMenu>
+  );
+};
+
+export const Active = () => {
+  return (
+    <VerticalMenu>
+      <VerticalMenuItem
+        iconType="analysis"
+        active={(isOpen) => !isOpen}
+        title="Item 1"
+      >
+        <VerticalMenuItem active title="ChildItem 1" href="/child-item-1" />
+        <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+      </VerticalMenuItem>
+    </VerticalMenu>
+  );
+};
+
+export const CustomItemPadding = () => {
+  return (
+    <VerticalMenu>
+      <VerticalMenuItem
+        iconType="analysis"
+        title="Item 1"
+        padding="0 0 0 80px"
+      />
+    </VerticalMenu>
+  );
+};
+
+export const CustomItemHeight = () => {
+  return (
+    <VerticalMenu>
+      <VerticalMenuItem height="100px" iconType="analysis" title="Item 1" />
+    </VerticalMenu>
+  );
+};
+
+export const CustomComponent = () => {
+  return (
+    <VerticalMenu>
+      <VerticalMenuItem
+        iconType="analysis"
+        title="Item 1"
+        component={Link}
+        to="/item-1"
+      />
+    </VerticalMenu>
+  );
+};
+
+export const FullScreen = () => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const fullscreenViewBreakPoint = useMediaQuery("(max-width: 1200px)");
+
+  const menuItems = (
+    <>
+      <VerticalMenuItem iconType="analysis" title="Item 1">
+        <VerticalMenuItem
+          title="ChildItem 1"
+          href="/child-item-1"
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              10
+            </Pill>
+          }
+        />
+        <VerticalMenuItem href="/child-item-2" title="ChildItem 2" />
+      </VerticalMenuItem>
+
+      <VerticalMenuItem iconType="admin" href="/item1" title="Item 2" />
+
+      <VerticalMenuItem iconType="home" title="Item 3">
+        <VerticalMenuItem
+          title="Very long text that will be wrapped"
+          href="/very-long-text-that-will-be-wrapped"
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              100
+            </Pill>
+          }
+        />
+        <VerticalMenuItem
+          title="Active item"
+          href="/active-item"
+          active
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              29
+            </Pill>
+          }
+        />
+      </VerticalMenuItem>
+
+      <VerticalMenuItem iconType="alert" title="Item 4" href="/item-4" />
+
+      <VerticalMenuItem iconType="bank" title="Item 5">
+        <VerticalMenuItem title="ChildItem 1" href="/child-item-1" />
+        <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+      </VerticalMenuItem>
+
+      <VerticalMenuItem iconType="basket" title="Item 6" href="/item-6" />
+
+      <VerticalMenuItem
+        iconType="calendar"
+        title="Item 7 - More text to wrap the whole title. More text to wrap the whole title. More text to wrap the whole title. More text to wrap the whole title. "
+      >
+        <VerticalMenuItem title="ChildItem 1" href="/child-item-1" />
+        <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+      </VerticalMenuItem>
+    </>
+  );
+
+  if (fullscreenViewBreakPoint) {
+    return (
+      <>
+        <VerticalMenuTrigger onClick={() => setIsMenuOpen(!isMenuOpen)}>
+          Menu
+        </VerticalMenuTrigger>
+        <VerticalMenuFullScreen
+          isOpen={isMenuOpen}
+          onClose={() => setIsMenuOpen(false)}
+        >
+          {menuItems}
+        </VerticalMenuFullScreen>
+      </>
+    );
+  }
+
+  return <VerticalMenu>{menuItems}</VerticalMenu>;
+};

--- a/src/components/vertical-menu/vertical-menu.style.ts
+++ b/src/components/vertical-menu/vertical-menu.style.ts
@@ -1,0 +1,137 @@
+import styled, { css } from "styled-components";
+import { padding, PaddingProps } from "styled-system";
+
+import StyledIcon from "../icon/icon.style";
+import Icon from "../icon";
+import Box from "../box";
+
+export const StyledList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+interface StyledVerticalMenuProps extends PaddingProps {
+  active?: boolean;
+  height: string;
+}
+
+export const StyledVerticalMenuItem = styled.div<StyledVerticalMenuProps>`
+  min-height: ${({ height }) => height};
+  width: 100%;
+  display: flex;
+  border: none;
+  align-items: center;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  color: var(--colorsComponentsLeftnavWinterStandardContent);
+  position: relative;
+  box-sizing: border-box;
+  text-decoration: none;
+  background-color: var(--colorsComponentsLeftnavWinterStandardBackground);
+
+  ${padding}
+
+  &:hover {
+    background-color: var(--colorsComponentsLeftnavWinterStandardHover);
+  }
+
+  &:focus {
+    outline: 3px solid var(--colorsSemanticFocus500);
+    outline-offset: -3px;
+  }
+
+  ${({ active }) =>
+    active &&
+    css`
+      &:before {
+        background: var(--colorsComponentsLeftnavWinterStandardSelected);
+        content: "";
+        height: calc(100% - 16px);
+        left: 24px;
+        position: absolute;
+        top: 8px;
+        width: calc(100% - 48px);
+        z-index: 0;
+      }
+
+      &:hover {
+        &:before {
+          background: var(--colorsComponentsLeftnavWinterStandardHover);
+        }
+      }
+    `}
+
+  ${StyledIcon} {
+    width: 20px;
+  }
+`;
+
+export const StyledTitle = styled.h3`
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 21px;
+  margin: 0;
+  z-index: 1;
+  text-align: left;
+`;
+
+export const StyledAdornment = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 1;
+`;
+
+export const StyledTitleIcon = styled(Icon)`
+  margin-right: 12px;
+  width: 20px;
+  color: var(--colorsComponentsLeftnavWinterStandardContent);
+`;
+
+export const StyledChevronIcon = styled(Icon)`
+  margin-left: auto;
+  padding-left: 12px;
+  width: 20px;
+  color: var(--colorsComponentsLeftnavWinterStandardContent);
+`;
+
+export const StyledVerticalMenu = styled(Box)`
+  // TODO remove hardcoded values when DS have had chance to review which token to use
+  &::-webkit-scrollbar-track {
+    background-color: #cccccc;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #808080;
+  }
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+`;
+
+export const StyledVerticalMenuFullScreen = styled(Box)`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  height: 100vh;
+  width: 100%;
+  outline: none;
+  padding: 8px 0px;
+  overflow: auto;
+  background-color: var(--colorsComponentsLeftnavWinterStandardBackground);
+  box-sizing: border-box;
+  transition: all 0.3s ease;
+  z-index: ${({ theme }) => theme.zIndex.fullScreenModal};
+
+  // TODO remove hardcoded values when DS have had chance to review which token to use
+  &::-webkit-scrollbar-track {
+    background-color: #cccccc;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #808080;
+  }
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+`;

--- a/src/components/vertical-menu/vertical-menu.test.js
+++ b/src/components/vertical-menu/vertical-menu.test.js
@@ -1,0 +1,443 @@
+import React from "react";
+import {
+  Default,
+  VerticalMenuItemCustom,
+  VerticalMenuTriggerCustom,
+  VerticalMenuItemCustomHref,
+  VerticalMenuFullScreenCustom,
+} from "./vertical-menu-test.stories";
+import VerticalMenuTrigger from "./vertical-menu-trigger.component";
+import * as stories from "./vertical-menu.stories";
+import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
+import {
+  checkGoldenOutline,
+  useJQueryCssValueAndAssert,
+} from "../../../cypress/support/component-helper/common-steps";
+import {
+  verticalMenuComponent,
+  verticalMenuItem,
+  verticalMenuTrigger,
+  verticalMenuFullScreen,
+} from "../../../cypress/locators/vertical-menu";
+import { closeIconButton } from "../../../cypress/locators/index";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+
+const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+const testData = CHARACTERS.STANDARD;
+
+context("Testing Vertical Menu component", () => {
+  describe("should render Vertical Menu component", () => {
+    describe.each(["aria-label", "aria-labelledby"])(
+      "when %s prop is passed",
+      (propName) => {
+        it(`verify that the ${propName} is set to cypress-standard`, () => {
+          const props = { [propName]: CHARACTERS.STANDARD };
+          CypressMountWithProviders(<Default {...props} />);
+
+          verticalMenuComponent().should(
+            "have.attr",
+            propName,
+            CHARACTERS.STANDARD
+          );
+        });
+      }
+    );
+
+    it.each([200, 350, 632])(
+      "should render Vertical Menu component with %s as a width",
+      (width) => {
+        CypressMountWithProviders(<Default width={`${width}px`} />);
+
+        verticalMenuComponent().then(($el) => {
+          useJQueryCssValueAndAssert($el, "width", width);
+        });
+      }
+    );
+
+    it.each([
+      ["30%", 230],
+      ["45%", 345],
+      ["95%", 729],
+    ])(
+      "should render Vertical Menu component with %s as a height",
+      (height, heightInPx) => {
+        CypressMountWithProviders(<Default height={height} />);
+
+        verticalMenuComponent().then(($el) => {
+          expect($el).to.have.attr("height").to.equals(height);
+          useJQueryCssValueAndAssert($el, "height", heightInPx);
+        });
+      }
+    );
+
+    it.each(specialCharacters)(
+      "should render Vertical Menu Item with %s as title",
+      (title) => {
+        CypressMountWithProviders(<VerticalMenuItemCustom title={title} />);
+
+        verticalMenuItem().should("contain.text", title);
+      }
+    );
+
+    it("should render Vertical Menu Item with adornment prop", () => {
+      CypressMountWithProviders(<VerticalMenuItemCustom />);
+
+      verticalMenuItem()
+        .eq(0)
+        .find("div > span")
+        .should("have.attr", "data-component", "pill")
+        .and("be.visible");
+
+      verticalMenuItem().eq(0).click();
+
+      verticalMenuItem()
+        .eq(1)
+        .find("div > span")
+        .should("have.attr", "data-component", "pill")
+        .and("be.visible");
+
+      verticalMenuItem().eq(0).find("div").find("span").should("not.exist");
+
+      verticalMenuItem().eq(0).click();
+
+      verticalMenuItem()
+        .eq(0)
+        .find("div > span")
+        .should("have.attr", "data-component", "pill")
+        .and("be.visible");
+
+      verticalMenuItem().eq(1).should("not.exist");
+    });
+
+    it("should render Vertical Menu Item with adornment prop", () => {
+      CypressMountWithProviders(<VerticalMenuItemCustom iconType="filter" />);
+
+      verticalMenuItem()
+        .eq(0)
+        .find("span")
+        .eq(0)
+        .should("have.attr", "data-element", "filter")
+        .and("be.visible");
+    });
+
+    it("should render Vertical Menu Item with adornment prop", () => {
+      CypressMountWithProviders(
+        <VerticalMenuItemCustom active={(isOpen) => !isOpen} />
+      );
+
+      verticalMenuItem().then(($els) => {
+        // get Window reference from element
+        const win = $els[0].ownerDocument.defaultView;
+        // use getComputedStyle to read the pseudo selector
+        const before = win.getComputedStyle($els[0], "before");
+        // read the value of the `background-color` CSS property
+        const backgroundValue = before.getPropertyValue("background-color");
+        // the returned value will have double quotes around it, but this is correct
+        expect(backgroundValue).to.eq("rgba(255, 255, 255, 0.3)");
+      });
+    });
+
+    it.each(["27px", "59px", "77px"])(
+      "should render Vertical Menu Item with %s height prop",
+      (height) => {
+        CypressMountWithProviders(<VerticalMenuItemCustom height={height} />);
+
+        verticalMenuItem().should("have.css", "min-height", height);
+      }
+    );
+
+    it("should render Vertical Menu Item without href prop", () => {
+      CypressMountWithProviders(<VerticalMenuItemCustomHref />);
+
+      verticalMenuItem().click();
+      verticalMenuItem().eq(1).parent().find("div").should("be.visible");
+    });
+
+    it("should render Vertical Menu Item with href prop", () => {
+      CypressMountWithProviders(<VerticalMenuItemCustomHref href={testData} />);
+
+      verticalMenuItem().click();
+      verticalMenuItem().eq(1).parent().find("a").should("be.visible");
+    });
+
+    it("should render Vertical Menu Item without href prop", () => {
+      CypressMountWithProviders(<stories.CustomComponent />);
+
+      verticalMenuComponent()
+        .find("li")
+        .find("a")
+        .should("have.attr", "href", "/item-1")
+        .and("be.visible");
+    });
+
+    describe("with beforeEach for VerticalMenuFullScreen", () => {
+      beforeEach(() => {
+        cy.viewport(320, 599);
+      });
+
+      describe.each(["aria-label", "aria-labelledby"])(
+        "when %s prop is passed",
+        (propName) => {
+          it(`verify that the ${propName} is set to cypress_standard`, () => {
+            cy.viewport(320, 599);
+            const props = { [propName]: CHARACTERS.STANDARD };
+            CypressMountWithProviders(
+              <VerticalMenuFullScreenCustom {...props} />
+            );
+
+            verticalMenuTrigger().click();
+
+            verticalMenuFullScreen().should(
+              "have.attr",
+              propName,
+              CHARACTERS.STANDARD
+            );
+          });
+
+          it("should close the Vertical Menu Full Screen when escape key is pressed", () => {
+            const callback = cy.stub();
+
+            CypressMountWithProviders(
+              <VerticalMenuFullScreenCustom onClose={callback} />
+            );
+
+            verticalMenuTrigger().click();
+
+            verticalMenuFullScreen().trigger("keydown", { key: "Escape" });
+
+            verticalMenuFullScreen().then(() => {
+              // eslint-disable-next-line no-unused-expressions
+              expect(callback).to.have.been.calledOnce;
+            });
+          });
+
+          // TODO remove skip as part of FE-5650
+          it.skip("should render Vertical Menu Full Screen without isOpen prop", () => {
+            CypressMountWithProviders(<VerticalMenuFullScreenCustom />);
+
+            verticalMenuItem().should("not.be.visible");
+          });
+
+          it("should render Vertical Menu Full Screen with isOpen prop", () => {
+            CypressMountWithProviders(<VerticalMenuFullScreenCustom isOpen />);
+
+            verticalMenuItem().should("be.visible");
+          });
+        }
+      );
+    });
+
+    it.each(["25px", "55px", "77px"])(
+      "should render Vertical Menu Trigger with height prop is set to %spx",
+      (height) => {
+        CypressMountWithProviders(
+          <VerticalMenuTriggerCustom height={height} />
+        );
+
+        verticalMenuTrigger().then(($el) => {
+          expect($el).to.have.attr("height").to.equals(height);
+          useJQueryCssValueAndAssert($el, "min-height", parseInt(height));
+        });
+      }
+    );
+
+    it("should render Vertical Menu Trigger with children prop is set to cypress_test", () => {
+      CypressMountWithProviders(
+        <VerticalMenuTrigger onClick={() => {}}>{testData}</VerticalMenuTrigger>
+      );
+
+      verticalMenuTrigger().should("have.text", testData);
+    });
+
+    it("should navigate to the 3rd item using Tab key", () => {
+      CypressMountWithProviders(<Default />);
+
+      verticalMenuItem().tab().tab();
+      cy.contains("Item 3").should("be.focused");
+    });
+
+    it("should navigate to the 5th item using Tab key", () => {
+      CypressMountWithProviders(<Default />);
+
+      verticalMenuItem().tab().tab().tab().tab();
+      cy.contains("Item 5").should("be.focused");
+    });
+
+    it("should navigate to the 4th item using Shift Tab key", () => {
+      CypressMountWithProviders(<Default />);
+
+      verticalMenuItem().eq(5).tab({ shift: true }).tab({ shift: true });
+      cy.contains("Item 4").should("be.focused");
+    });
+
+    it("should expand to item 3 using click", () => {
+      CypressMountWithProviders(<Default />);
+
+      verticalMenuItem().eq(2).click();
+      cy.contains("Active item").should("be.visible");
+    });
+
+    it("should collapse to item 3 using click", () => {
+      CypressMountWithProviders(<Default />);
+
+      verticalMenuItem().eq(2).click().click();
+      cy.contains("Active item").should("not.exist");
+    });
+
+    it.each([
+      ["expand", "Space", 1, "be.visible"],
+      ["expand", "Enter", 1, "be.visible"],
+      ["collapse", "Space", 2, "not.exist"],
+      ["collapse", "Enter", 2, "not.exist"],
+    ])(
+      "should %s Item 2 using keyboard %s",
+      (action, key, index, assertion) => {
+        CypressMountWithProviders(<Default />);
+
+        for (let i = 0; i < index; i++) {
+          verticalMenuItem().eq(2).focus().realPress(key);
+        }
+
+        cy.contains("Active item").should(assertion);
+      }
+    );
+
+    it("should navigate to the children element using Tab key", () => {
+      CypressMountWithProviders(<Default />);
+
+      verticalMenuItem().tab().tab().click().tab().tab();
+      cy.contains("Active item").should("be.focused");
+    });
+
+    it("should check the golden outline", () => {
+      CypressMountWithProviders(<Default />);
+
+      verticalMenuItem().tab();
+      verticalMenuItem()
+        .eq(1)
+        .then(($el) => {
+          checkGoldenOutline($el);
+        });
+    });
+  });
+
+  describe("check events for Vertical Menu component", () => {
+    let callback;
+
+    beforeEach(() => {
+      callback = cy.stub();
+    });
+
+    it("should call onClick callback when a click event is triggered", () => {
+      CypressMountWithProviders(
+        <VerticalMenuTriggerCustom onClick={callback} />
+      );
+
+      verticalMenuTrigger()
+        .click()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          expect(callback).to.have.been.calledOnce;
+        });
+    });
+
+    it("should call onClose callback when a click event is triggered for VerticalMenuFullScreen", () => {
+      cy.viewport(320, 599);
+      CypressMountWithProviders(
+        <VerticalMenuFullScreenCustom onClose={callback} />
+      );
+
+      verticalMenuTrigger().click();
+
+      closeIconButton().click();
+
+      verticalMenuFullScreen().then(() => {
+        // eslint-disable-next-line no-unused-expressions
+        expect(callback).to.have.been.calledOnce;
+      });
+    });
+
+    it.each(["Space", "Enter"])(
+      "should call onClose callback when a %s key event is triggered for VerticalMenuFullScreen",
+      (key) => {
+        cy.viewport(320, 599);
+        CypressMountWithProviders(
+          <VerticalMenuFullScreenCustom onClose={callback} />
+        );
+
+        verticalMenuTrigger().click();
+
+        closeIconButton().focus().realPress(key);
+
+        verticalMenuFullScreen().then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          expect(callback).to.have.been.calledOnce;
+        });
+      }
+    );
+  });
+
+  describe("should check the accessibility tests", () => {
+    it("should check accessiblity for verticalMenuComponent", () => {
+      CypressMountWithProviders(<Default />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessiblity for verticalMenuComponent open", () => {
+      CypressMountWithProviders(<Default isOpen />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessiblity for verticalMenuComponent Active", () => {
+      CypressMountWithProviders(
+        <VerticalMenuItemCustom active={(isOpen) => !isOpen} />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessiblity for verticalMenuComponent Adornment", () => {
+      CypressMountWithProviders(<stories.Adornment />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessiblity for verticalMenuComponent CustomItemHeight", () => {
+      CypressMountWithProviders(<stories.CustomItemHeight />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessiblity for verticalMenuComponent CustomItemHeight", () => {
+      CypressMountWithProviders(<stories.CustomItemPadding />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessiblity for verticalMenuComponent FullScreen", () => {
+      cy.viewport(320, 599);
+      CypressMountWithProviders(<VerticalMenuFullScreenCustom />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessiblity for verticalMenuComponent FullScreen open", () => {
+      cy.viewport(320, 599);
+      CypressMountWithProviders(<VerticalMenuFullScreenCustom isOpen />);
+
+      cy.checkAccessibility();
+    });
+  });
+
+  describe("href redirect", () => {
+    it("should navigate to the children href", () => {
+      CypressMountWithProviders(<Default />);
+
+      verticalMenuItem().eq(1).click();
+
+      cy.location("pathname").should("eq", "/item1");
+    });
+  });
+});

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -127,6 +127,11 @@ const enGB: Locale = {
       close: () => "Close",
     },
   },
+  verticalMenuFullScreen: {
+    ariaLabels: {
+      close: () => "Close",
+    },
+  },
 };
 
 export default enGB;

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -106,6 +106,11 @@ interface Locale {
       close: () => string;
     };
   };
+  verticalMenuFullScreen: {
+    ariaLabels: {
+      close: () => string;
+    };
+  };
 }
 
 export default Locale;

--- a/src/locales/pl-pl.ts
+++ b/src/locales/pl-pl.ts
@@ -127,6 +127,11 @@ const plPL: Locale = {
       close: () => "Zamknij",
     },
   },
+  verticalMenuFullScreen: {
+    ariaLabels: {
+      close: () => "Zamknij",
+    },
+  },
 };
 
 export default plPL;


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Sidebar` component to use the new cypress-component-react framework for testing.
- Refactor `sidebar-test.stories.js` to the corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `sidebar.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `sidebar` tests are not running twice.