### PR TITLE
Focus trap fixes

### DIFF
--- a/cypress/locators/menu/index.js
+++ b/cypress/locators/menu/index.js
@@ -24,6 +24,7 @@ export const menuComponent = (index) =>
 export const submenuItem = (index) =>
   menuComponent(index).find(SUBMENU).find("ul > li");
 export const menuCanvas = () => cy.get(DLS_ROOT);
+export const fullScreenMenuWrapper = () => cy.get(FULLSCREEN_MENU);
 export const fullscreenMenu = (index) =>
   cy.get(FULLSCREEN_MENU).find("div").eq(index);
 export const fullScreenMenuItem = (index) =>

--- a/src/__internal__/focus-trap/focus-trap-utils.ts
+++ b/src/__internal__/focus-trap/focus-trap-utils.ts
@@ -62,11 +62,6 @@ const getNextElement = (
   if (currentIndex === -1) {
     // we're not currently on a focusable element - most likely because the focusableElements come from a different focus trap!
     // So we need to leave focus where it is.
-    // The exception is when the focus is on the document body - perhaps because the previously-focused element was dynamically removed.
-    // In that case focus the first element.
-    if (element === document.body) {
-      return focusableElements[0];
-    }
     return undefined;
   }
 
@@ -208,9 +203,9 @@ const trapFunction = (
 
   // special case if focus is on document body
   if (activeElement === document.body) {
-    // TODO: fix this to only work if we're in the top modal [FE-5620]
     ev.preventDefault();
     setElementFocus(firstElement as HTMLElement);
+    return;
   }
 
   if (!focusableSelectors) {

--- a/src/__internal__/focus-trap/focus-trap.component.tsx
+++ b/src/__internal__/focus-trap/focus-trap.component.tsx
@@ -2,7 +2,6 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -10,14 +9,18 @@ import React, {
 
 import {
   defaultFocusableSelectors,
-  getNextElement,
   setElementFocus,
+  onTabGuardFocus,
+  trapFunction,
 } from "./focus-trap-utils";
 import {
   ModalContext,
   ModalContextProps,
 } from "../../components/modal/modal.component";
 import usePrevious from "../../hooks/__internal__/usePrevious";
+
+const TAB_GUARD_TOP = "tab-guard-top";
+const TAB_GUARD_BOTTOM = "tab-guard-bottom";
 
 // TODO investigate why React.RefObject<T> produces a failed prop type when current = null
 export type CustomRefObject<T> = {
@@ -38,7 +41,7 @@ export interface FocusTrapProps {
   /** optional selector to identify the focusable elements, if not provided a default selector is used */
   focusableSelectors?: string;
   /** a ref to the container wrapping the focusable elements */
-  wrapperRef?: CustomRefObject<HTMLElement>;
+  wrapperRef: CustomRefObject<HTMLElement>;
   /* whether the modal (etc.) component that the focus trap is inside is open or not */
   isOpen?: boolean;
   /** an optional array of refs to containers whose content should also be reachable from the FocusTrap */
@@ -56,11 +59,6 @@ const FocusTrap = ({
   additionalWrapperRefs,
 }: FocusTrapProps) => {
   const trapRef = useRef<HTMLDivElement>(null);
-  const [focusableElements, setFocusableElements] = useState<
-    HTMLElement[] | undefined
-  >();
-  const [firstElement, setFirstElement] = useState<HTMLElement | undefined>();
-  const [lastElement, setLastElement] = useState<HTMLElement | undefined>();
   const [currentFocusedElement, setCurrentFocusedElement] = useState<
     HTMLElement | undefined
   >();
@@ -68,17 +66,6 @@ const FocusTrap = ({
     isAnimationComplete = true,
     triggerRefocusFlag,
   } = useContext<ModalContextProps>(ModalContext);
-
-  const hasNewInputs = useCallback(
-    (candidate) => {
-      if (!focusableElements || candidate.length !== focusableElements.length) {
-        return true;
-      }
-
-      return Array.from(candidate).some((el, i) => el !== focusableElements[i]);
-    },
-    [focusableElements]
-  );
 
   const trapWrappers = useMemo(
     () =>
@@ -88,57 +75,63 @@ const FocusTrap = ({
     [additionalWrapperRefs, wrapperRef]
   );
 
-  const allRefs: Array<HTMLElement | undefined | null> = trapWrappers.map(
-    (ref: CustomRefObject<HTMLElement> | undefined) => ref?.current
+  const onTabGuardTopFocus = useMemo(
+    () => onTabGuardFocus(trapWrappers, focusableSelectors, "top"),
+    [focusableSelectors, trapWrappers]
   );
 
-  const updateFocusableElements = useCallback(() => {
-    const elements: Element[] = [];
-    allRefs.forEach((ref) => {
-      if (ref) {
-        elements.push(
-          ...Array.from(
-            ref.querySelectorAll(
-              focusableSelectors || defaultFocusableSelectors
-            )
-          ).filter((el) => Number((el as HTMLElement).tabIndex) !== -1)
-        );
-      }
-    });
-
-    if (hasNewInputs(elements)) {
-      setFocusableElements(Array.from(elements) as HTMLElement[]);
-      setFirstElement(elements[0] as HTMLElement);
-      setLastElement(elements[elements.length - 1] as HTMLElement);
-    }
-  }, [hasNewInputs, allRefs, focusableSelectors]);
+  const onTabGuardBottomFocus = useMemo(
+    () => onTabGuardFocus(trapWrappers, focusableSelectors, "bottom"),
+    [focusableSelectors, trapWrappers]
+  );
 
   useEffect(() => {
-    const observer = new MutationObserver(updateFocusableElements);
-
-    trapWrappers.forEach((wrapper) => {
-      if (wrapper?.current) {
-        observer.observe(wrapper?.current as Node, {
-          subtree: true,
-          childList: true,
-          attributes: true,
-          characterData: true,
-        });
+    additionalWrapperRefs?.forEach((ref) => {
+      const { current: containerElement } = ref;
+      // istanbul ignore else
+      if (containerElement) {
+        // istanbul ignore else
+        if (
+          !containerElement.previousElementSibling?.matches(
+            `[data-element=${TAB_GUARD_TOP}]`
+          )
+        ) {
+          const topTabGuard = document.createElement("div");
+          topTabGuard.tabIndex = 0;
+          topTabGuard.dataset.element = TAB_GUARD_TOP;
+          containerElement.insertAdjacentElement("beforebegin", topTabGuard);
+          topTabGuard.addEventListener("focus", onTabGuardTopFocus(ref));
+        }
+        // istanbul ignore else
+        if (
+          !containerElement.nextElementSibling?.matches(
+            `[data-element=${TAB_GUARD_BOTTOM}]`
+          )
+        ) {
+          const bottomTabGuard = document.createElement("div");
+          bottomTabGuard.tabIndex = 0;
+          bottomTabGuard.dataset.element = TAB_GUARD_BOTTOM;
+          containerElement.insertAdjacentElement("afterend", bottomTabGuard);
+          bottomTabGuard.addEventListener("focus", onTabGuardBottomFocus(ref));
+        }
       }
     });
 
-    return () => observer.disconnect();
-  }, [updateFocusableElements, trapWrappers]);
+    return () => {
+      additionalWrapperRefs?.forEach((ref) => {
+        const previousElement = ref.current?.previousElementSibling;
+        if (previousElement?.matches(`[data-element=${TAB_GUARD_TOP}]`)) {
+          previousElement.remove();
+        }
+        const nextElement = ref.current?.nextElementSibling;
+        if (nextElement?.matches(`[data-element=${TAB_GUARD_BOTTOM}]`)) {
+          nextElement.remove();
+        }
+      });
+    };
+  }, [additionalWrapperRefs, onTabGuardTopFocus, onTabGuardBottomFocus]);
 
-  useLayoutEffect(() => {
-    updateFocusableElements();
-  }, [children, updateFocusableElements]);
-
-  const shouldSetFocus =
-    autoFocus &&
-    isOpen &&
-    isAnimationComplete &&
-    (focusFirstElement || wrapperRef?.current);
+  const shouldSetFocus = autoFocus && isOpen && isAnimationComplete;
 
   const prevShouldSetFocus = usePrevious(shouldSetFocus);
 
@@ -148,45 +141,44 @@ const FocusTrap = ({
         focusFirstElement && "current" in focusFirstElement
           ? focusFirstElement.current
           : focusFirstElement;
-      setElementFocus(
-        (candidateFirstElement || wrapperRef?.current) as HTMLElement
-      );
+      const elementToFocus =
+        (candidateFirstElement as HTMLElement | null | undefined) ||
+        wrapperRef.current;
+      // istanbul ignore else
+      if (elementToFocus) {
+        setElementFocus(elementToFocus);
+      }
     }
   }, [shouldSetFocus, prevShouldSetFocus, focusFirstElement, wrapperRef]);
 
+  const getFocusableElements = useCallback(
+    (selector: string) => {
+      const elements: Element[] = [];
+      trapWrappers.forEach((ref) => {
+        // istanbul ignore else
+        if (ref.current) {
+          elements.push(
+            ...Array.from(ref.current.querySelectorAll(selector)).filter(
+              (el) => Number((el as HTMLElement).tabIndex) !== -1
+            )
+          );
+        }
+      });
+      return elements as HTMLElement[];
+    },
+    [trapWrappers]
+  );
+
   useEffect(() => {
     const trapFn = (ev: KeyboardEvent) => {
-      if (bespokeTrap) {
-        bespokeTrap(ev, firstElement, lastElement);
-        return;
-      }
-
-      if (ev.key !== "Tab") return;
-
-      if (!focusableElements?.length) {
-        /* Block the trap */
-        ev.preventDefault();
-        return;
-      }
-
-      const activeElement = document.activeElement as HTMLElement;
-
-      const isWrapperFocused = activeElement === wrapperRef?.current;
-
-      const elementWhenWrapperFocused = ev.shiftKey
-        ? (firstElement as HTMLElement)
-        : (lastElement as HTMLElement);
-
-      const elementToFocus = getNextElement(
-        isWrapperFocused ? elementWhenWrapperFocused : activeElement,
+      const focusableElements = getFocusableElements(defaultFocusableSelectors);
+      trapFunction(
+        ev,
         focusableElements,
-        ev.shiftKey
+        document.activeElement === wrapperRef.current,
+        focusableSelectors,
+        bespokeTrap
       );
-
-      if (elementToFocus) {
-        setElementFocus(elementToFocus);
-        ev.preventDefault();
-      }
     };
 
     document.addEventListener("keydown", trapFn, true);
@@ -194,9 +186,12 @@ const FocusTrap = ({
     return function cleanup() {
       document.removeEventListener("keydown", trapFn, true);
     };
-  }, [firstElement, lastElement, focusableElements, bespokeTrap, wrapperRef]);
+  }, [bespokeTrap, wrapperRef, focusableSelectors, getFocusableElements]);
 
   const updateCurrentFocusedElement = useCallback(() => {
+    const focusableElements = getFocusableElements(
+      focusableSelectors || defaultFocusableSelectors
+    );
     const element = focusableElements?.find(
       (el) => el === document.activeElement
     );
@@ -204,22 +199,32 @@ const FocusTrap = ({
     if (element) {
       setCurrentFocusedElement(element);
     }
-  }, [focusableElements]);
+  }, [getFocusableElements, focusableSelectors]);
 
   const refocusTrap = useCallback(() => {
-    /* istanbul ignore else */
     if (
       currentFocusedElement &&
       !currentFocusedElement.hasAttribute("disabled")
     ) {
       // the trap breaks if it tries to refocus a disabled element
       setElementFocus(currentFocusedElement);
-    } else if (wrapperRef?.current?.hasAttribute("tabindex")) {
+    } else if (wrapperRef.current?.hasAttribute("tabindex")) {
       setElementFocus(wrapperRef.current);
-    } else if (firstElement) {
-      setElementFocus(firstElement);
+    } else {
+      const focusableElements = getFocusableElements(
+        focusableSelectors || defaultFocusableSelectors
+      );
+      /* istanbul ignore else */
+      if (focusableElements.length) {
+        setElementFocus(focusableElements[0]);
+      }
     }
-  }, [currentFocusedElement, firstElement, wrapperRef]);
+  }, [
+    currentFocusedElement,
+    wrapperRef,
+    focusableSelectors,
+    getFocusableElements,
+  ]);
 
   useEffect(() => {
     if (triggerRefocusFlag) {
@@ -260,17 +265,17 @@ const FocusTrap = ({
   return (
     <div ref={trapRef}>
       <div
-        data-element="tab-guard-top"
+        data-element={TAB_GUARD_TOP}
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
-        onFocus={() => setElementFocus(lastElement as HTMLElement)}
+        onFocus={onTabGuardTopFocus(wrapperRef)}
       />
       {clonedChildren}
       <div
-        data-element="tab-guard-bottom"
+        data-element={TAB_GUARD_BOTTOM}
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
-        onFocus={() => setElementFocus(firstElement as HTMLElement)}
+        onFocus={onTabGuardBottomFocus(wrapperRef)}
       />
     </div>
   );

--- a/src/__internal__/focus-trap/focus-trap.spec.tsx
+++ b/src/__internal__/focus-trap/focus-trap.spec.tsx
@@ -10,37 +10,38 @@ import { ModalContext } from "../../components/modal/modal.component";
 
 jest.useFakeTimers();
 
-interface MockComponentProps extends FocusTrapProps {
+interface MockComponentProps extends Omit<FocusTrapProps, "wrapperRef"> {
   isAnimationComplete?: boolean;
   triggerRefocusFlag?: boolean;
   tabIndex?: number;
   children: React.ReactNode;
   shouldFocusFirstElement?: boolean;
   dataTestId?: string;
+  onKeyDown?: (ev: React.KeyboardEvent) => void;
 }
 
 const WRAPPER_ID = "test wrapper";
-const SECOND_WRAPPER_ID = "test wrapper 2";
 const FIRST_ELEMENT = "first element";
 const BUTTON_ONE = "Test button One";
 const BUTTON_TWO = "Test button Two";
 const BUTTON_THREE = "Test button Three";
 const BUTTON_FOUR = "Test button Four";
+const BUTTON_FIVE = "Test button Five";
+const BUTTON_SIX = "Test button Six";
 const RADIO_LABEL_ONE = "Radio one";
 const RADIO_LABEL_TWO = "Radio two";
 const RADIO_GROUP_ONE = "Radio group one";
 const RADIO_GROUP_TWO = "Radio group two";
+const BUTTON_IN_WRAPPER = "Button in wrapper";
+const BUTTON_IN_ADDITIONAL_WRAPPER_ONE = "Button in additional wrapper one";
+const BUTTON_IN_ADDITIONAL_WRAPPER_TWO = "Button in additional wrapper two";
+const BUTTON_IN_CONDITIONAL_WRAPPER = "Button in conditional wrapper";
 
-const tabPress = (wrapperTestId = WRAPPER_ID) =>
-  fireEvent.keyDown(screen.getByTestId(wrapperTestId), {
-    key: "Tab",
-  });
+const user = userEvent.setup({ delay: null });
 
-const shiftTabPress = () =>
-  fireEvent.keyDown(screen.getByTestId(WRAPPER_ID), {
-    key: "Tab",
-    shiftKey: true,
-  });
+const tabPress = async () => user.tab();
+
+const shiftTabPress = () => user.tab({ shift: true });
 
 const focusElement = (target: HTMLElement) => {
   target.focus();
@@ -54,6 +55,7 @@ const MockComponent = ({
   tabIndex,
   shouldFocusFirstElement,
   dataTestId = WRAPPER_ID,
+  onKeyDown,
   ...rest
 }: MockComponentProps) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -62,35 +64,54 @@ const MockComponent = ({
 
   return (
     <ModalContext.Provider value={{ isAnimationComplete, triggerRefocusFlag }}>
-      <FocusTrap
-        wrapperRef={ref}
-        {...rest}
-        isOpen
-        focusFirstElement={shouldFocusFirstElement ? firstRef : undefined}
-      >
-        <div ref={ref} data-testid={dataTestId} tabIndex={tabIndex}>
-          {React.Children.map(children, (child) => {
-            const focusableChild = child as React.ReactElement;
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+      <div onKeyDown={onKeyDown}>
+        <FocusTrap
+          wrapperRef={ref}
+          {...rest}
+          isOpen
+          focusFirstElement={shouldFocusFirstElement ? firstRef : undefined}
+        >
+          <div ref={ref} data-testid={dataTestId} tabIndex={tabIndex}>
+            {React.Children.map(children, (child) => {
+              const focusableChild = child as React.ReactElement;
 
-            if (focusableChild?.props?.id === "disable-on-focus") {
-              return React.cloneElement(focusableChild, {
-                onFocus: () => setIsDisabled(true),
-                disabled: isDisabled,
-              });
-            }
+              if (focusableChild?.props?.id === "disable-on-focus") {
+                return React.cloneElement(focusableChild, {
+                  onFocus: () => setIsDisabled(true),
+                  disabled: isDisabled,
+                });
+              }
 
-            return child;
-          })}
-          {shouldFocusFirstElement && (
-            <button type="button" ref={firstRef}>
-              {FIRST_ELEMENT}
-            </button>
-          )}
-        </div>
-      </FocusTrap>
+              return child;
+            })}
+            {shouldFocusFirstElement && (
+              <button type="button" ref={firstRef}>
+                {FIRST_ELEMENT}
+              </button>
+            )}
+          </div>
+        </FocusTrap>
+      </div>
     </ModalContext.Provider>
   );
 };
+
+const MockComponentWithCustomSelector = (
+  props: Partial<MockComponentProps>
+) => (
+  <MockComponent {...props} focusableSelectors="button.focusable-button">
+    <button type="button" className="focusable-button">
+      {BUTTON_ONE}
+    </button>
+    <button type="button" className="not-focusable-button">
+      {BUTTON_TWO}
+    </button>
+    <button type="button" className="focusable-button">
+      {BUTTON_THREE}
+    </button>
+  </MockComponent>
+);
 
 const defaultChildren = (
   <>
@@ -105,6 +126,68 @@ const mockComponentToRender = ({
 }: Partial<MockComponentProps> = {}) => (
   <MockComponent {...rest}>{children}</MockComponent>
 );
+
+const WithAdditionalWrapperRefs = () => {
+  const wrapperRef = useRef(null);
+  const otherContentRef1 = useRef(null);
+  const otherContentRef2 = useRef(null);
+  const additionalRef = useRef(null);
+  const [useAdditionalWrapper, setUseAdditionalWrapper] = useState(false);
+  const additionalRefs = [
+    otherContentRef1,
+    otherContentRef2,
+    ...(useAdditionalWrapper ? [additionalRef] : []),
+  ];
+
+  return (
+    <div data-testid={WRAPPER_ID}>
+      <button type="button" id="outside1">
+        outside focus trap
+      </button>
+      <ModalContext.Provider value={{ isAnimationComplete: true }}>
+        <FocusTrap
+          wrapperRef={wrapperRef}
+          additionalWrapperRefs={additionalRefs}
+          isOpen
+        >
+          <div ref={wrapperRef}>
+            <button
+              type="button"
+              id="insidewrapper"
+              onClick={() => setUseAdditionalWrapper(true)}
+            >
+              {BUTTON_IN_WRAPPER}
+            </button>
+          </div>
+        </FocusTrap>
+      </ModalContext.Provider>
+      <button type="button" id="outside2">
+        outside focus trap
+      </button>
+      <div ref={otherContentRef1}>
+        <button type="button" id="insideother1">
+          {BUTTON_IN_ADDITIONAL_WRAPPER_ONE}
+        </button>
+      </div>
+      <button type="button" id="outside3">
+        outside focus trap
+      </button>
+      <div ref={otherContentRef2}>
+        <button type="button" id="insideother2">
+          {BUTTON_IN_ADDITIONAL_WRAPPER_TWO}
+        </button>
+      </div>
+      <div ref={additionalRef}>
+        <button type="button" id="insideconditional">
+          {BUTTON_IN_CONDITIONAL_WRAPPER}
+        </button>
+      </div>
+      <button type="button" id="outside4">
+        outside focus trap
+      </button>
+    </div>
+  );
+};
 
 describe("FocusTrap", () => {
   describe("triggerRefocusFlag", () => {
@@ -143,10 +226,13 @@ describe("FocusTrap", () => {
       const { rerender } = render(
         mockComponentToRender({ autoFocus: false, triggerRefocusFlag: false })
       );
+      // need to blur the wrapper to remove the tabindex
+      fireEvent.blur(screen.getByTestId(WRAPPER_ID));
+
       rerender(
         mockComponentToRender({ autoFocus: false, triggerRefocusFlag: true })
       );
-      expect(screen.getByTestId(WRAPPER_ID)).toHaveFocus();
+      expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
     });
 
     it("refocuses the container if last element that had focus becomes disabled", () => {
@@ -192,23 +278,23 @@ describe("FocusTrap", () => {
       render(mockComponentToRender({ shouldFocusFirstElement: true }));
     });
 
-    it("should focus the element that ref passed to focusFirstElement and loop round when back tabbing", () => {
+    it("should focus the element that ref passed to focusFirstElement and loop round when back tabbing", async () => {
       expect(screen.getByText(FIRST_ELEMENT)).toHaveFocus();
-      shiftTabPress();
+      await shiftTabPress();
       expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
-      shiftTabPress();
+      await shiftTabPress();
       expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
-      shiftTabPress();
+      await shiftTabPress();
       expect(screen.getByText(FIRST_ELEMENT)).toHaveFocus();
     });
 
-    it("should focus the element that ref passed to focusFirstElement and loop round when tabbing", () => {
+    it("should focus the element that ref passed to focusFirstElement and loop round when tabbing", async () => {
       expect(screen.getByText(FIRST_ELEMENT)).toHaveFocus();
-      tabPress();
+      await tabPress();
       expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
-      tabPress();
+      await tabPress();
       expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
-      tabPress();
+      await tabPress();
       expect(screen.getByText(FIRST_ELEMENT)).toHaveFocus();
     });
   });
@@ -221,8 +307,8 @@ describe("FocusTrap", () => {
       render(mockComponentToRender({ bespokeTrap: bespokeFn }));
     });
 
-    it("calls the function with expected arguments on TAB press", () => {
-      tabPress();
+    it("calls the function with expected arguments on TAB press", async () => {
+      await tabPress();
       expect(bespokeFn).toHaveBeenCalledWith(
         expect.objectContaining({ key: "Tab", type: "keydown" }),
         screen.getByRole("button", { name: BUTTON_ONE }),
@@ -230,8 +316,8 @@ describe("FocusTrap", () => {
       );
     });
 
-    it("calls the function with expected arguments on SHIFT + TAB press", () => {
-      shiftTabPress();
+    it("calls the function with expected arguments on SHIFT + TAB press", async () => {
+      await shiftTabPress();
       expect(bespokeFn).toHaveBeenCalledWith(
         expect.objectContaining({
           key: "Tab",
@@ -260,27 +346,27 @@ describe("FocusTrap", () => {
         expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
       });
 
-      it("should move focus back to the last item when `shift + tab` pressed and first focusable item is activeElement", () => {
+      it("should move focus back to the last item when `shift + tab` pressed and first focusable item is activeElement", async () => {
         focusElement(screen.getByText(BUTTON_ONE));
-        shiftTabPress();
+        await shiftTabPress();
         expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
       });
 
-      it("should back to the first item when use `shift + tab`", () => {
+      it("should back to the first item when use `shift + tab`", async () => {
         focusElement(screen.getByText(BUTTON_TWO));
-        shiftTabPress();
+        await shiftTabPress();
         expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
       });
 
-      it("should go to the second item when use TAB", () => {
+      it("should go to the second item when use TAB", async () => {
         focusElement(screen.getByText(BUTTON_ONE));
-        tabPress();
+        await tabPress();
         expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
       });
 
-      it("should move to the first focusable item if TAB pressed on last focusable item", () => {
+      it("should move to the first focusable item if TAB pressed on last focusable item", async () => {
         focusElement(screen.getByText(BUTTON_TWO));
-        tabPress();
+        await tabPress();
         expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
       });
     });
@@ -290,15 +376,15 @@ describe("FocusTrap", () => {
         render(mockComponentToRender({ children: <p>Test content</p> }));
       });
 
-      it("should block tabbing if `tab` pressed", () => {
+      it("should block tabbing if `tab` pressed", async () => {
         expect(screen.getByTestId(WRAPPER_ID)).toHaveFocus();
-        tabPress();
+        await tabPress();
         expect(screen.getByTestId(WRAPPER_ID)).toHaveFocus();
       });
 
-      it("should block shift tabbing if `shift + tab` is pressed", () => {
+      it("should block shift tabbing if `shift + tab` is pressed", async () => {
         expect(screen.getByTestId(WRAPPER_ID)).toHaveFocus();
-        shiftTabPress();
+        await shiftTabPress();
         expect(screen.getByTestId(WRAPPER_ID)).toHaveFocus();
       });
     });
@@ -319,11 +405,11 @@ describe("FocusTrap", () => {
         );
       });
 
-      it("only focuses those that are not", () => {
+      it("only focuses those that are not", async () => {
         focusElement(screen.getByText(BUTTON_ONE));
-        tabPress();
+        await tabPress();
         expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
-        tabPress();
+        await tabPress();
         expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
       });
     });
@@ -351,17 +437,17 @@ describe("FocusTrap", () => {
     });
 
     describe("when focus on first radio button shift-tab pressed", () => {
-      it("should loop focus to the last focusable element", () => {
+      it("should loop focus to the last focusable element", async () => {
         focusElement(screen.getByLabelText(RADIO_LABEL_ONE));
-        shiftTabPress();
+        await shiftTabPress();
         expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
       });
     });
 
     describe("when focus on second radio button shift-tab pressed", () => {
-      it("should loop focus to the last focusable element", () => {
+      it("should loop focus to the last focusable element", async () => {
         focusElement(screen.getByLabelText(RADIO_LABEL_TWO));
-        shiftTabPress();
+        await shiftTabPress();
         expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
       });
     });
@@ -416,11 +502,11 @@ describe("FocusTrap", () => {
     });
 
     describe("when focus on first radio button of second group shift-tab pressed", () => {
-      it("should focus the selected button of the first group", () => {
+      it("should focus the selected button of the first group", async () => {
         focusElement(
           screen.getByLabelText(`${RADIO_LABEL_ONE}-${RADIO_GROUP_TWO}`)
         );
-        shiftTabPress();
+        await shiftTabPress();
         expect(
           screen.getByLabelText(`${RADIO_LABEL_ONE}-${RADIO_GROUP_ONE}`)
         ).toHaveFocus();
@@ -428,11 +514,84 @@ describe("FocusTrap", () => {
     });
 
     describe("when focus on second radio button of second group shift-tab pressed", () => {
-      it("should focus the selected button of the first group", () => {
+      it("should focus the selected button of the first group", async () => {
         focusElement(
           screen.getByLabelText(`${RADIO_LABEL_TWO}-${RADIO_GROUP_TWO}`)
         );
-        shiftTabPress();
+        await shiftTabPress();
+        expect(
+          screen.getByLabelText(`${RADIO_LABEL_ONE}-${RADIO_GROUP_ONE}`)
+        ).toHaveFocus();
+      });
+    });
+  });
+
+  describe("with 2 different focusable radio groups and a custom selector", () => {
+    beforeEach(() => {
+      render(
+        <MockComponent focusableSelectors="input[type=radio]">
+          <RadioButtonGroup
+            name="radiogroup1"
+            legend="How do you want to create this address?"
+            legendInline
+            onChange={() => jest.fn()}
+            value="1"
+            legendWidth={40}
+          >
+            <RadioButton
+              value="1"
+              label={`${RADIO_LABEL_ONE}-${RADIO_GROUP_ONE}`}
+              size="large"
+            />
+            <RadioButton
+              value="2"
+              label={`${RADIO_LABEL_TWO}-${RADIO_GROUP_ONE}`}
+              size="large"
+            />
+          </RadioButtonGroup>
+          <RadioButtonGroup
+            name="radiogroup2"
+            legend="How do you want to create this address?"
+            legendInline
+            onChange={() => jest.fn()}
+            value="1"
+            legendWidth={40}
+          >
+            <RadioButton
+              value="1"
+              label={`${RADIO_LABEL_ONE}-${RADIO_GROUP_TWO}`}
+              size="large"
+            />
+            <RadioButton
+              value="2"
+              label={`${RADIO_LABEL_TWO}-${RADIO_GROUP_TWO}`}
+              size="large"
+            />
+          </RadioButtonGroup>
+          <button type="button">{BUTTON_ONE}</button>
+          <button type="button">{BUTTON_TWO}</button>
+        </MockComponent>
+      );
+    });
+
+    describe("when focus on first radio button of second group shift-tab pressed", () => {
+      it("should focus the selected button of the first group", async () => {
+        focusElement(
+          screen.getByLabelText(`${RADIO_LABEL_ONE}-${RADIO_GROUP_TWO}`)
+        );
+        await shiftTabPress();
+        expect(
+          screen.getByLabelText(`${RADIO_LABEL_ONE}-${RADIO_GROUP_ONE}`)
+        ).toHaveFocus();
+      });
+    });
+
+    describe("when focus on second radio button of second group shift-tab pressed", () => {
+      it("should focus the selected button of the first group", async () => {
+        focusElement(
+          screen.getByLabelText(`${RADIO_LABEL_TWO}-${RADIO_GROUP_TWO}`)
+        );
+        await shiftTabPress();
         expect(
           screen.getByLabelText(`${RADIO_LABEL_ONE}-${RADIO_GROUP_ONE}`)
         ).toHaveFocus();
@@ -462,17 +621,17 @@ describe("FocusTrap", () => {
     });
 
     describe("when focus on second radio button tab pressed", () => {
-      it("should loop focus to the first focusable element", () => {
+      it("should loop focus to the first focusable element", async () => {
         focusElement(screen.getByLabelText(RADIO_LABEL_TWO));
-        tabPress();
+        await tabPress();
         expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
       });
     });
 
     describe("when focus on first radio button tab pressed", () => {
-      it("should loop focus to the first focusable element", () => {
+      it("should loop focus to the first focusable element", async () => {
         focusElement(screen.getByLabelText(RADIO_LABEL_ONE));
-        tabPress();
+        await tabPress();
         expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
       });
     });
@@ -500,48 +659,101 @@ describe("FocusTrap", () => {
     });
 
     describe("when focus on first radio button shift-tab pressed", () => {
-      it("should move focus to the previous focusable element", () => {
+      it("should move focus to the previous focusable element", async () => {
         focusElement(screen.getByLabelText(RADIO_LABEL_ONE));
-        shiftTabPress();
+        await shiftTabPress();
         expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
       });
     });
 
     describe("when focus on second radio button shift-tab pressed", () => {
-      it("should move focus to the previous focusable element", () => {
+      it("should move focus to the previous focusable element", async () => {
         focusElement(screen.getByLabelText(RADIO_LABEL_TWO));
-        shiftTabPress();
+        await shiftTabPress();
         expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
       });
     });
 
     describe("when tabbing into the radio group", () => {
-      it("should move focus to the first radio button when none was previously selected", () => {
+      it("should move focus to the first radio button when none was previously selected", async () => {
         focusElement(screen.getByText(BUTTON_ONE));
-        tabPress();
+        await tabPress();
         expect(screen.getByLabelText(RADIO_LABEL_ONE)).toHaveFocus();
       });
 
-      it("should move focus to the selected radio button if one is selected", () => {
+      it("should move focus to the selected radio button if one is selected", async () => {
         fireEvent.click(screen.getByLabelText(RADIO_LABEL_TWO));
         focusElement(screen.getByText(BUTTON_ONE));
-        tabPress();
+        await tabPress();
         expect(screen.getByLabelText(RADIO_LABEL_TWO)).toHaveFocus();
       });
     });
 
     describe("when shift tabbing into the radio group", () => {
-      it("should move focus to the last radio button when none was previously selected", () => {
+      it("should move focus to the last radio button when none was previously selected", async () => {
         focusElement(screen.getByText(BUTTON_TWO));
-        shiftTabPress();
+        await shiftTabPress();
         expect(screen.getByLabelText(RADIO_LABEL_TWO)).toHaveFocus();
       });
 
-      it("should move focus to the selected radio button if one is selected", () => {
+      it("should move focus to the selected radio button if one is selected", async () => {
         fireEvent.click(screen.getByLabelText(RADIO_LABEL_TWO));
         focusElement(screen.getByText(BUTTON_ONE));
-        shiftTabPress();
-        shiftTabPress();
+        await shiftTabPress();
+        await shiftTabPress();
+        expect(screen.getByLabelText(RADIO_LABEL_TWO)).toHaveFocus();
+      });
+    });
+  });
+
+  describe("when trap contains radio buttons when using a custom selector", () => {
+    beforeEach(() => {
+      render(
+        <MockComponent focusableSelectors="input[type=radio]">
+          <button type="button">{BUTTON_ONE}</button>
+          <RadioButtonGroup
+            name="mybuttongroup"
+            legend="How do you want to create this address?"
+            legendInline
+            onChange={() => jest.fn()}
+            value={undefined}
+            legendWidth={40}
+          >
+            <RadioButton value="1" label={RADIO_LABEL_ONE} size="large" />
+            <RadioButton value="2" label={RADIO_LABEL_TWO} size="large" />
+          </RadioButtonGroup>
+          <button type="button">{BUTTON_TWO}</button>
+        </MockComponent>
+      );
+    });
+
+    describe("when tabbing into the radio group", () => {
+      it("should move focus to the first radio button when none was previously selected", async () => {
+        focusElement(screen.getByText(BUTTON_ONE));
+        await tabPress();
+        expect(screen.getByLabelText(RADIO_LABEL_ONE)).toHaveFocus();
+      });
+
+      it("should move focus to the selected radio button if one is selected", async () => {
+        fireEvent.click(screen.getByLabelText(RADIO_LABEL_TWO));
+        focusElement(screen.getByText(BUTTON_ONE));
+        await tabPress();
+        expect(screen.getByLabelText(RADIO_LABEL_TWO)).toHaveFocus();
+      });
+    });
+
+    describe("when shift tabbing into the radio group", () => {
+      it("should move focus to the last radio button when none was previously selected", async () => {
+        focusElement(screen.getByText(BUTTON_TWO));
+        await shiftTabPress();
+        expect(screen.getByLabelText(RADIO_LABEL_TWO)).toHaveFocus();
+      });
+
+      it("should move focus to the selected radio button if one is selected", async () => {
+        fireEvent.click(screen.getByLabelText(RADIO_LABEL_TWO));
+        focusElement(screen.getByText(BUTTON_ONE));
+        await shiftTabPress();
+        await shiftTabPress();
         expect(screen.getByLabelText(RADIO_LABEL_TWO)).toHaveFocus();
       });
     });
@@ -554,16 +766,46 @@ describe("FocusTrap", () => {
           children: <button type="button">{BUTTON_ONE}</button>,
         })
       );
+      focusElement(screen.getByText(BUTTON_ONE));
     });
 
-    it("pressing tab does not move focus", () => {
-      tabPress();
+    it("pressing tab does not move focus", async () => {
+      await tabPress();
       expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
     });
 
-    it("pressing shift tab does not move focus", () => {
-      shiftTabPress();
+    it("pressing shift tab does not move focus", async () => {
+      await shiftTabPress();
       expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
+    });
+  });
+
+  describe("when trap contains only one focusable element according to a custom selector", () => {
+    beforeEach(() => {
+      render(
+        mockComponentToRender({
+          children: (
+            <>
+              <button type="button">{BUTTON_ONE}</button>
+              <button type="button" className="focusable-button">
+                {BUTTON_TWO}
+              </button>
+            </>
+          ),
+          focusableSelectors: "button.focusable-button",
+        })
+      );
+      focusElement(screen.getByText(BUTTON_TWO));
+    });
+
+    it("pressing tab does not move focus", async () => {
+      await tabPress();
+      expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
+    });
+
+    it("pressing shift tab does not move focus", async () => {
+      await shiftTabPress();
+      expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
     });
   });
 
@@ -584,32 +826,52 @@ describe("FocusTrap", () => {
           </RadioButtonGroup>
         </MockComponent>
       );
+      focusElement(screen.getByLabelText(RADIO_LABEL_ONE));
     });
 
-    it("pressing tab does not move focus", () => {
-      tabPress();
+    it("pressing tab does not move focus", async () => {
+      await tabPress();
       expect(screen.getByLabelText(RADIO_LABEL_ONE)).toHaveFocus();
     });
 
-    it("pressing shift tab does not move focus", () => {
-      shiftTabPress();
+    it("pressing shift tab does not move focus", async () => {
+      await shiftTabPress();
+      expect(screen.getByLabelText(RADIO_LABEL_ONE)).toHaveFocus();
+    });
+  });
+
+  describe("when trap contains one radio button group and no other focusable elements according to a custom selector", () => {
+    beforeEach(() => {
+      render(
+        <MockComponent focusableSelectors="input[type=radio]">
+          <RadioButtonGroup
+            name="mybuttongroup"
+            legend="How do you want to create this address?"
+            legendInline
+            onChange={() => jest.fn()}
+            value="1"
+            legendWidth={40}
+          >
+            <RadioButton value="1" label={RADIO_LABEL_ONE} size="large" />
+            <RadioButton value="2" label={RADIO_LABEL_TWO} size="large" />
+          </RadioButtonGroup>
+          <button type="button">{BUTTON_ONE}</button>
+        </MockComponent>
+      );
+    });
+
+    it("pressing tab does not move focus", async () => {
+      await tabPress();
+      expect(screen.getByLabelText(RADIO_LABEL_ONE)).toHaveFocus();
+    });
+
+    it("pressing shift tab does not move focus", async () => {
+      await shiftTabPress();
       expect(screen.getByLabelText(RADIO_LABEL_ONE)).toHaveFocus();
     });
   });
 
   describe("wrapperRef", () => {
-    it("renders without wrapperRef provided", () => {
-      expect(() => {
-        render(
-          <ModalContext.Provider value={{ isAnimationComplete: true }}>
-            <FocusTrap>
-              <div id="myComponent">Content</div>
-            </FocusTrap>
-          </ModalContext.Provider>
-        );
-      }).not.toThrow();
-    });
-
     it("should not update focusable elements if wrapper ref isn't found", () => {
       const wrapperRef = { current: null };
       expect(() => {
@@ -625,62 +887,48 @@ describe("FocusTrap", () => {
   });
 
   describe("additionalWrapperRefs", () => {
-    const BUTTON_IN_WRAPPER = "Button in wrapper";
-    const BUTTON_IN_ADDITIONAL_WRAPPER_ONE = "Button in additional wrapper one";
-    const BUTTON_IN_ADDITIONAL_WRAPPER_TWO = "Button in additional wrapper two";
-
     beforeEach(() => {
-      const wrapperRef = { current: null };
-      const otherContentRef1 = { current: null };
-      const otherContentRef2 = { current: null };
-
-      render(
-        <ModalContext.Provider value={{ isAnimationComplete: true }}>
-          <FocusTrap
-            wrapperRef={wrapperRef}
-            additionalWrapperRefs={[otherContentRef1, otherContentRef2]}
-          >
-            <div data-testid={WRAPPER_ID}>
-              <button type="button" id="outside1">
-                outside focus trap
-              </button>
-              <div ref={wrapperRef}>
-                <button type="button" id="insidewrapper">
-                  {BUTTON_IN_WRAPPER}
-                </button>
-              </div>
-              <button type="button" id="outside2">
-                outside focus trap
-              </button>
-              <div ref={otherContentRef1}>
-                <button type="button" id="insideother1">
-                  {BUTTON_IN_ADDITIONAL_WRAPPER_ONE}
-                </button>
-              </div>
-              <button type="button" id="outside3">
-                outside focus trap
-              </button>
-              <div ref={otherContentRef2}>
-                <button type="button" id="insideother2">
-                  {BUTTON_IN_ADDITIONAL_WRAPPER_TWO}
-                </button>
-              </div>
-              <button type="button" id="outside4">
-                outside focus trap
-              </button>
-            </div>
-          </FocusTrap>
-        </ModalContext.Provider>
-      );
+      render(<WithAdditionalWrapperRefs />);
     });
 
-    it("tab should cycle through focusable elements inside the provided container refs and ignore all others", () => {
+    it("tab should cycle through focusable elements inside the provided container refs and ignore all others", async () => {
       focusElement(screen.getByText(BUTTON_IN_WRAPPER));
-      tabPress();
+      await tabPress();
       expect(screen.getByText(BUTTON_IN_ADDITIONAL_WRAPPER_ONE)).toHaveFocus();
-      tabPress();
+      await tabPress();
       expect(screen.getByText(BUTTON_IN_ADDITIONAL_WRAPPER_TWO)).toHaveFocus();
-      tabPress();
+      await tabPress();
+      expect(screen.getByText(BUTTON_IN_WRAPPER)).toHaveFocus();
+    });
+
+    it("shift-tab should cycle through focusable elements inside the provided container refs and ignore all others", async () => {
+      focusElement(screen.getByText(BUTTON_IN_WRAPPER));
+      await shiftTabPress();
+      expect(screen.getByText(BUTTON_IN_ADDITIONAL_WRAPPER_TWO)).toHaveFocus();
+      await shiftTabPress();
+      expect(screen.getByText(BUTTON_IN_ADDITIONAL_WRAPPER_ONE)).toHaveFocus();
+      await shiftTabPress();
+      expect(screen.getByText(BUTTON_IN_WRAPPER)).toHaveFocus();
+    });
+
+    it("continues to work both forwards and backwards after the wrapper refs are dynamically altered", async () => {
+      fireEvent.click(screen.getByText(BUTTON_IN_WRAPPER));
+      focusElement(screen.getByText(BUTTON_IN_WRAPPER));
+      await tabPress();
+      expect(screen.getByText(BUTTON_IN_ADDITIONAL_WRAPPER_ONE)).toHaveFocus();
+      await tabPress();
+      expect(screen.getByText(BUTTON_IN_ADDITIONAL_WRAPPER_TWO)).toHaveFocus();
+      await tabPress();
+      expect(screen.getByText(BUTTON_IN_CONDITIONAL_WRAPPER)).toHaveFocus();
+      await tabPress();
+      expect(screen.getByText(BUTTON_IN_WRAPPER)).toHaveFocus();
+      await shiftTabPress();
+      expect(screen.getByText(BUTTON_IN_CONDITIONAL_WRAPPER)).toHaveFocus();
+      await shiftTabPress();
+      expect(screen.getByText(BUTTON_IN_ADDITIONAL_WRAPPER_TWO)).toHaveFocus();
+      await shiftTabPress();
+      expect(screen.getByText(BUTTON_IN_ADDITIONAL_WRAPPER_ONE)).toHaveFocus();
+      await shiftTabPress();
       expect(screen.getByText(BUTTON_IN_WRAPPER)).toHaveFocus();
     });
   });
@@ -715,8 +963,55 @@ describe("FocusTrap", () => {
       await waitFor(() => {
         expect(screen.getByText(BUTTON_ONE)).toBeInTheDocument();
       });
-      tabPress();
+      await tabPress();
       expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
+    });
+
+    it("should detect any new focusable elements and focus them when they are tabbed to when using a custom selector", async () => {
+      const ChangingChild = () => {
+        const [loading, setLoading] = useState(true);
+
+        useEffect(() => {
+          setTimeout(() => {
+            setLoading(false);
+          }, 2000);
+        }, []);
+
+        if (loading) {
+          return <input aria-label="input" type="text" className="focusable" />;
+        }
+
+        return (
+          <>
+            <button type="button">{BUTTON_ONE}</button>
+          </>
+        );
+      };
+
+      render(
+        mockComponentToRender({
+          children: (
+            <>
+              <ChangingChild />
+              <button type="button" className="focusable">
+                {BUTTON_TWO}
+              </button>
+            </>
+          ),
+          focusableSelectors: ".focusable",
+        })
+      );
+      expect(screen.getByTestId(WRAPPER_ID)).toHaveFocus();
+      await tabPress();
+      expect(screen.getByLabelText("input")).toHaveFocus();
+      act(() => {
+        jest.runAllTimers();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(BUTTON_ONE)).toBeInTheDocument();
+      });
+      await tabPress();
+      expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
     });
 
     it("should detect when additionalWrappers update and remove any elements no longer visible from focusableElements", async () => {
@@ -745,12 +1040,13 @@ describe("FocusTrap", () => {
           <FocusTrap
             wrapperRef={wrapperRef}
             additionalWrapperRefs={[additionalRef]}
+            isOpen
           >
             <div data-testid={WRAPPER_ID} ref={wrapperRef}>
-              <button type="button" id="insidewrapper">
+              <button type="button" id="insidewrapper1">
                 {BUTTON_ONE}
               </button>
-              <button type="button" id="insidewrapper">
+              <button type="button" id="insidewrapper2">
                 {BUTTON_TWO}
               </button>
             </div>
@@ -760,11 +1056,11 @@ describe("FocusTrap", () => {
       );
       const additionalButton = screen.getByText(ADDITIONAL_BUTTON);
 
-      tabPress();
+      await tabPress();
       expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
-      tabPress();
+      await tabPress();
       expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
-      tabPress();
+      await tabPress();
       expect(additionalButton).toHaveFocus();
 
       act(() => {
@@ -774,46 +1070,38 @@ describe("FocusTrap", () => {
         expect(additionalButton).not.toBeInTheDocument();
       });
 
-      tabPress();
+      await tabPress();
       expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
-      tabPress();
+      await tabPress();
       expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
-      tabPress();
+      await tabPress();
       expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
     });
   });
 
   describe("when using a custom focusable element selector", () => {
-    it("should only focus elements which meet the custom selector", () => {
-      render(
-        <MockComponent focusableSelectors="button.focusable-button">
-          <button type="button" className="focusable-button">
-            {BUTTON_ONE}
-          </button>
-          <button type="button" className="not-focusable-button">
-            {BUTTON_TWO}
-          </button>
-          <button type="button" className="focusable-button">
-            {BUTTON_THREE}
-          </button>
-        </MockComponent>
-      );
+    it("should only focus elements which meet the custom selector, when tabbing both forwards and backwards", async () => {
+      render(<MockComponentWithCustomSelector />);
 
       focusElement(screen.getByText(BUTTON_ONE));
-      tabPress();
+      await tabPress();
+      expect(screen.getByText(BUTTON_THREE)).toHaveFocus();
+      await shiftTabPress();
+      expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
+      await shiftTabPress();
       expect(screen.getByText(BUTTON_THREE)).toHaveFocus();
     });
   });
 
   describe("when multiple focus traps are open at once", () => {
-    it("focus moves correctly between the elements of the currently-focused trap", () => {
+    it("focus moves correctly between the elements of the currently-focused trap", async () => {
       render(
         <>
-          <MockComponent dataTestId={WRAPPER_ID}>
+          <MockComponent>
             <button type="button">{BUTTON_ONE}</button>
             <button type="button">{BUTTON_TWO}</button>
           </MockComponent>
-          <MockComponent dataTestId={SECOND_WRAPPER_ID}>
+          <MockComponent>
             <button type="button">{BUTTON_THREE}</button>
             <button type="button">{BUTTON_FOUR}</button>
           </MockComponent>
@@ -821,23 +1109,56 @@ describe("FocusTrap", () => {
       );
 
       focusElement(screen.getByText(BUTTON_ONE));
-      tabPress(WRAPPER_ID);
+      await tabPress();
       expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
-      tabPress(WRAPPER_ID);
+      await tabPress();
       expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
 
       focusElement(screen.getByText(BUTTON_THREE));
-      tabPress(SECOND_WRAPPER_ID);
+      await tabPress();
       expect(screen.getByText(BUTTON_FOUR)).toHaveFocus();
-      tabPress(SECOND_WRAPPER_ID);
+      await tabPress();
       expect(screen.getByText(BUTTON_THREE)).toHaveFocus();
+    });
+
+    it("focus moves correctly between the elements of the currently-focused trap when using a custom selector", async () => {
+      render(
+        <>
+          <MockComponent>
+            <button type="button">{BUTTON_ONE}</button>
+            <button type="button">{BUTTON_TWO}</button>
+            <button type="button">{BUTTON_THREE}</button>
+          </MockComponent>
+          <MockComponent focusableSelectors="button.focusable-button">
+            <button className="focusable-button" type="button">
+              {BUTTON_FOUR}
+            </button>
+            <button type="button">{BUTTON_FIVE}</button>
+            <button className="focusable-button" type="button">
+              {BUTTON_SIX}
+            </button>
+          </MockComponent>
+        </>
+      );
+
+      focusElement(screen.getByText(BUTTON_ONE));
+      await tabPress();
+      expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
+      await tabPress();
+      expect(screen.getByText(BUTTON_THREE)).toHaveFocus();
+      await tabPress();
+      expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
+
+      focusElement(screen.getByText(BUTTON_FOUR));
+      await tabPress();
+      expect(screen.getByText(BUTTON_SIX)).toHaveFocus();
+      await tabPress();
+      expect(screen.getByText(BUTTON_FOUR)).toHaveFocus();
     });
   });
 
   describe("when focuses an element that programatically focuses another nonfocusable element", () => {
     it("should allow focusing out from the focused element", async () => {
-      const user = userEvent.setup({ delay: null });
-
       const ProgramaticallyFocusesNextElement = () => {
         const buttonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -867,27 +1188,25 @@ describe("FocusTrap", () => {
         </MockComponent>
       );
 
-      await user.tab();
+      await tabPress();
       expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
 
-      await user.tab();
+      await tabPress();
       expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
 
-      await user.tab();
+      await tabPress();
       expect(screen.getByText(BUTTON_THREE)).toHaveFocus();
 
-      await user.tab();
+      await tabPress();
       expect(screen.getByText(BUTTON_FOUR)).toHaveFocus();
 
-      await user.tab();
+      await tabPress();
       expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
     });
   });
 
   describe("when the the focus is on a non focusable element that is the last element", () => {
     it("should focus the first focusable element", async () => {
-      const user = userEvent.setup({ delay: null });
-
       render(
         <MockComponent>
           <button type="button">{BUTTON_ONE}</button>
@@ -899,15 +1218,13 @@ describe("FocusTrap", () => {
       );
 
       focusElement(screen.getByText(BUTTON_THREE));
-      await user.tab();
+      await tabPress();
       expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
     });
   });
 
   describe("when the the focus is on a non focusable element that is the first element", () => {
     it("should focus the last focusable element", async () => {
-      const user = userEvent.setup({ delay: null });
-
       render(
         <MockComponent>
           <button type="button" tabIndex={-1}>
@@ -919,8 +1236,45 @@ describe("FocusTrap", () => {
       );
 
       focusElement(screen.getByText(BUTTON_ONE));
-      await user.tab({ shift: true });
+      await shiftTabPress();
       expect(screen.getByText(BUTTON_THREE)).toHaveFocus();
+    });
+  });
+
+  describe("preventDefault", () => {
+    const callIfDefaultPrevented = jest.fn();
+    const onKeyDown = (e: React.KeyboardEvent) => {
+      if (e.defaultPrevented) {
+        callIfDefaultPrevented();
+      }
+    };
+
+    beforeEach(() => {
+      callIfDefaultPrevented.mockClear();
+    });
+
+    it("when focusableSelectors is not used, preventDefault is not called at all while tabbing through the trap", async () => {
+      render(mockComponentToRender({ onKeyDown }));
+      await tabPress();
+      expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
+      await tabPress();
+      expect(screen.getByText(BUTTON_TWO)).toHaveFocus();
+      await tabPress();
+      expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
+      expect(callIfDefaultPrevented).not.toHaveBeenCalled();
+    });
+
+    it("when focusableSelectors is used, preventDefault is only called when needed to prevent undesired elements being focused", async () => {
+      render(<MockComponentWithCustomSelector onKeyDown={onKeyDown} />);
+      await tabPress();
+      expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
+      expect(callIfDefaultPrevented).not.toHaveBeenCalled();
+      await tabPress();
+      expect(screen.getByText(BUTTON_THREE)).toHaveFocus();
+      expect(callIfDefaultPrevented).toHaveBeenCalledTimes(1);
+      await tabPress();
+      expect(screen.getByText(BUTTON_ONE)).toHaveFocus();
+      expect(callIfDefaultPrevented).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/components/dialog-full-screen/dialog-full-screen.test.js
+++ b/src/components/dialog-full-screen/dialog-full-screen.test.js
@@ -167,6 +167,21 @@ context("Testing DialogFullScreen component", () => {
       getElement("dialog").should("have.attr", "aria-modal").and("eq", "true");
     });
 
+    it("should always place focus on the inner dialog when tabbing with nested dialogs after focus is lost", () => {
+      CypressMountWithProviders(<NestedDialog />);
+
+      openDialogByName(`Open ${mainDialogTitle}`).click();
+
+      openDialogByName(`Open ${nestedDialogTitle}`).click();
+
+      dialogPreview().tab();
+
+      // click on the body in order to lose focus
+      cy.get("body").click().tab();
+
+      closeIconButton().eq(1).should("be.focused");
+    });
+
     it("should render nested dialogs with the aria-modal property only set on the top one, even when the dialogs are wrapped in separate CarbonProviders", () => {
       cy.mount(<MultipleDialogsInDifferentProviders />);
 

--- a/src/components/dialog/dialog-test.stories.tsx
+++ b/src/components/dialog/dialog-test.stories.tsx
@@ -224,6 +224,7 @@ export const DialogComponentWithTextEditor = ({
   ...props
 }: Partial<DialogProps> & StoryProps) => {
   const [isOpen, setIsOpen] = useState(true);
+  const [value, setValue] = useState(EditorState.createEmpty());
   return (
     <>
       <Dialog
@@ -235,8 +236,8 @@ export const DialogComponentWithTextEditor = ({
         <Textbox label="Textbox1" value="Textbox1" />
         <Textbox label="Textbox2" value="Textbox2" />
         <TextEditor
-          onChange={() => {}}
-          value={EditorState.createEmpty()}
+          onChange={(state) => setValue(state)}
+          value={value}
           labelText="Text Editor Label"
         />
         <Textbox label="Textbox3" value="Textbox3" />

--- a/src/components/dialog/dialog.test.js
+++ b/src/components/dialog/dialog.test.js
@@ -229,17 +229,17 @@ context("Testing Dialog component", () => {
       );
       cy.get("body").tab();
       closeIconButton().should("be.focused");
-      cy.get("body").tab();
+      cy.focused().tab();
       buttonDataComponent().eq(0).should("be.focused");
-      cy.get("body").tab();
+      cy.focused().tab();
       buttonDataComponent().eq(1).should("be.focused");
-      cy.get("body").tab();
+      cy.focused().tab();
       getInput(0).should("be.focused");
-      cy.get("body").tab();
+      cy.focused().tab();
       getInput(1).should("be.focused");
-      cy.get("body").tab();
+      cy.focused().tab();
       getInput(2).should("be.focused");
-      cy.get("body").tab();
+      cy.focused().tab();
       closeIconButton().should("be.focused");
     });
 
@@ -263,19 +263,18 @@ context("Testing Dialog component", () => {
       CypressMountWithProviders(
         <stories.DialogComponent focusFirstElement={undefined} />
       );
-      cy.get("body").tab();
-      closeIconButton().should("be.focused");
-      cy.get("body").tab({ shift: true });
+      dialogPreview().should("be.focused");
+      cy.focused().tab({ shift: true });
       getInput(2).should("be.focused");
-      cy.get("body").tab({ shift: true });
+      cy.focused().tab({ shift: true });
       getInput(1).should("be.focused");
-      cy.get("body").tab({ shift: true });
+      cy.focused().tab({ shift: true });
       getInput(0).should("be.focused");
-      cy.get("body").tab({ shift: true });
+      cy.focused().tab({ shift: true });
       buttonDataComponent().eq(1).should("be.focused");
-      cy.get("body").tab({ shift: true });
+      cy.focused().tab({ shift: true });
       buttonDataComponent().eq(0).should("be.focused");
-      cy.get("body").tab({ shift: true });
+      cy.focused().tab({ shift: true });
       closeIconButton().should("be.focused");
     });
 

--- a/src/components/dialog/dialog.test.js
+++ b/src/components/dialog/dialog.test.js
@@ -282,7 +282,8 @@ context("Testing Dialog component", () => {
       CypressMountWithProviders(<stories.DialogComponentWithTextEditor />);
       cy.get("body").tab();
       closeIconButton().should("be.focused");
-      cy.get("body").tab({ shift: true });
+      // needs to shift and tab twice on the body to gain focus else it loses it to the text editor pane
+      cy.get("body").tab({ shift: true }).tab({ shift: true });
       getInput(2).should("be.focused");
       cy.focused().tab({ shift: true });
       textEditorToolbar("bold").should("be.focused");
@@ -305,6 +306,195 @@ context("Testing Dialog component", () => {
       buttonDataComponent().should("be.focused");
       buttonDataComponent().click();
       toastComponent().should("be.focused");
+    });
+
+    it("focuses Toast close button when tab is pressed after non-focusable content has been selected", () => {
+      CypressMountWithProviders(<stories.DialogComponentWithToast />);
+
+      buttonDataComponent().click();
+      cy.get("body").click().tab();
+      closeIconButton().should("be.focused");
+    });
+  });
+
+  describe("Accessibility tests for Dialog component", () => {
+    it("should pass accessibility tests for Dialog default story", () => {
+      CypressMountWithProviders(<stories.DialogComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each([0, 1, 100, 1000])(
+      "should pass accessibility tests for Dialog component with %s as a height parameter",
+      (height) => {
+        CypressMountWithProviders(
+          <stories.DialogComponent height={`${height}px`} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(specialCharacters)(
+      "should pass accessibility tests for Dialog using %s as a title",
+      (title) => {
+        CypressMountWithProviders(<stories.DialogComponent title={title} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(specialCharacters)(
+      "should pass accessibility tests for Dialog using %s as a subtitle",
+      (subtitle) => {
+        CypressMountWithProviders(
+          <stories.DialogComponent title="Sample dialog" subtitle={subtitle} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      SIZE.EXTRASMALL,
+      SIZE.SMALL,
+      SIZE.MEDIUMSMALL,
+      SIZE.MEDIUM,
+      SIZE.MEDIUMLARGE,
+      SIZE.LARGE,
+      SIZE.EXTRALARGE,
+    ])(
+      "should pass accessibility tests for Dialog component with %s as a size",
+      (size) => {
+        CypressMountWithProviders(<stories.DialogComponent size={size} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibility tests for ShowCloseIcon is set to false", () => {
+      CypressMountWithProviders(
+        <stories.DialogComponent showCloseIcon={false} />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Dialog component with DisableClose", () => {
+      CypressMountWithProviders(<stories.DialogComponent disableClose />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Dialog component with help", () => {
+      CypressMountWithProviders(
+        <stories.DialogComponent title="Sample Dialog" help="Some help text" />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Dialog component using focusFirstElement", () => {
+      CypressMountWithProviders(<stories.DialogComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Dialog component disabling autofocus", () => {
+      CypressMountWithProviders(<stories.DialogComponent disableAutoFocus />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Dialog component with Toast", () => {
+      CypressMountWithProviders(<stories.DialogComponentWithToast />);
+
+      buttonDataComponent()
+        .click()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for Dialog Editable story", () => {
+      CypressMountWithProviders(<defaultStories.Editable />);
+
+      openPreviewButton()
+        .click()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for Dialog WithHelp story", () => {
+      CypressMountWithProviders(<defaultStories.WithHelp />);
+
+      openPreviewButton()
+        .click()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for Dialog DynamicContent story", () => {
+      CypressMountWithProviders(<defaultStories.DynamicContent />);
+
+      openPreviewButton()
+        .click()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for Dialog FocusingADifferentFirstElement story", () => {
+      CypressMountWithProviders(
+        <defaultStories.FocusingADifferentFirstElement />
+      );
+
+      getComponent("button")
+        .eq(0)
+        .click()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for Dialog OverridingContentPadding story", () => {
+      CypressMountWithProviders(<defaultStories.OverridingContentPadding />);
+
+      openPreviewButton()
+        .click()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for Dialog OtherFocusableContainers story", () => {
+      CypressMountWithProviders(<defaultStories.OtherFocusableContainers />);
+
+      openPreviewButton()
+        .click()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for Dialog Responsive story", () => {
+      CypressMountWithProviders(<defaultStories.Responsive />);
+
+      openPreviewButton()
+        .click()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          cy.checkAccessibility();
+        });
     });
   });
 

--- a/src/components/dialog/dialog.test.js
+++ b/src/components/dialog/dialog.test.js
@@ -247,15 +247,15 @@ context("Testing Dialog component", () => {
       CypressMountWithProviders(<stories.DialogComponentWithTextEditor />);
       cy.get("body").tab();
       closeIconButton().should("be.focused");
-      cy.get("body").tab();
+      cy.focused().tab();
       getInput(0).should("be.focused");
-      cy.get("body").tab();
+      cy.focused().tab();
       getInput(1).should("be.focused");
-      cy.get("body").tab();
+      cy.focused().tab();
       textEditorInput().should("be.focused");
-      cy.get("body").tab();
+      cy.focused().tab();
       textEditorToolbar("bold").should("be.focused");
-      cy.get("body").tab();
+      cy.focused().tab();
       getInput(2).should("be.focused");
     });
 
@@ -284,15 +284,15 @@ context("Testing Dialog component", () => {
       closeIconButton().should("be.focused");
       cy.get("body").tab({ shift: true });
       getInput(2).should("be.focused");
-      cy.get("body").tab({ shift: true });
+      cy.focused().tab({ shift: true });
       textEditorToolbar("bold").should("be.focused");
-      cy.get("body").tab({ shift: true });
+      cy.focused().tab({ shift: true });
       textEditorInput().should("be.focused");
-      cy.get("body").tab({ shift: true });
+      cy.focused().tab({ shift: true });
       getInput(1).should("be.focused");
-      cy.get("body").tab({ shift: true });
+      cy.focused().tab({ shift: true });
       getInput(0).should("be.focused");
-      cy.get("body").tab({ shift: true });
+      cy.focused().tab({ shift: true });
       closeIconButton().should("be.focused");
     });
 

--- a/src/components/menu/menu.test.js
+++ b/src/components/menu/menu.test.js
@@ -19,6 +19,7 @@ import {
   menuComponent,
   submenuItem,
   fullscreenMenu,
+  fullScreenMenuWrapper,
   menu,
   menuItem,
   fullScreenMenuItem,
@@ -1178,14 +1179,17 @@ context("Testing Menu component", () => {
     });
 
     it("should verify that close icon is focused in Menu Fullscreen", () => {
-      pressTABKey(1);
+      fullScreenMenuWrapper().tab();
       closeIconButton().then(($el) => {
         checkGoldenOutline($el);
       });
     });
 
     it("should verify that inner Menu is available with tabbing in Menu Fullscreen", () => {
-      pressTABKey(5);
+      fullScreenMenuWrapper().tab();
+      for (let i = 0; i < 4; i++) {
+        cy.focused().tab();
+      }
       fullScreenMenuItem(positionOfElement("fourth"))
         .find("ul > li")
         .eq(1)
@@ -1209,7 +1213,10 @@ context("Testing Menu component", () => {
     });
 
     it("should verify that inner Menu is available with shift-tabbing in Menu Fullscreen", () => {
-      pressTABKey(6);
+      fullScreenMenuWrapper().tab();
+      for (let i = 0; i < 5; i++) {
+        cy.focused().tab();
+      }
       cy.focused().tab({ shift: true });
       fullScreenMenuItem(positionOfElement("fourth"))
         .find("ul > li")

--- a/src/components/sidebar/sidebar.test.js
+++ b/src/components/sidebar/sidebar.test.js
@@ -222,10 +222,10 @@ context("Testing Sidebar component", () => {
     it("should render Sidebar with first input and button as focusableSelectors", () => {
       CypressMountWithProviders(<SidebarComponentFocusable />);
 
-      sidebarPreview().trigger("keydown", keyCode("Tab"));
-      sidebarPreview().trigger("keydown", keyCode("Tab"));
+      sidebarPreview().tab();
+      cy.focused().tab();
       getDataElementByValue("input").eq(0).should("be.focused");
-      sidebarPreview().trigger("keydown", keyCode("Tab"));
+      cy.focused().tab();
       getDataElementByValue("input").eq(1).should("not.be.focused");
       getDataElementByValue("open-toast").should("be.focused");
     });

--- a/src/components/sidebar/sidebar.test.js
+++ b/src/components/sidebar/sidebar.test.js
@@ -230,6 +230,16 @@ context("Testing Sidebar component", () => {
       getDataElementByValue("open-toast").should("be.focused");
     });
 
+    it("should return focus to the Toast within Sidebar after non-focusable content has been selected", () => {
+      CypressMountWithProviders(<SidebarComponentFocusable />);
+
+      getComponent("toast").should("not.exist");
+      getDataElementByValue("open-toast").click();
+      getComponent("toast").should("exist");
+      cy.get("body").click().tab();
+      closeIconButton().eq(1).should("be.focused");
+    });
+
     it("should call onCancel callback when a click event is triggered", () => {
       const callback = cy.stub();
 

--- a/src/components/vertical-menu/vertical-menu.test.js
+++ b/src/components/vertical-menu/vertical-menu.test.js
@@ -225,6 +225,15 @@ context("Testing Vertical Menu component", () => {
           });
         }
       );
+
+      it("should return focus to Vertical Menu Full Screen close button with tabbing", () => {
+        CypressMountWithProviders(<VerticalMenuFullScreenCustom isOpen />);
+
+        verticalMenuItem().should("be.visible");
+        verticalMenuFullScreen().find("div").eq(0).click();
+        verticalMenuFullScreen().tab();
+        closeIconButton().should("be.focused");
+      });
     });
 
     it.each(["25px", "55px", "77px"])(


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

Fixes 2 separate issues within the FocusTrap internal component (which is used by Dialog and related components to trap focus inside when tabbing):

1) Carbon should as far as possible not interfere with the behaviour of any 3rd-party libraries which the consumer is using that, by not calling `preventDefault` on the keyboard event (see first paragraph of "current behaviour" for details). This has been achieved by relying on focusable "tab guard" elements before and after the focus trap which "redirect" the focus as needed when focused, and otherwise relying on browser default behaviour (as modified by any other libraries in use) except when this would result in incorrect behaviour in Carbon (which happens in only one situation - when the consumer is using a custom `focusableSelectors` string - and even there the PR avoids calling `preventDefault` except when absolutely necessary). (fixes #5749 )

2) when multiple dialogs are open and a non-focusable element is clicked, resulting in focus being lost to the document body, tabbing should always result in focus going to the first focusable element of the top modal (fixes #5754 )

### Current behaviour

1) The current implementation relies on calling the `preventDefault` method on the keyboard event whenever the user tabs, in order to work out programatically the next element to focus. This breaks any third-party libraries - such as AG Grid - which implement their own behaviour on tab press and check that the default wasn't prevented before doing anything (thereby effectively making their implementation a new default, as calling `preventDefault` stops the library code from working as intended).

2) when multiple dialogs are open and a non-focusable element is clicked, resulting in focus being lost to the document body, tabbing can lead to a race condition between more than one focus trap both trying to focus their own first element. This leads to the possibility that the wrong element may be focused, as it is only the "top" modal that should get the focus on its first element.

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
Ensure both linked issues have been fixed.

Also regression test all components that use FocusTrap - Dialog, DialogFullScree, Sidebar, MenuFullScreen and VerticalMenuFullScreen

<!-- Add CodeSandbox here -->
