### PR TITLE
test(heading): refactor for accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -66,6 +66,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("preview") &&
       !prepareUrl[0].startsWith("detail") &&
       !prepareUrl[0].startsWith("help") &&
+      !prepareUrl[0].startsWith("heading") &&
       !prepareUrl[0].startsWith("toast") &&
       !prepareUrl[0].startsWith("sidebar") &&
       !prepareUrl[0].startsWith("dialog-full-screen") &&

--- a/src/components/heading/heading-test.stories.tsx
+++ b/src/components/heading/heading-test.stories.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import Heading, { HeadingProps } from ".";
+
+export default {
+  title: "Heading/Test",
+  includeStories: "Default",
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disable: true,
+    },
+  },
+};
+
+export const Default = ({
+  title,
+  subheader,
+  ...args
+}: Partial<HeadingProps>) => {
+  return <Heading title={title} subheader={subheader} {...args} />;
+};
+
+Default.storyName = "default";
+Default.args = {
+  title: "This is a heading",
+  children: "This is content beneath a heading",
+  subheader: "This is a subheading",
+  help: "",
+  helpLink: "",
+  backLink: "",
+  divider: true,
+  separator: false,
+  helpAriaLabel: "",
+  pills: "",
+  subtitleId: "",
+  titleId: "",
+};
+
+export const HeadingComponent = ({ ...props }) => {
+  return (
+    <Heading
+      title="This is a Title"
+      subheader="This is a subheader"
+      {...props}
+    />
+  );
+};

--- a/src/components/heading/heading.test.js
+++ b/src/components/heading/heading.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Heading from "./heading.component";
+import { HeadingComponent } from "./heading-test.stories";
 import Pill from "../../components/pill";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
@@ -23,16 +23,6 @@ import { CHARACTERS } from "../../../cypress/support/component-helper/constants"
 
 const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testData = ["https://carbon.sage.com/"];
-
-const HeadingComponent = ({ ...props }) => {
-  return (
-    <Heading
-      title="This is a Title"
-      subheader="This is a subheader"
-      {...props}
-    />
-  );
-};
 
 context("Testing Heading component", () => {
   describe("should render Heading component", () => {
@@ -161,5 +151,132 @@ context("Testing Heading component", () => {
         }
       }
     );
+
+    describe("should render Heading component and check accessibility issues", () => {
+      it("should check heading accessibility", () => {
+        CypressMountWithProviders(<HeadingComponent />);
+
+        cy.checkAccessibility();
+      });
+
+      it.each(specialCharacters)(
+        "should check accessibility when children as %s for Heading component",
+        (children) => {
+          CypressMountWithProviders(
+            <HeadingComponent> {children} </HeadingComponent>
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check accessibility when title as %s for Heading component",
+        (titleText) => {
+          CypressMountWithProviders(<HeadingComponent title={titleText} />);
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check accessibility when titleId as %s for Heading component",
+        (titleId) => {
+          CypressMountWithProviders(<HeadingComponent titleId={titleId} />);
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check accessibility when subheader as %s for Heading component",
+        (subheader) => {
+          CypressMountWithProviders(<HeadingComponent subheader={subheader} />);
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check accessibility when subtitleId as %s for Heading component",
+        (subtitleId) => {
+          CypressMountWithProviders(
+            <HeadingComponent subtitleId={subtitleId} />
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check accessibility when help text as %s for Heading component",
+        (helpText) => {
+          CypressMountWithProviders(<HeadingComponent help={helpText} />);
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check accessibility when helpAriaLabel as %s for Heading component",
+        (ariaLabel) => {
+          CypressMountWithProviders(
+            <HeadingComponent
+              help="This is a Title"
+              helpAriaLabel={ariaLabel}
+            />
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check accessibility when pill for Heading component",
+        (pillText) => {
+          CypressMountWithProviders(
+            <HeadingComponent pills={<Pill>{pillText}</Pill>} />
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check accessibility when %s as help link for Heading component",
+        (helpLink) => {
+          CypressMountWithProviders(<HeadingComponent helpLink={helpLink} />);
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check accessibility when %s as back link for Heading component",
+        (backLink) => {
+          CypressMountWithProviders(<HeadingComponent backLink={backLink} />);
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each([true, false])(
+        "should check accessibility when separator is %s for Heading component",
+        (boolVal) => {
+          CypressMountWithProviders(<HeadingComponent separator={boolVal} />);
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each([true, false])(
+        "should check accessibility when separator is %s for Heading component",
+        (boolVal) => {
+          CypressMountWithProviders(<HeadingComponent divider={boolVal} />);
+
+          cy.checkAccessibility();
+        }
+      );
+    });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Heading` component to use the new cypress-component-react framework for testing.
- Refactor `heading-test.stories.js` to the corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `heading.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `heading` tests are not running twice.