### PR TITLE
test(pod): refactor for accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -77,6 +77,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("profile") &&
       !prepareUrl[0].startsWith("date-range") &&
       !prepareUrl[0].startsWith("pages") &&
+      !prepareUrl[0].startsWith("pod") &&
       !prepareUrl[0].startsWith("button-toggle-group") &&
       !prepareUrl[0].startsWith("progress-tracker") &&
       !prepareUrl[0].startsWith("portrait") &&

--- a/src/components/pod/pod-test.stories.tsx
+++ b/src/components/pod/pod-test.stories.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-import { ComponentMeta } from "@storybook/react";
 
 import Pod, { PodProps } from "./pod.component";
 import { POD_ALIGNMENTS, POD_SIZES, POD_VARIANTS } from "./pod.config";
 
 export default {
-  component: Pod,
   title: "Pod/Test",
+  includeStories: "Default",
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -53,7 +52,7 @@ export default {
     onDelete: { action: "onDelete", control: false },
     onUndo: { action: "onUndo", control: false },
   },
-} as ComponentMeta<typeof Pod>;
+};
 
 export const Default = ({ children, ...args }: PodProps) => (
   <Pod {...args}>{children}</Pod>
@@ -75,4 +74,21 @@ Default.args = {
   internalEditButton: false,
   softDelete: false,
   triggerEditOnContent: false,
+};
+
+export const PodExample = ({ ...props }) => {
+  return (
+    <Pod
+      title="Title"
+      subtitle="Subtitle"
+      footer="Footer"
+      onEdit={() => {}}
+      onDelete={() => {}}
+      {...props}
+    />
+  );
+};
+
+export const PodDefault = ({ ...props }) => {
+  return <Pod title="Title" {...props} />;
 };

--- a/src/components/pod/pod.test.js
+++ b/src/components/pod/pod.test.js
@@ -1,7 +1,8 @@
 import React from "react";
 import Pod from ".";
-import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import Content from "../content";
+import { PodExample, PodDefault } from "./pod-test.stories";
+import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
 import {
   podComponent,
@@ -28,19 +29,6 @@ import {
 } from "../../../cypress/support/component-helper/constants";
 
 const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
-
-const PodExample = ({ ...props }) => {
-  return (
-    <Pod
-      title="Title"
-      subtitle="Subtitle"
-      footer="Footer"
-      onEdit={() => {}}
-      onDelete={() => {}}
-      {...props}
-    />
-  );
-};
 
 const SoftDeleteExample = ({ ...props }) => {
   return (
@@ -372,6 +360,128 @@ context("Testing Pod component", () => {
 
       cy.contains("Content").should("have.css", "color", childrenColor);
       cy.contains("More content").should("have.css", "color", childrenColor);
+    });
+  });
+
+  describe("should render Pod component and check accessibility", () => {
+    it("should check accessibility for pod component", () => {
+      CypressMountWithProviders(<PodDefault />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each(["primary", "secondary", "tertiary", "tile", "transparent"])(
+      "should check %s variant accessibility for Pod component",
+      (variant) => {
+        CypressMountWithProviders(<PodDefault variant={variant} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["left", "center", "right"])(
+      "should check title alignment accessbility for Pod component when text is aligned to the %s",
+      (alignTitle) => {
+        CypressMountWithProviders(<PodDefault alignTitle={alignTitle} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      SIZE.EXTRASMALL,
+      SIZE.SMALL,
+      SIZE.MEDIUM,
+      SIZE.LARGE,
+      SIZE.EXTRALARGE,
+    ])(
+      "should check accessbility when size is %s for Pod component",
+      (size) => {
+        CypressMountWithProviders(<PodDefault size={size} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "when internalEditButton is %s for Pod component, check accessbility",
+      (boolVal) => {
+        CypressMountWithProviders(<PodDefault internalEditButton={boolVal} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([false, true])(
+      "should check accessibility when editContentFullWidth is %s for Pod component",
+      (boolVal) => {
+        CypressMountWithProviders(
+          <PodDefault editContentFullWidth={boolVal} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(specialCharacters)(
+      "should check accessbility when title is %s for Pod component",
+      (title) => {
+        CypressMountWithProviders(<PodDefault title={title} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(specialCharacters)(
+      "should check accessbility when subtitle is %s for Pod component",
+      (subtitle) => {
+        CypressMountWithProviders(<PodDefault subtitle={subtitle} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(specialCharacters)(
+      "should check accessibility when footer text is %s for Pod component",
+      (footerText) => {
+        CypressMountWithProviders(<PodDefault footer={footerText} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["100px", "200px", "300px"])(
+      "should check accessibility with correct height when height prop is %s for pod component",
+      (height) => {
+        CypressMountWithProviders(<PodDefault height={height} />);
+
+        cy.checkAccessibility();
+      }
+    );
+    it("should check accessibility when delete button is focused and internalEditButton prop is true", () => {
+      CypressMountWithProviders(
+        <Pod onDelete={() => {}} internalEditButton>
+          Content
+        </Pod>
+      );
+
+      podDelete().focus();
+      cy.checkAccessibility();
+    });
+
+    it.each([true, false])(
+      "should check accessbility when softDelete is %s",
+      (boolVal) => {
+        CypressMountWithProviders(<SoftDeleteExample softDelete={boolVal} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check accessbility for SoftDelete with chidlren", () => {
+      CypressMountWithProviders(<SoftDeleteExampleWithChildren />);
+
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Pod` component to use the new cypress-component-react framework for testing.
- Move testing component to the `pod-test.stories.tsx`

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `pod.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Pod` tests are not running twice.