### PR TITLE
test(flat-table): add test for icon node and a child - FE-5613

### DIFF
--- a/src/components/flat-table/flat-table.test.js
+++ b/src/components/flat-table/flat-table.test.js
@@ -2792,6 +2792,15 @@ context("Tests for Flat Table component", () => {
       }
     });
 
+    it("should render Flat Table with icon node as children", () => {
+      CypressMountWithProviders(
+        <FlatTableComponent>
+          <Icon type="business" color="white" />
+        </FlatTableComponent>
+      );
+      flatTable().find("span").should("have.attr", "data-component", "icon");
+    });
+
     it("should render Flat Table Header with strings as children", () => {
       CypressMountWithProviders(<FlatTableComponent />);
 


### PR DESCRIPTION
### Proposed behaviour

Add a test to cover icon node and a child for Flat Table as this was left out during the refactor work due to a lint error.

### Current behaviour

No test covering icon node and a child due to lint error when original refactor work was done.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Test should pass and QA should be happy with the code quality.
