### PR TITLE
test(number): refactor tests to TS

### DIFF
--- a/cypress/components/number/number.cy.tsx
+++ b/cypress/components/number/number.cy.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { NumberProps } from "../../../src/components/number";
 import { NumberInputComponent } from "../../../src/components/number/number-test.stories";
 import * as stories from "../../../src/components/number/number.stories";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
@@ -22,7 +23,7 @@ const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 context("Tests for Number component", () => {
   describe("check props for Number component", () => {
-    it.each(testData)(
+    it.each(testData as NumberProps["label"][])(
       "should render Number label using %s special characters",
       (labelValue) => {
         CypressMountWithProviders(<NumberInputComponent label={labelValue} />);
@@ -31,7 +32,7 @@ context("Tests for Number component", () => {
       }
     );
 
-    it.each(testData)(
+    it.each(testData as NumberProps["labelHelp"][])(
       "should render labelHelp message using %s special characters",
       (labelHelpValue) => {
         CypressMountWithProviders(
@@ -43,7 +44,7 @@ context("Tests for Number component", () => {
       }
     );
 
-    it.each(testData)(
+    it.each(testData as NumberProps["fieldHelp"][])(
       "should render fieldHelp message using %s special characters",
       (fieldHelpValue) => {
         CypressMountWithProviders(
@@ -54,7 +55,7 @@ context("Tests for Number component", () => {
       }
     );
 
-    it.each(testData)(
+    it.each(testData as NumberProps["prefix"][])(
       "should render prefix using %s special characters",
       (prefixValue) => {
         CypressMountWithProviders(
@@ -65,7 +66,7 @@ context("Tests for Number component", () => {
       }
     );
 
-    it.each(testData)(
+    it.each(testData as NumberProps["placeholder"][])(
       "should render placeholder using %s special characters",
       (placeholderValue) => {
         CypressMountWithProviders(
@@ -184,7 +185,7 @@ context("Tests for Number component", () => {
       [SIZE.SMALL, "32px"],
       [SIZE.MEDIUM, "40px"],
       [SIZE.LARGE, "48px"],
-    ])(
+    ] as [NumberProps["size"], string][])(
       "should use %s as size and render Number with %s as height",
       (size, height) => {
         CypressMountWithProviders(<NumberInputComponent size={size} />);
@@ -218,7 +219,7 @@ context("Tests for Number component", () => {
     it.each([
       ["right", "end"],
       ["left", "start"],
-    ])(
+    ] as [NumberProps["labelAlign"], string][])(
       "should use %s as labelAligment and render it with flex-%s as css properties",
       (alignment, cssProp) => {
         CypressMountWithProviders(
@@ -232,11 +233,11 @@ context("Tests for Number component", () => {
       }
     );
 
-    it.each([
+    it.each(([
       ["10", "90", 135, 1229],
       ["30", "70", 409, 956],
       ["80", "20", 1092, 273],
-    ])(
+    ] as unknown) as [NumberProps["labelWidth"], NumberProps["inputWidth"], number, number][])(
       "should use %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
       (label, input, labelRatio, inputRatio) => {
         CypressMountWithProviders(
@@ -285,75 +286,29 @@ context("Tests for Number component", () => {
 
   describe("check events for Number component", () => {
     const inputValue = "1";
-    let callback;
-
-    beforeEach(() => {
-      callback = cy.stub();
-    });
 
     it("should call onChange callback when a type event is triggered", () => {
+      const callback: NumberProps["onChange"] = cy.stub().as("onChange");
+
       CypressMountWithProviders(<NumberInputComponent onChange={callback} />);
 
-      commonDataElementInputPreview()
-        .type(inputValue)
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      commonDataElementInputPreview().type(inputValue);
+
+      cy.get("@onChange").should("have.been.calledOnce");
     });
 
-    it.each([
-      [1000, "1"],
-      [5000, "5"],
-      [10000, "10"],
-    ])(
-      "should use %s as deferTimeout and defer onChangeDeferred event for %s seconds",
-      (timeout) => {
-        const callbackOnChange = cy.stub();
-        const callbackOnChangeDeff = cy.stub();
-
-        CypressMountWithProviders(
-          <NumberInputComponent
-            deferTimeout={timeout}
-            onChange={callbackOnChange}
-            onChangeDeferred={callbackOnChangeDeff}
-          />
-        );
-
-        cy.clock();
-
-        commonDataElementInputPreview()
-          .type(inputValue)
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callbackOnChange).to.have.been.calledOnce;
-            // eslint-disable-next-line no-unused-expressions
-            expect(callbackOnChangeDeff).to.not.have.been.called;
-          })
-          .then(() => {
-            cy.tick(timeout);
-          })
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callbackOnChangeDeff).to.have.been.calledOnce;
-          });
-      }
-    );
-
-    it.each([["downarrow"], ["leftarrow"], ["rightarrow"], ["uparrow"]])(
+    it.each(["downarrow", "leftarrow", "rightarrow", "uparrow"])(
       "should call onKeyDown callback when a %s keydown event is triggered",
       (key) => {
+        const callback: NumberProps["onKeyDown"] = cy.stub().as("onKeyDown");
+
         CypressMountWithProviders(
           <NumberInputComponent onKeyDown={callback} />
         );
 
-        commonDataElementInputPreview()
-          .clear()
-          .type(key)
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callback).to.have.been.called;
-          });
+        commonDataElementInputPreview().clear().type(key);
+
+        cy.get("@onKeyDown").should("have.been.called");
       }
     );
   });

--- a/cypress/components/number/number.cy.tsx
+++ b/cypress/components/number/number.cy.tsx
@@ -233,11 +233,11 @@ context("Tests for Number component", () => {
       }
     );
 
-    it.each(([
-      ["10", "90", 135, 1229],
-      ["30", "70", 409, 956],
-      ["80", "20", 1092, 273],
-    ] as unknown) as [NumberProps["labelWidth"], NumberProps["inputWidth"], number, number][])(
+    it.each([
+      [10, 90, 135, 1229],
+      [30, 70, 409, 956],
+      [80, 20, 1092, 273],
+    ] as [NumberProps["labelWidth"], NumberProps["inputWidth"], number, number][])(
       "should use %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
       (label, input, labelRatio, inputRatio) => {
         CypressMountWithProviders(

--- a/cypress/components/textarea/textarea.cy.tsx
+++ b/cypress/components/textarea/textarea.cy.tsx
@@ -135,11 +135,11 @@ context("Tests for Textarea component", () => {
       }
     );
 
-    it.each(([
-      ["10", "90", 135, 1229],
-      ["30", "70", 409, 956],
-      ["80", "20", 1092, 273],
-    ] as unknown) as [TextareaProps["labelWidth"], TextareaProps["inputWidth"], number, number][])(
+    it.each([
+      [10, 90, 135, 1229],
+      [30, 70, 409, 956],
+      [80, 20, 1092, 273],
+    ] as [TextareaProps["labelWidth"], TextareaProps["inputWidth"], number, number][])(
       "should use %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
       (label, input, labelRatio, inputRatio) => {
         CypressMountWithProviders(

--- a/cypress/components/textbox/textbox.cy.tsx
+++ b/cypress/components/textbox/textbox.cy.tsx
@@ -187,11 +187,11 @@ context("Tests for Textbox component", () => {
       }
     );
 
-    it.each(([
-      ["10", "90", 135, 1229],
-      ["30", "70", 409, 956],
-      ["80", "20", 1092, 273],
-    ] as unknown) as [TextboxProps["labelWidth"], TextboxProps["inputWidth"], number, number][])(
+    it.each([
+      [10, 90, 135, 1229],
+      [30, 70, 409, 956],
+      [80, 20, 1092, 273],
+    ] as [TextboxProps["labelWidth"], TextboxProps["inputWidth"], number, number][])(
       "should use %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
       (label, input, labelRatio, inputRatio) => {
         CypressMountWithProviders(
@@ -516,11 +516,11 @@ context("Tests for Textbox component", () => {
         .and("be.visible");
     });
 
-    it.each(([
-      ["flex", "399"],
-      ["flex", "400"],
-      ["block", "401"],
-    ] as unknown) as [string, TextboxProps["adaptiveLabelBreakpoint"]][])(
+    it.each([
+      ["flex", 399],
+      ["flex", 400],
+      ["block", 401],
+    ] as [string, TextboxProps["adaptiveLabelBreakpoint"]][])(
       "should check Textbox label alignment is %s with adaptiveLabelBreakpoint %s and viewport 400",
       (displayValue, breakpoint) => {
         cy.viewport(400, 300);

--- a/src/components/number/number-test.stories.tsx
+++ b/src/components/number/number-test.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
 
-import Number from "./number.component";
+import Number, { NumberProps } from "./number.component";
 import {
   CommonTextboxArgs,
   commonTextboxArgTypes,
@@ -62,7 +62,7 @@ Default.args = {
   ...getCommonTextboxArgs(),
 };
 
-export const NumberInputComponent = ({ ...props }) => {
+export const NumberInputComponent = (props: NumberProps) => {
   const [state, setState] = React.useState("");
 
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
### Proposed behaviour

- Rename the `number.cy.js` to `number.cy.tsx` file in `./cypress/components/number/` folder.
- Refactor tests to Typescript.  

### Current behaviour

Number tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the `number.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed