### PR TITLE
fix(form): add context so children only set fieldSpacing if no custom margin set

### DIFF
--- a/src/__internal__/checkable-input/checkable-input.component.tsx
+++ b/src/__internal__/checkable-input/checkable-input.component.tsx
@@ -169,7 +169,7 @@ const CheckableInput = React.forwardRef(
         reverse={reverse}
       >
         <InputBehaviour>
-          <FormField {...formFieldProps}>
+          <FormField {...formFieldProps} my={0}>
             <StyledCheckableInput>
               <HiddenCheckableInput {...inputProps} />
               {children}

--- a/src/__internal__/fieldset/fieldset.component.tsx
+++ b/src/__internal__/fieldset/fieldset.component.tsx
@@ -8,6 +8,7 @@ import {
 } from "./fieldset.style";
 import ValidationIcon from "../validations/validation-icon.component";
 import { InputGroupBehaviour, InputGroupContext } from "../input-behaviour";
+import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
 
 export interface FieldsetProps extends MarginProps {
   /** Role */
@@ -55,36 +56,45 @@ const Fieldset = ({
   isRequired,
   blockGroupBehaviour,
   ...rest
-}: FieldsetProps) => (
-  <InputGroupBehaviour blockGroupBehaviour={blockGroupBehaviour}>
-    <StyledFieldset data-component="fieldset" m={0} {...rest}>
-      {legend && (
-        <InputGroupContext.Consumer>
-          {({ onMouseEnter, onMouseLeave }) => (
-            <StyledLegend
-              onMouseEnter={onMouseEnter}
-              onMouseLeave={onMouseLeave}
-              inline={inline}
-              width={legendWidth}
-              align={legendAlign}
-              rightPadding={legendSpacing}
-            >
-              <StyledLegendContent isRequired={isRequired}>
-                {legend}
-                <ValidationIcon
-                  error={error}
-                  warning={warning}
-                  info={info}
-                  tooltipFlipOverrides={["top", "bottom"]}
-                />
-              </StyledLegendContent>
-            </StyledLegend>
-          )}
-        </InputGroupContext.Consumer>
-      )}
-      {children}
-    </StyledFieldset>
-  </InputGroupBehaviour>
-);
+}: FieldsetProps) => {
+  const marginProps = useFormSpacing(rest);
+
+  return (
+    <InputGroupBehaviour blockGroupBehaviour={blockGroupBehaviour}>
+      <StyledFieldset
+        data-component="fieldset"
+        m={0}
+        {...marginProps}
+        {...rest}
+      >
+        {legend && (
+          <InputGroupContext.Consumer>
+            {({ onMouseEnter, onMouseLeave }) => (
+              <StyledLegend
+                onMouseEnter={onMouseEnter}
+                onMouseLeave={onMouseLeave}
+                inline={inline}
+                width={legendWidth}
+                align={legendAlign}
+                rightPadding={legendSpacing}
+              >
+                <StyledLegendContent isRequired={isRequired}>
+                  {legend}
+                  <ValidationIcon
+                    error={error}
+                    warning={warning}
+                    info={info}
+                    tooltipFlipOverrides={["top", "bottom"]}
+                  />
+                </StyledLegendContent>
+              </StyledLegend>
+            )}
+          </InputGroupContext.Consumer>
+        )}
+        {children}
+      </StyledFieldset>
+    </InputGroupBehaviour>
+  );
+};
 
 export default Fieldset;

--- a/src/__internal__/form-field/form-field.component.tsx
+++ b/src/__internal__/form-field/form-field.component.tsx
@@ -10,7 +10,6 @@ import { MarginProps } from "styled-system";
 import invariant from "invariant";
 
 import { ValidationProps } from "../validations";
-import { filterStyledSystemMarginProps } from "../../style/utils";
 import FormFieldStyle, { FieldLineStyle } from "./form-field.style";
 import Label from "../label";
 import FieldHelp from "../field-help";
@@ -18,6 +17,7 @@ import tagComponent, { TagProps } from "../utils/helpers/tags/tags";
 import { TabContext, TabContextProps } from "../../components/tabs/tab";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 import { IconType } from "../../components/icon";
