### PR TITLE
test(typography): add cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -108,10 +108,6 @@ jobs:
             1,
             2,
             3,
-            4,
-            5,
-            6,
-            7,
           ]
     container: 
       image: cypress/browsers:node-18.14.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1

--- a/cypress/components/typography/typography.test.js
+++ b/cypress/components/typography/typography.test.js
@@ -1,0 +1,291 @@
+import React from "react";
+import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
+import Typography from "../../../src/components/typography";
+import * as testStories from "../../../src/components/typography/typography-test.stories";
+import * as stories from "../../../src/components/typography/typography.stories";
+import { CHARACTERS } from "../../support/component-helper/constants";
+
+const testCypress = CHARACTERS.STANDARD;
+
+const VARIANT_TYPES = [
+  "h1-large",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "segment-header",
+  "segment-header-small",
+  "segment-subheader",
+  "segment-subheader-alt",
+  "p",
+  "small",
+  "big",
+  "sup",
+  "sub",
+  "strong",
+  "b",
+  "em",
+  "ul",
+  "ol",
+];
+
+const getAs = (variant) => {
+  switch (variant) {
+    case "h1-large":
+      return "h1";
+    case "segment-header":
+    case "segment-header-small":
+    case "segment-subheader":
+    case "segment-subheader-alt":
+      return "h5";
+    case "big":
+      return "p";
+    default:
+      return variant;
+  }
+};
+
+const getSize = (variant) => {
+  switch (variant) {
+    case "h1-large":
+      return "32px";
+    case "h1":
+      return "24px";
+    case "h2":
+      return "22px";
+    case "h3":
+    case "segment-header":
+      return "20px";
+    case "h4":
+    case "segment-header-small":
+      return "18px";
+    case "h5":
+    case "segment-subheader":
+    case "big":
+      return "16px";
+    case "small":
+    case "sub":
+    case "sup":
+      return "13px";
+    case "segment-subheader-alt":
+    case "p":
+    case "b":
+    case "strong":
+    case "em":
+    default:
+      return "14px";
+  }
+};
+
+const getLineHeight = (variant) => {
+  switch (variant) {
+    case "h1-large":
+      return "40px";
+    case "h1":
+    case "segment-subheader":
+      return "31px";
+    case "h2":
+      return "29px";
+    case "h3":
+    case "segment-header":
+      return "26px";
+    case "big":
+      return "24px";
+    case "h4":
+    case "segment-header-small":
+      return "23px";
+    case "small":
+    case "sub":
+    case "sup":
+      return "20px";
+    case "h5":
+    case "segment-subheader-alt":
+    case "p":
+    case "b":
+    case "strong":
+    case "em":
+    default:
+      return "21px";
+  }
+};
+
+const getWeight = (variant) => {
+  switch (variant) {
+    case "h1-large":
+    case "h1":
+    case "segment-header":
+    case "segment-header-small":
+      return "900";
+    case "h2":
+    case "h3":
+    case "segment-subheader":
+    case "segment-subheader-alt":
+    case "b":
+    case "em":
+    case "strong":
+      return "700";
+    case "h4":
+    case "h5":
+    case "p":
+    case "small":
+    case "big":
+    case "sub":
+    case "sup":
+    default:
+      return "400";
+  }
+};
+
+const getTransform = (variant) => {
+  if (variant === "segment-subheader-alt") {
+    return "uppercase";
+  }
+  return "none";
+};
+
+const getDecoration = (variant) => {
+  if (variant === "em") {
+    return "underline";
+  }
+  return "none";
+};
+
+context("Tests for Typography component", () => {
+  describe("should check Typography component properties", () => {
+    it.each(VARIANT_TYPES)(
+      "should check variant prop set to %s for Typography component",
+      (variant) => {
+        CypressMountWithProviders(
+          <Typography variant={variant}>{testCypress}</Typography>
+        );
+
+        const variantElem = getAs(variant);
+
+        cy.get(variantElem).should("have.text", testCypress);
+      }
+    );
+
+    it.each(VARIANT_TYPES)(
+      "should check font-size for %s variant prop for Typography component",
+      (variant) => {
+        CypressMountWithProviders(
+          <Typography variant={variant}>{testCypress}</Typography>
+        );
+
+        const variantElem = getAs(variant);
+        const fontSize = getSize(variant);
+
+        cy.get(variantElem).should("have.css", "font-size", fontSize);
+      }
+    );
+
+    it.each(VARIANT_TYPES)(
+      "should check line-height for %s variant prop for Typography component",
+      (variant) => {
+        CypressMountWithProviders(
+          <Typography variant={variant}>{testCypress}</Typography>
+        );
+
+        const variantElem = getAs(variant);
+        const lineHeight = getLineHeight(variant);
+
+        cy.get(variantElem).should("have.css", "line-height", lineHeight);
+      }
+    );
+
+    it.each(VARIANT_TYPES)(
+      "should check font-weight for %s variant prop for Typography component",
+      (variant) => {
+        CypressMountWithProviders(
+          <Typography variant={variant}>{testCypress}</Typography>
+        );
+
+        const variantElem = getAs(variant);
+        const fontWeight = getWeight(variant);
+
+        cy.get(variantElem).should("have.css", "font-weight", fontWeight);
+      }
+    );
+
+    it.each(VARIANT_TYPES)(
+      "should check text-transform for %s variant prop for Typography component",
+      (variant) => {
+        CypressMountWithProviders(
+          <Typography variant={variant}>{testCypress}</Typography>
+        );
+
+        const variantElem = getAs(variant);
+        const textTransform = getTransform(variant);
+
+        cy.get(variantElem).should("have.css", "text-transform", textTransform);
+      }
+    );
+
+    it.each(VARIANT_TYPES)(
+      "should check text-decoration-line for %s variant prop for Typography component",
+      (variant) => {
+        CypressMountWithProviders(
+          <Typography variant={variant}>{testCypress}</Typography>
+        );
+
+        const variantElem = getAs(variant);
+        const textDecorationLine = getDecoration(variant);
+
+        cy.get(variantElem).should(
+          "have.css",
+          "text-decoration-line",
+          textDecorationLine
+        );
+      }
+    );
+
+    it.each(["ol", "ul"])(
+      "should check as prop set to %s for List component",
+      (as) => {
+        CypressMountWithProviders(<testStories.ListComponent as={as} />);
+
+        cy.get(as).should("exist").and("be.visible");
+      }
+    );
+
+    it.each([
+      [true, "have"],
+      [false, "not.have"],
+    ])(
+      "should check truncate prop set to %s for Typography component",
+      (truncate, assertion) => {
+        CypressMountWithProviders(
+          <div
+            style={{
+              height: "80px",
+              width: "80px",
+            }}
+          >
+            <Typography variant="h1" truncate={truncate}>
+              {testCypress}
+            </Typography>
+          </div>
+        );
+
+        cy.get("h1")
+          .should("have.text", testCypress)
+          .and(`${assertion}.css`, "text-overflow", "ellipsis");
+      }
+    );
+  });
+
+  describe("should check accessibility for Typography component", () => {
+    it("should check accessibility for Typography component VariantsStory", () => {
+      CypressMountWithProviders(<stories.VariantsStory />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for Typography component TruncateStory", () => {
+      CypressMountWithProviders(<stories.TruncateStory />);
+
+      cy.checkAccessibility();
+    });
+  });
+});

--- a/cypress/e2e/accessibility/a11y-fifth-part.test.ts
+++ b/cypress/e2e/accessibility/a11y-fifth-part.test.ts
@@ -1,3 +1,0 @@
-import tests from "../../support/accessibility/a11y-utils";
-
-tests(301, 375);

--- a/cypress/e2e/accessibility/a11y-fourth-part.test.ts
+++ b/cypress/e2e/accessibility/a11y-fourth-part.test.ts
@@ -1,3 +1,0 @@
-import tests from "../../support/accessibility/a11y-utils";
-
-tests(226, 300);

--- a/cypress/e2e/accessibility/a11y-sixth-part.test.ts
+++ b/cypress/e2e/accessibility/a11y-sixth-part.test.ts
@@ -1,3 +1,0 @@
-import tests from "../../support/accessibility/a11y-utils";
-
-tests(376, 450);

--- a/cypress/support/accessibility/a11y-utils.ts
+++ b/cypress/support/accessibility/a11y-utils.ts
@@ -104,10 +104,10 @@ export default (from: number, end: number) => {
       !prepareUrl[0].startsWith("fieldset") &&
       !prepareUrl[0].startsWith("form") &&
       !prepareUrl[0].startsWith("drawer") &&
-      !prepareUrl[0].startsWith("group-character") &&
-      !prepareUrl[0].startsWith("duelling-picklist") &&
+      !prepareUrl[0].startsWith("groupedcharacter") &&
+      !prepareUrl[0].startsWith("duellingpicklist") &&
       !prepareUrl[0].startsWith("multi-action-button") &&
-      !prepareUrl[0].startsWith("settings-row") &&
+      !prepareUrl[0].startsWith("setting-row") &&
       !prepareUrl[0].startsWith("numeral-date") &&
       !prepareUrl[0].startsWith("global-header") &&
       !prepareUrl[0].startsWith("grid") &&
@@ -121,6 +121,8 @@ export default (from: number, end: number) => {
       !prepareUrl[0].startsWith("text-editor") &&
       !prepareUrl[0].startsWith("hr") &&
       !prepareUrl[0].startsWith("simple-color-picker") &&
+      !prepareUrl[0].startsWith("typography") &&
+      !prepareUrl[0].startsWith("breadcrumbs") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);
@@ -145,10 +147,11 @@ export default (from: number, end: number) => {
             });
           }
 
