### PR TITLE
test(inline-inputs): refactor to TS

### DIFF
--- a/cypress/components/inline-inputs/inline-inputs.cy.tsx
+++ b/cypress/components/inline-inputs/inline-inputs.cy.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import Textbox from "../../../src/components/textbox";
 import Decimal from "../../../src/components/decimal";
-import { Option, Select as SimpleSelect } from "../../../src/components/select";
-import InlineInputs from "../../../src/components/inline-inputs/inline-inputs.component";
+import InlineInputs, {
+  InlineInputsProps,
+} from "../../../src/components/inline-inputs/inline-inputs.component";
 import * as stories from "../../../src/components/inline-inputs/inline-inputs.stories";
+import { Default as InlineInputComponent } from "../../../src/components/inline-inputs/inline-inputs-test.stories";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import {
   inlineInputContainer,
@@ -16,25 +18,6 @@ import { SIZE, CHARACTERS } from "../../support/component-helper/constants";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
-const InlineInputComponent = ({ ...props }) => {
-  return (
-    <InlineInputs label="Inline Input" {...props}>
-      <Textbox hasWarning inputIcon="warning" tooltipMessage="warning" />
-
-      <Decimal onChange={function noRefCheck() {}} value="0.00" />
-
-      <SimpleSelect onChange={function noRefCheck() {}} value="">
-        <Option text="Amber" value="1" />
-        <Option text="Black" value="2" />
-        <Option text="Blue" value="3" />
-        <Option text="Brown" value="4" />
-        <Option text="Green" value="5" />
-        <Option text="Orange" value="6" />
-      </SimpleSelect>
-    </InlineInputs>
-  );
-};
-
 context("Tests for InlineInputs component", () => {
   describe("should check InlineInputs component properties", () => {
     it.each([
@@ -46,7 +29,7 @@ context("Tests for InlineInputs component", () => {
       [SIZE.MEDIUMLARGE, -28],
       [SIZE.LARGE, -32],
       [SIZE.EXTRALARGE, -40],
-    ])(
+    ] as [InlineInputsProps["gutter"], number][])(
       "should check when gutter size is %s for InlineInputs component",
       (size, gutterMargin) => {
         CypressMountWithProviders(<InlineInputComponent gutter={size} />);
@@ -145,7 +128,7 @@ context("Tests for InlineInputs component", () => {
       "medium-large",
       "large",
       "extra-large",
-    ])(
+    ] as InlineInputsProps["gutter"][])(
       "should have the expected border radius styling when gutter is %s and has three input children",
       (gutter) => {
         const firstInputResult = gutter === "none" ? "4px 0px 0px 4px" : "4px";
@@ -180,7 +163,7 @@ context("Tests for InlineInputs component", () => {
       "medium-large",
       "large",
       "extra-large",
-    ])(
+    ] as InlineInputsProps["gutter"][])(
       "should have the expected border radius styling when gutter is %s and has two input children",
       (gutter) => {
         const firstInputResult = gutter === "none" ? "4px 0px 0px 4px" : "4px";
@@ -188,8 +171,13 @@ context("Tests for InlineInputs component", () => {
 
         CypressMountWithProviders(
           <InlineInputs label="Inline Input" gutter={gutter}>
-            <Textbox hasWarning inputIcon="warning" tooltipMessage="warning" />
-            <Decimal onChange={function noRefCheck() {}} value="0.00" />
+            <Textbox warning inputIcon="warning" />
+            <Decimal
+              onChange={function noRefCheck() {
+                ("");
+              }}
+              value="0.00"
+            />
           </InlineInputs>
         );
         inlineInputContainer()
@@ -214,12 +202,12 @@ context("Tests for InlineInputs component", () => {
       "medium-large",
       "large",
       "extra-large",
-    ])(
+    ] as InlineInputsProps["gutter"][])(
       "should have the expected border radius styling when gutter is %s and has one input child",
       (gutter) => {
         CypressMountWithProviders(
           <InlineInputs label="Inline Input" gutter={gutter}>
-            <Textbox hasWarning inputIcon="warning" tooltipMessage="warning" />
+            <Textbox warning inputIcon="warning" />
           </InlineInputs>
         );
         inlineInputContainer()

--- a/src/components/inline-inputs/inline-inputs-test.stories.tsx
+++ b/src/components/inline-inputs/inline-inputs-test.stories.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import InlineInputs, { InlineInputsProps } from ".";
+import Textbox from "../textbox";
+import Decimal from "../decimal";
+import SimpleSelect from "../select/simple-select";
+import Option from "../select/option";
+
+export default {
+  title: "Inline Inputs/Test",
+  includeStories: ["Default"],
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+};
+
+export const Default = (props: InlineInputsProps) => {
+  return (
+    <InlineInputs label="Inline Input" {...props}>
+      <Textbox warning inputIcon="warning" />
+
+      <Decimal
+        onChange={function noRefCheck() {
+          ("");
+        }}
+        value="0.00"
+      />
+
+      <SimpleSelect
+        onChange={function noRefCheck() {
+          ("");
+        }}
+        value=""
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+        <Option text="Brown" value="4" />
+        <Option text="Green" value="5" />
+        <Option text="Orange" value="6" />
+      </SimpleSelect>
+    </InlineInputs>
+  );
+};
+
+Default.storyName = "default";


### PR DESCRIPTION
### Proposed behaviour

- Rename the `inline-inputs.cy.js` to the `inline-inputs.cy.tsx` file in `./cypress/components/inline-inputs/` folder.
- Refactor tests to Typescript.  
- Create `inline-inputs-test.stories.tsx` file

### Current behaviour

Inline Inputs tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the `inline-inputs.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed
<!-- Add CodeSandbox here -->