### PR TITLE
test(note): typescript refactor

### DIFF
--- a/cypress/components/note/note.cy.tsx
+++ b/cypress/components/note/note.cy.tsx
@@ -4,6 +4,7 @@ import {
   NoteComponentWithInlineControl,
 } from "../../../src/components/note/note-test.stories";
 import Box from "../../../src/components/box";
+import { NoteProps } from "../../../src/components/note";
 import LinkPreview from "../../../src/components/link-preview";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import { cyRoot, tooltipPreview } from "../../locators";
@@ -19,6 +20,7 @@ import {
   noteContent,
 } from "../../locators/note";
 import { actionPopoverWrapper } from "../../locators/action-popover";
+
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
@@ -45,8 +47,10 @@ context("Tests for Note component", () => {
         noteComponent()
           .should("have.attr", "width", width)
           .then(($el) => {
-            const value = $el.css("width");
-            expect(parseInt(value)).to.be.within(widthInPx - 1, widthInPx + 1);
+            const value = parseInt($el.css("width"));
+            cy.wrap(value).should("be.gte", widthInPx - 1)
+            .and("be.lte", widthInPx + 1);
+           
           });
       }
     );
@@ -73,9 +77,9 @@ context("Tests for Note component", () => {
     });
 
     it("should render Note with createdDate prop", () => {
-      const createdDate = "25 June 2022, 11:57 AM";
+      const createdDate = "25 June 2022, 11:57 AM" as string;
 
-      CypressMountWithProviders(<NoteComponent createdDate={createdDate} />);
+      CypressMountWithProviders(<NoteComponent createdDate={createdDate}  />);
 
       noteFooterChangeTime().should("have.text", createdDate);
     });
@@ -101,11 +105,13 @@ context("Tests for Note component", () => {
     it("should render Note with previews prop", () => {
       const previews = [
         <LinkPreview
+          key="linkPreview1" 
           title="This is an example of a title"
           url="https://www.bbc.co.uk"
           description="Captain, why are we out here chasing comets?"
         />,
         <LinkPreview
+          key="linkPreview2" 
           title="This is an example of a title"
           url="https://www.sage.com"
           description="Captain, why are we out here chasing comets?"
@@ -118,16 +124,13 @@ context("Tests for Note component", () => {
     });
 
     it("should call onLinkAdded callback when a valid url is detected by Note component", () => {
-      const callback = cy.stub();
+      const callback: NoteProps["onLinkAdded"] = cy.stub().as("onLinkAdded");
 
       CypressMountWithProviders(
         <NoteComponent onLinkAdded={callback} text="https://carbon.s" />
       );
 
-      noteComponent().then(() => {
-        // eslint-disable-next-line no-unused-expressions
-        expect(callback).to.have.been.calledOnce;
-      });
+      cy.get("@onLinkAdded").should("have.been.calledOnce");
     });
   });
 
@@ -174,7 +177,7 @@ context("Tests for Note component", () => {
     );
 
     it("should render Note with createdDate prop for accessibility tests", () => {
-      const createdDate = "25 June 2022, 11:57 AM";
+      const createdDate = "25 June 2022, 11:57 AM" as string;
 
       CypressMountWithProviders(<NoteComponent createdDate={createdDate} />);
 
@@ -199,11 +202,13 @@ context("Tests for Note component", () => {
     it("should render Note with previews prop for accessibility tests", () => {
       const previews = [
         <LinkPreview
+          key="linkPreview1" 
           title="This is an example of a title"
           url="https://www.bbc.co.uk"
           description="Captain, why are we out here chasing comets?"
         />,
         <LinkPreview
+          key="linkPreview2" 
           title="This is an example of a title"
           url="https://www.sage.com"
           description="Captain, why are we out here chasing comets?"

--- a/src/components/note/note-test.stories.tsx
+++ b/src/components/note/note-test.stories.tsx
@@ -42,8 +42,12 @@ DefaultStory.story = {
 
 export const NoteComponent = ({
   text,
+  createdDate = "23 May 2020, 12:08 PM",
   ...props
-}: Omit<NoteProps, "noteContent" | "createdDate"> & { text?: string }) => {
+}: Omit<NoteProps, "noteContent" | "createdDate"> & {
+  text?: string;
+  createdDate?: string;
+}) => {
   const initialValue = text
     ? EditorState.createWithContent(ContentState.createFromText(text))
     : EditorState.createEmpty();
@@ -53,7 +57,7 @@ export const NoteComponent = ({
       title="Here is a Title"
       name="Lauren Smith"
       noteContent={initialValue}
-      createdDate="23 May 2020, 12:08 PM"
+      createdDate={createdDate}
       {...props}
     />
   );


### PR DESCRIPTION
### Proposed behaviour
- Rename the `note.cy.js` to the `note.cy.tsx` file in `./cypress/components/note/` folder.
- Refactor tests to Typescript.  

### Current behaviour

Currently Note component is in JS not in TS.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

### Testing instructions
- [ ] Run `npx cypress open --component` to check if the `note.cy.tsx` file passed
- [ ] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed