### PR TITLE
test(decimal): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -82,6 +82,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("portrait") &&
       !prepareUrl[0].startsWith("draggable") &&
       !prepareUrl[0].startsWith("definition-list") &&
+      !prepareUrl[0].startsWith("decimal") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/decimal/decimal-test.stories.tsx
+++ b/src/components/decimal/decimal-test.stories.tsx
@@ -13,6 +13,7 @@ import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 export default {
   title: "Decimal Input/Test",
+  includeStories: "DefaultStory",
   parameters: {
     info: { disable: true },
     chromatic: {

--- a/src/components/decimal/decimal.test.js
+++ b/src/components/decimal/decimal.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Decimal from "./decimal.component";
+import * as stories from "./decimal.stories.tsx";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
 import {
@@ -316,6 +317,119 @@ context("Tests for Decimal component", () => {
             callback.getCalls()[0].args[0].target.value.formattedValue
           ).to.equals("123.00");
         });
+    });
+  });
+
+  describe("Accessibility tests for Decimal component", () => {
+    it("should pass accessibility tests for Decimal with different input sizes", () => {
+      CypressMountWithProviders(<stories.Sizes />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Decimal with label aligned left", () => {
+      CypressMountWithProviders(<stories.LabelAlign />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Decimal with custom precision", () => {
+      CypressMountWithProviders(<stories.WithCustomPrecision />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Decimal with custom label width and input width", () => {
+      CypressMountWithProviders(<stories.WithCustomLabelWidthAndInputWidth />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Decimal with custom max width", () => {
+      CypressMountWithProviders(<stories.WithCustomMaxWidth />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Decimal with field help", () => {
+      CypressMountWithProviders(<stories.WithFieldHelp fieldHelp="Help" />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Decimal with label help", () => {
+      CypressMountWithProviders(<stories.WithLabelHelp labelHelp="Help" />);
+
+      getDataElementByValue("question")
+        .trigger("mouseover")
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for Decimal required", () => {
+      CypressMountWithProviders(<stories.Required />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Decimal left aligned", () => {
+      CypressMountWithProviders(<stories.LeftAligned />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Decimal with validation", () => {
+      CypressMountWithProviders(<stories.Validations />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Decimal validations redesigned", () => {
+      CypressMountWithProviders(<stories.ValidationsRedesign />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Decimal default", () => {
+      CypressMountWithProviders(
+        <Decimal
+          label="Decimal"
+          onChange={function noRefCheck() {}}
+          value="0.01"
+        />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Decimal with readOnly prop", () => {
+      CypressMountWithProviders(
+        <Decimal
+          label="Decimal"
+          onChange={function noRefCheck() {}}
+          value="0.01"
+          readOnly
+        />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    // FE-5382
+    describe.skip("skip", () => {
+      it("should pass accessibility tests for Decimal with tooltip", () => {
+        CypressMountWithProviders(<stories.ValidationsTooltip />);
+
+        cy.checkAccessibility();
+      });
+
+      it("should pass accessibility tests for Decimal with tooltip label", () => {
+        CypressMountWithProviders(<stories.ValidationsTooltipLabel />);
+
+        cy.checkAccessibility();
+      });
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Decimal` component to use the new cypress-component-react framework for testing.
- Refactor `decimal.stories.test.mdx` to corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there is newly added test.file
- [ ] Check if the `decimal.test.js` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `decimal` tests are not running twice.