### PR TITLE
test(search): refactor ts

### DIFF
--- a/src/components/search/search-test.stories.tsx
+++ b/src/components/search/search-test.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
-import Search from ".";
+import Search, { SearchProps } from ".";
 import { SearchEvent } from "./search.component";
 
 export default {
@@ -67,7 +67,7 @@ Default.args = {
   variant: undefined,
 };
 
-export const SearchComponent = ({ ...props }) => {
+export const SearchComponent = (props: SearchProps) => {
   const [value, setValue] = React.useState("");
 
   return (


### PR DESCRIPTION
### Proposed behaviour

- Rename the `search.cy.js` to the `search.cy.tsx` file in `./cypress/components/search/` folder.
- Refactor tests to Typescript.  
- Add eslint rule to cover `cypress` folder as well

### Current behaviour

Search tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the `search.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed
<!-- Add CodeSandbox here -->