### PR TITLE
test(icon-button): typescript refactor

### DIFF
--- a/cypress/components/icon-button/icon-button.cy.tsx
+++ b/cypress/components/icon-button/icon-button.cy.tsx
@@ -1,9 +1,12 @@
 import React from "react";
+import { IconButtonProps } from "components/icon-button";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import { icon } from "../../locators";
 import { IconButtonComponent } from "../../../src/components/icon-button/icon-button-test.stories";
 import { CHARACTERS } from "../../support/component-helper/constants";
 import { keyCode } from "../../support/helper";
+
+const keyToTrigger = ["Space", "Enter"] as const;
 
 context("Tests for IconButton component", () => {
   describe("check props for IconButton component", () => {
@@ -32,95 +35,67 @@ context("Tests for IconButton component", () => {
   });
 
   describe("check events for IconButton component", () => {
-    let callback;
-
-    beforeEach(() => {
-      callback = cy.stub();
-    });
-
     it("should call onBlur callback when a blur event is triggered", () => {
+      const callback: IconButtonProps["onBlur"] = cy.stub().as("onBlur");
       CypressMountWithProviders(<IconButtonComponent onBlur={callback} />);
 
-      icon()
-        .parent()
-        .focus()
-        .blur()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      icon().parent().focus().blur();
+      cy.get("@onBlur").should("have.been.calledOnce");
     });
 
     it("should call onFocus callback when a focus event is triggered", () => {
+      const callback: IconButtonProps["onFocus"] = cy.stub().as("onFocus");
       CypressMountWithProviders(<IconButtonComponent onFocus={callback} />);
 
-      icon()
-        .parent()
-        .focus()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      icon().parent().focus();
+      cy.get("@onFocus").should("have.been.calledOnce");
     });
 
     it("should call onMouseEnter callback when a mouseover event is triggered", () => {
+      const callback: IconButtonProps["onMouseEnter"] = cy
+        .stub()
+        .as("onMouseEnter");
       CypressMountWithProviders(
         <IconButtonComponent onMouseEnter={callback} />
       );
 
-      icon()
-        .parent()
-        .trigger("mouseover")
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      icon().parent().trigger("mouseover");
+      cy.get("@onMouseEnter").should("have.been.calledOnce");
     });
 
     it("should call onMouseLeave callback when a mouseout event is triggered", () => {
+      const callback: IconButtonProps["onMouseLeave"] = cy
+        .stub()
+        .as("onMouseLeave");
       CypressMountWithProviders(
         <IconButtonComponent onMouseLeave={callback} />
       );
 
-      icon()
-        .parent()
-        .trigger("mouseover")
-        .trigger("mouseout")
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      icon().parent().trigger("mouseover").trigger("mouseout");
+      cy.get("@onMouseLeave").should("have.been.calledOnce");
     });
 
     it("should call onClick callback when a click event is triggered", () => {
+      const callback: IconButtonProps["onClick"] = cy.stub().as("onClick");
       CypressMountWithProviders(<IconButtonComponent onClick={callback} />);
 
-      icon()
-        .parent()
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      icon().parent().click();
+      cy.get("@onClick").should("have.been.calledOnce");
     });
 
-    it.each(["Space", "Enter"])(
+    it.each([...keyToTrigger])(
       "should call onClick callback when a keydown event is triggered with %s",
       (key) => {
+        const callback: IconButtonProps["onClick"] = cy.stub().as("onClick");
         CypressMountWithProviders(<IconButtonComponent onClick={callback} />);
 
-        icon()
-          .parent()
-          .trigger("keydown", keyCode(key))
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callback).to.have.been.calledOnce;
-          });
+        icon().parent().trigger("keydown", keyCode(key));
+        cy.get("@onClick").should("have.been.calledOnce");
       }
     );
   });
 
-  describe("check props for IconButton component", () => {
+  describe("check accessibility tests for IconButton component", () => {
     it("should pass accessibility tests for aria-label prop", () => {
       CypressMountWithProviders(
         <IconButtonComponent aria-label={CHARACTERS.STANDARD} />
@@ -141,9 +116,8 @@ context("Tests for IconButton component", () => {
 
   it("render with the expected border radius when roundness is %s", () => {
     CypressMountWithProviders(<IconButtonComponent />);
-    icon()
-      .parent()
-      .focus()
-      .then(() => icon().parent().should("have.css", "border-radius", "4px"));
+
+    icon().parent().focus();
+    icon().parent().should("have.css", "border-radius", "4px");
   });
 });

--- a/src/components/icon-button/icon-button-test.stories.tsx
+++ b/src/components/icon-button/icon-button-test.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Icon from "../icon";
-import IconButton from ".";
+import IconButton, { IconButtonProps } from ".";
 
 export default {
   title: "Icon Button/Test",
@@ -13,7 +13,7 @@ export default {
   },
 };
 
-export const Default = ({ ...props }) => {
+export const Default = (props: IconButtonProps) => {
   return (
     <IconButton aria-label="icon-button" onClick={() => {}} {...props}>
       <Icon type="home" />
@@ -23,7 +23,7 @@ export const Default = ({ ...props }) => {
 
 Default.storyName = "default";
 
-export const IconButtonComponent = ({ ...props }) => {
+export const IconButtonComponent = (props: Partial<IconButtonProps>) => {
   return (
     <IconButton aria-label="icon-button" onClick={() => {}} {...props}>
       <Icon type="home" />


### PR DESCRIPTION
### Proposed behaviour

- Rename the `icon-button.cy.js` to `icon-button.cy.tsx` file in `./cypress/components/icon-button/` folder.
- Refactor tests to Typescript.  

### Current behaviour

Icon-button tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [ ] Run `npx cypress open --component` to check if the`icon-button.cy.tsx` file passed
- [ ] Run `npx cypress run --component` to check none of the other *.cy.tsx files have regressed
<!-- Add CodeSandbox here -->