### PR TITLE
test(select): typescript refactor

### DIFF
--- a/cypress/components/select/filterable-select/filterable-select.cy.tsx
+++ b/cypress/components/select/filterable-select/filterable-select.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
+import { FilterableSelectProps } from "../../../../src/components/select";
 import * as stories from "../../../../src/components/select/filterable-select/filterable-select-test.stories";
 import CypressMountWithProviders from "../../../support/component-helper/cypress-mount";
-
 import {
   getDataElementByValue,
   helpIcon,
@@ -9,7 +9,6 @@ import {
   commonDataElementInputPreview,
   body,
 } from "../../../locators";
-
 import {
   selectList,
   selectListWrapper,
@@ -32,18 +31,13 @@ import {
   boldedAndUnderlinedValue,
   multiColumnsSelectListNoResultsMessage,
 } from "../../../locators/select";
-
 import { loader } from "../../../locators/loader";
-
 import { alertDialogPreview } from "../../../locators/dialog";
-
 import {
   assertCssValueIsApproximately,
   verifyRequiredAsteriskForLabel,
 } from "../../../support/component-helper/common-steps";
-
 import { keyCode, positionOfElement } from "../../../support/helper";
-
 import { SIZE, CHARACTERS } from "../../../support/component-helper/constants";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
@@ -51,6 +45,7 @@ const testPropValue = CHARACTERS.STANDARD;
 const addElementText = "Add a New Element";
 const columns = 3;
 const icon = "add";
+const keyToTrigger = ["downarrow", "uparrow", "Home", "End", "Enter"] as const;
 
 context("Tests for FilterableSelect component", () => {
   describe("check props for FilterableSelect component", () => {
@@ -146,7 +141,7 @@ context("Tests for FilterableSelect component", () => {
       ["bottom", "0px", "0px", "0px", "0px"],
       ["left", "200px", "0px", "200px", "0px"],
       ["right", "200px", "0px", "0px", "200px"],
-    ])(
+    ] as [FilterableSelectProps["tooltipPosition"], string, string, string, string][])(
       "should render the help tooltip in the %s position",
       (tooltipPositionValue, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -187,7 +182,7 @@ context("Tests for FilterableSelect component", () => {
       [SIZE.SMALL, 32],
       [SIZE.MEDIUM, 40],
       [SIZE.LARGE, 48],
-    ])(
+    ] as [FilterableSelectProps["size"], number][])(
       "should use %s as size and render FilterableSelect with %s as height",
       (size, height) => {
         CypressMountWithProviders(
@@ -227,9 +222,9 @@ context("Tests for FilterableSelect component", () => {
     });
 
     it.each([
-      ["flex", "399"],
-      ["flex", "400"],
-      ["block", "401"],
+      ["flex", 399],
+      ["flex", 400],
+      ["block", 401],
     ])(
       "should check FilterableSelect label alignment is %s with adaptiveLabelBreakpoint %s and viewport 400",
       (displayValue, breakpoint) => {
@@ -252,7 +247,7 @@ context("Tests for FilterableSelect component", () => {
     it.each([
       ["right", "end"],
       ["left", "start"],
-    ])(
+    ] as [FilterableSelectProps["labelAlign"], string][])(
       "should use %s as labelAligment and render it with flex-%s as css properties",
       (alignment, cssProp) => {
         CypressMountWithProviders(
@@ -270,9 +265,9 @@ context("Tests for FilterableSelect component", () => {
     );
 
     it.each([
-      ["10", "90", 135, 1229],
-      ["30", "70", 409, 956],
-      ["80", "20", 1092, 273],
+      [10, 90, 135, 1229],
+      [30, 70, 409, 956],
+      [80, 20, 1092, 273],
     ])(
       "should use %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
       (label, input, labelRatio, inputRatio) => {
@@ -389,23 +384,29 @@ context("Tests for FilterableSelect component", () => {
     });
 
     it.each([
-      ["open", "downarrow"],
-      ["open", "uparrow"],
-      ["open", "Home"],
-      ["open", "End"],
-      ["not open", "Enter"],
+      keyToTrigger[0],
+      keyToTrigger[1],
+      keyToTrigger[2],
+      keyToTrigger[3],
     ])(
-      "should %s the list when %s is pressed with FilterableSelect input in focus",
-      (state, key) => {
+      "should open the list when %s is pressed with FilterableSelect input in focus",
+      (key) => {
         CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
         commonDataElementInputPreview().focus();
         selectInput().trigger("keydown", { ...keyCode(key), force: true });
-        if (state === "open") {
-          selectListWrapper().should("be.visible");
-        } else {
-          selectListWrapper().should("not.be.visible");
-        }
+        selectListWrapper().should("be.visible");
+      }
+    );
+
+    it.each([keyToTrigger[4]])(
+      "should not open the list when %s is pressed with FilterableSelect input in focus",
+      (key) => {
+        CypressMountWithProviders(<stories.FilterableSelectComponent />);
+
+        commonDataElementInputPreview().focus();
+        selectInput().trigger("keydown", { ...keyCode(key), force: true });
+        selectListWrapper().should("not.be.visible");
       }
     );
 
@@ -460,8 +461,7 @@ context("Tests for FilterableSelect component", () => {
       }
     });
 
-    // FE-5300 raised to fix the issue with the loader not reappeearing
-    it.skip("should render the lazy loader when the prop is set and list is opened again", () => {
+    it("should render the lazy loader when the prop is set and list is opened again", () => {
       CypressMountWithProviders(
         <stories.FilterableSelectLazyLoadTwiceComponent />
       );
@@ -516,11 +516,7 @@ context("Tests for FilterableSelect component", () => {
       selectInput().should("have.attr", "aria-expanded", "false");
       selectListWrapper().should("not.be.visible");
       dropdownButton().click();
-      selectListWrapper()
-        .find("li")
-        .should(($lis) => {
-          expect($lis).to.have.length(count);
-        });
+      selectListWrapper().find("li").should("have.length", count);
     });
 
     it("should check list is open when input is focussed and openOnFocus is set", () => {
@@ -578,7 +574,7 @@ context("Tests for FilterableSelect component", () => {
       ["bottom", "600px", "0px", "0px", "20px"],
       ["left", "200px", "0px", "0px", "900px"],
       ["right", "200px", "0px", "500px", "20px"],
-    ])(
+    ] as [FilterableSelectProps["listPlacement"], string, string, string, string][])(
       "should flip list to opposite position when there is not enough space to render it in %s position",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -604,9 +600,6 @@ context("Tests for FilterableSelect component", () => {
         }
         if (position === "right") {
           flipPosition = "left";
-        }
-        if (position === "auto") {
-          flipPosition = "right";
         }
 
         dropdownButton().click();
@@ -779,11 +772,9 @@ context("Tests for FilterableSelect component", () => {
 
       filterableSelectAddElementButton().should("be.visible");
 
-      selectListWrapper().then((wrapperElement) => {
-        const actualHeight = parseInt(wrapperElement.css("height"));
-        expect(actualHeight).to.be.above(220);
-        expect(actualHeight).to.be.below(250);
-      });
+      selectListWrapper()
+        .then(($element) => parseInt($element.css("height")))
+        .should("be.within", 220, 250);
     });
 
     it("when navigating with the keyboard, the selected option is not hidden behind an action button", () => {
@@ -836,78 +827,65 @@ context("Tests for FilterableSelect component", () => {
   });
 
   describe("check events for FilterableSelect component", () => {
-    let callback;
-    beforeEach(() => {
-      callback = cy.stub();
-    });
-
     it("should call onClick event when mouse is clicked on text input", () => {
+      const callback: FilterableSelectProps["onClick"] = cy
+        .stub()
+        .as("onClick");
       CypressMountWithProviders(
         <stories.FilterableSelectComponent onClick={callback} />
       );
 
-      dropdownButton()
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      dropdownButton().click();
+      cy.get("@onClick").should("have.been.calledOnce");
     });
 
     it("should call onFocus when FilterableSelect is brought into focus", () => {
+      const callback: FilterableSelectProps["onFocus"] = cy
+        .stub()
+        .as("onFocus");
       CypressMountWithProviders(
         <stories.FilterableSelectComponent onFocus={callback} />
       );
 
-      commonDataElementInputPreview()
-        .focus()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      commonDataElementInputPreview().focus();
+      cy.get("@onFocus").should("have.been.calledOnce");
     });
 
     it("should call onOpen when FilterableSelect is opened by focusing the input", () => {
+      const callback: FilterableSelectProps["onOpen"] = cy.stub().as("onOpen");
       CypressMountWithProviders(
         <stories.FilterableSelectComponent openOnFocus onOpen={callback} />
       );
 
-      commonDataElementInputPreview()
-        .focus()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          cy.wrap(callback).should("have.been.calledOnce");
-        });
+      commonDataElementInputPreview().focus();
+      cy.get("@onOpen").should("have.been.calledOnce");
     });
 
     it("should call onOpen when FilterableSelect is opened by clicking on Icon", () => {
+      const callback: FilterableSelectProps["onOpen"] = cy.stub().as("onOpen");
       CypressMountWithProviders(
         <stories.FilterableSelectComponent onOpen={callback} />
       );
 
-      dropdownButton()
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      dropdownButton().click();
+      cy.get("@onOpen").should("have.been.calledOnce");
     });
 
     it("should call onBlur event when the list is closed", () => {
+      const callback: FilterableSelectProps["onBlur"] = cy.stub().as("onBlur");
       CypressMountWithProviders(
         <stories.FilterableSelectComponent onBlur={callback} />
       );
 
       dropdownButton().click();
-      commonDataElementInputPreview()
-        .blur()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      commonDataElementInputPreview().blur();
+      cy.get("@onBlur").should("have.been.calledOnce");
     });
 
     it("should call onChange event when a list option is selected", () => {
+      const callback: FilterableSelectProps["onChange"] = cy
+        .stub()
+        .as("onChange");
       CypressMountWithProviders(
         <stories.FilterableSelectComponent onChange={callback} />
       );
@@ -916,34 +894,33 @@ context("Tests for FilterableSelect component", () => {
       const option = "1";
 
       dropdownButton().click();
-      selectOption(positionOfElement(position))
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledWith({
-            target: { value: option },
-          });
-        });
+      selectOption(positionOfElement(position)).click();
+      cy.get("@onChange").should("have.been.calledWith", {
+        target: { value: option },
+      });
     });
 
-    it.each([["downarrow"], ["uparrow"]])(
+    it.each([keyToTrigger[0], keyToTrigger[1]])(
       "should call onKeyDown event when %s key is pressed",
       (key) => {
+        const callback: FilterableSelectProps["onKeyDown"] = cy
+          .stub()
+          .as("onKeyDown");
         CypressMountWithProviders(
           <stories.FilterableSelectComponent onKeyDown={callback} />
         );
 
         commonDataElementInputPreview()
           .focus()
-          .trigger("keydown", { ...keyCode(key), force: true })
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callback).to.have.been.calledOnce;
-          });
+          .trigger("keydown", { ...keyCode(key), force: true });
+        cy.get("@onKeyDown").should("have.been.calledOnce");
       }
     );
 
     it("should call onFilterChange event when a filter string is input", () => {
+      const callback: FilterableSelectProps["onFilterChange"] = cy
+        .stub()
+        .as("onFilterChange");
       CypressMountWithProviders(
         <stories.FilterableSelectOnChangeEventComponent
           onFilterChange={callback}
@@ -952,17 +929,15 @@ context("Tests for FilterableSelect component", () => {
 
       const text = "B";
 
-      commonDataElementInputPreview()
-        .click()
-        .type(text)
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-          expect(callback).to.have.been.calledWith(text);
-        });
+      commonDataElementInputPreview().click().type(text);
+      cy.get("@onFilterChange").should("have.been.calledOnce");
+      cy.get("@onFilterChange").should("have.been.calledWith", text);
     });
 
     it("should call onListAction event when the Action Button is clicked", () => {
+      const callback: FilterableSelectProps["onListAction"] = cy
+        .stub()
+        .as("onListAction");
       CypressMountWithProviders(
         <stories.FilterableSelectListActionEventComponent
           onListAction={callback}
@@ -970,27 +945,21 @@ context("Tests for FilterableSelect component", () => {
       );
 
       dropdownButton().click();
-      filterableSelectAddElementButton()
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      filterableSelectAddElementButton().click();
+      cy.get("@onListAction").should("have.been.calledOnce");
     });
 
     it("should call onListScrollBottom event when the list is scrolled to the bottom", () => {
+      const callback: FilterableSelectProps["onListScrollBottom"] = cy
+        .stub()
+        .as("onListScrollBottom");
       CypressMountWithProviders(
         <stories.FilterableSelectComponent onListScrollBottom={callback} />
       );
 
       dropdownButton().click();
-      selectListWrapper()
-        .scrollTo("bottom")
-        .wait(250)
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      selectListWrapper().scrollTo("bottom").wait(250);
+      cy.get("@onListScrollBottom").should("have.been.calledOnce");
     });
   });
 
@@ -1038,18 +1007,12 @@ context("Tests for FilterableSelect component", () => {
       CypressMountWithProviders(<stories.FilterableSelectNestedInDialog />);
 
       dropdownButton().click();
-      commonDataElementInputPreview()
-        .type("{esc}", { force: true })
-        .then(() => {
-          selectList().should("not.be.visible");
-          alertDialogPreview().should("exist");
-        });
+      commonDataElementInputPreview().type("{esc}", { force: true });
+      selectList().should("not.be.visible");
+      alertDialogPreview().should("exist");
 
-      commonDataElementInputPreview()
-        .type("{esc}", { force: true })
-        .then(() => {
-          alertDialogPreview().should("not.exist");
-        });
+      commonDataElementInputPreview().type("{esc}", { force: true });
+      alertDialogPreview().should("not.exist");
     });
 
     it("should not refocus the select textbox when closing it by clicking outside", () => {
@@ -1067,9 +1030,8 @@ context("Tests for FilterableSelect component", () => {
     it("should pass accessibilty tests for FilterableSelect", () => {
       CypressMountWithProviders(<stories.FilterableSelectComponent />);
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     it.each(testData)(
@@ -1112,7 +1074,7 @@ context("Tests for FilterableSelect component", () => {
       ["bottom", "0px", "0px", "0px", "0px"],
       ["left", "200px", "0px", "200px", "0px"],
       ["right", "200px", "0px", "0px", "200px"],
-    ])(
+    ] as [FilterableSelectProps["tooltipPosition"], string, string, string, string][])(
       "should pass accessibilty tests for FilterableSelect tooltip prop in the %s position",
       (tooltipPositionValue, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -1142,12 +1104,15 @@ context("Tests for FilterableSelect component", () => {
       CypressMountWithProviders(<stories.FilterableSelectComponent readOnly />);
 
       cy.checkAccessibility();
-      selectInput()
-        .click()
-        .then(() => cy.checkAccessibility());
+      selectInput().click();
+      cy.checkAccessibility();
     });
 
-    it.each([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE])(
+    it.each([
+      SIZE.SMALL,
+      SIZE.MEDIUM,
+      SIZE.LARGE,
+    ] as FilterableSelectProps["size"][])(
       "should pass accessibilty tests for FilterableSelect size prop",
       (size) => {
         CypressMountWithProviders(
@@ -1181,9 +1146,9 @@ context("Tests for FilterableSelect component", () => {
     });
 
     it.each([
-      ["flex", "399"],
-      ["flex", "400"],
-      ["block", "401"],
+      ["flex", 399],
+      ["flex", 400],
+      ["block", 401],
     ])(
       "should pass accessibilty tests for FilterableSelect adaptiveLabelBreakpoint prop set as %s and viewport 400",
       (displayValue, breakpoint) => {
@@ -1200,7 +1165,7 @@ context("Tests for FilterableSelect component", () => {
       }
     );
 
-    it.each(["right", "left"])(
+    it.each(["right", "left"] as FilterableSelectProps["labelAlign"][])(
       "should pass accessibilty tests for FilterableSelect labelAlign prop set as %s",
       (alignment) => {
         CypressMountWithProviders(
@@ -1215,9 +1180,9 @@ context("Tests for FilterableSelect component", () => {
     );
 
     it.each([
-      ["10", "90"],
-      ["30", "70"],
-      ["80", "20"],
+      [10, 90],
+      [30, 70],
+      [80, 20],
     ])(
       "should pass accessibilty tests for FilterableSelect labelWidth prop set as %s and inputWidth set as %s",
       (label, input) => {
@@ -1259,12 +1224,10 @@ context("Tests for FilterableSelect component", () => {
         <stories.FilterableSelectWithInfiniteScrollComponent />
       );
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
-      selectListWrapper()
-        .scrollTo("bottom")
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
+      selectListWrapper().scrollTo("bottom");
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for FilterableSelect openOnFocus prop", () => {
@@ -1272,9 +1235,8 @@ context("Tests for FilterableSelect component", () => {
         <stories.FilterableSelectComponent openOnFocus />
       );
 
-      commonDataElementInputPreview()
-        .focus()
-        .then(() => cy.checkAccessibility());
+      commonDataElementInputPreview().focus();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for FilterableSelect with object as value", () => {
@@ -1282,9 +1244,8 @@ context("Tests for FilterableSelect component", () => {
         <stories.FilterableSelectObjectAsValueComponent />
       );
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for FilterableSelect listMaxHeight prop", () => {
@@ -1292,9 +1253,8 @@ context("Tests for FilterableSelect component", () => {
         <stories.FilterableSelectComponent listMaxHeight={200} />
       );
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     it.each([
@@ -1302,7 +1262,7 @@ context("Tests for FilterableSelect component", () => {
       ["bottom", "600px", "0px", "0px", "20px"],
       ["left", "200px", "0px", "0px", "900px"],
       ["right", "200px", "0px", "500px", "20px"],
-    ])(
+    ] as [FilterableSelectProps["listPlacement"], string, string, string, string][])(
       "should pass accessibilty tests for FilterableSelect listPlacement and flipEnabled props",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -1327,9 +1287,8 @@ context("Tests for FilterableSelect component", () => {
         <stories.FilterableSelectMultiColumnsComponent />
       );
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for FilterableSelect with multiple columns and nested component", () => {
@@ -1337,9 +1296,8 @@ context("Tests for FilterableSelect component", () => {
         <stories.FilterableSelectMultiColumnsNestedComponent />
       );
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for FilterableSelect with an action button and trigger Dialog on action", () => {
@@ -1347,9 +1305,8 @@ context("Tests for FilterableSelect component", () => {
         <stories.FilterableSelectWithActionButtonComponent />
       );
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for FilterableSelect with virtual scrolling", () => {
@@ -1357,17 +1314,15 @@ context("Tests for FilterableSelect component", () => {
         <stories.FilterableSelectWithManyOptionsAndVirtualScrolling />
       );
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for FilterableSelect in nested dialog", () => {
       CypressMountWithProviders(<stories.FilterableSelectNestedInDialog />);
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     // FE-5764
@@ -1378,9 +1333,8 @@ context("Tests for FilterableSelect component", () => {
         </div>
       );
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
   });
 });

--- a/cypress/components/select/multi-select/multi-select.cy.tsx
+++ b/cypress/components/select/multi-select/multi-select.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
+import { MultiSelectProps } from "../../../../src/components/select";
 import * as stories from "../../../../src/components/select/multi-select/multi-select-test.stories";
 import CypressMountWithProviders from "../../../support/component-helper/cypress-mount";
-
 import {
   getDataElementByValue,
   helpIcon,
@@ -9,7 +9,6 @@ import {
   commonDataElementInputPreview,
   body,
 } from "../../../locators";
-
 import {
   selectList,
   selectListWrapper,
@@ -32,18 +31,13 @@ import {
   multiSelectPillByText,
   selectResetButton,
 } from "../../../locators/select";
-
 import { pillCloseIcon } from "../../../locators/pill";
-
 import { loader } from "../../../locators/loader";
-
 import { alertDialogPreview } from "../../../locators/dialog";
-
 import {
   assertCssValueIsApproximately,
   verifyRequiredAsteriskForLabel,
 } from "../../../support/component-helper/common-steps";
-
 import { positionOfElement } from "../../../support/helper";
 import { SIZE, CHARACTERS } from "../../../support/component-helper/constants";
 
@@ -54,6 +48,15 @@ const option1 = "Green";
 const option2 = "Purple";
 const option3 = "Yellow";
 const defaultValue = ["10"];
+const keyToTrigger = [
+  "ArrowDown",
+  "ArrowUp",
+  "ArrowLeft",
+  "ArrowRight",
+  "Home",
+  "End",
+  "Enter",
+] as const;
 
 context("Tests for MultiSelect component", () => {
   describe("check props for MultiSelect component", () => {
@@ -149,7 +152,7 @@ context("Tests for MultiSelect component", () => {
       ["bottom", "0px", "0px", "0px", "0px"],
       ["left", "200px", "0px", "200px", "0px"],
       ["right", "200px", "0px", "0px", "200px"],
-    ])(
+    ] as [MultiSelectProps["tooltipPosition"], string, string, string, string][])(
       "should render the help tooltip in the %s position",
       (tooltipPositionValue, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -190,7 +193,7 @@ context("Tests for MultiSelect component", () => {
       [SIZE.SMALL, 32],
       [SIZE.MEDIUM, 40],
       [SIZE.LARGE, 48],
-    ])(
+    ] as [MultiSelectProps["size"], number][])(
       "should use %s as size and render MultiSelect with %s as height",
       (size, height) => {
         CypressMountWithProviders(<stories.MultiSelectComponent size={size} />);
@@ -224,9 +227,9 @@ context("Tests for MultiSelect component", () => {
     });
 
     it.each([
-      ["flex", "399"],
-      ["flex", "400"],
-      ["block", "401"],
+      ["flex", 399],
+      ["flex", 400],
+      ["block", 401],
     ])(
       "should check MultiSelect label alignment is %s with adaptiveLabelBreakpoint %s and viewport 400",
       (displayValue, breakpoint) => {
@@ -249,7 +252,7 @@ context("Tests for MultiSelect component", () => {
     it.each([
       ["right", "end"],
       ["left", "start"],
-    ])(
+    ] as [MultiSelectProps["labelAlign"], string][])(
       "should use %s as labelAligment and render it with flex-%s as css properties",
       (alignment, cssProp) => {
         CypressMountWithProviders(
@@ -264,9 +267,9 @@ context("Tests for MultiSelect component", () => {
     );
 
     it.each([
-      ["10", "90", 135, 1229],
-      ["30", "70", 409, 954],
-      ["80", "20", 1092, 273],
+      [10, 90, 135, 1229],
+      [30, 70, 409, 954],
+      [80, 20, 1092, 273],
     ])(
       "should use %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
       (label, input, labelRatio, inputRatio) => {
@@ -381,23 +384,29 @@ context("Tests for MultiSelect component", () => {
     });
 
     it.each([
-      ["open", "ArrowDown"],
-      ["open", "ArrowUp"],
-      ["open", "Home"],
-      ["open", "End"],
-      ["not open", "Enter"],
+      keyToTrigger[0],
+      keyToTrigger[1],
+      keyToTrigger[4],
+      keyToTrigger[5],
     ])(
-      "should %s the list when %s is pressed with MultiSelect input in focus",
-      (state, key) => {
+      "should open the list when %s is pressed with MultiSelect input in focus",
+      (key) => {
         CypressMountWithProviders(<stories.MultiSelectComponent />);
 
         commonDataElementInputPreview().focus();
         selectInput().realPress(key);
-        if (state === "open") {
-          selectListWrapper().should("be.visible");
-        } else {
-          selectListWrapper().should("not.be.visible");
-        }
+        selectListWrapper().should("be.visible");
+      }
+    );
+
+    it.each([keyToTrigger[6]])(
+      "should not open the list when %s is pressed with MultiSelect input in focus",
+      (key) => {
+        CypressMountWithProviders(<stories.MultiSelectComponent />);
+
+        commonDataElementInputPreview().focus();
+        selectInput().realPress(key);
+        selectListWrapper().should("not.be.visible");
       }
     );
 
@@ -514,11 +523,7 @@ context("Tests for MultiSelect component", () => {
       selectInput().should("have.attr", "aria-expanded", "true");
       selectListWrapper().should("be.visible");
       dropdownButton().click().click();
-      selectListWrapper()
-        .find("li")
-        .should(($lis) => {
-          expect($lis).to.have.length(count);
-        });
+      selectListWrapper().find("li").should("have.length", count);
     });
 
     it("should check list is open when input is focussed and openOnFocus is set", () => {
@@ -553,7 +558,7 @@ context("Tests for MultiSelect component", () => {
       ["bottom", "600px", "0px", "0px", "20px"],
       ["left", "200px", "0px", "0px", "900px"],
       ["right", "200px", "0px", "500px", "20px"],
-    ])(
+    ] as [MultiSelectProps["listPlacement"], string, string, string, string][])(
       "should flip list to opposite position when there is not enough space to render it in %s position",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -579,9 +584,6 @@ context("Tests for MultiSelect component", () => {
         }
         if (position === "right") {
           flipPosition = "left";
-        }
-        if (position === "auto") {
-          flipPosition = "right";
         }
 
         dropdownButton().click();
@@ -731,9 +733,9 @@ context("Tests for MultiSelect component", () => {
     });
 
     it.each([
-      ["third", "Blue as the sky on a summer's day"],
-      ["fifth", "Green as the grass in a spring meadow"],
-    ])(
+      ["third" as const, "Blue as the sky on a summer's day"],
+      ["fifth" as const, "Green as the grass in a spring meadow"],
+    ] as ["third" | "fifth", string][])(
       "should select %s list option and show pill with complete long text wrapped in the input",
       (option, text) => {
         CypressMountWithProviders(
@@ -811,65 +813,49 @@ context("Tests for MultiSelect component", () => {
   });
 
   describe("check events for MultiSelect component", () => {
-    let callback;
-    beforeEach(() => {
-      callback = cy.stub();
-    });
-
     it("should call onClick event when mouse is clicked on text input", () => {
+      const callback: MultiSelectProps["onClick"] = cy.stub().as("onClick");
       CypressMountWithProviders(
         <stories.MultiSelectComponent onClick={callback} />
       );
 
-      commonDataElementInputPreview()
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      commonDataElementInputPreview().click();
+      cy.get("@onClick").should("have.been.calledOnce");
     });
 
     it("should call onFocus when MultiSelect is brought into focus", () => {
+      const callback: MultiSelectProps["onFocus"] = cy.stub().as("onFocus");
       CypressMountWithProviders(
         <stories.MultiSelectComponent onFocus={callback} />
       );
 
-      commonDataElementInputPreview()
-        .focus()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      commonDataElementInputPreview().focus();
+      cy.get("@onFocus").should("have.been.calledOnce");
     });
 
     it("should call onOpen when MultiSelect is opened", () => {
+      const callback: MultiSelectProps["onOpen"] = cy.stub().as("onOpen");
       CypressMountWithProviders(
         <stories.MultiSelectComponent onOpen={callback} />
       );
 
-      dropdownButton()
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      dropdownButton().click();
+      cy.get("@onOpen").should("have.been.calledOnce");
     });
 
     it("should call onBlur event when the list is closed", () => {
+      const callback: MultiSelectProps["onBlur"] = cy.stub().as("onBlur");
       CypressMountWithProviders(
         <stories.MultiSelectComponent onBlur={callback} />
       );
 
       dropdownButton().click();
-      selectInput()
-        .blur()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      selectInput().blur();
+      cy.get("@onBlur").should("have.been.calledOnce");
     });
 
     it("should call onChange event once when a list option is selected", () => {
+      const callback: MultiSelectProps["onChange"] = cy.stub().as("onChange");
       CypressMountWithProviders(
         <stories.MultiSelectComponent onChange={callback} />
       );
@@ -878,34 +864,32 @@ context("Tests for MultiSelect component", () => {
       const option = ["1"];
 
       dropdownButton().click();
-      selectOption(positionOfElement(position))
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnceWith({
-            target: { value: option },
-          });
-        });
+      selectOption(positionOfElement(position)).click();
+      cy.get("@onChange").should("have.been.calledWith", {
+        target: { value: option },
+      });
     });
 
-    it.each(["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Enter"])(
-      "should call onKeyDown event when %s key is pressed",
-      (key) => {
-        CypressMountWithProviders(
-          <stories.MultiSelectComponent onKeyDown={callback} />
-        );
+    it.each([
+      keyToTrigger[0],
+      keyToTrigger[1],
+      keyToTrigger[2],
+      keyToTrigger[3],
+      keyToTrigger[6],
+    ])("should call onKeyDown event when %s key is pressed", (key) => {
+      const callback: MultiSelectProps["onKeyDown"] = cy.stub().as("onKeyDown");
+      CypressMountWithProviders(
+        <stories.MultiSelectComponent onKeyDown={callback} />
+      );
 
-        commonDataElementInputPreview()
-          .focus()
-          .realPress(key)
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callback).to.have.been.calledOnce;
-          });
-      }
-    );
+      commonDataElementInputPreview().focus().realPress(key);
+      cy.get("@onKeyDown").should("have.been.calledOnce");
+    });
 
     it("should call onFilterChange event when a filter string is input", () => {
+      const callback: MultiSelectProps["onFilterChange"] = cy
+        .stub()
+        .as("onFilterChange");
       CypressMountWithProviders(
         <stories.MultiSelectOnFilterChangeEventComponent
           onFilterChange={callback}
@@ -914,14 +898,9 @@ context("Tests for MultiSelect component", () => {
 
       const text = "B";
 
-      commonDataElementInputPreview()
-        .click()
-        .type(text)
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-          expect(callback).to.have.been.calledWith(text);
-        });
+      commonDataElementInputPreview().click().type(text);
+      cy.get("@onFilterChange").should("have.been.calledOnce");
+      cy.get("@onFilterChange").should("have.been.calledWith", text);
     });
   });
 
@@ -969,18 +948,12 @@ context("Tests for MultiSelect component", () => {
       CypressMountWithProviders(<stories.MultiSelectNestedInDialog />);
 
       dropdownButton().click();
-      commonDataElementInputPreview()
-        .type("{esc}", { force: true })
-        .then(() => {
-          selectList().should("not.be.visible");
-          alertDialogPreview().should("exist");
-        });
+      commonDataElementInputPreview().type("{esc}", { force: true });
+      selectList().should("not.be.visible");
+      alertDialogPreview().should("exist");
 
-      commonDataElementInputPreview()
-        .type("{esc}", { force: true })
-        .then(() => {
-          alertDialogPreview().should("not.exist");
-        });
+      commonDataElementInputPreview().type("{esc}", { force: true });
+      alertDialogPreview().should("not.exist");
     });
 
     it("should not refocus the select textbox when closing it by clicking outside", () => {
@@ -1016,9 +989,8 @@ context("Tests for MultiSelect component", () => {
     it("should pass accessibilty tests for MultiSelect", () => {
       CypressMountWithProviders(<stories.MultiSelectComponent />);
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     it.each(testData)(
@@ -1061,7 +1033,7 @@ context("Tests for MultiSelect component", () => {
       ["bottom", "0px", "0px", "0px", "0px"],
       ["left", "200px", "0px", "200px", "0px"],
       ["right", "200px", "0px", "0px", "200px"],
-    ])(
+    ] as [MultiSelectProps["tooltipPosition"], string, string, string, string][])(
       "should pass accessibilty tests for MultiSelect tooltip prop in the %s position",
       (tooltipPositionValue, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -1091,12 +1063,15 @@ context("Tests for MultiSelect component", () => {
       CypressMountWithProviders(<stories.MultiSelectComponent readOnly />);
 
       cy.checkAccessibility();
-      selectInput()
-        .click()
-        .then(() => cy.checkAccessibility());
+      selectInput().click();
+      cy.checkAccessibility();
     });
 
-    it.each([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE])(
+    it.each([
+      SIZE.SMALL,
+      SIZE.MEDIUM,
+      SIZE.LARGE,
+    ] as MultiSelectProps["size"][])(
       "should pass accessibilty tests for MultiSelect size prop",
       (size) => {
         CypressMountWithProviders(<stories.MultiSelectComponent size={size} />);
@@ -1124,9 +1099,9 @@ context("Tests for MultiSelect component", () => {
     });
 
     it.each([
-      ["flex", "399"],
-      ["flex", "400"],
-      ["block", "401"],
+      ["flex", 399],
+      ["flex", 400],
+      ["block", 401],
     ])(
       "should pass accessibilty tests for MultiSelect adaptiveLabelBreakpoint prop set as %s and viewport 400",
       (displayValue, breakpoint) => {
@@ -1143,7 +1118,7 @@ context("Tests for MultiSelect component", () => {
       }
     );
 
-    it.each(["right", "left"])(
+    it.each(["right", "left"] as MultiSelectProps["labelAlign"][])(
       "should pass accessibilty tests for MultiSelect labelAlign prop set as %s",
       (alignment) => {
         CypressMountWithProviders(
@@ -1155,9 +1130,9 @@ context("Tests for MultiSelect component", () => {
     );
 
     it.each([
-      ["10", "90"],
-      ["30", "70"],
-      ["80", "20"],
+      [10, 90],
+      [30, 70],
+      [80, 20],
     ])(
       "should pass accessibilty tests for MultiSelect labelWidth prop set as %s and inputWidth set as %s",
       (label, input) => {
@@ -1197,18 +1172,16 @@ context("Tests for MultiSelect component", () => {
     it("should pass accessibilty tests for MultiSelect openOnFocus prop", () => {
       CypressMountWithProviders(<stories.MultiSelectComponent openOnFocus />);
 
-      commonDataElementInputPreview()
-        .focus()
-        .then(() => cy.checkAccessibility());
+      commonDataElementInputPreview().focus();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for MultiSelect with object as value", () => {
       CypressMountWithProviders(<stories.MultiSelectObjectAsValueComponent />);
 
       dropdownButton().click();
-      selectListText(option2)
-        .click()
-        .then(() => cy.checkAccessibility());
+      selectListText(option2).click();
+      cy.checkAccessibility();
     });
 
     it.each([
@@ -1216,7 +1189,7 @@ context("Tests for MultiSelect component", () => {
       ["bottom", "600px", "0px", "0px", "20px"],
       ["left", "200px", "0px", "0px", "900px"],
       ["right", "200px", "0px", "500px", "20px"],
-    ])(
+    ] as [MultiSelectProps["listPlacement"], string, string, string, string][])(
       "should pass accessibilty tests for MultiSelect listPlacement and flipEnabled props",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -1244,17 +1217,15 @@ context("Tests for MultiSelect component", () => {
         </div>
       );
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for MultiSelect with multiple columns", () => {
       CypressMountWithProviders(<stories.MultiSelectMultiColumnsComponent />);
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     it.each(["3", "7"])(
@@ -1274,7 +1245,7 @@ context("Tests for MultiSelect component", () => {
       cy.checkAccessibility();
     });
 
-    it.each(["third", "fifth"])(
+    it.each([["third"], ["fifth"]] as ["third" | "fifth"][])(
       "should pass accessibilty tests for MultiSelect wrapPillText prop",
       (option) => {
         CypressMountWithProviders(
@@ -1293,17 +1264,15 @@ context("Tests for MultiSelect component", () => {
         <stories.MultiSelectWithManyOptionsAndVirtualScrolling />
       );
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for MultiSelect in nested dialog", () => {
       CypressMountWithProviders(<stories.MultiSelectNestedInDialog />);
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     // FE-5764

--- a/cypress/components/select/simple-select/simple-select.cy.tsx
+++ b/cypress/components/select/simple-select/simple-select.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
+import { SimpleSelectProps } from "../../../../src/components/select";
 import * as stories from "../../../../src/components/select/simple-select/simple-select-test.stories";
 import CypressMountWithProviders from "../../../support/component-helper/cypress-mount";
-
 import {
   getDataElementByValue,
   helpIcon,
@@ -9,7 +9,6 @@ import {
   commonDataElementInputPreview,
   body,
 } from "../../../locators";
-
 import {
   selectText,
   selectInput,
@@ -31,19 +30,17 @@ import {
   selectList,
 } from "../../../locators/select";
 import { alertDialogPreview } from "../../../locators/dialog";
-
 import { loader } from "../../../locators/loader";
-
 import {
   assertCssValueIsApproximately,
   verifyRequiredAsteriskForLabel,
 } from "../../../support/component-helper/common-steps";
-
 import { keyCode, positionOfElement } from "../../../support/helper";
 import { SIZE, CHARACTERS } from "../../../support/component-helper/constants";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testPropValue = CHARACTERS.STANDARD;
+const keyToTrigger = ["downarrow", "uparrow", "Space", "Home", "End"] as const;
 
 context("Tests for SimpleSelect component", () => {
   describe("check props for SimpleSelect component", () => {
@@ -119,7 +116,7 @@ context("Tests for SimpleSelect component", () => {
       ["bottom", "0px", "0px", "0px", "0px"],
       ["left", "200px", "0px", "200px", "0px"],
       ["right", "200px", "0px", "0px", "200px"],
-    ])(
+    ] as [SimpleSelectProps["tooltipPosition"], string, string, string, string][])(
       "should render the help tooltip in the %s position",
       (tooltipPositionValue, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -171,7 +168,7 @@ context("Tests for SimpleSelect component", () => {
       [SIZE.SMALL, "32px"],
       [SIZE.MEDIUM, "40px"],
       [SIZE.LARGE, "48px"],
-    ])(
+    ] as [SimpleSelectProps["size"], string][])(
       "should use %s as size and render SimpleSelect with %s as height",
       (size, height) => {
         CypressMountWithProviders(
@@ -207,7 +204,7 @@ context("Tests for SimpleSelect component", () => {
     it.each([
       ["right", "end"],
       ["left", "start"],
-    ])(
+    ] as [SimpleSelectProps["labelAlign"], string][])(
       "should use %s as labelAligment and render it with flex-%s as css properties",
       (alignment, cssProp) => {
         CypressMountWithProviders(
@@ -222,9 +219,9 @@ context("Tests for SimpleSelect component", () => {
     );
 
     it.each([
-      ["10", "90", 135, 1229],
-      ["30", "70", 409, 956],
-      ["80", "20", 1092, 273],
+      [10, 90, 135, 1229],
+      [30, 70, 409, 956],
+      [80, 20, 1092, 273],
     ])(
       "should use %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
       (label, input, labelRatio, inputRatio) => {
@@ -322,7 +319,7 @@ context("Tests for SimpleSelect component", () => {
       selectListWrapper().should("not.be.visible");
     });
 
-    it.each([["downarrow"], ["uparrow"], ["Space"], ["Home"], ["End"]])(
+    it.each([...keyToTrigger])(
       "should open the list when %s is pressed with Select input in focus",
       (key) => {
         CypressMountWithProviders(<stories.SimpleSelectComponent />);
@@ -535,7 +532,7 @@ context("Tests for SimpleSelect component", () => {
 
       selectText().click();
       selectListWrapper().should("be.visible");
-      selectListOptionGroup("1").should("have.text", "Group one");
+      selectListOptionGroup().should("have.text", "Group one");
     });
 
     it("should render option list with proper maxHeight value", () => {
@@ -554,7 +551,7 @@ context("Tests for SimpleSelect component", () => {
       ["bottom", "0px", "0px", "0px", "20px"],
       ["left", "200px", "0px", "500px", "20px"],
       ["right", "200px", "0px", "0px", "500px"],
-    ])(
+    ] as [SimpleSelectProps["listPlacement"], string, string, string, string][])(
       "should render list in %s position when margins are top %s, bottom %s, left %s and right %s",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -579,7 +576,7 @@ context("Tests for SimpleSelect component", () => {
       ["bottom", "600px", "0px", "0px", "20px"],
       ["left", "200px", "0px", "0px", "900px"],
       ["right", "200px", "0px", "500px", "20px"],
-    ])(
+    ] as [SimpleSelectProps["listPlacement"], string, string, string, string][])(
       "should flip list to opposite position when there is not enough space to render it in %s position",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -695,12 +692,8 @@ context("Tests for SimpleSelect component", () => {
   });
 
   describe("check events for SimpleSelect component", () => {
-    let callback;
-    beforeEach(() => {
-      callback = cy.stub();
-    });
-
     it("should call onChange event when a list option is selected", () => {
+      const callback: SimpleSelectProps["onChange"] = cy.stub().as("onChange");
       CypressMountWithProviders(
         <stories.SimpleSelectEventsComponent onChange={callback} />
       );
@@ -708,81 +701,65 @@ context("Tests for SimpleSelect component", () => {
       const position = "first";
 
       selectText().click();
-      selectOption(positionOfElement(position))
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      selectOption(positionOfElement(position)).click();
+      cy.get("@onChange").should("have.been.calledOnce");
     });
 
     it("should call onBlur event when the list is closed", () => {
+      const callback: SimpleSelectProps["onBlur"] = cy.stub().as("onBlur");
       CypressMountWithProviders(
         <stories.SimpleSelectComponent onBlur={callback} />
       );
 
       selectText().click();
-      commonDataElementInputPreview()
-        .blur()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      commonDataElementInputPreview().blur();
+      cy.get("@onBlur").should("have.been.calledOnce");
     });
 
     it("should call onClick event when mouse is clicked on text input", () => {
+      const callback: SimpleSelectProps["onClick"] = cy.stub().as("onClick");
       CypressMountWithProviders(
         <stories.SimpleSelectComponent onClick={callback} />
       );
 
-      commonDataElementInputPreview()
-        .realClick()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      commonDataElementInputPreview().realClick();
+      cy.get("@onClick").should("have.been.calledOnce");
     });
 
     it("should call onOpen when SimpleSelect is opened", () => {
+      const callback: SimpleSelectProps["onOpen"] = cy.stub().as("onOpen");
       CypressMountWithProviders(
         <stories.SimpleSelectComponent onOpen={callback} />
       );
 
-      commonDataElementInputPreview()
-        .realClick()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      commonDataElementInputPreview().realClick();
+      cy.get("@onOpen").should("have.been.calledOnce");
     });
 
     it("should call onFocus when SimpleSelect is brought into focus", () => {
+      const callback: SimpleSelectProps["onFocus"] = cy.stub().as("onFocus");
       CypressMountWithProviders(
         <stories.SimpleSelectComponent onFocus={callback} />
       );
 
-      commonDataElementInputPreview()
-        .focus()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(callback).to.have.been.calledOnce;
-        });
+      commonDataElementInputPreview().focus();
+      cy.get("@onFocus").should("have.been.calledOnce");
     });
 
-    it.each([["downarrow"], ["uparrow"]])(
+    it.each([keyToTrigger[0], keyToTrigger[1]])(
       "should call onKeyDown event when %s key is pressed",
       (key) => {
+        const callback: SimpleSelectProps["onKeyDown"] = cy
+          .stub()
+          .as("onKeyDown");
         CypressMountWithProviders(
           <stories.SimpleSelectComponent onKeyDown={callback} />
         );
 
         commonDataElementInputPreview()
           .focus()
-          .trigger("keydown", { ...keyCode(key), force: true })
-          .then(() => {
-            // eslint-disable-next-line no-unused-expressions
-            expect(callback).to.have.been.calledOnce;
-          });
+          .trigger("keydown", { ...keyCode(key), force: true });
+        cy.get("@onKeyDown").should("have.been.calledOnce");
       }
     );
   });
@@ -820,18 +797,12 @@ context("Tests for SimpleSelect component", () => {
       CypressMountWithProviders(<stories.SimpleSelectNestedInDialog />);
 
       selectText().click();
-      commonDataElementInputPreview()
-        .type("{esc}", { force: true })
-        .then(() => {
-          selectList().should("not.be.visible");
-          alertDialogPreview().should("exist");
-        });
+      commonDataElementInputPreview().type("{esc}", { force: true });
+      selectList().should("not.be.visible");
+      alertDialogPreview().should("exist");
 
-      commonDataElementInputPreview()
-        .type("{esc}", { force: true })
-        .then(() => {
-          alertDialogPreview().should("not.exist");
-        });
+      commonDataElementInputPreview().type("{esc}", { force: true });
+      alertDialogPreview().should("not.exist");
     });
 
     it("should not refocus the select textbox when closing it by clicking outside", () => {
@@ -849,9 +820,8 @@ context("Tests for SimpleSelect component", () => {
     it("should pass accessibilty tests for SimpleSelect", () => {
       CypressMountWithProviders(<stories.SimpleSelectComponent />);
 
-      dropdownButton()
-        .click()
-        .then(() => cy.checkAccessibility());
+      dropdownButton().click();
+      cy.checkAccessibility();
     });
 
     it.each(testData)(
@@ -894,7 +864,7 @@ context("Tests for SimpleSelect component", () => {
       ["bottom", "0px", "0px", "0px", "0px"],
       ["left", "200px", "0px", "200px", "0px"],
       ["right", "200px", "0px", "0px", "200px"],
-    ])(
+    ] as [SimpleSelectProps["tooltipPosition"], string, string, string, string][])(
       "should pass accessibilty tests for SimpleSelect tooltip prop in the %s position",
       (tooltipPositionValue, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -924,9 +894,8 @@ context("Tests for SimpleSelect component", () => {
       CypressMountWithProviders(<stories.SimpleSelectComponent readOnly />);
 
       cy.checkAccessibility();
-      selectText()
-        .click()
-        .then(() => cy.checkAccessibility());
+      selectText().click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for SimpleSelect transparent prop", () => {
@@ -935,7 +904,11 @@ context("Tests for SimpleSelect component", () => {
       cy.checkAccessibility();
     });
 
-    it.each([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE])(
+    it.each([
+      SIZE.SMALL,
+      SIZE.MEDIUM,
+      SIZE.LARGE,
+    ] as SimpleSelectProps["size"][])(
       "should pass accessibilty tests for SimpleSelect size prop",
       (size) => {
         CypressMountWithProviders(
@@ -964,7 +937,7 @@ context("Tests for SimpleSelect component", () => {
       cy.checkAccessibility();
     });
 
-    it.each(["right", "left"])(
+    it.each(["right", "left"] as SimpleSelectProps["labelAlign"][])(
       "should pass accessibilty tests for SimpleSelect labelAlign prop set as %s",
       (alignment) => {
         CypressMountWithProviders(
@@ -976,9 +949,9 @@ context("Tests for SimpleSelect component", () => {
     );
 
     it.each([
-      ["10", "90"],
-      ["30", "70"],
-      ["80", "20"],
+      [10, 90],
+      [30, 70],
+      [80, 20],
     ])(
       "should pass accessibilty tests for SimpleSelect labelWidth prop set as %s and inputWidth set as %s",
       (label, input) => {
@@ -1020,12 +993,10 @@ context("Tests for SimpleSelect component", () => {
         <stories.SimpleSelectWithInfiniteScrollComponent />
       );
 
-      selectText()
-        .click()
-        .then(() => cy.checkAccessibility());
-      selectListWrapper()
-        .scrollTo("bottom")
-        .then(() => cy.checkAccessibility());
+      selectText().click();
+      cy.checkAccessibility();
+      selectListWrapper().scrollTo("bottom");
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for SimpleSelect with multiple columns", () => {
@@ -1037,18 +1008,16 @@ context("Tests for SimpleSelect component", () => {
         ...keyCode("downarrow"),
         force: true,
       });
-      commonDataElementInputPreview()
-        .focus()
-        .then(() => cy.checkAccessibility());
+      commonDataElementInputPreview().focus();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for SimpleSelect with object as value", () => {
       CypressMountWithProviders(<stories.SimpleSelectObjectAsValueComponent />);
 
       selectText().click();
-      selectOption(positionOfElement("first"))
-        .click()
-        .then(() => cy.checkAccessibility());
+      selectOption(positionOfElement("first")).click();
+      cy.checkAccessibility();
     });
 
     it.each(["1", "2", "3"])(
@@ -1066,9 +1035,8 @@ context("Tests for SimpleSelect component", () => {
     it("should pass accessibilty tests for SimpleSelect group component", () => {
       CypressMountWithProviders(<stories.SimpleSelectGroupComponent />);
 
-      selectText()
-        .click()
-        .then(() => cy.checkAccessibility());
+      selectText().click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for SimpleSelect listMaxHeight prop", () => {
@@ -1076,9 +1044,8 @@ context("Tests for SimpleSelect component", () => {
         <stories.SimpleSelectComponent listMaxHeight={200} />
       );
 
-      selectText()
-        .click()
-        .then(() => cy.checkAccessibility());
+      selectText().click();
+      cy.checkAccessibility();
     });
 
     it.each([
@@ -1086,7 +1053,7 @@ context("Tests for SimpleSelect component", () => {
       ["bottom", "0px", "0px", "0px", "20px"],
       ["left", "200px", "0px", "500px", "20px"],
       ["right", "200px", "0px", "0px", "500px"],
-    ])(
+    ] as [SimpleSelectProps["listPlacement"], string, string, string, string][])(
       "should pass accessibilty tests for SimpleSelect listPlacement prop",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -1099,9 +1066,8 @@ context("Tests for SimpleSelect component", () => {
           />
         );
 
-        selectText()
-          .click()
-          .then(() => cy.checkAccessibility());
+        selectText().click();
+        cy.checkAccessibility();
       }
     );
 
@@ -1110,7 +1076,7 @@ context("Tests for SimpleSelect component", () => {
       ["bottom", "600px", "0px", "0px", "20px"],
       ["left", "200px", "0px", "0px", "900px"],
       ["right", "200px", "0px", "500px", "20px"],
-    ])(
+    ] as [SimpleSelectProps["listPlacement"], string, string, string, string][])(
       "should pass accessibilty tests for SimpleSelect flipEnabled prop",
       (position, top, bottom, left, right) => {
         CypressMountWithProviders(
@@ -1124,9 +1090,8 @@ context("Tests for SimpleSelect component", () => {
           />
         );
 
-        selectText()
-          .click()
-          .then(() => cy.checkAccessibility());
+        selectText().click();
+        cy.checkAccessibility();
       }
     );
 
@@ -1148,9 +1113,8 @@ context("Tests for SimpleSelect component", () => {
         <stories.SimpleSelectWithLongWrappingTextComponent />
       );
 
-      selectText()
-        .click()
-        .then(() => cy.checkAccessibility());
+      selectText().click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for SimpleSelect with virtual scrolling", () => {
@@ -1158,17 +1122,15 @@ context("Tests for SimpleSelect component", () => {
         <stories.SimpleSelectWithManyOptionsAndVirtualScrolling />
       );
 
-      selectText()
-        .click()
-        .then(() => cy.checkAccessibility());
+      selectText().click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for SimpleSelect in nested dialog", () => {
       CypressMountWithProviders(<stories.SimpleSelectNestedInDialog />);
 
-      selectText()
-        .click()
-        .then(() => cy.checkAccessibility());
+      selectText().click();
+      cy.checkAccessibility();
     });
   });
 });

--- a/src/components/select/filterable-select/filterable-select-test.stories.tsx
+++ b/src/components/select/filterable-select/filterable-select-test.stories.tsx
@@ -46,7 +46,9 @@ export const DefaultStory = () => (
 
 DefaultStory.storyName = "default";
 
-export const FilterableSelectComponent = ({ ...props }) => {
+export const FilterableSelectComponent = (
+  props: Partial<FilterableSelectProps>
+) => {
   const [value, setValue] = React.useState("");
 
   function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
@@ -76,7 +78,9 @@ export const FilterableSelectComponent = ({ ...props }) => {
   );
 };
 
-export const FilterableSelectWithLazyLoadingComponent = ({ ...props }) => {
+export const FilterableSelectWithLazyLoadingComponent = (
+  props: Partial<FilterableSelectProps>
+) => {
   const preventLoading = React.useRef(false);
   const [value, setValue] = React.useState("black");
   const [isLoading, setIsLoading] = React.useState(true);
@@ -122,7 +126,9 @@ export const FilterableSelectWithLazyLoadingComponent = ({ ...props }) => {
   );
 };
 
-export const FilterableSelectLazyLoadTwiceComponent = ({ ...props }) => {
+export const FilterableSelectLazyLoadTwiceComponent = (
+  props: Partial<FilterableSelectProps>
+) => {
   const preventLoading = React.useRef(false);
   const [value, setValue] = useState("");
   const [isLoading, setIsLoading] = useState(true);
@@ -171,7 +177,9 @@ export const FilterableSelectLazyLoadTwiceComponent = ({ ...props }) => {
   );
 };
 
-export const FilterableSelectWithInfiniteScrollComponent = ({ ...props }) => {
+export const FilterableSelectWithInfiniteScrollComponent = (
+  props: Partial<FilterableSelectProps>
+) => {
   const preventLoading = React.useRef(false);
   const preventLazyLoading = React.useRef(false);
   const lazyLoadingCounter = React.useRef(0);
@@ -255,7 +263,9 @@ export const FilterableSelectWithInfiniteScrollComponent = ({ ...props }) => {
   );
 };
 
-export const FilterableSelectObjectAsValueComponent = ({ ...props }) => {
+export const FilterableSelectObjectAsValueComponent = (
+  props: Partial<FilterableSelectProps>
+) => {
   const [value, setValue] = useState<Record<string, unknown>>({
     id: "Green",
     value: 5,
@@ -374,7 +384,9 @@ export const FilterableSelectObjectAsValueComponent = ({ ...props }) => {
   );
 };
 
-export const FilterableSelectMultiColumnsComponent = ({ ...props }) => {
+export const FilterableSelectMultiColumnsComponent = (
+  props: Partial<FilterableSelectProps>
+) => {
   return (
     <FilterableSelect
       multiColumn
@@ -417,7 +429,9 @@ export const FilterableSelectMultiColumnsComponent = ({ ...props }) => {
   );
 };
 
-export const FilterableSelectMultiColumnsNestedComponent = ({ ...props }) => {
+export const FilterableSelectMultiColumnsNestedComponent = (
+  props: Partial<FilterableSelectProps>
+) => {
   return (
     <FilterableSelect
       multiColumn
@@ -525,7 +539,7 @@ export const FilterableSelectWithActionButtonComponent = () => {
 export const FilterableSelectOnChangeEventComponent = ({
   onChange,
   ...props
-}: FilterableSelectProps) => {
+}: Partial<FilterableSelectProps>) => {
   const [state, setState] = React.useState("");
 
   const setValue = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -552,7 +566,9 @@ export const FilterableSelectOnChangeEventComponent = ({
   );
 };
 
-export const FilterableSelectListActionEventComponent = ({ ...props }) => {
+export const FilterableSelectListActionEventComponent = (
+  props: Partial<FilterableSelectProps>
+) => {
   const [value, setValue] = React.useState("");
 
   return (

--- a/src/components/select/multi-select/multi-select-test.stories.tsx
+++ b/src/components/select/multi-select/multi-select-test.stories.tsx
@@ -59,7 +59,7 @@ export const Default = () => {
 
 Default.storyName = "default";
 
-export const MultiSelectComponent = ({ ...props }) => {
+export const MultiSelectComponent = (props: Partial<MultiSelectProps>) => {
   const [value, setValue] = useState<string[]>([]);
   function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
     setValue((event.target.value as unknown) as string[]);
@@ -88,7 +88,9 @@ export const MultiSelectComponent = ({ ...props }) => {
   );
 };
 
-export const MultiSelectDefaultValueComponent = ({ ...props }) => {
+export const MultiSelectDefaultValueComponent = (
+  props: Partial<MultiSelectProps>
+) => {
   return (
     <MultiSelect label="color" labelInline {...props}>
       <Option text="Amber" value="1" />
@@ -106,7 +108,9 @@ export const MultiSelectDefaultValueComponent = ({ ...props }) => {
   );
 };
 
-export const MultiSelectLongPillComponent = ({ ...props }) => {
+export const MultiSelectLongPillComponent = (
+  props: Partial<MultiSelectProps>
+) => {
   const [value, setValue] = useState<string[]>([]);
   function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
     setValue((event.target.value as unknown) as string[]);
@@ -141,7 +145,9 @@ export const MultiSelectLongPillComponent = ({ ...props }) => {
   );
 };
 
-export const MultiSelectWithLazyLoadingComponent = ({ ...props }) => {
+export const MultiSelectWithLazyLoadingComponent = (
+  props: Partial<MultiSelectProps>
+) => {
   const preventLoading = React.useRef(false);
   const [value, setValue] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -185,7 +191,9 @@ export const MultiSelectWithLazyLoadingComponent = ({ ...props }) => {
   );
 };
 
-export const MultiSelectLazyLoadTwiceComponent = ({ ...props }) => {
+export const MultiSelectLazyLoadTwiceComponent = (
+  props: Partial<MultiSelectProps>
+) => {
   const preventLoading = React.useRef(false);
   const [value, setValue] = useState<string[]>([]);
   const [isLoading, setIsLoading] = React.useState(true);
@@ -237,7 +245,9 @@ export const MultiSelectLazyLoadTwiceComponent = ({ ...props }) => {
   );
 };
 
-export const MultiSelectObjectAsValueComponent = ({ ...props }) => {
+export const MultiSelectObjectAsValueComponent = (
+  props: Partial<MultiSelectProps>
+) => {
   const [value, setValue] = useState<Record<string, unknown>[]>([
     { id: "Green", value: 5, text: "Green" },
   ]);
@@ -355,7 +365,9 @@ export const MultiSelectObjectAsValueComponent = ({ ...props }) => {
   );
 };
 
-export const MultiSelectMultiColumnsComponent = ({ ...props }) => {
+export const MultiSelectMultiColumnsComponent = (
+  props: Partial<MultiSelectProps>
+) => {
   return (
     <MultiSelect
       multiColumn
@@ -398,7 +410,9 @@ export const MultiSelectMultiColumnsComponent = ({ ...props }) => {
   );
 };
 
-export const MultiSelectMaxOptionsComponent = ({ ...props }) => {
+export const MultiSelectMaxOptionsComponent = (
+  props: Partial<MultiSelectProps>
+) => {
   const maxSelectionsAllowed = 2;
   const [selectedPills, setSelectedPills] = useState<string[]>([]);
 
@@ -435,7 +449,7 @@ export const MultiSelectMaxOptionsComponent = ({ ...props }) => {
 export const MultiSelectOnFilterChangeEventComponent = ({
   onChange,
   ...props
-}: MultiSelectProps) => {
+}: Partial<MultiSelectProps>) => {
   const [state, setState] = useState<string[]>([]);
 
   const setValue = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -462,7 +476,9 @@ export const MultiSelectOnFilterChangeEventComponent = ({
   );
 };
 
-export const MultiSelectCustomColorComponent = ({ ...props }) => {
+export const MultiSelectCustomColorComponent = (
+  props: Partial<MultiSelectProps>
+) => {
   return (
     <MultiSelect label="color" labelInline defaultValue={["1", "3"]} {...props}>
       <Option text="Amber" value="1" borderColor="#FFBF00" fill />

--- a/src/components/select/simple-select/simple-select-test.stories.tsx
+++ b/src/components/select/simple-select/simple-select-test.stories.tsx
@@ -166,7 +166,7 @@ export const DelayedReposition = () => {
 
 DelayedReposition.storyName = "delayed reposition";
 
-export const SimpleSelectComponent = ({ ...props }) => {
+export const SimpleSelectComponent = (props: Partial<SimpleSelectProps>) => {
   const [value, setValue] = React.useState("");
 
   function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
@@ -199,7 +199,9 @@ export const SimpleSelectComponent = ({ ...props }) => {
   );
 };
 
-export const SimpleSelectWithLazyLoadingComponent = ({ ...props }) => {
+export const SimpleSelectWithLazyLoadingComponent = (
+  props: Partial<SimpleSelectProps>
+) => {
   const preventLoading = React.useRef(false);
   const [value, setValue] = React.useState("black");
   const [isLoading, setIsLoading] = React.useState(true);
@@ -247,7 +249,9 @@ export const SimpleSelectWithLazyLoadingComponent = ({ ...props }) => {
   );
 };
 
-export const SimpleSelectWithInfiniteScrollComponent = ({ ...props }) => {
+export const SimpleSelectWithInfiniteScrollComponent = (
+  props: Partial<SimpleSelectProps>
+) => {
   const preventLoading = React.useRef(false);
   const preventLazyLoading = React.useRef(false);
   const lazyLoadingCounter = React.useRef(0);
@@ -335,7 +339,9 @@ export const SimpleSelectWithInfiniteScrollComponent = ({ ...props }) => {
   );
 };
 
-export const SimpleSelectObjectAsValueComponent = ({ ...props }) => {
+export const SimpleSelectObjectAsValueComponent = (
+  props: Partial<SimpleSelectProps>
+) => {
   const [value, setValue] = useState<Record<string, unknown>>({
     id: "Green",
     value: 5,
@@ -460,7 +466,9 @@ export const SimpleSelectObjectAsValueComponent = ({ ...props }) => {
   );
 };
 
-export const SimpleSelectMultipleColumnsComponent = ({ ...props }) => {
+export const SimpleSelectMultipleColumnsComponent = (
+  props: Partial<SimpleSelectProps>
+) => {
   return (
     <SimpleSelect
       name="withMultipleColumns"
@@ -505,7 +513,9 @@ export const SimpleSelectMultipleColumnsComponent = ({ ...props }) => {
   );
 };
 
-export const SimpleSelectCustomOptionChildrenComponent = ({ ...props }) => {
+export const SimpleSelectCustomOptionChildrenComponent = (
+  props: Partial<SimpleSelectProps>
+) => {
   return (
     <SimpleSelect
       name="customOptionChildren"
@@ -528,7 +538,9 @@ export const SimpleSelectCustomOptionChildrenComponent = ({ ...props }) => {
   );
 };
 
-export const SimpleSelectGroupComponent = ({ ...props }) => {
+export const SimpleSelectGroupComponent = (
+  props: Partial<SimpleSelectProps>
+) => {
   return (
     <SimpleSelect name="optGroups" id="optGroups" {...props}>
       <OptionGroupHeader label="Group one" icon="individual" />
@@ -552,7 +564,7 @@ export const SimpleSelectGroupComponent = ({ ...props }) => {
 export const SimpleSelectEventsComponent = ({
   onChange,
   ...props
-}: SimpleSelectProps) => {
+}: Partial<SimpleSelectProps>) => {
   const [state, setState] = useState("");
 
   const setValue = (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
### Proposed behaviour

- Rename the `multi-select.cy.js`, `filterable-select.cy.js`, `simple-select.cy.js` to `multi-select.cy.tsx`, `filterable-select.cy.tsx`, `simple-select.cy.tsx` file in `./cypress/components/select/` folder.
- Refactor tests to Typescript.  

### Current behaviour

`Select` tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the `multi-select.cy.tsx`, `filterable-select.cy.tsx`, `simple-select.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed
<!-- Add CodeSandbox here -->