### PR TITLE
test(form): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -100,6 +100,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("icon") &&
       !prepareUrl[0].startsWith("pager") &&
       !prepareUrl[0].startsWith("fieldset") &&
+      !prepareUrl[0].startsWith("form") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/form/form-test.stories.tsx
+++ b/src/components/form/form-test.stories.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import Form from ".";
+import Button from "../button";
+import { Tab, Tabs } from "../tabs";
+import Box from "../box";
+import Textbox from "../textbox";
+
+export default {
+  title: "Form/Test",
+  includeStories: "DefaultWithStickyFooter",
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+};
+
+export const DefaultWithStickyFooter = () => (
+  <Form
+    onSubmit={() => console.log("submit")}
+    leftSideButtons={
+      <Button onClick={() => console.log("cancel")}>Cancel</Button>
+    }
+    saveButton={
+      <Button buttonType="primary" type="submit">
+        Save
+      </Button>
+    }
+    stickyFooter
+  >
+    <Tabs mb={2}>
+      <Tab
+        pl="3px"
+        customLayout={
+          <Box mx="16px" my="10px">
+            Tab1
+          </Box>
+        }
+        tabId="tab1"
+      />
+    </Tabs>
+    <Textbox label="Textbox" />
+    <Textbox label="Textbox" />
+    <Textbox label="Textbox" />
+    <Textbox label="Textbox" />
+    <Textbox label="Textbox" />
+    <Textbox label="Textbox" />
+    <Textbox label="Textbox" />
+  </Form>
+);
+
+DefaultWithStickyFooter.storyName = "default";
+
+export const FormComponent = ({ ...props }) => {
+  return (
+    <Form
+      saveButton={
+        <Button buttonType="primary" type="submit">
+          Save
+        </Button>
+      }
+      {...props}
+    >
+      <Textbox label="Textbox1" />
+      <Textbox label="Textbox2" />
+      <Textbox label="Textbox3" />
+    </Form>
+  );
+};

--- a/src/components/form/form.test.js
+++ b/src/components/form/form.test.js
@@ -1,7 +1,9 @@
 import React from "react";
-import Form from "../form/form.component";
+import Form from "./form.component";
+import { FormComponent } from "./form-test.stories";
 import Textbox from "../textbox/textbox.component";
 import Button from "../button/button.component";
+import * as stories from "./form.stories";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-helper/common-steps";
 import { getElement, getComponent } from "../../../cypress/locators/index";
@@ -10,23 +12,7 @@ import {
   formFooterComponent,
   formButtonComponent,
 } from "../../../cypress/locators/form/index";
-
-const FormComponent = ({ ...props }) => {
-  return (
-    <Form
-      saveButton={
-        <Button buttonType="primary" type="submit">
-          Save
-        </Button>
-      }
-      {...props}
-    >
-      <Textbox label="Textbox1" />
-      <Textbox label="Textbox2" />
-      <Textbox label="Textbox3" />
-    </Form>
-  );
-};
+import { dataComponentButtonByText } from "../../../cypress/locators/pages";
 
 context("Tests for Form component", () => {
   describe("check props for Form component", () => {
@@ -211,5 +197,119 @@ context("Tests for Form component", () => {
         });
       }
     );
+  });
+
+  describe("Accessibility tests for Form component", () => {
+    it("should pass accessibility tests for DefaultWithStickyFooter story", () => {
+      CypressMountWithProviders(<stories.DefaultWithStickyFooter />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for FormAlignmentExample story", () => {
+      CypressMountWithProviders(<stories.FormAlignmentExample />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for InDialog story", () => {
+      CypressMountWithProviders(<stories.InDialog />);
+
+      dataComponentButtonByText("Open Preview")
+        .click()
+        .then(() => {
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for InDialogFullScreen story", () => {
+      CypressMountWithProviders(<stories.InDialogFullScreen />);
+
+      dataComponentButtonByText("Open Preview")
+        .click()
+        .then(() => {
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for InDialogFullScreenWithStickyFooter story", () => {
+      CypressMountWithProviders(<stories.InDialogFullScreenWithStickyFooter />);
+
+      dataComponentButtonByText("Open Preview")
+        .click()
+        .then(() => {
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for InDialogWithStickyFooter story", () => {
+      CypressMountWithProviders(<stories.InDialogWithStickyFooter />);
+
+      dataComponentButtonByText("Open Preview")
+        .click()
+        .then(() => {
+          cy.checkAccessibility();
+        });
+    });
+
+    it("should pass accessibility tests for OverrideFieldSpacing story", () => {
+      CypressMountWithProviders(<stories.OverrideFieldSpacing />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithAdditionalButtons story", () => {
+      CypressMountWithProviders(<stories.WithAdditionalButtons />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithBothErrorsAndWarningsSummary story", () => {
+      CypressMountWithProviders(<stories.WithBothErrorsAndWarningsSummary />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithButtonsAlignedToTheLeft story", () => {
+      CypressMountWithProviders(<stories.WithButtonsAlignedToTheLeft />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithCustomFooterPadding story", () => {
+      CypressMountWithProviders(<stories.WithCustomFooterPadding />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithDifferentSpacing story", () => {
+      CypressMountWithProviders(<stories.WithDifferentSpacing />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithErrorsSummary story", () => {
+      CypressMountWithProviders(<stories.WithErrorsSummary />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithFullWidthButtons story", () => {
+      CypressMountWithProviders(<stories.WithFullWidthButtons />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithLabelsInline story", () => {
+      CypressMountWithProviders(<stories.WithLabelsInline />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithWarningsSummary story", () => {
+      CypressMountWithProviders(<stories.WithWarningsSummary />);
+
+      cy.checkAccessibility();
+    });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

#### Button
- Add `accessibility` Cypress tests for the `Form` component to use the new cypress-component-react framework for testing.
- Move testing component to the `form-test.stories.tsx`

#### Chromatic
- change the behaviour or disabling stories

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added test.file
- [x] Check if the `form.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Button` tests are not running twice.