### PR TITLE
docs(step-sequence): fix error with test story not being recognised by storybook

### DIFF
--- a/src/components/step-sequence/step-sequence-test.stories.tsx
+++ b/src/components/step-sequence/step-sequence-test.stories.tsx
@@ -10,7 +10,7 @@ import {
 
 export default {
   title: "Step Sequence/Test",
-  includeStories: "DefaultStory",
+  includeStories: "StepSequenceStory",
   parameters: {
     info: { disable: true },
     chromatic: {


### PR DESCRIPTION
### Proposed behaviour

Fix typo in test stories file meaning storybook does not recognise the test story to include when building docs.

### Current behaviour

Currently get this console error when loading storybook in the browser:
``ReferenceError: StepSequenceStory is not defined``

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required
