### PR TITLE
fix(textarea, textbox): accessibility enhancements on character counter

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -28,6 +28,7 @@
   "coveragePathIgnorePatterns": [
     "node_modules",
     "src/__spec_helper__",
+    "src/locales",
     "lib",
     "esm"
   ],

--- a/src/__internal__/character-count/character-count.component.tsx
+++ b/src/__internal__/character-count/character-count.component.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 
 import StyledCharacterCount from "./character-count.style";
+import useLocale from "../../hooks/__internal__/useLocale";
 
 interface CharacterCountProps {
-  value: string;
-  limit: string;
+  value: number;
+  limit: number;
   isOverLimit: boolean;
   "data-element"?: string;
 }
@@ -14,14 +15,31 @@ const CharacterCount = ({
   limit,
   isOverLimit,
   "data-element": dataElement,
-}: CharacterCountProps) => (
-  <StyledCharacterCount
-    aria-live="polite"
-    isOverLimit={isOverLimit}
-    data-element={dataElement}
-  >
-    {`${value}/${limit}`}
-  </StyledCharacterCount>
-);
+}: CharacterCountProps) => {
+  const limitMinusValue: number = +limit - +value;
+  const valueMinusLimit: number = +value - +limit;
+  const l = useLocale();
+
+  const getFormatNumber = (rawValue: number, locale: string) =>
+    new Intl.NumberFormat(locale).format(rawValue);
+
+  return (
+    <StyledCharacterCount
+      aria-live="polite"
+      isOverLimit={isOverLimit}
+      data-element={dataElement}
+    >
+      {!isOverLimit
+        ? l.characterCount.charactersLeft(
+            limitMinusValue,
+            getFormatNumber(limitMinusValue, l.locale())
+          )
+        : l.characterCount.tooManyCharacters(
+            valueMinusLimit,
+            getFormatNumber(valueMinusLimit, l.locale())
+          )}
+    </StyledCharacterCount>
+  );
+};
 
 export default CharacterCount;

--- a/src/__internal__/character-count/character-count.spec.tsx
+++ b/src/__internal__/character-count/character-count.spec.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import { mount, ReactWrapper } from "enzyme";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import CharacterCount from ".";
+import StyledCharacterCount from "../character-count/character-count.style";
 
 describe("CharacterCount", () => {
   let wrapper: ReactWrapper;
 
   beforeEach(() => {
     wrapper = mount(
-      <CharacterCount value="5" limit="10" isOverLimit={false} />
+      <CharacterCount value={5} limit={10} isOverLimit={false} />
     );
   });
 
@@ -36,6 +37,24 @@ describe("CharacterCount", () => {
           color: "var(--colorsSemanticNegative500)",
         },
         wrapper
+      );
+    });
+
+    it("character count string should be correct", () => {
+      wrapper = mount(<CharacterCount value={4} limit={3} isOverLimit />);
+      expect(wrapper.find(StyledCharacterCount).text()).toBe(
+        "You have 1 character too many"
+      );
+    });
+  });
+
+  describe("when isOverLimit prop is false", () => {
+    it("character count string should be correct", () => {
+      wrapper = mount(
+        <CharacterCount value={2} limit={3} isOverLimit={false} />
+      );
+      expect(wrapper.find(StyledCharacterCount).text()).toBe(
+        "You have 1 character remaining"
       );
     });
   });

--- a/src/components/date/date.d.ts
+++ b/src/components/date/date.d.ts
@@ -27,7 +27,6 @@ export interface DateInputProps
     | "iconOnMouseDown"
     | "enforceCharacterLimit"
     | "characterLimit"
