### PR TITLE
test(profile): typescript refactor

### DIFF
--- a/cypress/components/profile/profile.cy.tsx
+++ b/cypress/components/profile/profile.cy.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { ProfileProps } from "components/profile/profile.component";
 import { ProfileComponentTest as ProfileComponent } from "../../../src/components/profile/profile-test.stories";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import { assertCssValueIsApproximately } from "../../support/component-helper/common-steps";
@@ -73,13 +74,16 @@ context("Tests for Profile component", () => {
       [PROFILE_SIZES[4], 70],
       [PROFILE_SIZES[5], 102],
       [PROFILE_SIZES[6], 126],
-    ])("should check %s size for Profile component", (size, heightAndWidth) => {
-      CypressMountWithProviders(<ProfileComponent size={size} />);
-      initialPreview().then(($el) => {
-        assertCssValueIsApproximately($el, "height", heightAndWidth);
-        assertCssValueIsApproximately($el, "width", heightAndWidth);
-      });
-    });
+    ] as [ProfileProps["size"], number][])(
+      "should check %s size for Profile component",
+      (size, heightAndWidth) => {
+        CypressMountWithProviders(<ProfileComponent size={size} />);
+        initialPreview().then(($el) => {
+          assertCssValueIsApproximately($el, "height", heightAndWidth);
+          assertCssValueIsApproximately($el, "width", heightAndWidth);
+        });
+      }
+    );
 
     it.each([
       ["Dan Jin", "DJ"],

--- a/src/components/profile/profile-test.stories.tsx
+++ b/src/components/profile/profile-test.stories.tsx
@@ -36,7 +36,7 @@ DefaultStory.story = {
   },
 };
 
-export const ProfileComponentTest = ({ ...props }) => {
+export const ProfileComponentTest = (props: Partial<ProfileProps>) => {
   return (
     <Profile email="email@email.com" initials="JD" name="John Doe" {...props} />
   );


### PR DESCRIPTION
### Proposed behaviour
- Rename the `profile.cy.js` to `profile.cy.tsx` file in `./cypress/components/profile/` folder.
- Refactor tests to Typescript.  

### Current behaviour

Currently profile component is in JS not in TS.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

### Testing instructions
- [ ] Run `npx cypress open --component` to check if the`profile.cy.tsx` file passed
- [ ] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed