### PR TITLE
feat(help): improve accessibility

### DIFF
--- a/src/components/button-toggle-group/button-toggle-group.spec.tsx
+++ b/src/components/button-toggle-group/button-toggle-group.spec.tsx
@@ -21,7 +21,7 @@ import ButtonToggle from "../button-toggle/button-toggle.component";
 import StyledButtonToggleGroup from "./button-toggle-group.style";
 import FormFieldStyle from "../../__internal__/form-field/form-field.style";
 import FormField from "../../__internal__/form-field";
-import StyledHelp from "../help/help.style";
+import { VisuallyHidden as HelpVisuallyHidden } from "../help/help.style";
 
 jest.mock("../../__internal__/utils/helpers/guid");
 (guid as jest.MockedFunction<typeof guid>).mockImplementation(
@@ -59,8 +59,9 @@ describe("ButtonToggleGroup", () => {
       helpAriaLabel: text,
     });
 
-    const ariaLabel = wrapper.find(StyledHelp).prop("aria-label");
-    expect(ariaLabel).toEqual(text);
+    const helpVisuallyHiddenText = wrapper.find(HelpVisuallyHidden).text();
+
+    expect(helpVisuallyHiddenText).toContain(text);
   });
 
   it("when inputWidth prop is passed, renders component with correct width", () => {

--- a/src/components/button-toggle-group/button-toggle-group.test.js
+++ b/src/components/button-toggle-group/button-toggle-group.test.js
@@ -245,11 +245,7 @@ context("Testing Button-Toggle-Group component", () => {
         <stories.ButtonToggleGroupComponent helpAriaLabel={testPropValue} />
       );
 
-      buttonToggleGroupHelpIcon().should(
-        "have.attr",
-        "aria-label",
-        testPropValue
-      );
+      buttonToggleGroupHelpIcon().contains(testPropValue).should("exist");
     });
 
     it.each([

--- a/src/components/checkbox/checkbox.spec.tsx
+++ b/src/components/checkbox/checkbox.spec.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../__spec_helper__/test-utils";
 import Label from "../../__internal__/label";
 import Tooltip from "../tooltip";
-import StyledHelp from "../help/help.style";
+import { VisuallyHidden as HelpVisuallyHidden } from "../help/help.style";
 import Logger from "../../__internal__/utils/logger";
 import checkableInput from "../../__internal__/checkable-input";
 
@@ -583,9 +583,9 @@ describe("Checkbox", () => {
         { label: "foo", labelHelp: text, helpAriaLabel: text },
         mount
       );
-      const help = wrapper.find(StyledHelp);
+      const helpVisuallyHiddenText = wrapper.find(HelpVisuallyHidden).text();
 
-      expect(help.prop("aria-label")).toEqual(text);
+      expect(helpVisuallyHiddenText).toContain(text);
     });
   });
 

