### PR TITLE
fix(date): enable width customization (FE-5659)

### DIFF
--- a/src/components/date/date.component.js
+++ b/src/components/date/date.component.js
@@ -66,6 +66,9 @@ const DateInput = React.forwardRef(
       tooltipPosition,
       value,
       inputRef,
+      inputWidth,
+      labelWidth,
+      maxWidth,
       ...rest
     },
     ref
@@ -372,6 +375,8 @@ const DateInput = React.forwardRef(
         data-role={dataRole}
         {...marginProps}
         applyDateRangeStyling={!!inputRefMap}
+        maxWidth={maxWidth}
+        inputWidth={inputWidth}
       >
         <Textbox
           {...filterOutStyledSystemSpacingProps(rest)}
@@ -395,6 +400,9 @@ const DateInput = React.forwardRef(
           size={size}
           disabled={disabled}
           readOnly={readOnly}
+          inputWidth={inputWidth}
+          labelWidth={labelWidth}
+          maxWidth={maxWidth}
           m={0}
         />
         <DatePicker

--- a/src/components/date/date.spec.js
+++ b/src/components/date/date.spec.js
@@ -122,17 +122,39 @@ describe("Date", () => {
     <DateInput onChange={jest.fn} value="" {...props} />
   ));
 
-  describe("styles", () => {
-    it.each([
+  describe("when the size pop is set", () => {
+    describe.each([
       ["small", "120px"],
       ["medium", "135px"],
       ["large", "140px"],
-    ])("render correctly for %s size", (size, width) => {
-      assertStyleMatch(
-        { flex: "none", width },
-        mount(<StyledDateInput size={size} />),
-        { modifier: `& ${StyledInputPresentation}` }
-      );
+    ])("to %s", (size, expectedValue) => {
+      it("then the width attribute of StyledInputPresentation should match expected value", () => {
+        assertStyleMatch(
+          { width: expectedValue },
+          mount(<StyledDateInput size={size} />),
+          { modifier: `& ${StyledInputPresentation}` }
+        );
+      });
+
+      describe("with the inputWidth prop set", () => {
+        it("then the width attribute of StyledInputPresentation should be undefined", () => {
+          assertStyleMatch(
+            { width: undefined },
+            mount(<StyledDateInput size={size} inputWidth={50} />),
+            { modifier: `& ${StyledInputPresentation}` }
+          );
+        });
+      });
+
+      describe("with the maxWidth prop set", () => {
+        it("then the width attribute of StyledInputPresentation should be undefined", () => {
+          assertStyleMatch(
+            { width: undefined },
+            mount(<StyledDateInput size={size} maxWidth="300px" />),
+            { modifier: `& ${StyledInputPresentation}` }
+          );
+        });
+      });
     });
   });
 

--- a/src/components/date/date.stories.mdx
+++ b/src/components/date/date.stories.mdx
@@ -199,10 +199,10 @@ be used to set the input value like in the example below, although the component
   </Story>
 </Canvas>
 
-### With custom labelWidth
+### With custom width
 
 <Canvas>
-  <Story name="with custom labelWidth">
+  <Story name="with custom width">
     {() => {
       const [state, setState] = useState("01/10/2016");
       const setValue = ({ target }) => {
@@ -214,7 +214,9 @@ be used to set the input value like in the example below, although the component
           value={state}
           onChange={setValue}
           labelInline
-          labelWidth={10}
+          labelWidth={20}
+          inputWidth={70}
+          maxWidth="300px"
         />
       );
     }}
@@ -639,7 +641,6 @@ Due to the `Textbox` component being used internally by the `Date` component the
 <ArgsTable
   of={Textbox}
   exclude={[
-    "maxWidth",
     "value",
     "formattedValue",
     "rawValue",

--- a/src/components/date/date.style.js
+++ b/src/components/date/date.style.js
@@ -20,19 +20,20 @@ const StyledDateInput = styled.div`
 
   & ${StyledInputPresentation} {
     flex: none;
-    width: ${({ size }) => datePickerWidth[size]};
+    width: ${({ inputWidth, maxWidth, size }) =>
+      maxWidth || inputWidth ? "" : datePickerWidth[size]};
 
     ${StyledInput} {
       margin-right: -8px;
     }
   }
 
-  ${({ applyDateRangeStyling, size, labelInline }) =>
+  ${({ applyDateRangeStyling, maxWidth, size, labelInline }) =>
     applyDateRangeStyling &&
     !labelInline &&
     css`
       ${FieldLineStyle} {
-        max-width: ${datePickerWidth[size]};
+        max-width: ${maxWidth || datePickerWidth[size]}};
       }
 
       ${StyledValidationMessage}, ${StyledLabel} {

--- a/src/components/date/date.test.js
+++ b/src/components/date/date.test.js
@@ -42,7 +42,10 @@ import {
   fieldHelpPreview,
 } from "../../../cypress/locators";
 import { keyCode } from "../../../cypress/support/helper";
-import { verifyRequiredAsteriskForLabel } from "../../../cypress/support/component-helper/common-steps";
+import {
+  verifyRequiredAsteriskForLabel,
+  useJQueryCssValueAndAssert,
+} from "../../../cypress/support/component-helper/common-steps";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import {
   SIZE,
@@ -324,6 +327,54 @@ context("Test for DateInput component", () => {
         .invoke("height")
         .should("be.greaterThan", minValue)
         .and("be.lessThan", maxValue);
+    });
+
+    it.each([
+      [10, 90, 135, 1229],
+      [30, 70, 409, 956],
+      [80, 20, 1092, 273],
+    ])(
+      "should use %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
+      (label, input, labelRatio, inputRatio) => {
+        CypressMountWithProviders(
+          <DateInputCustom labelInline labelWidth={label} inputWidth={input} />
+        );
+
+        getDataElementByValue("label")
+          .parent()
+          .then(($el) => {
+            useJQueryCssValueAndAssert($el, "width", labelRatio);
+          });
+
+        getDataElementByValue("input")
+          .parent()
+          .then(($el) => {
+            useJQueryCssValueAndAssert($el, "width", inputRatio);
+          });
+      }
+    );
+
+    it.each(["10%", "30%", "50%", "80%", "100%"])(
+      "should check maxWidth as %s for Date Input component",
+      (maxWidth) => {
+        CypressMountWithProviders(<DateInputCustom maxWidth={maxWidth} />);
+
+        getDataElementByValue("input")
+          .parent()
+          .parent()
+          .should("have.css", "max-width", maxWidth);
+      }
+    );
+
+    it("when maxWidth has no value it should render as 100%", () => {
+      CypressMountWithProviders(
+        <DateInputCustom inputWidth={100} maxWidth="" />
+      );
+
+      getDataElementByValue("input")
+        .parent()
+        .parent()
+        .should("have.css", "max-width", "100%");
     });
   });
 


### PR DESCRIPTION
### Proposed behaviour

allow the use of labelWidth, inputWidth and MaxWidth props

### Current behaviour

labelWidth, inputWidth and MaxWidth props are ignored, width of the component is non-changeable

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
~~- [ ] Screenshots are included in the PR if useful~~
~~- [ ] All themes are supported if required~~
- [x] Unit tests added or updated if required
~~- [ ] Cypress automation tests added or updated if required~~
- [x] Storybook added or updated if required
~~- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required~~
~~- [ ] Typescript `d.ts` file added or updated if required~~
~~- [ ] Related docs have been updated if required~~

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

fixes #5787

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
