### PR TITLE
feat(checkbox): add support for new validation - FE-5754

### DIFF
--- a/cypress/components/checkbox/checkbox.cy.tsx
+++ b/cypress/components/checkbox/checkbox.cy.tsx
@@ -1,11 +1,15 @@
 /* eslint-disable no-shadow, jest/valid-expect, no-unused-expressions */
 import React from "react";
-import { CheckboxGroupProps } from "components/checkbox";
 import Box from "../../../src/components/box";
-import { Checkbox, CheckboxProps } from "../../../src/components/checkbox";
+import {
+  Checkbox,
+  CheckboxProps,
+  CheckboxGroupProps,
+} from "../../../src/components/checkbox";
 import {
   CheckboxComponent,
   CheckboxGroupComponent,
+  CheckboxGroupComponentNewValidation,
 } from "../../../src/components/checkbox/checkbox-test.stories";
 
 import * as stories from "../../../src/components/checkbox/checkbox.stories";
@@ -82,222 +86,244 @@ context("Testing Checkbox component", () => {
         checkboxRole().should(assertion);
       }
     );
-  });
 
-  it.each(testData)(
-    "should render Checkbox component with %s as a label",
-    (label) => {
-      CypressMountWithProviders(<CheckboxComponent label={label} />);
+    it.each(testData)(
+      "should render Checkbox component with %s as a label",
+      (label) => {
+        CypressMountWithProviders(<CheckboxComponent label={label} />);
 
-      checkboxLabel().should("have.text", label);
-    }
-  );
-
-  it.each(testData)(
-    "should render Checkbox component with %s as fieldHelp",
-    (fieldHelp) => {
-      CypressMountWithProviders(<CheckboxComponent fieldHelp={fieldHelp} />);
-
-      fieldHelpPreview().should("have.text", fieldHelp);
-    }
-  );
-
-  it("should render Checkbox component with inline fieldHelp", () => {
-    CypressMountWithProviders(
-      <CheckboxComponent fieldHelp="Inline fieldhelp" fieldHelpInline />
+        checkboxLabel().should("have.text", label);
+      }
     );
 
-    checkboxInlineFieldHelp().should("have.text", "Inline fieldhelp");
-  });
+    it.each(testData)(
+      "should render Checkbox component with %s as fieldHelp",
+      (fieldHelp) => {
+        CypressMountWithProviders(<CheckboxComponent fieldHelp={fieldHelp} />);
 
-  it("should render Checkbox component with helpAriaLabel", () => {
-    CypressMountWithProviders(
-      <CheckboxComponent
-        label="Label For CheckBox"
-        labelHelp="Label Help"
-        helpAriaLabel="This text provides more information for the label"
-      />
+        fieldHelpPreview().should("have.text", fieldHelp);
+      }
     );
 
-    checkboxIcon().trigger("mouseover");
-    checkboxHelpIcon().should(
-      "have.attr",
-      "aria-label",
-      "This text provides more information for the label"
-    );
-  });
+    it("should render Checkbox component with inline fieldHelp", () => {
+      CypressMountWithProviders(
+        <CheckboxComponent fieldHelp="Inline fieldhelp" fieldHelpInline />
+      );
 
-  it.each([
-    [true, "be.disabled"],
-    [false, "not.be.disabled"],
-  ])(
-    "should render Checkbox component with disabled prop set to %s",
-    (booleanValue, assertion) => {
-      CypressMountWithProviders(<CheckboxComponent disabled={booleanValue} />);
-      checkboxRole().should(assertion);
-    }
-  );
+      checkboxInlineFieldHelp().should("have.text", "Inline fieldhelp");
+    });
 
-  it("should render Checkbox component with id", () => {
-    CypressMountWithProviders(<CheckboxComponent id={CHARACTERS.STANDARD} />);
-    checkboxRole().should("have.id", CHARACTERS.STANDARD);
-  });
-
-  it("should render Checkbox component with name", () => {
-    CypressMountWithProviders(<CheckboxComponent name="confirm permission" />);
-    checkboxRole().should("have.attr", "name", "confirm permission");
-  });
-
-  it("should render Checkbox component with value prop", () => {
-    CypressMountWithProviders(<CheckboxComponent value="checkboxvalue" />);
-    checkboxRole().should("have.value", "checkboxvalue");
-  });
-
-  it.each([
-    [SIZE.SMALL, 16],
-    [SIZE.LARGE, 24],
-  ])(
-    "should render Checkbox component with size set to %s",
-    (size, sizeInPx) => {
-      CypressMountWithProviders(<CheckboxComponent size={size} />);
-      checkboxRole().then(($el) => {
-        assertCssValueIsApproximately($el, "height", sizeInPx);
-        assertCssValueIsApproximately($el, "width", sizeInPx);
-      });
-    }
-  );
-
-  it.each([
-    [1, "8px"],
-    [2, "16px"],
-  ])(
-    "should render Checkbox component with %s as labelSpacing",
-    (spacing, padding) => {
-      CypressMountWithProviders(<CheckboxComponent labelSpacing={spacing} />);
-
-      checkboxLabel().parent().should("have.css", "padding-left", padding);
-    }
-  );
-
-  it.each([
-    ["10", "90", 135, 1229],
-    ["30", "70", 409, 956],
-    ["80", "20", 1092, 273],
-  ])(
-    "should render Checkbox using %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
-    (labelWidth, inputWidth, labelRatio, inputRatio) => {
+    it("should render Checkbox component with helpAriaLabel", () => {
       CypressMountWithProviders(
         <CheckboxComponent
-          labelInline
-          labelWidth={labelWidth}
-          inputWidth={inputWidth}
+          label="Label For CheckBox"
+          labelHelp="Label Help"
+          helpAriaLabel="This text provides more information for the label"
         />
       );
 
-      checkboxLabel()
-        .parent()
-        .then(($el) => {
-          assertCssValueIsApproximately($el, "width", labelRatio);
-        });
-      checkboxRole()
-        .parent()
-        .then(($el) => {
-          assertCssValueIsApproximately($el, "width", inputRatio);
-        });
-    }
-  );
-
-  it("should render Checkbox component as a required field", () => {
-    CypressMountWithProviders(
-      <CheckboxComponent label="Required Checkbox" required />
-    );
-    verifyRequiredAsteriskForLabel();
-  });
-
-  it("should render Checkbox component with autoFocus", () => {
-    CypressMountWithProviders(<CheckboxComponent autoFocus />);
-    checkboxRole().should("be.focused");
-  });
-
-  it("should render Checkbox component with error", () => {
-    CypressMountWithProviders(<CheckboxComponent error />);
-
-    checkboxSvg().should("have.css", "border-bottom-color", VALIDATION.ERROR);
-  });
-
-  it("should render Checkbox component with warning", () => {
-    CypressMountWithProviders(<CheckboxComponent warning />);
-
-    checkboxSvg().should("have.css", "border-bottom-color", VALIDATION.WARNING);
-  });
-
-  it("should render Checkbox component with info", () => {
-    CypressMountWithProviders(<CheckboxComponent info />);
-
-    checkboxSvg().should("have.css", "border-bottom-color", VALIDATION.INFO);
-  });
-
-  it("should render Checkbox component with error icon", () => {
-    CypressMountWithProviders(<CheckboxComponent error="Error has occurred" />);
-
-    checkboxIcon().should("have.attr", "data-element", "error");
-  });
-
-  it("should render Checkbox component with warning icon", () => {
-    CypressMountWithProviders(
-      <CheckboxComponent warning="Warning has occurred" />
-    );
-
-    checkboxIcon().should("have.attr", "data-element", "warning");
-  });
-
-  it("should render Checkbox component with info icon", () => {
-    CypressMountWithProviders(<CheckboxComponent info="Info has occurred" />);
-
-    checkboxIcon().should("have.attr", "data-element", "info");
-  });
-
-  it.each([
-    [true, 0],
-    [false, 1],
-  ])(
-    "should render Checkbox with reverse prop set to %s",
-    (reverseValue, position) => {
-      CypressMountWithProviders(
-        <CheckboxComponent label="Checkbox Label" reverse={reverseValue} />
-      );
-
-      checkboxComponent()
-        .find("div:nth-child(1) > div > div:nth-child(1)")
-        .children()
-        .eq(position)
-        .should("have.text", "Checkbox Label");
-    }
-  );
-
-  it.each(["bottom", "left", "right", "top"])(
-    "should render CheckboxComponent component with tooltip positioned to the %s",
-    (position) => {
-      CypressMountWithProviders(
-        <Box m="250px">
-          <CheckboxComponent
-            labelHelp="Tooltip info"
-            tooltipPosition={position}
-          />
-        </Box>
-      );
       checkboxIcon().trigger("mouseover");
-      tooltipPreview()
-        .should("have.text", "Tooltip info")
-        .should("have.attr", "data-placement", `${position}`);
-    }
-  );
+      checkboxHelpIcon().should(
+        "have.attr",
+        "aria-label",
+        "This text provides more information for the label"
+      );
+    });
 
-  it("should render Checkbox component with tick color set to black by default", () => {
-    CypressMountWithProviders(<CheckboxComponent checked />);
-    checkboxRole()
-      .should("be.checked")
-      .should("have.css", "color", COLOR.BLACK);
+    it.each([
+      [true, "be.disabled"],
+      [false, "not.be.disabled"],
+    ])(
+      "should render Checkbox component with disabled prop set to %s",
+      (booleanValue, assertion) => {
+        CypressMountWithProviders(
+          <CheckboxComponent disabled={booleanValue} />
+        );
+        checkboxRole().should(assertion);
+      }
+    );
+
+    it("should render Checkbox component with id", () => {
+      CypressMountWithProviders(<CheckboxComponent id={CHARACTERS.STANDARD} />);
+      checkboxRole().should("have.id", CHARACTERS.STANDARD);
+    });
+
+    it("should render Checkbox component with name", () => {
+      CypressMountWithProviders(
+        <CheckboxComponent name="confirm permission" />
+      );
+      checkboxRole().should("have.attr", "name", "confirm permission");
+    });
+
+    it("should render Checkbox component with value prop", () => {
+      CypressMountWithProviders(<CheckboxComponent value="checkboxvalue" />);
+      checkboxRole().should("have.value", "checkboxvalue");
+    });
+
+    it.each([
+      [SIZE.SMALL, 16],
+      [SIZE.LARGE, 24],
+    ])(
+      "should render Checkbox component with size set to %s",
+      (size, sizeInPx) => {
+        CypressMountWithProviders(<CheckboxComponent size={size} />);
+        checkboxRole().then(($el) => {
+          assertCssValueIsApproximately($el, "height", sizeInPx);
+          assertCssValueIsApproximately($el, "width", sizeInPx);
+        });
+      }
+    );
+
+    it.each([
+      [1, "8px"],
+      [2, "16px"],
+    ])(
+      "should render Checkbox component with %s as labelSpacing",
+      (spacing, padding) => {
+        CypressMountWithProviders(<CheckboxComponent labelSpacing={spacing} />);
+
+        checkboxLabel().parent().should("have.css", "padding-left", padding);
+      }
+    );
+
+    it.each([
+      ["10", "90", 135, 1229],
+      ["30", "70", 409, 956],
+      ["80", "20", 1092, 273],
+    ])(
+      "should render Checkbox using %s as labelWidth, %s as inputWidth and render it with correct label and input width ratios",
+      (labelWidth, inputWidth, labelRatio, inputRatio) => {
+        CypressMountWithProviders(
+          <CheckboxComponent
+            labelInline
+            labelWidth={labelWidth}
+            inputWidth={inputWidth}
+          />
+        );
+
+        checkboxLabel()
+          .parent()
+          .then(($el) => {
+            assertCssValueIsApproximately($el, "width", labelRatio);
+          });
+        checkboxRole()
+          .parent()
+          .then(($el) => {
+            assertCssValueIsApproximately($el, "width", inputRatio);
+          });
+      }
+    );
+
+    it("should render Checkbox component as a required field", () => {
+      CypressMountWithProviders(
+        <CheckboxComponent label="Required Checkbox" required />
+      );
+      verifyRequiredAsteriskForLabel();
+    });
+
+    it("should render Checkbox component with autoFocus", () => {
+      CypressMountWithProviders(<CheckboxComponent autoFocus />);
+      checkboxRole().should("be.focused");
+    });
+
+    it("should render Checkbox component with error", () => {
+      CypressMountWithProviders(<CheckboxComponent error />);
+
+      checkboxSvg().should("have.css", "border-bottom-color", VALIDATION.ERROR);
+    });
+
+    it("should render Checkbox component with warning", () => {
+      CypressMountWithProviders(<CheckboxComponent warning />);
+
+      checkboxSvg().should(
+        "have.css",
+        "border-bottom-color",
+        VALIDATION.WARNING
+      );
+    });
+
+    it("should render Checkbox component with info", () => {
+      CypressMountWithProviders(<CheckboxComponent info />);
+
+      checkboxSvg().should("have.css", "border-bottom-color", VALIDATION.INFO);
+    });
+
+    it("should render Checkbox component with error icon", () => {
+      CypressMountWithProviders(
+        <CheckboxComponent error="Error has occurred" />
+      );
+
+      checkboxIcon().should("have.attr", "data-element", "error");
+    });
+
+    it("should render Checkbox component with warning icon", () => {
+      CypressMountWithProviders(
+        <CheckboxComponent warning="Warning has occurred" />
+      );
+
+      checkboxIcon().should("have.attr", "data-element", "warning");
+    });
+
+    it("should render Checkbox component with info icon", () => {
+      CypressMountWithProviders(<CheckboxComponent info="Info has occurred" />);
+
+      checkboxIcon().should("have.attr", "data-element", "info");
+    });
+
+    it.each([
+      [true, 0],
+      [false, 1],
+    ])(
+      "should render Checkbox with reverse prop set to %s",
+      (reverseValue, position) => {
+        CypressMountWithProviders(
+          <CheckboxComponent label="Checkbox Label" reverse={reverseValue} />
+        );
+
+        checkboxComponent()
+          .find("div:nth-child(1) > div > div:nth-child(1)")
+          .children()
+          .eq(position)
+          .should("have.text", "Checkbox Label");
+      }
+    );
+
+    it.each(["bottom", "left", "right", "top"])(
+      "should render CheckboxComponent component with tooltip positioned to the %s",
+      (position) => {
+        CypressMountWithProviders(
+          <Box m="250px">
+            <CheckboxComponent
+              labelHelp="Tooltip info"
+              tooltipPosition={position}
+            />
+          </Box>
+        );
+        checkboxIcon().trigger("mouseover");
+        tooltipPreview()
+          .should("have.text", "Tooltip info")
+          .should("have.attr", "data-placement", `${position}`);
+      }
+    );
+
+    it("should render Checkbox component with tick color set to black by default", () => {
+      CypressMountWithProviders(<CheckboxComponent checked />);
+      checkboxRole()
+        .should("be.checked")
+        .should("have.css", "color", COLOR.BLACK);
+    });
+
+    it.each(["small", "large"])(
+      "should render with the expected border radius styling when size is %s",
+      (size) => {
+        CypressMountWithProviders(<CheckboxComponent size={size} />);
+        checkboxSvg().should(
+          "have.css",
+          "border-radius",
+          size === "small" ? "2px" : "4px"
+        );
+      }
+    );
   });
 
   describe("should render CheckBox component and check events", () => {
@@ -358,170 +384,216 @@ context("Testing Checkbox component", () => {
           expect(callback).to.have.been.calledOnce;
         });
     });
+  });
 
