### PR TITLE
fix(menu): ensure onSubmenuOpen is only called once when the submenu opens

### DIFF
--- a/cypress/components/menu/menu.cy.js
+++ b/cypress/components/menu/menu.cy.js
@@ -1554,7 +1554,7 @@ context("Testing Menu component", () => {
     let callback;
 
     beforeEach(() => {
-      callback = cy.stub();
+      callback = cy.stub().as("callback");
     });
 
     it("should call onClick callback when a click event is triggered", () => {
@@ -1579,13 +1579,9 @@ context("Testing Menu component", () => {
         </Box>
       );
 
-      submenu()
-        .eq(positionOfElement("first"), div)
-        .trigger("mouseover")
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      submenu().eq(positionOfElement("first"), div).trigger("mouseover");
+
+      cy.get("@callback").should("have.been.calledOnce");
     });
 
     it("should call onSubmenuOpen callback when a click event is triggered", () => {
@@ -1603,43 +1599,42 @@ context("Testing Menu component", () => {
         </Box>
       );
 
-      menuComponent(positionOfElement("second"))
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      menuComponent(positionOfElement("second")).click();
+
+      cy.get("@callback").should("have.been.calledOnce");
     });
 
-    // "Skipped test of Space/Enter/downArrow/upArrow because of ticket FE-5510"
-    it.skip("should call onSubmenuOpen callback when a keyboard event is triggered", (key) => {
-      CypressMountWithProviders(
-        <Box mb={150}>
-          <Menu>
-            <MenuItem
-              clickToOpen
-              onSubmenuOpen={callback}
-              submenu="Menu Item One"
-            >
-              <MenuSegmentTitle />
-            </MenuItem>
-          </Menu>
-        </Box>
-      );
+    it.each(["Space", "Enter", "downarrow", "uparrow"])(
+      "should call onSubmenuOpen callback when a keyboard event is triggered",
+      (key) => {
+        CypressMountWithProviders(
+          <Box mb={150}>
+            <Menu>
+              <MenuItem
+                clickToOpen
+                onSubmenuOpen={callback}
+                submenu="Menu Item One"
+              >
+                <MenuSegmentTitle />
+              </MenuItem>
+            </Menu>
+          </Box>
+        );
 
-      menuComponent(positionOfElement("second"))
-        .trigger("keydown", keyCode(key))
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
-    });
+        menuComponent(positionOfElement("second")).trigger(
+          "keydown",
+          keyCode(key)
+        );
+
+        cy.get("@callback").should("have.been.calledOnce");
+      }
+    );
 
     it("should call onSubmenuClose callback when menu is closed", () => {
       CypressMountWithProviders(
         <Box mb={150}>
           <Menu>
-            <MenuItem onSubmenuOpen={callback} submenu="Menu Item One">
+            <MenuItem onSubmenuClose={callback} submenu="Menu Item One">
               <MenuSegmentTitle />
             </MenuItem>
             <MenuItem submenu="Menu Item Two">
@@ -1650,13 +1645,9 @@ context("Testing Menu component", () => {
       );
 
       submenu().eq(positionOfElement("first"), div).trigger("mouseover");
-      submenu()
-        .eq(positionOfElement("second"), div)
-        .trigger("mouseover")
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      submenu().eq(positionOfElement("second"), div).trigger("mouseover");
+
+      cy.get("@callback").should("have.been.calledOnce");
     });
 
     it("should call onClose callback when Menu Fullscreen is closed", () => {

--- a/cypress/components/menu/menu.cy.js
+++ b/cypress/components/menu/menu.cy.js
@@ -1602,7 +1602,7 @@ context("Testing Menu component", () => {
     });
 
     it.each(["Space", "Enter", "downarrow", "uparrow"])(
-      "should call onSubmenuOpen callback when a keyboard event is triggered",
+      "should call onSubmenuOpen callback when a %s keyboard event is triggered",
       (key) => {
         CypressMountWithProviders(
           <Box mb={150}>

--- a/cypress/components/menu/menu.cy.js
+++ b/cypress/components/menu/menu.cy.js
@@ -1560,12 +1560,9 @@ context("Testing Menu component", () => {
     it("should call onClick callback when a click event is triggered", () => {
       CypressMountWithProviders(<MenuComponent onClick={callback} />);
 
-      menuComponent(positionOfElement("fifth"))
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      menuComponent(positionOfElement("fifth")).click();
+
+      cy.get("@callback").should("have.been.calledOnce");
     });
 
     it("should call onSubmenuOpen callback when mouseover event is triggered", () => {
@@ -1655,13 +1652,9 @@ context("Testing Menu component", () => {
 
       cy.viewport(1200, 800);
       menuItem().eq(positionOfElement("first"), div).click();
-      closeIconButton()
-        .eq(0)
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      closeIconButton().eq(0).click();
+
+      cy.get("@callback").should("have.been.calledOnce");
     });
 
     it("should have correct keyboard navigation order when children of submenu update", () => {
@@ -1699,13 +1692,9 @@ context("Testing Menu component", () => {
     it("should pass accessibility tests for Menu expanded", () => {
       CypressMountWithProviders(<MenuComponent />);
 
-      submenu()
-        .eq(positionOfElement("first"), div)
-        .trigger("mouseover")
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          cy.checkAccessibility();
-        });
+      submenu().eq(positionOfElement("first"), div).trigger("mouseover");
+
+      cy.checkAccessibility();
     });
 
     it.each(["default", "large"])(
@@ -1713,13 +1702,9 @@ context("Testing Menu component", () => {
       (divider) => {
         CypressMountWithProviders(<MenuComponent size={divider} />);
 
-        submenu()
-          .eq(positionOfElement("first"), div)
-          .trigger("mouseover")
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            cy.checkAccessibility();
-          });
+        submenu().eq(positionOfElement("first"), div).trigger("mouseover");
+
+        cy.checkAccessibility();
       }
     );
 
@@ -1732,12 +1717,9 @@ context("Testing Menu component", () => {
       cy.wait(50);
       pressTABKey(0);
       cy.wait(50);
-      cy.focused()
-        .trigger("keydown", keyCode("downarrow"))
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          cy.checkAccessibility();
-        });
+      cy.focused().trigger("keydown", keyCode("downarrow"));
+
+      cy.checkAccessibility();
     });
 
     it("should pass accessibility tests for Menu when a submenu has a long label", () => {
@@ -1756,13 +1738,9 @@ context("Testing Menu component", () => {
         </Box>
       );
 
-      submenu()
-        .eq(positionOfElement("first"))
-        .trigger("mouseover")
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          cy.checkAccessibility();
-        });
+      submenu().eq(positionOfElement("first")).trigger("mouseover");
+
+      cy.checkAccessibility();
     });
 
     it("should pass accessibility tests for Menu when a menu item has a long label", () => {
@@ -1780,12 +1758,8 @@ context("Testing Menu component", () => {
       );
 
       submenu().eq(positionOfElement("first")).trigger("mouseover");
-      submenu()
-        .eq(positionOfElement("first"))
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          cy.checkAccessibility();
-        });
+
+      cy.checkAccessibility();
     });
 
     it.each(["450px", "675px", "1200px"])(

--- a/src/components/menu/__internal__/submenu/submenu.component.tsx
+++ b/src/components/menu/__internal__/submenu/submenu.component.tsx
@@ -23,6 +23,7 @@ import {
   ALL_CHILDREN_SELECTOR,
 } from "../locators";
 import { VariantType } from "../../menu-item";
+import useStableCallback from "../../../../hooks/__internal__/useStableCallback/useStableCallback";
 
 export interface SubmenuProps {
   /** Children elements */
@@ -89,7 +90,7 @@ const Submenu = React.forwardRef<
       href,
       maxWidth,
       asPassiveItem,
-      onSubmenuOpen,
+      onSubmenuOpen: onSubmenuOpenProp,
       onSubmenuClose,
       onClick,
       ...rest
@@ -112,6 +113,8 @@ const Submenu = React.forwardRef<
     const shiftTabPressed = useRef(false);
     const focusFirstMenuItemOnOpen = useRef(false);
     const numberOfChildren = submenuItemIds.length;
+
+    const onSubmenuOpen = useStableCallback(onSubmenuOpenProp);
 
     const blockIndex = useMemo(() => {
       const items = submenuRef.current?.querySelectorAll(BLOCK_INDEX_SELECTOR);
@@ -156,10 +159,13 @@ const Submenu = React.forwardRef<
     const openSubmenu = useCallback(() => {
       setSubmenuOpen(true);
       setOpenSubmenuId(submenuId.current);
-      if (onSubmenuOpen) {
+    }, [setOpenSubmenuId]);
+
+    useEffect(() => {
+      if (submenuOpen && onSubmenuOpen) {
         onSubmenuOpen();
       }
-    }, [onSubmenuOpen, setOpenSubmenuId]);
+    }, [submenuOpen, onSubmenuOpen]);
 
     const closeSubmenu = useCallback(() => {
       shiftTabPressed.current = false;


### PR DESCRIPTION
### Proposed behaviour

The onSubmenuOpen prop, if provided, should only be called once each time the submenu opens - even if subsequent events are triggered while it is open, that would open it if it weren't already open.

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

onSubmenuOpen is called multiple times in some situations:

- when pressing the Enter or Space key to open a submenu with the keyboard, the function is called twice
- when moving the mouse over the item, the function is called multiple times (typically 3 to 4), even though the submenu only opens once

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/trusting-water-yiyzf3?file=/src/App.tsx
