### PR TITLE
fix(check_rfcs): ship the index file in the published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "files": [
     "lib",
     "esm",
-    "scripts/check_rfcs/check_rfcs.js"
+    "scripts/check_rfcs/check_rfcs.js",
+    "scripts/check_rfcs/index.js"
   ],
   "scripts": {
     "start": "node ./scripts/check_node_version.js && NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 9001 -c .storybook",


### PR DESCRIPTION
### Proposed behaviour

Add the `scripts/check_rfcs/index.js` file as it is causing the installation to fail as the file is not ending up in the published package since https://github.com/Sage/carbon/commit/d850a25883b7eff9a03ad6ce47755af2e202b63d

### Current behaviour

The installation fails with the missing index of the check_rfc file. This can be worked around by `npm install --ignore-scripts` flag. CodeSanbox cannot be use as it ignores the postinstall scripts by default, e.g. this still works but will fail on a local install by default: https://codesandbox.io/s/angry-andras-opoejq?file=/package.json

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Install the latest version and see the error. Install the proposal version to see that it works fine.

<!-- Add CodeSandbox here -->