-    describe("Testing CheckboxGroup component", () => {
-      it.each(testData)(
-        "should render CheckboxGroup component with %s as legend",
-        (legendValue) => {
-          CypressMountWithProviders(
-            <CheckboxGroupComponent legend={legendValue} />
-          );
-          checkboxgroupLegend().should("have.text", legendValue);
-        }
-      );
-
-      it("should render CheckboxGroup component with error", () => {
-        CypressMountWithProviders(<CheckboxGroupComponent error />);
-
-        checkboxSvg().should(
-          "have.css",
-          "border-bottom-color",
-          VALIDATION.ERROR
-        );
-      });
-
-      it("should render CheckboxGroup component with warning", () => {
-        CypressMountWithProviders(<CheckboxGroupComponent warning />);
-
-        checkboxSvg().should(
-          "have.css",
-          "border-bottom-color",
-          VALIDATION.WARNING
-        );
-      });
-
-      it("should render CheckboxGroup component with info", () => {
-        CypressMountWithProviders(<CheckboxGroupComponent info />);
-
-        checkboxSvg().should(
-          "have.css",
-          "border-bottom-color",
-          VALIDATION.INFO
-        );
-      });
-
-      it("should render CheckboxGroup component with error message", () => {
+  describe("Testing CheckboxGroup component", () => {
+    it.each(testData)(
+      "should render CheckboxGroup component with %s as legend",
+      (legendValue) => {
         CypressMountWithProviders(
-          <CheckboxGroupComponent error="Error has occurred" />
+          <CheckboxGroupComponent legend={legendValue} />
         );
+        checkboxgroupLegend().should("have.text", legendValue);
+      }
+    );
 
-        checkboxGroupIcon().should("have.attr", "data-element", "error");
-      });
+    it("should render CheckboxGroup component with error", () => {
+      CypressMountWithProviders(<CheckboxGroupComponent error />);
 
-      it("should render CheckboxGroup component with warning message", () => {
-        CypressMountWithProviders(
-          <CheckboxGroupComponent warning="Warning has occurred" />
-        );
-
-        checkboxGroupIcon().should("have.attr", "data-element", "warning");
-      });
-
-      it("should render CheckboxGroup component with info message", () => {
-        CypressMountWithProviders(
-          <CheckboxGroupComponent info="Info has occurred" />
-        );
-
-        checkboxGroupIcon().should("have.attr", "data-element", "info");
-      });
-
-      it.each([
-        ["left", "flex-start"],
-        ["right", "flex-end"],
-      ] as [CheckboxGroupProps["legendAlign"], string][])(
-        "should render CheckboxGroup component with inline legend aligned to %s",
-        (position, assertion) => {
-          CypressMountWithProviders(
-            <CheckboxGroupComponent
-              legend="CheckBox Legend"
-              legendWidth={20}
-              legendAlign={position}
-              legendInline
-            />
-          );
-          checkboxgroupLegend().should(
-            "have.css",
-            "justify-content",
-            assertion
-          );
-        }
-      );
-
-      it.each([20, 40])(
-        "should render CheckboxGroup component with inline legend width set to %s",
-        (width) => {
-          CypressMountWithProviders(
-            <CheckboxGroupComponent
-              legend="CheckBox Legend"
-              legendWidth={width}
-              legendInline
-            />
-          );
-          checkboxgroupLegend().should("have.attr", "width", width);
-        }
-      );
-
-      it("should render CheckboxGroup component with children", () => {
-        CypressMountWithProviders(
-          <CheckboxGroupComponent>
-            <Checkbox
-              id="checkbox_id three"
-              key="checkbox_id-three"
-              name="checkbox_id-three"
-              label="Checkbox 3"
-            />
-          </CheckboxGroupComponent>
-        );
-        checkboxGroup().should("contain.text", "Checkbox 3");
-      });
-
-      it.each([
-        [1, "8px"],
-        [2, "16px"],
-      ] as [CheckboxGroupProps["legendSpacing"], string][])(
-        "should render CheckboxGroup component with legendSpacing set to %s",
-        (spacing, padding) => {
-          CypressMountWithProviders(
-            <CheckboxGroupComponent
-              legend="AVeryVeryLongLegend"
-              legendSpacing={spacing}
-              legendWidth={10}
-              legendInline
-            />
-          );
-          checkboxgroupLegend().should("have.css", "padding-right", padding);
-        }
-      );
-
-      it.each([
-        "top",
-        "bottom",
-        "left",
-        "right",
-      ] as CheckboxGroupProps["tooltipPosition"][])(
-        "should render CheckboxGroupComponent component with tooltip positioned to the %s",
-        (position) => {
-          CypressMountWithProviders(
-            <CheckboxGroupComponent
-              legend="Checkbox Legend"
-              error="Something is wrong"
-              tooltipPosition={position}
-            />
-          );
-          checkboxGroupIcon().trigger("mouseover");
-          tooltipPreview()
-            .should("have.text", "Something is wrong")
-            .should("have.attr", "data-placement", position);
-        }
-      );
-
-      it("should render CheckboxGroup component as a required field", () => {
-        CypressMountWithProviders(
-          <CheckboxGroupComponent legend="Required CheckboxGroup" required />
-        );
-
-        verifyRequiredAsteriskForLegend();
-      });
+      checkboxSvg().should("have.css", "border-bottom-color", VALIDATION.ERROR);
     });
+
+    it("should render CheckboxGroup component with warning", () => {
+      CypressMountWithProviders(<CheckboxGroupComponent warning />);
+
+      checkboxSvg().should(
+        "have.css",
+        "border-bottom-color",
+        VALIDATION.WARNING
+      );
+    });
+
+    it("should render CheckboxGroup component with info", () => {
+      CypressMountWithProviders(<CheckboxGroupComponent info />);
+
+      checkboxSvg().should("have.css", "border-bottom-color", VALIDATION.INFO);
+    });
+
+    it("should render CheckboxGroup component with error message", () => {
+      CypressMountWithProviders(
+        <CheckboxGroupComponent error="Error has occurred" />
+      );
+
+      checkboxGroupIcon().should("have.attr", "data-element", "error");
+    });
+
+    it("should render CheckboxGroup component with warning message", () => {
+      CypressMountWithProviders(
+        <CheckboxGroupComponent warning="Warning has occurred" />
+      );
+
+      checkboxGroupIcon().should("have.attr", "data-element", "warning");
+    });
+
+    it("should render CheckboxGroup component with info message", () => {
+      CypressMountWithProviders(
+        <CheckboxGroupComponent info="Info has occurred" />
+      );
+
+      checkboxGroupIcon().should("have.attr", "data-element", "info");
+    });
+
+    it.each([
+      ["left", "flex-start"],
+      ["right", "flex-end"],
+    ] as [CheckboxGroupProps["legendAlign"], string][])(
+      "should render CheckboxGroup component with inline legend aligned to %s",
+      (position, assertion) => {
+        CypressMountWithProviders(
+          <CheckboxGroupComponent
+            legend="CheckBox Legend"
+            legendWidth={20}
+            legendAlign={position}
+            legendInline
+          />
+        );
+        checkboxgroupLegend().should("have.css", "justify-content", assertion);
+      }
+    );
+
+    it.each([20, 40])(
+      "should render CheckboxGroup component with inline legend width set to %s",
+      (width) => {
+        CypressMountWithProviders(
+          <CheckboxGroupComponent
+            legend="CheckBox Legend"
+            legendWidth={width}
+            legendInline
+          />
+        );
+        checkboxgroupLegend().should("have.attr", "width", width);
+      }
+    );
+
+    it("should render CheckboxGroup component with children", () => {
+      CypressMountWithProviders(
+        <CheckboxGroupComponent>
+          <Checkbox
+            id="checkbox_id three"
+            key="checkbox_id-three"
+            name="checkbox_id-three"
+            label="Checkbox 3"
+          />
+        </CheckboxGroupComponent>
+      );
+      checkboxGroup().should("contain.text", "Checkbox 3");
+    });
+
+    it.each([
+      [1, "8px"],
+      [2, "16px"],
+    ] as [CheckboxGroupProps["legendSpacing"], string][])(
+      "should render CheckboxGroup component with legendSpacing set to %s",
+      (spacing, padding) => {
+        CypressMountWithProviders(
+          <CheckboxGroupComponent
+            legend="AVeryVeryLongLegend"
+            legendSpacing={spacing}
+            legendWidth={10}
+            legendInline
+          />
+        );
+        checkboxgroupLegend().should("have.css", "padding-right", padding);
+      }
+    );
+
+    it.each([
+      "top",
+      "bottom",
+      "left",
+      "right",
+    ] as CheckboxGroupProps["tooltipPosition"][])(
+      "should render CheckboxGroupComponent component with tooltip positioned to the %s",
+      (position) => {
+        CypressMountWithProviders(
+          <CheckboxGroupComponent
+            legend="Checkbox Legend"
+            error="Something is wrong"
+            tooltipPosition={position}
+          />
+        );
+        checkboxGroupIcon().trigger("mouseover");
+        tooltipPreview()
+          .should("have.text", "Something is wrong")
+          .should("have.attr", "data-placement", position);
+      }
+    );
+
+    it("should render CheckboxGroup component as a required field", () => {
+      CypressMountWithProviders(
+        <CheckboxGroupComponent legend="Required CheckboxGroup" required />
+      );
+
+      verifyRequiredAsteriskForLegend();
+    });
+
+    it("should render CheckboxGroup component with new validation error", () => {
+      CypressMountWithProviders(
+        <CheckboxGroupComponentNewValidation error="Error Message (Fix is required)" />
+      );
+
+      checkboxGroup()
+        .children()
+        .eq(2)
+        .children()
+        .should("contain.text", "Error Message (Fix is required)")
+        .and("have.css", "color", "rgb(199, 56, 79)");
+      checkboxGroup()
+        .children()
+        .eq(2)
+        .children()
+        .eq(1)
+        .should("have.css", "background-color", "rgb(199, 56, 79)")
+        .and("have.css", "position", "absolute");
+    });
+
+    it("should render CheckboxGroup component with new validation warning", () => {
+      CypressMountWithProviders(
+        <CheckboxGroupComponentNewValidation warning="Warning Message (Fix is optional)" />
+      );
+
+      checkboxGroup()
+        .children()
+        .eq(2)
+        .children()
+        .should("contain.text", "Warning Message (Fix is optional)")
+        .and("have.css", "color", "rgb(191, 82, 0)");
+      checkboxGroup()
+        .children()
+        .eq(2)
+        .children()
+        .eq(1)
+        .should("have.css", "background-color", "rgb(233, 100, 0)")
+        .and("have.css", "position", "absolute");
+    });
+
+    it.each([
+      [true, "row"],
+      [false, "column"],
+    ])(
+      "should render CheckboxGroup component with new validation and inline prop set to %s",
+      (bool, flex) => {
+        CypressMountWithProviders(
+          <CheckboxGroupComponentNewValidation required inline={bool} />
+        );
+
+        checkboxGroup()
+          .children()
+          .eq(2)
+          .children()
+          .should("have.css", "flex-direction", flex);
+      }
+    );
   });
 
   describe("should check accessibility for Checkbox", () => {
@@ -719,7 +791,7 @@ context("Testing Checkbox component", () => {
       "left",
       "right",
     ] as CheckboxGroupProps["tooltipPosition"][])(
-      "should pass accessibility tests for CheckboxGroupComponent component with tooltip positioned to the %s",
+      "should pass accessibility tests for CheckboxGroup component with tooltip positioned to the %s",
       (position) => {
         CypressMountWithProviders(
           <CheckboxGroupComponent
@@ -737,16 +809,4 @@ context("Testing Checkbox component", () => {
       }
     );
   });
-
-  it.each(["small", "large"])(
-    "should render with the expected border radius styling when size is %s",
-    (size) => {
-      CypressMountWithProviders(<CheckboxComponent size={size} />);
-      checkboxSvg().should(
-        "have.css",
-        "border-radius",
-        size === "small" ? "2px" : "4px"
-      );
-    }
-  );
 });

--- a/src/components/checkbox/checkbox-group.component.tsx
+++ b/src/components/checkbox/checkbox-group.component.tsx
@@ -1,16 +1,22 @@
-import React from "react";
+import React, { useContext } from "react";
 import { MarginProps } from "styled-system";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
-import StyledCheckboxGroup from "./checkbox-group.style";
+import StyledCheckboxGroup, { StyledHintText } from "./checkbox-group.style";
 import Fieldset from "../../__internal__/fieldset";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import { ValidationProps } from "../../__internal__/validations";
 import FormSpacingProvider from "../../__internal__/form-spacing-provider";
+import { NewValidationContext } from "../carbon-provider/carbon-provider.component";
+import ValidationMessage from "../../__internal__/validation-message/validation-message.component";
+import Box from "../../components/box";
+import { ErrorBorder } from "../../components/textbox/textbox.style";
 
 export interface CheckboxGroupProps extends ValidationProps, MarginProps {
   /** The content for the CheckboxGroup Legend */
   legend?: string;
+  /** The content for the CheckboxGroup Legend Help text  */
+  legendHelp?: string;
   /** When true, legend is placed inline with the checkboxes */
   legendInline?: boolean;
   /** Percentage width of legend (only when legend is inline)  */
@@ -27,11 +33,15 @@ export interface CheckboxGroupProps extends ValidationProps, MarginProps {
   required?: boolean;
   /** Overrides the default tooltip */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
+  /** When true, Checkboxes are in line */
+  inline?: boolean;
 }
 
 export const CheckboxGroupContext = React.createContext<ValidationProps>({});
 
 export const CheckboxGroup = (props: CheckboxGroupProps) => {
+  const { validationRedesignOptIn } = useContext(NewValidationContext);
+
   const {
     children,
     legend,
@@ -43,43 +53,88 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
     legendWidth,
     legendAlign,
     legendSpacing,
+    legendHelp,
     tooltipPosition,
+    inline,
   } = props;
 
   return (
-    <TooltipProvider tooltipPosition={tooltipPosition}>
-      <Fieldset
-        legend={legend}
-        inline={legendInline}
-        legendWidth={legendWidth}
-        legendAlign={legendAlign}
-        legendSpacing={legendSpacing}
-        error={error}
-        warning={warning}
-        info={info}
-        isRequired={required}
-        {...tagComponent("checkboxgroup", props)}
-        blockGroupBehaviour={!(error || warning || info)}
-        {...filterStyledSystemMarginProps(props)}
-      >
-        <StyledCheckboxGroup
-          data-component="checkbox-group"
-          legendInline={legendInline}
+    <>
+      {validationRedesignOptIn ? (
+        <Fieldset
+          legend={legend}
+          inline={legendInline}
+          legendWidth={legendWidth}
+          legendAlign={legendAlign}
+          legendSpacing={legendSpacing}
+          error={error}
+          warning={warning}
+          info={info}
+          isRequired={required}
+          {...tagComponent("checkboxgroup", props)}
+          blockGroupBehaviour={!(error || warning)}
+          {...filterStyledSystemMarginProps(props)}
         >
-          <CheckboxGroupContext.Provider
-            value={{
-              error: !!error,
-              warning: !!warning,
-              info: !!info,
-            }}
+          {legendHelp && <StyledHintText>{legendHelp}</StyledHintText>}
+          <Box position="relative">
+            <ValidationMessage error={error} warning={warning} />
+            {(error || warning) && (
+              <ErrorBorder warning={!!(!error && warning)} inline={inline} />
+            )}
+            <StyledCheckboxGroup
+              data-component="checkbox-group"
+              legendInline={legendInline}
+              inline={inline}
+            >
+              <CheckboxGroupContext.Provider
+                value={{
+                  error: !!error,
+                  warning: !!warning,
+                }}
+              >
+                <FormSpacingProvider marginBottom={undefined}>
+                  {children}
+                </FormSpacingProvider>
+              </CheckboxGroupContext.Provider>
+            </StyledCheckboxGroup>
+          </Box>
+        </Fieldset>
+      ) : (
+        <TooltipProvider tooltipPosition={tooltipPosition}>
+          <Fieldset
+            legend={legend}
+            inline={legendInline}
+            legendWidth={legendWidth}
+            legendAlign={legendAlign}
+            legendSpacing={legendSpacing}
+            error={error}
+            warning={warning}
+            info={info}
+            isRequired={required}
+            {...tagComponent("checkboxgroup", props)}
+            blockGroupBehaviour={!(error || warning || info)}
+            {...filterStyledSystemMarginProps(props)}
           >
-            <FormSpacingProvider marginBottom={undefined}>
-              {children}
-            </FormSpacingProvider>
-          </CheckboxGroupContext.Provider>
-        </StyledCheckboxGroup>
-      </Fieldset>
-    </TooltipProvider>
+            <StyledCheckboxGroup
+              data-component="checkbox-group"
+              legendInline={legendInline}
+            >
+              <CheckboxGroupContext.Provider
+                value={{
+                  error: !!error,
+                  warning: !!warning,
+                  info: !!info,
+                }}
+              >
+                <FormSpacingProvider marginBottom={undefined}>
+                  {children}
+                </FormSpacingProvider>
+              </CheckboxGroupContext.Provider>
+            </StyledCheckboxGroup>
+          </Fieldset>
+        </TooltipProvider>
+      )}
+    </>
   );
 };
 

--- a/src/components/checkbox/checkbox-group.spec.tsx
+++ b/src/components/checkbox/checkbox-group.spec.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { mount } from "enzyme";
+import CarbonProvider from "components/carbon-provider/carbon-provider.component";
 import CheckboxGroup, { CheckboxGroupProps } from "./checkbox-group.component";
 import { Checkbox } from ".";
 import {
@@ -7,10 +8,11 @@ import {
   testStyledSystemMargin,
 } from "../../__spec_helper__/test-utils";
 import StyledCheckbox from "./checkbox.style";
-import StyledCheckboxGroup from "./checkbox-group.style";
+import StyledCheckboxGroup, { StyledHintText } from "./checkbox-group.style";
 import Fieldset from "../../__internal__/fieldset";
 import Tooltip from "../tooltip";
 import StyledFormField from "../../__internal__/form-field/form-field.style";
+import { ErrorBorder } from "../textbox/textbox.style";
 
 const checkboxValues = ["required", "optional"];
 
@@ -34,6 +36,31 @@ function renderCheckboxGroup(
     <CheckboxGroup legend="Test CheckboxGroup Label" {...props}>
       {children}
     </CheckboxGroup>
+  );
+}
+
+function renderCheckboxGroupWithCarbonProvider(
+  props: Partial<CheckboxGroupProps>,
+  childProps = {},
+  renderer = mount
+) {
+  const children = checkboxValues.map((value) => (
+    <Checkbox
+      id={`cId-${value}`}
+      key={`cKey-${value}`}
+      name={`check-${value}`}
+      onChange={jest.fn()}
+      value={value}
+      {...childProps}
+    />
+  ));
+
+  return renderer(
+    <CarbonProvider validationRedesignOptIn>
+      <CheckboxGroup legend="Test CheckboxGroup Label" {...props}>
+        {children}
+      </CheckboxGroup>
+    </CarbonProvider>
   );
 }
 
@@ -133,6 +160,71 @@ describe("CheckboxGroup", () => {
       const { position } = wrapper.find(Tooltip).props();
 
       expect(position).toEqual("bottom");
+    });
+  });
+
+  describe("New Validations", () => {
+    let wrapper;
+    it("should apply the correct styles for error", () => {
+      wrapper = renderCheckboxGroupWithCarbonProvider({ error: "message" });
+      assertStyleMatch(
+        {
+          position: "absolute",
+          zIndex: "6",
+          width: "2px",
+          backgroundColor: "var(--colorsSemanticNegative500)",
+          left: "-12px",
+          bottom: "0px",
+          top: "0px",
+        },
+        wrapper.find(ErrorBorder)
+      );
+    });
+
+    it("should apply the correct styles for error when used inline", () => {
+      wrapper = renderCheckboxGroupWithCarbonProvider({
+        error: "message",
+        inline: true,
+      });
+      assertStyleMatch(
+        {
+          flexDirection: "row",
+        },
+        wrapper.find(StyledCheckboxGroup)
+      );
+    });
+
+    it("should apply the correct styles for warning", () => {
+      wrapper = renderCheckboxGroupWithCarbonProvider({ warning: "message" });
+      assertStyleMatch(
+        {
+          position: "absolute",
+          zIndex: "6",
+          width: "2px",
+          backgroundColor: "var(--colorsSemanticCaution500)",
+          left: "-12px",
+          bottom: "0px",
+          top: "0px",
+        },
+        wrapper.find(ErrorBorder)
+      );
+    });
+
+    it("should apply the correct styles for legend help", () => {
+      wrapper = renderCheckboxGroupWithCarbonProvider({
+        error: "message",
+        legend: "Label",
+        legendHelp: "Hint Text",
+      });
+      assertStyleMatch(
+        {
+          marginTop: "-4px",
+          marginBottom: "8px",
+          color: "var(--colorsUtilityYin055)",
+          fontSize: "14px",
+        },
+        wrapper.find(StyledHintText)
+      );
     });
   });
 });