-    | "warnOverLimit"
     | "iconTabIndex"
   > {
   /** Boolean to allow the input to have an empty value */

--- a/src/components/date/date.stories.mdx
+++ b/src/components/date/date.stories.mdx
@@ -655,7 +655,6 @@ Due to the `Textbox` component being used internally by the `Date` component the
     "iconOnMouseDown",
     "enforceCharacterLimit",
     "characterLimit",
-    "warnOverLimit",
     "prefix",
     "inputIcon",
     "iconTabIndex",

--- a/src/components/form/form.spec.tsx
+++ b/src/components/form/form.spec.tsx
@@ -96,7 +96,7 @@ describe("Form", () => {
         wrapper = mount(
           <Form fieldSpacing={spacing}>
             <Textbox />
-            <Textarea characterLimit="50" />
+            <Textarea characterLimit={50} />
             <RadioButtonGroup name="bar">
               <RadioButton value="1" />
             </RadioButtonGroup>
@@ -157,7 +157,7 @@ describe("Form", () => {
         wrapper = mount(
           <Form fieldSpacing={spacing}>
             <Textbox my={1} />
-            <Textarea characterLimit="50" my={1} />
+            <Textarea characterLimit={50} my={1} />
             <Button my={1}>Foo</Button>
             <RadioButtonGroup name="bar" my={1}>
               <RadioButton value="1" />

--- a/src/components/number/number.test.js
+++ b/src/components/number/number.test.js
@@ -84,40 +84,55 @@ context("Tests for Number component", () => {
     );
 
     it.each([
-      ["11", "11"],
-      ["10", "10"],
+      [11, 11],
+      [10, 10],
     ])(
       "should input %s characters and enforce character limit of %s in Number",
       (charactersUsed, limit) => {
+        const inputValue = "12345678901";
+        const underCharacters =
+          limit - charactersUsed === 1 ? "character" : "characters";
+        const overCharacters =
+          charactersUsed - limit === 1 ? "character" : "characters";
+
         CypressMountWithProviders(
           <NumberInputComponent enforceCharacterLimit characterLimit={limit} />
         );
-
-        const inputValue = "12345678901";
 
         commonDataElementInputPreview()
           .type(inputValue)
           .then(() => {
             commonInputCharacterLimit().should(
               "have.text",
-              `${charactersUsed}/${limit}`
+              `${
+                charactersUsed - limit
+                  ? `You have ${
+                      limit - charactersUsed
+                    } ${overCharacters} too many`
+                  : `You have ${
+                      charactersUsed - limit
+                    } ${underCharacters} remaining`
+              }`
             );
           });
       }
     );
 
     it.each([
-      ["11", "11", "rgba(0, 0, 0, 0.55)"],
-      ["11", "10", "rgb(203, 55, 74)"],
+      [11, 11, "rgba(0, 0, 0, 0.55)"],
+      [11, 10, "rgb(203, 55, 74)"],
     ])(
       "should input %s characters and warn if over character limit of %s in Number",
       (charactersUsed, limit, color) => {
         const inputValue = "12345678901";
+        const underCharacters =
+          limit - charactersUsed === 1 ? "character" : "characters";
+        const overCharacters =
+          charactersUsed - limit === 1 ? "character" : "characters";
 
         CypressMountWithProviders(
           <NumberInputComponent
             enforceCharacterLimit={false}
-            warnOverLimit
             characterLimit={limit}
           />
         );
@@ -126,7 +141,18 @@ context("Tests for Number component", () => {
           .type(inputValue)
           .then(() => {
             commonInputCharacterLimit()
-              .should("have.text", `${charactersUsed}/${limit}`)
+              .should(
+                "have.text",
+                `${
+                  charactersUsed - limit
+                    ? `You have ${
+                        charactersUsed - limit
+                      } ${overCharacters} too many`
+                    : `You have ${
+                        charactersUsed - limit
+                      } ${underCharacters} remaining`
+                }`
+              )
               .and("have.css", "color", color);
           });
       }

--- a/src/components/textarea/textarea-test.stories.tsx
+++ b/src/components/textarea/textarea-test.stories.tsx
@@ -101,7 +101,6 @@ export default {
     fieldHelp: "",
     characterLimit: undefined,
     inputWidth: 100,
-    warnOverLimit: false,
     enforceCharacterLimit: true,
     label: "Textarea",
     labelHelp: "",

--- a/src/components/textarea/textarea.spec.tsx
+++ b/src/components/textarea/textarea.spec.tsx
@@ -17,7 +17,11 @@ import { StyledLabelContainer } from "../../__internal__/label/label.style";
 import Tooltip from "../tooltip";
 import StyledHelp from "../help/help.style";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
-import { ErrorBorder, StyledHintText } from "../textbox/textbox.style";
+import {
+  ErrorBorder,
+  StyledHintText,
+  StyledInputHint,
+} from "../textbox/textbox.style";
 import StyledValidationMessage from "../../__internal__/validation-message/validation-message.style";
 import StyledTextarea from "./textarea.style";
 import Logger from "../../__internal__/utils/logger";
@@ -217,6 +221,25 @@ describe("Textarea", () => {
           }
         );
 
+        describe("and inputHint props are present", () => {
+          it("renders a character counter hint", () => {
+            wrapper = mount(<Textarea value="test string" inputHint="foo" />);
+            expect(wrapper.find(StyledInputHint).text()).toBe("foo");
+          });
+
+          it("assigns a character counter hint via guid", () => {
+            wrapper = mount(<Textarea value="test string" inputHint="bar" />);
+            expect(wrapper.find(StyledInputHint).prop("id")).toBe(mockedGuid);
+          });
+
+          it("should render a valid 'aria-describedby' on input", () => {
+            wrapper = mount(<Textarea inputHint="baz" />);
+            expect(wrapper.find(Input).prop("aria-describedby")).toBe(
+              mockedGuid
+            );
+          });
+        });
+
         describe("and fieldHelp props are present", () => {
           it("should render a valid 'aria-describedby'", () => {
             const textarea = mount(
@@ -257,6 +280,45 @@ describe("Textarea", () => {
           );
         });
       });
+    });
+  });
+
+  describe(`when the characterLimit prop is passed`, () => {
+    it.each([2, 3, 4])("renders a character counter", (characterLimit) => {
+      const valueString = "foo";
+      const limitMinusValue = characterLimit - valueString.length >= 0;
+      wrapper = mount(
+        <Textarea value={valueString} characterLimit={characterLimit} />
+      );
+      const underCharacters =
+        characterLimit - valueString.length === 1 ? "character" : "characters";
+      const overCharacters =
+        valueString.length - characterLimit === 1 ? "character" : "characters";
+
+      expect(wrapper.find(CharacterCount).text()).toBe(
+        `${
+          limitMinusValue
+            ? `You have ${
+                characterLimit - valueString.length
+              } ${underCharacters} remaining`
+            : `You have ${
+                valueString.length - characterLimit
+              } ${overCharacters} too many`
+        }`
+      );
+    });
+
+    it("renders a character counter hint", () => {
+      wrapper = mount(<Textarea value="foo" characterLimit={4} />);
+
+      expect(wrapper.find(StyledInputHint).text()).toBe(
+        "Input contains a character counter"
+      );
+    });
+
+    it("character counter hint is given a valid id", () => {
+      wrapper = mount(<Textarea value="test string" characterLimit={4} />);
+      expect(wrapper.find(StyledInputHint).prop("id")).toBe(mockedGuid);
     });
   });
 
@@ -314,22 +376,6 @@ describe("Textarea", () => {
 
       it("should have a CharacterCount as it's child", () => {
         expect(wrapper.find(CharacterCount).exists()).toBe(true);
-      });
-
-      describe("and when warnOverLimit prop is true and a limit is over", () => {
-        it("should be styled for warn over limit", () => {
-          wrapper.setProps({
-            warnOverLimit: true,
-            value: "abcdefg",
-            onChange: jest.fn(),
-          });
-          assertStyleMatch(
-            {
-              color: "var(--colorsSemanticNegative500)",
-            },
-            wrapper.find(CharacterCount)
-          );
-        });
       });
     });
   });

--- a/src/components/textarea/textarea.stories.mdx
+++ b/src/components/textarea/textarea.stories.mdx
@@ -95,6 +95,22 @@ import Textarea from "carbon-react/lib/components/textarea";
   />
 </Canvas>
 
+### with characterLimit - with translations
+
+Various translations can be applied to both the hint message which appears before the input, and the character 
+counter below the input. 
+
+These translations have been split up to include a number which represents the current character count which
+is over/under the set `characterLimit`. Please see below how this has been achieved with a French translation.
+Include the formatted number count wherever makes sense for the language you're translating too.
+
+<Canvas>
+  <Story 
+    name="with characterLimit with translations" 
+    story={stories.TranslationsCharacterLimitStory}
+  />
+</Canvas>
+
 ### With labelInline
 
 <Canvas>

--- a/src/components/textarea/textarea.stories.tsx
+++ b/src/components/textarea/textarea.stories.tsx
@@ -4,6 +4,7 @@ import { ComponentStory } from "@storybook/react";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 import Textarea from ".";
+import I18nProvider from "../i18n-provider";
 
 export const DefaultStory: ComponentStory<typeof Textarea> = () => {
   const [state, setState] = useState("");
@@ -63,7 +64,7 @@ export const CharacterLimitStory: ComponentStory<typeof Textarea> = () => {
       expandable
       value={value}
       onChange={({ target }) => setValue(target.value)}
-      characterLimit="50"
+      characterLimit={50}
     />
   );
 };
@@ -78,14 +79,46 @@ export const UnenforcedCharacterLimitStory: ComponentStory<
       expandable
       value={value}
       onChange={({ target }) => setValue(target.value)}
-      characterLimit="50"
+      characterLimit={50}
       enforceCharacterLimit={false}
-      warnOverLimit
     />
   );
 };
 UnenforcedCharacterLimitStory.parameters = {
   chromatic: { disableSnapshot: true },
+};
+
+export const TranslationsCharacterLimitStory: ComponentStory<
+  typeof Textarea
+> = () => {
+  const [value, setValue] = useState("");
+  return (
+    <I18nProvider
+      locale={{
+        locale: () => "fr-FR",
+        characterCount: {
+          hintString: () => "L'entrée contient un compteur de caractères",
+          tooManyCharacters: (count, formattedCount) =>
+            count === 1
+              ? `Vous avez ${formattedCount} personnage de trop`
+              : `Vous avez ${formattedCount} personnages de trop`,
+          charactersLeft: (count, formattedCount) =>
+            count === 1
+              ? `Il vous reste ${formattedCount} personnage`
+              : `Il vous reste ${formattedCount} personnages`,
+        },
+      }}
+    >
+      <Textarea
+        label="Textarea"
+        expandable
+        value={value}
+        onChange={({ target }) => setValue(target.value)}
+        characterLimit={50}
+        enforceCharacterLimit={false}
+      />
+    </I18nProvider>
+  );
 };
 
 export const LabelInlineStory: ComponentStory<typeof Textarea> = () => {

--- a/src/components/textarea/textarea.test.js
+++ b/src/components/textarea/textarea.test.js
@@ -168,17 +168,20 @@ context("Tests for Textarea component", () => {
     });
 
     it.each([
-      ["11", "11", "rgba(0, 0, 0, 0.55)"],
-      ["11", "10", "rgb(203, 55, 74)"],
+      [11, 11, "rgba(0, 0, 0, 0.55)"],
+      [11, 10, "rgb(203, 55, 74)"],
     ])(
       "should input %s characters and warn if over character limit of %s in Textarea",
       (charactersUsed, limit, color) => {
         const inputValue = "12345678901";
+        const underCharacters =
+          limit - charactersUsed === 1 ? "character" : "characters";
+        const overCharacters =
+          charactersUsed - limit === 1 ? "character" : "characters";
 
         CypressMountWithProviders(
           <TextareaComponent
             enforceCharacterLimit={false}
-            warnOverLimit
             characterLimit={limit}
           />
         );
@@ -187,9 +190,54 @@ context("Tests for Textarea component", () => {
           .type(inputValue)
           .then(() => {
             commonInputCharacterLimit()
-              .should("have.text", `${charactersUsed}/${limit}`)
+              .should(
+                "have.text",
+                `${
+                  charactersUsed - limit
+                    ? `You have ${
+                        charactersUsed - limit
+                      } ${overCharacters} too many`
+                    : `You have ${
+                        charactersUsed - limit
+                      } ${underCharacters} remaining`
+                }`
+              )
               .and("have.css", "color", color);
           });
+      }
+    );
+
+    it.each([
+      ["foo", "exist"],
+      ["", "not.exist"],
+    ])(
+      "input hint should be conditionally rendered",
+      (inputHint, renderStatus) => {
+        CypressMountWithProviders(
+          <TextareaComponent
+            enforceCharacterLimit={false}
+            inputHint={inputHint}
+          />
+        );
+
+        getDataElementByValue("input-hint").should(renderStatus);
+      }
+    );
+
+    it.each([
+      [4, "exist"],
+      ["", "not.exist"],
+    ])(
+      "character counter hint should be conditionally rendered",
+      (characterLimit, renderStatus) => {
+        CypressMountWithProviders(
+          <TextareaComponent
+            enforceCharacterLimit={false}
+            characterLimit={characterLimit}
+          />
+        );
+
+        getDataElementByValue("input-hint").should(renderStatus);
       }
     );
 
@@ -215,23 +263,35 @@ context("Tests for Textarea component", () => {
     });
 
     it.each([
-      ["11", "11"],
-      ["10", "10"],
+      [11, 11],
+      [10, 10],
     ])(
       "should input %s characters and enforce character limit of %s in Textarea",
       (charactersUsed, limit) => {
+        const inputValue = "12345678901";
+        const underCharacters =
+          limit - charactersUsed === 1 ? "character" : "characters";
+        const overCharacters =
+          charactersUsed - limit === 1 ? "character" : "characters";
+
         CypressMountWithProviders(
           <TextareaComponent enforceCharacterLimit characterLimit={limit} />
         );
-
-        const inputValue = "12345678901";
 
         textareaChildren()
           .type(inputValue)
           .then(() => {
             commonInputCharacterLimit().should(
               "have.text",
-              `${charactersUsed}/${limit}`
+              `${
+                charactersUsed - limit
+                  ? `You have ${
+                      limit - charactersUsed
+                    } ${underCharacters} too many`
+                  : `You have ${
+                      charactersUsed - limit
+                    } ${overCharacters} remaining`
+              }`
             );
           });
       }

--- a/src/components/textbox/textbox-test.stories.tsx
+++ b/src/components/textbox/textbox-test.stories.tsx
@@ -32,7 +32,6 @@ export const getCommonTextboxArgs = (
     required: false,
     enforceCharacterLimit: false,
     characterLimit: undefined,
-    warnOverLimit: false,
     error: "",
     warning: "",
   };

--- a/src/components/textbox/textbox.stories.mdx
+++ b/src/components/textbox/textbox.stories.mdx
@@ -56,6 +56,19 @@ import Textbox from "carbon-react/lib/components/textbox";
   <Story name="character counter" story={stories.CharacterCounter} />
 </Canvas>
 
+### Character counter with translations
+
+Various translations can be applied to both the hint message which appears before the input, and the character 
+counter below the input. 
+
+These translations have been split up to include a number which represents the current character count which
+is over/under the set `characterLimit`. Please see below how this has been achieved with a French translation.
+Include the formatted number count wherever makes sense for the language you're translating too.
+
+<Canvas>
+  <Story name="character counter with translations" story={stories.CharacterCounterTranslations} />
+</Canvas>
+
 ### Prefix
 
 <Canvas>

--- a/src/components/textbox/textbox.stories.tsx
+++ b/src/components/textbox/textbox.stories.tsx
@@ -4,6 +4,7 @@ import { ComponentStory } from "@storybook/react";
 import Textbox from ".";
 import Box from "../box";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
+import I18nProvider from "../i18n-provider";
 
 export const SIZES = ["small", "medium", "large"] as const;
 export const VALIDATIONS = ["error", "warning", "info"] as const;
@@ -26,10 +27,44 @@ export const CharacterCounter: ComponentStory<typeof Textbox> = () => {
       label="Textbox"
       value={state}
       onChange={setValue}
-      characterLimit="10"
+      characterLimit={10}
       enforceCharacterLimit={false}
-      warnOverLimit
     />
+  );
+};
+
+export const CharacterCounterTranslations: ComponentStory<
+  typeof Textbox
+> = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <I18nProvider
+      locale={{
+        locale: () => "fr-FR",
+        characterCount: {
+          hintString: () => "L'entrée contient un compteur de caractères",
+          tooManyCharacters: (count, formattedCount) =>
+            count === 1
+              ? `Vous avez ${formattedCount} personnage de trop`
+              : `Vous avez ${formattedCount} personnages de trop`,
+          charactersLeft: (count, formattedCount) =>
+            count === 1
+              ? `Il vous reste ${formattedCount} personnage`
+              : `Il vous reste ${formattedCount} personnages`,
+        },
+      }}
+    >
+      <Textbox
+        label="Textbox"
+        value={state}
+        onChange={setValue}
+        characterLimit={10}
+        enforceCharacterLimit={false}
+      />
+    </I18nProvider>
   );
 };
 

--- a/src/components/textbox/textbox.style.ts
+++ b/src/components/textbox/textbox.style.ts
@@ -15,11 +15,20 @@ const ErrorBorder = styled.span`
     `}
 `;
 
-const StyledHintText = styled.p`
+const StyledInputHint = styled.p`
+  display: block;
+  flex: 1;
+  margin-top: -3px;
+  margin-bottom: 8px;
+  color: var(--colorsUtilityYin055);
+  white-space: pre-wrap;
+`;
+
+const StyledHintText = styled.div`
   margin-top: 0px;
   margin-bottom: 8px;
   color: var(--colorsUtilityYin055);
   font-size: 14px;
 `;
 
-export { StyledHintText, ErrorBorder };
+export { StyledHintText, ErrorBorder, StyledInputHint };

--- a/src/components/textbox/textbox.test.js
+++ b/src/components/textbox/textbox.test.js
@@ -186,6 +186,40 @@ context("Tests for Textbox component", () => {
       }
     );
 
+    it.each([
+      ["foo", "exist"],
+      ["", "not.exist"],
+    ])(
+      "input hint should be conditionally rendered",
+      (inputHint, renderStatus) => {
+        CypressMountWithProviders(
+          <stories.TextboxComponent
+            enforceCharacterLimit={false}
+            inputHint={inputHint}
+          />
+        );
+
+        getDataElementByValue("input-hint").should(renderStatus);
+      }
+    );
+
+    it.each([
+      [4, "exist"],
+      ["", "not.exist"],
+    ])(
+      "character counter hint should be conditionally rendered",
+      (characterLimit, renderStatus) => {
+        CypressMountWithProviders(
+          <stories.TextboxComponent
+            enforceCharacterLimit={false}
+            characterLimit={characterLimit}
+          />
+        );
+
+        getDataElementByValue("input-hint").should(renderStatus);
+      }
+    );
+
     it.each(["10%", "30%", "50%", "80%", "100%"])(
       "should check maxWidth as %s for TextBox component",
       (maxWidth) => {
@@ -216,17 +250,20 @@ context("Tests for Textbox component", () => {
     });
 
     it.each([
-      ["11", "11", "rgba(0, 0, 0, 0.55)"],
-      ["11", "10", "rgb(203, 55, 74)"],
+      [11, 11, "rgba(0, 0, 0, 0.55)"],
+      [11, 10, "rgb(203, 55, 74)"],
     ])(
       "should input %s characters and warn if over character limit of %s in Textbox",
       (charactersUsed, limit, color) => {
         const inputValue = "12345678901";
+        const underCharacters =
+          limit - charactersUsed === 1 ? "character" : "characters";
+        const overCharacters =
+          charactersUsed - limit === 1 ? "character" : "characters";
 
         CypressMountWithProviders(
           <stories.TextboxComponent
             enforceCharacterLimit={false}
-            warnOverLimit
             characterLimit={limit}
           />
         );
@@ -235,18 +272,35 @@ context("Tests for Textbox component", () => {
           .type(inputValue)
           .then(() => {
             commonInputCharacterLimit()
-              .should("have.text", `${charactersUsed}/${limit}`)
+              .should(
+                "have.text",
+                `${
+                  charactersUsed - limit
+                    ? `You have ${
+                        charactersUsed - limit
+                      } ${overCharacters} too many`
+                    : `You have ${
+                        charactersUsed - limit
+                      } ${underCharacters} remaining`
+                }`
+              )
               .and("have.css", "color", color);
           });
       }
     );
 
     it.each([
-      ["11", "11"],
-      ["10", "10"],
+      [11, 11],
+      [10, 10],
     ])(
       "should input %s characters and enforce character limit of %s in Textbox",
       (charactersUsed, limit) => {
+        const inputValue = "12345678901";
+        const underCharacters =
+          limit - charactersUsed === 1 ? "character" : "characters";
+        const overCharacters =
+          charactersUsed - limit === 1 ? "character" : "characters";
+
         CypressMountWithProviders(
           <stories.TextboxComponent
             enforceCharacterLimit
@@ -254,14 +308,20 @@ context("Tests for Textbox component", () => {
           />
         );
 
-        const inputValue = "12345678901";
-
         textboxInput()
           .type(inputValue)
           .then(() => {
             commonInputCharacterLimit().should(
               "have.text",
-              `${charactersUsed}/${limit}`
+              `${
+                charactersUsed - limit
+                  ? `You have ${
+                      limit - charactersUsed
+                    } ${overCharacters} too many`
+                  : `You have ${
+                      charactersUsed - limit
+                    } ${underCharacters} remaining`
+              }`
             );
           });
       }

--- a/src/hooks/__internal__/useCharacterCount/useCharacterCount.spec.tsx
+++ b/src/hooks/__internal__/useCharacterCount/useCharacterCount.spec.tsx
@@ -1,28 +1,22 @@
 import * as React from "react";
 import { mount, MountRendererProps } from "enzyme";
-
-import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
 import CharacterCount from "../../../__internal__/character-count";
-import I18nProvider from "../../../components/i18n-provider";
 import useCharacterCount from ".";
 
 interface TestComponentProps {
   value: string;
   characterLimit?: number;
-  warnOverLimit?: boolean;
   enforceCharacterLimit?: boolean;
 }
 
 const TestComponent = ({
   value,
   characterLimit,
-  warnOverLimit,
   enforceCharacterLimit,
 }: TestComponentProps) => {
   const [maxLength, characterCount] = useCharacterCount(
     value,
     characterLimit,
-    warnOverLimit,
     enforceCharacterLimit
   );
 
@@ -39,43 +33,65 @@ const render = (props: TestComponentProps, params?: MountRendererProps) =>
 const mockValue = "test string";
 
 describe("useCharacterCount", () => {
-  it("returns a counter and no maxLength", () => {
-    const wrapper = render({
-      value: mockValue,
-      characterLimit: 100,
-      enforceCharacterLimit: false,
-    });
+  it.each([5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])(
+    "returns a counter and no maxLength",
+    (characterLimit) => {
+      const limitMinusVlaue = characterLimit - mockValue.length >= 0;
+      const underCharacters =
+        characterLimit - mockValue.length === 1 ? "character" : "characters";
+      const overCharacters =
+        mockValue.length - characterLimit === 1 ? "character" : "characters";
+      const wrapper = render({
+        value: mockValue,
+        characterLimit,
+        enforceCharacterLimit: false,
+      });
 
-    expect(wrapper.find('[data-element="max-length"]').text()).toBe("");
-    expect(wrapper.find(CharacterCount).text()).toBe(`${mockValue.length}/100`);
-  });
+      expect(wrapper.find('[data-element="max-length"]').text()).toBe("");
+      expect(wrapper.find(CharacterCount).text()).toBe(
+        `${
+          limitMinusVlaue
+            ? `You have ${
+                characterLimit - mockValue.length
+              } ${underCharacters} remaining`
+            : `You have ${
+                mockValue.length - characterLimit
+              } ${overCharacters} too many`
+        }`
+      );
+    }
+  );
 
-  it("returns a counter and maxLength", () => {
-    const wrapper = render({
-      value: mockValue,
-      characterLimit: 100,
-      enforceCharacterLimit: true,
-    });
+  it.each([5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])(
+    "returns a counter and maxLength",
+    (characterLimit) => {
+      const limitMinusVlaue = characterLimit - mockValue.length >= 0;
+      const underCharacters =
+        characterLimit - mockValue.length === 1 ? "character" : "characters";
+      const overCharacters =
+        mockValue.length - characterLimit === 1 ? "character" : "characters";
+      const wrapper = render({
+        value: mockValue,
+        characterLimit,
+        enforceCharacterLimit: true,
+      });
 
-    expect(wrapper.find('[data-element="max-length"]').text()).toBe("100");
-    expect(wrapper.find(CharacterCount).text()).toBe(`${mockValue.length}/100`);
-  });
-
-  it("returns a counter with an overlimit warning", () => {
-    const wrapper = render({
-      value: mockValue,
-      characterLimit: 10,
-      warnOverLimit: true,
-      enforceCharacterLimit: false,
-    });
-
-    assertStyleMatch(
-      {
-        color: "var(--colorsSemanticNegative500)",
-      },
-      wrapper
-    );
-  });
+      expect(wrapper.find('[data-element="max-length"]').text()).toBe(
+        `${characterLimit}`
+      );
+      expect(wrapper.find(CharacterCount).text()).toBe(
+        `${
+          limitMinusVlaue
+            ? `You have ${
+                characterLimit - mockValue.length
+              } ${underCharacters} remaining`
+            : `You have ${
+                mockValue.length - characterLimit
+              } ${overCharacters} too many`
+        }`
+      );
+    }
+  );
 
   it("does not return a counter and no maxLength", () => {
     const wrapper = render({
@@ -84,29 +100,5 @@ describe("useCharacterCount", () => {
 
     expect(wrapper.find('[data-element="max-length"]').text()).toBe("");
     expect(wrapper.find(CharacterCount).exists()).toBe(false);
-  });
-
-  describe("i18n", () => {
-    it.each([
-      ["en-GB", "0/1,000,000"],
-      ["fr-FR", "0/1 000 000"],
-    ])("displays %s format", (locale, limit) => {
-      const wrapper = render(
-        {
-          value: "",
-          characterLimit: 1000000,
-        },
-        {
-          wrappingComponent: I18nProvider,
-          wrappingComponentProps: {
-            locale: {
-              locale: () => locale,
-            },
-          },
-        }
-      );
-
-      expect(wrapper.find(CharacterCount).text()).toBe(limit);
-    });
   });
 });

--- a/src/hooks/__internal__/useCharacterCount/useCharacterCount.tsx
+++ b/src/hooks/__internal__/useCharacterCount/useCharacterCount.tsx
@@ -1,19 +1,23 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useRef } from "react";
 import CharacterCount from "../../../__internal__/character-count";
 import useLocale from "../useLocale";
-
-const getFormatNumber = (value: number, locale: string) =>
-  new Intl.NumberFormat(locale).format(value);
+import guid from "../../../__internal__/utils/helpers/guid";
 
 const useCharacterCount = (
   value = "",
   characterLimit?: number,
-  warnOverLimit = false,
   enforceCharacterLimit = true
-): [number | undefined, JSX.Element | null] => {
+): [
+  number | undefined,
+  JSX.Element | null,
+  string | undefined,
+  string | null
+] => {
   const isCharacterLimitValid =
     typeof characterLimit === "number" && !Number.isNaN(characterLimit);
   const l = useLocale();
+  const hintString = l.characterCount.hintString();
+  const hintId = useRef(guid());
   const isOverLimit = useMemo(() => {
     if (value && isCharacterLimitValid) {
       return value.length > characterLimit;
@@ -25,12 +29,14 @@ const useCharacterCount = (
     enforceCharacterLimit && isCharacterLimitValid ? characterLimit : undefined,
     isCharacterLimitValid ? (
       <CharacterCount
-        isOverLimit={isOverLimit && warnOverLimit}
-        value={getFormatNumber(value.length, l.locale())}
-        limit={getFormatNumber(characterLimit, l.locale())}
+        isOverLimit={isOverLimit}
+        value={value.length}
+        limit={characterLimit}
         data-element="character-limit"
       />
     ) : null,
+    hintId.current,
+    isCharacterLimitValid ? hintString : null,
   ];
 };
 

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -20,6 +20,17 @@ const enGB: Locale = {
     no: () => "No",
     yes: () => "Yes",
   },
+  characterCount: {
+    hintString: () => "Input contains a character counter",
+    tooManyCharacters: (count, formattedCount) =>
+      count === 1
+        ? `You have ${formattedCount} character too many`
+        : `You have ${formattedCount} characters too many`,
+    charactersLeft: (count, formattedCount) =>
+      count === 1
+        ? `You have ${formattedCount} character remaining`
+        : `You have ${formattedCount} characters remaining`,
+  },
   date: {
     dateFnsLocale: () => enGBDateLocale,
   },

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -12,6 +12,11 @@ interface Locale {
   batchSelection: {
     selected: (count: number | string) => string;
   };
+  characterCount: {
+    hintString: () => string;
+    tooManyCharacters: (count: number, formattedCount: string) => string;
+    charactersLeft: (count: number, formattedCount: string) => string;
+  };
   confirm: {
     no: () => string;
     yes: () => string;

--- a/src/locales/pl-pl.spec.tsx
+++ b/src/locales/pl-pl.spec.tsx
@@ -1,0 +1,25 @@
+import { PolishPlurals } from "./pl-pl";
+
+describe("PolishPlural function checks", () => {
+  it("if value is 1 singularNominativ is returned", () => {
+    const count = 1;
+    const test = PolishPlurals("znak", "znaki", "znaków", count);
+    expect(test).toBe("znak");
+  });
+
+  it.each([2, 3, 4, 22, 23, 24])(
+    "if value is %s pluralNominativ is returned",
+    (count) => {
+      const test = PolishPlurals("znak", "znaki", "znaków", count);
+      expect(test).toBe("znaki");
+    }
+  );
+
+  it.each([5, 6, 7, 8, 9, 10])(
+    "if value is %s pluralGenitive is returned",
+    (count) => {
+      const test = PolishPlurals("znak", "znaki", "znaków", count);
+      expect(test).toBe("znaków");
+    }
+  );
+});

--- a/src/locales/pl-pl.ts
+++ b/src/locales/pl-pl.ts
@@ -4,6 +4,25 @@ import { pl as plDateLocale } from "./date-fns-locales";
 const isSingular = (count: string | number): boolean =>
   (typeof count === "string" ? parseInt(count) : count) === 1;
 
+export const PolishPlural = (
+  singularNominativ: string,
+  pluralNominativ: string,
+  pluralGenitive: string,
+  value: number
+) => {
+  if (value === 1) {
+    return singularNominativ;
+  }
+  if (
+    value % 10 >= 2 &&
+    value % 10 <= 4 &&
+    (value % 100 < 10 || value % 100 >= 20)
+  ) {
+    return pluralNominativ;
+  }
+  return pluralGenitive;
+};
+
 const plPL: Locale = {
   locale: () => "pl-PL",
   actions: {
@@ -20,6 +39,24 @@ const plPL: Locale = {
     no: () => "Nie",
     yes: () => "Tak",
   },
+  characterCount: {
+    hintString: () => "Pole zawiera licznik znaków",
+    tooManyCharacters: (count, formattedCount) =>
+      `Masz o ${formattedCount} ${PolishPlural(
+        "znak",
+        "znaki",
+        "znaków",
+        count
+      )} za dużo`,
+    charactersLeft: (count, formattedCount) =>
+      `Masz ${formattedCount} ${PolishPlural(
+        "pozostały",
+        "pozostałe",
+        "pozostałych",
+        count
+      )} ${PolishPlural("znak", "znaki", "znaków", count)}`,
+  },
+
   date: {
     dateFnsLocale: () => plDateLocale,
   },
@@ -137,4 +174,5 @@ const plPL: Locale = {
   },
 };
 
+export { PolishPlural as PolishPlurals };
 export default plPL;


### PR DESCRIPTION
fix #5717

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

<img width="945" alt="Screenshot 2023-02-21 at 10 36 42" src="https://user-images.githubusercontent.com/114918852/220322089-6ac550a1-6065-4002-807b-0cfbcd73f309.png">

<img width="943" alt="Screenshot 2023-02-21 at 10 36 29" src="https://user-images.githubusercontent.com/114918852/220322116-836ab267-bfc2-409d-86ee-7b52b413b769.png">


This PR will introduce a mandatory hint string before the input, which explicitly states that the input contains a character counter/limit. Also, this hint has been given a unique Id and is referenced within the Input with an `aria-describedby` attribute. This ensures users using AT will also be able to benefit from the additional information the hint provides.

Also, the wording of the actual counter below the input has now been changed from numerical to a sentence, mirroring the [GOV.UK character count component](https://design-system.service.gov.uk/components/character-count/), this sentence description will be more descriptive for users reading the string visually, but also sounds much clearer on the `aria-live` region which reads this count on change.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

![Screenshot 2023-02-17 at 16 23 51](https://user-images.githubusercontent.com/114918852/219708743-b4ce5035-bdf8-4182-a452-77188a63c2f7.png)

![Screenshot 2023-02-17 at 16 23 39](https://user-images.githubusercontent.com/114918852/219708754-e3c5aca7-882d-4178-a4a6-2391da02738c.png)

Currently there is no hint text to inform all users that the input contains a character counter/limit, and the count itself is numerical, which can may be unclear for all users, especially those using AT.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
