### PR TITLE
test(date): refactor to ts

### DIFF
--- a/cypress/support/component-helper/cypress-mount.tsx
+++ b/cypress/support/component-helper/cypress-mount.tsx
@@ -11,7 +11,7 @@ import "../../../src/style/fonts.css";
 const CypressMountWithProviders = (
   children: React.ReactNode,
   theme: Partial<ThemeObject> = sageTheme,
-  locale: Locale = enGB
+  locale: Partial<Locale> = enGB
 ) => {
   return cy.mount(
     <CarbonProvider theme={theme}>

--- a/src/components/date/date-test.stories.tsx
+++ b/src/components/date/date-test.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
 
-import DateInput, { DateChangeEvent } from "./date.component";
+import DateInput, { DateChangeEvent, DateInputProps } from "./date.component";
 import {
   CommonTextboxArgs,
   commonTextboxArgTypes,
@@ -86,4 +86,80 @@ NewValidationStory.args = {
   allowEmptyValue: false,
   mt: 0,
   ...getCommonTextboxArgs(),
+};
+
+export const DateInputCustom = ({
+  onChange,
+  onBlur,
+  ...props
+}: Partial<CommonTextboxArgs> & Partial<DateInputProps>) => {
+  const [state, setState] = React.useState("01/05/2022");
+
+  const handleOnChange = (ev: DateChangeEvent) => {
+    if (onChange) {
+      onChange(ev);
+    }
+
+    setState(ev.target.value.formattedValue);
+  };
+
+  const handleOnBlur = (ev: DateChangeEvent) => {
+    if (onBlur) {
+      onBlur(ev);
+    }
+  };
+
+  return (
+    <DateInput
+      label="Date"
+      name="date-input"
+      value={state}
+      onChange={handleOnChange}
+      onBlur={handleOnBlur}
+      {...props}
+    />
+  );
+};
+
+export const DateInputValidationNewDesign = () => {
+  const [state1, setState1] = React.useState("01/10/2016");
+  const setValue1 = ({ target }: DateChangeEvent) => {
+    setState1(target.value.formattedValue);
+  };
+  const [state2, setState2] = React.useState("01/10/2016");
+  const setValue2 = ({ target }: DateChangeEvent) => {
+    setState2(target.value.formattedValue);
+  };
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      {(["error", "warning"] as const).map((validationType) =>
+        (["small", "medium", "large"] as const).map((size) => (
+          <div
+            style={{ width: "296px" }}
+            key={`${size}-${validationType}-string-label`}
+          >
+            <DateInput
+              label={`${size} - ${validationType}`}
+              value={state1}
+              onChange={setValue1}
+              validationOnLabel
+              size={size}
+              {...{ [validationType]: "Message" }}
+              m={4}
+            />
+            <DateInput
+              label={`readOnly - ${size} - ${validationType}`}
+              value={state2}
+              onChange={setValue2}
+              validationOnLabel
+              size={size}
+              readOnly
+              {...{ [validationType]: "Message" }}
+              m={4}
+            />
+          </div>
+        ))
+      )}
+    </CarbonProvider>
+  );
 };


### PR DESCRIPTION
### Proposed behaviour

- Rename the `date.cy.js` to the `date.cy.tsx` file in the `./cypress/components/date/` folder.
- Refactor tests to Typescript.  

### Current behaviour

`Date Input` tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- [x] Run `npx cypress open --component` to check if the `date.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed
<!-- Add CodeSandbox here -->