### PR TITLE
test(sidebar): refactor ts

### DIFF
--- a/src/components/sidebar/sidebar-test.stories.tsx
+++ b/src/components/sidebar/sidebar-test.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from "react";
 import { action } from "@storybook/addon-actions";
-
+import Typography from "../../../src/components/typography";
 import Button from "../button";
 import Sidebar, { SidebarProps } from ".";
 import { SIDEBAR_ALIGNMENTS, SIDEBAR_SIZES } from "./sidebar.config";
@@ -97,7 +97,7 @@ Default.args = {
   disableEscKey: false,
 };
 
-export const SidebarComponent = ({ ...props }) => {
+export const SidebarComponent = (props: Partial<SidebarProps>) => {
   return (
     <>
       <Sidebar
@@ -160,5 +160,49 @@ export const SidebarBackgroundScrollWithOtherFocusableContainers = () => {
         Toast message 2
       </Toast>
     </Box>
+  );
+};
+
+export const SidebarComponentFocusable = (props: Partial<SidebarProps>) => {
+  const [setIsDialogOpen] = React.useState(false);
+  const [isToastOpen, setIsToastOpen] = React.useState(false);
+  const toastRef = React.useRef(null);
+  const CUSTOM_SELECTOR = "button, .focusable-container input";
+  return (
+    <>
+      <Sidebar
+        open
+        onCancel={() => setIsDialogOpen}
+        header={<Typography variant="h3">Sidebar header</Typography>}
+        focusableContainers={[toastRef]}
+        focusableSelectors={CUSTOM_SELECTOR}
+        {...props}
+      >
+        <div className="focusable-container">
+          <Textbox label="First Name" />
+        </div>
+        <div>
+          <Textbox label="Surname" />
+        </div>
+        <div className="focusable-container">
+          <Button
+            buttonType="primary"
+            data-element="open-toast"
+            onClick={() => setIsToastOpen(true)}
+          >
+            Show toast
+          </Button>
+        </div>
+      </Sidebar>
+      <Toast
+        open={isToastOpen}
+        onDismiss={() => setIsToastOpen(false)}
+        ref={toastRef}
+        targetPortalId="stacked"
+        data-element="toast"
+      >
+        Toast Message
+      </Toast>
+    </>
   );
 };


### PR DESCRIPTION
### Proposed behaviour

- Rename the `sidebar.cy.js` file to `sidebar.cy.tsx` file in `./cypress/components/sidebar/` folder.
- Refactor tests to Typescript.
- Formatting for `sidebar` test file


### Current behaviour

Sidebar tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- [x] Run npx cypress open --component to check if the sidebar.cy.tsx file passed
- [x] Run npx cypress run --component --browser chrome to check none of the other *.cy.tsx files have regressed
