### PR TITLE
test(duelling-picklist): typescript refactor

### DIFF
--- a/cypress/components/duelling-picklist/duelling-picklist.cy.tsx
+++ b/cypress/components/duelling-picklist/duelling-picklist.cy.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { PicklistItemProps } from "../../../src/components/duelling-picklist/picklist-item/picklist-item.component";
 import {
   DuellingPicklistComponent,
+  DuellingPicklistComponentPicklistItemProps,
   DuellingPicklistComponentPicklistProps,
 } from "../../../src/components/duelling-picklist/duelling-picklist-test.stories";
 import PicklistPlaceholder from "../../../src/components/duelling-picklist/picklist-placeholder/picklist-placeholder.component";
@@ -30,6 +32,7 @@ const specialCharacters = [
   CHARACTERS.DIACRITICS,
   CHARACTERS.SPECIALCHARACTERS,
 ];
+const keyToTrigger = ["Space", "Enter"] as const;
 
 context("Testing Duelling-Picklist component", () => {
   describe("should render Duelling-Picklist component", () => {
@@ -98,7 +101,7 @@ context("Testing Duelling-Picklist component", () => {
       assignedPicklistItems().should("have.length", 0);
     });
 
-    it.each(["Enter", "Space"])(
+    it.each([...keyToTrigger])(
       "should verify item is added to assigned picklist when %s key is pressed",
       (pressed) => {
         CypressMountWithProviders(<DuellingPicklistComponent />);
@@ -109,7 +112,7 @@ context("Testing Duelling-Picklist component", () => {
       }
     );
 
-    it.each(["Enter", "Space"])(
+    it.each([...keyToTrigger])(
       "should verify item is removed from assigned picklist when %s key is pressed",
       (pressed) => {
         CypressMountWithProviders(<DuellingPicklistComponent />);
@@ -185,7 +188,7 @@ context("Testing Duelling-Picklist component", () => {
   });
 
   describe("should render Duelling-Picklist component to test Picklist props", () => {
-    it.each(specialCharacters)(
+    it.each([...specialCharacters])(
       "should verify picklist placeholder is set to %s",
       (chars) => {
         CypressMountWithProviders(
@@ -208,7 +211,7 @@ context("Testing Duelling-Picklist component", () => {
       "should verify picklist item is %s when locked prop is %s",
       (state, bool, attribute, backColor) => {
         CypressMountWithProviders(
-          <DuellingPicklistComponentPicklistProps locked={bool} />
+          <DuellingPicklistComponentPicklistItemProps locked={bool} />
         );
 
         unassignedPicklistItems().should(
@@ -224,7 +227,7 @@ context("Testing Duelling-Picklist component", () => {
 
     it("should verify picklist tooltip is 'Item Locked' when locked prop is true", () => {
       CypressMountWithProviders(
-        <DuellingPicklistComponentPicklistProps
+        <DuellingPicklistComponentPicklistItemProps
           locked
           tooltipMessage="Item Locked"
         />
@@ -301,67 +304,53 @@ context("Testing Duelling-Picklist component", () => {
   });
 
   describe("check events for Duelling-Picklist component", () => {
-    let callback;
-
-    beforeEach(() => {
-      callback = cy.stub();
-    });
-
     it("should call onChange when add button clicked", () => {
+      const callback: PicklistItemProps["onChange"] = cy.stub().as("onChange");
       CypressMountWithProviders(
-        <DuellingPicklistComponentPicklistProps onChange={callback} />
+        <DuellingPicklistComponentPicklistItemProps onChange={callback} />
       );
 
-      addButton(0)
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      addButton(0).click();
+      cy.get("@onChange").should("have.been.calledOnce");
     });
 
     it("should call onChange when remove button clicked", () => {
+      const callback: PicklistItemProps["onChange"] = cy.stub().as("onChange");
       CypressMountWithProviders(
-        <DuellingPicklistComponentPicklistProps onChange={callback} />
+        <DuellingPicklistComponentPicklistItemProps onChange={callback} />
       );
 
-      removeButton(0)
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      removeButton(0).click();
+      cy.get("@onChange").should("have.been.calledOnce");
     });
 
-    it.each(["Enter", "Space"])(
+    it.each([...keyToTrigger])(
       "should call onChange when %s key pressed on add button",
       (pressed) => {
+        const callback: PicklistItemProps["onChange"] = cy
+          .stub()
+          .as("onChange");
         CypressMountWithProviders(
-          <DuellingPicklistComponentPicklistProps onChange={callback} />
+          <DuellingPicklistComponentPicklistItemProps onChange={callback} />
         );
 
-        addButton(0)
-          .trigger("keydown", keyCode(pressed))
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callback).to.have.been.calledOnce;
-          });
+        addButton(0).trigger("keydown", keyCode(pressed));
+        cy.get("@onChange").should("have.been.calledOnce");
       }
     );
 
-    it.each(["Enter", "Space"])(
+    it.each([...keyToTrigger])(
       "should call onChange when %s key pressed on remove button",
       (pressed) => {
+        const callback: PicklistItemProps["onChange"] = cy
+          .stub()
+          .as("onChange");
         CypressMountWithProviders(
-          <DuellingPicklistComponentPicklistProps onChange={callback} />
+          <DuellingPicklistComponentPicklistItemProps onChange={callback} />
         );
 
-        removeButton(0)
-          .trigger("keydown", keyCode(pressed))
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callback).to.have.been.calledOnce;
-          });
+        removeButton(0).trigger("keydown", keyCode(pressed));
+        cy.get("@onChange").should("have.been.calledOnce");
       }
     );
   });
@@ -388,12 +377,8 @@ context("Testing Duelling-Picklist component", () => {
     it("should pass accessibility tests for Duelling-Picklist InDialog story", () => {
       CypressMountWithProviders(<stories.InDialog />);
 
-      getDataElementByValue("main-text")
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          cy.checkAccessibility();
-        });
+      getDataElementByValue("main-text").click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibility tests for Duelling-Picklist AddItem story", () => {
@@ -417,15 +402,12 @@ context("Testing Duelling-Picklist component", () => {
     it("should pass accessibility tests for Duelling-Picklist CustomTooltipMessage story", () => {
       CypressMountWithProviders(<stories.CustomTooltipMessage />);
 
-      getDataElementByValue("locked")
-        .realHover()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          cy.checkAccessibility();
-        });
+      getDataElementByValue("locked").realHover();
+      cy.checkAccessibility();
     });
 
     // FE-5711
+    // eslint-disable-next-line jest/no-disabled-tests
     describe.skip("skip", () => {
       it("should pass accessibility tests for Duelling-Picklist disabled", () => {
         CypressMountWithProviders(<DuellingPicklistComponent disabled />);

--- a/src/components/duelling-picklist/duelling-picklist-test.stories.tsx
+++ b/src/components/duelling-picklist/duelling-picklist-test.stories.tsx
@@ -7,6 +7,8 @@ import {
   PicklistItemProps,
   PicklistDivider,
   PicklistPlaceholder,
+  DuellingPicklistProps,
+  PicklistProps,
 } from ".";
 import Search from "../search";
 import { Checkbox } from "../checkbox";
@@ -173,7 +175,9 @@ export const Default = () => {
 
 Default.storyName = "default";
 
-export const DuellingPicklistComponent = ({ ...props }) => {
+export const DuellingPicklistComponent = (
+  props: Partial<DuellingPicklistProps>
+) => {
   const mockData: Item[] = useMemo(() => {
     const arr = [];
     for (let i = 0; i < 10; i++) {
@@ -324,7 +328,9 @@ export const DuellingPicklistComponent = ({ ...props }) => {
   );
 };
 
-export const DuellingPicklistComponentPicklistProps = ({ ...props }) => {
+export const DuellingPicklistComponentPicklistItemProps = (
+  props: Partial<PicklistItemProps>
+) => {
   const mockData: Item[] = useMemo(() => {
     const arr = [];
     for (let i = 0; i < 10; i++) {
@@ -397,6 +403,123 @@ export const DuellingPicklistComponentPicklistProps = ({ ...props }) => {
             onChange={handler}
             {...props}
           >
+            <div style={{ display: "flex", width: "100%" }}>
+              <div style={{ width: "50%" }}>
+                <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+                  {item.title}
+                </p>
+              </div>
+              <div style={{ width: "50%" }}>
+                <p style={{ margin: 0 }}>{item.description}</p>
+              </div>
+            </div>
+          </PicklistItem>
+        );
+      }
+      return items;
+    }, [] as JSX.Element[]);
+  return (
+    <div>
+      <DuellingPicklist
+        leftLabel={`List 1 (${Object.keys(notSelectedItems).length})`}
+        rightLabel={`List 2 (${Object.keys(selectedItems).length})`}
+        disabled={isEachItemSelected}
+      >
+        <Picklist
+          disabled={isEachItemSelected}
+          placeholder={<PicklistPlaceholder text="Unassigned list empty" />}
+          {...props}
+        >
+          {renderItems(
+            isSearchMode ? notSelectedSearch : notSelectedItems,
+            "add",
+            onAdd
+          )}
+        </Picklist>
+        <Picklist
+          disabled={isEachItemSelected}
+          placeholder={<PicklistPlaceholder text="Nothing to see here" />}
+        >
+          {renderItems(
+            isSearchMode ? notSelectedSearch : notSelectedItems,
+            "remove",
+            onRemove
+          )}
+        </Picklist>
+      </DuellingPicklist>
+    </div>
+  );
+};
+
+export const DuellingPicklistComponentPicklistProps = (
+  props: Partial<PicklistProps>
+) => {
+  const mockData: Item[] = useMemo(() => {
+    const arr = [];
+    for (let i = 0; i < 10; i++) {
+      const data = {
+        key: i.toString(),
+        title: `Content ${i + 1}`,
+        description: `Description ${i + 1}`,
+      };
+      arr.push(data);
+    }
+    return arr;
+  }, []);
+
+  const allItems = useMemo(() => {
+    return mockData.reduce((obj, item) => {
+      obj[item.key] = item;
+      return obj;
+    }, {} as { [key: string]: Item });
+  }, [mockData]);
+
+  const [isEachItemSelected] = useState(false);
+  const [order] = useState(mockData.map(({ key }) => key));
+  const [notSelectedItems, setNotSelectedItems] = useState<AllItems>(allItems);
+  const [notSelectedSearch, setNotSelectedSearch] = useState<AllItems>({});
+  const [selectedItems, setSelectedItems] = useState<AllItems>({});
+  const [searchQuery] = useState("");
+  const isSearchMode = Boolean(searchQuery.length);
+
+  const onAdd = useCallback(
+    (item) => {
+      const { [item.key]: removed, ...rest } = notSelectedItems;
+      setNotSelectedItems(rest);
+      setSelectedItems({ ...selectedItems, [item.key]: item });
+      const { [item.key]: removed2, ...rest2 } = notSelectedSearch;
+      setNotSelectedSearch(rest2);
+    },
+    [notSelectedItems, notSelectedSearch, selectedItems]
+  );
+
+  const onRemove = React.useCallback(
+    (item) => {
+      const { [item.key]: removed, ...rest } = selectedItems;
+      setSelectedItems(rest);
+      setNotSelectedItems({ ...notSelectedItems, [item.key]: item });
+      if (isSearchMode && item.title.includes(searchQuery)) {
+        setNotSelectedSearch({ ...notSelectedSearch, [item.key]: item });
+      }
+    },
+    [
+      isSearchMode,
+      notSelectedItems,
+      notSelectedSearch,
+      searchQuery,
+      selectedItems,
+    ]
+  );
+  const renderItems = (
+    list: AllItems,
+    type: PicklistItemProps["type"],
+    handler: PicklistItemProps["onChange"]
+  ) =>
+    order.reduce((items, key) => {
+      const item = list[key];
+      if (item) {
+        items.push(
+          <PicklistItem key={key} type={type} item={item} onChange={handler}>
             <div style={{ display: "flex", width: "100%" }}>
               <div style={{ width: "50%" }}>
                 <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>


### PR DESCRIPTION
### Proposed behaviour

- Rename the `duelling-picklist.cy.js` to `duelling-picklist.cy.tsx` file in `./cypress/components/duelling-picklist/` folder.
- Refactor tests to Typescript.  

### Current behaviour

Duelling-picklist tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the`duelling-picklist.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other *.cy.tsx files have regressed
<!-- Add CodeSandbox here -->