### PR TITLE
test(popover-container): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -110,6 +110,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("global-header") &&
       !prepareUrl[0].startsWith("grid") &&
       !prepareUrl[0].startsWith("image") &&
+      !prepareUrl[0].startsWith("popover-container") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/popover-container/popover-container-test.stories.tsx
+++ b/src/components/popover-container/popover-container-test.stories.tsx
@@ -5,6 +5,7 @@ import { Select, Option } from "../select";
 
 export default {
   title: "Popover Container/Test",
+  includeStories: ["Default", "WithSelect"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -45,4 +46,50 @@ Default.story = {
     title: "Title",
     open: true,
   },
+};
+
+export const PopoverContainerComponent = ({ ...props }) => {
+  const [isOpen, setIsOpen] = React.useState(true);
+
+  const onOpen = () => setIsOpen(isOpen);
+  const onClose = () => setIsOpen(!isOpen);
+
+  return (
+    <div
+      style={{
+        height: 150,
+        margin: "100px",
+      }}
+    >
+      <PopoverContainer
+        title="Cypress is awesome"
+        containerAriaLabel="popover-container"
+        openButtonAriaLabel="open"
+        open={isOpen}
+        onOpen={onOpen}
+        onClose={onClose}
+        {...props}
+      >
+        Contents
+      </PopoverContainer>
+    </div>
+  );
+};
+
+export const PopoverContainerWithSelect = () => {
+  return (
+    <div style={{ height: 100 }}>
+      <PopoverContainer
+        containerAriaLabel="popover-container"
+        openButtonAriaLabel="open"
+        title="select example"
+      >
+        <Select label="my select">
+          <Option value="red" text="red" />
+          <Option value="green" text="green" />
+          <Option value="blue" text="blue" />
+        </Select>
+      </PopoverContainer>
+    </div>
+  );
 };

--- a/src/components/popover-container/popover-container.test.js
+++ b/src/components/popover-container/popover-container.test.js
@@ -1,8 +1,12 @@
 import React from "react";
 import PopoverContainer from "./popover-container.component";
+import {
+  PopoverContainerComponent,
+  PopoverContainerWithSelect,
+} from "./popover-container-test.stories";
+import * as stories from "./popover-container.stories";
 import Button from "../button";
 import Portrait from "../portrait";
-import { Select, Option } from "../select";
 
 import { getDataElementByValue, getComponent } from "../../../cypress/locators";
 import {
@@ -22,52 +26,6 @@ import { CHARACTERS } from "../../../cypress/support/component-helper/constants"
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testCypress = "test-cypress";
-
-const PopoverContainerComponent = ({ ...props }) => {
-  const [isOpen, setIsOpen] = React.useState(true);
-
-  const onOpen = () => setIsOpen(isOpen);
-  const onClose = () => setIsOpen(!isOpen);
-
-  return (
-    <div
-      style={{
-        height: 150,
-        margin: "100px",
-      }}
-    >
-      <PopoverContainer
-        title="Cypress is awesome"
-        containerAriaLabel="popover-container"
-        openButtonAriaLabel="open"
-        open={isOpen}
-        onOpen={onOpen}
-        onClose={onClose}
-        {...props}
-      >
-        Contents
-      </PopoverContainer>
-    </div>
-  );
-};
-
-const PopoverContainerWithSelect = () => {
-  return (
-    <div style={{ height: 100 }}>
-      <PopoverContainer
-        containerAriaLabel="popover-container"
-        openButtonAriaLabel="open"
-        title="select example"
-      >
-        <Select label="my select">
-          <Option value="red" text="red" />
-          <Option value="green" text="green" />
-          <Option value="blue" text="blue" />
-        </Select>
-      </PopoverContainer>
-    </div>
-  );
-};
 
 context("Test for Popover Container component", () => {
   describe("check props for Popover Container component", () => {
@@ -357,5 +315,79 @@ context("Test for Popover Container component", () => {
           });
       }
     );
+  });
+
+  describe("Accessibility tests for Popover Container component", () => {
+    it("should pass accessibilty tests for Popover Container Default story", () => {
+      CypressMountWithProviders(<stories.Default />);
+
+      popoverSettingsIcon().click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for Popover Container Title story", () => {
+      CypressMountWithProviders(<stories.Title />);
+
+      popoverSettingsIcon().click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for Popover Container Position story", () => {
+      CypressMountWithProviders(<stories.Position />);
+
+      popoverSettingsIcon().click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for Popover Container CoverButton story", () => {
+      CypressMountWithProviders(<stories.CoverButton />);
+
+      popoverSettingsIcon().click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for Popover Container RenderProps story", () => {
+      CypressMountWithProviders(<stories.RenderProps />);
+
+      popoverSettingsIcon().click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for Popover Container Controlled story", () => {
+      CypressMountWithProviders(<stories.Controlled />);
+
+      popoverSettingsIcon().click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for Popover Container Complex story", () => {
+      CypressMountWithProviders(<stories.Complex />);
+
+      popoverSettingsIcon().click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for Popover Container Filter story", () => {
+      CypressMountWithProviders(<stories.Filter />);
+
+      popoverSettingsIcon().click();
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for Popover Container Filter story with filter button clicked", () => {
+      CypressMountWithProviders(<stories.Filter />);
+
+      popoverSettingsIcon().click();
+      cy.get(`[role="checkbox"]`).eq(0).check();
+      cy.get(`[role="checkbox"]`).eq(1).check();
+      cy.get(`[role="checkbox"]`).eq(2).check();
+      getDataElementByValue("main-text")
+        .eq(1)
+        .click()
+        .then(() => {
+          // eslint-disable-next-line no-unused-expressions
+          cy.checkAccessibility();
+        });
+    });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `Popover-Container` component to use the new cypress-component-react framework for testing.
- Move component stories to the `popover-container-test.stories.tsx`

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added test.file
- [x] Check if the `popover-container.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Popover-Container` tests are not running twice.