### PR TITLE
feat(option-group-header, option-row, option): allow custom IDs and surface data selectors

### DIFF
--- a/cypress/components/select/filterable-select/filterable-select.cy.tsx
+++ b/cypress/components/select/filterable-select/filterable-select.cy.tsx
@@ -46,6 +46,7 @@ const addElementText = "Add a New Element";
 const columns = 3;
 const icon = "add";
 const keyToTrigger = ["downarrow", "uparrow", "Home", "End", "Enter"] as const;
+const listOption = "Amber";
 
 context("Tests for FilterableSelect component", () => {
   describe("check props for FilterableSelect component", () => {
@@ -95,7 +96,7 @@ context("Tests for FilterableSelect component", () => {
       );
     });
 
-    it("should render FilterableSelect with id prop prop set to test value", () => {
+    it("should render FilterableSelect with id prop set to test value", () => {
       CypressMountWithProviders(
         <stories.FilterableSelectComponent id={testPropValue} />
       );
@@ -823,6 +824,80 @@ context("Tests for FilterableSelect component", () => {
       CypressMountWithProviders(<stories.FilterableSelectComponent />);
       selectInput().should("have.css", "border-radius", "4px");
       selectListWrapper().should("have.css", "border-radius", "4px");
+    });
+
+    it("should contain custom option row id 3", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectMultiColumnsComponent />
+      );
+
+      dropdownButton().click();
+      multiColumnsSelectListBody().parent().should("have.attr", "id", "3");
+    });
+
+    it("should render option row data-component prop set to option-row", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectMultiColumnsComponent />
+      );
+
+      dropdownButton().click();
+      multiColumnsSelectListBody()
+        .parent()
+        .should("have.attr", "data-component", "option-row");
+    });
+
+    it("should render option row data-role prop set to option-row", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectMultiColumnsComponent />
+      );
+
+      dropdownButton().click();
+      multiColumnsSelectListBody()
+        .parent()
+        .should("have.attr", "data-role", "option-row");
+    });
+
+    it("should render option row data-element prop set to option-row", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectMultiColumnsComponent />
+      );
+
+      dropdownButton().click();
+      multiColumnsSelectListBody()
+        .parent()
+        .should("have.attr", "data-element", "option-row");
+    });
+
+    it("should contain custom option id option1", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
+
+      dropdownButton().click();
+      selectListText(listOption).should("have.attr", "id", "option1");
+    });
+
+    it("should render option data-component prop set to option", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
+
+      dropdownButton().click();
+      selectListText(listOption).should(
+        "have.attr",
+        "data-component",
+        "option"
+      );
+    });
+
+    it("should render option data-role prop set to option1", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
+
+      dropdownButton().click();
+      selectListText(listOption).should("have.attr", "data-role", "option1");
+    });
+
+    it("should render option data-element prop set to option1", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent />);
+
+      dropdownButton().click();
+      selectListText(listOption).should("have.attr", "data-element", "option1");
     });
   });
 

--- a/cypress/components/select/multi-select/multi-select.cy.tsx
+++ b/cypress/components/select/multi-select/multi-select.cy.tsx
@@ -47,6 +47,7 @@ const columns = 3;
 const option1 = "Green";
 const option2 = "Purple";
 const option3 = "Yellow";
