### PR TITLE
docs: fix broken Design Tokens link

### DIFF
--- a/docs/colors.stories.mdx
+++ b/docs/colors.stories.mdx
@@ -52,7 +52,7 @@ Where there is a collision between CSS strings and the palette color (e.g. gold)
 
 Using design tokens ensures visual consistency across the application and means that we will always have up-to-date values, if the colors are updated by designers using design tools.
 
-The name of the chosen design token must be always preceded by `--`, for example, if we want to use `colorsYang100` token in our code, we have to pass `--colorsYang100` as a prop. See [Design Tokens](https://zeroheight.com/2ccf2b601/p/217e24-design-tokens/b/46fb17) documentation for details.
+The name of the chosen design token must be always preceded by `--`, for example, if we want to use `colorsYang100` token in our code, we have to pass `--colorsYang100` as a prop. See the [Design Tokens](https://zeroheight.com/2ccf2b601/p/217e24-design-tokens/b/46fb17) documentation for details.
 
 ```jsx
 <Typography color='--colorsUtilityYang100'>...</Typography>

--- a/docs/colors.stories.mdx
+++ b/docs/colors.stories.mdx
@@ -52,7 +52,7 @@ Where there is a collision between CSS strings and the palette color (e.g. gold)
 
 Using design tokens ensures visual consistency across the application and means that we will always have up-to-date values, if the colors are updated by designers using design tools.
 
-The name of the chosen design token must be always preceded by `--`, for example, if we want to use `colorsYang100` token in our code, we have to pass `--colorsYang100` as a prop. See [Design Tokens](https://sage.jaha.pro) documentation for more information.
+The name of the chosen design token must be always preceded by `--`, for example, if we want to use `colorsYang100` token in our code, we have to pass `--colorsYang100` as a prop. See [Design Tokens](https://zeroheight.com/2ccf2b601/p/217e24-design-tokens/b/46fb17) documentation for details.
 
 ```jsx
 <Typography color='--colorsUtilityYang100'>...</Typography>


### PR DESCRIPTION
### Proposed behaviour

Fixes broken link to the external Design Tokens page,

Was pointing to https://sage.jaha.pro/

Now points to https://zeroheight.com/2ccf2b601/p/217e24-design-tokens/b/46fb17

Slack discussion [here](https://sageone.slack.com/archives/C0D6DD3N2/p1685615050409499).