### PR TITLE
Sage/DSY-2333(FE-5717): ShowEditPod Storybook Update

### DIFF
--- a/src/components/show-edit-pod/show-edit-pod.component.js
+++ b/src/components/show-edit-pod/show-edit-pod.component.js
@@ -10,10 +10,13 @@ import Events from "../../__internal__/utils/helpers/events";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import LocaleContext from "../../__internal__/i18n-context";
 import StyledPod from "./show-edit-pod.style";
+import Logger from "../../__internal__/utils/logger";
 
 const marginPropTypes = filterStyledSystemMarginProps(
   styledSystemPropTypes.space
 );
+
+let deprecateWarnTriggered = false;
 
 const ShowEditPod = ({
   border = false,
@@ -39,6 +42,13 @@ const ShowEditPod = ({
   variant = "transparent",
   ...rest
 }) => {
+  if (!deprecateWarnTriggered) {
+    deprecateWarnTriggered = true;
+    Logger.deprecate(
+      "The ShowEditPod component is deprecated and will soon be removed. Please use alternatives such as the Fieldset, Form or Pod components instead."
+    );
+  }
+
   const locale = useContext(LocaleContext);
 
   const ref = useRef();

--- a/src/components/show-edit-pod/show-edit-pod.spec.js
+++ b/src/components/show-edit-pod/show-edit-pod.spec.js
@@ -11,9 +11,31 @@ import {
   rootTagTest,
 } from "../../__internal__/utils/helpers/tags/tags-specs";
 import { testStyledSystemMargin } from "../../__spec_helper__/test-utils";
+import Logger from "../../__internal__/utils/logger";
+
+jest.mock("../../__internal__/utils/logger");
 
 describe("ShowEditPod", () => {
   testStyledSystemMargin((props) => <ShowEditPod {...props} />);
+
+  it("when user uses the component, a deprecation warning is raised in the console", () => {
+    const loggerSpy = jest.spyOn(Logger, "deprecate");
+    jest.restoreAllMocks();
+    mount(
+      <>
+        <ShowEditPod />
+        <ShowEditPod />
+      </>
+    );
+
+    expect(loggerSpy).toHaveBeenCalledTimes(1);
+    expect(loggerSpy).toHaveBeenCalledWith(
+      "The ShowEditPod component is deprecated and will soon be removed. Please use alternatives such as the Fieldset, Form or Pod components instead."
+    );
+
+    loggerSpy.mockRestore();
+    loggerSpy.mockClear();
+  });
 
   describe('when the "editing" prop is set on mount', () => {
     let wrapper;

--- a/src/components/show-edit-pod/show-edit-pod.stories.mdx
+++ b/src/components/show-edit-pod/show-edit-pod.stories.mdx
@@ -2,6 +2,7 @@ import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import styled from "styled-components";
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+import DeprecationWarning from "../../__internal__/DeprecationWarning";
 
 import ShowEditPod from "./";
 import Heading from "../heading";
@@ -12,6 +13,10 @@ import Textbox from "../textbox";
 <Meta title="ShowEditPod" parameters={{ info: { disable: true } }} />
 
 # ShowEditPod
+
+<DeprecationWarning>
+We've deprecated ShowEditPod. It's no longer available in the Design System and we recommend that you do not use it in new products. See Related Components section for alternatives.
+</DeprecationWarning>
 
 ## Contents
 


### PR DESCRIPTION
### Proposed behaviour
<img width="1066" alt="Screenshot 2023-03-10 at 11 56 40" src="https://user-images.githubusercontent.com/48626342/224310093-63d905e6-e130-482f-82cc-9e7a3a5aa48b.png">

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour
<img width="1079" alt="Screenshot 2023-03-10 at 11 57 18" src="https://user-images.githubusercontent.com/48626342/224310193-d64b0c59-efcc-4c04-83be-f04b3c647f8f.png">


<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
