### PR TITLE
test(hr): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -115,6 +115,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("inline-inputs") &&
       !prepareUrl[0].startsWith("radiobutton") &&
       !prepareUrl[0].startsWith("tile") &&
+      !prepareUrl[0].startsWith("hr") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/hr/hr.test.js
+++ b/src/components/hr/hr.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Hr from "./hr.component";
+import * as stories from "./hr.stories";
 import hrComponent from "../../../cypress/locators/hr";
 import CypressMountWithProviders from "../../../cypress/support/component-helper/cypress-mount";
 import { useJQueryCssValueAndAssert } from "../../../cypress/support/component-helper/common-steps";
@@ -39,5 +40,37 @@ context("Testing Hr component", () => {
         });
       }
     );
+  });
+
+  describe("Accessibility tests for Hr component", () => {
+    it("should pass accessibility tests for Default story", () => {
+      CypressMountWithProviders(<stories.Default />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for DifferentSpacing story", () => {
+      CypressMountWithProviders(<stories.DifferentSpacing />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for EnablingAdaptiveBehaviour story", () => {
+      CypressMountWithProviders(<stories.EnablingAdaptiveBehaviour />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for InsideForm story", () => {
+      CypressMountWithProviders(<stories.InsideForm />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for InsideFormInlineLabels story", () => {
+      CypressMountWithProviders(<stories.InsideFormInlineLabels />);
+
+      cy.checkAccessibility();
+    });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `Hr` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there is newly added tests for `accessibility`
- [ ] Check if the `hr.test.js` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Hr` tests are not running twice.