### PR TITLE
chore: update import paths to be relative

### DIFF
--- a/src/__internal__/form-field/form-field.component.tsx
+++ b/src/__internal__/form-field/form-field.component.tsx
@@ -6,9 +6,10 @@ import React, {
   useRef,
 } from "react";
 
-import { ValidationProps } from "__internal__/validations";
 import { MarginProps } from "styled-system";
 import invariant from "invariant";
+
+import { ValidationProps } from "../validations";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import FormFieldStyle, { FieldLineStyle } from "./form-field.style";
 import Label from "../label";

--- a/src/__internal__/label/label.component.tsx
+++ b/src/__internal__/label/label.component.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext } from "react";
-import { TooltipPositions } from "components/tooltip/tooltip.config";
+import { TooltipPositions } from "../../components/tooltip/tooltip.config";
 import Help from "../../components/help";
 import StyledLabel, {
   StyledLabelContainer,

--- a/src/__spec_helper__/test-utils.ts
+++ b/src/__spec_helper__/test-utils.ts
@@ -11,7 +11,7 @@ import {
 } from "styled-system";
 import { ReactTestRendererJSON } from "react-test-renderer";
 
-import { space } from "style/themes/base/base-theme.config";
+import { space } from "../style/themes/base/base-theme.config";
 
 import { carbonThemeList } from "../style/themes";
 import { mockMatchMedia } from "./mock-match-media";

--- a/src/components/button-bar/button-bar.spec.tsx
+++ b/src/components/button-bar/button-bar.spec.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { mount } from "enzyme";
 import TestRenderer from "react-test-renderer";
-import Icon from "components/icon";
-import { IconType } from "../icon/icon-type";
+import Icon, { IconType } from "../icon";
 import Button from "../button";
 import ButtonBar from "./button-bar.component";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";

--- a/src/components/button/button.spec.tsx
+++ b/src/components/button/button.spec.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { shallow, mount, ShallowWrapper, ReactWrapper } from "enzyme";
 import { act } from "react-dom/test-utils";
 import TestRenderer from "react-test-renderer";
+import { space } from "../../style/themes/base/base-theme.config";
 
-import Icon from "components/icon";
-import { space } from "style/themes/base/base-theme.config";
+import Icon from "../icon";
 import Button, {
   ButtonProps,
   ButtonTypes,

--- a/src/components/button/button.style.ts
+++ b/src/components/button/button.style.ts
@@ -1,6 +1,6 @@
 import styled, { css } from "styled-components";
 import { space, SpaceProps } from "styled-system";
-import { IconType } from "components/icon/icon-type";
+import { IconType } from "../icon";
 
 import BaseTheme from "../../style/themes/base";
 import buttonTypes from "./button-types.style";

--- a/src/components/dialog/dialog.spec.tsx
+++ b/src/components/dialog/dialog.spec.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { mount, ReactWrapper } from "enzyme";
 import { act } from "react-dom/test-utils";
 
-import { space } from "style/themes/base/base-theme.config";
+import { space } from "../../style/themes/base/base-theme.config";
 import guid from "../../__internal__/utils/helpers/guid";
 import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
 import Dialog, { DialogProps } from "./dialog.component";

--- a/src/components/global-header/global-header.component.tsx
+++ b/src/components/global-header/global-header.component.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled, { css } from "styled-components";
 import { PaddingProps, FlexboxProps } from "styled-system";
-import { ThemeObject } from "style/themes/base";
+import { ThemeObject } from "../../style/themes/base";
 import { baseTheme } from "../../style/themes";
 import StyledNavigationBar, {
   StyledNavigationBarProps,

--- a/src/components/help/help.spec.tsx
+++ b/src/components/help/help.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { act } from "react-dom/test-utils";
 import { shallow, mount, ShallowWrapper, ReactWrapper } from "enzyme";
-import Icon from "components/icon";
+import Icon from "../icon";
 import Help, { HelpProps } from "./help.component";
 import { rootTagTest } from "../../__internal__/utils/helpers/tags/tags-specs";
 import StyledHelp from "./help.style";

--- a/src/components/link/link.component.tsx
+++ b/src/components/link/link.component.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
-import { IconType } from "components/icon/icon-type";
 
-import Icon from "../icon";
+import Icon, { IconType } from "../icon";
 import Event from "../../__internal__/utils/helpers/events";
 import { StyledLink, StyledContent, StyledLinkProps } from "./link.style";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";

--- a/src/components/menu/menu-item/menu-item.d.ts
+++ b/src/components/menu/menu-item/menu-item.d.ts
@@ -1,6 +1,6 @@
-import { IconType } from "components/icon/icon-type";
 import * as React from "react";
 import { FlexboxProps, LayoutProps } from "styled-system";
+import { IconType } from "../../icon";
 
 export interface MenuItemBaseProps extends LayoutProps, FlexboxProps {
   /** Custom className */

--- a/src/components/split-button/split-button.spec.tsx
+++ b/src/components/split-button/split-button.spec.tsx
@@ -4,7 +4,7 @@ import TestRenderer from "react-test-renderer";
 import { act } from "react-dom/test-utils";
 
 import { ThemeProvider } from "styled-components";
-import { ThemeObject } from "style/themes/base";
+import { ThemeObject } from "../../style/themes/base";
 import SplitButton from "./split-button.component";
 import StyledSplitButton from "./split-button.style";
 import StyledSplitButtonToggle from "./split-button-toggle.style";

--- a/src/components/switch/switch.spec.tsx
+++ b/src/components/switch/switch.spec.tsx
@@ -3,7 +3,7 @@ import { act } from "react-dom/test-utils";
 import { ThemeProvider } from "styled-components";
 import { mount, ReactWrapper, MountRendererProps } from "enzyme";
 
-import { ThemeObject } from "style/themes/base";
+import { ThemeObject } from "../../style/themes/base";
 import Switch, { SwitchProps } from ".";
 import CheckableInput from "../../__internal__/checkable-input";
 import { StyledCheckableInput } from "../../__internal__/checkable-input/checkable-input.style";

--- a/src/style/design-tokens/carbon-scoped-tokens-provider/carbon-scoped-tokens-provider.component.ts
+++ b/src/style/design-tokens/carbon-scoped-tokens-provider/carbon-scoped-tokens-provider.component.ts
@@ -1,6 +1,6 @@
-import { ThemeObject } from "style/themes/base";
 import styled from "styled-components";
 import { baseTheme } from "../../themes";
+import { ThemeObject } from "../../themes/base";
 import generateCssVariables from "../generate-css-variables.util";
 
 /**

--- a/src/style/utils/color.ts
+++ b/src/style/utils/color.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import { color as styledColor } from "styled-system";
 import tokens from "@sage/design-tokens/js/base/common";
-import { ThemeObject } from "style/themes/base";
+import { ThemeObject } from "../themes/base";
 
 /*
  * styled-system/color allows users to use a color from the theme, from the `colors` object.


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Updates import paths to be relative in `Label`, `Button` `ButtonBar` `Link`, `MenuItem`, `Dialog` `SplitButton`, `Switch`, `Help` and so on

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Some import paths are not relative

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
