### PR TITLE
test(split button): refactor cypress accessibility tests

### DIFF
--- a/cypress/components/split-button/split-button.test.js
+++ b/cypress/components/split-button/split-button.test.js
@@ -1,12 +1,14 @@
-import React, { useState } from "react";
-import SplitButton from "../../../src/components/split-button";
-import Button from "../../../src/components/button";
+import React from "react";
+import {
+  SplitButtonList,
+  SplitButtonNestedInDialog,
+} from "../../../src/components/split-button/split-button-test.stories.tsx";
 import { Accordion } from "../../../src/components/accordion";
-import Dialog from "../../../src/components/dialog";
+import * as stories from "../../../src/components/split-button/split-button.stories.tsx";
 
 import { buttonSubtextPreview } from "../../locators/button";
 import { keyCode, positionOfElement } from "../../../cypress/support/helper";
-import { icon, getDataElementByValue } from "../../locators";
+import { cyRoot, icon, getDataElementByValue } from "../../locators";
 
 import {
   splitToggleButton,
@@ -23,33 +25,10 @@ import CypressMountWithProviders from "../../support/component-helper/cypress-mo
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
-const SplitButtonList = ({ ...props }) => {
-  return (
-    <SplitButton text="default text" {...props}>
-      <Button>Button 1</Button>
-      <Button>Button 2</Button>
-      <Button>Button 3</Button>
-    </SplitButton>
-  );
-};
-
-const SplitButtonNestedInDialog = () => {
-  const [isOpen, setIsOpen] = useState(true);
-  return (
-    <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
-      <SplitButton text="default text">
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-        <Button>Button 3</Button>
-      </SplitButton>
-    </Dialog>
-  );
-};
-
-context("Tests for Split Button component", () => {
-  describe("check props for Split Button component", () => {
+context("Tests for SplitButton component", () => {
+  describe("check props for SplitButton component", () => {
     it.each(testData)(
-      "should render Split Button text using %s as special characters",
+      "should render SplitButton text using %s as special characters",
       (text) => {
         CypressMountWithProviders(<SplitButtonList text={text} />);
 
@@ -58,7 +37,7 @@ context("Tests for Split Button component", () => {
     );
 
     it.each(testData)(
-      "should render Split Button subtext with %s as special characters",
+      "should render SplitButton subtext with %s as special characters",
       (subtext) => {
         CypressMountWithProviders(
           <SplitButtonList size="large" subtext={subtext} />
@@ -68,7 +47,7 @@ context("Tests for Split Button component", () => {
       }
     );
 
-    it("should check Split Button data element prop", () => {
+    it("should check SplitButton data element prop", () => {
       CypressMountWithProviders(
         <SplitButtonList data-element="split-button-cypress-element" />
       );
@@ -80,7 +59,7 @@ context("Tests for Split Button component", () => {
       );
     });
 
-    it("should check Split Button data role prop", () => {
+    it("should check SplitButton data role prop", () => {
       CypressMountWithProviders(
         <SplitButtonList data-role="split-button-cypress-role" />
       );
@@ -93,7 +72,7 @@ context("Tests for Split Button component", () => {
     });
 
     it.each(["left", "right"])(
-      "should align the Split Button to the %s",
+      "should align the SplitButton to the %s",
       (alignment) => {
         CypressMountWithProviders(<SplitButtonList align={alignment} />);
 
@@ -101,7 +80,7 @@ context("Tests for Split Button component", () => {
       }
     );
 
-    it("should check Split Button is disabled", () => {
+    it("should check SplitButton is disabled", () => {
       CypressMountWithProviders(<SplitButtonList disabled />);
 
       mainButton().trigger("mouseover", { force: true });
@@ -115,7 +94,7 @@ context("Tests for Split Button component", () => {
       ["after", "left"],
       ["before", "right"],
     ])(
-      "should set position to %s for icon in a Split Button",
+      "should set position to %s for icon in a SplitButton",
       (iconPosition, margin) => {
         CypressMountWithProviders(
           <SplitButtonList iconType="add" iconPosition={iconPosition}>
@@ -127,7 +106,7 @@ context("Tests for Split Button component", () => {
       }
     );
 
-    it("should invoke Split Button component and expands", () => {
+    it("should invoke SplitButton component and expands", () => {
       CypressMountWithProviders(<SplitButtonList />);
 
       getDataElementByValue("dropdown").trigger("mouseover");
@@ -137,7 +116,7 @@ context("Tests for Split Button component", () => {
       splitToggleButton().should("have.attr", "aria-expanded", "true");
     });
 
-    it("should click a main element of Split Button component", () => {
+    it("should click a main element of SplitButton component", () => {
       const callback = cy.stub();
 
       CypressMountWithProviders(<SplitButtonList onClick={callback} />);
@@ -150,7 +129,7 @@ context("Tests for Split Button component", () => {
         });
     });
 
-    it("should invoke Split Button component in a hidden container", () => {
+    it("should invoke SplitButton component in a hidden container", () => {
       CypressMountWithProviders(
         <Accordion title="Heading">
           <SplitButtonList />
@@ -460,12 +439,12 @@ context("Tests for Split Button component", () => {
     }
   );
   // https://github.com/cypress-io/cypress/issues/21511
-  describe("should check colors for Split Button component", () => {
+  describe("should check colors for SplitButton component", () => {
     it.each([
       ["primary", "rgb(0, 126, 69)", "rgb(255, 255, 255)", "rgba(0, 0, 0, 0)"],
       ["secondary", "rgba(0, 0, 0, 0)", "rgb(0, 126, 69)", "rgb(0, 126, 69)"],
     ])(
-      "check %s type of Split Button uses %s as background color and %s as color and %s as border color",
+      "check %s type of SplitButton uses %s as background color and %s as color and %s as border color",
       (buttonType, backgroundColor, color, borderColor) => {
         CypressMountWithProviders(<SplitButtonList buttonType={buttonType} />);
 
@@ -482,7 +461,7 @@ context("Tests for Split Button component", () => {
     );
   });
 
-  describe("when nested inside of a Dialog component", () => {
+  describe("when SplitButton is nested inside of a Dialog component", () => {
     it("should not close the Dialog when SplitButton is closed by pressing an escape key", () => {
       CypressMountWithProviders(<SplitButtonNestedInDialog />);
 
@@ -497,5 +476,118 @@ context("Tests for Split Button component", () => {
       splitToggleButton().eq(0).type("{esc}");
       alertDialogPreview().should("not.exist");
     });
+  });
+});
+
+describe("check accessibility for SplitButton component", () => {
+  it("should pass accessibility tests for SplitButton Default story", () => {
+    CypressMountWithProviders(<stories.Default />);
+
+    cy.checkAccessibility();
+  });
+
+  it("should pass accessibility tests for SplitButton Default story when the additional buttons are opened", () => {
+    CypressMountWithProviders(<stories.Default />);
+
+    splitToggleButton().eq(0).trigger("click");
+
+    cy.checkAccessibility();
+  });
+
+  it("should pass accessibility tests for SplitButton Disabled story", () => {
+    CypressMountWithProviders(<stories.Disabled />);
+
+    cy.checkAccessibility();
+  });
+
+  it("should pass accessibility tests for SplitButton ButtonTypes story", () => {
+    CypressMountWithProviders(<stories.ButtonTypes />);
+
+    cy.checkAccessibility();
+  });
+
+  it("should pass accessibility tests for SplitButton ButtonTypes story Primary type", () => {
+    CypressMountWithProviders(<stories.ButtonTypes />);
+
+    splitToggleButton().eq(0).trigger("click");
+
+    cy.checkAccessibility();
+  });
+
+  it("should pass accessibility tests for SplitButton ButtonTypes story Primary type hover main button", () => {
+    CypressMountWithProviders(<stories.ButtonTypes />);
+
+    splitMainButtonDataComponent(positionOfElement("first")).realHover();
+
+    cy.checkAccessibility();
+
+    // to reset hover()
+    cyRoot().realHover({ position: "topLeft" });
+  });
+
+  it("should pass accessibility tests for SplitButton ButtonTypes story Primary type hover additional button", () => {
+    CypressMountWithProviders(<stories.ButtonTypes />);
+
+    splitToggleButton().eq(0).realHover();
+
+    cy.checkAccessibility();
+
+    // to reset hover()
+    cyRoot().realHover({ position: "topLeft" });
+  });
+
+  it("should pass accessibility tests for SplitButton ButtonTypes story Secondary type hover main button", () => {
+    CypressMountWithProviders(<stories.ButtonTypes />);
+
+    splitMainButtonDataComponent(positionOfElement("third")).realHover();
+
+    cy.checkAccessibility();
+
+    // to reset hover()
+    cyRoot().realHover({ position: "topLeft" });
+  });
+
+  it("should pass accessibility tests for SplitButton ButtonTypes story Secondary type hover additional button", () => {
+    CypressMountWithProviders(<stories.ButtonTypes />);
+
+    splitToggleButton().eq(1).realHover();
+
+    cy.checkAccessibility();
+
+    // to reset hover()
+    cyRoot().realHover({ position: "topLeft" });
+  });
+
+  it("should pass accessibility tests for SplitButton Sizes story", () => {
+    CypressMountWithProviders(<stories.Sizes />);
+
+    cy.checkAccessibility();
+  });
+
+  it("should pass accessibility tests for SplitButton Align story", () => {
+    CypressMountWithProviders(<stories.Align />);
+
+    cy.checkAccessibility();
+  });
+
+  it("should pass accessibility tests for SplitButton Subtext story", () => {
+    CypressMountWithProviders(<stories.Subtext />);
+
+    cy.checkAccessibility();
+  });
+
+  it("should pass accessibility tests for SplitButton WithIcon story", () => {
+    CypressMountWithProviders(<stories.WithIcon />);
+
+    cy.checkAccessibility();
+  });
+
+  it("should pass accessibility tests for SplitButton InOverflowHiddenContainer story", () => {
+    CypressMountWithProviders(<stories.InOverflowHiddenContainer />);
+
+    accordionDefaultTitle().click();
+    splitToggleButton().eq(0).trigger("click");
+
+    cy.checkAccessibility();
   });
 });

--- a/cypress/support/accessibility/a11y-utils.ts
+++ b/cypress/support/accessibility/a11y-utils.ts
@@ -125,6 +125,7 @@ export default (from: number, end: number) => {
       !prepareUrl[0].startsWith("breadcrumbs") &&
       !prepareUrl[0].startsWith("tabs") &&
       !prepareUrl[0].startsWith("tooltip") &&
+      !prepareUrl[0].startsWith("split-button") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/split-button/split-button-test.stories.tsx
+++ b/src/components/split-button/split-button-test.stories.tsx
@@ -1,15 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
 import Button from "../button";
 import Box from "../box";
 import { ICONS } from "../icon/icon-config";
+import Dialog from "../dialog";
 import {
   SPLIT_BUTTON_ALIGNMENTS,
   SPLIT_BUTTON_ICON_POSITIONS,
   SPLIT_BUTTON_SIZES,
   SPLIT_BUTTON_THEMES,
 } from "./split-button.config";
-import SplitButton from "./split-button.component";
+import SplitButton, { SplitButtonProps } from "./split-button.component";
 
 export default {
   title: "Split Button/Test",
@@ -53,44 +54,31 @@ export default {
   },
 };
 
-/* eslint-disable react/prop-types */
 export const SplitButtonStory = ({
   buttonType,
-  dataElement,
-  dataRole,
-  text,
   subtext,
-  iconType,
-  iconPosition,
   ...args
-  /* eslint-enable */
-}) => {
-  return (
-    <Box height={400} mt={100} ml={100}>
-      <SplitButton
-        buttonType={buttonType}
-        data-element={dataElement}
-        data-role={dataRole}
-        text={text}
-        subtext={subtext}
-        iconType={iconType}
-        iconPosition={iconPosition}
-        {...args}
-        onClick={action("click")}
-      >
-        <Button {...args} onClick={action("click")}>
-          Example Button
-        </Button>
-        <Button {...args} onClick={action("click")}>
-          Example Button with long text
-        </Button>
-        <Button {...args} onClick={action("click")}>
-          Short
-        </Button>
-      </SplitButton>
-    </Box>
-  );
-};
+}: Partial<SplitButtonProps>) => (
+  <Box height={400} mt={100} ml={100}>
+    <SplitButton
+      buttonType={buttonType}
+      text="text"
+      subtext={subtext}
+      {...args}
+      onClick={action("click")}
+    >
+      <Button {...args} onClick={action("click")}>
+        Example Button
+      </Button>
+      <Button {...args} onClick={action("click")}>
+        Example Button with long text
+      </Button>
+      <Button {...args} onClick={action("click")}>
+        Short
+      </Button>
+    </SplitButton>
+  </Box>
+);
 
 SplitButtonStory.story = {
   name: "default",
@@ -106,4 +94,27 @@ SplitButtonStory.story = {
     text: "Example Split Button",
     subtext: "",
   },
+};
+
+export const SplitButtonList = ({ ...props }) => {
+  return (
+    <SplitButton text="default text" {...props}>
+      <Button>Button 1</Button>
+      <Button>Button 2</Button>
+      <Button>Button 3</Button>
+    </SplitButton>
+  );
+};
+
+export const SplitButtonNestedInDialog = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
+      <SplitButton text="default text">
+        <Button>Button 1</Button>
+        <Button>Button 2</Button>
+        <Button>Button 3</Button>
+      </SplitButton>
+    </Dialog>
+  );
 };


### PR DESCRIPTION
### Proposed behaviour

Add accessibility Cypress tests for the Split Button component to use the new cypress-component-react framework for testing.

### Current behaviour

Old approach with separate test files and run jobs for accessibility tests.

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run npx cypress open --component and run the split-button.test.js file
- [ ] Check the split-button.test.js file passed
- [ ] Run npx cypress run --component to check none of the other *.test.js files have regressed
- [ ] Run npm run build-storybook -> npx sb extract -> npx http-server storybook-static -p 9001 and run npx cypress run --e2e and check the Split Button tests do not run.

<!-- Add CodeSandbox here -->
