### PR TITLE
test(message): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -69,6 +69,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("toast") &&
       !prepareUrl[0].startsWith("dialog-full-screen") &&
       !prepareUrl[0].startsWith("verticalmenu") &&
+      !prepareUrl[0].startsWith("message") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/message/message.test.js
+++ b/src/components/message/message.test.js
@@ -145,4 +145,83 @@ context("Tests for Message component", () => {
         });
     });
   });
+
+  describe("Accessibility tests for Message component", () => {
+    it.each(["info", "error", "success", "warning"])(
+      "should check %s as variant for accessibility tests",
+      (variant) => {
+        CypressMountWithProviders(<MessageComponent variant={variant} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check %s as children for accessibility tests",
+      (stringValue) => {
+        CypressMountWithProviders(<Message>{stringValue}</Message>);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check %s as className for accessibility tests",
+      (className) => {
+        CypressMountWithProviders(<MessageComponent className={className} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)("should check %s as id for accessibility tests", (id) => {
+      CypressMountWithProviders(<MessageComponent id={id} />);
+      cy.checkAccessibility();
+    });
+
+    it.each([true, false])(
+      "should check open value is %s for accessibility tests",
+      (boolVal) => {
+        CypressMountWithProviders(<MessageComponent open={boolVal} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check %s as title for accessibility tests",
+      (title) => {
+        CypressMountWithProviders(<MessageComponent title={title} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "should check transparent value is %s for accessibility tests",
+      (boolVal) => {
+        CypressMountWithProviders(<MessageComponent transparent={boolVal} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "should check showCloseIcon value is %s for accessibility tests",
+      (boolVal) => {
+        CypressMountWithProviders(<MessageComponent showCloseIcon={boolVal} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check %s as closeButtonAriaLabel for accessibility tests",
+      (ariaLabel) => {
+        CypressMountWithProviders(
+          <MessageComponent closeButtonAriaLabel={ariaLabel} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check onDismiss for accessibility tests", () => {
+      const callback = cy.stub();
+      CypressMountWithProviders(<MessageComponent onDismiss={callback} />);
+      cy.checkAccessibility();
+    });
+  });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Message` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `message.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `alert` tests are not running twice.