### PR TITLE
test(progress-tracker): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -77,6 +77,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("date-range") &&
       !prepareUrl[0].startsWith("pages") &&
       !prepareUrl[0].startsWith("button-toggle-group") &&
+      !prepareUrl[0].startsWith("progress-tracker") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/progress-tracker/progress-tracker.test.js
+++ b/src/components/progress-tracker/progress-tracker.test.js
@@ -17,6 +17,20 @@ const ProgressTrackerComponent = ({ ...props }) => {
   return <ProgressTracker progress={50} showDefaultLabels {...props} />;
 };
 
+const DEFAULT_PROP_VALUE = 50;
+
+const checkPropName = (propName) =>
+  propName.endsWith("now") &&
+  propName.endsWith("min") &&
+  propName.endsWith("max");
+
+const getProps = (propName, shouldBeDefault) => {
+  if (!shouldBeDefault) {
+    return { [propName]: DEFAULT_PROP_VALUE };
+  }
+  return { [propName]: CHARACTERS.STANDARD };
+};
+
 context("Tests for ProgressTracker component", () => {
   describe("check props for ProgressTracker component", () => {
     describe.each([
@@ -28,15 +42,15 @@ context("Tests for ProgressTracker component", () => {
       "aria-valuetext",
     ])("when %s prop is passed", (propName) => {
       it(`verify that the ${propName} is set to cypress-standard`, () => {
-        const props = { [propName]: CHARACTERS.STANDARD };
+        const isNowMinOrMax = checkPropName(propName);
+        const props = getProps(propName, isNowMinOrMax);
+        const assertion = !isNowMinOrMax
+          ? DEFAULT_PROP_VALUE
+          : CHARACTERS.STANDARD;
 
         CypressMountWithProviders(<ProgressTrackerComponent {...props} />);
 
-        progressTrackerComponent().should(
-          "have.attr",
-          propName,
-          CHARACTERS.STANDARD
-        );
+        progressTrackerComponent().should("have.attr", propName, assertion);
       });
     });
 
@@ -166,6 +180,127 @@ context("Tests for ProgressTracker component", () => {
 
         progressTrackerMinVal(index).should("have.text", "50%");
         progressTrackerMaxVal(index).should("have.text", "100%");
+      }
+    );
+  });
+
+  describe("should check accessibility tests for progress tracker component", () => {
+    describe.each([
+      "aria-label",
+      "aria-describedby",
+      "aria-valuenow",
+      "aria-valuemin",
+      "aria-valuemax",
+      "aria-valuetext",
+    ])("when %s prop is passed", (propName) => {
+      it(`check the accessibility when the ${propName} is set to cypress-standard`, () => {
+        const isNowMinOrMax = checkPropName(propName);
+        const props = getProps(propName, isNowMinOrMax);
+
+        CypressMountWithProviders(<ProgressTrackerComponent {...props} />);
+
+        cy.checkAccessibility();
+      });
+    });
+
+    it.each([
+      PROGRESS_TRACKER_SIZES[0],
+      PROGRESS_TRACKER_SIZES[1],
+      PROGRESS_TRACKER_SIZES[2],
+    ])(
+      "should check the accessibility when component is rendered with %s size",
+      (size) => {
+        CypressMountWithProviders(<ProgressTrackerComponent size={size} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["150px", "350px", "550px"])(
+      "should check the accessibility when component is rendered %s length",
+      (length) => {
+        CypressMountWithProviders(<ProgressTrackerComponent length={length} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([12, 47, 100])(
+      "should check the accessibility when component is rendered with %s% of progress",
+      (progress) => {
+        CypressMountWithProviders(
+          <ProgressTrackerComponent progress={progress} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check the accessibility when component is rendered with error prop", () => {
+      CypressMountWithProviders(
+        <ProgressTrackerComponent error showDefaultLabels progress={35} />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it.each([true, false])(
+      "should check the accessibility when component is rendered with showDefaultLabels is set to %s",
+      (boolean) => {
+        CypressMountWithProviders(
+          <ProgressTrackerComponent showDefaultLabels={boolean} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+      "should check the accessibility when component is rendered with currentProgressLabel is set to %s",
+      (currentProgressLabel) => {
+        CypressMountWithProviders(
+          <ProgressTrackerComponent
+            currentProgressLabel={currentProgressLabel}
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+      "should check the accessibility when component is rendered with maxProgressLabel is set to %s",
+      (maxProgressLabel) => {
+        CypressMountWithProviders(
+          <ProgressTrackerComponent maxProgressLabel={maxProgressLabel} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+      "should check the accessibility when component is rendered with customValuePreposition is set to %s",
+      (customValuePreposition) => {
+        CypressMountWithProviders(
+          <ProgressTrackerComponent
+            customValuePreposition={customValuePreposition}
+            showDefaultLabels
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["top", "bottom"])(
+      "should check the accessibility when component is rendered with labelsPosition is set to %s",
+      (labelsPosition) => {
+        CypressMountWithProviders(
+          <ProgressTrackerComponent labelsPosition={labelsPosition} />
+        );
+
+        cy.checkAccessibility();
       }
     );
   });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Progress-Tracker` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `progress-tracker.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Progress Tracker` tests are not running twice.