### PR TITLE
test(select): add accessibility tests

### DIFF
--- a/cypress/components/select/filterable-select/filterable-select.test.js
+++ b/cypress/components/select/filterable-select/filterable-select.test.js
@@ -1,8 +1,5 @@
-import React, { useState } from "react";
-import { FilterableSelect, Option } from "../../../../src/components/select";
-import OptionRow from "../../../../src/components/select/option-row/option-row.component";
-import Button from "../../../../src/components/button";
-import Dialog from "../../../../src/components/dialog";
+import React from "react";
+import * as stories from "../../../../src/components/select/filterable-select/filterable-select-test.stories";
 import CypressMountWithProviders from "../../../support/component-helper/cypress-mount";
 
 import {
@@ -49,578 +46,19 @@ import { keyCode, positionOfElement } from "../../../../cypress/support/helper";
 
 import { SIZE, CHARACTERS } from "../../../support/component-helper/constants";
 
-const FilterableSelectComponent = ({ ...props }) => {
-  const [value, setValue] = React.useState("");
-
-  function onChangeHandler(event) {
-    setValue(event.target.value);
-  }
-
-  return (
-    <FilterableSelect
-      label="filterable select"
-      labelInline
-      value={value}
-      onChange={onChangeHandler}
-      {...props}
-    >
-      <Option text="Amber" value="1" />
-      <Option text="Black" value="2" />
-      <Option text="Blue" value="3" />
-      <Option text="Brown" value="4" />
-      <Option text="Green" value="5" />
-      <Option text="Orange" value="6" />
-      <Option text="Pink" value="7" />
-      <Option text="Purple" value="8" />
-      <Option text="Red" value="9" />
-      <Option text="White" value="10" />
-      <Option text="Yellow" value="11" />
-    </FilterableSelect>
-  );
-};
-
-const FilterableSelectWithLazyLoadingComponent = ({ ...props }) => {
-  const preventLoading = React.useRef(false);
-  const [value, setValue] = React.useState("black");
-  const [isLoading, setIsLoading] = React.useState(true);
-  const asyncList = [
-    <Option text="Amber" value="amber" key="Amber" />,
-    <Option text="Black" value="black" key="Black" />,
-    <Option text="Blue" value="blue" key="Blue" />,
-    <Option text="Brown" value="brown" key="Brown" />,
-    <Option text="Green" value="green" key="Green" />,
-  ];
-  const [optionList, setOptionList] = React.useState([
-    <Option text="Black" value="black" key="Black" />,
-  ]);
-
-  function onChangeHandler(event) {
-    setValue(event.target.value);
-  }
-
-  function loadList() {
-    if (preventLoading.current) {
-      return;
-    }
-
-    preventLoading.current = true;
-    setIsLoading(true);
-    setTimeout(() => {
-      setIsLoading(false);
-      setOptionList(asyncList);
-    }, 2000);
-  }
-
-  return (
-    <FilterableSelect
-      label="color"
-      value={value}
-      onChange={onChangeHandler}
-      onOpen={() => loadList()}
-      isLoading={isLoading}
-      {...props}
-    >
-      {optionList}
-    </FilterableSelect>
-  );
-};
-
-const FilterableSelectLazyLoadTwiceComponent = ({ ...props }) => {
-  const preventLoading = React.useRef(false);
-  const [value, setValue] = React.useState("");
-  const [isLoading, setIsLoading] = React.useState(true);
-  const asyncList = [
-    <Option text="Amber" value="amber" key="Amber" />,
-    <Option text="Black" value="black" key="Black" />,
-    <Option text="Blue" value="blue" key="Blue" />,
-    <Option text="Brown" value="brown" key="Brown" />,
-    <Option text="Green" value="green" key="Green" />,
-  ];
-  const [optionList, setOptionList] = React.useState([]);
-
-  function loadList() {
-    if (preventLoading.current) {
-      return;
-    }
-    preventLoading.current = true;
-    setIsLoading(true);
-    setTimeout(() => {
-      setIsLoading(false);
-      setOptionList(asyncList);
-    }, 2000);
-  }
-  function clearData() {
-    setOptionList([]);
-    setValue("");
-    preventLoading.current = false;
-  }
-
-  return (
-    <div>
-      <Button onClick={clearData} mb={2} data-element="reset-button">
-        reset
-      </Button>
-      <FilterableSelect
-        label="color"
-        value={value}
-        onChange={(event) => setValue(event.target.value)}
-        onOpen={() => loadList()}
-        isLoading={isLoading}
-        {...props}
-      >
-        {optionList}
-      </FilterableSelect>
-    </div>
-  );
-};
-
-const FilterableSelectWithInfiniteScrollComponent = ({ ...props }) => {
-  const preventLoading = React.useRef(false);
-  const preventLazyLoading = React.useRef(false);
-  const lazyLoadingCounter = React.useRef(0);
-  const [value, setValue] = React.useState("");
-  const [isLoading, setIsLoading] = React.useState(true);
-  const asyncList = [
-    <Option text="Amber" value="amber" key="Amber" />,
-    <Option text="Black" value="black" key="Black" />,
-    <Option text="Blue" value="blue" key="Blue" />,
-    <Option text="Brown" value="brown" key="Brown" />,
-    <Option text="Green" value="green" key="Green" />,
-  ];
-
-  const getLazyLoaded = () => {
-    const counter = lazyLoadingCounter.current;
-    return [
-      <Option
-        text={`Lazy Loaded A${counter}`}
-        value={`lazyA${counter}`}
-        key={`lazyA${counter}`}
-      />,
-      <Option
-        text={`Lazy Loaded B${counter}`}
-        value={`lazyB${counter}`}
-        key={`lazyB${counter}`}
-      />,
-      <Option
-        text={`Lazy Loaded C${counter}`}
-        value={`lazyC${counter}`}
-        key={`lazyC${counter}`}
-      />,
-    ];
-  };
-
-  const [optionList, setOptionList] = React.useState([]);
-
-  function onChangeHandler(event) {
-    setValue(event.target.value);
-  }
-
-  function loadList() {
-    if (preventLoading.current) {
-      return;
-    }
-
-    preventLoading.current = true;
-    setIsLoading(true);
-    setTimeout(() => {
-      setIsLoading(false);
-      setOptionList(asyncList);
-    }, 2000);
-  }
-
-  function onLazyLoading() {
-    if (preventLazyLoading.current) {
-      return;
-    }
-
-    preventLazyLoading.current = true;
-    setIsLoading(true);
-    setTimeout(() => {
-      preventLazyLoading.current = false;
-      lazyLoadingCounter.current += 1;
-      setIsLoading(false);
-      setOptionList((prevList) => [...prevList, ...getLazyLoaded()]);
-    }, 2000);
-  }
-
-  return (
-    <FilterableSelect
-      label="color"
-      value={value}
-      onChange={onChangeHandler}
-      onOpen={() => loadList()}
-      isLoading={isLoading}
-      onListScrollBottom={onLazyLoading}
-      {...props}
-    >
-      {optionList}
-    </FilterableSelect>
-  );
-};
-
-const FilterableSelectObjectAsValueComponent = ({ ...props }) => {
-  const [value, setValue] = React.useState({
-    id: "Green",
-    value: 5,
-    text: "Green",
-  });
-  const optionList = React.useRef([
-    <Option
-      text="Amber"
-      key="Amber"
-      value={{
-        id: "Amber",
-        value: 1,
-        text: "Amber",
-      }}
-    />,
-    <Option
-      text="Black"
-      key="Black"
-      value={{
-        id: "Black",
-        value: 2,
-        text: "Black",
-      }}
-    />,
-    <Option
-      text="Blue"
-      key="Blue"
-      value={{
-        id: "Blue",
-        value: 3,
-        text: "Blue",
-      }}
-    />,
-    <Option
-      text="Brown"
-      key="Brown"
-      value={{
-        id: "Brown",
-        value: 4,
-        text: "Brown",
-      }}
-    />,
-    <Option
-      text="Green"
-      key="Green"
-      value={{
-        id: "Green",
-        value: 5,
-        text: "Green",
-      }}
-    />,
-    <Option
-      text="Orange"
-      key="Orange"
-      value={{
-        id: "Orange",
-        value: 6,
-        text: "Orange",
-      }}
-    />,
-    <Option
-      text="Pink"
-      key="Pink"
-      value={{
-        id: "Pink",
-        value: 7,
-        text: "Pink",
-      }}
-    />,
-    <Option
-      text="Purple"
-      key="Purple"
-      value={{
-        id: "Purple",
-        value: 8,
-        text: "Purple",
-      }}
-    />,
-    <Option
-      text="Red"
-      key="Red"
-      value={{
-        id: "Red",
-        value: 9,
-        text: "Red",
-      }}
-    />,
-    <Option
-      text="White"
-      key="White"
-      value={{
-        id: "White",
-        value: 10,
-        text: "White",
-      }}
-    />,
-    <Option
-      text="Yellow"
-      key="Yellow"
-      value={{
-        id: "Yellow",
-        value: 11,
-        text: "Yellow",
-      }}
-    />,
-  ]);
-
-  function onChangeHandler(event) {
-    setValue(event.target.value);
-  }
-
-  return (
-    <FilterableSelect value={value} onChange={onChangeHandler} {...props}>
-      {optionList.current}
-    </FilterableSelect>
-  );
-};
-
-const FilterableSelectMultiColumnsComponent = ({ ...props }) => {
-  return (
-    <FilterableSelect
-      multiColumn
-      defaultValue="2"
-      {...props}
-      tableHeader={
-        <tr>
-          <th>Name</th>
-          <th>Surname</th>
-          <th>Occupation</th>
-        </tr>
-      }
-    >
-      <OptionRow value="1" text="John Doe">
-        <td>John</td>
-        <td>Doe</td>
-        <td>Welder</td>
-      </OptionRow>
-      <OptionRow value="2" text="Joe Vick">
-        <td>Joe</td>
-        <td>Vick</td>
-        <td>Accountant</td>
-      </OptionRow>
-      <OptionRow value="3" text="Jane Poe">
-        <td>Jane</td>
-        <td>Poe</td>
-        <td>Accountant</td>
-      </OptionRow>
-      <OptionRow value="4" text="Jill Moe">
-        <td>Jill</td>
-        <td>Moe</td>
-        <td>Engineer</td>
-      </OptionRow>
-      <OptionRow value="5" text="Bill Zoe">
-        <td>Bill</td>
-        <td>Zoe</td>
-        <td>Astronaut</td>
-      </OptionRow>
-    </FilterableSelect>
-  );
-};
-
-const FilterableSelectMultiColumnsNestedComponent = ({ ...props }) => {
-  return (
-    <FilterableSelect
-      multiColumn
-      defaultValue="2"
-      {...props}
-      tableHeader={
-        <tr>
-          <th>Name</th>
-          <th>Surname</th>
-          <th>Occupation</th>
-        </tr>
-      }
-      listActionButton={
-        <Button iconType="add" iconPosition="after">
-          Add a New Element
-        </Button>
-      }
-      onListAction={() => console.log("Action")}
-    >
-      <OptionRow value="1" text="John Doe">
-        <td>John</td>
-        <td>Doe</td>
-        <td>Welder</td>
-      </OptionRow>
-      <OptionRow value="2" text="Joe Vick">
-        <td>Joe</td>
-        <td>Vick</td>
-        <td>Accountant</td>
-      </OptionRow>
-      <OptionRow value="3" text="Jane Poe">
-        <td>Jane</td>
-        <td>Poe</td>
-        <td>Accountant</td>
-      </OptionRow>
-      <OptionRow value="4" text="Jill Moe">
-        <td>Jill</td>
-        <td>Moe</td>
-        <td>Engineer</td>
-      </OptionRow>
-      <OptionRow value="5" text="Bill Zoe">
-        <td>Bill</td>
-        <td>Zoe</td>
-        <td>Astronaut</td>
-      </OptionRow>
-    </FilterableSelect>
-  );
-};
-
-const FilterableSelectWithActionButtonComponent = () => {
-  const [value, setValue] = React.useState("");
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [optionList, setOptionList] = React.useState([
-    <Option text="Amber" value="amber" key="Amber" />,
-    <Option text="Black" value="black" key="Black" />,
-    <Option text="Blue" value="blue" key="Blue" />,
-    <Option text="Brown" value="brown" key="Brown" />,
-    <Option text="Green" value="green" key="Green" />,
-    <Option text="Amber" value="amber1" key="Amber1" />,
-    <Option text="Black" value="black1" key="Black1" />,
-    <Option text="Blue" value="blue1" key="Blue1" />,
-    <Option text="Brown" value="brown1" key="Brown1" />,
-    <Option text="Green" value="green1" key="Green1" />,
-  ]);
-
-  function addNew() {
-    const counter = optionList.length.toString();
-    setOptionList((newOptionList) => [
-      ...newOptionList,
-      <Option
-        text={`New${counter}`}
-        value={`val${counter}`}
-        key={`New${counter}`}
-      />,
-    ]);
-    setIsOpen(false);
-    setValue(`val${counter}`);
-  }
-
-  return (
-    <>
-      <FilterableSelect
-        label="color"
-        value={value}
-        onChange={(event) => setValue(event.target.value)}
-        listActionButton={
-          <Button iconType="add" iconPosition="after">
-            Add a New Element
-          </Button>
-        }
-        onListAction={() => setIsOpen(true)}
-      >
-        {optionList}
-      </FilterableSelect>
-      <Dialog
-        open={isOpen}
-        onCancel={() => setIsOpen(false)}
-        title="Dialog component triggered on action"
-      >
-        <Button onClick={addNew}>Add new</Button>
-      </Dialog>
-    </>
-  );
-};
-
-const FilterableSelectOnChangeEventComponent = ({ onChange, ...props }) => {
-  const [state, setState] = React.useState("");
-
-  const setValue = ({ target }) => {
-    setState(target.value.rawValue);
-    if (onChange) {
-      onChange(target);
-    }
-  };
-
-  return (
-    <FilterableSelect
-      label="color"
-      value={state}
-      labelInline
-      onChange={setValue}
-      {...props}
-    >
-      <Option text="Amber" value="1" />
-      <Option text="Black" value="2" />
-      <Option text="Blue" value="3" />
-      <Option text="Brown" value="4" />
-      <Option text="Green" value="5" />
-    </FilterableSelect>
-  );
-};
-
-const FilterableSelectListActionEventComponent = ({ ...props }) => {
-  const [value, setValue] = React.useState("");
-
-  return (
-    <FilterableSelect
-      label="color"
-      value={value}
-      labelInline
-      onChange={(event) => setValue(event.target.value)}
-      {...props}
-      listActionButton={
-        <Button iconType="add" iconPosition="after">
-          Add a New Element
-        </Button>
-      }
-    >
-      <Option text="Amber" value="1" />
-      <Option text="Black" value="2" />
-      <Option text="Blue" value="3" />
-      <Option text="Brown" value="4" />
-      <Option text="Green" value="5" />
-    </FilterableSelect>
-  );
-};
-
-const FilterableSelectWithManyOptionsAndVirtualScrolling = () => (
-  <FilterableSelect
-    name="virtualised"
-    id="virtualised"
-    label="choose an option"
-    labelInline
-    enableVirtualScroll
-    virtualScrollOverscan={10}
-  >
-    {Array(10000)
-      .fill()
-      .map((_, index) => (
-        <Option key={index} value={`${index}`} text={`Option ${index + 1}.`} />
-      ))}
-  </FilterableSelect>
-);
-
-const FilterableSelectNestedInDialog = () => {
-  const [isOpen, setIsOpen] = useState(true);
-  return (
-    <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
-      <FilterableSelect name="testSelect" id="testSelect">
-        <Option value="opt1" text="red" />
-        <Option value="opt2" text="green" />
-        <Option value="opt3" text="blue" />
-        <Option value="opt4" text="black" />
-      </FilterableSelect>
-    </Dialog>
-  );
-};
-
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testPropValue = CHARACTERS.STANDARD;
 const addElementText = "Add a New Element";
 const columns = 3;
 const icon = "add";
 
-context("Tests for Filterable Select component", () => {
-  describe("check props for Filterable Select component", () => {
+context("Tests for FilterableSelect component", () => {
+  describe("check props for FilterableSelect component", () => {
     it.each(testData)(
-      "should render Filterable Select label using %s special characters",
+      "should render FilterableSelect label using %s special characters",
       (labelValue) => {
         CypressMountWithProviders(
-          <FilterableSelectComponent label={labelValue} />
+          <stories.FilterableSelectComponent label={labelValue} />
         );
 
         getDataElementByValue("label").should("have.text", labelValue);
@@ -631,7 +69,7 @@ context("Tests for Filterable Select component", () => {
       "should render labelHelp message using %s special characters",
       (labelHelpValue) => {
         CypressMountWithProviders(
-          <FilterableSelectComponent labelHelp={labelHelpValue} />
+          <stories.FilterableSelectComponent labelHelp={labelHelpValue} />
         );
 
         helpIcon().trigger("mouseover");
@@ -643,16 +81,16 @@ context("Tests for Filterable Select component", () => {
       "should render placeholder using %s special characters",
       (placeholderValue) => {
         CypressMountWithProviders(
-          <FilterableSelectComponent placeholder={placeholderValue} />
+          <stories.FilterableSelectComponent placeholder={placeholderValue} />
         );
 
         selectInput().should("have.attr", "placeholder", placeholderValue);
       }
     );
 
-    it("should render Filterable Select with name prop set to test value", () => {
+    it("should render FilterableSelect with name prop set to test value", () => {
       CypressMountWithProviders(
-        <FilterableSelectComponent name={testPropValue} />
+        <stories.FilterableSelectComponent name={testPropValue} />
       );
 
       commonDataElementInputPreview().should(
@@ -662,17 +100,17 @@ context("Tests for Filterable Select component", () => {
       );
     });
 
-    it("should render Filterable Select with id prop prop set to test value", () => {
+    it("should render FilterableSelect with id prop prop set to test value", () => {
       CypressMountWithProviders(
-        <FilterableSelectComponent id={testPropValue} />
+        <stories.FilterableSelectComponent id={testPropValue} />
       );
 
       commonDataElementInputPreview().should("have.attr", "id", testPropValue);
     });
 
-    it("should render Filterable Select with data-component prop set to test value", () => {
+    it("should render FilterableSelect with data-component prop set to test value", () => {
       CypressMountWithProviders(
-        <FilterableSelectComponent data-component={testPropValue} />
+        <stories.FilterableSelectComponent data-component={testPropValue} />
       );
 
       selectElementInput()
@@ -681,9 +119,9 @@ context("Tests for Filterable Select component", () => {
         .should("have.attr", "data-component", testPropValue);
     });
 
-    it("should render Filterable Select with data-element prop set to test value", () => {
+    it("should render FilterableSelect with data-element prop set to test value", () => {
       CypressMountWithProviders(
-        <FilterableSelectComponent data-element={testPropValue} />
+        <stories.FilterableSelectComponent data-element={testPropValue} />
       );
 
       selectElementInput()
@@ -692,9 +130,9 @@ context("Tests for Filterable Select component", () => {
         .should("have.attr", "data-element", testPropValue);
     });
 
-    it("should render Filterable Select with data-role prop set to test value", () => {
+    it("should render FilterableSelect with data-role prop set to test value", () => {
       CypressMountWithProviders(
-        <FilterableSelectComponent data-role={testPropValue} />
+        <stories.FilterableSelectComponent data-role={testPropValue} />
       );
 
       selectElementInput()
@@ -712,7 +150,7 @@ context("Tests for Filterable Select component", () => {
       "should render the help tooltip in the %s position",
       (tooltipPositionValue, top, bottom, left, right) => {
         CypressMountWithProviders(
-          <FilterableSelectComponent
+          <stories.FilterableSelectComponent
             labelHelp="Help"
             tooltipPosition={tooltipPositionValue}
             mt={top}
@@ -729,16 +167,16 @@ context("Tests for Filterable Select component", () => {
       }
     );
 
-    it("should check Filterable Select is disabled", () => {
-      CypressMountWithProviders(<FilterableSelectComponent disabled />);
+    it("should check FilterableSelect is disabled", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent disabled />);
 
       commonDataElementInputPreview()
         .should("be.disabled")
         .and("have.attr", "disabled");
     });
 
-    it("should render Filterable Select as read only", () => {
-      CypressMountWithProviders(<FilterableSelectComponent readOnly />);
+    it("should render FilterableSelect as read only", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent readOnly />);
 
       commonDataElementInputPreview().should("have.attr", "readOnly");
       selectInput().click();
@@ -750,9 +188,11 @@ context("Tests for Filterable Select component", () => {
       [SIZE.MEDIUM, 40],
       [SIZE.LARGE, 48],
     ])(
-      "should use %s as size and render Filterable Select with %s as height",
+      "should use %s as size and render FilterableSelect with %s as height",
       (size, height) => {
-        CypressMountWithProviders(<FilterableSelectComponent size={size} />);
+        CypressMountWithProviders(
+          <stories.FilterableSelectComponent size={size} />
+        );
 
         commonDataElementInputPreview()
           .parent()
@@ -762,20 +202,24 @@ context("Tests for Filterable Select component", () => {
       }
     );
 
-    it("should check Filterable Select has autofocus", () => {
-      CypressMountWithProviders(<FilterableSelectComponent autoFocus />);
+    it("should check FilterableSelect has autofocus", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectComponent autoFocus />
+      );
 
       commonDataElementInputPreview().should("be.focused");
     });
 
-    it("should check Filterable Select is required", () => {
-      CypressMountWithProviders(<FilterableSelectComponent required />);
+    it("should check FilterableSelect is required", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent required />);
 
       verifyRequiredAsteriskForLabel();
     });
 
-    it("should check Filterable Select label is inline", () => {
-      CypressMountWithProviders(<FilterableSelectComponent labelInline />);
+    it("should check FilterableSelect label is inline", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectComponent labelInline />
+      );
 
       getDataElementByValue("label")
         .parent()
@@ -787,12 +231,12 @@ context("Tests for Filterable Select component", () => {
       ["flex", "400"],
       ["block", "401"],
     ])(
-      "should check Filterable Select label alignment is %s with adaptiveLabelBreakpoint %s and viewport 400",
+      "should check FilterableSelect label alignment is %s with adaptiveLabelBreakpoint %s and viewport 400",
       (displayValue, breakpoint) => {
         cy.viewport(400, 300);
 
         CypressMountWithProviders(
-          <FilterableSelectComponent
+          <stories.FilterableSelectComponent
             labelInline
             adaptiveLabelBreakpoint={breakpoint}
           />
@@ -812,7 +256,10 @@ context("Tests for Filterable Select component", () => {
       "should use %s as labelAligment and render it with flex-%s as css properties",
       (alignment, cssProp) => {
         CypressMountWithProviders(
-          <FilterableSelectComponent labelInline labelAlign={alignment} />
+          <stories.FilterableSelectComponent
+            labelInline
+            labelAlign={alignment}
+          />
         );
 
         getDataElementByValue("label")
@@ -830,7 +277,7 @@ context("Tests for Filterable Select component", () => {
       "should use %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
       (label, input, labelRatio, inputRatio) => {
         CypressMountWithProviders(
-          <FilterableSelectComponent
+          <stories.FilterableSelectComponent
             labelInline
             labelWidth={label}
             inputWidth={input}
@@ -855,7 +302,7 @@ context("Tests for Filterable Select component", () => {
       "should check maxWidth as %s for FilterableSelect component",
       (maxWidth) => {
         CypressMountWithProviders(
-          <FilterableSelectComponent maxWidth={maxWidth} />
+          <stories.FilterableSelectComponent maxWidth={maxWidth} />
         );
 
         getDataElementByValue("input")
@@ -866,7 +313,9 @@ context("Tests for Filterable Select component", () => {
     );
 
     it("when maxWidth has no value it should render as 100%", () => {
-      CypressMountWithProviders(<FilterableSelectComponent maxWidth="" />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectComponent maxWidth="" />
+      );
 
       getDataElementByValue("input")
         .parent()
@@ -874,8 +323,8 @@ context("Tests for Filterable Select component", () => {
         .should("have.css", "max-width", "100%");
     });
 
-    it("should not open the list with focus on Filterable Select input", () => {
-      CypressMountWithProviders(<FilterableSelectComponent />);
+    it("should not open the list with focus on FilterableSelect input", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
       commonDataElementInputPreview().focus();
       commonDataElementInputPreview()
@@ -884,8 +333,8 @@ context("Tests for Filterable Select component", () => {
       selectListWrapper().should("not.be.visible");
     });
 
-    it("should not open the list with mouse click on Filterable Select input", () => {
-      CypressMountWithProviders(<FilterableSelectComponent />);
+    it("should not open the list with mouse click on FilterableSelect input", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
       commonDataElementInputPreview().click();
       commonDataElementInputPreview()
@@ -895,14 +344,14 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should open the list with mouse click on dropdown button", () => {
-      CypressMountWithProviders(<FilterableSelectComponent />);
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
     });
 
     it("should close the list with mouse click on dropdown button", () => {
-      CypressMountWithProviders(<FilterableSelectComponent />);
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
       dropdownButton().click();
       dropdownButton().click();
@@ -910,7 +359,7 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should close the list with the Tab key", () => {
-      CypressMountWithProviders(<FilterableSelectComponent />);
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
@@ -920,7 +369,7 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should close the list with the Esc key", () => {
-      CypressMountWithProviders(<FilterableSelectComponent />);
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
@@ -930,7 +379,7 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should close the list by clicking out of the component", () => {
-      CypressMountWithProviders(<FilterableSelectComponent />);
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
@@ -946,9 +395,9 @@ context("Tests for Filterable Select component", () => {
       ["open", "End"],
       ["not open", "Enter"],
     ])(
-      "should %s the list when %s is pressed with Filterable Select input in focus",
+      "should %s the list when %s is pressed with FilterableSelect input in focus",
       (state, key) => {
-        CypressMountWithProviders(<FilterableSelectComponent />);
+        CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
         commonDataElementInputPreview().focus();
         selectInput().trigger("keydown", { ...keyCode(key), force: true });
@@ -963,7 +412,7 @@ context("Tests for Filterable Select component", () => {
     it.each([["Amber"], ["Yellow"]])(
       "should select option %s when clicked from the list",
       (option) => {
-        CypressMountWithProviders(<FilterableSelectComponent />);
+        CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
         dropdownButton().click();
         selectListText(option).click();
@@ -979,7 +428,7 @@ context("Tests for Filterable Select component", () => {
     ])(
       "should filter options when %s is typed",
       (text, optionValue1, optionValue2, optionValue3) => {
-        CypressMountWithProviders(<FilterableSelectComponent />);
+        CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
         commonDataElementInputPreview().type(text);
         selectInput().should("have.attr", "aria-expanded", "true");
@@ -1000,7 +449,9 @@ context("Tests for Filterable Select component", () => {
     );
 
     it("should render the lazy loader when the prop is set", () => {
-      CypressMountWithProviders(<FilterableSelectWithLazyLoadingComponent />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectWithLazyLoadingComponent />
+      );
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
@@ -1011,7 +462,9 @@ context("Tests for Filterable Select component", () => {
 
     // FE-5300 raised to fix the issue with the loader not reappeearing
     it.skip("should render the lazy loader when the prop is set and list is opened again", () => {
-      CypressMountWithProviders(<FilterableSelectLazyLoadTwiceComponent />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectLazyLoadTwiceComponent />
+      );
 
       const option = "Amber";
 
@@ -1032,7 +485,7 @@ context("Tests for Filterable Select component", () => {
 
     it("should render a lazy loaded option when the infinite scroll prop is set", () => {
       CypressMountWithProviders(
-        <FilterableSelectWithInfiniteScrollComponent />
+        <stories.FilterableSelectWithInfiniteScrollComponent />
       );
 
       const option = "Lazy Loaded A1";
@@ -1052,7 +505,7 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should list options when value is set and select list is opened again", () => {
-      CypressMountWithProviders(<FilterableSelectComponent />);
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
       const option = "Amber";
       const count = 11;
@@ -1071,7 +524,9 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should check list is open when input is focussed and openOnFocus is set", () => {
-      CypressMountWithProviders(<FilterableSelectComponent openOnFocus />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectComponent openOnFocus />
+      );
 
       commonDataElementInputPreview().focus();
       selectInput().should("have.attr", "aria-expanded", "true");
@@ -1079,7 +534,9 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should check list is open when input is clicked and openOnFocus is set", () => {
-      CypressMountWithProviders(<FilterableSelectComponent openOnFocus />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectComponent openOnFocus />
+      );
 
       commonDataElementInputPreview().click();
       selectInput().should("have.attr", "aria-expanded", "true");
@@ -1087,7 +544,9 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should open correct list and select one when an object is already set as a value", () => {
-      CypressMountWithProviders(<FilterableSelectObjectAsValueComponent />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectObjectAsValueComponent />
+      );
 
       const position = "first";
       const positionValue = "Amber";
@@ -1106,7 +565,7 @@ context("Tests for Filterable Select component", () => {
     it("should render option list with proper maxHeight value", () => {
       const maxHeight = 200;
       CypressMountWithProviders(
-        <FilterableSelectComponent listMaxHeight={maxHeight} />
+        <stories.FilterableSelectComponent listMaxHeight={maxHeight} />
       );
       dropdownButton().click();
       selectListWrapper()
@@ -1123,7 +582,7 @@ context("Tests for Filterable Select component", () => {
       "should flip list to opposite position when there is not enough space to render it in %s position",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
-          <FilterableSelectComponent
+          <stories.FilterableSelectComponent
             listPlacement={position}
             flipEnabled
             mt={top}
@@ -1166,7 +625,7 @@ context("Tests for Filterable Select component", () => {
       "should render list in %s position with the most space when listPosition is not set",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
-          <FilterableSelectComponent
+          <stories.FilterableSelectComponent
             mt={top}
             mb={bottom}
             ml={left}
@@ -1189,7 +648,7 @@ context("Tests for Filterable Select component", () => {
       (state, numberOfChildren) => {
         CypressMountWithProviders(
           <div>
-            <FilterableSelectComponent disablePortal={state} />
+            <stories.FilterableSelectComponent disablePortal={state} />
           </div>
         );
 
@@ -1201,7 +660,9 @@ context("Tests for Filterable Select component", () => {
     );
 
     it("should render list options with multiple columns", () => {
-      CypressMountWithProviders(<FilterableSelectMultiColumnsComponent />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectMultiColumnsComponent />
+      );
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
@@ -1219,7 +680,9 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should check table header content in list with multiple columns", () => {
-      CypressMountWithProviders(<FilterableSelectMultiColumnsComponent />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectMultiColumnsComponent />
+      );
 
       const headerCol1 = "Name";
       const headerCol2 = "Surname";
@@ -1238,7 +701,9 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should indicate a matched filtered string with bold and underline", () => {
-      CypressMountWithProviders(<FilterableSelectMultiColumnsComponent />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectMultiColumnsComponent />
+      );
 
       const text = "Do";
 
@@ -1251,7 +716,9 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should indicate no results match entered string", () => {
-      CypressMountWithProviders(<FilterableSelectMultiColumnsComponent />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectMultiColumnsComponent />
+      );
 
       const text = "Xyz";
 
@@ -1266,7 +733,7 @@ context("Tests for Filterable Select component", () => {
 
     it("should render list options with multiple columns and nested component", () => {
       CypressMountWithProviders(
-        <FilterableSelectMultiColumnsNestedComponent />
+        <stories.FilterableSelectMultiColumnsNestedComponent />
       );
 
       dropdownButton().click();
@@ -1286,7 +753,9 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should render list options with an action button and trigger Dialog on action", () => {
-      CypressMountWithProviders(<FilterableSelectWithActionButtonComponent />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectWithActionButtonComponent />
+      );
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
@@ -1301,7 +770,9 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should render list options with an action button that is visible without scrolling and without affecting the list height", () => {
-      CypressMountWithProviders(<FilterableSelectWithActionButtonComponent />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectWithActionButtonComponent />
+      );
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
@@ -1316,7 +787,9 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("when navigating with the keyboard, the selected option is not hidden behind an action button", () => {
-      CypressMountWithProviders(<FilterableSelectWithActionButtonComponent />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectWithActionButtonComponent />
+      );
 
       dropdownButton().click();
 
@@ -1330,7 +803,9 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should add new list option from Add new Dialog", () => {
-      CypressMountWithProviders(<FilterableSelectWithActionButtonComponent />);
+      CypressMountWithProviders(
+        <stories.FilterableSelectWithActionButtonComponent />
+      );
 
       const newOption = "New10";
 
@@ -1343,7 +818,7 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should have correct hover state of list option", () => {
-      CypressMountWithProviders(<FilterableSelectComponent />);
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
       const optionValue = "Blue";
 
@@ -1352,9 +827,15 @@ context("Tests for Filterable Select component", () => {
         .realHover()
         .should("have.css", "background-color", "rgb(204, 214, 219)");
     });
+
+    it("should have the expected border radius styling", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
+      selectInput().should("have.css", "border-radius", "4px");
+      selectListWrapper().should("have.css", "border-radius", "4px");
+    });
   });
 
-  describe("check events for Filterable Select component", () => {
+  describe("check events for FilterableSelect component", () => {
     let callback;
     beforeEach(() => {
       callback = cy.stub();
@@ -1362,7 +843,7 @@ context("Tests for Filterable Select component", () => {
 
     it("should call onClick event when mouse is clicked on text input", () => {
       CypressMountWithProviders(
-        <FilterableSelectComponent onClick={callback} />
+        <stories.FilterableSelectComponent onClick={callback} />
       );
 
       dropdownButton()
@@ -1373,9 +854,9 @@ context("Tests for Filterable Select component", () => {
         });
     });
 
-    it("should call onFocus when Filterable Select is brought into focus", () => {
+    it("should call onFocus when FilterableSelect is brought into focus", () => {
       CypressMountWithProviders(
-        <FilterableSelectComponent onFocus={callback} />
+        <stories.FilterableSelectComponent onFocus={callback} />
       );
 
       commonDataElementInputPreview()
@@ -1386,9 +867,9 @@ context("Tests for Filterable Select component", () => {
         });
     });
 
-    it("should call onOpen when Filterable Select is opened by focusing the input", () => {
+    it("should call onOpen when FilterableSelect is opened by focusing the input", () => {
       CypressMountWithProviders(
-        <FilterableSelectComponent openOnFocus onOpen={callback} />
+        <stories.FilterableSelectComponent openOnFocus onOpen={callback} />
       );
 
       commonDataElementInputPreview()
@@ -1399,9 +880,9 @@ context("Tests for Filterable Select component", () => {
         });
     });
 
-    it("should call onOpen when Filterable Select is opened by clicking on Icon", () => {
+    it("should call onOpen when FilterableSelect is opened by clicking on Icon", () => {
       CypressMountWithProviders(
-        <FilterableSelectComponent onOpen={callback} />
+        <stories.FilterableSelectComponent onOpen={callback} />
       );
 
       dropdownButton()
@@ -1414,7 +895,7 @@ context("Tests for Filterable Select component", () => {
 
     it("should call onBlur event when the list is closed", () => {
       CypressMountWithProviders(
-        <FilterableSelectComponent onBlur={callback} />
+        <stories.FilterableSelectComponent onBlur={callback} />
       );
 
       dropdownButton().click();
@@ -1428,7 +909,7 @@ context("Tests for Filterable Select component", () => {
 
     it("should call onChange event when a list option is selected", () => {
       CypressMountWithProviders(
-        <FilterableSelectComponent onChange={callback} />
+        <stories.FilterableSelectComponent onChange={callback} />
       );
 
       const position = "first";
@@ -1449,7 +930,7 @@ context("Tests for Filterable Select component", () => {
       "should call onKeyDown event when %s key is pressed",
       (key) => {
         CypressMountWithProviders(
-          <FilterableSelectComponent onKeyDown={callback} />
+          <stories.FilterableSelectComponent onKeyDown={callback} />
         );
 
         commonDataElementInputPreview()
@@ -1464,7 +945,9 @@ context("Tests for Filterable Select component", () => {
 
     it("should call onFilterChange event when a filter string is input", () => {
       CypressMountWithProviders(
-        <FilterableSelectOnChangeEventComponent onFilterChange={callback} />
+        <stories.FilterableSelectOnChangeEventComponent
+          onFilterChange={callback}
+        />
       );
 
       const text = "B";
@@ -1481,7 +964,9 @@ context("Tests for Filterable Select component", () => {
 
     it("should call onListAction event when the Action Button is clicked", () => {
       CypressMountWithProviders(
-        <FilterableSelectListActionEventComponent onListAction={callback} />
+        <stories.FilterableSelectListActionEventComponent
+          onListAction={callback}
+        />
       );
 
       dropdownButton().click();
@@ -1495,7 +980,7 @@ context("Tests for Filterable Select component", () => {
 
     it("should call onListScrollBottom event when the list is scrolled to the bottom", () => {
       CypressMountWithProviders(
-        <FilterableSelectComponent onListScrollBottom={callback} />
+        <stories.FilterableSelectComponent onListScrollBottom={callback} />
       );
 
       dropdownButton().click();
@@ -1512,7 +997,7 @@ context("Tests for Filterable Select component", () => {
   describe("check virtual scrolling", () => {
     it("renders only an appropriate number of options into the DOM when first opened", () => {
       CypressMountWithProviders(
-        <FilterableSelectWithManyOptionsAndVirtualScrolling />
+        <stories.FilterableSelectWithManyOptionsAndVirtualScrolling />
       );
 
       dropdownButton().click();
@@ -1524,7 +1009,7 @@ context("Tests for Filterable Select component", () => {
 
     it("changes the rendered options when you scroll down", () => {
       CypressMountWithProviders(
-        <FilterableSelectWithManyOptionsAndVirtualScrolling />
+        <stories.FilterableSelectWithManyOptionsAndVirtualScrolling />
       );
 
       dropdownButton().click();
@@ -1538,7 +1023,7 @@ context("Tests for Filterable Select component", () => {
 
     it("should filter options when text is typed, taking into account non-rendered options", () => {
       CypressMountWithProviders(
-        <FilterableSelectWithManyOptionsAndVirtualScrolling />
+        <stories.FilterableSelectWithManyOptionsAndVirtualScrolling />
       );
 
       commonDataElementInputPreview().type("Option 100");
@@ -1550,7 +1035,7 @@ context("Tests for Filterable Select component", () => {
 
   describe("when nested inside of a Dialog component", () => {
     it("should not close the Dialog when Select is closed by pressing an escape key", () => {
-      CypressMountWithProviders(<FilterableSelectNestedInDialog />);
+      CypressMountWithProviders(<stories.FilterableSelectNestedInDialog />);
 
       dropdownButton().click();
       commonDataElementInputPreview()
@@ -1568,7 +1053,7 @@ context("Tests for Filterable Select component", () => {
     });
 
     it("should not refocus the select textbox when closing it by clicking outside", () => {
-      CypressMountWithProviders(<FilterableSelectNestedInDialog />);
+      CypressMountWithProviders(<stories.FilterableSelectNestedInDialog />);
 
       dropdownButton().click();
       body().click();
@@ -1578,9 +1063,324 @@ context("Tests for Filterable Select component", () => {
     });
   });
 
-  it("should have the expected border radius styling", () => {
-    CypressMountWithProviders(<FilterableSelectComponent />);
-    selectInput().should("have.css", "border-radius", "4px");
-    selectListWrapper().should("have.css", "border-radius", "4px");
+  describe("Accessibility tests for FilterableSelect component", () => {
+    it("should pass accessibilty tests for FilterableSelect", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it.each(testData)(
+      "should pass accessibilty tests for FilterableSelect label prop using %s special characters",
+      (labelValue) => {
+        CypressMountWithProviders(
+          <stories.FilterableSelectComponent label={labelValue} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should pass accessibilty tests for FilterableSelect labelHelp prop using %s special characters",
+      (labelHelpValue) => {
+        CypressMountWithProviders(
+          <stories.FilterableSelectComponent labelHelp={labelHelpValue} />
+        );
+
+        helpIcon()
+          .trigger("mouseover")
+          .then(() => cy.checkAccessibility());
+      }
+    );
+
+    it.each(testData)(
+      "should pass accessibilty tests for FilterableSelect placeholder prop using %s special characters",
+      (placeholderValue) => {
+        CypressMountWithProviders(
+          <stories.FilterableSelectComponent placeholder={placeholderValue} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      ["top", "200px", "0px", "0px", "0px"],
+      ["bottom", "0px", "0px", "0px", "0px"],
+      ["left", "200px", "0px", "200px", "0px"],
+      ["right", "200px", "0px", "0px", "200px"],
+    ])(
+      "should pass accessibilty tests for FilterableSelect tooltip prop in the %s position",
+      (tooltipPositionValue, top, bottom, left, right) => {
+        CypressMountWithProviders(
+          <stories.FilterableSelectComponent
+            labelHelp="Help"
+            tooltipPosition={tooltipPositionValue}
+            mt={top}
+            mb={bottom}
+            ml={left}
+            mr={right}
+          />
+        );
+
+        helpIcon()
+          .trigger("mouseover")
+          .then(() => cy.checkAccessibility());
+      }
+    );
+
+    it("should pass accessibilty tests for FilterableSelect disabled prop", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent disabled />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for FilterableSelect readOnly prop", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent readOnly />);
+
+      cy.checkAccessibility();
+      selectInput()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it.each([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE])(
+      "should pass accessibilty tests for FilterableSelect size prop",
+      (size) => {
+        CypressMountWithProviders(
+          <stories.FilterableSelectComponent size={size} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibilty tests for FilterableSelect autoFocus prop", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectComponent autoFocus />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for FilterableSelect required prop", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent required />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for FilterableSelect labelInline prop", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectComponent labelInline />
+      );
+
+      cy.checkAccessibility();
+    });
+
+    it.each([
+      ["flex", "399"],
+      ["flex", "400"],
+      ["block", "401"],
+    ])(
+      "should pass accessibilty tests for FilterableSelect adaptiveLabelBreakpoint prop set as %s and viewport 400",
+      (displayValue, breakpoint) => {
+        cy.viewport(400, 300);
+
+        CypressMountWithProviders(
+          <stories.FilterableSelectComponent
+            labelInline
+            adaptiveLabelBreakpoint={breakpoint}
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["right", "left"])(
+      "should pass accessibilty tests for FilterableSelect labelAlign prop set as %s",
+      (alignment) => {
+        CypressMountWithProviders(
+          <stories.FilterableSelectComponent
+            labelInline
+            labelAlign={alignment}
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      ["10", "90"],
+      ["30", "70"],
+      ["80", "20"],
+    ])(
+      "should pass accessibilty tests for FilterableSelect labelWidth prop set as %s and inputWidth set as %s",
+      (label, input) => {
+        CypressMountWithProviders(
+          <stories.FilterableSelectComponent
+            labelInline
+            labelWidth={label}
+            inputWidth={input}
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["10%", "30%", "50%", "80%", "100%"])(
+      "should pass accessibilty tests for FilterableSelect maxWidth prop set as %s",
+      (maxWidth) => {
+        CypressMountWithProviders(
+          <stories.FilterableSelectComponent maxWidth={maxWidth} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibilty tests for FilterableSelect isLoading prop", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectWithLazyLoadingComponent />
+      );
+
+      dropdownButton().click();
+      loader(1).should("be.visible");
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for FilterableSelect onListScrollBottom prop", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectWithInfiniteScrollComponent />
+      );
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+      selectListWrapper()
+        .scrollTo("bottom")
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for FilterableSelect openOnFocus prop", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectComponent openOnFocus />
+      );
+
+      commonDataElementInputPreview()
+        .focus()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for FilterableSelect with object as value", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectObjectAsValueComponent />
+      );
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for FilterableSelect listMaxHeight prop", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectComponent listMaxHeight={200} />
+      );
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it.each([
+      ["top", "0px", "0px", "0px", "20px"],
+      ["bottom", "600px", "0px", "0px", "20px"],
+      ["left", "200px", "0px", "0px", "900px"],
+      ["right", "200px", "0px", "500px", "20px"],
+    ])(
+      "should pass accessibilty tests for FilterableSelect listPlacement and flipEnabled props",
+      (position, top, bottom, left, right) => {
+        CypressMountWithProviders(
+          <stories.FilterableSelectComponent
+            listPlacement={position}
+            flipEnabled
+            mt={top}
+            mb={bottom}
+            ml={left}
+            mr={right}
+          />
+        );
+
+        dropdownButton()
+          .click()
+          .then(() => cy.checkAccessibility());
+      }
+    );
+
+    it("should pass accessibilty tests for FilterableSelect with multiple columns", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectMultiColumnsComponent />
+      );
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for FilterableSelect with multiple columns and nested component", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectMultiColumnsNestedComponent />
+      );
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for FilterableSelect with an action button and trigger Dialog on action", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectWithActionButtonComponent />
+      );
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for FilterableSelect with virtual scrolling", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectWithManyOptionsAndVirtualScrolling />
+      );
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for FilterableSelect in nested dialog", () => {
+      CypressMountWithProviders(<stories.FilterableSelectNestedInDialog />);
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    // FE-5764
+    it.skip("should pass accessibilty tests for FilterableSelect disablePortal prop", () => {
+      CypressMountWithProviders(
+        <div>
+          <stories.FilterableSelectComponent disablePortal />
+        </div>
+      );
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
   });
 });

--- a/cypress/components/select/multi-select/multi-select.test.js
+++ b/cypress/components/select/multi-select/multi-select.test.js
@@ -1,11 +1,6 @@
-import React, { useState } from "react";
-import { MultiSelect, Option } from "../../../../src/components/select";
-import OptionRow from "../../../../src/components/select/option-row/option-row.component";
-import Button from "../../../../src/components/button/button.component";
+import React from "react";
+import * as stories from "../../../../src/components/select/multi-select/multi-select-test.stories";
 import CypressMountWithProviders from "../../../support/component-helper/cypress-mount";
-import Dialog from "../../../../src/components/dialog";
-import Box from "../../../../src/components/box";
-import CarbonProvider from "../../../../src/components/carbon-provider/carbon-provider.component";
 
 import {
   getDataElementByValue,
@@ -52,504 +47,6 @@ import {
 import { positionOfElement } from "../../../../cypress/support/helper";
 import { SIZE, CHARACTERS } from "../../../support/component-helper/constants";
 
-const MultiSelectComponent = ({ ...props }) => {
-  const [value, setValue] = React.useState([]);
-
-  function onChangeHandler(event) {
-    setValue(event.target.value);
-  }
-
-  return (
-    <MultiSelect
-      label="color"
-      labelInline
-      value={value}
-      onChange={onChangeHandler}
-      {...props}
-    >
-      <Option text="Amber" value="1" />
-      <Option text="Black" value="2" />
-      <Option text="Blue" value="3" />
-      <Option text="Brown" value="4" />
-      <Option text="Green" value="5" />
-      <Option text="Orange" value="6" />
-      <Option text="Pink" value="7" />
-      <Option text="Purple" value="8" />
-      <Option text="Red" value="9" />
-      <Option text="White" value="10" />
-      <Option text="Yellow" value="11" />
-    </MultiSelect>
-  );
-};
-
-const MultiSelectDefaultValueComponent = ({ ...props }) => {
-  return (
-    <MultiSelect label="color" labelInline {...props}>
-      <Option text="Amber" value="1" />
-      <Option text="Black" value="2" />
-      <Option text="Blue" value="3" />
-      <Option text="Brown" value="4" />
-      <Option text="Green" value="5" />
-      <Option text="Orange" value="6" />
-      <Option text="Pink" value="7" />
-      <Option text="Purple" value="8" />
-      <Option text="Red" value="9" />
-      <Option text="White" value="10" />
-      <Option text="Yellow" value="11" />
-    </MultiSelect>
-  );
-};
-
-const MultiSelectLongPillComponent = ({ ...props }) => {
-  const [value, setValue] = React.useState([]);
-
-  function onChangeHandler(event) {
-    setValue(event.target.value);
-  }
-
-  return (
-    <div
-      style={{
-        maxWidth: "200px",
-      }}
-    >
-      <MultiSelect
-        label="color"
-        labelInline
-        value={value}
-        onChange={onChangeHandler}
-        {...props}
-      >
-        <Option text="Amber" value="1" />
-        <Option text="Black" value="2" />
-        <Option text="Blue as the sky on a summer's day" value="3" />
-        <Option text="Brown" value="4" />
-        <Option text="Green as the grass in a spring meadow" value="5" />
-        <Option text="Orange" value="6" />
-        <Option text="Pink" value="7" />
-        <Option text="Purple" value="8" />
-        <Option text="Red" value="9" />
-        <Option text="White" value="10" />
-        <Option text="Yellow" value="11" />
-      </MultiSelect>
-    </div>
-  );
-};
-
-const MultiSelectWithLazyLoadingComponent = ({ ...props }) => {
-  const preventLoading = React.useRef(false);
-  const [value, setValue] = React.useState([]);
-  const [isLoading, setIsLoading] = React.useState(true);
-  const asyncList = [
-    <Option text="Amber" value="amber" key="Amber" />,
-    <Option text="Black" value="black" key="Black" />,
-    <Option text="Blue" value="blue" key="Blue" />,
-    <Option text="Brown" value="brown" key="Brown" />,
-    <Option text="Green" value="green" key="Green" />,
-  ];
-  const [optionList, setOptionList] = React.useState([]);
-
-  function onChangeHandler(event) {
-    setValue(event.target.value);
-  }
-
-  function loadList() {
-    if (preventLoading.current) {
-      return;
-    }
-
-    preventLoading.current = true;
-    setIsLoading(true);
-    setTimeout(() => {
-      setIsLoading(false);
-      setOptionList(asyncList);
-    }, 2000);
-  }
-
-  return (
-    <MultiSelect
-      label="color"
-      value={value}
-      onChange={onChangeHandler}
-      onOpen={() => loadList()}
-      isLoading={isLoading}
-      {...props}
-    >
-      {optionList}
-    </MultiSelect>
-  );
-};
-
-const MultiSelectLazyLoadTwiceComponent = ({ ...props }) => {
-  const preventLoading = React.useRef(false);
-  const [value, setValue] = React.useState([]);
-  const [isLoading, setIsLoading] = React.useState(true);
-  const asyncList = [
-    <Option text="Amber" value="amber" key="Amber" />,
-    <Option text="Black" value="black" key="Black" />,
-    <Option text="Blue" value="blue" key="Blue" />,
-    <Option text="Brown" value="brown" key="Brown" />,
-    <Option text="Green" value="green" key="Green" />,
-  ];
-  const [optionList, setOptionList] = React.useState([]);
-
-  function loadList() {
-    if (preventLoading.current) {
-      return;
-    }
-    preventLoading.current = true;
-    setIsLoading(true);
-    setTimeout(() => {
-      setIsLoading(false);
-      setOptionList(asyncList);
-    }, 2000);
-  }
-
-  function clearData() {
-    setOptionList([]);
-    setValue("");
-    preventLoading.current = false;
-  }
-
-  return (
-    <div>
-      <Button onClick={clearData} mb={2} data-element="reset-button">
-        reset
-      </Button>
-      <MultiSelect
-        label="color"
-        value={value}
-        onChange={(event) => setValue(event.target.value)}
-        onOpen={() => loadList()}
-        isLoading={isLoading}
-        {...props}
-      >
-        {optionList}
-      </MultiSelect>
-    </div>
-  );
-};
-
-const MultiSelectObjectAsValueComponent = ({ ...props }) => {
-  const [value, setValue] = React.useState([
-    {
-      id: "Green",
-      value: 5,
-      text: "Green",
-    },
-  ]);
-  const optionList = React.useRef([
-    <Option
-      text="Amber"
-      key="Amber"
-      value={{
-        id: "Amber",
-        value: 1,
-        text: "Amber",
-      }}
-    />,
-    <Option
-      text="Black"
-      key="Black"
-      value={{
-        id: "Black",
-        value: 2,
-        text: "Black",
-      }}
-    />,
-    <Option
-      text="Blue"
-      key="Blue"
-      value={{
-        id: "Blue",
-        value: 3,
-        text: "Blue",
-      }}
-    />,
-    <Option
-      text="Brown"
-      key="Brown"
-      value={{
-        id: "Brown",
-        value: 4,
-        text: "Brown",
-      }}
-    />,
-    <Option
-      text="Green"
-      key="Green"
-      value={{
-        id: "Green",
-        value: 5,
-        text: "Green",
-      }}
-    />,
-    <Option
-      text="Orange"
-      key="Orange"
-      value={{
-        id: "Orange",
-        value: 6,
-        text: "Orange",
-      }}
-    />,
-    <Option
-      text="Pink"
-      key="Pink"
-      value={{
-        id: "Pink",
-        value: 7,
-        text: "Pink",
-      }}
-    />,
-    <Option
-      text="Purple"
-      key="Purple"
-      value={{
-        id: "Purple",
-        value: 8,
-        text: "Purple",
-      }}
-    />,
-    <Option
-      text="Red"
-      key="Red"
-      value={{
-        id: "Red",
-        value: 9,
-        text: "Red",
-      }}
-    />,
-    <Option
-      text="White"
-      key="White"
-      value={{
-        id: "White",
-        value: 10,
-        text: "White",
-      }}
-    />,
-    <Option
-      text="Yellow"
-      key="Yellow"
-      value={{
-        id: "Yellow",
-        value: 11,
-        text: "Yellow",
-      }}
-    />,
-  ]);
-
-  function onChangeHandler(event) {
-    setValue(event.target.value);
-  }
-
-  return (
-    <MultiSelect value={value} onChange={onChangeHandler} {...props}>
-      {optionList.current}
-    </MultiSelect>
-  );
-};
-
-const MultiSelectMultiColumnsComponent = ({ ...props }) => {
-  return (
-    <MultiSelect
-      multiColumn
-      defaultValue={["2"]}
-      {...props}
-      tableHeader={
-        <tr>
-          <th>Name</th>
-          <th>Surname</th>
-          <th>Occupation</th>
-        </tr>
-      }
-    >
-      <OptionRow value="1" text="John Doe">
-        <td>John</td>
-        <td>Doe</td>
-        <td>Welder</td>
-      </OptionRow>
-      <OptionRow value="2" text="Joe Vick">
-        <td>Joe</td>
-        <td>Vick</td>
-        <td>Accountant</td>
-      </OptionRow>
-      <OptionRow value="3" text="Jane Poe">
-        <td>Jane</td>
-        <td>Poe</td>
-        <td>Accountant</td>
-      </OptionRow>
-      <OptionRow value="4" text="Jill Moe">
-        <td>Jill</td>
-        <td>Moe</td>
-        <td>Engineer</td>
-      </OptionRow>
-      <OptionRow value="5" text="Bill Zoe">
-        <td>Bill</td>
-        <td>Zoe</td>
-        <td>Astronaut</td>
-      </OptionRow>
-    </MultiSelect>
-  );
-};
-
-const MultiSelectMaxOptionsComponent = ({ ...props }) => {
-  const maxSelectionsAllowed = 2;
-  const [selectedPills, setSelectedPills] = React.useState([]);
-
-  function onChangeHandler(event) {
-    if (event.target.value.length <= maxSelectionsAllowed) {
-      setSelectedPills(event.target.value);
-    }
-  }
-
-  return (
-    <MultiSelect
-      value={selectedPills}
-      onChange={onChangeHandler}
-      disablePortal
-      openOnFocus
-      label="color"
-      {...props}
-    >
-      <Option text="Amber" value="1" />
-      <Option text="Black" value="2" />
-      <Option text="Blue" value="3" />
-      <Option text="Brown" value="4" />
-      <Option text="Green" value="5" />
-      <Option text="Orange" value="6" />
-      <Option text="Pink" value="7" />
-      <Option text="Purple" value="8" />
-      <Option text="Red" value="9" />
-      <Option text="White" value="10" />
-      <Option text="Yellow" value="11" />
-    </MultiSelect>
-  );
-};
-
-const MultiSelectOnFilterChangeEventComponent = ({ onChange, ...props }) => {
-  const [state, setState] = React.useState("");
-
-  const setValue = ({ target }) => {
-    setState(target.value.rawValue);
-    if (onChange) {
-      onChange(target);
-    }
-  };
-
-  return (
-    <MultiSelect
-      label="color"
-      value={state}
-      labelInline
-      onChange={setValue}
-      {...props}
-    >
-      <Option text="Amber" value="1" />
-      <Option text="Black" value="2" />
-      <Option text="Blue" value="3" />
-      <Option text="Brown" value="4" />
-      <Option text="Green" value="5" />
-    </MultiSelect>
-  );
-};
-
-const MultiSelectCustomColorComponent = ({ ...props }) => {
-  return (
-    <MultiSelect label="color" labelInline defaultValue={["1", "3"]} {...props}>
-      <Option text="Amber" value="1" borderColor="#FFBF00" fill />
-      <Option text="Black" value="2" borderColor="blackOpacity65" fill />
-      <Option text="Blue" value="3" borderColor="productBlue" />
-      <Option text="Brown" value="4" borderColor="brown" fill />
-      <Option text="Green" value="5" borderColor="productGreen" />
-      <Option text="Orange" value="6" borderColor="orange" />
-      <Option text="Pink" value="7" borderColor="pink" />
-      <Option text="Purple" value="8" borderColor="purple" />
-      <Option text="Red" value="9" borderColor="red" fill />
-      <Option text="White" value="10" borderColor="white" />
-      <Option text="Yellow" value="11" borderColor="yellow" fill />
-    </MultiSelect>
-  );
-};
-
-const MultiSelectWithManyOptionsAndVirtualScrolling = () => (
-  <MultiSelect
-    name="virtualised"
-    id="virtualised"
-    label="choose an option"
-    labelInline
-    enableVirtualScroll
-    virtualScrollOverscan={10}
-  >
-    {Array(10000)
-      .fill()
-      .map((_, index) => (
-        <Option key={index} value={`${index}`} text={`Option ${index + 1}.`} />
-      ))}
-  </MultiSelect>
-);
-
-const MultiSelectNestedInDialog = () => {
-  const [isOpen, setIsOpen] = useState(true);
-  return (
-    <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
-      <MultiSelect name="testSelect" id="testSelect">
-        <Option value="opt1" text="red" />
-        <Option value="opt2" text="green" />
-        <Option value="opt3" text="blue" />
-        <Option value="opt4" text="black" />
-      </MultiSelect>
-    </Dialog>
-  );
-};
-
-const MultiSelectErrorOnChangeNewValidation = () => {
-  const [selectedPills, setSelectedPills] = useState([]);
-  const [showError, setShowError] = useState(false);
-
-  const handleOnChange = (event) => {
-    if (event.target.value.length < 3) {
-      setShowError(false);
-      setSelectedPills(event.target.value);
-    } else {
-      setShowError(true);
-    }
-  };
-
-  const handleError = showError ? "Error" : "";
-
-  return (
-    <CarbonProvider validationRedesignOptIn>
-      Open dropdown and try to select more than 2 pills
-      <Box width="300px" ml={10} mt={10}>
-        <MultiSelect
-          name="testing"
-          value={selectedPills}
-          onChange={handleOnChange}
-          disablePortal
-          openOnFocus
-          label="Test"
-          placeholder="FooBar"
-          error={handleError}
-        >
-          <Option text="Amber" value="1" />
-          <Option text="Black" value="2" />
-          <Option text="Blue" value="3" />
-          <Option text="Brown" value="4" />
-          <Option text="Green" value="5" />
-          <Option text="Orange" value="6" />
-          <Option text="Pink" value="7" />
-          <Option text="Purple" value="8" />
-          <Option text="Red" value="9" />
-          <Option text="White" value="10" />
-          <Option text="Yellow" value="11" />
-        </MultiSelect>
-      </Box>
-    </CarbonProvider>
-  );
-};
-
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testPropValue = CHARACTERS.STANDARD;
 const columns = 3;
@@ -558,12 +55,14 @@ const option2 = "Purple";
 const option3 = "Yellow";
 const defaultValue = ["10"];
 
-context("Tests for Multi Select component", () => {
-  describe("check props for Multi Select component", () => {
+context("Tests for MultiSelect component", () => {
+  describe("check props for MultiSelect component", () => {
     it.each(testData)(
-      "should render Multi Select label using %s special characters",
+      "should render MultiSelect label using %s special characters",
       (labelValue) => {
-        CypressMountWithProviders(<MultiSelectComponent label={labelValue} />);
+        CypressMountWithProviders(
+          <stories.MultiSelectComponent label={labelValue} />
+        );
 
         getDataElementByValue("label").should("have.text", labelValue);
       }
@@ -573,7 +72,7 @@ context("Tests for Multi Select component", () => {
       "should render labelHelp message using %s special characters",
       (labelHelpValue) => {
         CypressMountWithProviders(
-          <MultiSelectComponent labelHelp={labelHelpValue} />
+          <stories.MultiSelectComponent labelHelp={labelHelpValue} />
         );
 
         helpIcon().trigger("mouseover");
@@ -585,15 +84,17 @@ context("Tests for Multi Select component", () => {
       "should render placeholder using %s special characters",
       (placeholderValue) => {
         CypressMountWithProviders(
-          <MultiSelectComponent placeholder={placeholderValue} />
+          <stories.MultiSelectComponent placeholder={placeholderValue} />
         );
 
         selectInput().should("have.attr", "placeholder", placeholderValue);
       }
     );
 
-    it("should render Multi Select with name prop set to test value", () => {
-      CypressMountWithProviders(<MultiSelectComponent name={testPropValue} />);
+    it("should render MultiSelect with name prop set to test value", () => {
+      CypressMountWithProviders(
+        <stories.MultiSelectComponent name={testPropValue} />
+      );
 
       commonDataElementInputPreview().should(
         "have.attr",
@@ -602,15 +103,17 @@ context("Tests for Multi Select component", () => {
       );
     });
 
-    it("should render Multi Select with id prop set to test value", () => {
-      CypressMountWithProviders(<MultiSelectComponent id={testPropValue} />);
+    it("should render MultiSelect with id prop set to test value", () => {
+      CypressMountWithProviders(
+        <stories.MultiSelectComponent id={testPropValue} />
+      );
 
       commonDataElementInputPreview().should("have.attr", "id", testPropValue);
     });
 
-    it("should render Multi Select with data-component prop set to test value", () => {
+    it("should render MultiSelect with data-component prop set to test value", () => {
       CypressMountWithProviders(
-        <MultiSelectComponent data-component={testPropValue} />
+        <stories.MultiSelectComponent data-component={testPropValue} />
       );
 
       selectElementInput()
@@ -619,9 +122,9 @@ context("Tests for Multi Select component", () => {
         .should("have.attr", "data-component", testPropValue);
     });
 
-    it("should render Multi Select with data-element prop set to test value", () => {
+    it("should render MultiSelect with data-element prop set to test value", () => {
       CypressMountWithProviders(
-        <MultiSelectComponent data-element={testPropValue} />
+        <stories.MultiSelectComponent data-element={testPropValue} />
       );
 
       selectElementInput()
@@ -630,9 +133,9 @@ context("Tests for Multi Select component", () => {
         .should("have.attr", "data-element", testPropValue);
     });
 
-    it("should render Multi Select with data-role prop set to test value", () => {
+    it("should render MultiSelect with data-role prop set to test value", () => {
       CypressMountWithProviders(
-        <MultiSelectComponent data-role={testPropValue} />
+        <stories.MultiSelectComponent data-role={testPropValue} />
       );
 
       selectElementInput()
@@ -650,7 +153,7 @@ context("Tests for Multi Select component", () => {
       "should render the help tooltip in the %s position",
       (tooltipPositionValue, top, bottom, left, right) => {
         CypressMountWithProviders(
-          <MultiSelectComponent
+          <stories.MultiSelectComponent
             labelHelp="Help"
             tooltipPosition={tooltipPositionValue}
             mt={top}
@@ -667,16 +170,16 @@ context("Tests for Multi Select component", () => {
       }
     );
 
-    it("should check Multi Select is disabled", () => {
-      CypressMountWithProviders(<MultiSelectComponent disabled />);
+    it("should check MultiSelect is disabled", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent disabled />);
 
       commonDataElementInputPreview()
         .should("be.disabled")
         .and("have.attr", "disabled");
     });
 
-    it("should render Multi Select as read only", () => {
-      CypressMountWithProviders(<MultiSelectComponent readOnly />);
+    it("should render MultiSelect as read only", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent readOnly />);
 
       commonDataElementInputPreview().should("have.attr", "readOnly");
       selectInput().click();
@@ -688,9 +191,9 @@ context("Tests for Multi Select component", () => {
       [SIZE.MEDIUM, 40],
       [SIZE.LARGE, 48],
     ])(
-      "should use %s as size and render Multi Select with %s as height",
+      "should use %s as size and render MultiSelect with %s as height",
       (size, height) => {
-        CypressMountWithProviders(<MultiSelectComponent size={size} />);
+        CypressMountWithProviders(<stories.MultiSelectComponent size={size} />);
 
         commonDataElementInputPreview()
           .parent()
@@ -700,20 +203,20 @@ context("Tests for Multi Select component", () => {
       }
     );
 
-    it("should check Multi Select has autofocus", () => {
-      CypressMountWithProviders(<MultiSelectComponent autoFocus />);
+    it("should check MultiSelect has autofocus", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent autoFocus />);
 
       commonDataElementInputPreview().should("be.focused");
     });
 
-    it("should check Multi Select is required", () => {
-      CypressMountWithProviders(<MultiSelectComponent required />);
+    it("should check MultiSelect is required", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent required />);
 
       verifyRequiredAsteriskForLabel();
     });
 
-    it("should check Multi Select label is inline", () => {
-      CypressMountWithProviders(<MultiSelectComponent labelInline />);
+    it("should check MultiSelect label is inline", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent labelInline />);
 
       getDataElementByValue("label")
         .parent()
@@ -725,12 +228,12 @@ context("Tests for Multi Select component", () => {
       ["flex", "400"],
       ["block", "401"],
     ])(
-      "should check Multi Select label alignment is %s with adaptiveLabelBreakpoint %s and viewport 400",
+      "should check MultiSelect label alignment is %s with adaptiveLabelBreakpoint %s and viewport 400",
       (displayValue, breakpoint) => {
         cy.viewport(400, 300);
 
         CypressMountWithProviders(
-          <MultiSelectComponent
+          <stories.MultiSelectComponent
             labelInline
             adaptiveLabelBreakpoint={breakpoint}
           />
@@ -750,7 +253,7 @@ context("Tests for Multi Select component", () => {
       "should use %s as labelAligment and render it with flex-%s as css properties",
       (alignment, cssProp) => {
         CypressMountWithProviders(
-          <MultiSelectComponent labelInline labelAlign={alignment} />
+          <stories.MultiSelectComponent labelInline labelAlign={alignment} />
         );
 
         getDataElementByValue("label")
@@ -768,7 +271,7 @@ context("Tests for Multi Select component", () => {
       "should use %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
       (label, input, labelRatio, inputRatio) => {
         CypressMountWithProviders(
-          <MultiSelectComponent
+          <stories.MultiSelectComponent
             labelInline
             labelWidth={label}
             inputWidth={input}
@@ -792,7 +295,9 @@ context("Tests for Multi Select component", () => {
     it.each(["10%", "30%", "50%", "80%", "100%"])(
       "should check maxWidth as %s for MultiSelect component",
       (maxWidth) => {
-        CypressMountWithProviders(<MultiSelectComponent maxWidth={maxWidth} />);
+        CypressMountWithProviders(
+          <stories.MultiSelectComponent maxWidth={maxWidth} />
+        );
 
         getDataElementByValue("input")
           .parent()
@@ -802,7 +307,7 @@ context("Tests for Multi Select component", () => {
     );
 
     it("when maxWidth has no value it should render as 100%", () => {
-      CypressMountWithProviders(<MultiSelectComponent maxWidth="" />);
+      CypressMountWithProviders(<stories.MultiSelectComponent maxWidth="" />);
 
       getDataElementByValue("input")
         .parent()
@@ -810,8 +315,8 @@ context("Tests for Multi Select component", () => {
         .should("have.css", "max-width", "100%");
     });
 
-    it("should not open the list with focus on Multi Select input", () => {
-      CypressMountWithProviders(<MultiSelectComponent />);
+    it("should not open the list with focus on MultiSelect input", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
 
       commonDataElementInputPreview().focus();
       commonDataElementInputPreview()
@@ -820,8 +325,8 @@ context("Tests for Multi Select component", () => {
       selectListWrapper().should("not.be.visible");
     });
 
-    it("should not open the list with mouse click on Multi Select input", () => {
-      CypressMountWithProviders(<MultiSelectComponent />);
+    it("should not open the list with mouse click on MultiSelect input", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
 
       commonDataElementInputPreview().click();
       commonDataElementInputPreview()
@@ -831,14 +336,14 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should open the list with mouse click on dropdown button", () => {
-      CypressMountWithProviders(<MultiSelectComponent />);
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
     });
 
     it("should close the list with mouse click on dropdown button", () => {
-      CypressMountWithProviders(<MultiSelectComponent />);
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
 
       dropdownButton().click();
       dropdownButton().click();
@@ -846,7 +351,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should close the list with the Tab key", () => {
-      CypressMountWithProviders(<MultiSelectComponent />);
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
@@ -856,7 +361,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should close the list with the Esc key", () => {
-      CypressMountWithProviders(<MultiSelectComponent />);
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
@@ -866,7 +371,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should close the list by clicking out of the component", () => {
-      CypressMountWithProviders(<MultiSelectComponent />);
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
@@ -882,9 +387,9 @@ context("Tests for Multi Select component", () => {
       ["open", "End"],
       ["not open", "Enter"],
     ])(
-      "should %s the list when %s is pressed with Multi Select input in focus",
+      "should %s the list when %s is pressed with MultiSelect input in focus",
       (state, key) => {
-        CypressMountWithProviders(<MultiSelectComponent />);
+        CypressMountWithProviders(<stories.MultiSelectComponent />);
 
         commonDataElementInputPreview().focus();
         selectInput().realPress(key);
@@ -899,7 +404,7 @@ context("Tests for Multi Select component", () => {
     it.each([["Amber"], ["Yellow"]])(
       "should select option %s when clicked from the list and create option pill in the input",
       (option) => {
-        CypressMountWithProviders(<MultiSelectComponent />);
+        CypressMountWithProviders(<stories.MultiSelectComponent />);
 
         dropdownButton().click();
         selectListText(option).click();
@@ -910,7 +415,7 @@ context("Tests for Multi Select component", () => {
     );
 
     it("should select two options and create option pills in the input", () => {
-      CypressMountWithProviders(<MultiSelectComponent />);
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
 
       dropdownButton().click();
       selectListText(option1).click();
@@ -923,7 +428,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should check number of selected options are limited to 2", () => {
-      CypressMountWithProviders(<MultiSelectMaxOptionsComponent />);
+      CypressMountWithProviders(<stories.MultiSelectMaxOptionsComponent />);
 
       const length = 2;
 
@@ -945,7 +450,7 @@ context("Tests for Multi Select component", () => {
     ])(
       "should filter options when %s is typed",
       (text, optionValue1, optionValue2, optionValue3) => {
-        CypressMountWithProviders(<MultiSelectComponent />);
+        CypressMountWithProviders(<stories.MultiSelectComponent />);
 
         commonDataElementInputPreview().type(text);
         selectInput().should("have.attr", "aria-expanded", "true");
@@ -966,7 +471,9 @@ context("Tests for Multi Select component", () => {
     );
 
     it("should render the lazy loader when the prop is set", () => {
-      CypressMountWithProviders(<MultiSelectWithLazyLoadingComponent />);
+      CypressMountWithProviders(
+        <stories.MultiSelectWithLazyLoadingComponent />
+      );
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
@@ -976,7 +483,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should render the lazy loader when the prop is set and list is opened again", () => {
-      CypressMountWithProviders(<MultiSelectLazyLoadTwiceComponent />);
+      CypressMountWithProviders(<stories.MultiSelectLazyLoadTwiceComponent />);
 
       const option = "Amber";
 
@@ -996,7 +503,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should list options when value is set and select list is opened again", () => {
-      CypressMountWithProviders(<MultiSelectComponent />);
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
 
       const option = "Amber";
       const count = 11;
@@ -1015,7 +522,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should check list is open when input is focussed and openOnFocus is set", () => {
-      CypressMountWithProviders(<MultiSelectComponent openOnFocus />);
+      CypressMountWithProviders(<stories.MultiSelectComponent openOnFocus />);
 
       commonDataElementInputPreview().focus();
       selectInput().should("have.attr", "aria-expanded", "true");
@@ -1023,7 +530,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should check list is open when input is clicked and openOnFocus is set", () => {
-      CypressMountWithProviders(<MultiSelectComponent openOnFocus />);
+      CypressMountWithProviders(<stories.MultiSelectComponent openOnFocus />);
 
       commonDataElementInputPreview().click();
       selectInput().should("have.attr", "aria-expanded", "true");
@@ -1031,7 +538,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should open correct list and select one when an object is already set as a value", () => {
-      CypressMountWithProviders(<MultiSelectObjectAsValueComponent />);
+      CypressMountWithProviders(<stories.MultiSelectObjectAsValueComponent />);
 
       multiSelectPill().should("have.attr", "title", option1);
       selectInput().should("have.attr", "aria-expanded", "false");
@@ -1050,7 +557,7 @@ context("Tests for Multi Select component", () => {
       "should flip list to opposite position when there is not enough space to render it in %s position",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
-          <MultiSelectComponent
+          <stories.MultiSelectComponent
             listPlacement={position}
             flipEnabled
             mt={top}
@@ -1093,7 +600,12 @@ context("Tests for Multi Select component", () => {
       "should render list in %s position with the most space when listPosition is not set",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
-          <MultiSelectComponent mt={top} mb={bottom} ml={left} mr={right} />
+          <stories.MultiSelectComponent
+            mt={top}
+            mb={bottom}
+            ml={left}
+            mr={right}
+          />
         );
 
         dropdownButton().click();
@@ -1111,7 +623,7 @@ context("Tests for Multi Select component", () => {
       (state, numberOfChildren) => {
         CypressMountWithProviders(
           <div>
-            <MultiSelectComponent disablePortal={state} />
+            <stories.MultiSelectComponent disablePortal={state} />
           </div>
         );
 
@@ -1123,7 +635,7 @@ context("Tests for Multi Select component", () => {
     );
 
     it("should render list options with multiple columns", () => {
-      CypressMountWithProviders(<MultiSelectMultiColumnsComponent />);
+      CypressMountWithProviders(<stories.MultiSelectMultiColumnsComponent />);
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
@@ -1141,7 +653,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should check table header content in list with multiple columns", () => {
-      CypressMountWithProviders(<MultiSelectMultiColumnsComponent />);
+      CypressMountWithProviders(<stories.MultiSelectMultiColumnsComponent />);
 
       const headerCol1 = "Name";
       const headerCol2 = "Surname";
@@ -1160,7 +672,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should indicate a matched filtered string with bold and underline", () => {
-      CypressMountWithProviders(<MultiSelectMultiColumnsComponent />);
+      CypressMountWithProviders(<stories.MultiSelectMultiColumnsComponent />);
 
       const text = "Do";
 
@@ -1175,7 +687,7 @@ context("Tests for Multi Select component", () => {
     it.each(["Xyz", " "])(
       'should indicate no results match entered string "%s"',
       (text) => {
-        CypressMountWithProviders(<MultiSelectMultiColumnsComponent />);
+        CypressMountWithProviders(<stories.MultiSelectMultiColumnsComponent />);
 
         commonDataElementInputPreview().click().should("be.focused");
         commonDataElementInputPreview().type(text);
@@ -1194,7 +706,7 @@ context("Tests for Multi Select component", () => {
       "should set defaultValue prop to %s and show option pill %s preselected",
       (value, option) => {
         CypressMountWithProviders(
-          <MultiSelectDefaultValueComponent defaultValue={[value]} />
+          <stories.MultiSelectDefaultValueComponent defaultValue={[value]} />
         );
 
         multiSelectPill().should("have.attr", "title", option);
@@ -1202,13 +714,13 @@ context("Tests for Multi Select component", () => {
     );
 
     it("should have no pill option preselected if defaultValue prop is not set", () => {
-      CypressMountWithProviders(<MultiSelectDefaultValueComponent />);
+      CypressMountWithProviders(<stories.MultiSelectDefaultValueComponent />);
 
       multiSelectPill().should("not.exist");
     });
 
-    it("should render Multi Select with custom coloured pills", () => {
-      CypressMountWithProviders(<MultiSelectCustomColorComponent />);
+    it("should render MultiSelect with custom coloured pills", () => {
+      CypressMountWithProviders(<stories.MultiSelectCustomColorComponent />);
 
       multiSelectPillByPosition(0)
         .should("have.css", "borderColor", "rgb(255, 191, 0)")
@@ -1225,7 +737,7 @@ context("Tests for Multi Select component", () => {
       "should select %s list option and show pill with complete long text wrapped in the input",
       (option, text) => {
         CypressMountWithProviders(
-          <MultiSelectLongPillComponent wrapPillText />
+          <stories.MultiSelectLongPillComponent wrapPillText />
         );
 
         dropdownButton().click();
@@ -1236,7 +748,7 @@ context("Tests for Multi Select component", () => {
 
     it("should show selected pill option with correctly formatted delete button when focussed", () => {
       CypressMountWithProviders(
-        <MultiSelectDefaultValueComponent defaultValue={defaultValue} />
+        <stories.MultiSelectDefaultValueComponent defaultValue={defaultValue} />
       );
 
       multiSelectPill().should("have.attr", "title", "White");
@@ -1248,7 +760,7 @@ context("Tests for Multi Select component", () => {
 
     it("should delete pill option with delete button", () => {
       CypressMountWithProviders(
-        <MultiSelectDefaultValueComponent defaultValue={defaultValue} />
+        <stories.MultiSelectDefaultValueComponent defaultValue={defaultValue} />
       );
 
       multiSelectPill().should("have.attr", "title", "White");
@@ -1258,7 +770,7 @@ context("Tests for Multi Select component", () => {
 
     it("should delete pill option with backspace key", () => {
       CypressMountWithProviders(
-        <MultiSelectDefaultValueComponent defaultValue={defaultValue} />
+        <stories.MultiSelectDefaultValueComponent defaultValue={defaultValue} />
       );
 
       multiSelectPill().should("have.attr", "title", "White");
@@ -1267,7 +779,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should delete all selected pill options and leave list open", () => {
-      CypressMountWithProviders(<MultiSelectComponent />);
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
 
       dropdownButton().click();
       selectListText(option1).click();
@@ -1283,23 +795,31 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should have correct hover state of list option", () => {
-      CypressMountWithProviders(<MultiSelectComponent />);
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
 
       dropdownButton().click();
       selectListText(option1)
         .realHover()
         .should("have.css", "background-color", "rgb(204, 214, 219)");
     });
+
+    it("should have the expected border radius styling", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
+      selectInput().should("have.css", "border-radius", "4px");
+      selectListWrapper().should("have.css", "border-radius", "4px");
+    });
   });
 
-  describe("check events for Multi Select component", () => {
+  describe("check events for MultiSelect component", () => {
     let callback;
     beforeEach(() => {
       callback = cy.stub();
     });
 
     it("should call onClick event when mouse is clicked on text input", () => {
-      CypressMountWithProviders(<MultiSelectComponent onClick={callback} />);
+      CypressMountWithProviders(
+        <stories.MultiSelectComponent onClick={callback} />
+      );
 
       commonDataElementInputPreview()
         .click()
@@ -1309,8 +829,10 @@ context("Tests for Multi Select component", () => {
         });
     });
 
-    it("should call onFocus when Multi Select is brought into focus", () => {
-      CypressMountWithProviders(<MultiSelectComponent onFocus={callback} />);
+    it("should call onFocus when MultiSelect is brought into focus", () => {
+      CypressMountWithProviders(
+        <stories.MultiSelectComponent onFocus={callback} />
+      );
 
       commonDataElementInputPreview()
         .focus()
@@ -1320,8 +842,10 @@ context("Tests for Multi Select component", () => {
         });
     });
 
-    it("should call onOpen when Multi Select is opened", () => {
-      CypressMountWithProviders(<MultiSelectComponent onOpen={callback} />);
+    it("should call onOpen when MultiSelect is opened", () => {
+      CypressMountWithProviders(
+        <stories.MultiSelectComponent onOpen={callback} />
+      );
 
       dropdownButton()
         .click()
@@ -1332,7 +856,9 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should call onBlur event when the list is closed", () => {
-      CypressMountWithProviders(<MultiSelectComponent onBlur={callback} />);
+      CypressMountWithProviders(
+        <stories.MultiSelectComponent onBlur={callback} />
+      );
 
       dropdownButton().click();
       selectInput()
@@ -1344,7 +870,9 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should call onChange event once when a list option is selected", () => {
-      CypressMountWithProviders(<MultiSelectComponent onChange={callback} />);
+      CypressMountWithProviders(
+        <stories.MultiSelectComponent onChange={callback} />
+      );
 
       const position = "first";
       const option = ["1"];
@@ -1364,7 +892,7 @@ context("Tests for Multi Select component", () => {
       "should call onKeyDown event when %s key is pressed",
       (key) => {
         CypressMountWithProviders(
-          <MultiSelectComponent onKeyDown={callback} />
+          <stories.MultiSelectComponent onKeyDown={callback} />
         );
 
         commonDataElementInputPreview()
@@ -1379,7 +907,9 @@ context("Tests for Multi Select component", () => {
 
     it("should call onFilterChange event when a filter string is input", () => {
       CypressMountWithProviders(
-        <MultiSelectOnFilterChangeEventComponent onFilterChange={callback} />
+        <stories.MultiSelectOnFilterChangeEventComponent
+          onFilterChange={callback}
+        />
       );
 
       const text = "B";
@@ -1398,7 +928,7 @@ context("Tests for Multi Select component", () => {
   describe("check virtual scrolling", () => {
     it("renders only an appropriate number of options into the DOM when first opened", () => {
       CypressMountWithProviders(
-        <MultiSelectWithManyOptionsAndVirtualScrolling />
+        <stories.MultiSelectWithManyOptionsAndVirtualScrolling />
       );
 
       dropdownButton().click();
@@ -1410,7 +940,7 @@ context("Tests for Multi Select component", () => {
 
     it("changes the rendered options when you scroll down", () => {
       CypressMountWithProviders(
-        <MultiSelectWithManyOptionsAndVirtualScrolling />
+        <stories.MultiSelectWithManyOptionsAndVirtualScrolling />
       );
 
       dropdownButton().click();
@@ -1424,7 +954,7 @@ context("Tests for Multi Select component", () => {
 
     it("should filter options when text is typed, taking into account non-rendered options", () => {
       CypressMountWithProviders(
-        <MultiSelectWithManyOptionsAndVirtualScrolling />
+        <stories.MultiSelectWithManyOptionsAndVirtualScrolling />
       );
 
       commonDataElementInputPreview().type("Option 100");
@@ -1436,7 +966,7 @@ context("Tests for Multi Select component", () => {
 
   describe("when nested inside of a Dialog component", () => {
     it("should not close the Dialog when Select is closed by pressing an escape key", () => {
-      CypressMountWithProviders(<MultiSelectNestedInDialog />);
+      CypressMountWithProviders(<stories.MultiSelectNestedInDialog />);
 
       dropdownButton().click();
       commonDataElementInputPreview()
@@ -1454,7 +984,7 @@ context("Tests for Multi Select component", () => {
     });
 
     it("should not refocus the select textbox when closing it by clicking outside", () => {
-      CypressMountWithProviders(<MultiSelectNestedInDialog />);
+      CypressMountWithProviders(<stories.MultiSelectNestedInDialog />);
 
       dropdownButton().click();
       body().click();
@@ -1466,7 +996,9 @@ context("Tests for Multi Select component", () => {
 
   describe("When error is triggered by onChange", () => {
     it("should display correctly", () => {
-      CypressMountWithProviders(<MultiSelectErrorOnChangeNewValidation />);
+      CypressMountWithProviders(
+        <stories.MultiSelectErrorOnChangeNewValidation />
+      );
 
       dropdownButton().click();
       selectListText(option1).click();
@@ -1480,9 +1012,312 @@ context("Tests for Multi Select component", () => {
     });
   });
 
-  it("should have the expected border radius styling", () => {
-    CypressMountWithProviders(<MultiSelectComponent />);
-    selectInput().should("have.css", "border-radius", "4px");
-    selectListWrapper().should("have.css", "border-radius", "4px");
+  describe("Accessibility tests for MultiSelect component", () => {
+    it("should pass accessibilty tests for MultiSelect", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it.each(testData)(
+      "should pass accessibilty tests for MultiSelect label prop using %s special characters",
+      (labelValue) => {
+        CypressMountWithProviders(
+          <stories.MultiSelectComponent label={labelValue} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should pass accessibilty tests for MultiSelect labelHelp prop using %s special characters",
+      (labelHelpValue) => {
+        CypressMountWithProviders(
+          <stories.MultiSelectComponent labelHelp={labelHelpValue} />
+        );
+
+        helpIcon()
+          .trigger("mouseover")
+          .then(() => cy.checkAccessibility());
+      }
+    );
+
+    it.each(testData)(
+      "should pass accessibilty tests for MultiSelect placeholder prop using %s special characters",
+      (placeholderValue) => {
+        CypressMountWithProviders(
+          <stories.MultiSelectComponent placeholder={placeholderValue} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      ["top", "200px", "0px", "0px", "0px"],
+      ["bottom", "0px", "0px", "0px", "0px"],
+      ["left", "200px", "0px", "200px", "0px"],
+      ["right", "200px", "0px", "0px", "200px"],
+    ])(
+      "should pass accessibilty tests for MultiSelect tooltip prop in the %s position",
+      (tooltipPositionValue, top, bottom, left, right) => {
+        CypressMountWithProviders(
+          <stories.MultiSelectComponent
+            labelHelp="Help"
+            tooltipPosition={tooltipPositionValue}
+            mt={top}
+            mb={bottom}
+            ml={left}
+            mr={right}
+          />
+        );
+
+        helpIcon()
+          .trigger("mouseover")
+          .then(() => cy.checkAccessibility());
+      }
+    );
+
+    it("should pass accessibilty tests for MultiSelect disabled prop", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent disabled />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for MultiSelect readOnly prop", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent readOnly />);
+
+      cy.checkAccessibility();
+      selectInput()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it.each([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE])(
+      "should pass accessibilty tests for MultiSelect size prop",
+      (size) => {
+        CypressMountWithProviders(<stories.MultiSelectComponent size={size} />);
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibilty tests for MultiSelect autoFocus prop", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent autoFocus />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for MultiSelect required prop", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent required />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for MultiSelect labelInline prop", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent labelInline />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each([
+      ["flex", "399"],
+      ["flex", "400"],
+      ["block", "401"],
+    ])(
+      "should pass accessibilty tests for MultiSelect adaptiveLabelBreakpoint prop set as %s and viewport 400",
+      (displayValue, breakpoint) => {
+        cy.viewport(400, 300);
+
+        CypressMountWithProviders(
+          <stories.MultiSelectComponent
+            labelInline
+            adaptiveLabelBreakpoint={breakpoint}
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["right", "left"])(
+      "should pass accessibilty tests for MultiSelect labelAlign prop set as %s",
+      (alignment) => {
+        CypressMountWithProviders(
+          <stories.MultiSelectComponent labelInline labelAlign={alignment} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      ["10", "90"],
+      ["30", "70"],
+      ["80", "20"],
+    ])(
+      "should pass accessibilty tests for MultiSelect labelWidth prop set as %s and inputWidth set as %s",
+      (label, input) => {
+        CypressMountWithProviders(
+          <stories.MultiSelectComponent
+            labelInline
+            labelWidth={label}
+            inputWidth={input}
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["10%", "30%", "50%", "80%", "100%"])(
+      "should pass accessibilty tests for MultiSelect maxWidth prop set as %s",
+      (maxWidth) => {
+        CypressMountWithProviders(
+          <stories.MultiSelectComponent maxWidth={maxWidth} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibilty tests for MultiSelect isLoading prop", () => {
+      CypressMountWithProviders(
+        <stories.MultiSelectWithLazyLoadingComponent />
+      );
+
+      dropdownButton().click();
+      loader(1).should("be.visible");
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for MultiSelect openOnFocus prop", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent openOnFocus />);
+
+      commonDataElementInputPreview()
+        .focus()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for MultiSelect with object as value", () => {
+      CypressMountWithProviders(<stories.MultiSelectObjectAsValueComponent />);
+
+      dropdownButton().click();
+      selectListText(option2)
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it.each([
+      ["top", "0px", "0px", "0px", "20px"],
+      ["bottom", "600px", "0px", "0px", "20px"],
+      ["left", "200px", "0px", "0px", "900px"],
+      ["right", "200px", "0px", "500px", "20px"],
+    ])(
+      "should pass accessibilty tests for MultiSelect listPlacement and flipEnabled props",
+      (position, top, bottom, left, right) => {
+        CypressMountWithProviders(
+          <stories.MultiSelectComponent
+            listPlacement={position}
+            flipEnabled
+            mt={top}
+            mb={bottom}
+            ml={left}
+            mr={right}
+          />
+        );
+
+        dropdownButton()
+          .click()
+          .then(() => cy.checkAccessibility());
+      }
+    );
+
+    // FE-5764
+    it.skip("should pass accessibilty tests for MultiSelect disablePortal prop", () => {
+      CypressMountWithProviders(
+        <div>
+          <stories.MultiSelectComponent disablePortal />
+        </div>
+      );
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for MultiSelect with multiple columns", () => {
+      CypressMountWithProviders(<stories.MultiSelectMultiColumnsComponent />);
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it.each(["3", "7"])(
+      "should pass accessibilty tests for MultiSelect defaultValue prop",
+      (value) => {
+        CypressMountWithProviders(
+          <stories.MultiSelectDefaultValueComponent defaultValue={[value]} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibilty tests for MultiSelect with custom coloured pills", () => {
+      CypressMountWithProviders(<stories.MultiSelectCustomColorComponent />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each(["third", "fifth"])(
+      "should pass accessibilty tests for MultiSelect wrapPillText prop",
+      (option) => {
+        CypressMountWithProviders(
+          <stories.MultiSelectLongPillComponent wrapPillText />
+        );
+
+        dropdownButton().click();
+        selectOption(positionOfElement(option))
+          .click()
+          .then(() => cy.checkAccessibility());
+      }
+    );
+
+    it("should pass accessibilty tests for MultiSelect with virtual scrolling", () => {
+      CypressMountWithProviders(
+        <stories.MultiSelectWithManyOptionsAndVirtualScrolling />
+      );
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for MultiSelect in nested dialog", () => {
+      CypressMountWithProviders(<stories.MultiSelectNestedInDialog />);
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    // FE-5764
+    it.skip("should pass accessibilty tests for MultiSelect When error is triggered by onChange", () => {
+      CypressMountWithProviders(
+        <stories.MultiSelectErrorOnChangeNewValidation />
+      );
+
+      dropdownButton().click();
+      selectListText(option1).click();
+      selectListText(option2).click();
+      selectListText(option3).click();
+
+      cy.checkAccessibility();
+    });
   });
 });

--- a/cypress/components/select/simple-select/simple-select.test.js
+++ b/cypress/components/select/simple-select/simple-select.test.js
@@ -1,11 +1,6 @@
-import React, { useState } from "react";
-import { Select as SimpleSelect, Option } from "../../../../src/components/select";
-import OptionRow from "../../../../src/components/select/option-row/option-row.component";
-import OptionGroupHeader from "../../../../src/components/select/option-group-header/option-group-header.component";
-import Icon from "../../../../src/components/icon";
-import Box from "../../../../src/components/box";
+import React from "react";
+import * as stories from "../../../../src/components/select/simple-select/simple-select-test.stories";
 import CypressMountWithProviders from "../../../support/component-helper/cypress-mount";
-import Dialog from "../../../../src/components/dialog";
 
 import {
   getDataElementByValue,
@@ -50,470 +45,14 @@ import { SIZE, CHARACTERS } from "../../../support/component-helper/constants";
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testPropValue = CHARACTERS.STANDARD;
 
-const SimpleSelectComponent = ({ ...props }) => {
-  const [value, setValue] = React.useState("");
-
-  function onChangeHandler(event) {
-    setValue(event.target.value);
-  }
-
-  return (
-    <SimpleSelect
-      label="simple select"
-      labelInline
-      value={value}
-      onChange={onChangeHandler}
-      {...props}
-    >
-      <Option text="Amber" value="1" />
-      <Option text="Black" value="2" />
-      <Option text="Blue" value="3" />
-      <Option text="Brown" value="4" />
-      <Option text="Green" value="5" />
-      <Option text="Orange" value="6" />
-      <Option text="Pink" value="7" />
-      <Option
-        text="Like a lot of intelligent animals, most crows are quite social. For instance, American crows spend most of the year living in pairs or small family groups. During the winter months, they will congregate with hundreds or even thousands of their peers to sleep together at night"
-        value="8"
-      />
-      <Option text="Red" value="9" />
-      <Option text="White" value="10" />
-      <Option text="Yellow" value="11" />
-    </SimpleSelect>
-  );
-};
-
-const SimpleSelectWithLazyLoadingComponent = ({ ...props }) => {
-  const preventLoading = React.useRef(false);
-  const [value, setValue] = React.useState("black");
-  const [isLoading, setIsLoading] = React.useState(true);
-  const asyncList = [
-    <Option text="Amber" value="amber" key="Amber" />,
-    <Option text="Black" value="black" key="Black" />,
-    <Option text="Blue" value="blue" key="Blue" />,
-    <Option text="Brown" value="brown" key="Brown" />,
-    <Option text="Green" value="green" key="Green" />,
-  ];
-  const [optionList, setOptionList] = React.useState([
-    <Option text="Black" value="black" key="Black" />,
-  ]);
-
-  function onChangeHandler(event) {
-    setValue(event.target.value);
-  }
-
-  function loadList() {
-    if (preventLoading.current) {
-      return;
-    }
-
-    preventLoading.current = true;
-    setIsLoading(true);
-    setTimeout(() => {
-      setIsLoading(false);
-      setOptionList(asyncList);
-    }, 2000);
-  }
-
-  return (
-    <SimpleSelect
-      name="isLoading"
-      id="isLoading"
-      label="color"
-      value={value}
-      onChange={onChangeHandler}
-      onOpen={() => loadList()}
-      isLoading={isLoading}
-      {...props}
-    >
-      {optionList}
-    </SimpleSelect>
-  );
-};
-
-const SimpleSelectWithInfiniteScrollComponent = ({ ...props }) => {
-  const preventLoading = React.useRef(false);
-  const preventLazyLoading = React.useRef(false);
-  const lazyLoadingCounter = React.useRef(0);
-  const [value, setValue] = React.useState("");
-  const [isLoading, setIsLoading] = React.useState(true);
-  const asyncList = [
-    <Option text="Amber" value="amber" key="Amber" />,
-    <Option text="Black" value="black" key="Black" />,
-    <Option text="Blue" value="blue" key="Blue" />,
-    <Option text="Brown" value="brown" key="Brown" />,
-    <Option text="Green" value="green" key="Green" />,
-  ];
-
-  const getLazyLoaded = () => {
-    const counter = lazyLoadingCounter.current;
-    return [
-      <Option
-        text={`Lazy Loaded A${counter}`}
-        value={`lazyA${counter}`}
-        key={`lazyA${counter}`}
-      />,
-      <Option
-        text={`Lazy Loaded B${counter}`}
-        value={`lazyB${counter}`}
-        key={`lazyB${counter}`}
-      />,
-      <Option
-        text={`Lazy Loaded C${counter}`}
-        value={`lazyC${counter}`}
-        key={`lazyC${counter}`}
-      />,
-    ];
-  };
-
-  const [optionList, setOptionList] = React.useState([]);
-
-  function onChangeHandler(event) {
-    setValue(event.target.value);
-  }
-
-  function loadList() {
-    if (preventLoading.current) {
-      return;
-    }
-
-    preventLoading.current = true;
-    setIsLoading(true);
-    setTimeout(() => {
-      setIsLoading(false);
-      setOptionList(asyncList);
-    }, 2000);
-  }
-
-  function onLazyLoading() {
-    if (preventLazyLoading.current) {
-      return;
-    }
-
-    preventLazyLoading.current = true;
-    setIsLoading(true);
-    setTimeout(() => {
-      preventLazyLoading.current = false;
-      lazyLoadingCounter.current += 1;
-      setIsLoading(false);
-      setOptionList((prevList) => [...prevList, ...getLazyLoaded()]);
-    }, 2000);
-  }
-
-  return (
-    <SimpleSelect
-      name="infiniteScroll"
-      id="infiniteScroll"
-      label="color"
-      value={value}
-      onChange={onChangeHandler}
-      onOpen={() => loadList()}
-      isLoading={isLoading}
-      onListScrollBottom={onLazyLoading}
-      {...props}
-    >
-      {optionList}
-    </SimpleSelect>
-  );
-};
-
-const SimpleSelectObjectAsValueComponent = ({ ...props }) => {
-  const [value, setValue] = React.useState({
-    id: "Green",
-    value: 5,
-    text: "Green",
-  });
-  const optionList = React.useRef([
-    <Option
-      text="Amber"
-      key="Amber"
-      value={{
-        id: "Amber",
-        value: 1,
-        text: "Amber",
-      }}
-    />,
-    <Option
-      text="Black"
-      key="Black"
-      value={{
-        id: "Black",
-        value: 2,
-        text: "Black",
-      }}
-    />,
-    <Option
-      text="Blue"
-      key="Blue"
-      value={{
-        id: "Blue",
-        value: 3,
-        text: "Blue",
-      }}
-    />,
-    <Option
-      text="Brown"
-      key="Brown"
-      value={{
-        id: "Brown",
-        value: 4,
-        text: "Brown",
-      }}
-    />,
-    <Option
-      text="Green"
-      key="Green"
-      value={{
-        id: "Green",
-        value: 5,
-        text: "Green",
-      }}
-    />,
-    <Option
-      text="Orange"
-      key="Orange"
-      value={{
-        id: "Orange",
-        value: 6,
-        text: "Orange",
-      }}
-    />,
-    <Option
-      text="Pink"
-      key="Pink"
-      value={{
-        id: "Pink",
-        value: 7,
-        text: "Pink",
-      }}
-    />,
-    <Option
-      text="Purple"
-      key="Purple"
-      value={{
-        id: "Purple",
-        value: 8,
-        text: "Purple",
-      }}
-    />,
-    <Option
-      text="Red"
-      key="Red"
-      value={{
-        id: "Red",
-        value: 9,
-        text: "Red",
-      }}
-    />,
-    <Option
-      text="White"
-      key="White"
-      value={{
-        id: "White",
-        value: 10,
-        text: "White",
-      }}
-    />,
-    <Option
-      text="Yellow"
-      key="Yellow"
-      value={{
-        id: "Yellow",
-        value: 11,
-        text: "Yellow",
-      }}
-    />,
-  ]);
-
-  function onChangeHandler(event) {
-    setValue(event.target.value);
-  }
-
-  return (
-    <SimpleSelect
-      id="withObject"
-      name="withObject"
-      value={value}
-      onChange={onChangeHandler}
-      {...props}
-    >
-      {optionList.current}
-    </SimpleSelect>
-  );
-};
-
-const SimpleSelectMultipleColumnsComponent = ({ ...props }) => {
-  return (
-    <SimpleSelect
-      name="withMultipleColumns"
-      id="withMultipleColumns"
-      multiColumn
-      defaultValue="2"
-      {...props}
-      tableHeader={
-        <tr>
-          <th>Name</th>
-          <th>Surname</th>
-          <th>Occupation</th>
-        </tr>
-      }
-    >
-      <OptionRow value="1" text="John Doe">
-        <td>John</td>
-        <td>Doe</td>
-        <td>Welder</td>
-      </OptionRow>
-      <OptionRow value="2" text="Joe Vick">
-        <td>Joe</td>
-        <td>Vick</td>
-        <td>Accountant</td>
-      </OptionRow>
-      <OptionRow value="3" text="Jane Poe">
-        <td>Jane</td>
-        <td>Poe</td>
-        <td>Accountant</td>
-      </OptionRow>
-      <OptionRow value="4" text="Jill Moe">
-        <td>Jill</td>
-        <td>Moe</td>
-        <td>Engineer</td>
-      </OptionRow>
-      <OptionRow value="5" text="Bill Zoe">
-        <td>Bill</td>
-        <td>Zoe</td>
-        <td>Astronaut</td>
-      </OptionRow>
-    </SimpleSelect>
-  );
-};
-
-const SimpleSelectCustomOptionChildrenComponent = ({ ...props }) => {
-  return (
-    <SimpleSelect
-      name="customOptionChildren"
-      id="customOptionChildren"
-      defaultValue="4"
-      disablePortal
-      label="Pick your favourite color"
-      {...props}
-    >
-      <Option text="Orange" value="1">
-        <Icon type="favourite" color="orange" mr={1} /> Orange
-      </Option>
-      <Option text="Black" value="2">
-        <Icon type="money_bag" color="black" mr={1} /> Black
-      </Option>
-      <Option text="Blue" value="3">
-        <Icon type="gift" color="blue" mr={1} /> Blue
-      </Option>
-    </SimpleSelect>
-  );
-};
-
-const SimpleSelectGroupComponent = ({ ...props }) => {
-  return (
-    <SimpleSelect name="optGroups" id="optGroups" {...props}>
-      <OptionGroupHeader label="Group one" icon="individual" />
-      <Option text="Amber" value="1" />
-      <Option text="Black" value="2" />
-      <Option text="Blue" value="3" />
-      <Option text="Brown" value="4" />
-      <OptionGroupHeader label="Group two" icon="shop" />
-      <Option text="Green" value="5" />
-      <Option text="Orange" value="6" />
-      <Option text="Pink" value="7" />
-      <OptionGroupHeader label="Group three" />
-      <Option text="Purple" value="8" />
-      <Option text="Red" value="9" />
-      <Option text="White" value="10" />
-      <Option text="Yellow" value="11" />
-    </SimpleSelect>
-  );
-};
-
-const SimpleSelectEventsComponent = ({ onChange, ...props }) => {
-  const [state, setState] = React.useState("");
-
-  const setValue = ({ target }) => {
-    setState(target.value.rawValue);
-    if (onChange) {
-      onChange(target);
-    }
-  };
-
-  return (
-    <SimpleSelect
-      label="color"
-      value={state}
-      labelInline
-      onChange={setValue}
-      {...props}
-    >
-      <Option text="Amber" value="1" />
-      <Option text="Black" value="2" />
-      <Option text="Blue" value="3" />
-      <Option text="Brown" value="4" />
-      <Option text="Green" value="5" />
-      <Option text="Orange" value="6" />
-      <Option text="Pink" value="7" />
-      <Option text="Purple" value="8" />
-      <Option text="Red" value="9" />
-      <Option text="White" value="10" />
-      <Option text="Yellow" value="11" />
-    </SimpleSelect>
-  );
-};
-
-const SimpleSelectWithLongWrappingTextComponent = () => (
-  <Box width={400}>
-    <SimpleSelect name="simple" id="simple" label="label" labelInline>
-      <Option
-        text="Like a lot of intelligent animals, most crows are quite social. 
-        For instance, American crows spend most of the year living in pairs or small family groups.
-        During the winter months, they will congregate with hundreds or even thousands of their peers to sleep together at night."
-        value="1"
-      />
-    </SimpleSelect>
-  </Box>
-);
-
-const SimpleSelectWithManyOptionsAndVirtualScrolling = () => (
-  <SimpleSelect
-    name="virtualised"
-    id="virtualised"
-    label="choose an option"
-    labelInline
-    enableVirtualScroll
-    virtualScrollOverscan={10}
-  >
-    {Array(10000)
-      .fill()
-      .map((_, index) => (
-        <Option key={index} value={`${index}`} text={`Option ${index + 1}.`} />
-      ))}
-  </SimpleSelect>
-);
-
-const SimpleSelectNestedInDialog = () => {
-  const [isOpen, setIsOpen] = useState(true);
-  return (
-    <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
-      <SimpleSelect name="testSelect" id="testSelect">
-        <Option value="opt1" text="red" />
-        <Option value="opt2" text="green" />
-        <Option value="opt3" text="blue" />
-        <Option value="opt4" text="black" />
-      </SimpleSelect>
-    </Dialog>
-  );
-};
-
-context("Tests for Simple Select component", () => {
-  describe("check props for Simple Select component", () => {
+context("Tests for SimpleSelect component", () => {
+  describe("check props for SimpleSelect component", () => {
     it.each(testData)(
-      "should render Simple Select label using %s special characters",
+      "should render SimpleSelect label using %s special characters",
       (labelValue) => {
-        CypressMountWithProviders(<SimpleSelectComponent label={labelValue} />);
+        CypressMountWithProviders(
+          <stories.SimpleSelectComponent label={labelValue} />
+        );
 
         getDataElementByValue("label").should("have.text", labelValue);
       }
@@ -523,7 +62,7 @@ context("Tests for Simple Select component", () => {
       "should render labelHelp message using %s special characters",
       (labelHelpValue) => {
         CypressMountWithProviders(
-          <SimpleSelectComponent labelHelp={labelHelpValue} />
+          <stories.SimpleSelectComponent labelHelp={labelHelpValue} />
         );
 
         helpIcon().trigger("mouseover");
@@ -535,16 +74,16 @@ context("Tests for Simple Select component", () => {
       "should render placeholder using %s special characters",
       (placeholderValue) => {
         CypressMountWithProviders(
-          <SimpleSelectComponent placeholder={placeholderValue} />
+          <stories.SimpleSelectComponent placeholder={placeholderValue} />
         );
 
         selectText().should("have.text", placeholderValue);
       }
     );
 
-    it("should render Simple Select with data-component prop set to cypress_data", () => {
+    it("should render SimpleSelect with data-component prop set to cypress_data", () => {
       CypressMountWithProviders(
-        <SimpleSelectComponent data-component={testPropValue} />
+        <stories.SimpleSelectComponent data-component={testPropValue} />
       );
 
       selectElementInput()
@@ -553,9 +92,9 @@ context("Tests for Simple Select component", () => {
         .should("have.attr", "data-component", testPropValue);
     });
 
-    it("should render Simple Select with data-element prop set to cypress_data", () => {
+    it("should render SimpleSelect with data-element prop set to cypress_data", () => {
       CypressMountWithProviders(
-        <SimpleSelectComponent data-element={testPropValue} />
+        <stories.SimpleSelectComponent data-element={testPropValue} />
       );
 
       selectElementInput()
@@ -564,9 +103,9 @@ context("Tests for Simple Select component", () => {
         .should("have.attr", "data-element", testPropValue);
     });
 
-    it("should render Simple Select with data-role prop set to cypress_data", () => {
+    it("should render SimpleSelect with data-role prop set to cypress_data", () => {
       CypressMountWithProviders(
-        <SimpleSelectComponent data-role={testPropValue} />
+        <stories.SimpleSelectComponent data-role={testPropValue} />
       );
 
       selectElementInput()
@@ -584,7 +123,7 @@ context("Tests for Simple Select component", () => {
       "should render the help tooltip in the %s position",
       (tooltipPositionValue, top, bottom, left, right) => {
         CypressMountWithProviders(
-          <SimpleSelectComponent
+          <stories.SimpleSelectComponent
             labelHelp="Help"
             tooltipPosition={tooltipPositionValue}
             mt={top}
@@ -601,16 +140,16 @@ context("Tests for Simple Select component", () => {
       }
     );
 
-    it("should check Simple Select is disabled", () => {
-      CypressMountWithProviders(<SimpleSelectComponent disabled />);
+    it("should check SimpleSelect is disabled", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent disabled />);
 
       commonDataElementInputPreview()
         .should("be.disabled")
         .and("have.attr", "disabled");
     });
 
-    it("should render Simple Select as read only", () => {
-      CypressMountWithProviders(<SimpleSelectComponent readOnly />);
+    it("should render SimpleSelect as read only", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent readOnly />);
 
       selectText().click();
       commonDataElementInputPreview().should("have.attr", "readOnly");
@@ -618,8 +157,8 @@ context("Tests for Simple Select component", () => {
       selectListWrapper().should("not.be.visible");
     });
 
-    it("should render Simple Select as transparent", () => {
-      CypressMountWithProviders(<SimpleSelectComponent transparent />);
+    it("should render SimpleSelect as transparent", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent transparent />);
 
       getDataElementByValue("input").should(
         "have.css",
@@ -633,9 +172,11 @@ context("Tests for Simple Select component", () => {
       [SIZE.MEDIUM, "40px"],
       [SIZE.LARGE, "48px"],
     ])(
-      "should use %s as size and render Simple Select with %s as height",
+      "should use %s as size and render SimpleSelect with %s as height",
       (size, height) => {
-        CypressMountWithProviders(<SimpleSelectComponent size={size} />);
+        CypressMountWithProviders(
+          <stories.SimpleSelectComponent size={size} />
+        );
 
         commonDataElementInputPreview()
           .parent()
@@ -643,20 +184,20 @@ context("Tests for Simple Select component", () => {
       }
     );
 
-    it("should check Simple Select has autofocus", () => {
-      CypressMountWithProviders(<SimpleSelectComponent autoFocus />);
+    it("should check SimpleSelect has autofocus", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent autoFocus />);
 
       commonDataElementInputPreview().should("be.focused");
     });
 
-    it("should check Simple Select is required", () => {
-      CypressMountWithProviders(<SimpleSelectComponent required />);
+    it("should check SimpleSelect is required", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent required />);
 
       verifyRequiredAsteriskForLabel();
     });
 
-    it("should check Simple Select label is inline", () => {
-      CypressMountWithProviders(<SimpleSelectComponent labelInline />);
+    it("should check SimpleSelect label is inline", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent labelInline />);
 
       getDataElementByValue("label")
         .parent()
@@ -670,7 +211,7 @@ context("Tests for Simple Select component", () => {
       "should use %s as labelAligment and render it with flex-%s as css properties",
       (alignment, cssProp) => {
         CypressMountWithProviders(
-          <SimpleSelectComponent labelInline labelAlign={alignment} />
+          <stories.SimpleSelectComponent labelInline labelAlign={alignment} />
         );
 
         getDataElementByValue("label")
@@ -688,7 +229,7 @@ context("Tests for Simple Select component", () => {
       "should use %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
       (label, input, labelRatio, inputRatio) => {
         CypressMountWithProviders(
-          <SimpleSelectComponent
+          <stories.SimpleSelectComponent
             labelInline
             labelWidth={label}
             inputWidth={input}
@@ -713,7 +254,7 @@ context("Tests for Simple Select component", () => {
       "should check maxWidth as %s for SimpleSelect component",
       (maxWidth) => {
         CypressMountWithProviders(
-          <SimpleSelectComponent maxWidth={maxWidth} />
+          <stories.SimpleSelectComponent maxWidth={maxWidth} />
         );
 
         getDataElementByValue("input")
@@ -724,7 +265,7 @@ context("Tests for Simple Select component", () => {
     );
 
     it("when maxWidth has no value it should render as 100%", () => {
-      CypressMountWithProviders(<SimpleSelectComponent maxWidth="" />);
+      CypressMountWithProviders(<stories.SimpleSelectComponent maxWidth="" />);
 
       getDataElementByValue("input")
         .parent()
@@ -733,7 +274,7 @@ context("Tests for Simple Select component", () => {
     });
 
     it("should open the list with mouse click on Select input", () => {
-      CypressMountWithProviders(<SimpleSelectComponent />);
+      CypressMountWithProviders(<stories.SimpleSelectComponent />);
 
       selectText().click();
       commonDataElementInputPreview().should(
@@ -745,14 +286,14 @@ context("Tests for Simple Select component", () => {
     });
 
     it("should open the list with mouse click on dropdown button", () => {
-      CypressMountWithProviders(<SimpleSelectComponent />);
+      CypressMountWithProviders(<stories.SimpleSelectComponent />);
 
       dropdownButton().click();
       selectListWrapper().should("be.visible");
     });
 
     it("should close the list with the Tab key", () => {
-      CypressMountWithProviders(<SimpleSelectComponent />);
+      CypressMountWithProviders(<stories.SimpleSelectComponent />);
 
       selectText().click();
       selectListWrapper().should("be.visible");
@@ -762,7 +303,7 @@ context("Tests for Simple Select component", () => {
     });
 
     it("should close the list with the Esc key", () => {
-      CypressMountWithProviders(<SimpleSelectComponent />);
+      CypressMountWithProviders(<stories.SimpleSelectComponent />);
 
       selectText().click();
       selectListWrapper().should("be.visible");
@@ -772,7 +313,7 @@ context("Tests for Simple Select component", () => {
     });
 
     it("should close the list by clicking out of the component", () => {
-      CypressMountWithProviders(<SimpleSelectComponent />);
+      CypressMountWithProviders(<stories.SimpleSelectComponent />);
 
       selectText().click();
       selectListWrapper().should("be.visible");
@@ -784,7 +325,7 @@ context("Tests for Simple Select component", () => {
     it.each([["downarrow"], ["uparrow"], ["Space"], ["Home"], ["End"]])(
       "should open the list when %s is pressed with Select input in focus",
       (key) => {
-        CypressMountWithProviders(<SimpleSelectComponent />);
+        CypressMountWithProviders(<stories.SimpleSelectComponent />);
 
         commonDataElementInputPreview().focus();
         selectInput().trigger("keydown", { ...keyCode(key), force: true });
@@ -795,7 +336,7 @@ context("Tests for Simple Select component", () => {
     it.each([["Amber"], ["Yellow"]])(
       "should select option %s when clicked from the list",
       (option) => {
-        CypressMountWithProviders(<SimpleSelectComponent />);
+        CypressMountWithProviders(<stories.SimpleSelectComponent />);
 
         selectText().click();
         selectListText(option).click();
@@ -806,7 +347,7 @@ context("Tests for Simple Select component", () => {
     );
 
     it("should render an option that wraps onto more than one line correctly", () => {
-      CypressMountWithProviders(<SimpleSelectComponent />);
+      CypressMountWithProviders(<stories.SimpleSelectComponent />);
 
       const optionValue8 =
         "Like a lot of intelligent animals, most crows are quite social. For instance, American crows spend most of the year living in pairs or small family groups. During the winter months, they will congregate with hundreds or even thousands of their peers to sleep together at night";
@@ -824,7 +365,9 @@ context("Tests for Simple Select component", () => {
     });
 
     it("should render the lazy loader when the prop is set", () => {
-      CypressMountWithProviders(<SimpleSelectWithLazyLoadingComponent />);
+      CypressMountWithProviders(
+        <stories.SimpleSelectWithLazyLoadingComponent />
+      );
 
       selectText().click();
       selectListWrapper().should("be.visible");
@@ -834,7 +377,9 @@ context("Tests for Simple Select component", () => {
     });
 
     it("should render a lazy loaded option when the infinite scroll prop is set", () => {
-      CypressMountWithProviders(<SimpleSelectWithInfiniteScrollComponent />);
+      CypressMountWithProviders(
+        <stories.SimpleSelectWithInfiniteScrollComponent />
+      );
 
       const option = "Lazy Loaded A1";
 
@@ -853,7 +398,9 @@ context("Tests for Simple Select component", () => {
     });
 
     it("infinite scroll example should not cycle back to the start when using down arrow key", () => {
-      CypressMountWithProviders(<SimpleSelectWithInfiniteScrollComponent />);
+      CypressMountWithProviders(
+        <stories.SimpleSelectWithInfiniteScrollComponent />
+      );
 
       const pressDownArrow = () =>
         commonDataElementInputPreview().trigger("keydown", {
@@ -883,7 +430,9 @@ context("Tests for Simple Select component", () => {
     });
 
     it("keyboard navigation should work correctly in multicolumn mode and ensure the selected option is visible", () => {
-      CypressMountWithProviders(<SimpleSelectMultipleColumnsComponent />);
+      CypressMountWithProviders(
+        <stories.SimpleSelectMultipleColumnsComponent />
+      );
 
       const pressDownArrow = () =>
         commonDataElementInputPreview().trigger("keydown", {
@@ -903,7 +452,7 @@ context("Tests for Simple Select component", () => {
     });
 
     it("should open correct list and select one when an object is already set as a value", () => {
-      CypressMountWithProviders(<SimpleSelectObjectAsValueComponent />);
+      CypressMountWithProviders(<stories.SimpleSelectObjectAsValueComponent />);
 
       const position = "first";
       const positionValue = "Amber";
@@ -920,7 +469,9 @@ context("Tests for Simple Select component", () => {
     });
 
     it("should render list options with multiple columns", () => {
-      CypressMountWithProviders(<SimpleSelectMultipleColumnsComponent />);
+      CypressMountWithProviders(
+        <stories.SimpleSelectMultipleColumnsComponent />
+      );
 
       const columns = 3;
 
@@ -940,7 +491,9 @@ context("Tests for Simple Select component", () => {
     });
 
     it("should check table header content in list with multiple columns", () => {
-      CypressMountWithProviders(<SimpleSelectMultipleColumnsComponent />);
+      CypressMountWithProviders(
+        <stories.SimpleSelectMultipleColumnsComponent />
+      );
 
       const headerCol1 = "Name";
       const headerCol2 = "Surname";
@@ -966,7 +519,7 @@ context("Tests for Simple Select component", () => {
       "should render list option %s with custom option %s icon and custom icon color %s",
       (option, type, color) => {
         CypressMountWithProviders(
-          <SimpleSelectCustomOptionChildrenComponent />
+          <stories.SimpleSelectCustomOptionChildrenComponent />
         );
 
         selectText().click();
@@ -978,7 +531,7 @@ context("Tests for Simple Select component", () => {
     );
 
     it("should list option group header Group one", () => {
-      CypressMountWithProviders(<SimpleSelectGroupComponent />);
+      CypressMountWithProviders(<stories.SimpleSelectGroupComponent />);
 
       selectText().click();
       selectListWrapper().should("be.visible");
@@ -988,7 +541,7 @@ context("Tests for Simple Select component", () => {
     it("should render option list with proper maxHeight value", () => {
       const maxHeight = 200;
       CypressMountWithProviders(
-        <SimpleSelectComponent listMaxHeight={maxHeight} />
+        <stories.SimpleSelectComponent listMaxHeight={maxHeight} />
       );
       selectText().click();
       selectListWrapper()
@@ -1005,7 +558,7 @@ context("Tests for Simple Select component", () => {
       "should render list in %s position when margins are top %s, bottom %s, left %s and right %s",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
-          <SimpleSelectComponent
+          <stories.SimpleSelectComponent
             listPlacement={position}
             mt={top}
             mb={bottom}
@@ -1030,7 +583,7 @@ context("Tests for Simple Select component", () => {
       "should flip list to opposite position when there is not enough space to render it in %s position",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
-          <SimpleSelectComponent
+          <stories.SimpleSelectComponent
             listPlacement={position}
             flipEnabled
             mt={top}
@@ -1070,7 +623,12 @@ context("Tests for Simple Select component", () => {
       "should render list in %s position with the most space when listPosition is not set",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
-          <SimpleSelectComponent mt={top} mb={bottom} ml={left} mr={right} />
+          <stories.SimpleSelectComponent
+            mt={top}
+            mb={bottom}
+            ml={left}
+            mr={right}
+          />
         );
 
         selectText().click();
@@ -1088,7 +646,7 @@ context("Tests for Simple Select component", () => {
       (state, numberOfChildren) => {
         CypressMountWithProviders(
           <div>
-            <SimpleSelectComponent disablePortal={state} />
+            <stories.SimpleSelectComponent disablePortal={state} />
           </div>
         );
 
@@ -1100,7 +658,7 @@ context("Tests for Simple Select component", () => {
     );
 
     it("should have correct hover state of list option", () => {
-      CypressMountWithProviders(<SimpleSelectComponent />);
+      CypressMountWithProviders(<stories.SimpleSelectComponent />);
 
       const optionValue3 = "Blue";
 
@@ -1109,20 +667,34 @@ context("Tests for Simple Select component", () => {
         .realHover()
         .should("have.css", "background-color", "rgb(204, 214, 219)");
     });
+
+    it("should have the expected border radius styling", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent />);
+      selectInput().should("have.css", "border-radius", "4px");
+      selectListWrapper().should("have.css", "border-radius", "4px");
+    });
   });
 
   describe("check height of Select list when opened", () => {
     it("should not cut off any text with long option text", () => {
-      CypressMountWithProviders(<SimpleSelectWithLongWrappingTextComponent />);
+      CypressMountWithProviders(
+        <stories.SimpleSelectWithLongWrappingTextComponent />
+      );
 
       selectText().click();
       selectListWrapper()
         .should("have.css", "height", "152px")
         .and("be.visible");
     });
+
+    it("should have the expected border radius styling", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent />);
+      selectInput().should("have.css", "border-radius", "4px");
+      selectListWrapper().should("have.css", "border-radius", "4px");
+    });
   });
 
-  describe("check events for Simple Select component", () => {
+  describe("check events for SimpleSelect component", () => {
     let callback;
     beforeEach(() => {
       callback = cy.stub();
@@ -1130,7 +702,7 @@ context("Tests for Simple Select component", () => {
 
     it("should call onChange event when a list option is selected", () => {
       CypressMountWithProviders(
-        <SimpleSelectEventsComponent onChange={callback} />
+        <stories.SimpleSelectEventsComponent onChange={callback} />
       );
 
       const position = "first";
@@ -1145,7 +717,9 @@ context("Tests for Simple Select component", () => {
     });
 
     it("should call onBlur event when the list is closed", () => {
-      CypressMountWithProviders(<SimpleSelectComponent onBlur={callback} />);
+      CypressMountWithProviders(
+        <stories.SimpleSelectComponent onBlur={callback} />
+      );
 
       selectText().click();
       commonDataElementInputPreview()
@@ -1157,7 +731,9 @@ context("Tests for Simple Select component", () => {
     });
 
     it("should call onClick event when mouse is clicked on text input", () => {
-      CypressMountWithProviders(<SimpleSelectComponent onClick={callback} />);
+      CypressMountWithProviders(
+        <stories.SimpleSelectComponent onClick={callback} />
+      );
 
       commonDataElementInputPreview()
         .realClick()
@@ -1167,8 +743,10 @@ context("Tests for Simple Select component", () => {
         });
     });
 
-    it("should call onOpen when Simple Select is opened", () => {
-      CypressMountWithProviders(<SimpleSelectComponent onOpen={callback} />);
+    it("should call onOpen when SimpleSelect is opened", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectComponent onOpen={callback} />
+      );
 
       commonDataElementInputPreview()
         .realClick()
@@ -1178,8 +756,10 @@ context("Tests for Simple Select component", () => {
         });
     });
 
-    it("should call onFocus when Simple Select is brought into focus", () => {
-      CypressMountWithProviders(<SimpleSelectComponent onFocus={callback} />);
+    it("should call onFocus when SimpleSelect is brought into focus", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectComponent onFocus={callback} />
+      );
 
       commonDataElementInputPreview()
         .focus()
@@ -1193,7 +773,7 @@ context("Tests for Simple Select component", () => {
       "should call onKeyDown event when %s key is pressed",
       (key) => {
         CypressMountWithProviders(
-          <SimpleSelectComponent onKeyDown={callback} />
+          <stories.SimpleSelectComponent onKeyDown={callback} />
         );
 
         commonDataElementInputPreview()
@@ -1210,7 +790,7 @@ context("Tests for Simple Select component", () => {
   describe("check virtual scrolling", () => {
     it("renders only an appropriate number of options into the DOM when first opened", () => {
       CypressMountWithProviders(
-        <SimpleSelectWithManyOptionsAndVirtualScrolling />
+        <stories.SimpleSelectWithManyOptionsAndVirtualScrolling />
       );
 
       selectText().click();
@@ -1222,7 +802,7 @@ context("Tests for Simple Select component", () => {
 
     it("changes the rendered options when you scroll down", () => {
       CypressMountWithProviders(
-        <SimpleSelectWithManyOptionsAndVirtualScrolling />
+        <stories.SimpleSelectWithManyOptionsAndVirtualScrolling />
       );
 
       selectText().click();
@@ -1237,7 +817,7 @@ context("Tests for Simple Select component", () => {
 
   describe("when nested inside of a Dialog component", () => {
     it("should not close the Dialog when Select is closed by pressing an escape key", () => {
-      CypressMountWithProviders(<SimpleSelectNestedInDialog />);
+      CypressMountWithProviders(<stories.SimpleSelectNestedInDialog />);
 
       selectText().click();
       commonDataElementInputPreview()
@@ -1255,7 +835,7 @@ context("Tests for Simple Select component", () => {
     });
 
     it("should not refocus the select textbox when closing it by clicking outside", () => {
-      CypressMountWithProviders(<SimpleSelectNestedInDialog />);
+      CypressMountWithProviders(<stories.SimpleSelectNestedInDialog />);
 
       selectText().click();
       body().click();
@@ -1265,9 +845,330 @@ context("Tests for Simple Select component", () => {
     });
   });
 
-  it("should have the expected border radius styling", () => {
-    CypressMountWithProviders(<SimpleSelectComponent />);
-    selectInput().should("have.css", "border-radius", "4px");
-    selectListWrapper().should("have.css", "border-radius", "4px");
+  describe("Accessibility tests for SimpleSelect component", () => {
+    it("should pass accessibilty tests for SimpleSelect", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent />);
+
+      dropdownButton()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it.each(testData)(
+      "should pass accessibilty tests for SimpleSelect label prop using %s special characters",
+      (labelValue) => {
+        CypressMountWithProviders(
+          <stories.SimpleSelectComponent label={labelValue} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(testData)(
+      "should pass accessibilty tests for SimpleSelect labelHelp prop using %s special characters",
+      (labelHelpValue) => {
+        CypressMountWithProviders(
+          <stories.SimpleSelectComponent labelHelp={labelHelpValue} />
+        );
+
+        helpIcon()
+          .trigger("mouseover")
+          .then(() => cy.checkAccessibility());
+      }
+    );
+
+    it.each(testData)(
+      "should pass accessibilty tests for SimpleSelect placeholder prop using %s special characters",
+      (placeholderValue) => {
+        CypressMountWithProviders(
+          <stories.SimpleSelectComponent placeholder={placeholderValue} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      ["top", "200px", "0px", "0px", "0px"],
+      ["bottom", "0px", "0px", "0px", "0px"],
+      ["left", "200px", "0px", "200px", "0px"],
+      ["right", "200px", "0px", "0px", "200px"],
+    ])(
+      "should pass accessibilty tests for SimpleSelect tooltip prop in the %s position",
+      (tooltipPositionValue, top, bottom, left, right) => {
+        CypressMountWithProviders(
+          <stories.SimpleSelectComponent
+            labelHelp="Help"
+            tooltipPosition={tooltipPositionValue}
+            mt={top}
+            mb={bottom}
+            ml={left}
+            mr={right}
+          />
+        );
+
+        helpIcon()
+          .trigger("mouseover")
+          .then(() => cy.checkAccessibility());
+      }
+    );
+
+    it("should pass accessibilty tests for SimpleSelect disabled prop", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent disabled />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for SimpleSelect readOnly prop", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent readOnly />);
+
+      cy.checkAccessibility();
+      selectText()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for SimpleSelect transparent prop", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent transparent />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE])(
+      "should pass accessibilty tests for SimpleSelect size prop",
+      (size) => {
+        CypressMountWithProviders(
+          <stories.SimpleSelectComponent size={size} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibilty tests for SimpleSelect autoFocus prop", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent autoFocus />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for SimpleSelect required prop", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent required />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for SimpleSelect labelInline prop", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent labelInline />);
+
+      cy.checkAccessibility();
+    });
+
+    it.each(["right", "left"])(
+      "should pass accessibilty tests for SimpleSelect labelAlign prop set as %s",
+      (alignment) => {
+        CypressMountWithProviders(
+          <stories.SimpleSelectComponent labelInline labelAlign={alignment} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each([
+      ["10", "90"],
+      ["30", "70"],
+      ["80", "20"],
+    ])(
+      "should pass accessibilty tests for SimpleSelect labelWidth prop set as %s and inputWidth set as %s",
+      (label, input) => {
+        CypressMountWithProviders(
+          <stories.SimpleSelectComponent
+            labelInline
+            labelWidth={label}
+            inputWidth={input}
+          />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it.each(["10%", "30%", "50%", "80%", "100%"])(
+      "should pass accessibilty tests for SimpleSelect maxWidth prop set as %s",
+      (maxWidth) => {
+        CypressMountWithProviders(
+          <stories.SimpleSelectComponent maxWidth={maxWidth} />
+        );
+
+        cy.checkAccessibility();
+      }
+    );
+
+    it("should pass accessibilty tests for SimpleSelect isLoading prop", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectWithLazyLoadingComponent />
+      );
+
+      selectText().click();
+      loader(1).should("be.visible");
+      cy.checkAccessibility();
+    });
+
+    it("should pass accessibilty tests for SimpleSelect onListScrollBottom prop", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectWithInfiniteScrollComponent />
+      );
+
+      selectText()
+        .click()
+        .then(() => cy.checkAccessibility());
+      selectListWrapper()
+        .scrollTo("bottom")
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for SimpleSelect with multiple columns", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectMultipleColumnsComponent />
+      );
+
+      commonDataElementInputPreview().trigger("keydown", {
+        ...keyCode("downarrow"),
+        force: true,
+      });
+      commonDataElementInputPreview()
+        .focus()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for SimpleSelect with object as value", () => {
+      CypressMountWithProviders(<stories.SimpleSelectObjectAsValueComponent />);
+
+      selectText().click();
+      selectOption(positionOfElement("first"))
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it.each(["1", "2", "3"])(
+      "should pass accessibilty tests for SimpleSelect with custom option %s icon and custom icon color %s",
+      (option) => {
+        CypressMountWithProviders(
+          <stories.SimpleSelectCustomOptionChildrenComponent />
+        );
+
+        selectText().click();
+        selectListCustomChild(option).then(() => cy.checkAccessibility());
+      }
+    );
+
+    it("should pass accessibilty tests for SimpleSelect group component", () => {
+      CypressMountWithProviders(<stories.SimpleSelectGroupComponent />);
+
+      selectText()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for SimpleSelect listMaxHeight prop", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectComponent listMaxHeight={200} />
+      );
+
+      selectText()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it.each([
+      ["top", "300px", "0px", "200px", "20px"],
+      ["bottom", "0px", "0px", "0px", "20px"],
+      ["left", "200px", "0px", "500px", "20px"],
+      ["right", "200px", "0px", "0px", "500px"],
+    ])(
+      "should pass accessibilty tests for SimpleSelect listPlacement prop",
+      (position, top, bottom, left, right) => {
+        CypressMountWithProviders(
+          <stories.SimpleSelectComponent
+            listPlacement={position}
+            mt={top}
+            mb={bottom}
+            ml={left}
+            mr={right}
+          />
+        );
+
+        selectText()
+          .click()
+          .then(() => cy.checkAccessibility());
+      }
+    );
+
+    it.each([
+      ["top", "0px", "0px", "0px", "20px"],
+      ["bottom", "600px", "0px", "0px", "20px"],
+      ["left", "200px", "0px", "0px", "900px"],
+      ["right", "200px", "0px", "500px", "20px"],
+    ])(
+      "should pass accessibilty tests for SimpleSelect flipEnabled prop",
+      (position, top, bottom, left, right) => {
+        CypressMountWithProviders(
+          <stories.SimpleSelectComponent
+            listPlacement={position}
+            flipEnabled
+            mt={top}
+            mb={bottom}
+            ml={left}
+            mr={right}
+          />
+        );
+
+        selectText()
+          .click()
+          .then(() => cy.checkAccessibility());
+      }
+    );
+
+    // FE-5764
+    it.skip("should pass accessibilty tests for SimpleSelect disablePortal prop", () => {
+      CypressMountWithProviders(
+        <div>
+          <stories.SimpleSelectComponent disablePortal />
+        </div>
+      );
+
+      selectText()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for SimpleSelect with long option text", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectWithLongWrappingTextComponent />
+      );
+
+      selectText()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for SimpleSelect with virtual scrolling", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectWithManyOptionsAndVirtualScrolling />
+      );
+
+      selectText()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
+
+    it("should pass accessibilty tests for SimpleSelect in nested dialog", () => {
+      CypressMountWithProviders(<stories.SimpleSelectNestedInDialog />);
+
+      selectText()
+        .click()
+        .then(() => cy.checkAccessibility());
+    });
   });
 });

--- a/cypress/support/accessibility/a11y-utils.ts
+++ b/cypress/support/accessibility/a11y-utils.ts
@@ -127,6 +127,7 @@ export default (from: number, end: number) => {
       !prepareUrl[0].startsWith("tooltip") &&
       !prepareUrl[0].startsWith("split-button") &&
       !prepareUrl[0].startsWith("flat-table") &&
+      !prepareUrl[0].startsWith("select") &&
       !prepareUrl[0].endsWith("test")
     ) {
       urlList.push([prepareUrl[0], prepareUrl[1]]);

--- a/src/components/select/filterable-select/filterable-select-test.stories.tsx
+++ b/src/components/select/filterable-select/filterable-select-test.stories.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import partialAction from "../../../__internal__/utils/storybook/partial-action";
-
-import { FilterableSelect, Option } from "..";
+import { FilterableSelect, Option, FilterableSelectProps } from "..";
+import OptionRow from "../option-row/option-row.component";
+import Dialog from "../../dialog";
+import Button from "../../button";
 
 export default {
   component: FilterableSelect,
@@ -43,3 +45,565 @@ export const DefaultStory = () => (
 );
 
 DefaultStory.storyName = "default";
+
+export const FilterableSelectComponent = ({ ...props }) => {
+  const [value, setValue] = React.useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  return (
+    <FilterableSelect
+      label="filterable select"
+      labelInline
+      value={value}
+      onChange={onChangeHandler}
+      {...props}
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
+    </FilterableSelect>
+  );
+};
+
+export const FilterableSelectWithLazyLoadingComponent = ({ ...props }) => {
+  const preventLoading = React.useRef(false);
+  const [value, setValue] = React.useState("black");
+  const [isLoading, setIsLoading] = React.useState(true);
+  const asyncList = [
+    <Option text="Amber" value="amber" key="Amber" />,
+    <Option text="Black" value="black" key="Black" />,
+    <Option text="Blue" value="blue" key="Blue" />,
+    <Option text="Brown" value="brown" key="Brown" />,
+    <Option text="Green" value="green" key="Green" />,
+  ];
+  const [optionList, setOptionList] = React.useState([
+    <Option text="Black" value="black" key="Black" />,
+  ]);
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  function loadList() {
+    if (preventLoading.current) {
+      return;
+    }
+
+    preventLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+      setOptionList(asyncList);
+    }, 2000);
+  }
+
+  return (
+    <FilterableSelect
+      label="color"
+      value={value}
+      onChange={onChangeHandler}
+      onOpen={() => loadList()}
+      isLoading={isLoading}
+      {...props}
+    >
+      {optionList}
+    </FilterableSelect>
+  );
+};
+
+export const FilterableSelectLazyLoadTwiceComponent = ({ ...props }) => {
+  const preventLoading = React.useRef(false);
+  const [value, setValue] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const asyncList = [
+    <Option text="Amber" value="amber" key="Amber" />,
+    <Option text="Black" value="black" key="Black" />,
+    <Option text="Blue" value="blue" key="Blue" />,
+    <Option text="Brown" value="brown" key="Brown" />,
+    <Option text="Green" value="green" key="Green" />,
+  ];
+  const [optionList, setOptionList] = useState<React.ReactElement[]>([]);
+
+  function loadList() {
+    if (preventLoading.current) {
+      return;
+    }
+    preventLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+      setOptionList(asyncList);
+    }, 2000);
+  }
+  function clearData() {
+    setOptionList([]);
+    setValue("");
+    preventLoading.current = false;
+  }
+
+  return (
+    <div>
+      <Button onClick={clearData} mb={2} data-element="reset-button">
+        reset
+      </Button>
+      <FilterableSelect
+        label="color"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        onOpen={() => loadList()}
+        isLoading={isLoading}
+        {...props}
+      >
+        {optionList}
+      </FilterableSelect>
+    </div>
+  );
+};
+
+export const FilterableSelectWithInfiniteScrollComponent = ({ ...props }) => {
+  const preventLoading = React.useRef(false);
+  const preventLazyLoading = React.useRef(false);
+  const lazyLoadingCounter = React.useRef(0);
+  const [value, setValue] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const asyncList = [
+    <Option text="Amber" value="amber" key="Amber" />,
+    <Option text="Black" value="black" key="Black" />,
+    <Option text="Blue" value="blue" key="Blue" />,
+    <Option text="Brown" value="brown" key="Brown" />,
+    <Option text="Green" value="green" key="Green" />,
+  ];
+
+  const getLazyLoaded = () => {
+    const counter = lazyLoadingCounter.current;
+    return [
+      <Option
+        text={`Lazy Loaded A${counter}`}
+        value={`lazyA${counter}`}
+        key={`lazyA${counter}`}
+      />,
+      <Option
+        text={`Lazy Loaded B${counter}`}
+        value={`lazyB${counter}`}
+        key={`lazyB${counter}`}
+      />,
+      <Option
+        text={`Lazy Loaded C${counter}`}
+        value={`lazyC${counter}`}
+        key={`lazyC${counter}`}
+      />,
+    ];
+  };
+
+  const [optionList, setOptionList] = useState<React.ReactElement[]>([]);
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  function loadList() {
+    if (preventLoading.current) {
+      return;
+    }
+
+    preventLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+      setOptionList(asyncList);
+    }, 2000);
+  }
+
+  function onLazyLoading() {
+    if (preventLazyLoading.current) {
+      return;
+    }
+
+    preventLazyLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      preventLazyLoading.current = false;
+      lazyLoadingCounter.current += 1;
+      setIsLoading(false);
+      setOptionList((prevList) => [...prevList, ...getLazyLoaded()]);
+    }, 2000);
+  }
+
+  return (
+    <FilterableSelect
+      label="color"
+      value={value}
+      onChange={onChangeHandler}
+      onOpen={() => loadList()}
+      isLoading={isLoading}
+      onListScrollBottom={onLazyLoading}
+      {...props}
+    >
+      {optionList}
+    </FilterableSelect>
+  );
+};
+
+export const FilterableSelectObjectAsValueComponent = ({ ...props }) => {
+  const [value, setValue] = useState<Record<string, unknown>>({
+    id: "Green",
+    value: 5,
+    text: "Green",
+  });
+  const optionList = React.useRef([
+    <Option
+      text="Amber"
+      key="Amber"
+      value={{
+        id: "Amber",
+        value: 1,
+        text: "Amber",
+      }}
+    />,
+    <Option
+      text="Black"
+      key="Black"
+      value={{
+        id: "Black",
+        value: 2,
+        text: "Black",
+      }}
+    />,
+    <Option
+      text="Blue"
+      key="Blue"
+      value={{
+        id: "Blue",
+        value: 3,
+        text: "Blue",
+      }}
+    />,
+    <Option
+      text="Brown"
+      key="Brown"
+      value={{
+        id: "Brown",
+        value: 4,
+        text: "Brown",
+      }}
+    />,
+    <Option
+      text="Green"
+      key="Green"
+      value={{
+        id: "Green",
+        value: 5,
+        text: "Green",
+      }}
+    />,
+    <Option
+      text="Orange"
+      key="Orange"
+      value={{
+        id: "Orange",
+        value: 6,
+        text: "Orange",
+      }}
+    />,
+    <Option
+      text="Pink"
+      key="Pink"
+      value={{
+        id: "Pink",
+        value: 7,
+        text: "Pink",
+      }}
+    />,
+    <Option
+      text="Purple"
+      key="Purple"
+      value={{
+        id: "Purple",
+        value: 8,
+        text: "Purple",
+      }}
+    />,
+    <Option
+      text="Red"
+      key="Red"
+      value={{
+        id: "Red",
+        value: 9,
+        text: "Red",
+      }}
+    />,
+    <Option
+      text="White"
+      key="White"
+      value={{
+        id: "White",
+        value: 10,
+        text: "White",
+      }}
+    />,
+    <Option
+      text="Yellow"
+      key="Yellow"
+      value={{
+        id: "Yellow",
+        value: 11,
+        text: "Yellow",
+      }}
+    />,
+  ]);
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue((event.target.value as unknown) as Record<string, unknown>);
+  }
+
+  return (
+    <FilterableSelect value={value} onChange={onChangeHandler} {...props}>
+      {optionList.current}
+    </FilterableSelect>
+  );
+};
+
+export const FilterableSelectMultiColumnsComponent = ({ ...props }) => {
+  return (
+    <FilterableSelect
+      multiColumn
+      defaultValue="2"
+      {...props}
+      tableHeader={
+        <tr>
+          <th>Name</th>
+          <th>Surname</th>
+          <th>Occupation</th>
+        </tr>
+      }
+    >
+      <OptionRow id="1" value="1" text="John Doe">
+        <td>John</td>
+        <td>Doe</td>
+        <td>Welder</td>
+      </OptionRow>
+      <OptionRow id="2" value="2" text="Joe Vick">
+        <td>Joe</td>
+        <td>Vick</td>
+        <td>Accountant</td>
+      </OptionRow>
+      <OptionRow id="3" value="3" text="Jane Poe">
+        <td>Jane</td>
+        <td>Poe</td>
+        <td>Accountant</td>
+      </OptionRow>
+      <OptionRow id="4" value="4" text="Jill Moe">
+        <td>Jill</td>
+        <td>Moe</td>
+        <td>Engineer</td>
+      </OptionRow>
+      <OptionRow id="5" value="5" text="Bill Zoe">
+        <td>Bill</td>
+        <td>Zoe</td>
+        <td>Astronaut</td>
+      </OptionRow>
+    </FilterableSelect>
+  );
+};
+
+export const FilterableSelectMultiColumnsNestedComponent = ({ ...props }) => {
+  return (
+    <FilterableSelect
+      multiColumn
+      defaultValue="2"
+      {...props}
+      tableHeader={
+        <tr>
+          <th>Name</th>
+          <th>Surname</th>
+          <th>Occupation</th>
+        </tr>
+      }
+      listActionButton={
+        <Button iconType="add" iconPosition="after">
+          Add a New Element
+        </Button>
+      }
+      onListAction={() => console.log("Action")}
+    >
+      <OptionRow id="1" value="1" text="John Doe">
+        <td>John</td>
+        <td>Doe</td>
+        <td>Welder</td>
+      </OptionRow>
+      <OptionRow id="2" value="2" text="Joe Vick">
+        <td>Joe</td>
+        <td>Vick</td>
+        <td>Accountant</td>
+      </OptionRow>
+      <OptionRow id="3" value="3" text="Jane Poe">
+        <td>Jane</td>
+        <td>Poe</td>
+        <td>Accountant</td>
+      </OptionRow>
+      <OptionRow id="4" value="4" text="Jill Moe">
+        <td>Jill</td>
+        <td>Moe</td>
+        <td>Engineer</td>
+      </OptionRow>
+      <OptionRow id="5" value="5" text="Bill Zoe">
+        <td>Bill</td>
+        <td>Zoe</td>
+        <td>Astronaut</td>
+      </OptionRow>
+    </FilterableSelect>
+  );
+};
+
+export const FilterableSelectWithActionButtonComponent = () => {
+  const [value, setValue] = React.useState("");
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [optionList, setOptionList] = React.useState([
+    <Option text="Amber" value="amber" key="Amber" />,
+    <Option text="Black" value="black" key="Black" />,
+    <Option text="Blue" value="blue" key="Blue" />,
+    <Option text="Brown" value="brown" key="Brown" />,
+    <Option text="Green" value="green" key="Green" />,
+    <Option text="Amber" value="amber1" key="Amber1" />,
+    <Option text="Black" value="black1" key="Black1" />,
+    <Option text="Blue" value="blue1" key="Blue1" />,
+    <Option text="Brown" value="brown1" key="Brown1" />,
+    <Option text="Green" value="green1" key="Green1" />,
+  ]);
+
+  function addNew() {
+    const counter = optionList.length.toString();
+    setOptionList((newOptionList) => [
+      ...newOptionList,
+      <Option
+        text={`New${counter}`}
+        value={`val${counter}`}
+        key={`New${counter}`}
+      />,
+    ]);
+    setIsOpen(false);
+    setValue(`val${counter}`);
+  }
+
+  return (
+    <>
+      <FilterableSelect
+        label="color"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        listActionButton={
+          <Button iconType="add" iconPosition="after">
+            Add a New Element
+          </Button>
+        }
+        onListAction={() => setIsOpen(true)}
+      >
+        {optionList}
+      </FilterableSelect>
+      <Dialog
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        title="Dialog component triggered on action"
+      >
+        <Button onClick={addNew}>Add new</Button>
+      </Dialog>
+    </>
+  );
+};
+
+export const FilterableSelectOnChangeEventComponent = ({
+  onChange,
+  ...props
+}: FilterableSelectProps) => {
+  const [state, setState] = React.useState("");
+
+  const setValue = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setState(event.target.value);
+    if (onChange) {
+      onChange(event);
+    }
+  };
+
+  return (
+    <FilterableSelect
+      label="color"
+      value={state}
+      labelInline
+      onChange={setValue}
+      {...props}
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+    </FilterableSelect>
+  );
+};
+
+export const FilterableSelectListActionEventComponent = ({ ...props }) => {
+  const [value, setValue] = React.useState("");
+
+  return (
+    <FilterableSelect
+      label="color"
+      value={value}
+      labelInline
+      onChange={(event) => setValue(event.target.value)}
+      {...props}
+      listActionButton={
+        <Button iconType="add" iconPosition="after">
+          Add a New Element
+        </Button>
+      }
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+    </FilterableSelect>
+  );
+};
+
+export const FilterableSelectWithManyOptionsAndVirtualScrolling = () => (
+  <FilterableSelect
+    name="virtualised"
+    id="virtualised"
+    label="choose an option"
+    labelInline
+    enableVirtualScroll
+    virtualScrollOverscan={10}
+  >
+    {Array(10000)
+      .fill(undefined)
+      .map((_, index) => (
+        <Option key={index} value={`${index}`} text={`Option ${index + 1}.`} />
+      ))}
+  </FilterableSelect>
+);
+
+export const FilterableSelectNestedInDialog = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
+      <FilterableSelect name="testSelect" id="testSelect">
+        <Option value="opt1" text="red" />
+        <Option value="opt2" text="green" />
+        <Option value="opt3" text="blue" />
+        <Option value="opt4" text="black" />
+      </FilterableSelect>
+    </Dialog>
+  );
+};

--- a/src/components/select/multi-select/multi-select-test.stories.tsx
+++ b/src/components/select/multi-select/multi-select-test.stories.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from "react";
-import { MultiSelect, Option } from "..";
+import { MultiSelect, Option, MultiSelectProps } from "..";
 import partialAction from "../../../__internal__/utils/storybook/partial-action";
+import OptionRow from "../option-row/option-row.component";
+import Button from "../../button/button.component";
+import Dialog from "../../dialog";
+import Box from "../../box";
+import CarbonProvider from "../../carbon-provider/carbon-provider.component";
 
 export default {
   component: MultiSelect,
@@ -53,3 +58,501 @@ export const Default = () => {
 };
 
 Default.storyName = "default";
+
+export const MultiSelectComponent = ({ ...props }) => {
+  const [value, setValue] = useState<string[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue((event.target.value as unknown) as string[]);
+  }
+
+  return (
+    <MultiSelect
+      label="color"
+      labelInline
+      value={value}
+      onChange={onChangeHandler}
+      {...props}
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
+    </MultiSelect>
+  );
+};
+
+export const MultiSelectDefaultValueComponent = ({ ...props }) => {
+  return (
+    <MultiSelect label="color" labelInline {...props}>
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
+    </MultiSelect>
+  );
+};
+
+export const MultiSelectLongPillComponent = ({ ...props }) => {
+  const [value, setValue] = useState<string[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue((event.target.value as unknown) as string[]);
+  }
+
+  return (
+    <div
+      style={{
+        maxWidth: "200px",
+      }}
+    >
+      <MultiSelect
+        label="color"
+        labelInline
+        value={value}
+        onChange={onChangeHandler}
+        {...props}
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue as the sky on a summer's day" value="3" />
+        <Option text="Brown" value="4" />
+        <Option text="Green as the grass in a spring meadow" value="5" />
+        <Option text="Orange" value="6" />
+        <Option text="Pink" value="7" />
+        <Option text="Purple" value="8" />
+        <Option text="Red" value="9" />
+        <Option text="White" value="10" />
+        <Option text="Yellow" value="11" />
+      </MultiSelect>
+    </div>
+  );
+};
+
+export const MultiSelectWithLazyLoadingComponent = ({ ...props }) => {
+  const preventLoading = React.useRef(false);
+  const [value, setValue] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const asyncList = [
+    <Option text="Amber" value="amber" key="Amber" />,
+    <Option text="Black" value="black" key="Black" />,
+    <Option text="Blue" value="blue" key="Blue" />,
+    <Option text="Brown" value="brown" key="Brown" />,
+    <Option text="Green" value="green" key="Green" />,
+  ];
+  const [optionList, setOptionList] = useState<React.ReactElement[]>([]);
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue((event.target.value as unknown) as string[]);
+  }
+
+  function loadList() {
+    if (preventLoading.current) {
+      return;
+    }
+
+    preventLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+      setOptionList(asyncList);
+    }, 2000);
+  }
+
+  return (
+    <MultiSelect
+      label="color"
+      value={value}
+      onChange={onChangeHandler}
+      onOpen={() => loadList()}
+      isLoading={isLoading}
+      {...props}
+    >
+      {optionList}
+    </MultiSelect>
+  );
+};
+
+export const MultiSelectLazyLoadTwiceComponent = ({ ...props }) => {
+  const preventLoading = React.useRef(false);
+  const [value, setValue] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = React.useState(true);
+  const asyncList = [
+    <Option text="Amber" value="amber" key="Amber" />,
+    <Option text="Black" value="black" key="Black" />,
+    <Option text="Blue" value="blue" key="Blue" />,
+    <Option text="Brown" value="brown" key="Brown" />,
+    <Option text="Green" value="green" key="Green" />,
+  ];
+  const [optionList, setOptionList] = useState<React.ReactElement[]>([]);
+
+  function loadList() {
+    if (preventLoading.current) {
+      return;
+    }
+    preventLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+      setOptionList(asyncList);
+    }, 2000);
+  }
+
+  function clearData() {
+    setOptionList([]);
+    setValue([]);
+    preventLoading.current = false;
+  }
+
+  return (
+    <div>
+      <Button onClick={clearData} mb={2} data-element="reset-button">
+        reset
+      </Button>
+      <MultiSelect
+        label="color"
+        value={value}
+        onChange={(event) =>
+          setValue((event.target.value as unknown) as string[])
+        }
+        onOpen={() => loadList()}
+        isLoading={isLoading}
+        {...props}
+      >
+        {optionList}
+      </MultiSelect>
+    </div>
+  );
+};
+
+export const MultiSelectObjectAsValueComponent = ({ ...props }) => {
+  const [value, setValue] = useState<Record<string, unknown>[]>([
+    { id: "Green", value: 5, text: "Green" },
+  ]);
+
+  const optionList = React.useRef([
+    <Option
+      text="Amber"
+      key="Amber"
+      value={{
+        id: "Amber",
+        value: 1,
+        text: "Amber",
+      }}
+    />,
+    <Option
+      text="Black"
+      key="Black"
+      value={{
+        id: "Black",
+        value: 2,
+        text: "Black",
+      }}
+    />,
+    <Option
+      text="Blue"
+      key="Blue"
+      value={{
+        id: "Blue",
+        value: 3,
+        text: "Blue",
+      }}
+    />,
+    <Option
+      text="Brown"
+      key="Brown"
+      value={{
+        id: "Brown",
+        value: 4,
+        text: "Brown",
+      }}
+    />,
+    <Option
+      text="Green"
+      key="Green"
+      value={{
+        id: "Green",
+        value: 5,
+        text: "Green",
+      }}
+    />,
+    <Option
+      text="Orange"
+      key="Orange"
+      value={{
+        id: "Orange",
+        value: 6,
+        text: "Orange",
+      }}
+    />,
+    <Option
+      text="Pink"
+      key="Pink"
+      value={{
+        id: "Pink",
+        value: 7,
+        text: "Pink",
+      }}
+    />,
+    <Option
+      text="Purple"
+      key="Purple"
+      value={{
+        id: "Purple",
+        value: 8,
+        text: "Purple",
+      }}
+    />,
+    <Option
+      text="Red"
+      key="Red"
+      value={{
+        id: "Red",
+        value: 9,
+        text: "Red",
+      }}
+    />,
+    <Option
+      text="White"
+      key="White"
+      value={{
+        id: "White",
+        value: 10,
+        text: "White",
+      }}
+    />,
+    <Option
+      text="Yellow"
+      key="Yellow"
+      value={{
+        id: "Yellow",
+        value: 11,
+        text: "Yellow",
+      }}
+    />,
+  ]);
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue((event.target.value as unknown) as Record<string, unknown>[]);
+  }
+
+  return (
+    <MultiSelect value={value} onChange={onChangeHandler} {...props}>
+      {optionList.current}
+    </MultiSelect>
+  );
+};
+
+export const MultiSelectMultiColumnsComponent = ({ ...props }) => {
+  return (
+    <MultiSelect
+      multiColumn
+      defaultValue={["2"]}
+      {...props}
+      tableHeader={
+        <tr>
+          <th>Name</th>
+          <th>Surname</th>
+          <th>Occupation</th>
+        </tr>
+      }
+    >
+      <OptionRow id="1" value="1" text="John Doe">
+        <td>John</td>
+        <td>Doe</td>
+        <td>Welder</td>
+      </OptionRow>
+      <OptionRow id="2" value="2" text="Joe Vick">
+        <td>Joe</td>
+        <td>Vick</td>
+        <td>Accountant</td>
+      </OptionRow>
+      <OptionRow id="3" value="3" text="Jane Poe">
+        <td>Jane</td>
+        <td>Poe</td>
+        <td>Accountant</td>
+      </OptionRow>
+      <OptionRow id="4" value="4" text="Jill Moe">
+        <td>Jill</td>
+        <td>Moe</td>
+        <td>Engineer</td>
+      </OptionRow>
+      <OptionRow id="5" value="5" text="Bill Zoe">
+        <td>Bill</td>
+        <td>Zoe</td>
+        <td>Astronaut</td>
+      </OptionRow>
+    </MultiSelect>
+  );
+};
+
+export const MultiSelectMaxOptionsComponent = ({ ...props }) => {
+  const maxSelectionsAllowed = 2;
+  const [selectedPills, setSelectedPills] = useState<string[]>([]);
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    if (event.target.value.length <= maxSelectionsAllowed) {
+      setSelectedPills((event.target.value as unknown) as string[]);
+    }
+  }
+
+  return (
+    <MultiSelect
+      value={selectedPills}
+      onChange={onChangeHandler}
+      disablePortal
+      openOnFocus
+      label="color"
+      {...props}
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
+    </MultiSelect>
+  );
+};
+
+export const MultiSelectOnFilterChangeEventComponent = ({
+  onChange,
+  ...props
+}: MultiSelectProps) => {
+  const [state, setState] = useState<string[]>([]);
+
+  const setValue = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setState((event.target.value as unknown) as string[]);
+    if (onChange) {
+      onChange(event);
+    }
+  };
+
+  return (
+    <MultiSelect
+      label="color"
+      value={state}
+      labelInline
+      onChange={setValue}
+      {...props}
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+    </MultiSelect>
+  );
+};
+
+export const MultiSelectCustomColorComponent = ({ ...props }) => {
+  return (
+    <MultiSelect label="color" labelInline defaultValue={["1", "3"]} {...props}>
+      <Option text="Amber" value="1" borderColor="#FFBF00" fill />
+      <Option text="Black" value="2" borderColor="blackOpacity65" fill />
+      <Option text="Blue" value="3" borderColor="productBlue" />
+      <Option text="Brown" value="4" borderColor="brown" fill />
+      <Option text="Green" value="5" borderColor="productGreen" />
+      <Option text="Orange" value="6" borderColor="orange" />
+      <Option text="Pink" value="7" borderColor="pink" />
+      <Option text="Purple" value="8" borderColor="purple" />
+      <Option text="Red" value="9" borderColor="red" fill />
+      <Option text="White" value="10" borderColor="white" />
+      <Option text="Yellow" value="11" borderColor="yellow" fill />
+    </MultiSelect>
+  );
+};
+
+export const MultiSelectWithManyOptionsAndVirtualScrolling = () => (
+  <MultiSelect
+    name="virtualised"
+    id="virtualised"
+    label="choose an option"
+    labelInline
+    enableVirtualScroll
+    virtualScrollOverscan={10}
+  >
+    {Array(10000)
+      .fill(undefined)
+      .map((_, index) => (
+        <Option key={index} value={`${index}`} text={`Option ${index + 1}.`} />
+      ))}
+  </MultiSelect>
+);
+
+export const MultiSelectNestedInDialog = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
+      <MultiSelect name="testSelect" id="testSelect">
+        <Option value="opt1" text="red" />
+        <Option value="opt2" text="green" />
+        <Option value="opt3" text="blue" />
+        <Option value="opt4" text="black" />
+      </MultiSelect>
+    </Dialog>
+  );
+};
+
+export const MultiSelectErrorOnChangeNewValidation = () => {
+  const [selectedPills, setSelectedPills] = useState<string[]>([]);
+  const [showError, setShowError] = useState(false);
+
+  const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.value.length < 3) {
+      setShowError(false);
+      setSelectedPills((event.target.value as unknown) as string[]);
+    } else {
+      setShowError(true);
+    }
+  };
+
+  const handleError = showError ? "Error" : "";
+
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      Open dropdown and try to select more than 2 pills
+      <Box width="300px" ml={10} mt={10}>
+        <MultiSelect
+          name="testing"
+          value={selectedPills}
+          onChange={handleOnChange}
+          disablePortal
+          openOnFocus
+          label="Test"
+          placeholder="FooBar"
+          error={handleError}
+        >
+          <Option text="Amber" value="1" />
+          <Option text="Black" value="2" />
+          <Option text="Blue" value="3" />
+          <Option text="Brown" value="4" />
+          <Option text="Green" value="5" />
+          <Option text="Orange" value="6" />
+          <Option text="Pink" value="7" />
+          <Option text="Purple" value="8" />
+          <Option text="Red" value="9" />
+          <Option text="White" value="10" />
+          <Option text="Yellow" value="11" />
+        </MultiSelect>
+      </Box>
+    </CarbonProvider>
+  );
+};

--- a/src/components/select/simple-select/simple-select-test.stories.tsx
+++ b/src/components/select/simple-select/simple-select-test.stories.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
+import { Select as SimpleSelect } from "../../../../src/components/select";
+import OptionRow from "../option-row/option-row.component";
+import OptionGroupHeader from "../option-group-header/option-group-header.component";
 import Box from "../../box";
 import Icon from "../../icon";
 import Dialog from "../../dialog";
-
 import { Select, Option, SimpleSelectProps } from "..";
 
 export default {
@@ -163,3 +165,466 @@ export const DelayedReposition = () => {
 };
 
 DelayedReposition.storyName = "delayed reposition";
+
+export const SimpleSelectComponent = ({ ...props }) => {
+  const [value, setValue] = React.useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  return (
+    <SimpleSelect
+      label="simple select"
+      labelInline
+      value={value}
+      onChange={onChangeHandler}
+      {...props}
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option
+        text="Like a lot of intelligent animals, most crows are quite social. For instance, American crows spend most of the year living in pairs or small family groups. During the winter months, they will congregate with hundreds or even thousands of their peers to sleep together at night"
+        value="8"
+      />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
+    </SimpleSelect>
+  );
+};
+
+export const SimpleSelectWithLazyLoadingComponent = ({ ...props }) => {
+  const preventLoading = React.useRef(false);
+  const [value, setValue] = React.useState("black");
+  const [isLoading, setIsLoading] = React.useState(true);
+  const asyncList = [
+    <Option text="Amber" value="amber" key="Amber" />,
+    <Option text="Black" value="black" key="Black" />,
+    <Option text="Blue" value="blue" key="Blue" />,
+    <Option text="Brown" value="brown" key="Brown" />,
+    <Option text="Green" value="green" key="Green" />,
+  ];
+  const [optionList, setOptionList] = React.useState([
+    <Option text="Black" value="black" key="Black" />,
+  ]);
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  function loadList() {
+    if (preventLoading.current) {
+      return;
+    }
+
+    preventLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+      setOptionList(asyncList);
+    }, 2000);
+  }
+
+  return (
+    <SimpleSelect
+      name="isLoading"
+      id="isLoading"
+      label="color"
+      value={value}
+      onChange={onChangeHandler}
+      onOpen={() => loadList()}
+      isLoading={isLoading}
+      {...props}
+    >
+      {optionList}
+    </SimpleSelect>
+  );
+};
+
+export const SimpleSelectWithInfiniteScrollComponent = ({ ...props }) => {
+  const preventLoading = React.useRef(false);
+  const preventLazyLoading = React.useRef(false);
+  const lazyLoadingCounter = React.useRef(0);
+  const [value, setValue] = React.useState("");
+  const [isLoading, setIsLoading] = React.useState(true);
+  const asyncList = [
+    <Option text="Amber" value="amber" key="Amber" />,
+    <Option text="Black" value="black" key="Black" />,
+    <Option text="Blue" value="blue" key="Blue" />,
+    <Option text="Brown" value="brown" key="Brown" />,
+    <Option text="Green" value="green" key="Green" />,
+  ];
+
+  const getLazyLoaded = () => {
+    const counter = lazyLoadingCounter.current;
+    return [
+      <Option
+        text={`Lazy Loaded A${counter}`}
+        value={`lazyA${counter}`}
+        key={`lazyA${counter}`}
+      />,
+      <Option
+        text={`Lazy Loaded B${counter}`}
+        value={`lazyB${counter}`}
+        key={`lazyB${counter}`}
+      />,
+      <Option
+        text={`Lazy Loaded C${counter}`}
+        value={`lazyC${counter}`}
+        key={`lazyC${counter}`}
+      />,
+    ];
+  };
+
+  const [optionList, setOptionList] = useState([
+    <Option text="" value="" key="" />,
+  ]);
+  useState<string[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  function loadList() {
+    if (preventLoading.current) {
+      return;
+    }
+
+    preventLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+      setOptionList(asyncList);
+    }, 2000);
+  }
+
+  function onLazyLoading() {
+    if (preventLazyLoading.current) {
+      return;
+    }
+
+    preventLazyLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      preventLazyLoading.current = false;
+      lazyLoadingCounter.current += 1;
+      setIsLoading(false);
+      setOptionList((prevList) => [...prevList, ...getLazyLoaded()]);
+    }, 2000);
+  }
+
+  return (
+    <SimpleSelect
+      name="infiniteScroll"
+      id="infiniteScroll"
+      label="color"
+      value={value}
+      onChange={onChangeHandler}
+      onOpen={() => loadList()}
+      isLoading={isLoading}
+      onListScrollBottom={onLazyLoading}
+      {...props}
+    >
+      {optionList}
+    </SimpleSelect>
+  );
+};
+
+export const SimpleSelectObjectAsValueComponent = ({ ...props }) => {
+  const [value, setValue] = useState<Record<string, unknown>>({
+    id: "Green",
+    value: 5,
+    text: "Green",
+  });
+  const optionList = React.useRef([
+    <Option
+      text="Amber"
+      key="Amber"
+      value={{
+        id: "Amber",
+        value: "1",
+        text: "Amber",
+      }}
+    />,
+    <Option
+      text="Black"
+      key="Black"
+      value={{
+        id: "Black",
+        value: "2",
+        text: "Black",
+      }}
+    />,
+    <Option
+      text="Blue"
+      key="Blue"
+      value={{
+        id: "Blue",
+        value: "3",
+        text: "Blue",
+      }}
+    />,
+    <Option
+      text="Brown"
+      key="Brown"
+      value={{
+        id: "Brown",
+        value: "4",
+        text: "Brown",
+      }}
+    />,
+    <Option
+      text="Green"
+      key="Green"
+      value={{
+        id: "Green",
+        value: "5",
+        text: "Green",
+      }}
+    />,
+    <Option
+      text="Orange"
+      key="Orange"
+      value={{
+        id: "Orange",
+        value: "6",
+        text: "Orange",
+      }}
+    />,
+    <Option
+      text="Pink"
+      key="Pink"
+      value={{
+        id: "Pink",
+        value: "7",
+        text: "Pink",
+      }}
+    />,
+    <Option
+      text="Purple"
+      key="Purple"
+      value={{
+        id: "Purple",
+        value: "8",
+        text: "Purple",
+      }}
+    />,
+    <Option
+      text="Red"
+      key="Red"
+      value={{
+        id: "Red",
+        value: "9",
+        text: "Red",
+      }}
+    />,
+    <Option
+      text="White"
+      key="White"
+      value={{
+        id: "White",
+        value: "10",
+        text: "White",
+      }}
+    />,
+    <Option
+      text="Yellow"
+      key="Yellow"
+      value={{
+        id: "Yellow",
+        value: "11",
+        text: "Yellow",
+      }}
+    />,
+  ]);
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue((event.target.value as unknown) as Record<string, unknown>);
+  }
+
+  return (
+    <SimpleSelect
+      id="withObject"
+      name="withObject"
+      value={value}
+      onChange={onChangeHandler}
+      {...props}
+    >
+      {optionList.current}
+    </SimpleSelect>
+  );
+};
+
+export const SimpleSelectMultipleColumnsComponent = ({ ...props }) => {
+  return (
+    <SimpleSelect
+      name="withMultipleColumns"
+      id="withMultipleColumns"
+      multiColumn
+      defaultValue="2"
+      {...props}
+      tableHeader={
+        <tr>
+          <th>Name</th>
+          <th>Surname</th>
+          <th>Occupation</th>
+        </tr>
+      }
+    >
+      <OptionRow id="1" value="1" text="John Doe">
+        <td>John</td>
+        <td>Doe</td>
+        <td>Welder</td>
+      </OptionRow>
+      <OptionRow id="2" value="2" text="Joe Vick">
+        <td>Joe</td>
+        <td>Vick</td>
+        <td>Accountant</td>
+      </OptionRow>
+      <OptionRow id="3" value="3" text="Jane Poe">
+        <td>Jane</td>
+        <td>Poe</td>
+        <td>Accountant</td>
+      </OptionRow>
+      <OptionRow id="4" value="4" text="Jill Moe">
+        <td>Jill</td>
+        <td>Moe</td>
+        <td>Engineer</td>
+      </OptionRow>
+      <OptionRow id="5" value="5" text="Bill Zoe">
+        <td>Bill</td>
+        <td>Zoe</td>
+        <td>Astronaut</td>
+      </OptionRow>
+    </SimpleSelect>
+  );
+};
+
+export const SimpleSelectCustomOptionChildrenComponent = ({ ...props }) => {
+  return (
+    <SimpleSelect
+      name="customOptionChildren"
+      id="customOptionChildren"
+      defaultValue="4"
+      disablePortal
+      label="Pick your favourite color"
+      {...props}
+    >
+      <Option text="Orange" value="1">
+        <Icon type="favourite" color="orange" mr={1} /> Orange
+      </Option>
+      <Option text="Black" value="2">
+        <Icon type="money_bag" color="black" mr={1} /> Black
+      </Option>
+      <Option text="Blue" value="3">
+        <Icon type="gift" color="blue" mr={1} /> Blue
+      </Option>
+    </SimpleSelect>
+  );
+};
+
+export const SimpleSelectGroupComponent = ({ ...props }) => {
+  return (
+    <SimpleSelect name="optGroups" id="optGroups" {...props}>
+      <OptionGroupHeader label="Group one" icon="individual" />
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <OptionGroupHeader label="Group two" icon="shop" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <OptionGroupHeader label="Group three" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
+    </SimpleSelect>
+  );
+};
+
+export const SimpleSelectEventsComponent = ({
+  onChange,
+  ...props
+}: SimpleSelectProps) => {
+  const [state, setState] = useState("");
+
+  const setValue = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setState(event.target.value);
+    if (onChange) {
+      onChange(event);
+    }
+  };
+
+  return (
+    <SimpleSelect
+      label="color"
+      value={state}
+      labelInline
+      onChange={setValue}
+      {...props}
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
+    </SimpleSelect>
+  );
+};
+
+export const SimpleSelectWithLongWrappingTextComponent = () => (
+  <Box width={400}>
+    <SimpleSelect name="simple" id="simple" label="label" labelInline>
+      <Option
+        text="Like a lot of intelligent animals, most crows are quite social. 
+        For instance, American crows spend most of the year living in pairs or small family groups.
+        During the winter months, they will congregate with hundreds or even thousands of their peers to sleep together at night."
+        value="1"
+      />
+    </SimpleSelect>
+  </Box>
+);
+
+export const SimpleSelectWithManyOptionsAndVirtualScrolling = () => (
+  <SimpleSelect
+    name="virtualised"
+    id="virtualised"
+    label="choose an option"
+    labelInline
+    enableVirtualScroll
+    virtualScrollOverscan={10}
+  >
+    {Array(10000)
+      .fill(undefined)
+      .map((_, index) => (
+        <Option key={index} value={`${index}`} text={`Option ${index + 1}.`} />
+      ))}
+  </SimpleSelect>
+);
+
+export const SimpleSelectNestedInDialog = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
+      <SimpleSelect name="testSelect" id="testSelect">
+        <Option value="opt1" text="red" />
+        <Option value="opt2" text="green" />
+        <Option value="opt3" text="blue" />
+        <Option value="opt4" text="black" />
+      </SimpleSelect>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
### Proposed behaviour

- Add `accessibility` Cypress tests for the `Select` component to use the new cypress-component-react framework for testing.

### Current behaviour
Old approach for accessibility tests

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [ ] Run `npx cypress open --component` to check if there is newly added test.file
- [ ] Check if the `Simple-Select.test.js`, `Multi-Select.test.js` and `Filterable-Select.test.js` files passed
- [ ] Run `npx cypress run --component` to check none of the other *.test.js files have regressed
- [ ] Run `npx cypress run --e2e` to check none of the feature files have regressed
- [ ] Run `npm run build-storybook` -> `npx sb extract` -> `npx http-server storybook-static -p 9001` and run `npx cypress run --e2e` and check that `Select` tests are not running twice.