### PR TITLE
test(button-toggle): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -71,6 +71,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("card") &&
       !prepareUrl[0].startsWith("date-input") &&
       !prepareUrl[0].startsWith("step-sequence") &&
+      !prepareUrl[0].startsWith("button-toggle") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/button-toggle/button-toggle-test.stories.tsx
+++ b/src/components/button-toggle/button-toggle-test.stories.tsx
@@ -5,6 +5,7 @@ import ButtonToggle from ".";
 
 export default {
   title: "Button Toggle/Test",
+  includeStories: "DefaultStory",
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -13,7 +14,7 @@ export default {
   },
 };
 
-export const Default = ({ children, ...args }: { children: string }) => (
+export const DefaultStory = ({ children, ...args }: { children: string }) => (
   <div>
     <ButtonToggle
       name="new-button-toggle"
@@ -48,7 +49,60 @@ export const Default = ({ children, ...args }: { children: string }) => (
   </div>
 );
 
-Default.storyName = "default";
-Default.args = {
-  children: "Options",
+DefaultStory.storyName = "default";
+
+export const ButtonToggleComponent = ({
+  // eslint-disable-next-line react/prop-types
+  children = "This is an example of an alert",
+  ...props
+}) => {
+  return (
+    <div>
+      <ButtonToggle
+        name="button-toggle-one"
+        onBlur={function noRefCheck() {
+          ("");
+        }}
+        onChange={function noRefCheck() {
+          ("");
+        }}
+        onFocus={function noRefCheck() {
+          ("");
+        }}
+        {...props}
+      >
+        {children}
+      </ButtonToggle>
+      <ButtonToggle
+        name="button-toggle-two"
+        onBlur={function noRefCheck() {
+          ("");
+        }}
+        onChange={function noRefCheck() {
+          ("");
+        }}
+        onFocus={function noRefCheck() {
+          ("");
+        }}
+        {...props}
+      >
+        Second
+      </ButtonToggle>
+      <ButtonToggle
+        name="button-toggle-three"
+        onBlur={function noRefCheck() {
+          ("");
+        }}
+        onChange={function noRefCheck() {
+          ("");
+        }}
+        onFocus={function noRefCheck() {
+          ("");
+        }}
+        {...props}
+      >
+        Third
+      </ButtonToggle>
+    </div>
+  );
 };

--- a/src/components/button-toggle/button-toggle.test.js
+++ b/src/components/button-toggle/button-toggle.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ButtonToggle from "./button-toggle.component";
+import { ButtonToggleComponent } from "./button-toggle-test.stories";
 import {
   buttonToggleLabelPreview,
   buttonTogglePreview,
@@ -13,41 +14,6 @@ import {
   CHARACTERS,
 } from "../../../cypress/support/component-helper/constants";
 import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-helper/common-steps";
-
-const ButtonToggleComponent = ({ children, ...props }) => {
-  return (
-    <div>
-      <ButtonToggle
-        name="button-toggle-one"
-        label="Default example"
-        onBlur={function noRefCheck() {}}
-        onChange={function noRefCheck() {}}
-        onFocus={function noRefCheck() {}}
-        {...props}
-      >
-        First
-      </ButtonToggle>
-      <ButtonToggle
-        name="button-toggle-two"
-        onBlur={function noRefCheck() {}}
-        onChange={function noRefCheck() {}}
-        onFocus={function noRefCheck() {}}
-        {...props}
-      >
-        Second
-      </ButtonToggle>
-      <ButtonToggle
-        name="button-toggle-three"
-        onBlur={function noRefCheck() {}}
-        onChange={function noRefCheck() {}}
-        onFocus={function noRefCheck() {}}
-        {...props}
-      >
-        Third
-      </ButtonToggle>
-    </div>
-  );
-};
 
 context("Testing Button-Toggle component", () => {
   describe("should render Button-Toggle component", () => {
@@ -264,5 +230,51 @@ context("Testing Button-Toggle component", () => {
           expect(callback).to.have.been.calledOnce;
         });
     });
+  });
+
+  describe("Accessibility tests for Button-Toggle component", () => {
+    it("should pass accessibility tests for Button-Toggle default story", () => {
+      CypressMountWithProviders(<ButtonToggleComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Button-Toggle disabled", () => {
+      CypressMountWithProviders(<ButtonToggleComponent disabled />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Button-Toggle grouped", () => {
+      CypressMountWithProviders(<ButtonToggleComponent grouped />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each([
+      [SIZE.SMALL, 32],
+      [SIZE.MEDIUM, 40],
+      [SIZE.LARGE, 48],
+    ])("should pass accessibility tests for Button-Toggle %s", (size) => {
+      CypressMountWithProviders(
+        <ButtonToggleComponent size={size}> {size}</ButtonToggleComponent>
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it.each(["add", "share", "tick"])(
+      "should pass accessibility tests for Button-Toggle with %s icon",
+      (type) => {
+        CypressMountWithProviders(
+          <ButtonToggleComponent buttonIcon={type} buttonIconSize="large">
+            {" "}
+            {type}
+          </ButtonToggleComponent>
+        );
+
+        cy.checkAccessibility();
+      }
+    );
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Button-Toggle` component to use the new cypress-component-react framework for testing.
- Refactor `button-toggle.stories.test.mdx` to corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [] Run `npx cypress open --component` to check if there is newly added test.file
- [] Check if the `button-toggletest.js` file passed
- [] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `button-toggle` tests are not running twice.