### PR TITLE
test(global-header): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -105,6 +105,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("group-character") &&
       !prepareUrl[0].startsWith("duelling-picklist") &&
       !prepareUrl[0].startsWith("settings-row") &&
+      !prepareUrl[0].startsWith("global-header") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/global-header/global-header-test.stories.tsx
+++ b/src/components/global-header/global-header-test.stories.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import GlobalHeader from "./global-header.component";
-import { Menu, MenuItem } from "../menu";
+import { Menu, MenuItem, MenuDivider } from "../menu";
 import VerticalDivider from "../vertical-divider";
-
+import NavigationBar from "../navigation-bar";
 import carbonLogo from "../../../logo/carbon-logo.png";
 
 export default {
   title: "Global Header/Test",
+  includeStories: ["MenuWithIconOnlyButtonsStory"], // exclude `FullMenuExample` from storybook
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -54,3 +55,44 @@ MenuWithIconOnlyButtonsStory.parameters = {
     },
   },
 };
+
+export const FullMenuExample = () => (
+  <>
+    <GlobalHeader>
+      <Menu menuType="black" display="flex" flex="1">
+        <MenuItem flex="1" submenu="Product Switcher">
+          <MenuItem href="#">Product A</MenuItem>
+        </MenuItem>
+        <MenuItem flex="0 0 auto" submenu="Parent Menu 1">
+          <MenuItem href="#">Child Item 1</MenuItem>
+          <MenuItem href="#">Child Item 2</MenuItem>
+          <MenuItem href="#">Child Item 3</MenuItem>
+        </MenuItem>
+        <MenuItem flex="0 0 auto" submenu="Parent Menu 2">
+          <MenuItem>Child Item</MenuItem>
+        </MenuItem>
+      </Menu>
+    </GlobalHeader>
+    <NavigationBar position="fixed" orientation="top" offset="40px">
+      <Menu display="flex" flex="1">
+        <MenuItem flex="1">Menu Item One</MenuItem>
+        <MenuItem flex="0 0 auto" href="#">
+          Menu Item Two
+        </MenuItem>
+        <MenuItem flex="0 0 auto" submenu="Menu Item Three">
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+          <MenuDivider />
+          <MenuItem icon="settings" href="#">
+            Item Submenu Three
+          </MenuItem>
+          <MenuItem href="#">Item Submenu Four</MenuItem>
+        </MenuItem>
+        <MenuItem flex="0 0 auto" submenu="Menu Item Four">
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+        </MenuItem>
+      </Menu>
+    </NavigationBar>
+  </>
+);

--- a/src/components/global-header/global-header.test.js
+++ b/src/components/global-header/global-header.test.js
@@ -1,8 +1,6 @@
 import React from "react";
-import { Menu, MenuItem, MenuDivider } from "../menu";
-import NavigationBar from "../navigation-bar";
 import GlobalHeader from "./global-header.component";
-
+import { FullMenuExample } from "./global-header-test.stories";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
 import carbonLogo from "../../../logo/carbon-logo.png";
@@ -11,47 +9,6 @@ import {
   globalHeader,
   globalHeaderLogo,
 } from "../../../cypress/locators/global-header";
-
-const FullMenuExample = () => (
-  <>
-    <GlobalHeader>
-      <Menu menuType="black" display="flex" flex="1">
-        <MenuItem flex="1" submenu="Product Switcher">
-          <MenuItem href="#">Product A</MenuItem>
-        </MenuItem>
-        <MenuItem flex="0 0 auto" submenu="Parent Menu 1">
-          <MenuItem href="#">Child Item 1</MenuItem>
-          <MenuItem href="#">Child Item 2</MenuItem>
-          <MenuItem href="#">Child Item 3</MenuItem>
-        </MenuItem>
-        <MenuItem flex="0 0 auto" submenu="Parent Menu 2">
-          <MenuItem>Child Item</MenuItem>
-        </MenuItem>
-      </Menu>
-    </GlobalHeader>
-    <NavigationBar position="fixed" orientation="top" offset="40px">
-      <Menu display="flex" flex="1">
-        <MenuItem flex="1">Menu Item One</MenuItem>
-        <MenuItem flex="0 0 auto" href="#">
-          Menu Item Two
-        </MenuItem>
-        <MenuItem flex="0 0 auto" submenu="Menu Item Three">
-          <MenuItem href="#">Item Submenu One</MenuItem>
-          <MenuItem href="#">Item Submenu Two</MenuItem>
-          <MenuDivider />
-          <MenuItem icon="settings" href="#">
-            Item Submenu Three
-          </MenuItem>
-          <MenuItem href="#">Item Submenu Four</MenuItem>
-        </MenuItem>
-        <MenuItem flex="0 0 auto" submenu="Menu Item Four">
-          <MenuItem href="#">Item Submenu One</MenuItem>
-          <MenuItem href="#">Item Submenu Two</MenuItem>
-        </MenuItem>
-      </Menu>
-    </NavigationBar>
-  </>
-);
 
 context("Testing Global Header component", () => {
   it("should check that z-index of component is greater than that of NavigationBar", () => {
@@ -85,5 +42,31 @@ context("Testing Global Header component", () => {
     CypressMountWithProviders(<GlobalHeader logo={logo}>Example</GlobalHeader>);
 
     globalHeaderLogo().should("have.css", "height", `${expectedHeight}px`);
+  });
+
+  describe("Accessibility tests for Global-Header component", () => {
+    it("should pass accessibility tests for Global-Header FullMenuExample", () => {
+      CypressMountWithProviders(<FullMenuExample />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for Global-Header when logo prop is passed", () => {
+      const logoHeight = 41;
+
+      const logo = (
+        <img
+          data-element="logo"
+          height={logoHeight}
+          src={carbonLogo}
+          alt="Carbon logo"
+        />
+      );
+      CypressMountWithProviders(
+        <GlobalHeader logo={logo}>Example</GlobalHeader>
+      );
+
+      cy.checkAccessibility();
+    });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `Global-Header` component to use the new cypress-component-react framework for testing.
- Move component stories to the `global-header-test.stories.tsx`

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added test.file
- [x] Check if the `global-header.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Global-Header` tests are not running twice.