### PR TITLE
fix(multi-action-button): remove unused props from interface

### DIFF
--- a/src/components/multi-action-button/multi-action-button.component.tsx
+++ b/src/components/multi-action-button/multi-action-button.component.tsx
@@ -18,7 +18,7 @@ import useMenuKeyboardNavigation from "../../hooks/__internal__/useMenuKeyboardN
 
 export interface MultiActionButtonProps
   extends WidthProps,
-    Omit<SplitButtonProps, "buttonType"> {
+    Omit<SplitButtonProps, "buttonType" | "iconPosition" | "iconType"> {
   /** Button type: "primary" | "secondary" | "tertiary" */
   buttonType?: "primary" | "secondary" | "tertiary";
   /** Second text child, renders under main text, only when size is "large" */


### PR DESCRIPTION
The iconType and iconPosition props on MultiActionButton have no effect as they are passed to the Button but deliberately overridden by hardcoded values. These are now removed from the props interface to avoid confusion for consumers.

fix #6059

### Proposed behaviour

`iconType` and `iconPosition` should not be accepted by the TypeScript compiler as valid props for `MultiActionButton`, nor should they be documented on Storybook.

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

The `iconType` and `iconPosition` props are listed in the props on storybook, and are accepted by Typescript, even though they do nothing.

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

The fact that these props do not do anything appears to be deliberate, and it has been like this way since 2020 - this was the PR where this was introduced: https://github.com/Sage/carbon/pull/2669

### Testing instructions

<!-- How can a reviewer test this PR? -->

No QA should be required on the component as the change only affects typescript types, not behaviour.

Check the docs for MultiActionButton to make sure the `iconType` and `iconPosition` props are no longer listed in the main props table (note that they are there, correctly, for the `Button` props table below - this is to document the props for any child buttons used, not the main component).

<!-- Add CodeSandbox here -->
