### PR TITLE
test(settings-row): refactor ts

### DIFF
--- a/cypress/components/settings-row/settings-row.cy.tsx
+++ b/cypress/components/settings-row/settings-row.cy.tsx
@@ -3,6 +3,7 @@ import Link from "../../../src/components/link";
 import { SettingsRowComponent } from "../../../src/components/settings-row/settings-row-test.stories";
 import * as stories from "../../../src/components/settings-row/settings-row.stories";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
+import { SettingsRowProps } from "../../../src/components/settings-row";
 import { getDataElementByValue } from "../../locators";
 import {
   settingsRowPreview,
@@ -24,7 +25,13 @@ context("Tests for SettingsRow component", () => {
       }
     );
 
-    it.each(["h1", "h2", "h3", "h4", "h5"])(
+    it.each([
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+    ] as SettingsRowProps["headingType"][])(
       "should check HTML heading element is correct when headingType is %s",
       (headingType) => {
         CypressMountWithProviders(
@@ -35,7 +42,7 @@ context("Tests for SettingsRow component", () => {
           />
         );
 
-        cy.get(headingType).contains("foo");
+        cy.get(String(headingType)).contains("foo");
       }
     );
 
@@ -75,7 +82,7 @@ context("Tests for SettingsRow component", () => {
               "solid",
               "rgb(230, 235, 237)"
             );
-            expect(elem.css("padding-bottom")).to.equals("30px");
+            settingsRowPreview().should("have.css", "padding-bottom", "30px");
           });
         } else {
           settingsRowPreview()

--- a/src/components/settings-row/settings-row-test.stories.tsx
+++ b/src/components/settings-row/settings-row-test.stories.tsx
@@ -44,6 +44,6 @@ Default.args = {
   divider: true,
 };
 
-export const SettingsRowComponent = ({ ...props }) => {
+export const SettingsRowComponent = (props: SettingsRowProps) => {
   return <SettingsRow title="title" description="description" {...props} />;
 };


### PR DESCRIPTION
### Proposed behaviour
- Rename the `settings-row.cy.js` to `settings-row.cy.tsx` file in `./cypress/components/settings-row/` folder.
- Refactor tests to Typescript.  

### Current behaviour

Currently settings-row component is in JS not in TS.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

### Testing instructions
- [ ] Run `npx cypress open --component` to check if the`settings-row.cy.tsx` file passed
- [ ] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed