### PR TITLE
feat(announcer): introduce utility for creating custom screen reader announcements (FE-5685)

### DIFF
--- a/src/utils/Announcer/Announcer.spec.ts
+++ b/src/utils/Announcer/Announcer.spec.ts
@@ -1,0 +1,60 @@
+import { screen, waitForElementToBeRemoved } from "@testing-library/dom";
+import Announcer from ".";
+
+describe("Announcer", () => {
+  afterEach(() => {
+    Announcer.cleanup();
+  });
+
+  it("when announcePolitely is called, inserts passed message into polite live region", () => {
+    const message = "foo";
+    Announcer.announcePolitely(message);
+
+    const region = screen.getByRole("status");
+    expect(region).toHaveTextContent(message);
+  });
+
+  it("when announcePolitely is called, inserted message is cleared after delay", async () => {
+    const message = "bar";
+    Announcer.announcePolitely(message);
+
+    const region = screen.getByRole("status");
+    expect(region).toHaveTextContent(message);
+    await waitForElementToBeRemoved(() => screen.queryByText(message));
+  });
+
+  it("when announcePolitely is called and polite live region exists in document, do not recreate", () => {
+    Announcer.announcePolitely("some message");
+
+    expect(screen.queryByRole("status")).toBeInTheDocument();
+
+    Announcer.announcePolitely("new message");
+    expect(screen.queryAllByRole("status")).toHaveLength(1);
+  });
+
+  it("when announceAssertively is called, inserts passed message into assertive live region", () => {
+    const message = "baz";
+    Announcer.announceAssertively(message);
+
+    const region = screen.getByRole("alert");
+    expect(region).toHaveTextContent(message);
+  });
+
+  it("when announceAssertively is called,inserted message is cleared after delay", async () => {
+    const message = "buzz";
+    Announcer.announceAssertively(message);
+
+    const region = screen.getByRole("alert");
+    expect(region).toHaveTextContent(message);
+    await waitForElementToBeRemoved(() => screen.queryByText(message));
+  });
+
+  it("when announceAssertively is called and assertive live region exists in document, do not recreate", () => {
+    Announcer.announceAssertively("some message");
+
+    expect(screen.queryByRole("alert")).toBeInTheDocument();
+
+    Announcer.announceAssertively("new message");
+    expect(screen.queryAllByRole("alert")).toHaveLength(1);
+  });
+});

--- a/src/utils/Announcer/Announcer.ts
+++ b/src/utils/Announcer/Announcer.ts
@@ -1,0 +1,93 @@
+type Politeness = "polite" | "assertive";
+
+/* Due to possibility of having multiple Carbon versions being used on
+ * the same page, it is neccessary to maintain the same values for the
+ * following ids */
+const CARBON_INTERNALS__LIVE_REGION_IDS: Record<Politeness, string> = {
+  polite: "carbon-polite-live-region",
+  assertive: "carbon-assertive-live-region",
+};
+
+const parentNode = document.body;
+const TIMEOUT_DURATION = 200;
+const roles: Record<Politeness, string> = {
+  polite: "status",
+  assertive: "alert",
+};
+
+function getRegion(politeness: Politeness): HTMLElement {
+  const region = document.getElementById(
+    CARBON_INTERNALS__LIVE_REGION_IDS[politeness]
+  );
+
+  if (region) return region;
+
+  const element: HTMLDivElement = document.createElement("div");
+  const visuallyHiddenStyles: Partial<CSSStyleDeclaration> = {
+    clip: "rect(0 0 0 0)",
+    clipPath: "inset(50%)",
+    height: "1px",
+    overflow: "hidden",
+    position: "absolute",
+    whiteSpace: "nowrap",
+    width: "1px",
+  };
+  element.setAttribute("id", CARBON_INTERNALS__LIVE_REGION_IDS[politeness]);
+  element.setAttribute("role", roles[politeness]);
+  element.setAttribute("aria-live", politeness);
+  element.setAttribute("aria-atomic", "false");
+  element.setAttribute("aria-relevant", "additions");
+  Object.assign(element.style, visuallyHiddenStyles);
+
+  return parentNode.appendChild(element);
+}
+
+/**
+ * Dispatches a message for a screen reader to announce to users.
+ * Message will be announced at the next graceful opportunity, such as
+ * when the user is idle or any current announcements have finished being
+ * spoken. */
+function announcePolitely(message: string): void {
+  const politeRegion = getRegion("polite");
+
+  politeRegion.textContent = message;
+
+  window.setTimeout(() => {
+    politeRegion.textContent = "";
+  }, TIMEOUT_DURATION);
+}
+
+/**
+ * Dispatches a critical, time-sensitive message for a screen reader
+ * to announce immediately to users.
+ *
+ * WARNING - Use sparingly to avoid overwhelming users with alerts. */
+function announceAssertively(message: string): void {
+  const assertiveRegion = getRegion("assertive");
+
+  assertiveRegion.textContent = message;
+
+  window.setTimeout(() => {
+    assertiveRegion.textContent = "";
+  }, TIMEOUT_DURATION);
+}
+
+/** Remove all DOM elements used by the Announcer utility */
+function cleanup() {
+  const politeRegion = document.getElementById(
+    CARBON_INTERNALS__LIVE_REGION_IDS.polite
+  );
+  if (politeRegion) politeRegion.remove();
+  const assertiveRegion = document.getElementById(
+    CARBON_INTERNALS__LIVE_REGION_IDS.assertive
+  );
+  if (assertiveRegion) assertiveRegion.remove();
+}
+
+const Announcer = {
+  announcePolitely,
+  announceAssertively,
+  cleanup,
+};
+
+export default Announcer;

