### PR TITLE
docs(dialog): fix error with includeStories parameter - FE-5704

### DIFF
--- a/src/components/dialog/dialog-test.stories.tsx
+++ b/src/components/dialog/dialog-test.stories.tsx
@@ -15,7 +15,7 @@ import { DIALOG_SIZES } from "./dialog.config";
 
 export default {
   title: "Dialog/Test",
-  includeStories: "DefaultStory",
+  includeStories: "Default",
   parameters: {
     info: { disable: true },
     chromatic: {


### PR DESCRIPTION
### Proposed behaviour

No errors should appear in console related to dialog stories.

### Current behaviour

![image](https://user-images.githubusercontent.com/56251247/222472958-f4bb39a4-5237-4537-99c3-38142adad4c5.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Open Storybook in LocalHost. 
- Open the console and make sure no error is there for dialog's test story.
- Check everything still work as it should too and all tests pass.