--- a/src/components/checkbox/checkbox-group.style.ts
+++ b/src/components/checkbox/checkbox-group.style.ts
@@ -5,10 +5,19 @@ import CheckboxStyle from "./checkbox.style";
 import { StyledLabelContainer } from "../../__internal__/label/label.style";
 import StyledValidationIcon from "../../__internal__/validations/validation-icon.style";
 
-const StyledCheckboxGroup = styled.div<{ legendInline?: boolean }>`
+export const StyledHintText = styled.div`
+  margin-top: -4px;
+  margin-bottom: 8px;
+  color: var(--colorsUtilityYin055);
+  font-size: 14px;
+`;
+
+const StyledCheckboxGroup = styled.div<{
+  legendInline?: boolean;
+  inline?: boolean;
+}>`
   display: flex;
   flex-direction: column;
-
   ${StyledIcon}::before {
     font-size: 16px;
   }
@@ -41,6 +50,15 @@ const StyledCheckboxGroup = styled.div<{ legendInline?: boolean }>`
     css`
       ${CheckboxStyle}:first-child {
         padding-top: 4px;
+      }
+    `}
+
+  ${({ inline }) =>
+    inline &&
+    css`
+      flex-direction: row;
+      ${CheckboxStyle}:not(:first-of-type) {
+        margin-left: 32px;
       }
     `}
 `;

