### PR TITLE
feat(flat-table): allow react components as subrow prop

### DIFF
--- a/src/components/flat-table/flat-table-expandable.stories.mdx
+++ b/src/components/flat-table/flat-table-expandable.stories.mdx
@@ -1368,6 +1368,72 @@ truncated styling applied, this is because of the caret icon that is rendered wi
   </Story>
 </Canvas>
 
+### Sub rows as component
+
+<Canvas>
+  <Story name="sub rows as component" parameters={{ chromatic: { disableSnapshot: true } }}>
+    {() => {
+      const SubRowsComponent = () => {
+        console.log("I am only rendered when I am really needed.");
+        return (
+          <>
+            <FlatTableRow>
+              <FlatTableCell>Child one</FlatTableCell>
+              <FlatTableCell>York</FlatTableCell>
+              <FlatTableCell>Single</FlatTableCell>
+              <FlatTableCell>2</FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow>
+              <FlatTableCell>Child two</FlatTableCell>
+              <FlatTableCell>Edinburgh</FlatTableCell>
+              <FlatTableCell>Single</FlatTableCell>
+              <FlatTableCell>1</FlatTableCell>
+            </FlatTableRow>
+          </>
+        );
+      };
+      return (
+        <FlatTable>
+          <FlatTableHead>
+            <FlatTableRow>
+              <FlatTableHeader width={60}>Name</FlatTableHeader>
+              <FlatTableHeader>Location</FlatTableHeader>
+              <FlatTableHeader>Relationship Status</FlatTableHeader>
+              <FlatTableHeader>Dependents</FlatTableHeader>
+            </FlatTableRow>
+          </FlatTableHead>
+          <FlatTableBody>
+            <FlatTableRow expandable subRows={SubRowsComponent}>
+              <FlatTableCell>John Doe</FlatTableCell>
+              <FlatTableCell>London</FlatTableCell>
+              <FlatTableCell>Single</FlatTableCell>
+              <FlatTableCell>0</FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow expandable subRows={SubRowsComponent}>
+              <FlatTableCell>Jane Doe</FlatTableCell>
+              <FlatTableCell>York</FlatTableCell>
+              <FlatTableCell>Married</FlatTableCell>
+              <FlatTableCell>2</FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow expandable subRows={SubRowsComponent}>
+              <FlatTableCell>John Smith</FlatTableCell>
+              <FlatTableCell>Edinburgh</FlatTableCell>
+              <FlatTableCell>Single</FlatTableCell>
+              <FlatTableCell>1</FlatTableCell>
+            </FlatTableRow>
+            <FlatTableRow expandable subRows={SubRowsComponent}>
+              <FlatTableCell>Jane Smith</FlatTableCell>
+              <FlatTableCell>Newcastle</FlatTableCell>
+              <FlatTableCell>Married</FlatTableCell>
+              <FlatTableCell>5</FlatTableCell>
+            </FlatTableRow>
+          </FlatTableBody>
+        </FlatTable>
+      );
+    }}
+  </Story>
+</Canvas>
+
 ### Table Sizes
 
 <Canvas>

--- a/src/components/flat-table/flat-table-row/flat-table-row.component.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.js
@@ -277,6 +277,25 @@ const FlatTableRow = React.forwardRef(
       </FlatTableRowDraggable>
     );
 
+    let subRowContent = null;
+
+    if (isExpanded && subRows) {
+      if (subRows instanceof Array) {
+        subRowContent = React.Children.map(
+          subRows,
+          (child, index) =>
+            child &&
+            React.cloneElement(child, {
+              isSubRow: true,
+              isFirstSubRow: index === 0,
+              ...child.props,
+            })
+        );
+      } else {
+        subRowContent = React.createElement(subRows);
+      }
+    }
+
     return (
       <DrawerSidebarContext.Consumer>
         {({ isInSidebar }) => (
@@ -284,18 +303,7 @@ const FlatTableRow = React.forwardRef(
             {draggable
               ? draggableComponent(isInSidebar)
               : rowComponent(isInSidebar)}
-            {isExpanded &&
-              subRows &&
-              React.Children.map(
-                subRows,
-                (child, index) =>
-                  child &&
-                  React.cloneElement(child, {
-                    isSubRow: true,
-                    isFirstSubRow: index === 0,
-                    ...child.props,
-                  })
-              )}
+            {subRowContent}
           </>
         )}
       </DrawerSidebarContext.Consumer>

--- a/src/components/flat-table/flat-table-row/flat-table-row.d.ts
+++ b/src/components/flat-table/flat-table-row/flat-table-row.d.ts
@@ -21,7 +21,7 @@ export interface FlatTableRowProps {
   /** Allows developers to manually control selected state for the row. */
   selected?: boolean;
   /** Sub rows to be shown when the row is expanded, must be used with the `expandable` prop. */
-  subRows?: React.ReactNodeArray;
+  subRows?: React.ReactNodeArray | React.ComponentType;
 }
 
 declare function FlatTableRow(

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.js
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.js
@@ -858,6 +858,26 @@ describe("FlatTableRow", () => {
         expect(wrapper.find(StyledFlatTableRow).length).toEqual(3);
       });
 
+      it("should lazy load the sub rows if they are defined as a component", () => {
+        const subRows = jest.fn(() => SubRows);
+        const wrapper = renderFlatTableRow({
+          expandable: true,
+          subRows,
+        });
+
+        expect(subRows).not.toHaveBeenCalled();
+
+        act(() => {
+          wrapper.find(StyledFlatTableRow).at(0).props().onClick();
+        });
+
+        wrapper.update();
+
+        expect(subRows).toHaveBeenCalled();
+
+        expect(wrapper.find(StyledFlatTableRow).length).toEqual(3);
+      });
+
       describe("when onClick prop set", () => {
         it("should call the onClick function", () => {
           const onClickFn = jest.fn();


### PR DESCRIPTION
### Proposed behaviour

We would like to use the flat table with sub rows. The content of the sub rows is not available in our app when we first render the table and we would like to pass in a component as the `subRows` prop so when the component is rendered, we can fetch the data and lazy load the rows from the server.

### Current behaviour

Currently we can only pass an array of `FlatTableRow`s to the `subRows` prop.

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required


### Testing instructions

Please see the newly added story in the story book

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

Sample usecase: 
https://codesandbox.io/s/carbon-quickstart-forked-ml3dhl?file=/src/App.js
