### PR TITLE
fix(split-button, multi-action-button): remove children iteration

### DIFF
--- a/cypress/components/multi-action-button/multi-action-button.cy.tsx
+++ b/cypress/components/multi-action-button/multi-action-button.cy.tsx
@@ -5,6 +5,7 @@ import {
   MultiActionButtonWithOneChild,
   MultiActionNestedInDialog,
   MultiActionWithHrefChildren,
+  WithWrapper,
 } from "../../../src/components/multi-action-button/multi-action-button-test.stories";
 import { Accordion } from "../../../src/components/accordion/accordion.component";
 import * as stories from "../../../src/components/multi-action-button/multi-action-button.stories";
@@ -212,218 +213,441 @@ context("Tests for MultiActionButton component", () => {
     });
   });
 
-  describe("pressing ArrowUp while MultiActionButton is open", () => {
-    it("should move focus to previous child button and should not loop to last button when first is focused", () => {
-      CypressMountWithProviders(
-        <>
-          <MultiActionButtonList />
-          <MultiActionButtonList />
-        </>
-      );
+  describe("user interactions with MultiActionutton", () => {
+    describe("pressing ArrowUp while MultiActionButton is open", () => {
+      it("should move focus to previous child button and should not loop to last button when first is focused", () => {
+        CypressMountWithProviders(
+          <>
+            <MultiActionButtonList />
+            <MultiActionButtonList />
+          </>
+        );
 
-      multiActionButton().eq(0).trigger("mouseover");
-      multiActionButtonList().eq(2).focus();
-      multiActionButtonListContainer()
-        .eq(0)
-        .trigger("keydown", keyCode("uparrow"));
-      multiActionButtonList().eq(1).should("be.focused");
-      multiActionButtonListContainer()
-        .eq(0)
-        .trigger("keydown", keyCode("uparrow"));
-      multiActionButtonList().eq(0).should("be.focused");
-      multiActionButtonListContainer()
-        .eq(0)
-        .trigger("keydown", keyCode("uparrow"));
-      multiActionButtonList().eq(0).should("be.focused");
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(2).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("uparrow"));
+        multiActionButtonList().eq(1).should("be.focused");
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("uparrow"));
+        multiActionButtonList().eq(0).should("be.focused");
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("uparrow"));
+        multiActionButtonList().eq(0).should("be.focused");
+      });
+    });
+
+    describe("pressing shift and tab while MultiActionButton is open", () => {
+      it("should move focus to previous child button and focus the main button when pressed and first button is focused", () => {
+        CypressMountWithProviders(
+          <>
+            <MultiActionButtonList />
+            <MultiActionButtonList />
+          </>
+        );
+
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(1).focus();
+        multiActionButton().eq(0).tab({ shift: true });
+        multiActionButtonList().eq(0).should("be.focused");
+        multiActionButton().eq(0).tab({ shift: true });
+        multiActionButton().eq(0).should("be.focused");
+      });
+    });
+
+    describe("pressing ArrowDown while MultiActionButton is open", () => {
+      it("should move focus to next child button and should not loop to first button when last is focused", () => {
+        CypressMountWithProviders(
+          <>
+            <MultiActionButtonList />
+            <MultiActionButtonList />
+          </>
+        );
+
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(0).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("downarrow"));
+        multiActionButtonList().eq(1).should("be.focused");
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("downarrow"));
+        multiActionButtonList().eq(2).should("be.focused");
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("downarrow"));
+        multiActionButtonList().eq(2).should("be.focused");
+      });
+    });
+
+    describe("pressing tab while MultiActionButton is open", () => {
+      it("should move focus to next child button and to second MultiActionButton when end of list reached", () => {
+        CypressMountWithProviders(
+          <>
+            <MultiActionButtonList />
+            <MultiActionButtonList />
+          </>
+        );
+
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(1).focus();
+        multiActionButton().eq(0).tab();
+        multiActionButtonList().eq(2).should("be.focused");
+        multiActionButton().eq(0).tab();
+        multiActionButton().eq(1).should("be.focused");
+      });
+    });
+
+    describe("pressing metaKey + ArrowUp while MultiActionButton is open", () => {
+      it("should move focus to first child button", () => {
+        CypressMountWithProviders(
+          <>
+            <MultiActionButtonList />
+            <MultiActionButtonList />
+          </>
+        );
+
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(2).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", { metaKey: true, key: "ArrowUp" });
+        multiActionButtonList().eq(0).should("be.focused");
+      });
+    });
+
+    describe("pressing ctrlKey + ArrowUp while MultiActionButton is open", () => {
+      it("should move focus to first child button", () => {
+        CypressMountWithProviders(
+          <>
+            <MultiActionButtonList />
+            <MultiActionButtonList />
+          </>
+        );
+
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(2).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", { ctrlKey: true, key: "ArrowUp" });
+        multiActionButtonList().eq(0).should("be.focused");
+      });
+    });
+
+    describe("pressing Home while MultiActionButton is open", () => {
+      it("should move focus to first child button", () => {
+        CypressMountWithProviders(
+          <>
+            <MultiActionButtonList />
+            <MultiActionButtonList />
+          </>
+        );
+
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(2).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("Home"));
+        multiActionButtonList().eq(0).should("be.focused");
+      });
+    });
+
+    describe("pressing metaKey + ArrowDown while MultiActionButton is open", () => {
+      it("should move focus to last child button", () => {
+        CypressMountWithProviders(
+          <>
+            <MultiActionButtonList />
+            <MultiActionButtonList />
+          </>
+        );
+
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(0).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", { metaKey: true, key: "ArrowDown" });
+        multiActionButtonList().eq(2).should("be.focused");
+      });
+    });
+
+    describe("pressing ctrlKey + ArrowDown while MultiActionButton is open", () => {
+      it("should move focus to last child button", () => {
+        CypressMountWithProviders(
+          <>
+            <MultiActionButtonList />
+            <MultiActionButtonList />
+          </>
+        );
+
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(0).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", { ctrlKey: true, key: "ArrowDown" });
+        multiActionButtonList().eq(2).should("be.focused");
+      });
+    });
+
+    describe("pressing End while MultiActionButton is open", () => {
+      it("should move focus to last child button", () => {
+        CypressMountWithProviders(
+          <>
+            <MultiActionButtonList />
+            <MultiActionButtonList />
+          </>
+        );
+
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(0).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("End"));
+        multiActionButtonList().eq(2).should("be.focused");
+      });
+    });
+
+    describe("pressing esc while MultiActionButton is open", () => {
+      it("should close MultiActionButton", () => {
+        CypressMountWithProviders(<MultiActionButtonList />);
+
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(1).focus();
+        multiActionButtonComponent().type("{esc}");
+        multiActionButtonListContainer().should("not.exist");
+      });
+    });
+
+    describe("clicking one of the additional buttons", () => {
+      it("should close MultiActionButton", () => {
+        CypressMountWithProviders(<MultiActionButtonList />);
+
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(0).click();
+        multiActionButtonListContainer().should("not.exist");
+      });
     });
   });
 
