### PR TITLE
feat(tab): introduce titleProps for passing props to corresponding title

### DIFF
--- a/src/components/tabs/__internal__/tab-title/tab-title.component.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.component.js
@@ -20,6 +20,7 @@ const TabTitle = React.forwardRef(
     {
       isTabSelected,
       dataTabId,
+      "data-role": dataRole,
       title,
       position = "top",
       error,
@@ -136,6 +137,7 @@ const TabTitle = React.forwardRef(
             aria-selected={isTabSelected}
             data-element="select-tab"
             data-tabid={dataTabId}
+            data-role={dataRole}
             role="tab"
             position={position}
             isTabSelected={isTabSelected}
@@ -235,6 +237,8 @@ TabTitle.propTypes = {
   isTabSelected: PropTypes.bool,
   position: PropTypes.oneOf(["top", "left"]),
   className: PropTypes.string,
+  /** Identifier used for testing purposes */
+  "data-role": PropTypes.string,
   dataTabId: PropTypes.string,
   id: PropTypes.string,
   onClick: PropTypes.func,

--- a/src/components/tabs/__internal__/tab-title/tab-title.d.ts
+++ b/src/components/tabs/__internal__/tab-title/tab-title.d.ts
@@ -5,6 +5,8 @@ export interface TabTitleContextProps {
 }
 
 export interface TabTitleProps {
+  /** Identifier used for testing purposes */
+  "data-role"?: string;
   title: string;
   id?: string;
   dataTabId?: string;

--- a/src/components/tabs/__internal__/tab-title/tab-title.spec.js
+++ b/src/components/tabs/__internal__/tab-title/tab-title.spec.js
@@ -51,17 +51,23 @@ describe("TabTitle", () => {
   });
 
   describe("attributes", () => {
-    wrapper = render();
     it('role equals "tab"', () => {
+      wrapper = render();
       expect(wrapper.find("[role='tab']").exists()).toEqual(true);
     });
     it('data-element equals "select-tab"', () => {
+      wrapper = render();
       expect(wrapper.find("[data-element='select-tab']").exists()).toEqual(
         true
       );
     });
     it("data-tabid equals tabId", () => {
+      wrapper = render();
       expect(wrapper.find("[data-tabid='uniqueid1']").exists()).toEqual(true);
+    });
+    it("when 'data-role' is set, pass to title element", () => {
+      wrapper = render({ "data-role": "foobar" });
+      expect(wrapper.find("[data-role='foobar']").exists()).toBeTruthy();
     });
   });
 

--- a/src/components/tabs/tab/tab.component.js
+++ b/src/components/tabs/tab/tab.component.js
@@ -24,6 +24,7 @@ const Tab = ({
   updateInfos,
   href,
   title,
+  titleProps,
   ...rest
 }) => {
   const [tabErrors, setTabErrors] = useState({});
@@ -120,6 +121,11 @@ Tab.propTypes = {
   titlePosition: PropTypes.oneOf(["before", "after"]),
   /** Allows Tab to be a link */
   href: PropTypes.string,
+  /** Additional props to be passed to the Tab's corresponding title */
+  titleProps: PropTypes.shape({
+    /** Identifier used for testing purposes */
+    "data-role": PropTypes.string,
+  }),
 };
 
 export { TabContext };

--- a/src/components/tabs/tab/tab.d.ts
+++ b/src/components/tabs/tab/tab.d.ts
@@ -32,6 +32,11 @@ export interface TabProps extends PaddingProps {
   href?: string;
   /** Overrides default layout with a one defined in this prop */
   customLayout?: React.ReactNode;
+  /** Additional props to be passed to the Tab's corresponding title. */
+  titleProps?: {
+    /** Identifier used for testing purposes */
+    "data-role"?: string;
+  };
 }
 
 export interface TabAllProps {

--- a/src/components/tabs/tabs.component.js
+++ b/src/components/tabs/tabs.component.js
@@ -187,6 +187,7 @@ const Tabs = ({
         infoMessage,
         href,
         customLayout,
+        titleProps,
       } = child.props;
       const refId = `${tabId}-tab`;
       const errors = tabsErrors[tabId];
@@ -234,8 +235,9 @@ const Tabs = ({
         return summaryOfMessages.map((value) => `• ${value}`).join("\n");
       };
 
-      const tabTitle = (
+      return (
         <TabTitle
+          {...titleProps}
           position={isInSidebar ? "left" : position}
           className={child.props.className || ""}
           dataTabId={tabId}
@@ -266,8 +268,6 @@ const Tabs = ({
           align={align}
         />
       );
-
-      return tabTitle;
     });
 
     return (
@@ -285,37 +285,32 @@ const Tabs = ({
     );
   };
 
-  /** Builds the single currently selected tab */
-  const visibleTab = () => {
-    const tab = filteredChildren.find((child) =>
-      isTabSelected(child.props.tabId)
-    );
-
-    return (
-      tab &&
-      cloneElement(tab, {
-        ...tab.props,
-        role: "tabpanel",
-        position,
-        isTabSelected: isTabSelected(tab.props.tabId),
-        key: `${tab.props.tabId}-tab`,
-        ariaLabelledby: `${tab.props.tabId}-tab`,
-        updateErrors,
-        updateWarnings,
-        updateInfos,
-      })
-    );
-  };
-
   /** Builds all tabs where non selected tabs have class of hidden */
   const renderTabs = () => {
     if (isInSidebar) return null;
 
     if (!renderHiddenTabs) {
-      return visibleTab();
+      const tab = filteredChildren.find((child) =>
+        isTabSelected(child.props.tabId)
+      );
+
+      return (
+        tab &&
+        cloneElement(tab, {
+          ...tab.props,
+          role: "tabpanel",
+          position,
+          isTabSelected: isTabSelected(tab.props.tabId),
+          key: `${tab.props.tabId}-tab`,
+          ariaLabelledby: `${tab.props.tabId}-tab`,
+          updateErrors,
+          updateWarnings,
+          updateInfos,
+        })
+      );
     }
 
-    const tabs = filteredChildren.map((child) => {
+    return filteredChildren.map((child) => {
       return cloneElement(child, {
         ...child.props,
         role: "tabpanel",
@@ -328,8 +323,6 @@ const Tabs = ({
         updateInfos,
       });
     });
-
-    return tabs;
   };
 
   return (

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -1034,6 +1034,24 @@ describe("tags", () => {
     });
   });
 
+  it("when child Tab has `data-role` prop set, renders corresponding tab title with that `data-role`", () => {
+    const dataRole = "foobar";
+    const wrapper = mount(
+      <Tabs>
+        <Tab
+          titleProps={{
+            "data-role": dataRole,
+          }}
+          title="Tab Title 1"
+          tabId="uniqueid"
+        >
+          Content for Tab 1
+        </Tab>
+      </Tabs>
+    );
+    expect(wrapper.find(TabTitle).prop("data-role")).toEqual(dataRole);
+  });
+
   describe("when children of Tab have validation failures", () => {
     const MockComponent = ({ show = true, error, warning, info }) => (
       <Tabs data-element="bar" data-role="baz">

--- a/src/components/tabs/tabs.stories.mdx
+++ b/src/components/tabs/tabs.stories.mdx
@@ -1,11 +1,13 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
+import { ArgsTable } from "@storybook/components";
 import LinkTo from "@storybook/addon-links/react";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+
 import { useState, useRef } from "react";
 import { Tabs, Tab } from "./tabs.component";
 import { Checkbox } from "../checkbox";
 import Icon from "../icon";
 import Pill from "../pill";
-import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import Box from "../box";
 
 <Meta title="Tabs" parameters={{ info: { disable: true } }} />
@@ -15,9 +17,9 @@ import Box from "../box";
 <a
   target="_blank"
   href="https://zeroheight.com/2ccf2b601/p/54468c-tab"
-  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+  style={{ color: "#007E45", fontWeight: "bold", textDecoration: "underline" }}
 >
-  Product Design System component 
+  Product Design System component
 </a>
 
 Switch between content panes or filtered views of tables.
@@ -1766,80 +1768,98 @@ CSS string.
 
 ### With string validations summarised
 
-By default the strings passed to `errorMessage`, `warningMessage` and `infoMessage` props are what is 
-used in the validation tooltip. However, setting the `showValidationsSumary` prop allows for the 
-summarising of validation messages from the children of a given `Tab`. You can see an example of this 
+By default the strings passed to `errorMessage`, `warningMessage` and `infoMessage` props are what is
+used in the validation tooltip. However, setting the `showValidationsSumary` prop allows for the
+summarising of validation messages from the children of a given `Tab`. You can see an example of this
 by hovering your mouse pointer over the `ValidationIcon`s in the example below.
 
 <Canvas>
-  <Story name="with string validations summarised" parameters={{ chromatic: { disable: true } }}>
+  <Story
+    name="with string validations summarised"
+    parameters={{ chromatic: { disable: true } }}
+  >
     {() => {
       const [errors, setErrors] = useState({
-        one: 'This is an error',
-        two: 'Here is another error'
+        one: "This is an error",
+        two: "Here is another error",
       });
       const [warnings, setWarnings] = useState({
-        one: 'This is a warning',
-        two: 'Here is another warning'
+        one: "This is a warning",
+        two: "Here is another warning",
       });
-      const [infos, setInfos] = useState({ 
-        one: 'This is an info', 
-        two: 'Here is another info'
+      const [infos, setInfos] = useState({
+        one: "This is an info",
+        two: "Here is another info",
       });
       return (
         <div style={{ padding: "4px" }}>
           <Tabs align="left" position="top" showValidationsSummary>
-            <Tab
-              tabId="tab-1"
-              title="Tab 1"
-              key="tab-1"
-            >
+            <Tab tabId="tab-1" title="Tab 1" key="tab-1">
               <Checkbox
                 label="Error 1"
                 error={errors.one}
-                onChange={e => e.target.checked ? setErrors({ ...errors, one: 'This is an error' }) : setErrors({ ...errors, one: '' })}
+                onChange={(e) =>
+                  e.target.checked
+                    ? setErrors({ ...errors, one: "This is an error" })
+                    : setErrors({ ...errors, one: "" })
+                }
                 checked={errors.one}
               />
               <Checkbox
                 label="Error 2"
                 error={errors.two}
-                onChange={e => e.target.checked ? setErrors({ ...errors, two: 'Here is another error' }) : setErrors({ ...errors, two: '' })}
+                onChange={(e) =>
+                  e.target.checked
+                    ? setErrors({ ...errors, two: "Here is another error" })
+                    : setErrors({ ...errors, two: "" })
+                }
                 checked={errors.two}
               />
             </Tab>
-            <Tab
-              tabId="tab-2"
-              title="Tab 2"
-              key="tab-2"
-            >
+            <Tab tabId="tab-2" title="Tab 2" key="tab-2">
               <Checkbox
                 label="Warning 1"
                 warning={warnings.one}
-                onChange={e => e.target.checked ? setWarnings({ ...warnings, one: 'This is a warning' }) : setWarnings({ ...warnings, one: '' })}
+                onChange={(e) =>
+                  e.target.checked
+                    ? setWarnings({ ...warnings, one: "This is a warning" })
+                    : setWarnings({ ...warnings, one: "" })
+                }
                 checked={warnings.one}
               />
               <Checkbox
                 label="Warning 2"
                 warning={warnings.two}
-                onChange={e => e.target.checked ? setWarnings({ ...warnings, two: 'Here is another warning' }) : setWarnings({ ...warnings, two: '' })}
+                onChange={(e) =>
+                  e.target.checked
+                    ? setWarnings({
+                        ...warnings,
+                        two: "Here is another warning",
+                      })
+                    : setWarnings({ ...warnings, two: "" })
+                }
                 checked={warnings.two}
               />
             </Tab>
-            <Tab
-              tabId="tab-3"
-              title="Tab 3"
-              key="tab-3"
-            >
+            <Tab tabId="tab-3" title="Tab 3" key="tab-3">
               <Checkbox
                 label="Info 1"
                 info={infos.one}
-                onChange={e => e.target.checked ? setInfos({ ...infos, one: true }) : setInfos({ ...infos, one: '' })}
+                onChange={(e) =>
+                  e.target.checked
+                    ? setInfos({ ...infos, one: true })
+                    : setInfos({ ...infos, one: "" })
+                }
                 checked={infos.one}
               />
               <Checkbox
                 label="Info 2"
                 info={infos.two}
-                onChange={e => e.target.checked ? setInfos({ ...infos, two: 'This is a warning' }) : setInfos({ ...infos, two: '' })}
+                onChange={(e) =>
+                  e.target.checked
+                    ? setInfos({ ...infos, two: "This is a warning" })
+                    : setInfos({ ...infos, two: "" })
+                }
                 checked={infos.two}
               />
             </Tab>
@@ -1923,3 +1943,15 @@ const App = () => {
 ### Tab
 
 <StyledSystemProps of={Tab} padding noHeader />
+
+#### `titleProps`
+
+<ArgsTable
+  rows={[
+    {
+      name: "data-role",
+      type: { summary: "string" },
+      description: "Identifier used for testing purposes",
+    },
+  ]}
+/>


### PR DESCRIPTION
### Proposed behaviour

- `Tab`: Add new `titleProps` prop - which accepts an object of props to pass to the tab's corresponding `TabTitle`.
- `TabTitle`: Accepts new `data-role` prop to be used for testing and analytics purposes

### Current behaviour

- Consumers cannot set a `data-role` property for a `Tab`'s corresponding `TabTitle`, which has been raised as a feature request to allow consumers to query a tab's title using testing/analytics tools.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

### Testing instructions

- Verify tab title has `data-role` property set when specified
- Double check typescript and docs definitions 

The following CodeSandbox is an example of the broken behaviour: [Go to codesandbox](https://codesandbox.io/s/tab-data-role-6v5wvp?file=/src/App.js)
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.