### PR TITLE
test(navigation-bar): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -110,6 +110,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("global-header") &&
       !prepareUrl[0].startsWith("grid") &&
       !prepareUrl[0].startsWith("image") &&
+      !prepareUrl[0].startsWith("navigation-bar") &&
       !prepareUrl[0].startsWith("popover-container") &&
       !prepareUrl[0].startsWith("menu") &&
       !prepareUrl[0].endsWith("test")

--- a/src/components/navigation-bar/navigation-bar.test.js
+++ b/src/components/navigation-bar/navigation-bar.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import Box from "../box/box.component";
 import NavigationBar from "./navigation-bar.component";
 import { Menu, MenuItem } from "../menu";
+import * as stories from "./navigation-bar.stories";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 
 import navigationBar from "../../../cypress/locators/navigation-bar";
@@ -177,5 +178,67 @@ context("Testing NavigationBar component", () => {
         navigationBar().eq(1).should("be.visible");
       }
     );
+  });
+
+  describe("Accessibility tests for NavigationBar component", () => {
+    it("should pass accessibility tests for NavigationBar Default story", () => {
+      CypressMountWithProviders(<stories.Default />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NavigationBar DarkTheme story", () => {
+      CypressMountWithProviders(<stories.DarkTheme />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NavigationBar WhiteTheme story", () => {
+      CypressMountWithProviders(<stories.WhiteTheme />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NavigationBar BlackTheme story", () => {
+      CypressMountWithProviders(<stories.BlackTheme />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NavigationBar ExampleWithMenu story", () => {
+      CypressMountWithProviders(<stories.ExampleWithMenu />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NavigationBar IsLoading story", () => {
+      CypressMountWithProviders(<stories.IsLoading />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NavigationBar WithCustomSpacing story", () => {
+      CypressMountWithProviders(<stories.WithCustomSpacing />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NavigationBar ContentMaxWidthBox story", () => {
+      CypressMountWithProviders(<stories.ContentMaxWidthBox />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NavigationBar Sticky story", () => {
+      CypressMountWithProviders(<stories.Sticky />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for NavigationBar Fixed story", () => {
+      CypressMountWithProviders(<stories.Fixed />);
+
+      cy.checkAccessibility();
+    });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `Navigation-bar` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there is newly added test.file
- [ ] Check if the `navigation-bar.test.js` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Navigation-bar` tests are not running twice.