### PR TITLE
test(draggable): add accessibility tests

### DIFF
--- a/cypress/e2e/accessibility/a11y-eleventh-part.test.js
+++ b/cypress/e2e/accessibility/a11y-eleventh-part.test.js
@@ -1,3 +1,0 @@
-import tests from "../../support/accessibility/a11y-utils";
-
-tests(751, 825);

--- a/cypress/e2e/accessibility/a11y-ninth-part.test.js
+++ b/cypress/e2e/accessibility/a11y-ninth-part.test.js
@@ -1,3 +1,0 @@
-import tests from "../../support/accessibility/a11y-utils";
-
-tests(601, 675);

--- a/cypress/e2e/accessibility/a11y-tenth-part.test.js
+++ b/cypress/e2e/accessibility/a11y-tenth-part.test.js
@@ -1,3 +1,0 @@
-import tests from "../../support/accessibility/a11y-utils";
-
-tests(676, 750);

--- a/cypress/e2e/accessibility/a11y-twelfth-part.test.js
+++ b/cypress/e2e/accessibility/a11y-twelfth-part.test.js
@@ -1,3 +1,0 @@
-import tests from "../../support/accessibility/a11y-utils";
-
-tests(826);

--- a/cypress/locators/progress-tracker/index.js
+++ b/cypress/locators/progress-tracker/index.js
@@ -10,3 +10,5 @@ export const progressTrackerMaxVal = (index = 0) =>
   progressTrackerComponent().children().eq(index).find("span").eq(2);
 export const progressTrackerCustomValuePreposition = (index = 0) =>
   progressTrackerComponent().children().eq(index).find("span").eq(1);
+export const progressTrackerDescription = (index = 0) =>
+  progressTrackerComponent().children().eq(index).find("span").eq(3);

--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -79,6 +79,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("button-toggle-group") &&
       !prepareUrl[0].startsWith("progress-tracker") &&
       !prepareUrl[0].startsWith("portrait") &&
+      !prepareUrl[0].startsWith("draggable") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/draggable/draggable.test.js
+++ b/src/components/draggable/draggable.test.js
@@ -134,4 +134,28 @@ context("Test for Draggable component", () => {
         });
     });
   });
+
+  describe("accessibility tests for Draggable component", () => {
+    it("should pass accessibility tests for Draggable default", () => {
+      CypressMountWithProviders(<DraggableCustom />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Draggable with different containers", () => {
+      CypressMountWithProviders(<DraggableDifferentContainers />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Draggable with getOrder callback", () => {
+      const callback = cy.stub();
+
+      CypressMountWithProviders(
+        <DraggableDifferentContainers getOrder={callback} />
+      );
+
+      cy.checkAccessibility();
+    });
+  });
 });

--- a/src/components/progress-tracker/progress-tracker.test.js
+++ b/src/components/progress-tracker/progress-tracker.test.js
@@ -11,6 +11,7 @@ import {
   progressTrackerMinVal,
   progressTrackerMaxVal,
   progressTrackerCustomValuePreposition,
+  progressTrackerDescription,
 } from "../../../cypress/locators/progress-tracker";
 
 const ProgressTrackerComponent = ({ ...props }) => {
@@ -182,6 +183,20 @@ context("Tests for ProgressTracker component", () => {
         progressTrackerMaxVal(index).should("have.text", "100%");
       }
     );
+
+    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+      "render component with description prop set to %s",
+      (description) => {
+        CypressMountWithProviders(
+          <ProgressTrackerComponent
+            showDefaultLabels
+            description={description}
+          />
+        );
+
+        progressTrackerDescription().should("have.text", description);
+      }
+    );
   });
 
   describe("should check accessibility tests for progress tracker component", () => {
@@ -298,6 +313,17 @@ context("Tests for ProgressTracker component", () => {
       (labelsPosition) => {
         CypressMountWithProviders(
           <ProgressTrackerComponent labelsPosition={labelsPosition} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+      "should check the accessibility when component is rendered with description prop set to %s",
+      (description) => {
+        CypressMountWithProviders(
+          <ProgressTrackerComponent description={description} />
         );
 
         cy.checkAccessibility();


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Draggable` component to use the new cypress-component-react framework for testing.
- Remove unused `accessibility` files
- Add a missing test for `progress-tracker`

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `draggable.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Draggable` tests are not running twice.