### PR TITLE
fix(date): update abbreviated day translations in picker component for German locale FE-5660

### DIFF
--- a/src/components/date/__internal__/date-picker/date-picker.component.js
+++ b/src/components/date/__internal__/date-picker/date-picker.component.js
@@ -54,20 +54,19 @@ const DatePicker = React.forwardRef(
       () => Array.from({ length: 7 }).map((_, i) => localize.day(i)),
       [localize]
     );
-    const weekdaysShort = useMemo(
-      () =>
-        Array.from({ length: 7 }).map((_, i) =>
-          localize
-            .day(
-              i,
-              ["de", "pl"].filter((str) => l.locale().includes(str)).length
-                ? { width: "wide" }
-                : { width: "abbreviated" }
-            )
-            .substring(0, 3)
-        ),
-      [l, localize]
-    );
+    const weekdaysShort = useMemo(() => {
+      const isGivenLocale = (str) => l.locale().includes(str);
+      return Array.from({ length: 7 }).map((_, i) =>
+        localize
+          .day(
+            i,
+            ["de", "pl"].some(isGivenLocale)
+              ? { width: "wide" }
+              : { width: "abbreviated" }
+          )
+          .substring(0, isGivenLocale("de") ? 2 : 3)
+      );
+    }, [l, localize]);
 
     const handleDayClick = (date, { disabled }, ev) => {
       if (!disabled) {

--- a/src/components/date/__internal__/date-picker/date-picker.spec.js
+++ b/src/components/date/__internal__/date-picker/date-picker.spec.js
@@ -257,7 +257,7 @@ describe("StyledDayPicker", () => {
 
           expect(title).toEqual(long[i]);
           expect(children).toEqual(
-            locale === "de-DE" ? long[i].substring(0, 3) : short[i]
+            locale === "de-DE" ? long[i].substring(0, 2) : short[i]
           );
         });
       });


### PR DESCRIPTION
fix #5786

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Ensures that the abbreviated day translations in the picker component are only two characters long when locale is `de` (German)

![image](https://user-images.githubusercontent.com/44157880/217890840-55a396af-2159-4c40-b64b-1281e4709fb1.png)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
The abbreviated day translations in the picker component are three characters long when locale is `de` (German)

![image](https://user-images.githubusercontent.com/44157880/217890689-8a417253-435a-4f4c-8e74-aa6068c0a244.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
