### PR TITLE
test(definition-list): typescript refactor

### DIFF
--- a/cypress/components/definition-list/definition-list.cy.tsx
+++ b/cypress/components/definition-list/definition-list.cy.tsx
@@ -1,11 +1,15 @@
 import React from "react";
-import Dl from "../../../src/components/definition-list/dl.component";
+import {
+  DLComponent,
+  DLBoxComponent,
+} from "../../../src/components/definition-list/definition-list-test.stories";
+import Dl, {
+  DlProps,
+} from "../../../src/components/definition-list/dl.component";
 import Dt from "../../../src/components/definition-list/dt.component";
 import Dd from "../../../src/components/definition-list/dd.component";
 import Box from "../../../src/components/box";
 import Icon from "../../../src/components/icon";
-import Hr from "../../../src/components/hr";
-import Typography from "../../../src/components/typography";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import { getDataElementByValue } from "../../locators/index";
 import { CHARACTERS } from "../../support/component-helper/constants";
@@ -16,82 +20,37 @@ const specialCharacters = [
   CHARACTERS.DIACRITICS,
   CHARACTERS.SPECIALCHARACTERS,
 ];
-const widths = [
-  [135, 1229, 10, 90],
-  [683, 683, 50, 50],
-  [1229, 135, 90, 10],
-];
+
 const alignValue = ["left", "center", "right"];
