### PR TITLE
test(typography): refactor to TS

### DIFF
--- a/cypress/components/fieldset/fieldset.cy.tsx
+++ b/cypress/components/fieldset/fieldset.cy.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import Fieldset from "../../../src/components/fieldset";
-import { FormProps }  from "../../../src/components/form";
+import Form, { FormProps } from "../../../src/components/form";
 import { FieldsetComponent } from "../../../src/components/fieldset/fieldset-test.stories";
 import legendPreview from "../../locators/fieldset";
 import Textbox from "../../../src/components/textbox";
-import Form from "../../../src/components/form";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import { getDataElementByValue } from "../../locators/index";
 import { positionOfElement } from "../../support/helper";
@@ -233,7 +232,7 @@ context("Testing Fieldset component", () => {
         );
         cy.checkAccessibility();
       }
-    );  
+    );
 
     it.each(["error", "warning", "info"])(
       "should pass accessibility tests for Fieldset with %s validation icon on input",

--- a/cypress/components/loader-bar/loader-bar.cy.tsx
+++ b/cypress/components/loader-bar/loader-bar.cy.tsx
@@ -18,20 +18,21 @@ context("Tests for LoaderBar component", () => {
       (size, height) => {
         CypressMountWithProviders(<LoaderBarComponent size={size} mt={2} />);
 
-      loaderBar()
-        .children()
-        .then(($el) => {
-          assertCssValueIsApproximately($el, "height", height);
-        });
-      loaderBar()
-        .children()
-        .children()
-        .then(($el) => {
-          assertCssValueIsApproximately($el, "height", height);
-          expect($el.css("animation-duration")).to.equals("2s");
-          expect($el.css("animation-play-state")).to.equals("running");
-        });
-    });
+        loaderBar()
+          .children()
+          .then(($el) => {
+            assertCssValueIsApproximately($el, "height", height);
+          });
+        loaderBar()
+          .children()
+          .children()
+          .then(($el) => {
+            assertCssValueIsApproximately($el, "height", height);
+            expect($el.css("animation-duration")).to.equals("2s");
+            expect($el.css("animation-play-state")).to.equals("running");
+          });
+      }
+    );
   });
 
   describe("Accessibility tests for LoaderBar", () => {

--- a/cypress/components/message/message.cy.tsx
+++ b/cypress/components/message/message.cy.tsx
@@ -2,7 +2,10 @@
 /* eslint-disable jest/valid-expect, no-unused-expressions */
 import React from "react";
 import Message, { MessageProps } from "../../../src/components/message";
-import { MessageComponent, MessageComponentWithRef } from "../../../src/components/message/message-test.stories";
+import {
+  MessageComponent,
+  MessageComponentWithRef,
+} from "../../../src/components/message/message-test.stories";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import { getDataElementByValue } from "../../locators";
 import {

--- a/cypress/components/note/note.cy.tsx
+++ b/cypress/components/note/note.cy.tsx
@@ -21,7 +21,6 @@ import {
 } from "../../locators/note";
 import { actionPopoverWrapper } from "../../locators/action-popover";
 
-
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 context("Tests for Note component", () => {
@@ -48,9 +47,9 @@ context("Tests for Note component", () => {
           .should("have.attr", "width", width)
           .then(($el) => {
             const value = parseInt($el.css("width"));
-            cy.wrap(value).should("be.gte", widthInPx - 1)
-            .and("be.lte", widthInPx + 1);
-           
+            cy.wrap(value)
+              .should("be.gte", widthInPx - 1)
+              .and("be.lte", widthInPx + 1);
           });
       }
     );
@@ -79,7 +78,7 @@ context("Tests for Note component", () => {
     it("should render Note with createdDate prop", () => {
       const createdDate = "25 June 2022, 11:57 AM" as string;
 
-      CypressMountWithProviders(<NoteComponent createdDate={createdDate}  />);
+      CypressMountWithProviders(<NoteComponent createdDate={createdDate} />);
 
       noteFooterChangeTime().should("have.text", createdDate);
     });
@@ -105,13 +104,13 @@ context("Tests for Note component", () => {
     it("should render Note with previews prop", () => {
       const previews = [
         <LinkPreview
-          key="linkPreview1" 
+          key="linkPreview1"
           title="This is an example of a title"
           url="https://www.bbc.co.uk"
           description="Captain, why are we out here chasing comets?"
         />,
         <LinkPreview
-          key="linkPreview2" 
+          key="linkPreview2"
           title="This is an example of a title"
           url="https://www.sage.com"
           description="Captain, why are we out here chasing comets?"
@@ -202,13 +201,13 @@ context("Tests for Note component", () => {
     it("should render Note with previews prop for accessibility tests", () => {
       const previews = [
         <LinkPreview
-          key="linkPreview1" 
+          key="linkPreview1"
           title="This is an example of a title"
           url="https://www.bbc.co.uk"
           description="Captain, why are we out here chasing comets?"
         />,
         <LinkPreview
-          key="linkPreview2" 
+          key="linkPreview2"
           title="This is an example of a title"
           url="https://www.sage.com"
           description="Captain, why are we out here chasing comets?"

--- a/cypress/components/numeral-date/numeral-date.cy.tsx
+++ b/cypress/components/numeral-date/numeral-date.cy.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import NumeralDate, {
-  NumeralDateProps
+  NumeralDateProps,
 } from "../../../src/components/numeral-date";
 import Box from "../../../src/components/box";
 import { NumeralDateComponent } from "../../../src/components/numeral-date/numeral-date-test.stories";
@@ -8,7 +8,7 @@ import * as stories from "../../../src/components/numeral-date/numeral-date.stor
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import {
   assertCssValueIsApproximately,
-  verifyRequiredAsteriskForLabel
+  verifyRequiredAsteriskForLabel,
 } from "../../support/component-helper/common-steps";
 
 import {
@@ -18,17 +18,17 @@ import {
   tooltipPreview,
   fieldHelpPreview,
   errorIcon,
-  warningIcon
+  warningIcon,
 } from "../../locators";
 import {
   numeralDateComponent,
-  numeralDateInputByPosition
+  numeralDateInputByPosition,
 } from "../../locators/numeralDate";
 
 import {
   CHARACTERS,
   SIZE,
-  VALIDATION
+  VALIDATION,
 } from "../../support/component-helper/constants";
 import { ICON } from "../../locators/locators";
 
@@ -96,7 +96,7 @@ context("Tests for NumeralDate component", () => {
 
     it.each([
       ["left", "start"],
-      ["right", "end"]
+      ["right", "end"],
     ] as [NumeralDateProps["labelAlign"], string][])(
       "should render NumeralDate with labelAlign prop set to %s",
       (labelAlign, cssValue) => {
@@ -124,7 +124,7 @@ context("Tests for NumeralDate component", () => {
 
     it.each([
       [1, "8px"],
-      [2, "16px"]
+      [2, "16px"],
     ] as [NumeralDateProps["labelSpacing"], string][])(
       "should render NumeralDate with labelSpacing prop set to %s",
       (spacing, padding) => {
@@ -141,7 +141,7 @@ context("Tests for NumeralDate component", () => {
     it.each([
       [10, 135],
       [30, 409],
-      [80, 1092]
+      [80, 1092],
     ] as [NumeralDateProps["labelWidth"], number][])(
       "should use %s as labelWidth and render it with correct label ratio",
       (label, labelRatio) => {
@@ -243,7 +243,7 @@ context("Tests for NumeralDate component", () => {
     it.each([
       [0, "Day should be a number within a 1-31 range."],
       [1, "Month should be a number within a 1-12 range."],
-      [2, "Year should be a number within a 1800-2200 range."]
+      [2, "Year should be a number within a 1800-2200 range."],
     ])(
       "should render NumeralDate with enableInternalError prop",
       (inputIndex, tooltipText) => {
@@ -264,7 +264,7 @@ context("Tests for NumeralDate component", () => {
     it.each([
       [0, "Day should be a number within a 1-31 range."],
       [1, "Month should be a number within a 1-12 range."],
-      [2, "Year should be a number within a 1800-2200 range."]
+      [2, "Year should be a number within a 1800-2200 range."],
     ])(
       "should render NumeralDate with enableInternalWarning prop",
       (inputIndex, tooltipText) => {
@@ -335,7 +335,7 @@ context("Tests for NumeralDate component", () => {
       [VALIDATION.INFO, "info", true],
       ["rgb(102, 132, 148)", "error", false],
       ["rgb(102, 132, 148)", "warning", false],
-      ["rgb(102, 132, 148)", "info", false]
+      ["rgb(102, 132, 148)", "info", false],
     ])(
       "should verify NumeralDate input border colour is %s when validation is %s and boolean prop is %s",
       (borderColor, type, bool) => {
@@ -359,7 +359,7 @@ context("Tests for NumeralDate component", () => {
     it.each([
       [SIZE.SMALL, 30],
       [SIZE.MEDIUM, 38],
-      [SIZE.LARGE, 46]
+      [SIZE.LARGE, 46],
     ] as [NumeralDateProps["size"], number][])(
       "should use %s as size and render NumeralDate with %s as height",
       (size, height) => {
@@ -374,7 +374,7 @@ context("Tests for NumeralDate component", () => {
     it.each([
       ["flex", 399],
       ["flex", 400],
-      ["block", 401]
+      ["block", 401],
     ])(
       "should check NumeralDate label alignment is %s with adaptiveLabelBreakpoint %s and viewport 400",
       (displayValue, breakpoint) => {
@@ -406,7 +406,7 @@ context("Tests for NumeralDate component", () => {
       "top",
       "bottom",
       "left",
-      "right"
+      "right",
     ] as NumeralDateProps["tooltipPosition"][])(
       "should render NumeralDate component with tooltip positioned to the %s",
       (position) => {

--- a/cypress/components/numeral-date/numeral-date.cy.tsx
+++ b/cypress/components/numeral-date/numeral-date.cy.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import NumeralDate, {
-  NumeralDateProps,
+  NumeralDateProps
 } from "../../../src/components/numeral-date";
 import Box from "../../../src/components/box";
 import { NumeralDateComponent } from "../../../src/components/numeral-date/numeral-date-test.stories";
@@ -8,7 +8,7 @@ import * as stories from "../../../src/components/numeral-date/numeral-date.stor
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import {
   assertCssValueIsApproximately,
-  verifyRequiredAsteriskForLabel,
+  verifyRequiredAsteriskForLabel
 } from "../../support/component-helper/common-steps";
 
 import {
@@ -18,17 +18,17 @@ import {
   tooltipPreview,
   fieldHelpPreview,
   errorIcon,
-  warningIcon,
+  warningIcon
 } from "../../locators";
 import {
   numeralDateComponent,
-  numeralDateInputByPosition,
+  numeralDateInputByPosition
 } from "../../locators/numeralDate";
 
 import {
   CHARACTERS,
   SIZE,
-  VALIDATION,
+  VALIDATION
 } from "../../support/component-helper/constants";
 import { ICON } from "../../locators/locators";
 
@@ -96,7 +96,7 @@ context("Tests for NumeralDate component", () => {
 
     it.each([
       ["left", "start"],
-      ["right", "end"],
+      ["right", "end"]
     ] as [NumeralDateProps["labelAlign"], string][])(
       "should render NumeralDate with labelAlign prop set to %s",
       (labelAlign, cssValue) => {
@@ -124,7 +124,7 @@ context("Tests for NumeralDate component", () => {
 
     it.each([
       [1, "8px"],
-      [2, "16px"],
+      [2, "16px"]
     ] as [NumeralDateProps["labelSpacing"], string][])(
       "should render NumeralDate with labelSpacing prop set to %s",
       (spacing, padding) => {
@@ -141,7 +141,7 @@ context("Tests for NumeralDate component", () => {
     it.each([
       [10, 135],
       [30, 409],
-      [80, 1092],
+      [80, 1092]
     ] as [NumeralDateProps["labelWidth"], number][])(
       "should use %s as labelWidth and render it with correct label ratio",
       (label, labelRatio) => {
@@ -243,7 +243,7 @@ context("Tests for NumeralDate component", () => {
     it.each([
       [0, "Day should be a number within a 1-31 range."],
       [1, "Month should be a number within a 1-12 range."],
-      [2, "Year should be a number within a 1800-2200 range."],
+      [2, "Year should be a number within a 1800-2200 range."]
     ])(
       "should render NumeralDate with enableInternalError prop",
       (inputIndex, tooltipText) => {
@@ -264,7 +264,7 @@ context("Tests for NumeralDate component", () => {
     it.each([
       [0, "Day should be a number within a 1-31 range."],
       [1, "Month should be a number within a 1-12 range."],
-      [2, "Year should be a number within a 1800-2200 range."],
+      [2, "Year should be a number within a 1800-2200 range."]
     ])(
       "should render NumeralDate with enableInternalWarning prop",
       (inputIndex, tooltipText) => {
@@ -335,7 +335,7 @@ context("Tests for NumeralDate component", () => {
       [VALIDATION.INFO, "info", true],
       ["rgb(102, 132, 148)", "error", false],
       ["rgb(102, 132, 148)", "warning", false],
-      ["rgb(102, 132, 148)", "info", false],
+      ["rgb(102, 132, 148)", "info", false]
     ])(
       "should verify NumeralDate input border colour is %s when validation is %s and boolean prop is %s",
       (borderColor, type, bool) => {
@@ -359,7 +359,7 @@ context("Tests for NumeralDate component", () => {
     it.each([
       [SIZE.SMALL, 30],
       [SIZE.MEDIUM, 38],
-      [SIZE.LARGE, 46],
+      [SIZE.LARGE, 46]
     ] as [NumeralDateProps["size"], number][])(
       "should use %s as size and render NumeralDate with %s as height",
       (size, height) => {
@@ -374,7 +374,7 @@ context("Tests for NumeralDate component", () => {
     it.each([
       ["flex", 399],
       ["flex", 400],
-      ["block", 401],
+      ["block", 401]
     ])(
       "should check NumeralDate label alignment is %s with adaptiveLabelBreakpoint %s and viewport 400",
       (displayValue, breakpoint) => {
@@ -406,7 +406,7 @@ context("Tests for NumeralDate component", () => {
       "top",
       "bottom",
       "left",
-      "right",
+      "right"
     ] as NumeralDateProps["tooltipPosition"][])(
       "should render NumeralDate component with tooltip positioned to the %s",
       (position) => {

--- a/cypress/components/typography/typography.cy.tsx
+++ b/cypress/components/typography/typography.cy.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
-import Typography from "../../../src/components/typography";
+import Typography, {
+  TypographyProps,
+} from "../../../src/components/typography";
 import * as testStories from "../../../src/components/typography/typography-test.stories";
 import * as stories from "../../../src/components/typography/typography.stories";
 import { CHARACTERS } from "../../support/component-helper/constants";
@@ -30,7 +32,9 @@ const VARIANT_TYPES = [
   "ol",
 ];
 
-const getAs = (variant) => {
+type VariantTypes = typeof VARIANT_TYPES[number];
+
+const getAs = (variant: VariantTypes) => {
   switch (variant) {
     case "h1-large":
       return "h1";
@@ -46,7 +50,7 @@ const getAs = (variant) => {
   }
 };
 
-const getSize = (variant) => {
+const getSize = (variant: VariantTypes) => {
   switch (variant) {
     case "h1-large":
       return "32px";
@@ -78,7 +82,7 @@ const getSize = (variant) => {
   }
 };
 
-const getLineHeight = (variant) => {
+const getLineHeight = (variant: VariantTypes) => {
   switch (variant) {
     case "h1-large":
       return "40px";
@@ -110,7 +114,7 @@ const getLineHeight = (variant) => {
   }
 };
 
-const getWeight = (variant) => {
+const getWeight = (variant: VariantTypes) => {
   switch (variant) {
     case "h1-large":
     case "h1":
@@ -137,14 +141,14 @@ const getWeight = (variant) => {
   }
 };
 
-const getTransform = (variant) => {
+const getTransform = (variant: VariantTypes) => {
   if (variant === "segment-subheader-alt") {
     return "uppercase";
   }
   return "none";
 };
 
-const getDecoration = (variant) => {
+const getDecoration = (variant: VariantTypes) => {
   if (variant === "em") {
     return "underline";
   }
@@ -153,84 +157,84 @@ const getDecoration = (variant) => {
 
 context("Tests for Typography component", () => {
   describe("should check Typography component properties", () => {
-    it.each(VARIANT_TYPES)(
+    it.each(VARIANT_TYPES as TypographyProps["variant"][])(
       "should check variant prop set to %s for Typography component",
       (variant) => {
         CypressMountWithProviders(
           <Typography variant={variant}>{testCypress}</Typography>
         );
 
-        const variantElem = getAs(variant);
+        const variantElem = getAs(String(variant));
 
         cy.get(variantElem).should("have.text", testCypress);
       }
     );
 
-    it.each(VARIANT_TYPES)(
+    it.each(VARIANT_TYPES as TypographyProps["variant"][])(
       "should check font-size for %s variant prop for Typography component",
       (variant) => {
         CypressMountWithProviders(
           <Typography variant={variant}>{testCypress}</Typography>
         );
 
-        const variantElem = getAs(variant);
-        const fontSize = getSize(variant);
+        const variantElem = getAs(String(variant));
+        const fontSize = getSize(String(variant));
 
         cy.get(variantElem).should("have.css", "font-size", fontSize);
       }
     );
 
-    it.each(VARIANT_TYPES)(
+    it.each(VARIANT_TYPES as TypographyProps["variant"][])(
       "should check line-height for %s variant prop for Typography component",
       (variant) => {
         CypressMountWithProviders(
           <Typography variant={variant}>{testCypress}</Typography>
         );
 
-        const variantElem = getAs(variant);
-        const lineHeight = getLineHeight(variant);
+        const variantElem = getAs(String(variant));
+        const lineHeight = getLineHeight(String(variant));
 
         cy.get(variantElem).should("have.css", "line-height", lineHeight);
       }
     );
 
-    it.each(VARIANT_TYPES)(
+    it.each(VARIANT_TYPES as TypographyProps["variant"][])(
       "should check font-weight for %s variant prop for Typography component",
       (variant) => {
         CypressMountWithProviders(
           <Typography variant={variant}>{testCypress}</Typography>
         );
 
-        const variantElem = getAs(variant);
-        const fontWeight = getWeight(variant);
+        const variantElem = getAs(String(variant));
+        const fontWeight = getWeight(String(variant));
 
         cy.get(variantElem).should("have.css", "font-weight", fontWeight);
       }
     );
 
-    it.each(VARIANT_TYPES)(
+    it.each(VARIANT_TYPES as TypographyProps["variant"][])(
       "should check text-transform for %s variant prop for Typography component",
       (variant) => {
         CypressMountWithProviders(
           <Typography variant={variant}>{testCypress}</Typography>
         );
 
-        const variantElem = getAs(variant);
-        const textTransform = getTransform(variant);
+        const variantElem = getAs(String(variant));
+        const textTransform = getTransform(String(variant));
 
         cy.get(variantElem).should("have.css", "text-transform", textTransform);
       }
     );
 
-    it.each(VARIANT_TYPES)(
+    it.each(VARIANT_TYPES as TypographyProps["variant"][])(
       "should check text-decoration-line for %s variant prop for Typography component",
       (variant) => {
         CypressMountWithProviders(
           <Typography variant={variant}>{testCypress}</Typography>
         );
 
-        const variantElem = getAs(variant);
-        const textDecorationLine = getDecoration(variant);
+        const variantElem = getAs(String(variant));
+        const textDecorationLine = getDecoration(String(variant));
 
         cy.get(variantElem).should(
           "have.css",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "jest --config=./jest.config.json",
     "test-update": "jest --config=./jest.config.json --updateSnapshot",
     "cypress:react": "npx cypress open --component --browser chrome",
-    "format": "prettier --write './src/**/*.{js,jsx,ts,tsx}'",
+    "format": "prettier --write './{src,cypress}/**/*.{js,jsx,ts,tsx}'",
     "lint": "eslint ./src",
     "build": "node ./scripts/build.js",
     "copy-files": "node ./scripts/copy-files.js",


### PR DESCRIPTION
### Proposed behaviour

- Rename the `typography.cy.js` to the `typography.cy.tsx` file in `./cypress/components/typography/` folder.
- Refactor tests to Typescript.  
- Apply `prettier` to run over `cypress` folder too to avoid such conflits  

### Current behaviour

Typography tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the `typography.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed
<!-- Add CodeSandbox here -->