### PR TITLE
docs(dialog-full-screen): fix storybook docs from hanging on load

### DIFF
--- a/src/components/dialog-full-screen/dialog-full-screen.stories.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.tsx
@@ -78,7 +78,7 @@ export const Default = () => {
 };
 Default.parameters = { chromatic: { disable: true } };
 
-export const WithComplexExample = ({ ...props }) => {
+export const WithComplexExample = () => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
   const [activeTab, setActiveTab] = useState("tab-1");
   const padding40 = useMediaQuery("(min-width: 1260px)");
@@ -514,7 +514,6 @@ export const WithComplexExample = ({ ...props }) => {
         disableEscKey={false}
         showCloseIcon
         disableContentPadding
-        {...props}
       >
         <Drawer sidebar={SidebarContent}>
           <Box p={5}>{showCorrectContent()}</Box>
@@ -524,7 +523,7 @@ export const WithComplexExample = ({ ...props }) => {
   );
 };
 
-export const WithDisableContentPadding = ({ ...props }) => {
+export const WithDisableContentPadding = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -536,7 +535,6 @@ export const WithDisableContentPadding = ({ ...props }) => {
         title="Title"
         subtitle="Subtitle"
         disableContentPadding
-        {...props}
       >
         <Form
           stickyFooter
@@ -565,7 +563,7 @@ export const WithDisableContentPadding = ({ ...props }) => {
 };
 WithDisableContentPadding.parameters = { chromatic: { disable: true } };
 
-export const WithHeaderChildren = ({ ...props }) => {
+export const WithHeaderChildren = () => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
   const aboveBreakpoint = useMediaQuery("(min-width: 568px)");
   const verticalMargin = aboveBreakpoint ? "26px" : 0;
@@ -586,7 +584,6 @@ export const WithHeaderChildren = ({ ...props }) => {
         title="An example of a long header"
         subtitle="Subtitle"
         headerChildren={HeaderChildren}
-        {...props}
       >
         <Form
           stickyFooter
@@ -615,7 +612,7 @@ export const WithHeaderChildren = ({ ...props }) => {
 };
 WithDisableContentPadding.parameters = { viewports: [500, 1400] };
 
-export const WithHelp = ({ ...props }) => {
+export const WithHelp = () => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
@@ -626,7 +623,6 @@ export const WithHelp = ({ ...props }) => {
         title="An example of a long header"
         subtitle="Subtitle"
         help="Some help text"
-        {...props}
       >
         <Form
           stickyFooter
@@ -654,7 +650,7 @@ export const WithHelp = ({ ...props }) => {
   );
 };
 
-export const WithHideableHeaderChildren = ({ ...props }) => {
+export const WithHideableHeaderChildren = () => {
   const [isOpen, setIsOpen] = useState(false);
   const aboveBreakpoint = useMediaQuery("(min-width: 568px)");
   const verticalMargin = aboveBreakpoint ? "26px" : 0;
@@ -698,7 +694,6 @@ export const WithHideableHeaderChildren = ({ ...props }) => {
             ? HeaderChildrenAboveBreakpoint
             : HeaderChildrenBelowBreakpoint
         }
-        {...props}
       >
         <Form
           stickyFooter
@@ -727,7 +722,7 @@ export const WithHideableHeaderChildren = ({ ...props }) => {
 };
 WithHideableHeaderChildren.parameters = { chromatic: { disable: true } };
 
-export const WithBox = ({ ...props }) => {
+export const WithBox = () => {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <>
@@ -737,7 +732,6 @@ export const WithBox = ({ ...props }) => {
         onCancel={() => setIsOpen(false)}
         title="Title"
         subtitle="Subtitle"
-        {...props}
       >
         <Box p="0px 40px">
           <Form
@@ -768,7 +762,7 @@ export const WithBox = ({ ...props }) => {
 };
 WithBox.parameters = { chromatic: { disable: true } };
 
-export const FocusingADifferentFirstElement = ({ ...props }) => {
+export const FocusingADifferentFirstElement = () => {
   const [isOpenOne, setIsOpenOne] = useState(false);
   const [isOpenTwo, setIsOpenTwo] = useState(false);
   const ref = useRef<HTMLButtonElement | null>(null);
@@ -783,7 +777,6 @@ export const FocusingADifferentFirstElement = ({ ...props }) => {
         onCancel={() => setIsOpenOne(false)}
         title="Title"
         subtitle="Subtitle"
-        {...props}
       >
         <p>Focus an element that doesnt support autofocus</p>
         <div
@@ -830,7 +823,7 @@ export const FocusingADifferentFirstElement = ({ ...props }) => {
 };
 FocusingADifferentFirstElement.parameters = { chromatic: { disable: true } };
 
-export const OtherFocusableContainers = ({ ...props }) => {
+export const OtherFocusableContainers = () => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isToast1Open, setIsToast1Open] = useState(false);
   const [isToast2Open, setIsToast2Open] = useState(false);
@@ -847,7 +840,6 @@ export const OtherFocusableContainers = ({ ...props }) => {
         title="Title"
         subtitle="Subtitle"
         focusableContainers={[toast1Ref, toast2Ref]}
-        {...props}
       >
         <Form
           stickyFooter

--- a/src/components/dialog-full-screen/dialog-full-screen.test.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.test.js
@@ -9,6 +9,7 @@ import {
   nestedDialogTitle,
 } from "./dialog-full-screen-test.stories";
 import {
+  Default as DefaultDocsStory,
   WithComplexExample,
   WithDisableContentPadding,
   WithHeaderChildren,
@@ -36,6 +37,7 @@ import {
   getComponent,
   getElement,
 } from "../../../cypress/locators/index";
+import { buttonDataComponent } from "../../../cypress/locators/button";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { contentElement } from "../../../cypress/locators/content/index";
 import { keyCode } from "../../../cypress/support/helper";
@@ -278,57 +280,90 @@ context("Testing DialogFullScreen component", () => {
 
   describe("should check accessibility for Dialog Full Screen", () => {
     it("should check accessibility for default Dialog Full Screen component", () => {
-      CypressMountWithProviders(<DialogFullScreenComponent open />);
+      CypressMountWithProviders(<DefaultDocsStory />);
 
-      cy.checkAccessibility();
+      buttonDataComponent()
+        .contains("Open DialogFullScreen")
+        .click()
+        .then(() => cy.checkAccessibility());
     });
 
     it("should check accessibility for default Dialog Full Screen with complex example", () => {
-      CypressMountWithProviders(<WithComplexExample open />);
+      CypressMountWithProviders(<WithComplexExample />);
 
-      cy.checkAccessibility();
+      buttonDataComponent()
+        .contains("Open DialogFullScreen")
+        .click()
+        .then(() => cy.checkAccessibility());
     });
 
     it("should check accessibility for default Dialog Full Screen with disabled content padding", () => {
-      CypressMountWithProviders(<WithDisableContentPadding open />);
+      CypressMountWithProviders(<WithDisableContentPadding />);
 
-      cy.checkAccessibility();
+      buttonDataComponent()
+        .contains("Open DialogFullScreen")
+        .click()
+        .then(() => cy.checkAccessibility());
     });
 
     it("should check accessibility for default Dialog Full Screen component with header children", () => {
-      CypressMountWithProviders(<WithHeaderChildren open />);
+      CypressMountWithProviders(<WithHeaderChildren />);
 
-      cy.checkAccessibility();
+      buttonDataComponent()
+        .contains("Open DialogFullScreen")
+        .click()
+        .then(() => cy.checkAccessibility());
     });
 
     it("should check accessibility for default Dialog Full Screen component with help", () => {
-      CypressMountWithProviders(<WithHelp open />);
+      CypressMountWithProviders(<WithHelp />);
 
-      cy.checkAccessibility();
+      buttonDataComponent()
+        .contains("Open DialogFullScreen")
+        .click()
+        .then(() => cy.checkAccessibility());
     });
 
     it("should check accessibility for default Dialog Full Screen component with hideable header children", () => {
-      CypressMountWithProviders(<WithHideableHeaderChildren open />);
+      CypressMountWithProviders(<WithHideableHeaderChildren />);
 
-      cy.checkAccessibility();
+      buttonDataComponent()
+        .contains("Open DialogFullScreen")
+        .click()
+        .then(() => cy.checkAccessibility());
     });
 
     it("should check accessibility for default Dialog Full Screen component with box", () => {
-      CypressMountWithProviders(<WithBox open />);
+      CypressMountWithProviders(<WithBox />);
 
-      cy.checkAccessibility();
+      buttonDataComponent()
+        .contains("Open DialogFullScreen")
+        .click()
+        .then(() => cy.checkAccessibility());
     });
 
     it("should check accessibility for default Dialog Full Screen component using autoFocus", () => {
-      CypressMountWithProviders(<FocusingADifferentFirstElement open />);
+      CypressMountWithProviders(<FocusingADifferentFirstElement />);
 
-      cy.checkAccessibility();
+      buttonDataComponent()
+        .contains("Open Demo using focusFirstElement")
+        .click()
+        .then(() => cy.checkAccessibility());
+      closeIconButton().click();
+
+      buttonDataComponent()
+        .contains("Open Demo using autoFocus")
+        .click()
+        .then(() => cy.checkAccessibility());
     });
 
     it("should check accessibility for default Dialog Full Screen component with other focusable containers", () => {
-      CypressMountWithProviders(<OtherFocusableContainers open />);
+      CypressMountWithProviders(<OtherFocusableContainers />);
 
-      cy.checkAccessibility();
+      buttonDataComponent()
+        .contains("Open DialogFullScreen")
+        .click()
+        .then(() => cy.checkAccessibility());
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

- Remove typos with spreaded props in consumer-facing stories
- Amend cypress accessibility tests so the content within an open dialog is validated

### Current behaviour

- Storybook docs for `DialogFullscreen` currently do not load due to the page hanging indefinitely. This is because an argument to the component's consumer-facing stories has been incorrectly spread.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- Open `DialogFullscreen`'s docs page locally and check it loads: https://carbon.sage.com/?path=/docs/dialog-full-screen--default
- Check the amendments to cypress accessibility tests are satisfactory.