### PR TITLE
fix(focus-trap): prevent scroll to bottom when tabbing through

### DIFF
--- a/cypress/components/dialog-full-screen/dialog-full-screen.cy.js
+++ b/cypress/components/dialog-full-screen/dialog-full-screen.cy.js
@@ -7,6 +7,8 @@ import {
   DialogFullScreenWithHeaderChildren,
   mainDialogTitle,
   nestedDialogTitle,
+  DialogFullScreenBackgroundScrollTestComponent,
+  DialogFullScreenBackgroundScrollWithOtherFocusableContainers,
 } from "../../../src/components/dialog-full-screen/dialog-full-screen-test.stories";
 import {
   Default as DefaultDocsStory,
@@ -40,7 +42,7 @@ import {
 import { buttonDataComponent } from "../../locators/button";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import { contentElement } from "../../locators/content/index";
-import { keyCode } from "../../support/helper";
+import { keyCode, continuePressingTABKey } from "../../support/helper";
 import { CHARACTERS } from "../../support/component-helper/constants";
 
 const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
@@ -379,6 +381,56 @@ context("Testing DialogFullScreen component", () => {
         .contains("Open DialogFullScreen")
         .click()
         .then(() => cy.checkAccessibility());
+    });
+  });
+
+  describe("test background scroll when tabbing", () => {
+    it("tabbing forward through the dialog and back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(
+        <DialogFullScreenBackgroundScrollTestComponent />
+      );
+
+      continuePressingTABKey(3);
+
+      closeIconButton().should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
+
+    it("tabbing backward through the dialog and back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(
+        <DialogFullScreenBackgroundScrollTestComponent />
+      );
+
+      continuePressingTABKey(2, true);
+
+      closeIconButton().should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
+
+    it("tabbing forward through the dialog and other focusable containers back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(
+        <DialogFullScreenBackgroundScrollWithOtherFocusableContainers />
+      );
+
+      continuePressingTABKey(6);
+
+      closeIconButton().eq(0).should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
+
+    it("tabbing backward through the dialog and other focusable containers back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(
+        <DialogFullScreenBackgroundScrollWithOtherFocusableContainers />
+      );
+
+      continuePressingTABKey(7, true);
+
+      closeIconButton().eq(0).should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
     });
   });
 });

--- a/cypress/components/dialog/dialog.cy.js
+++ b/cypress/components/dialog/dialog.cy.js
@@ -9,7 +9,7 @@ import {
 } from "../../locators/dialog";
 import { textEditorInput, textEditorToolbar } from "../../locators/text-editor";
 import { formFooterComponent } from "../../locators/form";
-import { keyCode } from "../../support/helper";
+import { keyCode, continuePressingTABKey } from "../../support/helper";
 import { buttonDataComponent } from "../../locators/button";
 import {
   backgroundUILocator,
@@ -682,5 +682,55 @@ context("Testing Dialog component", () => {
       "border-radius",
       "0px 0px 16px 16px"
     );
+  });
+
+  describe("test background scroll when tabbing", () => {
+    it("tabbing forward through the dialog and back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(
+        <stories.DialogBackgroundScrollTestComponent />
+      );
+
+      continuePressingTABKey(3);
+
+      closeIconButton().should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
+
+    it("tabbing backward through the dialog and back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(
+        <stories.DialogBackgroundScrollTestComponent />
+      );
+
+      continuePressingTABKey(2, true);
+
+      closeIconButton().should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
+
+    it("tabbing forward through the dialog and other focusable containers back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(
+        <stories.DialogBackgroundScrollWithOtherFocusableContainers />
+      );
+
+      continuePressingTABKey(6);
+
+      closeIconButton().eq(0).should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
+
+    it("tabbing backward through the dialog and other focusable containers back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(
+        <stories.DialogBackgroundScrollWithOtherFocusableContainers />
+      );
+
+      continuePressingTABKey(7, true);
+
+      closeIconButton().eq(0).should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
   });
 });

--- a/cypress/components/menu/menu.cy.js
+++ b/cypress/components/menu/menu.cy.js
@@ -260,6 +260,20 @@ const MenuComponentFullScreen = ({ ...props }) => {
   ];
 };
 
