### PR TITLE
test(icon): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -96,6 +96,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("dismissible-box") &&
       !prepareUrl[0].startsWith("dialog") &&
       !prepareUrl[0].startsWith("button") &&
+      !prepareUrl[0].startsWith("icon") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/icon/icon-test.stories.tsx
+++ b/src/components/icon/icon-test.stories.tsx
@@ -11,6 +11,7 @@ import Icon from ".";
 
 export default {
   title: "Icon/Test",
+  includeStories: ["Default", "All"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -139,4 +140,29 @@ All.story = {
     },
     themeProvider: { chromatic: { theme: "sage" } },
   },
+};
+
+export const IconComponent = ({ ...props }) => {
+  return <Icon type="add" tooltipVisible {...props} />;
+};
+
+export const IconTooltipComponent = ({ ...props }) => {
+  return (
+    <div
+      style={{
+        marginLeft: "300px",
+        marginRight: "64px",
+        marginTop: "64px",
+        marginBottom: "64px",
+      }}
+    >
+      <Icon
+        type="add"
+        tooltipVisible
+        tooltipMessage="Hey I'm a tooltip with a different position!"
+        {...props}
+      />
+      ;
+    </div>
+  );
 };

--- a/src/components/icon/icon.test.js
+++ b/src/components/icon/icon.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Icon from "./icon.component";
+import { IconComponent, IconTooltipComponent } from "./icon-test.stories";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { icon, getDataElementByValue, cyRoot } from "../../../cypress/locators";
 import {
@@ -11,31 +11,6 @@ import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-h
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const colorData = [COLOR.ORANGE, COLOR.RED, COLOR.BLACK, COLOR.BROWN];
-
-const IconComponent = ({ ...props }) => {
-  return <Icon type="add" tooltipVisible {...props} />;
-};
-
-const IconTooltipComponent = ({ ...props }) => {
-  return (
-    <div
-      style={{
-        marginLeft: "300px",
-        marginRight: "64px",
-        marginTop: "64px",
-        marginBottom: "64px",
-      }}
-    >
-      <Icon
-        type="add"
-        tooltipVisible
-        tooltipMessage="Hey I'm a tooltip with a different position!"
-        {...props}
-      />
-      ;
-    </div>
-  );
-};
 
 context("Tests for Icon component", () => {
   describe("should check Icon component properties", () => {
@@ -191,6 +166,7 @@ context("Tests for Icon component", () => {
         );
       }
     );
+
     it.each(testData)(
       "should check tooltip id as %s for Icon component",
       (tooltipId) => {
@@ -236,6 +212,177 @@ context("Tests for Icon component", () => {
     it.each(testData)("should check id as %s for Icon component", (id) => {
       CypressMountWithProviders(<IconComponent id={id} />);
       icon().should("have.id", id);
+    });
+  });
+
+  describe("Accessibility tests for Icon component", () => {
+    it.each(["error", "add", "admin", "alert"])(
+      "should check %s type for accessibilty tests",
+      (iconType) => {
+        CypressMountWithProviders(<IconComponent type={iconType} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      SIZE.EXTRASMALL,
+      SIZE.SMALL,
+      SIZE.MEDIUM,
+      SIZE.LARGE,
+      SIZE.EXTRALARGE,
+    ])("should check %s bgSize for accessibilty tests", (size) => {
+      CypressMountWithProviders(<IconComponent bgSize={size} />);
+      cy.checkAccessibility();
+    });
+
+    it.each(["circle", "rounded-rect", "square"])(
+      "should check bgShape as %s for accessibilty tests",
+      (bgShape) => {
+        CypressMountWithProviders(<IconComponent bgShape={bgShape} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE, SIZE.EXTRALARGE])(
+      "should check %s fontSize for accessibilty tests",
+      (fontSize) => {
+        CypressMountWithProviders(<IconComponent fontSize={fontSize} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(colorData)(
+      "should check %s background color for accessibilty tests",
+      (backgroundColor) => {
+        CypressMountWithProviders(<IconComponent bg={backgroundColor} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(colorData)(
+      "should check icon color as %s for accessibilty tests",
+      (iconColor) => {
+        CypressMountWithProviders(<IconComponent color={iconColor} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "should check when disabled is %s for accessibilty tests",
+      (bool) => {
+        CypressMountWithProviders(<IconComponent disabled={bool} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["true", "false"])(
+      "should check when aria-hidden is %s for accessibilty tests",
+      (bool) => {
+        CypressMountWithProviders(<IconComponent aria-hidden={bool} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check tooltipMessage as %s for accessibilty tests",
+      (tooltipMessage) => {
+        CypressMountWithProviders(
+          <IconTooltipComponent tooltipMessage={tooltipMessage} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["bottom", "left", "right", "top"])(
+      "should check %s position of tooltip for accessibilty tests",
+      (position) => {
+        CypressMountWithProviders(
+          <IconTooltipComponent tooltipPosition={position} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([true, false])(
+      "should check when tooltip visibility is %s for accessibilty tests",
+      (bool) => {
+        CypressMountWithProviders(
+          <IconTooltipComponent tooltipVisible={bool} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(colorData)(
+      "should check tooltip background-color as %s for accessibilty tests",
+      (tooltipBgColor) => {
+        CypressMountWithProviders(
+          <IconTooltipComponent tooltipBgColor={tooltipBgColor} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(colorData)(
+      "should check tooltip font color as %s for accessibilty tests",
+      (tooltipFontColor) => {
+        CypressMountWithProviders(
+          <IconTooltipComponent tooltipFontColor={tooltipFontColor} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check tooltip id as %s for accessibilty tests",
+      (tooltipId) => {
+        CypressMountWithProviders(
+          <IconTooltipComponent tooltipId={tooltipId} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      ["left", "bottom"],
+      ["top", "bottom"],
+      ["left", "top"],
+      ["bottom", "top"],
+      ["bottom", "left"],
+      ["bottom", "right"],
+      ["top", "left"],
+      ["top", "right"],
+      ["right", "bottom"],
+      ["right", "top"],
+    ])(
+      "should check flip position to the %s when tooltip position is %s and scrolling to the %s side for accessibilty tests",
+      (flipPosition, tooltipPosition) => {
+        CypressMountWithProviders(
+          <div style={{ padding: "60px 60px 60px 60px" }}>
+            <IconTooltipComponent
+              tooltipFlipOverrides={[flipPosition]}
+              tooltipPosition={tooltipPosition}
+            />
+          </div>
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)("should check id as %s for accessibilty tests", (id) => {
+      CypressMountWithProviders(<IconComponent id={id} />);
+      cy.checkAccessibility();
+    });
+
+    // FE-4643
+    describe.skip("Accessibility tests for ariaLabel", () => {
+      it.each(testData)(
+        "should check ariaLabel as %s for accessibilty tests",
+        (ariaLabel) => {
+          CypressMountWithProviders(<IconComponent ariaLabel={ariaLabel} />);
+          cy.checkAccessibility();
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `Icon` component to use the new cypress-component-react framework for testing.
- Move testing component to the `icon-test.stories.tsx`

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added test.file
- [x] Check if the `icon.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Icon` tests are not running twice.