### PR TITLE
chore: disable storybook telemetry

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,12 +12,16 @@ const getStories = () =>
   });
 
 module.exports = {
+  framework: "@storybook/react",
   stories: (list) => [
     ...list,
     "./welcome-page/welcome.stories.js",
     "../docs/*.stories.mdx",
     ...getStories(),
   ],
+  core: {
+    disableTelemetry: true,
+  },
   addons: [
     "@storybook/addon-actions",
     "@storybook/addon-docs",


### PR DESCRIPTION
### Proposed behaviour

- Explicitly opt-out of telemetry in main storybook config

### Current behaviour

- Carbon is currently opted-in for Storybook to collect data about how its used in Carbon. For more details, [see this full list of information Storybook collects](https://storybook.js.org/docs/react/configure/telemetry#how-to-opt-out). 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
