### PR TITLE
test(simple-color-picker): add accessibility tests

### DIFF
--- a/cypress/support/accessibility/a11y-utils.js
+++ b/cypress/support/accessibility/a11y-utils.js
@@ -116,6 +116,7 @@ export default (from, end) => {
       !prepareUrl[0].startsWith("radiobutton") &&
       !prepareUrl[0].startsWith("tile") &&
       !prepareUrl[0].startsWith("hr") &&
+      !prepareUrl[0].startsWith("simple-color-picker") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/simple-color-picker/simple-color-picker.test.js
+++ b/src/components/simple-color-picker/simple-color-picker.test.js
@@ -554,4 +554,123 @@ context("Testing SimpleColorPicker component", () => {
         });
     });
   });
+
+  describe("check Accessibility for SimpleColorPicker component", () => {
+    it("should check Accessibility for all proper colors ", () => {
+      CypressMountWithProviders(<SimpleColorPickerCustom />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each(testData)(
+      "should render SimpleColorPicker and set legend to %s for Accessibility tests",
+      (legend) => {
+        CypressMountWithProviders(<SimpleColorPickerCustom legend={legend} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should render SimpleColorPicker and set name to %s for Accessibility tests",
+      (name) => {
+        CypressMountWithProviders(<SimpleColorPickerCustom name={name} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["250", "450"])(
+      "should render SimpleColorPicker with maxWidth prop set to %s for Accessibility tests",
+      (maxWidth) => {
+        CypressMountWithProviders(
+          <SimpleColorPickerCustom maxWidth={maxWidth} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      ["300", "75"],
+      ["100", "60"],
+    ])(
+      "should render SimpleColorPicker with childWidth prop set to %s for Accessibility tests",
+      (maxWidth, childWidth) => {
+        CypressMountWithProviders(
+          <SimpleColorPickerCustom
+            maxWidth={maxWidth}
+            childWidth={childWidth}
+          />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should render SimpleColorPicker with required prop for Accessibility tests", () => {
+      CypressMountWithProviders(<SimpleColorPickerCustom required />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each(["error", "warning", "info"])(
+      "should render SimpleColorPicker and set type to %s and set as string for Accessibility tests",
+      (type) => {
+        CypressMountWithProviders(
+          <SimpleColorPickerCustom {...{ [type]: "Message" }} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["error", "warning", "info"])(
+      "should render SimpleColorPicker and set type to %s as string and have validationOnLegend prop for Accessibility tests",
+      (type) => {
+        CypressMountWithProviders(
+          <SimpleColorPickerCustom
+            {...{ [type]: "Message" }}
+            validationOnLegend
+          />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["error", "warning", "info"])(
+      "should render SimpleColorPicker and set type to %s as boolean for Accessibility tests",
+      (type) => {
+        CypressMountWithProviders(
+          <SimpleColorPickerCustom {...{ [type]: true }} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check the value prop in SimpleColor item for Accessibility tests", () => {
+      CypressMountWithProviders(<SimpleColorCustom value={colors[7].color} />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check the name prop in SimpleColor item for Accessibility tests", () => {
+      CypressMountWithProviders(<SimpleColorCustom name={testPropValue} />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each([true, false])(
+      "should check the checked prop is set to %s in SimpleColor item for Accessibility tests",
+      (checkedBool) => {
+        CypressMountWithProviders(<SimpleColorCustom checked={checkedBool} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should check the className prop in SimpleColor item for Accessibility tests", () => {
+      CypressMountWithProviders(
+        <SimpleColorCustom className={testPropValue} />
+      );
+      cy.checkAccessibility();
+    });
+  });
 });


### PR DESCRIPTION
### Proposed behaviour

#### Simple Color Picker
- Add `accessibility` Cypress tests for the `Simple-color-picker` components to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added tests for `accessibility`
- [x] Check if the `simple-color-picker.test.js` files passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Simple-color-picker` tests are not running twice.