### PR TITLE
test(fieldset): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -97,6 +97,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("dialog") &&
       !prepareUrl[0].startsWith("button") &&
       !prepareUrl[0].startsWith("icon") &&
+      !prepareUrl[0].startsWith("fieldset") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/fieldset/fieldset-test.stories.tsx
+++ b/src/components/fieldset/fieldset-test.stories.tsx
@@ -1,23 +1,24 @@
 import React from "react";
-import { ComponentMeta } from "@storybook/react";
 import Fieldset from "./fieldset.component";
 import Textbox from "../textbox";
+import Checkbox from "../checkbox/checkbox.component";
 
 export default {
   title: "Fieldset/Test",
+  includeStories: "Default",
   parameters: {
     info: { disable: true },
     chromatic: {
       disableSnapshot: true,
     },
   },
-} as ComponentMeta<typeof Fieldset>;
+};
 
 type FieldsetStoryProps = {
   legend?: string;
 };
 
-export const DefaultStory = ({ legend }: FieldsetStoryProps) => {
+export const Default = ({ legend }: FieldsetStoryProps) => {
   return (
     <Fieldset legend={legend}>
       <Textbox
@@ -45,4 +46,51 @@ export const DefaultStory = ({ legend }: FieldsetStoryProps) => {
   );
 };
 
-DefaultStory.storyName = "default";
+Default.storyName = "default";
+
+export const FieldsetComponent = ({ ...props }) => {
+  return (
+    <div>
+      <Fieldset legend="Fieldset" {...props}>
+        <Textbox
+          label="First Name"
+          labelInline
+          labelAlign="right"
+          labelWidth={30}
+        />
+        <Textbox
+          label="Last Name"
+          labelInline
+          labelAlign="right"
+          labelWidth={30}
+        />
+        <Textbox
+          label="Address"
+          labelInline
+          labelAlign="right"
+          labelWidth={30}
+        />
+        <Checkbox
+          label="Checkbox"
+          labelAlign="right"
+          labelWidth={30}
+          labelSpacing={2}
+          reverse
+        />
+        <Textbox label="City" labelInline labelAlign="right" labelWidth={30} />
+        <Textbox
+          label="Country"
+          labelInline
+          labelAlign="right"
+          labelWidth={30}
+        />
+        <Textbox
+          label="Telephone"
+          labelInline
+          labelAlign="right"
+          labelWidth={30}
+        />
+      </Fieldset>
+    </div>
+  );
+};

--- a/src/components/fieldset/fieldset.test.js
+++ b/src/components/fieldset/fieldset.test.js
@@ -1,8 +1,8 @@
 import React from "react";
 import Fieldset from "./fieldset.component";
+import { FieldsetComponent } from "./fieldset-test.stories";
 import legendPreview from "../../../cypress/locators/fieldset";
 import Textbox from "../textbox/textbox.component";
-import Checkbox from "../checkbox/checkbox.component";
 import Form from "../form/form.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { getDataElementByValue } from "../../../cypress/locators/index";
@@ -19,53 +19,6 @@ const specialCharacters = [
   CHARACTERS.DIACRITICS,
   CHARACTERS.SPECIALCHARACTERS,
 ];
-
-const FieldsetComponent = ({ ...props }) => {
-  return (
-    <div>
-      <Fieldset legend="Fieldset" {...props}>
-        <Textbox
-          label="First Name"
-          labelInline
-          labelAlign="right"
-          labelWidth={30}
-        />
-        <Textbox
-          label="Last Name"
-          labelInline
-          labelAlign="right"
-          labelWidth={30}
-        />
-        <Textbox
-          label="Address"
-          labelInline
-          labelAlign="right"
-          labelWidth={30}
-        />
-        <Checkbox
-          label="Checkbox"
-          labelAlign="right"
-          labelWidth={30}
-          labelSpacing={2}
-          reverse
-        />
-        <Textbox label="City" labelInline labelAlign="right" labelWidth={30} />
-        <Textbox
-          label="Country"
-          labelInline
-          labelAlign="right"
-          labelWidth={30}
-        />
-        <Textbox
-          label="Telephone"
-          labelInline
-          labelAlign="right"
-          labelWidth={30}
-        />
-      </Fieldset>
-    </div>
-  );
-};
 
 context("Testing Fieldset component", () => {
   describe("should render Fieldset component", () => {
@@ -207,5 +160,125 @@ context("Testing Fieldset component", () => {
           .and("have.css", "margin-bottom", `${margin}px`);
       }
     );
+  });
+
+  describe("Accessibility tests for Fieldset component", () => {
+    it("should pass accessibility tests for Fieldset default story", () => {
+      CypressMountWithProviders(<FieldsetComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each(specialCharacters)(
+      "should pass accessibility tests for Fieldset when preview text is %s",
+      (chars) => {
+        CypressMountWithProviders(<FieldsetComponent legend={chars} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      ["inline", true],
+      ["as a column", false],
+    ])(
+      "should pass accessibility tests for Fieldset when displayed %s",
+      (state, bool) => {
+        CypressMountWithProviders(<FieldsetComponent inline={bool} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      [VALIDATION.ERROR, "error", true],
+      [VALIDATION.WARNING, "warning", true],
+      [VALIDATION.INFO, "info", true],
+      ["rgb(102, 132, 148)", "error", false],
+      ["rgb(102, 132, 148)", "warning", false],
+      ["rgb(102, 132, 148)", "info", false],
+    ])(
+      "should pass accessibility tests for Fieldset with input border colour %s when validation is %s and boolean prop is %s",
+      (borderColor, type, bool) => {
+        CypressMountWithProviders(
+          <Fieldset
+            key={`${type}-boolean`}
+            legend={`Fieldset ${type} as boolean`}
+          >
+            <Textbox
+              label="Address"
+              labelInline
+              labelAlign="right"
+              {...{ [type]: bool }}
+            />
+          </Fieldset>
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([0, 4, 7])(
+      "should pass accessibility tests for Fieldset displayed inside a Form when field spacing is %s",
+      (spacing) => {
+        CypressMountWithProviders(
+          <Form fieldSpacing={spacing} data-element="form">
+            <Fieldset>
+              <Textbox label="Fieldset 1 Field 1" labelInline />
+              <Textbox label="Fieldset 1 Field 2" labelInline />
+            </Fieldset>
+            <Textbox label="Separate Field" labelInline />
+          </Form>
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    // FE-5382
+    describe.skip("skip", () => {
+      it.each(["error", "warning", "info"])(
+        "should pass accessibility tests for Fieldset with %s validation icon on input",
+        (type) => {
+          CypressMountWithProviders(
+            <Fieldset
+              key={`${type}-string-component`}
+              legend={`Fieldset ${type} on component`}
+            >
+              <Textbox
+                label="Address"
+                labelInline
+                labelAlign="right"
+                {...{ [type]: "Message" }}
+              />
+            </Fieldset>
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+
+      it.each(["error", "warning", "info"])(
+        "should pass accessibility tests for Fieldset with %s validation icon on label",
+        (type) => {
+          CypressMountWithProviders(
+            <Fieldset
+              key={`${type}-string-label`}
+              legend={`Fieldset ${type} on label`}
+            >
+              <Textbox
+                label="Address"
+                labelInline
+                labelAlign="right"
+                validationOnLabel
+                {...{ [type]: "Message" }}
+              />
+            </Fieldset>
+          );
+
+          cy.checkAccessibility();
+        }
+      );
+    });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `Fieldset` component to use the new cypress-component-react framework for testing.
- Move component stories to the `fieldset.stories.tsx`

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there is newly added test.file
- [ ] Check if the `fieldset.test.js` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Fieldset` tests are not running twice.