### PR TITLE
test(password): refactor to ts

### DIFF
--- a/cypress/components/password/password.cy.tsx
+++ b/cypress/components/password/password.cy.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import Password from "../../../src/components/password/password.component";
+import { PasswordProps } from "../../../src/components/password/password.component";
+import { PasswordComponent } from "../../../src/components/password/password-test.stories";
 import * as stories from "../../../src/components/password/password.stories";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import {
@@ -19,22 +20,6 @@ const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const transparent = "rgba(0, 0, 0, 0)";
 const colorsActionMinor500 = "rgb(51, 91, 112)";
 const colorsUtilityMajor300 = "rgb(102, 132, 148)";
-
-// eslint-disable-next-line react/prop-types
-const PasswordComponent = ({ onChange, ...props }) => {
-  const [state, setState] = React.useState("test");
-
-  const setValue = (ev) => {
-    setState(ev.target.value);
-    if (onChange) {
-      onChange(ev);
-    }
-  };
-
-  return (
-    <Password label="Password" value={state} onChange={setValue} {...props} />
-  );
-};
 
 context("Tests for Password component", () => {
   describe("check Password specific props", () => {
@@ -57,13 +42,8 @@ context("Tests for Password component", () => {
     it("input type should change from password to text on click", () => {
       CypressMountWithProviders(<PasswordComponent />);
 
-      buttonMinorComponent()
-        .click()
-        .then(() => {
-          getDataElementByValue("input")
-            .eq(0)
-            .should("have.attr", "type", "text");
-        });
+      buttonMinorComponent().click();
+      getDataElementByValue("input").eq(0).should("have.attr", "type", "text");
     });
 
     it("autoComplete attribute is 'off'", () => {
@@ -114,11 +94,8 @@ context("Tests for Password component", () => {
     it("iconType should change from 'view' to 'hide' onClick", () => {
       CypressMountWithProviders(<PasswordComponent />);
 
-      buttonMinorComponent()
-        .click()
-        .then(() => {
-          icon().should("have.attr", "type", "hide");
-        });
+      buttonMinorComponent().click();
+      icon().should("have.attr", "type", "hide");
     });
 
     it("default iconPosition should be 'before'", () => {
@@ -140,11 +117,8 @@ context("Tests for Password component", () => {
     it("label should change from 'Show' to 'Hide' onClick", () => {
       CypressMountWithProviders(<PasswordComponent />);
 
-      buttonMinorComponent()
-        .click()
-        .then(() => {
-          buttonMinorComponent().contains("Hide");
-        });
+      buttonMinorComponent().click();
+      buttonMinorComponent().contains("Hide");
     });
 
     it("default aria-label should be 'Show password'", () => {
@@ -156,15 +130,8 @@ context("Tests for Password component", () => {
     it("aria-label should change from 'Show password' to 'Hide password' onClick", () => {
       CypressMountWithProviders(<PasswordComponent />);
 
-      buttonMinorComponent()
-        .click()
-        .then(() => {
-          buttonMinorComponent().should(
-            "have.attr",
-            "aria-label",
-            "Hide password"
-          );
-        });
+      buttonMinorComponent().click();
+      buttonMinorComponent().should("have.attr", "aria-label", "Hide password");
     });
 
     it("buttonType is 'tertiary', when in password default styling should be correct", () => {
@@ -176,59 +143,51 @@ context("Tests for Password component", () => {
         .and("have.css", "color", colorsActionMinor500);
       buttonMinorComponent()
         .getDesignTokensByCssProperty("color")
-        .should(($el) => {
-          expect($el[1]).to.deep.equal("--colorsActionMinor500");
-        });
+        .as("colorToken");
+
+      cy.get("@colorToken").its("1").should("equal", "--colorsActionMinor500");
     });
 
     it("buttonType is 'tertiary', when in password default styling should be correct onHover", () => {
       CypressMountWithProviders(<PasswordComponent />);
 
+      buttonMinorComponent().realHover();
       buttonMinorComponent()
-        .realHover()
-        .then(() => {
-          buttonMinorComponent()
-            .should("be.visible")
-            .and("have.css", "background-color", transparent)
-            .and("have.css", "color", colorsActionMinor500);
-          buttonMinorComponent()
-            .getDesignTokensByCssProperty("color")
-            .then(($el) => {
-              expect($el[2]).to.equal("--colorsActionMinor500");
-            });
-        });
+        .should("be.visible")
+        .and("have.css", "background-color", transparent)
+        .and("have.css", "color", colorsActionMinor500);
+      buttonMinorComponent()
+        .getDesignTokensByCssProperty("color")
+        .as("colorToken");
+
+      cy.get("@colorToken").its("2").should("equal", "--colorsActionMinor500");
 
       // reset the hover state
       cyRoot().realHover({ position: "topLeft" });
     });
 
-    it("icon color is 'colorsActionMajorYang300'", () => {
+    it("icon color is 'colorsUtilityMajor300'", () => {
       CypressMountWithProviders(<PasswordComponent />);
 
       icon()
         .should("be.visible")
         .and("have.css", "color", colorsUtilityMajor300);
-      icon()
-        .getDesignTokensByCssProperty("color")
-        .should(($el) => {
-          expect($el[3]).to.equal("--colorsUtilityMajor300");
-        });
+      icon().getDesignTokensByCssProperty("color").as("colorToken");
+
+      cy.get("@colorToken").its("3").should("equal", "--colorsUtilityMajor300");
     });
 
-    it("icon color is 'colorsActionMajorYang300' onHover'", () => {
+    it("icon color is 'colorsUtilityMajor300' onHover'", () => {
       CypressMountWithProviders(<PasswordComponent />);
 
-      buttonMinorComponent()
-        .realHover()
-        .then(() => {
-          icon()
-            .should("be.visible")
-            .and("have.css", "color", colorsUtilityMajor300)
-            .getDesignTokensByCssProperty("color")
-            .should(($el) => {
-              expect($el[4]).to.equal("--colorsUtilityMajor300");
-            });
-        });
+      buttonMinorComponent().realHover();
+      icon()
+        .should("be.visible")
+        .and("have.css", "color", colorsUtilityMajor300)
+        .getDesignTokensByCssProperty("color")
+        .as("colorToken");
+
+      cy.get("@colorToken").its("4").should("equal", "--colorsUtilityMajor300");
 
       // reset the hover state
       cyRoot().realHover({ position: "topLeft" });
@@ -245,13 +204,10 @@ context("Tests for Password component", () => {
     it("when user clicks to show password, aria-live region should contain the correct text", () => {
       CypressMountWithProviders(<PasswordComponent />);
 
-      buttonMinorComponent()
-        .click()
-        .then(() => {
-          cy.get("p").contains(
-            "Your password has been shown. Focus on the password input to have it read to you, if it is safe to do so."
-          );
-        });
+      buttonMinorComponent().click();
+      cy.get("p").contains(
+        "Your password has been shown. Focus on the password input to have it read to you, if it is safe to do so."
+      );
     });
 
     it("aria-live region text should be visually hidden", () => {
@@ -274,7 +230,7 @@ context("Tests for Password component", () => {
       [SIZE.SMALL, "32px"],
       [SIZE.MEDIUM, "40px"],
       [SIZE.LARGE, "48px"],
-    ])(
+    ] as [PasswordProps["size"], string][])(
       "should use %s as size and render it with %s as height",
       (size, height) => {
         CypressMountWithProviders(<PasswordComponent size={size} />);
@@ -347,7 +303,7 @@ context("Tests for Password component", () => {
     it.each([
       ["right", "end"],
       ["left", "start"],
-    ])(
+    ] as [PasswordProps["labelAlign"], string][])(
       "should use %s as labelAligment and render it with %s as css properties",
       (alignment, cssProp) => {
         CypressMountWithProviders(

--- a/src/components/password/password-test.stories.tsx
+++ b/src/components/password/password-test.stories.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from "react";
+import Password, { PasswordProps } from ".";
+
+export default {
+  title: "Password/Test",
+  includeStories: ["Default"],
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+  argTypes: {
+    labelInline: {
+      control: {
+        type: "boolean",
+      },
+    },
+    labelAlign: {
+      options: ["left", "right"],
+      control: {
+        type: "select",
+      },
+    },
+    inputWidth: {
+      control: {
+        min: 0,
+        max: 100,
+        step: 1,
+        type: "range",
+      },
+    },
+    labelWidth: {
+      control: {
+        min: 0,
+        max: 100,
+        step: 1,
+        type: "range",
+      },
+    },
+    value: {
+      control: {
+        type: "text",
+      },
+    },
+    error: {
+      control: {
+        type: "text",
+      },
+    },
+    warning: {
+      control: {
+        type: "text",
+      },
+    },
+    info: {
+      control: {
+        type: "text",
+      },
+    },
+    characterLimit: {
+      control: {
+        type: "number",
+      },
+    },
+    maxWidth: {
+      control: {
+        type: "text",
+      },
+    },
+    forceObscurity: {
+      control: {
+        type: "boolean",
+      },
+    },
+    inputHint: {
+      control: {
+        type: "text",
+      },
+    },
+    prefix: {
+      control: {
+        type: "text",
+      },
+    },
+  },
+};
+
+export const Default = (props: PasswordProps) => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password label="Password" value={state} onChange={setValue} {...props} />
+  );
+};
+
+Default.storyName = "default";
+
+export const PasswordComponent = ({ onChange, ...props }: PasswordProps) => {
+  const [state, setState] = React.useState("test");
+
+  const setValue = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    setState(ev.target.value);
+    if (onChange) {
+      onChange(ev);
+    }
+  };
+
+  return (
+    <Password label="Password" value={state} onChange={setValue} {...props} />
+  );
+};

--- a/src/components/password/password.stories.tsx
+++ b/src/components/password/password.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { ComponentStory } from "@storybook/react";
 import Password from ".";
 import Box from "../box/box.component";
 import CarbonProvider from "../carbon-provider";
@@ -7,7 +6,7 @@ import CarbonProvider from "../carbon-provider";
 export const SIZES = ["small", "medium", "large"] as const;
 export const VALIDATIONS = ["error", "warning", "info"] as const;
 
-export const Default: ComponentStory<typeof Password> = () => {
+export const Default = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -16,7 +15,7 @@ export const Default: ComponentStory<typeof Password> = () => {
   return <Password label="Password" value={state} onChange={setValue} />;
 };
 
-export const ForceObscurity: ComponentStory<typeof Password> = () => {
+export const ForceObscurity = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -32,7 +31,7 @@ export const ForceObscurity: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const InputHint: ComponentStory<typeof Password> = () => {
+export const InputHint = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -48,7 +47,7 @@ export const InputHint: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const CharacterCounter: ComponentStory<typeof Password> = () => {
+export const CharacterCounter = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -65,7 +64,7 @@ export const CharacterCounter: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const Prefix: ComponentStory<typeof Password> = () => {
+export const Prefix = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -81,7 +80,7 @@ export const Prefix: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const Sizes: ComponentStory<typeof Password> = () => {
+export const Sizes = () => {
   const [smallState, setSmallState] = useState("Password");
   const setSmallValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setSmallState(target.value);
@@ -125,7 +124,7 @@ export const Sizes: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const Margins: ComponentStory<typeof Password> = () => {
+export const Margins = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -134,7 +133,7 @@ export const Margins: ComponentStory<typeof Password> = () => {
   return <Password m={4} label="Password" value={state} onChange={setValue} />;
 };
 
-export const Disabled: ComponentStory<typeof Password> = () => {
+export const Disabled = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -145,7 +144,7 @@ export const Disabled: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const ReadOnly: ComponentStory<typeof Password> = () => {
+export const ReadOnly = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -156,7 +155,7 @@ export const ReadOnly: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const AutoFocus: ComponentStory<typeof Password> = () => {
+export const AutoFocus = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -169,7 +168,7 @@ export const AutoFocus: ComponentStory<typeof Password> = () => {
 
 AutoFocus.parameters = { chromatic: { disable: true } };
 
-export const WithLabelInline: ComponentStory<typeof Password> = () => {
+export const WithLabelInline = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -182,7 +181,7 @@ export const WithLabelInline: ComponentStory<typeof Password> = () => {
 
 WithLabelInline.parameters = { chromatic: { disable: true } };
 
-export const WithLabelAlign: ComponentStory<typeof Password> = () => {
+export const WithLabelAlign = () => {
   const [leftAlignState, setLeftAlignState] = useState("Password");
   const setVLeftAlignValue = ({
     target,
@@ -221,9 +220,7 @@ export const WithLabelAlign: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const WithCustomLabelWidthAndInputWidth: ComponentStory<
-  typeof Password
-> = () => {
+export const WithCustomLabelWidthAndInputWidth = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -241,7 +238,7 @@ export const WithCustomLabelWidthAndInputWidth: ComponentStory<
   );
 };
 
-export const WithCustomMaxWidth: ComponentStory<typeof Password> = () => {
+export const WithCustomMaxWidth = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -257,7 +254,7 @@ export const WithCustomMaxWidth: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const WithFieldHelp: ComponentStory<typeof Password> = () => {
+export const WithFieldHelp = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -273,7 +270,7 @@ export const WithFieldHelp: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const WithLabelHelp: ComponentStory<typeof Password> = () => {
+export const WithLabelHelp = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -289,7 +286,7 @@ export const WithLabelHelp: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const WithRequired: ComponentStory<typeof Password> = () => {
+export const WithRequired = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -300,7 +297,7 @@ export const WithRequired: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const ValidationsAsAString: ComponentStory<typeof Password> = () => {
+export const ValidationsAsAString = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -330,9 +327,7 @@ export const ValidationsAsAString: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const ValidationsAsAStringWithTooltipCustom: ComponentStory<
-  typeof Password
-> = () => {
+export const ValidationsAsAStringWithTooltipCustom = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -359,9 +354,7 @@ ValidationsAsAStringWithTooltipCustom.parameters = {
   chromatic: { disableSnapshot: true },
 };
 
-export const ValidationsAsAStringDisplayedOnLabel: ComponentStory<
-  typeof Password
-> = () => {
+export const ValidationsAsAStringDisplayedOnLabel = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -393,7 +386,7 @@ export const ValidationsAsAStringDisplayedOnLabel: ComponentStory<
   );
 };
 
-export const NewDesignsValidation: ComponentStory<typeof Password> = () => {
+export const NewDesignsValidation = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -431,9 +424,7 @@ export const NewDesignsValidation: ComponentStory<typeof Password> = () => {
   );
 };
 
-export const ValidationsAsAStringWithTooltipDefault: ComponentStory<
-  typeof Password
-> = () => {
+export const ValidationsAsAStringWithTooltipDefault = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
@@ -461,7 +452,7 @@ ValidationsAsAStringWithTooltipDefault.parameters = {
   chromatic: { disableSnapshot: true },
 };
 
-export const ValidationsAsABoolean: ComponentStory<typeof Password> = () => {
+export const ValidationsAsABoolean = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);


### PR DESCRIPTION
### Proposed behaviour

- Rename the `password.cy.js` to the `password.cy.tsx` file in the `./cypress/components/password/` folder.
- Refactor tests to Typescript.  

### Current behaviour

`Password ` tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the `password.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed
<!-- Add CodeSandbox here -->