--- a/src/components/checkbox/checkbox-test.stories.tsx
+++ b/src/components/checkbox/checkbox-test.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
 
 import { Checkbox, CheckboxProps, CheckboxGroup, CheckboxGroupProps } from ".";
+import CarbonProvider from "../../components/carbon-provider";
 
 export default {
   title: "Checkbox/Test",
@@ -144,6 +145,45 @@ export const CheckboxGroupComponent = ({
           </>
         )}
       </CheckboxGroup>
+    </div>
+  );
+};
+
+export const CheckboxGroupComponentNewValidation = ({
+  children,
+  ...props
+}: Partial<CheckboxGroupProps>) => {
+  const [isChecked, setIsChecked] = useState(false);
+  return (
+    <div
+      style={{
+        marginTop: "64px",
+        marginLeft: "64px",
+      }}
+    >
+      <CarbonProvider validationRedesignOptIn>
+        <CheckboxGroup
+          legend="Checkbox Group Label"
+          legendHelp="Hint Text"
+          required
+          {...props}
+        >
+          {children || (
+            <>
+              {["One", "Two", "Three"].map((label) => (
+                <Checkbox
+                  label={label}
+                  id={`checkbox-group-${label}`}
+                  key={`checkbox-group-${label}`}
+                  name={`checkbox-group-${label}`}
+                  checked={isChecked}
+                  onChange={(e) => setIsChecked(e.target.checked)}
+                />
+              ))}
+            </>
+          )}
+        </CheckboxGroup>
+      </CarbonProvider>
     </div>
   );
 };

