### PR TITLE
docs(alert): fix not showing code example - FE-5739

### DIFF
--- a/src/components/alert/alert.stories.mdx
+++ b/src/components/alert/alert.stories.mdx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import AlertComponent from "./alert.stories";
+import * as stories from "./alert.stories";
 import Alert from ".";
 
 <Meta
@@ -40,7 +40,7 @@ import Alert from "carbon-react/lib/components/alert";
 ### Default
 
 <Canvas>
-  <Story name="default" story={AlertComponent} />
+  <Story name="default" story={stories.DefaultAlert} />
 </Canvas>
 
 ## Props

--- a/src/components/alert/alert.stories.tsx
+++ b/src/components/alert/alert.stories.tsx
@@ -2,11 +2,14 @@ import React, { useState } from "react";
 import { ComponentStory } from "@storybook/react";
 import Alert from ".";
 import Button from "../button";
+
 import isChromatic from "../../../.storybook/isChromatic";
 
 const defaultOpenState = isChromatic();
 
-const AlertComponent: ComponentStory<typeof Alert> = () => {
+// Added to avoid default export warning which causes storybook to not display `show code` examples - https://github.com/storybookjs/storybook/issues/8104
+// eslint-disable-next-line import/prefer-default-export
+export const DefaultAlert: ComponentStory<typeof Alert> = () => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
@@ -26,5 +29,3 @@ const AlertComponent: ComponentStory<typeof Alert> = () => {
     </>
   );
 };
-
-export default AlertComponent;


### PR DESCRIPTION
### Proposed behaviour

![Screenshot 2023-04-04 at 10 56 21](https://user-images.githubusercontent.com/56251247/229760139-3bf3ba2d-73df-40c9-ab91-2fe6124231e7.png)

### Current behaviour

![Screenshot 2023-04-04 at 11 10 53](https://user-images.githubusercontent.com/56251247/229760331-255a22b0-6e3b-4ccb-aff3-a02b80939267.png)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

In the Alert docs, you should be able to view the code that the story is composed from.
