### PR TITLE
 fix(advanced-color-picker): add visually hidden description list to describe selected color

### DIFF
--- a/cypress/locators/advanced-color-picker/index.js
+++ b/cypress/locators/advanced-color-picker/index.js
@@ -1,5 +1,6 @@
 import {
   ADVANCED_COLOR_PICKER_CELL,
+  CURRENT_COLOR_DESCRIPTION,
   SIMPLE_COLOR,
   SIMPLE_COLOR_PICKER,
 } from "./locators";
@@ -8,6 +9,7 @@ export const simpleColorPickerInput = (index) =>
   cy.get(SIMPLE_COLOR).find("input").eq(index);
 export const simpleColorPicker = (index) =>
   cy.get(SIMPLE_COLOR_PICKER).find(SIMPLE_COLOR).eq(index).find("input");
+export const currentColorDescription = () => cy.get(CURRENT_COLOR_DESCRIPTION);
 export const advancedColorPickerCell = () => cy.get(ADVANCED_COLOR_PICKER_CELL);
 export const advancedColorPicker = (index) => {
   return cy.get(SIMPLE_COLOR).eq(index);

--- a/cypress/locators/advanced-color-picker/locators.js
+++ b/cypress/locators/advanced-color-picker/locators.js
@@ -1,4 +1,6 @@
 // component preview locators
 export const ADVANCED_COLOR_PICKER_CELL = '[data-element="color-picker-cell"]';
+export const CURRENT_COLOR_DESCRIPTION =
+  '[data-element="current-color-description"]';
 export const SIMPLE_COLOR = '[data-component="simple-color"]';
 export const SIMPLE_COLOR_PICKER = '[data-component="simple-color-picker"]';

--- a/src/components/advanced-color-picker/advanced-color-picker.component.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.component.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from "react";
 import { MarginProps } from "styled-system";
 import {
   StyledAdvancedColorPickerWrapper,
+  HiddenCurrentColorList,
   StyledAdvancedColorPickerCell,
   StyledAdvancedColorPickerPreview,
   DialogStyle,
@@ -9,6 +10,9 @@ import {
 import { SimpleColorPicker, SimpleColor } from "../simple-color-picker";
 import Events from "../../__internal__/utils/helpers/events";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import guid from "../../__internal__/utils/helpers/guid";
+import useLocale from "../../hooks/__internal__/useLocale";
+import { Dt, Dd } from "../definition-list";
 
 export interface AdvancedColor {
   label: string;
@@ -74,6 +78,9 @@ export const AdvancedColorPicker = ({
     setSelectedColorRef,
   ] = useState<HTMLInputElement | null>(null);
 
+  const descriptionId = useRef(guid());
+  const l = useLocale();
+
   const simpleColorPickerData = useRef<{
     gridItemRefs: Array<HTMLInputElement | null>;
   }>(null);
@@ -90,6 +97,14 @@ export const AdvancedColorPicker = ({
           : null,
     };
   });
+
+  const currentSelectedColor = () => {
+    const returnedColor = availableColors.find(
+      (color) => color.value === currentColor
+    )?.label as string;
+
+    return returnedColor || currentColor;
+  };
 
   useEffect(() => {
     if (dialogOpen || open) {
@@ -198,11 +213,26 @@ export const AdvancedColorPicker = ({
     >
       <StyledAdvancedColorPickerCell
         data-element="color-picker-cell"
+        aria-label={l.advancedColorPicker.ariaLabel()}
+        aria-describedby={descriptionId.current}
         onClick={handleOnOpen}
         onKeyDown={handleOnKeyDown}
         color={currentColor}
         tabIndex={0}
       />
+      <HiddenCurrentColorList
+        id={descriptionId.current}
+        data-element="current-color-description"
+      >
+        <Dt>
+          {l.advancedColorPicker.currentColorDescriptionTerm(
+            currentSelectedColor()
+          )}
+        </Dt>
+        <Dd>
+          {l.advancedColorPicker.currentColorAssigned(currentSelectedColor())}
+        </Dd>
+      </HiddenCurrentColorList>
       <DialogStyle
         aria-describedby={ariaDescribedBy}
         aria-label={ariaLabel}

--- a/src/components/advanced-color-picker/advanced-color-picker.spec.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.spec.tsx
@@ -70,6 +70,23 @@ const shiftTabKey = new KeyboardEvent("keydown", {
   shiftKey: true,
 });
 
+const MockComponent = () => {
+  const [color, setColor] = useState<string>();
+
+  function handleOnChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setColor(e.target.value);
+  }
+
+  return (
+    <AdvancedColorPicker
+      {...requiredProps}
+      selectedColor={color}
+      onChange={handleOnChange}
+      open
+    />
+  );
+};
+
 describe("AdvancedColorPicker", () => {
   testStyledSystemMargin((props) => (
     <AdvancedColorPicker {...requiredProps} {...props} />
@@ -110,12 +127,60 @@ describe("AdvancedColorPicker", () => {
     );
   });
 
+  describe("color description list", () => {
+    let wrapper: ReactWrapper;
+
+    it("description is correct when no color is selected - uses currentColor instead", () => {
+      wrapper = mount(
+        <AdvancedColorPicker {...requiredProps} selectedColor="orchid" />
+      );
+      expect(
+        wrapper
+          .find('[data-element="current-color-description"]')
+          .first()
+          .text()
+      ).toBe(`Current color assigned: orchid`);
+      wrapper.unmount();
+    });
+
+    it.each([0, 1, 2])(
+      "description is correct when color is selected",
+      (colorIndex) => {
+        wrapper = mount(<MockComponent />);
+        jest.runAllTimers();
+        const color = wrapper.find(SimpleColor).at(colorIndex);
+
+        color.find("input").first().getDOMNode<HTMLInputElement>().click();
+        wrapper.update();
+
+        expect(
+          wrapper
+            .find('[data-element="current-color-description"]')
+            .first()
+            .text()
+        ).toBe(`Current color assigned: ${demoColors[colorIndex].label}`);
+        wrapper.unmount();
+      }
+    );
+  });
+
   describe("color picker cell button", () => {
     it("should have the color prop set to defaultColor", () => {
       const wrapper = render({ ...requiredProps });
       expect(
         wrapper.find('[data-element="color-picker-cell"]').first().prop("color")
       ).toBe(defaultColor);
+      wrapper.unmount();
+    });
+
+    it("should have the correct aria-label", () => {
+      const wrapper = render({ ...requiredProps });
+      expect(
+        wrapper
+          .find('[data-element="color-picker-cell"]')
+          .first()
+          .prop("aria-label")
+      ).toBe("Change colour");
       wrapper.unmount();
     });
 
@@ -233,22 +298,6 @@ describe("AdvancedColorPicker", () => {
 
   describe("when the component value is controlled, and a color is selected", () => {
     // eslint-disable-next-line react/prop-types
-    const MockComponent = () => {
-      const [color, setColor] = useState<string>();
-
-      function handleOnChange(e: React.ChangeEvent<HTMLInputElement>) {
-        setColor(e.target.value);
-      }
-
-      return (
-        <AdvancedColorPicker
-          {...requiredProps}
-          selectedColor={color}
-          onChange={handleOnChange}
-          open
-        />
-      );
-    };
     let wrapper: ReactWrapper;
 
     beforeEach(() => {

--- a/src/components/advanced-color-picker/advanced-color-picker.stories.mdx
+++ b/src/components/advanced-color-picker/advanced-color-picker.stories.mdx
@@ -1,9 +1,11 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import AdvancedColorPicker from ".";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
-import { useState } from "react";
+import * as stories from "./advanced-color-picker.stories.tsx"
 
-<Meta title="Advanced Color Picker" />
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+
+<Meta title="Advanced Color Picker" parameters={{ info: { disable: true } }} />
 
 # Advanced Color Picker
 
@@ -30,45 +32,7 @@ import AdvancedColorPicker from "carbon-react/lib/components/advanced-color-pick
 Shows how the color picker can be used to select a color from a predefined set.
 
 <Canvas>
-  <Story name="default" parameters={{ info: { disable: true } }}>
-    {() => {
-      const [open, setOpen] = useState(true);
-      const [color, setColor] = useState();
-      const onChange = (e) => {
-        const { value } = e.target;
-        setColor(value);
-      };
-      return (
-        <AdvancedColorPicker
-          name="advancedPicker"
-          availableColors={[
-            { value: "#FFFFFF", label: "white" },
-            { value: "transparent", label: "transparent" },
-            { value: "#000000", label: "black" },
-            { value: "#A3CAF0", label: "blue" },
-            { value: "#FD9BA3", label: "pink" },
-            { value: "#B4AEEA", label: "purple" },
-            { value: "#ECE6AF", label: "goldenrod" },
-            { value: "#EBAEDE", label: "orchid" },
-            { value: "#EBC7AE", label: "desert" },
-            { value: "#AEECEB", label: "turquoise" },
-            { value: "#AEECD6", label: "mint" },
-          ]}
-          defaultColor="#EBAEDE"
-          selectedColor={color}
-          onChange={onChange}
-          onOpen={() => {
-            setOpen(!open);
-          }}
-          onClose={() => {
-            setOpen(false);
-          }}
-          onBlur={() => {}}
-          open={open}
-        />
-      );
-    }}
-  </Story>
+  <Story name="default" story={stories.Default} />
 </Canvas>
 
 ## Props
@@ -76,3 +40,31 @@ Shows how the color picker can be used to select a color from a predefined set.
 ### AdvancedColorPicker
 
 <StyledSystemProps of={AdvancedColorPicker} noHeader margin />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "advancedColorPicker.currentColorDescriptionTerm",
+      description: "The text which specifies the term in the visually hidden color description list",
+      type: "func",
+      returnType: "string",
+    },
+        {
+      name: "advancedColorPicker.currentColorAssigned",
+      description: "The text which specifies the currently selected color in the visually hidden color description list",
+      type: "func",
+      returnType: "string",
+    },
+            {
+      name: "advancedColorPicker.ariaLabel",
+      description: "The text which specifies the aria-label which will be applied to the color picker cell button which opens the component",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/advanced-color-picker/advanced-color-picker.stories.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.stories.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+import { ComponentStory } from "@storybook/react";
+import AdvancedColorPicker from ".";
+import isChromatic from "../../../.storybook/isChromatic";
+
+/* eslint-disable import/prefer-default-export */
+/** Added to avoid default export warning which causes storybook to not display `show code` examples 
+github issue link here https://github.com/storybookjs/storybook/issues/8104#issuecomment-932279083 */
+
+const defaultOpenState = isChromatic();
+
+export const Default: ComponentStory<typeof AdvancedColorPicker> = () => {
+  const [open, setOpen] = useState(defaultOpenState);
+  const [color, setColor] = useState("orchid");
+  const onChange = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setColor(target.value);
+  };
+  return (
+    <AdvancedColorPicker
+      name="advancedPicker"
+      availableColors={[
+        { value: "#FFFFFF", label: "white" },
+        { value: "transparent", label: "transparent" },
+        { value: "#000000", label: "black" },
+        { value: "#A3CAF0", label: "blue" },
+        { value: "#FD9BA3", label: "pink" },
+        { value: "#B4AEEA", label: "purple" },
+        { value: "#ECE6AF", label: "goldenrod" },
+        { value: "#EBAEDE", label: "orchid" },
+        { value: "#EBC7AE", label: "desert" },
+        { value: "#AEECEB", label: "turquoise" },
+        { value: "#AEECD6", label: "mint" },
+      ]}
+      defaultColor="#EBAEDE"
+      selectedColor={color}
+      onChange={onChange}
+      onOpen={() => {
+        setOpen(!open);
+      }}
+      onClose={() => {
+        setOpen(false);
+      }}
+      onBlur={() => {}}
+      open={open}
+    />
+  );
+};

--- a/src/components/advanced-color-picker/advanced-color-picker.style.ts
+++ b/src/components/advanced-color-picker/advanced-color-picker.style.ts
@@ -11,10 +11,17 @@ import Dialog from "../dialog/dialog.component";
 import StyledIconButton from "../icon-button/icon-button.style";
 import checkerBoardSvg from "../simple-color-picker/simple-color/checker-board.svg";
 import baseTheme from "../../style/themes/base";
+import visuallyHiddenStyles from "../../style/utils/visually-hidden";
+import { Dl } from "../definition-list";
 
 const StyledAdvancedColorPickerWrapper = styled.div`
   ${margin}
   display: inline-block;
+`;
+
+/** To be replaced by accessibly hidden class added in FE-5503 */
+const HiddenCurrentColorList = styled(Dl)`
+  ${visuallyHiddenStyles}
 `;
 
 StyledAdvancedColorPickerWrapper.defaultProps = {
@@ -85,6 +92,7 @@ const DialogStyle = styled(Dialog)`
 
 export {
   StyledAdvancedColorPickerWrapper,
+  HiddenCurrentColorList,
   StyledAdvancedColorPickerCell,
   StyledAdvancedColorPickerPreview,
   DialogStyle,

--- a/src/components/advanced-color-picker/advanced-color-picker.test.js
+++ b/src/components/advanced-color-picker/advanced-color-picker.test.js
@@ -3,6 +3,7 @@ import CypressMountWithProviders from "../../../cypress/support/component-helper
 import AdvancedColorPicker from "./advanced-color-picker.component";
 import {
   simpleColorPicker,
+  currentColorDescription,
   advancedColorPickerCell,
   advancedColorPicker,
   simpleColorPickerInput,
@@ -135,6 +136,18 @@ context("Testing AdvancedColorPicker component", () => {
         "have.attr",
         "aria-label",
         testPropValue
+      );
+    });
+
+    it("should render AdvancedColorPicker open button with aria-label prop", () => {
+      CypressMountWithProviders(
+        <AdvancedColorPickerCustom aria-label="Change colour" />
+      );
+
+      advancedColorPickerCell().should(
+        "have.attr",
+        "aria-label",
+        "Change colour"
       );
     });
 
@@ -289,9 +302,15 @@ context("Testing AdvancedColorPicker component", () => {
     });
   });
 
+  describe("Should render a current color description list", () => {
+    it("description is correct when color is selected", () => {
+      CypressMountWithProviders(<AdvancedColorPickerCustom />);
+      currentColorDescription().contains("Current color assigned: orchid");
+    });
+  });
+
   describe("Accessibility tests for AdvancedColorPicker component", () => {
-    // Test skipped because of issue FE-5591
-    it.skip("should pass accessibility tests for AdvancedColorPicker default", () => {
+    it("should pass accessibility tests for AdvancedColorPicker default", () => {
       CypressMountWithProviders(<AdvancedColorPickerCustom />);
 
       cy.checkAccessibility();

--- a/src/components/definition-list/dl.component.tsx
+++ b/src/components/definition-list/dl.component.tsx
@@ -18,6 +18,8 @@ export interface DlProps
     StyledDlProps,
     StyledDtDivProps,
     StyledDdDivProps {
+  /** HTML id attribute of the input */
+  id?: string;
   /** prop to render children. */
   children: React.ReactNode;
 }

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -13,6 +13,11 @@ const enGB: Locale = {
   actionPopover: {
     ariaLabel: () => "actions",
   },
+  advancedColorPicker: {
+    ariaLabel: () => "Change colour",
+    currentColorDescriptionTerm: () => "Current color assigned: ",
+    currentColorAssigned: (currentColor) => currentColor,
+  },
   batchSelection: {
     selected: (count) => `${count} selected`,
   },

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -9,6 +9,11 @@ interface Locale {
   actionPopover: {
     ariaLabel: () => string;
   };
+  advancedColorPicker: {
+    ariaLabel: () => string;
+    currentColorDescriptionTerm: (currentColor: string) => string;
+    currentColorAssigned: (currentColor: string) => string;
+  };
   batchSelection: {
     selected: (count: number | string) => string;
   };

--- a/src/locales/pl-pl.ts
+++ b/src/locales/pl-pl.ts
@@ -23,6 +23,35 @@ export const PolishPlural = (
   return pluralGenitive;
 };
 
+const translateColor = (color: string) => {
+  switch (color.toLowerCase()) {
+    case "white":
+      return "biały";
+    case "transparent":
+      return "przezroczysty";
+    case "black":
+      return "czarny";
+    case "blue":
+      return "niebieski";
+    case "pink":
+      return "różowy";
+    case "purple":
+      return "fioletowy";
+    case "goldenrod":
+      return "złoty";
+    case "orchid":
+      return "ciemny róż";
+    case "desert":
+      return "pustynny";
+    case "turquoise":
+      return "turkusowy";
+    case "mint":
+      return "miętowy";
+    default:
+      return color;
+  }
+};
+
 const plPL: Locale = {
   locale: () => "pl-PL",
   actions: {
@@ -31,6 +60,15 @@ const plPL: Locale = {
   },
   actionPopover: {
     ariaLabel: () => "akcje",
+  },
+  advancedColorPicker: {
+    ariaLabel: () => "Zmień kolor",
+    currentColorDescriptionTerm: (currentColor: string) =>
+      translateColor(currentColor) === "biały"
+        ? "Aktualny przypisany kolor: "
+        : "Aktualnie przypisany kolor: ",
+    currentColorAssigned: (currentColor: string) =>
+      translateColor(currentColor),
   },
   batchSelection: {
     selected: (count) => `${count} wybrano`,

--- a/src/style/utils/visually-hidden.ts
+++ b/src/style/utils/visually-hidden.ts
@@ -1,0 +1,11 @@
+import { css } from "styled-components";
+
+export default css`
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+`;


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

This pull request will add a visually hidden description list which will describe the currently selected colour, as well as an `aria-describedby` attribute to the button which opens the component, to create an association between the two. However, this is just a part-solution to improve accessibility in the short-term, as an accessible re-design of how this component is opened is due to take place in the foreseeable future, which will integrate with the changes made in this PR.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

Currently, there is no indication of the button's purpose due to a lack of any proper labelling. Also, the current chosen colour is only returned to the user visually, so users unable to see colour will not know which colour is currently selected.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
