### PR TITLE
test(pager): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -97,6 +97,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("dialog") &&
       !prepareUrl[0].startsWith("button") &&
       !prepareUrl[0].startsWith("icon") &&
+      !prepareUrl[0].startsWith("pager") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/pager/pager-test.stories.tsx
+++ b/src/components/pager/pager-test.stories.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
 import Pager, { PagerProps } from ".";
+import Form from "../form";
+import useMediaQuery from "../../hooks/useMediaQuery";
 
 export default {
   title: "Pager/Test",
+  includeStories: "Default",
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -95,4 +98,112 @@ Default.args = {
   showFirstAndLastButtons: true,
   showPreviousAndNextButtons: true,
   showPageCount: true,
+};
+
+export const records = [
+  {
+    id: "1",
+    name: 1,
+  },
+  {
+    id: "10",
+    name: 10,
+  },
+  {
+    id: "25",
+    name: 25,
+  },
+  {
+    id: "50",
+    name: 50,
+  },
+  {
+    id: "100",
+    name: 100,
+  },
+];
+
+export const PagerComponent = ({ ...props }) => {
+  return (
+    <Pager
+      currentPage="1"
+      onPagination={() => {}}
+      pageSizeSelectionOptions={records}
+      totalRecords="100"
+      {...props}
+    />
+  );
+};
+
+export const PagerComponentResponsive = () => {
+  const query1 = useMediaQuery("(max-width: 1000px)");
+  const query2 = useMediaQuery("(max-width: 900px)");
+  const query3 = useMediaQuery("(max-width: 800px)");
+  const query4 = useMediaQuery("(max-width: 700px)");
+  const query5 = useMediaQuery("(max-width: 600px)");
+
+  const responsiveProps = () => {
+    if (query5) {
+      return {
+        showPageSizeSelection: false,
+        showTotalRecords: false,
+        showFirstAndLastButtons: false,
+      };
+    }
+
+    if (query4) {
+      return {
+        showFirstAndLastButtons: false,
+        showTotalRecords: false,
+        showPageSizeLabelBefore: false,
+        showPageSizeLabelAfter: false,
+      };
+    }
+
+    if (query3) {
+      return {
+        showFirstAndLastButtons: false,
+        showTotalRecords: false,
+        showPageSizeLabelBefore: false,
+        showPageSizeLabelAfter: false,
+      };
+    }
+
+    if (query2) {
+      return {
+        showFirstAndLastButtons: false,
+        showTotalRecords: false,
+      };
+    }
+
+    if (query1) {
+      return {
+        showPageSizeSelection: true,
+        showFirstAndLastButtons: false,
+      };
+    }
+
+    return {
+      showPageSizeSelection: true,
+    };
+  };
+
+  return (
+    <Pager
+      totalRecords={1000}
+      pageSize={10}
+      currentPage={1}
+      onPagination={() => {}}
+      {...responsiveProps()}
+      pageSizeSelectionOptions={records}
+    />
+  );
+};
+
+export const PagerInForm = () => {
+  return (
+    <Form>
+      <PagerComponent />
+    </Form>
+  );
 };

--- a/src/components/pager/pager.test.js
+++ b/src/components/pager/pager.test.js
@@ -1,5 +1,15 @@
 import React from "react";
-import Pager from "./pager.component";
+import { selectListWrapper } from "../../../cypress/locators/select/index";
+import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
+import { keyCode } from "../../../cypress/support/helper";
+import { checkGoldenOutline } from "../../../cypress/support/component-helper/common-steps";
+import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+
+import {
+  PagerComponent,
+  PagerComponentResponsive,
+  PagerInForm,
+} from "./pager-test.stories";
 
 import {
   pageSelect,
@@ -17,37 +27,8 @@ import {
   currentPageSection,
   pager,
 } from "../../../cypress/locators/pager/index";
-import { selectListWrapper } from "../../../cypress/locators/select/index";
-import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
-import { keyCode } from "../../../cypress/support/helper";
-import useMediaQuery from "../../hooks/useMediaQuery";
-import { checkGoldenOutline } from "../../../cypress/support/component-helper/common-steps";
-import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
-import Form from "../form";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
-const records = [
-  {
-    id: "1",
-    name: 1,
-  },
-  {
-    id: "10",
-    name: 10,
-  },
-  {
-    id: "25",
-    name: 25,
-  },
-  {
-    id: "50",
-    name: 50,
-  },
-  {
-    id: "100",
-    name: 100,
-  },
-];
 
 const recordsDiff = [
   {
@@ -63,91 +44,6 @@ const recordsDiff = [
     name: 819,
   },
 ];
-
-const PagerComponent = ({ ...props }) => {
-  return (
-    <Pager
-      currentPage="1"
-      onPagination={() => {}}
-      pageSizeSelectionOptions={records}
-      totalRecords="100"
-      {...props}
-    />
-  );
-};
-
-const PagerComponentResponsive = () => {
-  const query1 = useMediaQuery("(max-width: 1000px)");
-  const query2 = useMediaQuery("(max-width: 900px)");
-  const query3 = useMediaQuery("(max-width: 800px)");
-  const query4 = useMediaQuery("(max-width: 700px)");
-  const query5 = useMediaQuery("(max-width: 600px)");
-
-  const responsiveProps = () => {
-    if (query5) {
-      return {
-        showPageSizeSelection: false,
-        showTotalRecords: false,
-        showFirstAndLastButtons: false,
-      };
-    }
-
-    if (query4) {
-      return {
-        showFirstAndLastButtons: false,
-        showTotalRecords: false,
-        showPageSizeLabelBefore: false,
-        showPageSizeLabelAfter: false,
-      };
-    }
-
-    if (query3) {
-      return {
-        showFirstAndLastButtons: false,
-        showTotalRecords: false,
-        showPageSizeLabelBefore: false,
-        showPageSizeLabelAfter: false,
-      };
-    }
-
-    if (query2) {
-      return {
-        showFirstAndLastButtons: false,
-        showTotalRecords: false,
-      };
-    }
-
-    if (query1) {
-      return {
-        showPageSizeSelection: true,
-        showFirstAndLastButtons: false,
-      };
-    }
-
-    return {
-      showPageSizeSelection: true,
-    };
-  };
-
-  return (
-    <Pager
-      totalRecords={1000}
-      pageSize={10}
-      currentPage={1}
-      onPagination={() => {}}
-      {...responsiveProps()}
-      pageSizeSelectionOptions={records}
-    />
-  );
-};
-
-const PagerInForm = () => {
-  return (
-    <Form>
-      <PagerComponent />
-    </Form>
-  );
-};
 
 context("Test for Pager component", () => {
   describe("check props for Pager component", () => {
@@ -356,7 +252,6 @@ context("Test for Pager component", () => {
       CypressMountWithProviders(
         <PagerComponent currentPage={7} hideDisabledElements />
       );
-
       firstArrow().should("be.visible");
       previousArrow().should("be.visible");
     });
@@ -587,6 +482,200 @@ context("Test for Pager component", () => {
       CypressMountWithProviders(<PagerInForm />);
 
       currentPageWrapper().should("have.css", "margin-bottom", "0px");
+    });
+  });
+
+  describe("Accessibility tests for Pager component", () => {
+    it.each([2, 5, 7])(
+      "should render Pager with currentPage prop set to %s for accessibility tests",
+      (currentPage) => {
+        CypressMountWithProviders(<PagerComponent currentPage={currentPage} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([50, 100, 235])(
+      "should render Pager with totalRecords prop set to %s for accessibility tests",
+      (totalRecords) => {
+        CypressMountWithProviders(
+          <PagerComponent totalRecords={totalRecords} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([1, 10, 25, 100])(
+      "should render Pager with pageSize prop set to %s for accessibility tests",
+      (pageSizeVal) => {
+        CypressMountWithProviders(
+          <PagerComponent pageSize={pageSizeVal} showPageSizeSelection />
+        );
+        cy.checkAccessibility();
+      }
+    );
+    it("should render Pager with pageSizeSelectionOptions prop for accessibility tests", () => {
+      CypressMountWithProviders(
+        <PagerComponent
+          pageSizeSelectionOptions={recordsDiff}
+          showPageSizeSelection
+        />
+      );
+      cy.checkAccessibility();
+    });
+
+    it.each([true, false])(
+      "should render Pager with showPageSizeSelection prop set to %s for accessibility tests",
+      (bool) => {
+        CypressMountWithProviders(
+          <PagerComponent showPageSizeSelection={bool} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "should render Pager with showPageSizeLabelAfter prop set to %s for accessibility tests",
+      (boolVal) => {
+        CypressMountWithProviders(
+          <PagerComponent
+            showPageSizeLabelAfter={boolVal}
+            showPageSizeSelection
+          />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "should render Pager with showTotalRecords prop set to %s for accessibility tests",
+      (boolVal) => {
+        CypressMountWithProviders(
+          <PagerComponent showTotalRecords={boolVal} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "should render Pager with showFirstAndLastButtons prop set to %s for accessibility tests",
+      (boolVal) => {
+        CypressMountWithProviders(
+          <PagerComponent showFirstAndLastButtons={boolVal} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "should render Pager with showPreviousAndNextButtons prop set to %s for accessibility tests",
+      (boolVal) => {
+        CypressMountWithProviders(
+          <PagerComponent showPreviousAndNextButtons={boolVal} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "should render Pager with showPageCount prop set to %s for accessibility tests",
+      (boolVal) => {
+        CypressMountWithProviders(<PagerComponent showPageCount={boolVal} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["default", "alternate"])(
+      "should render Pager with variant prop set to %s for accessibility tests",
+      (variant) => {
+        CypressMountWithProviders(<PagerComponent variant={variant} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "pager links are rendered as intended when hideDisabledElements is set to %s and currentPage is 1 for accessibility tests",
+      (boolVal) => {
+        CypressMountWithProviders(
+          <PagerComponent currentPage={1} hideDisabledElements={boolVal} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "pager links are rendered as intended when hideDisabledElements is set to %s and currentPage is 10 for accessibility tests",
+      (boolVal) => {
+        CypressMountWithProviders(
+          <PagerComponent currentPage={10} hideDisabledElements={boolVal} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it("both pager links are rendered when hideDisabledElements is set to true, but currenPage is above 1 for accessibility tests", () => {
+      CypressMountWithProviders(
+        <PagerComponent currentPage={7} hideDisabledElements />
+      );
+      cy.checkAccessibility();
+    });
+
+    it.each([-1, -10, -100, testData[0], testData[1]])(
+      "should set totalRecords out of scope to %s for accessibility tests",
+      (totalRecords) => {
+        CypressMountWithProviders(
+          <PagerComponent totalRecords={totalRecords} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should disable nextArrow and lastArrow buttons after clicking on lastArrow button for accessibility tests", () => {
+      CypressMountWithProviders(<PagerComponent currentPage={3} />);
+      lastArrow().click();
+      cy.checkAccessibility();
+    });
+
+    it("should disable firstArrow and previousArrow buttons after clicking on firstArrow button for accessibility tests", () => {
+      CypressMountWithProviders(<PagerComponent currentPage={3} />);
+      firstArrow().click();
+      cy.checkAccessibility();
+    });
+
+    it("should disable firstArrow and previousArrow buttons after clicking on previousArrow button for accessibility tests", () => {
+      CypressMountWithProviders(<PagerComponent currentPage={2} />);
+      previousArrow().click();
+      cy.checkAccessibility();
+    });
+
+    it("should disable firstArrow and previousArrow buttons after clicking on nextArrow button for accessibility tests", () => {
+      CypressMountWithProviders(<PagerComponent currentPage={9} />);
+      nextArrow().click();
+      cy.checkAccessibility();
+    });
+
+    it.each([1001, 901, 701, 601, 45])(
+      "should render Pager in %s px width for accessibility tests",
+      (viewportWidth) => {
+        cy.viewport(viewportWidth, 768);
+        CypressMountWithProviders(<PagerComponentResponsive />);
+        cy.checkAccessibility();
+      }
+    );
+
+    // FE-4659
+    describe.skip("should render Pager component for accessibility tests", () => {
+      it.each([true, false])(
+        "should render Pager with showPageSizeLabelBefore prop set to %s for accessibility tests",
+        (boolVal) => {
+          CypressMountWithProviders(
+            <PagerComponent
+              showPageSizeLabelBefore={boolVal}
+              showPageSizeSelection
+            />
+          );
+          cy.checkAccessibility();
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Pager` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there are newly added tests
- [x] Check if the `pager.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Pager` tests are not running twice.