### PR TITLE
test(search): refactor accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -67,6 +67,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("heading") &&
       !prepareUrl[0].startsWith("toast") &&
       !prepareUrl[0].startsWith("sidebar") &&
+      !prepareUrl[0].startsWith("search") &&
       !prepareUrl[0].startsWith("dialog-full-screen") &&
       !prepareUrl[0].startsWith("verticalmenu") &&
       !prepareUrl[0].startsWith("message") &&

--- a/src/components/search/index.ts
+++ b/src/components/search/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./search.component";
-export type { SearchProps } from "./search.component";
+export type { SearchProps, SearchEvent } from "./search.component";

--- a/src/components/search/search-test.stories.tsx
+++ b/src/components/search/search-test.stories.tsx
@@ -5,6 +5,7 @@ import { SearchEvent } from "./search.component";
 
 export default {
   title: "Search/Test",
+  includeStories: "Default",
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -64,4 +65,17 @@ Default.args = {
   searchWidth: "",
   threshold: 3,
   variant: undefined,
+};
+
+export const SearchComponent = ({ ...props }) => {
+  const [value, setValue] = React.useState("");
+
+  return (
+    <Search
+      placeholder="Search..."
+      onChange={(e) => setValue(e.target.value)}
+      value={value}
+      {...props}
+    />
+  );
 };

--- a/src/components/search/search.stories.mdx
+++ b/src/components/search/search.stories.mdx
@@ -2,10 +2,9 @@ import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { useState } from "react";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import Search from ".";
-import Button from "../button";
-import Box from "../box";
+import * as stories from "./search.stories";
 
-<Meta title="Search" />
+<Meta title="Search" parameters={{ info: { disable: true } }}/>
 
 # Search
 
@@ -38,69 +37,37 @@ import Search from "carbon-react/lib/components/search";
 ### Search without Search Button and default width
 
 <Canvas>
-  <Story name="default" parameters={{ info: { disable: true } }}>
-    <Search placeholder="Search..." defaultValue="" />
-  </Story>
+  <Story name="default" story={stories.Default} />
 </Canvas>
 
 ### Search can be controlled
 
 <Canvas>
-  <Story name="controlled" parameters={{ info: { disable: true } }}>
-    {() => {
-      const [value, setValue] = useState("");
-      return (
-        <div>
-          <Button onClick={() => setValue("")}>Clear value</Button>
-          <Button onClick={() => setValue("test value")} ml={2}>
-            Set value
-          </Button>
-          <Search
-            id="test"
-            name="test"
-            placeholder="Search..."
-            onChange={(e) => setValue(e.target.value)}
-            value={value}
-            searchButton
-          />
-        </div>
-      );
-    }}
-  </Story>
+  <Story name="controlled" story={stories.Controlled} />
 </Canvas>
 
 ### Search with Search Button and default width
 
 <Canvas>
-  <Story name="with SearchButton" parameters={{ info: { disable: true } }}>
-    <Search defaultValue="Here is some text" searchButton />
-  </Story>
+  <Story name="with SearchButton" story={stories.WithSearchButton} />
 </Canvas>
 
 ### Search without Search Button, default width and colour background
 
 <Canvas style={{ backgroundColor: "#e6ebed" }}>
   <Story
-    name="default with colour background"
-    parameters={{ info: { disable: true }, chromatic: { disable: true } }}
-  >
-    <Search placeholder="Search..." defaultValue="" />
-  </Story>
+    name="default with colour background" 
+    story={stories.DefaultWithColourBackground} 
+  />
 </Canvas>
 
 ### Search with Search Button, default width and colour background
 
 <Canvas style={{ backgroundColor: "#e6ebed" }}>
   <Story
-    name="with SearchButton and colour background"
-    parameters={{ info: { disable: true }, chromatic: { disable: true } }}
-  >
-    <Search
-      placeholder="Search..."
-      defaultValue="Here is some text"
-      searchButton
-    />
-  </Story>
+    name="with SearchButton and colour background" 
+    story={stories.WithSearchButtonAndColourBackground} 
+  />
 </Canvas>
 
 ### Search without Search Button and custom width
@@ -108,9 +75,7 @@ import Search from "carbon-react/lib/components/search";
 In this example the `searchWidth` prop is 375px.
 
 <Canvas>
-  <Story name="custom Width using px" parameters={{ info: { disable: true } }}>
-    <Search placeholder="Search..." defaultValue="" searchWidth="375px" />
-  </Story>
+  <Story name="custom Width using px" story={stories.CustomWidthUsingPx} />
 </Canvas>
 
 ### Search with Search Button and custom width
@@ -120,10 +85,8 @@ In this example the `searchWidth` prop is 375px.
 <Canvas>
   <Story
     name="with SearchButton and Custom Width using px"
-    parameters={{ info: { disable: true } }}
-  >
-    <Search defaultValue="Here is some text" searchButton searchWidth="375px" />
-  </Story>
+    story={stories.WithSearchButtonAndCustomWidthUsingPx} 
+  />
 </Canvas>
 
 ### Search without Search Button and custom width
@@ -131,9 +94,10 @@ In this example the `searchWidth` prop is 375px.
 In this example the `searchWidth` prop is 70%.
 
 <Canvas>
-  <Story name="custom Width using %" parameters={{ info: { disable: true } }}>
-    <Search placeholder="Search..." defaultValue="" searchWidth="70%" />
-  </Story>
+  <Story 
+    name="custom Width using %" 
+    story={stories.CustomWidthUsingPercentage} 
+  />
 </Canvas>
 
 ### Search with Search Button and custom width
@@ -143,10 +107,8 @@ In this example the `searchWidth` prop is 70%.
 <Canvas>
   <Story
     name="with SearchButton and Custom Width using %"
-    parameters={{ info: { disable: true } }}
-  >
-    <Search defaultValue="Here is some text" searchButton searchWidth="70%" />
-  </Story>
+    story={stories.WithSearchButtonAndCustomWidthUsingPercentage} 
+  />
 </Canvas>
 
 ### With custom maxWidth
@@ -156,10 +118,8 @@ In this example the `maxWidth` prop is 50%.
 <Canvas>
   <Story 
     name="with custom maxWidth"
-    parameters={{ info: { disable: true } }}
-  >
-    <Search defaultValue="Here is some text" searchButton maxWidth="50%" />
-  </Story>
+    story={stories.WithCustomMaxWidth} 
+  />
 </Canvas>
 
 ### Search with Alternative Styling
@@ -167,18 +127,7 @@ In this example the `maxWidth` prop is 50%.
 In this example the `variant` prop is "dark" and `searchButton` is true.
 
 <Canvas>
-  <Story name="with Alt Styling" parameters={{ info: { disable: true } }}>
-    <Box width="700px" height="108px">
-      <div style={{ padding: "32px", backgroundColor: "#003349" }}>
-        <Search
-          placeholder="Search..."
-          defaultValue="Here is some text"
-          searchButton
-          variant="dark"
-        />
-      </div>
-    </Box>
-  </Story>
+  <Story name="with Alt Styling" story={stories.WithAltStyling} />
 </Canvas>
 
 ### Search with Alternative Styling and No Button
@@ -188,14 +137,8 @@ In this example the `variant` prop is "dark" and no search button is present.
 <Canvas>
   <Story
     name="with Alt Styling and no button"
-    parameters={{ info: { disable: true } }}
-  >
-    <Box width="700px" height="108px">
-      <div style={{ padding: "32px", backgroundColor: "#003349" }}>
-        <Search placeholder="Search..." defaultValue="" variant="dark" />
-      </div>
-    </Box>
-  </Story>
+    story={stories.WithAltStylingAndNoButton} 
+  />
 </Canvas>
 
 ### Validations
@@ -211,29 +154,7 @@ For more information check our [Validations](?path=/docs/documentation-validatio
 #### As a string
 
 <Canvas>
-  <Story name="validations - string - component">
-    {() => {
-      const [state, setState] = useState({
-        error: "<foo>",
-        warning: "<foo>",
-        info: "<foo>",
-      });
-      const handleChange = (validation) => (e) => {
-        setState({ ...state, [validation]: e.target.value });
-      };
-      return ["error", "warning", "info"].map((validationType) => (
-        <div key={`${validationType}-string-component`}>
-          <Search
-            label="Search"
-            value={state[validationType]}
-            onChange={handleChange(validationType)}
-            searchButton
-            {...{ [validationType]: "Invalid characters" }}
-          />
-        </div>
-      ));
-    }}
-  </Story>
+  <Story name="validations - string - component" story={stories.ValidationsStringComponent} />
 </Canvas>
 
 It is possible to use the `tooltipPosition` to override the default placement of tooltips rendered as part of this component.
@@ -241,59 +162,15 @@ It is possible to use the `tooltipPosition` to override the default placement of
 <Canvas>
   <Story
     name="validations - string - with tooltipPosition overriden - component"
-    parameters={{ chromatic: { disable: true } }}
-  >
-    {() => {
-      const [state, setState] = useState({
-        error: "<foo>",
-        warning: "<foo>",
-        info: "<foo>",
-      });
-      const handleChange = (validation) => (e) => {
-        setState({ ...state, [validation]: e.target.value });
-      };
-      return ["error", "warning", "info"].map((validationType) => (
-        <div key={`${validationType}-string-component`}>
-          <Search
-            label="Search"
-            value={state[validationType]}
-            onChange={handleChange(validationType)}
-            searchButton
-            {...{ [validationType]: "Invalid characters" }}
-            tooltipPosition="bottom"
-          />
-        </div>
-      ));
-    }}
-  </Story>
+    story={stories.ValidationsStringWithTooltipPositionOverridenComponent} 
+  />
+   
 </Canvas>
 
 #### As a boolean
 
 <Canvas>
-  <Story name="validations - boolean">
-    {() => {
-      const [state, setState] = useState({
-        error: "<foo>",
-        warning: "<foo>",
-        info: "<foo>",
-      });
-      const handleChange = (validation) => (e) => {
-        setState({ ...state, [validation]: e.target.value });
-      };
-      return ["error", "warning", "info"].map((validationType) => (
-        <div key={`${validationType}-boolean-component`}>
-          <Search
-            label="Search"
-            value={state[validationType]}
-            searchButton
-            onChange={handleChange(validationType)}
-            {...{ [validationType]: true }}
-          />
-        </div>
-      ));
-    }}
-  </Story>
+  <Story name="validations - boolean" story={stories.ValidationsBoolean} />
 </Canvas>
 
 ## Props

--- a/src/components/search/search.stories.tsx
+++ b/src/components/search/search.stories.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from "react";
+import { ComponentStory } from "@storybook/react";
+
+import Search, { SearchEvent } from ".";
+import Box from "../box";
+import Button from "../button";
+
+export const VALIDATIONS = ["error", "warning", "info"] as const;
+
+export const Default: ComponentStory<typeof Search> = () => {
+  return <Search placeholder="Search..." defaultValue="" />;
+};
+
+export const Controlled: ComponentStory<typeof Search> = () => {
+  const [value, setValue] = useState("");
+  return (
+    <div>
+      <Button onClick={() => setValue("")}>Clear value</Button>
+      <Button onClick={() => setValue("test value")} ml={2}>
+        Set value
+      </Button>
+      <Search
+        id="test"
+        name="test"
+        placeholder="Search..."
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+        searchButton
+      />
+    </div>
+  );
+};
+
+export const WithSearchButton: ComponentStory<typeof Search> = () => {
+  return <Search defaultValue="Here is some text" searchButton />;
+};
+
+export const DefaultWithColourBackground: ComponentStory<
+  typeof Search
+> = () => {
+  return <Search placeholder="Search..." defaultValue="" />;
+};
+export const WithSearchButtonAndColourBackground: ComponentStory<
+  typeof Search
+> = () => {
+  return (
+    <Search
+      placeholder="Search..."
+      defaultValue="Here is some text"
+      searchButton
+    />
+  );
+};
+
+export const CustomWidthUsingPx: ComponentStory<typeof Search> = () => {
+  return <Search placeholder="Search..." defaultValue="" searchWidth="375px" />;
+};
+
+export const WithSearchButtonAndCustomWidthUsingPx: ComponentStory<
+  typeof Search
+> = () => {
+  return (
+    <Search defaultValue="Here is some text" searchButton searchWidth="375px" />
+  );
+};
+
+export const CustomWidthUsingPercentage: ComponentStory<typeof Search> = () => {
+  return <Search placeholder="Search..." defaultValue="" searchWidth="70%" />;
+};
+
+export const WithSearchButtonAndCustomWidthUsingPercentage: ComponentStory<
+  typeof Search
+> = () => {
+  return (
+    <Search defaultValue="Here is some text" searchButton searchWidth="70%" />
+  );
+};
+
+export const WithCustomMaxWidth: ComponentStory<typeof Search> = () => {
+  return (
+    <Search defaultValue="Here is some text" searchButton maxWidth="50%" />
+  );
+};
+
+export const WithAltStyling: ComponentStory<typeof Search> = () => {
+  return (
+    <Box width="700px" height="108px">
+      <div
+        style={{
+          padding: "32px",
+          backgroundColor: "#003349",
+        }}
+      >
+        <Search
+          placeholder="Search..."
+          defaultValue="Here is some text"
+          searchButton
+          variant="dark"
+        />
+      </div>
+    </Box>
+  );
+};
+
+export const WithAltStylingAndNoButton: ComponentStory<typeof Search> = () => {
+  return (
+    <Box width="700px" height="108px">
+      <div
+        style={{
+          padding: "32px",
+          backgroundColor: "#003349",
+        }}
+      >
+        <Search placeholder="Search..." defaultValue="" variant="dark" />
+      </div>
+    </Box>
+  );
+};
+
+type Validation = "error" | "warning" | "info";
+
+export const ValidationsStringComponent: ComponentStory<typeof Search> = () => {
+  const [state, setState] = useState({
+    error: "<foo>",
+    warning: "<foo>",
+    info: "<foo>",
+  });
+
+  const handleChange = (validation: Validation) => (e: SearchEvent) => {
+    setState({ ...state, [validation]: e.target.value });
+  };
+
+  return (
+    <>
+      {VALIDATIONS.map((validationType) => (
+        <div key={`${validationType}-string-component`}>
+          <Search
+            value={state[validationType]}
+            onChange={handleChange(validationType)}
+            searchButton
+            {...{ [validationType]: "Invalid characters" }}
+          />
+        </div>
+      ))}
+    </>
+  );
+};
+
+export const ValidationsStringWithTooltipPositionOverridenComponent: ComponentStory<
+  typeof Search
+> = () => {
+  const [state, setState] = useState({
+    error: "<foo>",
+    warning: "<foo>",
+    info: "<foo>",
+  });
+
+  const handleChange = (validation: Validation) => (e: SearchEvent) => {
+    setState({ ...state, [validation]: e.target.value });
+  };
+
+  return (
+    <>
+      {VALIDATIONS.map((validationType) => (
+        <div key={`${validationType}-string-component`}>
+          <Search
+            value={state[validationType]}
+            onChange={handleChange(validationType)}
+            searchButton
+            {...{ [validationType]: "Invalid characters" }}
+            tooltipPosition="bottom"
+          />
+        </div>
+      ))}
+    </>
+  );
+};
+
+export const ValidationsBoolean: ComponentStory<typeof Search> = () => {
+  const [state, setState] = useState({
+    error: "<foo>",
+    warning: "<foo>",
+    info: "<foo>",
+  });
+
+  const handleChange = (validation: Validation) => (e: SearchEvent) => {
+    setState({ ...state, [validation]: e.target.value });
+  };
+
+  return (
+    <>
+      {VALIDATIONS.map((validationType) => (
+        <div key={`${validationType}-boolean-component`}>
+          <Search
+            value={state[validationType]}
+            searchButton
+            onChange={handleChange(validationType)}
+            {...{ [validationType]: true }}
+          />
+        </div>
+      ))}
+    </>
+  );
+};

--- a/src/components/search/search.test.js
+++ b/src/components/search/search.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Search from "./search.component";
+import { SearchComponent } from "./search-test.stories";
 import Box from "../box";
 
 import {
@@ -33,19 +34,6 @@ const validationTypes = [
   ["warning", VALIDATION.WARNING],
   ["info", VALIDATION.INFO],
 ];
-
-const SearchComponent = ({ ...props }) => {
-  const [value, setValue] = React.useState("");
-
-  return (
-    <Search
-      placeholder="Search..."
-      onChange={(e) => setValue(e.target.value)}
-      value={value}
-      {...props}
-    />
-  );
-};
 
 context("Test for Search component", () => {
   describe("check props for Search component", () => {
@@ -255,7 +243,7 @@ context("Test for Search component", () => {
       }
     );
 
-    it.each([["top"], ["bottom"], ["left"], ["right"]])(
+    it.each(["top", "bottom", "left", "right"])(
       "should render Search with the tooltip in the %s position",
       (tooltipPositionValue) => {
         CypressMountWithProviders(
@@ -401,6 +389,156 @@ context("Test for Search component", () => {
             // eslint-disable-next-line no-unused-expressions
             expect(callback).to.have.been.calledOnce;
           });
+      }
+    );
+  });
+  describe("Accessibility tests for Search", () => {
+    it.each(testData)(
+      "should check accessibility for Search with placeholder using %s as special characters",
+      (placeholder) => {
+        CypressMountWithProviders(
+          <SearchComponent placeholder={placeholder} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check accessibility for Search with defaultValue prop", () => {
+      CypressMountWithProviders(<Search defaultValue={testCypress} />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for Search with value prop", () => {
+      CypressMountWithProviders(<SearchComponent value={testCypress} />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for Search with id prop", () => {
+      CypressMountWithProviders(<SearchComponent id={testCypress} />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for Search with name prop", () => {
+      CypressMountWithProviders(<SearchComponent name={testCypress} />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for Search with aria-label prop", () => {
+      CypressMountWithProviders(<SearchComponent aria-label={testCypress} />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for searchButton", () => {
+      CypressMountWithProviders(<SearchComponent searchButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each(["34%", "70%"])(
+      "should check accessibility for Search with searchWidth prop set to %s",
+      (widthInPercentage) => {
+        CypressMountWithProviders(
+          <SearchComponent searchWidth={widthInPercentage} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["475px", "250px"])(
+      "should check accessibility for Search with searchWidth prop set to %s",
+      (width) => {
+        CypressMountWithProviders(<SearchComponent searchWidth={width} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["10%", "34%", "70%", "100%"])(
+      "should check accessibility for Search with maxWidth prop set to %s",
+      (widthInPercentage) => {
+        CypressMountWithProviders(
+          <SearchComponent maxWidth={widthInPercentage} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check accessibility for Search with tabIndex prop", () => {
+      CypressMountWithProviders(<SearchComponent tabIndex={-5} />);
+
+      cy.checkAccessibility();
+    });
+
+    // FE-4670
+    describe.skip("should render Search component", () => {
+      it.each(validationTypes)(
+        "should check accessibility for Search and set type to %s as string",
+        (type) => {
+          CypressMountWithProviders(
+            <SearchComponent {...{ [type]: "Message" }} />
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(["top", "bottom", "left", "right"])(
+        "should check accessibility for Search with the tooltip in the %s position",
+        (tooltipPositionValue) => {
+          CypressMountWithProviders(
+            <Box width="700px" height="108px">
+              <div
+                style={{
+                  padding: "100px",
+                }}
+              >
+                <SearchComponent
+                  error={testCypress}
+                  tooltipPosition={tooltipPositionValue}
+                />
+              </div>
+            </Box>
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(["default", "dark"])(
+        "should check accessibility for Search with variant prop set to %s",
+        (variant) => {
+          CypressMountWithProviders(
+            <Box width="700px" height="108px">
+              <div
+                style={{
+                  padding: "32px",
+                  backgroundColor: "#003349",
+                }}
+              >
+                <SearchComponent variant={variant} />
+              </div>
+            </Box>
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+    });
+
+    it.each(validationTypes)(
+      "should check accessibility for Search and set type to %s as boolean",
+      (type) => {
+        CypressMountWithProviders(<SearchComponent {...{ [type]: true }} />);
+
+        cy.checkAccessibility();
       }
     );
   });


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `Search` component to use the new cypress-component-react framework for testing.
- Move component stories to the `search.stories.tsx`
- Refactor for `search.stories.mdx` file
- Move testing component to the `search-test.stories.tsx`
- Create the `search.stories.tsx`

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there is newly added test.file
- [ ] Check if the `search.test.js` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Search` tests are not running twice.