### PR TITLE
test(drawer): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -101,6 +101,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("pager") &&
       !prepareUrl[0].startsWith("fieldset") &&
       !prepareUrl[0].startsWith("form") &&
+      !prepareUrl[0].startsWith("drawer") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/drawer/drawer-test.stories.tsx
+++ b/src/components/drawer/drawer-test.stories.tsx
@@ -17,6 +17,7 @@ import Button from "../button";
 
 export default {
   title: "Drawer/Test",
+  includeStories: "Default",
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -25,7 +26,7 @@ export default {
   },
 };
 
-export const DrawerStory = () => {
+export const DefaultStory = () => {
   const [isExpanded, setIsExpanded] = useState(true);
   const onChangeHandler = useCallback(() => {
     setIsExpanded(!isExpanded);
@@ -472,4 +473,28 @@ export const DrawerStory = () => {
   );
 };
 
-DrawerStory.storyName = "visual";
+DefaultStory.storyName = "default";
+
+export const DrawerCustom = ({ ...props }) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const onChangeHandler = React.useCallback(() => {
+    setIsExpanded(!isExpanded);
+  }, [isExpanded]);
+
+  return (
+    <Drawer
+      onChange={onChangeHandler}
+      sidebar={
+        <ul>
+          <li>link a</li>
+          <li>link b</li>
+          <li>link c</li>
+        </ul>
+      }
+      title={<Typography variant="h2">Drawer title</Typography>}
+      {...props}
+    >
+      content body for Drawer
+    </Drawer>
+  );
+};

--- a/src/components/drawer/drawer.test.js
+++ b/src/components/drawer/drawer.test.js
@@ -1,9 +1,8 @@
 import React from "react";
+import { DrawerCustom } from "./drawer-test.stories.tsx";
 import Box from "../box";
 import Button from "../button";
 import { Checkbox } from "../checkbox";
-import Drawer from "./drawer.component";
-import Typography from "../typography";
 
 import {
   drawer,
@@ -17,31 +16,6 @@ import { stickyFooter } from "../../../cypress/locators";
 import { positionOfElement } from "../../../cypress/support/helper";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-helper/common-steps";
-
-const DrawerCustom = ({ ...props }) => {
-  const [isExpanded, setIsExpanded] = React.useState(false);
-  const onChangeHandler = React.useCallback(() => {
-    setIsExpanded(!isExpanded);
-  }, [isExpanded]);
-
-  return (
-    <Drawer
-      id="drawer"
-      onChange={onChangeHandler}
-      sidebar={
-        <ul>
-          <li>link a</li>
-          <li>link b</li>
-          <li>link c</li>
-        </ul>
-      }
-      title={<Typography variant="h2">Drawer title</Typography>}
-      {...props}
-    >
-      content body for Drawer
-    </Drawer>
-  );
-};
 
 context("Test for Drawer component", () => {
   describe("check props for Drawer component", () => {
@@ -72,7 +46,7 @@ context("Test for Drawer component", () => {
       }
     );
 
-    it.each([["3s"], ["15s"]])(
+    it.each(["3s", "15s"])(
       "should check animation time is set to %s",
       (animationDuration) => {
         CypressMountWithProviders(
@@ -448,6 +422,223 @@ context("Test for Drawer component", () => {
           // eslint-disable-next-line no-unused-expressions
           expect(callback).to.have.been.calledOnce;
         });
+    });
+  });
+
+  describe("Accessibility tests for Drawer", () => {
+    it.each([
+      ["expanded", 0],
+      ["not expanded", 1],
+    ])(
+      "should pass accessibility tests for Drawer when chevron is %s",
+      (state, times) => {
+        CypressMountWithProviders(<DrawerCustom showControls />);
+
+        for (let i = 0; i < times; i++) {
+          drawerToggle().click().wait(500);
+        }
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["3s", "15s"])(
+      "should pass accessibility tests for Drawer when animation time is set to %s",
+      (animationDuration) => {
+        CypressMountWithProviders(
+          <DrawerCustom showControls animationDuration={animationDuration} />
+        );
+
+        drawerToggle().click().wait(500);
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibility tests for Drawer when closed by default", () => {
+      CypressMountWithProviders(<DrawerCustom defaultExpanded={false} />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Drawer when expanded prop is true", () => {
+      CypressMountWithProviders(<DrawerCustom expanded />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Drawer with custom sidebar", () => {
+      CypressMountWithProviders(
+        <DrawerCustom
+          sidebar={
+            <ul>
+              <li>cypress</li>
+            </ul>
+          }
+        />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Drawer with custom expandedWidth", () => {
+      CypressMountWithProviders(<DrawerCustom expandedWidth="65%" />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Drawer with custom backgroundColor", () => {
+      CypressMountWithProviders(<DrawerCustom backgroundColor="#FF0000" />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Drawer with custom height", () => {
+      CypressMountWithProviders(<DrawerCustom height="75%" />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Drawer with custom title", () => {
+      CypressMountWithProviders(<DrawerCustom title="cypress_title" />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Drawer with custom footer", () => {
+      CypressMountWithProviders(
+        <div
+          style={{
+            height: "200px",
+          }}
+        >
+          <DrawerCustom
+            sidebar={
+              <Box mb={9}>
+                <Checkbox
+                  label="Example checkbox"
+                  name="checkbox-default"
+                  ml="40px"
+                  mt="40px"
+                />
+                <Checkbox
+                  label="Example checkbox"
+                  name="checkbox-default"
+                  ml="40px"
+                  mt="40px"
+                />
+                <Checkbox
+                  label="Example checkbox"
+                  name="checkbox-default"
+                  ml="40px"
+                  mt="40px"
+                />
+              </Box>
+            }
+            footer={
+              <Box>
+                <Button mr="16px">Cancel</Button>
+                <Button buttonType="primary" type="submit">
+                  Action
+                </Button>
+              </Box>
+            }
+          />
+        </div>
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Drawer custom stickyFooter", () => {
+      CypressMountWithProviders(
+        <div
+          style={{
+            height: "200px",
+          }}
+        >
+          <DrawerCustom
+            sidebar={
+              <Box mb={9}>
+                <Checkbox
+                  label="Example checkbox"
+                  name="checkbox-default"
+                  ml="40px"
+                  mt="40px"
+                />
+                <Checkbox
+                  label="Example checkbox"
+                  name="checkbox-default"
+                  ml="40px"
+                  mt="40px"
+                />
+                <Checkbox
+                  label="Example checkbox"
+                  name="checkbox-default"
+                  ml="40px"
+                  mt="40px"
+                />
+              </Box>
+            }
+            footer={
+              <Box>
+                <Button mr="16px">Cancel</Button>
+                <Button buttonType="primary" type="submit">
+                  Action
+                </Button>
+              </Box>
+            }
+            stickyFooter
+          />
+        </div>
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Drawer with custom stickyHeader", () => {
+      CypressMountWithProviders(
+        <div
+          style={{
+            height: "200px",
+          }}
+        >
+          <DrawerCustom
+            sidebar={
+              <Box mb={9}>
+                <Checkbox
+                  label="Example checkbox"
+                  name="checkbox-default"
+                  ml="40px"
+                  mt="40px"
+                />
+                <Checkbox
+                  label="Example checkbox"
+                  name="checkbox-default"
+                  ml="40px"
+                  mt="40px"
+                />
+                <Checkbox
+                  label="Example checkbox"
+                  name="checkbox-default"
+                  ml="40px"
+                  mt="40px"
+                />
+              </Box>
+            }
+            footer={
+              <Box>
+                <Button mr="16px">Cancel</Button>
+                <Button buttonType="primary" type="submit">
+                  Action
+                </Button>
+              </Box>
+            }
+            stickyHeader
+          />
+        </div>
+      );
+
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `Drawer` component to use the new cypress-component-react framework for testing.
- Move component stories to the `drawer.stories.tsx`

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there is newly added test.file
- [ ] Check if the `drawer.test.js` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Drawer` tests are not running twice.