### PR TITLE
fix(icon-button): use onClick instead of onAction to ensure keyboard behaviour is handled by default

### DIFF
--- a/src/components/batch-selection/batch-selection-test.stories.tsx
+++ b/src/components/batch-selection/batch-selection-test.stories.tsx
@@ -23,13 +23,13 @@ export default {
 
 export const Default = (args: Omit<BatchSelectionProps, "children">) => (
   <BatchSelection {...args}>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="csv" />
     </IconButton>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="bin" />
     </IconButton>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="pdf" />
     </IconButton>
   </BatchSelection>

--- a/src/components/batch-selection/batch-selection.spec.tsx
+++ b/src/components/batch-selection/batch-selection.spec.tsx
@@ -16,7 +16,7 @@ function renderBatchSelection(
 ) {
   return renderer(
     <BatchSelection {...props}>
-      <IconButton onAction={() => {}}>
+      <IconButton onClick={() => {}}>
         <Icon type="edit" />
       </IconButton>
     </BatchSelection>

--- a/src/components/batch-selection/batch-selection.stories.tsx
+++ b/src/components/batch-selection/batch-selection.stories.tsx
@@ -10,13 +10,13 @@ export const Default = () => (
     <Button size="small" mx={1} buttonType="secondary">
       Select All 38 items
     </Button>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="csv" />
     </IconButton>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="bin" />
     </IconButton>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="pdf" />
     </IconButton>
   </BatchSelection>
@@ -24,13 +24,13 @@ export const Default = () => (
 
 export const Dark = () => (
   <BatchSelection selectedCount={1} colorTheme="dark">
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="csv" />
     </IconButton>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="bin" />
     </IconButton>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="pdf" />
     </IconButton>
   </BatchSelection>
@@ -38,13 +38,13 @@ export const Dark = () => (
 
 export const Light = () => (
   <BatchSelection selectedCount={2} colorTheme="light">
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="csv" />
     </IconButton>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="bin" />
     </IconButton>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="pdf" />
     </IconButton>
   </BatchSelection>
@@ -52,13 +52,13 @@ export const Light = () => (
 
 export const White = () => (
   <BatchSelection selectedCount={3} colorTheme="white">
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="csv" />
     </IconButton>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="bin" />
     </IconButton>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="pdf" />
     </IconButton>
   </BatchSelection>
@@ -66,13 +66,13 @@ export const White = () => (
 
 export const Disabled = () => (
   <BatchSelection selectedCount={4} disabled>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="csv" />
     </IconButton>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="bin" />
     </IconButton>
-    <IconButton onAction={() => {}}>
+    <IconButton onClick={() => {}}>
       <Icon type="pdf" />
     </IconButton>
   </BatchSelection>

--- a/src/components/button-bar/button-bar-test.stories.tsx
+++ b/src/components/button-bar/button-bar-test.stories.tsx
@@ -48,7 +48,7 @@ export const DefaultWithWrapper = ({ ...args }) => {
   return (
     <ButtonBar {...args}>
       <WrappedComponent />
-      <IconButton onAction={() => undefined}>
+      <IconButton onClick={() => undefined}>
         <Icon type="csv" />
       </IconButton>
     </ButtonBar>
@@ -67,13 +67,13 @@ export const Preview = () => {
   return (
     <>
       <ButtonBar ml={2} mt={2}>
-        <IconButton onAction={() => {}}>
+        <IconButton onClick={() => {}}>
           <Icon type="pdf" />
         </IconButton>
-        <IconButton onAction={() => {}}>
+        <IconButton onClick={() => {}}>
           <Icon type="csv" />
         </IconButton>
-        <IconButton onAction={() => {}}>
+        <IconButton onClick={() => {}}>
           <Icon type="search" />
         </IconButton>
       </ButtonBar>

--- a/src/components/button-bar/button-bar.spec.tsx
+++ b/src/components/button-bar/button-bar.spec.tsx
@@ -27,7 +27,7 @@ const renderButtonWithIconBar = (icons: IconType[], props = {}) => {
   const buttons = [];
   for (const icon of icons) {
     buttons.push(
-      <IconButton onAction={() => undefined}>
+      <IconButton onClick={() => {}}>
         <Icon type={icon} />
       </IconButton>
     );
@@ -142,7 +142,7 @@ describe("Button Bar", () => {
     it("renders an icon correctly", () => {
       const wrapper = mount(
         <ButtonBar>
-          <IconButton onAction={() => undefined}>
+          <IconButton onClick={() => {}}>
             <Icon type="csv" />
           </IconButton>
         </ButtonBar>
@@ -162,7 +162,7 @@ describe("Button Bar", () => {
       const wrapper = mount(
         <ButtonBar>
           <Button>bar</Button>
-          <IconButton onAction={() => undefined}>
+          <IconButton onClick={() => undefined}>
             <Icon type="csv" />
           </IconButton>
         </ButtonBar>
@@ -176,7 +176,7 @@ describe("Button Bar", () => {
       const wrapper = mount(
         <ButtonBar>
           <Button>bar</Button>
-          <IconButton aria-label="foobar" onAction={() => undefined}>
+          <IconButton aria-label="foobar" onClick={() => undefined}>
             <Icon type="csv" />
           </IconButton>
         </ButtonBar>
@@ -209,7 +209,7 @@ describe("Button Bar", () => {
         const wrapper = mount(
           <ButtonBar {...buttonBarProps}>
             <WrappedComponent />
-            <IconButton onAction={() => undefined}>
+            <IconButton onClick={() => undefined}>
               <Icon type="csv" />
             </IconButton>
           </ButtonBar>

--- a/src/components/button-bar/button-bar.stories.mdx
+++ b/src/components/button-bar/button-bar.stories.mdx
@@ -98,13 +98,13 @@ Button bars with different icon positions.
 <Canvas>
   <Story name="icon buttons">
     <ButtonBar ml={2} mt={2}>
-      <IconButton onAction={() => {}}>
+      <IconButton onClick={() => {}}>
         <Icon type="csv" />
       </IconButton>
-      <IconButton onAction={() => {}}>
+      <IconButton onClick={() => {}}>
         <Icon type="pdf" />
       </IconButton>
-      <IconButton onAction={() => {}}>
+      <IconButton onClick={() => {}}>
         <Icon type="bin" />
       </IconButton>
     </ButtonBar>

--- a/src/components/card/card.stories.tsx
+++ b/src/components/card/card.stories.tsx
@@ -252,16 +252,16 @@ export const MoreExamplesOfCardFooter: StoryFn = () => (
           justifyContent="space-around"
         >
           <Box flexGrow={1}>
-            <IconButton aria-label="Phone icon button" onAction={() => {}}>
+            <IconButton aria-label="Phone icon button" onClick={() => {}}>
               <Icon bgSize="medium" type="phone" />
             </IconButton>
-            <IconButton aria-label="Phone icon button" onAction={() => {}}>
+            <IconButton aria-label="Phone icon button" onClick={() => {}}>
               <Icon bgSize="medium" type="phone" />
             </IconButton>
-            <IconButton aria-label="Phone icon button" onAction={() => {}}>
+            <IconButton aria-label="Phone icon button" onClick={() => {}}>
               <Icon bgSize="medium" type="phone" />
             </IconButton>
-            <IconButton aria-label="Phone icon button" onAction={() => {}}>
+            <IconButton aria-label="Phone icon button" onClick={() => {}}>
               <Icon bgSize="medium" type="phone" />
             </IconButton>
           </Box>

--- a/src/components/dialog-full-screen/dialog-full-screen.component.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.tsx
@@ -112,7 +112,7 @@ export const DialogFullScreen = ({
       <IconButton
         data-element="close"
         aria-label={locale.dialogFullScreen.ariaLabels.close()}
-        onAction={onCancel}
+        onClick={onCancel}
       >
         <Icon type="close" />
       </IconButton>

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.tsx
@@ -146,7 +146,7 @@ export const WithComplexExample = () => {
                   <Typography variant="b">Example text</Typography>
                   <Typography mb={0}>Example text without bold</Typography>
                 </Box>
-                <IconButton onAction={() => {}} aria-label="flag-button">
+                <IconButton onClick={() => {}} aria-label="flag-button">
                   <Icon type="flag" />
                 </IconButton>
                 <ActionPopover>
@@ -171,7 +171,7 @@ export const WithComplexExample = () => {
                   <Typography variant="b">Example text</Typography>
                   <Typography mb={0}>Example text without bold</Typography>
                 </Box>
-                <IconButton onAction={() => {}} aria-label="flag-button">
+                <IconButton onClick={() => {}} aria-label="flag-button">
                   <Icon type="flag" />
                 </IconButton>
                 <ActionPopover>
@@ -196,7 +196,7 @@ export const WithComplexExample = () => {
                   <Typography variant="b">Example text</Typography>
                   <Typography mb={0}>Example text without bold</Typography>
                 </Box>
-                <IconButton onAction={() => {}} aria-label="flag-button">
+                <IconButton onClick={() => {}} aria-label="flag-button">
                   <Icon type="flag" />
                 </IconButton>
                 <ActionPopover>
@@ -253,7 +253,7 @@ export const WithComplexExample = () => {
                     Primary
                   </Pill>
                 </Box>
-                <IconButton onAction={() => {}} aria-label="flag-button">
+                <IconButton onClick={() => {}} aria-label="flag-button">
                   <Icon type="flag" />
                 </IconButton>
                 <ActionPopover>
@@ -277,7 +277,7 @@ export const WithComplexExample = () => {
                 <div style={{ flexGrow: 1 }}>
                   <Typography variant="b">Example text</Typography>
                 </div>
-                <IconButton onAction={() => {}} aria-label="flag-button">
+                <IconButton onClick={() => {}} aria-label="flag-button">
                   <Icon type="flag" />
                 </IconButton>
                 <ActionPopover>

--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -205,7 +205,7 @@ export const Dialog = ({
       <IconButton
         data-element="close"
         aria-label={locale.dialog.ariaLabels.close()}
-        onAction={onCancel}
+        onClick={onCancel}
         disabled={disableClose}
       >
         <Icon type="close" />

--- a/src/components/dismissible-box/dismissible-box.component.tsx
+++ b/src/components/dismissible-box/dismissible-box.component.tsx
@@ -40,7 +40,7 @@ export const DismissibleBox = ({
   >
     {children}
     <span data-element="close-button-wrapper">
-      <IconButton onAction={onClose} aria-label="close-button" ml={3}>
+      <IconButton onClick={onClose} aria-label="close-button" ml={3}>
         <Icon type="close" color="--colorsActionMinor500" />
       </IconButton>
     </span>

--- a/src/components/flat-table/flat-table-expandable.stories.mdx
+++ b/src/components/flat-table/flat-table-expandable.stories.mdx
@@ -681,13 +681,13 @@ By writing your own selectable logic, both parent and child rows can be made sel
             disabled={selectedCount === 0}
             selectedCount={selectedCount}
           >
-            <IconButton aria-label="download as csv" onAction={() => {}}>
+            <IconButton aria-label="download as csv" onClick={() => {}}>
               <Icon type="csv" />
             </IconButton>
-            <IconButton aria-label="bin" onAction={() => {}}>
+            <IconButton aria-label="bin" onClick={() => {}}>
               <Icon type="bin" />
             </IconButton>
-            <IconButton aria-label="download as pdf" onAction={() => {}}>
+            <IconButton aria-label="download as pdf" onClick={() => {}}>
               <Icon type="pdf" />
             </IconButton>
           </BatchSelection>
@@ -888,13 +888,13 @@ By writing your own selectable logic, the parent rows only can be made selectabl
             disabled={selectedCount === 0}
             selectedCount={selectedCount}
           >
-            <IconButton aria-label="download as csv" onAction={() => {}}>
+            <IconButton aria-label="download as csv" onClick={() => {}}>
               <Icon type="csv" />
             </IconButton>
-            <IconButton aria-label="bin" onAction={() => {}}>
+            <IconButton aria-label="bin" onClick={() => {}}>
               <Icon type="bin" />
             </IconButton>
-            <IconButton aria-label="download as pdf" onAction={() => {}}>
+            <IconButton aria-label="download as pdf" onClick={() => {}}>
               <Icon type="pdf" />
             </IconButton>
           </BatchSelection>
@@ -1117,13 +1117,13 @@ By writing your own selectable logic, the child rows only can be made selectable
             disabled={selectedCount === 0}
             selectedCount={selectedCount}
           >
-            <IconButton aria-label="download as csv" onAction={() => {}}>
+            <IconButton aria-label="download as csv" onClick={() => {}}>
               <Icon type="csv" />
             </IconButton>
-            <IconButton aria-label="bin" onAction={() => {}}>
+            <IconButton aria-label="bin" onClick={() => {}}>
               <Icon type="bin" />
             </IconButton>
-            <IconButton aria-label="download as pdf" onAction={() => {}}>
+            <IconButton aria-label="download as pdf" onClick={() => {}}>
               <Icon type="pdf" />
             </IconButton>
           </BatchSelection>

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -1469,13 +1469,13 @@ Where icons are used for batch actions, they have text labels too, or tooltips t
             disabled={selectedCount === 0}
             selectedCount={selectedCount}
           >
-            <IconButton aria-label="csv" onAction={() => {}}>
+            <IconButton aria-label="csv" onClick={() => {}}>
               <Icon type="csv" />
             </IconButton>
-            <IconButton aria-label="delete" onAction={() => {}}>
+            <IconButton aria-label="delete" onClick={() => {}}>
               <Icon type="bin" />
             </IconButton>
-            <IconButton aria-label="pdf" onAction={() => {}}>
+            <IconButton aria-label="pdf" onClick={() => {}}>
               <Icon type="pdf" />
             </IconButton>
           </BatchSelection>
@@ -1674,13 +1674,13 @@ It is also possible to integrate selection of multiple rows and the highlighting
             disabled={selectedCount === 0}
             selectedCount={selectedCount}
           >
-            <IconButton aria-label="csv" onAction={() => {}}>
+            <IconButton aria-label="csv" onClick={() => {}}>
               <Icon type="csv" />
             </IconButton>
-            <IconButton aria-label="delete" onAction={() => {}}>
+            <IconButton aria-label="delete" onClick={() => {}}>
               <Icon type="bin" />
             </IconButton>
-            <IconButton aria-label="pdf" onAction={() => {}}>
+            <IconButton aria-label="pdf" onClick={() => {}}>
               <Icon type="pdf" />
             </IconButton>
           </BatchSelection>
@@ -2113,13 +2113,13 @@ of the button control.
             disabled={selectedCount === 0}
             selectedCount={selectedCount}
           >
-            <IconButton aria-label="csv" onAction={() => {}}>
+            <IconButton aria-label="csv" onClick={() => {}}>
               <Icon type="csv" />
             </IconButton>
-            <IconButton aria-label="delete" onAction={() => {}}>
+            <IconButton aria-label="delete" onClick={() => {}}>
               <Icon type="bin" />
             </IconButton>
-            <IconButton aria-label="pdf" onAction={() => {}}>
+            <IconButton aria-label="pdf" onClick={() => {}}>
               <Icon type="pdf" />
             </IconButton>
           </BatchSelection>

--- a/src/components/flat-table/flat-table.test.js
+++ b/src/components/flat-table/flat-table.test.js
@@ -959,13 +959,13 @@ const FlatTableColorRowSelectableComponent = ({ ...props }) => {
         disabled={selectedCount === 0}
         selectedCount={selectedCount}
       >
-        <IconButton aria-label="csv" onAction={() => {}}>
+        <IconButton aria-label="csv" onClick={() => {}}>
           <Icon type="csv" />
         </IconButton>
-        <IconButton aria-label="delete" onAction={() => {}}>
+        <IconButton aria-label="delete" onClick={() => {}}>
           <Icon type="bin" />
         </IconButton>
-        <IconButton aria-label="pdf" onAction={() => {}}>
+        <IconButton aria-label="pdf" onClick={() => {}}>
           <Icon type="pdf" />
         </IconButton>
       </BatchSelection>
@@ -1081,13 +1081,13 @@ const FlatTableCheckboxComponent = ({ ...props }) => {
         disabled={selectedCount === 0}
         selectedCount={selectedCount}
       >
-        <IconButton aria-label="csv" onAction={() => {}}>
+        <IconButton aria-label="csv" onClick={() => {}}>
           <Icon type="csv" />
         </IconButton>
-        <IconButton aria-label="delete" onAction={() => {}}>
+        <IconButton aria-label="delete" onClick={() => {}}>
           <Icon type="bin" />
         </IconButton>
-        <IconButton aria-label="pdf" onAction={() => {}}>
+        <IconButton aria-label="pdf" onClick={() => {}}>
           <Icon type="pdf" />
         </IconButton>
       </BatchSelection>
@@ -1218,13 +1218,13 @@ const FlatTableHighlightableComponent = ({ ...props }) => {
         disabled={selectedCount === 0}
         selectedCount={selectedCount}
       >
-        <IconButton aria-label="csv" onAction={() => {}}>
+        <IconButton aria-label="csv" onClick={() => {}}>
           <Icon type="csv" />
         </IconButton>
-        <IconButton aria-label="delete" onAction={() => {}}>
+        <IconButton aria-label="delete" onClick={() => {}}>
           <Icon type="bin" />
         </IconButton>
-        <IconButton aria-label="pdf" onAction={() => {}}>
+        <IconButton aria-label="pdf" onClick={() => {}}>
           <Icon type="pdf" />
         </IconButton>
       </BatchSelection>
@@ -2023,13 +2023,13 @@ const FlatTableAllSubrowSelectableComponent = () => {
         disabled={selectedCount === 0}
         selectedCount={selectedCount}
       >
-        <IconButton aria-label="download as csv" onAction={() => {}}>
+        <IconButton aria-label="download as csv" onClick={() => {}}>
           <Icon type="csv" />
         </IconButton>
-        <IconButton aria-label="bin" onAction={() => {}}>
+        <IconButton aria-label="bin" onClick={() => {}}>
           <Icon type="bin" />
         </IconButton>
-        <IconButton aria-label="download as pdf" onAction={() => {}}>
+        <IconButton aria-label="download as pdf" onClick={() => {}}>
           <Icon type="pdf" />
         </IconButton>
       </BatchSelection>
@@ -2210,13 +2210,13 @@ const FlatTableParentSubrowSelectableComponent = () => {
         disabled={selectedCount === 0}
         selectedCount={selectedCount}
       >
-        <IconButton aria-label="download as csv" onAction={() => {}}>
+        <IconButton aria-label="download as csv" onClick={() => {}}>
           <Icon type="csv" />
         </IconButton>
-        <IconButton aria-label="bin" onAction={() => {}}>
+        <IconButton aria-label="bin" onClick={() => {}}>
           <Icon type="bin" />
         </IconButton>
-        <IconButton aria-label="download as pdf" onAction={() => {}}>
+        <IconButton aria-label="download as pdf" onClick={() => {}}>
           <Icon type="pdf" />
         </IconButton>
       </BatchSelection>
@@ -2431,13 +2431,13 @@ const FlatTableChildSubrowSelectableComponent = () => {
         disabled={selectedCount === 0}
         selectedCount={selectedCount}
       >
-        <IconButton aria-label="download as csv" onAction={() => {}}>
+        <IconButton aria-label="download as csv" onClick={() => {}}>
           <Icon type="csv" />
         </IconButton>
-        <IconButton aria-label="bin" onAction={() => {}}>
+        <IconButton aria-label="bin" onClick={() => {}}>
           <Icon type="bin" />
         </IconButton>
-        <IconButton aria-label="download as pdf" onAction={() => {}}>
+        <IconButton aria-label="download as pdf" onClick={() => {}}>
           <Icon type="pdf" />
         </IconButton>
       </BatchSelection>

--- a/src/components/icon-button/icon-button.component.tsx
+++ b/src/components/icon-button/icon-button.component.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useCallback, useContext } from "react";
 import { SpaceProps } from "styled-system";
-
+import invariant from "invariant";
 import Events from "../../__internal__/utils/helpers/events";
 import StyledIconButton from "./icon-button.style";
 import { IconProps } from "../icon";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import { ButtonBarContext } from "../button-bar/button-bar.component";
+import Logger from "../../__internal__/utils/logger";
 
 export interface IconButtonProps extends SpaceProps {
   /** Prop to specify the aria-label of the icon-button component */
@@ -20,27 +21,48 @@ export interface IconButtonProps extends SpaceProps {
   onMouseEnter?: (ev: React.MouseEvent<HTMLButtonElement>) => void;
   /** Callback triggered on mouse leave */
   onMouseLeave?: (ev: React.MouseEvent<HTMLButtonElement>) => void;
-  /** Action callback */
-  onAction: (
+  /** [DEPRECATED - use `onClick` instead] Action callback */
+  onAction?: (
     e:
       | React.KeyboardEvent<HTMLButtonElement>
       | React.MouseEvent<HTMLButtonElement>
   ) => void;
   /** Set the button to disabled */
   disabled?: boolean;
+  /** Callback triggered on click */
+  onClick?: (
+    e:
+      | React.KeyboardEvent<HTMLButtonElement>
+      | React.MouseEvent<HTMLButtonElement>
+  ) => void;
 }
+
+let onActionButtonWarnTriggered = false;
 
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (
     {
       "aria-label": ariaLabel,
       onAction,
+      onClick,
       children,
       disabled,
       ...rest
     }: IconButtonProps,
     ref
   ) => {
+    if (!onActionButtonWarnTriggered && onAction) {
+      onActionButtonWarnTriggered = true;
+      Logger.deprecate(
+        "The `onAction` callback for the `IconButton` component is deprecated and will soon be removed. Please use `onClick` instead"
+      );
+    }
+
+    invariant(
+      !(onClick && onAction),
+      "onClick and onAction have both been set, please use onClick as onAction will soon be deprecated"
+    );
+
     const [internalRef, setInternalRef] = useState<HTMLButtonElement>();
 
     const context = useContext(ButtonBarContext);
@@ -55,14 +77,14 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
     const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
       if (Events.isEnterKey(e) || Events.isSpaceKey(e)) {
         e.preventDefault();
-        onAction(e);
-      } else {
-        e.stopPropagation();
+        onAction?.(e);
+        onClick?.(e);
       }
     };
 
     const handleOnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-      onAction(e);
+      onAction?.(e);
+      onClick?.(e);
     };
 
     const setRefs = useCallback(

--- a/src/components/icon-button/icon-button.stories.mdx
+++ b/src/components/icon-button/icon-button.stories.mdx
@@ -21,7 +21,7 @@ import IconButton from "carbon-react/lib/components/icon-button";
 
 <Canvas>
   <Story name="default">
-    <IconButton aria-label="icon-button" onAction={() => {}}>
+    <IconButton aria-label="icon-button" onClick={() => {}}>
       <Icon type="home" />
     </IconButton>
   </Story>
@@ -31,7 +31,7 @@ import IconButton from "carbon-react/lib/components/icon-button";
 
 <Canvas>
   <Story name="with tooltip">
-    <IconButton aria-label="icon-button" onAction={() => {}}>
+    <IconButton aria-label="icon-button" onClick={() => {}}>
       <Icon type="home" tooltipMessage="Hey I'm a tooltip!" />
     </IconButton>
   </Story>
@@ -41,7 +41,7 @@ import IconButton from "carbon-react/lib/components/icon-button";
 
 <Canvas>
   <Story name="disabled">
-    <IconButton disabled aria-label="icon-button" onAction={() => {}}>
+    <IconButton disabled aria-label="icon-button" onClick={() => {}}>
       <Icon type="home" />
     </IconButton>
   </Story>

--- a/src/components/icon-button/icon-button.test.js
+++ b/src/components/icon-button/icon-button.test.js
@@ -9,7 +9,7 @@ import { keyCode } from "../../../cypress/support/helper";
 
 const IconButtonComponent = ({ ...props }) => {
   return (
-    <IconButton aria-label="icon-button" onAction={() => {}} {...props}>
+    <IconButton aria-label="icon-button" onClick={() => {}} {...props}>
       <Icon type="home" />
     </IconButton>
   );
@@ -102,8 +102,8 @@ context("Tests for IconButton component", () => {
         });
     });
 
-    it("should call onAction callback when a click event is triggered", () => {
-      CypressMountWithProviders(<IconButtonComponent onAction={callback} />);
+    it("should call onClick callback when a click event is triggered", () => {
+      CypressMountWithProviders(<IconButtonComponent onClick={callback} />);
 
       icon()
         .parent()
@@ -115,9 +115,9 @@ context("Tests for IconButton component", () => {
     });
 
     it.each(["Space", "Enter"])(
-      "should call onAction callback when a keydown event is triggered with %s",
+      "should call onClick callback when a keydown event is triggered with %s",
       (key) => {
-        CypressMountWithProviders(<IconButtonComponent onAction={callback} />);
+        CypressMountWithProviders(<IconButtonComponent onClick={callback} />);
 
         icon()
           .parent()

--- a/src/components/link-preview/link-preview.component.tsx
+++ b/src/components/link-preview/link-preview.component.tsx
@@ -95,7 +95,7 @@ export const LinkPreview = ({
         <StyledCloseIconWrapper>
           <IconButton
             aria-label="link preview close button"
-            onAction={() => onClose(url)}
+            onClick={() => onClose(url)}
           >
             <Icon type="close" />
           </IconButton>

--- a/src/components/menu/menu-full-screen/menu-full-screen.component.js
+++ b/src/components/menu/menu-full-screen/menu-full-screen.component.js
@@ -67,7 +67,7 @@ const MenuFullscreen = ({
             >
               <IconButton
                 aria-label="menu fullscreen close button"
-                onAction={onClose}
+                onClick={onClose}
                 data-element="close"
               >
                 <Icon type="close" color={iconColors[menuType]} />

--- a/src/components/message/message.component.tsx
+++ b/src/components/message/message.component.tsx
@@ -61,7 +61,7 @@ export const Message = ({
       <IconButton
         data-element="close"
         aria-label={closeButtonAriaLabel || l.message.closeButtonAriaLabel()}
-        onAction={onDismiss}
+        onClick={onDismiss}
       >
         <Icon type="close" />
       </IconButton>

--- a/src/components/pill/pill.component.tsx
+++ b/src/components/pill/pill.component.tsx
@@ -59,7 +59,7 @@ export const Pill = ({
     {children}
     {onDelete && (
       <IconButton
-        onAction={onDelete}
+        onClick={onDelete}
         data-element="close"
         aria-label={ariaLabelOfRemoveButton}
       >

--- a/src/components/pod/pod.component.tsx
+++ b/src/components/pod/pod.component.tsx
@@ -240,7 +240,7 @@ const Pod = React.forwardRef<HTMLDivElement, PodProps>(
                 noBorder={!border}
                 size={size}
                 variant={variant}
-                onAction={processPodAction(onUndo)}
+                onClick={processPodAction(onUndo)}
               >
                 <Icon type="undo" />
               </StyledUndoButton>
@@ -276,7 +276,7 @@ const Pod = React.forwardRef<HTMLDivElement, PodProps>(
                 noBorder={!border}
                 size={size}
                 variant={variant}
-                onAction={processPodAction(onDelete)}
+                onClick={processPodAction(onDelete)}
               >
                 <Icon type="delete" />
               </StyledDeleteButton>

--- a/src/components/popover-container/popover-container.component.tsx
+++ b/src/components/popover-container/popover-container.component.tsx
@@ -43,7 +43,7 @@ export const renderOpen = ({
 }: RenderOpenProps) => (
   <PopoverContainerOpenIcon
     tabIndex={tabIndex}
-    onAction={onClick}
+    onClick={onClick}
     data-element={dataElement}
     ref={ref}
     aria-label={ariaLabel}
@@ -75,7 +75,7 @@ export const renderClose = ({
   <PopoverContainerCloseIcon
     data-element={dataElement}
     tabIndex={tabIndex}
-    onAction={onClick}
+    onClick={onClick}
     ref={ref}
     aria-label={ariaLabel}
   >

--- a/src/components/popover-container/popover-container.spec.tsx
+++ b/src/components/popover-container/popover-container.spec.tsx
@@ -109,7 +109,7 @@ describe("PopoverContainer", () => {
     expect(wrapper.find(Transition).props().in).toBe(false);
 
     act(() => {
-      wrapper.find(PopoverContainerOpenIcon).props().onAction();
+      wrapper.find(PopoverContainerOpenIcon).props().onClick();
     });
 
     wrapper.update();
@@ -162,7 +162,7 @@ describe("PopoverContainer", () => {
 
   it("`shouldCoverButton` should be false by default", () => {
     act(() => {
-      wrapper.find(PopoverContainerOpenIcon).props().onAction();
+      wrapper.find(PopoverContainerOpenIcon).props().onClick();
     });
 
     wrapper.update();
@@ -219,7 +219,7 @@ describe("PopoverContainer", () => {
               open: true,
             });
 
-            wrapper.find(PopoverContainerOpenIcon).props().onAction();
+            wrapper.find(PopoverContainerOpenIcon).props().onClick();
           }).not.toThrow();
         });
       });
@@ -232,7 +232,7 @@ describe("PopoverContainer", () => {
             onClose: onCloseFn,
           });
 
-          wrapper.find(PopoverContainerOpenIcon).props().onAction();
+          wrapper.find(PopoverContainerOpenIcon).props().onClick();
           expect(onCloseFn).toHaveBeenCalled();
         });
 
@@ -243,7 +243,7 @@ describe("PopoverContainer", () => {
             onClose: onCloseFn,
           });
 
-          wrapper.find(PopoverContainerCloseIcon).props().onAction();
+          wrapper.find(PopoverContainerCloseIcon).props().onClick();
           expect(onCloseFn).toHaveBeenCalled();
         });
       });
@@ -258,7 +258,7 @@ describe("PopoverContainer", () => {
             onOpen: onOpenFn,
           });
 
-          wrapper.find(PopoverContainerOpenIcon).props().onAction();
+          wrapper.find(PopoverContainerOpenIcon).props().onClick();
           expect(onOpenFn).toHaveBeenCalled();
         });
       });
@@ -270,7 +270,7 @@ describe("PopoverContainer", () => {
               open: false,
             });
 
-            wrapper.find(PopoverContainerOpenIcon).props().onAction();
+            wrapper.find(PopoverContainerOpenIcon).props().onClick();
           }).not.toThrow();
         });
       });
@@ -293,7 +293,7 @@ describe("PopoverContainer", () => {
       wrapper = render();
 
       act(() => {
-        wrapper.find(PopoverContainerOpenIcon).props().onAction();
+        wrapper.find(PopoverContainerOpenIcon).props().onClick();
       });
 
       wrapper.update();
@@ -304,7 +304,7 @@ describe("PopoverContainer", () => {
       wrapper = render();
 
       act(() => {
-        wrapper.find(PopoverContainerOpenIcon).props().onAction();
+        wrapper.find(PopoverContainerOpenIcon).props().onClick();
       });
 
       wrapper.update();
@@ -380,7 +380,7 @@ describe("PopoverContainer", () => {
         wrapper.update();
 
         act(() => {
-          wrapper.find(PopoverContainerCloseIcon).props().onAction();
+          wrapper.find(PopoverContainerCloseIcon).props().onClick();
         });
 
         wrapper.update();
@@ -445,7 +445,7 @@ describe("PopoverContainer", () => {
         expect(wrapper.find(MyOpenButton).text()).toBe("isOpen is true");
 
         act(() => {
-          wrapper.find(PopoverContainerCloseIcon).props().onAction();
+          wrapper.find(PopoverContainerCloseIcon).props().onClick();
         });
 
         wrapper.update();
@@ -558,13 +558,13 @@ describe("PopoverContainer", () => {
         wrapper = renderAttached();
 
         act(() => {
-          wrapper.find(PopoverContainerOpenIcon).props().onAction();
+          wrapper.find(PopoverContainerOpenIcon).props().onClick();
         });
 
         wrapper.update();
 
         act(() => {
-          wrapper.find(PopoverContainerCloseIcon).props().onAction();
+          wrapper.find(PopoverContainerCloseIcon).props().onClick();
         });
 
         wrapper.update();
@@ -578,7 +578,7 @@ describe("PopoverContainer", () => {
 describe("PopoverContainerOpenIcon", () => {
   it("should render correct style", () => {
     const wrapper = mount(
-      <PopoverContainerOpenIcon onAction={() => {}}>
+      <PopoverContainerOpenIcon onClick={() => {}}>
         <Icon type="settings" />
       </PopoverContainerOpenIcon>
     );
@@ -669,7 +669,7 @@ describe("open state when click event triggered", () => {
   it("should close the container when uncontrolled and target is outside wrapper element", () => {
     const wrapper = render({});
     act(() => {
-      wrapper.find(PopoverContainerOpenIcon).props().onAction();
+      wrapper.find(PopoverContainerOpenIcon).props().onClick();
     });
     expect(wrapper.update().find(PopoverContainerOpenIcon).prop("id")).toBe(
       undefined
@@ -685,7 +685,7 @@ describe("open state when click event triggered", () => {
   it("should not close the container when uncontrolled and target is inside wrapper element", () => {
     const wrapper = render({});
     act(() => {
-      wrapper.find(PopoverContainerOpenIcon).props().onAction();
+      wrapper.find(PopoverContainerOpenIcon).props().onClick();
     });
     expect(wrapper.update().find(PopoverContainerOpenIcon).prop("id")).toBe(
       undefined

--- a/src/components/sidebar/sidebar.component.tsx
+++ b/src/components/sidebar/sidebar.component.tsx
@@ -138,7 +138,7 @@ export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
       return (
         <IconButton
           aria-label={locale.sidebar.ariaLabels.close()}
-          onAction={onCancel}
+          onClick={onCancel}
           data-element="close"
         >
           <Icon type="close" />

--- a/src/components/toast/toast.component.tsx
+++ b/src/components/toast/toast.component.tsx
@@ -135,7 +135,7 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
         <IconButton
           aria-label={locale.toast.ariaLabels.close()}
           data-element="close"
-          onAction={onDismiss}
+          onClick={onDismiss}
           ref={closeIconRef}
         >
           <Icon type="close" />

--- a/src/components/vertical-menu/vertical-menu-full-screen.component.tsx
+++ b/src/components/vertical-menu/vertical-menu-full-screen.component.tsx
@@ -79,7 +79,7 @@ export const VerticalMenuFullScreen = ({
           >
             <IconButton
               aria-label={l.verticalMenuFullScreen.ariaLabels.close()}
-              onAction={onClose}
+              onClick={onClose}
               data-element="close"
             >
               <Icon


### PR DESCRIPTION
fix #5791

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

A deprecation warning has been added for the use of `onAction` within the `IconButton` component, and `onClick` has been added to replace its functionality, and will ensure keyboard behaviour is handled by default. All instances of `onAction` have been replaced by `onClick` internally also. As `onAction` will soon be removed and `onClick` has been added, an invariant has been added to ensure both cannot be used at the same time, as this would result in potentially incorrect behaviour.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

Currently, when `IconButton` is focused, it stops propagation on any key that is not enter or space due to `onAction` event being primarily used within `IconButton`.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.
https://codesandbox.io/s/carbon-quickstart-forked-98jlke?file=/src/App.js
<!-- Add CodeSandbox here -->