+const MenuFullScreenBackgroundScrollTest = () => {
+  return (
+    <Box height="2000px" position="relative">
+      <Box height="100px" id="bottom-box" position="absolute" bottom="0px">
+        I should not be scrolled into view
+      </Box>
+      <MenuFullscreen isOpen onClose={() => {}}>
+        <MenuItem href="#">Menu Item One</MenuItem>
+        <MenuItem href="#">Menu Item Two</MenuItem>
+      </MenuFullscreen>
+    </Box>
+  );
+};
+
 const MenuComponentItems = ({ ...props }) => {
   return (
     <Box mb={150}>
@@ -2151,6 +2165,28 @@ context("Testing Menu component", () => {
         .find("a")
         .last()
         .should("have.css", "border-radius", "0px 0px 0px 8px");
+    });
+  });
+
+  describe("MenuFullScreen test background scroll when tabbing", () => {
+    it("tabbing forward through the menu and back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(<MenuFullScreenBackgroundScrollTest />);
+
+      continuePressingTABKey(4);
+
+      closeIconButton().should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
+
+    it("tabbing backward through the menu and back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(<MenuFullScreenBackgroundScrollTest />);
+
+      continuePressingTABKey(3, true);
+
+      closeIconButton().should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
     });
   });
 });

--- a/cypress/components/sidebar/sidebar.cy.js
+++ b/cypress/components/sidebar/sidebar.cy.js
@@ -1,7 +1,11 @@
 import React from "react";
 import Sidebar from "../../../src/components/sidebar";
 import { sidebarPreview } from "../../locators/sidebar";
-import { SidebarComponent } from "../../../src/components/sidebar/sidebar-test.stories";
+import {
+  SidebarComponent,
+  SidebarBackgroundScrollTestComponent,
+  SidebarBackgroundScrollWithOtherFocusableContainers,
+} from "../../../src/components/sidebar/sidebar-test.stories";
 import {
   backgroundUILocator,
   closeIconButton,
@@ -12,7 +16,7 @@ import Button from "../../../src/components/button";
 import Textbox from "../../../src/components/textbox";
 import Toast from "../../../src/components/toast";
 import Typography from "../../../src/components/typography";
-import { keyCode } from "../../support/helper";
+import { keyCode, continuePressingTABKey } from "../../support/helper";
 import { CHARACTERS } from "../../support/component-helper/constants";
 import {
   SIDEBAR_SIZES,
@@ -295,6 +299,52 @@ context("Testing Sidebar component", () => {
       CypressMountWithProviders(<SidebarComponent size={size} />);
 
       cy.checkAccessibility();
+    });
+  });
+
+  describe("test background scroll when tabbing", () => {
+    it("tabbing forward through the sidebar and back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(<SidebarBackgroundScrollTestComponent />);
+
+      continuePressingTABKey(3);
+
+      closeIconButton().should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
+
+    it("tabbing backward through the sidebar and back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(<SidebarBackgroundScrollTestComponent />);
+
+      continuePressingTABKey(2, true);
+
+      closeIconButton().should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
+
+    it("tabbing forward through the sidebar and other focusable containers back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(
+        <SidebarBackgroundScrollWithOtherFocusableContainers />
+      );
+
+      continuePressingTABKey(6);
+
+      closeIconButton().eq(0).should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
+
+    it("tabbing backward through the sidebar and other focusable containers back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(
+        <SidebarBackgroundScrollWithOtherFocusableContainers />
+      );
+
+      continuePressingTABKey(7, true);
+
+      closeIconButton().eq(0).should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
     });
   });
 });

--- a/cypress/components/vertical-menu/vertical-menu.cy.js
+++ b/cypress/components/vertical-menu/vertical-menu.cy.js
@@ -5,6 +5,7 @@ import {
   VerticalMenuTriggerCustom,
   VerticalMenuItemCustomHref,
   VerticalMenuFullScreenCustom,
+  VerticalMenuFullScreenBackgroundScrollTest,
 } from "../../../src/components/vertical-menu/vertical-menu-test.stories";
 import VerticalMenuTrigger from "../../../src/components/vertical-menu/vertical-menu-trigger.component";
 import * as stories from "../../../src/components/vertical-menu/vertical-menu.stories";
