### PR TITLE
test(message): typescript refactor

### DIFF
--- a/cypress/components/message/message.cy.tsx
+++ b/cypress/components/message/message.cy.tsx
@@ -1,11 +1,9 @@
-/* eslint-disable no-undef */
-import React, { useState } from "react";
-import Button from "../../../src/components/button";
-import Message from "../../../src/components/message";
+/* eslint-disable jest/valid-expect, no-unused-expressions */
+import React from "react";
+import Message, { MessageProps } from "../../../src/components/message";
+import { MessageComponent } from "../../../src/components/message/message-test.stories";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
-
 import { getDataElementByValue } from "../../locators";
-
 import {
   messagePreview,
   messageChildren,
@@ -21,18 +19,6 @@ import {
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
-const MessageComponent = ({ ...props }) => {
-  const [isOpen, setIsOpen] = useState(true);
-  return (
-    <div>
-      {!isOpen && <Button onClick={() => setIsOpen(true)}>Open Message</Button>}
-      <Message open={isOpen} onDismiss={() => setIsOpen(false)} {...props}>
-        Some custom message
-      </Message>
-    </div>
-  );
-};
-
 context("Tests for Message component", () => {
   describe("should check Message component properties", () => {
     it.each([
@@ -40,7 +26,7 @@ context("Tests for Message component", () => {
       ["error", VALIDATION.ERROR],
       ["success", "rgb(0, 138, 33)"],
       ["warning", VALIDATION.WARNING],
-    ])(
+    ] as [MessageProps["variant"], string][])(
       "should check %s variant for Message component",
       (variant, backgroundColor) => {
         CypressMountWithProviders(<MessageComponent variant={variant} />);
@@ -154,14 +140,18 @@ context("Tests for Message component", () => {
       messageDismissIcon()
         .click()
         .then(() => {
-          // eslint-disable-next-line no-unused-expressions
           expect(callback).to.have.been.calledOnce;
         });
     });
   });
 
   describe("Accessibility tests for Message component", () => {
-    it.each(["info", "error", "success", "warning"])(
+    it.each([
+      "info",
+      "error",
+      "success",
+      "warning",
+    ] as MessageProps["variant"][])(
       "should check %s as variant for accessibility tests",
       (variant) => {
         CypressMountWithProviders(<MessageComponent variant={variant} />);

--- a/src/components/message/message-test.stories.tsx
+++ b/src/components/message/message-test.stories.tsx
@@ -54,3 +54,15 @@ Default.args = {
   children: "This is some information from the Message Component.",
   showCloseIcon: true,
 };
+
+export const MessageComponent = (props: MessageProps) => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <div>
+      {!isOpen && <Button onClick={() => setIsOpen(true)}>Open Message</Button>}
+      <Message open={isOpen} onDismiss={() => setIsOpen(false)} {...props}>
+        Some custom message
+      </Message>
+    </div>
+  );
+};


### PR DESCRIPTION
### Proposed behaviour
- Rename the `message.cy.js` to `message.cy.tsx` file in `./cypress/components/message/` folder.
- Refactor tests to Typescript.  

### Current behaviour

Currently Message component is in JS not in TS.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the`message.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other *.cy.tsx files have regressed
- [x] Run `npm run type-check` to make sure there is no type issue

<!-- Add CodeSandbox here -->