--- a/src/components/checkbox/checkbox-validations.stories.mdx
+++ b/src/components/checkbox/checkbox-validations.stories.mdx
@@ -25,6 +25,24 @@ Passing a boolean to these props will display only a properly colored border.
 
 For more information check our [Validations](?path=/docs/documentation-validations--page "Validations") documentation page
 
+### New Validations
+
+<Canvas>
+  <Story name="New Valdations - string" story={stories.NewStringValidation} />
+</Canvas>
+
+<Canvas>
+  <Story name="New Validations - string inline default" story={stories.NewInline} />
+</Canvas>
+
+<Canvas>
+  <Story name="New Valdations - string inline" story={stories.NewStringValidationInline} />
+</Canvas>
+
+<Canvas>
+  <Story name="New Valdations - boolean" story={stories.NewBooleanValidation} />
+</Canvas>
+
 ### As a string applied to single Checkbox
 
 <Canvas>

--- a/src/components/checkbox/checkbox-validations.stories.tsx
+++ b/src/components/checkbox/checkbox-validations.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ComponentStory } from "@storybook/react";
 import { Checkbox, CheckboxGroup } from ".";
+import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 export const StringValidation: ComponentStory<typeof Checkbox> = () => (
   <>
@@ -20,10 +21,10 @@ export const StringValidation: ComponentStory<typeof Checkbox> = () => (
     />
     <Checkbox
       id="checkbox_info"
-      info="Message"
       key="checkbox_info"
       label="Example checkbox (info)"
       name="checkbox_info"
+      info="Message"
     />
   </>
 );
@@ -308,4 +309,164 @@ export const Required: ComponentStory<typeof Checkbox> = () => (
     name="required"
     required
   />
+);
+
+export const NewStringValidation: ComponentStory<typeof Checkbox> = () => (
+  <CarbonProvider validationRedesignOptIn>
+    <CheckboxGroup
+      error="Error message (Fix is required)"
+      legend="Label"
+      legendHelp="Hint Text"
+      required
+    >
+      <Checkbox
+        id="checkbox-one-error"
+        key="checkbox-one-error"
+        label="Example checkbox one"
+        name="checkbox-one-error"
+      />
+      <Checkbox
+        id="checkbox-two-error"
+        key="checkbox-two-error"
+        label="Example checkbox two"
+        name="checkbox-two-error"
+      />
+      <Checkbox
+        id="checkbox-three-error"
+        key="checkbox-three-error"
+        label="Example checkbox three"
+        name="checkbox-three-error"
+      />
+    </CheckboxGroup>
+    <CheckboxGroup
+      mt={2}
+      warning="Warning message (Fix is optional)"
+      legend="Label"
+      legendHelp="Hint text"
+      required
+    >
+      <Checkbox
+        id="checkbox-one-warning"
+        key="checkbox-one-warning"
+        label="Example checkbox one"
+        name="checkbox-one-warning"
+      />
+      <Checkbox
+        id="checkbox-two-warning"
+        key="checkbox-two-warning"
+        label="Example checkbox two"
+        name="checkbox-two-warning"
+      />
+      <Checkbox
+        id="checkbox-three-warning"
+        key="checkbox-three-warning"
+        label="Example checkbox three"
+        name="checkbox-three-warning"
+      />
+    </CheckboxGroup>
+  </CarbonProvider>
+);
+
+export const NewStringValidationInline: ComponentStory<
+  typeof Checkbox
+> = () => (
+  <CarbonProvider validationRedesignOptIn>
+    <CheckboxGroup
+      error="Error message (Fix is required)"
+      legend="Label"
+      legendHelp="Hint Text"
+      required
+      inline
+    >
+      <Checkbox
+        id="checkbox-one-error-inline"
+        key="checkbox-one-error-inline"
+        label="Example checkbox one"
+        name="checkbox-one-error-inline"
+      />
+      <Checkbox
+        id="checkbox-two-error-inline"
+        key="checkbox-two-error-inline"
+        label="Example checkbox two"
+        name="checkbox-two-error-inline"
+      />
+      <Checkbox
+        id="checkbox-three-error-inline"
+        key="checkbox-three-error-inline"
+        label="Example checkbox three"
+        name="checkbox-three-error-inline"
+      />
+    </CheckboxGroup>
+    <CheckboxGroup
+      mt={2}
+      warning="Warning message (Fix is optional)"
+      legend="Label"
+      legendHelp="Hint text"
+      required
+      inline
+    >
+      <Checkbox
+        id="checkbox-one-warning-inline"
+        key="checkbox-one-warning-inline"
+        label="Example checkbox one"
+        name="checkbox-one-warning-inline"
+      />
+      <Checkbox
+        id="checkbox-two-warning-inline"
+        key="checkbox-two-warning-inline"
+        label="Example checkbox two"
+        name="checkbox-two-warning-inline"
+      />
+      <Checkbox
+        id="checkbox-three-warning-inline"
+        key="checkbox-three-warning-inline"
+        label="Example checkbox three"
+        name="checkbox-three-warning-inline"
+      />
+    </CheckboxGroup>
+  </CarbonProvider>
+);
+
+export const NewInline: ComponentStory<typeof Checkbox> = () => (
+  <CarbonProvider validationRedesignOptIn>
+    <CheckboxGroup legend="Label" legendHelp="Hint Text" required inline>
+      <Checkbox
+        id="checkbox-one-new-inline"
+        key="checkbox-one-new-inline"
+        label="Example checkbox one"
+        name="checkbox-one-new-inline"
+      />
+      <Checkbox
+        id="checkbox-two-new-inline"
+        key="checkbox-two-new-inline"
+        label="Example checkbox two"
+        name="checkbox-two-new-inline"
+      />
+      <Checkbox
+        id="checkbox-three-new-inline"
+        key="checkbox-three-new-inline"
+        label="Example checkbox three"
+        name="checkbox-three-new-inline"
+      />
+    </CheckboxGroup>
+  </CarbonProvider>
+);
+
+export const NewBooleanValidation: ComponentStory<typeof Checkbox> = () => (
+  <CarbonProvider validationRedesignOptIn>
+    <Checkbox
+      error="message"
+      id="checkbox-one-error-boolean"
+      key="checkbox-one-error-boolean"
+      label="Example checkbox one - Error"
+      name="checkbox-one-error-boolean"
+    />
+    <Checkbox
+      warning
+      id="checkbox-two-warning-boolean"
+      key="checkbox-two-warning-boolean"
+      label="Example checkbox two - Warning"
+      name="checkbox-two-warning-boolean"
+    />
+  </CarbonProvider>
 );

--- a/src/components/checkbox/checkbox.component.tsx
+++ b/src/components/checkbox/checkbox.component.tsx
@@ -127,48 +127,60 @@ export const Checkbox = React.forwardRef(
       labelHelp,
       labelSpacing,
       required,
-      error: contextError || error,
-      warning: contextWarning || warning,
-      info: contextInfo || info,
       fieldHelpInline,
       checked,
       disabled,
       inputWidth,
       labelWidth,
-      tooltipPosition,
       ref: ref || inputRef,
       ...rest,
     };
 
+    const validationProps = {
+      error: contextError || error,
+      warning: contextWarning || warning,
+      ...(validationRedesignOptIn
+        ? { validationOnLabel: false }
+        : { info: contextInfo || info }),
+    };
+
     const marginProps = useFormSpacing(rest);
 
-    return (
-      <TooltipProvider
-        helpAriaLabel={helpAriaLabel}
-        tooltipPosition={tooltipPosition}
+    const componentToRender = (
+      <CheckboxStyle
+        data-component={dataComponent}
+        data-role={dataRole}
+        data-element={dataElement}
+        disabled={disabled}
+        labelSpacing={labelSpacing}
+        inputWidth={inputWidth}
+        adaptiveSpacingSmallScreen={adaptiveSpacingSmallScreen}
+        {...validationProps}
+        fieldHelpInline={fieldHelpInline}
+        reverse={reverse}
+        size={size}
+        applyNewValidation={validationRedesignOptIn}
+        {...marginProps}
       >
-        <CheckboxStyle
-          data-component={dataComponent}
-          data-role={dataRole}
-          data-element={dataElement}
-          disabled={disabled}
-          labelSpacing={labelSpacing}
-          inputWidth={inputWidth}
-          adaptiveSpacingSmallScreen={adaptiveSpacingSmallScreen}
-          error={contextError || error}
-          warning={contextWarning || warning}
-          info={contextInfo || info}
-          fieldHelpInline={fieldHelpInline}
-          reverse={reverse}
-          size={size}
-          applyNewValidation={validationRedesignOptIn}
-          {...marginProps}
-        >
-          <CheckableInput {...inputProps}>
-            <CheckboxSvg />
-          </CheckableInput>
-        </CheckboxStyle>
-      </TooltipProvider>
+        <CheckableInput {...inputProps} {...validationProps}>
+          <CheckboxSvg />
+        </CheckableInput>
+      </CheckboxStyle>
+    );
+
+    return (
+      <>
+        {validationRedesignOptIn ? (
+          componentToRender
+        ) : (
+          <TooltipProvider
+            helpAriaLabel={helpAriaLabel}
+            tooltipPosition={tooltipPosition}
+          >
+            {componentToRender}
+          </TooltipProvider>
+        )}
+      </>
     );
   }
 );

