### PR TITLE
test(definition-list): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -81,6 +81,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("progress-tracker") &&
       !prepareUrl[0].startsWith("portrait") &&
       !prepareUrl[0].startsWith("draggable") &&
+      !prepareUrl[0].startsWith("definition-list") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/definition-list/definition-list.test.js
+++ b/src/components/definition-list/definition-list.test.js
@@ -215,4 +215,108 @@ context("Testing Definition List component", () => {
         .should("have.attr", "data-component", "dl");
     });
   });
+
+  describe("Accessibility tests for Definition List component", () => {
+    it.each(alignValue)(
+      "should pass accessibility tests for Definition List when text is %s aligned",
+      (align) => {
+        CypressMountWithProviders(
+          <DLComponent dtTextAlign={align} ddTextAlign="right" />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(alignValue)(
+      "should pass accessibility tests for Definition List when DD text is %s aligned",
+      (align) => {
+        CypressMountWithProviders(<DLComponent ddTextAlign={align} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(widths)(
+      "should pass the accessibility tests when text width is %spx and definition width is %spx, %s%/%s% of the Definition List width",
+      (dtPixels, ddPixels, dtPercent) => {
+        CypressMountWithProviders(<DLComponent w={dtPercent} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(specialCharacters)(
+      "should pass accessibility tests for Definition List if text is %s when children prop is set to %s",
+      (text) => {
+        CypressMountWithProviders(
+          <Dl>
+            <Dt>{text}</Dt>
+            <Dd>Definition</Dd>
+          </Dl>
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(specialCharacters)(
+      "should pass accessibility tests for Definition List if is %s when children prop is set to %s",
+      (definition) => {
+        CypressMountWithProviders(
+          <Dl>
+            <Dt>Text</Dt>
+            <Dd data-element="dd">{definition}</Dd>
+          </Dl>
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibility tests for Definition List when text is displayed as a single column", () => {
+      CypressMountWithProviders(
+        <DLComponent dtTextAlign="left" asSingleColumn />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Definition List when definition is displayed with a tick icon", () => {
+      CypressMountWithProviders(
+        <Dl>
+          <Dt>Text</Dt>
+          <Dd data-element="dd">
+            <Box display="inline-flex" alignItems="center">
+              <Box mr={1}>Details example</Box>
+              <Icon type="tick" />
+            </Box>
+          </Dd>
+        </Dl>
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Definition List is displayed with children inside React fragment", () => {
+      CypressMountWithProviders(
+        <Dl>
+          {true && (
+            <>
+              <Dt>Text inside React Fragment</Dt>
+              <Dd data-element="dd">Description inside React Fragment</Dd>
+            </>
+          )}
+        </Dl>
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Definition List within a box combined with typography and hr components", () => {
+      CypressMountWithProviders(<DLBoxComponent />);
+
+      cy.checkAccessibility();
+    });
+  });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Definition List` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there are newly added tests
- [ ] Check if the `definition-list.test.js` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Definition List` tests are not running twice.