### PR TITLE
chore: deprecation warning for uncontrolled inputs - FE-5331

### DIFF
--- a/src/__internal__/input/input.component.tsx
+++ b/src/__internal__/input/input.component.tsx
@@ -26,7 +26,7 @@ export interface CommonInputProps
   onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
   /** Specify a callback triggered on change */
   onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
-  /** pecify a callback triggered on click */
+  /** Specify a callback triggered on click */
   onClick?: (ev: React.MouseEvent<HTMLInputElement>) => void;
   /** Specify a callback triggered on focus */
   onFocus?: (ev: React.FocusEvent<HTMLInputElement>) => void;
@@ -45,9 +45,9 @@ export interface CommonInputProps
 export interface InputProps extends CommonInputProps {
   /** The visible width of the text control, in average character widths */
   cols?: number;
-  /** Integer to determine a timeout for the defered callback */
+  /** Integer to determine a timeout for the deferred callback */
   deferTimeout?: number;
-  /** Defered callback to be called after the onChange event */
+  /** Deferred callback to be called after the onChange event */
   onChangeDeferred?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   /** The number of visible text lines for the control */
   rows?: number;

--- a/src/components/advanced-color-picker/advanced-color-picker.component.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.component.tsx
@@ -13,7 +13,9 @@ import { filterStyledSystemMarginProps } from "../../style/utils";
 import guid from "../../__internal__/utils/helpers/guid";
 import useLocale from "../../hooks/__internal__/useLocale";
 import { Dt, Dd } from "../definition-list";
+import Logger from "../../__internal__/utils/logger";
 
+let deprecateUncontrolledWarnTriggered = false;
 export interface AdvancedColor {
   label: string;
   value: string;
@@ -205,6 +207,13 @@ export const AdvancedColorPicker = ({
     },
     [onBlur]
   );
+
+  if (!deprecateUncontrolledWarnTriggered && !onChange) {
+    deprecateUncontrolledWarnTriggered = true;
+    Logger.deprecate(
+      "Uncontrolled behaviour in `Advanced Color Picker` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+    );
+  }
 
   return (
     <StyledAdvancedColorPickerWrapper

--- a/src/components/advanced-color-picker/advanced-color-picker.spec.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.spec.tsx
@@ -10,10 +10,13 @@ import { SimpleColor } from "../simple-color-picker";
 import guid from "../../__internal__/utils/helpers/guid";
 import { testStyledSystemMargin } from "../../__spec_helper__/test-utils";
 import { StyledAdvancedColorPickerPreview } from "./advanced-color-picker.style";
+import Logger from "../../__internal__/utils/logger";
 
 const mockedGuid = "mocked-guid";
 
 config.disabled = true;
+
+jest.mock("../../__internal__/utils/logger");
 
 jest.mock("../../__internal__/utils/helpers/guid");
 (guid as jest.MockedFunction<typeof guid>).mockReturnValue(mockedGuid);
@@ -88,9 +91,35 @@ const MockComponent = () => {
 };
 
 describe("AdvancedColorPicker", () => {
+  let loggerSpy: jest.SpyInstance<void, [message: string]> | jest.Mock;
+
   testStyledSystemMargin((props) => (
     <AdvancedColorPicker {...requiredProps} {...props} />
   ));
+
+  describe("Deprecation warning for uncontrolled", () => {
+    beforeEach(() => {
+      loggerSpy = jest.spyOn(Logger, "deprecate");
+      jest.restoreAllMocks();
+    });
+
+    afterEach(() => {
+      loggerSpy.mockRestore();
+    });
+
+    afterAll(() => {
+      loggerSpy.mockClear();
+    });
+
+    it("should display deprecation warning once", () => {
+      render({ ...requiredProps });
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Advanced Color Picker` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 
   describe("when focused on color picker cell button", () => {
     const keyDownEvents = [

--- a/src/components/button-toggle/button-toggle.component.tsx
+++ b/src/components/button-toggle/button-toggle.component.tsx
@@ -14,6 +14,10 @@ import ButtonToggleInput, {
 
 import { InputGroupContext } from "../../__internal__/input-behaviour";
 
+import Logger from "../../__internal__/utils/logger";
+
+let deprecateUncontrolledWarnTriggered = false;
+
 export interface ButtonToggleProps
   extends ButtonToggleInputProps,
     Partial<StyledButtonToggleLabelProps> {
@@ -76,6 +80,13 @@ export const ButtonToggle = ({
 
   function handleClick() {
     inputRef.current?.focus();
+  }
+
+  if (!deprecateUncontrolledWarnTriggered && !onChange) {
+    deprecateUncontrolledWarnTriggered = true;
+    Logger.deprecate(
+      "Uncontrolled behaviour in `Button Toggle` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+    );
   }
 
   return (

--- a/src/components/button-toggle/button-toggle.spec.tsx
+++ b/src/components/button-toggle/button-toggle.spec.tsx
@@ -15,6 +15,9 @@ import {
 } from "./button-toggle.style";
 import { InputGroupContext } from "../../__internal__/input-behaviour";
 import { ThemeObject } from "../../style/themes/base";
+import Logger from "../../__internal__/utils/logger";
+
+jest.mock("../../__internal__/utils/logger");
 
 jest.mock("../../__internal__/utils/helpers/guid");
 (guid as jest.MockedFunction<typeof guid>).mockImplementation(
@@ -49,6 +52,32 @@ function renderButtonToggleWithContext(
 }
 
 describe("ButtonToggle", () => {
+  let loggerSpy: jest.SpyInstance<void, [message: string]> | jest.Mock;
+
+  beforeEach(() => {
+    loggerSpy = jest.spyOn(Logger, "deprecate");
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    loggerSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    loggerSpy.mockClear();
+  });
+
+  describe("Deprecation warning for uncontrolled", () => {
+    it("should display deprecation warning once", () => {
+      renderButtonToggle();
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Button Toggle` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
   describe("functionality", () => {
     it("pass onChange props to input", () => {
       const onChangeMock = jest.fn();

--- a/src/components/checkbox/checkbox.component.tsx
+++ b/src/components/checkbox/checkbox.component.tsx
@@ -40,6 +40,7 @@ export interface CheckboxProps extends CommonCheckableInputProps, MarginProps {
 }
 
 let deprecateInputRefWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
 
 export const Checkbox = React.forwardRef(
   (
@@ -95,6 +96,13 @@ export const Checkbox = React.forwardRef(
       deprecateInputRefWarnTriggered = true;
       Logger.deprecate(
         "The `inputRef` prop in `Checkbox` component is deprecated and will soon be removed. Please use `ref` instead."
+      );
+    }
+
+    if (!deprecateUncontrolledWarnTriggered && !onChange) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Checkbox` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
       );
     }
 

--- a/src/components/checkbox/checkbox.spec.tsx
+++ b/src/components/checkbox/checkbox.spec.tsx
@@ -18,6 +18,8 @@ import StyledHelp from "../help/help.style";
 import Logger from "../../__internal__/utils/logger";
 import checkableInput from "../../__internal__/checkable-input";
 
+jest.mock("../../__internal__/utils/logger");
+
 jest.mock("../../__internal__/utils/helpers/guid");
 (guid as jest.MockedFunction<typeof guid>).mockImplementation(
   () => "guid-12345"
@@ -57,6 +59,33 @@ function getValidationBorderColor(
 }
 
 describe("Checkbox", () => {
+  let loggerSpy: jest.SpyInstance<void, [message: string]> | jest.Mock;
+
+  beforeEach(() => {
+    loggerSpy = jest.spyOn(Logger, "deprecate");
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    loggerSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    loggerSpy.mockClear();
+  });
+
+  describe("Deprecation warning for uncontrolled", () => {
+    it("should display deprecation warning once", () => {
+      mount(<Checkbox name="my-checkbox" />);
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Checkbox` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   testStyledSystemMargin((props) => (
     <Checkbox name="my-checkbox" value="test" {...props} />
   ));
@@ -65,7 +94,6 @@ describe("Checkbox", () => {
     let wrapper: ReactWrapper;
 
     it("should display deprecation warning when the inputRef prop is used", () => {
-      const loggerSpy = jest.spyOn(Logger, "deprecate");
       const ref = { current: null };
 
       wrapper = renderCheckbox({ inputRef: ref });

--- a/src/components/decimal/decimal.component.tsx
+++ b/src/components/decimal/decimal.component.tsx
@@ -72,6 +72,7 @@ export interface DecimalProps
 }
 
 let deprecateInputRefWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
 
 export const Decimal = React.forwardRef(
   (
@@ -326,6 +327,13 @@ export const Decimal = React.forwardRef(
       toStandardDecimal,
       value,
     ]);
+
+    if (!deprecateUncontrolledWarnTriggered && !isControlled) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Decimal` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+    }
 
     return (
       <>

--- a/src/components/grouped-character/grouped-character.component.tsx
+++ b/src/components/grouped-character/grouped-character.component.tsx
@@ -49,6 +49,7 @@ export interface GroupedCharacterProps
 }
 
 let deprecateInputRefWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
 
 export const GroupedCharacter = React.forwardRef(
   (
@@ -76,6 +77,13 @@ export const GroupedCharacter = React.forwardRef(
       deprecateInputRefWarnTriggered = true;
       Logger.deprecate(
         "The `inputRef` prop in `GroupedCharacter` component is deprecated and will soon be removed. Please use `ref` instead."
+      );
+    }
+
+    if (!deprecateUncontrolledWarnTriggered && !isControlled) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Grouped Character` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
       );
     }
 

--- a/src/components/grouped-character/grouped-character.spec.tsx
+++ b/src/components/grouped-character/grouped-character.spec.tsx
@@ -13,6 +13,8 @@ import Label from "../../__internal__/label";
 import { InputPresentation } from "../../__internal__/input";
 import Logger from "../../__internal__/utils/logger";
 
+jest.mock("../../__internal__/utils/logger");
+
 const mountComponent = (props: GroupedCharacterProps) =>
   mount(<GroupedCharacter {...props} />);
 
@@ -37,6 +39,33 @@ describe("GroupedCharacter", () => {
     (wrapper) => wrapper.find(FormFieldStyle),
     { modifier: "&&&" }
   );
+
+  let loggerSpy: jest.SpyInstance<void, [message: string]> | jest.Mock;
+
+  describe("Deprecation warning for uncontrolled", () => {
+    beforeEach(() => {
+      loggerSpy = jest.spyOn(Logger, "deprecate");
+      jest.restoreAllMocks();
+    });
+
+    afterEach(() => {
+      loggerSpy.mockRestore();
+    });
+
+    afterAll(() => {
+      loggerSpy.mockClear();
+    });
+
+    it("should display deprecation warning once", () => {
+      mount(<GroupedCharacter groups={[2, 2, 3]} separator="-" />);
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Grouped Character` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 
   describe("uncontrolled behaviour", () => {
     let instance: ReactWrapper;
@@ -288,7 +317,6 @@ describe("GroupedCharacter", () => {
     let wrapper: ReactWrapper;
 
     it("should display deprecation warning when the inputRef prop is used", () => {
-      const loggerSpy = jest.spyOn(Logger, "deprecate");
       const ref = () => {};
 
       wrapper = renderGroupedCharacter({ inputRef: ref });

--- a/src/components/number/number.component.tsx
+++ b/src/components/number/number.component.tsx
@@ -3,6 +3,8 @@ import Textbox, { TextboxProps } from "../textbox";
 import Logger from "../../__internal__/utils/logger";
 
 let deprecateInputRefWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
+
 export interface NumberProps extends Omit<TextboxProps, "value"> {
   /** Value passed to the input */
   value?: string;
@@ -27,6 +29,13 @@ export const Number = React.forwardRef(
       deprecateInputRefWarnTriggered = true;
       Logger.deprecate(
         "The `inputRef` prop in `Number` component is deprecated and will soon be removed. Please use `ref` instead."
+      );
+    }
+
+    if (!deprecateUncontrolledWarnTriggered && !onChange) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Number` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
       );
     }
 

--- a/src/components/number/number.spec.tsx
+++ b/src/components/number/number.spec.tsx
@@ -7,6 +7,8 @@ import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import InputPresentation from "../../__internal__/input/input-presentation.component";
 import Logger from "../../__internal__/utils/logger";
 
+jest.mock("../../__internal__/utils/logger");
+
 function renderNumberInput(
   props: NumberProps & React.RefAttributes<HTMLInputElement>
 ) {
@@ -32,6 +34,33 @@ describe("Number Input", () => {
   const selectionStart = 2;
   const selectionEnd = 4;
   const defaultInputValue = "123456789";
+
+  let loggerSpy: jest.SpyInstance<void, [message: string]> | jest.Mock;
+
+  beforeEach(() => {
+    loggerSpy = jest.spyOn(Logger, "deprecate");
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    loggerSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    loggerSpy.mockClear();
+  });
+
+  describe("Deprecation warning for uncontrolled", () => {
+    it("should display deprecation warning once", () => {
+      mount(<Number />);
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Number` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 
   describe("when rendered", () => {
     it("should have the Textbox component as it's child", () => {
@@ -179,7 +208,7 @@ describe("Number Input", () => {
 
   describe("refs", () => {
     it("should display deprecation warning when the inputRef prop is used", () => {
-      const loggerSpy = jest.spyOn(Logger, "deprecate");
+      loggerSpy = jest.spyOn(Logger, "deprecate");
       const ref = () => {};
 
       wrapper = renderNumberInput({ inputRef: ref });

--- a/src/components/numeral-date/numeral-date.component.tsx
+++ b/src/components/numeral-date/numeral-date.component.tsx
@@ -17,6 +17,9 @@ import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import { NewValidationContext } from "../carbon-provider/carbon-provider.component";
 import NumeralDateContext from "./numeral-date-context";
 import FormSpacingProvider from "../../__internal__/form-spacing-provider";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecateUncontrolledWarnTriggered = false;
 
 export const ALLOWED_DATE_FORMATS = [
   ["dd", "mm", "yyyy"],
@@ -329,6 +332,13 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
   const internalWarning = enableInternalWarning
     ? internalMessage + warning
     : warning;
+
+  if (!deprecateUncontrolledWarnTriggered && !isControlled.current) {
+    deprecateUncontrolledWarnTriggered = true;
+    Logger.deprecate(
+      "Uncontrolled behaviour in `Numeral Date` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+    );
+  }
 
   return (
     <TooltipProvider helpAriaLabel={helpAriaLabel}>

--- a/src/components/numeral-date/numeral-date.spec.tsx
+++ b/src/components/numeral-date/numeral-date.spec.tsx
@@ -20,6 +20,9 @@ import StyledHelp from "../help/help.style";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import { ErrorBorder, StyledHintText } from "../textbox/textbox.style";
 import StyledValidationMessage from "../../__internal__/validation-message/validation-message.style";
+import Logger from "../../__internal__/utils/logger";
+
+jest.mock("../../__internal__/utils/logger");
 
 const ddmmMessage =
   "Day should be a number within a 1-31 range.\n" +
@@ -68,6 +71,33 @@ describe("NumeralDate", () => {
   beforeEach(() => {
     onBlur.mockReset();
     onChange.mockReset();
+  });
+
+  let loggerSpy: jest.SpyInstance<void, [message: string]> | jest.Mock;
+
+  describe("Deprecation warning for uncontrolled", () => {
+    beforeEach(() => {
+      loggerSpy = jest.spyOn(Logger, "deprecate");
+      jest.restoreAllMocks();
+    });
+
+    afterEach(() => {
+      loggerSpy.mockRestore();
+    });
+
+    afterAll(() => {
+      loggerSpy.mockClear();
+    });
+
+    it("should display deprecation warning once", () => {
+      renderWrapper({});
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Numeral Date` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("propTypes", () => {

--- a/src/components/radio-button/radio-button-group.component.tsx
+++ b/src/components/radio-button/radio-button-group.component.tsx
@@ -8,7 +8,9 @@ import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint"
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import { ValidationProps } from "../../__internal__/validations";
+import Logger from "../../__internal__/utils/logger";
 
+let deprecateUncontrolledWarnTriggered = false;
 export interface RadioButtonGroupProps extends ValidationProps, MarginProps {
   /** Breakpoint for adaptive legend (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLegendBreakpoint?: number;
@@ -66,6 +68,13 @@ export const RadioButtonGroup = (props: RadioButtonGroupProps) => {
     required,
     tooltipPosition,
   } = props;
+
+  if (!deprecateUncontrolledWarnTriggered && !onChange) {
+    deprecateUncontrolledWarnTriggered = true;
+    Logger.deprecate(
+      "Uncontrolled behaviour in `Radio Button` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+    );
+  }
 
   const marginProps = filterStyledSystemMarginProps(props);
 

--- a/src/components/radio-button/radio-button.spec.tsx
+++ b/src/components/radio-button/radio-button.spec.tsx
@@ -14,6 +14,8 @@ import Tooltip from "../tooltip";
 import StyledHelp from "../help/help.style";
 import Logger from "../../__internal__/utils/logger";
 
+jest.mock("../../__internal__/utils/logger");
+
 const mockedGuid = "mocked-guid";
 jest.mock("../../__internal__/utils/helpers/guid");
 
@@ -48,6 +50,37 @@ const borderColorsByValidationTypes = {
 };
 
 describe("RadioButton", () => {
+  let loggerSpy: jest.SpyInstance<void, [message: string]> | jest.Mock;
+
+  beforeEach(() => {
+    loggerSpy = jest.spyOn(Logger, "deprecate");
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    loggerSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    loggerSpy.mockClear();
+  });
+
+  describe("Deprecation warning for uncontrolled", () => {
+    it("should display deprecation warning once", () => {
+      mount(
+        <RadioButtonGroup name="radio-button-group">
+          <RadioButton value="test" />
+        </RadioButtonGroup>
+      );
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Radio Button` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("propTypes", () => {
     it("does not allow a children prop", () => {
       const consoleSpy = jest
@@ -82,7 +115,6 @@ describe("RadioButton", () => {
   });
 
   it("should display deprecation warning when the inputRef prop is used", () => {
-    const loggerSpy = jest.spyOn(Logger, "deprecate");
     const ref = { current: null };
 
     const wrapper = mount(<RadioButton inputRef={ref} value="test" />);
@@ -107,7 +139,7 @@ describe("RadioButton", () => {
 
       it("applies the correct circle styles", () => {
         assertStyleMatch(
-          { fill: "var(--colorsCtilityDisabled400)" },
+          { fill: "var(--colorsUtilityDisabled400)" },
           getRadioButton(wrapper),
           { modifier: "circle" }
         );

--- a/src/components/radio-button/radio-button.style.ts
+++ b/src/components/radio-button/radio-button.style.ts
@@ -62,7 +62,7 @@ const RadioButtonStyle = styled(CheckboxStyle)<
     ${disabled &&
     css`
       circle {
-        fill: var(--colorsCtilityDisabled400);
+        fill: var(--colorsUtilityDisabled400);
       }
 
       ${HiddenCheckableInputStyle}:checked + ${StyledCheckableInputSvgWrapper} circle {

--- a/src/components/search/search.component.tsx
+++ b/src/components/search/search.component.tsx
@@ -69,6 +69,7 @@ export interface SearchProps extends ValidationProps, MarginProps {
 }
 
 let deprecateInputRefWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
 
 export const Search = React.forwardRef(
   (
@@ -106,6 +107,13 @@ export const Search = React.forwardRef(
       deprecateInputRefWarnTriggered = true;
       Logger.deprecate(
         "The `inputRef` prop in `Search` component is deprecated and will soon be removed. Please use `ref` instead."
+      );
+    }
+
+    if (!deprecateUncontrolledWarnTriggered && !isControlled) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Search` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
       );
     }
 

--- a/src/components/search/search.spec.tsx
+++ b/src/components/search/search.spec.tsx
@@ -17,6 +17,8 @@ import TextBox from "../textbox";
 import { rootTagTest } from "../../__internal__/utils/helpers/tags/tags-specs";
 import Logger from "../../__internal__/utils/logger";
 
+jest.mock("../../__internal__/utils/logger");
+
 describe("Search", () => {
   let wrapper: ReactWrapper;
   let onBlur: jest.Mock;
@@ -32,6 +34,33 @@ describe("Search", () => {
   ) {
     return mount(<Search {...props} />);
   }
+
+  let loggerSpy: jest.SpyInstance<void, [message: string]> | jest.Mock;
+
+  describe("Deprecation warning for uncontrolled", () => {
+    beforeEach(() => {
+      loggerSpy = jest.spyOn(Logger, "deprecate");
+      jest.restoreAllMocks();
+    });
+
+    afterEach(() => {
+      loggerSpy.mockRestore();
+    });
+
+    afterAll(() => {
+      loggerSpy.mockClear();
+    });
+
+    it("should display deprecation warning once", () => {
+      wrapper = renderSearch({ defaultValue: "foo" });
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Search` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 
   describe("styles", () => {
     it("matches the expected styles", () => {
@@ -609,7 +638,6 @@ describe("Search", () => {
 
   describe("refs", () => {
     it("should display deprecation warning when the inputRef prop is used", () => {
-      const loggerSpy = jest.spyOn(Logger, "deprecate");
       const ref = { current: null };
 
       wrapper = renderSearch({ inputRef: ref, value: "" });

--- a/src/components/select/filterable-select/filterable-select.component.js
+++ b/src/components/select/filterable-select/filterable-select.component.js
@@ -18,6 +18,7 @@ import useFormSpacing from "../../../hooks/__internal__/useFormSpacing";
 import useInputAccessibility from "../../../hooks/__internal__/useInputAccessibility/useInputAccessibility";
 
 let deprecateInputRefWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
 
 const FilterableSelectList = withFilter(SelectList);
 
@@ -89,7 +90,17 @@ const FilterableSelect = React.forwardRef(
     if (!deprecateInputRefWarnTriggered && inputRef) {
       deprecateInputRefWarnTriggered = true;
       Logger.deprecate(
-        "The `inputRef` prop in `FilterableSelect` component is deprecated and will soon be removed. Please use `ref` instead."
+        "The `inputRef` prop in `Filterable Select` component is deprecated and will soon be removed. Please use `ref` instead."
+      );
+    }
+
+    const componentIsUncontrolled =
+      !isControlled || (!onChange && defaultValue);
+
+    if (!deprecateUncontrolledWarnTriggered && componentIsUncontrolled) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Filterable Select` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
       );
     }
 

--- a/src/components/select/filterable-select/filterable-select.spec.js
+++ b/src/components/select/filterable-select/filterable-select.spec.js
@@ -19,11 +19,40 @@ import { InputPresentation } from "../../../__internal__/input";
 import Logger from "../../../__internal__/utils/logger";
 
 const mockedGuid = "mocked-guid";
+jest.mock("../../../__internal__/utils/logger");
+
 jest.mock("../../../__internal__/utils/helpers/guid");
 
 guid.mockReturnValue(mockedGuid);
 
 describe("FilterableSelect", () => {
+  let loggerSpy;
+
+  describe("Deprecation warning for uncontrolled", () => {
+    beforeEach(() => {
+      loggerSpy = jest.spyOn(Logger, "deprecate");
+      jest.restoreAllMocks();
+    });
+
+    afterEach(() => {
+      loggerSpy.mockRestore();
+    });
+
+    afterAll(() => {
+      loggerSpy.mockClear();
+    });
+
+    it("should display deprecation warning once", () => {
+      renderSelect({ defaultValue: "opt1" });
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Filterable Select` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   testStyledSystemMargin((props) => getSelect(props));
 
   it('the Textbox should have type of "text"', () => {
@@ -162,19 +191,22 @@ describe("FilterableSelect", () => {
   });
 
   describe("when the inputRef function prop is specified", () => {
-    it("should display deprecation warning when the inputRef prop is usedll", () => {
-      const loggerSpy = jest.spyOn(Logger, "deprecate");
+    it("should display deprecation warning when the inputRef prop is used", () => {
       const inputRefFn = jest.fn();
       const wrapper = renderSelect({ inputRef: inputRefFn });
 
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "The `inputRef` prop in `FilterableSelect` component is deprecated and will soon be removed. Please use `ref` instead."
-      );
+      expect(loggerSpy.mock.calls).toEqual([
+        [
+          "The `inputRef` prop in `Filterable Select` component is deprecated and will soon be removed. Please use `ref` instead.",
+        ],
+        [
+          "The `inputRef` prop in `Textbox` component is deprecated and will soon be removed. Please use `ref` instead.",
+        ],
+      ]);
       expect(loggerSpy).toHaveBeenCalledTimes(2);
       // will be called twice because the prop is passed to Textbox where another deprecation warning is triggered.
       wrapper.setProps({ prop1: true });
       expect(loggerSpy).toHaveBeenCalledTimes(2);
-      loggerSpy.mockRestore();
     });
 
     it("then the input reference should be returned on call", () => {

--- a/src/components/select/multi-select/multi-select.component.js
+++ b/src/components/select/multi-select/multi-select.component.js
@@ -30,6 +30,7 @@ import useFormSpacing from "../../../hooks/__internal__/useFormSpacing";
 import useInputAccessibility from "../../../hooks/__internal__/useInputAccessibility/useInputAccessibility";
 
 let deprecateInputRefWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
 
 const FilterableSelectList = withFilter(SelectList);
 
@@ -106,7 +107,17 @@ const MultiSelect = React.forwardRef(
     if (!deprecateInputRefWarnTriggered && inputRef) {
       deprecateInputRefWarnTriggered = true;
       Logger.deprecate(
-        "The `inputRef` prop in `MultiSelect` component is deprecated and will soon be removed. Please use `ref` instead."
+        "The `inputRef` prop in `Multi Select` component is deprecated and will soon be removed. Please use `ref` instead."
+      );
+    }
+
+    const componentIsUncontrolled =
+      !isControlled || (!onChange && defaultValue);
+
+    if (!deprecateUncontrolledWarnTriggered && componentIsUncontrolled) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Multi Select` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
       );
     }
 

--- a/src/components/select/multi-select/multi-select.spec.js
+++ b/src/components/select/multi-select/multi-select.spec.js
@@ -11,12 +11,12 @@ import Textbox from "../../textbox";
 import Option from "../option/option.component";
 import SelectList from "../select-list/select-list.component";
 import { StyledSelectList } from "../select-list/select-list.style";
+import StyledSelectListContainer from "../select-list/select-list-container.style";
 import Pill from "../../pill";
 import Label from "../../../__internal__/label";
 import InputPresentationStyle from "../../../__internal__/input/input-presentation.style";
 import { InputPresentation } from "../../../__internal__/input";
 import Logger from "../../../__internal__/utils/logger";
-import StyledSelectListContainer from "../select-list/select-list-container.style";
 import guid from "../../../__internal__/utils/helpers/guid";
 
 const mockedGuid = "mocked-guid";
@@ -24,7 +24,36 @@ jest.mock("../../../__internal__/utils/helpers/guid");
 
 guid.mockReturnValue(mockedGuid);
 
+jest.mock("../../../__internal__/utils/logger");
+
 describe("MultiSelect", () => {
+  let loggerSpy;
+
+  describe("Deprecation warning for uncontrolled", () => {
+    beforeEach(() => {
+      loggerSpy = jest.spyOn(Logger, "deprecate");
+      jest.restoreAllMocks();
+    });
+
+    afterEach(() => {
+      loggerSpy.mockRestore();
+    });
+
+    afterAll(() => {
+      loggerSpy.mockClear();
+    });
+
+    it("should display deprecation warning once", () => {
+      renderSelect({ defaultValue: ["opt2", "opt1"] });
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Multi Select` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   testStyledSystemMargin((props) => getSelect(props));
 
   it("when text is passed in placeholder prop, input element in textbox uses it as placeholder text", () => {
@@ -163,14 +192,18 @@ describe("MultiSelect", () => {
   });
 
   describe("when the inputRef function prop is specified", () => {
-    it("should display deprecation warning when the inputRef prop is usedll", () => {
-      const loggerSpy = jest.spyOn(Logger, "deprecate");
+    it("should display deprecation warning when the inputRef prop is used", () => {
       const inputRefFn = jest.fn();
       const wrapper = renderSelect({ inputRef: inputRefFn });
 
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "The `inputRef` prop in `MultiSelect` component is deprecated and will soon be removed. Please use `ref` instead."
-      );
+      expect(loggerSpy.mock.calls).toEqual([
+        [
+          "The `inputRef` prop in `Multi Select` component is deprecated and will soon be removed. Please use `ref` instead.",
+        ],
+        [
+          "The `inputRef` prop in `Textbox` component is deprecated and will soon be removed. Please use `ref` instead.",
+        ],
+      ]);
       expect(loggerSpy).toHaveBeenCalledTimes(2);
       // will be called twice because the prop is passed to Textbox where another deprecation warning is triggered.
       wrapper.setProps({ prop1: true });

--- a/src/components/select/simple-select/simple-select.component.js
+++ b/src/components/select/simple-select/simple-select.component.js
@@ -24,6 +24,7 @@ import useFormSpacing from "../../../hooks/__internal__/useFormSpacing";
 import useInputAccessibility from "../../../hooks/__internal__/useInputAccessibility/useInputAccessibility";
 
 let deprecateInputRefWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
 
 const SimpleSelect = React.forwardRef(
   (
@@ -90,7 +91,17 @@ const SimpleSelect = React.forwardRef(
     if (!deprecateInputRefWarnTriggered && inputRef) {
       deprecateInputRefWarnTriggered = true;
       Logger.deprecate(
-        "The `inputRef` prop in `Select` component is deprecated and will soon be removed. Please use `ref` instead."
+        "The `inputRef` prop in `Simple Select` component is deprecated and will soon be removed. Please use `ref` instead."
+      );
+    }
+
+    const componentIsUncontrolled =
+      !isControlled || (!onChange && defaultValue);
+
+    if (!deprecateUncontrolledWarnTriggered && componentIsUncontrolled) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Simple Select` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
       );
     }
 

--- a/src/components/select/simple-select/simple-select.spec.js
+++ b/src/components/select/simple-select/simple-select.spec.js
@@ -23,7 +23,36 @@ jest.mock("../../../__internal__/utils/helpers/guid");
 
 guid.mockReturnValue(mockedGuid);
 
+jest.mock("../../../__internal__/utils/logger");
+
 describe("SimpleSelect", () => {
+  let loggerSpy;
+
+  describe("Deprecation warning for uncontrolled", () => {
+    beforeEach(() => {
+      loggerSpy = jest.spyOn(Logger, "deprecate");
+      jest.restoreAllMocks();
+    });
+
+    afterEach(() => {
+      loggerSpy.mockRestore();
+    });
+
+    afterAll(() => {
+      loggerSpy.mockClear();
+    });
+
+    it("should display deprecation warning once", () => {
+      renderSelect({ defaultValue: "opt1" });
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Simple Select` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe("when the id prop is set", () => {
     const mockId = "foo";
     const wrapper = renderSelect({ id: mockId, label: "bar" });
@@ -227,14 +256,19 @@ describe("SimpleSelect", () => {
   });
 
   describe("when the inputRef prop is specified", () => {
-    it("should display deprecation warning when the inputRef prop is usedll", () => {
-      const loggerSpy = jest.spyOn(Logger, "deprecate");
+    it("should display deprecation warning when the inputRef prop is used", () => {
       const inputRefFn = jest.fn();
       const wrapper = renderSelect({ inputRef: inputRefFn });
 
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "The `inputRef` prop in `Select` component is deprecated and will soon be removed. Please use `ref` instead."
-      );
+      expect(loggerSpy.mock.calls).toEqual([
+        [
+          "The `inputRef` prop in `Simple Select` component is deprecated and will soon be removed. Please use `ref` instead.",
+        ],
+        [
+          "The `inputRef` prop in `Textbox` component is deprecated and will soon be removed. Please use `ref` instead.",
+        ],
+      ]);
+
       expect(loggerSpy).toHaveBeenCalledTimes(2);
       // will be called twice because the prop is passed to Textbox where another deprecation warning is triggered.
       wrapper.setProps({ prop1: true });

--- a/src/components/simple-color-picker/simple-color-picker.component.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.component.tsx
@@ -20,6 +20,9 @@ import ValidationIcon from "../../__internal__/validations/validation-icon.compo
 import { InputGroupContext } from "../../__internal__/input-behaviour";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { ValidationProps } from "../../__internal__/validations";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecateUncontrolledWarnTriggered = false;
 
 export interface SimpleColorPickerProps extends ValidationProps, MarginProps {
   /** The SimpleColor components to be rendered in the group */
@@ -287,6 +290,13 @@ export const SimpleColorPicker = React.forwardRef<
     warning,
     info,
   };
+
+  if (!deprecateUncontrolledWarnTriggered && !onChange) {
+    deprecateUncontrolledWarnTriggered = true;
+    Logger.deprecate(
+      "Uncontrolled behaviour in `Simple Color Picker` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+    );
+  }
 
   return (
     <Fieldset

--- a/src/components/simple-color-picker/simple-color-picker.spec.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.spec.tsx
@@ -16,6 +16,9 @@ import {
 } from "../../__spec_helper__/test-utils";
 import StyledValidationIcon from "../../__internal__/validations/validation-icon.style";
 import Fieldset from "../../__internal__/fieldset";
+import Logger from "../../__internal__/utils/logger";
+
+jest.mock("../../__internal__/utils/logger");
 
 const colorValues = [
   { color: "#00A376" },
@@ -71,6 +74,32 @@ function render(
 }
 
 describe("SimpleColorPicker", () => {
+  let loggerSpy: jest.SpyInstance<void, [message: string]> | jest.Mock;
+
+  beforeEach(() => {
+    loggerSpy = jest.spyOn(Logger, "deprecate");
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    loggerSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    loggerSpy.mockClear();
+  });
+
+  describe("Deprecation warning for uncontrolled", () => {
+    it("should display deprecation warning once", () => {
+      <SimpleColor id="1" key={`radio-key-${1}`} value="#0073C1" />;
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Simple Color Picker` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
   describe("Styled System", () => {
     testStyledSystemMargin((props) => (
       <SimpleColorPicker

--- a/src/components/switch/switch.component.tsx
+++ b/src/components/switch/switch.component.tsx
@@ -41,6 +41,7 @@ export interface SwitchProps extends CommonCheckableInputProps, MarginProps {
 }
 
 let deprecateInputRefWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
 
 export const Switch = React.forwardRef(
   (
@@ -88,6 +89,13 @@ export const Switch = React.forwardRef(
       deprecateInputRefWarnTriggered = true;
       Logger.deprecate(
         "The `inputRef` prop in `Switch` component is deprecated and will soon be removed. Please use `ref` instead."
+      );
+    }
+
+    if (!deprecateUncontrolledWarnTriggered && !onChange) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Switch` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
       );
     }
 

--- a/src/components/switch/switch.spec.tsx
+++ b/src/components/switch/switch.spec.tsx
@@ -27,6 +27,8 @@ import Tooltip from "../tooltip";
 import StyledHelp from "../help/help.style";
 import Logger from "../../__internal__/utils/logger";
 
+jest.mock("../../__internal__/utils/logger");
+
 const mockedGuid = "guid-12345";
 jest.mock("../../__internal__/utils/helpers/guid");
 
@@ -76,6 +78,33 @@ function renderWithTheme(
 }
 
 describe("Switch", () => {
+  let loggerSpy: jest.SpyInstance<void, [message: string]> | jest.Mock;
+
+  beforeEach(() => {
+    loggerSpy = jest.spyOn(Logger, "deprecate");
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    loggerSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    loggerSpy.mockClear();
+  });
+
+  describe("Deprecation warning for uncontrolled", () => {
+    it("should display deprecation warning once", () => {
+      <Switch name="my-switch" defaultValue="test" />;
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Switch` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("Styled System", () => {
     testStyledSystemMargin((props) => <Switch {...props} />);
   });
@@ -84,7 +113,6 @@ describe("Switch", () => {
     let wrapper: ReactWrapper;
 
     it("should display deprecation warning when the inputRef prop is used", () => {
-      const loggerSpy = jest.spyOn(Logger, "deprecate");
       const ref = { current: null };
 
       wrapper = render({ inputRef: ref });

--- a/src/components/textarea/textarea.component.tsx
+++ b/src/components/textarea/textarea.component.tsx
@@ -123,6 +123,7 @@ export interface TextareaProps
 }
 
 let deprecateInputRefWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
 
 export const Textarea = React.forwardRef(
   (
@@ -198,6 +199,13 @@ export const Textarea = React.forwardRef(
       deprecateInputRefWarnTriggered = true;
       Logger.deprecate(
         "The `inputRef` prop in `Textarea` component is deprecated and will soon be removed. Please use `ref` instead."
+      );
+    }
+
+    if (!deprecateUncontrolledWarnTriggered && !onChange) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Textarea` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
       );
     }
 

--- a/src/components/textarea/textarea.spec.tsx
+++ b/src/components/textarea/textarea.spec.tsx
@@ -26,6 +26,8 @@ import StyledValidationMessage from "../../__internal__/validation-message/valid
 import StyledTextarea from "./textarea.style";
 import Logger from "../../__internal__/utils/logger";
 
+jest.mock("../../__internal__/utils/logger");
+
 jest.mock("../../__internal__/utils/helpers/guid");
 const mockedGuid = "guid-12345";
 (guid as jest.MockedFunction<typeof guid>).mockImplementation(() => mockedGuid);
@@ -39,6 +41,33 @@ function renderTextarea(
 
 describe("Textarea", () => {
   let wrapper: ReactWrapper;
+
+  let loggerSpy: jest.SpyInstance<void, [message: string]> | jest.Mock;
+
+  beforeEach(() => {
+    loggerSpy = jest.spyOn(Logger, "deprecate");
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    loggerSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    loggerSpy.mockClear();
+  });
+
+  describe("Deprecation warning for uncontrolled", () => {
+    it("should display deprecation warning once", () => {
+      <Textarea name="my-textarea" defaultValue="test" />;
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Textarea` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 
   testStyledSystemMargin((props) => <Textarea {...props} />);
   describe("when textarea is rendered with default props", () => {
@@ -605,7 +634,7 @@ describe("componentWillUnmount", () => {
       );
 
       wrapper.setProps({ prop1: true });
-      expect(loggerSpy).toHaveBeenCalledTimes(1);
+      expect(loggerSpy).toHaveBeenCalledTimes(2);
       loggerSpy.mockRestore();
     });
 

--- a/src/components/textbox/textbox.component.tsx
+++ b/src/components/textbox/textbox.component.tsx
@@ -129,6 +129,7 @@ export interface TextboxProps extends CommonTextboxProps {
 }
 
 let deprecateInputRefWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
 
 export const Textbox = React.forwardRef(
   (
@@ -211,6 +212,13 @@ export const Textbox = React.forwardRef(
       deprecateInputRefWarnTriggered = true;
       Logger.deprecate(
         "The `inputRef` prop in `Textbox` component is deprecated and will soon be removed. Please use `ref` instead."
+      );
+    }
+
+    if (!deprecateUncontrolledWarnTriggered && !onChange) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Textbox` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
       );
     }
 

--- a/src/components/textbox/textbox.spec.tsx
+++ b/src/components/textbox/textbox.spec.tsx
@@ -22,6 +22,8 @@ import StyledValidationMessage from "../../__internal__/validation-message/valid
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import Logger from "../../__internal__/utils/logger";
 
+jest.mock("../../__internal__/utils/logger");
+
 const mockedGuid = "mocked-guid";
 jest.mock("../../__internal__/utils/helpers/guid");
 
@@ -30,6 +32,33 @@ jest.mock("../../__internal__/utils/helpers/guid");
 );
 
 describe("Textbox", () => {
+  let loggerSpy: jest.SpyInstance<void, [message: string]> | jest.Mock;
+
+  beforeEach(() => {
+    loggerSpy = jest.spyOn(Logger, "deprecate");
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    loggerSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    loggerSpy.mockClear();
+  });
+
+  describe("Deprecation warning for uncontrolled", () => {
+    it("should display deprecation warning once", () => {
+      <Textbox name="my-textbox" defaultValue="test" />;
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "Uncontrolled behaviour in `Textbox` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
+      );
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   testStyledSystemMargin(
     (props) => <Textbox {...props} />,
     undefined,
@@ -76,7 +105,6 @@ describe("Textbox", () => {
     let wrapper: ReactWrapper;
 
     it("should display deprecation warning when the inputRef prop is used", () => {
-      const loggerSpy = jest.spyOn(Logger, "deprecate");
       const ref = () => {};
 
       wrapper = mount(<Textbox inputRef={ref} />);


### PR DESCRIPTION
As per the rfc `remove-support-for-uncontrolled-inputs`, a warning deprecation has been placed on our input
components that can be used in an uncontrolled way.

### Proposed behaviour

Warn our users that uncontrolled behaviour is being deprecated via a deprecation warning.

### Current behaviour

No warning currently exists.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
