### PR TITLE
fix(switch): fix styling defect caused by box-sizing border-box css - FE-5738

### DIFF
--- a/src/components/switch/__internal__/__snapshots__/switch-slider.spec.tsx.snap
+++ b/src/components/switch/__internal__/__snapshots__/switch-slider.spec.tsx.snap
@@ -24,7 +24,7 @@ exports[`SwitchSlider base theme renders as expected 1`] = `
   display: flex;
   font-size: 12px;
   font-weight: bold;
-  height: 24px;
+  height: 28px;
   left: 0;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -33,7 +33,7 @@ exports[`SwitchSlider base theme renders as expected 1`] = `
   position: absolute;
   text-transform: uppercase;
   top: 0;
-  width: 60px;
+  width: 64px;
   min-width: -webkit-fit-content;
   min-width: -moz-fit-content;
   min-width: fit-content;
@@ -42,6 +42,7 @@ exports[`SwitchSlider base theme renders as expected 1`] = `
   border-style: solid;
   border-color: var(--colorsActionMinor400);
   border-width: var(--borderWidth200);
+  box-sizing: border-box;
 }
 
 .c0::before {

--- a/src/components/switch/__internal__/switch-slider.style.ts
+++ b/src/components/switch/__internal__/switch-slider.style.ts
@@ -24,19 +24,20 @@ const StyledSwitchSlider = styled.span`
     display: flex;
     font-size: 12px;
     font-weight: bold;
-    height: 24px;
+    height: 28px;
     left: 0;
     letter-spacing: 1px;
     position: absolute;
     text-transform: uppercase;
     top: 0;
-    width: 60px;
+    width: 64px;
     min-width: fit-content;
     z-index: 2;
     border-radius: 90px;
     border-style: solid;
     border-color: var(--colorsActionMinor400);
     border-width: var(--borderWidth200);
+    box-sizing: border-box;
 
     &::before {
       background-color: var(--colorsActionMinor400);

--- a/src/components/switch/switch.spec.tsx
+++ b/src/components/switch/switch.spec.tsx
@@ -394,8 +394,8 @@ describe("Switch", () => {
         const wrapper = render({ size: "large" });
 
         const largeSizes = {
-          height: "40px",
-          width: "78px",
+          height: "44px",
+          width: "82px",
         };
 
         it("applies the correct CheckableInput styles", () => {

--- a/src/components/switch/switch.style.ts
+++ b/src/components/switch/switch.style.ts
@@ -138,8 +138,8 @@ const StyledSwitch = styled.div`
     ${size === "large" &&
     css`
       ${StyledCheckableInput}, ${HiddenCheckableInputStyle}, ${StyledSwitchSlider} {
-        height: 40px;
-        width: 78px;
+        height: 44px;
+        width: 82px;
         min-width: fit-content;
       }
 

--- a/src/components/switch/switch.test.js
+++ b/src/components/switch/switch.test.js
@@ -366,7 +366,7 @@ context("Testing Switch component", () => {
 
     it.each([
       [SIZE.SMALL, 60, 24],
-      [SIZE.LARGE, 78, 40],
+      [SIZE.LARGE, 82, 44],
     ])("verify Switch component with size set to %s", (size, width, height) => {
       CypressMountWithProviders(<SwitchComponent size={size} />);
 


### PR DESCRIPTION
if border-box css is applied globally, it effects the styling of the swtich component. This fix address this bug by applying box-sixing: border-box to the switch-slider span element.

fixes FE-5738

### Proposed behaviour

<img width="591" alt="Screenshot 2023-04-03 at 16 46 20" src="https://user-images.githubusercontent.com/56251247/229560905-d501f30e-09cf-4d27-9a3c-c2483629d4b9.png">

### Current behaviour

![Screenshot 2023-04-03 at 16 45 31](https://user-images.githubusercontent.com/56251247/229560745-4588c91b-ddbe-49de-979c-5d3d8f964358.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Switch component should look and behave exactly as it did before this change. 
- Codesandbox that was created for the ticket - https://codesandbox.io/s/lucid-faraday-unr1n1?file=/src/App.js
- Codesandbox that uses the same code but built from this PR - https://codesandbox.io/s/carbon-quickstart-forked-dow72s
