### PR TITLE
test(flat table): add accessibility tests

### DIFF
--- a/cypress/components/flat-table/flat-table.test.js
+++ b/cypress/components/flat-table/flat-table.test.js
@@ -4658,4 +4658,260 @@ context("Tests for Flat Table component", () => {
         });
     });
   });
+
+  describe("check accessibility tests for Flat Table component", () => {
+    it("should render Flat Table with ariaDescribedBy for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableComponent />);
+      cy.checkAccessibility();
+    });
+
+    it.each([CHARACTERS.SPECIALCHARACTERS, CHARACTERS.DIACRITICS])(
+      "should render Flat Table with caption prop set as %s for accessibility tests",
+      (captionValue) => {
+        CypressMountWithProviders(
+          <FlatTableComponent caption={captionValue} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    // a11y error!scrollable-region-focusable on 1 Node. Ticket FE-5604 logged to investigate
+    it.skip("should render Flat Table Row with cell nodes as children for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableSpanComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table with truncated cells for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableTruncateBgComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    // a11y error!color-contrast on 1 Node. Ticket FE-5766 logged to investigate
+    it.skip("should render Flat Table Checkbox with ariaLabelledBy for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableColorRowSelectableComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table with sticky header for accessibility tests", () => {
+      CypressMountWithProviders(
+        <div style={{ height: "150px" }}>
+          <FlatTableComponent hasStickyHead />
+        </div>
+      );
+      cy.wait(300);
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table with sticky footer for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableFooterComponent hasStickyFooter />);
+      cy.checkAccessibility();
+    });
+
+    it.each(colorThemes)(
+      "should render Flat Table in the %s theme for accessibility tests",
+      (colorTheme) => {
+        CypressMountWithProviders(
+          <FlatTableComponent colorTheme={colorTheme} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should render Flat Table with zebra stripes for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableComponent isZebra />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each(sizes)(
+      "should check Flat Table size is %s for accessibility tests",
+      (sizeName) => {
+        CypressMountWithProviders(<FlatTableComponent size={sizeName} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(heightWidth)(
+      "should render Flat Table with %spx as a height parameter for accessibility tests",
+      (height) => {
+        CypressMountWithProviders(
+          <FlatTableComponent height={`${height}px`} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([150, 249, 250, 251, 300])(
+      "should render Flat Table with %spx as a height parameter and minHeight set to 250px for accessibility tests",
+      (height) => {
+        CypressMountWithProviders(
+          <FlatTableComponent height={`${height}px`} minHeight="250px" />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should render Flat Table with hasMaxHeight parameter for accessibility tests", () => {
+      CypressMountWithProviders(
+        <FlatTableComponent height="400px" hasMaxHeight />
+      );
+      cy.checkAccessibility();
+    });
+
+    it.each(heightWidth)(
+      "should render Flat Table with %spx as a width parameter for accessibility tests",
+      (width) => {
+        CypressMountWithProviders(<FlatTableComponent width={`${width}px`} />);
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["visible", "hidden", "clip", "scroll", "auto"])(
+      "should render Flat Table with %s as a overflowX parameter and width set to 500px for accessibility tests",
+      (overflow) => {
+        CypressMountWithProviders(
+          <FlatTableComponent width="500px" overflowX={overflow} />
+        );
+        cy.checkAccessibility();
+      }
+    );
+
+    // a11y error!scrollable-region-focusable on 1 Node. Ticket FE-5604 logged to investigate
+    it.skip("should render Flat Table with rowSpan set to make header cells span 2 rows for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableSpanComponent width="500px" />);
+      cy.checkAccessibility();
+    });
+
+    // a11y error!scrollable-region-focusable on 1 Node. Ticket FE-5604 logged to investigate
+    it.skip("should render Flat Table with multiple sticky row headers for accessibility tests", () => {
+      cy.viewport(700, 700);
+
+      CypressMountWithProviders(<FlatTableMutipleStickyComponent />);
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table with colSpan set to make cells span 4 columns for accessibility tests", () => {
+      CypressMountWithProviders(
+        <FlatTableCellColSpanComponent width="500px" />
+      );
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table with rowSpan set to make cells span 3 rows for accessibility tests", () => {
+      CypressMountWithProviders(
+        <FlatTableCellRowSpanComponent width="500px" />
+      );
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table with FlatTableFooterComponent for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableFooterComponent />);
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table with FlatTableCustomPaddingComponent for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableCustomPaddingComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table Header and Cells with FlatTableVerticalBordersComponent for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableVerticalBordersComponent />);
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table with custom horizontal borders for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableHorizontalBordersComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    // a11y error!color-contrast on 1 Node. Ticket FE-5766 logged to investigate
+    it.skip("should render Flat Table with custom color row for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableColorRowSelectableComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    // a11y error!color-contrast on 1 Node. Ticket FE-5766 logged to investigate
+    it.skip("should render Flat Table rows with the mouse for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableHighlightableComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table Row Header with truncated string in header for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableTruncateHeaderComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table Row Header with title for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableTitleAlignComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should render sorted Flat Table for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableSortingComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table with all expandable rows closed for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableNoAccSubRowComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it("when first column of expandable row is opened, rendered Flat Table passes accessibility checks", () => {
+      CypressMountWithProviders(<FlatTableFirstColExpandableComponent />);
+      flatTableCell(0).focus().trigger("keydown", keyCode("Space"));
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table with all expandable rows expanded for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableAlreadyExpandedComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    // a11y error!color-contrast on 1 Node. Ticket FE-5766 logged to investigate
+    it.skip("should render Flat Table with parent expandable and child subrows selectable for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableAllSubrowSelectableComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    // a11y error!color-contrast on 1 Node. Ticket FE-5766 logged to investigate
+    it.skip("should render Flat Table with parent expandable row only selectable for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableParentSubrowSelectableComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    // a11y error!color-contrast on 1 Node. Ticket FE-5766 logged to investigate
+    it.skip("should render Flat Table with child subrow only selectable for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableChildSubrowSelectableComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    // a11y error! empty-table-header on 1 Node. Ticket FE-5767 logged to investigate
+    it.skip("should render Flat Table with FlatTableDraggableComponent for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTableDraggableComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should render Flat Table with pager and sticky header for accessibility tests", () => {
+      CypressMountWithProviders(<FlatTablePagerStickyHeaderComponent />);
+
+      cy.checkAccessibility();
+    });
+  });
 });

--- a/cypress/support/accessibility/a11y-utils.ts
+++ b/cypress/support/accessibility/a11y-utils.ts
@@ -126,6 +126,7 @@ export default (from: number, end: number) => {
       !prepareUrl[0].startsWith("tabs") &&
       !prepareUrl[0].startsWith("tooltip") &&
       !prepareUrl[0].startsWith("split-button") &&
+      !prepareUrl[0].startsWith("flat-table") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/icon-button/icon-button-test.stories.tsx
+++ b/src/components/icon-button/icon-button-test.stories.tsx
@@ -3,7 +3,7 @@ import Icon from "../icon";
 import IconButton from ".";
 
 export default {
-  title: "IconButton/Test",
+  title: "Icon Button/Test",
   includeStories: ["Default"],
   parameters: {
     info: { disable: true },


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `flat-table` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run `npx cypress open --component` to check if there is newly added tests for `accessibility`
- [x] Check if the `flat-table.test.js` files passed
- [x] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [x] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [x] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `FlatTable` tests are not running twice.