### PR TITLE
test(link-preview): refactor ts

### DIFF
--- a/cypress/components/link-preview/link-preview.cy.tsx
+++ b/cypress/components/link-preview/link-preview.cy.tsx
@@ -1,6 +1,8 @@
+/* eslint-disable jest/valid-expect, no-unused-expressions */
 import React from "react";
 import { LinkPreviewComponentTest as LinkPreviewComponent } from "../../../src/components/link-preview/link-preview-test.stories";
 import { getComponent } from "../../locators";
+import { LinkPreviewProps } from "../../../src/components/link-preview";
 import {
   linkPreview,
   linkPreviewCloseIcon,
@@ -15,10 +17,11 @@ import CypressMountWithProviders from "../../support/component-helper/cypress-mo
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testCypress = "test-cypress";
 const urlProp = "./carbon-by-sage-logo.png";
+const keysToTrigger = ["Space", "Enter"] as const;
 
 context("Test for Link Preview component", () => {
   describe("check props for Link Preview component", () => {
-    it.each([["div"], ["a"]])(
+    it.each(["div", "a"] as LinkPreviewProps["as"][])(
       "should render Link Preview as prop using %s",
       (as) => {
         CypressMountWithProviders(<LinkPreviewComponent as={as} />);
@@ -110,13 +113,8 @@ context("Test for Link Preview component", () => {
   });
 
   describe("check events for Link Preview component", () => {
-    let callback;
-
-    beforeEach(() => {
-      callback = cy.stub();
-    });
-
     it("should call onClose callback when a click event is triggered", () => {
+      const callback: LinkPreviewProps["onClose"] = cy.stub();
       CypressMountWithProviders(
         <LinkPreviewComponent as="div" onClose={callback} />
       );
@@ -124,14 +122,15 @@ context("Test for Link Preview component", () => {
       linkPreviewCloseIcon()
         .click()
         .then(() => {
-          // eslint-disable-next-line no-unused-expressions
           expect(callback).to.have.been.calledOnce;
         });
     });
 
-    it.each([["Enter"], ["Space"]])(
+    it.each([keysToTrigger])(
       "should call onClose callback when a keyboard event is triggered",
       (key) => {
+        const callback: LinkPreviewProps["onClose"] = cy.stub();
+
         CypressMountWithProviders(
           <LinkPreviewComponent as="div" onClose={callback} />
         );
@@ -139,7 +138,6 @@ context("Test for Link Preview component", () => {
         linkPreviewCloseIcon()
           .trigger("keydown", keyCode(key))
           .then(() => {
-            // eslint-disable-next-line no-unused-expressions
             expect(callback).to.have.been.calledOnce;
           });
       }

--- a/src/components/link-preview/link-preview-test.stories.tsx
+++ b/src/components/link-preview/link-preview-test.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
 
-import LinkPreview from "./link-preview.component";
+import LinkPreview, { LinkPreviewProps } from "./link-preview.component";
 
 export default {
   title: "Link Preview/Test",
@@ -26,7 +26,7 @@ export const Default = () => (
 
 Default.storyName = "default";
 
-export const LinkPreviewComponentTest = ({ ...props }) => {
+export const LinkPreviewComponentTest = (props: LinkPreviewProps) => {
   return (
     <LinkPreview
       title="This is an example of a title"


### PR DESCRIPTION
### Proposed behaviour
- Rename the `link-preview.cy.js` to `link-preview.cy.tsx` file in `./cypress/components/link-preview/` folder.
- Refactor tests to Typescript.  

### Current behaviour

Currently link-preview component is in JS not in TS.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

### Testing instructions
- [ ] Run `npx cypress open --component` to check if the`link-preview.cy.tsx` file passed
- [ ] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed