### PR TITLE
test(checkbox): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -87,6 +87,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("box") &&
       !prepareUrl[0].startsWith("carbon-provider") &&
       !prepareUrl[0].startsWith("pill") &&
+      !prepareUrl[0].startsWith("checkbox") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/checkbox/checkbox-test.stories.tsx
+++ b/src/components/checkbox/checkbox-test.stories.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
 
-import { Checkbox, CheckboxProps } from ".";
+import { Checkbox, CheckboxProps, CheckboxGroup } from ".";
 
 export default {
   title: "Checkbox/Test",
+  includeStories: "Default",
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -93,4 +94,54 @@ Default.args = {
   ml: "0",
   adaptiveSpacingBreakpoint: undefined,
   required: false,
+};
+
+export const CheckboxComponent = ({ ...props }) => {
+  const [isChecked, setIsChecked] = useState(false);
+  return (
+    <>
+      <div
+        style={{
+          marginTop: "64px",
+        }}
+      >
+        <Checkbox
+          label="Checkbox 1"
+          checked={isChecked}
+          onChange={(e) => setIsChecked(e.target.checked)}
+          {...props}
+        />
+      </div>
+    </>
+  );
+};
+
+export const CheckboxGroupComponent = ({
+  // eslint-disable-next-line react/prop-types
+  children = "This is an example of a checkbox",
+  ...props
+}) => {
+  const [isChecked, setIsChecked] = useState(false);
+  return (
+    <div
+      style={{
+        marginTop: "64px",
+        marginLeft: "64px",
+      }}
+    >
+      <CheckboxGroup legend="Test CheckboxGroup Label" {...props}>
+        {["One", "Two", "Three"].map((label) => (
+          <Checkbox
+            label={label}
+            id={`checkbox-group-${label}`}
+            key={`checkbox-group-${label}`}
+            name={`checkbox-group-${label}`}
+            checked={isChecked}
+            onChange={(e) => setIsChecked(e.target.checked)}
+          />
+        ))}
+        {children}
+      </CheckboxGroup>
+    </div>
+  );
 };

--- a/src/components/checkbox/checkbox.test.js
+++ b/src/components/checkbox/checkbox.test.js
@@ -2,7 +2,11 @@
 import React from "react";
 import Box from "../box";
 import Checkbox from "./checkbox.component";
-import CheckboxGroup from "./checkbox-group.component";
+import {
+  CheckboxComponent,
+  CheckboxGroupComponent,
+} from "./checkbox-test.stories.tsx";
+import * as stories from "./checkbox.stories.tsx";
 import {
   checkboxComponent,
   checkboxRole,
@@ -34,63 +38,6 @@ import {
 } from "../../../cypress/support/component-helper/constants";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
-const CheckboxComponent = ({ ...props }) => {
-  const [setIsChecked] = React.useState(false);
-  return (
-    <>
-      <div
-        style={{
-          marginTop: "64px",
-        }}
-      >
-        <Checkbox
-          label="Checkbox 1"
-          checked={() => setIsChecked(false)}
-          onChange={(e) => setIsChecked(e.target.checked)}
-          {...props}
-        />
-      </div>
-    </>
-  );
-};
-
-const CheckboxGroupComponent = ({ children, ...props }) => {
-  const [setIsChecked] = React.useState(false);
-  return (
-    <div
-      style={{
-        marginTop: "64px",
-        marginLeft: "64px",
-      }}
-    >
-      <CheckboxGroup
-        id="checkboxgroup"
-        name="checkboxgroup"
-        legend="Test CheckboxGroup Label"
-        {...props}
-      >
-        <Checkbox
-          label="Required"
-          id="checkbox-Required"
-          key="checkbox-Required"
-          name="checkbox-Required"
-          checked={() => setIsChecked(false)}
-          onChange={(e) => setIsChecked(e.target.checked)}
-        />
-        <Checkbox
-          label="Optional"
-          id="checkbox-Required"
-          key="checkbox-Required"
-          name="checkbox-Required"
-          checked={() => setIsChecked(false)}
-          onChange={(e) => setIsChecked(e.target.checked)}
-        />
-
-        {children}
-      </CheckboxGroup>
-    </div>
-  );
-};
 
 context("Testing Checkbox component", () => {
   describe("should render Checkbox component", () => {
@@ -585,6 +532,229 @@ context("Testing Checkbox component", () => {
 
         verifyRequiredAsteriskForLegend();
       });
+    });
+  });
+
+  describe("should check accessibility for Checkbox", () => {
+    it.each([true, false])(
+      "should pass accessibility tests for Checkbox component with checked state set to %s",
+      (booleanValue) => {
+        CypressMountWithProviders(<CheckboxComponent checked={booleanValue} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibility tests for Checkbox component with fieldHelp", () => {
+      CypressMountWithProviders(
+        <CheckboxComponent fieldHelp="Inline fieldhelp" />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Checkbox component with inline fieldHelp", () => {
+      CypressMountWithProviders(
+        <CheckboxComponent fieldHelp="Inline fieldhelp" fieldHelpInline />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Checkbox component with help icon", () => {
+      CypressMountWithProviders(
+        <CheckboxComponent label="Label For CheckBox" labelHelp="Label Help" />
+      );
+
+      checkboxIcon()
+        .trigger("mouseover")
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for Checkbox disabled", () => {
+      CypressMountWithProviders(<CheckboxComponent disabled />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Checkbox with different sizes", () => {
+      CypressMountWithProviders(<stories.Sizes />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Checkbox reversed", () => {
+      CypressMountWithProviders(<stories.Reversed />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Checkbox with custom label width", () => {
+      CypressMountWithProviders(<stories.WithCustomLabelWidth />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each([1, 2])(
+      "should pass accessibility tests for Checkbox component with %s as labelSpacing",
+      (spacing) => {
+        CypressMountWithProviders(<CheckboxComponent labelSpacing={spacing} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibility tests for Checkbox component as a required field", () => {
+      CypressMountWithProviders(
+        <CheckboxComponent label="Required Checkbox" required />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Checkbox component with autoFocus", () => {
+      CypressMountWithProviders(<CheckboxComponent autoFocus />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each(["bottom", "left", "right", "top"])(
+      "should render CheckboxComponent component with tooltip positioned to the %s",
+      (position) => {
+        CypressMountWithProviders(
+          <Box m="250px">
+            <CheckboxComponent
+              labelHelp="Tooltip info"
+              tooltipPosition={position}
+            />
+          </Box>
+        );
+
+        checkboxIcon()
+          .trigger("mouseover")
+          .then(() => {
+            // eslint-disable-next-line no-unused-expressions
+            cy.checkAccessibility();
+          });
+      }
+    );
+
+    // FE-5382
+    describe.skip("skip", () => {
+      it("should pass accessibility tests for Checkbox component with error message", () => {
+        CypressMountWithProviders(
+          <CheckboxComponent error="Error has occurred" />
+        );
+
+        cy.checkAccessibility();
+      });
+
+      it("should pass accessibility tests for Checkbox component with warning message", () => {
+        CypressMountWithProviders(
+          <CheckboxComponent warning="Warning has occurred" />
+        );
+
+        cy.checkAccessibility();
+      });
+
+      it("should pass accessibility tests for Checkbox component with info message", () => {
+        CypressMountWithProviders(
+          <CheckboxComponent info="Info has occurred" />
+        );
+
+        cy.checkAccessibility();
+      });
+    });
+  });
+
+  describe("should check accessibility for Checkbox Group", () => {
+    it("should pass accessibility tests for CheckboxGroup component with !@#$%^*()_+-=~[];:.,?{}&\"'<> as legend", () => {
+      CypressMountWithProviders(
+        <CheckboxGroupComponent legend={CHARACTERS.SPECIALCHARACTERS} />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it.each(["left", "right"])(
+      "should pass accessibility tests for CheckboxGroup component with inline legend aligned to %s",
+      (position) => {
+        CypressMountWithProviders(
+          <CheckboxGroupComponent
+            legend="CheckBox Legend"
+            legendWidth={20}
+            legendAlign={position}
+            legendInline
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([20, 40])(
+      "should pass accessibility tests for CheckboxGroup component with inline legend width set to %s",
+      (width) => {
+        CypressMountWithProviders(
+          <CheckboxGroupComponent
+            legend="CheckBox Legend"
+            legendWidth={width}
+            legendInline
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([1, 2])(
+      "should pass accessibility tests for CheckboxGroup component with legendSpacing set to %s",
+      (spacing) => {
+        CypressMountWithProviders(
+          <CheckboxGroupComponent
+            legend="AVeryVeryLongLegend"
+            legendSpacing={spacing}
+            legendWidth="10"
+            legendInline
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibility tests for CheckboxGroup component as a required field", () => {
+      CypressMountWithProviders(
+        <CheckboxGroupComponent legend="Required CheckboxGroup" required />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    // FE-5382
+    describe.skip("skip", () => {
+      it.each(["top", "bottom", "left", "right"])(
+        "should pass accessibility tests for CheckboxGroupComponent component with tooltip positioned to the %s",
+        (position) => {
+          CypressMountWithProviders(
+            <CheckboxGroupComponent
+              legend="Checkbox Legend"
+              error="Something is wrong"
+              tooltipPosition={position}
+            />
+          );
+
+          checkboxGroupIcon()
+            .trigger("mouseover")
+            .then(() => {
+              // eslint-disable-next-line no-unused-expressions
+              cy.checkAccessibility();
+            });
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Checkbox` component to use the new cypress-component-react framework for testing.
- Refactor `checkbox.stories.test.mdx` to corresponding `*.tsx`files.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there is newly added test.file
- [ ] Check if the `checkbox.test.js` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `checkbox` tests are not running twice.