+const listOption = "Amber";
 const defaultValue = ["10"];
 const keyToTrigger = [
   "ArrowDown",
@@ -494,14 +495,12 @@ context("Tests for MultiSelect component", () => {
     it("should render the lazy loader when the prop is set and list is opened again", () => {
       CypressMountWithProviders(<stories.MultiSelectLazyLoadTwiceComponent />);
 
-      const option = "Amber";
-
       dropdownButton().click();
       selectListWrapper().should("be.visible");
       for (let i = 0; i < 3; i++) {
         loader(i).should("be.visible");
       }
-      selectListText(option).should("be.visible");
+      selectListText(listOption).should("be.visible");
       dropdownButton().click();
       selectResetButton().click({ force: true });
       dropdownButton().click();
@@ -514,12 +513,11 @@ context("Tests for MultiSelect component", () => {
     it("should list options when value is set and select list is opened again", () => {
       CypressMountWithProviders(<stories.MultiSelectComponent />);
 
-      const option = "Amber";
       const count = 11;
 
       dropdownButton().click();
-      selectListText(option).click();
-      multiSelectPill().should("have.attr", "title", option);
+      selectListText(listOption).click();
+      multiSelectPill().should("have.attr", "title", listOption);
       selectInput().should("have.attr", "aria-expanded", "true");
       selectListWrapper().should("be.visible");
       dropdownButton().click().click();
@@ -964,6 +962,72 @@ context("Tests for MultiSelect component", () => {
 
       selectList().should("not.be.visible");
       commonDataElementInputPreview().should("not.be.focused");
+    });
+
+    it("should contain custom option id option1", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
+
+      dropdownButton().click();
+      selectListText(listOption).should("have.attr", "id", "option1");
+    });
+
+    it("should render option data-component prop set to option", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
+
+      dropdownButton().click();
+      selectListText(listOption).should(
+        "have.attr",
+        "data-component",
+        "option"
+      );
+    });
+
+    it("should render option data-role prop set to option1", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
+
+      dropdownButton().click();
+      selectListText(listOption).should("have.attr", "data-role", "option1");
+    });
+
+    it("should render option data-element prop set to option1", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent />);
+
+      dropdownButton().click();
+      selectListText(listOption).should("have.attr", "data-element", "option1");
+    });
+
+    it("should contain custom option row id 3", () => {
+      CypressMountWithProviders(<stories.MultiSelectMultiColumnsComponent />);
+
+      dropdownButton().click();
+      multiColumnsSelectListBody().parent().should("have.attr", "id", "3");
+    });
+
+    it("should render option row data-component prop set to option-row", () => {
+      CypressMountWithProviders(<stories.MultiSelectMultiColumnsComponent />);
+
+      dropdownButton().click();
+      multiColumnsSelectListBody()
+        .parent()
+        .should("have.attr", "data-component", "option-row");
+    });
+
+    it("should render option row data-role prop set to option-row", () => {
+      CypressMountWithProviders(<stories.MultiSelectMultiColumnsComponent />);
+
+      dropdownButton().click();
+      multiColumnsSelectListBody()
+        .parent()
+        .should("have.attr", "data-role", "option-row");
+    });
+
+    it("should render option row data-element prop set to option-row", () => {
+      CypressMountWithProviders(<stories.MultiSelectMultiColumnsComponent />);
+
+      dropdownButton().click();
+      multiColumnsSelectListBody()
+        .parent()
+        .should("have.attr", "data-element", "option-row");
     });
   });
 

--- a/cypress/components/select/simple-select/simple-select.cy.tsx
+++ b/cypress/components/select/simple-select/simple-select.cy.tsx
@@ -535,6 +535,134 @@ context("Tests for SimpleSelect component", () => {
       selectListOptionGroup().should("have.text", "Group one");
     });
 
+    it("should contain custom option group header id groupHeader1", () => {
+      CypressMountWithProviders(<stories.SimpleSelectGroupComponent />);
+
+      selectText().click();
+      selectListWrapper().should("be.visible");
+      selectListOptionGroup()
+        .parent()
+        .should("have.attr", "id", "groupHeader1");
+    });
+
+    it("should render option group header data-component prop set to group-header", () => {
+      CypressMountWithProviders(<stories.SimpleSelectGroupComponent />);
+
+      selectText().click();
+      selectListWrapper().should("be.visible");
+      selectListOptionGroup()
+        .parent()
+        .should("have.attr", "data-component", "group-header");
+    });
+
+    it("should render option group header data-role prop set to group-header", () => {
+      CypressMountWithProviders(<stories.SimpleSelectGroupComponent />);
+
+      selectText().click();
+      selectListWrapper().should("be.visible");
+      selectListOptionGroup()
+        .parent()
+        .should("have.attr", "data-role", "group-header");
+    });
+
+    it("should render option group header data-element prop set to group-header", () => {
+      CypressMountWithProviders(<stories.SimpleSelectGroupComponent />);
+
+      selectText().click();
+      selectListWrapper().should("be.visible");
+      selectListOptionGroup()
+        .parent()
+        .should("have.attr", "data-element", "group-header");
+    });
+
+    it("should contain custom option row id 3", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectMultipleColumnsComponent />
+      );
+
+      selectText().click();
+      multiColumnsSelectListBody().parent().should("have.attr", "id", "3");
+    });
+
+    it("should render option row data-component prop set to option-row", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectMultipleColumnsComponent />
+      );
+
+      selectText().click();
+      multiColumnsSelectListBody()
+        .parent()
+        .should("have.attr", "data-component", "option-row");
+    });
+
+    it("should render option row data-role prop set to option-row", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectMultipleColumnsComponent />
+      );
+
+      selectText().click();
+      multiColumnsSelectListBody()
+        .parent()
+        .should("have.attr", "data-role", "option-row");
+    });
+
+    it("should render option row data-element prop set to option-row", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectMultipleColumnsComponent />
+      );
+
+      selectText().click();
+      multiColumnsSelectListBody()
+        .parent()
+        .should("have.attr", "data-element", "option-row");
+    });
+
+    it("should contain custom option id option1", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectCustomOptionChildrenComponent />
+      );
+
+      selectText().click();
+      selectListWrapper().should("be.visible");
+      selectListCustomChild(1).parent().should("have.attr", "id", "option1");
+    });
+
+    it("should render custom option data-component prop set to option", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectCustomOptionChildrenComponent />
+      );
+
+      selectText().click();
+      selectListWrapper().should("be.visible");
+      selectListCustomChild(1)
+        .parent()
+        .should("have.attr", "data-component", "option");
+    });
+
+    it("should render custom option data-role prop set to option", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectCustomOptionChildrenComponent />
+      );
+
+      selectText().click();
+      selectListWrapper().should("be.visible");
+      selectListCustomChild(1)
+        .parent()
+        .should("have.attr", "data-role", "option");
+    });
+
+    it("should render custom option data-element prop set to option", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectCustomOptionChildrenComponent />
+      );
+
+      selectText().click();
+      selectListWrapper().should("be.visible");
+      selectListCustomChild(1)
+        .parent()
+        .should("have.attr", "data-element", "option");
+    });
+
     it("should render option list with proper maxHeight value", () => {
       const maxHeight = 200;
       CypressMountWithProviders(

--- a/src/components/select/filterable-select/filterable-select-test.stories.tsx
+++ b/src/components/select/filterable-select/filterable-select-test.stories.tsx
@@ -63,7 +63,13 @@ export const FilterableSelectComponent = (
       onChange={onChangeHandler}
       {...props}
     >
-      <Option text="Amber" value="1" />
+      <Option
+        id="option1"
+        text="Amber"
+        value="1"
+        data-role="option1"
+        data-element="option1"
+      />
       <Option text="Black" value="2" />
       <Option text="Blue" value="3" />
       <Option text="Brown" value="4" />
@@ -410,7 +416,14 @@ export const FilterableSelectMultiColumnsComponent = (
         <td>Vick</td>
         <td>Accountant</td>
       </OptionRow>
-      <OptionRow id="3" value="3" text="Jane Poe">
+      <OptionRow
+        id="3"
+        value="3"
+        text="Jane Poe"
+        data-component="option-row"
+        data-role="option-row"
+        data-element="option-row"
+      >
         <td>Jane</td>
         <td>Poe</td>
         <td>Accountant</td>

--- a/src/components/select/multi-select/multi-select-test.stories.tsx
+++ b/src/components/select/multi-select/multi-select-test.stories.tsx
@@ -73,7 +73,13 @@ export const MultiSelectComponent = (props: Partial<MultiSelectProps>) => {
       onChange={onChangeHandler}
       {...props}
     >
-      <Option text="Amber" value="1" />
+      <Option
+        id="option1"
+        text="Amber"
+        value="1"
+        data-role="option1"
+        data-element="option1"
+      />
       <Option text="Black" value="2" />
       <Option text="Blue" value="3" />
       <Option text="Brown" value="4" />
@@ -391,7 +397,14 @@ export const MultiSelectMultiColumnsComponent = (
         <td>Vick</td>
         <td>Accountant</td>
       </OptionRow>
-      <OptionRow id="3" value="3" text="Jane Poe">
+      <OptionRow
+        id="3"
+        value="3"
+        text="Jane Poe"
+        data-component="option-row"
+        data-role="option-row"
+        data-element="option-row"
+      >
         <td>Jane</td>
         <td>Poe</td>
         <td>Accountant</td>

--- a/src/components/select/option-group-header/option-group-header.component.tsx
+++ b/src/components/select/option-group-header/option-group-header.component.tsx
@@ -1,9 +1,15 @@
 import React from "react";
 import { CSSProperties } from "styled-components";
+import { TagProps } from "__internal__/utils/helpers/tags";
 import StyledOptionGroupHeader from "./option-group-header.style";
 import Icon, { IconProps } from "../../icon";
 
-export interface OptionGroupHeaderProps {
+export interface OptionGroupHeaderProps extends TagProps {
+  /**
+   * Unique identifier for the component.
+   * Will use a randomly generated GUID if none is provided.
+   */
+  id?: string;
   /** Heading text */
   label: string;
   /** Any valid Carbon icon name */

--- a/src/components/select/option-group-header/option-group-header.spec.tsx
+++ b/src/components/select/option-group-header/option-group-header.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import OptionGroupHeader, { OptionGroupHeaderProps } from ".";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -18,6 +18,25 @@ describe("OptionGroupHeader", () => {
     it("then it should display the icon", () => {
       const props = { label: "Heading", icon: "individual" as const };
       expect(renderOption(props, TestRenderer.create)).toMatchSnapshot();
+    });
+  });
+
+  describe("tags on component", () => {
+    it("includes correct component, element and role data tags", () => {
+      const wrapper = mount(
+        <OptionGroupHeader
+          label="Heading"
+          data-component="foo"
+          data-element="bar"
+          data-role="baz"
+        />
+      );
+
+      expect(wrapper.getDOMNode().getAttribute("data-component")).toEqual(
+        "foo"
+      );
+      expect(wrapper.getDOMNode().getAttribute("data-element")).toEqual("bar");
+      expect(wrapper.getDOMNode().getAttribute("data-role")).toEqual("baz");
     });
   });
 });

--- a/src/components/select/option-row/option-row.component.tsx
+++ b/src/components/select/option-row/option-row.component.tsx
@@ -1,9 +1,10 @@
 import React, { useContext } from "react";
 import { CSSProperties } from "styled-components";
+import { TagProps } from "__internal__/utils/helpers/tags";
 import StyledOptionRow from "./option-row.style";
 import SelectListContext from "../__internal__/select-list-context";
 
-export interface OptionRowProps {
+export interface OptionRowProps extends TagProps {
   /** The option's visible text, displayed within <Textbox> of <Select> */
   text: string;
   /** Row content, should consist of multiple td elements */
@@ -11,17 +12,16 @@ export interface OptionRowProps {
   /** The option's invisible internal value */
   value: string | Record<string, unknown>;
   /**
-   * @private
-   * @ignore
-   * Component id (prop added by the SelectList component)
+   * Unique identifier for the component.
+   * Will use a randomly generated GUID if none is provided.
    */
-  id: string;
+  id?: string;
   /**
    * @private
    * @ignore
    * Callback to return value when the element is selected (prop added by the SelectList component) */
   onSelect?: (ev: {
-    id: string;
+    id?: string;
     text: string;
     value: string | Record<string, unknown>;
   }) => void;

--- a/src/components/select/option-row/option-row.spec.tsx
+++ b/src/components/select/option-row/option-row.spec.tsx
@@ -96,4 +96,26 @@ describe("OptionRow", () => {
       });
     });
   });
+
+  describe("tags on component", () => {
+    it("includes correct component, element and role data tags", () => {
+      const wrapper = mount(
+        <OptionRow
+          value="1"
+          text="one"
+          data-component="foo"
+          data-element="bar"
+          data-role="baz"
+        >
+          <td>qux</td>
+        </OptionRow>
+      );
+
+      expect(wrapper.getDOMNode().getAttribute("data-component")).toEqual(
+        "foo"
+      );
+      expect(wrapper.getDOMNode().getAttribute("data-element")).toEqual("bar");
+      expect(wrapper.getDOMNode().getAttribute("data-role")).toEqual("baz");
+    });
+  });
 });

--- a/src/components/select/option/option.component.tsx
+++ b/src/components/select/option/option.component.tsx
@@ -1,12 +1,19 @@
 import React, { useContext } from "react";
+import { TagProps } from "__internal__/utils/helpers/tags";
 import StyledOption from "./option.style";
 import SelectListContext from "../__internal__/select-list-context";
 
 export interface OptionProps
   extends Omit<
-    React.InputHTMLAttributes<HTMLLIElement>,
-    "value" | "onSelect" | "onClick"
-  > {
+      React.InputHTMLAttributes<HTMLLIElement>,
+      "value" | "onSelect" | "onClick"
+    >,
+    TagProps {
+  /**
+   * Unique identifier for the component.
+   * Will use a randomly generated GUID if none is provided.
+   */
+  id?: string;
   /** The option's visible text, displayed within <Textbox> of <Select>, and used for filtering */
   text: string;
   /** Optional: alternative rendered content, displayed within <SelectList> of <Select> (eg: an icon, an image, etc) */

--- a/src/components/select/option/option.spec.tsx
+++ b/src/components/select/option/option.spec.tsx
@@ -85,4 +85,24 @@ describe("Option", () => {
       });
     });
   });
+
+  describe("tags on component", () => {
+    it("includes correct component, element and role data tags", () => {
+      const wrapper = mount(
+        <Option
+          value="1"
+          text="one"
+          data-component="foo"
+          data-element="bar"
+          data-role="baz"
+        />
+      );
+
+      expect(wrapper.getDOMNode().getAttribute("data-component")).toEqual(
+        "foo"
+      );
+      expect(wrapper.getDOMNode().getAttribute("data-element")).toEqual("bar");
+      expect(wrapper.getDOMNode().getAttribute("data-role")).toEqual("baz");
+    });
+  });
 });

