### PR TITLE
fix(submenu): ensure focus order is correct when submenu parent item is clicked first

### DIFF
--- a/src/components/menu/__internal__/submenu/submenu.component.js
+++ b/src/components/menu/__internal__/submenu/submenu.component.js
@@ -134,7 +134,7 @@ const Submenu = React.forwardRef(
       (id) => {
         const index = submenuItemIds.findIndex((itemId) => itemId === id);
 
-        return index === -1 ? 0 : index;
+        return index;
       },
       [submenuItemIds]
     );
@@ -181,7 +181,7 @@ const Submenu = React.forwardRef(
           }
 
           if (Events.isTabKey(event) && Events.isShiftKey(event)) {
-            if (nextIndex === 0) {
+            if (nextIndex <= 0) {
               closeSubmenu();
               return;
             }

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -16,13 +16,24 @@ import {
   assertStyleMatch,
 } from "../../__spec_helper__/test-utils";
 import openSubmenu from "./__internal__/spec-helper";
-import { StyledSubmenu } from "./__internal__/submenu/submenu.style";
+import {
+  StyledSubmenu,
+  StyledSubmenuWrapper,
+} from "./__internal__/submenu/submenu.style";
 import StyledMenuItemWrapper from "./menu-item/menu-item.style";
 import menuConfigVariants from "./menu.config";
 
 const events = {
   end: {
     key: "End",
+    preventDefault: jest.fn(),
+  },
+  tab: {
+    key: "Tab",
+    preventDefault: jest.fn(),
+  },
+  arrowDown: {
+    key: "ArrowDown",
     preventDefault: jest.fn(),
   },
 };
@@ -242,5 +253,48 @@ describe("Menu", () => {
       expect(openSubmenus.length).toEqual(1);
       expect(openSubmenus.at(0).html()).toContain("submenu 2");
     });
+  });
+
+  describe("when clicking a submenu parent item", () => {
+    it.each(["tab", "arrowDown"])(
+      "should move focus to the first item in the submenu when %s key pressed",
+      (key) => {
+        const element = document.createElement("div");
+        const htmlElement = document.body.appendChild(element);
+
+        wrapper = mount(
+          <Menu>
+            <MenuItem submenu="submenu 1">
+              <MenuItem href="#">submenu 1 item 1</MenuItem>
+              <MenuItem href="#">submenu 1 item 2</MenuItem>
+            </MenuItem>
+          </Menu>,
+          { attachTo: htmlElement }
+        );
+
+        const menuItem = wrapper
+          .find(StyledSubmenuWrapper)
+          .first()
+          .find("button");
+
+        openSubmenu(wrapper, 0);
+
+        act(() => {
+          menuItem.props().onClick();
+        });
+
+        wrapper.update();
+
+        act(() => {
+          menuItem.props().onKeyDown(events[key]);
+        });
+
+        wrapper.update();
+
+        expect(
+          wrapper.find(StyledMenuItemWrapper).at(1).find("a")
+        ).toBeFocused();
+      }
+    );
   });
 });

--- a/src/components/menu/menu.test.js
+++ b/src/components/menu/menu.test.js
@@ -47,6 +47,7 @@ import CypressMountWithProviders from "../../../cypress/support/component-helper
 
 const span = "span";
 const div = "div";
+const button = "button";
 
 const MenuComponent = ({ ...props }) => {
   return (
@@ -307,6 +308,20 @@ context("Testing Menu component", () => {
       innerMenu(positionOfElement("fifth"), span).click({ multiple: true });
       cy.focused().trigger("keydown", keyCode("uparrow"));
       cy.focused().trigger("keydown", keyCode("uparrow"));
+    });
+
+    it("should verify a the first submenu item is focused using keyboard tabbing after the parent item was clicked", () => {
+      CypressMountWithProviders(<MenuComponent />);
+
+      submenu().eq(positionOfElement("first"), button).click();
+      cy.focused().tab();
+    });
+
+    it("should verify a the first submenu item is focused using keyboard down arrow after the parent item was clicked", () => {
+      CypressMountWithProviders(<MenuComponent />);
+
+      submenu().eq(positionOfElement("first"), button).click();
+      cy.focused().trigger("keydown", keyCode("downarrow"));
     });
 
     it("should verify number and type of elements in submenu", () => {


### PR DESCRIPTION
fix #5850

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Ensures that when a `MenuItem` with a `Submenu` is clicked the first child item within the submenu is focused when tab or arrow down key is pressed

![sub-parent-click-fix](https://user-images.githubusercontent.com/44157880/221853789-80162b49-c96e-4a4d-afdc-cdc77d589e95.gif)


### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
When a `MenuItem` with a `Submenu` is clicked the first child item within the submenu is not focused when tab or arrow down key is pressed

![sub-parent-click-broke](https://user-images.githubusercontent.com/44157880/221854065-ab86cf77-5090-42d8-9279-3e76106c41fe.gif)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
click item with submenu, press tab or down arrow key and confirm first item in submenu is focused

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