@@ -21,6 +22,7 @@ import {
 } from "../../locators/vertical-menu";
 import { closeIconButton } from "../../locators/index";
 import { CHARACTERS } from "../../support/component-helper/constants";
+import { continuePressingTABKey } from "../../support/helper";
 
 const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testData = CHARACTERS.STANDARD;
@@ -470,7 +472,30 @@ context("Testing Vertical Menu component", () => {
     });
   });
 
+  describe("VerticalMenuFullScreen test background scroll when tabbing", () => {
+    it("tabbing forward through the menu and back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(<VerticalMenuFullScreenBackgroundScrollTest />);
+
+      continuePressingTABKey(4);
+
+      closeIconButton().should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
+
+    it("tabbing backward through the menu and back to the start should not make the background scroll to the bottom", () => {
+      CypressMountWithProviders(<VerticalMenuFullScreenBackgroundScrollTest />);
+
+      continuePressingTABKey(3, true);
+
+      closeIconButton().should("be.focused");
+
+      cy.checkNotInViewport("#bottom-box");
+    });
+  });
+
   describe("href redirect", () => {
+    // this test must be last in the test suite as the navigation to a new page messes up any later tests
     it("should navigate to the children href", () => {
       CypressMountWithProviders(<Default />);
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -15,6 +15,7 @@ declare global {
       mount: typeof mount;
       checkAccessibility: typeof checkAccessibility;
       getDesignTokensByCssProperty(cssProperty: string): Chainable<string[]>;
+      checkNotInViewport: typeof checkNotInViewport;
     }
   }
 }
@@ -64,3 +65,15 @@ function checkAccessibility() {
 }
 
 Cypress.Commands.add("checkAccessibility", checkAccessibility);
+
+function checkNotInViewport(selector: string) {
+  cy.get(selector).then(($el) => {
+    const { documentElement } = window.document;
+    const bottom = documentElement.clientHeight;
+    const rect = $el[0].getBoundingClientRect();
+
+    expect(rect.top).greaterThan(bottom);
+  });
+}
+
+Cypress.Commands.add("checkNotInViewport", checkNotInViewport);

--- a/cypress/support/helper.ts
+++ b/cypress/support/helper.ts
@@ -47,9 +47,9 @@ export function pressShiftTABKey(count: number) {
   }
 }
 
-export function continuePressingTABKey(count: number) {
+export function continuePressingTABKey(count: number, shift = false) {
   for (let i = 0; i < count; i++) {
-    cy.focused().tab();
+    cy.focused().tab({ shift });
   }
 }
 

--- a/src/__internal__/focus-trap/focus-trap.component.tsx
+++ b/src/__internal__/focus-trap/focus-trap.component.tsx
@@ -20,8 +20,8 @@ import {
 import usePrevious from "../../hooks/__internal__/usePrevious";
 import TopModalContext from "../../components/carbon-provider/top-modal-context";
 
-const TAB_GUARD_TOP = "tab-guard-top";
-const TAB_GUARD_BOTTOM = "tab-guard-bottom";
+export const TAB_GUARD_TOP = "tab-guard-top";
+export const TAB_GUARD_BOTTOM = "tab-guard-bottom";
 
 // TODO investigate why React.RefObject<T> produces a failed prop type when current = null
 export type CustomRefObject<T> = {

--- a/src/components/dialog-full-screen/dialog-full-screen-test.stories.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen-test.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { action } from "@storybook/addon-actions";
 import DialogFullScreen, { DialogFullScreenProps } from ".";
 import Dialog from "../dialog";
@@ -8,6 +8,7 @@ import Textbox from "../textbox";
 import Pill from "../pill";
 import Box from "../box";
 import CarbonProvider from "../carbon-provider";
+import Toast from "../toast";
 
 export default {
   title: "Dialog Full Screen/Test",
@@ -281,5 +282,43 @@ export const DialogFullScreenWithHeaderChildren = () => {
         </Form>
       </DialogFullScreen>
     </>
+  );
+};
+
+export const DialogFullScreenBackgroundScrollTestComponent = () => {
+  return (
+    <Box height="2000px" position="relative">
+      <Box height="100px" id="bottom-box" position="absolute" bottom="0px">
+        I should not be scrolled into view
+      </Box>
+      <DialogFullScreen open onCancel={() => {}}>
+        <Textbox label="textbox" />
+      </DialogFullScreen>
+    </Box>
+  );
+};
+
+export const DialogFullScreenBackgroundScrollWithOtherFocusableContainers = () => {
+  const toast1Ref = useRef(null);
+  const toast2Ref = useRef(null);
+  return (
+    <Box height="2000px" position="relative">
+      <Box height="100px" id="bottom-box" position="absolute" bottom="0px">
+        I should not be scrolled into view
+      </Box>
+      <DialogFullScreen
+        open
+        onCancel={() => {}}
+        focusableContainers={[toast1Ref, toast2Ref]}
+      >
+        <Textbox label="textbox" />
+      </DialogFullScreen>
+      <Toast open onDismiss={() => {}} ref={toast1Ref} targetPortalId="stacked">
+        Toast message 1
+      </Toast>
+      <Toast open onDismiss={() => {}} ref={toast2Ref} targetPortalId="stacked">
+        Toast message 2
+      </Toast>
+    </Box>
   );
 };

--- a/src/components/dialog/dialog-test.stories.tsx
+++ b/src/components/dialog/dialog-test.stories.tsx
@@ -11,6 +11,7 @@ import Toast from "../toast";
 import { Checkbox } from "../checkbox";
 import { Select, Option } from "../select";
 import TextEditor from "../text-editor";
+import Box from "../box";
 import { DIALOG_SIZES } from "./dialog.config";
 
 export default {
@@ -245,5 +246,43 @@ export const DialogComponentWithTextEditor = ({
         <Textbox label="Textbox3" value="Textbox3" />
       </Dialog>
     </>
+  );
+};
+
+export const DialogBackgroundScrollTestComponent = () => {
+  return (
+    <Box height="2000px" position="relative">
+      <Box height="100px" id="bottom-box" position="absolute" bottom="0px">
+        I should not be scrolled into view
+      </Box>
+      <Dialog open onCancel={() => {}}>
+        <Textbox label="textbox" />
+      </Dialog>
+    </Box>
+  );
+};
+
+export const DialogBackgroundScrollWithOtherFocusableContainers = () => {
+  const toast1Ref = useRef(null);
+  const toast2Ref = useRef(null);
+  return (
+    <Box height="2000px" position="relative">
+      <Box height="100px" id="bottom-box" position="absolute" bottom="0px">
+        I should not be scrolled into view
+      </Box>
+      <Dialog
+        open
+        onCancel={() => {}}
+        focusableContainers={[toast1Ref, toast2Ref]}
+      >
+        <Textbox label="textbox" />
+      </Dialog>
+      <Toast open onDismiss={() => {}} ref={toast1Ref} targetPortalId="stacked">
+        Toast message 1
+      </Toast>
+      <Toast open onDismiss={() => {}} ref={toast2Ref} targetPortalId="stacked">
+        Toast message 2
+      </Toast>
+    </Box>
   );
 };

--- a/src/components/sidebar/sidebar-test.stories.tsx
+++ b/src/components/sidebar/sidebar-test.stories.tsx
@@ -1,9 +1,12 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { action } from "@storybook/addon-actions";
 
 import Button from "../button";
 import Sidebar, { SidebarProps } from ".";
 import { SIDEBAR_ALIGNMENTS, SIDEBAR_SIZES } from "./sidebar.config";
+import Box from "../box";
+import Toast from "../toast";
+import Textbox from "../textbox";
 
 export default {
   component: Sidebar,
@@ -119,5 +122,43 @@ export const SidebarComponent = ({ ...props }) => {
         </div>
       </Sidebar>
     </>
+  );
+};
+
+export const SidebarBackgroundScrollTestComponent = () => {
+  return (
+    <Box height="2000px" position="relative">
+      <Box height="100px" id="bottom-box" position="absolute" bottom="0px">
+        I should not be scrolled into view
+      </Box>
+      <Sidebar open onCancel={() => {}}>
+        <Textbox label="textbox" />
+      </Sidebar>
+    </Box>
+  );
+};
+
+export const SidebarBackgroundScrollWithOtherFocusableContainers = () => {
+  const toast1Ref = useRef(null);
+  const toast2Ref = useRef(null);
+  return (
+    <Box height="2000px" position="relative">
+      <Box height="100px" id="bottom-box" position="absolute" bottom="0px">
+        I should not be scrolled into view
+      </Box>
+      <Sidebar
+        open
+        onCancel={() => {}}
+        focusableContainers={[toast1Ref, toast2Ref]}
+      >
+        <Textbox label="textbox" />
+      </Sidebar>
+      <Toast open onDismiss={() => {}} ref={toast1Ref} targetPortalId="stacked">
+        Toast message 1
+      </Toast>
+      <Toast open onDismiss={() => {}} ref={toast2Ref} targetPortalId="stacked">
+        Toast message 2
+      </Toast>
+    </Box>
   );
 };

--- a/src/components/vertical-menu/vertical-menu-test.stories.tsx
+++ b/src/components/vertical-menu/vertical-menu-test.stories.tsx
@@ -295,3 +295,17 @@ export const VerticalMenuFullScreenCustom: ComponentStory<
   }
   return <VerticalMenu>{menuItems}</VerticalMenu>;
 };
+
+export const VerticalMenuFullScreenBackgroundScrollTest = () => {
+  return (
+    <Box height="2000px" position="relative">
+      <Box height="100px" id="bottom-box" position="absolute" bottom="0px">
+        I should not be scrolled into view
+      </Box>
+      <VerticalMenuFullScreen isOpen onClose={() => {}}>
+        <VerticalMenuItem title="Menu Item One" href="#" />
+        <VerticalMenuItem title="Menu Item Two" href="#" />
+      </VerticalMenuFullScreen>
+    </Box>
+  );
+};

--- a/src/style/global-style.ts
+++ b/src/style/global-style.ts
@@ -1,4 +1,8 @@
 import { createGlobalStyle } from "styled-components";
+import {
+  TAB_GUARD_TOP,
+  TAB_GUARD_BOTTOM,
+} from "../__internal__/focus-trap/focus-trap.component";
 
 const GlobalStyle = createGlobalStyle`
   body {
@@ -21,6 +25,10 @@ const GlobalStyle = createGlobalStyle`
   h4, .h4 { font-size: 18px; font-weight: 700; margin-bottom: 22px; }
   h5, .h5 { font-size: 16px; font-weight: 700; margin-bottom: 20px; }
   h6, .h6 { font-size: 14px; font-weight: 700; margin-bottom: 18px; }
+
+  [data-element=${TAB_GUARD_TOP}], [data-element=${TAB_GUARD_BOTTOM}] {
+    position: fixed;
+  }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
The addition of invisible "tab guard" divs at the top and bottom of each focus trap causes the browser to scroll these into view when tabbing into them - causing the user to see the background of the page jump to the bottom when tabbing from the bottom element in the trap to the top one, and vice versa. This is now fixed by giving these divs a CSS `position: fixed` property, which keeps them permanently in the viewport so stops the browser scrolling anything.

fix #5986

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

When tabbing through a dialog or other modal component, the background should stay in the same place at all times, and not scroll/jump unexpectedly.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

When tabbing across the "edge" of a modal component (forward tabbing from the last focusable element to focus the first one, or back tabbing from the first to focus the last), the background "jumps" to the bottom, which is unexpected and a potential usability problem.

Affects the following components:
- Dialog
- DialogFullScreen
- Sidebar
- MenuFullScreen
- VerticalMenuFullScreen

(Note that for the "full screen" components, it's not instantly obvious that the "background jump" has happened, because it's hidden behind the modal - but if you then close the modal, you will see that the page has scrolled to the bottom.)

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

No codesandbox needed as this is visible on any of the storybook docs pages - just open one of the dialogs when not scrolled to the bottom of the page (which you shouldn't be).

Test each of the 5 components listed above:
- Dialog
- DialogFullScreen
- Sidebar
- MenuFullScreen
- VerticalMenuFullScreen

Ensure that the issue is fixed, in each situation. Pay particular attention to those stories for Dialog/DialogFullScreen/Sidebar which use the `focusableContainers` prop and ensure you test when tabbing round all the focusable containers, in both directions, back to where you started.

Ensure no regressions on any of these 5 components.

<!-- Add CodeSandbox here -->
