### PR TITLE
test(alert): typescript refactor

### DIFF
--- a/cypress/components/alert/alert.cy.tsx
+++ b/cypress/components/alert/alert.cy.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jest/valid-expect */
+/* eslint-disable no-unused-expressions */
 import React from "react";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import { AlertComponentTest as AlertComponent } from "../../../src/components/alert/alert-test.stories";
@@ -108,7 +110,7 @@ context("Testing Alert component", () => {
       [SIZE.MEDIUMLARGE, 850],
       [SIZE.LARGE, 960],
       [SIZE.EXTRALARGE, 1080],
-    ])(
+    ] as [string, number][])(
       "should render Alert component with %s as a size and has width property set to %s",
       (size, width) => {
         CypressMountWithProviders(
@@ -133,7 +135,6 @@ context("Testing Alert component", () => {
       closeIconButton()
         .click()
         .then(() => {
-          // eslint-disable-next-line no-unused-expressions
           expect(callback).to.have.been.calledOnce;
         });
     });


### PR DESCRIPTION
### Proposed behaviour

Rename the `alert.cy.js` into `alert.cy.tsx` file in `./cypress/components/alert/` folder
Refactor tests to Typescript
Move any remaining stories in `alert.test.tsx` file to `alert-test.stories.tsx` in './src/components/alert/' folder.

### Current behaviour

tests are in js not ts

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the`alert.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other *.cy.tsx files have regressed
<!-- Add CodeSandbox here -->
