### PR TITLE
test(step-sequence): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -69,6 +69,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("message") &&
       !prepareUrl[0].startsWith("card") &&
       !prepareUrl[0].startsWith("date-input") &&
+      !prepareUrl[0].startsWith("step-sequence") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/step-sequence/step-sequence-test.stories.tsx
+++ b/src/components/step-sequence/step-sequence-test.stories.tsx
@@ -10,6 +10,7 @@ import {
 
 export default {
   title: "Step Sequence/Test",
+  includeStories: "DefaultStory",
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -100,16 +101,18 @@ export const StepSequenceItemStory = ({
   children,
   ...args
 }: StepSequenceItemStoryProps) => (
-  <StepSequenceItem
-    indicator={indicator || "1"}
-    hideIndicator={hideIndicator}
-    hiddenCompleteLabel={hiddenCompleteLabel}
-    hiddenCurrentLabel={hiddenCurrentLabel}
-    aria-label={ariaLabel}
-    {...args}
-  >
-    {children}
-  </StepSequenceItem>
+  <StepSequence>
+    <StepSequenceItem
+      indicator={indicator || "1"}
+      hideIndicator={hideIndicator}
+      hiddenCompleteLabel={hiddenCompleteLabel}
+      hiddenCurrentLabel={hiddenCurrentLabel}
+      aria-label={ariaLabel}
+      {...args}
+    >
+      {children}
+    </StepSequenceItem>
+  </StepSequence>
 );
 
 StepSequenceItemStory.storyName = "step sequence item";
@@ -122,4 +125,73 @@ StepSequenceItemStory.args = {
   hiddenCurrentLabel: "",
   ariaLabel: "Step 1 of 5",
   children: "Step Label",
+};
+
+export const StepSequenceComponent = ({ ...props }) => {
+  return (
+    <StepSequence {...props}>
+      <StepSequenceItem
+        aria-label="Step 1 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="1"
+        status="complete"
+      >
+        Name
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 2 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="2"
+        status="complete"
+      >
+        Delivery Address
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 3 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="3"
+        status="current"
+      >
+        Delivery Details
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 4 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="4"
+        status="incomplete"
+      >
+        Payment
+      </StepSequenceItem>
+      <StepSequenceItem
+        aria-label="Step 5 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="5"
+        status="incomplete"
+      >
+        Confirm
+      </StepSequenceItem>
+    </StepSequence>
+  );
+};
+
+export const StepSequenceItemCustom = ({ ...props }) => {
+  return (
+    <StepSequence>
+      <StepSequenceItem
+        aria-label="Step 1 of 5"
+        hiddenCompleteLabel="Complete"
+        hiddenCurrentLabel="Current"
+        indicator="1"
+        status="complete"
+        {...props}
+      >
+        Name
+      </StepSequenceItem>
+    </StepSequence>
+  );
 };

--- a/src/components/step-sequence/step-sequence.test.js
+++ b/src/components/step-sequence/step-sequence.test.js
@@ -1,6 +1,8 @@
 import React from "react";
-import StepSequence from "./step-sequence.component";
-import StepSequenceItem from "./step-sequence-item/step-sequence-item.component";
+import {
+  StepSequenceComponent,
+  StepSequenceItemCustom,
+} from "./step-sequence-test.stories";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import {
   stepSequenceItemIndicator,
@@ -11,73 +13,6 @@ import { ICON } from "../../../cypress/locators/locators";
 import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
-
-const StepSequenceComponent = ({ ...props }) => {
-  return (
-    <StepSequence {...props}>
-      <StepSequenceItem
-        aria-label="Step 1 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="1"
-        status="complete"
-      >
-        Name
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 2 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="2"
-        status="complete"
-      >
-        Delivery Address
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 3 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="3"
-        status="current"
-      >
-        Delivery Details
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 4 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="4"
-        status="incomplete"
-      >
-        Payment
-      </StepSequenceItem>
-      <StepSequenceItem
-        aria-label="Step 5 of 5"
-        hiddenCompleteLabel="Complete"
-        hiddenCurrentLabel="Current"
-        indicator="5"
-        status="incomplete"
-      >
-        Confirm
-      </StepSequenceItem>
-    </StepSequence>
-  );
-};
-
-const StepSequenceItemCustom = ({ ...props }) => {
-  return (
-    <StepSequenceItem
-      aria-label="Step 1 of 5"
-      hiddenCompleteLabel="Complete"
-      hiddenCurrentLabel="Current"
-      indicator="1"
-      status="complete"
-      {...props}
-    >
-      Name
-    </StepSequenceItem>
-  );
-};
 
 context("Testing StepSequence component", () => {
   describe("should render StepSequence component", () => {
@@ -210,5 +145,88 @@ context("Testing StepSequence component", () => {
           .should("have.length", spanCount);
       }
     );
+  });
+
+  describe("Accessibility tests for StepSequence component", () => {
+    it.each(["horizontal", "vertical"])(
+      "should check %s orientation for accessibility tests",
+      (orientation) => {
+        CypressMountWithProviders(
+          <StepSequenceComponent orientation={orientation} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    describe("check StepSequenceItem component for accessibility tests", () => {
+      it("should check StepSequenceItem with children for accessibility tests", () => {
+        CypressMountWithProviders(<StepSequenceItemCustom />);
+        cy.checkAccessibility();
+      });
+
+      it.each([["-100"], ["0"], ["999"], testData[0], testData[1]])(
+        "should check StepSequenceItem with indicator set to %s for accessibility tests",
+        (indicator) => {
+          CypressMountWithProviders(
+            <StepSequenceItemCustom status="incomplete" indicator={indicator} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check StepSequenceItem with ariaLabel set to %s for accessibility tests",
+        (ariaLabel) => {
+          CypressMountWithProviders(
+            <StepSequenceItemCustom aria-label={ariaLabel} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(["complete", "current", "incomplete"])(
+        "should check StepSequenceItem with status set to %s for accessibility tests",
+        (status) => {
+          CypressMountWithProviders(<StepSequenceItemCustom status={status} />);
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check StepSequenceItem with hiddenCompleteLabel set to %s for accessibility tests",
+        (hiddenCompleteLabel) => {
+          CypressMountWithProviders(
+            <StepSequenceItemCustom
+              status="complete"
+              hiddenCompleteLabel={hiddenCompleteLabel}
+            />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check StepSequenceItem with hiddenCurrentLabel set to %s for accessibility tests",
+        (hiddenCurrentLabel) => {
+          CypressMountWithProviders(
+            <StepSequenceItemCustom
+              status="current"
+              hiddenCurrentLabel={hiddenCurrentLabel}
+            />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(["complete", "current", "incomplete"])(
+        "should check StepSequenceItem with hideIndicator prop and status set to %s for accessibility tests",
+        (status) => {
+          CypressMountWithProviders(
+            <StepSequenceItemCustom status={status} hideIndicator />
+          );
+          cy.checkAccessibility();
+        }
+      );
+    });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `step-sequence` component to use the new cypress-component-react framework for testing.
- Refactor `step-sequence-test.stories.js` to the corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `step-sequence.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `alert` tests are not running twice.