### PR TITLE
fix: resolve an issue with styles being overriden in child buttons in SplitButton/MultiActionButton - FE-5678/FE-5700

### DIFF
--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
@@ -339,7 +339,6 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
 
 .c14 .c1 {
   border: 1px solid var(--colorsActionMajorTransparent);
-  color: var(--colorsActionMajor500);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -352,12 +351,6 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
   min-width: 100%;
   text-align: left;
   z-index: 1000;
-}
-
-.c14 .c1:focus,
-.c14 .c1:hover {
-  background-color: var(--colorsActionMajor600);
-  color: var(--colorsActionMajorYang100);
 }
 
 .c14 .c1 + .c16 .c1 {

--- a/src/components/multi-action-button/multi-action-button.stories.mdx
+++ b/src/components/multi-action-button/multi-action-button.stories.mdx
@@ -14,9 +14,9 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 <a
   target="_blank"
   href="https://zeroheight.com/2ccf2b601/p/7428b1-button-multi-action/b/18aaff"
-  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+  style={{ color: "#007E45", fontWeight: "bold", textDecoration: "underline" }}
 >
-  Product Design System component 
+  Product Design System component
 </a>
 
 ## Contents
@@ -47,7 +47,7 @@ import MultiActionButton from "carbon-react/lib/components/multi-action-button";
 
 ### Custom width
 
-Numbers from 0-1 are converted to percentage widths. Numbers greater than 1 are converted to pixel values. 
+Numbers from 0-1 are converted to percentage widths. Numbers greater than 1 are converted to pixel values.
 String values are passed as raw CSS values. `size` prop can still be used to set desired height.
 
 <Canvas>
@@ -60,10 +60,18 @@ String values are passed as raw CSS values. `size` prop can still be used to set
   <Story name="button types" story={stories.ButtonTypes} />
 </Canvas>
 
+### Child Button types
+
+Buttons used as a content of `MultiActionButton` can be of any type.
+
+<Canvas>
+  <Story name="child button types" story={stories.ChildButtonTypes} />
+</Canvas>
+
 ### Sizes
 
 <Canvas>
-  <Story name="sizes" story={stories.Sizes}/>
+  <Story name="sizes" story={stories.Sizes} />
 </Canvas>
 
 ### Alignment
@@ -84,14 +92,16 @@ Subtext only works when `size` is `large`
 
 <Canvas>
   <Story
-    name="in overflow hidden container" story={stories.InOverflowHiddenContainer} />
+    name="in overflow hidden container"
+    story={stories.InOverflowHiddenContainer}
+  />
 </Canvas>
 
 ## Props
 
 ### MultiActionButton
 
-<StyledSystemProps of={MultiActionButton} width noHeader margin/>
+<StyledSystemProps of={MultiActionButton} width noHeader margin />
 
 ### Button
 

--- a/src/components/multi-action-button/multi-action-button.stories.tsx
+++ b/src/components/multi-action-button/multi-action-button.stories.tsx
@@ -74,6 +74,29 @@ export const ButtonTypes = () => {
   );
 };
 
