### PR TITLE
feat(search): add searchButtonAriaLabel prop to component - FE-5880

### DIFF
--- a/cypress/components/search/search.cy.js
+++ b/cypress/components/search/search.cy.js
@@ -72,6 +72,15 @@ context("Test for Search component", () => {
       searchDefaultInput().should("have.attr", "aria-label", testCypress);
     });
 
+    it("should render Search button with aria-label prop", () => {
+      CypressMountWithProviders(
+        <SearchComponent searchButton searchButtonAriaLabel={testCypress} />
+      );
+
+      searchDefaultInput().clear().type(testCypress);
+      searchButton().should("have.attr", "aria-label", testCypress);
+    });
+
     it.each([
       [true, "be.visible"],
       [false, "not.exist"],
@@ -430,6 +439,14 @@ context("Test for Search component", () => {
 
     it("should check accessibility for searchButton", () => {
       CypressMountWithProviders(<SearchComponent searchButton />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for searchButton with searchButtonAriaLabel", () => {
+      CypressMountWithProviders(
+        <SearchComponent searchButton searchButtonAriaLabel={testCypress} />
+      );
 
       cy.checkAccessibility();
     });

--- a/src/components/search/search.component.tsx
+++ b/src/components/search/search.component.tsx
@@ -22,6 +22,8 @@ export interface SearchEvent {
 export interface SearchProps extends ValidationProps, MarginProps {
   /** Prop to specify the aria-label of the search component */
   "aria-label"?: string;
+  /** Prop to specify the aria-label of the search button */
+  searchButtonAriaLabel?: string;
   /** Prop for `uncontrolled` use */
   defaultValue?: string;
   /** Prop for `id` */
@@ -87,6 +89,7 @@ export const Search = React.forwardRef(
       searchWidth,
       maxWidth,
       searchButton,
+      searchButtonAriaLabel = "search button",
       placeholder,
       variant = "default",
       "aria-label": ariaLabel = "search",
@@ -286,7 +289,12 @@ export const Search = React.forwardRef(
         {searchButton && (
           <StyledSearchButton>
             {isSearchTyped && (
-              <Button size="medium" px="16px" {...buttonProps}>
+              <Button
+                aria-label={searchButtonAriaLabel}
+                size="medium"
+                px="16px"
+                {...buttonProps}
+              >
                 <StyledButtonIcon>
                   <Icon type="search" />
                 </StyledButtonIcon>

--- a/src/components/search/search.spec.tsx
+++ b/src/components/search/search.spec.tsx
@@ -278,6 +278,39 @@ describe("Search", () => {
         { modifier: `${StyledIcon}:hover` }
       );
     });
+
+    it("renders with the expected border radius styling", () => {
+      wrapper = renderSearch({ value: "" });
+      assertStyleMatch(
+        {
+          borderRadius: "var(--borderRadius050)",
+        },
+        wrapper.find(StyledInput)
+      );
+    });
+
+    it("renders with the expected border radius styling when searchButton is enabled and input has value", () => {
+      wrapper = renderSearch({ value: "foo", searchButton: true });
+      assertStyleMatch(
+        {
+          borderTopRightRadius: "var(--borderRadius000)",
+          borderBottomRightRadius: "var(--borderRadius000)",
+        },
+        wrapper,
+        { modifier: `${StyledTextInput}` }
+      );
+
+      assertStyleMatch(
+        {
+          borderTopLeftRadius: "var(--borderRadius000)",
+          borderBottomLeftRadius: "var(--borderRadius000)",
+          borderTopRightRadius: "var(--borderRadius050)",
+          borderBottomRightRadius: "var(--borderRadius050)",
+        },
+        wrapper.find(StyledSearchButton),
+        { modifier: `& ${StyledButton}` }
+      );
+    });
   });
 
   describe("When button is true and textbox is active", () => {
@@ -677,36 +710,33 @@ describe("Search", () => {
     });
   });
 
-  it("renders with the expected border radius styling", () => {
-    wrapper = renderSearch({ value: "" });
-    assertStyleMatch(
-      {
-        borderRadius: "var(--borderRadius050)",
-      },
-      wrapper.find(StyledInput)
-    );
-  });
+  describe("aria-label", () => {
+    it("has a default aria-label passed to Search", () => {
+      wrapper = renderSearch({ defaultValue: "foo" });
+      const search = wrapper.find(TextBox);
+      expect(search.prop("aria-label")).toEqual("search");
+    });
 
-  it("renders with the expected border radius styling when searchButton is enabled and input has value", () => {
-    wrapper = renderSearch({ value: "foo", searchButton: true });
-    assertStyleMatch(
-      {
-        borderTopRightRadius: "var(--borderRadius000)",
-        borderBottomRightRadius: "var(--borderRadius000)",
-      },
-      wrapper,
-      { modifier: `${StyledTextInput}` }
-    );
+    it("has a default aria-label passed to Search button", () => {
+      wrapper = renderSearch({ defaultValue: "foo", searchButton: true });
+      const searchButton = wrapper.find(Button);
+      expect(searchButton.prop("aria-label")).toEqual("search button");
+    });
 
-    assertStyleMatch(
-      {
-        borderTopLeftRadius: "var(--borderRadius000)",
-        borderBottomLeftRadius: "var(--borderRadius000)",
-        borderTopRightRadius: "var(--borderRadius050)",
-        borderBottomRightRadius: "var(--borderRadius050)",
-      },
-      wrapper.find(StyledSearchButton),
-      { modifier: `& ${StyledButton}` }
-    );
+    it("supports a custom aria-label passed to Search", () => {
+      wrapper = renderSearch({ defaultValue: "foo", "aria-label": "foobar" });
+      const search = wrapper.find(Search);
+      expect(search.prop("aria-label")).toEqual("foobar");
+    });
+
+    it("supports a custom aria-label passed to Search button", () => {
+      wrapper = renderSearch({
+        defaultValue: "foo",
+        searchButtonAriaLabel: "foobar button",
+        searchButton: true,
+      });
+      const searchButton = wrapper.find(Button);
+      expect(searchButton.prop("aria-label")).toEqual("foobar button");
+    });
   });
 });

--- a/src/components/search/search.stories.mdx
+++ b/src/components/search/search.stories.mdx
@@ -50,6 +50,8 @@ import Search from "carbon-react/lib/components/search";
 
 ### Search with Search Button and default width
 
+Please note, if you need to apply your own custom aria-label for the search button, this can be done by using the `searchButtonAriaLabel` prop. By default the aria-label is `search button`.
+
 <Canvas>
   <Story name="with SearchButton" story={stories.WithSearchButton} />
 </Canvas>

--- a/src/components/search/search.stories.tsx
+++ b/src/components/search/search.stories.tsx
@@ -32,7 +32,13 @@ export const Controlled: ComponentStory<typeof Search> = () => {
 };
 
 export const WithSearchButton: ComponentStory<typeof Search> = () => {
-  return <Search defaultValue="Here is some text" searchButton />;
+  return (
+    <Search
+      defaultValue="Here is some text"
+      searchButton
+      searchButtonAriaLabel="search button aria label"
+    />
+  );
 };
 
 export const DefaultWithColourBackground: ComponentStory<


### PR DESCRIPTION
New prop `searchButtonAriaLabel` has been created so that consumers can add their own aria-label to the Search component when rendered with a button.

fixes #6007

### Proposed behaviour

Add `searchAriaLabelButton` prop to component so that consumers can specify their own custom aria-label for the Search component's button when rendered. 

### Current behaviour

Currently no mechanism to specify a custom aria-label for Search's button.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Inspect the search button and ensure that a default aria-label appears correctly.
- Inspect the search button and ensure that a user-defined aria-label appears correctly.

