### PR TITLE
test(show-edit-pod): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -85,6 +85,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("definition-list") &&
       !prepareUrl[0].startsWith("decimal") &&
       !prepareUrl[0].startsWith("box") &&
+      !prepareUrl[0].startsWith("show-edit-pod") &&
       !prepareUrl[0].startsWith("carbon-provider") &&
       !prepareUrl[0].endsWith("test")
     ) {

--- a/src/components/show-edit-pod/show-edit-pod-test.stories.js
+++ b/src/components/show-edit-pod/show-edit-pod-test.stories.js
@@ -12,6 +12,7 @@ import {
 
 export default {
   component: ShowEditPod,
+  includeStories: "Default",
   title: "ShowEditPod/Test",
   parameters: {
     info: { disable: true },
@@ -130,3 +131,38 @@ export const Default = ({
 };
 
 Default.storyName = "default";
+
+export const ShowEditPodComponent = ({ ...props }) => {
+  return (
+    <ShowEditPod
+      title="Title"
+      onEdit={() => {}}
+      onDelete={() => {}}
+      saveText="Save"
+      deleteText="Delete"
+      cancelText="Cancel"
+      editFields={<Textbox label="Field" labelInline labelAlign="right" />}
+      {...props}
+    />
+  );
+};
+
+export const ShowEditPodAccessibilityComponent = ({ ...props }) => {
+  return (
+    <ShowEditPod
+      title="Title"
+      onDelete={() => {}}
+      saveText="Save"
+      deleteText="Delete"
+      cancelText="Cancel"
+      editFields={<Textbox label="Field" labelInline labelAlign="right" />}
+      {...props}
+    />
+  );
+};
+
+export const UndoShowEditPodComponent = ({ ...props }) => {
+  return (
+    <ShowEditPod title="With borders" onUndo={() => {}} softDelete {...props} />
+  );
+};

--- a/src/components/show-edit-pod/show-edit-pod.test.js
+++ b/src/components/show-edit-pod/show-edit-pod.test.js
@@ -1,5 +1,9 @@
 import React from "react";
-import ShowEditPod from "./show-edit-pod.component";
+import {
+  ShowEditPodComponent,
+  ShowEditPodAccessibilityComponent,
+  UndoShowEditPodComponent,
+} from "./show-edit-pod-test.stories";
 import Textbox from "../textbox/textbox.component";
 import Content from "../content/content.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
@@ -26,27 +30,6 @@ import { CHARACTERS } from "../../../cypress/support/component-helper/constants"
 import { checkOutlineCss } from "../../../cypress/support/component-helper/common-steps";
 
 const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
-
-const ShowEditPodComponent = ({ ...props }) => {
-  return (
-    <ShowEditPod
-      title="Title"
-      onEdit={() => {}}
-      onDelete={() => {}}
-      saveText="Save"
-      deleteText="Delete"
-      cancelText="Cancel"
-      editFields={<Textbox label="Field" labelInline labelAlign="right" />}
-      {...props}
-    />
-  );
-};
-
-const UndoShowEditPodComponent = ({ ...props }) => {
-  return (
-    <ShowEditPod title="With borders" onUndo={() => {}} softDelete {...props} />
-  );
-};
 
 context("Testing ShowEditPod component", () => {
   describe("should render ShowEditPod component", () => {
@@ -325,6 +308,214 @@ context("Testing ShowEditPod component", () => {
             // eslint-disable-next-line no-unused-expressions
             expect(callback).to.have.been.calledOnce;
           });
+      });
+    });
+
+    describe.only("Accessibility tests for ShowEditPod component", () => {
+      it.each(["primary", "secondary", "tertiary", "tile", "transparent"])(
+        "should check %s variant for accessibility tests",
+        (variant) => {
+          CypressMountWithProviders(
+            <ShowEditPodAccessibilityComponent variant={variant} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each([true, false])(
+        "should check when border is %s for accessibility tests",
+        (boolVal) => {
+          CypressMountWithProviders(
+            <ShowEditPodAccessibilityComponent border={boolVal} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check children as %s for accessibility tests",
+        (children) => {
+          CypressMountWithProviders(
+            <ShowEditPodAccessibilityComponent>
+              {" "}
+              <Content title="Content title">{children}</Content>{" "}
+            </ShowEditPodAccessibilityComponent>
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check className as %s for accessibility tests",
+        (className) => {
+          CypressMountWithProviders(
+            <ShowEditPodAccessibilityComponent className={className} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each([
+        [true, "be.visible"],
+        [false, "not.exist"],
+      ])(
+        "should check when editing is %s for accessibility tests",
+        (boolVal) => {
+          CypressMountWithProviders(
+            <ShowEditPodAccessibilityComponent editing={boolVal} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each([false, true])(
+        "should check when softDelete is %s for accessibility tests",
+        (boolVal) => {
+          CypressMountWithProviders(
+            <UndoShowEditPodComponent softDelete={boolVal} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each([false, true])(
+        "should check when hideDeleteButtonInViewMode is %s for accessibility tests",
+        (boolVal) => {
+          CypressMountWithProviders(
+            <ShowEditPodAccessibilityComponent
+              hideDeleteButtonInViewMode={boolVal}
+            />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it("should check editFields in textbox component for accessibility tests", () => {
+        CypressMountWithProviders(
+          <ShowEditPodComponent
+            editing
+            editFields={<Textbox label="Field" />}
+          />
+        );
+        cy.checkAccessibility();
+      });
+
+      it.each(["right", "left"])(
+        "should check when buttonAlign is %s for accessibility tests",
+        (align) => {
+          CypressMountWithProviders(
+            <ShowEditPodComponent editing buttonAlign={align} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each([false, true])(
+        "should check when cancel button is %s for accessibility tests",
+        (boolVal) => {
+          CypressMountWithProviders(
+            <ShowEditPodComponent editing cancel={boolVal} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check cancelText as %s for accessibility tests",
+        (cancelText) => {
+          CypressMountWithProviders(
+            <ShowEditPodComponent editing cancelText={cancelText} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check saveText as %s for for accessibility tests",
+        (saveText) => {
+          CypressMountWithProviders(
+            <ShowEditPodComponent editing saveText={saveText} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check deleteText as %s for accessibility tests",
+        (deleteText) => {
+          CypressMountWithProviders(
+            <ShowEditPodComponent editing deleteText={deleteText} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each([false, true])(
+        "should check saving state is %s for accessibility tests",
+        (boolVal) => {
+          CypressMountWithProviders(
+            <ShowEditPodComponent editing saving={boolVal} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(specialCharacters)(
+        "should check title as %s for accessibility tests",
+        (title) => {
+          CypressMountWithProviders(
+            <ShowEditPodAccessibilityComponent title={title} />
+          );
+          cy.checkAccessibility();
+        }
+      );
+
+      it("should check transitionName for accessibility tests", () => {
+        CypressMountWithProviders(
+          <ShowEditPodAccessibilityComponent transitionName="test_cypress" />
+        );
+        cy.checkAccessibility();
+      });
+
+      describe("should check ShowEditPod events for accessibility tests", () => {
+        let callback;
+
+        beforeEach(() => {
+          callback = cy.stub();
+        });
+
+        // it("should call onEdit callback when edit button is clicked for accessibility tests", () => {
+        //   CypressMountWithProviders(<showEditPod onEdit={callback} />);
+        //   cy.checkAccessibility();
+        // });
+
+        it("should call onDelete callback when delete button is clicked for accessibility tests", () => {
+          CypressMountWithProviders(
+            <ShowEditPodComponent editing onDelete={callback} />
+          );
+          cy.checkAccessibility();
+        });
+
+        it("should call onUndo callback when undo button is clicked for accessibility tests", () => {
+          CypressMountWithProviders(
+            <UndoShowEditPodComponent onUndo={callback} />
+          );
+          cy.checkAccessibility();
+        });
+
+        it("should call onSave callback when a click event is triggered for accessibility tests", () => {
+          CypressMountWithProviders(
+            <ShowEditPodComponent editing onSave={callback} />
+          );
+          cy.checkAccessibility();
+        });
+
+        it("should call onCancel callback when a click event is triggered for accessibility tests", () => {
+          CypressMountWithProviders(
+            <ShowEditPodComponent editing onCancel={callback} />
+          );
+          cy.checkAccessibility();
+        });
       });
     });
   });


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `show-edit-pod` component to use the new cypress-component-react framework for testing.
- Move testing component to the `show-edit-pod-test.stories.tsx`

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there is newly added test.file
- [ ] Check if the `show-edit-pod.test.js` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `show-edit-pod` tests are not running twice.