### PR TITLE
test(heading): typescript refactor

### DIFF
--- a/cypress/components/badge/badge.cy.tsx
+++ b/cypress/components/badge/badge.cy.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jest/valid-expect-in-promise, jest/valid-expect */
+/* eslint-disable no-unused-expressions */
 import React from "react";
 import { BadgeComponent } from "../../../src/components/badge/badge-test.stories";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
@@ -42,7 +44,6 @@ context("Testing Badge component", () => {
       CypressMountWithProviders(
         <BadgeComponent onClick={() => {}} counter="99" />
       );
-      // eslint-disable-next-line jest/valid-expect-in-promise
       badge()
         .realHover()
         .should("have.css", "background")
@@ -54,7 +55,6 @@ context("Testing Badge component", () => {
 
     it("badge should not display cross icon when hovered over with no onClick function passed to component", () => {
       CypressMountWithProviders(<BadgeComponent counter="99" />);
-      // eslint-disable-next-line jest/valid-expect-in-promise
       badge()
         .realHover()
         .should("have.css", "background")
@@ -72,7 +72,6 @@ context("Testing Badge component", () => {
       badge()
         .click()
         .then(() => {
-          // eslint-disable-next-line no-unused-expressions, jest/valid-expect
           expect(callback).to.have.been.calledOnce;
         });
     });

--- a/cypress/components/heading/heading.cy.tsx
+++ b/cypress/components/heading/heading.cy.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-conditional-expect, jest/valid-expect */
 import React from "react";
 import { HeadingComponent } from "../../../src/components/heading/heading-test.stories";
 import Pill from "../../../src/components/pill";
@@ -16,6 +17,7 @@ import { pillPreview } from "../../locators/pill";
 import { getDataElementByValue, getComponent, cyRoot } from "../../locators";
 
 import { CHARACTERS } from "../../support/component-helper/constants";
+import { HeadingProps } from "../../../src/components/heading";
 
 const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testData = ["https://carbon.sage.com/"];
@@ -149,13 +151,14 @@ context("Testing Heading component", () => {
     );
 
     describe("when headingType prop is provided", () => {
-      it.each(["h1", "h2", "h3", "h4", "h5"])(
+      it.each(["h1", "h2", "h3", "h4", "h5"] as NonNullable<
+        HeadingProps["headingType"]
+      >[])(
         "should check HTML heading element is correct when headingType is %s",
         (headingType) => {
           CypressMountWithProviders(
             <HeadingComponent headingType={headingType} title="foo" />
           );
-
           cy.get(headingType).contains("foo");
         }
       );
@@ -164,7 +167,6 @@ context("Testing Heading component", () => {
     describe("should render Heading component and check accessibility issues", () => {
       it("should check heading accessibility", () => {
         CypressMountWithProviders(<HeadingComponent />);
-
         cy.checkAccessibility();
       });
 
@@ -174,7 +176,6 @@ context("Testing Heading component", () => {
           CypressMountWithProviders(
             <HeadingComponent> {children} </HeadingComponent>
           );
-
           cy.checkAccessibility();
         }
       );
@@ -183,7 +184,6 @@ context("Testing Heading component", () => {
         "should check accessibility when title as %s for Heading component",
         (titleText) => {
           CypressMountWithProviders(<HeadingComponent title={titleText} />);
-
           cy.checkAccessibility();
         }
       );
@@ -192,7 +192,6 @@ context("Testing Heading component", () => {
         "should check accessibility when titleId as %s for Heading component",
         (titleId) => {
           CypressMountWithProviders(<HeadingComponent titleId={titleId} />);
-
           cy.checkAccessibility();
         }
       );
@@ -201,7 +200,6 @@ context("Testing Heading component", () => {
         "should check accessibility when subheader as %s for Heading component",
         (subheader) => {
           CypressMountWithProviders(<HeadingComponent subheader={subheader} />);
-
           cy.checkAccessibility();
         }
       );
@@ -212,7 +210,6 @@ context("Testing Heading component", () => {
           CypressMountWithProviders(
             <HeadingComponent subtitleId={subtitleId} />
           );
-
           cy.checkAccessibility();
         }
       );
@@ -221,7 +218,6 @@ context("Testing Heading component", () => {
         "should check accessibility when help text as %s for Heading component",
         (helpText) => {
           CypressMountWithProviders(<HeadingComponent help={helpText} />);
-
           cy.checkAccessibility();
         }
       );
@@ -235,7 +231,6 @@ context("Testing Heading component", () => {
               helpAriaLabel={ariaLabel}
             />
           );
-
           cy.checkAccessibility();
         }
       );
@@ -246,7 +241,6 @@ context("Testing Heading component", () => {
           CypressMountWithProviders(
             <HeadingComponent pills={<Pill>{pillText}</Pill>} />
           );
-
           cy.checkAccessibility();
         }
       );
@@ -255,7 +249,6 @@ context("Testing Heading component", () => {
         "should check accessibility when %s as help link for Heading component",
         (helpLink) => {
           CypressMountWithProviders(<HeadingComponent helpLink={helpLink} />);
-
           cy.checkAccessibility();
         }
       );
@@ -264,7 +257,6 @@ context("Testing Heading component", () => {
         "should check accessibility when %s as back link for Heading component",
         (backLink) => {
           CypressMountWithProviders(<HeadingComponent backLink={backLink} />);
-
           cy.checkAccessibility();
         }
       );
@@ -273,16 +265,14 @@ context("Testing Heading component", () => {
         "should check accessibility when separator is %s for Heading component",
         (boolVal) => {
           CypressMountWithProviders(<HeadingComponent separator={boolVal} />);
-
           cy.checkAccessibility();
         }
       );
 
       it.each([true, false])(
-        "should check accessibility when separator is %s for Heading component",
+        "should check accessibility when divider is %s for Heading component",
         (boolVal) => {
           CypressMountWithProviders(<HeadingComponent divider={boolVal} />);
-
           cy.checkAccessibility();
         }
       );

--- a/cypress/components/heading/heading.cy.tsx
+++ b/cypress/components/heading/heading.cy.tsx
@@ -151,15 +151,13 @@ context("Testing Heading component", () => {
     );
 
     describe("when headingType prop is provided", () => {
-      it.each(["h1", "h2", "h3", "h4", "h5"] as NonNullable<
-        HeadingProps["headingType"]
-      >[])(
+      it.each(["h1", "h2", "h3", "h4", "h5"] as HeadingProps["headingType"][])(
         "should check HTML heading element is correct when headingType is %s",
         (headingType) => {
           CypressMountWithProviders(
             <HeadingComponent headingType={headingType} title="foo" />
           );
-          cy.get(headingType).contains("foo");
+          cy.get(String(headingType)).contains("foo");
         }
       );
     });

--- a/src/components/heading/heading-test.stories.tsx
+++ b/src/components/heading/heading-test.stories.tsx
@@ -36,7 +36,7 @@ Default.args = {
   titleId: "",
 };
 
-export const HeadingComponent = ({ ...props }) => {
+export const HeadingComponent = (props: HeadingProps) => {
   return (
     <Heading
       title="This is a Title"


### PR DESCRIPTION
### Proposed behaviour
- Rename the `heading.cy.js` to `heading.cy.tsx` file in `./cypress/components/heading/` folder.
- Refactor tests to Typescript.  
- Added eslint comment for 'badge.cy.tsx'
### Current behaviour

Currently Badge component is in JS not in TS.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the`heading.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other *.cy.tsx files have regressed


<!-- Add CodeSandbox here -->
