### PR TITLE
test(date): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -1,8 +1,4 @@
 import { commonButtonPreviewRoot, getDataElementByValue } from "../../locators";
-import {
-  actionPopoverButton,
-  actionPopoverWrapper,
-} from "../../locators/action-popover";
 import { popoverSettingsIcon } from "../../locators/popover-container";
 import { visitComponentUrl } from "../helper";
 import storiesJSON from "../../../storybook-static/stories.json";
@@ -71,6 +67,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("dialog-full-screen") &&
       !prepareUrl[0].startsWith("verticalmenu") &&
       !prepareUrl[0].startsWith("message") &&
+      !prepareUrl[0].startsWith("date-input") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);
@@ -86,19 +83,6 @@ export default (from, end) => {
         "should render %s component with %s story and have no accessibility violations",
         (componentName, storyName) => {
           visitComponentUrl(componentName, storyName);
-
-          // open the action-popover component
-          if (
-            componentName.startsWith("action-popover") &&
-            !storyName.startsWith("with-custom-menu-button")
-          ) {
-            actionPopoverButton().eq(0).click({ force: true });
-          }
-
-          // open the action-popover component with-custom-menu-button story
-          if (storyName.startsWith("with-custom-menu-button")) {
-            actionPopoverWrapper().eq(0).click({ force: true });
-          }
 
           // open the pages component
           if (componentName.startsWith("pages")) {

--- a/src/components/date/date.test.js
+++ b/src/components/date/date.test.js
@@ -2,6 +2,7 @@
 import React from "react";
 import Confirm from "../confirm";
 import DateInput from "./date.component";
+import CarbonProvider from "../carbon-provider";
 import {
   enUS,
   zhCN,
@@ -46,6 +47,7 @@ import CypressMountWithProviders from "../../../cypress/support/component-helper
 import {
   SIZE,
   CHARACTERS,
+  VALIDATION,
 } from "../../../cypress/support/component-helper/constants";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
@@ -97,6 +99,49 @@ const DateInputCustom = ({ onChange, onBlur, ...props }) => {
       onBlur={handleOnBlur}
       {...props}
     />
+  );
+};
+
+const DateInputValidationNewDesign = () => {
+  const [state1, setState1] = React.useState("01/10/2016");
+  const setValue1 = ({ target }) => {
+    setState1(target.value.formattedValue);
+  };
+  const [state2, setState2] = React.useState("01/10/2016");
+  const setValue2 = ({ target }) => {
+    setState2(target.value.formattedValue);
+  };
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      {["error", "warning"].map((validationType) =>
+        ["small", "medium", "large"].map((size) => (
+          <div
+            style={{ width: "296px" }}
+            key={`${size}-${validationType}-string-label`}
+          >
+            <DateInput
+              label={`${size} - ${validationType}`}
+              value={state1}
+              onChange={setValue1}
+              validationOnLabel
+              size={size}
+              {...{ [validationType]: "Message" }}
+              m={4}
+            />
+            <DateInput
+              label={`readOnly - ${size} - ${validationType}`}
+              value={state2}
+              onChange={setValue2}
+              validationOnLabel
+              size={size}
+              readOnly
+              {...{ [validationType]: "Message" }}
+              m={4}
+            />
+          </div>
+        ))
+      )}
+    </CarbonProvider>
   );
 };
 
@@ -574,6 +619,145 @@ context("Test for DateInput component", () => {
         })
         .should("have.attr", "value")
         .and("be.empty");
+    });
+  });
+
+  describe("should check accessibility for the component", () => {
+    it("should check accessibility the default component", () => {
+      CypressMountWithProviders(<DateInputCustom />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility the default component with open prop", () => {
+      CypressMountWithProviders(<DateInputCustom open />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE])(
+      "should check accessibility with size set to %s",
+      (size) => {
+        CypressMountWithProviders(<DateInputCustom size={size} open />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check accessibility for component with autoFocus prop", () => {
+      CypressMountWithProviders(<DateInputCustom autoFocus />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for component with disabled prop", () => {
+      CypressMountWithProviders(<DateInputCustom disabled />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for component with readOnly prop", () => {
+      CypressMountWithProviders(<DateInputCustom readOnly />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each(testData)(
+      "should check accessibility with the fieldHelp renders %s",
+      (fieldHelp) => {
+        CypressMountWithProviders(<DateInputCustom fieldHelp={fieldHelp} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check accessibility with the label renders %s",
+      (label) => {
+        CypressMountWithProviders(<DateInputCustom label={label} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["left", "right"])(
+      "should check accessibility with the label align is set to %s",
+      (labelAlign) => {
+        CypressMountWithProviders(
+          <DateInputCustom
+            labelAlign={labelAlign}
+            labelHelp="labelHelp"
+            labelInline
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check accessibility for component with required prop", () => {
+      CypressMountWithProviders(<DateInputCustom required />);
+
+      cy.checkAccessibility();
+    });
+
+    // FE-5382
+    describe.skip("skip for each test", () => {
+      it.each(["error", "warning", "info"])(
+        "should check accessibility for DateInput with %s validation icon on label",
+        (type) => {
+          CypressMountWithProviders(
+            <DateInputCustom
+              labelInline
+              labelAlign="right"
+              validationOnLabel
+              {...{ [type]: "Message" }}
+            />
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(["error", "warning", "info"])(
+        "should check accessibility for DateInput with %s validation icon",
+        (type) => {
+          CypressMountWithProviders(
+            <DateInputCustom
+              labelInline
+              labelAlign="right"
+              {...{ [type]: "Message" }}
+            />
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+    });
+
+    it.each([
+      [VALIDATION.ERROR, "error", true],
+      [VALIDATION.WARNING, "warning", true],
+      [VALIDATION.INFO, "info", true],
+    ])(
+      "should check accessibility for DateInput is %s when validation is %s and boolean prop is %s",
+      (borderColor, type, bool) => {
+        CypressMountWithProviders(
+          <DateInputCustom
+            labelInline
+            labelAlign="right"
+            {...{ [type]: bool }}
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check accessibility for component with new validation", () => {
+      CypressMountWithProviders(<DateInputValidationNewDesign />);
+
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Date Input` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `date.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `date` tests are not running twice.