### PR TITLE
fix(flat-table): ensure window does not scroll when using up and down  arrow keys to navigate rows

### DIFF
--- a/src/components/flat-table/flat-table.component.js
+++ b/src/components/flat-table/flat-table.component.js
@@ -139,6 +139,7 @@ const FlatTable = ({
     );
 
     if (Events.isDownKey(ev)) {
+      ev.preventDefault();
       if (
         currentFocusIndex !== -1 &&
         currentFocusIndex < focusableElementsArray.length
@@ -153,6 +154,7 @@ const FlatTable = ({
         }
       }
     } else if (Events.isUpKey(ev)) {
+      ev.preventDefault();
       if (currentFocusIndex > 0) {
         focusableElementsArray[currentFocusIndex - 1]?.focus();
       } else {

--- a/src/components/flat-table/flat-table.spec.js
+++ b/src/components/flat-table/flat-table.spec.js
@@ -807,8 +807,9 @@ describe("FlatTable", () => {
   });
 
   describe("keyboard navigation", () => {
-    const arrowDown = { key: "ArrowDown" };
-    const arrowUp = { key: "ArrowUp" };
+    const preventDefault = jest.fn();
+    const arrowDown = { key: "ArrowDown", preventDefault };
+    const arrowUp = { key: "ArrowUp", preventDefault };
     const arrowLeft = { key: "ArrowLeft" };
 
     describe("when rows are clickable", () => {


### PR DESCRIPTION
fix #6152

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

Ensure the default browser behaviour is prevented when using up and down arrow keys to navigate clickable/ expandable rows

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Using up and down arrow keys to navigate clickable/ expandable rows scrolls the window

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.
This can be tested in storybook using any FlatTable story that has clickable rows or the expandable ones

<!-- Add CodeSandbox here -->