--- a/src/utils/Announcer/announcer.stories.mdx
+++ b/src/utils/Announcer/announcer.stories.mdx
@@ -1,0 +1,72 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import * as stories from "./announcer.stories.tsx";
+
+<Meta
+  title="Documentation/Utilties/Announcer"
+  parameters={{ info: { disable: true } }}
+/>
+
+# Announcer
+
+`Announcer` is an accessibility utility for dispatching messages which screen readers will vocally announce to users. It should be utilised for patterns where screen reader users need to be made aware of a dynamic change that has occurred on the page.
+
+```ts
+import Announcer from "carbon-react/lib/utils/Announcer";
+```
+
+## Contents
+
+- [Reference](#reference)
+  - [Returned values](#returns)
+- [Usage](#usage)
+
+## Reference
+
+The utility provides two announcement functions, `announcePolitely` and `announceAssertively`, which dispatch messages for screen readers to announce to users.
+
+The two announcement functions use [ARIA live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions), which screen readers are setup to monitor for changes and speak any content added into them. Both announcement functions have a single, corresponding live region in the DOM where messages will be inserted into. These live regions are visually hidden and placed at a high level in the DOM to ensure they remain rendered on a page.
+
+```tsx
+import Announcer from "carbon-react/lib/utils/Announcer";
+import Button from "carbon-react/lib/components/button";
+
+const MyComponent = () => {
+  const handleClick = () => {
+    Announcer.announcePolitely("You pressed the button, didn't you?");
+  };
+
+  return <Button onClick={handleClick}>Announce message</Button>;
+};
+```
+
+### Returns
+
+Returns an object containing two functions:
+
+- `announcePolitely`: Function that accepts a message to be as a string. Message will be announced at the next available opportunity once the user is idle, to avoid interrupting any current announcements being spoken.
+- `announceAssertively`: Function that accepts a message as a string. The announcement will be made immediately and interrupt any other announcements the screen reader may be making. For this reason, assertive announcements **should be used sparingly and for critical, time-sensitive alerts only**, to avoid overwhelming screen reader users with announcements.
+
+## Usage
+
+### Announce loading a new page
+
+<Canvas>
+  <Story name="announce loading a new page" story={stories.AnnouncePageLoad} />
+</Canvas>
+
+### Announce loading new content
+
+<Canvas>
+  <Story
+    name="announce loading new content"
+    story={stories.AnnounceContentLoad}
+  />
+</Canvas>
+
+### Form validation messages
+
+Since validation messages are generally non-interactive, a screen reader will not be aware of them when the user submits an erroneous form. The `useAnnouncer` hook can be used to notify the user of any errors so they can go back and correct. For multiple messages, it is recommended to combine them into a single summary message to reduce the number of announcements.
+
+<Canvas>
+  <Story name="form validation messages" story={stories.FormValidation} />
+</Canvas>

--- a/src/utils/Announcer/announcer.stories.tsx
+++ b/src/utils/Announcer/announcer.stories.tsx
@@ -1,0 +1,301 @@
+import React from "react";
+import { StoryFn } from "@storybook/react";
+
+import Announcer from ".";
+
+import {
+  FlatTable,
+  FlatTableHead,
+  FlatTableBody,
+  FlatTableRow,
+  FlatTableHeader,
+  FlatTableCell,
+} from "../../components/flat-table";
+import Form from "../../components/form";
+import Textbox from "../../components/textbox";
+import Button from "../../components/button";
+import Textarea from "../../components/textarea";
+import Box from "../../components/box";
+import Typography from "../../components/typography";
+import Loader from "../../components/loader";
+import Preview from "../../components/preview";
+import CarbonProvider from "../../components/carbon-provider";
+import { sageTheme } from "../../style/themes";
+import Message from "../../components/message";
+
+// Remove once re-design styles become the default
+const newValidationDecorator = (Story: React.FunctionComponent) => (
+  <CarbonProvider theme={sageTheme} validationRedesignOptIn>
+    <Story />
+  </CarbonProvider>
+);
+
+// Wrap around stories where a screen reader announcements would be made immediately on load otherwise
+const startDemoDecorator = (Story: React.FunctionComponent) => {
+  const StartDemoWrapper = ({ children }: { children: JSX.Element }) => {
+    const [beginDemo, setBeginDemo] = React.useState(false);
+
+    return beginDemo ? (
+      children
+    ) : (
+      <Box display="flex" flexDirection="column" alignItems="center">
+        <Typography variant="b" mb={2}>
+          Open this story in a separate canvas with your screen reader of
+          choice, then press button to begin.
+        </Typography>
+        <Button onClick={() => setBeginDemo(true)}>Begin demo</Button>
+      </Box>
+    );
+  };
+
+  return (
+    <StartDemoWrapper>
+      <Story />
+    </StartDemoWrapper>
+  );
+};
+
+export const AnnouncePageLoad: StoryFn = () => {
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    if (isLoading) window.setTimeout(() => setIsLoading(false), 5000);
+  }, [isLoading]);
+
+  React.useEffect(() => {
+    if (isLoading)
+      Announcer.announcePolitely("Retrieving reports, please wait.");
+    else Announcer.announcePolitely("Reports loaded.");
+  }, [isLoading]);
+
+  const LoadingPage = () => (
+    <Box display="flex" flexDirection="column" alignItems="center">
+      <Typography variant="h1">Retrieving reports</Typography>
+      <Typography mb={4}>Please wait...</Typography>
+      <Loader />
+    </Box>
+  );
+
+  const ReportsPage = () => {
+    const reports = [
+      {
+        id: 0,
+        report: "Monthly expenses",
+        description: "Summary of all company expenses per calendar month",
+        lastUpdated: "01/03/2023",
+      },
+      {
+        id: 1,
+        report: "Monthly profits",
+        description: "Summary of net returns calendar month",
+        lastUpdated: "02/03/2023",
+      },
+    ];
+
+    return (
+      <>
+        <Typography variant="h1" mb={2}>
+          Reports
+        </Typography>
+        <FlatTable>
+          <FlatTableHead>
+            <FlatTableRow>
+              <FlatTableHeader>Report</FlatTableHeader>
+              <FlatTableHeader>Description</FlatTableHeader>
+              <FlatTableHeader>Last updated</FlatTableHeader>
+              <FlatTableHeader>Actions</FlatTableHeader>
+            </FlatTableRow>
+          </FlatTableHead>
+          <FlatTableBody>
+            {reports.map((report) => (
+              <FlatTableRow key={report.id}>
+                <FlatTableCell>{report.report}</FlatTableCell>
+                <FlatTableCell>{report.description}</FlatTableCell>
+                <FlatTableCell>{report.lastUpdated}</FlatTableCell>
+                <FlatTableCell>
+                  <Button onClick={() => {}} my={1}>
+                    Open
+                  </Button>
+                </FlatTableCell>
+              </FlatTableRow>
+            ))}
+          </FlatTableBody>
+        </FlatTable>
+        <Button mt={2} onClick={() => setIsLoading(true)}>
+          Run demo again
+        </Button>
+      </>
+    );
+  };
+
+  return <Box m={2}>{isLoading ? <LoadingPage /> : <ReportsPage />}</Box>;
+};
+AnnouncePageLoad.decorators = [newValidationDecorator, startDemoDecorator];
+
+export const AnnounceContentLoad: StoryFn = () => {
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  const contacts = [
+    {
+      id: 0,
+      name: "Cecile Newman",
+      occuptation: "Senior QA",
+      location: "Newcastle",
+    },
+    {
+      id: 1,
+      name: "Lakisha Simon",
+      occuptation: "Team Lead",
+      location: "Vancouver",
+    },
+    {
+      id: 2,
+      name: "Mikel Lutz",
+      occuptation: "Graduate Software Engineer",
+      location: "Reading",
+    },
+  ];
+
+  React.useEffect(() => {
+    if (isLoading) window.setTimeout(() => setIsLoading(false), 5000);
+  }, [isLoading]);
+
+  React.useEffect(() => {
+    if (isLoading) Announcer.announcePolitely("Loading contacts, please wait.");
+    else Announcer.announcePolitely("Contacts loaded.");
+  }, [isLoading]);
+
+  return (
+    <Box m={2}>
+      <Typography variant="h1" mb={2}>
+        Contacts
+      </Typography>
+      <Preview loading={isLoading} lines={10}>
+        <FlatTable>
+          <FlatTableHead>
+            <FlatTableRow>
+              <FlatTableHeader>Name</FlatTableHeader>
+              <FlatTableHeader>Occuptation</FlatTableHeader>
+              <FlatTableHeader>Location</FlatTableHeader>
+            </FlatTableRow>
+          </FlatTableHead>
+          <FlatTableBody>
+            {contacts.map((contact) => (
+              <FlatTableRow key={contact.id}>
+                <FlatTableCell>{contact.name}</FlatTableCell>
+                <FlatTableCell>{contact.occuptation}</FlatTableCell>
+                <FlatTableCell>{contact.location}</FlatTableCell>
+              </FlatTableRow>
+            ))}
+          </FlatTableBody>
+        </FlatTable>
+      </Preview>
+      {!isLoading && (
+        <Button mt={2} onClick={() => setIsLoading(true)}>
+          Run demo again
+        </Button>
+      )}
+    </Box>
+  );
+};
+AnnounceContentLoad.decorators = [newValidationDecorator, startDemoDecorator];
+
+export const FormValidation: StoryFn = () => {
+  interface IFieldValues {
+    name: string;
+    email: string;
+    address: string;
+  }
+
+  interface IFieldErrors {
+    name?: string;
+    email?: string;
+  }
+
+  const [input, setInput] = React.useState<IFieldValues>({
+    name: "",
+    email: "",
+    address: "",
+  });
+  const [errors, setErrors] = React.useState<IFieldErrors>({});
+  const [submitted, setSubmitted] = React.useState(false);
+
+  const numOfErrors = React.useMemo(
+    () => Object.keys(errors).filter((field) => field !== undefined).length,
+    [errors]
+  );
+
+  const summaryMessage = (errorNum: number) =>
+    errorNum > 0
+      ? `${errorNum} error${
+          errorNum > 1 ? "s" : ""
+        } found. Please correct the form errors before resubmitting.`
+      : "Successfully submitted form!";
+
+  const updateField = (field: keyof IFieldValues, value: string) => {
+    setInput({ ...input, [field]: value });
+  };
+
+  const handleSubmit = (ev: React.FormEvent) => {
+    ev.preventDefault();
+    setSubmitted(true);
+
+    const fieldErrors: IFieldErrors = {};
+    const fields = ["name", "email"] as const;
+    fields.forEach((field) => {
+      if (input[field].length < 1)
+        fieldErrors[field] = "This field cannot be empty";
+    });
+
+    const summary = summaryMessage(Object.keys(fieldErrors).length);
+    Announcer.announcePolitely(summary);
+    setErrors(fieldErrors);
+  };
+
+  return (
+    <Box m={2}>
+      {submitted && (
+        <Message mb={2} open variant={numOfErrors > 0 ? "error" : "success"}>
+          {summaryMessage(numOfErrors)}
+        </Message>
+      )}
+      <Form
+        onSubmit={handleSubmit}
+        saveButton={
+          <Button buttonType="primary" type="submit">
+            Save
+          </Button>
+        }
+      >
+        <Textbox
+          label="Name"
+          labelHelp="Please write your full name."
+          required
+          value={input.name}
+          onChange={({ target }: React.ChangeEvent<HTMLInputElement>) =>
+            updateField("name", target.value)
+          }
+          error={errors.name}
+        />
+        <Textbox
+          label="Email"
+          required
+          value={input.email}
+          onChange={({ target }: React.ChangeEvent<HTMLInputElement>) =>
+            updateField("email", target.value)
+          }
+          error={errors.email}
+        />
+        <Textarea
+          label="Address"
+          labelHelp="This will be used for sending you updates on our products via post."
+          value={input.address}
+          onChange={({ target }: React.ChangeEvent<HTMLInputElement>) =>
+            updateField("address", target.value)
+          }
+        />
+      </Form>
+    </Box>
+  );
+};
+FormValidation.decorators = [newValidationDecorator];

--- a/src/utils/Announcer/index.ts
+++ b/src/utils/Announcer/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Announcer";


### PR DESCRIPTION
### Proposed behaviour

Introduce a new `Announcer` utility to add [ARIA live](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) support into Carbon - this allows consumers to make custom screen reader announcements.

- Utility returns two functions `announcePolitely` and `announceAssertively` that both accept a message to dispatch. The first function dispatches a polite announcement - which is only made when the user is idle and any existing announcements have been spoken. The second function dispatches an assertive announcement - which will immediately be spoken by the screen reader.
- Both returned functions have a corresponding live region, where each is attached to the `document.body`. All messages dispatched via these functions are then inserted into the polite or assertive region by mutating the DOM directly.
- Both the polite and assertive live regions are visually hidden from view.
- Both live regions are uniquely identifiable and cannot be duplicated - so micro-frontends can use the same two regions for communication.  

The approach to directly mutate the DOM to create and modify the live regions was opt-ed for two reasons. To ensure both regions are placed high in the DOM tree as possible, and so micro-frontends have an identical, global method of accessing them. For context, here are some examples from other open-source projects which also use this approach:
[@adobe/react-spectrum](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/live-announcer/src/LiveAnnouncer.tsx)
[@chakra-ui](https://github.com/chakra-ui/chakra-ui/blob/main/packages/components/live-region/src/live-region.ts)

### Current behaviour

Consumers have no means of specifying ARIA live region properties on Carbon components, meaning they must wrap components in html containers with live region properties themselves:

```tsx
const LoadableContent = () => (
   <div aria-live="polite"> {/* Any newly content added inside here will be announced */}
      <Box>
          {isLoading ? (
              <Loader aria-label="Loading content"/>
          ) : (
              {/* Render loaded content */}
          )}
      </Box>
   </div>
);
```
Live regions must also exist on the page before any changes occur, meaning they cannot be created at the same time when a consumer dispatches a message. To always ensure a live region is rendered, it needs to exist high in the React DOM as possible (closer to the root). A consumer could implement this themselves in their app, but this becomes more challenging in micro-frontend environments, since co-ordination between different micro-frontends is needed to prevent messages from being interrupted, lost among other incoming messages or spoken out of order.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Open storybook locally with `npm start` and navigate to <http://localhost:9001/?path=/docs/documentation-hooks-useannouncer>, then manually test the storybook examples using the following screen reader and browser combinations:

- Chrome/Edge + NVDA 
- Firefox + NVDA
- Safari + macOS VoiceOver

Using these combinations, verify if the following behaviour is observed for each storybook example:

#### Announce loading a new page
1. When retrieving reports message is shown, should announce *"Retrieving reports, please wait"* one time.
2. Then when reports table is shown, should announce *"Reports loaded"* one time

#### Announce loading new content
1. When placeholder lines underneath "Contacts" heading are shown, should announce *"Loading contacts, please wait"* one time.
2. Then when contacts table is shown, should announce *"Contacts loaded"* one time.

#### Form validation messages
- When save button is pressed and both the name and email fields are empty, should announce *"2 errors found. Please correct the form errors before resubmitting"* one time.
- When save button is pressed and one of the name and email fields are empty, should announce *"1 errors found. Please correct the form errors before resubmitting"* one time.
- When save button is pressed and both the name and email fields are filled, should announce *"Successfully submitted form"* one time.