--- a/src/components/checkbox/checkbox.test.js
+++ b/src/components/checkbox/checkbox.test.js
@@ -118,11 +118,9 @@ context("Testing Checkbox component", () => {
     );
 
     checkboxIcon().trigger("mouseover");
-    checkboxHelpIcon().should(
-      "have.attr",
-      "aria-label",
-      "This text provides more information for the label"
-    );
+    checkboxHelpIcon()
+      .contains("This text provides more information for the label")
+      .should("exist");
   });
 
   it.each([

--- a/src/components/date/date.spec.js
+++ b/src/components/date/date.spec.js
@@ -18,7 +18,7 @@ import I18nProvider from "../i18n-provider";
 import Label from "../../__internal__/label";
 import StyledInputPresentation from "../../__internal__/input/input-presentation.style";
 import Tooltip from "../tooltip";
-import StyledHelp from "../help/help.style";
+import { VisuallyHidden as HelpVisuallyHidden } from "../help/help.style";
 import ValidationIcon from "../../__internal__/validations";
 import DateRangeContext from "../date-range/date-range.context";
 import {
@@ -866,15 +866,15 @@ describe("Date", () => {
   describe("label help", () => {
     it("passes the expected values to the help component", () => {
       const text = "foo";
-      const { "aria-label": ariaLabel } = render({
+      wrapper = render({
         label: text,
         labelHelp: text,
         helpAriaLabel: text,
-      })
-        .find(StyledHelp)
-        .props();
+      });
 
-      expect(ariaLabel).toEqual(text);
+      const helpVisuallyHiddenText = wrapper.find(HelpVisuallyHidden).text();
+
+      expect(helpVisuallyHiddenText).toContain(text);
     });
   });
 

--- a/src/components/heading/heading.test.js
+++ b/src/components/heading/heading.test.js
@@ -105,7 +105,7 @@ context("Testing Heading component", () => {
         CypressMountWithProviders(
           <HeadingComponent help="This is a Title" helpAriaLabel={ariaLabel} />
         );
-        getComponent("help").should("have.attr", "aria-label", ariaLabel);
+        getComponent("help").contains(ariaLabel).should("exist");
       }
     );
 

--- a/src/components/help/help.style.ts
+++ b/src/components/help/help.style.ts
@@ -2,6 +2,7 @@ import styled, { css } from "styled-components";
 import { margin } from "styled-system";
 import baseTheme from "../../style/themes/base";
 import StyledIcon from "../icon/icon.style";
+import visuallyHiddenStyles from "../../style/utils/visually-hidden";
 
 interface StyledHelpProps {
   href?: string;
@@ -46,5 +47,9 @@ const StyledHelp = styled.div<StyledHelpProps>`
 StyledHelp.defaultProps = {
   theme: baseTheme,
 };
+
+export const VisuallyHidden = styled.span`
+  ${visuallyHiddenStyles}
+`;
 
 export default StyledHelp;

--- a/src/components/help/help.test.js
+++ b/src/components/help/help.test.js
@@ -194,10 +194,10 @@ context("Tests for Help component", () => {
     );
 
     it.each(testData)(
-      "should check aria-label as %s for Help component",
+      "should check accessibility label as %s for Help component",
       (label) => {
-        CypressMountWithProviders(<HelpComponent ariaLabel={label} />);
-        getComponent("help").should("have.attr", "aria-label", label);
+        CypressMountWithProviders(<HelpComponent accessibilityLabel={label} />);
+        getComponent("help").contains(label).should("exist");
       }
     );
 

--- a/src/components/numeral-date/numeral-date.spec.tsx
+++ b/src/components/numeral-date/numeral-date.spec.tsx
@@ -16,7 +16,7 @@ import FormFieldStyle from "../../__internal__/form-field/form-field.style";
 import FormField from "../../__internal__/form-field";
 import { rootTagTest } from "../../__internal__/utils/helpers/tags/tags-specs";
 import Label from "../../__internal__/label";
-import StyledHelp from "../help/help.style";
+import { VisuallyHidden as HelpVisuallyHidden } from "../help/help.style";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import { ErrorBorder, StyledHintText } from "../textbox/textbox.style";
 import StyledValidationMessage from "../../__internal__/validation-message/validation-message.style";
@@ -496,18 +496,18 @@ describe("NumeralDate", () => {
     it("should set the aria-label on the Help component", () => {
       const text = "foo";
 
-      const { "aria-label": ariaLabel } = mount(
+      wrapper = mount(
         <NumeralDate
           value={{ dd: "02", mm: "", yyyy: "" }}
           label={text}
           labelHelp={text}
           helpAriaLabel={text}
         />
-      )
-        .find(StyledHelp)
-        .props();
+      );
 
-      expect(ariaLabel).toEqual(text);
+      const helpVisuallyHiddenText = wrapper.find(HelpVisuallyHidden).text();
+
+      expect(helpVisuallyHiddenText).toContain(text);
     });
   });
 

--- a/src/components/numeral-date/numeral-date.test.js
+++ b/src/components/numeral-date/numeral-date.test.js
@@ -429,11 +429,7 @@ context("Tests for NumeralDate component", () => {
         />
       );
 
-      getComponent("help").should(
-        "have.attr",
-        "aria-label",
-        CHARACTERS.STANDARD
-      );
+      getComponent("help").contains(CHARACTERS.STANDARD).should("exist");
     });
   });
 

--- a/src/components/radio-button/radio-button.spec.tsx
+++ b/src/components/radio-button/radio-button.spec.tsx
@@ -11,7 +11,7 @@ import guid from "../../__internal__/utils/helpers/guid";
 import mintTheme from "../../style/themes/mint";
 import RadioButtonStyle from "./radio-button.style";
 import Tooltip from "../tooltip";
-import StyledHelp from "../help/help.style";
+import { VisuallyHidden as HelpVisuallyHidden } from "../help/help.style";
 import Logger from "../../__internal__/utils/logger";
 
 const mockedGuid = "mocked-guid";
@@ -246,18 +246,18 @@ describe("RadioButton", () => {
     it("should set the aria-label on the Help component", () => {
       const text = "foo";
 
-      const { "aria-label": ariaLabel } = mount(
+      const wrapper = mount(
         <RadioButton
           value="foo"
           label={text}
           labelHelp={text}
           helpAriaLabel={text}
         />
-      )
-        .find(StyledHelp)
-        .props();
+      );
 
-      expect(ariaLabel).toEqual(text);
+      const helpVisuallyHiddenText = wrapper.find(HelpVisuallyHidden).text();
+
+      expect(helpVisuallyHiddenText).toContain(text);
     });
   });
 });

--- a/src/components/radio-button/radiobutton.test.js
+++ b/src/components/radio-button/radiobutton.test.js
@@ -22,6 +22,7 @@ import {
   radiobuttonGroupIcon,
   radiobuttonRole,
   radiobutton,
+  radiobuttonHelpIcon,
 } from "../../../cypress/locators/radiobutton";
 
 import {
@@ -114,6 +115,21 @@ context("Testing RadioButton component", () => {
       );
 
       radiobuttonInlineFieldHelp().should("have.text", "Inline fieldhelp");
+    });
+
+    it("should render Radiobutton component with helpAriaLabel", () => {
+      CypressMountWithProviders(
+        <RadioButtonComponent
+          label="Label For CheckBox"
+          labelHelp="Label Help"
+          helpAriaLabel="This text provides more information for the label"
+        />
+      );
+
+      radiobuttonIcon().trigger("mouseover");
+      radiobuttonHelpIcon()
+        .contains("This text provides more information for the label")
+        .should("exist");
     });
 
     it.each([

--- a/src/components/switch/switch.spec.tsx
+++ b/src/components/switch/switch.spec.tsx
@@ -24,7 +24,7 @@ import SwitchStyle from "./switch.style";
 import Label from "../../__internal__/label";
 import I18nProvider, { I18nProviderProps } from "../i18n-provider";
 import Tooltip from "../tooltip";
-import StyledHelp from "../help/help.style";
+import { VisuallyHidden as HelpVisuallyHidden } from "../help/help.style";
 import Logger from "../../__internal__/utils/logger";
 
 const mockedGuid = "guid-12345";
@@ -593,9 +593,10 @@ describe("Switch", () => {
         { label: "foo", labelHelp: text, helpAriaLabel: text },
         mount
       );
-      const help = wrapper.find(StyledHelp);
 
-      expect(help.prop("aria-label")).toEqual(text);
+      const helpVisuallyHiddenText = wrapper.find(HelpVisuallyHidden).text();
+
+      expect(helpVisuallyHiddenText).toContain(text);
     });
   });
 

--- a/src/components/switch/switch.test.js
+++ b/src/components/switch/switch.test.js
@@ -436,11 +436,9 @@ context("Testing Switch component", () => {
       );
 
       switchIcon().trigger("mouseover");
-      switchHelpIcon().should(
-        "have.attr",
-        "aria-label",
-        "This text provides more information for the label"
-      );
+      switchHelpIcon()
+        .contains("This text provides more information for the label")
+        .should("exist");
     });
 
     it.each([

--- a/src/components/textarea/textarea.spec.tsx
+++ b/src/components/textarea/textarea.spec.tsx
@@ -15,7 +15,7 @@ import ValidationIcon from "../../__internal__/validations/validation-icon.compo
 import guid from "../../__internal__/utils/helpers/guid";
 import { StyledLabelContainer } from "../../__internal__/label/label.style";
 import Tooltip from "../tooltip";
-import StyledHelp from "../help/help.style";
+import { VisuallyHidden as HelpVisuallyHidden } from "../help/help.style";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import {
   ErrorBorder,
@@ -173,9 +173,9 @@ describe("Textarea", () => {
         { label: "foo", labelHelp: text, helpAriaLabel: text },
         mount
       );
-      const help = wrapper.find(StyledHelp);
+      const helpVisuallyHiddenText = wrapper.find(HelpVisuallyHidden).text();
 
-      expect(help.prop("aria-label")).toEqual(text);
+      expect(helpVisuallyHiddenText).toContain(text);
     });
   });
 
@@ -192,7 +192,9 @@ describe("Textarea", () => {
           />
         );
 
-        expect(wrapper.find(StyledHelp).prop("aria-label")).toEqual(text);
+        const helpVisuallyHiddenText = wrapper.find(HelpVisuallyHidden).text();
+
+        expect(helpVisuallyHiddenText).toContain(text);
       });
     });
 

--- a/src/components/textarea/textarea.test.js
+++ b/src/components/textarea/textarea.test.js
@@ -472,11 +472,7 @@ context("Tests for Textarea component", () => {
         />
       );
 
-      getComponent("help").should(
-        "have.attr",
-        "aria-label",
-        CHARACTERS.STANDARD
-      );
+      getComponent("help").contains(CHARACTERS.STANDARD).should("exist");
     });
 
     it.each(["left", "right"])(

--- a/src/components/textbox/textbox.spec.tsx
+++ b/src/components/textbox/textbox.spec.tsx
@@ -15,7 +15,7 @@ import Label from "../../__internal__/label";
 import FormFieldStyle from "../../__internal__/form-field/form-field.style";
 import CharacterCount from "../../__internal__/character-count";
 import Tooltip from "../tooltip";
-import StyledHelp from "../help/help.style";
+import { VisuallyHidden as HelpVisuallyHidden } from "../help/help.style";
 import createGuid from "../../__internal__/utils/helpers/guid";
 import { ErrorBorder, StyledHintText, StyledInputHint } from "./textbox.style";
 import StyledValidationMessage from "../../__internal__/validation-message/validation-message.style";
@@ -301,7 +301,9 @@ describe("Textbox", () => {
           />
         );
 
-        expect(wrapper.find(StyledHelp).prop("aria-label")).toEqual(text);
+        const helpVisuallyHiddenText = wrapper.find(HelpVisuallyHidden).text();
+
+        expect(helpVisuallyHiddenText).toContain(text);
       });
     });
 

--- a/src/components/textbox/textbox.test.js
+++ b/src/components/textbox/textbox.test.js
@@ -593,11 +593,7 @@ context("Tests for Textbox component", () => {
         />
       );
 
-      getComponent("help").should(
-        "have.attr",
-        "aria-label",
-        CHARACTERS.STANDARD
-      );
+      getComponent("help").contains(CHARACTERS.STANDARD).should("exist");
     });
 
     it.each(["left", "right"])(


### PR DESCRIPTION
Remove `role="button"` from help icon, and remove `aria-label` and `aria-describedby`. The relevant text is now included in the DOM directly in styles that make it not visible but are picked up by screenreaders - ensuring a good experience for screenreader users. Deprecate the `tooltipId` prop which is no longer necessary for accessibility, and deprecate `aria-label` and replace with `accessibilityLabel` (as the prop's value is no longer used for an `aria-label` attribute)

fix #5569

### Proposed behaviour

The help icon, which is not clickable and merely displays a tooltip on focus/hover, should not be announced as a button. There should be no Axe violations, and screenreaders should read both the supplied `ariaLabel` prop if supplied (otherwise it defaults to "help") and the tooltip text.

Further `ariaLabel` should be renamed (I have chosen `accessibilityLabel` but am open to better suggestions) because the prop is no longer used as an HTML `aria-label` attribute.

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

Help icon is announced as a button by screenreaders, which is incorrect and confusing.

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

Do both general regression testing and screenreader testing (both Voiceover with Safari on MacOS and NVDA with supported browsers on Windows) on the Help component and all other components which use it: Heading and the various input components

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
