### PR TITLE
test(button-toggle): refactor to TS

### DIFF
--- a/cypress/components/button-toggle/button-toggle.cy.tsx
+++ b/cypress/components/button-toggle/button-toggle.cy.tsx
@@ -1,5 +1,9 @@
+/* eslint-disable jest/valid-expect */
+/* eslint-disable no-unused-expressions */
 import React from "react";
-import ButtonToggle from "../../../src/components/button-toggle";
+import ButtonToggle, {
+  ButtonToggleProps,
+} from "../../../src/components/button-toggle";
 import { ButtonToggleComponent } from "../../../src/components/button-toggle/button-toggle-test.stories";
 import {
   buttonToggleLabelPreview,
@@ -88,7 +92,7 @@ context("Testing Button-Toggle component", () => {
       [SIZE.SMALL, 32],
       [SIZE.MEDIUM, 40],
       [SIZE.LARGE, 48],
-    ])(
+    ] as [ButtonToggleProps["size"], number][])(
       "should check when prop is %s that Button-Toggle height is %s",
       (size, height) => {
         CypressMountWithProviders(
@@ -101,7 +105,7 @@ context("Testing Button-Toggle component", () => {
       }
     );
 
-    it.each(["add", "share", "tick"])(
+    it.each(["add", "share", "tick"] as ButtonToggleProps["buttonIcon"][])(
       "should check that Button-Toggle has %s icon",
       (type) => {
         CypressMountWithProviders(
@@ -115,7 +119,11 @@ context("Testing Button-Toggle component", () => {
       }
     );
 
-    it.each([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE])(
+    it.each([
+      SIZE.SMALL,
+      SIZE.MEDIUM,
+      SIZE.LARGE,
+    ] as ButtonToggleProps["buttonIconSize"][])(
       "should check that Button-Toggle icon size is %s",
       (iconSize) => {
         CypressMountWithProviders(
@@ -171,13 +179,9 @@ context("Testing Button-Toggle component", () => {
   });
 
   describe("should render Button-Toggle component for event tests", () => {
-    let callback;
-
-    beforeEach(() => {
-      callback = cy.stub();
-    });
-
     it("should render Button-Toggle disabled", () => {
+      const callback: ButtonToggleProps["onClick"] = cy.stub();
+
       CypressMountWithProviders(<ButtonToggleComponent disabled />);
 
       buttonToggleInput().should("have.attr", "disabled");
@@ -185,12 +189,13 @@ context("Testing Button-Toggle component", () => {
         .eq(positionOfElement("first"))
         .click()
         .then(() => {
-          // eslint-disable-next-line no-unused-expressions
           expect(callback).not.to.have.been.called;
         });
     });
 
     it("should call onChange callback when a click event is triggered", () => {
+      const callback: ButtonToggleProps["onChange"] = cy.stub();
+
       CypressMountWithProviders(<ButtonToggleComponent onChange={callback} />);
 
       buttonTogglePreview()
@@ -203,6 +208,8 @@ context("Testing Button-Toggle component", () => {
     });
 
     it("should call onFocus callback when a focus event is triggered", () => {
+      const callback: ButtonToggleProps["onFocus"] = cy.stub();
+
       CypressMountWithProviders(<ButtonToggleComponent onFocus={callback} />);
 
       buttonToggleInput()
@@ -215,6 +222,8 @@ context("Testing Button-Toggle component", () => {
     });
 
     it("should call onBlur callback when a blur event is triggered", () => {
+      const callback: ButtonToggleProps["onBlur"] = cy.stub();
+
       CypressMountWithProviders(<ButtonToggleComponent onBlur={callback} />);
 
       buttonToggleInput().eq(positionOfElement("first")).focus();
@@ -252,15 +261,18 @@ context("Testing Button-Toggle component", () => {
       [SIZE.SMALL, 32],
       [SIZE.MEDIUM, 40],
       [SIZE.LARGE, 48],
-    ])("should pass accessibility tests for Button-Toggle %s", (size) => {
-      CypressMountWithProviders(
-        <ButtonToggleComponent size={size}> {size}</ButtonToggleComponent>
-      );
+    ] as [ButtonToggleProps["size"], number][])(
+      "should pass accessibility tests for Button-Toggle %s",
+      (size) => {
+        CypressMountWithProviders(
+          <ButtonToggleComponent size={size}> {size}</ButtonToggleComponent>
+        );
 
-      cy.checkAccessibility();
-    });
+        cy.checkAccessibility();
+      }
+    );
 
-    it.each(["add", "share", "tick"])(
+    it.each(["add", "share", "tick"] as ButtonToggleProps["buttonIcon"][])(
       "should pass accessibility tests for Button-Toggle with %s icon",
       (type) => {
         CypressMountWithProviders(

--- a/src/components/button-toggle/button-toggle-test.stories.tsx
+++ b/src/components/button-toggle/button-toggle-test.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
 
-import ButtonToggle from ".";
+import ButtonToggle, { ButtonToggleProps } from ".";
 
 export default {
   title: "Button Toggle/Test",
@@ -52,7 +52,7 @@ export const ButtonToggleComponent = ({
   // eslint-disable-next-line react/prop-types
   children = "This is an example of an alert",
   ...props
-}) => {
+}: ButtonToggleProps) => {
   return (
     <div>
       <ButtonToggle


### PR DESCRIPTION
### Proposed behaviour

- Rename the `button-toggle.cy.js` into `button-toggle.cy.tsx` file in `./cypress/components/button-toggle/` folder
- Refactor tests to Typescript

### Current behaviour

tests are in js not ts

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the `button-toggle.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed
