### PR TITLE
test(button-minor): refactor to ts

### DIFF
--- a/cypress/components/accordion/accordion.cy.tsx
+++ b/cypress/components/accordion/accordion.cy.tsx
@@ -114,7 +114,7 @@ context("Testing Accordion component", () => {
       }
     );
 
-    it.each([["left"], ["right"]])(
+    it.each(["left", "right"])(
       "should set Accordion iconAlign to %s",
       (iconAlign) => {
         CypressMountWithProviders(<AccordionComponent iconAlign={iconAlign} />);

--- a/cypress/components/button-minor/button-minor.cy.tsx
+++ b/cypress/components/button-minor/button-minor.cy.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-
+import { ButtonMinorProps } from "../../../src/components/button-minor";
 import {
   Default as ButtonMinor,
   ButtonMinorCustom,
@@ -20,6 +20,7 @@ import { cyRoot, icon, tooltipPreview } from "../../locators";
 import { CHARACTERS } from "../../support/component-helper/constants";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import { assertCssValueIsApproximately } from "../../support/component-helper/common-steps";
+import { keyCode } from "../../support/helper";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
@@ -27,7 +28,15 @@ const buttonTypesAndBackgrounds = [
   ["1st", "primary", 0],
   ["2nd", "secondary", 1],
   ["3rd", "tertiary", 2],
-];
+] as const;
+
+const keysToPress = [
+  "leftarrow",
+  "rightarrow",
+  "uparrow",
+  "downarrow",
+  "Enter",
+] as const;
 
 const destructive = "rgb(162, 44, 59)";
 const transparent = "rgba(0, 0, 0, 0)";
@@ -106,16 +115,25 @@ context("Test for Button Minor component", () => {
       [BUTTON_SIZES[0], 32],
       [BUTTON_SIZES[1], 40],
       [BUTTON_SIZES[2], 48],
-    ])("should render Button Minor in %s size", (size, minHeight) => {
-      CypressMountWithProviders(<ButtonMinor size={size}>{size}</ButtonMinor>);
+    ] as [ButtonMinorProps["size"], number][])(
+      "should render Button Minor in %s size",
+      (size, minHeight) => {
+        CypressMountWithProviders(
+          <ButtonMinor size={size}>{size}</ButtonMinor>
+        );
 
-      buttonMinorComponent().should("have.css", "min-height", `${minHeight}px`);
-    });
+        buttonMinorComponent().should(
+          "have.css",
+          "min-height",
+          `${minHeight}px`
+        );
+      }
+    );
 
     it.each([
       [BUTTON_ICON_POSITIONS[0], "right"],
       [BUTTON_ICON_POSITIONS[1], "left"],
-    ])(
+    ] as [ButtonMinorProps["iconPosition"], string][])(
       "should set position to %s for icon in a button",
       (iconPosition, margin) => {
         CypressMountWithProviders(
@@ -149,7 +167,7 @@ context("Test for Button Minor component", () => {
     it.each([
       [true, "white-space"],
       [false, "flex-wrap"],
-    ])(
+    ] as [ButtonMinorProps["noWrap"], string][])(
       "should render the Button Minor text with noWrap prop set to %s",
       (booleanState, cssValue) => {
         const assertion = booleanState ? "nowrap" : "wrap";
@@ -165,7 +183,11 @@ context("Test for Button Minor component", () => {
       }
     );
 
-    it.each(buttonTypesAndBackgrounds)(
+    it.each([...buttonTypesAndBackgrounds] as [
+      string,
+      ButtonMinorProps["buttonType"],
+      number
+    ][])(
       "should check Button Minor is disabled for the %s button",
       (position, type, index) => {
         CypressMountWithProviders(<ButtonMinorDifferentTypes disabled />);
@@ -176,7 +198,11 @@ context("Test for Button Minor component", () => {
       }
     );
 
-    it.each(buttonTypesAndBackgrounds)(
+    it.each([...buttonTypesAndBackgrounds] as [
+      string,
+      ButtonMinorProps["buttonType"],
+      number
+    ][])(
       "should check Button Minor is enabled for the %s button",
       (position, type, index) => {
         CypressMountWithProviders(<ButtonMinorDifferentTypes />);
@@ -185,7 +211,11 @@ context("Test for Button Minor component", () => {
       }
     );
 
-    it.each(buttonTypesAndBackgrounds)(
+    it.each([...buttonTypesAndBackgrounds] as [
+      string,
+      ButtonMinorProps["buttonType"],
+      number
+    ][])(
       "should check Button Minor is destructive for the %s button when buttonType is %s",
       (_, type, index) => {
         CypressMountWithProviders(
@@ -225,59 +255,46 @@ context("Test for Button Minor component", () => {
   });
 
   describe("check events for Button Minor component", () => {
-    let callback;
-
-    beforeEach(() => {
-      callback = cy.stub();
-    });
-
     it("should call onClick callback when a click event is triggered", () => {
+      const callback: ButtonMinorProps["onClick"] = cy.stub().as("onClick");
+
       CypressMountWithProviders(<ButtonMinorCustom onClick={callback} />);
 
-      buttonMinorComponent()
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      buttonMinorComponent().click();
+
+      cy.get("@onClick").should("be.calledOnce");
     });
 
     it("should call onBlur callback when a blur event is triggered", () => {
+      const callback: ButtonMinorProps["onBlur"] = cy.stub().as("onBlur");
+
       CypressMountWithProviders(<ButtonMinorCustom onBlur={callback} />);
 
-      buttonMinorComponent()
-        .focus()
-        .blur()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      buttonMinorComponent().focus().blur();
+      cy.get("@onBlur").should("be.calledOnce");
     });
 
-    it.each(["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Enter"])(
-      "should call onKeyDown callback when a keydown event is triggered",
+    it.each([...keysToPress])(
+      "should call onKeyDown callback when a keydown %s event is triggered",
       (key) => {
+        const callback: ButtonMinorProps["onKeyDown"] = cy
+          .stub()
+          .as("onKeyDown");
+
         CypressMountWithProviders(<ButtonMinorCustom onKeyDown={callback} />);
 
-        buttonMinorComponent()
-          .focus()
-          .realPress(key)
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callback).to.have.been.calledOnce;
-          });
+        buttonMinorComponent().focus().trigger("keydown", keyCode(key));
+        cy.get("@onKeyDown").should("be.calledOnce");
       }
     );
 
     it("should call onFocus callback when a focus event is triggered", () => {
+      const callback: ButtonMinorProps["onFocus"] = cy.stub().as("onFocus");
+
       CypressMountWithProviders(<ButtonMinorCustom onFocus={callback} />);
 
-      buttonMinorComponent()
-        .focus()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      buttonMinorComponent().focus();
+      cy.get("@onFocus").should("be.calledOnce");
     });
   });
 

--- a/src/components/button-minor/button-minor-test.stories.tsx
+++ b/src/components/button-minor/button-minor-test.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
-import { ButtonProps } from "../button";
-import ButtonMinor from "./button-minor.component";
+import ButtonMinor, { ButtonMinorProps } from "./button-minor.component";
 import { ICONS } from "../icon/icon-config";
 import {
   BUTTON_SIZES,
@@ -55,16 +54,16 @@ const commonArgsButtonMinor = {
   href: undefined,
   iconPosition: "before",
 };
-export const DefaultStory = (args: ButtonProps) => (
-  <ButtonMinor onClick={action("click")} {...args}>
+export const DefaultStory = (props: ButtonMinorProps) => (
+  <ButtonMinor onClick={action("click")} {...props}>
     Example Button
   </ButtonMinor>
 );
-export const Default = (args: ButtonProps) => <ButtonMinor {...args} />;
-export const ButtonMinorCustom = (props: ButtonProps) => (
+export const Default = (props: ButtonMinorProps) => <ButtonMinor {...props} />;
+export const ButtonMinorCustom = (props: ButtonMinorProps) => (
   <ButtonMinor {...props}>Example Button</ButtonMinor>
 );
-export const ButtonMinorDifferentTypes = (props: ButtonProps) => {
+export const ButtonMinorDifferentTypes = (props: ButtonMinorProps) => {
   return (
     <div>
       <ButtonMinor buttonType="primary" {...props}>


### PR DESCRIPTION
### Proposed behaviour

- Rename the `button-minor.cy.js` to `button-minor.cy.tsx` file in `./cypress/components/button-minor/` folder.
- Refactor tests to Typescript.  

### Current behaviour

bBtton-minor tests are in js.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions
- [ ] Run `npx cypress open --component` to check if the`button-minor.cy.tsx` file passed
- [ ] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed
<!-- Add CodeSandbox here -->
