### PR TITLE
test(sidebar): refactor accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -67,6 +67,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("detail") &&
       !prepareUrl[0].startsWith("help") &&
       !prepareUrl[0].startsWith("toast") &&
+      !prepareUrl[0].startsWith("sidebar") &&
       !prepareUrl[0].startsWith("dialog-full-screen") &&
       !prepareUrl[0].startsWith("verticalmenu") &&
       !prepareUrl[0].endsWith("test")

--- a/src/components/sidebar/sidebar-test.stories.tsx
+++ b/src/components/sidebar/sidebar-test.stories.tsx
@@ -92,3 +92,31 @@ Default.args = {
   enableBackgroundUI: false,
   disableEscKey: false,
 };
+
+export const SidebarComponent = ({ ...props }) => {
+  return (
+    <>
+      <Sidebar
+        aria-label="sidebar"
+        open
+        position="right"
+        size="medium"
+        {...props}
+      >
+        <div>
+          <Button buttonType="primary">Test</Button>
+          <Button buttonType="secondary" ml={2}>
+            Last
+          </Button>
+        </div>
+        <div
+          style={{
+            marginBottom: 3000,
+          }}
+        >
+          Main content
+        </div>
+      </Sidebar>
+    </>
+  );
+};

--- a/src/components/sidebar/sidebar.test.js
+++ b/src/components/sidebar/sidebar.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Sidebar from "./sidebar.component";
 import { sidebarPreview } from "../../../cypress/locators/sidebar";
+import { SidebarComponent } from "./sidebar-test.stories";
 import {
   backgroundUILocator,
   closeIconButton,
@@ -18,35 +19,6 @@ import CypressMountWithProviders from "../../../cypress/support/component-helper
 import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-helper/common-steps";
 
 const CUSTOM_SELECTOR = "button, .focusable-container input";
-
-const SidebarComponent = ({ ...props }) => {
-  return (
-    <>
-      <Sidebar
-        aria-label="sidebar"
-        onCancel={function noRefCheck() {}}
-        open
-        position="right"
-        size="medium"
-        {...props}
-      >
-        <div>
-          <Button buttonType="primary">Test</Button>
-          <Button buttonType="secondary" ml={2}>
-            Last
-          </Button>
-        </div>
-        <div
-          style={{
-            marginBottom: 3000,
-          }}
-        >
-          Main content
-        </div>
-      </Sidebar>
-    </>
-  );
-};
 
 const SidebarComponentFocusable = ({ ...props }) => {
   const [setIsDialogOpen] = React.useState(false);
@@ -269,6 +241,47 @@ context("Testing Sidebar component", () => {
           // eslint-disable-next-line no-unused-expressions
           expect(callback).to.have.been.calledOnce;
         });
+    });
+  });
+
+  describe("should render Sidebar component and check accessibility issues", () => {
+    it("should check sidebar accessibility", () => {
+      CypressMountWithProviders(<SidebarComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each(["left", "right"])(
+      "should check accessibility when sidebar position is %s",
+      (boolVal) => {
+        CypressMountWithProviders(<SidebarComponent position={boolVal} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check accessibility when sidebar has header", () => {
+      CypressMountWithProviders(
+        <SidebarComponent
+          header={<Typography variant="h3">Sidebar Header</Typography>}
+        />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it.each([
+      SIDEBAR_SIZES[0],
+      SIDEBAR_SIZES[1],
+      SIDEBAR_SIZES[2],
+      SIDEBAR_SIZES[3],
+      SIDEBAR_SIZES[4],
+      SIDEBAR_SIZES[5],
+      SIDEBAR_SIZES[6],
+    ])("should check accessibility when sidebar size is %s", (size) => {
+      CypressMountWithProviders(<SidebarComponent size={size} />);
+
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Sidebar` component to use the new cypress-component-react framework for testing.
- Refactor `sidebar-test.stories.js` to the corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `sidebar.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `sidebar` tests are not running twice.