-  describe("pressing shift and tab while MultiActionButton is open", () => {
-    it("should move focus to previous child button and focus the main button when pressed and first button is focused", () => {
-      CypressMountWithProviders(
-        <>
-          <MultiActionButtonList />
-          <MultiActionButtonList />
-        </>
-      );
+  describe("user interactions with MultiActionutton when wrapping the child buttons in a custom component", () => {
+    describe("pressing ArrowUp while MultiActionButton is open", () => {
+      it("should move focus to previous child button and should not loop to last button when first is focused", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      multiActionButton().eq(0).trigger("mouseover");
-      multiActionButtonList().eq(1).focus();
-      multiActionButton().eq(0).tab({ shift: true });
-      multiActionButtonList().eq(0).should("be.focused");
-      multiActionButton().eq(0).tab({ shift: true });
-      multiActionButton().eq(0).should("be.focused");
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(2).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("uparrow"));
+        multiActionButtonList().eq(1).should("be.focused");
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("uparrow"));
+        multiActionButtonList().eq(0).should("be.focused");
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("uparrow"));
+        multiActionButtonList().eq(0).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing ArrowDown while MultiActionButton is open", () => {
-    it("should move focus to next child button and should not loop to first button when last is focused", () => {
-      CypressMountWithProviders(
-        <>
-          <MultiActionButtonList />
-          <MultiActionButtonList />
-        </>
-      );
+    describe("pressing shift and tab while MultiActionButton is open", () => {
+      it("should move focus to previous child button and focus the main button when pressed and first button is focused", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      multiActionButton().eq(0).trigger("mouseover");
-      multiActionButtonList().eq(0).focus();
-      multiActionButtonListContainer()
-        .eq(0)
-        .trigger("keydown", keyCode("downarrow"));
-      multiActionButtonList().eq(1).should("be.focused");
-      multiActionButtonListContainer()
-        .eq(0)
-        .trigger("keydown", keyCode("downarrow"));
-      multiActionButtonList().eq(2).should("be.focused");
-      multiActionButtonListContainer()
-        .eq(0)
-        .trigger("keydown", keyCode("downarrow"));
-      multiActionButtonList().eq(2).should("be.focused");
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(1).focus();
+        multiActionButton().eq(0).tab({ shift: true });
+        multiActionButtonList().eq(0).should("be.focused");
+        multiActionButton().eq(0).tab({ shift: true });
+        multiActionButton().eq(0).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing tab while MultiActionButton is open", () => {
-    it("should move focus to next child button and to second MultiActionButton when end of list reached", () => {
-      CypressMountWithProviders(
-        <>
-          <MultiActionButtonList />
-          <MultiActionButtonList />
-        </>
-      );
+    describe("pressing ArrowDown while MultiActionButton is open", () => {
+      it("should move focus to next child button and should not loop to first button when last is focused", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      multiActionButton().eq(0).trigger("mouseover");
-      multiActionButtonList().eq(1).focus();
-      multiActionButton().eq(0).tab();
-      multiActionButtonList().eq(2).should("be.focused");
-      multiActionButton().eq(0).tab();
-      multiActionButton().eq(1).should("be.focused");
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(0).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("downarrow"));
+        multiActionButtonList().eq(1).should("be.focused");
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("downarrow"));
+        multiActionButtonList().eq(2).should("be.focused");
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("downarrow"));
+        multiActionButtonList().eq(2).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing metaKey + ArrowUp while MultiActionButton is open", () => {
-    it("should move focus to first child button", () => {
-      CypressMountWithProviders(
-        <>
-          <MultiActionButtonList />
-          <MultiActionButtonList />
-        </>
-      );
+    describe("pressing tab while MultiActionButton is open", () => {
+      it("should move focus to next child button and to second MultiActionButton when end of list reached", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      multiActionButton().eq(0).trigger("mouseover");
-      multiActionButtonList().eq(2).focus();
-      multiActionButtonListContainer()
-        .eq(0)
-        .trigger("keydown", { metaKey: true, key: "ArrowUp" });
-      multiActionButtonList().eq(0).should("be.focused");
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(1).focus();
+        multiActionButton().eq(0).tab();
+        multiActionButtonList().eq(2).should("be.focused");
+        multiActionButton().eq(0).tab();
+        multiActionButton().eq(1).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing ctrlKey + ArrowUp while MultiActionButton is open", () => {
-    it("should move focus to first child button", () => {
-      CypressMountWithProviders(
-        <>
-          <MultiActionButtonList />
-          <MultiActionButtonList />
-        </>
-      );
+    describe("pressing metaKey + ArrowUp while MultiActionButton is open", () => {
+      it("should move focus to first child button", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      multiActionButton().eq(0).trigger("mouseover");
-      multiActionButtonList().eq(2).focus();
-      multiActionButtonListContainer()
-        .eq(0)
-        .trigger("keydown", { ctrlKey: true, key: "ArrowUp" });
-      multiActionButtonList().eq(0).should("be.focused");
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(2).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", { metaKey: true, key: "ArrowUp" });
+        multiActionButtonList().eq(0).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing Home while MultiActionButton is open", () => {
-    it("should move focus to first child button", () => {
-      CypressMountWithProviders(
-        <>
-          <MultiActionButtonList />
-          <MultiActionButtonList />
-        </>
-      );
+    describe("pressing ctrlKey + ArrowUp while MultiActionButton is open", () => {
+      it("should move focus to first child button", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      multiActionButton().eq(0).trigger("mouseover");
-      multiActionButtonList().eq(2).focus();
-      multiActionButtonListContainer()
-        .eq(0)
-        .trigger("keydown", keyCode("Home"));
-      multiActionButtonList().eq(0).should("be.focused");
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(2).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", { ctrlKey: true, key: "ArrowUp" });
+        multiActionButtonList().eq(0).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing metaKey + ArrowDown while MultiActionButton is open", () => {
-    it("should move focus to last child button", () => {
-      CypressMountWithProviders(
-        <>
-          <MultiActionButtonList />
-          <MultiActionButtonList />
-        </>
-      );
+    describe("pressing Home while MultiActionButton is open", () => {
+      it("should move focus to first child button", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      multiActionButton().eq(0).trigger("mouseover");
-      multiActionButtonList().eq(0).focus();
-      multiActionButtonListContainer()
-        .eq(0)
-        .trigger("keydown", { metaKey: true, key: "ArrowDown" });
-      multiActionButtonList().eq(2).should("be.focused");
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(2).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("Home"));
+        multiActionButtonList().eq(0).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing ctrlKey + ArrowDown while MultiActionButton is open", () => {
-    it("should move focus to last child button", () => {
-      CypressMountWithProviders(
-        <>
-          <MultiActionButtonList />
-          <MultiActionButtonList />
-        </>
-      );
+    describe("pressing metaKey + ArrowDown while MultiActionButton is open", () => {
+      it("should move focus to last child button", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      multiActionButton().eq(0).trigger("mouseover");
-      multiActionButtonList().eq(0).focus();
-      multiActionButtonListContainer()
-        .eq(0)
-        .trigger("keydown", { ctrlKey: true, key: "ArrowDown" });
-      multiActionButtonList().eq(2).should("be.focused");
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(0).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", { metaKey: true, key: "ArrowDown" });
+        multiActionButtonList().eq(2).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing End while MultiActionButton is open", () => {
-    it("should move focus to last child button", () => {
-      CypressMountWithProviders(
-        <>
-          <MultiActionButtonList />
-          <MultiActionButtonList />
-        </>
-      );
+    describe("pressing ctrlKey + ArrowDown while MultiActionButton is open", () => {
+      it("should move focus to last child button", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      multiActionButton().eq(0).trigger("mouseover");
-      multiActionButtonList().eq(0).focus();
-      multiActionButtonListContainer().eq(0).trigger("keydown", keyCode("End"));
-      multiActionButtonList().eq(2).should("be.focused");
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(0).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", { ctrlKey: true, key: "ArrowDown" });
+        multiActionButtonList().eq(2).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing esc while MultiActionButton is open", () => {
-    it("should close MultiActionButton", () => {
-      CypressMountWithProviders(<MultiActionButtonList />);
+    describe("pressing End while MultiActionButton is open", () => {
+      it("should move focus to last child button", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      multiActionButton().eq(0).trigger("mouseover");
-      multiActionButtonList().eq(1).focus();
-      multiActionButtonComponent().type("{esc}");
-      multiActionButtonListContainer().should("not.exist");
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(0).focus();
+        multiActionButtonListContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("End"));
+        multiActionButtonList().eq(2).should("be.focused");
+      });
     });
-  });
 
-  describe("clicking one of the additional buttons", () => {
-    it("should close MultiActionButton", () => {
-      CypressMountWithProviders(<MultiActionButtonList />);
+    describe("pressing esc while MultiActionButton is open", () => {
+      it("should close MultiActionButton", () => {
+        CypressMountWithProviders(<WithWrapper />);
 
-      multiActionButton().eq(0).trigger("mouseover");
-      multiActionButtonList().eq(0).click();
-      multiActionButtonListContainer().should("not.exist");
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(1).focus();
+        multiActionButtonComponent().type("{esc}");
+        multiActionButtonListContainer().should("not.exist");
+      });
+    });
+
+    describe("clicking one of the additional buttons", () => {
+      it("should close MultiActionButton", () => {
+        CypressMountWithProviders(<WithWrapper />);
+
+        multiActionButton().eq(0).trigger("mouseover");
+        multiActionButtonList().eq(0).click();
+        multiActionButtonListContainer().should("not.exist");
+      });
     });
   });
 

--- a/cypress/components/split-button/split-button.cy.tsx
+++ b/cypress/components/split-button/split-button.cy.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   SplitButtonList,
   SplitButtonNestedInDialog,
+  WithWrapper,
 } from "../../../src/components/split-button/split-button-test.stories";
 import { Accordion } from "../../../src/components/accordion";
 import SplitButton, {
@@ -145,221 +146,455 @@ context("Tests for SplitButton component", () => {
     });
   });
 
-  describe("clicking the toggle button", () => {
-    it("should open the additional buttons", () => {
-      CypressMountWithProviders(<SplitButtonList />);
+  describe("user interactions with SplitButton", () => {
+    describe("clicking the toggle button", () => {
+      it("should open the additional buttons", () => {
+        CypressMountWithProviders(<SplitButtonList />);
 
-      splitToggleButton().eq(0).trigger("click");
-      additionalButton(0).should("be.visible");
-      additionalButton(1).should("be.visible");
-      additionalButton(2).should("be.visible");
+        splitToggleButton().eq(0).trigger("click");
+        additionalButton(0).should("be.visible");
+        additionalButton(1).should("be.visible");
+        additionalButton(2).should("be.visible");
+      });
+    });
+
+    describe("pressing tab while SplitButton is open", () => {
+      it("should move focus to next child button and to second SplitButton when end of list reached", () => {
+        CypressMountWithProviders(
+          <>
+            <SplitButtonList />
+            <SplitButtonList />
+          </>
+        );
+
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(1).focus();
+        splitToggleButton().eq(0).tab();
+        additionalButton(2).should("be.focused");
+        splitToggleButton().eq(0).tab();
+        mainButton().should("be.focused");
+      });
+    });
+
+    describe("pressing ArrowDown while SplitButton is open", () => {
+      it("should move focus to next child button and should not loop when last child is focused", () => {
+        CypressMountWithProviders(
+          <>
+            <SplitButtonList />
+            <SplitButtonList />
+          </>
+        );
+
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(0).focus();
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("downarrow"));
+        additionalButton(1).should("be.focused");
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("downarrow"));
+        additionalButton(2).should("be.focused");
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("downarrow"));
+        additionalButton(2).should("be.focused");
+      });
+    });
+
+    describe("pressing shift and tab while SplitButton is open", () => {
+      it("should move focus to previous child button and to main button when start of list reached", () => {
+        CypressMountWithProviders(
+          <>
+            <SplitButtonList />
+            <SplitButtonList />
+          </>
+        );
+
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(1).focus();
+        splitToggleButton().eq(0).tab({ shift: true });
+        additionalButton(0).should("be.focused");
+        splitToggleButton().eq(0).tab({ shift: true });
+        splitToggleButton().eq(0).should("be.focused");
+      });
+    });
+
+    describe("pressing ArrowUp while SplitButton is open", () => {
+      it("should move focus to previous child button and should not loop when first child is focused", () => {
+        CypressMountWithProviders(
+          <>
+            <SplitButtonList />
+            <SplitButtonList />
+          </>
+        );
+
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(2).focus();
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("uparrow"));
+        additionalButton(1).should("be.focused");
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("uparrow"));
+        additionalButton(0).should("be.focused");
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("uparrow"));
+        additionalButton(0).should("be.focused");
+      });
+    });
+
+    describe("pressing metaKey + ArrowUp while SplitButton is open", () => {
+      it("should move focus to first child button", () => {
+        CypressMountWithProviders(
+          <>
+            <SplitButtonList />
+            <SplitButtonList />
+          </>
+        );
+
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(2).focus();
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", { metaKey: true, key: "ArrowUp" });
+        additionalButton(0).should("be.focused");
+      });
+    });
+
+    describe("pressing ctrlKey + ArrowUp while SplitButton is open", () => {
+      it("should move focus to first child button", () => {
+        CypressMountWithProviders(
+          <>
+            <SplitButtonList />
+            <SplitButtonList />
+          </>
+        );
+
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(2).focus();
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", { ctrlKey: true, key: "ArrowUp" });
+        additionalButton(0).should("be.focused");
+      });
+    });
+
+    describe("pressing Home while SplitButton is open", () => {
+      it("should move focus to first child button", () => {
+        CypressMountWithProviders(
+          <>
+            <SplitButtonList />
+            <SplitButtonList />
+          </>
+        );
+
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(2).focus();
+        additionalButtonsContainer().eq(0).trigger("keydown", keyCode("Home"));
+        additionalButton(0).should("be.focused");
+      });
+    });
+
+    describe("pressing metaKey + ArrowDown while SplitButton is open", () => {
+      it("should move focus to last child button", () => {
+        CypressMountWithProviders(
+          <>
+            <SplitButtonList />
+            <SplitButtonList />
+          </>
+        );
+
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(0).focus();
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", { metaKey: true, key: "ArrowDown" });
+        additionalButton(2).should("be.focused");
+      });
+    });
+
+    describe("pressing ctrlKey + ArrowDown while SplitButton is open", () => {
+      it("should move focus to last child button", () => {
+        CypressMountWithProviders(
+          <>
+            <SplitButtonList />
+            <SplitButtonList />
+          </>
+        );
+
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(0).focus();
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", { ctrlKey: true, key: "ArrowDown" });
+        additionalButton(2).should("be.focused");
+      });
+    });
+
+    describe("pressing End while SplitButton is open", () => {
+      it("should move focus to last child button", () => {
+        CypressMountWithProviders(
+          <>
+            <SplitButtonList />
+            <SplitButtonList />
+          </>
+        );
+
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(0).focus();
+        additionalButtonsContainer().eq(0).trigger("keydown", keyCode("End"));
+        additionalButton(2).should("be.focused");
+      });
+    });
+
+    describe("clicking one of the additional buttons", () => {
+      it("should close SplitButton", () => {
+        CypressMountWithProviders(<SplitButtonList />);
+
+        splitToggleButton().eq(0).click();
+        additionalButton(0).click();
+        additionalButtonsContainer().should("not.exist");
+      });
+    });
+
+    describe("Pressing esc while SplitButton is open", () => {
+      it("should close SplitButton", () => {
+        CypressMountWithProviders(<SplitButtonList />);
+
+        splitToggleButton().eq(0).click();
+        additionalButton(1).focus();
+        splitToggleButton().eq(0).type("{esc}");
+        additionalButtonsContainer().should("not.exist");
+      });
     });
   });
 
-  describe("pressing tab while SplitButton is open", () => {
-    it("should move focus to next child button and to second SplitButton when end of list reached", () => {
-      CypressMountWithProviders(
-        <>
-          <SplitButtonList />
-          <SplitButtonList />
-        </>
-      );
+  describe("user interactions with SplitButton when wrapping the child buttons in a custom component", () => {
+    describe("clicking the toggle button", () => {
+      it("should open the additional buttons", () => {
+        CypressMountWithProviders(<WithWrapper />);
 
-      splitToggleButton().eq(0).trigger("mouseover");
-      additionalButton(1).focus();
-      splitToggleButton().eq(0).tab();
-      additionalButton(2).should("be.focused");
-      splitToggleButton().eq(0).tab();
-      mainButton().should("be.focused");
+        splitToggleButton().eq(0).trigger("click");
+        additionalButton(0).should("be.visible");
+        additionalButton(1).should("be.visible");
+        additionalButton(2).should("be.visible");
+      });
     });
-  });
 
-  describe("pressing ArrowDown while SplitButton is open", () => {
-    it("should move focus to next child button and should not loop when last child is focused", () => {
-      CypressMountWithProviders(
-        <>
-          <SplitButtonList />
-          <SplitButtonList />
-        </>
-      );
+    describe("pressing tab while SplitButton is open", () => {
+      it("should move focus to next child button and to second SplitButton when end of list reached", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      splitToggleButton().eq(0).trigger("mouseover");
-      additionalButton(0).focus();
-      additionalButtonsContainer()
-        .eq(0)
-        .trigger("keydown", keyCode("downarrow"));
-      additionalButton(1).should("be.focused");
-      additionalButtonsContainer()
-        .eq(0)
-        .trigger("keydown", keyCode("downarrow"));
-      additionalButton(2).should("be.focused");
-      additionalButtonsContainer()
-        .eq(0)
-        .trigger("keydown", keyCode("downarrow"));
-      additionalButton(2).should("be.focused");
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(1).focus();
+        splitToggleButton().eq(0).tab();
+        additionalButton(2).should("be.focused");
+        splitToggleButton().eq(0).tab();
+        mainButton().should("be.focused");
+      });
     });
-  });
 
-  describe("pressing shift and tab while SplitButton is open", () => {
-    it("should move focus to previous child button and to main button when start of list reached", () => {
-      CypressMountWithProviders(
-        <>
-          <SplitButtonList />
-          <SplitButtonList />
-        </>
-      );
+    describe("pressing ArrowDown while SplitButton is open", () => {
+      it("should move focus to next child button and should not loop when last child is focused", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      splitToggleButton().eq(0).trigger("mouseover");
-      additionalButton(1).focus();
-      splitToggleButton().eq(0).tab({ shift: true });
-      additionalButton(0).should("be.focused");
-      splitToggleButton().eq(0).tab({ shift: true });
-      splitToggleButton().eq(0).should("be.focused");
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(0).focus();
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("downarrow"));
+        additionalButton(1).should("be.focused");
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("downarrow"));
+        additionalButton(2).should("be.focused");
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("downarrow"));
+        additionalButton(2).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing ArrowUp while SplitButton is open", () => {
-    it("should move focus to previous child button and should not loop when first child is focused", () => {
-      CypressMountWithProviders(
-        <>
-          <SplitButtonList />
-          <SplitButtonList />
-        </>
-      );
+    describe("pressing shift and tab while SplitButton is open", () => {
+      it("should move focus to previous child button and to main button when start of list reached", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      splitToggleButton().eq(0).trigger("mouseover");
-      additionalButton(2).focus();
-      additionalButtonsContainer().eq(0).trigger("keydown", keyCode("uparrow"));
-      additionalButton(1).should("be.focused");
-      additionalButtonsContainer().eq(0).trigger("keydown", keyCode("uparrow"));
-      additionalButton(0).should("be.focused");
-      additionalButtonsContainer().eq(0).trigger("keydown", keyCode("uparrow"));
-      additionalButton(0).should("be.focused");
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(1).focus();
+        splitToggleButton().eq(0).tab({ shift: true });
+        additionalButton(0).should("be.focused");
+        splitToggleButton().eq(0).tab({ shift: true });
+        splitToggleButton().eq(0).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing metaKey + ArrowUp while SplitButton is open", () => {
-    it("should move focus to first child button", () => {
-      CypressMountWithProviders(
-        <>
-          <SplitButtonList />
-          <SplitButtonList />
-        </>
-      );
+    describe("pressing ArrowUp while SplitButton is open", () => {
+      it("should move focus to previous child button and should not loop when first child is focused", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      splitToggleButton().eq(0).trigger("mouseover");
-      additionalButton(2).focus();
-      additionalButtonsContainer()
-        .eq(0)
-        .trigger("keydown", { metaKey: true, key: "ArrowUp" });
-      additionalButton(0).should("be.focused");
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(2).focus();
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("uparrow"));
+        additionalButton(1).should("be.focused");
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("uparrow"));
+        additionalButton(0).should("be.focused");
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", keyCode("uparrow"));
+        additionalButton(0).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing ctrlKey + ArrowUp while SplitButton is open", () => {
-    it("should move focus to first child button", () => {
-      CypressMountWithProviders(
-        <>
-          <SplitButtonList />
-          <SplitButtonList />
-        </>
-      );
+    describe("pressing metaKey + ArrowUp while SplitButton is open", () => {
+      it("should move focus to first child button", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      splitToggleButton().eq(0).trigger("mouseover");
-      additionalButton(2).focus();
-      additionalButtonsContainer()
-        .eq(0)
-        .trigger("keydown", { ctrlKey: true, key: "ArrowUp" });
-      additionalButton(0).should("be.focused");
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(2).focus();
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", { metaKey: true, key: "ArrowUp" });
+        additionalButton(0).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing Home while SplitButton is open", () => {
-    it("should move focus to first child button", () => {
-      CypressMountWithProviders(
-        <>
-          <SplitButtonList />
-          <SplitButtonList />
-        </>
-      );
+    describe("pressing ctrlKey + ArrowUp while SplitButton is open", () => {
+      it("should move focus to first child button", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      splitToggleButton().eq(0).trigger("mouseover");
-      additionalButton(2).focus();
-      additionalButtonsContainer().eq(0).trigger("keydown", keyCode("Home"));
-      additionalButton(0).should("be.focused");
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(2).focus();
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", { ctrlKey: true, key: "ArrowUp" });
+        additionalButton(0).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing metaKey + ArrowDown while SplitButton is open", () => {
-    it("should move focus to last child button", () => {
-      CypressMountWithProviders(
-        <>
-          <SplitButtonList />
-          <SplitButtonList />
-        </>
-      );
+    describe("pressing Home while SplitButton is open", () => {
+      it("should move focus to first child button", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      splitToggleButton().eq(0).trigger("mouseover");
-      additionalButton(0).focus();
-      additionalButtonsContainer()
-        .eq(0)
-        .trigger("keydown", { metaKey: true, key: "ArrowDown" });
-      additionalButton(2).should("be.focused");
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(2).focus();
+        additionalButtonsContainer().eq(0).trigger("keydown", keyCode("Home"));
+        additionalButton(0).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing ctrlKey + ArrowDown while SplitButton is open", () => {
-    it("should move focus to last child button", () => {
-      CypressMountWithProviders(
-        <>
-          <SplitButtonList />
-          <SplitButtonList />
-        </>
-      );
+    describe("pressing metaKey + ArrowDown while SplitButton is open", () => {
+      it("should move focus to last child button", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      splitToggleButton().eq(0).trigger("mouseover");
-      additionalButton(0).focus();
-      additionalButtonsContainer()
-        .eq(0)
-        .trigger("keydown", { ctrlKey: true, key: "ArrowDown" });
-      additionalButton(2).should("be.focused");
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(0).focus();
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", { metaKey: true, key: "ArrowDown" });
+        additionalButton(2).should("be.focused");
+      });
     });
-  });
 
-  describe("pressing End while SplitButton is open", () => {
-    it("should move focus to last child button", () => {
-      CypressMountWithProviders(
-        <>
-          <SplitButtonList />
-          <SplitButtonList />
-        </>
-      );
+    describe("pressing ctrlKey + ArrowDown while SplitButton is open", () => {
+      it("should move focus to last child button", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      splitToggleButton().eq(0).trigger("mouseover");
-      additionalButton(0).focus();
-      additionalButtonsContainer().eq(0).trigger("keydown", keyCode("End"));
-      additionalButton(2).should("be.focused");
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(0).focus();
+        additionalButtonsContainer()
+          .eq(0)
+          .trigger("keydown", { ctrlKey: true, key: "ArrowDown" });
+        additionalButton(2).should("be.focused");
+      });
     });
-  });
 
-  describe("clicking one of the additional buttons", () => {
-    it("should close SplitButton", () => {
-      CypressMountWithProviders(<SplitButtonList />);
+    describe("pressing End while SplitButton is open", () => {
+      it("should move focus to last child button", () => {
+        CypressMountWithProviders(
+          <>
+            <WithWrapper />
+            <WithWrapper />
+          </>
+        );
 
-      splitToggleButton().eq(0).click();
-      additionalButton(0).click();
-      additionalButtonsContainer().should("not.exist");
+        splitToggleButton().eq(0).trigger("mouseover");
+        additionalButton(0).focus();
+        additionalButtonsContainer().eq(0).trigger("keydown", keyCode("End"));
+        additionalButton(2).should("be.focused");
+      });
     });
-  });
 
-  describe("Pressing esc while SplitButton is open", () => {
-    it("should close SplitButton", () => {
-      CypressMountWithProviders(<SplitButtonList />);
+    describe("clicking one of the additional buttons", () => {
+      it("should close SplitButton", () => {
+        CypressMountWithProviders(<WithWrapper />);
 
-      splitToggleButton().eq(0).click();
-      additionalButton(1).focus();
-      splitToggleButton().eq(0).type("{esc}");
-      additionalButtonsContainer().should("not.exist");
+        splitToggleButton().eq(0).click();
+        additionalButton(0).click();
+        additionalButtonsContainer().should("not.exist");
+      });
+    });
+
+    describe("Pressing esc while SplitButton is open", () => {
+      it("should close SplitButton", () => {
+        CypressMountWithProviders(<WithWrapper />);
+
+        splitToggleButton().eq(0).click();
+        additionalButton(1).focus();
+        splitToggleButton().eq(0).type("{esc}");
+        additionalButtonsContainer().should("not.exist");
+      });
     });
   });
 

--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -9,6 +9,7 @@ import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import Logger from "../../__internal__/utils/logger";
 import { TooltipPositions } from "../tooltip/tooltip.config";
 import { ButtonBarContext } from "../button-bar/button-bar.component";
+import SplitButtonContext from "../split-button/__internal__/split-button.context";
 
 export type ButtonTypes =
   | "primary"
@@ -194,6 +195,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       iconTooltipMessage,
       iconTooltipPosition,
       fullWidth: fullWidthProp = false,
+      onClick,
       ...rest
     }: ButtonProps,
     ref
@@ -236,6 +238,10 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     }
 
     const [internalRef, setInternalRef] = useState<HTMLButtonElement>();
+
+    const { inSplitButton, onChildButtonClick } = useContext(
+      SplitButtonContext
+    );
 
     let paddingX;
 
@@ -280,11 +286,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         }
         as={!disabled && href ? "a" : "button"}
         onKeyDown={href ? handleLinkKeyDown : undefined}
+        onClick={inSplitButton ? onChildButtonClick?.(onClick) : onClick}
         draggable={false}
         buttonType={buttonType}
         disabled={disabled}
         destructive={destructive}
-        role="button"
+        role={inSplitButton ? "menu-item" : "button"}
         type={href ? undefined : "button"}
         iconType={iconType}
         size={size}

--- a/src/components/multi-action-button/multi-action-button-test.stories.tsx
+++ b/src/components/multi-action-button/multi-action-button-test.stories.tsx
@@ -4,7 +4,7 @@ import Dialog from "../dialog";
 import MultiActionButton, {
   MultiActionButtonProps,
 } from "./multi-action-button.component";
-import Button from "../button";
+import Button, { ButtonProps } from "../button";
 import {
   MULTI_ACTION_BUTTON_ALIGNMENTS,
   MULTI_ACTION_BUTTON_SIZES,
@@ -117,5 +117,17 @@ export const MultiActionWithHrefChildren = () => (
 export const MultiActionButtonWithOneChild = () => (
   <MultiActionButton text="default text">
     <Button>Button 1</Button>
+  </MultiActionButton>
+);
+
+const ButtonWrapper = (props: ButtonProps) => {
+  return <Button {...props} />;
+};
+
+export const WithWrapper = (props: Partial<MultiActionButtonProps>) => (
+  <MultiActionButton text="Split button" {...props}>
+    <ButtonWrapper>Button 1</ButtonWrapper>
+    <ButtonWrapper>Button 2</ButtonWrapper>
+    <ButtonWrapper>Button 3</ButtonWrapper>
   </MultiActionButton>
 );

--- a/src/components/split-button/__internal__/split-button.context.ts
+++ b/src/components/split-button/__internal__/split-button.context.ts
@@ -1,0 +1,16 @@
+import React from "react";
+
+export interface SplitButtonContextProps {
+  inSplitButton: boolean;
+  onChildButtonClick?: (
+    childOnClick?: React.MouseEventHandler<
+      HTMLButtonElement | HTMLAnchorElement
+    >
+  ) =>
+    | React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>
+    | undefined;
+}
+
+export default React.createContext<SplitButtonContextProps>({
+  inSplitButton: false,
+});

--- a/src/components/split-button/split-button-test.stories.tsx
+++ b/src/components/split-button/split-button-test.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
-import Button from "../button";
+import Button, { ButtonProps } from "../button";
 import Box from "../box";
 import { ICONS } from "../icon/icon-config";
 import Dialog from "../dialog";
@@ -118,3 +118,15 @@ export const SplitButtonNestedInDialog = () => {
     </Dialog>
   );
 };
+
+const ButtonWrapper = (props: ButtonProps) => {
+  return <Button {...props} />;
+};
+
+export const WithWrapper = (props: Partial<SplitButtonProps>) => (
+  <SplitButton text="Split button" {...props}>
+    <ButtonWrapper>Button 1</ButtonWrapper>
+    <ButtonWrapper>Button 2</ButtonWrapper>
+    <ButtonWrapper>Button 3</ButtonWrapper>
+  </SplitButton>
+);

--- a/src/components/split-button/split-button.component.tsx
+++ b/src/components/split-button/split-button.component.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useContext,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useContext, useRef } from "react";
 import { ThemeContext } from "styled-components";
 import { MarginProps } from "styled-system";
 
@@ -14,7 +8,6 @@ import Button from "../button";
 import StyledSplitButton from "./split-button.style";
 import StyledSplitButtonToggle from "./split-button-toggle.style";
 import StyledSplitButtonChildrenContainer from "./split-button-children.style";
-import Events from "../../__internal__/utils/helpers/events";
 import guid from "../../__internal__/utils/helpers/guid";
 import Popover from "../../__internal__/popover";
 import {
@@ -22,7 +15,8 @@ import {
   filterOutStyledSystemSpacingProps,
 } from "../../style/utils";
 import { baseTheme } from "../../style/themes";
-import useMenuKeyboardNavigation from "../../hooks/__internal__/useMenuKeyboardNavigation";
+import useChildButtons from "../../hooks/__internal__/useChildButtons";
+import SplitButtonContext from "./__internal__/split-button.context";
 
 const CONTENT_WIDTH_RATIO = 0.75;
 
@@ -70,67 +64,19 @@ export const SplitButton = ({
 }: SplitButtonProps) => {
   const theme = useContext(ThemeContext) || baseTheme;
   const buttonLabelId = useRef(guid());
-  const buttonChildren = useMemo(() => React.Children.toArray(children), [
-    children,
-  ]);
-  const buttonChildrenRefs = useMemo<React.RefObject<HTMLButtonElement>[]>(
-    () => buttonChildren.map(() => React.createRef()),
-    [buttonChildren]
-  );
-  const splitButtonNode = useRef<HTMLDivElement>(null);
+
   const toggleButton = useRef<HTMLButtonElement>(null);
-  const [showAdditionalButtons, setShowAdditionalButtons] = useState(false);
-  const [minWidth, setMinWidth] = useState(0);
 
-  const hideButtons = useCallback(() => {
-    setShowAdditionalButtons(false);
-  }, []);
-
-  const handleKeyDown = useMenuKeyboardNavigation(
-    toggleButton,
-    buttonChildrenRefs,
+  const {
+    showAdditionalButtons,
+    showButtons,
     hideButtons,
-    showAdditionalButtons
-  );
-
-  function showButtons() {
-    setShowAdditionalButtons(true);
-
-    /* istanbul ignore else */
-    if (splitButtonNode.current) {
-      setMinWidth(
-        CONTENT_WIDTH_RATIO *
-          splitButtonNode.current.getBoundingClientRect().width
-      );
-    }
-  }
-
-  function handleToggleButtonKeyDown(
-    ev: React.KeyboardEvent<HTMLButtonElement>
-  ) {
-    if (
-      Events.isEnterKey(ev) ||
-      Events.isSpaceKey(ev) ||
-      Events.isDownKey(ev) ||
-      Events.isUpKey(ev)
-    ) {
-      ev.preventDefault();
-
-      if (!showAdditionalButtons) {
-        showButtons();
-      }
-
-      setTimeout(() => {
-        buttonChildrenRefs[0]?.current?.focus();
-      }, 0);
-    }
-  }
-
-  const hideButtonsIfTriggerNotFocused = useCallback(() => {
-    if (toggleButton.current === document.activeElement) return;
-
-    setShowAdditionalButtons(false);
-  }, []);
+    buttonNode,
+    hideButtonsIfTriggerNotFocused,
+    handleToggleButtonKeyDown,
+    wrapperProps,
+    contextValue,
+  } = useChildButtons(toggleButton, CONTENT_WIDTH_RATIO);
 
   const mainButtonProps = {
     onMouseEnter: hideButtonsIfTriggerNotFocused,
@@ -205,40 +151,19 @@ export const SplitButton = ({
     ];
   }
 
-  function childrenWithProps() {
-    const childArray = Array.isArray(children) ? children : [children];
-
-    return childArray.filter(Boolean).map((child, index) => {
-      const childProps = {
-        key: index.toString(),
-        role: "menuitem",
-        ref: buttonChildrenRefs[index],
-        tabIndex: -1,
-        onClick: (ev: React.MouseEvent<HTMLButtonElement>) => {
-          if (child.props.onClick) child.props.onClick(ev);
-          hideButtons();
-          toggleButton.current?.focus();
-        },
-      };
-
-      return React.cloneElement(child, childProps);
-    });
-  }
-
   function renderAdditionalButtons() {
     if (!showAdditionalButtons) return null;
 
     return (
-      <Popover placement="bottom-end" reference={splitButtonNode}>
+      <Popover placement="bottom-end" reference={buttonNode}>
         <StyledSplitButtonChildrenContainer
-          role="menu"
+          {...wrapperProps}
           aria-label={text}
-          data-element="additional-buttons"
           align={align}
-          minWidth={minWidth}
-          onKeyDown={handleKeyDown}
         >
-          {childrenWithProps()}
+          <SplitButtonContext.Provider value={contextValue}>
+            {children}
+          </SplitButtonContext.Provider>
         </StyledSplitButtonChildrenContainer>
       </Popover>
     );
@@ -251,7 +176,7 @@ export const SplitButton = ({
     <StyledSplitButton
       onMouseLeave={hideButtonsIfTriggerNotFocused}
       onClick={handleClick}
-      ref={splitButtonNode}
+      ref={buttonNode}
       {...componentTags()}
       {...marginProps}
     >

--- a/src/hooks/__internal__/useChildButtons/index.ts
+++ b/src/hooks/__internal__/useChildButtons/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./useChildButtons";

--- a/src/hooks/__internal__/useChildButtons/useChildButtons.tsx
+++ b/src/hooks/__internal__/useChildButtons/useChildButtons.tsx
@@ -1,0 +1,111 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import Events from "../../../__internal__/utils/helpers/events";
+import useMenuKeyboardNavigation from "../useMenuKeyboardNavigation";
+
+const useChildButtons = (
+  toggleButtonRef: React.RefObject<HTMLButtonElement>,
+  widthRatio = 1
+) => {
+  const [showAdditionalButtons, setShowAdditionalButtons] = useState(false);
+  const [minWidth, setMinWidth] = useState(0);
+
+  const buttonNode = useRef<HTMLDivElement>(null);
+  const childrenContainer = useRef<HTMLDivElement>(null);
+  const focusFirstChildButtonOnOpen = useRef(false);
+
+  const hideButtons = useCallback(() => {
+    setShowAdditionalButtons(false);
+  }, []);
+
+  function showButtons() {
+    setShowAdditionalButtons(true);
+
+    /* istanbul ignore else */
+    if (buttonNode.current) {
+      setMinWidth(
+        widthRatio * buttonNode.current.getBoundingClientRect().width
+      );
+    }
+  }
+
+  const getButtonChildren = useCallback(
+    () =>
+      childrenContainer.current?.querySelectorAll(
+        '[data-component="button"]'
+      ) as NodeListOf<HTMLButtonElement>,
+    []
+  );
+
+  useEffect(() => {
+    const firstChild = getButtonChildren()?.[0];
+    if (
+      focusFirstChildButtonOnOpen.current &&
+      showAdditionalButtons &&
+      firstChild
+    ) {
+      focusFirstChildButtonOnOpen.current = false;
+      firstChild.focus();
+    }
+  }, [showAdditionalButtons, getButtonChildren]);
+
+  const handleToggleButtonKeyDown = (
+    ev: React.KeyboardEvent<HTMLButtonElement>
+  ) => {
+    if (
+      Events.isEnterKey(ev) ||
+      Events.isSpaceKey(ev) ||
+      Events.isDownKey(ev) ||
+      Events.isUpKey(ev)
+    ) {
+      ev.preventDefault();
+
+      if (!showAdditionalButtons) {
+        showButtons();
+      }
+
+      focusFirstChildButtonOnOpen.current = true;
+    }
+  };
+
+  const handleKeyDown = useMenuKeyboardNavigation(
+    toggleButtonRef,
+    getButtonChildren,
+    hideButtons,
+    showAdditionalButtons
+  );
+
+  const onChildButtonClick = (
+    childOnClick?: React.MouseEventHandler<HTMLButtonElement>
+  ) => (ev: React.MouseEvent<HTMLButtonElement>) => {
+    childOnClick?.(ev);
+    hideButtons();
+    toggleButtonRef.current?.focus();
+  };
+
+  const hideButtonsIfTriggerNotFocused = useCallback(() => {
+    if (toggleButtonRef.current === document.activeElement) return;
+    setShowAdditionalButtons(false);
+  }, [toggleButtonRef]);
+
+  const wrapperProps = {
+    role: "menu",
+    "data-element": "additional-buttons",
+    onKeyDown: handleKeyDown,
+    minWidth,
+    ref: childrenContainer,
+  };
+  const contextValue = { inSplitButton: true, onChildButtonClick };
+
+  return {
+    showAdditionalButtons,
+    showButtons,
+    hideButtons,
+    buttonNode,
+    hideButtonsIfTriggerNotFocused,
+    handleToggleButtonKeyDown,
+    wrapperProps,
+    contextValue,
+  };
+};
+
+export default useChildButtons;

--- a/src/hooks/__internal__/useMenuKeyboardNavigation/useMenuKeyboardNavigation.spec.tsx
+++ b/src/hooks/__internal__/useMenuKeyboardNavigation/useMenuKeyboardNavigation.spec.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useCallback } from "react";
 import { render, screen, fireEvent, createEvent } from "@testing-library/react";
 import useMenuKeyboardNavigation from ".";
 
@@ -29,7 +29,20 @@ const MockComponent = ({ hideCb }: MockComponentProps) => {
     );
   });
 
-  const handleKeyDown = useMenuKeyboardNavigation(mainRef, refs, hideCb, true);
+  const getButtonChildren = useCallback(
+    () =>
+      document.querySelectorAll(
+        `[data-testid="${containerID}"] button`
+      ) as NodeListOf<HTMLButtonElement>,
+    []
+  );
+
+  const handleKeyDown = useMenuKeyboardNavigation(
+    mainRef,
+    getButtonChildren,
+    hideCb,
+    true
+  );
 
   return (
     <>


### PR DESCRIPTION
SplitButton and MultiActionButton used to clone their children and pass particular props, including refs - assuming each child was a Button component. This meant that the components failed to work properly when using custom child components that wrap one or more Carbon Buttons (at least unless forwardRef was used). This has now been replaced by a context-based approach using DOM selectors to achieve the same functionality no matter how the children are composed.

fix #4784

### Proposed behaviour

All functionality in SplitButton and MultiActionButton should work when consumers wrap Carbon Button in a custom child component

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

There are warnings in the console when using such a wrapper, and keyboard navigation fails to work

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

Ensure that the original issue is fixed, and perform regression testing on the SplitButton and MultiActionButton components.

<!-- Add CodeSandbox here -->
