### PR TITLE
feat(action-popover): align component with design system 

### DIFF
--- a/cypress/components/action-popover/action-popover.cy.tsx
+++ b/cypress/components/action-popover/action-popover.cy.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/prop-types */
+/* eslint-disable jest/valid-expect-in-promise, jest/valid-expect */
 import React from "react";
 import path from "path";
 
@@ -16,6 +16,9 @@ import {
   actionPopoverButton,
   actionPopover,
   actionPopoverSubmenu,
+  actionPopoverMenuItemIcon,
+  actionPopoverMenuItemInnerText,
+  actionPopoverMenuItemChevron,
   actionPopoverSubmenuByIndex,
   actionPopoverInnerItem,
   actionPopoverWrapper,
@@ -34,6 +37,14 @@ import {
   ActionPopoverWithProps,
   ActionPopoverMenuWithProps,
   ActionPopoverPropsComponent,
+  ActionPopoverWithNoIconsOrSubmenus,
+  ActionPopoverWithSomeSubmenusAndNoIcons,
+  ActionPopoverWithSubmenusAndNoIcons,
+  ActionPopoverWithIconsAndNoSubmenus,
+  ActionPopoverWithSubmenusAndIcons,
+  ActionPopoverWithIconsAndSomeSubmenus,
+  ActionPopoverWithSubmenusAndSomeIcons,
+  ActionPopoverWithVariableChildren,
 } from "../../../src/components/action-popover/action-popover-test.stories";
 import {
   ActionPopoverComponent,
@@ -41,11 +52,11 @@ import {
   ActionPopoverComponentDisabledItems,
   ActionPopoverComponentMenuRightAligned,
   ActionPopoverComponentContentAlignedRight,
+  ActionPopoverComponentSubmenuPositionedRight,
   ActionPopoverComponentNoIcons,
   ActionPopoverComponentCustomMenuButton,
   ActionPopoverComponentSubmenu,
   ActionPopoverComponentDisabledSubmenu,
-  ActionPopoverComponentSubmenuAlignedRight,
   ActionPopoverComponentMenuOpeningAbove,
   ActionPopoverComponentKeyboardNavigation,
   ActionPopoverComponentKeyboardNaviationLeftAlignedSubmenu,
@@ -461,6 +472,13 @@ context("Test for ActionPopover component", () => {
         .should("be.visible");
     });
 
+    it("should render ActionPopover with icons within a submenu", () => {
+      CypressMountWithProviders(<ActionPopoverWithSubmenusAndNoIcons />);
+
+      actionPopoverButton().eq(0).click();
+      actionPopoverMenuItemIcon().eq(0).should("exist");
+    });
+
     it.each([
       ["left", "start"],
       ["right", "end"],
@@ -475,6 +493,21 @@ context("Test for ActionPopover component", () => {
         actionPopover()
           .get("button")
           .should("have.css", "justify-content", `flex-${attrValue}`);
+      }
+    );
+
+    it.each([
+      ["left", "chevron_left_thick"],
+      ["right", "chevron_right_thick"],
+    ])(
+      "should render ActionPopover with submenuPosition prop set to %s",
+      (position, chevronType) => {
+        CypressMountWithProviders(
+          <ActionPopoverWithSubmenusAndIcons submenuPosition={position} />
+        );
+
+        actionPopoverButton().eq(0).click();
+        actionPopoverMenuItemChevron().should("have.attr", "type", chevronType);
       }
     );
 
@@ -577,6 +610,350 @@ context("Test for ActionPopover component", () => {
     });
   });
 
+  describe("padding checks on 'StyledMenuItemInnerText'", () => {
+    it.each([
+      ["left", "left"],
+      ["left", "right"],
+      ["right", "left"],
+      ["right", "right"],
+    ])(
+      "when horizontalAlignment is %s and submenuPosition is %s, then left and right padding is --spacing100",
+      (alignment, position) => {
+        CypressMountWithProviders(
+          <ActionPopoverWithNoIconsOrSubmenus
+            horizontalAlignment={alignment}
+            submenuPosition={position}
+          />
+        );
+
+        actionPopoverButton()
+          .eq(0)
+          .click()
+          .then(() => {
+            actionPopoverMenuItemInnerText()
+              .should("have.css", "padding-left", "8px")
+              .getDesignTokensByCssProperty("padding-left")
+              .then(($el) => {
+                expect($el[0]).to.equal("--spacing100");
+              });
+
+            actionPopoverMenuItemInnerText()
+              .should("have.css", "padding-right", "8px")
+              .getDesignTokensByCssProperty("padding-right")
+              .then(($el) => {
+                expect($el[0]).to.equal("--spacing100");
+              });
+          });
+      }
+    );
+
+    it("when horizontalAlignment is left, submenuPosition is left and Menu Item children have some submenus and no icons, then padding-left is --spacing400", () => {
+      CypressMountWithProviders(
+        <ActionPopoverWithSomeSubmenusAndNoIcons
+          horizontalAlignment="left"
+          submenuPosition="left"
+        />
+      );
+
+      actionPopoverButton()
+        .eq(0)
+        .click()
+        .then(() => {
+          actionPopoverMenuItemInnerText()
+            .eq(0)
+            .should("have.css", "padding-left", "32px")
+            .getDesignTokensByCssProperty("padding-left")
+            .then(($el) => {
+              expect($el[0]).to.equal("--spacing400");
+            });
+        });
+    });
+
+    it("when horizontalAlignment is right, submenuPosition is right and Menu Item children have some submenus and no icons, then padding-right is --spacing400", () => {
+      CypressMountWithProviders(
+        <ActionPopoverWithSomeSubmenusAndNoIcons
+          horizontalAlignment="right"
+          submenuPosition="right"
+        />
+      );
+
+      actionPopoverButton()
+        .eq(0)
+        .click()
+        .then(() => {
+          actionPopoverMenuItemInnerText()
+            .eq(0)
+            .should("have.css", "padding-right", "32px")
+            .getDesignTokensByCssProperty("padding-right")
+            .then(($el) => {
+              expect($el[0]).to.equal("--spacing400");
+            });
+        });
+    });
+
+    it("when horizontalAlignment is left, submenuPosition is left and Menu Item children have submenus and some icons, then padding-left is --spacing600", () => {
+      CypressMountWithProviders(
+        <ActionPopoverWithSubmenusAndSomeIcons
+          horizontalAlignment="left"
+          submenuPosition="left"
+        />
+      );
+
+      actionPopoverButton()
+        .eq(0)
+        .click()
+        .then(() => {
+          actionPopoverMenuItemInnerText()
+            .eq(0)
+            .should("have.css", "padding-left", "48px")
+            .getDesignTokensByCssProperty("padding-left")
+            .then(($el) => {
+              expect($el[0]).to.equal("--spacing600");
+            });
+        });
+    });
+
+    it("when horizontalAlignment is right, submenuPosition is right and Menu Item children have submenus and some icons, then padding-right is --spacing600", () => {
+      CypressMountWithProviders(
+        <ActionPopoverWithSubmenusAndSomeIcons
+          horizontalAlignment="right"
+          submenuPosition="right"
+        />
+      );
+
+      actionPopoverButton()
+        .eq(0)
+        .click()
+        .then(() => {
+          actionPopoverMenuItemInnerText()
+            .eq(0)
+            .should("have.css", "padding-right", "48px")
+            .getDesignTokensByCssProperty("padding-right")
+            .then(($el) => {
+              expect($el[0]).to.equal("--spacing600");
+            });
+        });
+    });
+
+    it("when horizontalAlignment is left, submenuPosition is left and Menu Item children are variable, then padding-left is --spacing900", () => {
+      CypressMountWithProviders(
+        <ActionPopoverWithVariableChildren
+          horizontalAlignment="left"
+          submenuPosition="left"
+        />
+      );
+
+      actionPopoverButton()
+        .eq(0)
+        .click()
+        .then(() => {
+          actionPopoverMenuItemInnerText()
+            .eq(0)
+            .should("have.css", "padding-left", "72px")
+            .getDesignTokensByCssProperty("padding-left")
+            .then(($el) => {
+              expect($el[0]).to.equal("--spacing900");
+            });
+        });
+    });
+
+    it("when horizontalAlignment is right, submenuPosition is right and Menu Item children are variable, then padding-right is --spacing900", () => {
+      CypressMountWithProviders(
+        <ActionPopoverWithVariableChildren
+          horizontalAlignment="right"
+          submenuPosition="right"
+        />
+      );
+
+      actionPopoverButton()
+        .eq(0)
+        .click()
+        .then(() => {
+          actionPopoverMenuItemInnerText()
+            .eq(0)
+            .should("have.css", "padding-right", "72px")
+            .getDesignTokensByCssProperty("padding-right")
+            .then(($el) => {
+              expect($el[0]).to.equal("--spacing900");
+            });
+        });
+    });
+
+    it.each([
+      ["left", "left", 1],
+      ["left", "right", 2],
+      ["right", "left", 3],
+      ["right", "right", 4],
+    ])(
+      "when horizontalAlignment is %s, submenuPosition is %s and Menu Item child is a submenu, then left and right padding is --spacing000",
+      (alignment, position, index) => {
+        CypressMountWithProviders(
+          <ActionPopoverMenuWithProps
+            horizontalAlignment={alignment}
+            submenuPosition={position}
+          />
+        );
+
+        actionPopoverButton()
+          .eq(0)
+          .click()
+          .then(() => {
+            actionPopoverMenuItemInnerText()
+              .eq(index)
+              .should("have.css", "padding-left", "0px")
+              .getDesignTokensByCssProperty("padding-left")
+              .then(($el) => {
+                expect($el[0]).to.equal("--spacing000");
+              });
+
+            actionPopoverMenuItemInnerText()
+              .eq(index)
+              .should("have.css", "padding-right", "0px")
+              .getDesignTokensByCssProperty("padding-right")
+              .then(($el) => {
+                expect($el[0]).to.equal("--spacing000");
+              });
+          });
+      }
+    );
+  });
+
+  describe("justify-content checks on 'StyledMenuItem'", () => {
+    it.each([
+      ["left", "flex-start"],
+      ["right", "flex-end"],
+    ])(
+      "when horizontalAlignment is %s then content should be justified %s",
+      (alignment, itemAlignment) => {
+        CypressMountWithProviders(
+          <ActionPopoverWithProps horizontalAlignment={alignment} />
+        );
+
+        actionPopoverButton().eq(0).click();
+        getDataElementByValue("menu-item1").should(
+          "have.css",
+          "justify-content",
+          itemAlignment
+        );
+      }
+    );
+
+    it.each([
+      ["left", "right", "space-between"],
+      ["right", "left", "flex-end"],
+    ])(
+      "when horizontalAlignment is %s, submenuPosition is %s and Menu Item children have no submenus, then content should be justified %s",
+      (alignment, position, itemAlignment) => {
+        CypressMountWithProviders(
+          <ActionPopoverWithProps
+            horizontalAlignment={alignment}
+            submenuPosition={position}
+          />
+        );
+
+        actionPopoverButton().eq(0).click();
+        getDataElementByValue("menu-item1").should(
+          "have.css",
+          "justify-content",
+          itemAlignment
+        );
+      }
+    );
+
+    it.each([
+      ["left", "right", "space-between"],
+      ["right", "left", "space-between"],
+    ])(
+      "when horizontalAlignment is %s, submenuPosition is %s and Menu Item children have a submenu, then content should be justified %s",
+      (alignment, position, itemAlignment) => {
+        CypressMountWithProviders(
+          <ActionPopoverWithSubmenusAndIcons
+            horizontalAlignment={alignment}
+            submenuPosition={position}
+          />
+        );
+
+        actionPopoverButton().eq(0).click();
+        getDataElementByValue("menu-item1").should(
+          "have.css",
+          "justify-content",
+          itemAlignment
+        );
+      }
+    );
+  });
+
+  describe("padding checks on 'MenuItemIcon'", () => {
+    it("padding is: --spacing100", () => {
+      CypressMountWithProviders(<ActionPopoverWithIconsAndNoSubmenus />);
+
+      actionPopoverButton()
+        .eq(0)
+        .click()
+        .then(() => {
+          actionPopoverMenuItemIcon()
+            .eq(0)
+            .should("have.css", "padding", "8px")
+            .getDesignTokensByCssProperty("padding")
+            .then(($el) => {
+              expect($el.join(" ")).to.deep.equal(
+                "--spacing100 --spacing100 --spacing100 --spacing100"
+              );
+            });
+        });
+    });
+
+    it.each([
+      [
+        "left",
+        "left",
+        "--spacing100 --spacing100 --spacing100 --spacing400",
+        "8px 8px 8px 32px",
+      ],
+      [
+        "left",
+        "right",
+        "--spacing100 --spacing100 --spacing100 --spacing100",
+        "8px",
+      ],
+      [
+        "right",
+        "left",
+        "--spacing100 --spacing100 --spacing100 --spacing100",
+        "8px",
+      ],
+      [
+        "right",
+        "right",
+        "--spacing100 --spacing400 --spacing100 --spacing100",
+        "8px 32px 8px 8px",
+      ],
+    ])(
+      "when horizontalAlignment is %s and submenuPosition is %s and Menu Item children have icons and some submenus, then padding is %s",
+      (position, alignment, spacing, padding) => {
+        CypressMountWithProviders(
+          <ActionPopoverWithIconsAndSomeSubmenus
+            submenuPosition={position}
+            horizontalAlignment={alignment}
+          />
+        );
+
+        actionPopoverButton()
+          .eq(0)
+          .click()
+          .then(() => {
+            actionPopoverMenuItemIcon()
+              .eq(0)
+              .should("have.css", "padding", padding)
+              .getDesignTokensByCssProperty("padding")
+              .then(($el) => {
+                expect($el.join(" ")).to.deep.equal(spacing);
+              });
+          });
+      }
+    );
+  });
+
   describe("Accessibility tests for ActionPopover", () => {
     it("should pass accessibility tests for ActionPopover with custom button", () => {
       CypressMountWithProviders(
@@ -639,6 +1016,15 @@ context("Test for ActionPopover component", () => {
       cy.checkAccessibility();
     });
 
+    it("should pass accessibility tests for ActionPopover with a right submenu position", () => {
+      CypressMountWithProviders(
+        <ActionPopoverComponentSubmenuPositionedRight />
+      );
+
+      actionPopoverButton().eq(0).click();
+      cy.checkAccessibility();
+    });
+
     it("should pass accessibility tests for ActionPopover with no icons", () => {
       CypressMountWithProviders(<ActionPopoverComponentNoIcons />);
 
@@ -665,14 +1051,6 @@ context("Test for ActionPopover component", () => {
       CypressMountWithProviders(<ActionPopoverComponentDisabledSubmenu />);
 
       actionPopoverButton().eq(0).click();
-      cy.checkAccessibility();
-    });
-
-    it("should pass accessibility tests for ActionPopover with submenu aligned right", () => {
-      CypressMountWithProviders(<ActionPopoverComponentSubmenuAlignedRight />);
-
-      actionPopoverButton().eq(0).click();
-      actionPopoverInnerItem(0).click();
       cy.checkAccessibility();
     });
 

--- a/cypress/locators/action-popover/index.js
+++ b/cypress/locators/action-popover/index.js
@@ -2,6 +2,9 @@ import {
   ACTION_POPOVER_BUTTON,
   ACTION_POPOVER_DATA_COMPONENT,
   ACTION_POPOVER_SUBMENU,
+  ACTION_POPOVER_MENU_ITEM_ICON,
+  ACTION_POPOVER_MENU_ITEM_INNER_TEXT,
+  ACTION_POPOVER_MENU_ITEM_CHEVRON,
   ACTION_POPOVER_WRAPPER,
 } from "./locators";
 
@@ -18,6 +21,12 @@ export const actionPopoverInnerItem = (index) =>
     .first();
 export const actionPopoverSubmenu = (index) =>
   cy.get(ACTION_POPOVER_SUBMENU).eq(1).children().eq(index).find("button");
+export const actionPopoverMenuItemIcon = () =>
+  cy.get(ACTION_POPOVER_MENU_ITEM_ICON);
+export const actionPopoverMenuItemInnerText = () =>
+  cy.get(ACTION_POPOVER_MENU_ITEM_INNER_TEXT);
+export const actionPopoverMenuItemChevron = () =>
+  cy.get(ACTION_POPOVER_MENU_ITEM_CHEVRON);
 export const actionPopoverSubmenuByIndex = () =>
   cy.get(ACTION_POPOVER_SUBMENU).eq(1);
 export const actionPopoverWrapper = () => cy.get(ACTION_POPOVER_WRAPPER);

--- a/cypress/locators/action-popover/locators.js
+++ b/cypress/locators/action-popover/locators.js
@@ -3,5 +3,11 @@ export const ACTION_POPOVER_BUTTON = '[data-element="action-popover-button"]';
 export const ACTION_POPOVER_DATA_COMPONENT =
   '[data-component="action-popover"]';
 export const ACTION_POPOVER_SUBMENU = '[data-element="action-popover-submenu"]';
+export const ACTION_POPOVER_MENU_ITEM_ICON =
+  '[data-element="action-popover-menu-item-icon"]';
+export const ACTION_POPOVER_MENU_ITEM_INNER_TEXT =
+  '[data-element="action-popover-menu-item-inner-text"]';
+export const ACTION_POPOVER_MENU_ITEM_CHEVRON =
+  '[data-element="action-popover-menu-item-chevron"]';
 export const ACTION_POPOVER_WRAPPER =
   '[data-component="action-popover-wrapper"]';

--- a/src/components/action-popover/action-popover-context.ts
+++ b/src/components/action-popover/action-popover-context.ts
@@ -1,8 +1,11 @@
 import React from "react";
 
+export type Alignment = "left" | "right";
+
 type ActionPopoverContextType = {
   setOpenPopover: (isOpen: boolean) => void;
   focusButton: () => void;
+  submenuPosition: Alignment;
   isOpenPopover: boolean;
 };
 

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -11,11 +11,13 @@ import {
   MenuItemIcon,
   SubMenuItemIcon,
   StyledMenuItem,
+  StyledMenuItemInnerText,
+  StyledMenuItemOuterContainer,
   StyledMenuItemWrapper,
 } from "../action-popover.style";
 import Events from "../../../__internal__/utils/helpers/events";
 import createGuid from "../../../__internal__/utils/helpers/guid";
-import ActionPopoverContext from "../action-popover-context";
+import ActionPopoverContext, { Alignment } from "../action-popover-context";
 import useLocale from "../../../hooks/__internal__/useLocale";
 
 import { IconType } from "../../icon";
@@ -47,55 +49,55 @@ export interface ActionPopoverItemProps {
   /** @ignore @private */
   focusItem?: boolean;
   /** @ignore @private */
-  horizontalAlignment?: "left" | "right";
+  horizontalAlignment?: Alignment;
+  /** @ignore @private */
+  childHasSubmenu?: boolean;
+  /** @ignore @private */
+  childHasIcon?: boolean;
+  /** @ignore @private */
+  currentSubmenuPosition?: Alignment;
+  /** @ignore @private */
+  setChildHasSubmenu?: (value: boolean) => void;
+  /** @ignore @private */
+  setChildHasIcon?: (value: boolean) => void;
+  /** @ignore @private */
+  setCurrentSubmenuPosition?: (value: Alignment) => void;
+  /** @ignore @private */
+  isASubmenu?: boolean;
 }
 
 const INTERVAL = 150;
 
 type ContainerPosition = {
-  left: number;
+  left: string | number;
   top?: string;
   bottom?: string;
-  right: "auto";
+  right: string | number;
 };
 
 function checkRef(ref: React.RefObject<HTMLElement>) {
   return Boolean(ref && ref.current);
 }
 
-function leftAlignSubmenu(
+function calculateSubmenuPosition(
   ref: React.RefObject<HTMLElement>,
-  submenuRef: React.RefObject<HTMLElement>
+  submenuRef: React.RefObject<HTMLElement>,
+  submenuPosition: Alignment,
+  currentSubmenuPosition?: Alignment
 ) {
   /* istanbul ignore if */
-  if (!ref.current || !submenuRef.current) return true;
 
-  const { left } = ref.current.getBoundingClientRect();
+  if (!ref.current || !submenuRef.current)
+    return currentSubmenuPosition || submenuPosition;
+
+  const { left, right } = ref.current.getBoundingClientRect();
   const { offsetWidth } = submenuRef.current;
+  const windowWidth = document.body.clientWidth;
 
-  return left >= offsetWidth;
-}
-
-function getContainerPosition(
-  itemRef: React.RefObject<HTMLElement>,
-  submenuRef: React.RefObject<HTMLElement>,
-  placement: "bottom" | "top"
-): ContainerPosition | undefined {
-  /* istanbul ignore if */
-  if (!itemRef.current || !submenuRef.current) return undefined;
-
-  const { offsetWidth: parentWidth } = itemRef.current;
-  const { offsetWidth: submenuWidth } = submenuRef.current;
-  const xPositionValue = leftAlignSubmenu(itemRef, submenuRef)
-    ? -submenuWidth
-    : parentWidth;
-  const yPositionName = placement === "top" ? "bottom" : "top";
-
-  return {
-    left: xPositionValue,
-    [yPositionName]: "calc(-1 * var(--spacing100))",
-    right: "auto",
-  };
+  if (submenuPosition === "left") {
+    return left >= offsetWidth ? "left" : "right";
+  }
+  return windowWidth >= right + offsetWidth ? "right" : "left";
 }
 
 export const ActionPopoverItem = ({
@@ -109,6 +111,13 @@ export const ActionPopoverItem = ({
   download,
   href,
   horizontalAlignment,
+  childHasSubmenu,
+  childHasIcon,
+  currentSubmenuPosition,
+  setChildHasSubmenu,
+  setChildHasIcon,
+  setCurrentSubmenuPosition,
+  isASubmenu = false,
   ...rest
 }: ActionPopoverItemProps) => {
   const l = useLocale();
@@ -124,7 +133,12 @@ export const ActionPopoverItem = ({
     "ActionPopoverItem only accepts submenu of type `ActionPopoverMenu`"
   );
 
-  const { setOpenPopover, isOpenPopover, focusButton } = context;
+  const {
+    setOpenPopover,
+    isOpenPopover,
+    focusButton,
+    submenuPosition,
+  } = context;
   const isHref = !!href;
   const [containerPosition, setContainerPosition] = useState<
     ContainerPosition | undefined
@@ -132,7 +146,6 @@ export const ActionPopoverItem = ({
   const [guid] = useState(createGuid());
   const [isOpen, setOpen] = useState(false);
   const [focusIndex, setFocusIndex] = useState<number>(0);
-  const [isLeftAligned, setIsLeftAligned] = useState(true);
 
   const submenuRef = useRef<HTMLDivElement>(null);
   const ref = useRef<HTMLButtonElement>(null);
@@ -145,21 +158,65 @@ export const ActionPopoverItem = ({
     }
   }, [isOpenPopover]);
 
-  const alignSubmenu = useCallback(() => {
-    if (checkRef(ref) && checkRef(submenuRef) && submenu) {
-      const align = leftAlignSubmenu(ref, submenuRef);
-      setIsLeftAligned(align);
-      setContainerPosition(getContainerPosition(ref, submenuRef, placement));
+  useEffect(() => {
+    if (icon) {
+      setChildHasIcon?.(true);
     }
-  }, [submenu, placement]);
+    if (submenu) {
+      setChildHasSubmenu?.(true);
+    }
+  }, [icon, setChildHasSubmenu, setChildHasIcon, submenu]);
+
+  const alignSubmenu = useCallback(() => {
+    const checkCalculatedSubmenuPosition = calculateSubmenuPosition(
+      ref,
+      submenuRef,
+      submenuPosition,
+      currentSubmenuPosition
+    );
+
+    setCurrentSubmenuPosition?.(checkCalculatedSubmenuPosition);
+
+    return checkRef(ref) && checkRef(submenuRef) && submenu;
+  }, [
+    submenu,
+    setCurrentSubmenuPosition,
+    submenuPosition,
+    currentSubmenuPosition,
+  ]);
 
   useEffect(() => {
-    alignSubmenu();
+    const getContainerPosition = () => {
+      /* istanbul ignore if */
+      if (!ref.current || !submenuRef.current) return undefined;
 
+      const { offsetWidth: submenuWidth } = submenuRef.current;
+
+      const leftAlignedSubmenu = currentSubmenuPosition === "left";
+      const leftValue = leftAlignedSubmenu ? -submenuWidth : "auto";
+      const rightValue = leftAlignedSubmenu ? "auto" : -submenuWidth;
+      const yPositionName = placement === "top" ? "bottom" : "top";
+
+      return {
+        left: leftValue,
+        [yPositionName]: "calc(-1 * var(--spacing100))",
+        right: rightValue,
+      };
+    };
+    setContainerPosition(getContainerPosition);
+  }, [submenu, currentSubmenuPosition, placement]);
+
+  useEffect(() => {
+    if (submenu) {
+      alignSubmenu();
+    }
+  }, [alignSubmenu, submenu]);
+
+  useEffect(() => {
     if (focusItem) {
       ref.current?.focus();
     }
-  }, [alignSubmenu, focusItem]);
+  }, [focusItem]);
 
   useEffect(() => {
     return function cleanup() {
@@ -205,7 +262,7 @@ export const ActionPopoverItem = ({
         e.stopPropagation();
       } else if (!disabled) {
         if (submenu) {
-          if (isLeftAligned) {
+          if (currentSubmenuPosition === "left") {
             // LEFT: open if has submenu and left aligned otherwise close submenu
             if (Events.isLeftKey(e) || Events.isEnterKey(e)) {
               setOpen(true);
@@ -242,7 +299,7 @@ export const ActionPopoverItem = ({
         e.stopPropagation();
       }
     },
-    [disabled, download, isHref, isLeftAligned, onClick, submenu]
+    [disabled, download, isHref, onClick, submenu, currentSubmenuPosition]
   );
 
   const itemSubmenuProps = {
@@ -283,7 +340,21 @@ export const ActionPopoverItem = ({
   };
 
   const renderMenuItemIcon = () => {
-    return icon && <MenuItemIcon as={undefined} type={icon} />;
+    return (
+      icon && (
+        <MenuItemIcon
+          type={icon}
+          data-element="action-popover-menu-item-icon"
+          horizontalAlignment={horizontalAlignment}
+          submenuPosition={currentSubmenuPosition}
+          childHasIcon={childHasIcon}
+          childHasSubmenu={childHasSubmenu}
+          hasIcon={!!icon}
+          hasSubmenu={!!submenu}
+          isASubmenu={isASubmenu}
+        />
+      )
+    );
   };
 
   return (
@@ -298,18 +369,40 @@ export const ActionPopoverItem = ({
           tabIndex={0}
           isDisabled={disabled}
           horizontalAlignment={horizontalAlignment}
+          submenuPosition={currentSubmenuPosition}
+          hasSubmenu={!!submenu}
+          childHasSubmenu={childHasSubmenu}
           {...(disabled && { "aria-disabled": true })}
           {...(isHref && { as: ("a" as unknown) as undefined, download, href })}
           {...(submenu && itemSubmenuProps)}
         >
-          {submenu && checkRef(ref) && isLeftAligned ? (
-            <SubMenuItemIcon type="chevron_left" />
+          {submenu && checkRef(ref) && currentSubmenuPosition === "left" ? (
+            <SubMenuItemIcon
+              data-element="action-popover-menu-item-chevron"
+              type="chevron_left_thick"
+            />
           ) : null}
-          {horizontalAlignment === "left" ? renderMenuItemIcon() : null}
-          {children}
-          {horizontalAlignment === "right" ? renderMenuItemIcon() : null}
-          {submenu && checkRef(ref) && !isLeftAligned ? (
-            <SubMenuItemIcon type="chevron_right" />
+          <StyledMenuItemOuterContainer>
+            {horizontalAlignment === "left" ? renderMenuItemIcon() : null}
+            <StyledMenuItemInnerText
+              data-element="action-popover-menu-item-inner-text"
+              horizontalAlignment={horizontalAlignment}
+              submenuPosition={currentSubmenuPosition}
+              isASubmenu={isASubmenu}
+              childHasSubmenu={childHasSubmenu}
+              childHasIcon={childHasIcon}
+              hasIcon={!!icon}
+              hasSubmenu={!!submenu}
+            >
+              {children}
+            </StyledMenuItemInnerText>
+            {horizontalAlignment === "right" ? renderMenuItemIcon() : null}
+          </StyledMenuItemOuterContainer>
+          {submenu && checkRef(ref) && currentSubmenuPosition === "right" ? (
+            <SubMenuItemIcon
+              data-element="action-popover-menu-item-chevron"
+              type="chevron_right_thick"
+            />
           ) : null}
         </StyledMenuItem>
         {React.isValidElement(submenu)
@@ -325,6 +418,8 @@ export const ActionPopoverItem = ({
                 setOpen,
                 setFocusIndex,
                 focusIndex,
+                isASubmenu: true,
+                horizontalAlignment,
               }
             )
           : null}

--- a/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
+++ b/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useContext } from "react";
+import React, { useCallback, useMemo, useContext, useState } from "react";
 import invariant from "invariant";
 
 import { Menu } from "../action-popover.style";
@@ -7,7 +7,7 @@ import ActionPopoverItem, {
   ActionPopoverItemProps,
 } from "../action-popover-item/action-popover-item.component";
 import ActionPopoverDivider from "../action-popover-divider/action-popover-divider.component";
-import ActionPopoverContext from "../action-popover-context";
+import ActionPopoverContext, { Alignment } from "../action-popover-context";
 
 export interface ActionPopoverMenuBaseProps {
   /** Children for the menu */
@@ -25,19 +25,21 @@ export interface ActionPopoverMenuBaseProps {
   /** Unique ID for the menu's parent */
   parentID?: string;
   /** Horizontal alignment of menu items content */
-  horizontalAlignment?: "left" | "right";
+  horizontalAlignment?: Alignment;
   /** Set whether the menu should open above or below the button */
   placement?: "bottom" | "top";
   /** @ignore @private */
   role?: string;
   /** @ignore @private */
+  isASubmenu?: boolean;
+  /** @ignore @private */
   "data-element"?: string;
   /** @ignore @private */
   style?: {
-    left: number;
+    left: string | number;
     top?: string;
     bottom?: string;
-    right: "auto";
+    right: string | number;
   };
 }
 
@@ -60,6 +62,7 @@ const ActionPopoverMenu = React.forwardRef<
       setFocusIndex,
       placement = "bottom",
       horizontalAlignment,
+      isASubmenu,
       ...rest
     }: ActionPopoverMenuBaseProps,
     ref
@@ -69,7 +72,7 @@ const ActionPopoverMenu = React.forwardRef<
       context,
       "ActionPopoverMenu must be used within an ActionPopover component"
     );
-    const { focusButton } = context;
+    const { focusButton, submenuPosition } = context;
 
     invariant(
       setOpen && setFocusIndex && typeof focusIndex !== "undefined",
@@ -164,6 +167,13 @@ const ActionPopoverMenu = React.forwardRef<
       [focusButton, setOpen, focusIndex, items, setFocusIndex]
     );
 
+    const [childHasSubmenu, setChildHasSubmenu] = useState(false);
+    const [childHasIcon, setChildHasIcon] = useState(false);
+    const [
+      currentSubmenuPosition,
+      setCurrentSubmenuPosition,
+    ] = useState<Alignment>(submenuPosition);
+
     const clonedChildren = useMemo(() => {
       let index = 0;
       return React.Children.map(children, (child) => {
@@ -175,13 +185,30 @@ const ActionPopoverMenu = React.forwardRef<
               focusItem: isOpen && focusIndex === index - 1,
               placement: child.props.submenu ? placement : undefined,
               horizontalAlignment,
+              childHasSubmenu,
+              setChildHasSubmenu,
+              childHasIcon,
+              setChildHasIcon,
+              currentSubmenuPosition,
+              setCurrentSubmenuPosition,
+              isASubmenu,
             }
           );
         }
 
         return child;
       });
-    }, [children, focusIndex, isOpen, placement, horizontalAlignment]);
+    }, [
+      children,
+      focusIndex,
+      isOpen,
+      placement,
+      horizontalAlignment,
+      childHasSubmenu,
+      childHasIcon,
+      currentSubmenuPosition,
+      isASubmenu,
+    ]);
 
     return (
       <Menu

--- a/src/components/action-popover/action-popover-test.stories.tsx
+++ b/src/components/action-popover/action-popover-test.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { action } from "@storybook/addon-actions";
 
@@ -270,11 +271,20 @@ export const ActionPopoverWithProps = ({ ...props }) => {
             <FlatTableCell>Doe</FlatTableCell>
             <FlatTableCell>
               <ActionPopover {...props}>
-                <ActionPopoverItem icon="email" disabled onClick={() => {}}>
+                <ActionPopoverItem
+                  data-element="menu-item1"
+                  icon="email"
+                  disabled
+                  onClick={() => {}}
+                >
                   Email Invoice
                 </ActionPopoverItem>
                 <ActionPopoverDivider />
-                <ActionPopoverItem onClick={() => {}} icon="delete">
+                <ActionPopoverItem
+                  data-element="menu-item2"
+                  onClick={() => {}}
+                  icon="delete"
+                >
                   Delete
                 </ActionPopoverItem>
               </ActionPopover>
@@ -283,6 +293,288 @@ export const ActionPopoverWithProps = ({ ...props }) => {
         </FlatTableBody>
       </FlatTable>
     </div>
+  );
+};
+
+export const ActionPopoverWithNoIconsOrSubmenus = ({ ...props }) => (
+  <ActionPopover {...props}>
+    <ActionPopoverItem onClick={() => {}}>Business</ActionPopoverItem>
+    <ActionPopoverItem onClick={() => {}}>Email Invoice</ActionPopoverItem>
+    <ActionPopoverItem onClick={() => {}}>Print Invoice</ActionPopoverItem>
+    <ActionPopoverItem onClick={() => {}}>Download PDF</ActionPopoverItem>
+    <ActionPopoverItem onClick={() => {}}>Download CSV</ActionPopoverItem>
+    <ActionPopoverDivider />
+    <ActionPopoverItem onClick={() => {}}>Delete</ActionPopoverItem>
+    <ActionPopoverItem onClick={() => {}}>Return Home</ActionPopoverItem>
+  </ActionPopover>
+);
+
+export const ActionPopoverWithSomeSubmenusAndNoIcons = ({ ...props }) => {
+  const submenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem data-element="submenu1" icon="bin" onClick={() => {}}>
+        Sub Menu 1
+      </ActionPopoverItem>
+      <ActionPopoverItem data-element="submenu2" onClick={() => {}}>
+        Sub Menu 2
+      </ActionPopoverItem>
+      <ActionPopoverItem data-element="submenu3" onClick={() => {}}>
+        Sub Menu 3
+      </ActionPopoverItem>
+      <ActionPopoverItem data-element="submenu4" onClick={() => {}}>
+        Sub Menu 4
+      </ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+
+  return (
+    <ActionPopover {...props}>
+      <ActionPopoverItem onClick={() => {}}>Business</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Email Invoice
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Print Invoice</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Download PDF</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Download CSV
+      </ActionPopoverItem>
+      <ActionPopoverDivider />
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Delete
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Return Home
+      </ActionPopoverItem>
+    </ActionPopover>
+  );
+};
+
+export const ActionPopoverWithSubmenusAndNoIcons = ({ ...props }) => {
+  const submenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem data-element="submenu1" icon="bin" onClick={() => {}}>
+        Sub Menu 1
+      </ActionPopoverItem>
+      <ActionPopoverItem data-element="submenu2" onClick={() => {}}>
+        Sub Menu 2
+      </ActionPopoverItem>
+      <ActionPopoverItem data-element="submenu3" onClick={() => {}}>
+        Sub Menu 3
+      </ActionPopoverItem>
+      <ActionPopoverItem data-element="submenu4" onClick={() => {}}>
+        Sub Menu 4
+      </ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+
+  return (
+    <ActionPopover {...props}>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Business
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Email Invoice
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Print Invoice
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Download PDF
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Download CSV
+      </ActionPopoverItem>
+      <ActionPopoverDivider />
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Delete
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Return Home
+      </ActionPopoverItem>
+    </ActionPopover>
+  );
+};
+export const ActionPopoverWithIconsAndNoSubmenus = ({ ...props }) => (
+  <ActionPopover {...props}>
+    <ActionPopoverItem icon="graph" onClick={() => {}}>
+      Business
+    </ActionPopoverItem>
+    <ActionPopoverItem icon="email" onClick={() => {}}>
+      Email Invoice
+    </ActionPopoverItem>
+    <ActionPopoverItem icon="print" onClick={() => {}}>
+      Print Invoice
+    </ActionPopoverItem>
+    <ActionPopoverItem icon="pdf" onClick={() => {}}>
+      Download PDF
+    </ActionPopoverItem>
+    <ActionPopoverItem icon="csv" onClick={() => {}}>
+      Download CSV
+    </ActionPopoverItem>
+    <ActionPopoverDivider />
+    <ActionPopoverItem icon="delete" onClick={() => {}}>
+      Delete
+    </ActionPopoverItem>
+    <ActionPopoverItem icon="home" onClick={() => {}}>
+      Return Home
+    </ActionPopoverItem>
+  </ActionPopover>
+);
+
+export const ActionPopoverWithSubmenusAndIcons = ({ ...props }) => {
+  const submenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem icon="bin" onClick={() => {}}>
+        Sub Menu 1
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 2</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 3</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 4</ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+
+  return (
+    <ActionPopover {...props}>
+      <ActionPopoverItem
+        data-element="menu-item1"
+        icon="graph"
+        onClick={() => {}}
+        submenu={submenu}
+      >
+        Business
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="email" onClick={() => {}} submenu={submenu}>
+        Email Invoice
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="print" onClick={() => {}} submenu={submenu}>
+        Print Invoice
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="pdf" onClick={() => {}} submenu={submenu}>
+        Download PDF
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="csv" onClick={() => {}} submenu={submenu}>
+        Download CSV
+      </ActionPopoverItem>
+      <ActionPopoverDivider />
+      <ActionPopoverItem icon="delete" onClick={() => {}} submenu={submenu}>
+        Delete
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="home" onClick={() => {}} submenu={submenu}>
+        Return Home
+      </ActionPopoverItem>
+    </ActionPopover>
+  );
+};
+
+export const ActionPopoverWithIconsAndSomeSubmenus = ({ ...props }) => {
+  const submenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem icon="bin" onClick={() => {}}>
+        Sub Menu 1
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 2</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 3</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 4</ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+
+  return (
+    <ActionPopover {...props}>
+      <ActionPopoverItem icon="graph" onClick={() => {}}>
+        Business
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="email" onClick={() => {}}>
+        Email Invoice
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="print" onClick={() => {}}>
+        Print Invoice
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="pdf" onClick={() => {}}>
+        Download PDF
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="csv" onClick={() => {}} submenu={submenu}>
+        Download CSV
+      </ActionPopoverItem>
+      <ActionPopoverDivider />
+      <ActionPopoverItem icon="delete" onClick={() => {}} submenu={submenu}>
+        Delete
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="home" onClick={() => {}} submenu={submenu}>
+        Return Home
+      </ActionPopoverItem>
+    </ActionPopover>
+  );
+};
+
+export const ActionPopoverWithSubmenusAndSomeIcons = ({ ...props }) => {
+  const submenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem icon="bin" onClick={() => {}}>
+        Sub Menu 1
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 2</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 3</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 4</ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+
+  return (
+    <ActionPopover {...props}>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Business
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Email Invoice
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Print Invoice
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}} submenu={submenu}>
+        Download PDF
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="csv" onClick={() => {}} submenu={submenu}>
+        Download CSV
+      </ActionPopoverItem>
+      <ActionPopoverDivider />
+      <ActionPopoverItem icon="delete" onClick={() => {}} submenu={submenu}>
+        Delete
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="home" onClick={() => {}} submenu={submenu}>
+        Return Home
+      </ActionPopoverItem>
+    </ActionPopover>
+  );
+};
+
+export const ActionPopoverWithVariableChildren = ({ ...props }) => {
+  const submenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem icon="bin" onClick={() => {}}>
+        Sub Menu 1
+      </ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 2</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 3</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 4</ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+
+  return (
+    <ActionPopover {...props}>
+      <ActionPopoverItem onClick={() => {}}>Business</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Email Invoice</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Print Invoice</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Download PDF</ActionPopoverItem>
+      <ActionPopoverItem icon="csv" onClick={() => {}} submenu={submenu}>
+        Download CSV
+      </ActionPopoverItem>
+      <ActionPopoverDivider />
+      <ActionPopoverItem icon="delete" onClick={() => {}} submenu={submenu}>
+        Delete
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="home" onClick={() => {}} submenu={submenu}>
+        Return Home
+      </ActionPopoverItem>
+    </ActionPopover>
   );
 };
 
@@ -297,6 +589,7 @@ export const ActionPopoverMenuWithProps = ({ ...props }) => {
             <ActionPopoverItem icon="print" disabled>
               Sub Menu 3
             </ActionPopoverItem>
+            <ActionPopoverItem icon="bin">Sub Menu 4</ActionPopoverItem>
           </ActionPopoverMenu>
         }
       >

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -20,7 +20,7 @@ import useLocale from "../../hooks/__internal__/useLocale";
 import ActionPopoverMenu from "./action-popover-menu/action-popover-menu.component";
 import ActionPopoverItem from "./action-popover-item/action-popover-item.component";
 import ActionPopoverDivider from "./action-popover-divider/action-popover-divider.component";
-import ActionPopoverContext from "./action-popover-context";
+import ActionPopoverContext, { Alignment } from "./action-popover-context";
 import useModalManager from "../../hooks/__internal__/useModalManager";
 
 export interface RenderButtonProps {
@@ -38,7 +38,9 @@ export interface ActionPopoverProps extends MarginProps {
   /** Children for popover component */
   children?: React.ReactNode;
   /** Horizontal alignment of menu items content */
-  horizontalAlignment?: "left" | "right";
+  horizontalAlignment?: Alignment;
+  /** Sets submenu position */
+  submenuPosition?: Alignment;
   /** Unique ID */
   id?: string;
   /** Callback to be called on menu open */
@@ -65,6 +67,7 @@ export const ActionPopover = ({
   renderButton,
   placement = "bottom",
   horizontalAlignment = "left",
+  submenuPosition = "left",
   ...rest
 }: ActionPopoverProps) => {
   const l = useLocale();
@@ -266,7 +269,12 @@ export const ActionPopover = ({
     >
       {menuButton(menuID)}
       <ActionPopoverContext.Provider
-        value={{ setOpenPopover: setOpen, focusButton, isOpenPopover: isOpen }}
+        value={{
+          setOpenPopover: setOpen,
+          focusButton,
+          submenuPosition,
+          isOpenPopover: isOpen,
+        }}
       >
         {isOpen && (
           <Popover placement={mappedPlacement} reference={buttonRef}>

--- a/src/components/action-popover/action-popover.spec.tsx
+++ b/src/components/action-popover/action-popover.spec.tsx
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import { ThemeProvider } from "styled-components";
 import { mount as enzymeMount, ReactWrapper } from "enzyme";
-
 import {
   simulate,
   assertStyleMatch,
@@ -25,6 +24,7 @@ import {
   MenuItemIcon,
   SubMenuItemIcon,
   StyledMenuItem,
+  StyledMenuItemInnerText,
   StyledButtonIcon,
   StyledMenuItemWrapper,
 } from "./action-popover.style";
@@ -101,13 +101,11 @@ describe("ActionPopover", () => {
     };
 
     renderer(
-      <ThemeProvider theme={mintTheme}>
-        <>
-          <input id="before" />
-          <ActionPopover {...defaultProps} {...props} />
-          <input id="after" />
-        </>
-      </ThemeProvider>
+      <>
+        <input id="before" />
+        <ActionPopover {...defaultProps} {...props} />
+        <input id="after" />
+      </>
     );
   }
 
@@ -116,6 +114,7 @@ describe("ActionPopover", () => {
       <ActionPopoverMenu>
         <ActionPopoverItem
           key="0"
+          icon="bin"
           {...{ onClick: onClickWrapper("sub menu 1") }}
         >
           Sub Menu 1
@@ -170,13 +169,243 @@ describe("ActionPopover", () => {
     };
 
     renderer(
-      <ThemeProvider theme={mintTheme}>
-        <>
-          <input id="before" />
-          <ActionPopover {...defaultProps} {...props} />
-          <input id="after" />
-        </>
-      </ThemeProvider>
+      <>
+        <input id="before" />
+        <ActionPopover {...defaultProps} {...props} />
+        <input id="after" />
+      </>
+    );
+  }
+
+  function renderActionPopoverWithNoIconsOrSubmenus(
+    props = {},
+    renderer = mount
+  ) {
+    const defaultProps = {
+      children: [
+        <ActionPopoverItem key="item-1" onClick={() => {}}>
+          Business
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-2" onClick={() => {}}>
+          Email Invoice
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-3" onClick={() => {}}>
+          Print Invoice
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-4" onClick={() => {}}>
+          Download PDF
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-5" onClick={() => {}}>
+          Download CSV
+        </ActionPopoverItem>,
+        <ActionPopoverDivider key="item-6" />,
+        <ActionPopoverItem key="item-7" onClick={() => {}}>
+          Delete
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-8" onClick={() => {}}>
+          Return Home
+        </ActionPopoverItem>,
+        null,
+        undefined,
+      ],
+      ...props,
+    };
+
+    renderer(
+      <>
+        <input id="before" />
+        <ActionPopover {...defaultProps} {...props} />
+        <input id="after" />
+      </>
+    );
+  }
+
+  function renderActionPopoverWithSomeSubmenusAndNoIcons(
+    props = {},
+    renderer = mount
+  ) {
+    const submenu = (
+      <ActionPopoverMenu>
+        <ActionPopoverItem icon="bin" onClick={() => {}}>
+          Sub Menu 1
+        </ActionPopoverItem>
+        <ActionPopoverItem onClick={() => {}}>Sub Menu 2</ActionPopoverItem>
+        <ActionPopoverItem onClick={() => {}}>Sub Menu 3</ActionPopoverItem>
+        <ActionPopoverItem onClick={() => {}}>Sub Menu 4</ActionPopoverItem>
+      </ActionPopoverMenu>
+    );
+
+    const defaultProps = {
+      children: [
+        <ActionPopoverItem key="item-1" onClick={() => {}}>
+          Business
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-2" onClick={() => {}} submenu={submenu}>
+          Email Invoice
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-3" onClick={() => {}}>
+          Print Invoice
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-4" onClick={() => {}}>
+          Download PDF
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-5" onClick={() => {}} submenu={submenu}>
+          Download CSV
+        </ActionPopoverItem>,
+        <ActionPopoverDivider key="item-6" />,
+        <ActionPopoverItem key="item-7" onClick={() => {}} submenu={submenu}>
+          Delete
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-8" onClick={() => {}} submenu={submenu}>
+          Return Home
+        </ActionPopoverItem>,
+        null,
+        undefined,
+      ],
+      ...props,
+    };
+
+    renderer(
+      <>
+        <input id="before" />
+        <ActionPopover {...defaultProps} {...props} />
+        <input id="after" />
+      </>
+    );
+  }
+
+  function renderActionPopoverWithSubmenusAndSomeIcons(
+    props = {},
+    renderer = mount
+  ) {
+    const submenu = (
+      <ActionPopoverMenu>
+        <ActionPopoverItem icon="bin" onClick={() => {}}>
+          Sub Menu 1
+        </ActionPopoverItem>
+        <ActionPopoverItem onClick={() => {}}>Sub Menu 2</ActionPopoverItem>
+        <ActionPopoverItem onClick={() => {}}>Sub Menu 3</ActionPopoverItem>
+        <ActionPopoverItem onClick={() => {}}>Sub Menu 4</ActionPopoverItem>
+      </ActionPopoverMenu>
+    );
+
+    const defaultProps = {
+      children: [
+        <ActionPopoverItem key="item-1" onClick={() => {}} submenu={submenu}>
+          Business
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-2" onClick={() => {}} submenu={submenu}>
+          Email Invoice
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-3" onClick={() => {}} submenu={submenu}>
+          Print Invoice
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-4" onClick={() => {}} submenu={submenu}>
+          Download PDF
+        </ActionPopoverItem>,
+        <ActionPopoverItem
+          key="item-5"
+          icon="csv"
+          onClick={() => {}}
+          submenu={submenu}
+        >
+          Download CSV
+        </ActionPopoverItem>,
+        <ActionPopoverDivider key="item-6" />,
+        <ActionPopoverItem
+          key="item-7"
+          icon="delete"
+          onClick={() => {}}
+          submenu={submenu}
+        >
+          Delete
+        </ActionPopoverItem>,
+        <ActionPopoverItem
+          key="item-8"
+          icon="home"
+          onClick={() => {}}
+          submenu={submenu}
+        >
+          Return Home
+        </ActionPopoverItem>,
+        null,
+        undefined,
+      ],
+      ...props,
+    };
+
+    renderer(
+      <>
+        <input id="before" />
+        <ActionPopover {...defaultProps} {...props} />
+        <input id="after" />
+      </>
+    );
+  }
+
+  function renderWithVariableChildren(props = {}, renderer = mount) {
+    const submenu = (
+      <ActionPopoverMenu>
+        <ActionPopoverItem icon="bin" onClick={() => {}}>
+          Sub Menu 1
+        </ActionPopoverItem>
+        <ActionPopoverItem onClick={() => {}}>Sub Menu 2</ActionPopoverItem>
+        <ActionPopoverItem onClick={() => {}}>Sub Menu 3</ActionPopoverItem>
+        <ActionPopoverItem onClick={() => {}}>Sub Menu 4</ActionPopoverItem>
+      </ActionPopoverMenu>
+    );
+
+    const defaultProps = {
+      children: [
+        <ActionPopoverItem key="item-1" onClick={() => {}}>
+          Business
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-2" onClick={() => {}}>
+          Email Invoice
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-3" onClick={() => {}}>
+          Print Invoice
+        </ActionPopoverItem>,
+        <ActionPopoverItem key="item-4" onClick={() => {}}>
+          Download PDF
+        </ActionPopoverItem>,
+        <ActionPopoverItem
+          key="item-5"
+          icon="csv"
+          onClick={() => {}}
+          submenu={submenu}
+        >
+          Download CSV
+        </ActionPopoverItem>,
+        <ActionPopoverDivider key="item-6" />,
+        <ActionPopoverItem
+          key="item-7"
+          icon="delete"
+          onClick={() => {}}
+          submenu={submenu}
+        >
+          Delete
+        </ActionPopoverItem>,
+        <ActionPopoverItem
+          key="item-8"
+          icon="home"
+          onClick={() => {}}
+          submenu={submenu}
+        >
+          Return Home
+        </ActionPopoverItem>,
+        null,
+        undefined,
+      ],
+      ...props,
+    };
+
+    renderer(
+      <>
+        <input id="before" />
+        <ActionPopover {...defaultProps} {...props} />
+        <input id="after" />
+      </>
     );
   }
 
@@ -234,13 +463,11 @@ describe("ActionPopover", () => {
   describe("if download prop and href prop are provided", () => {
     it("should render as a link component", () => {
       wrapper = enzymeMount(
-        <ThemeProvider theme={mintTheme}>
-          <ActionPopover>
-            <ActionPopoverItem key="1" onClick={jest.fn()} href="#" download>
-              test download
-            </ActionPopoverItem>
-          </ActionPopover>
-        </ThemeProvider>
+        <ActionPopover>
+          <ActionPopoverItem key="1" onClick={jest.fn()} href="#" download>
+            test download
+          </ActionPopoverItem>
+        </ActionPopover>
       );
 
       openMenu();
@@ -250,13 +477,11 @@ describe("ActionPopover", () => {
 
     it("should trigger click function if enter pressed", () => {
       wrapper = enzymeMount(
-        <ThemeProvider theme={mintTheme}>
-          <ActionPopover>
-            <ActionPopoverItem key="1" href="#" download>
-              test download
-            </ActionPopoverItem>
-          </ActionPopover>
-        </ThemeProvider>
+        <ActionPopover>
+          <ActionPopoverItem key="1" href="#" download>
+            test download
+          </ActionPopoverItem>
+        </ActionPopover>
       );
 
       act(() => {
@@ -349,12 +574,10 @@ describe("ActionPopover", () => {
       "applies proper placement prop to Popover component",
       (placement, rightAlignMenu, result) => {
         const myWrapper = enzymeMount(
-          <ThemeProvider theme={mintTheme}>
-            <ActionPopover
-              placement={placement}
-              rightAlignMenu={rightAlignMenu}
-            />
-          </ThemeProvider>
+          <ActionPopover
+            placement={placement}
+            rightAlignMenu={rightAlignMenu}
+          />
         );
 
         myWrapper.find(MenuButton).simulate("click");
@@ -845,13 +1068,11 @@ describe("ActionPopover", () => {
 
     expect(() => {
       enzymeMount(
-        <ThemeProvider theme={mintTheme}>
-          <ActionPopover>
-            <ActionPopoverItem onClick={() => {}}>Item</ActionPopoverItem>
-            Invalid children
-            <p>invalid children</p>
-          </ActionPopover>
-        </ThemeProvider>
+        <ActionPopover>
+          <ActionPopoverItem onClick={() => {}}>Item</ActionPopoverItem>
+          Invalid children
+          <p>invalid children</p>
+        </ActionPopover>
       );
     }).toThrow(
       "ActionPopover only accepts children of type `ActionPopoverItem`" +
@@ -872,11 +1093,11 @@ describe("ActionPopover", () => {
         const submenuIcon = item.find(SubMenuItemIcon);
         assertStyleMatch(
           {
-            left: "-2px",
+            left: "-5px",
           },
           submenuIcon
         );
-        expect(submenuIcon.props().type).toEqual("chevron_left");
+        expect(submenuIcon.props().type).toEqual("chevron_left_thick");
       });
 
       it("opens the submenu on mouseenter", () => {
@@ -1085,18 +1306,16 @@ describe("ActionPopover", () => {
 
       it("does not open a submenu if an item is disabled", () => {
         const tempWrapper = enzymeMount(
-          <ThemeProvider theme={mintTheme}>
-            <ActionPopover>
-              <ActionPopoverItem
-                icon="email"
-                disabled
-                submenu={<ActionPopoverMenu />}
-                {...{ onClick: onClickWrapper("email") }}
-              >
-                Foo
-              </ActionPopoverItem>
-            </ActionPopover>
-          </ThemeProvider>
+          <ActionPopover>
+            <ActionPopoverItem
+              icon="email"
+              disabled
+              submenu={<ActionPopoverMenu />}
+              {...{ onClick: onClickWrapper("email") }}
+            >
+              Foo
+            </ActionPopoverItem>
+          </ActionPopover>
         );
 
         tempWrapper.find(MenuButton).simulate("click");
@@ -1213,28 +1432,27 @@ describe("ActionPopover", () => {
     describe('when the "focusIndex" prop is -1', () => {
       it("does not focus the first of the items", () => {
         const item = enzymeMount(
-          <ThemeProvider theme={mintTheme}>
-            <ActionPopoverContext.Provider
-              value={{
-                setOpenPopover: jest.fn(),
-                focusButton: jest.fn(),
-                isOpenPopover: false,
-              }}
+          <ActionPopoverContext.Provider
+            value={{
+              setOpenPopover: jest.fn(),
+              focusButton: jest.fn(),
+              isOpenPopover: false,
+              submenuPosition: "left",
+            }}
+          >
+            <ActionPopoverMenu
+              setOpen={jest.fn()}
+              setFocusIndex={jest.fn()}
+              focusIndex={-1}
             >
-              <ActionPopoverMenu
-                setOpen={jest.fn()}
-                setFocusIndex={jest.fn()}
-                focusIndex={-1}
+              <ActionPopoverItem
+                key="0"
+                {...{ onClick: onClickWrapper("sub menu 1") }}
               >
-                <ActionPopoverItem
-                  key="0"
-                  {...{ onClick: onClickWrapper("sub menu 1") }}
-                >
-                  Sub Menu 1
-                </ActionPopoverItem>
-              </ActionPopoverMenu>
-            </ActionPopoverContext.Provider>
-          </ThemeProvider>
+                Sub Menu 1
+              </ActionPopoverItem>
+            </ActionPopoverMenu>
+          </ActionPopoverContext.Provider>
         ).find(ActionPopoverItem);
 
         expect(item).not.toBeFocused();
@@ -1247,7 +1465,7 @@ describe("ActionPopover", () => {
       });
     });
 
-    describe("right aligned", () => {
+    describe("submenu aligns right when parent container is too small and submenuPosition is 'left'", () => {
       let getBoundingClientRectSpy: jest.SpyInstance;
       beforeEach(() => {
         // Mock the parent boundingRect
@@ -1259,10 +1477,12 @@ describe("ActionPopover", () => {
           .fn()
           .mockImplementation(() => ({
             left: "-100",
-            right: "200",
+            right: "auto",
             top: "100",
           }));
-        renderWithSubmenu();
+        renderWithSubmenu({
+          submenuPosition: "left",
+        });
       });
 
       afterEach(() => {
@@ -1281,7 +1501,7 @@ describe("ActionPopover", () => {
           },
           submenuIcon
         );
-        expect(submenuIcon.props().type).toEqual("chevron_right");
+        expect(submenuIcon.props().type).toEqual("chevron_right_thick");
       });
 
       it("opens the submenu and focuses the first item when right key is pressed", () => {
@@ -1332,6 +1552,161 @@ describe("ActionPopover", () => {
       });
     });
 
+    describe("submenu aligns right when submenuPosition is 'right'", () => {
+      beforeEach(() => {
+        renderWithSubmenu({ submenuPosition: "right" });
+      });
+
+      it("renders an icon to indicate when a item has a submenu and is right aligned", () => {
+        openMenu();
+        const { items } = getElements();
+        const item = items.at(1);
+        const submenuIcon = item.find(SubMenuItemIcon);
+        assertStyleMatch(
+          {
+            right: "-5px",
+          },
+          submenuIcon
+        );
+        expect(submenuIcon.props().type).toEqual("chevron_right_thick");
+      });
+
+      it("opens the submenu and focuses the first item when right key is pressed", () => {
+        openMenu();
+        const { items } = getElements();
+        const item = items.at(1);
+
+        act(() => {
+          simulate.keydown.pressArrowRight(item.find(StyledMenuItem).at(0));
+        });
+        jest.runAllTimers();
+
+        act(() => {
+          expect(
+            item
+              .find(ActionPopoverMenu)
+              .find(ActionPopoverItem)
+              .at(0)
+              .find(StyledMenuItem)
+              .at(0)
+              .getDOMNode()
+          ).toBeFocused();
+        });
+      });
+
+      it("closes the submenu and returns focus to parent item when left key is pressed", () => {
+        openMenu();
+        const { items } = getElements();
+        const item = items.at(1);
+        act(() => {
+          simulate.keydown.pressArrowRight(item.find(StyledMenuItem).at(0));
+        });
+        act(() => {
+          simulate.keydown.pressArrowLeft(item.find(StyledMenuItem).at(0));
+        });
+        act(() => {
+          expect(
+            item
+              .find(ActionPopoverMenu)
+              .find(ActionPopoverItem)
+              .at(0)
+              .find(StyledMenuItem)
+              .at(0)
+              .getDOMNode()
+          ).not.toBeFocused();
+          expect(item.find(StyledMenuItem).at(0).getDOMNode()).toBeFocused();
+        });
+      });
+    });
+
+    describe("submenu aligns left when parent container is too small and submenuPosition is 'right'", () => {
+      let getBoundingClientRectSpy: jest.SpyInstance;
+      beforeEach(() => {
+        // Mock the parent boundingRect
+        getBoundingClientRectSpy = jest.spyOn(
+          Element.prototype,
+          "getBoundingClientRect"
+        );
+        Element.prototype.getBoundingClientRect = jest
+          .fn()
+          .mockImplementation(() => ({
+            left: "auto",
+            right: "100",
+            top: "100",
+          }));
+        renderWithSubmenu({
+          submenuPosition: "right",
+          rightAlignMenu: true,
+        });
+      });
+
+      afterEach(() => {
+        // Clear Mock from parent boundingRect
+        getBoundingClientRectSpy.mockRestore();
+      });
+
+      it("renders an icon to indicate when a item has a submenu and is left aligned", () => {
+        openMenu();
+        const { items } = getElements();
+        const item = items.at(1);
+        const submenuIcon = item.find(SubMenuItemIcon);
+        assertStyleMatch(
+          {
+            left: "-5px",
+          },
+          submenuIcon
+        );
+        expect(submenuIcon.props().type).toEqual("chevron_left_thick");
+      });
+
+      it("opens the submenu and focuses the first item when right key is pressed", () => {
+        openMenu();
+        const { items } = getElements();
+        const item = items.at(1);
+
+        act(() => {
+          simulate.keydown.pressArrowLeft(item.find(StyledMenuItem).at(0));
+        });
+        jest.runAllTimers();
+
+        act(() => {
+          expect(
+            item
+              .find(ActionPopoverMenu)
+              .find(ActionPopoverItem)
+              .at(0)
+              .find(StyledMenuItem)
+              .at(0)
+              .getDOMNode()
+          ).toBeFocused();
+        });
+      });
+
+      it("closes the submenu and returns focus to parent item when left key is pressed", () => {
+        openMenu();
+        const { items } = getElements();
+        const item = items.at(1);
+        act(() => {
+          simulate.keydown.pressArrowLeft(item.find(StyledMenuItem).at(0));
+        });
+        act(() => {
+          simulate.keydown.pressArrowRight(item.find(StyledMenuItem).at(0));
+        });
+        act(() => {
+          expect(
+            item
+              .find(ActionPopoverMenu)
+              .find(ActionPopoverItem)
+              .at(0)
+              .find(StyledMenuItem)
+              .at(0)
+              .getDOMNode()
+          ).not.toBeFocused();
+          expect(item.find(StyledMenuItem).at(0).getDOMNode()).toBeFocused();
+        });
+      });
+    });
+
     it("validates the submenu prop", () => {
       const globalConsoleSpy = jest
         .spyOn(global.console, "error")
@@ -1339,17 +1714,15 @@ describe("ActionPopover", () => {
 
       expect(() => {
         const tempWrapper = enzymeMount(
-          <ThemeProvider theme={mintTheme}>
-            <ActionPopover>
-              <ActionPopoverItem
-                submenu={<p>foo</p>}
-                icon="pdf"
-                onClick={jest.fn()}
-              >
-                item
-              </ActionPopoverItem>
-            </ActionPopover>
-          </ThemeProvider>
+          <ActionPopover>
+            <ActionPopoverItem
+              submenu={<p>foo</p>}
+              icon="pdf"
+              onClick={jest.fn()}
+            >
+              item
+            </ActionPopoverItem>
+          </ActionPopover>
         );
 
         tempWrapper.find(MenuButton).simulate("click");
@@ -1368,24 +1741,23 @@ describe("ActionPopover", () => {
 
       expect(() => {
         enzymeMount(
-          <ThemeProvider theme={mintTheme}>
-            <ActionPopoverContext.Provider
-              value={{
-                setOpenPopover: jest.fn(),
-                focusButton: jest.fn(),
-                isOpenPopover: true,
-              }}
+          <ActionPopoverContext.Provider
+            value={{
+              setOpenPopover: jest.fn(),
+              focusButton: jest.fn(),
+              isOpenPopover: true,
+              submenuPosition: "left",
+            }}
+          >
+            <ActionPopoverMenu
+              setOpen={jest.fn()}
+              setFocusIndex={jest.fn()}
+              focusIndex={-1}
             >
-              <ActionPopoverMenu
-                setOpen={jest.fn()}
-                setFocusIndex={jest.fn()}
-                focusIndex={-1}
-              >
-                Invalid
-                <p>Invalid</p>
-              </ActionPopoverMenu>
-            </ActionPopoverContext.Provider>
-          </ThemeProvider>
+              Invalid
+              <p>Invalid</p>
+            </ActionPopoverMenu>
+          </ActionPopoverContext.Provider>
         );
       }).toThrow(
         "ActionPopoverMenu only accepts children of type `ActionPopoverItem`" +
@@ -1414,25 +1786,23 @@ describe("ActionPopover", () => {
         }));
 
       wrapper = enzymeMount(
-        <ThemeProvider theme={mintTheme}>
-          <ActionPopover placement="top">
-            <ActionPopoverItem
-              onClick={onClick}
-              submenu={
-                <ActionPopoverMenu>
-                  <ActionPopoverItem
-                    key="0"
-                    {...{ onClick: onClickWrapper("sub menu 1") }}
-                  >
-                    Sub Menu 1
-                  </ActionPopoverItem>
-                </ActionPopoverMenu>
-              }
-            >
-              foo
-            </ActionPopoverItem>
-          </ActionPopover>
-        </ThemeProvider>
+        <ActionPopover placement="top">
+          <ActionPopoverItem
+            onClick={onClick}
+            submenu={
+              <ActionPopoverMenu>
+                <ActionPopoverItem
+                  key="0"
+                  {...{ onClick: onClickWrapper("sub menu 1") }}
+                >
+                  Sub Menu 1
+                </ActionPopoverItem>
+              </ActionPopoverMenu>
+            }
+          >
+            foo
+          </ActionPopoverItem>
+        </ActionPopover>
       );
     });
 
@@ -1454,23 +1824,21 @@ describe("ActionPopover", () => {
   describe("Custom Menu Button", () => {
     it("supports being passed an override component to act as the menu button", () => {
       const popover = enzymeMount(
-        <ThemeProvider theme={mintTheme}>
-          <ActionPopover
-            renderButton={(props) => (
-              <ActionPopoverMenuButton
-                buttonType="tertiary"
-                iconType="dropdown"
-                iconPosition="after"
-                size="small"
-                {...props}
-              >
-                Foo
-              </ActionPopoverMenuButton>
-            )}
-          >
-            <ActionPopoverItem onClick={jest.fn()}>foo</ActionPopoverItem>
-          </ActionPopover>
-        </ThemeProvider>
+        <ActionPopover
+          renderButton={(props) => (
+            <ActionPopoverMenuButton
+              buttonType="tertiary"
+              iconType="dropdown"
+              iconPosition="after"
+              size="small"
+              {...props}
+            >
+              Foo
+            </ActionPopoverMenuButton>
+          )}
+        >
+          <ActionPopoverItem onClick={jest.fn()}>foo</ActionPopoverItem>
+        </ActionPopover>
       ).find(ActionPopover);
 
       const menuButton = popover.find(ActionPopoverMenuButton);
@@ -1492,23 +1860,21 @@ describe("ActionPopover", () => {
 
     it("sets the tabIndex correctly when opened", () => {
       wrapper = enzymeMount(
-        <ThemeProvider theme={mintTheme}>
-          <ActionPopover
-            renderButton={(props) => (
-              <ActionPopoverMenuButton
-                buttonType="tertiary"
-                iconType="dropdown"
-                iconPosition="after"
-                size="small"
-                {...props}
-              >
-                Foo
-              </ActionPopoverMenuButton>
-            )}
-          >
-            <ActionPopoverItem onClick={jest.fn()}>foo</ActionPopoverItem>
-          </ActionPopover>
-        </ThemeProvider>
+        <ActionPopover
+          renderButton={(props) => (
+            <ActionPopoverMenuButton
+              buttonType="tertiary"
+              iconType="dropdown"
+              iconPosition="after"
+              size="small"
+              {...props}
+            >
+              Foo
+            </ActionPopoverMenuButton>
+          )}
+        >
+          <ActionPopoverItem onClick={jest.fn()}>foo</ActionPopoverItem>
+        </ActionPopover>
       );
 
       openMenu();
@@ -1519,37 +1885,233 @@ describe("ActionPopover", () => {
     });
   });
 
-  describe("when the horizontalAlignment prop is set to right", () => {
-    beforeEach(() => {
-      wrapper = enzymeMount(
-        <ThemeProvider theme={mintTheme}>
-          <ActionPopover horizontalAlignment="right">
-            <ActionPopoverItem key="1" href="#" icon="download">
-              test download
-            </ActionPopoverItem>
-          </ActionPopover>
-        </ThemeProvider>
-      );
-    });
+  describe("padding checks on 'StyledMenuItemInnerText'", () => {
+    it.each([
+      ["left", "left"],
+      ["left", "right"],
+      ["right", "left"],
+      ["right", "right"],
+    ])(
+      "when horizontalAlignment is %s and submenuPosition is %, then left and right padding is: var(--spacing100)",
+      (alignment, position) => {
+        renderActionPopoverWithNoIconsOrSubmenus({
+          submenuPosition: position,
+          horizontalAlignment: alignment,
+        });
+        openMenu();
+        assertStyleMatch(
+          {
+            paddingLeft: "var(--spacing100)",
+            paddingRight: "var(--spacing100)",
+          },
+          wrapper.find(StyledMenuItemInnerText).at(0)
+        );
+      }
+    );
 
-    it("then menu item content should be right aligned", () => {
+    it.each([
+      ["left", "left", "var(--spacing400)", "var(--spacing100)"],
+      ["right", "right", "var(--spacing100)", "var(--spacing400)"],
+    ])(
+      "when horizontalAlignment is %s, submenuPosition is %s and Menu Item children have some submenus and no icons, then padding-left is %s and padding-right is %s",
+      (alignment, position, paddingLeft, paddingRight) => {
+        renderActionPopoverWithSomeSubmenusAndNoIcons({
+          submenuPosition: position,
+          horizontalAlignment: alignment,
+        });
+        openMenu();
+        assertStyleMatch(
+          {
+            paddingLeft,
+            paddingRight,
+          },
+          wrapper.find(StyledMenuItemInnerText).at(0)
+        );
+      }
+    );
+
+    it.each([
+      ["left", "left", "var(--spacing600)", "var(--spacing100)"],
+      ["right", "right", "var(--spacing100)", "var(--spacing600)"],
+    ])(
+      "when horizontalAlignment is %s submenuPosition is %s and Menu Item children have submenus and some icons, then padding-left is %s and padding-right is %s",
+      (alignment, position, paddingLeft, paddingRight) => {
+        renderActionPopoverWithSubmenusAndSomeIcons({
+          submenuPosition: position,
+          horizontalAlignment: alignment,
+        });
+        openMenu();
+        assertStyleMatch(
+          {
+            paddingLeft,
+            paddingRight,
+          },
+          wrapper.find(StyledMenuItemInnerText).at(0)
+        );
+      }
+    );
+
+    it.each([
+      ["left", "left", "var(--spacing900)", "var(--spacing100)"],
+      ["right", "right", "var(--spacing100)", "var(--spacing900)"],
+    ])(
+      "when horizontalAlignment is %s submenuPosition is %s and Menu Item children are variable, then padding-left is %s and padding-right is %s",
+      (alignment, position, paddingLeft, paddingRight) => {
+        renderWithVariableChildren({
+          submenuPosition: position,
+          horizontalAlignment: alignment,
+        });
+        openMenu();
+        assertStyleMatch(
+          {
+            paddingLeft,
+            paddingRight,
+          },
+          wrapper.find(StyledMenuItemInnerText).at(0)
+        );
+      }
+    );
+
+    it.each([
+      ["left", "left"],
+      ["left", "right"],
+      ["right", "left"],
+      ["right", "right"],
+    ])(
+      "when horizontalAlignment is %s, submenuPosition is %s and child is a submenu, left and right padding is var(--spacing000)",
+      (alignment, position) => {
+        renderActionPopoverWithSubmenusAndSomeIcons({
+          submenuPosition: position,
+          horizontalAlignment: alignment,
+        });
+        openMenu();
+        const { items } = getElements();
+        const item = items.at(0);
+        const submenu = item.find(ActionPopoverMenu);
+        const disabledSubmenuItem = submenu
+          .find(ActionPopoverItem)
+          .at(1)
+          .find(StyledMenuItem)
+          .at(0);
+
+        assertStyleMatch(
+          {
+            paddingLeft: "var(--spacing000)",
+            paddingRight: "var(--spacing000)",
+          },
+          disabledSubmenuItem.find(StyledMenuItemInnerText)
+        );
+      }
+    );
+  });
+
+  describe("justify-content checks on 'StyledMenuItem'", () => {
+    it.each([
+      ["left", "flex-start"],
+      ["right", "flex-end"],
+    ])(
+      "when horizontalAlignment is %s, then content should be justified %s",
+      (alignment, itemAlignment) => {
+        render({ horizontalAlignment: alignment });
+        openMenu();
+        assertStyleMatch(
+          {
+            justifyContent: itemAlignment,
+          },
+          wrapper.find(StyledMenuItem)
+        );
+      }
+    );
+
+    it.each([
+      ["left", "right", "space-between", 0],
+      ["right", "left", "flex-end", 1],
+    ])(
+      "when horizontalAlignment is %s, submenuPosition is %s and Menu Item Children have no submenus, then content should be justified flex-end",
+      (alignment, position, itemAlignment, index) => {
+        render({ horizontalAlignment: alignment, submenuPosition: position });
+
+        openMenu();
+        assertStyleMatch(
+          {
+            justifyContent: itemAlignment,
+          },
+          wrapper.find(StyledMenuItem).at(index)
+        );
+      }
+    );
+
+    it.each([
+      ["left", "right", 0],
+      ["right", "left", 1],
+    ])(
+      "when horizontalAlignment is %s, submenuPosition is %s and Menu Item children have submenus, then content should be justified space-between",
+      (alignment, position, index) => {
+        renderWithSubmenu({
+          horizontalAlignment: alignment,
+          submenuPosition: position,
+        });
+
+        openMenu();
+        assertStyleMatch(
+          {
+            justifyContent: "space-between",
+          },
+          wrapper.find(StyledMenuItem).at(index)
+        );
+      }
+    );
+  });
+
+  describe("padding checks on 'MenuItemIcon'", () => {
+    it("padding is var(--spacing100)", () => {
+      renderWithSubmenu();
       openMenu();
       assertStyleMatch(
         {
-          justifyContent: "flex-end",
+          padding:
+            "var(--spacing100) var(--spacing100) var(--spacing100) var(--spacing100)",
         },
-        wrapper.find(StyledMenuItem)
+        wrapper.find(MenuItemIcon).at(1)
       );
     });
 
-    it("then menu item icon should have correct left padding", () => {
-      openMenu();
-      assertStyleMatch(
-        {
-          padding: "var(--spacing100)",
-        },
-        wrapper.find(MenuItemIcon)
-      );
-    });
+    it.each([
+      [
+        "left",
+        "left",
+        "var(--spacing100) var(--spacing100) var(--spacing100) var(--spacing400)",
+      ],
+      [
+        "left",
+        "right",
+        "var(--spacing100) var(--spacing100) var(--spacing100) var(--spacing100)",
+      ],
+      [
+        "right",
+        "left",
+        "var(--spacing100) var(--spacing100) var(--spacing100) var(--spacing100)",
+      ],
+      [
+        "right",
+        "right",
+        "var(--spacing100) var(--spacing400) var(--spacing100) var(--spacing100)",
+      ],
+    ])(
+      "when horizontalAlignment is %s, submenuPosition is %s and Menu Item children have icons and some submenus, then padding is %s",
+      (alignment, position, padding) => {
+        renderWithSubmenu({
+          submenuPosition: position,
+          horizontalAlignment: alignment,
+        });
+        openMenu();
+        assertStyleMatch(
+          {
+            padding,
+          },
+          wrapper.find(MenuItemIcon)
+        );
+      }
+    );
   });
 });

--- a/src/components/action-popover/action-popover.stories.mdx
+++ b/src/components/action-popover/action-popover.stories.mdx
@@ -133,24 +133,20 @@ leave.
   <Story name="with submenu" story={stories.ActionPopoverComponentSubmenu} />
 </Canvas>
 
+### With submenu positioned to right
+
+Submenu can be positioned on either the left of the right with the use of the `submenuPosition` prop.
+
+<Canvas>
+  <Story name="with submenu positioned to right" story={stories.ActionPopoverComponentSubmenuPositionedRight} />
+</Canvas>
+
 ### With disabled submenu
 
 A sub-menu will not open if the item is in a disabled state.
 
 <Canvas>
   <Story name="with disabled submenu" story={stories.ActionPopoverComponentDisabledSubmenu} />
-</Canvas>
-
-### With submenu aligned right
-
-The sub-menu will open to the right side when there is no space to render the sub-menu to the left.
-
-<Canvas>
-  <Story
-    name="with submenu aligned right"
-    parameters={{ docs: { disable: true } }}
-    story={stories.ActionPopoverComponentSubmenuAlignedRight} 
-  />
 </Canvas>
 
 ### With menu opening above

--- a/src/components/action-popover/action-popover.stories.tsx
+++ b/src/components/action-popover/action-popover.stories.tsx
@@ -300,31 +300,27 @@ export const ActionPopoverComponentDisabledSubmenu: ComponentStory<
   );
 };
 
-export const ActionPopoverComponentSubmenuAlignedRight: ComponentStory<
+export const ActionPopoverComponentSubmenuPositionedRight: ComponentStory<
   typeof ActionPopover
 > = () => {
+  const submenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 1</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 2</ActionPopoverItem>
+      <ActionPopoverItem disabled onClick={() => {}}>
+        Sub Menu 3
+      </ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
   return (
     <div style={{ height: "250px" }}>
       <Box>
-        <ActionPopover>
-          <ActionPopoverItem
-            icon="print"
-            onClick={() => {}}
-            submenu={
-              <ActionPopoverMenu>
-                <ActionPopoverItem icon="csv" onClick={() => {}}>
-                  CSV
-                </ActionPopoverItem>
-                <ActionPopoverItem icon="pdf" onClick={() => {}}>
-                  PDF
-                </ActionPopoverItem>
-              </ActionPopoverMenu>
-            }
-          >
-            Print
+        <ActionPopover submenuPosition="right">
+          <ActionPopoverItem icon="email" submenu={submenu}>
+            Email Invoice
           </ActionPopoverItem>
           <ActionPopoverDivider />
-          <ActionPopoverItem onClick={() => {}} icon="delete">
+          <ActionPopoverItem icon="delete" submenu={submenu}>
             Delete
           </ActionPopoverItem>
         </ActionPopover>

--- a/src/components/action-popover/action-popover.style.ts
+++ b/src/components/action-popover/action-popover.style.ts
@@ -19,12 +19,131 @@ const Menu = styled.div`
     `${theme.zIndex?.popover}`}; // TODO (tokens): implement elevation tokens - FE-4437
 `;
 
+function getPaddingValues(
+  childHasSubmenu?: boolean,
+  childHasIcon?: boolean,
+  hasIcon?: boolean,
+  hasSubmenu?: boolean
+) {
+  if (!childHasIcon && childHasSubmenu && !hasIcon && !hasSubmenu) {
+    return "var(--spacing400)";
+  }
+  if (childHasIcon && childHasSubmenu && !hasIcon && hasSubmenu) {
+    return "var(--spacing600)";
+  }
+  if (childHasIcon && childHasSubmenu && !hasIcon && !hasSubmenu) {
+    return "var(--spacing900)";
+  }
+  return "var(--spacing100)";
+}
+
+function getIconPaddingValues(
+  index: 1 | 2,
+  horizontalAlignment?: "left" | "right",
+  submenuPosition?: "left" | "right",
+  siblingsHaveIconAndSubmenu?: boolean,
+  isASubmenu?: boolean
+) {
+  const sameAlignment =
+    (horizontalAlignment === "left" && submenuPosition === "left") ||
+    (horizontalAlignment === "right" && submenuPosition === "right");
+
+  if (siblingsHaveIconAndSubmenu && sameAlignment) {
+    if (horizontalAlignment === "left") {
+      return index === 1 ? "var(--spacing100)" : "var(--spacing400)";
+    }
+    return index === 1 ? "var(--spacing400)" : "var(--spacing100)";
+  }
+
+  if (isASubmenu) {
+    if (horizontalAlignment === "left") {
+      return index === 1 ? "var(--spacing100)" : "var(--spacing000)";
+    }
+    return index === 1 ? "var(--spacing000)" : "var(--spacing100)";
+  }
+
+  return "var(--spacing100)";
+}
+
 type StyledMenuItemProps = {
   isDisabled: boolean;
-  horizontalAlignment: "left" | "right";
+  horizontalAlignment?: "left" | "right";
+  submenuPosition?: "left" | "right";
+  childHasSubmenu?: boolean;
+  childHasIcon?: boolean;
+  hasSubmenu?: boolean;
+  hasIcon?: boolean;
+  isASubmenu?: boolean;
 };
 
-const StyledMenuItem = styled.button<StyledMenuItemProps>`
+const StyledMenuItemInnerText = styled.div<
+  Omit<StyledMenuItemProps, "isDisabled">
+>`
+  ${({
+    childHasSubmenu,
+    childHasIcon,
+    hasIcon,
+    hasSubmenu,
+    submenuPosition,
+    horizontalAlignment,
+    isASubmenu,
+  }) => css`
+    padding-left: ${isASubmenu ? `var(--spacing000)` : `var(--spacing100)`};
+    padding-right: ${isASubmenu ? `var(--spacing000)` : `var(--spacing100)`};
+
+    ${horizontalAlignment === "left" &&
+    submenuPosition === "left" &&
+    !isASubmenu &&
+    css`
+      padding-left: ${getPaddingValues(
+        childHasSubmenu,
+        childHasIcon,
+        hasIcon,
+        hasSubmenu
+      )};
+    `}
+
+    ${horizontalAlignment === "right" &&
+    submenuPosition === "right" &&
+    !isASubmenu &&
+    css`
+      padding-right: ${getPaddingValues(
+        childHasSubmenu,
+        childHasIcon,
+        hasIcon,
+        hasSubmenu
+      )};
+    `}
+  `}
+`;
+
+const StyledMenuItemOuterContainer = styled.div`
+  display: inherit;
+`;
+const StyledMenuItem = styled.button<Omit<StyledMenuItemProps, "variant">>`
+  ${({ horizontalAlignment, submenuPosition, childHasSubmenu, hasSubmenu }) =>
+    css`
+      justify-content: ${horizontalAlignment === "left"
+        ? "flex-start"
+        : "flex-end"};
+
+      ${horizontalAlignment === "left" &&
+      submenuPosition === "right" &&
+      css`
+        justify-content: space-between;
+      `}
+
+      ${horizontalAlignment === "right" &&
+      submenuPosition === "left" &&
+      css`
+        ${childHasSubmenu &&
+        hasSubmenu &&
+        css`
+          justify-content: space-between;
+        `}
+      `}
+    `}
+
   text-decoration: none;
   background-color: var(--colorsActionMajorYang100);
   cursor: pointer;
@@ -41,8 +160,6 @@ const StyledMenuItem = styled.button<StyledMenuItemProps>`
   color: var(--colorsUtilityYin090);
   font-size: 14px;
   font-weight: 700;
-  justify-content: ${({ horizontalAlignment }) =>
-    horizontalAlignment === "left" ? "flex-start" : "flex-end"};
 
   &:focus {
     outline: var(--borderWidth300) solid var(--colorsSemanticFocus500);
@@ -112,20 +229,45 @@ const StyledButtonIcon = styled.div`
   }
 `;
 
-const MenuItemIcon = styled(Icon)`
-  padding: var(--spacing100);
-  color: var(--colorsUtilityYin065);
+const MenuItemIcon = styled(Icon)<Omit<StyledMenuItemProps, "isDisabled">>`
+  ${({
+    horizontalAlignment,
+    submenuPosition,
+    childHasIcon,
+    childHasSubmenu,
+    hasIcon,
+    hasSubmenu,
+    isASubmenu,
+  }) => css`
+    justify-content: ${horizontalAlignment};
+    padding: var(--spacing100)
+      ${getIconPaddingValues(
+        1,
+        horizontalAlignment,
+        submenuPosition,
+        childHasIcon && childHasSubmenu && hasIcon && !hasSubmenu,
+        isASubmenu
+      )}
+      var(--spacing100)
+      ${getIconPaddingValues(
+        2,
+        horizontalAlignment,
+        submenuPosition,
+        childHasIcon && childHasSubmenu && hasIcon && !hasSubmenu,
+        isASubmenu
+      )};
+    color: var(--colorsUtilityYin065);
+  `}
 `;
 
 const SubMenuItemIcon = styled(ButtonIcon)`
   ${({ type }) => css`
-    position: absolute;
-    ${type === "chevron_left" &&
+    ${type === "chevron_left_thick" &&
     css`
-      left: -2px;
+      left: -5px;
     `}
 
-    ${type === "chevron_right" &&
+    ${type === "chevron_right_thick" &&
     css`
       right: -5px;
       ${isSafari(navigator) &&
@@ -162,6 +304,8 @@ export {
   MenuItemDivider,
   SubMenuItemIcon,
   MenuButtonOverrideWrapper,
+  StyledMenuItemInnerText,
+  StyledMenuItemOuterContainer,
   StyledMenuItem,
   StyledMenuItemWrapper,
 };


### PR DESCRIPTION
fix #5801

### Proposed behaviour

Nine new design variations have been implemented for the component, each one varies based on specific props and attributes passed to individual children and siblings.

**Please see new designs below:**

**Number 1: All children and siblings have no icons or submenus.**

<img width="176" alt="Screenshot 2023-06-21 at 13 45 18" src="https://github.com/Sage/carbon/assets/114918852/9fed5d95-ded2-4e04-9c22-c449a2ac1edb">

**Number 2: All children and siblings have no icons, but only some have submenus.**

<img width="193" alt="Screenshot 2023-06-21 at 13 45 26" src="https://github.com/Sage/carbon/assets/114918852/5a93f312-6914-4050-951e-6fd66dcbc34e">

**Number 3: All children and siblings have no icons, but all have submenus.**

<img width="182" alt="Screenshot 2023-06-21 at 13 45 33" src="https://github.com/Sage/carbon/assets/114918852/ad7648d1-f7e5-4faf-8767-16144b83db1a">

**Number 4: All children and siblings have no submenus, but only some have icons.**

<img width="191" alt="Screenshot 2023-06-21 at 13 45 40" src="https://github.com/Sage/carbon/assets/114918852/5148ecc2-0ebc-41f3-bd0e-ab24e5c7d26a">

**Number 5: All children and siblings have no submenus, but all have icons.**

<img width="190" alt="Screenshot 2023-06-21 at 13 45 47" src="https://github.com/Sage/carbon/assets/114918852/e526dd12-2bc6-43e0-8fb7-96f9caeef41c">

**Number 6: All children and siblings have submenus and icons.**

<img width="226" alt="Screenshot 2023-06-21 at 13 46 06" src="https://github.com/Sage/carbon/assets/114918852/eadb9f1c-2ffa-42c6-9001-b42a6f796e41">

**Number 7: All children and siblings have icons, but only some have submenus.**

<img width="210" alt="Screenshot 2023-06-21 at 13 45 54" src="https://github.com/Sage/carbon/assets/114918852/90a9d258-3252-4f33-8314-795ca3aaaea1">

**Number 8: All children and siblings have submenus, but only some have icons.**

<img width="215" alt="Screenshot 2023-06-21 at 13 46 13" src="https://github.com/Sage/carbon/assets/114918852/4cea7168-0554-451f-93b4-50051e6cc7d3">

**Number 9: Some children and siblings have submenus and icons, but some have no submenus or icons.**

<img width="216" alt="Screenshot 2023-06-21 at 13 46 20" src="https://github.com/Sage/carbon/assets/114918852/378ebc5e-995b-469e-8256-3297e0fa5d32">

Please note, these designs also have various versions based on the `horizontalAlignment` and `submenuPosition` props, so in theory there are technically 36 new designs. A codeSandbox has been included [here](https://codesandbox.io/s/carbon-quickstart-forked-kctlch?file=/src/App.js) to test the new designs and variations. 


**Support for icon's in submenu's:**

<img width="345" alt="Screenshot 2023-06-21 at 13 46 57" src="https://github.com/Sage/carbon/assets/114918852/d1c272c4-0bed-48df-ab6a-316ace58a76a">

<img width="337" alt="Screenshot 2023-06-21 at 13 47 07" src="https://github.com/Sage/carbon/assets/114918852/ed15f6fe-d1cf-4e0e-b5b3-52afcc1e3be0">



**`submenuPosition` is temporarily switched from "left" to "right" or "right" to "left" when the container becomes too small for submenu:**

![2023-06-21 17 59 46](https://github.com/Sage/carbon/assets/114918852/a6083a6d-2a9c-4d32-8503-c2e2a71120ee)


<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

Currently, the `actionPopover` component is severely unaligned with Sage's design system, meaning specific designs and functionality seen within the design system, can not be replicated using the Carbon component. Currently, there is no support for any submenus to open to the right, and no support for icon's to be rendered within submenus also. Both of these are fairly major misalignments and could make a large difference to how the component is used and implemented.

Also, how text, and icons are aligned based on icon's and submenus being present amongst children and siblings is inconsistent, and also deviates from current design system guidance and best practices.

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
