### PR TITLE
docs(decimal): fix naming error with test story - FE-5695

### DIFF
--- a/src/components/decimal/decimal-test.stories.tsx
+++ b/src/components/decimal/decimal-test.stories.tsx
@@ -13,7 +13,7 @@ import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 export default {
   title: "Decimal Input/Test",
-  includeStories: "DefaultStory",
+  includeStories: "DecimalStory",
   parameters: {
     info: { disable: true },
     chromatic: {


### PR DESCRIPTION
Unexpected error while loading decimal-test-story is appearing in the console whilst using Storybook in localhost. This is due to a nonexistent story being definied as the includeStories parameter.

fixes #FE-5695

### Proposed behaviour

No error message relating to `decimal-test.stories` appears in the console when using localhost.

### Current behaviour

![Screenshot 2023-02-23 at 10 16 04](https://user-images.githubusercontent.com/56251247/220893058-e80bfed2-70f8-4982-a3df-2ba14f67a789.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

All tests should pass as usual and no error should appear in the console when using Storybook on localhost.
