### PR TITLE
test(tabs): fix cypress test returning false positive result

### DIFF
--- a/cypress/components/tabs/tabs.test.js
+++ b/cypress/components/tabs/tabs.test.js
@@ -313,17 +313,16 @@ context("Testing Tabs component", () => {
     );
 
     it.each(["error", "warning", "info"])(
-      "should no longer report the any validation failures of children no longer mounted",
+      "should no longer report any %s validation failures of children no longer mounted",
       (type) => {
-        const validation = { [type]: true };
-
         CypressMountWithProviders(
-          <TabsComponentValidationsUnregistering validation={validation} />
+          <TabsComponentValidationsUnregistering validationType={type} />
         );
 
+        tabById(1).get(ICON).should("exist");
         getDataElementByValue("foo-button").click();
 
-        tabById(1).children().children().should("not.exist");
+        tabById(1).get(ICON).should("not.exist");
       }
     );
 

--- a/src/components/tabs/tabs-test.stories.tsx
+++ b/src/components/tabs/tabs-test.stories.tsx
@@ -285,7 +285,11 @@ export const TabsComponentValidations = ({ ...props }: TabsProps) => {
   );
 };
 
-export const TabsComponentValidationsUnregistering = () => {
+export const TabsComponentValidationsUnregistering = ({
+  validationType,
+}: {
+  validationType: "error" | "warning" | "info";
+}) => {
   const [show, setShow] = React.useState(true);
 
   return (
@@ -310,7 +314,14 @@ export const TabsComponentValidationsUnregistering = () => {
           title="Tab 1"
           key="tab-1"
         >
-          {show && <Checkbox label="Add error" onChange={() => {}} checked />}
+          {show && (
+            <Checkbox
+              label={`Add ${validationType}`}
+              onChange={() => {}}
+              checked
+              {...{ [validationType]: true }}
+            />
+          )}
         </Tab>
       </Tabs>
     </div>


### PR DESCRIPTION
### Proposed behaviour

- Update cypress test which verifies when a `Tab` child with a validation failure is removed, the `Tab` no longer show a validation icon.  

### Current behaviour

- Currently, test passes given though a validation prop has not been set on the `Tab` child in the test case.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Open Cypress via `npx cypress open --component` and run the `Tabs` tests and verify for these three tests are passing correctly:
"should no longer report any error validation failures of children no longer mounted"
"should no longer report any warning validation failures of children no longer mounted",
"should no longer report any info validation failures of children no longer mounted",
