### PR TITLE
feat(password): add new component

### DIFF
--- a/cypress/components/password/password.cy.js
+++ b/cypress/components/password/password.cy.js
@@ -1,0 +1,445 @@
+import React from "react";
+import Password from "../../../src/components/password/password.component";
+import * as stories from "../../../src/components/password/password.stories";
+import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
+import {
+  fieldHelpPreview,
+  getDataElementByValue,
+  getElement,
+  tooltipPreview,
+  commonDataElementInputPreview,
+  icon,
+} from "../../locators/index";
+import { buttonDataComponent } from "../../locators/button";
+import { verifyRequiredAsteriskForLabel } from "../../support/component-helper/common-steps";
+import { SIZE, CHARACTERS } from "../../support/component-helper/constants";
+
+const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+const transparent = "rgba(0, 0, 0, 0)";
+const colorsActionMinor500 = "rgb(51, 91, 112)";
+const colorsUtilityMajor300 = "rgb(102, 132, 148)";
+
+const PasswordComponent = ({ onChange, ...props }) => {
+  const [state, setState] = React.useState("test");
+
+  const setValue = (ev) => {
+    setState(ev.target.value);
+    if (onChange) {
+      onChange(ev);
+    }
+  };
+
+  return (
+    <Password label="Password" value={state} onChange={setValue} {...props} />
+  );
+};
+
+context("Tests for Password component", () => {
+  describe("check Password specific props", () => {
+    it("default input type should be password", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      getDataElementByValue("input")
+        .eq(0)
+        .should("have.attr", "type", "password");
+    });
+
+    it("when 'forceObscurity' is 'true', input type should be password", () => {
+      CypressMountWithProviders(<PasswordComponent forceObscurity />);
+
+      getDataElementByValue("input")
+        .eq(0)
+        .should("have.attr", "type", "password");
+    });
+
+    it("input type should change from password to text on click", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      buttonDataComponent()
+        .click()
+        .then(() => {
+          getDataElementByValue("input")
+            .eq(0)
+            .should("have.attr", "type", "text");
+        });
+    });
+
+    it("autoComplete attribute is 'off'", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      getDataElementByValue("input")
+        .eq(0)
+        .should("have.attr", "autoComplete", "off");
+    });
+  });
+
+  describe("disabled checks", () => {
+    it("input should be disabled", () => {
+      CypressMountWithProviders(<PasswordComponent disabled />);
+
+      getDataElementByValue("input")
+        .eq(0)
+        .should("be.disabled")
+        .and("have.attr", "disabled");
+    });
+
+    it("button should be disabled", () => {
+      CypressMountWithProviders(<PasswordComponent disabled />);
+
+      buttonDataComponent().should("be.disabled").and("have.attr", "disabled");
+    });
+
+    it("when 'forceObscurity' is 'true', button should be disabled", () => {
+      CypressMountWithProviders(<PasswordComponent forceObscurity />);
+
+      buttonDataComponent().should("be.disabled").and("have.attr", "disabled");
+    });
+  });
+
+  describe("check buttonMinor specific props", () => {
+    it("aria-controls attribute is correct'", () => {
+      CypressMountWithProviders(<PasswordComponent id="baz" />);
+
+      buttonDataComponent().should("have.attr", "aria-controls", "baz");
+    });
+
+    it("default iconType should be 'view'", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      icon().should("have.attr", "type", "view");
+    });
+
+    it("iconType should change from 'view' to 'hide' onClick", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      buttonDataComponent()
+        .click()
+        .then(() => {
+          icon().should("have.attr", "type", "hide");
+        });
+    });
+
+    it("default iconPosition should be 'before'", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+      icon().should("have.css", "margin-right", "8px");
+    });
+
+    it("default size should be 'small'", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+      buttonDataComponent().should("have.css", "min-height", "32px");
+    });
+
+    it("default label should be 'Show'", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      buttonDataComponent().contains("Show");
+    });
+
+    it("label should change from 'Show' to 'Hide' onClick", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      buttonDataComponent()
+        .click()
+        .then(() => {
+          buttonDataComponent().contains("Hide");
+        });
+    });
+
+    it("default aria-label should be 'Show password'", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      buttonDataComponent().should("have.attr", "aria-label", "Show password");
+    });
+
+    it("aria-label should change from 'Show password' to 'Hide password' onClick", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      buttonDataComponent()
+        .click()
+        .then(() => {
+          buttonDataComponent().should(
+            "have.attr",
+            "aria-label",
+            "Hide password"
+          );
+        });
+    });
+
+    it("buttonType is 'tertiary', when in password default styling should be correct", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      buttonDataComponent()
+        .should("be.visible")
+        .and("have.css", "background-color", transparent)
+        .and("have.css", "color", colorsActionMinor500);
+      buttonDataComponent()
+        .getDesignTokensByCssProperty("color")
+        .should(($el) => {
+          expect($el[1]).to.deep.equal("--colorsActionMinor500");
+        });
+    });
+
+    it("buttonType is 'tertiary', when in password default styling should be correct onHover", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      buttonDataComponent()
+        .realHover()
+        .then(() => {
+          buttonDataComponent()
+            .should("be.visible")
+            .and("have.css", "background-color", transparent)
+            .and("have.css", "color", colorsActionMinor500);
+          buttonDataComponent()
+            .getDesignTokensByCssProperty("color")
+            .then(($el) => {
+              expect($el[2]).to.equal("--colorsActionMinor500");
+            });
+        });
+    });
+
+    it("icon color is 'colorsActionMajorYang300'", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      icon()
+        .should("be.visible")
+        .and("have.css", "color", colorsUtilityMajor300);
+      icon()
+        .getDesignTokensByCssProperty("color")
+        .should(($el) => {
+          expect($el[3]).to.equal("--colorsUtilityMajor300");
+        });
+    });
+
+    it("icon color is 'colorsActionMajorYang300' onHover'", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      buttonDataComponent()
+        .realHover()
+        .then(() => {
+          icon()
+            .should("be.visible")
+            .and("have.css", "color", colorsUtilityMajor300);
+          icon()
+            .getDesignTokensByCssProperty("color")
+            .should(($el) => {
+              expect($el[4]).to.equal("--colorsUtilityMajor300");
+            });
+        });
+    });
+  });
+
+  describe("aria-live region checks", () => {
+    it("when password is hidden, aria-live region should contain the correct text", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      cy.get("p").contains("Your Password is currently hidden.");
+    });
+
+    it("when user clicks to show password, aria-live region should contain the correct text", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      buttonDataComponent()
+        .click()
+        .then(() => {
+          cy.get("p").contains(
+            "Your password has been shown. Focus on the password input to have it read to you, if it is safe to do so."
+          );
+        });
+    });
+
+    it("aria-live region text should be visually hidden", () => {
+      CypressMountWithProviders(<PasswordComponent />);
+
+      cy.get("p")
+        .should("be.visible")
+        .and("have.css", "border", "0px none rgba(0, 0, 0, 0.9)")
+        .and("have.css", "height", "1px")
+        .and("have.css", "margin", "-1px")
+        .and("have.css", "overflow", "hidden")
+        .and("have.css", "padding", "0px")
+        .and("have.css", "position", "absolute")
+        .and("have.css", "width", "1px");
+    });
+  });
+
+  describe("check props for Textbox props for Password component", () => {
+    it.each([
+      [SIZE.SMALL, "32px"],
+      [SIZE.MEDIUM, "40px"],
+      [SIZE.LARGE, "48px"],
+    ])(
+      "should use %s as size and render it with %s as height",
+      (size, height) => {
+        CypressMountWithProviders(<PasswordComponent size={size} />);
+
+        commonDataElementInputPreview()
+          .parent()
+          .should("have.css", "min-height", height);
+      }
+    );
+
+    it.each(specialCharacters)(
+      "should check label renders properly with %s as specific value",
+      (specificValue) => {
+        CypressMountWithProviders(<PasswordComponent label={specificValue} />);
+
+        getDataElementByValue("label")
+          .first()
+          .should("have.text", specificValue);
+      }
+    );
+
+    it.each(specialCharacters)(
+      "should check fieldHelp renders properly with %s specific value",
+      (specificValue) => {
+        CypressMountWithProviders(
+          <PasswordComponent fieldHelp={specificValue} />
+        );
+
+        fieldHelpPreview().should("have.text", specificValue);
+      }
+    );
+
+    it.each(specialCharacters)(
+      "should check tooltip renders properly with %s specific values",
+      (specificValue) => {
+        CypressMountWithProviders(
+          <PasswordComponent labelHelp={specificValue} />
+        );
+
+        getDataElementByValue("question").trigger("mouseover");
+        tooltipPreview().should("have.text", specificValue);
+      }
+    );
+
+    it("should check add icon inside of the Password component renders", () => {
+      CypressMountWithProviders(<PasswordComponent inputIcon="add" />);
+
+      getDataElementByValue("add").should("be.visible");
+    });
+
+    it("should check the Password component is disabled", () => {
+      CypressMountWithProviders(<PasswordComponent disabled />);
+
+      commonDataElementInputPreview().parent().should("have.attr", "disabled");
+      commonDataElementInputPreview().should("be.disabled");
+    });
+
+    it("should check the Password component is required", () => {
+      CypressMountWithProviders(<PasswordComponent required />);
+
+      verifyRequiredAsteriskForLabel();
+    });
+
+    it("should check the Password component has autofocus", () => {
+      CypressMountWithProviders(<PasswordComponent autoFocus />);
+
+      commonDataElementInputPreview().should("be.focused");
+    });
+
+    it.each([
+      ["right", "end"],
+      ["left", "start"],
+    ])(
+      "should use %s as labelAligment and render it with %s as css properties",
+      (alignment, cssProp) => {
+        CypressMountWithProviders(
+          <PasswordComponent labelInline labelAlign={alignment} />
+        );
+
+        getDataElementByValue("label")
+          .parent()
+          .should("have.css", "-webkit-box-pack", cssProp)
+          .and("have.css", "justify-content", `flex-${cssProp}`);
+      }
+    );
+
+    it.each(["10%", "30%", "50%", "80%", "100%"])(
+      "should check maxWidth as %s for Password component",
+      (maxWidth) => {
+        CypressMountWithProviders(<PasswordComponent maxWidth={maxWidth} />);
+
+        getDataElementByValue("input")
+          .parent()
+          .parent()
+          .should("have.css", "max-width", maxWidth);
+      }
+    );
+
+    it("when maxWidth has no value it should render as 100%", () => {
+      CypressMountWithProviders(<PasswordComponent maxWidth="" />);
+
+      getDataElementByValue("input")
+        .parent()
+        .parent()
+        .should("have.css", "max-width", "100%");
+    });
+  });
+
+  describe("Accessibility tests for Password component", () => {
+    it("should pass accessibility tests for Default story", () => {
+      CypressMountWithProviders(<stories.Default />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for AutoFocus story", () => {
+      CypressMountWithProviders(<stories.AutoFocus />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for CharacterCounter story", () => {
+      CypressMountWithProviders(<stories.CharacterCounter />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Disabled story", () => {
+      CypressMountWithProviders(<stories.Disabled />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ForceObscurity story", () => {
+      CypressMountWithProviders(<stories.ForceObscurity />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for InputHint story", () => {
+      CypressMountWithProviders(<stories.InputHint />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Margins story", () => {
+      CypressMountWithProviders(<stories.Margins />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NewDesignsValidation story", () => {
+      CypressMountWithProviders(<stories.NewDesignsValidation />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Prefix story", () => {
+      CypressMountWithProviders(<stories.Prefix />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for ReadOnly story", () => {
+      CypressMountWithProviders(<stories.ReadOnly />);
+
+      cy.checkAccessibility();
+    });
+  });
+
+  it("should have the expected border radius styling on input", () => {
+    CypressMountWithProviders(<stories.Default />);
+    getElement("input").should("have.css", "border-radius", "4px");
+  });
+});

--- a/src/components/button-minor/button-minor.component.tsx
+++ b/src/components/button-minor/button-minor.component.tsx
@@ -2,12 +2,23 @@ import React from "react";
 import StyledButtonMinor from "./button-minor.style";
 import { ButtonProps } from "../button";
 
+export interface ButtonMinorProps extends ButtonProps {
+  /** @private @ignore */
+  isInPassword?: boolean;
+}
+
 export const ButtonMinor = ({
   buttonType = "secondary",
   size = "medium",
+  isInPassword,
   ...rest
-}: ButtonProps) => (
-  <StyledButtonMinor size={size} buttonType={buttonType} {...rest} />
+}: ButtonMinorProps) => (
+  <StyledButtonMinor
+    size={size}
+    buttonType={buttonType}
+    isInPassword={isInPassword}
+    {...rest}
+  />
 );
 
 ButtonMinor.displayName = "ButtonMinor";

--- a/src/components/button-minor/button-minor.style.ts
+++ b/src/components/button-minor/button-minor.style.ts
@@ -1,5 +1,6 @@
 import styled, { css } from "styled-components";
 import Button from "../button";
+import { ButtonMinorProps } from "./button-minor.component";
 
 import StyledIcon from "../icon/icon.style";
 import StyledLoaderSquare from "../loader/loader-square.style";
@@ -16,7 +17,7 @@ function makeColors(color: string) {
   `;
 }
 
-const StyledButtonMinor = styled(Button)`
+const StyledButtonMinor = styled(Button)<ButtonMinorProps>`
   border-radius: var(--borderRadius050);
 
   ${({ children }) =>
@@ -63,6 +64,23 @@ const StyledButtonMinor = styled(Button)`
           background: var(--colorsActionMinor600);
         }
       `}
+    `}
+    
+    ${({ isInPassword, disabled }) =>
+    isInPassword &&
+    !disabled &&
+    css`
+      ${StyledIcon} {
+        color: var(--colorsUtilityMajor300);
+      }
+
+      &:hover {
+        ${StyledIcon} {
+          color: var(--colorsUtilityMajor300);
+        }
+        color: var(--colorsActionMinor500);
+        background: transparent;
+      }
     `}
 
   ${({ size }) => css`

--- a/src/components/button-minor/index.ts
+++ b/src/components/button-minor/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./button-minor.component";
-export type { ButtonProps as ButtonMinorProps } from "../button";
+export type { ButtonMinorProps } from "./button-minor.component";

--- a/src/components/password/index.ts
+++ b/src/components/password/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./password.component";
+export type { PasswordProps } from "./password.component";

--- a/src/components/password/password.component.tsx
+++ b/src/components/password/password.component.tsx
@@ -1,0 +1,62 @@
+import React, { useRef, useState } from "react";
+import { TextboxProps } from "../textbox";
+import { StyledPassword, HiddenAriaLive } from "./password.style";
+import guid from "../../__internal__/utils/helpers/guid";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
+import useLocale from "../../hooks/__internal__/useLocale";
+import ButtonMinor from "../button-minor/button-minor.component";
+
+export interface PasswordProps extends TextboxProps, TagProps {
+  /** When `true` input `type` is `password` and text is obscured. */
+  forceObscurity?: boolean;
+}
+
+export const Password = ({
+  id,
+  disabled,
+  forceObscurity = false,
+  ...rest
+}: PasswordProps) => {
+  const internalInputId = useRef(id || guid());
+  const l = useLocale();
+
+  const [passwordShown, setPasswordShown] = useState(false);
+  const visibleInput = !forceObscurity && passwordShown;
+  return (
+    <>
+      <StyledPassword
+        {...tagComponent("password", rest)}
+        data-element="styled-password-container"
+        id={internalInputId.current}
+        autoComplete="off"
+        type={visibleInput ? "text" : "password"}
+        disabled={disabled}
+        {...rest}
+      >
+        <ButtonMinor
+          aria-label={visibleInput ? "Hide password" : "Show password"}
+          aria-controls={internalInputId.current}
+          onClick={() => setPasswordShown(!passwordShown)}
+          pr={1}
+          buttonType="tertiary"
+          iconType={visibleInput ? "hide" : "view"}
+          iconPosition="before"
+          size="small"
+          disabled={forceObscurity || disabled}
+          isInPassword
+        >
+          {visibleInput ? "Hide" : "Show"}
+        </ButtonMinor>
+      </StyledPassword>
+      <HiddenAriaLive role="status" aria-live="polite">
+        {visibleInput
+          ? l.password.ariaLiveShownMessage()
+          : l.password.ariaLiveHiddenMessage()}
+      </HiddenAriaLive>
+    </>
+  );
+};
+
+export default Password;

--- a/src/components/password/password.spec.tsx
+++ b/src/components/password/password.spec.tsx
@@ -1,0 +1,260 @@
+import React from "react";
+import { mount, ReactWrapper } from "enzyme";
+import { act } from "react-dom/test-utils";
+import Password, { PasswordProps } from "./password.component";
+import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import { HiddenAriaLive } from "./password.style";
+import StyledButtonMinor from "../button-minor/button-minor.style";
+import Label from "../../__internal__/label";
+import Textbox from "../textbox";
+import ButtonMinor from "../button-minor";
+import guid from "../../__internal__/utils/helpers/guid";
+import StyledInput from "../../__internal__/input/input.style";
+
+const mockedGuid = "guid-12345";
+jest.mock("../../__internal__/utils/helpers/guid");
+
+(guid as jest.MockedFunction<typeof guid>).mockImplementation(() => mockedGuid);
+
+function renderPasswordInput(props: PasswordProps) {
+  return mount(<Password {...props} />);
+}
+
+describe("Password Input", () => {
+  let wrapper: ReactWrapper;
+  let input: ReactWrapper;
+
+  const mockEvent = {
+    nativeEvent: {
+      stopImmediatePropagation: () => {},
+    },
+  };
+
+  describe("when rendered", () => {
+    it("should have the Textbox component as it's child", () => {
+      wrapper = renderPasswordInput({});
+      expect(wrapper.find(Textbox)).toHaveLength(1);
+    });
+    it("should have the ButtonMinor component as it's child", () => {
+      wrapper = renderPasswordInput({});
+      expect(wrapper.find(ButtonMinor)).toHaveLength(1);
+    });
+    it("renders with the expected border radius styling on input", () => {
+      assertStyleMatch(
+        {
+          borderRadius: "var(--borderRadius050)",
+        },
+        mount(<Password />).find(StyledInput)
+      );
+    });
+  });
+
+  describe("required", () => {
+    beforeAll(() => {
+      wrapper = renderPasswordInput({ label: "required", required: true });
+    });
+
+    it("the required prop is passed to the input", () => {
+      input = wrapper.find("input").at(0);
+      expect(input.prop("required")).toBe(true);
+    });
+
+    it("the isRequired prop is passed to the label", () => {
+      const label = wrapper.find(Label).at(0);
+      expect(label.prop("isRequired")).toBe(true);
+    });
+  });
+
+  describe("disabled", () => {
+    beforeAll(() => {
+      wrapper = renderPasswordInput({ label: "disabled", disabled: true });
+    });
+
+    it("the disabled prop is passed to the input", () => {
+      input = wrapper.find("input").at(0);
+      expect(input.prop("disabled")).toBe(true);
+    });
+
+    it("when the disabled is passed to the input, focus is prevented", () => {
+      input = wrapper.find("input").at(0);
+      const firstFocusableElement = document.querySelector("input");
+      expect(document.activeElement).not.toBe(firstFocusableElement);
+    });
+
+    it("the disabled prop is passed to ButtonMinor", () => {
+      const button = wrapper.find(StyledButtonMinor);
+      expect(button.prop("disabled")).toBe(true);
+    });
+
+    it("when 'forceObscurity' is 'true', ButtonMinor is disabled", () => {
+      wrapper = renderPasswordInput({ forceObscurity: true });
+      const button = wrapper.find(StyledButtonMinor);
+      expect(button.prop("disabled")).toBe(true);
+    });
+
+    it("when the disabled prop is passed to ButtonMinor, focus is prevented", () => {
+      input = wrapper.find("input").at(0);
+      const firstFocusableElement = document.querySelector("input");
+      expect(document.activeElement).not.toBe(firstFocusableElement);
+    });
+  });
+
+  describe("password prop checks", () => {
+    beforeAll(() => {
+      wrapper = renderPasswordInput({});
+    });
+
+    it("default input type is 'password'", () => {
+      expect(wrapper.find("input").at(0).prop("type")).toBe("password");
+    });
+
+    it("when 'forceObscurity' is 'true' input type is 'password'", () => {
+      wrapper = renderPasswordInput({ forceObscurity: true });
+      expect(wrapper.find("input").at(0).prop("type")).toBe("password");
+    });
+
+    it("input type should change from 'password' to 'text' on click", () => {
+      wrapper = renderPasswordInput({});
+      act(() => {
+        wrapper.find(StyledButtonMinor).simulate("click", mockEvent);
+      });
+      wrapper.update();
+      expect(wrapper.find("input").at(0).prop("type")).toBe("text");
+    });
+
+    it("autoComplete attribute is 'off'", () => {
+      expect(wrapper.find("input").at(0).prop("autoComplete")).toBe("off");
+    });
+
+    it("input id should equal value of 'id' prop when passed", () => {
+      wrapper = renderPasswordInput({ id: "foo" });
+      expect(wrapper.find("input").at(0).prop("id")).toBe("foo");
+    });
+
+    it("input id should be a generated guid when 'id' prop is undefined", () => {
+      wrapper = renderPasswordInput({ id: "" });
+      expect(wrapper.find("input").at(0).prop("id")).toBe(mockedGuid);
+    });
+  });
+
+  describe("buttonMinor prop checks", () => {
+    it("aria-controls attribute is correct", () => {
+      wrapper = renderPasswordInput({ id: "foo" });
+      expect(wrapper.find(StyledButtonMinor).prop("aria-controls")).toBe("foo");
+    });
+
+    it("buttonType attribute is correct", () => {
+      expect(wrapper.find(StyledButtonMinor).prop("buttonType")).toBe(
+        "tertiary"
+      );
+    });
+
+    it("iconPosition attribute is correct", () => {
+      expect(wrapper.find(StyledButtonMinor).prop("iconPosition")).toBe(
+        "before"
+      );
+    });
+
+    it("size attribute is correct", () => {
+      expect(wrapper.find(StyledButtonMinor).prop("size")).toBe("small");
+    });
+
+    it("default label text should be 'Show'", () => {
+      expect(wrapper.find(StyledButtonMinor).text()).toBe("Show");
+    });
+
+    it("label text should change from 'Show' to 'Hide' onClick", () => {
+      act(() => {
+        wrapper.find(StyledButtonMinor).simulate("click", mockEvent);
+      });
+      expect(wrapper.find(StyledButtonMinor).text()).toBe("Hide");
+    });
+
+    it("default aria-label text should be 'Show password'", () => {
+      expect(wrapper.find(StyledButtonMinor).prop("aria-label")).toBe(
+        "Show password"
+      );
+    });
+
+    it("aria-label text should change from 'Show Password' to 'Hide password' onClick", () => {
+      act(() => {
+        wrapper.find(StyledButtonMinor).simulate("click", mockEvent);
+      });
+      expect(wrapper.find(StyledButtonMinor).prop("aria-label")).toBe(
+        "Hide password"
+      );
+    });
+
+    it("default iconType should be 'view'", () => {
+      act(() => {
+        wrapper.find(StyledButtonMinor).simulate("click", mockEvent);
+      });
+      expect(wrapper.find(StyledButtonMinor).prop("iconType")).toBe("view");
+    });
+
+    it("iconType should change from 'show' to 'hide' onClick", () => {
+      act(() => {
+        wrapper.find(StyledButtonMinor).simulate("click", mockEvent);
+      });
+      expect(wrapper.find(StyledButtonMinor).prop("iconType")).toBe("hide");
+    });
+  });
+
+  describe("buttonMinor styling checks", () => {
+    it("default styling should be correct", () => {
+      wrapper = wrapper.find(StyledButtonMinor);
+      assertStyleMatch(
+        {
+          background: "transparent",
+          color: "var(--colorsActionMinor500)",
+        },
+        wrapper
+      );
+    });
+
+    it("styling should be correct onHover", () => {
+      wrapper = wrapper.find(StyledButtonMinor);
+      assertStyleMatch(
+        {
+          background: "transparent",
+          color: "var(--colorsActionMinor500)",
+        },
+        wrapper,
+        { modifier: ":hover" }
+      );
+    });
+  });
+
+  describe("aria-live region checks", () => {
+    it("default aria-live region text should be correct", () => {
+      wrapper = renderPasswordInput({});
+      expect(wrapper.find(HiddenAriaLive).text()).toBe(
+        "Your Password is currently hidden."
+      );
+    });
+
+    it("aria-live region text should be correct onChange", () => {
+      act(() => {
+        wrapper.find(StyledButtonMinor).simulate("click", mockEvent);
+      });
+      expect(wrapper.find(HiddenAriaLive).text()).toBe(
+        "Your password has been shown. Focus on the password input to have it read to you, if it is safe to do so."
+      );
+    });
+
+    it("aria-live region should be visually hidden", () => {
+      assertStyleMatch(
+        {
+          border: "0",
+          height: "1px",
+          margin: "-1px",
+          overflow: "hidden",
+          padding: "0",
+          position: "absolute",
+          width: "1px",
+        },
+        wrapper.find(HiddenAriaLive)
+      );
+    });
+  });
+});

--- a/src/components/password/password.stories.mdx
+++ b/src/components/password/password.stories.mdx
@@ -1,0 +1,243 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import LinkTo from "@storybook/addon-links/react";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import Password from ".";
+import * as stories from "./password.stories.tsx";
+
+<Meta title="Password" 
+      parameters={{
+        info: { disable: true },
+        themeProvider: { chromatic: { theme: "sage" } },
+  }} />
+
+# Password
+
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/09ca6b-password/b/158364"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component
+</a>
+
+Provide a way for the user to securely enter a password.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import Password from "carbon-react/lib/components/password";
+```
+
+## Examples
+
+### Default
+
+**Warning - Please ensure that the `forceObscurity` prop is `true` on form submission,**
+**this will ensure browsers do not remember the inputs content.** 
+We have set the `autocomplete` attribute to `off` on the component also, but this is not widely 
+supported across different browsers and can have unpredictable results.
+
+<Canvas>
+  <Story name="default" story={stories.Default} />
+</Canvas>
+
+### with forceObscurity
+
+When `forceObscurity` is `true` the input type is set to `password` and text is obscured, whilst in this state
+the input type will not be able to be changed to `text`. To be used primarily to change the type back to
+`password` on form submission. 
+
+<Canvas>
+  <Story name="with forceObscurity" story={stories.ForceObscurity} />
+</Canvas>
+
+### with inputHint
+
+<Canvas>
+  <Story name="with inputHint" story={stories.InputHint} />
+</Canvas>
+
+### Character counter
+
+<Canvas>
+  <Story name="with character counter" story={stories.CharacterCounter} />
+</Canvas>
+
+
+### Prefix
+
+<Canvas>
+  <Story name="with prefix" story={stories.Prefix} />
+</Canvas>
+
+
+### Sizes
+
+<Canvas>
+  <Story name="with sizes" story={stories.Sizes} />
+</Canvas>
+
+### Margins
+
+<Canvas>
+  <Story name="with margins" story={stories.Margins} />
+</Canvas>
+
+### Disabled
+
+<Canvas>
+  <Story name="disabled" story={stories.Disabled} />
+</Canvas>
+
+### ReadOnly
+
+<Canvas>
+  <Story name="readOnly" story={stories.ReadOnly} />
+</Canvas>
+
+### AutoFocus
+
+<Canvas>
+  <Story name="with autoFocus" story={stories.AutoFocus} />
+</Canvas>
+
+### With labelInline
+
+<Canvas>
+  <Story name="with labelInline" story={stories.WithLabelInline} />
+</Canvas>
+
+### With label Align
+
+<Canvas>
+  <Story name="with labelAlign" story={stories.WithLabelAlign} />
+</Canvas>
+
+### With custom labelWidth and inputWidth
+
+<Canvas>
+  <Story name="with custom labelWidth and inputWidth" story={stories.WithCustomLabelWidthAndInputWidth} />
+</Canvas>
+
+### With custom maxWidth
+
+<Canvas>
+  <Story name="with custom maxWidth" story={stories.WithCustomMaxWidth} />
+</Canvas>
+
+### With fieldHelp
+
+<Canvas>
+  <Story name="with fieldHelp" story={stories.WithFieldHelp} />
+</Canvas>
+
+### With labelHelp
+
+<Canvas>
+  <Story name="with labelHelp" story={stories.WithLabelHelp} />
+</Canvas>
+
+### With required
+
+<Canvas>
+  <Story name="required" story={stories.WithRequired} />
+</Canvas>
+
+
+
+### Validations
+
+Validation status can be set by passing `error`, `warning` or `info` prop to the component
+
+Passing a string to these props will display a properly colored border along with a validation icon and tooltip - string value will be displayed as the tooltip message.
+
+Passing a boolean to these props will display only a properly colored border.
+
+For more information check our [Validations](?path=/docs/documentation-validations--page "Validations") documentation page
+
+#### As a string
+
+<Canvas>
+  <Story
+    name="validations - string - component"
+    story={stories.ValidationsAsAString}
+  />
+</Canvas>
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Canvas>
+  <Story
+    name="validations - string - with tooltipPosition overriden - component"
+    story={stories.ValidationsAsAStringWithTooltipCustom}
+  />
+</Canvas>
+
+#### As a string, displayed on label
+
+<Canvas>
+  <Story
+    name="validations - string - label"
+    story={stories.ValidationsAsAStringDisplayedOnLabel}
+  />
+</Canvas>
+
+#### New designs validation
+
+<Canvas>
+  <Story
+    name="validations - string - new design"
+    story={stories.NewDesignsValidation}
+  />
+</Canvas>
+
+It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
+
+<Canvas>
+  <Story
+    name="validations - string - with tooltipPosition overriden - label"
+    story={stories.ValidationsAsAStringWithTooltipDefault}
+  />
+</Canvas>
+
+#### As a boolean
+
+<Canvas>
+  <Story name="validations - boolean" story={stories.ValidationsAsABoolean} />
+</Canvas>
+
+## Props
+
+### Password
+
+<StyledSystemProps of={Password} noHeader margin />
+
+**Any other supplied props will be provided to the underlying HTML input element**
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "password.ariaLiveShownMessage",
+      description: "The message that screen readers will announce when password is made visible.",
+      type: "func",
+      returnType: "string",
+    },
+        {
+      name: "password.ariaLiveHiddenMessage",
+      description: "The message that screen readers will announce when password is hidden.",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/password/password.stories.tsx
+++ b/src/components/password/password.stories.tsx
@@ -1,0 +1,492 @@
+import React, { useState } from "react";
+import { ComponentStory } from "@storybook/react";
+import Password from ".";
+import Box from "../box/box.component";
+import CarbonProvider from "../carbon-provider";
+
+export const SIZES = ["small", "medium", "large"] as const;
+export const VALIDATIONS = ["error", "warning", "info"] as const;
+
+export const Default: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return <Password label="Password" value={state} onChange={setValue} />;
+};
+
+export const ForceObscurity: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password
+      forceObscurity
+      label="Password"
+      value={state}
+      onChange={setValue}
+    />
+  );
+};
+
+export const InputHint: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password
+      inputHint="Please enter a password with at least 8 characters"
+      label="Password"
+      value={state}
+      onChange={setValue}
+    />
+  );
+};
+
+export const CharacterCounter: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password
+      label="Password"
+      value={state}
+      characterLimit={10}
+      onChange={setValue}
+      enforceCharacterLimit={false}
+    />
+  );
+};
+
+export const Prefix: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password
+      prefix="prefix"
+      label="Password"
+      value={state}
+      onChange={setValue}
+    />
+  );
+};
+
+export const Sizes: ComponentStory<typeof Password> = () => {
+  const [smallState, setSmallState] = useState("Password");
+  const setSmallValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setSmallState(target.value);
+  };
+  const [mediumState, setMediumState] = useState("Password");
+  const setMediumValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setMediumState(target.value);
+  };
+  const [largeState, setLargeState] = useState("Password");
+  const setLargeValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setLargeState(target.value);
+  };
+
+  return (
+    <>
+      <Password
+        key="Password - Small"
+        label="Password - Small"
+        value={smallState}
+        size="small"
+        onChange={setSmallValue}
+        mb={2}
+      />
+      <Password
+        key="Password - Medium"
+        label="Password - Medium"
+        value={mediumState}
+        size="medium"
+        onChange={setMediumValue}
+        mb={2}
+      />
+      <Password
+        key="Password - Large"
+        label="Password - Large"
+        value={largeState}
+        size="large"
+        onChange={setLargeValue}
+        mb={2}
+      />
+    </>
+  );
+};
+
+export const Margins: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return <Password m={4} label="Password" value={state} onChange={setValue} />;
+};
+
+export const Disabled: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password disabled label="Password" value={state} onChange={setValue} />
+  );
+};
+
+export const ReadOnly: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password readOnly label="Password" value={state} onChange={setValue} />
+  );
+};
+
+export const AutoFocus: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password autoFocus label="Password" value={state} onChange={setValue} />
+  );
+};
+
+AutoFocus.parameters = { chromatic: { disable: true } };
+
+export const WithLabelInline: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password labelInline label="Password" value={state} onChange={setValue} />
+  );
+};
+
+WithLabelInline.parameters = { chromatic: { disable: true } };
+
+export const WithLabelAlign: ComponentStory<typeof Password> = () => {
+  const [leftAlignState, setLeftAlignState] = useState("Password");
+  const setVLeftAlignValue = ({
+    target,
+  }: React.ChangeEvent<HTMLInputElement>) => {
+    setLeftAlignState(target.value);
+  };
+
+  const [rightAlignState, setRightAlignState] = useState("Password");
+  const setRightAlignValue = ({
+    target,
+  }: React.ChangeEvent<HTMLInputElement>) => {
+    setRightAlignState(target.value);
+  };
+
+  return (
+    <>
+      <Password
+        label="Password"
+        labelInline
+        value={leftAlignState}
+        onChange={setVLeftAlignValue}
+        inputWidth={50}
+        key="left"
+        labelAlign="left"
+      />
+      <Password
+        label="Password"
+        labelInline
+        value={rightAlignState}
+        onChange={setRightAlignValue}
+        inputWidth={50}
+        key="right"
+        labelAlign="right"
+      />
+    </>
+  );
+};
+
+export const WithCustomLabelWidthAndInputWidth: ComponentStory<
+  typeof Password
+> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password
+      labelWidth={50}
+      inputWidth={50}
+      labelInline
+      label="Password"
+      value={state}
+      onChange={setValue}
+    />
+  );
+};
+
+export const WithCustomMaxWidth: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password
+      maxWidth="70%"
+      label="Password"
+      value={state}
+      onChange={setValue}
+    />
+  );
+};
+
+export const WithFieldHelp: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password
+      fieldHelp="help"
+      label="Password"
+      value={state}
+      onChange={setValue}
+    />
+  );
+};
+
+export const WithLabelHelp: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password
+      labelHelp="help"
+      label="Password"
+      value={state}
+      onChange={setValue}
+    />
+  );
+};
+
+export const WithRequired: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password required label="Password" value={state} onChange={setValue} />
+  );
+};
+
+export const ValidationsAsAString: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Box>
+      {VALIDATIONS.map((validationType) => (
+        <Box key={`${validationType}-string-component`}>
+          <Password
+            label="Password"
+            value={state}
+            onChange={setValue}
+            {...{ [validationType]: "Message" }}
+            mb={2}
+          />
+          <Password
+            label="Password - readOnly"
+            value="Password"
+            readOnly
+            {...{ [validationType]: "Message" }}
+            mb={2}
+          />
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export const ValidationsAsAStringWithTooltipCustom: ComponentStory<
+  typeof Password
+> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Box>
+      {VALIDATIONS.map((validationType) => (
+        <Box key={`${validationType}-string-component`}>
+          <Password
+            label="Password"
+            value={state}
+            onChange={setValue}
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="bottom"
+          />
+        </Box>
+      ))}
+    </Box>
+  );
+};
+ValidationsAsAStringWithTooltipCustom.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
+export const ValidationsAsAStringDisplayedOnLabel: ComponentStory<
+  typeof Password
+> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Box>
+      {VALIDATIONS.map((validationType) => (
+        <Box key={`${validationType}-string-label`}>
+          <Password
+            label="Password"
+            value={state}
+            onChange={setValue}
+            validationOnLabel
+            {...{ [validationType]: "Message" }}
+            mb={2}
+          />
+          <Password
+            label="Password - readOnly"
+            value="Password"
+            validationOnLabel
+            readOnly
+            {...{ [validationType]: "Message" }}
+            mb={2}
+          />
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export const NewDesignsValidation: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Box>
+      <CarbonProvider validationRedesignOptIn>
+        {(["error", "warning"] as const).map((validationType) =>
+          SIZES.map((size) => (
+            <Box style={{ width: "296px" }} key={`${validationType}-${size}`}>
+              <Password
+                m={4}
+                label={`${size} - ${validationType}`}
+                value={state}
+                onChange={setValue}
+                labelHelp="Hint text (optional)"
+                size={size}
+                {...{ [validationType]: "Message" }}
+              />
+              <Password
+                m={4}
+                label={`readOnly - ${size} - ${validationType}`}
+                value="Password"
+                size={size}
+                labelHelp="Hint text (optional)"
+                readOnly
+                {...{ [validationType]: "Message" }}
+              />
+            </Box>
+          ))
+        )}
+      </CarbonProvider>
+    </Box>
+  );
+};
+
+export const ValidationsAsAStringWithTooltipDefault: ComponentStory<
+  typeof Password
+> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Box>
+      {VALIDATIONS.map((validationType) => (
+        <Box key={`${validationType}-string-label`}>
+          <Password
+            label="Password"
+            value={state}
+            onChange={setValue}
+            validationOnLabel
+            {...{ [validationType]: "Message" }}
+            mb={2}
+            tooltipPosition="bottom"
+          />
+        </Box>
+      ))}
+    </Box>
+  );
+};
+ValidationsAsAStringWithTooltipDefault.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
+export const ValidationsAsABoolean: ComponentStory<typeof Password> = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Box>
+      {VALIDATIONS.map((validationType) => (
+        <Box key={`${validationType}-boolean-component`}>
+          <Password
+            label="Password"
+            value={state}
+            onChange={setValue}
+            {...{ [validationType]: true }}
+            mb={2}
+          />
+          <Password
+            label="Password - readOnly"
+            value="Password"
+            readOnly
+            {...{ [validationType]: true }}
+            mb={2}
+          />
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/src/components/password/password.style.ts
+++ b/src/components/password/password.style.ts
@@ -1,0 +1,12 @@
+import styled from "styled-components";
+import { PasswordProps } from "./password.component";
+import Textbox from "../textbox";
+import visuallyHiddenStyles from "../../style/utils/visually-hidden";
+
+const StyledPassword = styled(Textbox)<PasswordProps>``;
+
+const HiddenAriaLive = styled.p`
+  ${visuallyHiddenStyles}
+`;
+
+export { StyledPassword, HiddenAriaLive };

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -107,6 +107,11 @@ const enGB: Locale = {
     pageX: () => "Page",
     ofY: (count) => `of ${count}`,
   },
+  password: {
+    ariaLiveShownMessage: () =>
+      "Your password has been shown. Focus on the password input to have it read to you, if it is safe to do so.",
+    ariaLiveHiddenMessage: () => "Your Password is currently hidden.",
+  },
   progressTracker: {
     of: () => "of",
   },

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -80,6 +80,10 @@ interface Locale {
     pageX: () => string;
     ofY: (count: string | number) => string;
   };
+  password: {
+    ariaLiveShownMessage: () => string;
+    ariaLiveHiddenMessage: () => string;
+  };
   progressTracker: {
     of: () => string;
   };

--- a/src/locales/pl-pl.ts
+++ b/src/locales/pl-pl.ts
@@ -166,6 +166,11 @@ const plPL: Locale = {
     pageX: () => "Strona",
     ofY: (count) => `z ${count}`,
   },
+  password: {
+    ariaLiveShownMessage: () =>
+      "Zostało wyświetlone Twoje hasło. Skup się na haśle, aby je odczytać, jeśli jest to bezpieczne.",
+    ariaLiveHiddenMessage: () => "Twoje hasło jest obecnie ukryte.",
+  },
   progressTracker: {
     of: () => "z",
   },


### PR DESCRIPTION
fix #5614

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

![Screenshot 2023-04-18 at 10 19 01](https://user-images.githubusercontent.com/114918852/232733003-54e5574b-6564-4917-abef-44f0f9bfb087.png)

This pull request aims to add a brand-new component into Carbon named `Password`, the component will render `Textbox` but provide further capacity for obscured text control. The component will also render `ButtonMinor` as a means to change the input type, as well as built-in approaches and attributes to ensure the component is accessible and secure. 

#### Changing type

<img width="1031" alt="Screenshot 2023-04-05 at 17 20 54" src="https://user-images.githubusercontent.com/114918852/230142793-207713ff-e2b8-4683-8f27-6c11fc4e5a6b.png">

The `Password` component will surface the HTML input type attribute on `Textbox` but limit the types to be either `text` or `password`, with the latter being the default. The component will also render the `ButtonMinor` carbon component to change type back and forth, allowing users to view and obscure their password when needed. The `ButtonMinor` will utilise a label of either `Show` and `Hide` and icons `View` and `Hide` depending on the current type state of the input. Also, the `buttonType` of `ButtonMinor` will be `tertiary`, with some slight amendments to remove all hover styling changes.

#### Keeping things accessible

A hidden `p` tag element has been created but accessibly hidden, to ensure its contents are still in the accessibility tree and accessible via assistive technology but not visible to users. Within this `p` tag is a string, which will update based on the input type being either `text` or `password`. This `p` tag has also been set as an `aria-live` region, so if the contents changes, assistive technology will recognise this and inform users. 

This ensures users using assistive technology will be informed that they have either shown/hidden their password, so they can focus on the input and have the password read to them when it is safe to do so. This is a much better approach than placing the `aria-live` region on the input itself, as the password can be read out automatically without any warning.

We have also used the `aria-controls` attribute on the input and `ButtonMinor`, so there is a clear association between the two inputs.

#### Keeping things secure

We have also disabled autocompletion on the input, as an initial layer of protection against a user's password accidentally being remembered by a browser. However, we have also placed a reminder within our documentation that consumers must ensure the input type is switched back to `password` on form submission, consumers can achieve this with the `forceObscurity` prop.

#### Next steps

This pull request has been created as an established platform to receive feedback regarding the quality of the code and approach taken, as well as feedback from the Design System team and any relevant accessibility team.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

Currently, there is no established method for Carbon consumers to provide end users with a dedicated component for password input, as the `Textbox` component does not currently have any supported mechanism to change the input type.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
