### PR TITLE
test(drawer): typescript refactor

### DIFF
--- a/cypress/components/drawer/drawer.cy.tsx
+++ b/cypress/components/drawer/drawer.cy.tsx
@@ -1,18 +1,16 @@
 import React from "react";
+import { DrawerProps } from "components/drawer";
 import { DrawerCustom } from "../../../src/components/drawer/drawer-test.stories";
 import Box from "../../../src/components/box";
 import Button from "../../../src/components/button";
 import { Checkbox } from "../../../src/components/checkbox";
-
 import {
   drawer,
   drawerToggle,
   drawerSidebar,
   drawerSidebarContentInnerElement,
 } from "../../locators/drawer";
-
 import { stickyFooter } from "../../locators";
-
 import { positionOfElement } from "../../support/helper";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import { assertCssValueIsApproximately } from "../../support/component-helper/common-steps";
@@ -109,10 +107,8 @@ context("Test for Drawer component", () => {
       drawer()
         .children()
         .first()
-        .should(($el) => {
-          expect($el).to.have.css("background-color").to.equal(color);
-          expect($el).to.have.css("border-right-color").to.equal(color);
-        });
+        .should("have.css", "background-color", color)
+        .and("have.css", "border-right-color", color);
     });
 
     it("should render component with custom height", () => {
@@ -392,36 +388,24 @@ context("Test for Drawer component", () => {
   });
 
   describe("check events for Drawer component", () => {
-    let callback;
-
-    beforeEach(() => {
-      callback = cy.stub();
-    });
-
     it("should call onChange callback when a component is closed", () => {
+      const callback: DrawerProps["onChange"] = cy.stub().as("onChange");
       CypressMountWithProviders(
         <DrawerCustom onChange={callback} showControls />
       );
 
-      drawerToggle()
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      drawerToggle().click();
+      cy.get("@onChange").should("have.been.calledOnce");
     });
 
     it("should call onChange callback when a component is expanded", () => {
+      const callback: DrawerProps["onChange"] = cy.stub().as("onChange");
       CypressMountWithProviders(
         <DrawerCustom onChange={callback} showControls expanded={false} />
       );
 
-      drawerToggle()
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      drawerToggle().click();
+      cy.get("@onChange").should("have.been.calledOnce");
     });
   });
 

--- a/src/components/drawer/drawer-test.stories.tsx
+++ b/src/components/drawer/drawer-test.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from "react";
 import { action } from "@storybook/addon-actions";
 
-import Drawer from ".";
+import Drawer, { DrawerProps } from ".";
 import {
   FlatTable,
   FlatTableHead,
@@ -475,7 +475,7 @@ export const DefaultStory = () => {
 
 DefaultStory.storyName = "default";
 
-export const DrawerCustom = ({ ...props }) => {
+export const DrawerCustom = (props: Partial<DrawerProps>) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const onChangeHandler = React.useCallback(() => {
     setIsExpanded(!isExpanded);


### PR DESCRIPTION
### Proposed behaviour

- Rename the `drawer.cy.js` to `drawer.cy.tsx` file in `./cypress/components/drawer/` folder.
- Refactor tests to Typescript.  

### Current behaviour

Drawer tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [ ] Run `npx cypress open --component` to check if the`drawer.cy.tsx` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.cy.tsx files have regressed
<!-- Add CodeSandbox here -->