### PR TITLE
chore: update jest-canvas-mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,7 @@
         "fs-extra": "^10.0.0",
         "husky": "^4.3.6",
         "jest": "^27.5.1",
-        "jest-canvas-mock": "^2.3.1",
+        "jest-canvas-mock": "^2.5.0",
         "jest-environment-jsdom": "^27.5.1",
         "jest-fetch-mock": "^3.0.3",
         "jest-styled-components": "^6.3.1",
@@ -21770,9 +21770,9 @@
       }
     },
     "node_modules/jest-canvas-mock": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.3.1.tgz",
-      "integrity": "sha512-5FnSZPrX3Q2ZfsbYNE3wqKR3+XorN8qFzDzB5o0golWgt6EOX1+emBnpOc9IAQ+NXFj8Nzm3h7ZdE/9H0ylBcg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.0.tgz",
+      "integrity": "sha512-s2bmY2f22WPMzhB2YA93kiyf7CAfWAnV/sFfY9s48IVOrGmwui1eSFluDPesq1M+7tSC1hJAit6mzO0ZNXvVBA==",
       "dev": true,
       "dependencies": {
         "cssfontparser": "^1.2.1",
@@ -53719,9 +53719,9 @@
       }
     },
     "jest-canvas-mock": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.3.1.tgz",
-      "integrity": "sha512-5FnSZPrX3Q2ZfsbYNE3wqKR3+XorN8qFzDzB5o0golWgt6EOX1+emBnpOc9IAQ+NXFj8Nzm3h7ZdE/9H0ylBcg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.0.tgz",
+      "integrity": "sha512-s2bmY2f22WPMzhB2YA93kiyf7CAfWAnV/sFfY9s48IVOrGmwui1eSFluDPesq1M+7tSC1hJAit6mzO0ZNXvVBA==",
       "dev": true,
       "requires": {
         "cssfontparser": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "fs-extra": "^10.0.0",
     "husky": "^4.3.6",
     "jest": "^27.5.1",
-    "jest-canvas-mock": "^2.3.1",
+    "jest-canvas-mock": "^2.5.0",
     "jest-environment-jsdom": "^27.5.1",
     "jest-fetch-mock": "^3.0.3",
     "jest-styled-components": "^6.3.1",


### PR DESCRIPTION
### Proposed behaviour

Update `jest-canvas-mock` from version `2.3.1` to `2.5.0`

### Current behaviour

Currently observing intermittent failure with our CI pipeline - where node raises an error of a memory leak. Looking at the CI logs for the failing check, it appears `jest-canvas-mock` is the cause:

```shell
Test suite failed to run

TypeError: Cannot redefine property: window

at Object.<anonymous> (node_modules/jest-canvas-mock/lib/index.js:19:17)
```

This error seems related to a similar issue someone else had raised with regards to `jest-canvas-mock` not working in Node 18 [as shown in this github issue](https://github.com/hustcc/jest-canvas-mock/issues/89). 

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- Verify that the tests have passed in Node 18 in the CI checks
