### PR TITLE
fix(crumb): ensure all props in interface are passed down and remove href as required prop FE-6006 

### DIFF
--- a/cypress/components/breadcrumbs/breadcrumbs.cy.js
+++ b/cypress/components/breadcrumbs/breadcrumbs.cy.js
@@ -77,6 +77,31 @@ context("Testing Breadcrumbs component", () => {
           });
       }
     });
+
+    it("should call the onClick callback when clicked", () => {
+      const callback = cy.stub().as("onClick");
+      CypressMountWithProviders(
+        <testStories.DefaultCrumb onClick={callback} />
+      );
+
+      crumb(0).click();
+      cy.get("@onClick").should("have.been.calledOnce");
+    });
+
+    it("should not set the onClick or href props when isCurrent is true", () => {
+      const callback = cy.stub().as("onClick");
+      CypressMountWithProviders(
+        <testStories.DefaultCrumb
+          href={CHARACTERS.STANDARD}
+          onClick={callback}
+          isCurrent
+        />
+      );
+
+      crumb(0).click();
+      cy.get("@onClick").should("not.have.been.called");
+      crumb(0).find("a").should("not.have.attr", "href");
+    });
   });
 
   describe("Accessibility tests for Breadcrumbs component", () => {

--- a/src/components/breadcrumbs/breadcrumbs.component.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.component.tsx
@@ -1,9 +1,10 @@
 import React from "react";
+import { SpaceProps } from "styled-system";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 import StyledBreadcrumbs from "./breadcrumbs.style";
 import useLocale from "../../hooks/__internal__/useLocale";
 
-export interface BreadcrumbsProps extends TagProps {
+export interface BreadcrumbsProps extends TagProps, SpaceProps {
   /** Child crumbs to display */
   children: React.ReactNode;
 }
@@ -17,6 +18,7 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
         role="navigation"
         {...tagComponent("breadcrumbs", rest)}
         aria-label={l.breadcrumbs.ariaLabel()}
+        {...rest}
       >
         <ol>{children}</ol>
       </StyledBreadcrumbs>

--- a/src/components/breadcrumbs/breadcrumbs.spec.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.spec.tsx
@@ -3,19 +3,28 @@ import "@testing-library/jest-dom";
 import { screen, render } from "@testing-library/react";
 import Breadcrumbs from "./breadcrumbs.component";
 import Crumb from "./crumb/crumb.component";
+import { testStyledSystemSpacing } from "../../__spec_helper__/test-utils";
 
-test("renders all child crumbs correctly", () => {
-  render(
-    <Breadcrumbs>
+describe("Breadcrumbs", () => {
+  testStyledSystemSpacing((props) => (
+    <Breadcrumbs {...props}>
       <Crumb href="#">Breadcrumb</Crumb>
-      <Crumb href="#">Breadcrumb</Crumb>
-      <Crumb href="#">Breadcrumb</Crumb>
-      <Crumb href="#" isCurrent>
-        Breadcrumb
-      </Crumb>
     </Breadcrumbs>
-  );
+  ));
 
-  const crumbElement = screen.getAllByText("Breadcrumb");
-  expect(crumbElement.length).toBe(4);
+  it("renders children as expected", () => {
+    render(
+      <Breadcrumbs>
+        <Crumb href="#">Breadcrumb</Crumb>
+        <Crumb href="#">Breadcrumb</Crumb>
+        <Crumb href="#">Breadcrumb</Crumb>
+        <Crumb href="#" isCurrent>
+          Breadcrumb
+        </Crumb>
+      </Breadcrumbs>
+    );
+
+    const crumbElement = screen.getAllByText("Breadcrumb");
+    expect(crumbElement.length).toBe(4);
+  });
 });

--- a/src/components/breadcrumbs/breadcrumbs.stories.mdx
+++ b/src/components/breadcrumbs/breadcrumbs.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import { Breadcrumbs, Crumb } from "./index";
 import * as stories from "./breadcrumbs.stories.tsx";
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 <Meta title="Breadcrumbs" parameters={{ info: { disable: true } }} />
 
@@ -43,9 +44,11 @@ import { Breadcrumbs, Crumb } from "carbon-react/lib/components/breadcrumbs";
 
 ### Breadcrumbs
 
-<ArgsTable
-   of={Breadcrumbs}
- />
+<StyledSystemProps
+  of={Breadcrumbs}
+  spacing
+  noHeader
+/>
 
 ### Crumb
 

--- a/src/components/breadcrumbs/breadcrumbs.style.ts
+++ b/src/components/breadcrumbs/breadcrumbs.style.ts
@@ -1,11 +1,19 @@
 import styled from "styled-components";
+import { space } from "styled-system";
+import baseTheme from "../../style/themes/base";
 
 const StyledBreadcrumbs = styled.nav`
+  ${space}
+
   ol {
+    padding: 0;
+    margin: 0;
     list-style: none;
     display: flex;
     flex-wrap: wrap;
   }
 `;
+
+StyledBreadcrumbs.defaultProps = { theme: baseTheme };
 
 export default StyledBreadcrumbs;

--- a/src/components/breadcrumbs/crumb/crumb.component.tsx
+++ b/src/components/breadcrumbs/crumb/crumb.component.tsx
@@ -25,20 +25,20 @@ export interface CrumbProps
     TagProps {
   /** This sets the Crumb to current, does not render Link */
   isCurrent?: boolean;
-  /** The href string for Crumb Link */
-  href: string;
 }
 
 const Crumb = React.forwardRef<HTMLLinkElement, CrumbProps>(
-  ({ href, isCurrent, children, ...rest }: CrumbProps, ref) => (
+  ({ href, isCurrent, children, onClick, ...rest }: CrumbProps, ref) => (
     <li>
       <StyledCrumb
         ref={ref}
         isCurrent={isCurrent}
         aria-current={isCurrent ? "page" : undefined}
         {...tagComponent("crumb", rest)}
+        {...rest}
         {...(!isCurrent && {
           href,
+          onClick,
         })}
       >
         {children}

--- a/src/components/breadcrumbs/crumb/crumb.spec.tsx
+++ b/src/components/breadcrumbs/crumb/crumb.spec.tsx
@@ -43,20 +43,20 @@ describe("Crumb", () => {
     const link = screen.getByText(LINK_TEXT);
     await userEvent.click(link);
 
-    expect(handleClickFn).toHaveBeenCalledTimes(0);
+    expect(handleClickFn).toHaveBeenCalledTimes(1);
   });
 
   it("does not call the handleClick callback if one is passed and isCurrent is true", async () => {
     const handleClickFn = jest.fn();
 
     render(
-      <Crumb href="#" onClick={handleClickFn}>
+      <Crumb href="#" onClick={handleClickFn} isCurrent>
         {LINK_TEXT}
       </Crumb>
     );
     const link = screen.getByText(LINK_TEXT);
     await userEvent.click(link);
 
-    expect(handleClickFn).not.toHaveBeenCalledTimes(1);
+    expect(handleClickFn).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
fix #6105
fix #6096

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Removes `href` as required props and ensures all props defined in interface are passed down to
rendered element

Adds `margin` and `padding` props to component to allow custom values to be passed. Overrides the
user agent styling on the `ol` element as well.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
User agent styling is adding unwanted padding and margin to `ol` element. No ability to pass custom margin or padding values.

`CrumbProps` interface extends `LinkProps`, overrides `href` to make it required and does not pass `rest` to rendered element so some props do not work such as `onClick`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
