### PR TITLE
test(breadcrumbs): refactor to TS

### DIFF
--- a/cypress/components/breadcrumbs/breadcrumbs.cy.tsx
+++ b/cypress/components/breadcrumbs/breadcrumbs.cy.tsx
@@ -68,13 +68,11 @@ context("Testing Breadcrumbs component", () => {
 
       crumb(0).children().eq(1).should(assertion);
       if (!boolean) {
-        crumb(0)
-          .children()
-          .eq(1)
-          .then(($el) => {
-            expect($el).to.have.text("/");
-            expect($el).to.have.css("color", "rgba(0, 0, 0, 0.55)");
-          });
+        crumb(0).children().eq(1).as("crumb");
+
+        cy.get("@crumb")
+          .should("have.text", "/")
+          .and("have.css", "color", "rgba(0, 0, 0, 0.55)");
       }
     });
 


### PR DESCRIPTION
### Proposed behaviour

- Rename the `breadcrumbs.cy.js` to `breadcrumbs.cy.tsx` file in `./cypress/components/breadcrumbs/` folder.
- Refactor tests to Typescript.  

### Current behaviour

Breadcrumbs tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the `breadcrumbs.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed
<!-- Add CodeSandbox here -->