### PR TITLE
test(date-range): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -73,6 +73,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("step-sequence") &&
       !prepareUrl[0].startsWith("button-toggle") &&
       !prepareUrl[0].startsWith("profile") &&
+      !prepareUrl[0].startsWith("date-range") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/date-range/date-range.test.js
+++ b/src/components/date-range/date-range.test.js
@@ -1,8 +1,9 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import DateRange from "./date-range.component";
+import CarbonProvider from "../carbon-provider";
 
-import { getDataElementByValue, icon } from "../../../cypress/locators";
+import { cyRoot, getDataElementByValue, icon } from "../../../cypress/locators";
 import {
   dateRange,
   dateRangeComponentLabel,
@@ -55,6 +56,43 @@ const DateRangeCustom = ({ onChange, onBlur, ...props }) => {
       id={testCypressText}
       {...props}
     />
+  );
+};
+
+const DateRangeNewValidation = () => {
+  const [state, setState] = React.useState(["01/10/2016", "30/10/2016"]);
+
+  const handleChange = ({ target }) => {
+    const newValue = [
+      target.value[0].formattedValue,
+      target.value[1].formattedValue,
+    ];
+    setState(newValue);
+  };
+
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      {[
+        {
+          startError: "Start error with long text string",
+          endError: "End error",
+        },
+        {
+          startWarning: "Start warning",
+          endWarning: "End warning with long text string",
+        },
+      ].map((validation) => (
+        <DateRange
+          key={`${Object.keys(validation)[0]}-string-component`}
+          startLabel="Start"
+          endLabel="End"
+          onChange={handleChange}
+          value={state}
+          {...validation}
+          m={4}
+        />
+      ))}
+    </CarbonProvider>
   );
 };
 
@@ -358,12 +396,15 @@ context("Test for DateRange component", () => {
             startError={testCypressText}
           />
         );
+
         icon().realHover();
         getDataElementByValue("tooltip").should(
           "have.attr",
           "data-placement",
           position
         );
+
+        cyRoot().realHover({ position: "topRight" });
       }
     );
   });
@@ -443,6 +484,226 @@ context("Test for DateRange component", () => {
             testCypressText
           );
         });
+    });
+  });
+
+  describe("should check accessibility for the component", () => {
+    it.each(testData)(
+      "should check accessibility with the startLabel renders as %s",
+      (startLabel) => {
+        CypressMountWithProviders(<DateRangeCustom startLabel={startLabel} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check accessibility with the endLabel renders as %s",
+      (endLabel) => {
+        CypressMountWithProviders(<DateRangeCustom endLabel={endLabel} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    // FE-5382
+    describe.skip("skip", () => {
+      it.each(testData)(
+        "should check accessibility with the startError as string renders as %s",
+        (startError) => {
+          CypressMountWithProviders(
+            <DateRangeCustom startError={startError} />
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check accessibility with the endError as string renders as %s",
+        (endError) => {
+          CypressMountWithProviders(<DateRangeCustom endError={endError} />);
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check accessibility with the startWarning as string renders as %s",
+        (startWarning) => {
+          CypressMountWithProviders(
+            <DateRangeCustom startWarning={startWarning} />
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check accessibility with the endWarning as string renders as %s",
+        (endWarning) => {
+          CypressMountWithProviders(
+            <DateRangeCustom endWarning={endWarning} />
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check accessibility with the startInfo as string renders as %s",
+        (startInfo) => {
+          CypressMountWithProviders(<DateRangeCustom startInfo={startInfo} />);
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check accessibility with the endInfo as string renders as %s",
+        (endInfo) => {
+          CypressMountWithProviders(<DateRangeCustom endInfo={endInfo} />);
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check accessibility with the validationOnLabel with error state",
+        (error) => {
+          CypressMountWithProviders(
+            <DateRangeCustom
+              startError={error}
+              endError={error}
+              validationOnLabel
+            />
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check accessibility with the validationOnLabel with warning state",
+        (warning) => {
+          CypressMountWithProviders(
+            <DateRangeCustom
+              startWarning={warning}
+              endWarning={warning}
+              validationOnLabel
+            />
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(testData)(
+        "should check accessibility with the validationOnLabel with info state",
+        (info) => {
+          CypressMountWithProviders(
+            <DateRangeCustom
+              startInfo={info}
+              endInfo={info}
+              validationOnLabel
+            />
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each([["top"], ["bottom"], ["left"], ["right"]])(
+        "should check accessibility with the tooltipPosition is set to %s",
+        (position) => {
+          CypressMountWithProviders(
+            <DateRangeCustom
+              m={9}
+              tooltipPosition={position}
+              startError={testCypressText}
+            />
+          );
+
+          icon().realHover();
+          cy.checkAccessibility();
+          cyRoot().realHover({ position: "topRight" });
+        }
+      );
+    });
+
+    it("should check accessibility with the startError as boolean", () => {
+      CypressMountWithProviders(<DateRangeCustom startError />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility with the endError as boolean", () => {
+      CypressMountWithProviders(<DateRangeCustom endError />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility with the startWarning as boolean", () => {
+      CypressMountWithProviders(<DateRangeCustom startWarning />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility with the endWarning as boolean", () => {
+      CypressMountWithProviders(<DateRangeCustom endWarning />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility with the startInfo as boolean", () => {
+      CypressMountWithProviders(<DateRangeCustom startInfo />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility with the endInfo as boolean", () => {
+      CypressMountWithProviders(<DateRangeCustom endInfo />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each([true, false])(
+      "should check accessibility with the labelsInline prop is set to %s",
+      (boolean) => {
+        CypressMountWithProviders(<DateRangeCustom labelsInline={boolean} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check accessibility with the startDateProps prop", () => {
+      CypressMountWithProviders(
+        <DateRangeCustom
+          startDateProps={{
+            disabled: true,
+          }}
+        />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility with the endDateProps prop", () => {
+      CypressMountWithProviders(
+        <DateRangeCustom
+          endDateProps={{
+            disabled: true,
+          }}
+        />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility with new validation", () => {
+      CypressMountWithProviders(<DateRangeNewValidation />);
+
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Date Range` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `date-range.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Date Range` tests are not running twice.