### PR TITLE
test(accordion, flat-table): add helper for testing rotation angle

### DIFF
--- a/cypress/support/helper.js
+++ b/cypress/support/helper.js
@@ -176,3 +176,18 @@ export function keyCode(type) {
     pageup: { key: "PageUp", keyCode: 33, which: 33 },
   }[type];
 }
+
+// converts from a "matrix(a, b, c, d, e, f)" string output from a CSS transform: rotate
+// to the actual rotation angle, while accounting for rounding errors in the calculation.
+// Adapted from https://css-tricks.com/get-value-of-css-rotation-through-javascript/
+export function getRotationAngle(cssTransformString) {
+  const matrixValues = cssTransformString
+    .split("(")[1]
+    .split(")")[0]
+    .split(",")
+    .map(Number);
+  const [a, b] = matrixValues;
+  const angleInRadians = Math.atan2(b, a);
+  const angleInDegrees = angleInRadians * (180 / Math.PI);
+  return Math.round(angleInDegrees);
+}

--- a/src/components/accordion/accordion.test.js
+++ b/src/components/accordion/accordion.test.js
@@ -8,7 +8,11 @@ import {
   accordionTitleContainerByPosition,
   accordionContent,
 } from "../../../cypress/locators/accordion";
-import { positionOfElement, keyCode } from "../../../cypress/support/helper";
+import {
+  positionOfElement,
+  keyCode,
+  getRotationAngle,
+} from "../../../cypress/support/helper";
 import { getDataElementByValue } from "../../../cypress/locators";
 import {
   ACCORDION_ADD_CONTENT,
@@ -92,10 +96,9 @@ context("Testing Accordion component", () => {
         accordionIcon()
           .should("have.attr", "type", iconType)
           .and("be.visible")
-          .and(
-            "have.css",
-            "transform",
-            "matrix(6.12323e-17, 1, -1, 6.12323e-17, 0, 0)"
+          .and("have.css", "transform")
+          .then((cssString) =>
+            expect(getRotationAngle(cssString)).to.equal(90)
           );
       }
     );
@@ -110,11 +113,7 @@ context("Testing Accordion component", () => {
         accordionIcon()
           .should("have.attr", "type", iconType)
           .and("be.visible")
-          .and(
-            "not.have.css",
-            "transform",
-            "matrix(6.12323e-17, 1, -1, 6.12323e-17, 0, 0)"
-          );
+          .and("have.css", "transform", "none");
       }
     );
 

--- a/src/components/flat-table/flat-table.test.js
+++ b/src/components/flat-table/flat-table.test.js
@@ -79,11 +79,10 @@ import {
   positionOfElement,
   pressTABKey,
   pressShiftTABKey,
+  getRotationAngle,
 } from "../../../cypress/support/helper";
 
 const { _, $ } = Cypress;
-
-const transform = "matrix(6.12323e-17, -1, 1, 6.12323e-17, 0, 0)";
 
 const sizes = [
   ["compact", "8px", "13px", 24],
@@ -3984,7 +3983,9 @@ context("Tests for Flat Table component", () => {
     it("should render Flat Table with expandable rows expanded by mouse, subrows not accessible", () => {
       CypressMountWithProviders(<FlatTableNoAccSubRowComponent />);
 
-      flatTableExpandableIcon(0).should("have.css", "transform", transform);
+      flatTableExpandableIcon(0)
+        .should("have.css", "transform")
+        .then((cssString) => expect(getRotationAngle(cssString)).to.equal(-90));
       flatTableSubrows().should("not.exist");
       flatTableBodyRowByPosition(0).click();
       flatTableSubrowByPosition(0).should("exist");
@@ -3999,7 +4000,9 @@ context("Tests for Flat Table component", () => {
     it("should render Flat Table with expandable rows expanded by Spacebar, subrows not accessible", () => {
       CypressMountWithProviders(<FlatTableNoAccSubRowComponent />);
 
-      flatTableExpandableIcon(0).should("have.css", "transform", transform);
+      flatTableExpandableIcon(0)
+        .should("have.css", "transform")
+        .then((cssString) => expect(getRotationAngle(cssString)).to.equal(-90));
       flatTableSubrows().should("not.exist");
       flatTableBodyRowByPosition(0)
         .focus()
@@ -4016,7 +4019,9 @@ context("Tests for Flat Table component", () => {
     it("should render Flat Table with expandable rows expanded by Enter key, subrows not accessible", () => {
       CypressMountWithProviders(<FlatTableNoAccSubRowComponent />);
 
-      flatTableExpandableIcon(0).should("have.css", "transform", transform);
+      flatTableExpandableIcon(0)
+        .should("have.css", "transform")
+        .then((cssString) => expect(getRotationAngle(cssString)).to.equal(-90));
       flatTableSubrows().should("not.exist");
       flatTableBodyRowByPosition(0)
         .focus()
@@ -4041,7 +4046,9 @@ context("Tests for Flat Table component", () => {
     it("should render Flat Table with expandable rows expanded by mouse, can tab to subrows", () => {
       CypressMountWithProviders(<FlatTableAccSubRowComponent />);
 
-      flatTableExpandableIcon(0).should("have.css", "transform", transform);
+      flatTableExpandableIcon(0)
+        .should("have.css", "transform")
+        .then((cssString) => expect(getRotationAngle(cssString)).to.equal(-90));
       flatTableSubrows().should("not.exist");
       flatTableBodyRowByPosition(0).click();
       flatTableSubrowByPosition(0).should("exist");
@@ -4089,7 +4096,9 @@ context("Tests for Flat Table component", () => {
     it("should render Flat Table expandable by any column in the row", () => {
       CypressMountWithProviders(<FlatTableNoAccSubRowComponent />);
 
-      flatTableExpandableIcon(0).should("have.css", "transform", transform);
+      flatTableExpandableIcon(0)
+        .should("have.css", "transform")
+        .then((cssString) => expect(getRotationAngle(cssString)).to.equal(-90));
 
       for (let i = 0; i < 4; i++) {
         flatTableSubrows().should("not.exist");
@@ -4102,7 +4111,9 @@ context("Tests for Flat Table component", () => {
     it("should render Flat Table expandable by first column only by mouse", () => {
       CypressMountWithProviders(<FlatTableFirstColExpandableComponent />);
 
-      flatTableExpandableIcon(0).should("have.css", "transform", transform);
+      flatTableExpandableIcon(0)
+        .should("have.css", "transform")
+        .then((cssString) => expect(getRotationAngle(cssString)).to.equal(-90));
       flatTableSubrows().should("not.exist");
 
       for (let i = 1; i < 4; i++) {
@@ -4118,7 +4129,9 @@ context("Tests for Flat Table component", () => {
     it("should render Flat Table expandable by first column only by Spacebar", () => {
       CypressMountWithProviders(<FlatTableFirstColExpandableComponent />);
 
-      flatTableExpandableIcon(0).should("have.css", "transform", transform);
+      flatTableExpandableIcon(0)
+        .should("have.css", "transform")
+        .then((cssString) => expect(getRotationAngle(cssString)).to.equal(-90));
       flatTableSubrows().should("not.exist");
       flatTableCell(0).focus().trigger("keydown", keyCode("Space"));
       flatTableSubrowByPosition(0).should("exist");
@@ -4128,7 +4141,9 @@ context("Tests for Flat Table component", () => {
     it("should render Flat Table expandable by first column only by Enter key", () => {
       CypressMountWithProviders(<FlatTableFirstColExpandableComponent />);
 
-      flatTableExpandableIcon(0).should("have.css", "transform", transform);
+      flatTableExpandableIcon(0)
+        .should("have.css", "transform")
+        .then((cssString) => expect(getRotationAngle(cssString)).to.equal(-90));
       flatTableSubrows().should("not.exist");
       flatTableCell(0).focus().trigger("keydown", keyCode("Enter"));
       flatTableSubrowByPosition(0).should("exist");
@@ -4138,10 +4153,10 @@ context("Tests for Flat Table component", () => {
     it("should render Flat Table with all expandable rows expanded", () => {
       CypressMountWithProviders(<FlatTableAlreadyExpandedComponent />);
 
-      flatTableExpandableIcon(0).should("not.have.css", transform);
-      flatTableExpandableIcon(12).should("not.have.css", transform);
-      flatTableExpandableIcon(24).should("not.have.css", transform);
-      flatTableExpandableIcon(36).should("not.have.css", transform);
+      flatTableExpandableIcon(0).should("have.css", "transform", "none");
+      flatTableExpandableIcon(12).should("have.css", "transform", "none");
+      flatTableExpandableIcon(24).should("have.css", "transform", "none");
+      flatTableExpandableIcon(36).should("have.css", "transform", "none");
       flatTableSubrows().should("exist");
     });
 


### PR DESCRIPTION
Currently the cypress tests for Accordion and FlatTable fail when run locally, although they pass on Github CI. This is because recent versions of Chrome (since v109) appear to calculate CSS transform matrices more accurately for rotations - the Github CI is currently running on v107, so to get this to pass we've had to test against specific CSS values that are not quite zero. This not only causes failure when using updated versions of Chrome, it's a very fragile way to test in general. To avoid this we should refactor to use a test utility specifically designed to compute the rotation angle from such a CSS matrix string, while accounting for rounding errors.

### Proposed behaviour

Cypress test should pass when run against all recent browser versions

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

Cypress tests fail when run locally on Chrome v110 (but pass on Github CI, currently running Chrome v107)

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