+          // @ts-ignore
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
           cy.injectAxe()
             // @ts-ignore
             .wait(250)
-            // @ts-ignore
             .then(() => cy.checkA11y(null, A11YOptions, terminalLog));
         }
       );

--- a/src/components/typography/typography-test.stories.tsx
+++ b/src/components/typography/typography-test.stories.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import Typography, { List, ListItem } from ".";
+
+export default {
+  title: "Typography/Test",
+  includeStories: ["Default"],
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+};
+
+export const Default = ({ ...props }) => {
+  return (
+    <Typography {...props} variant="b">
+      Some text
+    </Typography>
+  );
+};
+Default.storyName = "default";
+
+export const ListComponent = ({ ...props }) => {
+  return (
+    <List {...props}>
+      <ListItem>
+        Milk <Typography variant="b">2L</Typography>{" "}
+        <Typography variant="em">Skimmed</Typography>
+      </ListItem>
+      <ListItem>
+        Bread <Typography variant="b">500g</Typography>
+      </ListItem>
+      <ListItem>
+        Sugar <Typography variant="b">1Kg</Typography>
+      </ListItem>
+    </List>
+  );
+};
+ListComponent.storyName = "list component";


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `Typography` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added test.file
- [x] Check if the `typography.test.js` file passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Typography` tests are not running twice.