### PR TITLE
test(tooltip): typescript refactor

### DIFF
--- a/cypress/components/tooltip/tooltip.cy.tsx
+++ b/cypress/components/tooltip/tooltip.cy.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
+import { TooltipProps } from "../../../src/components/tooltip";
 import * as testStories from "../../../src/components/tooltip/tooltip-test.stories";
 import * as stories from "../../../src/components/tooltip/tooltip.stories";
 import {
@@ -14,6 +15,7 @@ import {
 } from "../../support/component-helper/constants";
 import { assertCssValueIsApproximately } from "../../support/component-helper/common-steps";
 import { getDataElementByValue } from "../../locators";
+import { TooltipPositions } from "../../../src/components/tooltip/tooltip.config";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const backgroundColors = [COLOR.ORANGE, COLOR.RED, COLOR.BLACK, COLOR.BROWN];
@@ -48,12 +50,12 @@ context("Tests for Tooltip component", () => {
       }
     );
 
-    it.each(["bottom", "left", "right", "top"])(
+    it.each(["bottom", "left", "right", "top"] as TooltipProps["position"][])(
       "should check %s position of tooltip for Tooltip component",
       (position) => {
         CypressMountWithProviders(
           <testStories.TooltipComponent position={position}>
-            {`This tooltip is positioned ${position}`}
+            <>{`This tooltip is positioned ${position}`}</>
           </testStories.TooltipComponent>
         );
         tooltipPreview().should("be.visible").and("have.css", position);
@@ -91,10 +93,13 @@ context("Tests for Tooltip component", () => {
     it.each([
       [SIZE.MEDIUM, 14],
       [SIZE.LARGE, 16],
-    ])("should check %s size for Tooltip component", (size, fontSize) => {
-      CypressMountWithProviders(<testStories.TooltipComponent size={size} />);
-      tooltipPreview().should("have.css", "font-size", `${fontSize}px`);
-    });
+    ] as [TooltipProps["size"], number][])(
+      "should check %s size for Tooltip component",
+      (size, fontSize) => {
+        CypressMountWithProviders(<testStories.TooltipComponent size={size} />);
+        tooltipPreview().should("have.css", "font-size", `${fontSize}px`);
+      }
+    );
 
     it.each([
       ["left", "bottom", "top"],
@@ -107,7 +112,7 @@ context("Tests for Tooltip component", () => {
       ["top", "right", "top"],
       ["right", "bottom", "right"],
       ["right", "top", "right"],
-    ])(
+    ] as [TooltipPositions, TooltipProps["position"], Cypress.PositionType][])(
       "should check flip position to the %s when tooltip position is %s and scrolling to the %s side for Tooltip component",
       (flipPosition, tooltipPosition, scrollPosition) => {
         CypressMountWithProviders(
@@ -124,31 +129,30 @@ context("Tests for Tooltip component", () => {
       }
     );
 
-    describe.each(["top", "bottom", "right", "left"])(
-      "when tooltip has %s position and",
-      (position) => {
-        it.each([
-          [SIZE.SMALL, { top: 15, bottom: 631, left: 47, right: 1040 }],
-          [SIZE.MEDIUM, { top: 14, bottom: 630, left: 44, right: 1037 }],
-          [SIZE.LARGE, { top: 10, bottom: 626, left: 40, right: 1033 }],
-        ])(
-          "when inputSize is %s should have correct styles applied",
-          (inputSize, offset) => {
-            CypressMountWithProviders(
-              <testStories.TooltipComponent
-                isPartOfInput
-                inputSize={inputSize}
-                position={position}
-              />
-            );
-            tooltipPreview().then(($el) => {
-              assertCssValueIsApproximately($el, position, offset[position]);
-              Cypress.dom.isVisible($el);
-            });
-          }
-        );
-      }
-    );
+    describe.each(["top", "bottom", "right", "left"] as NonNullable<
+      TooltipProps["position"]
+    >[])("when tooltip has %s position and", (position) => {
+      it.each([
+        [SIZE.SMALL, { top: 15, bottom: 631, left: 47, right: 1040 }],
+        [SIZE.MEDIUM, { top: 14, bottom: 630, left: 44, right: 1037 }],
+        [SIZE.LARGE, { top: 10, bottom: 626, left: 40, right: 1033 }],
+      ] as [TooltipProps["inputSize"], { top: number; bottom: number; left: number; right: number }][])(
+        "when inputSize is %s should have correct styles applied",
+        (inputSize, offset) => {
+          CypressMountWithProviders(
+            <testStories.TooltipComponent
+              isPartOfInput
+              inputSize={inputSize}
+              position={position}
+            />
+          );
+          tooltipPreview().then(($el) => {
+            assertCssValueIsApproximately($el, position, offset[position]);
+            Cypress.dom.isVisible($el);
+          });
+        }
+      );
+    });
 
     it("should show tooltip when target is hovered", () => {
       CypressMountWithProviders(<testStories.UncontrolledTooltipComponent />);
@@ -207,18 +211,15 @@ context("Tests for Tooltip component", () => {
     it("should pass accessibilty tests for Tooltip Default story", () => {
       CypressMountWithProviders(<stories.Default />);
 
-      getDataElementByValue("main-text")
-        .click()
-        .then(() => cy.checkAccessibility());
+      getDataElementByValue("main-text").click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for Tooltip Controlled story", () => {
       CypressMountWithProviders(<stories.Controlled />);
 
-      getDataElementByValue("main-text")
-        .eq(0)
-        .click()
-        .then(() => cy.checkAccessibility());
+      getDataElementByValue("main-text").eq(0).click();
+      cy.checkAccessibility();
     });
 
     it.each([
@@ -231,10 +232,8 @@ context("Tests for Tooltip component", () => {
       (position, button) => {
         CypressMountWithProviders(<stories.Positioning />);
 
-        getDataElementByValue("main-text")
-          .eq(button)
-          .click()
-          .then(() => cy.checkAccessibility());
+        getDataElementByValue("main-text").eq(button).click();
+        cy.checkAccessibility();
       }
     );
 
@@ -247,45 +246,29 @@ context("Tests for Tooltip component", () => {
     it("should pass accessibilty tests for Tooltip LargeTooltip story", () => {
       CypressMountWithProviders(<stories.LargeTooltip />);
 
-      getDataElementByValue("main-text")
-        .click()
-        .then(() => cy.checkAccessibility());
+      getDataElementByValue("main-text").click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for Tooltip Types story", () => {
       CypressMountWithProviders(<stories.Types />);
 
-      getDataElementByValue("main-text")
-        .eq(1)
-        .click()
-        .then(() => {
-          // eslint-disable-next-line no-unused-expressions
-          getDataElementByValue("main-text")
-            .eq(2)
-            .click()
-            .then(() => cy.checkAccessibility());
-        });
+      getDataElementByValue("main-text").eq(1).click();
+
+      getDataElementByValue("main-text").eq(2).click();
+      cy.checkAccessibility();
     });
 
     it("should pass accessibilty tests for Tooltip ColorOverrides story", () => {
       CypressMountWithProviders(<stories.ColorOverrides />);
 
-      getDataElementByValue("main-text")
-        .click()
-        .then(() => cy.checkAccessibility());
+      getDataElementByValue("main-text").click();
+      cy.checkAccessibility();
     });
 
-    it("should pass accessibilty tests for Tooltip ColorOverrides story", () => {
-      CypressMountWithProviders(<stories.ColorOverrides />);
-
-      getDataElementByValue("main-text")
-        .click()
-        .then(() => cy.checkAccessibility());
+    it("should render the Tooltip with the expected border radius styling", () => {
+      CypressMountWithProviders(<testStories.TooltipComponent />);
+      tooltipPreview().should("have.css", "border-radius", "4px");
     });
-  });
-
-  it("should render the Tooltip with the expected border radius styling", () => {
-    CypressMountWithProviders(<testStories.TooltipComponent />);
-    tooltipPreview().should("have.css", "border-radius", "4px");
   });
 });

--- a/src/components/tooltip/tooltip-test.stories.tsx
+++ b/src/components/tooltip/tooltip-test.stories.tsx
@@ -150,7 +150,10 @@ const SecondaryButton = forwardRef<HTMLButtonElement, ButtonProps>(
 );
 SecondaryButton.displayName = "Tooltip";
 
-export const TooltipComponent = ({ message, ...props }: TooltipProps) => (
+export const TooltipComponent = ({
+  message,
+  ...props
+}: Partial<TooltipProps>) => (
   <div
     style={{
       padding: "60px 60px 60px 160px",

--- a/src/components/tooltip/tooltip.stories.tsx
+++ b/src/components/tooltip/tooltip.stories.tsx
@@ -1,12 +1,10 @@
 import React, { forwardRef, useState } from "react";
-import { ComponentStory } from "@storybook/react";
-
 import Tooltip from ".";
 import Button, { ButtonProps } from "../button";
 import Box from "../box";
 import { TooltipPositions } from "./tooltip.config";
 
-export const Default: ComponentStory<typeof Tooltip> = () => {
+export const Default = () => {
   const Component = forwardRef<HTMLButtonElement, ButtonProps>(
     ({ children }: ButtonProps, ref) => (
       <Button buttonType="primary" ref={ref}>
@@ -24,7 +22,7 @@ export const Default: ComponentStory<typeof Tooltip> = () => {
   );
 };
 
-export const Controlled: ComponentStory<typeof Tooltip> = () => {
+export const Controlled = () => {
   const [isVisible, setIsVisible] = useState(false);
   const Component = forwardRef<HTMLButtonElement, ButtonProps>(
     ({ children }: ButtonProps, ref) => (
@@ -48,7 +46,7 @@ export const Controlled: ComponentStory<typeof Tooltip> = () => {
   );
 };
 
-export const Positioning: ComponentStory<typeof Tooltip> = () => {
+export const Positioning = () => {
   const [position, setPosition] = useState<TooltipPositions>("top");
   const Component = forwardRef<HTMLButtonElement, ButtonProps>(
     ({ children }: ButtonProps, ref) => (
@@ -75,7 +73,7 @@ export const Positioning: ComponentStory<typeof Tooltip> = () => {
   );
 };
 
-export const FlipBehviourOverrides: ComponentStory<typeof Tooltip> = () => {
+export const FlipBehviourOverrides = () => {
   const Component = forwardRef<HTMLButtonElement, ButtonProps>(
     ({ children }: ButtonProps, ref) => (
       <Button buttonType="primary" ref={ref}>
@@ -98,7 +96,7 @@ export const FlipBehviourOverrides: ComponentStory<typeof Tooltip> = () => {
   );
 };
 
-export const LargeTooltip: ComponentStory<typeof Tooltip> = () => {
+export const LargeTooltip = () => {
   const Component = forwardRef<HTMLButtonElement, ButtonProps>(
     ({ children }: ButtonProps, ref) => (
       <Button buttonType="primary" ref={ref}>
@@ -116,7 +114,7 @@ export const LargeTooltip: ComponentStory<typeof Tooltip> = () => {
   );
 };
 
-export const Types: ComponentStory<typeof Tooltip> = () => {
+export const Types = () => {
   const [type, setType] = useState<string | undefined>(undefined);
   const Component = forwardRef<HTMLButtonElement, ButtonProps>(
     ({ children }: ButtonProps, ref) => (
@@ -141,7 +139,7 @@ export const Types: ComponentStory<typeof Tooltip> = () => {
   );
 };
 
-export const ColorOverrides: ComponentStory<typeof Tooltip> = () => {
+export const ColorOverrides = () => {
   const Component = forwardRef<HTMLButtonElement, ButtonProps>(
     ({ children }: ButtonProps, ref) => (
       <Button buttonType="primary" ref={ref}>


### PR DESCRIPTION
### Proposed behaviour
- Rename the `tooltip.cy.js` to `tooltip.cy.tsx` file in `./cypress/components/tooltip/` folder.
- Refactor tests to Typescript.  

### Current behaviour

Currently Tooltip component is in JS not in TS.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the`tooltip.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other *.cy.tsx files have regressed


<!-- Add CodeSandbox here -->