+export const ChildButtonTypes = () => {
+  return (
+    <MultiActionButton text="Multi Action Button">
+      <Button>Default button</Button>
+      <Button buttonType="primary">Primary</Button>
+      <Button buttonType="primary" destructive>
+        Primary - destructive
+      </Button>
+      <Button buttonType="secondary">Secondary</Button>
+      <Button buttonType="secondary" destructive>
+        Secondary - destructive
+      </Button>
+      <Button buttonType="tertiary">Tertiary</Button>
+      <Button buttonType="tertiary" destructive>
+        Tertiary - destructive
+      </Button>
+      <Button disabled>Disabled</Button>
+    </MultiActionButton>
+  );
+};
+
+ChildButtonTypes.parameters = { chromatic: { disableSnapshot: true } };
+
 export const Alignment = () => {
   return (["left", "right"] as const).map(
     (align: MultiActionButtonProps["align"]) => (

--- a/src/components/multi-action-button/multi-action-button.style.ts
+++ b/src/components/multi-action-button/multi-action-button.style.ts
@@ -85,7 +85,6 @@ const StyledButtonChildrenContainer = styled.div<StyledButtonChildrenContainerPr
 
     ${StyledButton} {
       border: 1px solid var(--colorsActionMajorTransparent);
-      color: var(--colorsActionMajor500);
       display: flex;
       justify-content: ${align};
       margin-left: 0;
@@ -99,12 +98,6 @@ const StyledButtonChildrenContainer = styled.div<StyledButtonChildrenContainerPr
           display: -webkit-box;
           justify-content: ${align === "right" ? `flex-end` : `flex-start`};
         }
-      }
-
-      &:focus,
-      &:hover {
-        background-color: var(--colorsActionMajor600);
-        color: var(--colorsActionMajorYang100);
       }
 
       & + & {

--- a/src/components/split-button/split-button-children.style.ts
+++ b/src/components/split-button/split-button-children.style.ts
@@ -17,20 +17,12 @@ const StyledSplitButtonChildrenContainer = styled.div<StyledSplitButtonChildrenC
     box-shadow: var(--boxShadow100);
 
     ${StyledButton} {
-      background-color: var(--colorsActionMajorYang100);
       border: 1px solid var(--colorsActionMajorTransparent);
-      color: var(--colorsActionMajor500);
       display: block;
       margin-left: 0;
       min-width: 100%;
       text-align: ${align};
       z-index: ${theme.zIndex.overlay};
-
-      &:focus,
-      &:hover {
-        color: var(--colorsActionMajorYang100);
-        background-color: var(--colorsActionMajor600);
-      }
 
       & + & {
         margin-top: 3px;

--- a/src/components/split-button/split-button.spec.tsx
+++ b/src/components/split-button/split-button.spec.tsx
@@ -238,28 +238,6 @@ describe("SplitButton", () => {
       );
     });
 
-    it("has the expected style", () => {
-      assertStyleMatch(
-        {
-          backgroundColor: "var(--colorsActionMajorYang100)",
-          border: `1px solid var(--colorsActionMajorTransparent)`,
-        },
-        themedWrapper,
-        { modifier: `${StyledButton}` }
-      );
-    });
-
-    it('matches the expected style for the focused "additional button"', () => {
-      themedWrapper.find("button").simulate("focus");
-      assertStyleMatch(
-        {
-          backgroundColor: "var(--colorsActionMajor600)",
-        },
-        themedWrapper,
-        { modifier: `${StyledButton}:focus` }
-      );
-    });
-
     it("renders Toggle Button left border as expected", () => {
       const mockProps = {
         carbonTheme: theme as Partial<ThemeObject>,

--- a/src/components/split-button/split-button.stories.mdx
+++ b/src/components/split-button/split-button.stories.mdx
@@ -13,9 +13,9 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 <a
   target="_blank"
   href="https://zeroheight.com/2ccf2b601/p/861289-button-split"
-  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+  style={{ color: "#007E45", fontWeight: "bold", textDecoration: "underline" }}
 >
-  Product Design System component 
+  Product Design System component
 </a>
 
 # <h2>Contents</h2>
@@ -73,6 +73,33 @@ import SplitButton from "carbon-react/lib/components/split-button";
         </SplitButton>
       </Box>
     ))}
+  </Story>
+</Canvas>
+
+### Child button types
+
+Buttons used as a content of `SplitButton` can be of any type.
+
+<Canvas>
+  <Story
+    name="child button types"
+    parameters={{ chromatic: { disableSnapshot: true } }}
+  >
+    <SplitButton text="Split Button">
+      <Button>Default button</Button>
+      <Button buttonType="primary" destructive>
+        Primary - destructive
+      </Button>
+      <Button buttonType="secondary">Secondary</Button>
+      <Button buttonType="secondary" destructive>
+        Secondary - destructive
+      </Button>
+      <Button buttonType="tertiary">Tertiary</Button>
+      <Button buttonType="tertiary" destructive>
+        Tertiary - destructive
+      </Button>
+      <Button disabled>Disabled</Button>
+    </SplitButton>
   </Story>
 </Canvas>
 


### PR DESCRIPTION
### Proposed behaviour

Fixes #5720
Fixes #5874 

### Current behaviour

Styles of Buttons used inside the MultiActionButton or SplitButton are currently overriden by the parent component meaning that none of the following props work correctly on the Buttons: buttonType, disabled, destructive.
<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Either check the following sandboxes or check the new stories added to the SplitButton and MultiActionButton stories which covers scenarios where the used Buttons have different `buttonType` or are `disabled` or `destructive`

https://codesandbox.io/s/epic-blackwell-uk5u8q
https://codesandbox.io/s/spring-thunder-qntwkz
