### PR TITLE
feat(flat-table, flat-table-row): components can now be wrapped, subRows no longer need to be arrays FE-6050

### DIFF
--- a/cypress/components/flat-table/flat-table.cy.tsx
+++ b/cypress/components/flat-table/flat-table.cy.tsx
@@ -7,7 +7,6 @@ import {
 import * as stories from "../../../src/components/flat-table/flat-table-test.stories";
 import { FlatTableProps } from "../../../src/components/flat-table/flat-table.component";
 import { FlatTableRowProps } from "../../../src/components/flat-table/flat-table-row/flat-table-row.component";
-import { FlatTableCellProps } from "../../../src/components/flat-table/flat-table-cell/flat-table-cell.component";
 import Icon from "../../../src/components/icon";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 import { getDataElementByValue, cyRoot } from "../../locators";
@@ -60,6 +59,7 @@ import {
   positionOfElement,
   getRotationAngle,
 } from "../../support/helper";
+import { FlatTableRowContextProps } from "../../../src/components/flat-table/flat-table-row/__internal__/flat-table-row-context";
 
 const sizes = [
   ["compact", "8px", "13px", 24],
@@ -297,6 +297,21 @@ context("Tests for Flat Table component", () => {
           flatTableBodyRowByPosition(i).should("be.visible");
         }
       }
+    });
+
+    it("should render Flat Table with sticky header and multiple rows", () => {
+      CypressMountWithProviders(
+        <div style={{ height: "150px" }}>
+          <stories.FlatTableWithMultipleStickyHeaderRows />
+        </div>
+      );
+
+      flatTableHeaderRowByPosition(0)
+        .find("th")
+        .should("have.css", "top", "0px");
+      flatTableHeaderRowByPosition(1)
+        .find("th")
+        .should("have.css", "top", "40px");
     });
 
     it("should render Flat Table with sticky footer", () => {
@@ -2670,7 +2685,9 @@ context("Tests for Flat Table component", () => {
     });
 
     it("should call onClick when first Flat Table column is sorted", () => {
-      const callback: FlatTableCellProps["onClick"] = cy.stub().as("onClick");
+      const callback: FlatTableRowContextProps["onClick"] = cy
+        .stub()
+        .as("onClick");
       CypressMountWithProviders(
         <stories.FlatTableSortingComponent onClick={callback} />
       );

--- a/src/components/flat-table/__internal__/build-position-map.ts
+++ b/src/components/flat-table/__internal__/build-position-map.ts
@@ -1,0 +1,18 @@
+export default (
+  array: HTMLElement[],
+  propertyName: "offsetWidth" | "offsetHeight"
+) =>
+  array.reduce((acc: Record<string, number>, _, index) => {
+    const currentId = array[index].getAttribute("id");
+    if (currentId) {
+      if (index === 0) {
+        acc[currentId] = 0;
+      } else {
+        const previousId = array[index - 1].getAttribute("id");
+        if (previousId) {
+          acc[currentId] = acc[previousId] + array[index - 1][propertyName];
+        }
+      }
+    }
+    return acc;
+  }, {});

--- a/src/components/flat-table/__internal__/index.ts
+++ b/src/components/flat-table/__internal__/index.ts
@@ -1,0 +1,2 @@
+export { default as useCalculateStickyCells } from "./use-calculate-sticky-cells";
+export { default as buildPositionMap } from "./build-position-map";

--- a/src/components/flat-table/__internal__/use-calculate-sticky-cells.ts
+++ b/src/components/flat-table/__internal__/use-calculate-sticky-cells.ts
@@ -1,0 +1,32 @@
+import { useContext } from "react";
+import FlatTableRowContext from "../flat-table-row/__internal__/flat-table-row-context";
+
+export default (id: string) => {
+  const {
+    expandable,
+    firstCellId,
+    firstColumnExpandable,
+    leftPositions,
+    rightPositions,
+    onClick,
+    onKeyDown,
+  } = useContext(FlatTableRowContext);
+
+  const leftPosition = leftPositions[id];
+  const rightPosition = rightPositions[id];
+  const makeCellSticky =
+    leftPosition !== undefined || rightPosition !== undefined;
+  const isFirstCell = id === firstCellId;
+  const isExpandableCell = expandable && isFirstCell && firstColumnExpandable;
+
+  return {
+    expandable,
+    leftPosition,
+    rightPosition,
+    makeCellSticky,
+    onClick,
+    onKeyDown,
+    isFirstCell,
+    isExpandableCell,
+  };
+};

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.style.ts
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.style.ts
@@ -13,17 +13,15 @@ const verticalBorderSizes = {
 interface StyledFlatTableCellProps
   extends Pick<
       FlatTableCellProps,
-      | "align"
-      | "leftPosition"
-      | "rightPosition"
-      | "expandable"
-      | "verticalBorder"
-      | "verticalBorderColor"
+      "align" | "verticalBorder" | "verticalBorderColor"
     >,
     PaddingProps {
   makeCellSticky: boolean;
   colWidth?: number;
   isTruncated: boolean;
+  leftPosition: number;
+  rightPosition: number;
+  expandable?: boolean;
 }
 
 const StyledFlatTableCell = styled.td<StyledFlatTableCellProps>`
@@ -112,7 +110,7 @@ const StyledFlatTableCell = styled.td<StyledFlatTableCellProps>`
   `}
 `;
 
-const StyledCellContent = styled.div<Pick<FlatTableCellProps, "expandable">>`
+const StyledCellContent = styled.div<{ expandable?: boolean }>`
   ${({ expandable }) =>
     expandable &&
     css`

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.component.tsx
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.component.tsx
@@ -2,7 +2,9 @@ import React, { useLayoutEffect, useRef } from "react";
 import StyledFlatTableCheckbox from "./flat-table-checkbox.style";
 import { Checkbox } from "../../checkbox";
 import Events from "../../../__internal__/utils/helpers/events/events";
-import { TagProps } from "../../../__internal__/utils/helpers/tags";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags";
 
 export interface FlatTableCheckboxProps extends TagProps {
   /** Prop to polymorphically render either a 'th' or 'td' element */
@@ -84,9 +86,11 @@ export const FlatTableCheckbox = ({
       className={reportCellWidth ? "isSticky" : undefined}
       leftPosition={leftPosition}
       rightPosition={rightPosition}
-      data-element={dataElement}
       as={as}
-      {...rest}
+      {...tagComponent("flat-table-checkbox", {
+        "data-element": dataElement,
+        ...rest,
+      })}
     >
       {selectable && (
         <Checkbox

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.component.tsx
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.component.tsx
@@ -1,10 +1,12 @@
-import React, { useLayoutEffect, useRef } from "react";
+import React, { useContext, useRef } from "react";
 import StyledFlatTableCheckbox from "./flat-table-checkbox.style";
 import { Checkbox } from "../../checkbox";
 import Events from "../../../__internal__/utils/helpers/events/events";
 import tagComponent, {
   TagProps,
 } from "../../../__internal__/utils/helpers/tags";
+import guid from "../../../__internal__/utils/helpers/guid";
+import FlatTableRowContext from "../flat-table-row/__internal__/flat-table-row-context";
 
 export interface FlatTableCheckboxProps extends TagProps {
   /** Prop to polymorphically render either a 'th' or 'td' element */
@@ -19,30 +21,8 @@ export interface FlatTableCheckboxProps extends TagProps {
   onClick?: (ev: React.MouseEvent<HTMLElement>) => void;
   /** The id of the element that labels the input */
   ariaLabelledBy?: string;
-  /**
-   * @private
-   * @ignore
-   * Sets the left position when sticky column found
-   */
-  leftPosition?: number;
-  /**
-   * @private
-   * @ignore
-   * Sets the right position when sticky column found
-   */
-  rightPosition?: number;
-  /**
-   * @private
-   * @ignore
-   * Index of cell within row
-   */
-  cellIndex?: number;
-  /**
-   * @private
-   * @ignore
-   * Callback to report the offsetWidth
-   */
-  reportCellWidth?: (offset: number, index?: number) => void;
+  /** Sets an id string on the element */
+  id?: string;
 }
 
 export const FlatTableCheckbox = ({
@@ -51,20 +31,18 @@ export const FlatTableCheckbox = ({
   onChange,
   selectable = true,
   onClick,
-  leftPosition,
-  rightPosition,
-  cellIndex,
-  reportCellWidth,
   ariaLabelledBy,
+  id,
   ...rest
 }: FlatTableCheckboxProps) => {
   const ref = useRef<HTMLTableCellElement>(null);
+  const internalId = useRef(id || guid());
+  const { leftPositions, rightPositions } = useContext(FlatTableRowContext);
 
-  useLayoutEffect(() => {
-    if (ref.current && reportCellWidth) {
-      reportCellWidth(ref.current.offsetWidth, cellIndex);
-    }
-  }, [reportCellWidth, cellIndex]);
+  const leftPosition = leftPositions[internalId.current];
+  const rightPosition = rightPositions[internalId.current];
+  const makeCellSticky =
+    leftPosition !== undefined || rightPosition !== undefined;
 
   const dataElement = `flat-table-checkbox-${as === "td" ? "cell" : "header"}`;
 
@@ -82,8 +60,8 @@ export const FlatTableCheckbox = ({
   return (
     <StyledFlatTableCheckbox
       ref={ref}
-      makeCellSticky={!!reportCellWidth}
-      className={reportCellWidth ? "isSticky" : undefined}
+      makeCellSticky={makeCellSticky}
+      className={makeCellSticky ? "isSticky" : undefined}
       leftPosition={leftPosition}
       rightPosition={rightPosition}
       as={as}
@@ -91,6 +69,7 @@ export const FlatTableCheckbox = ({
         "data-element": dataElement,
         ...rest,
       })}
+      id={internalId.current}
     >
       {selectable && (
         <Checkbox

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.spec.tsx
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.spec.tsx
@@ -6,6 +6,7 @@ import FlatTableCheckbox, {
 import StyledFlatTableCheckbox from "./flat-table-checkbox.style";
 import guid from "../../../__internal__/utils/helpers/guid";
 import { Checkbox } from "../../checkbox";
+import { rootTagTest } from "../../../__internal__/utils/helpers/tags/tags-specs";
 
 jest.mock("../../../__internal__/utils/helpers/guid");
 (guid as jest.MockedFunction<typeof guid>).mockImplementation(
@@ -133,6 +134,19 @@ describe("FlatTableCheckbox", () => {
       const wrapper = render({ selectable: false });
 
       expect(wrapper.find(Checkbox).exists()).toEqual(false);
+    });
+  });
+
+  describe("data tags", () => {
+    it("has the expected attributes applied to the elements", () => {
+      const wrapper = render({ "data-element": "foo", "data-role": "bar" });
+
+      rootTagTest(
+        wrapper.find(StyledFlatTableCheckbox),
+        "flat-table-checkbox",
+        "foo",
+        "bar"
+      );
     });
   });
 });

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.style.ts
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.style.ts
@@ -3,11 +3,10 @@ import StyledCheckbox from "../../checkbox/checkbox.style";
 import { FlatTableCheckboxProps } from "./flat-table-checkbox.component";
 
 interface StyledFlatTableCheckboxProps
-  extends Pick<
-    FlatTableCheckboxProps,
-    "as" | "leftPosition" | "rightPosition"
-  > {
+  extends Pick<FlatTableCheckboxProps, "as"> {
   makeCellSticky: boolean;
+  leftPosition: number;
+  rightPosition: number;
 }
 
 const StyledFlatTableCheckbox = styled.td<StyledFlatTableCheckboxProps>`

--- a/src/components/flat-table/flat-table-header/flat-table-header.component.tsx
+++ b/src/components/flat-table/flat-table-header/flat-table-header.component.tsx
@@ -1,9 +1,11 @@
-import React, { useLayoutEffect, useRef, useContext } from "react";
+import React, { useRef, useContext } from "react";
 import { PaddingProps } from "styled-system";
 import { TableBorderSize, TableCellAlign } from "..";
 
 import StyledFlatTableHeader from "./flat-table-header.style";
 import { FlatTableThemeContext } from "../flat-table.component";
+import guid from "../../../__internal__/utils/helpers/guid";
+import useCalculateStickyCells from "../__internal__/use-calculate-sticky-cells";
 
 export interface FlatTableHeaderProps extends PaddingProps {
   /** Content alignment */
@@ -22,32 +24,8 @@ export interface FlatTableHeaderProps extends PaddingProps {
   verticalBorderColor?: string;
   /** Column width, pass a number to set a fixed width in pixels */
   width?: number;
-  /** Sets an id string on the DOM element */
+  /** Sets an id string on the element */
   id?: string;
-  /**
-   * @private
-   * @ignore
-   * Sets the left position when sticky column found
-   */
-  leftPosition?: number;
-  /**
-   * @private
-   * @ignore
-   * Sets the right position when sticky column found
-   */
-  rightPosition?: number;
-  /**
-   * @private
-   * @ignore
-   * Index of cell within row
-   */
-  cellIndex?: number;
-  /**
-   * @private
-   * @ignore
-   * Callback to report the offsetWidth
-   */
-  reportCellWidth?: (offset: number, index?: number) => void;
 }
 
 export const FlatTableHeader = ({
@@ -58,28 +36,25 @@ export const FlatTableHeader = ({
   width,
   py,
   px,
-  reportCellWidth,
-  cellIndex,
-  leftPosition,
-  rightPosition,
+  id,
   ...rest
 }: FlatTableHeaderProps) => {
   const ref = useRef<HTMLTableCellElement>(null);
+  const internalId = useRef(id || guid());
   const { colorTheme } = useContext(FlatTableThemeContext);
-
-  useLayoutEffect(() => {
-    if (ref.current && reportCellWidth) {
-      reportCellWidth(ref.current.offsetWidth, cellIndex);
-    }
-  }, [reportCellWidth, cellIndex]);
+  const {
+    leftPosition,
+    rightPosition,
+    makeCellSticky,
+  } = useCalculateStickyCells(internalId.current);
 
   return (
     <StyledFlatTableHeader
       ref={ref}
       leftPosition={leftPosition}
       rightPosition={rightPosition}
-      makeCellSticky={!!reportCellWidth}
-      className={reportCellWidth ? "isSticky" : undefined}
+      makeCellSticky={makeCellSticky}
+      className={makeCellSticky ? "isSticky" : undefined}
       align={align}
       colorTheme={colorTheme}
       data-element="flat-table-header"
@@ -89,6 +64,7 @@ export const FlatTableHeader = ({
       py={py}
       px={px}
       {...rest}
+      id={internalId.current}
     >
       <div>{children}</div>
     </StyledFlatTableHeader>

--- a/src/components/flat-table/flat-table-header/flat-table-header.spec.tsx
+++ b/src/components/flat-table/flat-table-header/flat-table-header.spec.tsx
@@ -141,4 +141,24 @@ describe("FlatTableHeader", () => {
       });
     }
   );
+
+  describe("when colspan and rowSpan are passed", () => {
+    it("should be set on the underlying element", () => {
+      const wrapper = mount(
+        <table>
+          <thead>
+            <tr>
+              <FlatTableHeader colspan={2}>Children</FlatTableHeader>
+            </tr>
+            <tr>
+              <FlatTableHeader rowspan={2}>Children</FlatTableHeader>
+            </tr>
+          </thead>
+        </table>
+      );
+
+      expect(wrapper.find(StyledFlatTableHeader).at(0).prop("colSpan")).toBe(2);
+      expect(wrapper.find(StyledFlatTableHeader).at(1).prop("rowSpan")).toBe(2);
+    });
+  });
 });

--- a/src/components/flat-table/flat-table-header/flat-table-header.style.ts
+++ b/src/components/flat-table/flat-table-header/flat-table-header.style.ts
@@ -15,17 +15,14 @@ const verticalBorderSizes = {
 interface StyledFlatTableHeaderProps
   extends Pick<
       FlatTableHeaderProps,
-      | "align"
-      | "leftPosition"
-      | "rightPosition"
-      | "verticalBorder"
-      | "verticalBorderColor"
-      | "alternativeBgColor"
+      "align" | "verticalBorder" | "verticalBorderColor" | "alternativeBgColor"
     >,
     PaddingProps {
   makeCellSticky: boolean;
   colWidth?: number;
   colorTheme: FlatTableProps["colorTheme"];
+  leftPosition: number;
+  rightPosition: number;
 }
 
 const StyledFlatTableHeader = styled.th<StyledFlatTableHeaderProps>`

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.tsx
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.tsx
@@ -1,9 +1,9 @@
 import React, {
   useCallback,
-  useEffect,
   useContext,
   useState,
   useRef,
+  useEffect,
 } from "react";
 import { PaddingProps } from "styled-system";
 import { TableBorderSize, TableCellAlign } from "..";
@@ -15,8 +15,12 @@ import {
 } from "./flat-table-row-header.style";
 import { FlatTableThemeContext } from "../flat-table.component";
 import guid from "../../../__internal__/utils/helpers/guid";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags/tags";
+import useCalculateStickyCells from "../__internal__/use-calculate-sticky-cells";
 
-export interface FlatTableRowHeaderProps extends PaddingProps {
+export interface FlatTableRowHeaderProps extends PaddingProps, TagProps {
   /** Content alignment */
   align?: TableCellAlign;
   /** RowHeader content */
@@ -37,47 +41,8 @@ export interface FlatTableRowHeaderProps extends PaddingProps {
   colspan?: number | string;
   /** Number of rows that a header cell should span */
   rowspan?: number | string;
-  /** Sets an id string on the DOM element */
+  /** Sets an id string on the element */
   id?: string;
-  /**
-   * @private
-   * @ignore
-   */
-  expandable?: boolean;
-  /**
-   * @private
-   * @ignore
-   */
-  onClick?: (ev: React.MouseEvent<HTMLElement>) => void;
-  /**
-   * @private
-   * @ignore
-   */
-  onKeyDown?: (ev: React.KeyboardEvent<HTMLElement>) => void;
-  /**
-   * @private
-   * @ignore
-   * Sets the left position when sticky column found
-   */
-  leftPosition?: number;
-  /**
-   * @private
-   * @ignore
-   * Sets the right position when sticky column found
-   */
-  rightPosition?: number;
-  /**
-   * @private
-   * @ignore
-   * Index of cell within row
-   */
-  cellIndex?: number;
-  /**
-   * @private
-   * @ignore
-   * Callback to report the offsetWidth
-   */
-  reportCellWidth?: (offset: number, index?: number) => void;
 }
 
 export const FlatTableRowHeader = ({
@@ -86,38 +51,47 @@ export const FlatTableRowHeader = ({
   width,
   py,
   px,
-  expandable = false,
-  onClick,
-  onKeyDown,
-  leftPosition,
-  rightPosition,
   truncate,
   title,
   stickyAlignment = "left",
   colspan,
   rowspan,
+  id,
   ...rest
 }: FlatTableRowHeaderProps) => {
-  const id = useRef(guid());
+  const internalId = useRef(id || guid());
   const [tabIndex, setTabIndex] = useState(-1);
   const { selectedId } = useContext(FlatTableThemeContext);
 
-  const handleOnClick = useCallback(
-    (ev: React.MouseEvent<HTMLElement>) => {
-      if (expandable && onClick) onClick(ev);
-    },
-    [expandable, onClick]
-  );
-  const handleOnKeyDown = useCallback(
-    (ev: React.KeyboardEvent<HTMLElement>) => {
-      if (expandable && onKeyDown) onKeyDown(ev);
-    },
-    [expandable, onKeyDown]
-  );
+  const {
+    leftPosition,
+    rightPosition,
+    expandable,
+    onClick,
+    onKeyDown,
+    isFirstCell,
+    isExpandableCell,
+  } = useCalculateStickyCells(internalId.current);
 
   useEffect(() => {
-    setTabIndex(selectedId === id.current ? 0 : -1);
-  }, [selectedId]);
+    setTabIndex(isExpandableCell && selectedId === internalId.current ? 0 : -1);
+  }, [selectedId, isExpandableCell]);
+
+  const handleOnClick = useCallback(
+    (ev: React.MouseEvent<HTMLElement>) => {
+      if (isExpandableCell && onClick) onClick(ev);
+    },
+    [isExpandableCell, onClick]
+  );
+
+  const handleOnKeyDown = useCallback(
+    (ev: React.KeyboardEvent<HTMLElement>) => {
+      if (isExpandableCell && onKeyDown) {
+        onKeyDown(ev);
+      }
+    },
+    [isExpandableCell, onKeyDown]
+  );
 
   return (
     <StyledFlatTableRowHeader
@@ -126,20 +100,23 @@ export const FlatTableRowHeader = ({
         stickyAlignment === "right" ? rightPosition || 0 : undefined
       }
       align={align}
-      data-element="flat-table-row-header"
+      {...tagComponent("flat-table-row-header", {
+        "data-element": "flat-table-row-header",
+        ...rest,
+      })}
       width={width}
       py={py || "10px"}
       px={px || 3}
       onClick={handleOnClick}
-      tabIndex={expandable && onClick ? tabIndex : undefined}
+      tabIndex={isExpandableCell ? tabIndex : undefined}
       onKeyDown={handleOnKeyDown}
       truncate={truncate}
       expandable={expandable}
       stickyAlignment={stickyAlignment}
-      id={id.current}
       {...(colspan !== undefined && { colSpan: Number(colspan) })}
       {...(rowspan !== undefined && { rowSpan: Number(rowspan) })}
       {...rest}
+      id={internalId.current}
     >
       <StyledFlatTableRowHeaderContent
         title={
@@ -147,7 +124,7 @@ export const FlatTableRowHeader = ({
         }
         expandable={expandable}
       >
-        {expandable && (
+        {expandable && isFirstCell && (
           <Icon type="chevron_down_thick" bgSize="extra-small" mr="8px" />
         )}
         {children}

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.spec.tsx
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.spec.tsx
@@ -10,6 +10,7 @@ import {
   testStyledSystemPadding,
 } from "../../../__spec_helper__/test-utils";
 import StyledIcon from "../../icon/icon.style";
+import FlatTableRowContext from "../flat-table-row/__internal__/flat-table-row-context";
 
 describe("FlatTableRowHeader", () => {
   testStyledSystemPadding(
@@ -106,13 +107,22 @@ describe("FlatTableRowHeader", () => {
     });
   });
 
-  describe("when expandable prop is true", () => {
+  describe("when expandable", () => {
     it("should render an arrow icon", () => {
       const wrapper = mount(
         <table>
           <thead>
             <tr>
-              <FlatTableRowHeader expandable />
+              <FlatTableRowContext.Provider
+                value={{
+                  expandable: true,
+                  firstCellId: "foo",
+                  leftPositions: {},
+                  rightPositions: {},
+                }}
+              >
+                <FlatTableRowHeader id="foo" />
+              </FlatTableRowContext.Provider>
             </tr>
           </thead>
         </table>
@@ -128,7 +138,18 @@ describe("FlatTableRowHeader", () => {
           <table>
             <thead>
               <tr>
-                <FlatTableRowHeader expandable onClick={onClickFn} />
+                <FlatTableRowContext.Provider
+                  value={{
+                    expandable: true,
+                    firstColumnExpandable: true,
+                    onClick: onClickFn,
+                    firstCellId: "foo",
+                    leftPositions: {},
+                    rightPositions: {},
+                  }}
+                >
+                  <FlatTableRowHeader id="foo" />
+                </FlatTableRowContext.Provider>
               </tr>
             </thead>
           </table>
@@ -147,7 +168,18 @@ describe("FlatTableRowHeader", () => {
           <table>
             <thead>
               <tr>
-                <FlatTableRowHeader expandable onKeyDown={onKeyDownFn} />
+                <FlatTableRowContext.Provider
+                  value={{
+                    expandable: true,
+                    firstColumnExpandable: true,
+                    onKeyDown: onKeyDownFn,
+                    firstCellId: "foo",
+                    leftPositions: {},
+                    rightPositions: {},
+                  }}
+                >
+                  <FlatTableRowHeader id="foo" />
+                </FlatTableRowContext.Provider>
               </tr>
             </thead>
           </table>
@@ -168,7 +200,16 @@ describe("FlatTableRowHeader", () => {
           <table>
             <thead>
               <tr>
-                <FlatTableRowHeader onClick={onClickFn} />
+                <FlatTableRowContext.Provider
+                  value={{
+                    onClick: onClickFn,
+                    firstCellId: "foo",
+                    leftPositions: {},
+                    rightPositions: {},
+                  }}
+                >
+                  <FlatTableRowHeader id="foo" />
+                </FlatTableRowContext.Provider>
               </tr>
             </thead>
           </table>
@@ -187,7 +228,16 @@ describe("FlatTableRowHeader", () => {
           <table>
             <thead>
               <tr>
-                <FlatTableRowHeader onKeyDown={onKeyDownFn} />
+                <FlatTableRowContext.Provider
+                  value={{
+                    onKeyDown: onKeyDownFn,
+                    firstCellId: "foo",
+                    leftPositions: {},
+                    rightPositions: {},
+                  }}
+                >
+                  <FlatTableRowHeader id="foo" />
+                </FlatTableRowContext.Provider>
               </tr>
             </thead>
           </table>
@@ -246,6 +296,31 @@ describe("FlatTableRowHeader", () => {
         expect(wrapper.find("div").props().title).toEqual("Bar");
       });
     });
+  });
+
+  describe("stickyAlignment", () => {
+    it.each<FlatTableRowHeaderProps["stickyAlignment"]>(["left", "right"])(
+      "sets the data-sticky-align attribute to %s",
+      (stickyAlignment) => {
+        const element = mount(
+          <table>
+            <thead>
+              <tr>
+                <FlatTableRowHeader stickyAlignment={stickyAlignment}>
+                  Foo
+                </FlatTableRowHeader>
+              </tr>
+            </thead>
+          </table>
+        )
+          .find(StyledFlatTableRowHeader)
+          .getDOMNode();
+
+        expect(element.getAttribute("data-sticky-align")).toEqual(
+          stickyAlignment
+        );
+      }
+    );
   });
 
   describe.each([

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.ts
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.ts
@@ -11,7 +11,19 @@ const verticalBorderSizes = {
   large: "4px",
 };
 
-const StyledFlatTableRowHeader = styled.th<FlatTableRowHeaderProps>`
+const StyledFlatTableRowHeader = styled.th.attrs(
+  ({
+    stickyAlignment,
+  }: {
+    stickyAlignment: FlatTableRowHeaderProps["stickyAlignment"];
+  }) => ({ "data-sticky-align": stickyAlignment })
+)<
+  FlatTableRowHeaderProps & {
+    expandable?: boolean;
+    leftPosition?: number;
+    rightPosition?: number;
+  }
+>`
   ${({
     align,
     theme,

--- a/src/components/flat-table/flat-table-row/__internal__/flat-table-row-context.tsx
+++ b/src/components/flat-table/flat-table-row/__internal__/flat-table-row-context.tsx
@@ -1,0 +1,17 @@
+import React, { createContext } from "react";
+
+export interface FlatTableRowContextProps {
+  expandable?: boolean;
+  onClick?: (ev?: React.MouseEvent<HTMLElement>) => void;
+  onKeyDown?: (ev: React.KeyboardEvent<HTMLElement>) => void;
+  firstCellId: string | null;
+  leftPositions: Record<string, number>;
+  rightPositions: Record<string, number>;
+  firstColumnExpandable?: boolean;
+}
+
+export default createContext<FlatTableRowContextProps>({
+  firstCellId: "",
+  leftPositions: {},
+  rightPositions: {},
+});

--- a/src/components/flat-table/flat-table-row/__internal__/flat-table-row-draggable.component.tsx
+++ b/src/components/flat-table/flat-table-row/__internal__/flat-table-row-draggable.component.tsx
@@ -12,6 +12,8 @@ export interface FlatTableRowDraggableProps {
   moveItem?: (id?: number | string, index?: number) => void;
   /** item is draggable */
   draggable?: boolean;
+  /** ref for row element */
+  rowRef?: React.ForwardedRef<HTMLTableRowElement | null>;
 }
 
 interface DragItem {
@@ -24,6 +26,7 @@ export const FlatTableRowDraggable = ({
   id,
   findItem,
   moveItem,
+  rowRef,
 }: FlatTableRowDraggableProps) => {
   const originalIndex = Number(findItem?.(id).index);
 
@@ -57,7 +60,17 @@ export const FlatTableRowDraggable = ({
     key: originalIndex,
     id,
     isDragging,
-    ref: (node: HTMLElement) => drag(drop(node)),
+    ref: (node: HTMLTableRowElement) => {
+      drag(drop(node));
+      /* istanbul ignore else */
+      if (rowRef) {
+        if (typeof rowRef === "function") {
+          rowRef(node);
+        } else {
+          rowRef.current = node;
+        }
+      }
+    },
   });
 };
 

--- a/src/components/flat-table/flat-table-row/__internal__/sub-row-provider.tsx
+++ b/src/components/flat-table/flat-table-row/__internal__/sub-row-provider.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useCallback, useState } from "react";
+
+export interface SubRowContextProps {
+  isSubRow?: boolean;
+  firstRowId: string;
+  addRow: (id: string) => void;
+  removeRow: (id: string) => void;
+}
+
+export const SubRowContext = createContext<SubRowContextProps>({
+  isSubRow: false,
+  firstRowId: "",
+  addRow: () => {},
+  removeRow: () => {},
+});
+
+const SubRowProvider = ({ children }: { children: React.ReactNode }) => {
+  const [rowIds, setRowIds] = useState<string[]>([]);
+
+  const addRow = useCallback((id: string) => {
+    setRowIds((p) => [...p, id]);
+  }, []);
+
+  const removeRow = useCallback((id: string) => {
+    setRowIds((p) => p.filter((rowId) => rowId !== id));
+  }, []);
+
+  return (
+    <SubRowContext.Provider
+      value={{ isSubRow: true, firstRowId: rowIds[0], addRow, removeRow }}
+    >
+      {children}
+    </SubRowContext.Provider>
+  );
+};
+
+SubRowProvider.displayName = "SubRowProvider";
+
+export default SubRowProvider;

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.ts
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.ts
@@ -124,13 +124,9 @@ interface StyledFlatTableRowProps
     FlatTableRowProps,
     | "bgColor"
     | "horizontalBorderColor"
-    | "stickyOffset"
     | "expandable"
     | "selected"
     | "highlighted"
-    | "isSubRow"
-    | "isFirstSubRow"
-    | "applyBorderLeft"
     | "draggable"
   > {
   isRowInteractive?: boolean;
@@ -145,6 +141,9 @@ interface StyledFlatTableRowProps
   size: FlatTableProps["size"];
   isDragging?: boolean;
   horizontalBorderSize: NonNullable<FlatTableRowProps["horizontalBorderSize"]>;
+  isSubRow?: boolean;
+  isFirstSubRow?: boolean;
+  stickyOffset?: number;
 }
 
 const StyledFlatTableRow = styled.tr<StyledFlatTableRowProps>`
@@ -169,7 +168,6 @@ const StyledFlatTableRow = styled.tr<StyledFlatTableRowProps>`
     isFirstSubRow,
     size,
     theme,
-    applyBorderLeft,
     isDragging,
     draggable,
   }) => {
@@ -256,7 +254,6 @@ const StyledFlatTableRow = styled.tr<StyledFlatTableRowProps>`
       }
 
       ${stickyOffset !== undefined &&
-      stickyOffset > 0 &&
       css`
         && th {
           top: ${stickyOffset}px;
@@ -377,14 +374,6 @@ const StyledFlatTableRow = styled.tr<StyledFlatTableRowProps>`
             background-color: ${backgroundColor ||
             "var(colorsUtilityMajor025)"};
           }
-        }
-      `}
-
-
-      ${applyBorderLeft &&
-      css`
-        th:first-of-type {
-          border-left: 1px solid ${customBorderColor || borderColor(colorTheme)};
         }
       `}
 

--- a/src/components/flat-table/flat-table-test.stories.tsx
+++ b/src/components/flat-table/flat-table-test.stories.tsx
@@ -36,6 +36,7 @@ import guid from "../../__internal__/utils/helpers/guid";
 import { FLAT_TABLE_THEMES } from "./flat-table.config";
 import { WithSortingHeaders } from "./flat-table.stories";
 import { CHARACTERS } from "../../../cypress/support/component-helper/constants";
+import { FlatTableRowContextProps } from "./flat-table-row/__internal__/flat-table-row-context";
 
 type SortType = "ascending" | "descending";
 type SortValue = "client" | "total";
@@ -84,7 +85,12 @@ type SubRowsShapeChildrenOnlySelectableStoryKey = keyof SubRowsShapeChildrenOnly
 
 export default {
   title: "Flat Table/Test",
-  includeStories: ["FlatTableStory", "ExpandableWithLink", "SortableStory"],
+  includeStories: [
+    "FlatTableStory",
+    "ExpandableWithLink",
+    "SortableStory",
+    "SubRowsAsAComponentStory",
+  ],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -1841,7 +1847,9 @@ export const FlatTableTitleAlignComponent = (
 };
 
 export const FlatTableSortingComponent = (
-  props: Partial<FlatTableProps> & FlatTableCellProps
+  props: Partial<FlatTableProps> &
+    FlatTableCellProps &
+    Partial<FlatTableRowContextProps>
 ) => {
   const headDataItems: HeadDataItems = [
     {
@@ -3259,6 +3267,84 @@ export const FlatTableLastColumnHasRowspan = () => {
         <FlatTableRow>
           <FlatTableCell>Foo</FlatTableCell>
           <FlatTableCell>Bar</FlatTableCell>
+        </FlatTableRow>
+      </FlatTableBody>
+    </FlatTable>
+  );
+};
+
+export const FlatTableWithMultipleStickyHeaderRows = () => (
+  <FlatTable hasStickyHead>
+    <FlatTableHead>
+      <FlatTableRow>
+        <FlatTableHeader>Foo</FlatTableHeader>
+      </FlatTableRow>
+      <FlatTableRow>
+        <FlatTableHeader>Foo</FlatTableHeader>
+      </FlatTableRow>
+    </FlatTableHead>
+    <FlatTableBody>
+      <FlatTableRow>
+        <FlatTableCell>Foo</FlatTableCell>
+      </FlatTableRow>
+      <FlatTableRow>
+        <FlatTableCell>Foo</FlatTableCell>
+      </FlatTableRow>
+    </FlatTableBody>
+  </FlatTable>
+);
+
+export const SubRowsAsAComponentStory = () => {
+  const SubRowsComponent = () => (
+    <>
+      <FlatTableRow>
+        <FlatTableCell>Child one</FlatTableCell>
+        <FlatTableCell>York</FlatTableCell>
+        <FlatTableCell>Single</FlatTableCell>
+        <FlatTableCell>2</FlatTableCell>
+      </FlatTableRow>
+      <FlatTableRow>
+        <FlatTableCell>Child two</FlatTableCell>
+        <FlatTableCell>Edinburgh</FlatTableCell>
+        <FlatTableCell>Single</FlatTableCell>
+        <FlatTableCell>1</FlatTableCell>
+      </FlatTableRow>
+    </>
+  );
+  return (
+    <FlatTable>
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader width={60}>Name</FlatTableHeader>
+          <FlatTableHeader>Location</FlatTableHeader>
+          <FlatTableHeader>Relationship Status</FlatTableHeader>
+          <FlatTableHeader>Dependents</FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+      <FlatTableBody>
+        <FlatTableRow expandable subRows={<SubRowsComponent />}>
+          <FlatTableCell>John Doe</FlatTableCell>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>0</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow expandable subRows={<SubRowsComponent />}>
+          <FlatTableCell>Jane Doe</FlatTableCell>
+          <FlatTableCell>York</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableCell>2</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow expandable subRows={<SubRowsComponent />}>
+          <FlatTableCell>John Smith</FlatTableCell>
+          <FlatTableCell>Edinburgh</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableCell>1</FlatTableCell>
+        </FlatTableRow>
+        <FlatTableRow expandable subRows={<SubRowsComponent />}>
+          <FlatTableCell>Jane Smith</FlatTableCell>
+          <FlatTableCell>Newcastle</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableCell>5</FlatTableCell>
         </FlatTableRow>
       </FlatTableBody>
     </FlatTable>

--- a/src/components/flat-table/flat-table.spec.tsx
+++ b/src/components/flat-table/flat-table.spec.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { ReactWrapper, mount } from "enzyme";
-import { act } from "react-dom/test-utils";
+
+import {
+  render as rtlRender,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 
 import FlatTable, { FlatTableProps } from "./flat-table.component";
 import FlatTableHead from "./flat-table-head/flat-table-head.component";
@@ -195,131 +201,6 @@ describe("FlatTable", () => {
 
         wrapper.find(StyledFlatTableWrapper),
         { modifier: `${StyledFlatTableHeader}` }
-      );
-    });
-  });
-
-  describe("when it has a sticky header with multiple rows", () => {
-    let wrapper: ReactWrapper;
-
-    const render = () => {
-      wrapper = mount(
-        <div style={{ height: "200px" }}>
-          <FlatTable hasStickyHead>
-            <FlatTableHead>
-              <FlatTableRow>
-                <FlatTableHeader>header1</FlatTableHeader>
-                <FlatTableHeader>header2</FlatTableHeader>
-                <FlatTableHeader>header3</FlatTableHeader>
-                <FlatTableHeader>header4</FlatTableHeader>
-              </FlatTableRow>
-              <FlatTableRow>
-                <FlatTableHeader>header1</FlatTableHeader>
-                <FlatTableHeader>header2</FlatTableHeader>
-                <FlatTableHeader>header3</FlatTableHeader>
-                <FlatTableHeader>header4</FlatTableHeader>
-              </FlatTableRow>
-            </FlatTableHead>
-            <FlatTableBody>
-              <FlatTableRow>
-                <FlatTableRowHeader>row header</FlatTableRowHeader>
-                <FlatTableCell>cell1</FlatTableCell>
-                <FlatTableCell>cell2</FlatTableCell>
-                <FlatTableCell rowspan="2">cell3</FlatTableCell>
-              </FlatTableRow>
-              <FlatTableRow>
-                <FlatTableRowHeader>row header</FlatTableRowHeader>
-                <FlatTableCell colspan="2">cell1</FlatTableCell>
-              </FlatTableRow>
-            </FlatTableBody>
-          </FlatTable>
-        </div>
-      );
-
-      jest
-        .spyOn(
-          wrapper
-            .find(StyledFlatTableRow)
-            .at(0)
-            .getDOMNode() as HTMLTableRowElement,
-          "clientHeight",
-          "get"
-        )
-        .mockImplementation(() => 40);
-    };
-
-    beforeEach(() => {
-      render();
-    });
-
-    afterEach(() => {
-      wrapper.unmount();
-    });
-
-    it("should set the correct 'top' css on each row", () => {
-      act(() => render());
-      wrapper.update();
-
-      expect(
-        wrapper.find(StyledFlatTableRow).at(1).props().stickyOffset
-      ).toEqual(40);
-
-      assertStyleMatch(
-        {
-          top: "40px",
-        },
-        wrapper.find(StyledFlatTableHead).find(StyledFlatTableRow).at(1),
-        { modifier: `&& th` }
-      );
-    });
-  });
-
-  describe("When FlatTable has sticky header and uses FlatTableRowHeaders so that the second column is made sticky", () => {
-    let wrapper: ReactWrapper;
-    const render = () => {
-      wrapper = mount(
-        <FlatTable hasStickyHead>
-          <FlatTableHead>
-            <FlatTableRow>
-              <FlatTableHeader rowspan={2}>heading one</FlatTableHeader>
-              <FlatTableRowHeader rowspan={2}>heading two</FlatTableRowHeader>
-              <FlatTableHeader colspan={2}>heading three</FlatTableHeader>
-              <FlatTableHeader rowspan={2} />
-              <FlatTableHeader colspan={2}>heading four</FlatTableHeader>
-            </FlatTableRow>
-            <FlatTableRow>
-              <FlatTableHeader>header 1</FlatTableHeader>
-              <FlatTableHeader>heading 2</FlatTableHeader>
-              <FlatTableHeader>heading 3</FlatTableHeader>
-              <FlatTableHeader>heading 4</FlatTableHeader>
-            </FlatTableRow>
-          </FlatTableHead>
-          <FlatTableBody>
-            <FlatTableRow>
-              <FlatTableCell>name</FlatTableCell>
-              <FlatTableRowHeader>unique id</FlatTableRowHeader>
-              <FlatTableCell>city</FlatTableCell>
-              <FlatTableCell>status</FlatTableCell>
-              <FlatTableCell>0</FlatTableCell>
-              <FlatTableCell>0</FlatTableCell>
-              <FlatTableCell>0</FlatTableCell>
-            </FlatTableRow>
-          </FlatTableBody>
-        </FlatTable>
-      );
-    };
-
-    it("should apply left border if preceding row has a FlatTableRowHeader and current one does not and when the preceding row has a rowspan applied", () => {
-      act(() => render());
-
-      assertStyleMatch(
-        {
-          borderLeft: "1px solid var(--colorsUtilityMajor400)",
-        },
-        wrapper.find(StyledFlatTableHead).find(StyledFlatTableRow).at(1),
-        {
-          modifier: `th:first-of-type`,
-        }
       );
     });
   });
@@ -797,42 +678,8 @@ describe("FlatTable", () => {
     const arrowLeft = { key: "ArrowLeft" };
 
     describe("when rows are clickable", () => {
-      it("should not move focus to first row when down arrow pressed and table wrapper focused", () => {
-        const element = document.createElement("div");
-        const htmlElement = document.body.appendChild(element);
-
-        const wrapper = mount(
-          <FlatTable>
-            <FlatTableBody>
-              <FlatTableRow onClick={() => {}}>
-                <FlatTableCell>one</FlatTableCell>
-                <FlatTableCell>two</FlatTableCell>
-              </FlatTableRow>
-              <FlatTableRow onClick={() => {}}>
-                <FlatTableCell>three</FlatTableCell>
-                <FlatTableCell>four</FlatTableCell>
-              </FlatTableRow>
-            </FlatTableBody>
-          </FlatTable>,
-          { attachTo: htmlElement }
-        );
-
-        act(() => {
-          (wrapper
-            .find(StyledFlatTableWrapper)
-            .getDOMNode() as HTMLDivElement).focus();
-        });
-        expect(wrapper.find(StyledFlatTableWrapper)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(wrapper.find(StyledFlatTableWrapper)).toBeFocused();
-      });
-
-      it("should set the first row's tabindex to 0 if no other rows are selected or highlighted", () => {
-        const wrapper = mount(
+      it("should not move focus to first row when down arrow pressed and table wrapper focused", async () => {
+        rtlRender(
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow onClick={() => {}}>
@@ -846,13 +693,32 @@ describe("FlatTable", () => {
             </FlatTableBody>
           </FlatTable>
         );
+        const tableWrapper = await screen.findByRole("region");
+        tableWrapper?.focus();
+        expect(tableWrapper).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(tableWrapper).toHaveFocus();
+      });
 
-        expect(
-          wrapper.update().find(StyledFlatTableRow).at(0).prop("tabIndex")
-        ).toBe(0);
-        expect(
-          wrapper.update().find(StyledFlatTableRow).at(1).prop("tabIndex")
-        ).toBe(-1);
+      it("should set the first row's tabindex to 0 if no other rows are selected or highlighted", async () => {
+        rtlRender(
+          <FlatTable>
+            <FlatTableBody>
+              <FlatTableRow data-testid="one" onClick={() => {}}>
+                <FlatTableCell>one</FlatTableCell>
+                <FlatTableCell>two</FlatTableCell>
+              </FlatTableRow>
+              <FlatTableRow data-testid="two" onClick={() => {}}>
+                <FlatTableCell>three</FlatTableCell>
+                <FlatTableCell>four</FlatTableCell>
+              </FlatTableRow>
+            </FlatTableBody>
+          </FlatTable>
+        );
+        await waitFor(() => {
+          expect(screen.getByTestId("one").getAttribute("tabindex")).toBe("0");
+          expect(screen.getByTestId("two").getAttribute("tabindex")).toBe("-1");
+        });
       });
 
       it("should set the a row's tabindex to 0 when it is selected", () => {
@@ -903,345 +769,232 @@ describe("FlatTable", () => {
         ).toBe(0);
       });
 
-      it("should move focus to the next row with an onClick when the down arrow key is pressed but not loop to the first when last reached", () => {
-        const element = document.createElement("div");
-        const htmlElement = document.body.appendChild(element);
-
-        const wrapper = mount(
+      it("should move focus to the next row with an onClick when the down arrow key is pressed but not loop to the first when last reached", async () => {
+        rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="one" onClick={() => {}}>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="two" onClick={() => {}}>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="three" onClick={() => {}}>
                 <FlatTableCell>five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="four" onClick={() => {}}>
                 <FlatTableCell>seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
-          </FlatTable>,
-          { attachTo: htmlElement }
+          </FlatTable>
         );
 
-        act(() => {
-          (wrapper
-            .find(StyledFlatTableRow)
-            .at(0)
-            .getDOMNode() as HTMLTableRowElement).focus();
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(0)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(1)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(2)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(3)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(3)).toBeFocused();
+        const tableWrapper = await screen.findByRole("region");
+        const firstRow = await screen.findByTestId("one");
+        const secondRow = await screen.findByTestId("two");
+        const thirdRow = await screen.findByTestId("three");
+        const fourthRow = await screen.findByTestId("four");
+        firstRow?.focus();
+        expect(firstRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(secondRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(thirdRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(fourthRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(fourthRow).toHaveFocus();
       });
 
-      it("should move focus to the previous row with an onClick when the up arrow key is pressed but not loop to the last when first reached", () => {
-        const element = document.createElement("div");
-        const htmlElement = document.body.appendChild(element);
-
-        const wrapper = mount(
+      it("should move focus to the previous row with an onClick when the up arrow key is pressed but not loop to the last when first reached", async () => {
+        rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="one" onClick={() => {}}>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="two" onClick={() => {}}>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="three" onClick={() => {}}>
                 <FlatTableCell>five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="four" onClick={() => {}}>
                 <FlatTableCell>seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
-          </FlatTable>,
-          { attachTo: htmlElement }
+          </FlatTable>
         );
 
-        act(() => {
-          (wrapper
-            .find(StyledFlatTableRow)
-            .at(3)
-            .getDOMNode() as HTMLTableRowElement).focus();
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(3)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(2)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(1)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(0)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(0)).toBeFocused();
+        const tableWrapper = await screen.findByRole("region");
+        const firstRow = await screen.findByTestId("one");
+        const secondRow = await screen.findByTestId("two");
+        const thirdRow = await screen.findByTestId("three");
+        const fourthRow = await screen.findByTestId("four");
+        fourthRow?.focus();
+        expect(fourthRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(thirdRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(secondRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(firstRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(firstRow).toHaveFocus();
       });
 
-      it("should not move focus from currently focused row when left arrow key pressed", () => {
-        const element = document.createElement("div");
-        const htmlElement = document.body.appendChild(element);
-
-        const wrapper = mount(
+      it("should not move focus from currently focused row when left arrow key pressed", async () => {
+        rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="one" onClick={() => {}}>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="two" onClick={() => {}}>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="three" onClick={() => {}}>
                 <FlatTableCell>five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="four" onClick={() => {}}>
                 <FlatTableCell>seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
-          </FlatTable>,
-          { attachTo: htmlElement }
+          </FlatTable>
         );
 
-        act(() => {
-          (wrapper
-            .find(StyledFlatTableRow)
-            .at(3)
-            .getDOMNode() as HTMLTableRowElement).focus();
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(3)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowLeft);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(3)).toBeFocused();
+        const tableWrapper = await screen.findByRole("region");
+        const fourthRow = await screen.findByTestId("four");
+        fourthRow?.focus();
+        expect(fourthRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowLeft);
+        expect(fourthRow).toHaveFocus();
       });
 
-      it("should move focus to the next expandable row when the down arrow key is pressed but not loop to the first when last reached", () => {
-        const element = document.createElement("div");
-        const htmlElement = document.body.appendChild(element);
-
-        const wrapper = mount(
+      it("should move focus to the next expandable row when the down arrow key is pressed but not loop to the first when last reached", async () => {
+        rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow expandable>
+              <FlatTableRow data-testid="one" expandable>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow expandable>
+              <FlatTableRow data-testid="two" expandable>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow expandable>
+              <FlatTableRow data-testid="three" expandable>
                 <FlatTableCell>five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow expandable>
+              <FlatTableRow data-testid="four" expandable>
                 <FlatTableCell>seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
-          </FlatTable>,
-          { attachTo: htmlElement }
+          </FlatTable>
         );
 
-        act(() => {
-          (wrapper
-            .find(StyledFlatTableRow)
-            .at(0)
-            .getDOMNode() as HTMLTableRowElement).focus();
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(0)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(1)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(2)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(3)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(3)).toBeFocused();
+        const tableWrapper = await screen.findByRole("region");
+        const firstRow = await screen.findByTestId("one");
+        const secondRow = await screen.findByTestId("two");
+        const thirdRow = await screen.findByTestId("three");
+        const fourthRow = await screen.findByTestId("four");
+        firstRow?.focus();
+        expect(firstRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(secondRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(thirdRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(fourthRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(fourthRow).toHaveFocus();
       });
 
-      it("should move focus to the previous expandable row when the up arrow key is pressed but not loop to the last when first reached", () => {
-        const element = document.createElement("div");
-        const htmlElement = document.body.appendChild(element);
-
-        const wrapper = mount(
+      it("should move focus to the previous expandable row when the up arrow key is pressed but not loop to the last when first reached", async () => {
+        rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow expandable>
+              <FlatTableRow data-testid="one" expandable>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow expandable>
+              <FlatTableRow data-testid="two" expandable>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow expandable>
+              <FlatTableRow data-testid="three" expandable>
                 <FlatTableCell>five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow expandable>
+              <FlatTableRow data-testid="four" expandable>
                 <FlatTableCell>seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
-          </FlatTable>,
-          { attachTo: htmlElement }
+          </FlatTable>
         );
 
-        act(() => {
-          (wrapper
-            .find(StyledFlatTableRow)
-            .at(3)
-            .getDOMNode() as HTMLTableRowElement).focus();
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(3)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(2)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(1)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(0)).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(0)).toBeFocused();
+        const tableWrapper = await screen.findByRole("region");
+        const firstRow = await screen.findByTestId("one");
+        const secondRow = await screen.findByTestId("two");
+        const thirdRow = await screen.findByTestId("three");
+        const fourthRow = await screen.findByTestId("four");
+        fourthRow?.focus();
+        expect(fourthRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(thirdRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(secondRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(firstRow).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(firstRow).toHaveFocus();
       });
 
-      it("should move focus to the next row when the down arrow key is pressed whilst a checkbox input child is focused", () => {
-        const element = document.createElement("div");
-        const htmlElement = document.body.appendChild(element);
-
-        const wrapper = mount(
+      it("should move focus to the next row when the down arrow key is pressed whilst a checkbox input child is focused", async () => {
+        rtlRender(
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow onClick={() => {}}>
                 <FlatTableCheckbox />
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="two" onClick={() => {}}>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
-          </FlatTable>,
-          { attachTo: htmlElement }
+          </FlatTable>
         );
 
-        act(() => {
-          (wrapper
-            .find(StyledFlatTableRow)
-            .at(0)
-            .find("input")
-            .getDOMNode() as HTMLInputElement).focus();
-        });
-
-        expect(
-          wrapper.find(StyledFlatTableRow).at(0).find("input")
-        ).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(1)).toBeFocused();
+        const tableWrapper = await screen.findByRole("region");
+        const secondRow = await screen.findByTestId("two");
+        const checkbox = await screen.findByRole("checkbox");
+        checkbox.focus();
+        expect(checkbox).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(secondRow).toHaveFocus();
       });
 
-      it("should move focus to the previous row when the up arrow key is pressed whilst a checkbox input child is focused", () => {
-        const element = document.createElement("div");
-        const htmlElement = document.body.appendChild(element);
-
-        const wrapper = mount(
+      it("should move focus to the previous row when the up arrow key is pressed whilst a checkbox input child is focused", async () => {
+        rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow onClick={() => {}}>
+              <FlatTableRow data-testid="one" onClick={() => {}}>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
@@ -1250,287 +1003,146 @@ describe("FlatTable", () => {
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
-          </FlatTable>,
-          { attachTo: htmlElement }
+          </FlatTable>
         );
 
-        act(() => {
-          (wrapper
-            .find(StyledFlatTableRow)
-            .at(1)
-            .find("input")
-            .getDOMNode() as HTMLInputElement).focus();
-        });
-
-        expect(
-          wrapper.find(StyledFlatTableRow).at(1).find("input")
-        ).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(wrapper.update().find(StyledFlatTableRow).at(0)).toBeFocused();
+        const tableWrapper = await screen.findByRole("region");
+        const firstRow = await screen.findByTestId("one");
+        const checkbox = await screen.findByRole("checkbox");
+        checkbox.focus();
+        expect(checkbox).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(firstRow).toHaveFocus();
       });
     });
 
     describe("when the first column is expandable", () => {
-      it("should set the first cell's tabindex to 0", () => {
-        const wrapper = mount(
+      it("should set the first cell's tabindex to 0", async () => {
+        rtlRender(
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell>one</FlatTableCell>
+                <FlatTableCell data-testid="one">one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell>three</FlatTableCell>
+                <FlatTableCell data-testid="two">three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
           </FlatTable>
         );
-
-        expect(
-          wrapper
-            .update()
-            .find(StyledFlatTableRow)
-            .at(0)
-            .find(StyledFlatTableCell)
-            .at(0)
-            .prop("tabIndex")
-        ).toBe(0);
-        expect(
-          wrapper
-            .update()
-            .find(StyledFlatTableRow)
-            .at(1)
-            .find(StyledFlatTableCell)
-            .at(0)
-            .prop("tabIndex")
-        ).toBe(-1);
+        await waitFor(() => {
+          expect(screen.getByTestId("one").getAttribute("tabindex")).toBe("0");
+          expect(screen.getByTestId("two").getAttribute("tabindex")).toBe("-1");
+        });
       });
 
-      it("should set the first row header's tabindex to 0", () => {
-        const wrapper = mount(
+      it("should set the first row header's tabindex to 0", async () => {
+        rtlRender(
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableRowHeader>one</FlatTableRowHeader>
+                <FlatTableRowHeader data-testid="one" id="one">
+                  one
+                </FlatTableRowHeader>
+                <FlatTableCell id="two">two</FlatTableCell>
+              </FlatTableRow>
+              <FlatTableRow expandableArea="firstColumn" expandable>
+                <FlatTableRowHeader data-testid="two" id="three">
+                  three
+                </FlatTableRowHeader>
+                <FlatTableCell id="four">four</FlatTableCell>
+              </FlatTableRow>
+            </FlatTableBody>
+          </FlatTable>
+        );
+        await waitFor(() => {
+          expect(screen.getByTestId("one").getAttribute("tabindex")).toBe("0");
+          expect(screen.getByTestId("two").getAttribute("tabindex")).toBe("-1");
+        });
+      });
+
+      it("should move focus to the next focusable cell when the down arrow key is pressed but not loop to the first when last reached", async () => {
+        rtlRender(
+          <FlatTable>
+            <FlatTableBody>
+              <FlatTableRow expandableArea="firstColumn" expandable>
+                <FlatTableCell data-testid="one">one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableRowHeader>three</FlatTableRowHeader>
+                <FlatTableCell data-testid="two">three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
+              </FlatTableRow>
+              <FlatTableRow expandableArea="firstColumn" expandable>
+                <FlatTableCell data-testid="three">five</FlatTableCell>
+                <FlatTableCell>six</FlatTableCell>
+              </FlatTableRow>
+              <FlatTableRow expandableArea="firstColumn" expandable>
+                <FlatTableCell data-testid="four">seven</FlatTableCell>
+                <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
           </FlatTable>
         );
 
-        expect(
-          wrapper.update().find(StyledFlatTableRowHeader).at(0).prop("tabIndex")
-        ).toBe(0);
-        expect(
-          wrapper.update().find(StyledFlatTableRowHeader).at(1).prop("tabIndex")
-        ).toBe(-1);
+        const tableWrapper = await screen.findByRole("region");
+        const firstFocusableCell = await screen.findByTestId("one");
+        const secondFocusableCell = await screen.findByTestId("two");
+        const thirdFocusableCell = await screen.findByTestId("three");
+        const fourthFocusableCell = await screen.findByTestId("four");
+        firstFocusableCell.focus();
+        expect(firstFocusableCell).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(secondFocusableCell).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(thirdFocusableCell).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(fourthFocusableCell).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowDown);
+        expect(fourthFocusableCell).toHaveFocus();
       });
 
-      it("should move focus to the next focusable cell when the down arrow key is pressed but not loop to the first when last reached", () => {
-        const element = document.createElement("div");
-        const htmlElement = document.body.appendChild(element);
-
-        const wrapper = mount(
+      it("should move focus to the previous focusable cell when the up arrow key is pressed but not loop to the last when first reached", async () => {
+        rtlRender(
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell>one</FlatTableCell>
+                <FlatTableCell data-testid="one">one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell>three</FlatTableCell>
+                <FlatTableCell data-testid="two">three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell>five</FlatTableCell>
+                <FlatTableCell data-testid="three">five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell>seven</FlatTableCell>
+                <FlatTableCell data-testid="four">seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
-          </FlatTable>,
-          { attachTo: htmlElement }
+          </FlatTable>
         );
 
-        act(() => {
-          (wrapper
-            .find(StyledFlatTableRow)
-            .at(0)
-            .find(StyledFlatTableCell)
-            .at(0)
-            .getDOMNode() as HTMLTableCellElement).focus();
-        });
-
-        expect(
-          wrapper
-            .update()
-            .find(StyledFlatTableRow)
-            .at(0)
-            .find(StyledFlatTableCell)
-            .at(0)
-        ).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(
-          wrapper
-            .update()
-            .find(StyledFlatTableRow)
-            .at(1)
-            .find(StyledFlatTableCell)
-            .at(0)
-        ).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(
-          wrapper
-            .update()
-            .find(StyledFlatTableRow)
-            .at(2)
-            .find(StyledFlatTableCell)
-            .at(0)
-        ).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(
-          wrapper
-            .update()
-            .find(StyledFlatTableRow)
-            .at(3)
-            .find(StyledFlatTableCell)
-            .at(0)
-        ).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowDown);
-        });
-
-        expect(
-          wrapper
-            .update()
-            .find(StyledFlatTableRow)
-            .at(3)
-            .find(StyledFlatTableCell)
-            .at(0)
-        ).toBeFocused();
-      });
-
-      it("should move focus to the previous focusable cell when the up arrow key is pressed but not loop to the last when first reached", () => {
-        const element = document.createElement("div");
-        const htmlElement = document.body.appendChild(element);
-
-        const wrapper = mount(
-          <FlatTable>
-            <FlatTableBody>
-              <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell>one</FlatTableCell>
-                <FlatTableCell>two</FlatTableCell>
-              </FlatTableRow>
-              <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell>three</FlatTableCell>
-                <FlatTableCell>four</FlatTableCell>
-              </FlatTableRow>
-              <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell>five</FlatTableCell>
-                <FlatTableCell>six</FlatTableCell>
-              </FlatTableRow>
-              <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell>seven</FlatTableCell>
-                <FlatTableCell>eight</FlatTableCell>
-              </FlatTableRow>
-            </FlatTableBody>
-          </FlatTable>,
-          { attachTo: htmlElement }
-        );
-
-        act(() => {
-          (wrapper
-            .find(StyledFlatTableRow)
-            .at(3)
-            .find(StyledFlatTableCell)
-            .at(0)
-            .getDOMNode() as HTMLTableCellElement).focus();
-        });
-
-        expect(
-          wrapper
-            .update()
-            .find(StyledFlatTableRow)
-            .at(3)
-            .find(StyledFlatTableCell)
-            .at(0)
-        ).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(
-          wrapper
-            .update()
-            .find(StyledFlatTableRow)
-            .at(2)
-            .find(StyledFlatTableCell)
-            .at(0)
-        ).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(
-          wrapper
-            .update()
-            .find(StyledFlatTableRow)
-            .at(1)
-            .find(StyledFlatTableCell)
-            .at(0)
-        ).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(
-          wrapper
-            .update()
-            .find(StyledFlatTableRow)
-            .at(0)
-            .find(StyledFlatTableCell)
-            .at(0)
-        ).toBeFocused();
-
-        act(() => {
-          wrapper.find(StyledFlatTableWrapper).props().onKeyDown(arrowUp);
-        });
-
-        expect(
-          wrapper
-            .update()
-            .find(StyledFlatTableRow)
-            .at(0)
-            .find(StyledFlatTableCell)
-            .at(0)
-        ).toBeFocused();
+        const tableWrapper = await screen.findByRole("region");
+        const firstFocusableCell = await screen.findByTestId("one");
+        const secondFocusableCell = await screen.findByTestId("two");
+        const thirdFocusableCell = await screen.findByTestId("three");
+        const fourthFocusableCell = await screen.findByTestId("four");
+        fourthFocusableCell.focus();
+        expect(fourthFocusableCell).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(thirdFocusableCell).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(secondFocusableCell).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(firstFocusableCell).toHaveFocus();
+        fireEvent.keyDown(tableWrapper, arrowUp);
+        expect(firstFocusableCell).toHaveFocus();
       });
     });
   });

--- a/src/components/flat-table/flat-table.stories.tsx
+++ b/src/components/flat-table/flat-table.stories.tsx
@@ -710,6 +710,12 @@ export const WithStickyHead: ComponentStory<typeof FlatTable> = () => (
           <FlatTableHeader>Relationship Status</FlatTableHeader>
           <FlatTableHeader>Dependents</FlatTableHeader>
         </FlatTableRow>
+        <FlatTableRow>
+          <FlatTableHeader>Name</FlatTableHeader>
+          <FlatTableHeader>Location</FlatTableHeader>
+          <FlatTableHeader>Relationship Status</FlatTableHeader>
+          <FlatTableHeader>Dependents</FlatTableHeader>
+        </FlatTableRow>
       </FlatTableHead>
       <FlatTableBody>
         <FlatTableRow>


### PR DESCRIPTION
fix #6219

- some tests were refactored to RTL as they now need to be async to allow the update to occur before the assertion

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Adds data tags to FlatTableCheckbox

Refactors `FlatTable` and sub-components to allow consumers greater flexibility with respect to
wrapping the components by removing code that relied on iterating over children and cloning.

Refactors `FlatTableRow` so that it is no longer required that an array is passed to the `subRows`
prop. Adds `FlatTableRowContext` and `SubRowProvider` as well as adding `data-sticky-align` attribute to `FlatTableRowHeader` and `id` attribute to all row children to support `expandable` and `sticky` column functionality.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Components rely heavily on children iteration and using cloning to pass props down to achieve desired functionality.
### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/romantic-kilby-mhhzsp?file=/src/App.js
https://codesandbox.io/s/table-forked-lq389j?file=/src/Table.js -- children mutation