### PR TITLE
refactor(select): remove css styling applied to transparent variant of select - FE-6000

### DIFF
--- a/src/components/select/__internal__/select-text/select-text.spec.tsx
+++ b/src/components/select/__internal__/select-text/select-text.spec.tsx
@@ -56,20 +56,4 @@ describe("SelectText", () => {
       wrapper
     );
   });
-
-  it("should have proper styling when transparent is set", () => {
-    const wrapper = renderSelectText({
-      transparent: true,
-      formattedValue: "foo",
-    });
-
-    assertStyleMatch(
-      {
-        textAlign: "right",
-        fontWeight: "900",
-        flexDirection: "row-reverse",
-      },
-      wrapper
-    );
-  });
 });

--- a/src/components/select/__internal__/select-text/select-text.style.ts
+++ b/src/components/select/__internal__/select-text/select-text.style.ts
@@ -9,7 +9,7 @@ interface StyledSelectTextProps
 }
 
 const StyledSelectText = styled.span<StyledSelectTextProps>`
-  ${({ disabled, hasPlaceholder, readOnly, transparent, size }) => css`
+  ${({ disabled, hasPlaceholder, readOnly, size }) => css`
     align-items: center;
     display: inline-flex;
     flex-grow: 1;
@@ -22,13 +22,6 @@ const StyledSelectText = styled.span<StyledSelectTextProps>`
     width: 30px;
     z-index: 1;
     padding-left: ${sizes[size].horizontalPadding};
-
-    ${transparent &&
-    css`
-      font-weight: 900;
-      text-align: right;
-      flex-direction: row-reverse;
-    `}
 
     ${hasPlaceholder &&
     css`


### PR DESCRIPTION
Currently the `transparent` variant of select renders with font weight of 900 and right aligned text. This is inconsistent with all other variants of this component.

fixes #6090

### Proposed behaviour

![Screenshot 2023-06-23 at 15 31 50](https://github.com/Sage/carbon/assets/56251247/e479a601-0854-44c4-aa72-91a0db48bf15)

### Current behaviour

![Screenshot 2023-06-23 at 15 31 42](https://github.com/Sage/carbon/assets/56251247/31482d76-1e4d-45fe-b16e-548b78cfebd2)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Transparent example of Select should no longer have font-weight of 900 and not be right aligned. 
- Ensure that no other visual regressions have been introduced to other examples of Select.
