### PR TITLE
refactor(form-field): remove hardcoded margin top css from form field

### DIFF
--- a/src/__internal__/form-field/form-field.style.ts
+++ b/src/__internal__/form-field/form-field.style.ts
@@ -3,10 +3,6 @@ import { space } from "styled-system";
 import { baseTheme } from "../../style/themes";
 
 const FormFieldStyle = styled.div`
-  & + & {
-    margin-top: 16px;
-  }
-
   &&& {
     ${space}
   }

--- a/src/components/button-toggle-group/button-toggle-group-validations.stories.tsx
+++ b/src/components/button-toggle-group/button-toggle-group-validations.stories.tsx
@@ -26,6 +26,7 @@ export const Error: ComponentStory<typeof ButtonToggleGroup> = () => (
       </ButtonToggle>
     </ButtonToggleGroup>
     <ButtonToggleGroup
+      mt={2}
       id="button-toggle-group-error-grouped-id"
       name="button-toggle-group-error-grouped"
       label="Grouped"
@@ -45,6 +46,7 @@ export const Error: ComponentStory<typeof ButtonToggleGroup> = () => (
       </ButtonToggle>
     </ButtonToggleGroup>
     <ButtonToggleGroup
+      mt={2}
       id="button-toggle-group-error-label-id"
       name="button-toggle-group-error-label"
       label="Error on the Label"
@@ -65,6 +67,7 @@ export const Error: ComponentStory<typeof ButtonToggleGroup> = () => (
       </ButtonToggle>
     </ButtonToggleGroup>
     <ButtonToggleGroup
+      mt={2}
       id="button-toggle-group-error-empty-id"
       name="button-toggle-group-error-empty"
       label="Without a message"
@@ -108,6 +111,7 @@ export const Warning: ComponentStory<typeof ButtonToggleGroup> = () => (
       </ButtonToggle>
     </ButtonToggleGroup>
     <ButtonToggleGroup
+      mt={2}
       id="button-toggle-group-warning-grouped-id"
       name="button-toggle-group-warning-grouped"
       label="Grouped"
@@ -127,6 +131,7 @@ export const Warning: ComponentStory<typeof ButtonToggleGroup> = () => (
       </ButtonToggle>
     </ButtonToggleGroup>
     <ButtonToggleGroup
+      mt={2}
       id="button-toggle-group-warning-label-id"
       name="button-toggle-group-warning-label"
       label="Error on the Label"
@@ -147,6 +152,7 @@ export const Warning: ComponentStory<typeof ButtonToggleGroup> = () => (
       </ButtonToggle>
     </ButtonToggleGroup>
     <ButtonToggleGroup
+      mt={2}
       id="button-toggle-group-warning-empty-id"
       name="button-toggle-group-warning-empty"
       label="Without a message"
@@ -190,6 +196,7 @@ export const Info: ComponentStory<typeof ButtonToggleGroup> = () => (
       </ButtonToggle>
     </ButtonToggleGroup>
     <ButtonToggleGroup
+      mt={2}
       id="button-toggle-group-info-grouped-id"
       name="button-toggle-group-info-grouped"
       label="Grouped"
@@ -209,6 +216,7 @@ export const Info: ComponentStory<typeof ButtonToggleGroup> = () => (
       </ButtonToggle>
     </ButtonToggleGroup>
     <ButtonToggleGroup
+      mt={2}
       id="button-toggle-group-info-label-id"
       name="button-toggle-group-info-label"
       label="Error on the Label"
@@ -229,6 +237,7 @@ export const Info: ComponentStory<typeof ButtonToggleGroup> = () => (
       </ButtonToggle>
     </ButtonToggleGroup>
     <ButtonToggleGroup
+      mt={2}
       id="button-toggle-group-info-empty-id"
       name="button-toggle-group-info-empty"
       label="Without a message"

--- a/src/components/button-toggle-group/button-toggle-group.style.ts
+++ b/src/components/button-toggle-group/button-toggle-group.style.ts
@@ -3,6 +3,7 @@ import {
   StyledButtonToggleLabel,
   StyledButtonToggle,
 } from "../button-toggle/button-toggle.style";
+
 import ValidationIconStyle from "../../__internal__/validations/validation-icon.style";
 
 import { ButtonToggleGroupProps } from ".";

--- a/src/components/grouped-character/grouped-character.stories.tsx
+++ b/src/components/grouped-character/grouped-character.stories.tsx
@@ -198,8 +198,9 @@ export const LabelAlign = () => {
     setState({ ...state, [alignment]: e.target.value.rawValue });
   };
 
-  return (["right", "left"] as const).map((alignment) => (
+  return (["right", "left"] as const).map((alignment, index) => (
     <GroupedCharacter
+      mt={index === 0 ? 0 : 2}
       label="GroupedCharacter"
       value={state[alignment]}
       onChange={handleChange(alignment)}
@@ -228,8 +229,9 @@ export const VariousSeparators = () => {
     setState({ ...state, [separator]: e.target.value.rawValue });
   };
 
-  return ([".", ",", " ", "-", "/", "|"] as const).map((separator) => (
+  return ([".", ",", " ", "-", "/", "|"] as const).map((separator, index) => (
     <GroupedCharacter
+      mt={index === 0 ? 0 : 2}
       label="GroupedCharacter"
       value={state[separator]}
       onChange={handleChange(separator)}
@@ -257,8 +259,9 @@ export const VariousGroups = () => {
     [1, 2, 4],
     [3, 2, 2],
     [3, 1, 3],
-  ].map((group) => (
+  ].map((group, index) => (
     <GroupedCharacter
+      mt={index === 0 ? 0 : 2}
       label="GroupedCharacter"
       value={state[group.join("-") as keyof typeof state]}
       onChange={handleChange(group.join("-"))}

--- a/src/components/number/number.stories.tsx
+++ b/src/components/number/number.stories.tsx
@@ -52,8 +52,9 @@ export const WithLabelAlign: ComponentStory<typeof Number> = () => {
 
   return (
     <>
-      {alignments.map((alignment) => (
+      {alignments.map((alignment, index) => (
         <Number
+          mt={index === 0 ? 0 : 2}
           label="Number"
           labelInline
           value="123456"

--- a/src/components/numeral-date/numeral-date.stories.tsx
+++ b/src/components/numeral-date/numeral-date.stories.tsx
@@ -24,10 +24,10 @@ export const Controlled: ComponentStory<typeof NumeralDate> = () => {
 export const AllowedDateFormats: ComponentStory<typeof NumeralDate> = () => (
   <>
     <NumeralDate label="DD/MM/YYYY - default" />
-    <NumeralDate label="MM/DD/YYYY" dateFormat={["mm", "dd", "yyyy"]} />
-    <NumeralDate label="DD/MM" dateFormat={["dd", "mm"]} />
-    <NumeralDate label="MM/DD" dateFormat={["mm", "dd"]} />
-    <NumeralDate label="MM/YYYY" dateFormat={["mm", "yyyy"]} />
+    <NumeralDate label="MM/DD/YYYY" dateFormat={["mm", "dd", "yyyy"]} mt={2} />
+    <NumeralDate label="DD/MM" dateFormat={["dd", "mm"]} mt={2} />
+    <NumeralDate label="MM/DD" dateFormat={["mm", "dd"]} mt={2} />
+    <NumeralDate label="MM/YYYY" dateFormat={["mm", "yyyy"]} mt={2} />
   </>
 );
 
@@ -134,11 +134,13 @@ export const Size: ComponentStory<typeof NumeralDate> = () => (
       label="Date of Birth"
       dateFormat={["dd", "mm", "yyyy"]}
       size="medium"
+      mt={2}
     />
     <NumeralDate
       label="Date of Birth"
       dateFormat={["dd", "mm", "yyyy"]}
       size="large"
+      mt={2}
     />
   </>
 );

--- a/src/components/textbox/textbox.stories.tsx
+++ b/src/components/textbox/textbox.stories.tsx
@@ -170,8 +170,9 @@ export const Required: ComponentStory<typeof Textbox> = () => {
 export const LabelAlign: ComponentStory<typeof Textbox> = () => {
   return (
     <Box>
-      {(["right", "left"] as const).map((alignment) => (
+      {(["right", "left"] as const).map((alignment, index) => (
         <Textbox
+          mt={index === 0 ? 0 : 2}
           label="Textbox"
           value="Textbox"
           labelInline


### PR DESCRIPTION
BREAKING CHANGE: Consumers now have the option to apply spacing props using styled-system.

[This block of code](https://github.com/Sage/carbon/commit/d24240ff62d978c3a5efb770c160556b5c855aaa#diff-7c7e2e1a202bcb43a977e3d8fa92ffd0a2a1da1f654e044a9dd0cfbd986538e3) is causing consumers issues when using and `FormField` based components inline as `margin-top: 16px` is being applied to the input elements that are placed immediately after another `FormField` based element. To get around this `mt={0}` can be applied as this will override the applied `margin-top`.

### Proposed behaviour

Remove code causing `FormField` based components to have a `margin-top` of `16px` even when placed side by side.

### Current behaviour

`FormField` based components have a `margin-top` of `16px` when placed side by side.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

N/A yet