+import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
 
 interface CommonFormFieldProps extends MarginProps, ValidationProps {
   /** If true, the component will be disabled */
@@ -132,7 +132,7 @@ const FormField = ({
   const { setError, setWarning, setInfo } = useContext<TabContextProps>(
     TabContext
   );
-
+  const marginProps = useFormSpacing(rest);
   const isMounted = useRef(false);
 
   useLayoutEffect(() => {
@@ -156,8 +156,6 @@ const FormField = ({
       }
     };
   }, [id, setError, setWarning, setInfo, error, warning, info]);
-
-  const marginProps = filterStyledSystemMarginProps(rest);
 
   const fieldHelp = fieldHelpContent ? (
     <FieldHelp

--- a/src/__internal__/form-spacing-provider/form-spacing-context.ts
+++ b/src/__internal__/form-spacing-provider/form-spacing-context.ts
@@ -1,0 +1,9 @@
+import React from "react";
+
+export interface FormSpacingContextProps {
+  marginBottom?: string;
+}
+
+export const FormSpacingContext = React.createContext<FormSpacingContextProps>(
+  {}
+);

--- a/src/__internal__/form-spacing-provider/form-spacing-provider.component.tsx
+++ b/src/__internal__/form-spacing-provider/form-spacing-provider.component.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import {
+  FormSpacingContext,
+  FormSpacingContextProps,
+} from "./form-spacing-context";
+
+interface FormSpacingProviderProps extends FormSpacingContextProps {
+  children: React.ReactNode;
+}
+
+const FormSpacingProvider = ({
+  marginBottom,
+  children,
+}: FormSpacingProviderProps) => (
+  <FormSpacingContext.Provider value={{ marginBottom }}>
+    {children}
+  </FormSpacingContext.Provider>
+);
+
+export default FormSpacingProvider;

--- a/src/__internal__/form-spacing-provider/index.ts
+++ b/src/__internal__/form-spacing-provider/index.ts
@@ -1,0 +1,3 @@
+export { FormSpacingContext } from "./form-spacing-context";
+export type { FormSpacingContextProps } from "./form-spacing-context";
+export { default } from "./form-spacing-provider.component";

--- a/src/components/checkbox/checkbox-group.component.tsx
+++ b/src/components/checkbox/checkbox-group.component.tsx
@@ -6,6 +6,7 @@ import Fieldset from "../../__internal__/fieldset";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import { ValidationProps } from "../../__internal__/validations";
+import FormSpacingProvider from "../../__internal__/form-spacing-provider";
 
 export interface CheckboxGroupProps extends ValidationProps, MarginProps {
   /** The content for the CheckboxGroup Legend */
@@ -72,7 +73,9 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
               info: !!info,
             }}
           >
-            {children}
+            <FormSpacingProvider marginBottom={undefined}>
+              {children}
+            </FormSpacingProvider>
           </CheckboxGroupContext.Provider>
         </StyledCheckboxGroup>
       </Fieldset>

--- a/src/components/checkbox/checkbox.component.tsx
+++ b/src/components/checkbox/checkbox.component.tsx
@@ -1,15 +1,16 @@
 import React, { useContext } from "react";
 import { MarginProps } from "styled-system";
+
 import CheckboxStyle from "./checkbox.style";
 import CheckableInput, {
   CommonCheckableInputProps,
 } from "../../__internal__/checkable-input/checkable-input.component";
 import CheckboxSvg from "./checkbox-svg.component";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
-import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import { CheckboxGroupContext } from "./checkbox-group.component";
 import Logger from "../../__internal__/utils/logger";
+import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
 
 export interface CheckboxProps extends CommonCheckableInputProps, MarginProps {
   /** Breakpoint for adaptive spacing (left margin changes to 0). Enables the adaptive behaviour when set */
@@ -72,7 +73,7 @@ export const Checkbox = React.forwardRef(
       "data-role": dataRole,
       helpAriaLabel,
       inputRef,
-      ...props
+      ...rest
     }: CheckboxProps,
     ref: React.ForwardedRef<HTMLInputElement>
   ) => {
@@ -80,11 +81,12 @@ export const Checkbox = React.forwardRef(
     const adaptiveSpacingSmallScreen = !!(
       adaptiveSpacingBreakpoint && !largeScreen
     );
+    const checkboxGroupContext = useContext(CheckboxGroupContext);
     const {
       error: contextError,
       warning: contextWarning,
       info: contextInfo,
-    } = useContext(CheckboxGroupContext);
+    } = checkboxGroupContext;
 
     if (!deprecateInputRefWarnTriggered && inputRef) {
       deprecateInputRefWarnTriggered = true;
@@ -120,8 +122,10 @@ export const Checkbox = React.forwardRef(
       labelWidth,
       tooltipPosition,
       ref: ref || inputRef,
-      ...props,
+      ...rest,
     };
+
+    const marginProps = useFormSpacing(rest);
 
     return (
       <TooltipProvider
@@ -142,7 +146,7 @@ export const Checkbox = React.forwardRef(
           fieldHelpInline={fieldHelpInline}
           reverse={reverse}
           size={size}
-          {...filterStyledSystemMarginProps(props)}
+          {...marginProps}
         >
           <CheckableInput {...inputProps}>
             <CheckboxSvg />

--- a/src/components/date-range/date-range.component.js
+++ b/src/components/date-range/date-range.component.js
@@ -255,6 +255,7 @@ const DateRange = ({
         value={{ inputRefMap, setInputRefMap: updateInputMap }}
       >
         <DateInput
+          my={0} // prevents any form spacing being applied
           {...dateProps("start")}
           onFocus={() => handleFocus("end")}
           data-element="start-date"
@@ -263,6 +264,7 @@ const DateRange = ({
           ref={startRef}
         />
         <DateInput
+          my={0} // prevents any form spacing being applied
           {...dateProps("end")}
           onFocus={() => handleFocus("start")}
           data-element="end-date"

--- a/src/components/date/date.component.js
+++ b/src/components/date/date.component.js
@@ -32,6 +32,7 @@ import DatePicker from "./__internal__/date-picker";
 import DateRangeContext from "../date-range/date-range.context";
 import useClickAwayListener from "../../hooks/__internal__/useClickAwayListener";
 import Logger from "../../__internal__/utils/logger";
+import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
@@ -358,6 +359,8 @@ const DateInput = React.forwardRef(
       return value;
     };
 
+    const marginProps = useFormSpacing(rest);
+
     return (
       <StyledDateInput
         ref={wrapperRef}
@@ -367,7 +370,7 @@ const DateInput = React.forwardRef(
         data-component={dataComponent || "date"}
         data-element={dataElement}
         data-role={dataRole}
-        {...filterStyledSystemMarginProps(rest)}
+        {...marginProps}
         applyDateRangeStyling={!!inputRefMap}
       >
         <Textbox
@@ -392,6 +395,7 @@ const DateInput = React.forwardRef(
           size={size}
           disabled={disabled}
           readOnly={readOnly}
+          m={0}
         />
         <DatePicker
           disablePortal={disablePortal}

--- a/src/components/fieldset/__snapshots__/fieldset.spec.tsx.snap
+++ b/src/components/fieldset/__snapshots__/fieldset.spec.tsx.snap
@@ -17,7 +17,9 @@ exports[`Fieldset renders correctly 1`] = `
       data-component="fieldset-style"
       inline={false}
     >
-      <Textbox />
+      <FormSpacingProvider>
+        <Textbox />
+      </FormSpacingProvider>
     </styled.div>
   </styled.fieldset>
 </ContextProvider>

--- a/src/components/fieldset/fieldset.component.tsx
+++ b/src/components/fieldset/fieldset.component.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { MarginProps } from "styled-system";
 
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
-import { filterStyledSystemMarginProps } from "../../style/utils";
 import {
   FieldsetStyle,
   LegendContainerStyle,
@@ -10,6 +9,8 @@ import {
   StyledFieldsetProps,
 } from "./fieldset.style";
 import { NewValidationContext } from "../carbon-provider/carbon-provider.component";
+import FormSpacingProvider from "../../__internal__/form-spacing-provider";
+import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
 
 export interface FieldsetProps extends StyledFieldsetProps, MarginProps {
   /** Child elements */
@@ -34,17 +35,21 @@ export const Fieldset = ({
     );
   };
 
+  const marginProps = useFormSpacing(rest);
+
   return (
     <NewValidationContext.Provider value={{ validationRedesignOptIn: false }}>
       <FieldsetStyle
         {...tagComponent("fieldset", rest)}
         {...rest}
         m={0}
-        {...filterStyledSystemMarginProps(rest)}
+        {...marginProps}
       >
         <FieldsetContentStyle data-component="fieldset-style" inline={inline}>
           {getLegend()}
-          {children}
+          <FormSpacingProvider marginBottom={undefined}>
+            {children}
+          </FormSpacingProvider>
         </FieldsetContentStyle>
       </FieldsetStyle>
     </NewValidationContext.Provider>

--- a/src/components/form/form-test.stories.tsx
+++ b/src/components/form/form-test.stories.tsx
@@ -4,6 +4,21 @@ import Button from "../button";
 import { Tab, Tabs } from "../tabs";
 import Box from "../box";
 import Textbox from "../textbox";
+import Textarea from "../textarea";
+import Fieldset from "../fieldset";
+import DateInput from "../date";
+import DateRange from "../date-range";
+import { Select, MultiSelect, Option, FilterableSelect } from "../select";
+import { RadioButton, RadioButtonGroup } from "../radio-button";
+import { Checkbox, CheckboxGroup } from "../checkbox";
+import Switch from "../switch";
+import Decimal from "../decimal";
+import Number from "../number";
+import GroupedCharacter from "../grouped-character";
+import { SimpleColorPicker, SimpleColor } from "../simple-color-picker";
+import NumeralDate from "../numeral-date";
+import Hr from "../hr";
+import InlineInputs from "../inline-inputs";
 
 export default {
   title: "Form/Test",
@@ -67,4 +82,248 @@ export const FormComponent = ({ ...props }) => {
       <Textbox label="Textbox3" />
     </Form>
   );
+};
+
+export const FormAlignmentCustomMarginsTextInputs = () => {
+  return (
+    <Form onSubmit={() => console.log("submit")} fieldSpacing={4} px="25%">
+      <Fieldset legend="Fieldset" mb={0}>
+        <Textbox
+          label="Textbox in Fieldset"
+          labelInline
+          labelAlign="right"
+          labelWidth={30}
+        />
+        <Checkbox
+          label="Checkbox in Fieldset"
+          labelAlign="right"
+          labelWidth={30}
+          labelSpacing={2}
+          reverse
+        />
+      </Fieldset>
+      <Decimal
+        label="Decimal"
+        placeholder="placeholder"
+        name="decimal"
+        labelInline
+        labelWidth={10}
+        inputWidth={30}
+        fieldHelp="This is some help text"
+        mb={0}
+      />
+      <Textbox
+        label="Textbox"
+        placeholder="placeholder"
+        name="textbox"
+        labelInline
+        labelWidth={10}
+        inputWidth={30}
+        labelSpacing={2}
+        mb={0}
+      />
+      <Number
+        label="Number"
+        placeholder="placeholder"
+        name="number"
+        labelInline
+        labelWidth={10}
+        inputWidth={30}
+        labelSpacing={2}
+        mb={0}
+      />
+      <GroupedCharacter
+        placeholder="placeholder"
+        label="GroupedCharacter"
+        name="grouped-character"
+        labelInline
+        groups={[2, 2, 3]}
+        separator="-"
+        mb={0}
+      />
+      <Textarea
+        key="input-three"
+        label="Textarea"
+        placeholder="placeholder"
+        name="textbox"
+        labelInline
+        labelWidth={10}
+        inputWidth={30}
+        mb={0}
+      />
+      <DateInput
+        name="date"
+        label="Date"
+        labelInline
+        labelWidth={10}
+        value=""
+        onChange={() => {}}
+        mb={0}
+      />
+      <DateRange
+        name="date"
+        startLabel="Start Date"
+        endLabel="End Date"
+        startDateProps={{ labelInline: true }}
+        endDateProps={{ labelInline: true }}
+        value={["", ""]}
+        onChange={() => {}}
+        mb={0}
+      />
+      <Select
+        mb={0}
+        name="simple-select"
+        id="simple-select"
+        labelInline
+        label="Simple Select"
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+        <Option text="Brown" value="4" />
+        <Option text="Green" value="5" />
+        <Option text="Orange" value="6" />
+        <Option text="Pink" value="7" />
+        <Option text="Purple" value="8" />
+        <Option text="Red" value="9" />
+        <Option text="White" value="10" />
+        <Option text="Yellow" value="11" />
+      </Select>
+      <FilterableSelect
+        mb={0}
+        name="fiterable-select"
+        id="fiterable-select"
+        labelInline
+        label="Filterable Select"
+        disablePortal
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+        <Option text="Brown" value="4" />
+        <Option text="Green" value="5" />
+        <Option text="Orange" value="6" />
+        <Option text="Pink" value="7" />
+        <Option text="Purple" value="8" />
+        <Option text="Red" value="9" />
+        <Option text="White" value="10" />
+        <Option text="Yellow" value="11" />
+      </FilterableSelect>
+      <MultiSelect
+        mb={0}
+        name="multi-select"
+        id="multi-select"
+        labelInline
+        label="Multi Select"
+        disablePortal
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+        <Option text="Brown" value="4" />
+        <Option text="Green" value="5" />
+        <Option text="Orange" value="6" />
+        <Option text="Pink" value="7" />
+        <Option text="Purple" value="8" />
+        <Option text="Red" value="9" />
+        <Option text="White" value="10" />
+        <Option text="Yellow" value="11" />
+      </MultiSelect>
+      <NumeralDate label="Numeral date" labelInline mb={0} />
+      <InlineInputs label="Inline inputs" mb={0}>
+        <Textbox />
+        <Textbox />
+        <Textbox />
+      </InlineInputs>
+      <Hr mx={1} my={0} />
+    </Form>
+  );
+};
+
+FormAlignmentCustomMarginsTextInputs.parameters = {
+  chromatic: {
+    disableSnapshot: false, // we want chromatic to capture this to catch any future regressions
+  },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const FormAlignmentCustomMarginNonTextInputs = () => {
+  return (
+    <Form onSubmit={() => console.log("submit")} fieldSpacing={4} px="25%">
+      <RadioButtonGroup
+        name="legend"
+        onChange={() => console.log("RADIO CHANGE")}
+        legend="Radio group"
+        legendInline
+        legendWidth={10}
+        legendSpacing={2}
+        mb={0}
+      >
+        <RadioButton
+          id="group-1-input-1"
+          value="group-1-input-1"
+          label="Radio Option 1"
+          labelWidth={10}
+        />
+        <RadioButton
+          id="group-1-input-2"
+          value="group-1-input-2"
+          label="Radio Option 2"
+          labelWidth={10}
+        />
+      </RadioButtonGroup>
+      <Checkbox
+        name="checkbox1"
+        onChange={() => console.log("CHECKBOX 1")}
+        label="Checkbox 1"
+        mb={0}
+      />
+      <CheckboxGroup legend="Checkbox Group" mb={0}>
+        {["One", "Two", "Three"].map((label) => (
+          <Checkbox
+            id={`checkbox-group-${label}`}
+            key={`checkbox-group-${label}`}
+            name={`checkbox-group-${label}`}
+            label={label}
+          />
+        ))}
+      </CheckboxGroup>
+      <Switch
+        name="switch"
+        label="Switch"
+        labelInline
+        onChange={() => console.log("SWITCH")}
+        labelWidth={10}
+        labelSpacing={2}
+        mb={0}
+      />
+      <SimpleColorPicker
+        name="picker-disabled-example"
+        legend="Simple Color Picker"
+        mb={0}
+      >
+        {[
+          { color: "transparent", label: "transparent" },
+          { color: "#0073C1", label: "blue" },
+          { color: "#582C83", label: "purple" },
+        ].map(({ color, label }) => (
+          <SimpleColor
+            value={color}
+            key={color}
+            aria-label={label}
+            id={color}
+            disabled
+          />
+        ))}
+      </SimpleColorPicker>
+      <Hr mx={1} my={0} />
+    </Form>
+  );
+};
+
+FormAlignmentCustomMarginNonTextInputs.parameters = {
+  chromatic: {
+    disableSnapshot: false, // we want chromatic to capture this to catch any future regressions
+  },
+  themeProvider: { chromatic: { theme: "sage" } },
 };

--- a/src/components/form/form.component.tsx
+++ b/src/components/form/form.component.tsx
@@ -12,7 +12,8 @@ import {
   StyledRightButtons,
   StyledFullWidthButtons,
 } from "./form.style";
-import { FormButtonAlignment } from "./form.config";
+import { FormButtonAlignment, formSpacing } from "./form.config";
+import FormSpacingProvider from "../../__internal__/form-spacing-provider";
 
 export interface FormProps extends SpaceProps {
   /** Alignment of buttons */
@@ -99,7 +100,9 @@ export const Form = ({
         stickyFooter={stickyFooter}
         isInModal={isInModal}
       >
-        {children}
+        <FormSpacingProvider marginBottom={formSpacing[fieldSpacing]}>
+          {children}
+        </FormSpacingProvider>
       </StyledFormContent>
       {!fullWidthButtons && renderFooter && (
         <StyledFormFooter

--- a/src/components/form/form.config.ts
+++ b/src/components/form/form.config.ts
@@ -1,2 +1,12 @@
 export const FORM_BUTTON_ALIGNMENTS = ["left", "right"] as const;
 export type FormButtonAlignment = typeof FORM_BUTTON_ALIGNMENTS[number];
+export const formSpacing = {
+  0: "var(--spacing000)",
+  1: "var(--spacing100)",
+  2: "var(--spacing200)",
+  3: "var(--spacing300)",
+  4: "var(--spacing400)",
+  5: "var(--spacing500)",
+  6: "var(--spacing600)",
+  7: "var(--spacing700)",
+};

--- a/src/components/form/form.spec.tsx
+++ b/src/components/form/form.spec.tsx
@@ -6,7 +6,7 @@ import {
   testStyledSystemSpacing,
   testStyledSystemPadding,
 } from "../../__spec_helper__/test-utils";
-import Form from "./form.component";
+import Form, { FormProps } from "./form.component";
 import {
   StyledLeftButtons,
   StyledRightButtons,
@@ -24,11 +24,21 @@ import {
 } from "./__internal__/form-summary.style";
 import Icon from "../icon";
 import Button from "../button";
+import Fieldset from "../fieldset";
 import { FieldsetStyle } from "../fieldset/fieldset.style";
 import StyledSearch from "../search/search.style";
 import Textarea from "../textarea";
+import Textbox from "../textbox";
+import { RadioButton, RadioButtonGroup } from "../radio-button";
 import StyledTextarea from "../textarea/textarea.style";
 import Dialog from "../dialog";
+import { formSpacing } from "./form.config";
+import StyledButton from "../button/button.style";
+import { StyledFieldset } from "../../__internal__/fieldset/fieldset.style";
+import { Select, Option } from "../select";
+import StyledSelect from "../select/select.style";
+import InlineInputs from "../inline-inputs";
+import StyledInlineInputs from "../inline-inputs/inline-inputs.style";
 
 jest.mock("lodash/debounce", () => jest.fn((fn) => fn));
 jest.mock("../../hooks/__internal__/useResizeObserver");
@@ -79,56 +89,122 @@ describe("Form", () => {
     });
   });
 
-  describe("When `fieldSpacing` applied", () => {
-    wrapper = mount(<StyledForm fieldSpacing={0} />);
+  describe.each<FormProps["fieldSpacing"]>([undefined, 0, 1, 2, 3, 4, 5, 6, 7])(
+    "When %s is passed to `fieldSpacing` prop",
+    (spacing) => {
+      it("applies the expected margin to the children inputs if they do not have custom values passed", () => {
+        wrapper = mount(
+          <Form fieldSpacing={spacing}>
+            <Textbox />
+            <Textarea characterLimit="50" />
+            <RadioButtonGroup name="bar">
+              <RadioButton value="1" />
+            </RadioButtonGroup>
+            <Select>
+              <Option value="1" text="text" />
+            </Select>
+            <Fieldset>
+              <Textbox />
+              <Select>
+                <Option value="1" text="text" />
+              </Select>
+            </Fieldset>
+            <InlineInputs>
+              <Textbox />
+              <Textbox />
+              <Textbox />
+            </InlineInputs>
+          </Form>
+        );
 
-    it("as default", () => {
-      assertStyleMatch(
-        {
-          marginTop: "0",
-          marginBottom: "var(--spacing300)",
-        },
-        wrapper,
-        {
-          modifier: `
-            ${FieldsetStyle}
-          `,
-        }
-      );
-    });
+        const result = {
+          marginBottom: formSpacing[spacing === undefined ? 3 : spacing],
+          marginTop: "var(--spacing000)",
+        };
 
-    it("as custom value", () => {
-      wrapper = mount(<StyledForm fieldSpacing={2} />);
-      assertStyleMatch(
-        {
-          marginTop: "0",
-          marginBottom: "var(--spacing200)",
-        },
-        wrapper,
-        {
-          modifier: `
-            ${FieldsetStyle}
-          `,
-        }
-      );
-    });
+        assertStyleMatch(result, wrapper.find(Textbox).find(StyledFormField), {
+          modifier: "&&&",
+        });
 
-    it("applies custom value to textarea with character count specified", () => {
-      wrapper = mount(
-        <StyledForm fieldSpacing={4}>
-          <Textarea label="Textarea with Character Limit" characterLimit="50" />
-        </StyledForm>
-      );
-      assertStyleMatch(
-        {
-          marginTop: "0",
-          marginBottom: "var(--spacing400)",
-        },
-        wrapper,
-        { modifier: `${StyledTextarea}` }
-      );
-    });
-  });
+        assertStyleMatch(result, wrapper.find(StyledTextarea));
+
+        assertStyleMatch(
+          result,
+          wrapper.find(RadioButtonGroup).find(StyledFieldset)
+        );
+
+        assertStyleMatch(result, wrapper.find(StyledSelect));
+
+        // does not apply form spacing to the composed input as well
+        assertStyleMatch(
+          { marginBottom: "var(--spacing000)", marginTop: "var(--spacing000)" },
+          wrapper.find(StyledSelect).find(StyledFormField),
+          { modifier: "&&&" }
+        );
+
+        assertStyleMatch(result, wrapper.find(FieldsetStyle));
+
+        // does not apply form spacing to the composed input as well
+        assertStyleMatch(
+          { marginBottom: undefined },
+          wrapper.find(FieldsetStyle).find(StyledSelect)
+        );
+
+        assertStyleMatch(result, wrapper.find(StyledInlineInputs));
+      });
+
+      it("does not apply margin to the children inputs if they have custom values passed", () => {
+        wrapper = mount(
+          <Form fieldSpacing={spacing}>
+            <Textbox my={1} />
+            <Textarea characterLimit="50" my={1} />
+            <Button my={1}>Foo</Button>
+            <RadioButtonGroup name="bar" my={1}>
+              <RadioButton value="1" />
+            </RadioButtonGroup>
+            <Select my={1}>
+              <Option value="1" text="text" />
+            </Select>
+            <Fieldset my={1}>
+              <Textbox />
+              <Select>
+                <Option value="1" text="text" />
+              </Select>
+            </Fieldset>
+            <InlineInputs my={1}>
+              <Textbox />
+              <Textbox />
+              <Textbox />
+            </InlineInputs>
+          </Form>
+        );
+
+        const result = {
+          marginBottom: "var(--spacing100)",
+          marginTop: "var(--spacing100)",
+        };
+
+        assertStyleMatch(result, wrapper.find(Textbox).find(StyledFormField), {
+          modifier: "&&&",
+        });
+
+        assertStyleMatch(result, wrapper.find(StyledTextarea));
+
+        assertStyleMatch(result, wrapper.find(StyledButton));
+
+        assertStyleMatch(
+          result,
+          wrapper.find(RadioButtonGroup).find(StyledFieldset)
+        );
+
+        assertStyleMatch(result, wrapper.find(StyledSelect));
+
+        assertStyleMatch(result, wrapper.find(FieldsetStyle));
+
+        assertStyleMatch(result, wrapper.find(StyledInlineInputs));
+      });
+    }
+  );
 
   describe("when stickyFooter prop is true", () => {
     const assertThatFooterIsSticky = () => {

--- a/src/components/form/form.stories.tsx
+++ b/src/components/form/form.stories.tsx
@@ -521,7 +521,6 @@ export const FormAlignmentExample = () => {
         legendInline
         legendWidth={10}
         legendSpacing={2}
-        mb={2}
       >
         <RadioButton
           id="group-1-input-1"
@@ -549,7 +548,6 @@ export const FormAlignmentExample = () => {
         onChange={() => console.log("RADIO CHANGE")}
         legend="Legend above"
         ml="10%"
-        mb={2}
       >
         <RadioButton
           id="group-2-input-1"

--- a/src/components/form/form.style.ts
+++ b/src/components/form/form.style.ts
@@ -2,12 +2,9 @@ import styled, { css } from "styled-components";
 
 import { space, padding } from "styled-system";
 import StyledFormField from "../../__internal__/form-field/form-field.style";
-import { StyledFieldset } from "../../__internal__/fieldset/fieldset.style";
 
 import StyledButton from "../button/button.style";
 import baseTheme from "../../style/themes/base";
-import { FieldsetStyle } from "../fieldset/fieldset.style";
-import StyledInlineInputs from "../inline-inputs/inline-inputs.style";
 import { FormButtonAlignment } from "./form.config";
 import StyledSearch from "../search/search.style";
 import StyledTextarea from "../textarea/textarea.style";
@@ -77,18 +74,6 @@ StyledFormFooter.defaultProps = {
   theme: baseTheme,
 };
 
-const formBottomMargins = (fieldSpacing: number) =>
-  ({
-    0: "var(--spacing000)",
-    1: "var(--spacing100)",
-    2: "var(--spacing200)",
-    3: "var(--spacing300)",
-    4: "var(--spacing400)",
-    5: "var(--spacing500)",
-    6: "var(--spacing600)",
-    7: "var(--spacing700)",
-  }[fieldSpacing]);
-
 // Accounts for height of the header of Modal parent, the height form footer and some additional spacing
 const HEIGHT_SPACING = 216;
 
@@ -109,29 +94,11 @@ export const StyledForm = styled.form<StyledFormProps>`
 
   ${({ fieldSpacing }) =>
     css`
-      &
-        ${StyledTextarea},
-        ${StyledFormField},
-        ${StyledFieldset},
-        ${FieldsetStyle},
-        > ${StyledButton} {
-        margin-top: 0;
-        margin-bottom: ${formBottomMargins(fieldSpacing)};
-      }
-
       ${StyledTextarea}
       ${StyledFormField} {
         margin-bottom: 4px;
       }
-
-      ${StyledInlineInputs} {
-        ${StyledFormField} {
-          margin-bottom: 0;
-        }
-
-        margin-bottom: ${formBottomMargins(fieldSpacing)};
-      }
-    `}  
+    `}
 
   ${StyledSearch} ${StyledFormField} {
     margin-bottom: 0px;

--- a/src/components/inline-inputs/inline-inputs.component.tsx
+++ b/src/components/inline-inputs/inline-inputs.component.tsx
@@ -7,10 +7,10 @@ import StyledInlineInputs, {
   StyledContentContainerProps,
   StyledInlineInputsProps,
 } from "./inline-inputs.style";
-
+import FormSpacingProvider from "../../__internal__/form-spacing-provider";
 import createGuid from "../../__internal__/utils/helpers/guid";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
-import { filterStyledSystemMarginProps } from "../../style/utils";
+import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
 
 interface InlineInputsContextProps {
   ariaLabelledBy?: string;
@@ -99,7 +99,7 @@ const InlineInputs = ({
     );
   }
 
-  const marginProps = filterStyledSystemMarginProps(rest);
+  const marginProps = useFormSpacing(rest);
 
   return (
     <StyledInlineInputs
@@ -116,7 +116,9 @@ const InlineInputs = ({
         data-element="inline-inputs-container"
         inputWidth={inputWidth}
       >
-        {columnWrapper(children, gutter, label ? labelId.current : undefined)}
+        <FormSpacingProvider marginBottom={undefined}>
+          {columnWrapper(children, gutter, label ? labelId.current : undefined)}
+        </FormSpacingProvider>
       </StyledContentContainer>
     </StyledInlineInputs>
   );

--- a/src/components/inline-inputs/inline-inputs.component.tsx
+++ b/src/components/inline-inputs/inline-inputs.component.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from "react";
+import { MarginProps } from "styled-system";
 import Label from "../../__internal__/label";
 import StyledInlineInputs, {
   StyledContentContainer,
@@ -9,6 +10,7 @@ import StyledInlineInputs, {
 
 import createGuid from "../../__internal__/utils/helpers/guid";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
+import { filterStyledSystemMarginProps } from "../../style/utils";
 
 interface InlineInputsContextProps {
   ariaLabelledBy?: string;
@@ -25,7 +27,8 @@ type GutterOptions =
   | "extra-large";
 
 export interface InlineInputsProps
-  extends StyledContentContainerProps,
+  extends MarginProps,
+    StyledContentContainerProps,
     StyledInlineInputsProps {
   /** Breakpoint for adaptive label (inline label change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint?: number;
@@ -72,6 +75,7 @@ const InlineInputs = ({
   labelInline = true,
   labelWidth,
   required,
+  ...rest
 }: InlineInputsProps) => {
   const labelId = useRef(createGuid());
   const largeScreen = useIsAboveBreakpoint(adaptiveLabelBreakpoint);
@@ -95,6 +99,8 @@ const InlineInputs = ({
     );
   }
 
+  const marginProps = filterStyledSystemMarginProps(rest);
+
   return (
     <StyledInlineInputs
       gutter={gutter}
@@ -102,6 +108,7 @@ const InlineInputs = ({
       className={className}
       labelWidth={labelWidth}
       labelInline={inlineLabel}
+      {...marginProps}
     >
       {renderLabel()}
       <StyledContentContainer

--- a/src/components/inline-inputs/inline-inputs.spec.tsx
+++ b/src/components/inline-inputs/inline-inputs.spec.tsx
@@ -7,6 +7,7 @@ import InlineInputs, { InlineInputsProps } from "./inline-inputs.component";
 import {
   assertStyleMatch,
   mockMatchMedia,
+  testStyledSystemMargin,
 } from "../../__spec_helper__/test-utils";
 import { StyledLabelContainer } from "../../__internal__/label/label.style";
 import StyledInlineInputs, {
@@ -33,6 +34,8 @@ function render(props: InlineInputsProps = {}) {
 
 describe("Inline Inputs", () => {
   let wrapper: ReactWrapper;
+
+  testStyledSystemMargin((props) => <InlineInputs {...props} />);
 
   describe("when a className prop is passed in", () => {
     it("renders with main class", () => {

--- a/src/components/inline-inputs/inline-inputs.spec.tsx
+++ b/src/components/inline-inputs/inline-inputs.spec.tsx
@@ -16,6 +16,7 @@ import StyledInlineInputs, {
 } from "./inline-inputs.style";
 import InputPresentation from "../../__internal__/input/input-presentation.style";
 import guid from "../../__internal__/utils/helpers/guid";
+import FormSpacingProvider from "../../__internal__/form-spacing-provider";
 
 jest.mock("../../__internal__/utils/helpers/guid");
 const mockedGuid = "guid-12345";
@@ -213,6 +214,7 @@ describe("Inline Inputs", () => {
       expect(
         mount(<InlineInputs />)
           .find(StyledContentContainer)
+          .find(FormSpacingProvider)
           .prop("children")
       ).toBe(null);
     });

--- a/src/components/inline-inputs/inline-inputs.stories.mdx
+++ b/src/components/inline-inputs/inline-inputs.stories.mdx
@@ -1,4 +1,5 @@
-import { Meta, ArgsTable, Canvas, Story } from "@storybook/addon-docs";
+import { Meta, Canvas, Story } from "@storybook/addon-docs";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import InlineInputs from ".";
 import Textbox from "../textbox";
 import Decimal from "../decimal";
@@ -139,4 +140,4 @@ import InlineInputs from "carbon-react/lib/components/inline-inputs";
 
 ### InlineInputs
 
-<ArgsTable of={InlineInputs} />
+<StyledSystemProps of={InlineInputs} noHeader margin />

--- a/src/components/inline-inputs/inline-inputs.style.ts
+++ b/src/components/inline-inputs/inline-inputs.style.ts
@@ -1,6 +1,6 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
 import InputPresentation from "../../__internal__/input/input-presentation.style";
-
 import { StyledLabelContainer } from "../../__internal__/label/label.style";
 import baseTheme from "../../style/themes/base";
 import { InlineInputsProps } from "./inline-inputs.component";
@@ -73,6 +73,8 @@ const StyledContentContainer = styled.div<InlineInputsProps>`
 `;
 
 const StyledInlineInputs = styled.div<InlineInputsProps>`
+  ${margin}
+
   display: ${({ labelInline }) => (labelInline ? `flex` : `block`)};
   align-items: center;
 

--- a/src/components/multi-action-button/multi-action-button.component.tsx
+++ b/src/components/multi-action-button/multi-action-button.component.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useRef, useMemo } from "react";
 import { WidthProps } from "styled-system";
+
 import useClickAwayListener from "../../hooks/__internal__/useClickAwayListener";
 import { SplitButtonProps } from "../split-button";
 import {
@@ -149,6 +150,8 @@ export const MultiActionButton = ({
     setShowAdditionalButtons(false);
   }, []);
 
+  const marginProps = filterStyledSystemMarginProps(rest);
+
   return (
     <StyledMultiActionButton
       aria-haspopup="true"
@@ -160,7 +163,7 @@ export const MultiActionButton = ({
       data-role={dataRole}
       displayed={showAdditionalButtons}
       width={width}
-      {...filterStyledSystemMarginProps(rest)}
+      {...marginProps}
     >
       <Button
         aria-haspopup="true"

--- a/src/components/numeral-date/numeral-date.component.tsx
+++ b/src/components/numeral-date/numeral-date.component.tsx
@@ -16,6 +16,7 @@ import { InputGroupBehaviour } from "../../__internal__/input-behaviour";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import { NewValidationContext } from "../carbon-provider/carbon-provider.component";
 import NumeralDateContext from "./numeral-date-context";
+import FormSpacingProvider from "../../__internal__/form-spacing-provider";
 
 export const ALLOWED_DATE_FORMATS = [
   ["dd", "mm", "yyyy"],
@@ -406,43 +407,45 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
                     isEnd={isEnd}
                     hasValidationIcon={hasValidationIcon}
                   >
-                    <Textbox
-                      {...(index === 0 && { id: uniqueId })}
-                      disabled={disabled}
-                      readOnly={readOnly}
-                      placeholder={datePart}
-                      value={dateValue[datePart as keyof NumeralDateObject]}
-                      onChange={(e) =>
-                        handleChange(e, datePart as keyof NumeralDateObject)
-                      }
-                      ref={(element) => {
-                        refs.current[index] = element;
-                        if (!inputRef) {
-                          return;
+                    <FormSpacingProvider marginBottom={undefined}>
+                      <Textbox
+                        {...(index === 0 && { id: uniqueId })}
+                        disabled={disabled}
+                        readOnly={readOnly}
+                        placeholder={datePart}
+                        value={dateValue[datePart as keyof NumeralDateObject]}
+                        onChange={(e) =>
+                          handleChange(e, datePart as keyof NumeralDateObject)
                         }
-                        if (typeof inputRef === "function") {
-                          inputRef(element);
-                        } else {
-                          inputRef.current = element;
+                        ref={(element) => {
+                          refs.current[index] = element;
+                          if (!inputRef) {
+                            return;
+                          }
+                          if (typeof inputRef === "function") {
+                            inputRef(element);
+                          } else {
+                            inputRef.current = element;
+                          }
+                        }}
+                        onBlur={() =>
+                          handleBlur(datePart as keyof NumeralDateObject)
                         }
-                      }}
-                      onBlur={() =>
-                        handleBlur(datePart as keyof NumeralDateObject)
-                      }
-                      error={!!internalError}
-                      warning={!!internalWarning}
-                      info={!!info}
-                      {...(required && { required })}
-                      {...(isEnd &&
-                        !validationRedesignOptIn &&
-                        !validationOnLabel && {
-                          error: internalError,
-                          warning: internalWarning,
-                          info,
-                        })}
-                      size={size}
-                      tooltipPosition={tooltipPosition}
-                    />
+                        error={!!internalError}
+                        warning={!!internalWarning}
+                        info={!!info}
+                        {...(required && { required })}
+                        {...(isEnd &&
+                          !validationRedesignOptIn &&
+                          !validationOnLabel && {
+                            error: internalError,
+                            warning: internalWarning,
+                            info,
+                          })}
+                        size={size}
+                        tooltipPosition={tooltipPosition}
+                      />
+                    </FormSpacingProvider>
                   </StyledDateField>
                 </NumeralDateContext.Provider>
               );

--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -2,10 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import PropTypes from "prop-types";
 import invariant from "invariant";
 
-import {
-  filterStyledSystemMarginProps,
-  filterOutStyledSystemSpacingProps,
-} from "../../../style/utils";
+import { filterOutStyledSystemSpacingProps } from "../../../style/utils";
 import SelectTextbox, {
   formInputPropTypes,
 } from "../select-textbox/select-textbox.component";
@@ -17,6 +14,7 @@ import isExpectedOption from "../utils/is-expected-option";
 import isNavigationKey from "../utils/is-navigation-key";
 import Logger from "../../../__internal__/utils/logger";
 import useStableCallback from "../../../hooks/__internal__/useStableCallback";
+import useFormSpacing from "../../../hooks/__internal__/useFormSpacing";
 
 let deprecateInputRefWarnTriggered = false;
 
@@ -553,6 +551,8 @@ const FilterableSelect = React.forwardRef(
       </FilterableSelectList>
     );
 
+    const marginProps = useFormSpacing(textboxProps);
+
     return (
       <StyledSelect
         hasTextCursor
@@ -562,7 +562,7 @@ const FilterableSelect = React.forwardRef(
         data-role={dataRole}
         data-element={dataElement}
         isOpen={isOpen}
-        {...filterStyledSystemMarginProps(textboxProps)}
+        {...marginProps}
       >
         <div ref={containerRef}>
           <SelectTextbox

--- a/src/components/select/multi-select/multi-select.component.js
+++ b/src/components/select/multi-select/multi-select.component.js
@@ -8,10 +8,7 @@ import React, {
 import PropTypes from "prop-types";
 import invariant from "invariant";
 
-import {
-  filterStyledSystemMarginProps,
-  filterOutStyledSystemSpacingProps,
-} from "../../../style/utils";
+import { filterOutStyledSystemSpacingProps } from "../../../style/utils";
 import SelectTextbox, {
   formInputPropTypes,
 } from "../select-textbox/select-textbox.component";
@@ -29,6 +26,7 @@ import isExpectedValue from "../utils/is-expected-value";
 import isNavigationKey from "../utils/is-navigation-key";
 import Logger from "../../../__internal__/utils/logger";
 import useStableCallback from "../../../hooks/__internal__/useStableCallback";
+import useFormSpacing from "../../../hooks/__internal__/useFormSpacing";
 
 let deprecateInputRefWarnTriggered = false;
 
@@ -552,6 +550,8 @@ const MultiSelect = React.forwardRef(
       </FilterableSelectList>
     );
 
+    const marginProps = useFormSpacing(textboxProps);
+
     return (
       <StyledSelectMultiSelect
         disabled={disabled}
@@ -562,7 +562,7 @@ const MultiSelect = React.forwardRef(
         data-role={dataRole}
         data-element={dataElement}
         isOpen={isOpen}
-        {...filterStyledSystemMarginProps(textboxProps)}
+        {...marginProps}
       >
         <div ref={containerRef}>
           <StyledAccessibilityLabelContainer

--- a/src/components/select/select-textbox/select-textbox.component.js
+++ b/src/components/select/select-textbox/select-textbox.component.js
@@ -163,6 +163,7 @@ const SelectTextbox = React.forwardRef(
         }
         {...getInputAriaAttributes()}
         {...getTextboxProps()}
+        my={0} // prevents any form spacing being applied
       >
         {!hasTextCursor && renderSelectText()}
       </Textbox>

--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -9,10 +9,7 @@ import PropTypes from "prop-types";
 import propTypes from "@styled-system/prop-types";
 import invariant from "invariant";
 
-import {
-  filterStyledSystemMarginProps,
-  filterOutStyledSystemSpacingProps,
-} from "../../../style/utils";
+import { filterOutStyledSystemSpacingProps } from "../../../style/utils";
 import StyledSelect from "../select.style";
 import SelectTextbox, {
   formInputPropTypes,
@@ -23,6 +20,7 @@ import getNextChildByText from "../utils/get-next-child-by-text";
 import isExpectedOption from "../utils/is-expected-option";
 import isNavigationKey from "../utils/is-navigation-key";
 import Logger from "../../../__internal__/utils/logger";
+import useFormSpacing from "../../../hooks/__internal__/useFormSpacing";
 
 let deprecateInputRefWarnTriggered = false;
 
@@ -431,6 +429,8 @@ const SimpleSelect = React.forwardRef(
       </SelectList>
     );
 
+    const marginProps = useFormSpacing(props);
+
     return (
       <StyledSelect
         transparent={transparent}
@@ -440,7 +440,7 @@ const SimpleSelect = React.forwardRef(
         data-role={dataRole}
         data-element={dataElement}
         isOpen={isOpen}
-        {...filterStyledSystemMarginProps(props)}
+        {...marginProps}
       >
         <div ref={containerRef}>
           <SelectTextbox

--- a/src/components/split-button/split-button.component.tsx
+++ b/src/components/split-button/split-button.component.tsx
@@ -245,6 +245,7 @@ export const SplitButton = ({
   }
 
   const handleClick = useClickAwayListener(hideButtons);
+  const marginProps = filterStyledSystemMarginProps(rest);
 
   return (
     <StyledSplitButton
@@ -253,7 +254,7 @@ export const SplitButton = ({
       onClick={handleClick}
       ref={splitButtonNode}
       {...componentTags()}
-      {...filterStyledSystemMarginProps(rest)}
+      {...marginProps}
     >
       {renderMainButton()}
       {renderAdditionalButtons()}

--- a/src/components/switch/switch.component.tsx
+++ b/src/components/switch/switch.component.tsx
@@ -8,8 +8,8 @@ import CheckableInput, {
 import SwitchSlider from "./__internal__/switch-slider.component";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
-import { filterStyledSystemMarginProps } from "../../style/utils";
 import Logger from "../../__internal__/utils/logger";
+import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
 
 export interface SwitchProps extends CommonCheckableInputProps, MarginProps {
   /** Identifier used for testing purposes, applied to the root element of the component. */
@@ -108,6 +108,8 @@ export const Switch = React.forwardRef(
     const shouldValidationBeOnLabel =
       labelInline && !reverse ? true : validationOnLabel;
 
+    const marginProps = useFormSpacing(rest);
+
     const switchStyleProps = {
       "data-component": dataComponent,
       "data-role": dataRole,
@@ -118,7 +120,7 @@ export const Switch = React.forwardRef(
       labelSpacing,
       reverse: !reverse, // switched to preserve backward compatibility
       size,
-      ...filterStyledSystemMarginProps(rest),
+      ...marginProps,
     };
 
     const switchSliderProps = {

--- a/src/components/textarea/textarea.component.tsx
+++ b/src/components/textarea/textarea.component.tsx
@@ -9,7 +9,6 @@ import useCharacterCount from "../../hooks/__internal__/useCharacterCount";
 
 import Input from "../../__internal__/input/input.component";
 import { InputBehaviour } from "../../__internal__/input-behaviour";
-import { filterStyledSystemMarginProps } from "../../style/utils";
 import InputIconToggle from "../../__internal__/input-icon-toggle";
 import guid from "../../__internal__/utils/helpers/guid";
 import StyledTextarea, { MIN_HEIGHT } from "./textarea.style";
@@ -20,6 +19,7 @@ import { ErrorBorder, StyledHintText } from "../textbox/textbox.style";
 import ValidationMessage from "../../__internal__/validation-message";
 import Box from "../box";
 import Logger from "../../__internal__/utils/logger";
+import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
 
 // TODO: Change characterLimit type to number - batch with other breaking changes
 export interface TextareaProps
@@ -159,7 +159,7 @@ export const Textarea = React.forwardRef(
       "data-role": dataRole,
       helpAriaLabel,
       inputRef,
-      ...props
+      ...rest
     }: TextareaProps,
     ref: React.ForwardedRef<HTMLTextAreaElement>
   ) => {
@@ -301,7 +301,7 @@ export const Textarea = React.forwardRef(
           id={id}
           as="textarea"
           inputRef={inputRef}
-          {...props}
+          {...rest}
         />
         {children}
         <InputIconToggle
@@ -320,6 +320,8 @@ export const Textarea = React.forwardRef(
       </InputPresentation>
     );
 
+    const marginProps = useFormSpacing(rest);
+
     return (
       <TooltipProvider
         tooltipPosition={tooltipPosition}
@@ -332,7 +334,7 @@ export const Textarea = React.forwardRef(
             data-role={dataRole}
             data-element={dataElement}
             hasIcon={hasIconInside}
-            {...filterStyledSystemMarginProps(props)}
+            {...marginProps}
           >
             <FormField
               fieldHelp={computeLabelPropValues(fieldHelp)}
@@ -349,7 +351,7 @@ export const Textarea = React.forwardRef(
               labelWidth={computeLabelPropValues(labelWidth)}
               labelHelp={computeLabelPropValues(labelHelp)}
               labelSpacing={labelSpacing}
-              isRequired={props.required}
+              isRequired={rest.required}
               useValidationIcon={computeLabelPropValues(validationOnLabel)}
               adaptiveLabelBreakpoint={adaptiveLabelBreakpoint}
               validationRedesignOptIn={validationRedesignOptIn}

--- a/src/hooks/__internal__/useFormSpacing/add-form-spacing/add-form-spacing.spec.ts
+++ b/src/hooks/__internal__/useFormSpacing/add-form-spacing/add-form-spacing.spec.ts
@@ -1,0 +1,51 @@
+import addFormSpacing from ".";
+
+describe("addFormSpacing", () => {
+  it("does not set mb and mt if passed props is empty object and no form spacing value is passed", () => {
+    expect(addFormSpacing({})).toEqual({});
+  });
+
+  it("sets mb and mt if passed props is empty object", () => {
+    expect(addFormSpacing({}, "5px")).toEqual({ mb: "5px", mt: 0 });
+  });
+
+  it.each(["mx", "marginX", "ml", "marginLeft", "mr", "marginRight"])(
+    "sets mb and mt if %s passed in props",
+    (marginProp) => {
+      expect(addFormSpacing({ [marginProp]: "10px" }, "5px")).toEqual({
+        [marginProp]: "10px",
+        mb: "5px",
+        mt: 0,
+      });
+    }
+  );
+
+  it.each(["mt", "marginTop"])(
+    "does not set mt if %s passed in props",
+    (marginProp) => {
+      expect(addFormSpacing({ [marginProp]: "10px" }, "5px")).toEqual({
+        [marginProp]: "10px",
+        mb: "5px",
+      });
+    }
+  );
+
+  it.each(["mb", "marginBottom"])(
+    "does not set mb if %s passed in props",
+    (marginProp) => {
+      expect(addFormSpacing({ [marginProp]: "10px" }, "5px")).toEqual({
+        [marginProp]: "10px",
+        mt: 0,
+      });
+    }
+  );
+
+  it.each(["my", "marginY", "m", "margin"])(
+    "does not set mb or mt if %s passed in props",
+    (marginProp) => {
+      expect(addFormSpacing({ [marginProp]: "10px" }, "5px")).toEqual({
+        [marginProp]: "10px",
+      });
+    }
+  );
+});

--- a/src/hooks/__internal__/useFormSpacing/add-form-spacing/index.ts
+++ b/src/hooks/__internal__/useFormSpacing/add-form-spacing/index.ts
@@ -1,0 +1,35 @@
+import { MarginProps } from "styled-system";
+
+export default (marginProps: MarginProps, formMarginBottom?: string) => {
+  if (!formMarginBottom) {
+    return marginProps;
+  }
+  const copiedProps = { ...marginProps };
+
+  const {
+    mb,
+    marginBottom,
+    mt,
+    marginTop,
+    my,
+    marginY,
+    m,
+    margin,
+  } = copiedProps;
+  const hasCustomMarginBottom = [mb, marginBottom, my, marginY, m, margin].some(
+    (prop) => prop !== undefined
+  );
+  const hasCustomMarginTop = [mt, marginTop, my, marginY, m, margin].some(
+    (prop) => prop !== undefined
+  );
+
+  if (!hasCustomMarginBottom) {
+    copiedProps.mb = formMarginBottom;
+  }
+
+  if (!hasCustomMarginTop) {
+    copiedProps.mt = 0;
+  }
+
+  return copiedProps;
+};

--- a/src/hooks/__internal__/useFormSpacing/index.ts
+++ b/src/hooks/__internal__/useFormSpacing/index.ts
@@ -1,0 +1,20 @@
+import { useContext } from "react";
+import { MarginProps } from "styled-system";
+import { filterStyledSystemMarginProps } from "../../../style/utils";
+import {
+  FormSpacingContextProps,
+  FormSpacingContext,
+} from "../../../__internal__/form-spacing-provider";
+import addFormSpacing from "./add-form-spacing";
+
+export default (props: Record<string, unknown> | MarginProps) => {
+  const { marginBottom } = useContext<FormSpacingContextProps>(
+    FormSpacingContext
+  );
+  const marginProps = addFormSpacing(
+    filterStyledSystemMarginProps(props),
+    marginBottom
+  );
+
+  return marginProps;
+};

--- a/src/hooks/__internal__/useFormSpacing/useFormSpacing.spec.tsx
+++ b/src/hooks/__internal__/useFormSpacing/useFormSpacing.spec.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import styled from "styled-components";
+import { margin } from "styled-system";
+import { render, screen } from "@testing-library/react";
+import useFormSpacing from ".";
+import FormSpacingProvider from "../../../__internal__/form-spacing-provider";
+
+const StyledDiv = styled.div`
+  ${margin}
+`;
+
+const MockComponent = (props: Record<string, unknown>) => {
+  const marginProps = useFormSpacing(props);
+  return <StyledDiv {...marginProps}>foo</StyledDiv>;
+};
+
+describe("useFormSpacing", () => {
+  it("applies the form spacing when no custom value exists", () => {
+    render(
+      <FormSpacingProvider marginBottom="10px">
+        <MockComponent />
+      </FormSpacingProvider>
+    );
+    expect(screen.getByText("foo")).toHaveStyle({
+      marginBottom: "10px",
+      marginTop: "0px",
+    });
+  });
+
+  it("applies the form spacing when custom values exist that don't override top or bottom margin", () => {
+    render(
+      <FormSpacingProvider marginBottom="10px">
+        <MockComponent mx="10px" />
+      </FormSpacingProvider>
+    );
+    expect(screen.getByText("foo")).toHaveStyle({
+      marginBottom: "10px",
+      marginTop: "0px",
+      marginLeft: "10px",
+      marginRight: "10px",
+    });
+  });
+
+  it("does not apply the form spacing when custom `my` value exists", () => {
+    render(
+      <FormSpacingProvider marginBottom="10px">
+        <MockComponent my="5px" />
+      </FormSpacingProvider>
+    );
+    expect(screen.getByText("foo")).toHaveStyle({
+      marginBottom: "5px",
+      marginTop: "5px",
+    });
+  });
+
+  it("does not apply the form spacing when custom `m` exists", () => {
+    render(
+      <FormSpacingProvider marginBottom="10px">
+        <MockComponent m="5px" />
+      </FormSpacingProvider>
+    );
+    expect(screen.getByText("foo")).toHaveStyle({
+      marginBottom: "5px",
+      marginTop: "5px",
+    });
+  });
+
+  it("does not apply the form spacing for top margin when custom `mt` value exists", () => {
+    render(
+      <FormSpacingProvider marginBottom="10px">
+        <MockComponent mt="5px" />
+      </FormSpacingProvider>
+    );
+    expect(screen.getByText("foo")).toHaveStyle({
+      marginBottom: "10px",
+      marginTop: "5px",
+    });
+  });
+
+  it("does not apply the form spacing for bottom margin when custom `mb` value exists", () => {
+    render(
+      <FormSpacingProvider marginBottom="10px">
+        <MockComponent mb="5px" />
+      </FormSpacingProvider>
+    );
+    expect(screen.getByText("foo")).toHaveStyle({
+      marginBottom: "5px",
+      marginTop: "0px",
+    });
+  });
+});


### PR DESCRIPTION
fix #5681

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

Replaces the previous implementation which targeted `FormField` and `Fieldset` in the `Form` styles to apply the given `fieldSpacing` value. This prevented any custom values being set on an input when it was rendered as a child of `Form`. `FormSpacingProvider`, `FormContext` and a `addFormSpacing` util have been added to support applying the field spacing on a child that has not been passed a custom margin value.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
The `fieldSpacing` is applied in `form.style.ts` and targets `FormField` and `Fieldset` which means that it overrides any custom value passed to a given input

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

Test stories were added to show that a custom margin value takes precedence over `fieldSpacing`

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
