### PR TITLE
fix(flat-table): fix sticky footer no longer at the foot of the table - FE-6018

### DIFF
--- a/src/components/flat-table/flat-table.component.js
+++ b/src/components/flat-table/flat-table.component.js
@@ -228,12 +228,12 @@ const FlatTable = ({
                 {children}
               </FlatTableThemeContext.Provider>
             </StyledFlatTable>
-            {footer && (
-              <StyledFlatTableFooter hasStickyFooter={hasStickyFooter}>
-                {footer}
-              </StyledFlatTableFooter>
-            )}
           </StyledTableContainer>
+          {footer && (
+            <StyledFlatTableFooter hasStickyFooter={hasStickyFooter}>
+              {footer}
+            </StyledFlatTableFooter>
+          )}
         </StyledFlatTableWrapper>
       )}
     </DrawerSidebarContext.Consumer>

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -1024,10 +1024,7 @@ of `220px`. There is not enough data to fill the flatTable but the style remains
 remains sticky.
 
 <Canvas>
-  <Story
-    name="with sticky footer inside of larger div"
-    parameters={{ chromatic: { disableSnapshot: true } }}
-  >
+  <Story name="with sticky footer inside of larger div">
     {() => {
       const rows = [
         <FlatTableRow key="0">

--- a/src/components/flat-table/flat-table.style.js
+++ b/src/components/flat-table/flat-table.style.js
@@ -15,9 +15,6 @@ const STICKY_FOOTER_OVERLAY_INCREMENT = 1;
 const ROW_HEADER_OVERLAY_INCREMENT = 5;
 
 const StyledTableContainer = styled.div`
-  display: grid;
-  grid-auto-rows: min-content;
-
   ${({ width, overflowX }) =>
     width &&
     css`


### PR DESCRIPTION
This work reverts back to the code before we had this bug introduced. This will reintroduce https://github.com/Sage/carbon/issues/5704 but this will be re-opened and fixed separately.

fixes FE-6018

### Proposed behaviour

![Screenshot 2023-06-14 at 09 11 47](https://github.com/Sage/carbon/assets/56251247/8ac50b4b-50f6-4bc7-b887-480d02d5f278)

### Current behaviour

![Screenshot 2023-06-14 at 09 12 27](https://github.com/Sage/carbon/assets/56251247/f8b740bb-cf03-4f23-b58b-6514b7a7dd00)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This work will reintroduce the bug addressed in #5704 but a new issue will be opened where we will address this without breaking the current implementations of FlatTable.

### Testing instructions

- `"with sticky footer inside of larger div"` example of Flat Table should be captured by Chromatic.
- `"with sticky footer inside of larger div"` should look correct with the pager rendered at the bottom of the table.
- No other visual regressions with FlatTable should occur. 
