### PR TITLE
test(numeral-date): refactor accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -105,6 +105,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("group-character") &&
       !prepareUrl[0].startsWith("duelling-picklist") &&
       !prepareUrl[0].startsWith("settings-row") &&
+      !prepareUrl[0].startsWith("numeral-date") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/numeral-date/numeral-date-test.stories.tsx
+++ b/src/components/numeral-date/numeral-date-test.stories.tsx
@@ -13,6 +13,7 @@ import CarbonProvider from "../carbon-provider";
 
 export default {
   title: "Numeral Date/Test",
+  includeStories: "Default",
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -158,5 +159,22 @@ export const TooltipPosition = () => {
         tooltipPosition="right"
       />
     </>
+  );
+};
+
+export const NumeralDateComponent = ({ ...props }) => {
+  const [value, setValue] = React.useState({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
+
+  return (
+    <NumeralDate
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      label="Default"
+      {...props}
+    />
   );
 };

--- a/src/components/numeral-date/numeral-date.test.js
+++ b/src/components/numeral-date/numeral-date.test.js
@@ -1,6 +1,8 @@
 import React from "react";
 import NumeralDate from ".";
 import Box from "../box";
+import { NumeralDateComponent } from "./numeral-date-test.stories";
+import * as stories from "./numeral-date.stories";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import {
   useJQueryCssValueAndAssert,
@@ -29,23 +31,6 @@ import {
 import { ICON } from "../../../cypress/locators/locators";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
-
-const NumeralDateComponent = ({ ...props }) => {
-  const [value, setValue] = React.useState({
-    dd: "",
-    mm: "",
-    yyyy: "",
-  });
-
-  return (
-    <NumeralDate
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      label="Default"
-      {...props}
-    />
-  );
-};
 
 const ALLOWED_DATE_FORMATS = [
   ["dd", "mm", "yyyy"],
@@ -482,6 +467,68 @@ context("Tests for NumeralDate component", () => {
           // eslint-disable-next-line no-unused-expressions
           expect(callback).to.have.been.calledOnce;
         });
+    });
+  });
+
+  describe("check accessibility for NumeralDate component", () => {
+    it("should pass accessibility tests for NumeralDate Default story", () => {
+      CypressMountWithProviders(<stories.Default />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NumeralDate Controlled story", () => {
+      CypressMountWithProviders(<stories.Controlled />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NumeralDate AllowedDateFormats story", () => {
+      CypressMountWithProviders(<stories.AllowedDateFormats />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NumeralDate InternalValidationError story", () => {
+      CypressMountWithProviders(<stories.InternalValidationError />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NumeralDate InternalValidationWarning story", () => {
+      CypressMountWithProviders(<stories.InternalValidationWarning />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NumeralDate InlineLabel story", () => {
+      CypressMountWithProviders(<stories.InlineLabel />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NumeralDate EnablingAdaptiveBehaviour story", () => {
+      CypressMountWithProviders(<stories.EnablingAdaptiveBehaviour />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NumeralDate WithLabelHelp story", () => {
+      CypressMountWithProviders(<stories.WithLabelHelp />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NumeralDate WithFieldHelp story", () => {
+      CypressMountWithProviders(<stories.WithFieldHelp />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NumeralDate Size story", () => {
+      CypressMountWithProviders(<stories.Size />);
+
+      cy.checkAccessibility();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour
- Add `accessibility` Cypress tests for the `Numeral-date` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there are newly added tests
- [ ] Check if the `numeral-date.test.js` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Numeral-date` tests are not running twice.