### PR TITLE
test(tile): add accesibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -1,5 +1,4 @@
 import { getDataElementByValue } from "../../locators";
-import { popoverSettingsIcon } from "../../locators/popover-container";
 import { visitComponentUrl } from "../helper";
 import storiesJSON from "../../../storybook-static/stories.json";
 
@@ -115,6 +114,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("menu") &&
       !prepareUrl[0].startsWith("inline-inputs") &&
       !prepareUrl[0].startsWith("radiobutton") &&
+      !prepareUrl[0].startsWith("tile") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);
@@ -131,10 +131,6 @@ export default (from, end) => {
         (componentName, storyName) => {
           visitComponentUrl(componentName, storyName);
 
-          // open the popover-container component
-          if (componentName.startsWith("popover-container")) {
-            popoverSettingsIcon().click({ multiple: true });
-          }
           // expand the select component
           if (componentName.startsWith("select")) {
             getDataElementByValue("input").click({

--- a/src/components/tile-select/tile-select-test.stories.tsx
+++ b/src/components/tile-select/tile-select-test.stories.tsx
@@ -1,0 +1,330 @@
+import React, { useState } from "react";
+
+import {
+  TileSelect,
+  TileSelectGroup,
+  TileSelectDeselectEvent,
+  TileSelectProps,
+  TileSelectGroupProps,
+} from ".";
+import Pill from "../pill";
+import Icon from "../icon";
+import Button from "../button";
+import Box from "../box";
+import Image from "../image";
+
+export default {
+  title: "Tile Select/Test",
+  includeStories: "DefaultStory",
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+};
+
+export const DefaultStory = () => {
+  const [value, setValue] = useState<string | null>(null);
+  return (
+    <TileSelectGroup
+      name="Tile Select"
+      value={value}
+      legend="Tile Select"
+      description="Pick one of the available options"
+      onChange={(e) => setValue(e.target.value)}
+    >
+      <TileSelect
+        value="1"
+        id="1"
+        aria-label="1"
+        title="Title"
+        subtitle="Subtitle"
+        description="Short and descriptive description"
+      />
+      <TileSelect
+        value="2"
+        id="2"
+        aria-label="2"
+        title="Title"
+        subtitle="Subtitle"
+        titleAdornment={<Pill>Message</Pill>}
+        description="Short and descriptive description"
+      />
+      <TileSelect
+        value="3"
+        id="3"
+        aria-label="3"
+        disabled
+        title="Title"
+        subtitle="Subtitle"
+        titleAdornment={
+          <Icon
+            type="info"
+            tooltipMessage="Short and non descriptive message"
+            tooltipVisible={false}
+          />
+        }
+        description="Short and descriptive description"
+      />
+      <TileSelect
+        value="4"
+        id="4"
+        aria-label="4"
+        title="Title"
+        subtitle="Subtitle"
+        titleAdornment={
+          <Icon
+            type="info"
+            tooltipMessage="Short and non descriptive message"
+          />
+        }
+        description="Short and descriptive description"
+      />
+    </TileSelectGroup>
+  );
+};
+
+export const TileSelectComponent = ({
+  multiSelect,
+  ...props
+}: Partial<TileSelectProps & TileSelectGroupProps>) => {
+  const [value, setValue] = React.useState(false);
+  return (
+    <TileSelectGroup
+      multiSelect={multiSelect}
+      name="Tile Select"
+      legend="Tile Select"
+      description="Pick one of the available options"
+      onChange={(e) => setValue(e.target.checked)}
+    >
+      <TileSelect
+        value="1"
+        id="1"
+        aria-label="1"
+        title="Title"
+        subtitle="Subtitle"
+        description="Short and descriptive description"
+        checked={value}
+        onChange={(e) => setValue(e.target.checked)}
+        {...props}
+      />
+    </TileSelectGroup>
+  );
+};
+
+export const MultiTileSelectGroupComponent = ({ ...props }) => {
+  const [value1, setValue1] = React.useState(false);
+  const [value2, setValue2] = React.useState(false);
+  const [value3, setValue3] = React.useState(false);
+  const [value4, setValue4] = React.useState(false);
+  return (
+    <TileSelectGroup name="TileSelectGroup" legend="Tile Select" {...props}>
+      <TileSelect
+        value="1"
+        name="multi-1"
+        id="multi-1"
+        aria-label="multi-1"
+        title="Title"
+        subtitle="Subtitle"
+        description="Short and descriptive description"
+        checked={value1}
+        onChange={(e) => setValue1(e.target.checked)}
+      />
+      <TileSelect
+        value="2"
+        name="multi-2"
+        id="multi-2"
+        aria-label="multi-2"
+        subtitle="Subtitle"
+        titleAdornment={<Pill>Message</Pill>}
+        description="Short and descriptive description"
+        checked={value2}
+        onChange={(e) => setValue2(e.target.checked)}
+      />
+      <TileSelect
+        value="3"
+        name="multi-3"
+        id="multi-3"
+        aria-label="multi-3"
+        disabled
+        title="Title"
+        subtitle="Subtitle"
+        titleAdornment={
+          <Icon
+            type="info"
+            tooltipMessage="Short and non descriptive message"
+            tooltipVisible={false}
+          />
+        }
+        description="Short and descriptive description"
+        checked={value3}
+        onChange={(e) => setValue3(e.target.checked)}
+      />
+      <TileSelect
+        value="4"
+        name="multi-4"
+        id="multi-4"
+        aria-label="multi-4"
+        title="Title"
+        subtitle="Subtitle"
+        titleAdornment={
+          <Icon
+            type="info"
+            tooltipMessage="Short and non descriptive message"
+          />
+        }
+        description="Short and descriptive description"
+        checked={value4}
+        onChange={(e) => setValue4(e.target.checked)}
+      />
+    </TileSelectGroup>
+  );
+};
+
+export const AccordionTileSelectComponent = ({ ...props }) => {
+  const [isChecked, setIsChecked] = React.useState(false);
+  const [expanded, setExpanded] = React.useState(true);
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement> | TileSelectDeselectEvent
+  ) => {
+    const { value } = e.target;
+    setIsChecked(value !== null);
+  };
+  return (
+    <TileSelect
+      value="1"
+      id="single-1"
+      aria-label="single-1"
+      name="single"
+      title="Title"
+      subtitle="Subtitle"
+      description="Short and descriptive description"
+      checked={isChecked}
+      onChange={handleChange}
+      prefixAdornment={<Image height="40px" width="40px" />}
+      accordionContent={
+        <Box display="flex" flexWrap="wrap">
+          <Box
+            width="100%"
+            height="100px"
+            bg="primary"
+            display="inline-block"
+          />
+          <Box
+            width="100%"
+            height="100px"
+            bg="primary"
+            display="inline-block"
+          />
+        </Box>
+      }
+      accordionControl={(controlId, contentId) => (
+        <Button
+          buttonType="tertiary"
+          iconPosition="before"
+          iconType="chevron_down"
+          data-element="accordion-button"
+          onClick={() => setExpanded((expandedState) => !expandedState)}
+          px={1}
+          mt={2}
+          aria-controls={contentId}
+          id={controlId}
+        >
+          {expanded ? "Close" : "Open"} accordion
+        </Button>
+      )}
+      accordionExpanded={expanded}
+      {...props}
+    />
+  );
+};
+
+export const ActionButtonAdornment = ({ ...props }) => {
+  const [, setValue] = React.useState(false);
+  return (
+    <TileSelectGroup
+      name="Tile Select"
+      legend="Tile Select"
+      description="Pick one of the available options"
+      onChange={(
+        e: React.ChangeEvent<HTMLInputElement> | TileSelectDeselectEvent
+      ) => setValue(e.target.checked)}
+    >
+      <TileSelect
+        value="2"
+        id="2"
+        aria-label="2"
+        title="Title"
+        subtitle="Subtitle"
+        titleAdornment={
+          <Icon
+            type="info"
+            tooltipMessage="Short and non descriptive message"
+          />
+        }
+        description="Short and descriptive description"
+        customActionButton={(onClick) => (
+          <Button
+            onClick={onClick}
+            buttonType="tertiary"
+            type="button"
+            px={1}
+            size="small"
+            destructive
+            disabled
+          >
+            Remove
+          </Button>
+        )}
+        actionButtonAdornment={
+          <Icon
+            type="info"
+            tooltipMessage="This tile cannot be removed at this time"
+          />
+        }
+        {...props}
+      />
+    </TileSelectGroup>
+  );
+};
+
+export const TileSelectGroupComponent = ({ ...props }) => {
+  const [value, setValue] = React.useState(false);
+  return (
+    <TileSelectGroup
+      name="Tile Select"
+      legend="Tile Select"
+      description="Pick one of the available options"
+      onChange={(
+        e: React.ChangeEvent<HTMLInputElement> | TileSelectDeselectEvent
+      ) => setValue(e.target.checked)}
+      {...props}
+    >
+      <TileSelect
+        value="1"
+        id="1"
+        aria-label="1"
+        title="Title"
+        subtitle="Subtitle"
+        description="Short and descriptive description"
+        checked={value}
+        onChange={(
+          e: React.ChangeEvent<HTMLInputElement> | TileSelectDeselectEvent
+        ) => setValue(e.target.checked)}
+      />
+      <TileSelect
+        value="2"
+        id="2"
+        aria-label="2"
+        title="Title1"
+        subtitle="Subtitle1"
+        description="Short and descriptive description1"
+        checked={value}
+        onChange={(
+          e: React.ChangeEvent<HTMLInputElement> | TileSelectDeselectEvent
+        ) => setValue(e.target.checked)}
+      />
+    </TileSelectGroup>
+  );
+};

--- a/src/components/tile-select/tile-select.test.js
+++ b/src/components/tile-select/tile-select.test.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { TileSelect, TileSelectGroup } from ".";
+import * as testStories from "./tile-select-test.stories";
+import * as stories from "./tile-select.stories";
 import Pill from "../pill/pill.component";
-import Image from "../image/image.component";
 import Button from "../button/button.component";
 import Icon from "../icon/icon.component";
-import Box from "../box/box.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
 
@@ -25,253 +25,14 @@ import {
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
-const TileSelectComponent = ({ multiSelect, ...props }) => {
-  const [value, setValue] = React.useState(null);
-  return (
-    <TileSelectGroup
-      multiSelect={multiSelect}
-      name="Tile Select"
-      value={value}
-      legend="Tile Select"
-      description="Pick one of the available options"
-      checked={value}
-      onChange={(e) => setValue(e.target.value)}
-    >
-      <TileSelect
-        value="1"
-        id="1"
-        aria-label="1"
-        title="Title"
-        subtitle="Subtitle"
-        description="Short and descriptive description"
-        checked={value}
-        onChange={(e) => setValue(e.target.value)}
-        {...props}
-      />
-    </TileSelectGroup>
-  );
-};
-
-const MultiTileSelectGroupComponent = ({ ...props }) => {
-  const [value1, setValue1] = React.useState(false);
-  const [value2, setValue2] = React.useState(false);
-  const [value3, setValue3] = React.useState(false);
-  const [value4, setValue4] = React.useState(false);
-  return (
-    <TileSelectGroup legend="Tile Select" {...props}>
-      <TileSelect
-        value="1"
-        name="multi-1"
-        id="multi-1"
-        aria-label="multi-1"
-        title="Title"
-        subtitle="Subtitle"
-        description="Short and descriptive description"
-        checked={value1}
-        onChange={(e) => setValue1(e.target.checked)}
-      />
-      <TileSelect
-        value="2"
-        name="multi-2"
-        id="multi-2"
-        aria-label="multi-2"
-        subtitle="Subtitle"
-        titleAdornment={<Pill>Message</Pill>}
-        description="Short and descriptive description"
-        checked={value2}
-        onChange={(e) => setValue2(e.target.checked)}
-      />
-      <TileSelect
-        value="3"
-        name="multi-3"
-        id="multi-3"
-        aria-label="multi-3"
-        disabled
-        title="Title"
-        subtitle="Subtitle"
-        titleAdornment={
-          <Icon
-            type="info"
-            tooltipMessage="Short and non descriptive message"
-            tooltipVisible={false}
-          />
-        }
-        description="Short and descriptive description"
-        checked={value3}
-        onChange={(e) => setValue3(e.target.checked)}
-      />
-      <TileSelect
-        value="4"
-        name="multi-4"
-        id="multi-4"
-        aria-label="multi-4"
-        title="Title"
-        subtitle="Subtitle"
-        titleAdornment={
-          <Icon
-            type="info"
-            tooltipMessage="Short and non descriptive message"
-          />
-        }
-        description="Short and descriptive description"
-        checked={value4}
-        onChange={(e) => setValue4(e.target.checked)}
-      />
-    </TileSelectGroup>
-  );
-};
-
-const AccordionTileSelectComponent = ({ ...props }) => {
-  const [isChecked, setIsChecked] = React.useState(false);
-  const [expanded, setExpanded] = React.useState(true);
-  const handleChange = (e) => {
-    const { value } = e.target;
-    setIsChecked(value !== null);
-  };
-  return (
-    <TileSelect
-      value="1"
-      id="single-1"
-      aria-label="single-1"
-      name="single"
-      title="Title"
-      subtitle="Subtitle"
-      description="Short and descriptive description"
-      checked={isChecked}
-      onChange={handleChange}
-      prefixAdornment={<Image height="40px" width="40px" />}
-      accordionContent={
-        <Box display="flex" flexWrap="wrap">
-          <Box flexGrow="1" pr={1}>
-            <Box
-              width="100%"
-              height="100px"
-              bg="primary"
-              display="inline-block"
-            />
-          </Box>
-          <Box flexGrow="1" pl={1}>
-            <Box
-              width="100%"
-              height="100px"
-              bg="primary"
-              display="inline-block"
-            />
-          </Box>
-        </Box>
-      }
-      accordionControl={(controlId, contentId) => (
-        <Button
-          buttonType="tertiary"
-          iconPosition="before"
-          iconType="chevron_down"
-          data-element="accordion-button"
-          onClick={() => setExpanded((expandedState) => !expandedState)}
-          px={1}
-          mt={2}
-          aria-controls={contentId}
-          id={controlId}
-        >
-          {expanded ? "Close" : "Open"} accordion
-        </Button>
-      )}
-      accordionExpanded={expanded}
-      setAccordionExpanded={setExpanded}
-      {...props}
-    />
-  );
-};
-
-const ActionButtonAdornment = ({ ...props }) => {
-  const [value, setValue] = React.useState(null);
-  return (
-    <TileSelectGroup
-      name="Tile Select"
-      value={value}
-      legend="Tile Select"
-      description="Pick one of the available options"
-      onChange={(e) => setValue(e.target.value)}
-    >
-      <TileSelect
-        value="2"
-        id="2"
-        aria-label="2"
-        title="Title"
-        subtitle="Subtitle"
-        titleAdornment={
-          <Icon
-            type="info"
-            tooltipMessage="Short and non descriptive message"
-          />
-        }
-        description="Short and descriptive description"
-        customActionButton={(onClick) => (
-          <Button
-            onClick={onClick}
-            buttonType="tertiary"
-            type="button"
-            px={1}
-            size="small"
-            destructive
-            disabled
-          >
-            Remove
-          </Button>
-        )}
-        actionButtonAdornment={
-          <Icon
-            type="info"
-            tooltipMessage="This tile cannot be removed at this time"
-          />
-        }
-        {...props}
-      />
-    </TileSelectGroup>
-  );
-};
-
-const TileSelectGroupComponent = ({ ...props }) => {
-  const [value, setValue] = React.useState(null);
-  return (
-    <TileSelectGroup
-      name="Tile Select"
-      value={value}
-      legend="Tile Select"
-      description="Pick one of the available options"
-      checked={value}
-      onChange={(e) => setValue(e.target.value)}
-      {...props}
-    >
-      <TileSelect
-        value="1"
-        id="1"
-        aria-label="1"
-        title="Title"
-        subtitle="Subtitle"
-        description="Short and descriptive description"
-        checked={value}
-        onChange={(e) => setValue(e.target.value)}
-      />
-      <TileSelect
-        value="2"
-        id="2"
-        aria-label="2"
-        title="Title1"
-        subtitle="Subtitle1"
-        description="Short and descriptive description1"
-        checked={value}
-        onChange={(e) => setValue(e.target.value)}
-      />
-    </TileSelectGroup>
-  );
-};
-
 context("Tests for TileSelect component", () => {
   describe("check props for TileSelect component", () => {
     it.each(testData)(
       "should check title as %s for TileSelect component",
       (title) => {
-        CypressMountWithProviders(<TileSelectComponent title={title} />);
+        CypressMountWithProviders(
+          <testStories.TileSelectComponent title={title} />
+        );
         titleElement().should("have.text", title);
       }
     );
@@ -280,7 +41,9 @@ context("Tests for TileSelect component", () => {
       "should check titleAdornment iconType as %s for TileSelect component",
       (iconType) => {
         CypressMountWithProviders(
-          <TileSelectComponent titleAdornment={<Icon type={iconType} />} />
+          <testStories.TileSelectComponent
+            titleAdornment={<Icon type={iconType} />}
+          />
         );
         getComponent("icon")
           .should("have.attr", "type", iconType)
@@ -291,7 +54,9 @@ context("Tests for TileSelect component", () => {
     it.each(testData)(
       "should check subtitle as %s for TileSelect component",
       (subtitle) => {
-        CypressMountWithProviders(<TileSelectComponent subtitle={subtitle} />);
+        CypressMountWithProviders(
+          <testStories.TileSelectComponent subtitle={subtitle} />
+        );
         subtitleElement().should("have.text", subtitle);
       }
     );
@@ -300,7 +65,7 @@ context("Tests for TileSelect component", () => {
       "should check description as %s for TileSelect component",
       (description) => {
         CypressMountWithProviders(
-          <TileSelectComponent description={description} />
+          <testStories.TileSelectComponent description={description} />
         );
         descElement().should("have.text", description);
       }
@@ -308,7 +73,7 @@ context("Tests for TileSelect component", () => {
 
     it("p element should be rendered when a description is passed to TileSelectGroup component", () => {
       CypressMountWithProviders(
-        <MultiTileSelectGroupComponent description="foo" />
+        <testStories.MultiTileSelectGroupComponent description="foo" />
       );
       getDataElementByValue("tile-select-group-description")
         .should("exist")
@@ -316,7 +81,7 @@ context("Tests for TileSelect component", () => {
     });
 
     it("p element should not be rendered when no description is passed to TileSelectGroup component", () => {
-      CypressMountWithProviders(<MultiTileSelectGroupComponent />);
+      CypressMountWithProviders(<testStories.MultiTileSelectGroupComponent />);
       getDataElementByValue("tile-select-group-description").should(
         "not.exist"
       );
@@ -328,7 +93,9 @@ context("Tests for TileSelect component", () => {
     ])(
       "should check when TileSelect component disabled prop set as %s",
       (disabled, borderColor) => {
-        CypressMountWithProviders(<TileSelectComponent disabled={disabled} />);
+        CypressMountWithProviders(
+          <testStories.TileSelectComponent disabled={disabled} />
+        );
         inputElement().should("have.css", "border-color", borderColor);
       }
     );
@@ -336,7 +103,9 @@ context("Tests for TileSelect component", () => {
     it.each(["1", "2", "3", "4"])(
       "should check value as %s for TileSelect component",
       (value) => {
-        CypressMountWithProviders(<TileSelectComponent value={value} />);
+        CypressMountWithProviders(
+          <testStories.TileSelectComponent value={value} />
+        );
         inputElement().should("have.attr", "value", value);
       }
     );
@@ -344,7 +113,7 @@ context("Tests for TileSelect component", () => {
     it.each(testData)(
       "should check id as %s for TileSelect component",
       (id) => {
-        CypressMountWithProviders(<TileSelectComponent id={id} />);
+        CypressMountWithProviders(<testStories.TileSelectComponent id={id} />);
         inputElement().should("have.attr", "id", id);
       }
     );
@@ -373,7 +142,7 @@ context("Tests for TileSelect component", () => {
       "should check className as %s for TileSelect component",
       (className) => {
         CypressMountWithProviders(
-          <TileSelectComponent className={className} />
+          <testStories.TileSelectComponent className={className} />
         );
         tileSelectDataComponent().should("have.class", className);
       }
@@ -381,7 +150,7 @@ context("Tests for TileSelect component", () => {
 
     it("should check footer for TileSelect component", () => {
       CypressMountWithProviders(
-        <TileSelectComponent
+        <testStories.TileSelectComponent
           footer={
             <Button
               ml={1}
@@ -403,7 +172,7 @@ context("Tests for TileSelect component", () => {
       "should check prefixAdornment as %s for TileSelect component",
       (PrefixAdornment) => {
         CypressMountWithProviders(
-          <TileSelectComponent
+          <testStories.TileSelectComponent
             prefixAdornment={
               <>
                 <Pill fill mr={1} mb="4px">
@@ -421,7 +190,7 @@ context("Tests for TileSelect component", () => {
 
     it("should check additionalInformation for TileSelect component", () => {
       CypressMountWithProviders(
-        <TileSelectComponent
+        <testStories.TileSelectComponent
           additionalInformation={
             <>
               <Pill fill mr={1} mb="4px">
@@ -442,14 +211,16 @@ context("Tests for TileSelect component", () => {
       "should check type as %s for TileSelect component",
       (type) => {
         CypressMountWithProviders(
-          <TileSelectComponent multiSelect type={type} />
+          <testStories.TileSelectComponent multiSelect type={type} />
         );
         inputElement().should("have.attr", "type", type);
       }
     );
 
     it("should check multiSelect for TileSelect component", () => {
-      CypressMountWithProviders(<MultiTileSelectGroupComponent multiSelect />);
+      CypressMountWithProviders(
+        <testStories.MultiTileSelectGroupComponent multiSelect />
+      );
       inputElement().eq(0).click().and("have.attr", "aria-checked", "true");
 
       inputElement().eq(1).click().and("have.attr", "aria-checked", "true");
@@ -467,7 +238,7 @@ context("Tests for TileSelect component", () => {
     "should check when accordionExpanded is set as %s for TileSelect component",
     (boolV, state) => {
       CypressMountWithProviders(
-        <AccordionTileSelectComponent accordionExpanded={boolV} />
+        <testStories.AccordionTileSelectComponent accordionExpanded={boolV} />
       );
       getElement("tile-select-accordion-content").parent().should(state);
     }
@@ -477,7 +248,9 @@ context("Tests for TileSelect component", () => {
     "should check accordionContent as %s for TileSelect component",
     (accordionContent) => {
       CypressMountWithProviders(
-        <AccordionTileSelectComponent accordionContent={accordionContent} />
+        <testStories.AccordionTileSelectComponent
+          accordionContent={accordionContent}
+        />
       );
       getElement("tile-select-accordion-content").should(
         "have.text",
@@ -490,7 +263,7 @@ context("Tests for TileSelect component", () => {
 describe("check props for ActionButtonAdornment", () => {
   it("should check customActionButton for TileSelect component", () => {
     CypressMountWithProviders(
-      <ActionButtonAdornment
+      <testStories.ActionButtonAdornment
         customActionButton={(onClick) => (
           <Button onClick={onClick}>tile select button</Button>
         )}
@@ -505,7 +278,7 @@ describe("check props for ActionButtonAdornment", () => {
     "should check actionButtonAdornment iconType as %s for TileSelect component",
     (iconType) => {
       CypressMountWithProviders(
-        <ActionButtonAdornment
+        <testStories.ActionButtonAdornment
           actionButtonAdornment={
             <Icon
               type={iconType}
@@ -525,7 +298,9 @@ describe("check props for TileSelectGroup component", () => {
   it.each(testData)(
     "should check name as %s for TileSelect component",
     (name) => {
-      CypressMountWithProviders(<TileSelectGroupComponent name={name} />);
+      CypressMountWithProviders(
+        <testStories.TileSelectGroupComponent name={name} />
+      );
       inputElement().should("have.attr", "name", name);
     }
   );
@@ -533,7 +308,9 @@ describe("check props for TileSelectGroup component", () => {
   it.each(testData)(
     "should check legend as %s for TileSelectGroup component",
     (legend) => {
-      CypressMountWithProviders(<TileSelectGroupComponent legend={legend} />);
+      CypressMountWithProviders(
+        <testStories.TileSelectGroupComponent legend={legend} />
+      );
       getElement("legend").should("be.visible").and("have.text", legend);
     }
   );
@@ -542,14 +319,16 @@ describe("check props for TileSelectGroup component", () => {
     "should check description as %s for TileSelectGroup component",
     (description) => {
       CypressMountWithProviders(
-        <TileSelectGroupComponent description={description} />
+        <testStories.TileSelectGroupComponent description={description} />
       );
       legendStyleComponent().should("be.visible");
     }
   );
 
   it("should check value for TileSelectGroup component", () => {
-    CypressMountWithProviders(<TileSelectGroupComponent value="1" />);
+    CypressMountWithProviders(
+      <testStories.TileSelectGroupComponent value="1" />
+    );
     inputElement().should("have.attr", "value", "1");
   });
 
@@ -576,7 +355,9 @@ describe("should render TileSelect component and check events", () => {
   });
 
   it("should call onChange callback when a click event is triggered for TileSelectGroup", () => {
-    CypressMountWithProviders(<TileSelectGroupComponent onChange={callback} />);
+    CypressMountWithProviders(
+      <testStories.TileSelectGroupComponent onChange={callback} />
+    );
     inputElement()
       .eq(0)
       .click()
@@ -587,7 +368,9 @@ describe("should render TileSelect component and check events", () => {
   });
 
   it("should call onBlur callback when a blur event is triggered for TileSelectGroup", () => {
-    CypressMountWithProviders(<TileSelectGroupComponent onBlur={callback} />);
+    CypressMountWithProviders(
+      <testStories.TileSelectGroupComponent onBlur={callback} />
+    );
     inputElement()
       .eq(0)
       .focus()
@@ -630,5 +413,72 @@ describe("should render TileSelect component and check events", () => {
         // eslint-disable-next-line no-unused-expressions
         expect(callback).to.have.been.calledOnce;
       });
+  });
+
+  describe("Accessibility tests for Accordion", () => {
+    // FE-4683
+    it.skip("should pass accessibility tests for Default story", () => {
+      CypressMountWithProviders(<stories.Default />);
+
+      cy.checkAccessibility();
+    });
+
+    // FE-4683
+    it.skip("should pass accessibility tests for MultiSelect story", () => {
+      CypressMountWithProviders(<stories.MultiSelect />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for SingleTile story", () => {
+      CypressMountWithProviders(<stories.SingleTile />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithAFooter story", () => {
+      CypressMountWithProviders(<stories.WithAFooter />);
+
+      cy.checkAccessibility();
+    });
+
+    // FE-4683
+    it.skip("should pass accessibility tests for WithAPrefixAdornment story", () => {
+      CypressMountWithProviders(<stories.WithAPrefixAdornment />);
+
+      cy.checkAccessibility();
+    });
+
+    // FE-4683
+    it.skip("should pass accessibility tests for WithAccordionFooter story", () => {
+      CypressMountWithProviders(<stories.WithAccordionFooter />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithActionButtonAdornment story", () => {
+      CypressMountWithProviders(<stories.WithActionButtonAdornment />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithAdditionalInformation story", () => {
+      CypressMountWithProviders(<stories.WithAdditionalInformation />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for WithCustomActionButton story", () => {
+      CypressMountWithProviders(<stories.WithCustomActionButton />);
+
+      cy.checkAccessibility();
+    });
+
+    // FE-4683
+    it.skip("should pass accessibility tests for WithCustomSpacing story", () => {
+      CypressMountWithProviders(<stories.WithCustomSpacing />);
+
+      cy.checkAccessibility();
+    });
   });
 });

--- a/src/components/tile/tile-test.stories.tsx
+++ b/src/components/tile/tile-test.stories.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import Tile, { TileProps } from ".";
+import TileFooter from "./tile-footer/tile-footer.component";
 import Content from "../content";
+import { Dl, Dt, Dd } from "../definition-list";
+import Accordion from "../accordion/accordion.component";
+import Button from "../button/button.component";
+import Typography from "../typography/typography.component";
 import { TILE_ORIENTATIONS, TILE_THEMES } from "./tile.config";
 
 export default {
   title: "Tile/Test",
+  includeStories: "DefaultStory",
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -91,4 +97,60 @@ DefaultStory.args = {
   contentThreeChildren: "Test Body Three",
   contentThreeTitle: "Test Title Three",
   contentThreeWidth: "",
+};
+
+export const TileComponent = ({ ...props }) => {
+  return (
+    <Tile {...props}>
+      <Content title="Test Title One">Test Body One</Content>
+      <Content title="Test Title Two">Test Body Two</Content>
+      <Content title="Test Title Three">Test Body Three</Content>
+    </Tile>
+  );
+};
+
+export const TileFooterComponent = ({ ...props }) => {
+  return (
+    <Tile p={0} orientation="vertical">
+      <Accordion p={0} borders="none" title="Accordion">
+        <Dl dtTextAlign="left" ddTextAlign="right">
+          <Dt>Coffee Subscription</Dt>
+          <Dd>£7.00 a month</Dd>
+          <Dt>Grind Size</Dt>
+          <Dd>Espresso</Dd>
+          <Dt>Quantity</Dt>
+          <Dd>3kg</Dd>
+          <Dd>
+            <Button
+              buttonType="tertiary"
+              href="https://goo.gl/maps/GMReLoBpbn9mdZVZ7"
+            >
+              Have a promo code?
+            </Button>
+          </Dd>
+        </Dl>
+      </Accordion>
+      <TileFooter {...props} p={3}>
+        <Typography pr={2} display="inline" variant="b">
+          Example footer text
+        </Typography>
+        <Typography display="inline">Example text</Typography>
+      </TileFooter>
+    </Tile>
+  );
+};
+
+export const DlTileComponent = ({ ...props }) => {
+  return (
+    <div>
+      <Dl data-element="dl" {...props}>
+        <Dt>Coffee Subscription</Dt>
+        <Dd data-element="dd">£7.00 a month</Dd>
+        <Dt>Grind Size</Dt>
+        <Dd>Espresso</Dd>
+        <Dt>Quantity</Dt>
+        <Dd>3kg</Dd>
+      </Dl>
+    </div>
+  );
 };

--- a/src/components/tile/tile.test.js
+++ b/src/components/tile/tile.test.js
@@ -1,9 +1,7 @@
 import React from "react";
 import Tile from ".";
 import Content from "../content";
-import { Dl, Dt, Dd } from "../definition-list";
-import Accordion from "../accordion/accordion.component";
-import Button from "../button/button.component";
+import * as testStories from "./tile-test.stories";
 import TileFooter from "./tile-footer";
 import Typography from "../typography/typography.component";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
@@ -18,69 +16,6 @@ import {
 
 const testData = ["left", "center", "right"];
 
-const TileComponent = ({ ...props }) => {
-  return (
-    <Tile {...props}>
-      <Content title="Test Title One">Test Body One</Content>
-      <Content title="Test Title Two">Test Body Two</Content>
-      <Content title="Test Title Three">Test Body Three</Content>
-    </Tile>
-  );
-};
-
-const TileFooterComponent = ({ ...props }) => {
-  return (
-    <Tile p={0} orientation="vertical">
-      <Accordion
-        p={0}
-        headerSpace={{
-          p: 3,
-        }}
-        borders="none"
-        title="Accordion"
-      >
-        <Dl dtTextAlign="left" ddTextAlign="right">
-          <Dt>Coffee Subscription</Dt>
-          <Dd>£7.00 a month</Dd>
-          <Dt>Grind Size</Dt>
-          <Dd>Espresso</Dd>
-          <Dt>Quantity</Dt>
-          <Dd>3kg</Dd>
-          <Dd>
-            <Button
-              buttonType="tertiary"
-              href="https://goo.gl/maps/GMReLoBpbn9mdZVZ7"
-            >
-              Have a promo code?
-            </Button>
-          </Dd>
-        </Dl>
-      </Accordion>
-      <TileFooter {...props} p={3}>
-        <Typography pr={2} display="inline" variant="b">
-          Example footer text
-        </Typography>
-        <Typography display="inline">Example text</Typography>
-      </TileFooter>
-    </Tile>
-  );
-};
-
-const DlTileComponent = ({ ...props }) => {
-  return (
-    <div>
-      <Dl data-element="dl" {...props}>
-        <Dt>Coffee Subscription</Dt>
-        <Dd data-element="dd">£7.00 a month</Dd>
-        <Dt>Grind Size</Dt>
-        <Dd>Espresso</Dd>
-        <Dt>Quantity</Dt>
-        <Dd>3kg</Dd>
-      </Dl>
-    </div>
-  );
-};
-
 context("Tests for Tile component", () => {
   describe("check props for Tile component", () => {
     it.each([
@@ -90,7 +25,9 @@ context("Tests for Tile component", () => {
     ])(
       "should check %s variant for Tile component",
       (variant, borderColor, backGroundColor) => {
-        CypressMountWithProviders(<TileComponent variant={variant} />);
+        CypressMountWithProviders(
+          <testStories.TileComponent variant={variant} />
+        );
         tile()
           .should("have.css", "border-color", borderColor)
           .and("have.css", "background-color", backGroundColor);
@@ -103,7 +40,9 @@ context("Tests for Tile component", () => {
     ])(
       "should check %s orientation for Tile component",
       (orientation, height) => {
-        CypressMountWithProviders(<TileComponent orientation={orientation} />);
+        CypressMountWithProviders(
+          <testStories.TileComponent orientation={orientation} />
+        );
         tile().then(($el) => {
           useJQueryCssValueAndAssert($el, "height", height);
         });
@@ -117,7 +56,9 @@ context("Tests for Tile component", () => {
     ])(
       "should check width as %s for Tile component",
       (widthInPercentage, widthInPixel) => {
-        CypressMountWithProviders(<TileComponent width={widthInPercentage} />);
+        CypressMountWithProviders(
+          <testStories.TileComponent width={widthInPercentage} />
+        );
         tile().then(($el) => {
           useJQueryCssValueAndAssert($el, "width", widthInPixel);
         });
@@ -136,7 +77,9 @@ context("Tests for Tile component", () => {
     it.each(testData)(
       "should check ddTextAlign as %s for Tile component",
       (align) => {
-        CypressMountWithProviders(<DlTileComponent ddTextAlign={align} />);
+        CypressMountWithProviders(
+          <testStories.DlTileComponent ddTextAlign={align} />
+        );
         getDataElementByValue("dd").should("have.css", "text-align", align);
       }
     );
@@ -145,7 +88,10 @@ context("Tests for Tile component", () => {
       "should check dtTextAlign as %s for Tile component",
       (align) => {
         CypressMountWithProviders(
-          <DlTileComponent dtTextAlign={align} ddTextAlign="right" />
+          <testStories.DlTileComponent
+            dtTextAlign={align}
+            ddTextAlign="right"
+          />
         );
         getDataElementByValue("dt").should("have.css", "text-align", align);
       }
@@ -153,7 +99,7 @@ context("Tests for Tile component", () => {
 
     it("should check single column for Tile component", () => {
       CypressMountWithProviders(
-        <DlTileComponent dtTextAlign="left" asSingleColumn />
+        <testStories.DlTileComponent dtTextAlign="left" asSingleColumn />
       );
       getDataElementByValue("dt")
         .should("have.css", "text-align", "left")
@@ -173,7 +119,11 @@ context("Tests for Tile component", () => {
       "should check dtTextAlign as %s for Tile component",
       (w, dtWidth, ddWidth) => {
         CypressMountWithProviders(
-          <DlTileComponent w={w} dtTextAlign="left" ddTextAlign="left" />
+          <testStories.DlTileComponent
+            w={w}
+            dtTextAlign="left"
+            ddTextAlign="left"
+          />
         );
         getDataElementByValue("dt")
           .should("have.css", "text-align", "left")
@@ -199,9 +149,11 @@ context("Tests for Tile component", () => {
       ["transparent", "rgba(0, 0, 0, 0)"],
       ["black", "rgb(0, 0, 0)"],
     ])(
-      "should check tile footer variant as %s for Tile component",
+      "should check Tile Footer variant as %s for Tile component",
       (variant, backGroundColor) => {
-        CypressMountWithProviders(<TileFooterComponent variant={variant} />);
+        CypressMountWithProviders(
+          <testStories.TileFooterComponent variant={variant} />
+        );
         tileFooter()
           .should("have.css", "background-color", backGroundColor)
           .then((elem) => {
@@ -218,7 +170,7 @@ context("Tests for Tile component", () => {
     );
 
     it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
-      "should check tile footer children as %s for Tile component",
+      "should check Tile Footer children as %s for Tile component",
       (children) => {
         CypressMountWithProviders(
           <Tile>
@@ -238,7 +190,7 @@ context("Tests for Tile component", () => {
       [30, 385],
       [60, 795],
     ])("should check w as %s for Tile component", (w, dtWidth) => {
-      CypressMountWithProviders(<DlTileComponent w={w} />);
+      CypressMountWithProviders(<testStories.DlTileComponent w={w} />);
       getDataElementByValue("dt").then(($el) => {
         useJQueryCssValueAndAssert($el, "width", dtWidth);
       });
@@ -252,10 +204,10 @@ context("Tests for Tile component", () => {
       ["caution", "rgb(239, 103, 0)"],
       ["info", "rgb(0, 96, 167)"],
     ])(
-      "should check border variant as %s for tile component",
+      "should check border variant as %s for Tile component",
       (borderVariant, borderColor) => {
         CypressMountWithProviders(
-          <TileComponent borderVariant={borderVariant} />
+          <testStories.TileComponent borderVariant={borderVariant} />
         );
         tile().should("have.css", "border-color", borderColor);
       }
@@ -268,12 +220,172 @@ context("Tests for Tile component", () => {
       ["borderWidth300", 3],
       ["borderWidth400", 4],
     ])(
-      "should check border width as %s for tile component",
+      "should check border width as %s for Tile component",
       (borderWidth, pixelWidth) => {
-        CypressMountWithProviders(<TileComponent borderWidth={borderWidth} />);
+        CypressMountWithProviders(
+          <testStories.TileComponent borderWidth={borderWidth} />
+        );
         tile().then(($el) => {
           useJQueryCssValueAndAssert($el, "border-width", pixelWidth);
         });
+      }
+    );
+  });
+
+  describe("check Accessibility for Tile component", () => {
+    it.each(["tile", "transparent", "active"])(
+      "should check Accessibility for %s variant for Tile component",
+      (variant) => {
+        CypressMountWithProviders(
+          <testStories.TileComponent variant={variant} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["vertical", "horizontal"])(
+      "should check Accessibility for %s orientation for Tile component",
+      (orientation) => {
+        CypressMountWithProviders(
+          <testStories.TileComponent orientation={orientation} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["30%", "50%", 0])(
+      "should check Accessibility for width as %s for Tile component",
+      (widthInPercentage) => {
+        CypressMountWithProviders(
+          <testStories.TileComponent width={widthInPercentage} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check Accessibility for children for Tile component", () => {
+      CypressMountWithProviders(
+        <Tile>
+          <Content title="children_test" />
+        </Tile>
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it.each(testData)(
+      "should check Accessibility for ddTextAlign as %s for Tile component",
+      (align) => {
+        CypressMountWithProviders(
+          <testStories.DlTileComponent ddTextAlign={align} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should check Accessibility for dtTextAlign as %s for Tile component",
+      (align) => {
+        CypressMountWithProviders(
+          <testStories.DlTileComponent
+            dtTextAlign={align}
+            ddTextAlign="right"
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check Accessibility for single column for Tile component", () => {
+      CypressMountWithProviders(
+        <testStories.DlTileComponent dtTextAlign="left" asSingleColumn />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it.each([10, 30])(
+      "should check Accessibility for dtTextAlign as %s for Tile component",
+      (w) => {
+        CypressMountWithProviders(
+          <testStories.DlTileComponent
+            w={w}
+            dtTextAlign="left"
+            ddTextAlign="left"
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["default", "transparent", "black"])(
+      "should check Accessibility for Tile Footer variant as %s for Tile component",
+      (variant) => {
+        CypressMountWithProviders(
+          <testStories.TileFooterComponent variant={variant} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS])(
+      "should check Accessibility for Tile Footer children as %s for Tile component",
+      (children) => {
+        CypressMountWithProviders(
+          <Tile>
+            <TileFooter p={3}>
+              <Typography pr={2} display="inline" variant="b">
+                {children}
+              </Typography>
+            </TileFooter>
+          </Tile>
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([10, 30, 60])(
+      "should check Accessibility for w as %s for Tile component",
+      (w) => {
+        CypressMountWithProviders(<testStories.DlTileComponent w={w} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["default", "selected", "positive", "negative", "caution", "info"])(
+      "should check Accessibility for border variant as %s for Tile component",
+      (borderVariant) => {
+        CypressMountWithProviders(
+          <testStories.TileComponent borderVariant={borderVariant} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      "borderWidth000",
+      "borderWidth100",
+      "borderWidth200",
+      "borderWidth300",
+      "borderWidth400",
+    ])(
+      "should check Accessibility for border width as %s for Tile component",
+      (borderWidth) => {
+        CypressMountWithProviders(
+          <testStories.TileComponent borderWidth={borderWidth} />
+        );
+
+        cy.checkAccessibility();
       }
     );
   });


### PR DESCRIPTION
### Proposed behaviour

#### Button
- Add `accessibility` Cypress tests for the `Tile` and `Tile Select` components to use the new cypress-component-react framework for testing.
- Move the testing component to the `tile-test.stories.tsx` and `tile-select-test.stories.tsx`

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added tests for `accessibility`
- [x] Check if the `tile.test.js` and `tile-select.test.js` files passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Tile` and `Tile Select` tests are not running twice.