### PR TITLE
test(inline-inputs): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -112,6 +112,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("image") &&
       !prepareUrl[0].startsWith("popover-container") &&
       !prepareUrl[0].startsWith("menu") &&
+      !prepareUrl[0].startsWith("inline-inputs") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/inline-inputs/inline-inputs.test.js
+++ b/src/components/inline-inputs/inline-inputs.test.js
@@ -4,6 +4,7 @@ import Decimal from "../decimal/decimal.component";
 import SimpleSelect from "../select/simple-select/simple-select.component";
 import Option from "../select/option/option.component";
 import InlineInputs from "./inline-inputs.component";
+import * as stories from "./inline-inputs.stories";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import {
   inlineInputContainer,
@@ -116,5 +117,24 @@ context("Tests for InlineInputs component", () => {
         inlineLabel().should("have.attr", "for", htmlFor);
       }
     );
+  });
+  describe("Accessibility tests for InlineInputs component", () => {
+    it("should pass accessibility tests for InlineInputs Default story", () => {
+      CypressMountWithProviders(<stories.Default />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for InlineInputs WithAdaptiveLabelBreakpoint story", () => {
+      CypressMountWithProviders(<stories.WithAdaptiveLabelBreakpoint />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for InlineInputs Required story", () => {
+      CypressMountWithProviders(<stories.Required />);
+
+      cy.checkAccessibility();
+    });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `Inline-inputs` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there is newly added test.file
- [ ] Check if the `inline-inputs.test.js` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Inline-inputs` tests are not running twice.