### PR TITLE
test(pill): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -86,6 +86,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("decimal") &&
       !prepareUrl[0].startsWith("box") &&
       !prepareUrl[0].startsWith("carbon-provider") &&
+      !prepareUrl[0].startsWith("pill") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/pill/pill.test.js
+++ b/src/components/pill/pill.test.js
@@ -125,7 +125,7 @@ context("Testing Pill component", () => {
       ["#123456", hexBlue, "rgb(18, 52, 86)"],
       [green, green, "rgb(0, 123, 10)"],
     ])(
-      "should render Pill component with borderColor set to %s.",
+      "should render Pill component with borderColor set to %s",
       (colourDescription, color, output) => {
         CypressMountWithProviders(
           <PillComponent pillRole="status" borderColor={color}>
@@ -213,6 +213,113 @@ context("Testing Pill component", () => {
             expect(callback).to.have.been.calledOnce;
           });
       });
+    });
+
+    describe("Accessibility tests for Pill component", () => {
+      it.each(specialCharacters)(
+        "should render Pill using %s as label for accessibility tests",
+        (label) => {
+          CypressMountWithProviders(<PillComponent>{label}</PillComponent>);
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(["warning", "neutral", "negative", "positive"])(
+        "should render Pill component with colorVariant set to %s for accessibility tests",
+        (color) => {
+          CypressMountWithProviders(
+            <PillComponent pillRole="status" colorVariant={color}>
+              Pill
+            </PillComponent>
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it("should render Pill component with data-element for accessibility tests", () => {
+        CypressMountWithProviders(<PillComponent data-element={testData} />);
+        cy.checkAccessibility();
+      });
+
+      it("should render Pill component with data-role for accessibility tests", () => {
+        CypressMountWithProviders(<PillComponent data-role={testData} />);
+        cy.checkAccessibility();
+      });
+
+      it.each(["warning", "neutral", "negative", "positive"])(
+        "should render Pill component with color fill to %s for accessibility tests",
+        (color) => {
+          CypressMountWithProviders(
+            <PillComponent pillRole="status" colorVariant={color} fill>
+              Pill
+            </PillComponent>
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(["tag", "status"])(
+        "should render Dialog component with pillRole set to %s for accessibility tests",
+        (role) => {
+          CypressMountWithProviders(
+            <PillComponent pillRole={role}>{role}</PillComponent>
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(["20px", "100px"])(
+        "should render Pill component with maxWidth set to %s for accessibility tests",
+        (maxWidth) => {
+          CypressMountWithProviders(
+            <Pill maxWidth={maxWidth}>Pill with a long label</Pill>
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each([small, medium, large, extraLarge])(
+        "should render Pill component with size set to %s for accessibility tests",
+        (size) => {
+          CypressMountWithProviders(<Pill size={size}>Pill</Pill>);
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each([
+        [true, "break-spaces"],
+        [false, "nowrap"],
+      ])(
+        "should render Pill component with wrapText set to %s for accessibility tests",
+        (booleanState) => {
+          CypressMountWithProviders(
+            <Pill maxWidth="44px" wrapText={booleanState}>
+              Wrapped pill
+            </Pill>
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each([
+        colorsSemanticCaution500,
+        blackOpacity65,
+        brilliantGreenShade20,
+        red,
+        hexBlue,
+        green,
+      ])(
+        "should render Pill component with borderColor set to %s for accessibility tests",
+        (color) => {
+          CypressMountWithProviders(
+            <PillComponent pillRole="status" borderColor={color}>
+              Pill
+            </PillComponent>
+          );
+          cy.checkAccessibility();
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Pill` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `pill.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Pill` tests are not running twice.