### PR TITLE
fix(portrait): rewrite types and add invariant for gravatar and src p…

### DIFF
--- a/src/components/portrait/portrait.component.tsx
+++ b/src/components/portrait/portrait.component.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useContext } from "react";
 import { MarginProps } from "styled-system";
+import invariant from "invariant";
 
 import { IconType } from "../icon";
 import Tooltip from "../tooltip";
@@ -18,7 +19,11 @@ export type PortraitShapes = "circle" | "square";
 
 export type PortraitSizes = "XS" | "S" | "M" | "ML" | "L" | "XL" | "XXL";
 
-export interface PortraitBaseProps extends MarginProps {
+export interface PortraitProps extends MarginProps {
+  /** An email address registered with Gravatar. */
+  gravatar?: string;
+  /** A custom image URL. */
+  src?: string;
   /** The size of the Portrait. */
   size?: PortraitSizes;
   /** The `alt` HTML string. */
@@ -51,20 +56,6 @@ export interface PortraitBaseProps extends MarginProps {
   tooltipFontColor?: string;
 }
 
-export interface PortraitWithGravatar extends PortraitBaseProps {
-  /** An email address registered with Gravatar. */
-  gravatar?: string;
-  src?: never;
-}
-
-export interface PortraitWithSrc extends PortraitBaseProps {
-  /** A custom image URL. */
-  src?: string;
-  gravatar?: never;
-}
-
-export type PortraitProps = PortraitWithGravatar | PortraitWithSrc;
-
 export const Portrait = ({
   alt = "",
   darkBackground = false,
@@ -88,6 +79,12 @@ export const Portrait = ({
   const [externalError, setExternalError] = useState(false);
   const { roundedCornersOptOut } = useContext(RoundedCornersOptOutContext);
   const defaultShape = roundedCornersOptOut ? "square" : "circle";
+
+  invariant(
+    !(src && gravatar),
+    "The `src` prop cannot be used in conjunction with the `gravatar` prop." +
+      " Please use one or the other."
+  );
 
   useEffect(() => {
     setExternalError(false);

--- a/src/components/portrait/portrait.spec.tsx
+++ b/src/components/portrait/portrait.spec.tsx
@@ -380,6 +380,37 @@ describe("PortraitComponent", () => {
     expect(wrapper.find(Tooltip).exists()).toBeTruthy();
   });
 
+  describe("invariant", () => {
+    it("validates an invariant is thrown if `src` and `gravatar` are set at the same time", () => {
+      const consoleSpy = jest.spyOn(console, "error");
+      consoleSpy.mockImplementation(() => {});
+
+      expect(() => shallow(<Portrait src="foo" gravatar="baz" />)).toThrow(
+        "The `src` prop cannot be used in conjunction with the `gravatar` prop. Please use one or the other."
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("validates an invariant is not thrown if `src` is passed and `gravatar` is not", () => {
+      const consoleSpy = jest.spyOn(console, "error");
+      consoleSpy.mockImplementation(() => {});
+
+      expect(() => shallow(<Portrait src="foo" />)).not.toThrow();
+
+      consoleSpy.mockRestore();
+    });
+
+    it("validates an invariant is not thrown if `gravatar` is passed and `src` is not", () => {
+      const consoleSpy = jest.spyOn(console, "error");
+      consoleSpy.mockImplementation(() => {});
+
+      expect(() => shallow(<Portrait gravatar="baz" />)).not.toThrow();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
   describe("roundedCornersOptOut", () => {
     it("sets the default shape to square when true", () => {
       const shape = mount(


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

Only one type interface will exist on the portrait component, named `PortraitProps` which will include all props from `PortraitBaseProps` and `PortraitWithSrc/PortraitWithGravatar`, an invariant has also been added to throw a better formatted and more informative error message to consumers with the `src` and `gravatar` props are used in conjunction.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

Currently, the interfaces `PortraitWithGravatar` and `PortraitWithSrc` are used to throw a type error when both the `src` and `gravatar` props are passed at the same time. This results in a type error which is not very descriptive or helpful, and could be handled better.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