-
-const DLComponent = ({ ...props }) => {
-  return (
-    <div>
-      <Dl data-element="dl" {...props}>
-        <Dt>First</Dt>
-        <Dd data-element="dd">Description 1</Dd>
-        <Dt>Second</Dt>
-        <Dd>Description 2</Dd>
-        <Dt>Third</Dt>
-        <Dd>Description 3</Dd>
-      </Dl>
-    </div>
-  );
-};
-
-const DLBoxComponent = () => {
-  return (
-    <div>
-      <Box data-element="box" width="65%" px={2} pt={4} pb={3}>
-        <Box width="90%">
-          <Typography color="rgba(0,0,0,0.55)" variant="segment-subheader-alt">
-            Segment Header
-          </Typography>
-          <Hr ml={0} mt={2} />
-        </Box>
-        <Box mb={3} display="flex">
-          <Box flexGrow="1">
-            <Dl dtTextAlign="left" asSingleColumn>
-              <Dt>First</Dt>
-              <Dd>Description 1</Dd>
-              <Dt>Second</Dt>
-              <Dd>Description 2</Dd>
-              <Dt>Third</Dt>
-              <Dd>Description</Dd>
-            </Dl>
-          </Box>
-        </Box>
-      </Box>
-    </div>
-  );
-};
 
 context("Testing Definition List component", () => {
   describe("should render Definition List component", () => {
-    it.each(alignValue)(
+    it.each(alignValue as DlProps["dtTextAlign"][])(
       "should verify Definition List text is %s aligned",
       (align) => {
         CypressMountWithProviders(
           <DLComponent dtTextAlign={align} ddTextAlign="right" />
         );
-
         getDataElementByValue("dt").should("have.css", "text-align", align);
       }
     );
 
-    it.each(alignValue)(
+    it.each(alignValue as DlProps["ddTextAlign"][])(
       "should verify Definition List definition is %s aligned",
       (align) => {
         CypressMountWithProviders(<DLComponent ddTextAlign={align} />);
-
         getDataElementByValue("dd").should("have.css", "text-align", align);
       }
     );
 
-    it.each(widths)(
-      "should verify text width is %spx and definition width is %spx, %s%/%s% of the Definition List width",
+    it.each([
+      [135, 1229, 10],
+      [683, 683, 50],
+      [1229, 135, 90],
+    ])(
+      "should verify text width is %spx and definition width is %spx, %s% of the Definition List width",
       (dtPixels, ddPixels, dtPercent) => {
         CypressMountWithProviders(<DLComponent w={dtPercent} />);
-
         getDataElementByValue("dl")
           .children()
           .then(($el) => {
@@ -107,7 +66,7 @@ context("Testing Definition List component", () => {
     );
 
     it.each(specialCharacters)(
-      "should check Definition List text is %s when children prop is set to %s",
+      "should check Definition List text when children prop is set to %s",
       (text) => {
         CypressMountWithProviders(
           <Dl>
@@ -115,13 +74,12 @@ context("Testing Definition List component", () => {
             <Dd>Definition</Dd>
           </Dl>
         );
-
         getDataElementByValue("dt").should("have.text", text);
       }
     );
 
     it.each(specialCharacters)(
-      "should check Definition List definition is %s when children prop is set to %s",
+      "should check Definition List when children prop is set to %s",
       (definition) => {
         CypressMountWithProviders(
           <Dl>
@@ -129,7 +87,6 @@ context("Testing Definition List component", () => {
             <Dd data-element="dd">{definition}</Dd>
           </Dl>
         );
-
         getDataElementByValue("dd").should("have.text", definition);
       }
     );
@@ -138,7 +95,6 @@ context("Testing Definition List component", () => {
       CypressMountWithProviders(
         <DLComponent dtTextAlign="left" asSingleColumn />
       );
-
       getDataElementByValue("dt")
         .should("have.css", "text-align", "left")
         .then(($el) => {
@@ -164,7 +120,6 @@ context("Testing Definition List component", () => {
           </Dd>
         </Dl>
       );
-
       getDataElementByValue("dd")
         .children()
         .children()
@@ -184,7 +139,6 @@ context("Testing Definition List component", () => {
           )}
         </Dl>
       );
-
       getDataElementByValue("dt").should(
         "have.text",
         "Text inside React Fragment"
@@ -217,37 +171,34 @@ context("Testing Definition List component", () => {
   });
 
   describe("Accessibility tests for Definition List component", () => {
-    it.each(alignValue)(
+    it.each(alignValue as DlProps["dtTextAlign"][])(
       "should pass accessibility tests for Definition List when text is %s aligned",
       (align) => {
         CypressMountWithProviders(
           <DLComponent dtTextAlign={align} ddTextAlign="right" />
         );
-
         cy.checkAccessibility();
       }
     );
 
-    it.each(alignValue)(
+    it.each(alignValue as DlProps["ddTextAlign"][])(
       "should pass accessibility tests for Definition List when DD text is %s aligned",
       (align) => {
         CypressMountWithProviders(<DLComponent ddTextAlign={align} />);
-
         cy.checkAccessibility();
       }
     );
 
-    it.each(widths)(
-      "should pass the accessibility tests when text width is %spx and definition width is %spx, %s%/%s% of the Definition List width",
-      (dtPixels, ddPixels, dtPercent) => {
+    it.each([10, 50, 90])(
+      "should pass the accessibility tests when text width is %spx",
+      (dtPercent) => {
         CypressMountWithProviders(<DLComponent w={dtPercent} />);
-
         cy.checkAccessibility();
       }
     );
 
     it.each(specialCharacters)(
-      "should pass accessibility tests for Definition List if text is %s when children prop is set to %s",
+      "should pass accessibility tests for Definition List if text is %s",
       (text) => {
         CypressMountWithProviders(
           <Dl>
@@ -255,13 +206,12 @@ context("Testing Definition List component", () => {
             <Dd>Definition</Dd>
           </Dl>
         );
-
         cy.checkAccessibility();
       }
     );
 
     it.each(specialCharacters)(
-      "should pass accessibility tests for Definition List if is %s when children prop is set to %s",
+      "should pass accessibility tests for Definition List when children prop is set to %s",
       (definition) => {
         CypressMountWithProviders(
           <Dl>
@@ -269,7 +219,6 @@ context("Testing Definition List component", () => {
             <Dd data-element="dd">{definition}</Dd>
           </Dl>
         );
-
         cy.checkAccessibility();
       }
     );
@@ -294,7 +243,6 @@ context("Testing Definition List component", () => {
           </Dd>
         </Dl>
       );
-
       cy.checkAccessibility();
     });
 
@@ -309,7 +257,6 @@ context("Testing Definition List component", () => {
           )}
         </Dl>
       );
-
       cy.checkAccessibility();
     });
 

--- a/src/components/definition-list/definition-list-test.stories.tsx
+++ b/src/components/definition-list/definition-list-test.stories.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import Dl, { DlProps } from "../definition-list/dl.component";
+import Dt from "../definition-list/dt.component";
+import Dd from "../definition-list/dd.component";
+import Typography from "../typography";
+import Hr from "../hr";
+import Box from "../box";
+
+export default {
+  title: "Definition-list/Test",
+  includeStories: ["DefaultStory"],
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+};
+
+export const DefaultStory = ({
+  children,
+  w,
+  dtTextAlign,
+  ddTextAlign,
+  asSingleColumn,
+  ...args
+}: DlProps) => {
+  return (
+    <Dl {...args}>
+      <Dt>First</Dt>
+      <Dd>Description</Dd>
+      <Dt>Second</Dt>
+      <Dd>Description</Dd>
+      <Dt>Third</Dt>
+      <Dd>Description</Dd>
+    </Dl>
+  );
+};
+
+DefaultStory.story = {
+  name: "default",
+  args: {
+    children: "This is an example of a Definition-list",
+    w: 50,
+    dtTextAlign: "right",
+    ddTextAlign: "left",
+    asSingleColumn: false,
+  },
+};
+
+export const DLComponent = (props: Partial<DlProps>) => {
+  return (
+    <div>
+      <Dl data-element="dl" {...props}>
+        <Dt>First</Dt>
+        <Dd data-element="dd">Description 1</Dd>
+        <Dt>Second</Dt>
+        <Dd>Description 2</Dd>
+        <Dt>Third</Dt>
+        <Dd>Description 3</Dd>
+      </Dl>
+    </div>
+  );
+};
+
+export const DLBoxComponent = () => {
+  return (
+    <div>
+      <Box data-element="box" width="65%" px={2} pt={4} pb={3}>
+        <Box width="90%">
+          <Typography color="rgba(0,0,0,0.55)" variant="segment-subheader-alt">
+            Segment Header
+          </Typography>
+          <Hr ml={0} mt={2} />
+        </Box>
+        <Box mb={3} display="flex">
+          <Box mr={1}>
+            <Dl dtTextAlign="left" asSingleColumn>
+              <Dt>First</Dt>
+              <Dd>Description 1</Dd>
+              <Dt>Second</Dt>
+              <Dd>Description 2</Dd>
+              <Dt>Third</Dt>
+              <Dd>Description</Dd>
+            </Dl>
+          </Box>
+        </Box>
+      </Box>
+    </div>
+  );
+};


### PR DESCRIPTION
### Proposed behaviour

- Rename the `definition-list.cy.js` to the `definition-list.cy.tsx` file in the `./cypress/components/definition-list/` folder.
- Added definition-list-test.stories.tsx
- Refactor tests to Typescript.  

### Current behaviour

`definition-list` tests are in js not ts.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions
- [x] Run `npx cypress open --component` to check if the `definition-list.cy.tsx` file passed
- [x] Run `npx cypress run --component` to check none of the other `*.cy.tsx` files have regressed
<!-- Add CodeSandbox here -->