### PR TITLE
fix(menu): ensure menu remains open when enter is pressed on search - FE-6035

### DIFF
--- a/cypress/components/menu/menu.cy.tsx
+++ b/cypress/components/menu/menu.cy.tsx
@@ -384,6 +384,18 @@ context("Testing Menu component", () => {
         .should("have.css", "background-color", "rgb(0, 50, 76)");
     });
 
+    it("should not close submenu when enter is pressed on search component", () => {
+      CypressMountWithProviders(<MenuComponentSearch />);
+
+      pressTABKey(1);
+      cy.focused().trigger("keydown", keyCode("Enter"));
+      cy.focused().trigger("keydown", keyCode("downarrow"));
+      searchDefaultInput().clear().type("FooBar");
+      cy.focused().tab();
+      cy.focused().trigger("keydown", keyCode("Enter"));
+      submenuBlock().should("be.visible");
+    });
+
     it("should verify if there is a Menu Item with a very long label inside a submenu, check that the width of the whole submenu is determined by this submenu item", () => {
       CypressMountWithProviders(
         <Box mb={150}>

--- a/src/__internal__/utils/helpers/events/events.ts
+++ b/src/__internal__/utils/helpers/events/events.ts
@@ -127,7 +127,7 @@ const Events = {
    */
   composedPath: (ev: CustomEvent): EventTarget[] => {
     return (
-      (ev.detail && ev.detail.enzymeTestingTarget && composedPath(ev)) ||
+      (ev.detail?.enzymeTestingTarget && composedPath(ev)) ||
       (ev.composedPath && ev.composedPath()) ||
       composedPath(ev)
     );

--- a/src/components/menu/__internal__/submenu/submenu.component.tsx
+++ b/src/components/menu/__internal__/submenu/submenu.component.tsx
@@ -297,15 +297,24 @@ const Submenu = React.forwardRef<
             setCharacterString("");
           }
 
-          if (Events.isEnterKey(event)) {
-            /* timeout enforces that the "closeSubmenu" method will be run after 
-              the browser navigates to the specified href of the menu-item. */
-            setTimeout(() => closeSubmenu());
-          }
+          const eventIsFromInput = Events.composedPath(event).find(
+            (p) =>
+              (p as HTMLElement).getAttribute("data-element") === "input" ||
+              (p as HTMLElement).getAttribute("data-element") ===
+                "input-icon-toggle"
+          );
 
-          if (href && Events.isEnterKey(event)) {
-            closeSubmenu();
-            return;
+          if (!eventIsFromInput) {
+            if (Events.isEnterKey(event)) {
+              /* timeout enforces that the "closeSubmenu" method will be run after 
+                the browser navigates to the specified href of the menu-item. */
+              setTimeout(() => closeSubmenu(), 0);
+            }
+
+            if (href && Events.isEnterKey(event)) {
+              closeSubmenu();
+              return;
+            }
           }
 
           if (nextIndex !== index) {

--- a/src/components/menu/__internal__/submenu/submenu.spec.tsx
+++ b/src/components/menu/__internal__/submenu/submenu.spec.tsx
@@ -1614,6 +1614,25 @@ describe("Submenu component", () => {
 
       expect(mockSubmenuhandleKeyDown).not.toHaveBeenCalled();
     });
+
+    it("should not close the submenu when enter is pressed", () => {
+      wrapper = renderWithSearchDefaultValue("dark", { clickToOpen: true });
+      openSubmenu(wrapper);
+
+      wrapper.update();
+
+      act(() => {
+        wrapper
+          .find(StyledMenuItemWrapper)
+          .at(1)
+          .props()
+          .onKeyDown(events.enter);
+      });
+
+      wrapper.update();
+
+      expect(wrapper.find(Submenu).exists()).toEqual(true);
+    });
   });
 
   describe("when children items are updated", () => {


### PR DESCRIPTION
A bug is present that means when the `enter` key is pressed on the Search component, the whole submenu closes. This fix ensures that the submenu does not close when enter is pressed when an event is fired from the input or the `X` icon inside Search.

fixes #6146

### Proposed behaviour

Submenu should only close if the `enter` key event comes outside of the Search input or `X` icon.

### Current behaviour

Submenu closes when the `enter` key is pressed inside of the Search component.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Codesandbox to test with: https://codesandbox.io/s/submenu-with-search-c4xdvw

 - Navigate to Search component
 - Type a value in the Search component
 - Press `Enter`
 - Submenu should stay open 