--- a/src/components/select/select-list/select-list.component.tsx
+++ b/src/components/select/select-list/select-list.component.tsx
@@ -196,8 +196,10 @@ const SelectList = React.forwardRef(
     // as that isn't absolutely guaranteed to never rerun when dependencies haven't changed.
     const setChildIds = () => {
       childIdsRef.current =
-        React.Children.map(children, () => guid()) ||
-        /* istanbul ignore next */ null;
+        React.Children.map(
+          children,
+          (child) => (React.isValidElement(child) && child?.props.id) || guid()
+        ) || /* istanbul ignore next */ null;
     };
 
     if (childIdsRef.current?.length !== React.Children.count(children)) {

--- a/src/components/select/select-list/select-list.spec.tsx
+++ b/src/components/select/select-list/select-list.spec.tsx
@@ -18,6 +18,7 @@ import Popover from "../../../__internal__/popover";
 import * as guidModule from "../../../__internal__/utils/helpers/guid";
 import StyledOption from "../option/option.style";
 import StyledOptionRow from "../option-row/option-row.style";
+import StyledOptionGroupHeader from "../option-group-header/option-group-header.style";
 
 const mockedGuid = "guid-12345";
 const guidSpy = jest.spyOn(guidModule, "default");
@@ -61,6 +62,7 @@ function getSelectList(props: Partial<SelectListProps>) {
     onSelect: () => {},
     onSelectListClose: () => {},
     isOpen: true,
+    id: props.id,
   };
 
   const WrapperComponent = (wrapperProps: Partial<SelectListProps>) => {
@@ -68,9 +70,9 @@ function getSelectList(props: Partial<SelectListProps>) {
 
     return (
       <SelectList ref={mockRef} {...defaultProps} {...props} {...wrapperProps}>
-        <Option value="opt1" text="red" />
-        <Option value="opt2" text="green" />
-        <Option value="opt3" text="blue" />
+        <Option id={defaultProps.id} value="opt1" text="red" />
+        <Option id={defaultProps.id} value="opt2" text="green" />
+        <Option id={defaultProps.id} value="opt3" text="blue" />
       </SelectList>
     );
   };
@@ -83,6 +85,7 @@ function getOptionRowSelectList(props: Partial<SelectListProps>) {
     onSelect: () => {},
     onSelectListClose: () => {},
     isOpen: true,
+    id: props.id,
   };
 
   const WrapperComponent = (wrapperProps: Partial<SelectListProps>) => {
@@ -96,13 +99,13 @@ function getOptionRowSelectList(props: Partial<SelectListProps>) {
         {...props}
         {...wrapperProps}
       >
-        <OptionRow id="1" value="opt1" text="red">
+        <OptionRow id={defaultProps.id} value="opt1" text="red">
           <td>red</td>
         </OptionRow>
-        <OptionRow id="2" value="opt2" text="green">
+        <OptionRow id={defaultProps.id} value="opt2" text="green">
           <td>green</td>
         </OptionRow>
-        <OptionRow id="3" value="opt3" text="blue">
+        <OptionRow id={defaultProps.id} value="opt3" text="blue">
           <td>blue</td>
         </OptionRow>
       </SelectList>
@@ -117,6 +120,7 @@ function getGroupedSelectList(props: Partial<SelectListProps>) {
     onSelect: () => {},
     onSelectListClose: () => {},
     isOpen: true,
+    id: props.id,
   };
 
   const WrapperComponent = (wrapperProps: Partial<SelectListProps>) => {
@@ -124,12 +128,12 @@ function getGroupedSelectList(props: Partial<SelectListProps>) {
 
     return (
       <SelectList ref={mockRef} {...defaultProps} {...props} {...wrapperProps}>
-        <OptionGroupHeader label="Heading one" />
-        <Option value="opt1" text="red" />
-        <Option value="opt2" text="green" />
-        <OptionGroupHeader label="Heading two" />
-        <Option value="opt3" text="blue" />
-        <Option value="opt4" text="black" />
+        <OptionGroupHeader id={defaultProps.id} label="Heading one" />
+        <Option id={defaultProps.id} value="opt1" text="red" />
+        <Option id={defaultProps.id} value="opt2" text="green" />
+        <OptionGroupHeader id={defaultProps.id} label="Heading two" />
+        <Option id={defaultProps.id} value="opt3" text="blue" />
+        <Option id={defaultProps.id} value="opt4" text="black" />
       </SelectList>
     );
   };
@@ -663,7 +667,7 @@ describe("SelectList", () => {
                 ref={ref}
               >
                 {multiColumn ? (
-                  <OptionRow id="1" value="opt1" text="red">
+                  <OptionRow value="opt1" text="red">
                     <td>foo</td>
                   </OptionRow>
                 ) : (
@@ -1047,6 +1051,33 @@ describe("SelectList", () => {
       expect(optionChildren.length).toBeLessThan(10);
     });
   });
+
+  describe.each([
+    ["Option", renderSelectList, StyledOption],
+    ["OptionRow", renderOptionRowSelectList, StyledOptionRow],
+    ["OptionGroupHeader", renderGroupedSelectList, StyledOptionGroupHeader],
+  ])(
+    "ID checks on %s children when SelectList is parent",
+    (component, listRenderer, optionType) => {
+      let wrapper: ReactWrapper;
+      let domNode: HTMLElement;
+      const id = "foo";
+
+      it("id attribute should equal the value of the id prop when passed", () => {
+        wrapper = listRenderer({ id });
+
+        domNode = wrapper.find(optionType).at(0).getDOMNode();
+        expect(domNode.getAttribute("id")).toBe(id);
+      });
+
+      it("when no id pop is passed, id attribute should be populated using a guid", () => {
+        wrapper = listRenderer();
+
+        domNode = wrapper.find(optionType).at(0).getDOMNode();
+        expect(domNode.getAttribute("id")).toBe(mockedGuid);
+      });
+    }
+  );
 
   describe("IDs are stable over the component's lifecycle", () => {
     let wrapper: ReactWrapper;

--- a/src/components/select/simple-select/simple-select-test.stories.tsx
+++ b/src/components/select/simple-select/simple-select-test.stories.tsx
@@ -494,7 +494,14 @@ export const SimpleSelectMultipleColumnsComponent = (
         <td>Vick</td>
         <td>Accountant</td>
       </OptionRow>
-      <OptionRow id="3" value="3" text="Jane Poe">
+      <OptionRow
+        id="3"
+        value="3"
+        text="Jane Poe"
+        data-component="option-row"
+        data-role="option-row"
+        data-element="option-row"
+      >
         <td>Jane</td>
         <td>Poe</td>
         <td>Accountant</td>
@@ -525,13 +532,20 @@ export const SimpleSelectCustomOptionChildrenComponent = (
       label="Pick your favourite color"
       {...props}
     >
-      <Option text="Orange" value="1">
+      <Option
+        id="option1"
+        text="Orange"
+        value="1"
+        data-component="option"
+        data-role="option"
+        data-element="option"
+      >
         <Icon type="favourite" color="orange" mr={1} /> Orange
       </Option>
-      <Option text="Black" value="2">
+      <Option id="option2" text="Black" value="2">
         <Icon type="money_bag" color="black" mr={1} /> Black
       </Option>
-      <Option text="Blue" value="3">
+      <Option id="option3" text="Blue" value="3">
         <Icon type="gift" color="blue" mr={1} /> Blue
       </Option>
     </SimpleSelect>
@@ -543,16 +557,23 @@ export const SimpleSelectGroupComponent = (
 ) => {
   return (
     <SimpleSelect name="optGroups" id="optGroups" {...props}>
-      <OptionGroupHeader label="Group one" icon="individual" />
+      <OptionGroupHeader
+        id="groupHeader1"
+        label="Group one"
+        icon="individual"
+        data-component="group-header"
+        data-role="group-header"
+        data-element="group-header"
+      />
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
       <Option text="Blue" value="3" />
       <Option text="Brown" value="4" />
-      <OptionGroupHeader label="Group two" icon="shop" />
+      <OptionGroupHeader id="groupHeader2" label="Group two" icon="shop" />
       <Option text="Green" value="5" />
       <Option text="Orange" value="6" />
       <Option text="Pink" value="7" />
-      <OptionGroupHeader label="Group three" />
+      <OptionGroupHeader id="groupHeader3" label="Group three" />
       <Option text="Purple" value="8" />
       <Option text="Red" value="9" />
       <Option text="White" value="10" />


### PR DESCRIPTION
fix #6126, fix #5810

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

A condition has been added to `SelectList` which checks if the `id` prop is present on any children, if it is the GUID is not applied. This provides consumers with flexibility to pass specific IDs to `OptionGroupHeader`, `OptionRow`, and `Option` component children. Also all interfaces in `Option`, `OptionRow` and `OptionGroupHeader` now extend `TagProps`, giving consumers access to the `data-role` and `data-element` attributes for testing purposes

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

Currently, a GUID is applied to every potential child of the `SelectList` component `(OptionGroupHeader, OptionRow, Option)`. Even when consumers pass the `id` prop, the id attribute is still overwritten with a GUID.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
