### PR TITLE
chore(storybook): ensure toolbars have titles - FE-6030

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -86,6 +86,7 @@ export const globalTypes = {
     description: "Internationalization locale",
     defaultValue: "en-GB",
     toolbar: {
+      title: "Locale",
       icon: "globe",
       items: [
         { value: "en-GB", right: "🇬🇧", title: "English" },

--- a/.storybook/withThemeProvider.js
+++ b/.storybook/withThemeProvider.js
@@ -129,9 +129,9 @@ export const globalThemeProvider = {
     description: "Global theme for components",
     defaultValue: sageTheme.name,
     toolbar: {
+      title: "Theme",
       icon: "paintbrush",
       items: Object.keys(themes),
-      showName: true,
     },
   },
 };


### PR DESCRIPTION
### Proposed behaviour

Warning relating to `showName is deprecated as name will stop having dual purposes in the future. Please specify a title in globalTypes instead.` should not be present in console.

### Current behaviour

<img width="508" alt="Screenshot 2023-06-20 at 16 31 45" src="https://github.com/Sage/carbon/assets/56251247/26027469-ea18-400c-8feb-8cf7422a8768">

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

These warnings are acceptable:

![Screenshot 2023-06-20 at 16 32 19](https://github.com/Sage/carbon/assets/56251247/c3b06836-9bdf-4235-a622-ad738dac07b7)

### Testing instructions

Open up Storybook locally and visit the console in dev tools. There should be no warning relating to `showName is deprecated`.