--- a/src/components/checkbox/checkbox.stories.mdx
+++ b/src/components/checkbox/checkbox.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import * as stories from "./checkbox.stories";
+import * as validationStories from "./checkbox-validations.stories";
 
 import { Checkbox, CheckboxGroup } from ".";
 
@@ -113,6 +114,28 @@ Passing a string to these props will display a properly colored border along wit
 Passing a boolean to these props will display only a properly colored border.
 
 For more information check our [Validations](?path=/docs/documentation-validations--string-validation "Validations") documentation page
+
+### New Validations
+
+This is an example of `Checkbox` in a `CheckboxGroup` with validations passed as a string.
+<Canvas>
+  <Story name="New Validations - string" story={validationStories.NewStringValidation} />
+</Canvas>
+
+This is an example of `Checkbox` in a `CheckboxGroup` displayed inline.
+<Canvas>
+  <Story name="New Validations - string inline default" story={validationStories.NewInline} />
+</Canvas>
+
+This is an example of `Checkbox` in a `CheckboxGroup` with validations passed as a string displayed inline.
+<Canvas>
+  <Story name="New Validations - string inline" story={validationStories.NewStringValidationInline} />
+</Canvas>
+
+This is an example of `Checkbox` with validations passed as boolean values.
+<Canvas>
+  <Story name="New Validations - boolean" story={validationStories.NewBooleanValidation} />
+</Canvas>
 
 ## Props
 


### PR DESCRIPTION
### Proposed behaviour

![Screenshot 2023-07-20 at 09 53 25](https://github.com/Sage/carbon/assets/56251247/48ead0c2-bcce-4dc4-b77e-ddb601244572)

### Current behaviour

New style validations are not supported in Checkbox

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

Styling for `size="large"` larger validation will be done in a separate piece of work

### Testing instructions

Testing instructions to follow
