### PR TITLE
test(icon-button): add accessibility tests

### DIFF
--- a/cypress/components/icon-button/icon-button.test.js
+++ b/cypress/components/icon-button/icon-button.test.js
@@ -1,19 +1,9 @@
 import React from "react";
-import IconButton from "../../../src/components/icon-button";
-import Icon from "../../../src/components/icon";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import { icon } from "../../locators";
-
+import { IconButtonComponent } from "../../../src/components/icon-button/icon-button-test.stories";
 import { CHARACTERS } from "../../support/component-helper/constants";
 import { keyCode } from "../../../cypress/support/helper";
-
-const IconButtonComponent = ({ ...props }) => {
-  return (
-    <IconButton aria-label="icon-button" onClick={() => {}} {...props}>
-      <Icon type="home" />
-    </IconButton>
-  );
-};
 
 context("Tests for IconButton component", () => {
   describe("check props for IconButton component", () => {
@@ -128,5 +118,24 @@ context("Tests for IconButton component", () => {
           });
       }
     );
+  });
+
+  describe("check props for IconButton component", () => {
+    it("should pass accessibility tests for aria-label prop", () => {
+      CypressMountWithProviders(
+        <IconButtonComponent aria-label={CHARACTERS.STANDARD} />
+      );
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for children prop", () => {
+      CypressMountWithProviders(<IconButtonComponent />);
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibility tests for disabled prop", () => {
+      CypressMountWithProviders(<IconButtonComponent disabled />);
+      cy.checkAccessibility();
+    });
   });
 });

--- a/src/components/icon-button/icon-button-test.stories.tsx
+++ b/src/components/icon-button/icon-button-test.stories.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import Icon from "../icon";
+import IconButton from ".";
+
+export default {
+  title: "IconButton/Test",
+  includeStories: ["Default"],
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+};
+
+export const Default = ({ ...props }) => {
+  return (
+    <IconButton aria-label="icon-button" onClick={() => {}} {...props}>
+      <Icon type="home" />
+    </IconButton>
+  );
+};
+
+Default.storyName = "default";
+
+export const IconButtonComponent = ({ ...props }) => {
+  return (
+    <IconButton aria-label="icon-button" onClick={() => {}} {...props}>
+      <Icon type="home" />
+    </IconButton>
+  );
+};


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `icon-button` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added tests for `accessibility`
- [x] Check if the `icon-button.test.js` files passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `IconButton` tests are not running twice.